### PR TITLE
Temporarily solves ZF-11322

### DIFF
--- a/library/Zend/Locale/Data/AbstractLocale.php
+++ b/library/Zend/Locale/Data/AbstractLocale.php
@@ -234,13 +234,13 @@ abstract class AbstractLocale
         throw new UnsupportedMethod('This implementation does not support the selected locale information');
     }
 
-    public static function toInteger()
-    public static function toFloat()
-    public static function toDecimal()
-    public static function toScientific()
+//    public static function toInteger()
+//    public static function toFloat()
+//    public static function toDecimal()
+//    public static function toScientific()
 
-    public static function toCurrency()
+//    public static function toCurrency()
 
-    public static function toArray()
-    public static function toDateString()
+//    public static function toArray()
+//    public static function toDateString()
 }


### PR DESCRIPTION
The following changes since commit 450663d7f9c566193444a640e277492183e2a6aa:

  s/Locater/Locator/gs (2011-04-14 15:24:55 -0500)

are available in the git repository at:
  git@github.com:scaraveos/zf2.git hotfix/ZF-11322

Vasilis Raptakis (1):
      Commented out invalid method declarations causing php error.

 library/Zend/Locale/Data/AbstractLocale.php |   14 +++++++-------
 1 files changed, 7 insertions(+), 7 deletions(-)
