### PR TITLE
Zf 8618

### DIFF
--- a/library/Zend/Json/Decoder.php
+++ b/library/Zend/Json/Decoder.php
@@ -147,7 +147,7 @@ class Decoder
      * {@link Zend_Json::TYPE_OBJECT}; defaults to TYPE_ARRAY
      * @return mixed
      */
-    public static function decode($source, $objectDecodeType = Json::TYPE_ARRAY)
+    public static function decode($source, $objectDecodeType = Json::TYPE_OBJECT)
     {
         $decoder = new self($source, $objectDecodeType);
         return $decoder->_decodeValue();

--- a/library/Zend/Json/Json.php
+++ b/library/Zend/Json/Json.php
@@ -73,7 +73,7 @@ class JSON
      * @return mixed
      * @throws Zend\Json\Exception\RuntimeException
      */
-    public static function decode($encodedValue, $objectDecodeType = self::TYPE_ARRAY)
+    public static function decode($encodedValue, $objectDecodeType = self::TYPE_OBJECT)
     {
         $encodedValue = (string) $encodedValue;
         if (function_exists('json_decode') && self::$useBuiltinEncoderDecoder !== true) {

--- a/library/Zend/Json/Server/Request.php
+++ b/library/Zend/Json/Server/Request.php
@@ -254,7 +254,7 @@ class Request
      */
     public function loadJson($json)
     {
-        $options = Json\Json::decode($json);
+        $options = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
         $this->setOptions($options);
     }
 

--- a/library/Zend/Json/Server/Server.php
+++ b/library/Zend/Json/Server/Server.php
@@ -22,7 +22,7 @@
  * @namespace
  */
 namespace Zend\Json\Server;
-use Zend\Server\Reflection,
+use Zend\Server\Reflection\Reflection,
     Zend\Server\Method;
 
 /**

--- a/tests/Zend/Json/JsonXmlTest.php
+++ b/tests/Zend/Json/JsonXmlTest.php
@@ -109,7 +109,7 @@ EOT;
         $jsonContents = Json\Json::fromXml($xmlStringContents, $ignoreXmlAttributes);
 
         // Convert the JSON string into a PHP array.
-        $phpArray = Json\Json::decode($jsonContents);
+        $phpArray = Json\Json::decode($jsonContents, Json\Json::TYPE_ARRAY);
         // Test if it is not a NULL object.
         $this->assertNotNull($phpArray, "JSON result for XML input 1 is NULL");
         // Test for one of the expected fields in the JSON result.
@@ -158,7 +158,7 @@ EOT;
         $jsonContents = Json\Json::fromXml($xmlStringContents, $ignoreXmlAttributes);
 
         // Convert the JSON string into a PHP array.
-        $phpArray = Json\Json::decode($jsonContents);
+        $phpArray = Json\Json::decode($jsonContents, Json\Json::TYPE_ARRAY);
         // Test if it is not a NULL object.
         $this->assertNotNull($phpArray, "JSON result for XML input 2 is NULL");
         // Test for one of the expected fields in the JSON result.
@@ -238,7 +238,7 @@ EOT;
         $jsonContents = Json\Json::fromXml($xmlStringContents, $ignoreXmlAttributes);
 
         // Convert the JSON string into a PHP array.
-        $phpArray = Json\Json::decode($jsonContents);
+        $phpArray = Json\Json::decode($jsonContents, Json\Json::TYPE_ARRAY);
         // Test if it is not a NULL object.
         $this->assertNotNull($phpArray, "JSON result for XML input 3 is NULL");
         // Test for one of the expected fields in the JSON result.
@@ -344,7 +344,7 @@ EOT;
         $jsonContents = Json\Json::fromXml($xmlStringContents, $ignoreXmlAttributes);
 
         // Convert the JSON string into a PHP array.
-        $phpArray = Json\Json::decode($jsonContents);
+        $phpArray = Json\Json::decode($jsonContents, Json\Json::TYPE_ARRAY);
         // Test if it is not a NULL object.
         $this->assertNotNull($phpArray, "JSON result for XML input 4 is NULL");
         // Test for one of the expected fields in the JSON result.
@@ -389,7 +389,7 @@ EOT;
         $jsonContents = Json\Json::fromXml($xmlStringContents, $ignoreXmlAttributes);
 
         // Convert the JSON string into a PHP array.
-        $phpArray = Json\Json::decode($jsonContents);
+        $phpArray = Json\Json::decode($jsonContents, Json\Json::TYPE_ARRAY);
         // Test if it is not a NULL object.
         $this->assertNotNull($phpArray, "JSON result for XML input 5 is NULL");
         // Test for one of the expected CDATA fields in the JSON result.
@@ -464,7 +464,7 @@ EOT;
         $jsonContents = Json\Json::fromXml($xmlStringContents, $ignoreXmlAttributes);
 
         // Convert the JSON string into a PHP array.
-        $phpArray = Json\Json::decode($jsonContents);
+        $phpArray = Json\Json::decode($jsonContents, Json\Json::TYPE_ARRAY);
         // Test if it is not a NULL object.
         $this->assertNotNull($phpArray, "JSON result for XML input 6 is NULL");
         // Test for one of the expected fields in the JSON result.

--- a/tests/Zend/Json/Server/ErrorTest.php
+++ b/tests/Zend/Json/Server/ErrorTest.php
@@ -151,14 +151,14 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
     {
         $this->setupError();
         $json = $this->error->toJSON();
-        $this->validateArray(Json\Json::decode($json));
+        $this->validateArray(Json\Json::decode($json, Json\Json::TYPE_ARRAY));
     }
 
     public function testCastingToStringShouldCastToJSON()
     {
         $this->setupError();
         $json = $this->error->__toString();
-        $this->validateArray(Json\Json::decode($json));
+        $this->validateArray(Json\Json::decode($json, Json\Json::TYPE_ARRAY));
     }
 
     public function setupError()

--- a/tests/Zend/Json/Server/RequestTest.php
+++ b/tests/Zend/Json/Server/RequestTest.php
@@ -263,7 +263,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     public function validateJSON($json, array $options)
     {
-        $test = Json\Json::decode($json);
+        $test = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
         $this->assertTrue(is_array($test), var_export($json, 1));
 
         $this->assertTrue(array_key_exists('id', $test));

--- a/tests/Zend/Json/Server/ResponseTest.php
+++ b/tests/Zend/Json/Server/ResponseTest.php
@@ -114,7 +114,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
                        ->setId('foo')
                        ->setVersion('2.0');
         $json = $this->response->toJSON();
-        $test = Json\Json::decode($json);
+        $test = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
 
         $this->assertTrue(is_array($test));
         $this->assertTrue(array_key_exists('result', $test));
@@ -136,7 +136,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
                        ->setResult(true)
                        ->setError($error);
         $json = $this->response->toJSON();
-        $test = Json\Json::decode($json);
+        $test = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
 
         $this->assertTrue(is_array($test));
         $this->assertTrue(array_key_exists('result', $test));
@@ -153,7 +153,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->response->setResult(true)
                        ->setId('foo');
         $json = $this->response->__toString();
-        $test = Json\Json::decode($json);
+        $test = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
 
         $this->assertTrue(is_array($test));
         $this->assertTrue(array_key_exists('result', $test));

--- a/tests/Zend/Json/Server/Smd/ServiceTest.php
+++ b/tests/Zend/Json/Server/Smd/ServiceTest.php
@@ -286,7 +286,7 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
     {
         $this->setupSmdValidationObject();
         $json = $this->service->toJSON();
-        $smd  = \Zend\Json\Json::decode($json);
+        $smd  = \Zend\Json\Json::decode($json, \Zend\Json\Json::TYPE_ARRAY);
 
         $this->assertTrue(array_key_exists('foo', $smd));
         $this->assertTrue(is_array($smd['foo']));

--- a/tests/Zend/Json/Server/SmdTest.php
+++ b/tests/Zend/Json/Server/SmdTest.php
@@ -340,7 +340,7 @@ class SmdTest extends \PHPUnit_Framework_TestCase
         $options = $this->getOptions();
         $this->smd->setOptions($options);
         $json = $this->smd->toJSON();
-        $smd  = Json\Json::decode($json);
+        $smd  = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
         $this->validateServiceArray($smd, $options);
     }
 
@@ -349,7 +349,7 @@ class SmdTest extends \PHPUnit_Framework_TestCase
         $options = $this->getOptions();
         $this->smd->setOptions($options);
         $json = $this->smd->__toString();
-        $smd  = Json\Json::decode($json);
+        $smd  = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
         $this->validateServiceArray($smd, $options);
     }
 

--- a/tests/Zend/Json/ServerTest.php
+++ b/tests/Zend/Json/ServerTest.php
@@ -400,7 +400,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->server->handle();
         $buffer = ob_get_clean();
 
-        $decoded = Json\Json::decode($buffer);
+        $decoded = Json\Json::decode($buffer, Json\Json::TYPE_ARRAY);
         $this->assertTrue(is_array($decoded));
         $this->assertTrue(array_key_exists('result', $decoded));
         $this->assertTrue(array_key_exists('id', $decoded));


### PR DESCRIPTION
ZF-8618: the default decode type should be TYPE_OBJECT (same behavior as of json_decode)
- fixed some zf2 class conflicts within Zend\Json\Server
