### PR TITLE
ZF-10973: Zend\View\PhpRenderer is broken

### DIFF
--- a/library/Zend/View/PhpRenderer.php
+++ b/library/Zend/View/PhpRenderer.php
@@ -23,7 +23,7 @@
  */
 namespace Zend\View;
 
-use Zend\Stdlib\FilterChain,
+use Zend\Filter\FilterChain,
     ArrayAccess;
 
 /**

--- a/tests/Zend/View/PhpRendererTest.php
+++ b/tests/Zend/View/PhpRendererTest.php
@@ -23,7 +23,7 @@ namespace ZendTest\View;
 
 use Zend\View\PhpRenderer,
     Zend\View\TemplatePathStack,
-    Zend\Stdlib\FilterChain;
+    Zend\Filter\FilterChain;
 
 /**
  * @category   Zend
@@ -140,7 +140,7 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
 
     public function testUsesFilterChainByDefault()
     {
-        $this->assertType('Zend\Stdlib\FilterChain', $this->renderer->getFilterChain());
+        $this->assertType('Zend\Filter\FilterChain', $this->renderer->getFilterChain());
     }
 
     public function testMaySetExplicitFilterChainInstance()


### PR DESCRIPTION
Zend\View\PhpRenderer is broken since Zend\StdLib\FilterChain has moved.
