### PR TITLE
[ZF-10882] Fixed invalid escape view helper method calls

### DIFF
--- a/library/Zend/Dojo/View/Helper/Dojo/Container.php
+++ b/library/Zend/Dojo/View/Helper/Dojo/Container.php
@@ -1126,14 +1126,14 @@ EOJ;
         $modulePaths = $this->getModulePaths();
         if (!empty($modulePaths)) {
             foreach ($modulePaths as $module => $path) {
-                $js[] =  'dojo.registerModulePath("' . $this->view->escape($module) . '", "' . $this->view->escape($path) . '");';
+                $js[] =  'dojo.registerModulePath("' . $this->view->vars()->escape($module) . '", "' . $this->view->vars()->escape($path) . '");';
             }
         }
 
         $modules = $this->getModules();
         if (!empty($modules)) {
             foreach ($modules as $module) {
-                $js[] = 'dojo.require("' . $this->view->escape($module) . '");';
+                $js[] = 'dojo.require("' . $this->view->vars()->escape($module) . '");';
             }
         }
 

--- a/library/Zend/Dojo/View/Helper/SimpleTextarea.php
+++ b/library/Zend/Dojo/View/Helper/SimpleTextarea.php
@@ -70,7 +70,7 @@ class SimpleTextarea extends Dijit
         $attribs = $this->_prepareDijit($attribs, $params, 'textarea');
 
         $html = '<textarea' . $this->_htmlAttribs($attribs) . '>'
-              . $this->view->escape($value)
+              . $this->view->vars()->escape($value)
               . "</textarea>\n";
 
         return $html;

--- a/library/Zend/View/Helper/FormButton.php
+++ b/library/Zend/View/Helper/FormButton.php
@@ -83,16 +83,16 @@ class FormButton extends FormElement
             $attribs['disabled'] = 'disabled';
         }
 
-        $content = ($escape) ? $this->view->escape($content) : $content;
+        $content = ($escape) ? $this->view->vars()->escape($content) : $content;
 
         $xhtml = '<button'
-                . ' name="' . $this->view->escape($name) . '"'
-                . ' id="' . $this->view->escape($id) . '"'
+                . ' name="' . $this->view->vars()->escape($name) . '"'
+                . ' id="' . $this->view->vars()->escape($id) . '"'
                 . ' type="' . $type . '"';
 
         // add a value if one is given
         if (!empty($value)) {
-            $xhtml .= ' value="' . $this->view->escape($value) . '"';
+            $xhtml .= ' value="' . $this->view->vars()->escape($value) . '"';
         }
 
         // add attributes and close start tag

--- a/library/Zend/View/Helper/FormCheckbox.php
+++ b/library/Zend/View/Helper/FormCheckbox.php
@@ -95,9 +95,9 @@ class FormCheckbox extends FormElement
             $xhtml = $this->_hidden($name, $checkedOptions['uncheckedValue']);
         }
         $xhtml .= '<input type="checkbox"'
-                . ' name="' . $this->view->escape($name) . '"'
-                . ' id="' . $this->view->escape($id) . '"'
-                . ' value="' . $this->view->escape($checkedOptions['checkedValue']) . '"'
+                . ' name="' . $this->view->vars()->escape($name) . '"'
+                . ' id="' . $this->view->vars()->escape($id) . '"'
+                . ' value="' . $this->view->vars()->escape($checkedOptions['checkedValue']) . '"'
                 . $checkedOptions['checkedString']
                 . $disabled
                 . $this->_htmlAttribs($attribs)

--- a/library/Zend/View/Helper/FormElement.php
+++ b/library/Zend/View/Helper/FormElement.php
@@ -189,8 +189,8 @@ abstract class FormElement extends HtmlElement
     protected function _hidden($name, $value = null, $attribs = null)
     {
         return '<input type="hidden"'
-             . ' name="' . $this->view->escape($name) . '"'
-             . ' value="' . $this->view->escape($value) . '"'
+             . ' name="' . $this->view->vars()->escape($name) . '"'
+             . ' value="' . $this->view->vars()->escape($value) . '"'
              . $this->_htmlAttribs($attribs) . $this->getClosingBracket();
     }
 }

--- a/library/Zend/View/Helper/FormFile.php
+++ b/library/Zend/View/Helper/FormFile.php
@@ -72,8 +72,8 @@ class FormFile extends FormElement
 
         // build the element
         $xhtml = '<input type="file"'
-                . ' name="' . $this->view->escape($name) . '"'
-                . ' id="' . $this->view->escape($id) . '"'
+                . ' name="' . $this->view->vars()->escape($name) . '"'
+                . ' id="' . $this->view->vars()->escape($id) . '"'
                 . $disabled
                 . $this->_htmlAttribs($attribs)
                 . $endTag;

