### PR TITLE
Revert "Fixed typo in Zend/Soap/AutoDiscover."

### DIFF
--- a/library/Zend/Soap/AutoDiscover.php
+++ b/library/Zend/Soap/AutoDiscover.php
@@ -99,7 +99,7 @@ class AutoDiscover implements \Zend\Server\Server
      */
     public function __construct($strategy = true, $uri=null, $wsdlClass=null)
     {
-        $this->_reflection = new \Zend\Server\Reflection\Reflection();
+        $this->_reflection = new \Zend\Server\Reflection();
         $this->setComplexTypeStrategy($strategy);
 
         if($uri !== null) {


### PR DESCRIPTION
This reverts commit c2a35fa8243c05b1eec922580a0ddf863569a265.
