### PR TITLE
Bugfix for Zend\Log\Writer\Syslog

### DIFF
--- a/library/Zend/Log/Writer/Syslog.php
+++ b/library/Zend/Log/Writer/Syslog.php
@@ -105,7 +105,7 @@ class Syslog extends AbstractWriter
 
         $runInitializeSyslog = true;
         if (isset($params['facility'])) {
-            $this->_facility = $this->setFacility($params['facility']);
+            $this->setFacility($params['facility']);
             $runInitializeSyslog = false;
         }
 


### PR DESCRIPTION
_facility got overwritten by the current object which lead to errors in subsequent openlog() calls
