### PR TITLE
Loader fix

### DIFF
--- a/library/Zend/Loader/Exception/BadMethodCallException.php
+++ b/library/Zend/Loader/Exception/BadMethodCallException.php
@@ -32,7 +32,7 @@ use Zend\Loader\Exception;
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class BadMethodCallException
-    extends \BadMethodCallException;
+    extends \BadMethodCallException
     implements Exception
 {
 }


### PR DESCRIPTION
fixed parse error on Zend\Loader\Exception\BadMethodCallException
