### PR TITLE
Namespace/log writer firebug test

### DIFF
--- a/tests/Zend/Log/Writer/FirebugTest.php
+++ b/tests/Zend/Log/Writer/FirebugTest.php
@@ -19,6 +19,13 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+namespace ZendTest\Log\Writer;
+
+use Zend\Log\Writer\Firebug as FirebugWriter,
+    Zend\Log\Logger,
+    Zend\Wildfire\Channel,
+    Zend\Wildfire\Plugin\FirePhp;
+
 /**
  * @category   Zend
  * @package    Zend_Log
@@ -27,54 +34,44 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */
-class Zend_Log_Writer_FirebugTest extends PHPUnit_Framework_TestCase
+class FirebugTest extends \PHPUnit_Framework_TestCase
 {
-
-
-    protected $_controller = null;
-    protected $_request = null;
-    protected $_response = null;
-    protected $_writer = null;
-    protected $_logger = null;
+    protected $_request;
+    protected $_response;
+    protected $_writer;
+    protected $_logger;
 
     public function setUp()
     {
-        $this->markTestIncomplete('Not testing until MVC converted to namespaces');
-        /*
-
         date_default_timezone_set('America/Los_Angeles');
 
         // Reset front controller to reset registered plugins and
         // registered request/response objects
-        Zend_Controller_Front::getInstance()->resetInstance();
+        \Zend\Controller\Front::getInstance()->resetInstance();
 
         $this->_request = new Zend_Log_Writer_FirebugTest_Request();
         $this->_response = new Zend_Log_Writer_FirebugTest_Response();
 
-        $channel = Zend_Wildfire_Channel_HttpHeaders::getInstance();
+        $channel = Channel\HttpHeaders::getInstance();
         $channel->setRequest($this->_request);
         $channel->setResponse($this->_response);
 
-        $this->_writer = new Zend_Log_Writer_Firebug();
+        $this->_writer = new FirebugWriter();
 
         // Explicitly enable writer as it is disabled by default
         // when running from the command line.
         $this->_writer->setEnabled(true);
 
-        $this->_logger = new Zend_Log($this->_writer);
+        $this->_logger = new Logger($this->_writer);
 
-        Zend_Wildfire_Plugin_FirePhp::getInstance()->setOption('includeLineNumbers', false);
-         */
+        FirePhp::getInstance()->setOption('includeLineNumbers', false);
     }
 
     public function tearDown()
     {
-        /*
-        Zend_Wildfire_Channel_HttpHeaders::destroyInstance();
-        Zend_Wildfire_Plugin_FirePhp::destroyInstance();
-         */
+        Channel\HttpHeaders::destroyInstance();
+        FirePhp::destroyInstance();
     }
-
 
     /**
      * Test for ZF-3960
@@ -84,11 +81,11 @@ class Zend_Log_Writer_FirebugTest extends PHPUnit_Framework_TestCase
      */
     public function testZf3960()
     {
-        Zend_Wildfire_Channel_HttpHeaders::destroyInstance();
-        Zend_Wildfire_Plugin_FirePhp::destroyInstance();
+        Channel\HttpHeaders::destroyInstance();
+        FirePhp::destroyInstance();
 
-        $log = new Zend_Log();
-        $writerFirebug = new Zend_Log_Writer_Firebug();
+        $log = new Logger();
+        $writerFirebug = new FirebugWriter();
         $log->addWriter($writerFirebug);
         $log->log('hi', 2);
     }
@@ -98,30 +95,29 @@ class Zend_Log_Writer_FirebugTest extends PHPUnit_Framework_TestCase
      */
     public function testSetFormatter()
     {
-        $firephp = Zend_Wildfire_Plugin_FirePhp::getInstance();
-        $channel = Zend_Wildfire_Channel_HttpHeaders::getInstance();
-        $protocol = $channel->getProtocol(Zend_Wildfire_Plugin_FirePhp::PROTOCOL_URI);
+        $firephp = FirePhp::getInstance();
+        $channel = Channel\HttpHeaders::getInstance();
+        $protocol = $channel->getProtocol(FirePhp::PROTOCOL_URI);
 
-        $this->_logger->log('Test Message 1', Zend_Log::INFO);
+        $this->_logger->log('Test Message 1', Logger::INFO);
 
         $formatter = new Zend_Log_Writer_FirebugTest_Formatter();
         $this->_writer->setFormatter($formatter);
 
-        $this->_logger->setEventItem('testLabel','Test Label');
-
-        $this->_logger->log('Test Message 2', Zend_Log::INFO);
+        $this->_logger->setEventItem('testLabel', 'Test Label');
+        $this->_logger->log('Test Message 2', Logger::INFO);
 
         $messages = $protocol->getMessages();
 
-        $message = $messages[Zend_Wildfire_Plugin_FirePhp::STRUCTURE_URI_FIREBUGCONSOLE]
-                            [Zend_Wildfire_Plugin_FirePhp::PLUGIN_URI]
+        $message = $messages[FirePhp::STRUCTURE_URI_FIREBUGCONSOLE]
+                            [FirePhp::PLUGIN_URI]
                             [0];
 
         $this->assertEquals($message,
                             '[{"Type":"INFO"},"Test Message 1"]');
 
-        $message = $messages[Zend_Wildfire_Plugin_FirePhp::STRUCTURE_URI_FIREBUGCONSOLE]
-                            [Zend_Wildfire_Plugin_FirePhp::PLUGIN_URI]
+        $message = $messages[FirePhp::STRUCTURE_URI_FIREBUGCONSOLE]
+                            [FirePhp::PLUGIN_URI]
                             [1];
 
         $this->assertEquals($message,
@@ -133,28 +129,26 @@ class Zend_Log_Writer_FirebugTest extends PHPUnit_Framework_TestCase
      */
     public function testEventItemLabel()
     {
-        $firephp = Zend_Wildfire_Plugin_FirePhp::getInstance();
-        $channel = Zend_Wildfire_Channel_HttpHeaders::getInstance();
-        $protocol = $channel->getProtocol(Zend_Wildfire_Plugin_FirePhp::PROTOCOL_URI);
+        $firephp = FirePhp::getInstance();
+        $channel = Channel\HttpHeaders::getInstance();
+        $protocol = $channel->getProtocol(FirePhp::PROTOCOL_URI);
 
-
-        $this->_logger->log('Test Message 1', Zend_Log::INFO);
+        $this->_logger->log('Test Message 1', Logger::INFO);
 
         $this->_logger->setEventItem('firebugLabel','Test Label');
-
-        $this->_logger->log('Test Message 2', Zend_Log::INFO);
+        $this->_logger->log('Test Message 2', Logger::INFO);
 
         $messages = $protocol->getMessages();
 
-        $message = $messages[Zend_Wildfire_Plugin_FirePhp::STRUCTURE_URI_FIREBUGCONSOLE]
-                            [Zend_Wildfire_Plugin_FirePhp::PLUGIN_URI]
+        $message = $messages[FirePhp::STRUCTURE_URI_FIREBUGCONSOLE]
+                            [FirePhp::PLUGIN_URI]
                             [0];
 
         $this->assertEquals($message,
                             '[{"Type":"INFO"},"Test Message 1"]');
 
-        $message = $messages[Zend_Wildfire_Plugin_FirePhp::STRUCTURE_URI_FIREBUGCONSOLE]
-                            [Zend_Wildfire_Plugin_FirePhp::PLUGIN_URI]
+        $message = $messages[FirePhp::STRUCTURE_URI_FIREBUGCONSOLE]
+                            [FirePhp::PLUGIN_URI]
                             [1];
 
         $this->assertEquals($message,
@@ -164,29 +158,29 @@ class Zend_Log_Writer_FirebugTest extends PHPUnit_Framework_TestCase
     public function testLogStyling()
     {
         $this->assertEquals($this->_writer->getDefaultPriorityStyle(),
-                            Zend_Wildfire_Plugin_FirePhp::LOG);
-        $this->assertEquals($this->_writer->setDefaultPriorityStyle(Zend_Wildfire_Plugin_FirePhp::WARN),
-                            Zend_Wildfire_Plugin_FirePhp::LOG);
+                            FirePhp::LOG);
+        $this->assertEquals($this->_writer->setDefaultPriorityStyle(FirePhp::WARN),
+                            FirePhp::LOG);
         $this->assertEquals($this->_writer->getDefaultPriorityStyle(),
-                            Zend_Wildfire_Plugin_FirePhp::WARN);
+                            FirePhp::WARN);
 
         $this->assertEquals($this->_writer->getPriorityStyle(9),
                             false);
-        $this->assertEquals($this->_writer->setPriorityStyle(9,Zend_Wildfire_Plugin_FirePhp::WARN),
+        $this->assertEquals($this->_writer->setPriorityStyle(9,FirePhp::WARN),
                             true);
         $this->assertEquals($this->_writer->getPriorityStyle(9),
-                            Zend_Wildfire_Plugin_FirePhp::WARN);
-        $this->assertEquals($this->_writer->setPriorityStyle(9,Zend_Wildfire_Plugin_FirePhp::LOG),
-                            Zend_Wildfire_Plugin_FirePhp::WARN);
+                            FirePhp::WARN);
+        $this->assertEquals($this->_writer->setPriorityStyle(9,FirePhp::LOG),
+                            FirePhp::WARN);
     }
 
     public function testBasicLogging()
     {
         $message = 'This is a log message!';
 
-        $this->_logger->log($message, Zend_Log::INFO);
+        $this->_logger->log($message, Logger::INFO);
 
-        Zend_Wildfire_Channel_HttpHeaders::getInstance()->flush();
+        Channel\HttpHeaders::getInstance()->flush();
 
         $headers = array();
         $headers['X-Wf-Protocol-1'] = 'http://meta.wildfirehq.org/Protocol/JsonStream/0.2';
@@ -197,24 +191,23 @@ class Zend_Log_Writer_FirebugTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->_response->verifyHeaders($headers));
     }
 
-
     /**
      * @group ZF-4934
      */
     public function testAdvancedLogging()
     {
-        Zend_Wildfire_Plugin_FirePhp::getInstance()->setOption('maxTraceDepth',0);
+        FirePhp::getInstance()->setOption('maxTraceDepth',0);
 
         $message = 'This is a log message!';
         $label = 'Test Label';
-        $table = array('Summary line for the table',
-                       array(
-                           array('Column 1', 'Column 2'),
-                           array('Row 1 c 1',' Row 1 c 2'),
-                           array('Row 2 c 1',' Row 2 c 2')
-                       )
-                      );
-
+        $table = array(
+            'Summary line for the table',
+            array(
+		        array('Column 1', 'Column 2'),
+		        array('Row 1 c 1',' Row 1 c 2'),
+		        array('Row 2 c 1',' Row 2 c 2')
+            )
+        );
 
         $this->_logger->addPriority('TRACE', 8);
         $this->_logger->addPriority('TABLE', 9);
@@ -225,47 +218,48 @@ class Zend_Log_Writer_FirebugTest extends PHPUnit_Framework_TestCase
         $this->_logger->table($table);
 
         try {
-          throw new Exception('Test Exception');
-        } catch (Exception $e) {
-          $this->_logger->err($e);
+            throw new \Exception('Test Exception');
+        } catch (\Exception $e) {
+            $this->_logger->err($e);
         }
 
         try {
-            Zend_Wildfire_Plugin_FirePhp::send($message, $label, 'UNKNOWN');
+            FirePhp::send($message, $label, 'UNKNOWN');
             $this->fail('Should not be able to log with undefined log style');
-        } catch (Exception $e) {
+        } catch (\Zend\Wildfire\Plugin\Exception\UnexpectedValueException $e) {
             // success
         }
 
-        $channel = Zend_Wildfire_Channel_HttpHeaders::getInstance();
-        $protocol = $channel->getProtocol(Zend_Wildfire_Plugin_FirePhp::PROTOCOL_URI);
+        $channel = Channel\HttpHeaders::getInstance();
+        $protocol = $channel->getProtocol(FirePhp::PROTOCOL_URI);
 
-        $messages = array(Zend_Wildfire_Plugin_FirePhp::STRUCTURE_URI_FIREBUGCONSOLE=>
-                          array(Zend_Wildfire_Plugin_FirePhp::PLUGIN_URI=>
-                                array(1=>'[{"Type":"TABLE"},["Summary line for the table",[["Column 1","Column 2"],["Row 1 c 1"," Row 1 c 2"],["Row 2 c 1"," Row 2 c 2"]]]]')));
+        $messages = array(
+            FirePhp::STRUCTURE_URI_FIREBUGCONSOLE => array(
+                FirePhp::PLUGIN_URI => array(
+                    1 => '[{"Type":"TABLE"},["Summary line for the table",[["Column 1","Column 2"],["Row 1 c 1"," Row 1 c 2"],["Row 2 c 1"," Row 2 c 2"]]]]'
+        )));
 
         $qued_messages = $protocol->getMessages();
 
-        unset($qued_messages[Zend_Wildfire_Plugin_FirePhp::STRUCTURE_URI_FIREBUGCONSOLE][Zend_Wildfire_Plugin_FirePhp::PLUGIN_URI][0]);
-        unset($qued_messages[Zend_Wildfire_Plugin_FirePhp::STRUCTURE_URI_FIREBUGCONSOLE][Zend_Wildfire_Plugin_FirePhp::PLUGIN_URI][2]);
+        unset($qued_messages[FirePhp::STRUCTURE_URI_FIREBUGCONSOLE][FirePhp::PLUGIN_URI][0]);
+        unset($qued_messages[FirePhp::STRUCTURE_URI_FIREBUGCONSOLE][FirePhp::PLUGIN_URI][2]);
 
         $this->assertEquals(serialize($qued_messages),
                             serialize($messages));
     }
-    
+
     public function testFactory()
     {
         $cfg = array('log' => array('memory' => array(
             'writerName' => "Firebug"
         )));
 
-        $logger = Zend_Log::factory($cfg['log']);
-        $this->assertTrue($logger instanceof Zend_Log);
+        $logger = Logger::factory($cfg['log']);
+        $this->assertTrue($logger instanceof Logger);
     }
 }
 
-/*
-class Zend_Log_Writer_FirebugTest_Formatter extends Zend_Log_Formatter_Firebug
+class Zend_Log_Writer_FirebugTest_Formatter extends \Zend\Log\Formatter\Firebug
 {
     public function format($event)
     {
@@ -273,8 +267,7 @@ class Zend_Log_Writer_FirebugTest_Formatter extends Zend_Log_Formatter_Firebug
     }
 }
 
-
-class Zend_Log_Writer_FirebugTest_Request extends Zend_Controller_Request_Http
+class Zend_Log_Writer_FirebugTest_Request extends \Zend\Controller\Request\Http
 {
     public function getHeader($header)
     {
@@ -284,10 +277,8 @@ class Zend_Log_Writer_FirebugTest_Request extends Zend_Controller_Request_Http
     }
 }
 
-
-class Zend_Log_Writer_FirebugTest_Response extends Zend_Controller_Response_Http
+class Zend_Log_Writer_FirebugTest_Response extends \Zend\Controller\Response\Http
 {
-
     public function canSendHeaders($throw = false)
     {
         return true;
@@ -295,7 +286,6 @@ class Zend_Log_Writer_FirebugTest_Response extends Zend_Controller_Response_Http
 
     public function verifyHeaders($headers)
     {
-
         $response_headers = $this->getHeaders();
         if (!$response_headers) {
             return false;
@@ -333,6 +323,4 @@ class Zend_Log_Writer_FirebugTest_Response extends Zend_Controller_Response_Http
 
         return true;
     }
-
 }
- */


### PR DESCRIPTION
This file has been forgotten in the namespace milestone (reason: "Not testing until MVC converted to namespaces").
