### PR TITLE
ZF-10190

### DIFF
--- a/library/Zend/Loader.php
+++ b/library/Zend/Loader.php
@@ -93,43 +93,12 @@ class Loader
      * This function uses the PHP include_path, where PHP's is_readable()
      * does not.
      *
-     * Note from ZF-2900:
-     * If you use custom error handler, please check whether return value
-     *  from error_reporting() is zero or not.
-     * At mark of fopen() can not suppress warning if the handler is used.
-     *
      * @param string   $filename
      * @return boolean
      */
     public static function isReadable($filename)
     {
-        if (is_readable($filename)) {
-            // Return early if the filename is readable without needing the 
-            // include_path
-            return true;
-        }
-
-        if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN'
-            && preg_match('/^[a-z]:/i', $filename)
-        ) {
-            // If on windows, and path provided is clearly an absolute path, 
-            // return false immediately
-            return false;
-        }
-
-        foreach (self::explodeIncludePath() as $path) {
-            if ($path == '.') {
-                if (is_readable($filename)) {
-                    return true;
-                }
-                continue;
-            }
-            $file = $path . '/' . $filename;
-            if (is_readable($file)) {
-                return true;
-            }
-        }
-        return false;
+        return (bool)stream_resolve_include_path($filename);
     }
 
     /**
@@ -137,8 +106,8 @@ class Loader
      *
      * If no path provided, uses current include_path. Works around issues that
      * occur when the path includes stream schemas.
-     * 
-     * @param  string|null $path 
+     *
+     * @param  string|null $path
      * @return array
      */
     public static function explodeIncludePath($path = null)
@@ -148,7 +117,7 @@ class Loader
         }
 
         if (PATH_SEPARATOR == ':') {
-            // On *nix systems, include_paths which include paths with a stream 
+            // On *nix systems, include_paths which include paths with a stream
             // schema cannot be safely explode'd, so we have to be a bit more
             // intelligent in the approach.
             $paths = preg_split('#:(?!//)#', $path);

--- a/library/Zend/Reflection/ReflectionFile.php
+++ b/library/Zend/Reflection/ReflectionFile.php
@@ -60,12 +60,12 @@ class ReflectionFile implements \Reflector
      * @var string
      */
     protected $_namespace       = null;
-    
+
     /**
      * @var string[]
      */
     protected $_uses            = array();
-    
+
     /**
      * @var string[]
      */
@@ -113,20 +113,12 @@ class ReflectionFile implements \Reflector
      * Find realpath of file based on include_path
      *
      * @param  string $fileName
-     * @return string
+     * @return string|boolean On success, the resolved absolute filename is returned.
+     *                        On failure, FALSE is returned.
      */
     public static function findRealpathInIncludePath($fileName)
     {
-        $includePaths = \Zend\Loader::explodeIncludePath();
-        while (count($includePaths) > 0) {
-            $filePath = array_shift($includePaths) . DIRECTORY_SEPARATOR . $fileName;
-
-            if ( ($foundRealpath = realpath($filePath)) !== false) {
-                break;
-            }
-        }
-
-        return $foundRealpath;
+        return stream_resolve_include_path($fileName);
     }
 
     /**
@@ -199,24 +191,24 @@ class ReflectionFile implements \Reflector
 
     /**
      * getNamespace()
-     * 
+     *
      * @return string
      */
     public function getNamespace()
     {
         return $this->_namespace;
     }
-    
+
     /**
      * getUses()
-     * 
+     *
      * @return array
      */
     public function getUses()
     {
         return $this->_uses;
     }
-    
+
     /**
      * Return the reflection classes of the classes found inside this file
      *
@@ -396,7 +388,7 @@ class ReflectionFile implements \Reflector
                 case T_NAMESPACE:
                     $namespaceTrapped = true;
                     continue;
-                    
+
                 // use
                 case T_USE:
                     $useTrapped = true;
@@ -405,12 +397,12 @@ class ReflectionFile implements \Reflector
                         'as' => ''
                         );
                     continue;
-                    
+
                 // use (as)
                 case T_AS:
                     $useAsTrapped = true;
                     continue;
-                    
+
                 // Functions
                 case T_FUNCTION:
                     if ($openBraces == 0) {
@@ -437,12 +429,12 @@ class ReflectionFile implements \Reflector
                     break;
             }
         }
-        
+
         // cleanup uses
         foreach ($this->_uses as $useIndex => $useInfo) {
             $this->_uses[$useIndex]['namespace'] = rtrim($this->_uses[$useIndex]['namespace'], '\\');
             $this->_uses[$useIndex]['as'] = rtrim($this->_uses[$useIndex]['as'], '\\');
-            
+
             if ($this->_uses[$useIndex]['as'] == '') {
                 if (($lastSeparator = strrpos($this->_uses[$useIndex]['namespace'], '\\')) !== false) {
                     $this->_uses[$useIndex]['asResolved'] = substr($this->_uses[$useIndex]['namespace'], $lastSeparator+1);
@@ -452,9 +444,9 @@ class ReflectionFile implements \Reflector
             } else {
                 $this->_uses[$useIndex]['asResolved'] = $this->_uses[$useIndex]['as'];
             }
-            
+
         }
-        
+
 
         $this->_endLine = count(explode("\n", $this->_contents));
     }

--- a/tests/Zend/Loader/LoaderTest.php
+++ b/tests/Zend/Loader/LoaderTest.php
@@ -143,8 +143,10 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsReadableShouldNotLockWhenTestingForNonExistantFileInPhar()
     {
-        if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-            $this->markTestSkipped();
+        if (ini_get('phar.readonly')) {
+            $this->markTestSkipped(
+                "creating phar archive is disabled by the php.ini setting 'phar.readonly'"
+            );
         }
 
         $pharFile = __DIR__ . '/_files/LoaderTest.phar';


### PR DESCRIPTION
ZF-10190:
- use the new build-in function 'stream_resolve_include_path'
  on Zend\Loader::isReadable and Zend\Reflection\ReflectionFile::findRealpathInIncludePath
- on Zend\Cache nothing is changed because refactoring

ZendTest\Loader\LoaderTest::testIsReadableShouldNotLockWhenTestingForNonExistantFileInPhar:
- removed skip if php < 5.3
- added skip if phar.readonly is enabled
