### PR TITLE
Refactor around the deletion of \Zend\Exception

### DIFF
--- a/library/Zend/Amf/Exception.php
+++ b/library/Zend/Amf/Exception.php
@@ -24,7 +24,7 @@
 namespace Zend\Amf;
 
 /**
- * @uses       \Zend\Exception
+ * @category   Zend
  * @package    Zend_Amf
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Application/Exception.php
+++ b/library/Zend/Application/Exception.php
@@ -26,7 +26,6 @@ namespace Zend\Application;
 /**
  * Exception class for Zend_Application
  *
- * @uses      \Zend\Exception
  * @category  Zend
  * @package   Zend_Application
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Cache/Backend/StaticBackend.php
+++ b/library/Zend/Cache/Backend/StaticBackend.php
@@ -389,7 +389,7 @@ class StaticBackend extends AbstractBackend implements Backend
             case Cache\Cache::CLEANING_MODE_MATCHING_TAG:
             case Cache\Cache::CLEANING_MODE_MATCHING_ANY_TAG:
                 if (empty($tags)) {
-                    throw new end\Exception('Cannot use tag matching modes as no tags were defined');
+                    throw new \InvalidArgumentException('Cannot use tag matching modes as no tags were defined');
                 }
                 if ($this->_tagged === null && $tagged = $this->getInnerCache()->load(self::INNER_CACHE_NAME)) {
                     $this->_tagged = $tagged;
@@ -429,7 +429,7 @@ class StaticBackend extends AbstractBackend implements Backend
                 break;
             case Cache\Cache::CLEANING_MODE_NOT_MATCHING_TAG:
                 if (empty($tags)) {
-                    throw new \Zend\Exception('Cannot use tag matching modes as no tags were defined');
+                    throw new \InvalidArgumentException('Cannot use tag matching modes as no tags were defined');
                 }
                 if ($this->_tagged === null) {
                     $tagged = $this->getInnerCache()->load(self::INNER_CACHE_NAME);

--- a/library/Zend/Cache/Exception.php
+++ b/library/Zend/Cache/Exception.php
@@ -24,9 +24,10 @@
 namespace Zend\Cache;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Exception
+ * @category   Zend
  * @package    Zend_Cache
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception {}
+class Exception extends \Exception {}

--- a/library/Zend/CodeGenerator/Exception.php
+++ b/library/Zend/CodeGenerator/Exception.php
@@ -25,7 +25,6 @@
 namespace Zend\CodeGenerator;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_CodeGenerator
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Config/Exception.php
+++ b/library/Zend/Config/Exception.php
@@ -24,7 +24,6 @@
 namespace Zend\Config;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Config
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Console/Exception/RuntimeException.php
+++ b/library/Zend/Console/Exception/RuntimeException.php
@@ -24,7 +24,6 @@
 namespace Zend\Console\Exception;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Console_Getopt
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Controller/Exception.php
+++ b/library/Zend/Controller/Exception.php
@@ -24,11 +24,11 @@
 namespace Zend\Controller;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_Controller
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {}

--- a/library/Zend/Controller/Router/Route/Route.php
+++ b/library/Zend/Controller/Router/Route/Route.php
@@ -493,7 +493,7 @@ class Route extends AbstractRoute
         } else {
             try {
                 $translator = \Zend\Registry::get('Zend_Translate');
-            } catch (\Zend\Exception $e) {
+            } catch (\RuntimeException $e) {
                 $translator = null;
             }
 
@@ -551,7 +551,7 @@ class Route extends AbstractRoute
         } else {
             try {
                 $locale = \Zend\Registry::get('Zend_Locale');
-            } catch (\Zend\Exception $e) {
+            } catch (\RuntimeException $e) {
                 $locale = null;
             }
 

--- a/library/Zend/Crypt/Exception.php
+++ b/library/Zend/Crypt/Exception.php
@@ -24,12 +24,12 @@
 namespace Zend\Crypt;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_Crypt
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {
 }

--- a/library/Zend/Date/Exception.php
+++ b/library/Zend/Date/Exception.php
@@ -24,7 +24,6 @@
 namespace Zend\Date;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Date
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Db/Exception.php
+++ b/library/Zend/Db/Exception.php
@@ -24,12 +24,12 @@
 namespace Zend\Db;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_Db
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {
 }

--- a/library/Zend/Dojo/Exception.php
+++ b/library/Zend/Dojo/Exception.php
@@ -26,7 +26,6 @@ namespace Zend\Dojo;
 /**
  * Exception class for Zend_Dojo
  *
- * @uses       \Zend\Exception
  * @package    Zend_Dojo
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Dom/Exception.php
+++ b/library/Zend/Dom/Exception.php
@@ -26,7 +26,6 @@ namespace Zend\Dom;
 /**
  * Zend_Dom Exceptions
  *
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Dom
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Feed/Exception.php
+++ b/library/Zend/Feed/Exception.php
@@ -28,12 +28,12 @@ namespace Zend\Feed;
  *
  * Class to represent exceptions that occur during Feed operations.
  *
- * @uses       \Zend\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_Feed
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {}
 

--- a/library/Zend/Feed/PubSubHubbub/Exception.php
+++ b/library/Zend/Feed/PubSubHubbub/Exception.php
@@ -24,11 +24,11 @@
 namespace Zend\Feed\PubSubHubbub;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_Feed_Pubsubhubbub
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {}

--- a/library/Zend/Feed/Reader/Exception.php
+++ b/library/Zend/Feed/Reader/Exception.php
@@ -28,11 +28,11 @@ namespace Zend\Feed\Reader;
 *
 * Class to represent exceptions that occur during Feed operations.
 *
-* @uses \Zend\Exception
+* @uses \Exception
 * @category Zend
 * @package Zend_Feed
 * @copyright Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
 * @license http://framework.zend.com/license/new-bsd New BSD License
 */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {}

--- a/library/Zend/Feed/Writer/Exception.php
+++ b/library/Zend/Feed/Writer/Exception.php
@@ -28,11 +28,11 @@ namespace Zend\Feed\Writer;
 *
 * Class to represent exceptions that occur during Feed operations.
 *
-* @uses \Zend\Exception
+* @uses \Exception
 * @category Zend
 * @package Zend_Feed
 * @copyright Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
 * @license http://framework.zend.com/license/new-bsd New BSD License
 */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {}

--- a/library/Zend/Feed/Writer/Exception/InvalidMethodException.php
+++ b/library/Zend/Feed/Writer/Exception/InvalidMethodException.php
@@ -38,5 +38,5 @@ require_once 'Zend/Feed/Exception.php';
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class InvalidMethodException extends \Zend\Exception
+class InvalidMethodException extends \Exception
 {}

--- a/library/Zend/Feed/Writer/InvalidMethodException.php
+++ b/library/Zend/Feed/Writer/InvalidMethodException.php
@@ -29,11 +29,11 @@ namespace Zend\Feed\Writer;
  *
  * Class to represent exceptions that occur during Feed operations.
  *
- * @uses       \Zend\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_Feed
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class InvalidMethodException extends \Zend\Exception
+class InvalidMethodException extends \Exception
 {}

--- a/library/Zend/File/Transfer/Exception.php
+++ b/library/Zend/File/Transfer/Exception.php
@@ -26,7 +26,6 @@ namespace Zend\File\Transfer;
 /**
  * Exception class for Zend_File_Transfer
  *
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_File_Transfer
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
@@ -34,22 +33,5 @@ namespace Zend\File\Transfer;
  */
 interface Exception
 {
-//    protected $_fileerror = null;
-//
-//    public function __construct($message, $fileerror = 0)
-//    {
-//        $this->_fileerror = $fileerror;
-//        parent::__construct($message);
-//    }
-//
-//    /**
-//     * Returns the transfer error code for the exception
-//     * This is not the exception code !!!
-//     *
-//     * @return integer
-//     */
-//    public function getFileError()
-//    {
-//        return $this->_fileerror;
-//    }
+
 }

--- a/library/Zend/Filter/Compress/Tar.php
+++ b/library/Zend/Filter/Compress/Tar.php
@@ -65,7 +65,7 @@ class Tar extends AbstractCompressionAlgorithm
         if (!class_exists('Archive_Tar')) {
             try {
                 \Zend\Loader::loadClass('Archive_Tar');
-            } catch (\Zend\Exception $e) {
+            } catch (\Exception $e) {
                 throw new Exception\ExtensionNotLoadedException('This filter needs PEARs Archive_Tar', 0, $e);
             }
         }

