### PR TITLE
Ignore eclipse workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 nbproject
-
+.project
+.settings


### PR DESCRIPTION
added .project and .settings to .gitignore to ignore eclipse workspace conifguration files.