--- a/library/Zend/View/Helper/FormImage.php
+++ b/library/Zend/View/Helper/FormImage.php
@@ -61,16 +61,16 @@ class FormImage extends FormElement
 
         // Determine if we should use the value or the src attribute
         if (isset($attribs['src'])) {
-            $src = ' src="' . $this->view->escape($attribs['src']) . '"';
+            $src = ' src="' . $this->view->vars()->escape($attribs['src']) . '"';
             unset($attribs['src']);
         } else {
-            $src = ' src="' . $this->view->escape($value) . '"';
+            $src = ' src="' . $this->view->vars()->escape($value) . '"';
             unset($value);
         }
 
         // Do we have a value?
         if (isset($value) && !empty($value)) {
-            $value = ' value="' . $this->view->escape($value) . '"';
+            $value = ' value="' . $this->view->vars()->escape($value) . '"';
         } else {
             $value = '';
         }
@@ -89,8 +89,8 @@ class FormImage extends FormElement
 
         // build the element
         $xhtml = '<input type="image"'
-                . ' name="' . $this->view->escape($name) . '"'
-                . ' id="' . $this->view->escape($id) . '"'
+                . ' name="' . $this->view->vars()->escape($name) . '"'
+                . ' id="' . $this->view->vars()->escape($id) . '"'
                 . $src
                 . $value
                 . $disabled

--- a/library/Zend/View/Helper/FormPassword.php
+++ b/library/Zend/View/Helper/FormPassword.php
@@ -71,7 +71,7 @@ class FormPassword extends FormElement
         $valueString = ' value=""';
         if (array_key_exists('renderPassword', $attribs)) {
             if ($attribs['renderPassword']) {
-                $valueString = ' value="' . $this->view->escape($value) . '"';
+                $valueString = ' value="' . $this->view->vars()->escape($value) . '"';
             }
             unset($attribs['renderPassword']);
         }
@@ -84,8 +84,8 @@ class FormPassword extends FormElement
 
         // render the element
         $xhtml = '<input type="password"'
-                . ' name="' . $this->view->escape($name) . '"'
-                . ' id="' . $this->view->escape($id) . '"'
+                . ' name="' . $this->view->vars()->escape($name) . '"'
+                . ' id="' . $this->view->vars()->escape($id) . '"'
                 . $valueString
                 . $disabled
                 . $this->_htmlAttribs($attribs)

--- a/library/Zend/View/Helper/FormRadio.php
+++ b/library/Zend/View/Helper/FormRadio.php
@@ -116,7 +116,7 @@ class FormRadio extends FormElement
         $list  = array();
 
         // should the name affect an array collection?
-        $name = $this->view->escape($name);
+        $name = $this->view->vars()->escape($name);
         if ($this->_isArray && ('[]' != substr($name, -2))) {
             $name .= '[]';
         }
@@ -136,7 +136,7 @@ class FormRadio extends FormElement
 
             // Should the label be escaped?
             if ($escape) {
-                $opt_label = $this->view->escape($opt_label);
+                $opt_label = $this->view->vars()->escape($opt_label);
             }
 
             // is it disabled?
@@ -163,7 +163,7 @@ class FormRadio extends FormElement
                     . '<input type="' . $this->_inputType . '"'
                     . ' name="' . $name . '"'
                     . ' id="' . $optId . '"'
-                    . ' value="' . $this->view->escape($opt_value) . '"'
+                    . ' value="' . $this->view->vars()->escape($opt_value) . '"'
                     . $checked
                     . $disabled
                     . $this->_htmlAttribs($attribs)

--- a/library/Zend/View/Helper/FormReset.php
+++ b/library/Zend/View/Helper/FormReset.php
@@ -70,13 +70,13 @@ class FormReset extends FormElement
 
         // Render button
         $xhtml = '<input type="reset"'
-               . ' name="' . $this->view->escape($name) . '"'
-               . ' id="' . $this->view->escape($id) . '"'
+               . ' name="' . $this->view->vars()->escape($name) . '"'
+               . ' id="' . $this->view->vars()->escape($id) . '"'
                . $disabled;
 
         // add a value if one is given
         if (! empty($value)) {
-            $xhtml .= ' value="' . $this->view->escape($value) . '"';
+            $xhtml .= ' value="' . $this->view->vars()->escape($value) . '"';
         }
 
         // add attributes, close, and return