--- a/library/Zend/Filter/Exception.php
+++ b/library/Zend/Filter/Exception.php
@@ -24,7 +24,6 @@
 namespace Zend\Filter;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Filter
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/GData/App/Exception.php
+++ b/library/Zend/GData/App/Exception.php
@@ -29,13 +29,13 @@ namespace Zend\GData\App;
  *
  * Class to represent exceptions that occur during Gdata App operations.
  *
- * @uses       \Zend\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_Gdata
  * @subpackage App
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {
 }

--- a/library/Zend/GData/GApps.php
+++ b/library/Zend/GData/GApps.php
@@ -126,7 +126,7 @@ class GApps extends GData
      * @throws \Zend\GData\GApps\ServiceException
      * @throws mixed
      */
-    public static function throwServiceExceptionIfDetected($e) 
+    public static function throwServiceExceptionIfDetected($e)
     {
         // Check to make sure that there actually response!
         // This can happen if the connection dies before the request
@@ -824,7 +824,7 @@ class GApps extends GData
                         $foundClassName = $name . '\\' . $class;
                      }
                      break;
-                 } catch (\Zend\Exception $e) {
+                 } catch (\Exception $e) {
                      // package wasn't here- continue searching
                  }
             }
@@ -888,7 +888,7 @@ class GApps extends GData
      * @throws \Zend\GData\App\InvalidArgumentException
      * @throws \Zend\GData\App\HttpException
      */
-    public function retrieveUser ($username) 
+    public function retrieveUser ($username)
     {
         $query = $this->newUserQuery($username);
         try {
@@ -1135,7 +1135,7 @@ class GApps extends GData
     {
         $i = 0;
         $group = $this->newGroupEntry();
-        
+
         $properties[$i] = $this->newProperty();
         $properties[$i]->name = 'groupId';
         $properties[$i]->value = $groupId;
@@ -1157,8 +1157,8 @@ class GApps extends GData
             $properties[$i]->name = 'emailPermission';
             $properties[$i]->value = $emailPermission;
             $i++;
-        }        
-        
+        }
+
         $group->property = $properties;
 
         return $this->insertGroup($group);
@@ -1197,7 +1197,7 @@ class GApps extends GData
      * @return Zend\GData\GApps\GroupFeed Collection of Zend\GData\GroupEntry objects
      *              representing all groups apart of the domain.
      */
-    public function retrieveAllGroups() 
+    public function retrieveAllGroups()
     {
         return $this->retrieveAllEntriesForFeed($this->retrievePageOfGroups());
     }
@@ -1214,7 +1214,7 @@ class GApps extends GData
 
         $this->delete($uri);
     }
