### PR TITLE
ZF2-13: removed own php error handler on reading config data

### DIFF
--- a/library/Zend/Config/Config.php
+++ b/library/Zend/Config/Config.php
@@ -86,15 +86,6 @@ class Config implements \Countable, \Iterator
     protected $_extends = array();
 
     /**
-     * Load file error string.
-     *
-     * Is null if there was no error while file loading
-     *
-     * @var string
-     */
-    protected $_loadFileErrorStr = null;
-
-    /**
      * Zend_Config provides a property based interface to
      * an array. The data are read-only unless $allowModifications
      * is set to true on construction.
@@ -432,23 +423,6 @@ class Config implements \Countable, \Iterator
         }
         // remember that this section extends another section
         $this->_extends[$extendingSection] = $extendedSection;
-    }
-
-    /**
-     * Handle any errors from simplexml_load_file or parse_ini_file
-     *
-     * @param integer $errno
-     * @param string $errstr
-     * @param string $errfile
-     * @param integer $errline
-     */
-    protected function _loadFileErrorHandler($errno, $errstr, $errfile, $errline)
-    {
-        if ($this->_loadFileErrorStr === null) {
-            $this->_loadFileErrorStr = $errstr;
-        } else {
-            $this->_loadFileErrorStr .= (PHP_EOL . $errstr);
-        }
     }
 
     /**

--- a/library/Zend/Config/Ini.php
+++ b/library/Zend/Config/Ini.php
@@ -148,28 +148,6 @@ class Ini extends Config
 
         $this->_loadedSection = $section;
     }
-    
-    /**
-     * Load the INI file from disk using parse_ini_file(). Use a private error
-     * handler to convert any loading errors into a Zend_Config_Exception
-     * 
-     * @param string $filename
-     * @throws \Zend\Config\Exception
-     * @return array
-     */
-    protected function _parseIniFile($filename)
-    {
-        set_error_handler(array($this, '_loadFileErrorHandler'));
-        $iniArray = parse_ini_file($filename, true); // Warnings and errors are suppressed
-        restore_error_handler();
-        
-        // Check if there was a error while loading file
-        if ($this->_loadFileErrorStr !== null) {
-            throw new Exception\RuntimeException($this->_loadFileErrorStr);
-        }
-        
-        return $iniArray;
-    }
 
     /**
      * Load the ini file and preprocess the section separator (':' in the
@@ -185,7 +163,12 @@ class Ini extends Config
      */
     protected function _loadIniFile($filename)
     {
-        $loaded = $this->_parseIniFile($filename);
+        $loaded = @parse_ini_file($filename, true);
+        if ($loaded === false) {
+            $err = error_get_last();
+            throw new Exception\RuntimeException($err['message']);
+        }
+
         $iniArray = array();
         foreach ($loaded as $key => $data)
         {

--- a/library/Zend/Config/Json.php
+++ b/library/Zend/Config/Json.php
@@ -102,15 +102,12 @@ class Json extends Config
             }
         }
 
-        set_error_handler(array($this, '_loadFileErrorHandler')); // Warnings and errors are suppressed
         if ($json[0] != '{') {
-            $json = file_get_contents($json);
-        }
-        restore_error_handler();
-
-        // Check if there was a error while loading file
-        if ($this->_loadFileErrorStr !== null) {
-            throw new Exception\RuntimeException($this->_loadFileErrorStr);
+            $json = @file_get_contents($json);
+            if ($json === false) {
+                $err = error_get_last();
+                throw new Exception\RuntimeException($err['message']);
+            }
         }
 
         // Replace constants
@@ -229,8 +226,8 @@ class Json extends Config
 
     /**
      * Flatten JSON object structure to associative array
-     * 
-     * @param  object|array $config 
+     *
+     * @param  object|array $config
      * @return array
      */
     protected function flattenObjects($config)

