### PR TITLE
Fix for ZF-11131 & support for supplying autoloader prefixes in application.ini

### DIFF
--- a/library/Zend/Application/Application.php
+++ b/library/Zend/Application/Application.php
@@ -321,8 +321,10 @@ class Application
 
         foreach ($namespaces as $namespace => $directory) {
             $autoloader->registerNamespace($namespace, $directory);
-        }
-
+        }        
+		
+		$autoloader->register();		
+		
         return $this;
     }
 	
@@ -339,7 +341,9 @@ class Application
         foreach ($prefixes as $prefix => $directory) {
             $autoloader->registerPrefix($prefix, $directory);
         }
-
+		
+		$autoloader->register();
+		
         return $this;
 	}
 

--- a/library/Zend/Application/Application.php
+++ b/library/Zend/Application/Application.php
@@ -173,6 +173,10 @@ class Application
         if (!empty($options['autoloadernamespaces'])) {
             $this->setAutoloaderNamespaces($options['autoloadernamespaces']);
         }
+		
+		if (!empty($option['autoloaderprefixes'])) {
+		
+		}
 
         if (!empty($options['autoloaderzfpath'])) {
             $autoloader = $this->getAutoloader();
@@ -315,12 +319,29 @@ class Application
     {
         $autoloader = $this->getAutoloader();
 
-        foreach ($namespaces as $namespace) {
-            $autoloader->registerNamespace($namespace);
+        foreach ($namespaces as $namespace => $directory) {
+            $autoloader->registerNamespace($namespace, $directory);
         }
 
         return $this;
     }
+	
+	/**
+	 * Set autoloader prefixes
+	 *
+	 * @param array $prefixes
+	 * @return \Zend\Application\Application
+	 */
+	public function setAutoloaderPrefixes(array $prefixes)
+	{
+        $autoloader = $this->getAutoloader();
+
+        foreach ($prefixes as $prefix => $directory) {
+            $autoloader->registerPrefix($prefix, $directory);
+        }
+
+        return $this;
+	}
 
     /**
      * Set bootstrap path/class

--- a/library/Zend/Application/Application.php
+++ b/library/Zend/Application/Application.php
@@ -323,7 +323,7 @@ class Application
             $autoloader->registerNamespace($namespace, $directory);
         }        
 		
-		$autoloader->register();		
+        $autoloader->register();		
 		
         return $this;
     }

--- a/library/Zend/Application/Application.php
+++ b/library/Zend/Application/Application.php
@@ -327,25 +327,25 @@ class Application
 		
         return $this;
     }
-	
-	/**
-	 * Set autoloader prefixes
-	 *
-	 * @param array $prefixes
-	 * @return \Zend\Application\Application
-	 */
-	public function setAutoloaderPrefixes(array $prefixes)
-	{
+
+    /**
+     * Set autoloader prefixes
+     *
+     * @param array $prefixes
+     * @return \Zend\Application\Application
+     */
+    public function setAutoloaderPrefixes(array $prefixes)
+    {
         $autoloader = $this->getAutoloader();
 
         foreach ($prefixes as $prefix => $directory) {
             $autoloader->registerPrefix($prefix, $directory);
         }
-		
-		$autoloader->register();
-		
+
+        $autoloader->register();
+
         return $this;
-	}
+    }
 
     /**
      * Set bootstrap path/class

--- a/library/Zend/Application/Application.php
+++ b/library/Zend/Application/Application.php
@@ -174,9 +174,9 @@ class Application
             $this->setAutoloaderNamespaces($options['autoloadernamespaces']);
         }
 		
-		if (!empty($option['autoloaderprefixes'])) {
-		
-		}
+        if (!empty($option['autoloaderprefixes'])) {
+	    $this->setAutoloaderPrefixes($options['autoloaderprefixes']);
+        }
 
         if (!empty($options['autoloaderzfpath'])) {
             $autoloader = $this->getAutoloader();


### PR DESCRIPTION
Fixed bug "autoloaderNamespaces in application.ini throws warnings" at http://framework.zend.com/issues/browse/ZF-11131 This implementation expects the autoloader namespaces config option to be passed like so:

```
  autoloaderNamespaces.MyApp = APPLICATION_PATH "/../library/MyApp"
```

Also added support for prefixes, with very similar behavior

```
  autoloaderPrefixes.OldLib_ = APPLICATION_PATH "/../library/OldLib"
```

After the prefix or namespace is registered internally by \Zend\Application\Application then register() is called on the autoloader so that spl is wise. 

This isn't the most extensive patch, but puts this functionality at a much better point. It's my understanding that \Zend\Application\Application will receive more attention soon so I didn't want to screw anything in too tight at the moment.
