### PR TITLE
[ZF-11031] Invalid addFilter calls in some Zend_Tool classes

### DIFF
--- a/library/Zend/Tool/Framework/Client/Console/Console.php
+++ b/library/Zend/Tool/Framework/Client/Console/Console.php
@@ -281,8 +281,8 @@ class Console
     {
         if (!$this->_filterToClientNaming) {
             $filter = new \Zend\Filter\FilterChain();
-            $filter->addFilter(new \Zend\Filter\Word\CamelCaseToDash());
-            $filter->addFilter(new \Zend\Filter\StringToLower());
+            $filter->attach(new \Zend\Filter\Word\CamelCaseToDash());
+            $filter->attach(new \Zend\Filter\StringToLower());
 
             $this->_filterToClientNaming = $filter;
         }

--- a/library/Zend/Tool/Framework/Client/Console/Manifest.php
+++ b/library/Zend/Tool/Framework/Client/Console/Manifest.php
@@ -88,8 +88,8 @@ class Manifest implements RegistryEnabled, MetadataManifestable
         // setup the camelCase to dashed filter to use since cli expects dashed named
         $ccToDashedFilter = new \Zend\Filter\FilterChain();
         $ccToDashedFilter
-            ->addFilter(new \Zend\Filter\Word\CamelCaseToDash())
-            ->addFilter(new \Zend\Filter\StringToLower());
+            ->attach(new \Zend\Filter\Word\CamelCaseToDash())
+            ->attach(new \Zend\Filter\StringToLower());
 
         // get the registry to get the action and provider repository
         $actionRepository   = $this->_registry->getActionRepository();

--- a/library/Zend/Tool/Framework/Client/Manifest.php
+++ b/library/Zend/Tool/Framework/Client/Manifest.php
@@ -88,7 +88,7 @@ class Manifest implements RegistryEnabled, MetadataManifestable
 
         // setup the camelCase to dashed filter to use since cli expects dashed named
         $lowerFilter = new \Zend\Filter\FilterChain();
-        $lowerFilter->addFilter(new \Zend\Filter\StringToLower());
+        $lowerFilter->attach(new \Zend\Filter\StringToLower());
 
         // get the registry to get the action and provider repository
         $actionRepository   = $this->_registry->getActionRepository();

--- a/library/Zend/Tool/Project/Context/Zf/ViewControllerScriptsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/ViewControllerScriptsDirectory.php
@@ -90,8 +90,8 @@ class ViewControllerScriptsDirectory extends \Zend\Tool\Project\Context\Filesyst
     protected function _convertControllerNameToFilesystemName($controllerName)
     {
         $filter = new \Zend\Filter\FilterChain();
-        $filter->addFilter(new \Zend\Filter\Word\CamelCaseToDash())
-            ->addFilter(new \Zend\Filter\StringToLower());
+        $filter->attach(new \Zend\Filter\Word\CamelCaseToDash())
+               ->attach(new \Zend\Filter\StringToLower());
         return $filter->filter($controllerName);
     }
 

--- a/library/Zend/Tool/Project/Context/Zf/ViewScriptFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/ViewScriptFile.php
@@ -208,8 +208,8 @@ EOS;
     protected function _convertActionNameToFilesystemName($actionName)
     {
         $filter = new \Zend\Filter\FilterChain();
-        $filter->addFilter(new \Zend\Filter\Word\CamelCaseToDash())
-        ->addFilter(new \Zend\Filter\StringToLower());
+        $filter->attach(new \Zend\Filter\Word\CamelCaseToDash())
+               ->attach(new \Zend\Filter\StringToLower());
         return $filter->filter($actionName);
     }
 

--- a/library/Zend/Tool/Project/Provider/DbTable.php
+++ b/library/Zend/Tool/Project/Provider/DbTable.php
@@ -222,7 +222,7 @@ class DbTable
         if ($this->_nameFilter == null) {
             $this->_nameFilter = new \Zend\Filter\FilterChain();
             $this->_nameFilter
-                ->addFilter(new \Zend\Filter\Word\UnderscoreToCamelCase());
+                ->attach(new \Zend\Filter\Word\UnderscoreToCamelCase());
         }
         
         return $this->_nameFilter->filter($tableName);


### PR DESCRIPTION
Replaced all calls to \Zend\Filter\FilterChain::addFilter with \Zend\Filter\FilterChain::attach (within the \Zend\Tool namespace)