-    
+
     /**
      * Check to see if a member id or group id is a member of group
      *
@@ -1226,7 +1226,7 @@ class GApps extends GData
     {
         $uri  = self::APPS_BASE_FEED_URI . self::APPS_GROUP_PATH . '/';
         $uri .= $this->getDomain() . '/' . $groupId . '/member/' . $memberId;
-        
+
         //if the enitiy is not a member, an exception is thrown
         try {
             $results = $this->get($uri);
@@ -1310,7 +1310,7 @@ class GApps extends GData
 
         $uri  = self::APPS_BASE_FEED_URI . self::APPS_GROUP_PATH . '/';
         $uri .= $this->getDomain() . '/' . $groupId . '/owner';
-        
+
         return $this->insertOwner($owner, $uri);
     }
 
@@ -1340,9 +1340,9 @@ class GApps extends GData
     {
         $uri  = self::APPS_BASE_FEED_URI . self::APPS_GROUP_PATH . '/';
         $uri .= $this->getDomain() . '/' . $groupId . '/owner/' . $email;
-        
+
         //if the enitiy is not an owner of the group, an exception is thrown
-        try {            
+        try {
             $results = $this->get($uri);
         } catch (Exception $e) {
             $results = false;
@@ -1384,7 +1384,7 @@ class GApps extends GData
     {
         $i = 0;
         $group = $this->newGroupEntry();
-        
+
         $properties[$i] = $this->newProperty();
         $properties[$i]->name = 'groupId';
         $properties[$i]->value = $groupId;
@@ -1410,20 +1410,20 @@ class GApps extends GData
             $properties[$i]->value = $emailPermission;
             $i++;
         }
-        
+
         $group->property = $properties;
 
         $uri  = self::APPS_BASE_FEED_URI . self::APPS_GROUP_PATH . '/';
         $uri .= $this->getDomain() . '/' . $groupId;
 
-        return $this->updateEntry($group, $uri, 'Zend\GData\GApps\GroupEntry');        
+        return $this->updateEntry($group, $uri, 'Zend\GData\GApps\GroupEntry');
     }
 
     /**
      * Retrieve all of the groups that a user is a member of
      *
      * @param string $memberId Member username
-     * @param bool $directOnly (Optional) If true, members with direct association 
+     * @param bool $directOnly (Optional) If true, members with direct association
      *             only will be considered
      * @return Zend\GData\GApps\GroupFeed Collection of Zend\GData\GroupEntry
      *              objects representing all groups member is apart of in the domain.

--- a/library/Zend/GData/GApps/ServiceException.php
+++ b/library/Zend/GData/GApps/ServiceException.php
@@ -33,7 +33,7 @@ use Zend\GData\App;
  * Several different errors may be represented by this exception. For a list
  * of error codes available, see getErrorCode.
  *
- * @uses       \Zend\Exception
+ * @uses       \Exception
  * @uses       \Zend\GData\App\Exception
  * @uses       \Zend\GData\GApps\Error
  * @category   Zend
@@ -42,7 +42,7 @@ use Zend\GData\App;
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class ServiceException extends \Zend\Exception
+class ServiceException extends \Exception
 {
 
     protected $_rootElement = "AppsForYourDomainErrors";

--- a/library/Zend/Layout/Exception.php
+++ b/library/Zend/Layout/Exception.php
@@ -24,12 +24,12 @@
 namespace Zend\Layout;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_Layout
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {}
 

--- a/library/Zend/Ldap/Exception.php
+++ b/library/Zend/Ldap/Exception.php
@@ -25,14 +25,13 @@
 namespace Zend\Ldap;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_Ldap
- * @uses       \Zend\Exception
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {
     const LDAP_SUCCESS                        = 0x00;
     const LDAP_OPERATIONS_ERROR               = 0x01;

--- a/library/Zend/Ldap/Filter/Exception.php
+++ b/library/Zend/Ldap/Filter/Exception.php
@@ -25,13 +25,13 @@
 namespace Zend\Ldap\Filter;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_Ldap
  * @subpackage Filter
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {
 }

--- a/library/Zend/Locale/Exception.php
+++ b/library/Zend/Locale/Exception.php
@@ -24,7 +24,6 @@
 namespace Zend\Locale;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Locale
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Mail/Exception.php
+++ b/library/Zend/Mail/Exception.php
@@ -24,7 +24,6 @@
 namespace Zend\Mail;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Mail
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Mail/Part/Exception.php
+++ b/library/Zend/Mail/Part/Exception.php
@@ -26,7 +26,7 @@ namespace Zend\Mail\Part;
 use Zend\Mail;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Zend\Mail\Exception
  * @category   Zend
  * @package    Zend_Mail
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Mail/Protocol/Exception.php
+++ b/library/Zend/Mail/Protocol/Exception.php
@@ -25,7 +25,7 @@ namespace Zend\Mail\Protocol;
 use Zend\Mail;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Zend\Mail\Exception
  * @category   Zend
  * @package    Zend_Mail
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Mail/Storage/Exception.php
+++ b/library/Zend/Mail/Storage/Exception.php
@@ -25,7 +25,7 @@ namespace Zend\Mail\Storage;
 use Zend\Mail;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Zend\Mail\Exception
  * @category   Zend
  * @package    Zend_Mail
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Mail/Transport/Exception.php
+++ b/library/Zend/Mail/Transport/Exception.php
@@ -25,7 +25,7 @@ namespace Zend\Mail\Transport;
 use Zend\Mail;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Zend\Mail\Exception
  * @category   Zend
  * @package    Zend_Mail
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Markup/Exception.php
+++ b/library/Zend/Markup/Exception.php
@@ -26,8 +26,7 @@ namespace Zend\Markup;
 /**
  * Exception class for Zend_Markup
  *
- * @uses       \Zend\Exception
- * @category   Zend 
+ * @category   Zend
  * @package    Zend_Markup
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Measure/Exception.php
+++ b/library/Zend/Measure/Exception.php
@@ -26,12 +26,12 @@ namespace Zend\Measure;
 /**
  * Exception class
  *
- * @uses      Zend\Exception
+ * @uses      \Exception
  * @category  Zend
  * @package   Zend_Measure
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {
 }

--- a/library/Zend/Memory/Container/AccessController.php
+++ b/library/Zend/Memory/Container/AccessController.php
@@ -143,7 +143,6 @@ class AccessController implements Container
      *
      * @param string $property
      * @param  string $value
-     * @throws \Zend\Exception
      */
     public function __set($property, $value)
     {

--- a/library/Zend/Memory/Container/Movable.php
+++ b/library/Zend/Memory/Container/Movable.php
@@ -155,7 +155,7 @@ class Movable extends AbstractContainer
      *
      * @param string $property
      * @param  string $value
-     * @throws \Zend\Exception
+     * @throws Exception\InvalidArgumentException
      */
     public function __set($property, $value)
     {

--- a/library/Zend/Memory/Exception.php
+++ b/library/Zend/Memory/Exception.php
@@ -24,7 +24,6 @@
 namespace Zend\Memory;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Memory
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Memory/MemoryManager.php
+++ b/library/Zend/Memory/MemoryManager.php
@@ -203,7 +203,6 @@ class MemoryManager
      * Set memory grow limit
      *
      * @param integer $newLimit
-     * @throws \Zend\Exception
      */
     public function setMemoryLimit($newLimit)
     {

--- a/library/Zend/Mime/Decode.php
+++ b/library/Zend/Mime/Decode.php
@@ -24,7 +24,7 @@
 namespace Zend\Mime;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Zend\Mime\Exception\RuntimeException
  * @uses       \Zend\Mime\Mime
  * @category   Zend
  * @package    Zend_Mime
@@ -41,7 +41,7 @@ class Decode
      * @param  string $body     raw body of message
      * @param  string $boundary boundary as found in content-type
      * @return array parts with content of each part, empty if no parts found
-     * @throws \Zend\Exception
+     * @throws Exception\RuntimeException
      */
     public static function splitMime($body, $boundary)
     {
@@ -86,7 +86,7 @@ class Decode
      * @param  string $boundary boundary as found in content-type
      * @param  string $EOL EOL string; defaults to {@link Zend_Mime::LINEEND}
      * @return array|null parts as array('header' => array(name => value), 'body' => content), null if no parts found
-     * @throws \Zend\Exception
+     * @throws Exception\RuntimeException
      */
     public static function splitMessageStruct($message, $boundary, $EOL = Mime::LINEEND)
     {
@@ -188,7 +188,7 @@ class Decode
      * @param  string $wantedPart the wanted part, else an array with all parts is returned
      * @param  string $firstName  key name for the first part
      * @return string|array wanted part or all parts as array($firstName => firstPart, partname => value)
-     * @throws \Zend\Exception
+     * @throws Exception\RuntimeException
      */
     public static function splitHeaderField($field, $wantedPart = null, $firstName = 0)
     {

--- a/library/Zend/Mime/Exception.php
+++ b/library/Zend/Mime/Exception.php
@@ -24,7 +24,6 @@
 namespace Zend\Mime;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Mime
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Mime/Message.php
+++ b/library/Zend/Mime/Message.php
@@ -24,7 +24,7 @@
 namespace Zend\Mime;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Zend\Mime\Exception\RuntimeException
  * @uses       \Zend\Mime\Mime
  * @uses       \Zend\Mime\Decode
  * @uses       \Zend\Mime\Part

--- a/library/Zend/OAuth/Exception.php
+++ b/library/Zend/OAuth/Exception.php
@@ -24,10 +24,10 @@
 namespace Zend\OAuth;
 
 /**
- * @uses       Zend\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_OAuth
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception {}
+class Exception extends \Exception {}

--- a/library/Zend/OpenId/Exception.php
+++ b/library/Zend/OpenId/Exception.php
@@ -27,13 +27,13 @@ namespace Zend\OpenId;
 /**
  * Exception class for Zend\OpenId
  *
- * @uses       Zend\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_OpenId
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {
 
     /**

--- a/library/Zend/Pdf/InternalType/StreamFilter/Ascii85.php
+++ b/library/Zend/Pdf/InternalType/StreamFilter/Ascii85.php
@@ -127,7 +127,7 @@ class Ascii85 implements StreamFilter
         $data = str_replace($whiteSpace, '', $data);
 
         if (substr($data, -2) != '~>') {
-            throw new \Zend\Exception\CorruptedPdfException('Invalid EOF marker');
+            throw new Exception\CorruptedPdfException('Invalid EOF marker');
             return '';
         }
 

--- a/library/Zend/ProgressBar/Exception.php
+++ b/library/Zend/ProgressBar/Exception.php
@@ -26,10 +26,8 @@ namespace Zend\ProgressBar;
 /**
  * Exception class for Zend_ProgressBar
  *
- * @uses      \Zend\Exception
  * @category  Zend
  * @package   Zend_ProgressBar
- * @uses      \Zend\Exception
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */

--- a/library/Zend/Queue/Exception.php
+++ b/library/Zend/Queue/Exception.php
@@ -24,12 +24,12 @@
 namespace Zend\Queue;
 
 /**
- * @uses       \Zend\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_Queue
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {
 }

--- a/library/Zend/Reflection/Exception.php
+++ b/library/Zend/Reflection/Exception.php
@@ -24,7 +24,6 @@
 namespace Zend\Reflection;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Reflection
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Registry.php
+++ b/library/Zend/Registry.php
@@ -27,7 +27,7 @@ namespace Zend;
  * Generic storage class helps to manage global data.
  *
  * @uses       ArrayObject
- * @uses       \Zend\Exception
+ * @uses       \RuntimeException
  * @uses       \Zend\Loader
  * @category   Zend
  * @package    Zend_Registry
@@ -68,12 +68,12 @@ class Registry extends \ArrayObject
      * @param \Zend\Registry $registry An object instance of type \Zend\Registry,
      *   or a subclass.
      * @return void
-     * @throws \Zend\Exception if registry is already initialized.
+     * @throws \RuntimeException if registry is already initialized.
      */
     public static function setInstance(Registry $registry)
     {
         if (self::$_registry !== null) {
-            throw new Exception('Registry is already initialized');
+            throw new \RuntimeException('Registry is already initialized');
         }
 
         self::setClassName(get_class($registry));
@@ -97,17 +97,17 @@ class Registry extends \ArrayObject
      *
      * @param string $registryClassName
      * @return void
-     * @throws \Zend\Exception if the registry is initialized or if the
+     * @throws \RuntimeException if the registry is initialized or if the
      *   class name is not valid.
      */
     public static function setClassName($registryClassName = '\\Zend\\Registry')
     {
         if (self::$_registry !== null) {
-            throw new Exception('Registry is already initialized');
+            throw new \RuntimeException('Registry is already initialized');
         }
 
         if (!is_string($registryClassName)) {
-            throw new Exception("Argument is not a class name");
+            throw new \RuntimeException("Argument is not a class name");
         }
 
         /**
@@ -139,14 +139,14 @@ class Registry extends \ArrayObject
      *
      * @param string $index - get the value associated with $index
      * @return mixed
-     * @throws \Zend\Exception if no entry is registerd for $index.
+     * @throws \RuntimeException if no entry is registerd for $index.
      */
     public static function get($index)
     {
         $instance = self::getInstance();
 
         if (!$instance->offsetExists($index)) {
-            throw new Exception("No entry is registered for key '$index'");
+            throw new \RuntimeException("No entry is registered for key '$index'");
         }
 
         return $instance->offsetGet($index);
@@ -207,5 +207,4 @@ class Registry extends \ArrayObject
     {
         return array_key_exists($index, $this);
     }
-
 }

--- a/library/Zend/Rest/Exception.php
+++ b/library/Zend/Rest/Exception.php
@@ -24,7 +24,6 @@
 namespace Zend\Rest;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Rest
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Search/Lucene/Exception/UnsupportedMethodCallException.php
+++ b/library/Zend/Search/Lucene/Exception/UnsupportedMethodCallException.php
@@ -2,6 +2,6 @@
 namespace Zend\Search\Lucene\Exception;
 
 class UnsupportedMethodCallException
-	extends \Zend\Exception
+	extends \BadMethodCallException
 	implements \Zend\Search\Lucene\Exception
 {}

--- a/library/Zend/Server/Exception.php
+++ b/library/Zend/Server/Exception.php
@@ -26,7 +26,6 @@ namespace Zend\Server;
 /**
  * Zend_Server exceptions
  *
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Server
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Service/Exception.php
+++ b/library/Zend/Service/Exception.php
@@ -30,6 +30,6 @@ namespace Zend\Service;
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {}
 

--- a/library/Zend/Service/LiveDocx/Exception.php
+++ b/library/Zend/Service/LiveDocx/Exception.php
@@ -25,7 +25,7 @@
 namespace Zend\Service\LiveDocx;
 
 /**
- * @uses       Zend\Service\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_Service
  * @subpackage LiveDocx
@@ -33,5 +33,5 @@ namespace Zend\Service\LiveDocx;
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @since      LiveDocx 1.0
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {}

--- a/library/Zend/Soap/Exception.php
+++ b/library/Zend/Soap/Exception.php
@@ -25,9 +25,11 @@
 namespace Zend\Soap;
 
 /**
- * @uses       \Zend\Exception
+ * @category   Zend
  * @package    Zend_Soap
  * @subpackage AutoDiscover
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 interface Exception
 {

--- a/library/Zend/TimeSync/Exception.php
+++ b/library/Zend/TimeSync/Exception.php
@@ -26,7 +26,6 @@ namespace Zend\TimeSync;
 /**
  * Exception class for Zend_TimeSync
  *
- * @uses      \Zend\Exception
  * @category  Zend
  * @package   Zend_TimeSync
  * @copyright Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Tool/Framework/Exception.php
+++ b/library/Zend/Tool/Framework/Exception.php
@@ -25,7 +25,6 @@
 namespace Zend\Tool\Framework;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Tool
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Tool/Project/Exception.php
+++ b/library/Zend/Tool/Project/Exception.php
@@ -25,7 +25,6 @@
 namespace Zend\Tool\Project;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Tool
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Uri/Exception.php
+++ b/library/Zend/Uri/Exception.php
@@ -26,7 +26,6 @@ namespace Zend\Uri;
 /**
  * Exceptions for Zend_Uri
  *
- * @uses      \Zend\Exception
  * @category  Zend
  * @package   Zend_Uri
  * @copyright Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Validator/CreditCard.php
+++ b/library/Zend/Validator/CreditCard.php
@@ -304,7 +304,7 @@ class CreditCard extends AbstractValidator
                     $this->_error(self::SERVICE, $value);
                     return false;
                 }
-            } catch (\Zend\Exception $e) {
+            } catch (\Exception $e) {
                 $this->_error(self::SERVICEFAILURE, $value);
                 return false;
             }

--- a/library/Zend/Validator/Exception.php
+++ b/library/Zend/Validator/Exception.php
@@ -24,7 +24,6 @@
 namespace Zend\Validator;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_Validate
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/View/Exception.php
+++ b/library/Zend/View/Exception.php
@@ -26,13 +26,13 @@ namespace Zend\View;
 /**
  * Exception for Zend_View class.
  *
- * @uses       \Zend\Exception
+ * @uses       \Exception
  * @category   Zend
  * @package    Zend_Date
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Exception extends \Zend\Exception
+class Exception extends \Exception
 {
     protected $view = null;
 

--- a/library/Zend/XmlRpc/Exception.php
+++ b/library/Zend/XmlRpc/Exception.php
@@ -24,7 +24,6 @@
 namespace Zend\XmlRpc;
 
 /**
- * @uses       \Zend\Exception
  * @category   Zend
  * @package    Zend_XmlRpc
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)

--- a/tests/Zend/Controller/Action/Helper/ActionStackTest.php
+++ b/tests/Zend/Controller/Action/Helper/ActionStackTest.php
@@ -156,7 +156,7 @@ class ActionStackTest extends \PHPUnit_Framework_TestCase
         try{
             $helper->direct('baz', 'bar', 'foo');
             $this->fail('Zend_Controller_Action_Exception should be thrown');
-        }catch(\Zend\Exception $e){
+        }catch(\Exception $e){
             $this->assertType('Zend\Controller\Action\Exception',
                    $e,
                    'Zend\Controller\Action\Exception expected, '.get_class($e).' caught');

--- a/tests/Zend/Db/Adapter/AbstractTest.php
+++ b/tests/Zend/Db/Adapter/AbstractTest.php
@@ -194,7 +194,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
             $db = new $adapterClass($params);
             $db->getConnection(); // force a connection
             $this->fail("Expected to catch $exceptionClass");
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType($exceptionClass, $e, "Expected to catch $exceptionClass, got ".get_class($e));
             $this->assertContains("Configuration array must have a key for '$param'", $e->getMessage());
         }
@@ -749,7 +749,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         try {
             $sql = $this->_db->limit('SELECT * FROM zfproducts', 0);
             $this->fail('Expected to catch Zend_Db_Adapter_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Adapter\Exception', $e,
                 'Expecting object of type Zend_Db_Adapter_Exception, got '.get_class($e));
         }
@@ -757,7 +757,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         try {
             $sql = $this->_db->limit('SELECT * FROM zfproducts', 1, -1);
             $this->fail('Expected to catch Zend_Db_Adapter_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Adapter\Exception', $e,
                 'Expecting object of type Zend_Db_Adapter_Exception, got '.get_class($e));
         }
@@ -869,7 +869,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         try {
             $lower = $this->_testAdapterOptionCaseFoldingCommon(-999);
             $this->fail('Expected exception not thrown');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Adapter\Exception', $e,
                 'Expecting object of type Zend_Db_Adapter_Exception, got '.get_class($e));
             $this->assertEquals("Case must be one of the following constants: Zend_Db::CASE_NATURAL, Zend_Db::CASE_LOWER, Zend_Db::CASE_UPPER", $e->getMessage());
@@ -906,7 +906,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         try {
             $this->_db->query('Bogus query');
             $this->fail('Expected exception not thrown');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Statement\Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
         }
@@ -922,7 +922,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         try {
             $this->_db->query('SELECT * FROM BogusTable');
             $this->fail('Expected exception not thrown');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Statement\Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
         }
@@ -1498,7 +1498,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         try {
             $this->_db->setFetchMode(-999);
             $this->fail('Expected exception not thrown');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Adapter\Exception', $e,
                 'Expecting object of type Zend_Db_Adapter_Exception, got '.get_class($e));
             $this->assertEquals("Invalid fetch mode '-999' specified", $e->getMessage());
@@ -1844,7 +1844,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         try {
             $this->_db->setProfiler($profilerOptions);
             $this->fail('Expected to catch Zend_Db_Profiler_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Profiler\Exception', $e);
             $this->assertEquals('Class stdClass does not extend Zend_Db_Profiler', $e->getMessage());
         }

--- a/tests/Zend/Db/Adapter/MysqliTest.php
+++ b/tests/Zend/Db/Adapter/MysqliTest.php
@@ -94,7 +94,7 @@ class MysqliTest extends AbstractTest
             $result2 = $stmt->fetchAll();
             $this->assertEquals(3, count($result2), 'Expected 3 rows in second query result');
             $this->assertEquals($result1, $result2);
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail('exception caught where none was expected.');
         }
     }

--- a/tests/Zend/Db/Adapter/PdoIbmTest.php
+++ b/tests/Zend/Db/Adapter/PdoIbmTest.php
@@ -82,7 +82,7 @@ class PdoIbmTest extends AbstractPdoTest
         try {
             $sql = $this->_db->limit("SELECT * FROM $products", 1, -1);
             $this->fail('Expected to catch Zend_Db_Adapter_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend_Db_Adapter_Exception', $e,
                 'Expecting object of type Zend_Db_Adapter_Exception, got '.get_class($e));
         }

--- a/tests/Zend/Db/Adapter/PdoMysqlTest.php
+++ b/tests/Zend/Db/Adapter/PdoMysqlTest.php
@@ -86,7 +86,7 @@ class PdoMysqlTest extends AbstractPdoTest
         try {
             $stmt = $this->_db->query($select);
             $result2 = $stmt->fetchAll();
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Statement\Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->fail('Unexpected exception '.get_class($e).' received: '.$e->getMessage());

--- a/tests/Zend/Db/Adapter/PdoSqliteTest.php
+++ b/tests/Zend/Db/Adapter/PdoSqliteTest.php
@@ -79,7 +79,7 @@ class PdoSqliteTest extends AbstractPdoTest
         try {
             $stmt = $this->_db->query($select);
             $result2 = $stmt->fetchAll();
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend_Db_Statement_Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->fail('Unexpected exception '.get_class($e).' received: '.$e->getMessage());

--- a/tests/Zend/Db/Adapter/StaticTest.php
+++ b/tests/Zend/Db/Adapter/StaticTest.php
@@ -96,7 +96,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         try {
             // this test used to read as 'TestNamespace', but due to ZF-5606 has been changed
             $db = Db\Db::factory('StaticAdapter', array('dbname' => 'dummy', 'adapterNamespace' => '\ZendTest\Db\Adapter\TestAsset\Testnamespace'));
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail('Caught exception of type '.get_class($e).' where none was expected: '.$e->getMessage());
         }
         
@@ -113,7 +113,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         try {
             $db = Db\Db::factory('Version', array('dbname' => 'dummy', 'adapterNamespace' => 'Zend'));
             $this->fail('Expected to catch Zend_Db_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Exception', $e,
                 'Expected exception of type Zend_Db_Exception, got '.get_class($e));
             $this->assertEquals("Adapter class 'Zend\Version' does not extend Zend\Db\Adapter\AbstractAdapter", $e->getMessage());
@@ -125,7 +125,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         try {
             $db = Db\Db::factory(null);
             $this->fail('Expected to catch Zend_Db_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Exception', $e,
                 'Expected exception of type Zend_Db_Exception, got '.get_class($e));
             $this->assertEquals($e->getMessage(), 'Adapter name must be specified in a string');
@@ -169,7 +169,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         try {
             $db = Db\Db::factory('StaticAdapter', array());
             $this->fail('Expected to catch Zend_Db_Adapter_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend_Db_Adapter_Exception', $e,
                 'Expected exception of type Zend_Db_Adapter_Exception, got '.get_class($e));
             $this->assertEquals("Configuration must have a key for 'dbname' that names the database instance", $e->getMessage());
@@ -203,7 +203,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         try {
             $db = Db\Db::factory($config1);
             $this->fail('Expected to catch Zend_Db_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend_Db_Exception', $e,
                 'Expected exception of type Zend_Db_Exception, got '.get_class($e));
             $this->assertEquals($e->getMessage(), 'Adapter name must be specified in a string');

--- a/tests/Zend/Db/Select/AbstractTest.php
+++ b/tests/Zend/Db/Select/AbstractTest.php
@@ -335,7 +335,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
                    ->reset(Select::FROM)
                    ->columns('product_id');
             $this->fail('Expected exception of type "Zend_Db_Select_Exception"');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Select\Exception', $e,
                               'Expected exception of type "Zend_Db_Select_Exception", got ' . get_class($e));
             $this->assertEquals("No table has been specified for the FROM clause", $e->getMessage());
@@ -623,7 +623,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         try {
             $select->foo();
             $this->fail('Expected exception of type "Zend_Db_Select_Exception"');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Select\Exception', $e,
                               'Expected exception of type "Zend_Db_Select_Exception", got ' . get_class($e));
             $this->assertEquals("Unrecognized method 'foo()'", $e->getMessage());
@@ -669,7 +669,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         try {
             $select->joinFooUsing();
             $this->fail('Expected exception of type "Zend_Db_Select_Exception"');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Select\Exception', $e,
                               'Expected exception of type "Zend_Db_Select_Exception", got ' . get_class($e));
             $this->assertEquals("Unrecognized method 'joinFooUsing()'", $e->getMessage());
@@ -695,7 +695,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         try {
             $select->joinCrossUsing("zfbugs_products", "$product_id");
             $this->fail('Expected exception of type "Zend_Db_Select_Exception"');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Select\Exception', $e,
                               'Expected exception of type "Zend_Db_Select_Exception", got ' . get_class($e));
             $this->assertEquals("Cannot perform a joinUsing with method 'joinCrossUsing()'", $e->getMessage());
@@ -867,7 +867,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
             $result = $stmt->fetchAll();
             $this->assertEquals(1, count($result));
             $this->assertEquals(200.45, $result[0]['price_total']);
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             setlocale(LC_ALL, $locale);
             throw $e;
         }

--- a/tests/Zend/Db/Statement/AbstractPdoTest.php
+++ b/tests/Zend/Db/Statement/AbstractPdoTest.php
@@ -65,7 +65,7 @@ abstract class AbstractPdoTest extends AbstractTest
         try {
             $stmt->nextRowset();
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Statement\Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->assertEquals('SQLSTATE[IM001]: Driver does not support this function: driver does not support multiple rowsets', $e->getMessage());
@@ -93,7 +93,7 @@ abstract class AbstractPdoTest extends AbstractTest
         try {
             $stmt = $this->_db->query($sql);
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Statement\Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->assertTrue($e->hasChainedException(), 'Missing Chained Exception');

--- a/tests/Zend/Db/Statement/AbstractTest.php
+++ b/tests/Zend/Db/Statement/AbstractTest.php
@@ -95,7 +95,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         try {
             $stmt = $this->_db->query($sql);
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Statement\Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
         }
@@ -188,7 +188,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
                 throw new Statement\Exception('dummy');
             }
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Statement\Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
         }
@@ -210,7 +210,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
                 throw new Statement\Exception('dummy');
             }
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Statement\Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
         }
@@ -322,7 +322,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
             // invalid value
             $stmt->setFetchMode(-999);
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Statement\Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->assertRegExp('#invalid fetch mode#i', $e->getMessage());
@@ -437,7 +437,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         try {
             $result = $stmt->fetchAll(-99);
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Statement\Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
         }
@@ -580,7 +580,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         try {
             $result = $stmt->fetch(-99);
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Statement\Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
         }
@@ -820,7 +820,7 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         try {
             $stmt->nextRowset();
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Statement\Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->assertEquals('nextRowset() is not implemented', $e->getMessage());
@@ -837,13 +837,13 @@ abstract class AbstractTest extends \ZendTest\Db\TestSetup
         $value = 'value';
         try {
             $stmt->setAttribute(1234, $value);
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertContains('This driver doesn\'t support setting attributes', $e->getMessage());
         }
 
         try {
             $this->assertEquals($value, $stmt->getAttribute(1234), "Expected '$value' #1");
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertContains('This driver doesn\'t support getting attributes', $e->getMessage());
             return;
         }

--- a/tests/Zend/Db/Statement/Db2Test.php
+++ b/tests/Zend/Db/Statement/Db2Test.php
@@ -94,7 +94,7 @@ class Db2Test extends AbstractTest
             // test with no colon prefix
             $this->assertTrue($stmt->bindParam('name', $productNameValue), 'Expected bindParam(\'name\') to return true');
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend_Db_Statement_Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->assertEquals("Invalid bind-variable name ':id'", $e->getMessage());
@@ -122,7 +122,7 @@ class Db2Test extends AbstractTest
             // test with no colon prefix
             $this->assertTrue($stmt->bindParam('name', $productNameValue), 'Expected bindParam(\'name\') to return true');
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend_Db_Statement_Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->assertEquals("Invalid bind-variable name ':id'", $e->getMessage());

--- a/tests/Zend/Db/Statement/MysqliTest.php
+++ b/tests/Zend/Db/Statement/MysqliTest.php
@@ -77,7 +77,7 @@ class MySQLiTest extends AbstractTest
             // test with no colon prefix
             $this->assertTrue($stmt->bindParam('name', $productNameValue), 'Expected bindParam(\'name\') to return true');
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend_Db_Statement_Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->assertEquals("Invalid bind-variable name ':id'", $e->getMessage());
@@ -100,7 +100,7 @@ class MySQLiTest extends AbstractTest
             // test with no colon prefix
             $this->assertTrue($stmt->bindParam('name', $productNameValue), 'Expected bindParam(\'name\') to return true');
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend_Db_Statement_Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->assertEquals("Invalid bind-variable name ':id'", $e->getMessage());
@@ -123,7 +123,7 @@ class MySQLiTest extends AbstractTest
         try {
             $stmt = $this->_db->query($sql);
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('int', $e->getCode());
         }
     }

--- a/tests/Zend/Db/Statement/OracleTest.php
+++ b/tests/Zend/Db/Statement/OracleTest.php
@@ -97,7 +97,7 @@ class OracleTest extends AbstractTest
         try {
             $stmt->nextRowset();
             $this->fail('Expected to catch Zend_Db_Statement_Oracle_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend_Db_Statement_Oracle_Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Oracle_Exception, got '.get_class($e));
             $this->assertEquals('HYC00 Optional feature not implemented', $e->getMessage());

--- a/tests/Zend/Db/Statement/PdoIbmTest.php
+++ b/tests/Zend/Db/Statement/PdoIbmTest.php
@@ -95,13 +95,13 @@ class PdoIbmTest extends AbstractPdoTest
         $value = 'value';
         try {
             $stmt->setAttribute(1234, $value);
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertContains('This driver doesn\'t support setting attributes', $e->getMessage());
         }
 
         try {
             $this->assertEquals($value, $stmt->getAttribute(1234), "Expected '$value' #1");
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertContains('Driver does not support this function: 1 Unknown attribute', $e->getMessage());
             return;
         }

--- a/tests/Zend/Db/Table/Relationships/AbstractTest.php
+++ b/tests/Zend/Db/Table/Relationships/AbstractTest.php
@@ -143,7 +143,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $result = $parentRow1->nonExistantMethod();
             $this->fail('Expected to catch Zend_Db_Table_Row_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend_Db_Table_Row_Exception got '.get_class($e));
             $this->assertEquals("Unrecognized method 'nonExistantMethod()'", $e->getMessage());
@@ -672,7 +672,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $table->getReference('\ZendTest\Db\Table\TestAsset\TableAccounts', 'Nonexistent');
             $this->fail('Expected to catch Zend\Db\Table\Exception for nonexistent reference rule');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\Exception got '.get_class($e));
         }
@@ -680,7 +680,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $table->getReference('Nonexistent', 'Reporter');
             $this->fail('Expected to catch Zend\Db\Table\Exception for nonexistent rule tableClass');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\Exception got '.get_class($e));
         }
@@ -688,7 +688,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $table->getReference('Nonexistent');
             $this->fail('Expected to catch Zend\Db\Table\Exception for nonexistent rule tableClass');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\Exception got '.get_class($e));
         }
@@ -887,7 +887,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $parentRow->$account_name = 'clarabell';
         try {
             $parentRow->save();
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail('Failed with unexpected '.get_class($e).': '.$e->getMessage());
         }
 
@@ -929,7 +929,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $bug_id = $childRow1->$bug_id_column;
         try {
             $childRow1->save();
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail('Failed with unexpected '.get_class($e).': '.$e->getMessage());
         }
 
@@ -967,7 +967,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $row1->$product_name = 'AmigaOS';
         try {
             $row1->save();
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail('Failed with unexpected '.get_class($e).': '.$e->getMessage());
         }
 

--- a/tests/Zend/Db/Table/Row/AbstractTest.php
+++ b/tests/Zend/Db/Table/Row/AbstractTest.php
@@ -102,7 +102,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $bug_description = $row1->bug_description;
             $this->fail('Expected to catch Zend\Db\Table\RowException');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals("Specified column \"bug_description\" is not in the row", $e->getMessage());
@@ -113,7 +113,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $row1 = new Row($config);
             $this->fail('Expected to catch Zend\Db\Table\RowException');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals("Data must be an array", $e->getMessage());
@@ -213,7 +213,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $this->assertEquals(1, $row1->$bug_id);
             $this->assertEquals('System needs electricity to run', $row1->$bug_description);
             $this->assertEquals('NEW', $row1->$bug_status);
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Caught exception of type \"".get_class($e)."\" where no exception was expected.  Exception message: \"".$e->getMessage()."\"\n");
         }
 
@@ -256,7 +256,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $row1->$bug_description = 'foo';
             $this->assertEquals('foo', $row1->$bug_description);
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Caught exception of type \"".get_class($e)."\" where no exception was expected.  Exception message: \"".$e->getMessage()."\"\n");
         }
     }
@@ -280,7 +280,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $this->assertEquals(1, $row1->offsetGet($bug_id));
             $this->assertEquals('System needs electricity to run', $row1->offsetGet($bug_description));
             $this->assertEquals('NEW', $row1->offsetGet($bug_status));
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Caught exception of type \"".get_class($e)."\" where no exception was expected.  Exception message: \"".$e->getMessage()."\"\n");
         }
     }
@@ -301,7 +301,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $row1->offsetSet($bug_description, 'foo');
             $this->assertEquals('foo', $row1->offsetGet($bug_description));
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Caught exception of type \"".get_class($e)."\" where no exception was expected.  Exception message: \"".$e->getMessage()."\"\n");
         }
     }
@@ -325,7 +325,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $this->assertTrue($row1->offsetExists($bug_description));
             $row1->offsetUnset($bug_description);
             $this->assertFalse($row1->offsetExists($bug_description));
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Caught exception of type \"".get_class($e)."\" where no exception was expected.  Exception message: \"".$e->getMessage()."\"\n");
         }
     }
@@ -355,7 +355,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $this->assertEquals($data[$bug_description], $row1->$bug_description);
             $this->assertEquals($data[$bug_status], $row1->$bug_status);
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Caught exception of type \"".get_class($e)."\" where no exception was expected.  Exception message: \"".$e->getMessage()."\"\n");
         }
     }
@@ -388,7 +388,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $button = $row1->btnAccept;
             $this->fail('Expected to catch Zend\Db\Table\RowException');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals("Specified column \"btnAccept\" is not in the row", $e->getMessage());
@@ -409,7 +409,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $this->assertEquals(5, $row3->bug_id);
             $this->assertEquals($data['bug_description'], $row3->bug_description);
             $this->assertEquals($data['bug_status'], $row3->bug_status);
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Caught exception of type \"".get_class($e)."\" where no exception was expected.  Exception message: \"".$e->getMessage()."\"\n");
         }
     }
@@ -428,7 +428,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $row3->save();
         try {
             $this->assertEquals(4, $row3->$product_id);
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Caught exception of type \"".get_class($e)."\" where no exception was expected.  Exception message: \"".$e->getMessage()."\"\n");
         }
     }
@@ -459,7 +459,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $this->assertEquals(1, $row1->$bug_id);
             $this->assertEquals($data[$bug_description], $row1->$bug_description);
             $this->assertEquals($data[$bug_status], $row1->$bug_status);
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Caught exception of type \"".get_class($e)."\" where no exception was expected.  Exception message: \"".$e->getMessage()."\"\n");
         }
     }
@@ -474,7 +474,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row->setTableColsToFail($table);
             $row->setTable($table);
             $this->fail('Expected to catch Zend\Db\Table\RowException for incorrect parent table');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\RowException got '.get_class($e));
             $this->assertEquals('The specified Table does not have the same columns as the Row', $e->getMessage());
@@ -486,7 +486,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row->setPrimaryKeyToFail1($table);
             $row->setTable($table);
             $this->fail('Expected to catch Zend\Db\Table\RowException for incorrect parent table');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\RowException got '.get_class($e));
             $this->assertEquals('The specified Table \'ZendTest\Db\Table\TestAsset\TableBugs\' does not have the same primary key as the Row', $e->getMessage());
@@ -507,7 +507,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row->setPrimaryKeyToFail1();
             $row->save();
             $this->fail('Expected to catch Zend\Db\Table\RowException for incorrect parent table');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\RowException got '.get_class($e));
             $this->assertEquals('The primary key must be set as an array', $e->getMessage());
@@ -518,7 +518,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row->setPrimaryKeyToFail2();
             $row->save();
             $this->fail('Expected to catch Zend\Db\Table\RowException for incorrect parent table');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\RowException got '.get_class($e));
             $this->assertEquals('The specified Table \'ZendTest\Db\Table\TestAsset\TableBugs\' does not have the same primary key as the Row', $e->getMessage());
@@ -537,7 +537,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $row->save();
             $this->fail('Expected to catch Zend\Db\Table\RowException for missing parent');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException got '.get_class($e));
             $this->assertEquals('Cannot refresh row as parent is missing', $e->getMessage());
@@ -562,7 +562,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $row1->setTable($table2);
             $this->fail('Expected to catch Zend\Db\Table\Exception for incorrect parent table');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\Exception got '.get_class($e));
             $this->assertEquals('The specified Table is of class ZendTest\Db\Table\TestAsset\TableProducts, expecting class to be instance of ZendTest\Db\Table\TestAsset\TableBugs', $e->getMessage());
@@ -579,7 +579,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row->setTableToFail();
             $row->setTable($table);
             $this->fail('Expected to catch Zend\Db\Table\RowException for incorrect parent table');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\RowException got '.get_class($e));
             $this->assertEquals('The specified Table is of class ZendTest\Db\Table\TestAsset\TableBugs, expecting class to be instance of foo', $e->getMessage());
@@ -602,7 +602,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $dummy = $row1->$column;
             $this->fail('Expected to catch Zend\Db\Table\RowException');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals("Specified column \"$column\" is not in the row", $e->getMessage());
@@ -625,7 +625,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $row1->$column = 'dummy value';
             $this->fail('Expected to catch Zend\Db\Table\RowException');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals("Specified column \"$column\" is not in the row", $e->getMessage());
@@ -643,7 +643,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $rowsAffected = $row->delete();
             $this->fail('Expected to catch Zend\Db\Table\RowException');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals("The specified Table 'ZendTest\Db\Table\TestAsset\TableBugsProducts' does not have the same primary key as the Row", $e->getMessage());
@@ -666,7 +666,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row1->$bug_id = 6;
             $row1->save();
             $this->assertEquals(6, $row1->$bug_id);
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Caught exception of type \"".get_class($e)."\" where no exception was expected.  Exception message: \"".$e->getMessage()."\"\n");
         }
     }
@@ -704,7 +704,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $row1New->save();
             $this->fail('Expected to catch Zend\Db\Table\RowException');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals("Cannot save a Row unless it is connected", $e->getMessage());
@@ -726,7 +726,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 
         try {
             $connected = $row1New->setTable($table);
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Caught exception of type \"".get_class($e)."\" where no exception was expected.  Exception message: \"".$e->getMessage()."\"\n");
         }
         $this->assertTrue($connected);
@@ -741,7 +741,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 
         try {
             $rowsAffected = $row1New->save();
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Caught exception of type \"".get_class($e)."\" where no exception was expected.  Exception message: \"".$e->getMessage()."\"\n");
         }
         $this->assertEquals(1, $rowsAffected);
@@ -762,14 +762,14 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 
         try {
             $connected = $row1New->setTable($table);
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Caught exception of type \"".get_class($e)."\" where no exception was expected.  Exception message: \"".$e->getMessage()."\"\n");
         }
         $this->assertTrue($connected);
 
         try {
             $rowsAffected = $row1New->delete();
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Caught exception of type \"".get_class($e)."\" where no exception was expected.  Exception message: \"".$e->getMessage()."\"\n");
         }
         $this->assertEquals(1, $rowsAffected);
@@ -793,7 +793,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $connected = $row1New->setTable($table2);
             $this->fail('Expected to catch Zend\Db\Table\RowException');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals('The specified Table is of class ZendTest\Db\Table\TestAsset\TableProducts, expecting class to be instance of ZendTest\Db\Table\TestAsset\TableBugs', $e->getMessage());
@@ -822,7 +822,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $row2->save();
             $this->fail('Expected to catch Zend\Db\Table\RowException');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals('This row has been marked read-only', $e->getMessage());
@@ -837,7 +837,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $row2->save();
             $this->fail('Expected to catch Zend\Db\Table\RowException');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals('This row has been marked read-only', $e->getMessage());
@@ -854,7 +854,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $row->setInvalidColumn();
             $this->fail('Expected to catch Zend\Db\Table\RowException for invalid column type');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\RowException got '.get_class($e));
             $this->assertEquals('Specified column is not a string', $e->getMessage());

--- a/tests/Zend/Db/Table/Rowset/AbstractTest.php
+++ b/tests/Zend/Db/Table/Rowset/AbstractTest.php
@@ -252,7 +252,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $connected = $rowsNew->setTable($table2);
             $this->fail('Expected to catch Zend_Db_Table_Row_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend_Db_Table_Row_Exception, got '.get_class($e));
             $this->assertEquals('The specified Table is of class ZendTest\Db\Table\TestAsset\TableProducts, expecting class to be instance of ZendTest\Db\Table\TestAsset\TableBugs', $e->getMessage());

--- a/tests/Zend/Db/Table/Select/AbstractTest.php
+++ b/tests/Zend/Db/Table/Select/AbstractTest.php
@@ -93,7 +93,7 @@ abstract class AbstractTest extends \ZendTest\Db\Select\AbstractTest
     protected function _getSelectTable($table)
     {
         if (!array_key_exists($table, $this->_table)) {
-            throw new \Zend\Exception('Non-existent table name');
+            throw new \RuntimeException('Non-existent table name');
         }
 
         return $this->_table[$table];
@@ -150,7 +150,7 @@ abstract class AbstractTest extends \ZendTest\Db\Select\AbstractTest
         try {
             $query = $select->assemble();
             $this->fail('Expected to catch Zend_Db_Table_Select_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend_Db_Table_Select_Exception', $e);
             $this->assertEquals('Select query cannot join with another table', $e->getMessage());
         }

--- a/tests/Zend/Db/Table/Table/AbstractTest.php
+++ b/tests/Zend/Db/Table/Table/AbstractTest.php
@@ -151,7 +151,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $value = $bugs->info('_non_existent_');
             $this->fail('Expected to catch Zend_Db_Table_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e);
             $this->assertEquals('There is no table information for the key "_non_existent_"', $e->getMessage());
         }
@@ -320,7 +320,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $ref = $table->getReference('\ZendTest\Db\Table\TestAsset\TableAccounts', 'Verifier');
             $this->fail('Expected to catch Zend_Db_Table_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e);
             $this->assertEquals('No reference rule "Verifier" from table ZendTest\Db\Table\TestAsset\TableBugs to table \ZendTest\Db\Table\TestAsset\TableAccounts', $e->getMessage());
         }
@@ -328,7 +328,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $ref = $table->getReference('\ZendTest\Db\Table\TestAsset\TableProducts');
             $this->fail('Expected to catch Zend_Db_Table_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e);
             $this->assertEquals('No reference from table ZendTest\Db\Table\TestAsset\TableBugs to table \ZendTest\Db\Table\TestAsset\TableProducts', $e->getMessage());
         }
@@ -336,7 +336,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $ref = $table->getReference('\ZendTest\Db\Table\TestAsset\TableProducts', 'Product');
             $this->fail('Expected to catch Zend_Db_Table_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e);
             $this->assertEquals('No reference rule "Product" from table ZendTest\Db\Table\TestAsset\TableBugs to table \ZendTest\Db\Table\TestAsset\TableProducts', $e->getMessage());
         }
@@ -344,7 +344,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $ref = $table->getReference('\ZendTest\Db\Table\TestAsset\TableProducts', 'Reporter');
             $this->fail('Expected to catch Zend_Db_Table_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e);
             $this->assertEquals('Reference rule "Reporter" does not reference table \ZendTest\Db\Table\TestAsset\TableProducts', $e->getMessage());
         }
@@ -394,7 +394,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $table = new \ZendTest\Db\Table\TestAsset\TableBugs();
             $this->fail('Zend_Db_Table_Exception should be thrown');
-        }catch(\Zend\Exception $e) {
+        }catch(\Exception $e) {
          $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
         }
@@ -429,7 +429,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             Table\AbstractTable::setDefaultAdapter(new \stdClass());
             $this->fail('Expected to catch Zend_Db_Table_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals("Argument must be of type Zend_Db_Adapter_Abstract, or a Registry key where a Zend_Db_Adapter_Abstract object is stored", $e->getMessage());
@@ -451,7 +451,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $table = $this->_getTable('\ZendTest\Db\Table\TestAsset\TableBugs', array('primary' => ''));
             $primary = $table->info(Table\AbstractTable::PRIMARY);
             $this->fail('Expected to catch Zend_Db_Table_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertContains("Primary key column(s)", $e->getMessage());
@@ -465,7 +465,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $table   = new \ZendTest\Db\Table\TestAsset\TableBugs(array('primary' => 'foo'));
             $primary = $table->info(Table\AbstractTable::PRIMARY);
             $this->fail('Expected to catch Zend_Db_Table_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertContains("Primary key column(s)", $e->getMessage());
@@ -484,7 +484,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
                 array('name' => $tableName));
             $primary = $table->info(Table\AbstractTable::PRIMARY);
             $this->fail('Expected to catch Zend_Db_Table_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals('A table must have a primary key, but none was found', $e->getMessage());
@@ -502,7 +502,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $table = $this->_getTable('\ZendTest\Db\Table\TestAsset\TableSpecial',
                 array('name' => $tableName, 'primary' => 'id'));
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail('Expected to succeed without a Zend_Db_Table_Exception');
         }
 
@@ -522,7 +522,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $table = new \ZendTest\Db\Table\TestAsset\TableBugs(array('db' => 327));
             $this->fail('Expected to catch Zend_Db_Table_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals("Argument must be of type Zend_Db_Adapter_Abstract, or a Registry key where a Zend_Db_Adapter_Abstract object is stored", $e->getMessage());
@@ -535,7 +535,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $table = new \ZendTest\Db\Table\TestAsset\TableBugs(array('db' => 'registered_db'));
             $this->fail('Expected to catch Zend_Db_Table_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals("Argument must be of type Zend_Db_Adapter_Abstract, or a Registry key where a Zend_Db_Adapter_Abstract object is stored", $e->getMessage());
@@ -566,7 +566,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $table->find(1);
             $this->fail('Expected to catch Zend_Db_Table_Exception for missing key');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals('Too few columns for the primary key', $e->getMessage());
@@ -579,7 +579,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $table->find(1, 2);
             $this->fail('Expected to catch Zend_Db_Table_Exception for incorrect key count');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals('Too many columns for the primary key', $e->getMessage());
@@ -610,7 +610,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $rowset = $table->find(array(1, 1), 2);
             $this->fail('Expected to catch Zend_Db_Table_Exception for incorrect key count');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals('Missing value(s) for the primary key', $e->getMessage());
@@ -1410,7 +1410,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             Table\AbstractTable::setDefaultMetadataCache(new \stdClass());
             $this->fail('Expected to catch Zend_Db_Table_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals("Argument must be of type Zend_Cache_Core, or a Registry key where a Zend_Cache_Core object is stored", $e->getMessage());
@@ -1436,7 +1436,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $table = new \ZendTest\Db\Table\TestAsset\TableBugs(array('metadataCache' => 327));
             $this->fail('Expected to catch Zend_Db_Table_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals("Argument must be of type Zend_Cache_Core, or a Registry key where a Zend_Cache_Core object is stored", $e->getMessage());
@@ -1449,7 +1449,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         try {
             $table = new \ZendTest\Db\Table\TestAsset\TableBugs(array('metadataCache' => 'registered_metadata_cache'));
             $this->fail('Expected to catch Zend_Db_Table_Exception');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals("Argument must be of type Zend_Cache_Core, or a Registry key where a Zend_Cache_Core object is stored", $e->getMessage());

--- a/tests/Zend/Db/TestSetup.php
+++ b/tests/Zend/Db/TestSetup.php
@@ -81,7 +81,7 @@ abstract class TestSetup extends \PHPUnit_Framework_TestCase
         $this->_db = \Zend\Db\DB::factory($this->getDriver(), $this->_util->getParams());
         try {
             $conn = $this->_db->getConnection();
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->_db = null;
             $this->assertType('Zend\Db\Adapter\Exception', $e,
                 'Expecting Zend_Db_Adapter_Exception, got ' . get_class($e));

--- a/tests/Zend/GData/GDataTest.php
+++ b/tests/Zend/GData/GDataTest.php
@@ -80,7 +80,7 @@ class GDataTest extends \PHPUnit_Framework_TestCase
             // and see if it throws an exception.
             $feed = $gdata->getFeed(new \stdClass());
             $this->fail('Expecting to catch Zend\GData\App\InvalidArgumentException');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\GData\App\InvalidArgumentException', $e,
                 'Expecting Zend\GData\App\InvalidArgumentException, got '.get_class($e));
             $this->assertEquals('You must specify the location as either a string URI or a child of Zend\GData\Query', $e->getMessage());
@@ -95,7 +95,7 @@ class GDataTest extends \PHPUnit_Framework_TestCase
             // and see if it throws an exception.
             $feed = $gdata->getEntry(new \stdClass());
             $this->fail('Expecting to catch Zend\GData\App\InvalidArgumentException');
-        } catch (\Zend\Exception $e) {
+        } catch (\Exception $e) {
             $this->assertType('Zend\GData\App\InvalidArgumentException', $e,
                 'Expecting Zend\GData\App\InvalidArgumentException, got '.get_class($e));
             $this->assertEquals('You must specify the location as either a string URI or a child of Zend\GData\Query', $e->getMessage());

--- a/tests/Zend/Mail/MessageTest.php
+++ b/tests/Zend/Mail/MessageTest.php
@@ -162,7 +162,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     {
         try {
             Mime\Decode::splitMessageStruct("--xxx\n", 'xxx');
-        } catch (\Zend\Exception $e) {
+        } catch (\Zend\Mime\Exception $e) {
             return; // ok
         }
 
@@ -173,7 +173,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     {
         try {
             $message = new Message(array('handler' => 1));
-        } catch (\Zend\Exception $e) {
+        } catch (\Zend\Mime\Exception $e) {
             return; // ok
         }
 
@@ -187,7 +187,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         try {
             $message = new Message(array('handler' => $mail));
-        } catch (\Zend\Exception $e) {
+        } catch (\Zend\Mime\Exception $e) {
             return; // ok
         }
 
@@ -230,7 +230,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $header = '';
         try {
             Mime\Decode::splitHeaderField($header);
-        } catch (\Zend\Exception $e) {
+        } catch (\Zend\Mime\Exception $e) {
             return; // ok
         }
 
@@ -268,7 +268,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         try {
             $message->getContent();
-        } catch (\Zend\Exception $e) {
+        } catch (\Zend\Mime\Exception $e) {
             return; // ok
         }
 
@@ -284,7 +284,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $subject = null;
         try {
             $subject = $message->subject;
-        } catch (\Zend\Exception $e) {
+        } catch (\Zend\Mime\Exception $e) {
             // ok
         }
         if ($subject) {
@@ -298,7 +298,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $part = null;
         try {
             $part = $message->getPart(1);
-        } catch (\Zend\Exception $e) {
+        } catch (\Zend\Mime\Exception $e) {
             // ok
         }
         if ($part) {
@@ -329,7 +329,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         try {
             $message->getPart(1);
-        } catch (\Zend\Exception $e) {
+        } catch (\Zend\Mime\Exception $e) {
             return; // ok
         }
         $this->fail('no exception raised while getting part from message without boundary');

--- a/tests/Zend/RegistryTest.php
+++ b/tests/Zend/RegistryTest.php
@@ -73,7 +73,7 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
         try {
             Registry::get('foo');
             $this->fail('Expected exception when trying to fetch a non-existent key.');
-        } catch (\Zend\Exception $e) {
+        } catch (\RuntimeException $e) {
             $this->assertContains('No entry is registered for key', $e->getMessage());
         }
         $registry = Registry::getInstance();
@@ -149,7 +149,7 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
         try {
             $registry = Registry::setClassName(new \stdClass());
             $this->fail('Expected exception, because setClassName() wants a string');
-        } catch (\Zend\Exception $e) {
+        } catch (\RuntimeException $e) {
             $this->assertContains('Argument is not a class name', $e->getMessage());
         }
     }
@@ -166,7 +166,7 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
         try {
             $foo = Registry::get('foo');
             $this->fail('Expected exception when trying to fetch a non-existent key.');
-        } catch (\Zend\Exception $e) {
+        } catch (\RuntimeException $e) {
             $this->assertContains('No entry is registered for key', $e->getMessage());
         }
     }
@@ -178,13 +178,13 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
         try {
             Registry::setClassName('anyclass');
             $this->fail('Expected exception, because we cannot initialize the registry if it is already initialized.');
-        } catch (\Zend\Exception $e) {
+        } catch (\RuntimeException $e) {
             $this->assertContains('Registry is already initialized', $e->getMessage());
         }
         try {
             Registry::setInstance(new Registry());
             $this->fail('Expected exception, because we cannot initialize the registry if it is already initialized.');
-        } catch (\Zend\Exception $e) {
+        } catch (\RuntimeException $e) {
             $this->assertContains('Registry is already initialized', $e->getMessage());
         }
     }

--- a/tests/Zend/Validator/EmailAddressTest.php
+++ b/tests/Zend/Validator/EmailAddressTest.php
@@ -471,7 +471,7 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals(Hostname::ALLOW_ALL, $options['allow']);
             $this->assertTrue($options['mx']);
             set_error_handler($handler);
-        } catch (\Zend\Exception $e) {
+        } catch (\Zend\Validator\Exception\InvalidArgumentException $e) {
             $this->markTestSkipped('MX not available on this system');
         }
     }


### PR DESCRIPTION
Fixed:
- extends
- tag @uses
- throw
- replace with a better Exception like \RuntimeException for \Zend\Registry

It's related to the [comment 949342](https://github.com/zendframework/zf2/pull/154#issuecomment-949342).
