### PR TITLE
Additional features for Getopt component

### DIFF
--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -118,10 +118,13 @@ namespace Zend\Console;
  *        Enable with Zend_Console_Getopt::CONFIG_FREEFORM_FLAGS
  *        All flag-like syntax is recognized, no flag generates an exception.
  *
- * @todo  Handle numeric options, e.g. -1, -2, -3, -1000
+ * @todo  [Done] Handle numeric options, e.g. -1, -2, -3, -1000
  *        Enable with Zend_Console_Getopt::CONFIG_NUMERIC_FLAGS
  *        The rule must specify a named flag and the '#' symbol as the
  *        parameter type. e.g.,  'lines=#'
+ *
+ *        @todo  Clerify situation when user will put several # sign. For ex.,
+ *               lines=#, limit=# (now the system will overwrite first param by last one)
  *
  * @todo  Enable user to specify header and footer content in the help message.
  *

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -114,7 +114,7 @@ namespace Zend\Console;
  *
  * @todo  Handle flags that implicitly print usage message, e.g. --help
  *
- * @todo  Handle freeform options, e.g. --set-variable
+ * @todo  [Done] Handle freeform options, e.g. --set-variable
  *        Enable with Zend_Console_Getopt::CONFIG_FREEFORM_FLAGS
  *        All flag-like syntax is recognized, no flag generates an exception.
  *

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -170,7 +170,9 @@ class Getopt
      * ruleMode is 'zend' format,
      * dashDash (--) token is enabled,
      * ignoreCase is not enabled,
