### PR TITLE
fix - shortend-url in README-GIT not work

### DIFF
--- a/README-GIT.txt
+++ b/README-GIT.txt
@@ -56,7 +56,7 @@ github or other public site, or setup/use your own repository.
   Option 2: Personal Repository
   -----------------------------
 
-  We assume you will use gitosis (http://short.e/m6t2pn) or gitolite
+  We assume you will use gitosis (http://progit.org/book/ch4-7.html) or gitolite
   (http://progit.org/book/ch4-8.html) to host your own repository.  If
   you go this route, we will assume you have the knowledge to do so, or
   know where to obtain it. We will not assist you in setting up such a


### PR DESCRIPTION
Maybe main site is 
http://eagain.net/gitweb/?p=gitosis.git .
But above url is not good for guide, and Gitolite's link is ProGit's, so I fix url as just this commit.
