### PR TITLE
Zend_Tool namespace separator

### DIFF
--- a/library/Zend/Tool/Project/Provider/Application.php
+++ b/library/Zend/Tool/Project/Provider/Application.php
@@ -51,8 +51,8 @@ class Application
         
         $originalClassNamePrefix = $classNamePrefix;
         
-        if (substr($classNamePrefix, -1) != '_') {
-            $classNamePrefix .= '_';
+        if (substr($classNamePrefix, -1) != '\\') {
+            $classNamePrefix .= '\\';
         }
         
         $configFileResource = $profile->search('ApplicationConfigFile');
@@ -90,5 +90,4 @@ class Application
         // store profile
         $this->_storeProfile();
     }
-    
 }


### PR DESCRIPTION
I changed the namespace separator in Zend\Tool  from '_' to '\'