-     * parseAll is enabled.
+     * parseAll is enabled,
+     * cumulative parameters are disabled,
+     * this means that subsequent options overwrite the parameter value.
      */
     protected $_getoptConfig = array(
         self::CONFIG_RULEMODE                => self::MODE_ZEND,

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -164,6 +164,7 @@ class Getopt
     const CONFIG_IGNORECASE                 = 'ignoreCase';
     const CONFIG_PARSEALL                   = 'parseAll';
     const CONFIG_CUMULATIVE_PARAMETERS      = 'cumulativeParameters';
+    const CONFIG_CUMULATIVE_FLAGS           = 'cumulativeFlags';
 
     /**
      * Defaults for getopt configuration are:
@@ -172,7 +173,8 @@ class Getopt
      * ignoreCase is not enabled,
      * parseAll is enabled,
      * cumulative parameters are disabled,
-     * this means that subsequent options overwrite the parameter value.
+     * this means that subsequent options overwrite the parameter value,
+     * cumulative flags are disable.
      */
     protected $_getoptConfig = array(
         self::CONFIG_RULEMODE                => self::MODE_ZEND,
@@ -180,6 +182,7 @@ class Getopt
         self::CONFIG_IGNORECASE              => false,
         self::CONFIG_PARSEALL                => true,
         self::CONFIG_CUMULATIVE_PARAMETERS   => false,
+        self::CONFIG_CUMULATIVE_FLAGS        => false
     );
 
     /**

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -163,6 +163,7 @@ class Getopt
     const CONFIG_DASHDASH                   = 'dashDash';
     const CONFIG_IGNORECASE                 = 'ignoreCase';
     const CONFIG_PARSEALL                   = 'parseAll';
+    const CONFIG_CUMULATIVE_PARAMETERS      = 'cumulativeParameters';
 
     /**
      * Defaults for getopt configuration are:
@@ -172,10 +173,11 @@ class Getopt
      * parseAll is enabled.
      */
     protected $_getoptConfig = array(
-        self::CONFIG_RULEMODE   => self::MODE_ZEND,
-        self::CONFIG_DASHDASH   => true,
-        self::CONFIG_IGNORECASE => false,
-        self::CONFIG_PARSEALL   => true,
+        self::CONFIG_RULEMODE                => self::MODE_ZEND,
+        self::CONFIG_DASHDASH                => true,
+        self::CONFIG_IGNORECASE              => false,
+        self::CONFIG_PARSEALL                => true,
+        self::CONFIG_CUMULATIVE_PARAMETERS   => false,
     );
 
     /**
@@ -799,7 +801,31 @@ class Getopt
             default:
                 $param = true;
         }
-        $this->_options[$realFlag] = $param;
+
+        $this->_setSingleOptionValue($realFlag, $param);
+    }
+
+    /**
+     * Add relative to options' flag value
+     * 
+     * If options list already has current flag as key
+     * and parser should follow cumulative params by configuration,
+     * we should to add new param to array, not to overwrite
+     *
+     * @param  string $flag
+     * @param  string $value
+     * @return null
+     */
+    protected function _setSingleOptionValue($flag, $value)
+    {
+        if (!array_key_exists($flag, $this->_options)) {
+            $this->_options[$flag] = $value;
+        } else if($this->_getoptConfig[self::CONFIG_CUMULATIVE_PARAMETERS]) {
+            $this->_options[$flag] = (array)$this->_options[$flag];
+            $this->_options[$flag][] = $value;
+        } else {
+            $this->_options[$flag] = $value;
+        }
     }
 
     /**

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -823,6 +823,13 @@ class Getopt
      */
     protected function _setSingleOptionValue($flag, $value)
     {
+        if (true === $value && $this->_getoptConfig[self::CONFIG_CUMULATIVE_FLAGS]) {
+            $this->_options[$flag] = array_key_exists($flag, $this->_options)
+                                   ? (int) $this->_options[$flag] + 1 : true;
+
+            return;
+        }
+
         if (!array_key_exists($flag, $this->_options)) {
             $this->_options[$flag] = $value;
         } else if($this->_getoptConfig[self::CONFIG_CUMULATIVE_PARAMETERS]) {

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -101,7 +101,7 @@ namespace Zend\Console;
  *        Enable with Zend_Console_Getopt::CONFIG_CUMULATIVE_PARAMETERS.
  *        Default is that subsequent options overwrite the parameter value.
  *
- * @todo  Handle flags occurring multiple times, e.g. -v -v -v
+ * @todo  [Done] Handle flags occurring multiple times, e.g. -v -v -v
  *        Set value of the option's parameter to the integer count of instances
  *        instead of a boolean.
  *        Enable with Zend_Console_Getopt::CONFIG_CUMULATIVE_FLAGS.

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -171,6 +171,7 @@ class Getopt
     const CONFIG_CUMULATIVE_FLAGS           = 'cumulativeFlags';
     const CONFIG_PARAMETER_SEPARATOR        = 'parameterSeparator';
     const CONFIG_FREEFORM_FLAGS             = 'freeformFlags';
+    const CONFIG_NUMERIC_FLAGS              = 'numericFlags';
 
     /**
      * Defaults for getopt configuration are:
@@ -191,7 +192,8 @@ class Getopt
         self::CONFIG_CUMULATIVE_PARAMETERS   => false,
         self::CONFIG_CUMULATIVE_FLAGS        => false,
         self::CONFIG_PARAMETER_SEPARATOR     => null,
-        self::CONFIG_FREEFORM_FLAGS          => false
+        self::CONFIG_FREEFORM_FLAGS          => false,
+        self::CONFIG_NUMERIC_FLAGS           => false
     );
 
     /**

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -95,7 +95,7 @@ namespace Zend\Console;
  *        If this config value is null or empty string, do not split values
  *        into arrays.  Default separator is comma (',').
  *
- * @todo  Handle params with multiple values specified with separate options
+ * @todo  [Done] Handle params with multiple values specified with separate options
  *        e.g. --colors red --colors green --colors blue should give one
  *        option with an array(red, green, blue).
  *        Enable with Zend_Console_Getopt::CONFIG_CUMULATIVE_PARAMETERS.
@@ -821,8 +821,8 @@ class Getopt
         if (!array_key_exists($flag, $this->_options)) {
             $this->_options[$flag] = $value;
         } else if($this->_getoptConfig[self::CONFIG_CUMULATIVE_PARAMETERS]) {
-            $this->_options[$flag] = (array)$this->_options[$flag];
-            $this->_options[$flag][] = $value;
+            $this->_options[$flag] = (array) $this->_options[$flag];
+            array_push($this->_options[$flag], $value);
         } else {
             $this->_options[$flag] = $value;
         }

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -89,42 +89,7 @@ namespace Zend\Console;
  * @version    Release: @package_version@
  * @since      Class available since Release 0.6.0
  *
- * @todo  [Done] Handle params with multiple values, e.g. --colors=red,green,blue
- *        Set value of parameter to the array of values.  Allow user to specify
- *        the separator with Zend_Console_Getopt::CONFIG_PARAMETER_SEPARATOR.
- *        If this config value is null or empty string, do not split values
- *        into arrays.  Default separator is comma (',').
- *
- *        @todo  Analyze what to do in case, when Getopt::CONFIG_PARAMETER_SEPARATOR not empty
- *               and Getopt::CONFIG_CUMULATIVE_PARAMETERS is true - do we have to return array
- *               of arrays, or just merge all values in one list?
- *
- * @todo  [Done] Handle params with multiple values specified with separate options
- *        e.g. --colors red --colors green --colors blue should give one
- *        option with an array(red, green, blue).
- *        Enable with Zend_Console_Getopt::CONFIG_CUMULATIVE_PARAMETERS.
- *        Default is that subsequent options overwrite the parameter value.
- *
- * @todo  [Done] Handle flags occurring multiple times, e.g. -v -v -v
- *        Set value of the option's parameter to the integer count of instances
- *        instead of a boolean.
- *        Enable with Zend_Console_Getopt::CONFIG_CUMULATIVE_FLAGS.
- *        Default is that the value is simply boolean true regardless of
- *        how many instances of the flag appear.
- *
  * @todo  Handle flags that implicitly print usage message, e.g. --help
- *
- * @todo  [Done] Handle freeform options, e.g. --set-variable
- *        Enable with Zend_Console_Getopt::CONFIG_FREEFORM_FLAGS
- *        All flag-like syntax is recognized, no flag generates an exception.
- *
- * @todo  [Done] Handle numeric options, e.g. -1, -2, -3, -1000
- *        Enable with Zend_Console_Getopt::CONFIG_NUMERIC_FLAGS
- *        The rule must specify a named flag and the '#' symbol as the
- *        parameter type. e.g.,  'lines=#'
- *
- *        @todo  Clerify situation when user will put several # sign. For ex.,
- *               lines=#, limit=# (now the system will overwrite first param by last one)
  *
  * @todo  Enable user to specify header and footer content in the help message.
  *

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -787,8 +787,7 @@ class Getopt
         }
         if (!isset($this->_ruleMap[$flag])) {
             // Don't throw Exception for flag-like param in case when freeform flags are allowed
-            if ((count($argv) > 0 && substr($argv[0], 0, 1) != '-')
-                    || !$this->_getoptConfig[self::CONFIG_FREEFORM_FLAGS]) {
+            if (!$this->_getoptConfig[self::CONFIG_FREEFORM_FLAGS]) {
                 throw new Exception\RuntimeException(
                     "Option \"$flag\" is not recognized.",
                     $this->getUsageMessage()
@@ -796,33 +795,35 @@ class Getopt
             }
 
             // Magic methods in future will use this mark as real flag value
-            $this->_ruleMap[$flag]  = $flag;
-            list($realFlag, $param) = array($flag, true);
+            $this->_ruleMap[$flag] = $flag;
+            $realFlag = $flag;
+            $this->_rules[$realFlag] = array('param' => 'optional');
         } else {
             $realFlag = $this->_ruleMap[$flag];
-            switch ($this->_rules[$realFlag]['param']) {
-                case 'required':
-                    if (count($argv) > 0) {
-                        $param = array_shift($argv);
-                        $this->_checkParameterType($realFlag, $param);
-                    } else {
-                        throw new Exception\RuntimeException(
-                            "Option \"$flag\" requires a parameter.",
-                            $this->getUsageMessage()
-                            );
-                    }
-                    break;
-                case 'optional':
-                    if (count($argv) > 0 && substr($argv[0], 0, 1) != '-') {
-                        $param = array_shift($argv);
-                        $this->_checkParameterType($realFlag, $param);
-                    } else {
-                        $param = true;
-                    }
-                    break;
-                default:
+        }
+        
+        switch ($this->_rules[$realFlag]['param']) {
+            case 'required':
+                if (count($argv) > 0) {
+                    $param = array_shift($argv);
+                    $this->_checkParameterType($realFlag, $param);
+                } else {
+                    throw new Exception\RuntimeException(
+                        "Option \"$flag\" requires a parameter.",
+                        $this->getUsageMessage()
+                        );
+                }
+                break;
+            case 'optional':
+                if (count($argv) > 0 && substr($argv[0], 0, 1) != '-') {
+                    $param = array_shift($argv);
+                    $this->_checkParameterType($realFlag, $param);
+                } else {
                     $param = true;
-            }
+                }
+                break;
+            default:
+                $param = true;
         }
 
         $this->_setSingleOptionValue($realFlag, $param);

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -824,10 +824,8 @@ class Getopt
     protected function _setSingleOptionValue($flag, $value)
     {
         if (true === $value && $this->_getoptConfig[self::CONFIG_CUMULATIVE_FLAGS]) {
-            $this->_options[$flag] = array_key_exists($flag, $this->_options)
-                                   ? (int) $this->_options[$flag] + 1 : true;
-
-            return;
+            // For boolean values we have to create new flag, or increase number of flags' usage count
+            return $this->_setBooleanFlagValue($flag);
         }
 
         if (!array_key_exists($flag, $this->_options)) {
@@ -838,6 +836,20 @@ class Getopt
         } else {
             $this->_options[$flag] = $value;
         }
+    }
+
+    /**
+     * Set TRUE value to given flag, if this option does not exist yet
+     * In other case increase value to show count of flags' usage
+     *
+     * @param  string $flag
+     * @return null
+     */
+    protected function _setBooleanFlagValue($flag)
+    {
+        $this->_options[$flag] = array_key_exists($flag, $this->_options)
+                               ? (int) $this->_options[$flag] + 1
+                               : true;
     }
 
     /**

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -248,15 +248,10 @@ class Getopt
     public function __construct($rules, $argv = null, $getoptConfig = array())
     {
         if (!isset($_SERVER['argv'])) {
-            if (ini_get('register_argc_argv') == false) {
-                throw new Exception\InvalidArgumentException(
-                    "argv is not available, because ini option 'register_argc_argv' is set Off"
-                );
-            } else {
-                throw new Exception\InvalidArgumentException(
-                    '$_SERVER["argv"] is not set, but Zend_Console_Getopt cannot work without this information.'
-                );
-            }
+            $errorDescription = (ini_get('register_argc_argv') == false)
+                ? "argv is not available, because ini option 'register_argc_argv' is set Off"
+                : '$_SERVER["argv"] is not set, but Zend_Console_Getopt cannot work without this information.';
+            throw new Exception\InvalidArgumentException($errorDescription);
         }
 
         $this->_progname = $_SERVER['argv'][0];

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -529,24 +529,22 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
     public function testGetoptIgnoreCumulativeParamsByDefault()
     {
         $opts = new Getopt(
-            array('colors|c' => 'Colors-option'),
-            array(
-                '--colors', 'red',
-                '--colors', 'green',
-                '--colors', 'blue'));
+            array('colors=s' => 'Colors-option'),
+            array('--colors=red', '--colors=green', '--colors=blue')
+        );
+        
+        $this->assertType('string', $opts->colors);
         $this->assertEquals('blue', $opts->colors, 'Should be equal to last variable');
     }
 
     public function testGetoptWithCumulativeParamsOptionHandleArrayValues()
     {
         $opts = new Getopt(
-            array('colors|c' => 'Colors-option'),
-            array(
-                '--colors', 'red',
-                '--colors', 'green',
-                '--colors', 'blue'
-            ),
-            array(Getopt::CONFIG_CUMULATIVE_PARAMETERS => true));
+            array('colors=s' => 'Colors-option'),
+            array('--colors=red', '--colors=green', '--colors=blue'),
+            array(Getopt::CONFIG_CUMULATIVE_PARAMETERS => true)
+        );
+
         $this->assertType('array', $opts->colors, 'Colors value should be an array');
         $this->assertEquals('red,green,blue', implode(',', $opts->colors));
     }

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -573,4 +573,15 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('red,green,blue', $opts->colors);
     }
+
+    public function testGetoptWithNotEmptyParameterSeparatorSplitMultipleValues()
+    {
+        $opts = new Getopt(
+            array('colors=s' => 'Colors-option'),
+            array('--colors=red,green,blue'),
+            array(Getopt::CONFIG_PARAMETER_SEPARATOR => ',')
+        );
+
+        $this->assertEquals('red:green:blue', implode(':', $opt->colors));
+    }
 }

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -552,7 +552,7 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
     public function testGetoptIgnoreCumulativeFlagsByDefault()
     {
         $opts = new Getopt('v', array('-v', '-v', '-v'));
-
+        
         $this->assertEquals(true, $opts->v);
     }
 
@@ -562,5 +562,15 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
                            array(Getopt::CONFIG_CUMULATIVE_FLAGS => true));
 
         $this->assertEquals(3, $opts->v);
+    }
+
+    public function testGetoptIgnoreParamsWithMultipleValuesByDefault()
+    {
+        $opts = new Getopt(
+            array('colors=s' => 'Colors-option'),
+            array('--colors=red,green,blue')
+        );
+
+        $this->assertEquals('red,green,blue', $opts->colors);
     }
 }

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -584,4 +584,15 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('red:green:blue', implode(':', $opts->colors));
     }
+
+    public function testGetoptWithFreeformFlagOptionRecognizeAllFlags()
+    {
+        $opts = new Getopt(
+            array('colors' => 'Colors-option'),
+            array('--freeform'),
+            array(Getopt::CONFIG_FREEFORM_FLAGS => true)
+        );
+
+        $this->assertEquals(true, $opts->freeform);
+    }
 }

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -614,7 +614,7 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
             array('red', 'green', '-3')
         );
 
-        $this->setExpectedException('\Zend\Console\Exception\RuntimeException', 'not recognized');
+        $this->setExpectedException('\Zend\Console\Exception\RuntimeException');
         $opts->parse();
     }
 
@@ -627,5 +627,17 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(5, $opts->lines);
+    }
+
+    public function testGetoptRaiseExceptionForNumericOptionsIfAneHandlerIsSpecified()
+    {
+        $opts = new Getopt(
+            array('lines=s' => 'Lines-option'),
+            array('other', 'arguments', '-5'),
+            array(Getopt::CONFIG_NUMERIC_FLAGS => true)
+        );
+
+        $this->setExpectedException('\Zend\Console\Exception\RuntimeException');
+        $opts->parse();
     }
 }

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -582,6 +582,6 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
             array(Getopt::CONFIG_PARAMETER_SEPARATOR => ',')
         );
 
-        $this->assertEquals('red:green:blue', implode(':', $opt->colors));
+        $this->assertEquals('red:green:blue', implode(':', $opts->colors));
     }
 }

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -617,4 +617,15 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\Zend\Console\Exception\RuntimeException', 'not recognized');
         $opts->parse();
     }
+
+    public function testGetoptCanRecognizeNumericOprions()
+    {
+        $opts = new Getopt(
+            array('lines=#' => 'Lines-option'),
+            array('other', 'arguments', '-5'),
+            array(Getopt::CONFIG_NUMERIC_FLAGS => true)
+        );
+
+        $this->assertEquals(5, $opts->lines);
+    }
 }

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -551,21 +551,15 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
 
     public function testGetoptIgnoreCumulativeFlagsByDefault()
     {
-        $opts = new Getopt(
-            'v',
-            array('-v', '-v', '-v')
-        );
+        $opts = new Getopt('v', array('-v', '-v', '-v'));
 
         $this->assertEquals(true, $opts->v);
     }
 
     public function testGetoptWithCumulativeFlagsOptionHandleCountOfEqualFlags()
     {
-        $opts = new Getopt(
-            'v',
-            array('-v', '-v', '-v'),
-            array(Getopt::CONFIG_CUMULATIVE_FLAGS => true)
-        );
+        $opts = new Getopt('v', array('-v', '-v', '-v'),
+                           array(Getopt::CONFIG_CUMULATIVE_FLAGS => true));
 
         $this->assertEquals(3, $opts->v);
     }

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -606,4 +606,15 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('test', $opts->freeform);
     }
+
+    public function testGetoptRaiseExceptionForNumericOptionsByDefault()
+    {
+        $opts = new Getopt(
+            array('colors=s' => 'Colors-option'),
+            array('red', 'green', '-3')
+        );
+
+        $this->setExpectedException('\Zend\Console\Exception\RuntimeException', 'not recognized');
+        $opts->parse();
+    }
 }

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -536,4 +536,18 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
                 '--colors', 'blue'));
         $this->assertEquals('blue', $opts->colors, 'Should be equal to last variable');
     }
+
+    public function testGetoptWithCumulativeParamsOptionHandleArrayValues()
+    {
+        $opts = new Getopt(
+            array('colors|c' => 'Colors-option'),
+            array(
+                '--colors', 'red',
+                '--colors', 'green',
+                '--colors', 'blue'
+            ),
+            array(Getopt::CONFIG_CUMULATIVE_PARAMETERS => true));
+        $this->assertType('array', $opts->colors, 'Colors value should be an array');
+        $this->assertEquals('red,green,blue', implode(',', $opts->colors));
+    }
 }

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -548,4 +548,15 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
         $this->assertType('array', $opts->colors, 'Colors value should be an array');
         $this->assertEquals('red,green,blue', implode(',', $opts->colors));
     }
+
+    public function testGetoptIgnoreCumulativeFlagsByDefault()
+    {
+        $opts = new Getopt(
+            'v',
+            array('-v', '-v', '-v')
+        );
+
+        $this->assertEquals(true, $opts->v);
+    }
+
 }

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -559,4 +559,14 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, $opts->v);
     }
 
+    public function testGetoptWithCumulativeFlagsOptionHandleCountOfEqualFlags()
+    {
+        $opts = new Getopt(
+            'v',
+            array('-v', '-v', '-v'),
+            array(Getopt::CONFIG_CUMULATIVE_FLAGS => true)
+        );
+
+        $this->assertEquals(3, $opts->v);
+    }
 }

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -525,4 +525,15 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals($fooValue, $opts->foo);
     }
+
+    public function testGetoptIgnoreCumulativeParamsByDefault()
+    {
+        $opts = new Getopt(
+            array('colors|c' => 'Colors-option'),
+            array(
+                '--colors', 'red',
+                '--colors', 'green',
+                '--colors', 'blue'));
+        $this->assertEquals('blue', $opts->colors, 'Should be equal to last variable');
+    }
 }

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -595,4 +595,15 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(true, $opts->freeform);
     }
+
+    public function testGetoptWithFreeformFlagOptionRecognizeFlagsWithValue()
+    {
+        $opts = new Getopt(
+            array('colors' => 'Colors-option'),
+            array('color', '--freeform', 'test', 'zend'),
+            array(Getopt::CONFIG_FREEFORM_FLAGS => true)
+        );
+
+        $this->assertEquals('test', $opts->freeform);
+    }
 }


### PR DESCRIPTION
Implemented some new features from @todo list in doc-block of Console\Getopt component:
- Handle params with multiple values
- Handle cumulative params with multiple values specified with separate options
- Handle flags occurring multiple times
- Handle freeform options, e.g. --set-variable
- Handle numeric options
  All new tests wrote and everything works in red now (both old and new tests).

P.S. I have to say, that one class Getopt is rather sophisticated now. I want to make some code refactoring with goals of making this functionality more flexible and open for inheritance. 