--- a/library/Zend/View/Helper/FormSelect.php
+++ b/library/Zend/View/Helper/FormSelect.php
@@ -105,8 +105,8 @@ class FormSelect extends FormElement
 
         // Build the surrounding select element first.
         $xhtml = '<select'
-                . ' name="' . $this->view->escape($name) . '"'
-                . ' id="' . $this->view->escape($id) . '"'
+                . ' name="' . $this->view->vars()->escape($name) . '"'
+                . ' id="' . $this->view->vars()->escape($id) . '"'
                 . $multiple
                 . $disabled
                 . $this->_htmlAttribs($attribs)
@@ -126,7 +126,7 @@ class FormSelect extends FormElement
                 }
                 $list[] = '<optgroup'
                         . $opt_disable
-                        . ' label="' . $this->view->escape($opt_value) .'">';
+                        . ' label="' . $this->view->vars()->escape($opt_value) .'">';
                 foreach ($opt_label as $val => $lab) {
                     $list[] = $this->_build($val, $lab, $value, $disable);
                 }
@@ -158,8 +158,8 @@ class FormSelect extends FormElement
         }
 
         $opt = '<option'
-             . ' value="' . $this->view->escape($value) . '"'
-             . ' label="' . $this->view->escape($label) . '"';
+             . ' value="' . $this->view->vars()->escape($value) . '"'
+             . ' label="' . $this->view->vars()->escape($label) . '"';
 
         // selected?
         if (in_array((string) $value, $selected)) {
@@ -171,7 +171,7 @@ class FormSelect extends FormElement
             $opt .= ' disabled="disabled"';
         }
 
-        $opt .= '>' . $this->view->escape($label) . "</option>";
+        $opt .= '>' . $this->view->vars()->escape($label) . "</option>";
 
         return $opt;
     }

--- a/library/Zend/View/Helper/FormSubmit.php
+++ b/library/Zend/View/Helper/FormSubmit.php
@@ -74,9 +74,9 @@ class FormSubmit extends FormElement
 
         // Render the button.
         $xhtml = '<input type="submit"'
-               . ' name="' . $this->view->escape($name) . '"'
-               . ' id="' . $this->view->escape($id) . '"'
-               . ' value="' . $this->view->escape($value) . '"'
+               . ' name="' . $this->view->vars()->escape($name) . '"'
+               . ' id="' . $this->view->vars()->escape($id) . '"'
+               . ' value="' . $this->view->vars()->escape($value) . '"'
                . $disabled
                . $this->_htmlAttribs($attribs)
                . $endTag;

--- a/library/Zend/View/Helper/FormTextarea.php
+++ b/library/Zend/View/Helper/FormTextarea.php
@@ -95,11 +95,11 @@ class FormTextarea extends FormElement
         }
 
         // build the element
-        $xhtml = '<textarea name="' . $this->view->escape($name) . '"'
-                . ' id="' . $this->view->escape($id) . '"'
+        $xhtml = '<textarea name="' . $this->view->vars()->escape($name) . '"'
+                . ' id="' . $this->view->vars()->escape($id) . '"'
                 . $disabled
                 . $this->_htmlAttribs($attribs) . '>'
-                . $this->view->escape($value) . '</textarea>';
+                . $this->view->vars()->escape($value) . '</textarea>';
 
         return $xhtml;
     }

--- a/tests/Zend/View/Helper/FormLabelTest.php
+++ b/tests/Zend/View/Helper/FormLabelTest.php
@@ -71,7 +71,7 @@ class FormLabelTest extends \PHPUnit_Framework_TestCase
     public function testFormLabelWithInputNeedingEscapesUsesViewEscaping()
     {
         $label = $this->helper->direct('<&foo', '</bar>');
-        $expected = '<label for="' . $this->view->escape('<&foo') . '">' . $this->view->escape('</bar>') . '</label>';
+        $expected = '<label for="' . $this->view->vars()->escape('<&foo') . '">' . $this->view->vars()->escape('</bar>') . '</label>';
         $this->assertEquals($expected, $label);
     }
 

--- a/tests/Zend/View/Helper/FormTest.php
+++ b/tests/Zend/View/Helper/FormTest.php
@@ -72,7 +72,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
     public function testFormWithInputNeedingEscapesUsesViewEscaping()
     {
         $form = $this->helper->direct('<&foo');
-        $this->assertContains($this->view->escape('<&foo'), $form);
+        $this->assertContains($this->view->vars()->escape('<&foo'), $form);
     }
 
     public function testPassingIdAsAttributeShouldRenderIdAttribAndNotName()


### PR DESCRIPTION
Changed the following statements:

$this->view->escape($param);

to

$this->view->vars()->escape($param);
