### PR TITLE
SignalSlot ResponseCollection

### DIFF
--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -333,13 +333,13 @@ class SessionManager extends AbstractManager
     public function isValid()
     {
         $validator = $this->getValidatorChain();
-        $return    = $validator->emitUntil(function($test) {
+        $responses = $validator->emitUntil(function($test) {
             return !$test;
         }, 'session.validate');
-        if (null === $return) {
+        if (null === $responses->last()) {
             return true;
         }
-        return (bool) $return;
+        return (bool) $responses->last();
     }
 
     /**

--- a/library/Zend/SignalSlot/GlobalSignals.php
+++ b/library/Zend/SignalSlot/GlobalSignals.php
@@ -70,7 +70,7 @@ class GlobalSignals implements StaticSignalSlot
      * 
      * @param  string $topic 
      * @param  mixed $args All arguments besides the topic are passed as arguments to the slot
-     * @return void
+     * @return ResponseCollection All handler return values 
      */
     public static function emit($signal, $args = null)
     {
@@ -90,7 +90,7 @@ class GlobalSignals implements StaticSignalSlot
      * @param  Callable $callback 
      * @param  string $signal 
      * @param  mixed $argv All arguments besides the topic are passed as arguments to the slot
-     * @return mixed
+     * @return ResponseCollection All handler return values
      * @throws InvalidCallbackException if invalid callback provided
      */
     public static function emitUntil($callback, $signal, $args = null)

--- a/library/Zend/SignalSlot/ResponseCollection.php
+++ b/library/Zend/SignalSlot/ResponseCollection.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_SignalSlot
+ * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+/**
+ * @namespace
+ */
+namespace Zend\SignalSlot;
+
+use Zend\Stdlib\SignalHandler;
+
+/**
+ * Collection of signal handler return values
+ *
+ * @uses       Zend\SignalSlot\SignalSlot
+ * @category   Zend
+ * @package    Zend_SignalSlot
+ * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class ResponseCollection extends \SplStack 
+{
+    /**
+     * Convenient access to the first handler return value.
+     *
+     * @return mixed The first handler return value
+     */
+    public function first()
+    {
+        return parent::bottom();
+    }
+
+    /**
+     * Convenient access to the last handler return value.
+     *
+     * @return mixed The last handler return value
+     */
+    public function last()
+    {
+        return parent::top();
+    }
+
+    /**
+     * Check if any of the responses match the given value.
+     *
+     * @param  mixed $value The value to look for among responses
+     */
+    public function contains($value)
+    {
+        foreach ($this as $response) {
+            if ($response === $value) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/library/Zend/SignalSlot/Signals.php
+++ b/library/Zend/SignalSlot/Signals.php
@@ -49,7 +49,7 @@ class Signals implements SignalSlot
      * 
      * @param  string $signal 
      * @param  mixed $argv All arguments besides the signal are passed as arguments to the handler
-     * @return void
+     * @return ResponseCollection All handler return values
      */
     public function emit($signal, $argv = null)
     {
@@ -72,7 +72,7 @@ class Signals implements SignalSlot
      * @param  Callable $callback 
      * @param  string $signal 
      * @param  mixed $argv All arguments besides the signal are passed as arguments to the handler
-     * @return mixed
+     * @return ResponseCollection All handler return values
      * @throws InvalidCallbackException if invalid callback provided
      */
     public function emitUntil($callback, $signal, $argv = null)
@@ -85,18 +85,18 @@ class Signals implements SignalSlot
             return;
         }
 
-        $return = null;
+        $responses = new ResponseCollection;
         if (!is_array($argv)) {
             $argv   = func_get_args();
             $argv   = array_slice($argv, 2);
         }
         foreach ($this->_signals[$signal] as $slot) {
-            $return = $slot->call($argv);
-            if (call_user_func($callback, $return)) {
+            $responses->push($slot->call($argv));
+            if (call_user_func($callback, $responses->last())) {
                 break;
             }
         }
-        return $return;
+        return $responses;
     }
 
     /**

--- a/tests/Zend/SignalSlot/GlobalSignalsTest.php
+++ b/tests/Zend/SignalSlot/GlobalSignalsTest.php
@@ -12,6 +12,7 @@
 
 namespace ZendTest\SignalSlot;
 use Zend\SignalSlot\GlobalSignals as SignalSlot,
+    Zend\SignalSlot\ResponseCollection,
     Zend\Stdlib\SignalHandler;
 
 class GlobalSignalsTest extends \PHPUnit_Framework_TestCase
@@ -100,12 +101,13 @@ class GlobalSignalsTest extends \PHPUnit_Framework_TestCase
     {
         SignalSlot::connect('foo.bar', 'strpos');
         SignalSlot::connect('foo.bar', 'strstr');
-        $value = SignalSlot::emitUntil(
+        $responses = SignalSlot::emitUntil(
             function ($value) { return (!$value); },
             'foo.bar',
             'foo', 'f'
         );
-        $this->assertSame(0, $value);
+        $this->assertTrue($responses instanceof ResponseCollection);
+        $this->assertSame(0, $responses->last());
     }
 
     public function handleTestTopic($message)


### PR DESCRIPTION
Revised SignalSlot component to preserve all handler return values.

The emit methods now capture handler return values in a new
ResponseCollection object and return the entire collection.

The ResponseCollection class extends from SplStack and adds a few
convenience methods: first(), last() and contains(). The contains
method takes a value and checks if any of the response match the
given value.

Updated SessionManager to expect the new return behavior.

Updated and extended SignalSlot tests as appropriate.
