### PR TITLE
Solves ZF-11323

### DIFF
--- a/library/Zend/Locale/Format.php
+++ b/library/Zend/Locale/Format.php
@@ -24,6 +24,8 @@
  */
 namespace Zend\Locale;
 
+use \Zend\Locale\Data\Cldr;
+
 /**
  * @uses       \Zend\Locale\Locale
  * @uses       \Zend\Locale\Data\Cldr


### PR DESCRIPTION
The following changes since commit 450663d7f9c566193444a640e277492183e2a6aa:

  s/Locater/Locator/gs (2011-04-14 15:24:55 -0500)

are available in the git repository at:
  git@github.com:scaraveos/zf2.git hotfix/ZF-11323

Vasilis Raptakis (1):
      Added 'use' operator to import/alias the \Zend\Locale\Data\Cldr class.

 library/Zend/Locale/Format.php |    2 ++
 1 files changed, 2 insertions(+), 0 deletions(-)
