### PR TITLE
Invalid Autoloader.php references in zf.php

### DIFF
--- a/bin/zf.php
+++ b/bin/zf.php
@@ -383,14 +383,14 @@ class ZF
     protected function _tryClientLoad()
     {
         $this->_clientLoaded = false;
-        $fh = @fopen('Zend/Loader/Autoloader.php', 'r', true);
+        $fh = @fopen('Zend/Loader/StandardAutoloader.php', 'r', true);
         if (!$fh) {
             return $this->_clientLoaded; // false
         } else {
             fclose($fh);
             unset($fh);
-            include 'Zend/Loader/Autoloader.php';
-            $this->_clientLoaded = class_exists('Zend\Loader\Autoloader', false);
+            include 'Zend/Loader/StandardAutoloader.php';
+            $this->_clientLoaded = class_exists('Zend\Loader\StandardAutoloader', false);
         }
         
         return $this->_clientLoaded;
@@ -603,8 +603,9 @@ EOS;
 	    
 	    // ensure that zf.php loads the Zend_Tool_Project features
 	    $configOptions['classesToLoad'] = 'Zend\Tool\Project\Provider\Manifest';
-	    
-	    Zend\Loader\Autoloader::getInstance();
+
+            $loader = new Zend\Loader\StandardAutoloader();
+            $loader->register();
 	    
 	    $console = new Zend\Tool\Framework\Client\Console\Console($configOptions);
 	    $console->dispatch();

--- a/bin/zfals.php
+++ b/bin/zfals.php
@@ -13,8 +13,9 @@ if (!strstr($incPath, $libPath)) {
 }
 
 // Setup autoloading
-require_once 'Zend/Loader/Autoloader.php';
-Zend\Loader\Autoloader::getInstance();
+require_once 'Zend/Loader/StandardAutoloader.php';
+$loader = new Zend\Loader\StandardAutoloader();
+$loader->register();
 
 $rules = array(
     'help|h'        => 'Get usage message',


### PR DESCRIPTION
Replaced Autoloader.php references with StandardAutoloader to get /bin/zf.php working again.
