### PR TITLE
Fixed incorrect reference to Module\Autoloader and fixed spacing in a doc block

### DIFF
--- a/library/Zend/Application/Application.php
+++ b/library/Zend/Application/Application.php
@@ -72,7 +72,7 @@ class Application
      * Initialize application. Potentially initializes include_paths, PHP
      * settings, and bootstrap class.
      *
-     * @param  string                   $environment
+     * @param  string $environment
      * @param  string|array|\Zend\Config\Config $options String path to configuration file, or array/\Zend\Config\Config of configuration options
      * @throws \Zend\Application\Exception When invalid options are provided
      * @return void

--- a/library/Zend/Application/Bootstrap.php
+++ b/library/Zend/Application/Bootstrap.php
@@ -137,7 +137,7 @@ class Bootstrap extends AbstractBootstrap
         ) {
             $r    = new \ReflectionClass($this);
             $path = $r->getFileName();
-            $autoloader = new ModuleAutoloader(array(
+            $autoloader = new Module\Autoloader(array(
                 'namespace' => $namespace,
                 'basePath'  => dirname($path),
             ));


### PR DESCRIPTION
This bug fix is minor in the sense that code would still continue to work without it. However, since I noticed, I thought of sending a pull request, and also to test the commit work flow (e.g. CLA) to use for subsequent fixes.
