### PR TITLE
ZF-11311: missing class Zend\Server\Reflection

### DIFF
--- a/library/Zend/Server/Reflection.php
+++ b/library/Zend/Server/Reflection.php
@@ -14,7 +14,6 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @subpackage Zend_Server_Reflection
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -22,19 +21,21 @@
 /**
  * @namespace
  */
-namespace Zend\Server\Reflection;
+namespace Zend\Server;
+
+use Zend\Server\Reflection\ReflectionClass,
+    Zend\Server\Reflection\ReflectionFunction;
 
 /**
  * Reflection for determining method signatures to use with server classes
  *
  * @uses       ReflectionClass
  * @uses       ReflectionObject
- * @uses       \Zend\Server\Reflection\ClassReflection
+ * @uses       \Zend\Server\Reflection\ReflectionClass
  * @uses       \Zend\Server\Reflection\Exception
- * @uses       \Zend\Server\Reflection\FunctionReflection
+ * @uses       \Zend\Server\Reflection\ReflectionFunction
  * @category   Zend
  * @package    Zend_Server
- * @subpackage Zend_Server_Reflection
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -64,11 +65,11 @@ class Reflection
         } elseif (class_exists($class)) {
             $reflection = new \ReflectionClass($class);
         } else {
-            throw new Exception\InvalidArgumentException('Invalid class or object passed to attachClass()');
+            throw new Reflection\Exception\InvalidArgumentException('Invalid class or object passed to attachClass()');
         }
 
         if ($argv && !is_array($argv)) {
-            throw new Exception\InvalidArgumentException('Invalid argv argument passed to reflectClass');
+            throw new Reflection\Exception\InvalidArgumentException('Invalid argv argument passed to reflectClass');
         }
 
         return new ReflectionClass($reflection, $namespace, $argv);
@@ -94,12 +95,11 @@ class Reflection
     public static function reflectFunction($function, $argv = false, $namespace = '')
     {
         if (!is_string($function) || !function_exists($function)) {
-            throw new Exception\InvalidArgumentException('Invalid function "' . $function . '" passed to reflectFunction');
+            throw new Reflection\Exception\InvalidArgumentException('Invalid function "' . $function . '" passed to reflectFunction');
         }
 
-
         if ($argv && !is_array($argv)) {
-            throw new Exception\InvalidArgumentException('Invalid argv argument passed to reflectClass');
+            throw new Reflection\Exception\InvalidArgumentException('Invalid argv argument passed to reflectClass');
         }
 
         return new ReflectionFunction(new \ReflectionFunction($function), $namespace, $argv);

--- a/tests/Zend/Server/Reflection/PrototypeTest.php
+++ b/tests/Zend/Server/Reflection/PrototypeTest.php
@@ -23,6 +23,7 @@
  * @namespace
  */
 namespace ZendTest\Server\Reflection;
+
 use Zend\Server\Reflection;
 
 /**
@@ -60,7 +61,7 @@ class PrototypeTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $class = new \ReflectionClass('\Zend\Server\Reflection\Reflection');
+        $class = new \ReflectionClass('\Zend\Server\Reflection');
         $method = $class->getMethod('reflectClass');
         $parameters = $method->getParameters();
         $this->_parametersRaw = $parameters;
@@ -99,7 +100,7 @@ class PrototypeTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertTrue($this->_r instanceof Reflection\Prototype);
     }
-    
+
     public function testConstructionThrowsExceptionOnInvalidParam()
     {
         $this->setExpectedException('Zend\Server\Reflection\Exception\InvalidArgumentException', 'One or more params are invalid');
@@ -111,7 +112,7 @@ class PrototypeTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Server\Reflection\Exception\InvalidArgumentException', 'Invalid parameters');
         $r1 = new Reflection\Prototype($this->_r->getReturnValue(), 'string');
     }
-    
+
     /**
      * getReturnType() test
      *

--- a/tests/Zend/Server/Reflection/ReflectionClassTest.php
+++ b/tests/Zend/Server/Reflection/ReflectionClassTest.php
@@ -23,6 +23,7 @@
  * @namespace
  */
 namespace ZendTest\Server\Reflection;
+
 use Zend\Server\Reflection;
 
 /**
@@ -51,7 +52,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
      */
     public function test__construct()
     {
-        $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection\Reflection'));
+        $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection'));
         $this->assertTrue($r instanceof Reflection\ReflectionClass);
         $this->assertEquals('', $r->getNamespace());
 
@@ -61,7 +62,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($m instanceof Reflection\ReflectionMethod);
         }
 
-        $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection\Reflection'), 'namespace');
+        $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection'), 'namespace');
         $this->assertEquals('namespace', $r->getNamespace());
     }
 
