### PR TITLE
Cache test fixes

### DIFF
--- a/tests/Zend/Cache/CoreTest.php
+++ b/tests/Zend/Cache/CoreTest.php
@@ -518,13 +518,13 @@ class CoreTest extends \PHPUnit_Framework_TestCase
      */
     public function testIfFileZendLogWasIncluded()
     {
-        if (class_exists('Zend_Log', false)) {
-            $this->markTestSkipped('File Zend/Log.php already included');
+        if (class_exists('Zend_Log_Logger', false)) {
+            $this->markTestSkipped('File Zend/Log/Logger.php already included');
         }
 
-        $cacheCore = new Zend_Cache_Core(
+        $cacheCore = new \Zend\Cache\Frontend\Core(
             array('logging' => true)
         );
-        $this->assertTrue($cacheCore->getOption('logger') instanceof Zend_Log);
+        $this->assertTrue($cacheCore->getOption('logger') instanceof \Zend\Log\Logger);
     }
 }

--- a/tests/Zend/Cache/ManagerTest.php
+++ b/tests/Zend/Cache/ManagerTest.php
@@ -220,7 +220,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $tagCacheConfig['backend']['options']['cache_dir'] = $this->getTmpDir();
         $manager->setTemplateOptions('pagetag', $tagCacheConfig);
         $tagCache = $manager->getCache('page')->getBackend()->getOption('tag_cache');
-        $this->assertTrue($tagCache instanceof Cache\Core);
+        $this->assertTrue($tagCache instanceof Cache\Frontend\Core);
     }
 
     // Helper Methods


### PR DESCRIPTION
Fixed a few namespace issues within the Zend\Cache unit tests which resolved all assertion failures
