### PR TITLE
Fixes/validator chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 nbproject
-
+.project
+.buildpath
+.settings
+tests/Zend/Service/GitHub/_files/

--- a/library/Zend/Session/ValidatorChain.php
+++ b/library/Zend/Session/ValidatorChain.php
@@ -62,13 +62,13 @@ class ValidatorChain extends Signals
 
     /**
      * Attach a handler to the session validator chain
-     * 
-     * @param  string $topic 
-     * @param  string|object|Closure $context 
-     * @param  null|string $handler 
+     *
+     * @param  string $topic
+     * @param  null|string|object|Closure $context
+     * @param  null|string $handler
      * @return Zend\Stdlib\SignalHandler
      */
-    public function connect($topic, $context, $handler = null)
+    public function connect($topic, $context = null, $handler = null)
     {
         if ($context instanceof Validator) {
             $data = $context->getData();


### PR DESCRIPTION
I've registered a fatal error, when running my unit tests, the Zend\Session\ValidatorChain::connect() method is not compatible with the Zend\SignalSlot\SignalSlot::connect() interface method.

These changes fix this issue.
Please ignore the .gitignore file. ;)
