### PR TITLE
[ZF-10872] Fixed invalid doctype view helper method calls

### DIFF
--- a/library/Zend/Dojo/View/Helper/Dojo/Container.php
+++ b/library/Zend/Dojo/View/Helper/Dojo/Container.php
@@ -961,7 +961,7 @@ EOJ;
             return '';
         }
 
-        $this->_isXhtml = $this->view->doctype()->isXhtml();
+        $this->_isXhtml = $this->view->broker('doctype')->isXhtml();
 
         if (DojoHelper::useDeclarative()) {
             if (null === $this->getDjConfigOption('parseOnLoad')) {

--- a/library/Zend/View/Helper/FormCheckbox.php
+++ b/library/Zend/View/Helper/FormCheckbox.php
@@ -85,7 +85,7 @@ class FormCheckbox extends FormElement
 
         // XHTML or HTML end tag?
         $endTag = ' />';
-        if (($this->view instanceof \Zend\View\AbstractView) && !$this->view->doctype()->isXhtml()) {
+        if (($this->view instanceof \Zend\View\AbstractView) && !$this->view->broker('doctype')->isXhtml()) {
             $endTag= '>';
         }
 

--- a/library/Zend/View/Helper/FormFile.php
+++ b/library/Zend/View/Helper/FormFile.php
@@ -66,7 +66,7 @@ class FormFile extends FormElement
 
         // XHTML or HTML end tag?
         $endTag = ' />';
-        if (($this->view instanceof \Zend\View\AbstractView) && !$this->view->doctype()->isXhtml()) {
+        if (($this->view instanceof \Zend\View\AbstractView) && !$this->view->broker('doctype')->isXhtml()) {
             $endTag= '>';
         }
 

--- a/library/Zend/View/Helper/FormImage.php
+++ b/library/Zend/View/Helper/FormImage.php
@@ -83,7 +83,7 @@ class FormImage extends FormElement
 
         // XHTML or HTML end tag?
         $endTag = ' />';
-        if (($this->view instanceof \Zend\View\AbstractView) && !$this->view->doctype()->isXhtml()) {
+        if (($this->view instanceof \Zend\View\AbstractView) && !$this->view->broker('doctype')->isXhtml()) {
             $endTag= '>';
         }
 

--- a/library/Zend/View/Helper/FormPassword.php
+++ b/library/Zend/View/Helper/FormPassword.php
@@ -78,7 +78,7 @@ class FormPassword extends FormElement
 
         // XHTML or HTML end tag?
         $endTag = ' />';
-        if (($this->view instanceof \Zend\View\AbstractView) && !$this->view->doctype()->isXhtml()) {
+        if (($this->view instanceof \Zend\View\AbstractView) && !$this->view->broker('doctype')->isXhtml()) {
             $endTag= '>';
         }
 

--- a/library/Zend/View/Helper/FormRadio.php
+++ b/library/Zend/View/Helper/FormRadio.php
@@ -126,7 +126,7 @@ class FormRadio extends FormElement
 
         // XHTML or HTML end tag?
         $endTag = ' />';
-        if (($this->view instanceof \Zend\View\AbstractView) && !$this->view->doctype()->isXhtml()) {
+        if (($this->view instanceof \Zend\View\AbstractView) && !$this->view->broker('doctype')->isXhtml()) {
             $endTag= '>';
         }
 

--- a/library/Zend/View/Helper/FormReset.php
+++ b/library/Zend/View/Helper/FormReset.php
@@ -64,7 +64,7 @@ class FormReset extends FormElement
 
         // get closing tag
         $endTag = '>';
-        if ($this->view->doctype()->isXhtml()) {
+        if ($this->view->broker('doctype')->isXhtml()) {
             $endTag = ' />';
         }
 

--- a/library/Zend/View/Helper/FormSubmit.php
+++ b/library/Zend/View/Helper/FormSubmit.php
@@ -68,7 +68,7 @@ class FormSubmit extends FormElement
 
         // XHTML or HTML end tag?
         $endTag = ' />';
-        if (($this->view instanceof \Zend\View\AbstractView) && !$this->view->doctype()->isXhtml()) {
+        if (($this->view instanceof \Zend\View\AbstractView) && !$this->view->broker('doctype')->isXhtml()) {
             $endTag= '>';
         }
 

--- a/library/Zend/View/Helper/FormText.php
+++ b/library/Zend/View/Helper/FormText.php
@@ -69,7 +69,7 @@ class FormText extends FormElement
 
         // XHTML or HTML end tag?
         $endTag = ' />';
-        if (($this->view instanceof \Zend\View\AbstractView) && !$this->view->doctype()->isXhtml()) {
+        if (($this->view instanceof \Zend\View\AbstractView) && !$this->view->broker('doctype')->isXhtml()) {
             $endTag= '>';
         }
 

--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -285,7 +285,7 @@ class HeadLink extends Placeholder\Container\Standalone
         }
 
         if ($this->view instanceof View\AbstractView) {
-            $link .= ($this->view->doctype()->isXhtml()) ? '/>' : '>';
+            $link .= ($this->view->broker('doctype')->isXhtml()) ? '/>' : '>';
         } else {
             $link .= '/>';
         }

--- a/library/Zend/View/Helper/HeadMeta.php
+++ b/library/Zend/View/Helper/HeadMeta.php
@@ -200,8 +200,8 @@ class HeadMeta extends Placeholder\Container\Standalone
         }
 
         if (!isset($item->content)
-        && (! $this->view->doctype()->isHtml5()
-        || (! $this->view->doctype()->isHtml5() && $item->type !== 'charset'))) {
+        && (! $this->view->broker('doctype')->isHtml5()
+        || (! $this->view->broker('doctype')->isHtml5() && $item->type !== 'charset'))) {
             return false;
         }
 
@@ -326,7 +326,7 @@ class HeadMeta extends Placeholder\Container\Standalone
 
         $modifiersString = '';
         foreach ($item->modifiers as $key => $value) {
-            if ($this->view->doctype()->isHtml5()
+            if ($this->view->broker('doctype')->isHtml5()
             && $key == 'scheme') {
                 throw new View\Exception('Invalid modifier '
                 . '"scheme" provided; not supported by HTML5');
@@ -338,12 +338,12 @@ class HeadMeta extends Placeholder\Container\Standalone
         }
 
         if ($this->view instanceof View\AbstractView) {
-            if ($this->view->doctype()->isHtml5()
+            if ($this->view->broker('doctype')->isHtml5()
             && $type == 'charset') {
-				$tpl = ($this->view->doctype()->isXhtml())
+				$tpl = ($this->view->broker('doctype')->isXhtml())
 					? '<meta %s="%s"/>'
 					: '<meta %s="%s">';
-            } elseif ($this->view->doctype()->isXhtml()) {
+            } elseif ($this->view->broker('doctype')->isXhtml()) {
                 $tpl = '<meta %s="%s" content="%s" %s/>';
             } else {
                 $tpl = '<meta %s="%s" content="%s" %s>';

--- a/library/Zend/View/Helper/HtmlElement.php
+++ b/library/Zend/View/Helper/HtmlElement.php
@@ -72,7 +72,7 @@ abstract class HtmlElement extends AbstractHelper
      */
     protected function _isXhtml()
     {
-        $doctype = $this->view->doctype();
+        $doctype = $this->view->broker('doctype');
         return $doctype->isXhtml();
     }
 

--- a/tests/Zend/View/Helper/FormCheckboxTest.php
+++ b/tests/Zend/View/Helper/FormCheckboxTest.php
@@ -252,7 +252,7 @@ class FormCheckboxTest extends \PHPUnit_Framework_TestCase
 
     public function testCanRendersAsXHtml()
     {
-        $this->view->doctype('XHTML1_STRICT');
+        $this->view->broker('doctype')->direct('XHTML1_STRICT');
         $test = $this->helper->direct('foo', 'bar');
         $this->assertContains(' />', $test);
     }

--- a/tests/Zend/View/Helper/FormFileTest.php
+++ b/tests/Zend/View/Helper/FormFileTest.php
@@ -94,7 +94,7 @@ class FormFileTest extends \PHPUnit_Framework_TestCase
 
     public function testCanRendersAsXHtml()
     {
-        $this->view->doctype('XHTML1_STRICT');
+        $this->view->broker('doctype')->direct('XHTML1_STRICT');
         $test = $this->helper->direct(array(
             'name'    => 'foo',
         ));

--- a/tests/Zend/View/Helper/FormMultiCheckboxTest.php
+++ b/tests/Zend/View/Helper/FormMultiCheckboxTest.php
@@ -114,7 +114,7 @@ class FormMultiCheckboxTest extends \PHPUnit_Framework_TestCase
 
     public function testCanRendersAsXHtml()
     {
-        $this->view->doctype('XHTML1_STRICT');
+        $this->view->broker('doctype')->direct('XHTML1_STRICT');
         $options = array(
             'foo' => 'Foo',
             'bar' => 'Bar',

--- a/tests/Zend/View/Helper/FormPasswordTest.php
+++ b/tests/Zend/View/Helper/FormPasswordTest.php
@@ -93,7 +93,7 @@ class FormPasswordTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldAllowRenderingAsXhtml()
     {
-        $this->view->doctype('XHTML1_STRICT');
+        $this->view->broker('doctype')->direct('XHTML1_STRICT');
         $test = $this->helper->direct('foo', 'bar');
         $this->assertContains(' />', $test);
     }

--- a/tests/Zend/View/Helper/FormResetTest.php
+++ b/tests/Zend/View/Helper/FormResetTest.php
@@ -96,7 +96,7 @@ class FormResetTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldAllowRenderingAsXHtml()
     {
-        $this->view->doctype('XHTML1_STRICT');
+        $this->view->broker('doctype')->direct('XHTML1_STRICT');
         $test = $this->helper->direct('foo', 'bar');
         $this->assertContains(' />', $test);
     }

--- a/tests/Zend/View/Helper/FormSubmitTest.php
+++ b/tests/Zend/View/Helper/FormSubmitTest.php
@@ -108,7 +108,7 @@ class FormSubmitTest extends \PHPUnit_Framework_TestCase
 
     public function testCanRendersAsXHtml()
     {
-        $this->view->doctype('XHTML1_STRICT');
+        $this->view->broker('doctype')->direct('XHTML1_STRICT');
         $test = $this->helper->direct('foo', 'bar');
         $this->assertContains(' />', $test);
     }

--- a/tests/Zend/View/Helper/FormTextTest.php
+++ b/tests/Zend/View/Helper/FormTextTest.php
@@ -119,7 +119,7 @@ class FormTextTest extends \PHPUnit_Framework_TestCase
 
     public function testCanRendersAsXHtml()
     {
-        $this->view->doctype('XHTML1_STRICT');
+        $this->view->broker('doctype')->direct('XHTML1_STRICT');
         $test = $this->helper->direct('foo', 'bar');
         $this->assertContains(' />', $test);
     }

--- a/tests/Zend/View/Helper/HeadLinkTest.php
+++ b/tests/Zend/View/Helper/HeadLinkTest.php
@@ -350,7 +350,7 @@ class HeadLinkTest extends \PHPUnit_Framework_TestCase
 
     public function testLinkRendersAsPlainHtmlIfDoctypeNotXhtml()
     {
-        $this->view->doctype('HTML4_STRICT');
+        $this->view->broker('doctype')->direct('HTML4_STRICT');
         $this->helper->direct(array('rel' => 'icon', 'src' => '/foo/bar'))
                      ->direct(array('rel' => 'foo', 'href' => '/bar/baz'));
         $test = $this->helper->toString();

--- a/tests/Zend/View/Helper/HeadMetaTest.php
+++ b/tests/Zend/View/Helper/HeadMetaTest.php
@@ -67,7 +67,7 @@ class HeadMetaTest extends \PHPUnit_Framework_TestCase
         }
         $this->basePath = __DIR__ . '/_files/modules';
         $this->view     = new View\View();
-        $this->view->doctype('XHTML1_STRICT');
+        $this->view->broker('doctype')->direct('XHTML1_STRICT');
         $this->helper   = new Helper\HeadMeta();
         $this->helper->setView($this->view);
     }
@@ -333,7 +333,7 @@ class HeadMetaTest extends \PHPUnit_Framework_TestCase
 
     public function testStringRepresentationReflectsDoctype()
     {
-        $this->view->doctype('HTML4_STRICT');
+        $this->view->broker('doctype')->direct('HTML4_STRICT');
         $this->helper->direct('some content', 'foo');
         $test = $this->helper->toString();
         $this->assertNotContains('/>', $test);

--- a/tests/Zend/View/Helper/HtmlObjectTest.php
+++ b/tests/Zend/View/Helper/HtmlObjectTest.php
@@ -85,7 +85,7 @@ class HtmlObjectTest extends \PHPUnit_Framework_TestCase
 
     public function testMakeHtmlObjectWithoutAttribsWithParamsHtml()
     {
-        $this->view->doctype(Helper\Doctype::HTML4_STRICT);
+        $this->view->broker('doctype')->direct(Helper\Doctype::HTML4_STRICT);
 
         $params = array('paramname1' => 'paramvalue1',
                         'paramname2' => 'paramvalue2');
@@ -104,7 +104,7 @@ class HtmlObjectTest extends \PHPUnit_Framework_TestCase
 
     public function testMakeHtmlObjectWithoutAttribsWithParamsXhtml()
     {
-        $this->view->doctype(Helper\Doctype::XHTML1_STRICT);
+        $this->view->broker('doctype')->direct(Helper\Doctype::XHTML1_STRICT);
 
         $params = array('paramname1' => 'paramvalue1',
                         'paramname2' => 'paramvalue2');


### PR DESCRIPTION
this->view->doctype() -> $this>view->broker('doctype')
$this->view->doctype($param) -> $this>view->broker('doctype')->direct($param)