--- a/library/Zend/Config/Xml.php
+++ b/library/Zend/Config/Xml.php
@@ -84,17 +84,34 @@ class Xml extends Config
             }
         }
 
-        set_error_handler(array($this, '_loadFileErrorHandler')); // Warnings and errors are suppressed
+        // load XML and throw exception of each failure using previous exception
+        $oldUseInternalErrors = libxml_use_internal_errors(true);
+        if ($oldUseInternalErrors) {
+            libxml_clear_errors();
+        }
         if (strstr($xml, '<' . '?xml')) { // string concat to fix syntax highlighting
             $config = simplexml_load_string($xml);
         } else {
             $config = simplexml_load_file($xml);
         }
+        $xmlErrors = libxml_get_errors();
+        if (!$oldUseInternalErrors) {
+            libxml_use_internal_errors(false);
+        }
+        if ( ($xmlErrorCnt = count($xmlErrors)) ) {
+            libxml_clear_errors();
 
-        restore_error_handler();
-        // Check if there was a error while loading file
-        if ($this->_loadFileErrorStr !== null) {
-            throw new Exception\InvalidArgumentException($this->_loadFileErrorStr);
+            // create and throw exception stack
+            $e = null;
+            foreach ($xmlErrors as $xmlError) {
+                $e = new Exception\InvalidArgumentException(
+                    trim($xmlError->message)
+                    . ' @ line/column ' . $xmlError->line . '/' . $xmlError->column,
+                    0,
+                    $e
+                );
+            }
+            throw $e;
         }
 
         if ($section === null) {

--- a/library/Zend/Config/Yaml.php
+++ b/library/Zend/Config/Yaml.php
@@ -158,14 +158,11 @@ class Yaml extends Config
             }
         }
 
-        // Suppress warnings and errors while loading file
-        set_error_handler(array($this, '_loadFileErrorHandler'));
-        $yaml = file_get_contents($yaml);
-        restore_error_handler();
-
-        // Check if there was a error while loading file
-        if ($this->_loadFileErrorStr !== null) {
-            throw new Exception\RuntimeException($this->_loadFileErrorStr);
+        // read the yaml file
+        $yaml = @file_get_contents($yaml);
+        if ($yaml === false) {
+            $err = error_get_last();
+            throw new Exception\RuntimeException($err['message']);
         }
 
         // Override static value for ignore_constants if provided in $options

--- a/tests/Zend/Config/XmlTest.php
+++ b/tests/Zend/Config/XmlTest.php
@@ -181,11 +181,24 @@ class XmlTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group ZF-3578
+     * @group ZF2-13
      */
     public function testInvalidXmlFile()
     {
-        $this->setExpectedException('Zend\Config\Exception\InvalidArgumentException', 'parser error');
-        $config = new Xml($this->_xmlFileInvalid);
+        try {
+            $config = new Xml($this->_xmlFileInvalid);
+            $this->fail('Missing expected exception');
+        } catch (\Zend\Config\Exception\InvalidArgumentException $e) {
+            // read exception stack
+            do {
+                $stack[] = $e;
+            } while ( ($e = $e->getPrevious()) );
+
+            // test two thrown xml errors
+            $this->assertEquals(2, count($stack));
+            $this->assertContains('tag mismatch', $stack[0]->getMessage());
+            $this->assertContains('undefined', $stack[1]->getMessage());
+        }
     }
 
     /**

--- a/tests/Zend/Config/_files/invalid.xml
+++ b/tests/Zend/Config/_files/invalid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config>
     <a extends="c">
-        <someKey>value_A</someKey>
+        <someKey>InvalidValue &undefined;</someKey>
     </a>
     <b extends="a">
         <someKey>value_B</someKey>


### PR DESCRIPTION
- on file_get_contents +parse_ini_file simply hide errors and on failure (returned false) get the last error to thow exception
- on simplexml_load_[string|file] use libxml error handler and throw exception of each reported error using previous exception
