### PR TITLE
parent and child class names in navigation menu

### DIFF
--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -447,7 +447,7 @@ class Menu extends AbstractHelper
             }
 
             // render li tag and page
-            $liClass = $isActive ? ' class="active"' : '';
+            $liClass = $isActive ? (' class="active ' . ((null !== $foundPage && $depth == $foundDepth-1) ? 'child' : 'parent').'"') : '';
             $html .= $myIndent . '    <li' . $liClass . '>' . self::EOL
                    . $myIndent . '        ' . $this->htmlify($page) . self::EOL;
 
@@ -605,8 +605,8 @@ class Menu extends AbstractHelper
         if (is_array($partial)) {
             if (count($partial) != 2) {
                 $e = new View\Exception(
-                    'Unable to render menu: A view partial supplied as ' 
-                    .  'an array must contain two values: partial view ' 
+                    'Unable to render menu: A view partial supplied as '
+                    .  'an array must contain two values: partial view '
                     .  'script and module where script can be found'
                 );
                 $e->setView($this->view);


### PR DESCRIPTION
This small change ease css selections for the menu, it adds parent and child class names to the active class name, so html will be like
...
li class="active parent"..
..... li class="active child"..
this was really helpful for me in some of my projects
