### PR TITLE
[ZF-10989] Note: Note: appearing in coding standards docs

### DIFF
--- a/documentation/manual/en/ref/coding_standard.xml
+++ b/documentation/manual/en/ref/coding_standard.xml
@@ -19,7 +19,7 @@
 
             <note>
                 <para>
-                    Note: Sometimes developers consider the establishment of a standard more
+                    Sometimes developers consider the establishment of a standard more
                     important than what that standard actually suggests at the most detailed level
                     of design. The guidelines in Zend Framework's coding standards capture
                     practices that have worked well on the Zend Framework project. You may modify
@@ -800,7 +800,7 @@ class Foo
 
                 <note>
                     <para>
-                        <emphasis>Note</emphasis>: Pass-by-reference is the only parameter passing
+                        Pass-by-reference is the only parameter passing
                         mechanism permitted in a method declaration.
                     </para>
                 </note>
@@ -1027,7 +1027,7 @@ switch ($numPeople) {
 
                 <note>
                     <para>
-                        <emphasis>Note</emphasis>: It is sometimes useful to write a
+                        It is sometimes useful to write a
                         <property>case</property> statement which falls through to the next case by
                         not including a <property>break</property> or <property>return</property>
                         within that case. To distinguish these cases from bugs, any


### PR DESCRIPTION
Fixed an issue in the docs where 'Note:' was being duplicated in the note blocks of the coding standards documentation.
