### PR TITLE
Added namespaces to Zend Tool Provider Config

### DIFF
--- a/library/Zend/Tool/Framework/System/Provider/Config.php
+++ b/library/Zend/Tool/Framework/System/Provider/Config.php
@@ -70,7 +70,7 @@ class Config extends Framework\Provider\AbstractProvider
 
         $homeDirectory = $this->_detectHomeDirectory();
 
-        $writer = new end\Config\Writer\Ini();
+        $writer = new \Zend\Config\Writer\Ini();
         $writer->setRenderWithoutSections();
         $filename = $homeDirectory."/.zf.ini";
 
@@ -79,7 +79,7 @@ class Config extends Framework\Provider\AbstractProvider
                 'includepath' => get_include_path(),
             ),
         );
-        $writer->write($filename, new end\Config\Config($config));
+        $writer->write($filename, new \Zend\Config\Config($config));
 
         $resp = $this->_registry->getResponse();
         $resp->appendContent("Successfully written Zend Tool config.");


### PR DESCRIPTION
Was imposible create a new config file (~/.zf.ini) with "zf.sh create config" becouse the class Zend\Tool\Framework\System\Provider\Config was calling nonexistent classes "end\Config\Writer\Ini" (\Zend\Config\Writer\Ini) and "end\Config\Config" (\Zend\Config\Config)
