### PR TITLE
Fixes issue #165 and #167

### DIFF
--- a/library/Zend/Locale/Data/AbstractLocale.php
+++ b/library/Zend/Locale/Data/AbstractLocale.php
@@ -234,13 +234,13 @@ abstract class AbstractLocale
         throw new UnsupportedMethod('This implementation does not support the selected locale information');
     }
 
-    public static function toInteger()
-    public static function toFloat()
-    public static function toDecimal()
-    public static function toScientific()
+//    public static function toInteger()
+//    public static function toFloat()
+//    public static function toDecimal()
+//    public static function toScientific()
 
-    public static function toCurrency()
+//    public static function toCurrency()
 
-    public static function toArray()
-    public static function toDateString()
+//    public static function toArray()
+//    public static function toDateString()
 }

--- a/library/Zend/Locale/Format.php
+++ b/library/Zend/Locale/Format.php
@@ -24,6 +24,8 @@
  */
 namespace Zend\Locale;
 
+use \Zend\Locale\Data\Cldr;
+
 /**
  * @uses       \Zend\Locale\Locale
  * @uses       \Zend\Locale\Data\Cldr


### PR DESCRIPTION
The following changes since commit 450663d7f9c566193444a640e277492183e2a6aa:

  s/Locater/Locator/gs (2011-04-14 15:24:55 -0500)

are available in the git repository at:
  git@github.com:scaraveos/zf2.git hotfix/ZF-165

Vasilis Raptakis (2):
      Added 'use' operator in \Zend\Locale\Format for importing class \Zend\Locale\Data\Cldr
      Commented out invalid method declarations in \Zend\Locale\Data\AbstractLocale

 library/Zend/Locale/Data/AbstractLocale.php |   14 +++++++-------
 library/Zend/Locale/Format.php              |    2 ++
 2 files changed, 9 insertions(+), 7 deletions(-)
