### PR TITLE
[ZF2-19]Rename Signal to Event on CallbackHandlerTest

### DIFF
--- a/tests/Zend/Stdlib/CallbackHandlerTest.php
+++ b/tests/Zend/Stdlib/CallbackHandlerTest.php
@@ -41,10 +41,10 @@ class CallbackHandlerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testGetSignalShouldReturnSignal()
+    public function testGetEventShouldReturnEvent()
     {
         $handler = new CallbackHandler('foo', 'rand');
-        $this->assertEquals('foo', $handler->getSignal());
+        $this->assertEquals('foo', $handler->getEvent());
     }
 
     public function testCallbackShouldBeStringIfNoHandlerPassedToConstructor()


### PR DESCRIPTION
Because CallbackHandlerTest calls undefined method getSignal(), so modify getSignal() to getEvent()
http://framework.zend.com/issues/browse/ZF2-19
