### PR TITLE
ZF-10537: File & Line info is incorrect for FirePHP messages sent via Zend_Wildfire

### DIFF
--- a/library/Zend/Log/Writer/Firebug.php
+++ b/library/Zend/Log/Writer/Firebug.php
@@ -196,6 +196,7 @@ class Firebug extends AbstractWriter
         FirePhp::getInstance()->send($message,
                                      $label,
                                      $type,
-                                     array('traceOffset'=>6));
+                                     array('traceOffset'=>4,
+                                           'fixZendLogOffsetIfApplicable'=>true));
     }
 }


### PR DESCRIPTION
Backport of the issue [ZF-10537](http://framework.zend.com/issues/browse/ZF-10537).
