### PR TITLE
Class name typo 

### DIFF
--- a/library/Zend/Controller/Dispatcher/Standard.php
+++ b/library/Zend/Controller/Dispatcher/Standard.php
@@ -445,7 +445,7 @@ class Standard extends AbstractDispatcher
             } else {
                 $moduleDir = $controllerDirs[$module];
                 $fileSpec  = $moduleDir . DIRECTORY_SEPARATOR . $this->classToFilename($default);
-                if (end\Loader::isReadable($fileSpec)) {
+                if (\Zend\Loader::isReadable($fileSpec)) {
                     $found = true;
                     $this->_curDirectory = $moduleDir;
                 }


### PR DESCRIPTION
Somehow, inserting namespaces, the class name got corrupted
