### PR TITLE
[ZF-10728] Added code to expose /ldml/numbers/defaultNumberingSystem in Zend\Locale\Data\Cldr


### DIFF
--- a/library/Zend/Locale/Data/Cldr.php
+++ b/library/Zend/Locale/Data/Cldr.php
@@ -1075,6 +1075,10 @@ class Cldr extends AbstractLocale
                 $temp = self::_getFile('main/' . $locale, '/ldml/dates/calendars/calendar[@type=\'' . $value[0] . '\']/fields/field/relative[@type=\'' . $value[1] . '\']', '', $value[1]);
                 break;
 
+            case 'defaultnumberingsystem':
+                $temp = self::_getFile($locale, '/ldml/numbers/defaultNumberingSystem', '', 'default');
+                break;
+
             case 'decimalnumber':
                 $temp = self::_getFile('main/' . $locale, '/ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat/pattern', '', 'default');
                 break;

--- a/tests/Zend/Locale/CldrTest.php
+++ b/tests/Zend/Locale/CldrTest.php
@@ -736,6 +736,16 @@ class CldrTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * test for reading defaultNumberingSystem from locale data
+     * @group ZF-10728
+     */
+    public function testDefaultNumberingSystem()
+    {
+        $value = Zend_Locale_Data::getContent('de_AT', 'defaultnumberingsystem');
+        $this->assertEquals('latn', $value);
+    }
+    
+    /**
      * test for reading decimalnumber from locale
      * expected array
      */


### PR DESCRIPTION
ZF-10728
Zend\Locale
Added code to expose /ldml/numbers/defaultNumberingSystem in Zend\Locale\Data\Cldr
