### PR TITLE
Code generator fix

### DIFF
--- a/library/Zend/CodeGenerator/Php/Docblock/Tag/LicenseTag.php
+++ b/library/Zend/CodeGenerator/Php/Docblock/Tag/LicenseTag.php
@@ -31,13 +31,13 @@ namespace Zend\CodeGenerator\Php\Docblock\Tag;
  * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Return extends \Zend\CodeGenerator\Php\PhpDocblockTag
+class LicenseTag extends \Zend\CodeGenerator\Php\PhpDocblockTag
 {
 
     /**
      * @var string
      */
-    protected $_datatype = null;
+    protected $_url = null;
 
     /**
      * @var string
@@ -48,39 +48,39 @@ class Return extends \Zend\CodeGenerator\Php\PhpDocblockTag
      * fromReflection()
      *
      * @param \Zend\Reflection\ReflectionDocblockTag $reflectionTagReturn
-     * @return \Zend\CodeGenerator\Php\Docblock\Tag\Return
+     * @return \Zend\CodeGenerator\Php\Docblock\Tag\LicenseTag
      */
-    public static function fromReflection(\Zend\Reflection\ReflectionDocblockTag $reflectionTagReturn)
+    public static function fromReflection(\Zend\Reflection\ReflectionDocblockTag $reflectionTagLicense)
     {
         $returnTag = new \self();
 
-        $returnTag->setName('return');
-        $returnTag->setDatatype($reflectionTagReturn->getType()); // @todo rename
-        $returnTag->setDescription($reflectionTagReturn->getDescription());
+        $returnTag->setName('license');
+        $returnTag->setUrl($reflectionTagLicense->getUrl());
+        $returnTag->setDescription($reflectionTagLicense->getDescription());
 
         return $returnTag;
     }
 
     /**
-     * setDatatype()
+     * setUrl()
      *
-     * @param string $datatype
-     * @return \Zend\CodeGenerator\Php\Docblock\Tag\Return
+     * @param string $url
+     * @return \Zend\CodeGenerator\Php\Docblock\Tag\LicenseTag
      */
-    public function setDatatype($datatype)
+    public function setUrl($url)
     {
-        $this->_datatype = $datatype;
+        $this->_url = $url;
         return $this;
     }
 
     /**
-     * getDatatype()
+     * getUrl()
      *
      * @return string
      */
-    public function getDatatype()
+    public function getUrl()
     {
-        return $this->_datatype;
+        return $this->_url;
     }
 
 
@@ -91,7 +91,7 @@ class Return extends \Zend\CodeGenerator\Php\PhpDocblockTag
      */
     public function generate()
     {
-        $output = '@return ' . $this->_datatype . ' ' . $this->_description;
+        $output = '@license ' . $this->_url . ' ' . $this->_description . self::LINE_FEED;
         return $output;
     }
 

--- a/library/Zend/CodeGenerator/Php/Docblock/Tag/ParamTag.php
+++ b/library/Zend/CodeGenerator/Php/Docblock/Tag/ParamTag.php
@@ -31,7 +31,7 @@ namespace Zend\CodeGenerator\Php\Docblock\Tag;
  * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Param extends \Zend\CodeGenerator\Php\PhpDocblockTag
+class ParamTag extends \Zend\CodeGenerator\Php\PhpDocblockTag
 {
 
     /**
@@ -53,7 +53,7 @@ class Param extends \Zend\CodeGenerator\Php\PhpDocblockTag
      * fromReflection()
      *
      * @param \Zend\Reflection\ReflectionDocblockTag $reflectionTagParam
-     * @return \Zend\CodeGenerator\Php\Docblock\Tag\Param
+     * @return \Zend\CodeGenerator\Php\Docblock\Tag\ParamTag
      */
     public static function fromReflection(\Zend\Reflection\ReflectionDocblockTag $reflectionTagParam)
     {
@@ -71,7 +71,7 @@ class Param extends \Zend\CodeGenerator\Php\PhpDocblockTag
      * setDatatype()
      *
      * @param string $datatype
-     * @return \Zend\CodeGenerator\Php\Docblock\Tag\Param
+     * @return \Zend\CodeGenerator\Php\Docblock\Tag\ParamTag
      */
     public function setDatatype($datatype)
     {
@@ -93,7 +93,7 @@ class Param extends \Zend\CodeGenerator\Php\PhpDocblockTag
      * setParamName()
      *
      * @param string $paramName
-     * @return \Zend\CodeGenerator\Php\Docblock\Tag\Param
+     * @return \Zend\CodeGenerator\Php\Docblock\Tag\ParamTag
      */
     public function setParamName($paramName)
     {

--- a/library/Zend/CodeGenerator/Php/Docblock/Tag/ReturnTag.php
+++ b/library/Zend/CodeGenerator/Php/Docblock/Tag/ReturnTag.php
@@ -31,13 +31,13 @@ namespace Zend\CodeGenerator\Php\Docblock\Tag;
  * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class License extends \Zend\CodeGenerator\Php\PhpDocblockTag
+class ReturnTag extends \Zend\CodeGenerator\Php\PhpDocblockTag
 {
 
     /**
      * @var string
      */
-    protected $_url = null;
+    protected $_datatype = null;
 
     /**
      * @var string
@@ -48,39 +48,39 @@ class License extends \Zend\CodeGenerator\Php\PhpDocblockTag
      * fromReflection()
      *
      * @param \Zend\Reflection\ReflectionDocblockTag $reflectionTagReturn
-     * @return \Zend\CodeGenerator\Php\Docblock\Tag\License
+     * @return \Zend\CodeGenerator\Php\Docblock\Tag\ReturnTag
      */
-    public static function fromReflection(\Zend\Reflection\ReflectionDocblockTag $reflectionTagLicense)
+    public static function fromReflection(\Zend\Reflection\ReflectionDocblockTag $reflectionTagReturn)
     {
         $returnTag = new \self();
 
-        $returnTag->setName('license');
-        $returnTag->setUrl($reflectionTagLicense->getUrl());
-        $returnTag->setDescription($reflectionTagLicense->getDescription());
+        $returnTag->setName('return');
+        $returnTag->setDatatype($reflectionTagReturn->getType()); // @todo rename
+        $returnTag->setDescription($reflectionTagReturn->getDescription());
 
         return $returnTag;
     }
 
     /**
-     * setUrl()
+     * setDatatype()
      *
-     * @param string $url
-     * @return \Zend\CodeGenerator\Php\Docblock\Tag\License
+     * @param string $datatype
+     * @return \Zend\CodeGenerator\Php\Docblock\Tag\ReturnTag
      */
-    public function setUrl($url)
+    public function setDatatype($datatype)
     {
-        $this->_url = $url;
+        $this->_datatype = $datatype;
         return $this;
     }
 
     /**
-     * getUrl()
+     * getDatatype()
      *
      * @return string
      */
-    public function getUrl()
+    public function getDatatype()
     {
-        return $this->_url;
+        return $this->_datatype;
     }
 
 
@@ -91,7 +91,7 @@ class License extends \Zend\CodeGenerator\Php\PhpDocblockTag
      */
     public function generate()
     {
-        $output = '@license ' . $this->_url . ' ' . $this->_description . self::LINE_FEED;
+        $output = '@return ' . $this->_datatype . ' ' . $this->_description;
         return $output;
     }
 

--- a/library/Zend/CodeGenerator/Php/PhpDocblockTag.php
+++ b/library/Zend/CodeGenerator/Php/PhpDocblockTag.php
@@ -26,8 +26,6 @@ namespace Zend\CodeGenerator\Php;
 
 /**
  * @uses       \Zend\CodeGenerator\AbstractCodeGenerator
- * @uses       \Zend\CodeGenerator\Php\Docblock\Tag\Param
- * @uses       \Zend\CodeGenerator\Php\Docblock\Tag\Return
  * @uses       \Zend\Loader\PluginLoader
  * @category   Zend
  * @package    Zend_CodeGenerator
@@ -51,7 +49,7 @@ class PhpDocblockTag extends AbstractPhp
             '@<name> <description>'
             )
         );
-    
+
     /**
      * @var string
      */

--- a/tests/Zend/CodeGenerator/Php/PhpClassTest.php
+++ b/tests/Zend/CodeGenerator/Php/PhpClassTest.php
@@ -106,7 +106,7 @@ class PhpClassTest extends \PHPUnit_Framework_TestCase
     {
         $codeGenClass = new Php\PhpClass();
         $codeGenClass->setProperty(array('name' => 'prop3'));
-        
+
         $this->setExpectedException(
             'Zend\CodeGenerator\Php\Exception\InvalidArgumentException',
             'A property by name prop3 already exists in this class'
@@ -117,7 +117,7 @@ class PhpClassTest extends \PHPUnit_Framework_TestCase
     public function testSetPropertyNoArrayOrPropertyThrowsException()
     {
         $codeGenClass = new Php\PhpClass();
-        
+
         $this->setExpectedException(
             'Zend\CodeGenerator\Php\Exception\InvalidArgumentException',
             'setProperty() expects either an array of property options or an instance of Zend_CodeGenerator_Php_Property'
@@ -248,8 +248,10 @@ EOS;
         $codeGen->setSourceDirty(true);
 
         $code = $codeGen->generate();
-        
-        $expectedClassDef = 'class ClassWithInterface implements OneInterface, TwoInterface';
+
+        $expectedClassDef = 'class ClassWithInterface'
+                          . ' implements ZendTest\CodeGenerator\Php\TestAsset\OneInterface'
+                          . ', ZendTest\CodeGenerator\Php\TestAsset\TwoInterface';
         $this->assertContains($expectedClassDef, $code);
     }
 
@@ -265,7 +267,9 @@ EOS;
 
         $code = $codeGen->generate();
 
-        $expectedClassDef = 'class NewClassWithInterface extends ClassWithInterface implements ThreeInterface';
+        $expectedClassDef = 'class NewClassWithInterface'
+                          . ' extends ZendTest\CodeGenerator\Php\TestAsset\ClassWithInterface'
+                          . ' implements ZendTest\CodeGenerator\Php\TestAsset\ThreeInterface';
         $this->assertContains($expectedClassDef, $code);
     }
 

--- a/tests/Zend/CodeGenerator/Php/PhpDocblockTagTest.php
+++ b/tests/Zend/CodeGenerator/Php/PhpDocblockTagTest.php
@@ -46,12 +46,12 @@ class TagTest extends \PHPUnit_Framework_TestCase
      */
     protected $_tag = null;
 
-    public function setup()
+    public function setUp()
     {
         $this->_tag = new \Zend\CodeGenerator\Php\PhpDocblockTag();
     }
 
-    public function teardown()
+    public function tearDown()
     {
         $this->_tag = null;
     }
@@ -67,7 +67,7 @@ class TagTest extends \PHPUnit_Framework_TestCase
         $this->_tag->setDescription('Foo foo foo');
         $this->assertEquals('Foo foo foo', $this->_tag->getDescription());
     }
-    
+
 
 
 //    public function testDatatypeGetterAndSetterPersistValue()
@@ -88,28 +88,6 @@ class TagTest extends \PHPUnit_Framework_TestCase
 //        $this->_tag->setDatatype('string');
 //        $this->_tag->setDescription('bar bar bar');
 //        $this->assertEquals('@param string $foo bar bar bar', $this->_tag->generate());
-//    }
-
-//
-//    /**
-//     * @var Zend_CodeGenerator_Php_Docblock_Tag
-//     */
-//    protected $_tag = null;
-//
-//    public function setup()
-//    {
-//        $this->_tag = new \Zend\CodeGenerator\Php\Docblock\Tag\Return();
-//    }
-//
-//    public function teardown()
-//    {
-//        $this->_tag = null;
-//    }
-//
-//    public function testDatatypeGetterAndSetterPersistValue()
-//    {
-//        $this->_tag->setDatatype('Foo');
-//        $this->assertEquals('Foo', $this->_tag->getDatatype());
 //    }
 
 }

--- a/tests/Zend/CodeGenerator/Php/PhpFileTest.php
+++ b/tests/Zend/CodeGenerator/Php/PhpFileTest.php
@@ -128,11 +128,10 @@ EOS;
 <?php
 /**
  * File header here
- * 
+ *
  * @author Ralph Schindler <ralph.schindler@zend.com>
- * 
+ *
  */
-
 
 /**
  * @namespace
@@ -141,18 +140,18 @@ namespace ZendTest\CodeGenerator\Php\TestAsset;
 
 /**
  * class docblock
- * 
+ *
  * @package Zend_Reflection_TestSampleSingleClass
- * 
+ *
  */
 class TestSampleSingleClass
 {
 
     /**
      * Enter description here...
-     * 
+     *
      * @return bool
-     * 
+     *
      */
     public function someMethod()
     {
@@ -167,12 +166,8 @@ class TestSampleSingleClass
 }
 
 
-
-
 EOS;
-
         $this->assertEquals($expectedOutput, $codeGenFileFromDisk->generate());
-
     }
 
     public function testFileLineEndingsAreAlwaysLineFeed()

--- a/tests/Zend/CodeGenerator/Php/PhpParameterTest.php
+++ b/tests/Zend/CodeGenerator/Php/PhpParameterTest.php
@@ -86,7 +86,7 @@ class PhpParameterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Foo $bar = 15', $this->_parameter->generate());
 
         $this->_parameter->setDefaultValue('foo');
-        $this->assertEquals('Foo $bar = \'foo\'', $this->_parameter->generate());
+        $this->assertEquals('Foo $bar = \'foo\';', $this->_parameter->generate());
     }
 
     public function testFromReflectionGetParameterName()


### PR DESCRIPTION
- fixed parse error by adding suffix "Tag" to class names of Zend\CodeGenerator\Php\Docblock\Tag*
- fixed some wrong tests