@@ -78,9 +79,9 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
      */
     public function test__call()
     {
-        $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection\Reflection'));
+        $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection'));
         $this->assertTrue(is_string($r->getName()));
-        $this->assertEquals('Zend\Server\Reflection\Reflection', $r->getName());
+        $this->assertEquals('Zend\Server\Reflection', $r->getName());
     }
 
     /**
@@ -88,7 +89,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetSet()
     {
-        $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection\Reflection'));
+        $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection'));
         $r->system = true;
         $this->assertTrue($r->system);
     }
@@ -102,7 +103,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetMethods()
     {
-        $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection\Reflection'));
+        $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection'));
 
         $methods = $r->getMethods();
         $this->assertTrue(is_array($methods));
@@ -116,7 +117,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetNamespace()
     {
-        $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection\Reflection'));
+        $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection'));
         $this->assertEquals('', $r->getNamespace());
         $r->setNamespace('namespace');
         $this->assertEquals('namespace', $r->getNamespace());
@@ -131,7 +132,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
      */
     public function test__wakeup()
     {
-        $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection\Reflection'));
+        $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection'));
         $s = serialize($r);
         $u = unserialize($s);
 

--- a/tests/Zend/Server/Reflection/ReflectionMethodTest.php
+++ b/tests/Zend/Server/Reflection/ReflectionMethodTest.php
@@ -23,6 +23,7 @@
  * @namespace
  */
 namespace ZendTest\Server\Reflection;
+
 use Zend\Server\Reflection;
 
 /**
@@ -43,7 +44,7 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->_classRaw = new \ReflectionClass('\Zend\Server\Reflection\Reflection');
+        $this->_classRaw = new \ReflectionClass('\Zend\Server\Reflection');
         $this->_method   = $this->_classRaw->getMethod('reflectClass');
         $this->_class    = new Reflection\ReflectionClass($this->_classRaw);
     }
@@ -106,6 +107,4 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($r->getName(), $u->getName());
         $this->assertEquals($r->getDeclaringClass()->getName(), $u->getDeclaringClass()->getName());
     }
-
-
 }

--- a/tests/Zend/Server/ReflectionTest.php
+++ b/tests/Zend/Server/ReflectionTest.php
@@ -23,6 +23,7 @@
  * @namespace
  */
 namespace ZendTest\Server;
+
 use Zend\Server\Reflection;
 
 /**
@@ -42,25 +43,25 @@ class ReflectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testReflectClass()
     {
-        $reflection = Reflection\Reflection::reflectClass('ZendTest\Server\ReflectionTestClass');
+        $reflection = Reflection::reflectClass('ZendTest\Server\ReflectionTestClass');
         $this->assertTrue($reflection instanceof Reflection\ReflectionClass);
 
-        $reflection = Reflection\Reflection::reflectClass(new ReflectionTestClass());
+        $reflection = Reflection::reflectClass(new ReflectionTestClass());
         $this->assertTrue($reflection instanceof Reflection\ReflectionClass);
     }
-    
+
     public function testReflectClassThrowsExceptionOnInvalidClass()
     {
         $this->setExpectedException('Zend\Server\Reflection\Exception\InvalidArgumentException', 'Invalid argv argument passed to reflectClass');
-        $reflection = Reflection\Reflection::reflectClass('ZendTest\Server\ReflectionTestClass', 'string');
+        $reflection = Reflection::reflectClass('ZendTest\Server\ReflectionTestClass', 'string');
     }
 
     public function testReflectClassThrowsExceptionOnInvalidParameter()
     {
         $this->setExpectedException('Zend\Server\Reflection\Exception\InvalidArgumentException', 'Invalid class or object passed to attachClass');
-        $reflection = Reflection\Reflection::reflectClass(false);
+        $reflection = Reflection::reflectClass(false);
     }
-    
+
     /**
      * reflectClass() test; test namespaces
      */
@@ -75,22 +76,22 @@ class ReflectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testReflectFunction()
     {
-        $reflection = Reflection\Reflection::reflectFunction('ZendTest\Server\reflectionTestFunction');
+        $reflection = Reflection::reflectFunction('ZendTest\Server\reflectionTestFunction');
         $this->assertTrue($reflection instanceof Reflection\ReflectionFunction);
     }
-    
+
     public function testReflectFunctionThrowsExceptionOnInvalidFunction()
     {
         $this->setExpectedException('Zend\Server\Reflection\Exception\InvalidArgumentException', 'Invalid function');
-        $reflection = Reflection\Reflection::reflectFunction('ZendTest\Server\reflectionTestClass', 'string');
+        $reflection = Reflection::reflectFunction('ZendTest\Server\ReflectionTestClass', 'string');
     }
 
     public function testReflectFunctionThrowsExceptionOnInvalidParam()
     {
         $this->setExpectedException('Zend\Server\Reflection\Exception\InvalidArgumentException', 'Invalid function');
-        $reflection = Reflection\Reflection::reflectFunction(false);
+        $reflection = Reflection::reflectFunction(false);
     }
-    
+
     /**
      * reflectFunction() test; test namespaces
      */


### PR DESCRIPTION
This pull request solves others pulls request [84](https://github.com/zendframework/zf2/pull/84), [125](https://github.com/zendframework/zf2/pull/125), and [163](https://github.com/zendframework/zf2/pull/163). You can close them without integration.
