### PR TITLE
ZF Tool Broken (ZF1 Classnames) & wrong method in ErrorController

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 nbproject
-
+.buildpath
+.project
+.settings/

--- a/library/Zend/Locale/Data/AbstractLocale.php
+++ b/library/Zend/Locale/Data/AbstractLocale.php
@@ -234,13 +234,11 @@ abstract class AbstractLocale
         throw new UnsupportedMethod('This implementation does not support the selected locale information');
     }
 
-    public static function toInteger()
-    public static function toFloat()
-    public static function toDecimal()
-    public static function toScientific()
-
-    public static function toCurrency()
-
-    public static function toArray()
-    public static function toDateString()
+    public static function toInteger();
+    public static function toFloat();
+    public static function toDecimal();
+    public static function toScientific();
+    public static function toCurrency();
+    public static function toArray();
+    public static function toDateString();
 }

--- a/library/Zend/Tool/Framework/Client/Console/Console.php
+++ b/library/Zend/Tool/Framework/Client/Console/Console.php
@@ -148,7 +148,7 @@ class Console
                 );
         }
 
-        // which classes are essential to initializing Zend_Tool_Framework_Client_Console
+        // which classes are essential to initializing Zend\Tool\Framework\Client\Console
         $classesToLoad = array(
             'Zend\Tool\Framework\Client\Console\Manifest',    
             'Zend\Tool\Framework\System\Manifest'

--- a/library/Zend/Tool/Framework/Client/Console/HelpSystem.php
+++ b/library/Zend/Tool/Framework/Client/Console/HelpSystem.php
@@ -353,7 +353,7 @@ class HelpSystem
         Metadata\Tool $actionMetadata,
         Metadata\Tool $specialtyMetadata,
         Metadata\Tool $parameterLongMetadata)//,
-        //Zend_Tool_Framework_Metadata_Tool $parameterShortMetadata)
+        //Zend\Tool\Framework\Metadata\Tool $parameterShortMetadata)
     {
         $this->_response->appendContent(
             '    zf ' . $actionMetadata->getValue() . ' ' . $providerMetadata->getValue(),

--- a/library/Zend/Tool/Framework/Client/Interactive/InputHandler.php
+++ b/library/Zend/Tool/Framework/Client/Interactive/InputHandler.php
@@ -54,7 +54,7 @@ class InputHandler
         if (is_string($inputRequest)) {
             $inputRequest = new InputRequest($inputRequest);
         } elseif (!$inputRequest instanceof InputRequest) {
-            throw new Client\Exception('promptInteractive() requires either a string or an instance of Zend_Tool_Framework_Client_Interactive_InputRequest.');
+            throw new Client\Exception('promptInteractive() requires either a string or an instance of Zend\\Tool\Framework\\Client\\Interactive\\InputRequest.');
         }
 
         $this->_inputRequest = $inputRequest;
@@ -68,7 +68,7 @@ class InputHandler
         if (is_string($inputResponse)) {
             $inputResponse = new InputResponse($inputResponse);
         } elseif (!$inputResponse instanceof InputResponse) {
-            throw new Client\Exception('The registered $_interactiveCallback for the client must either return a string or an instance of Zend_Tool_Framework_Client_Interactive_InputResponse.');
+            throw new Client\Exception('The registered $_interactiveCallback for the client must either return a string or an instance of Zend\\Tool\\Framework\\Client\\Interactive\\InputResponse.');
         }
 
         return $inputResponse;

--- a/library/Zend/Tool/Framework/Loader.php
+++ b/library/Zend/Tool/Framework/Loader.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Framework;
 
 /**
- * Basic Interface for factilities that load Zend_Tool providers or manifests.
+ * Basic Interface for factilities that load Zend\Tool providers or manifests.
  *
  * @category   Zend
  * @package    Zend_Tool

--- a/library/Zend/Tool/Framework/Loader/AbstractLoader.php
+++ b/library/Zend/Tool/Framework/Loader/AbstractLoader.php
@@ -108,14 +108,14 @@ abstract class AbstractLoader implements Loader, RegistryEnabled
 
             // reflect class to see if its something we want to load
             $reflectionClass = new \ReflectionClass($loadedClass);
-            if ($reflectionClass->implementsInterface('Zend_Tool_Framework_Manifest_Interface')
+            if ($reflectionClass->implementsInterface('Zend\\Tool\\Framework\\Manifest\\Interface')
                 && !$reflectionClass->isAbstract())
             {
                 $manifestRepository->addManifest($reflectionClass->newInstance());
                 $this->_loadedClasses[] = $loadedClass;
             }
 
-            if ($reflectionClass->implementsInterface('Zend_Tool_Framework_Provider_Interface')
+            if ($reflectionClass->implementsInterface('Zend\\Tool\\Framework\\Provider\\Interface')
                 && !$reflectionClass->isAbstract()
                 && !$providerRepository->hasProvider($reflectionClass->getName(), false))
             {

--- a/library/Zend/Tool/Framework/Loader/BasicLoader.php
+++ b/library/Zend/Tool/Framework/Loader/BasicLoader.php
@@ -44,7 +44,7 @@ use Zend\Tool\Framework\Loader,
 class BasicLoader implements Loader, RegistryEnabled
 {
     /**
-     * @var Zend_Tool_Framework_Repository_Interface
+     * @var Zend\Tool\Framework\Repository\Interface
      */
     protected $_registry = null;
 

--- a/library/Zend/Tool/Framework/Manifest.php
+++ b/library/Zend/Tool/Framework/Manifest.php
@@ -47,7 +47,7 @@ interface Manifest
      * Should either return a single metadata object or an array
      * of metadata objects
      *
-     * @return array|Zend_Tool_Framework_Manifest_Metadata
+     * @return array|Zend\Tool\Framework\Manifest\Metadata
      **
 
     public function getMetadata();

--- a/library/Zend/Tool/Framework/Manifest/MetadataManifestable.php
+++ b/library/Zend/Tool/Framework/Manifest/MetadataManifestable.php
@@ -41,7 +41,7 @@ interface MetadataManifestable extends Manifest
      * Should either return a single metadata object or an array
      * of metadata objects
      *
-     * @return array|Zend_Tool_Framework_Manifest_Metadata
+     * @return array|Zend\Tool\Framework\Manifest\Metadata
      */
     public function getMetadata();
 

--- a/library/Zend/Tool/Framework/Manifest/Repository.php
+++ b/library/Zend/Tool/Framework/Manifest/Repository.php
@@ -115,7 +115,7 @@ class Repository implements RegistryEnabled, \IteratorAggregate, \Countable
                 if (!$provider instanceof \Zend\Tool\Framework\Provider) {
                     throw new Exception\InvalidArgumentException(
                         'A provider provided by the ' . get_class($manifest)
-                        . ' does not implement Zend_Tool_Framework_Provider_Interface'
+                        . ' does not implement Zend\\Tool\\Framework\\Provider\\Interface'
                         );
                 }
                 if (!$providerRepository->hasProvider($provider, false)) {
@@ -160,7 +160,7 @@ class Repository implements RegistryEnabled, \IteratorAggregate, \Countable
     /**
      * addMetadata() - add a metadata peice by peice
      *
-     * @param Zend_Tool_Framework_Manifest_Metadata $metadata
+     * @param Zend\Tool\Framework\Manifest\Metadata $metadata
      * @return \Zend\Tool\Framework\Manifest\Repository
      */
     public function addMetadata(Metadata $metadata)
@@ -193,7 +193,7 @@ class Repository implements RegistryEnabled, \IteratorAggregate, \Countable
                     
                     if (!$metadata instanceof Metadata) {
                         throw new Exception\RuntimeException(
-                            'A Zend_Tool_Framework_Metadata_Interface object was not found in manifest ' . get_class($manifest)
+                            'A Zend\\Tool\\Framework\\Metadata\\Interface object was not found in manifest ' . get_class($manifest)
                             );
                     }
 
@@ -217,7 +217,7 @@ class Repository implements RegistryEnabled, \IteratorAggregate, \Countable
      *
      * @param array $searchProperties
      * @param bool $includeNonExistentProperties
-     * @return Zend_Tool_Framework_Manifest_Metadata[]
+     * @return Zend\Tool\Framework\Manifest\Metadata[]
      */
     public function getMetadatas(Array $searchProperties = array(), $includeNonExistentProperties = true)
     {
@@ -259,7 +259,7 @@ class Repository implements RegistryEnabled, \IteratorAggregate, \Countable
      *
      * @param array $searchProperties
      * @param bool $includeNonExistentProperties
-     * @return Zend_Tool_Framework_Manifest_Metadata
+     * @return Zend\Tool\Framework\Manifest\Metadata
      */
     public function getMetadata(Array $searchProperties = array(), $includeNonExistentProperties = true)
     {

--- a/library/Zend/Tool/Framework/Provider/Repository.php
+++ b/library/Zend/Tool/Framework/Provider/Repository.php
@@ -63,7 +63,7 @@ class Repository implements RegistryEnabled, \IteratorAggregate, \Countable
     protected $_providerSignatures = array();
 
     /**
-     * @var array Array of Zend_Tool_Framework_Provider_Inteface
+     * @var array Array of Zend\Tool\Framework\Provider\Inteface
      */
     protected $_providers = array();
 

--- a/library/Zend/Tool/Framework/Provider/Signature.php
+++ b/library/Zend/Tool/Framework/Provider/Signature.php
@@ -27,7 +27,7 @@ use Zend\Tool\Framework\Provider,
     Zend\Tool\Framework\RegistryEnabled;
 
 /**
- * The purpose of Zend_Tool_Framework_Provider_Signature is to derive
+ * The purpose of Zend\Tool\Framework\Provider\Signature is to derive
  * callable signatures from the provided provider.
  *
  * @uses       \Zend\Reflection\ReflectionClass
@@ -301,10 +301,10 @@ class Signature implements RegistryEnabled
             }
 
             /**
-             * check to see if the method was a required method by a Zend_Tool_* interface
+             * check to see if the method was a required method by a Zend\Tool\* interface
              */
             foreach ($method->getDeclaringClass()->getInterfaces() as $methodDeclaringClassInterface) {
-                if (strpos($methodDeclaringClassInterface->getName(), 'Zend_Tool_') === 0
+                if (strpos($methodDeclaringClassInterface->getName(), 'Zend\\Tool\\') === 0
                     && $methodDeclaringClassInterface->hasMethod($methodName)) {
                     continue 2;
                 }

--- a/library/Zend/Tool/Framework/Registry/FrameworkRegistry.php
+++ b/library/Zend/Tool/Framework/Registry/FrameworkRegistry.php
@@ -411,7 +411,7 @@ class FrameworkRegistry implements Registry
     public function enableRegistryOnObject($object)
     {
         if (!$this->isObjectRegistryEnablable($object)) {
-            throw new Exception\InvalidArgumentException('Object provided is not registry enablable, check first with Zend_Tool_Framework_Registry::isObjectRegistryEnablable()');
+            throw new Exception\InvalidArgumentException('Object provided is not registry enablable, check first with Zend\\Tool\\Framework\\Registry::isObjectRegistryEnablable()');
         }
 
         $object->setRegistry($this);

--- a/library/Zend/Tool/Framework/System/Provider/Config.php
+++ b/library/Zend/Tool/Framework/System/Provider/Config.php
@@ -61,7 +61,7 @@ class Config extends AbstractProvider
      */
     public function create()
     {
-        /* @var $userConfig Zend_Tool_Framework_Client_Config */
+        /* @var $userConfig Zend\Tool\Framework\Client\Config */
         $userConfig = $this->_registry->getConfig();
 
         $resp = $this->_registry->getResponse();
@@ -239,7 +239,7 @@ class Config extends AbstractProvider
     {
         end\Loader::loadClass($className);
         $reflClass = new \ReflectionClass($className);
-        if (!in_array("Zend_Tool_Framework_Manifest_Interface", $reflClass->getInterfaceNames())) {
+        if (!in_array("Zend\\Tool\\Framework\\Manifest\\Interface", $reflClass->getInterfaceNames())) {
             throw new Framework\Exception("Given class is not a manifest.");
         }
         $this->_doEnable($className);
@@ -293,7 +293,7 @@ class Config extends AbstractProvider
      */
     protected function _loadUserConfigIfExists()
     {
-        /* @var $userConfig Zend_Tool_Framework_Client_Config */
+        /* @var $userConfig Zend\Tool\Framework\Client\Config */
         $userConfig = $this->_registry->getConfig();
 
         $resp = $this->_registry->getResponse();

--- a/library/Zend/Tool/Project/Context/Content/Engine.php
+++ b/library/Zend/Tool/Project/Context/Content/Engine.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Content;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Content/Engine/CodeGenerator.php
+++ b/library/Zend/Tool/Project/Context/Content/Engine/CodeGenerator.php
@@ -26,7 +26,7 @@ namespace Zend\Tool\Project\Context\Content\Engine;
 use Zend\Tool\Project\Context;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Content/Engine/Phtml.php
+++ b/library/Zend/Tool/Project/Context/Content/Engine/Phtml.php
@@ -26,7 +26,7 @@ namespace Zend\Tool\Project\Context\Content\Engine;
 use Zend\Tool\Project\Context;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Filesystem/AbstractFilesystem.php
+++ b/library/Zend/Tool/Project/Context/Filesystem/AbstractFilesystem.php
@@ -27,7 +27,7 @@ namespace Zend\Tool\Project\Context\Filesystem;
 use Zend\Tool\Project\Profile\Resource\Resource;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Filesystem/Directory.php
+++ b/library/Zend/Tool/Project/Context/Filesystem/Directory.php
@@ -27,7 +27,7 @@ namespace Zend\Tool\Project\Context\Filesystem;
 use Zend\Tool\Project\Profile\Resource\Resource;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Filesystem/File.php
+++ b/library/Zend/Tool/Project/Context/Filesystem/File.php
@@ -27,7 +27,7 @@ namespace Zend\Tool\Project\Context\Filesystem;
 use Zend\Tool\Project\Profile\Resource\Resource;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/System.php
+++ b/library/Zend/Tool/Project/Context/System.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/System/NotOverwritable.php
+++ b/library/Zend/Tool/Project/Context/System/NotOverwritable.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\System;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/System/ProjectDirectory.php
+++ b/library/Zend/Tool/Project/Context/System/ProjectDirectory.php
@@ -27,7 +27,7 @@ use Zend\Tool\Project\Context\System,
     Zend\Tool\Project\Context\Exception;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/System/ProjectProfileFile.php
+++ b/library/Zend/Tool/Project/Context/System/ProjectProfileFile.php
@@ -26,7 +26,7 @@ namespace Zend\Tool\Project\Context\System;
 use Zend\Tool\Project\Context\System;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/System/ProjectProvidersDirectory.php
+++ b/library/Zend/Tool/Project/Context/System/ProjectProvidersDirectory.php
@@ -26,7 +26,7 @@ namespace Zend\Tool\Project\Context\System;
 use Zend\Tool\Project\Context\System;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/System/TopLevelRestrictable.php
+++ b/library/Zend/Tool/Project/Context/System/TopLevelRestrictable.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\System;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/AbstractClassFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/AbstractClassFile.php
@@ -27,7 +27,7 @@ namespace Zend\Tool\Project\Context\Zf;
 use Zend\Tool\Project\Profile\Resource\Resource;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ActionMethod.php
+++ b/library/Zend/Tool/Project/Context/Zf/ActionMethod.php
@@ -30,7 +30,7 @@ use Zend\Tool\Project\Context\Context,
     Zend\Tool\Project\Profile\Resource\Resource;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ApisDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/ApisDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ApplicationConfigFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/ApplicationConfigFile.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ApplicationDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/ApplicationDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/BootstrapFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/BootstrapFile.php
@@ -26,7 +26,7 @@ namespace Zend\Tool\Project\Context\Zf;
 use Zend\Tool\Project\Context\Exception;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/CacheDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/CacheDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ConfigFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/ConfigFile.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ConfigsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/ConfigsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ControllerFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/ControllerFile.php
@@ -174,8 +174,9 @@ EOS
                             new Php\PhpMethod(array(
                                 'name' => 'getLog',
                                 'body' => <<<'EOS'
+/* @var $bootstrap Zend\Application\Bootstrap */
 $bootstrap = $this->getInvokeArg('bootstrap');
-if (!$bootstrap->hasPluginResource('Log')) {
+if (!$bootstrap->hasResource('Log')) {
     return false;
 }
 $log = $bootstrap->getResource('Log');

--- a/library/Zend/Tool/Project/Context/Zf/ControllerFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/ControllerFile.php
@@ -26,7 +26,7 @@ namespace Zend\Tool\Project\Context\Zf;
 use Zend\CodeGenerator\Php;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ControllersDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/ControllersDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/DataDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/DataDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/DbTableDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/DbTableDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/DbTableFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/DbTableFile.php
@@ -26,7 +26,7 @@ namespace Zend\Tool\Project\Context\Zf;
 use Zend\CodeGenerator\Php;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/DocsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/DocsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/FormFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/FormFile.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/FormsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/FormsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/HtaccessFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/HtaccessFile.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/LayoutScriptFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/LayoutScriptFile.php
@@ -26,7 +26,7 @@ namespace Zend\Tool\Project\Context\Zf;
 use Zend\Tool\Project\Context\Exception;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/LayoutScriptsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/LayoutScriptsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/LayoutsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/LayoutsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/LibraryDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/LibraryDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/LocalesDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/LocalesDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/LogsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/LogsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ModelFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/ModelFile.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ModelsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/ModelsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ModuleDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/ModuleDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ModulesDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/ModulesDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ProjectProviderFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/ProjectProviderFile.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/PublicDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/PublicDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/PublicImagesDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/PublicImagesDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/PublicIndexFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/PublicIndexFile.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/PublicScriptsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/PublicScriptsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/PublicStylesheetsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/PublicStylesheetsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/SearchIndexesDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/SearchIndexesDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/SessionsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/SessionsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/TemporaryDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/TemporaryDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/TestApplicationBootstrapFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/TestApplicationBootstrapFile.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/TestApplicationControllerDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/TestApplicationControllerDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/TestApplicationControllerFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/TestApplicationControllerFile.php
@@ -26,7 +26,7 @@ namespace Zend\Tool\Project\Context\Zf;
 use Zend\CodeGenerator\Php;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/TestApplicationDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/TestApplicationDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/TestLibraryBootstrapFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/TestLibraryBootstrapFile.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/TestLibraryDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/TestLibraryDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/TestLibraryFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/TestLibraryFile.php
@@ -26,7 +26,7 @@ namespace Zend\Tool\Project\Context\Zf;
 use Zend\CodeGenerator\Php;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/TestLibraryNamespaceDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/TestLibraryNamespaceDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/TestPHPUnitConfigFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/TestPHPUnitConfigFile.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/TestsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/TestsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/UploadsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/UploadsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ViewControllerScriptsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/ViewControllerScriptsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ViewFiltersDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/ViewFiltersDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ViewHelpersDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/ViewHelpersDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ViewScriptFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/ViewScriptFile.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.
@@ -82,7 +82,7 @@ class ViewScriptFile extends \Zend\Tool\Project\Context\Filesystem\File
             $this->_scriptName = $scriptName;
             $this->_filesystemName = $scriptName . '.phtml';
         } else {
-            throw Zend_Tool_Project_Exception('Either a forActionName or scriptName is required.');
+            throw Zend\Tool\Project\Exception('Either a forActionName or scriptName is required.');
         }
 
         parent::init();

--- a/library/Zend/Tool/Project/Context/Zf/ViewScriptsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/ViewScriptsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ViewsDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/ViewsDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Context/Zf/ZfStandardLibraryDirectory.php
+++ b/library/Zend/Tool/Project/Context/Zf/ZfStandardLibraryDirectory.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Context\Zf;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Profile/FileParser/Xml.php
+++ b/library/Zend/Tool/Project/Profile/FileParser/Xml.php
@@ -153,7 +153,7 @@ class Xml implements FileParser
     protected function _serializeRecurser($resources, \SimpleXmlElement $xmlNode)
     {
         // @todo find a better way to handle concurrency.. if no clone, _position in node gets messed up
-        //if ($resources instanceof Zend_Tool_Project_Profile_Resource) {
+        //if ($resources instanceof Zend\Tool\Project\Profile\Resource) {
         //    $resources = clone $resources;
         //}
 

--- a/library/Zend/Tool/Project/Profile/Profile.php
+++ b/library/Zend/Tool/Project/Profile/Profile.php
@@ -25,7 +25,7 @@
 namespace Zend\Tool\Project\Profile;
 
 /**
- * This class is the front most class for utilizing Zend_Tool_Project
+ * This class is the front most class for utilizing Zend\Tool\Project
  *
  * A profile is a hierarchical set of resources that keep track of
  * items within a specific project.

--- a/library/Zend/Tool/Project/Profile/Resource/Container.php
+++ b/library/Zend/Tool/Project/Profile/Resource/Container.php
@@ -181,7 +181,7 @@ class Container implements \RecursiveIterator, \Countable
                 throw new Exception\InvalidArgumentException('Context by name ' . $context . ' was not found in the context registry.');
             }
         } elseif (!$context instanceof \Zend\Tool\Project\Context) {
-            throw new Exception\InvalidArgumentException('Context must be of type string or Zend_Tool_Project_Context_Interface.');
+            throw new Exception\InvalidArgumentException('Context must be of type string or Zend\\Tool\\Project\\Context\\Interface.');
         }
 
         $newResource = new Resource($context);

--- a/library/Zend/Tool/Project/Profile/Resource/Resource.php
+++ b/library/Zend/Tool/Project/Profile/Resource/Resource.php
@@ -56,7 +56,7 @@ class Resource extends Container
     /**#@-*/
 
     /**
-     * @var Zend_Tool_Project_Context|string
+     * @var Zend\Tool\Project\Context|string
      */
     protected $_context = null;
 

--- a/library/Zend/Tool/Project/Provider/Action.php
+++ b/library/Zend/Tool/Project/Provider/Action.php
@@ -55,11 +55,11 @@ class Action
     {
 
         if (!is_string($actionName)) {
-            throw new Exception\RuntimeException('Zend_Tool_Project_Provider_Action::createResource() expects \"actionName\" is the name of a action resource to create.');
+            throw new Exception\RuntimeException('Zend\\Tool\\Project\\Provider\\Action::createResource() expects \"actionName\" is the name of a action resource to create.');
         }
 
         if (!is_string($controllerName)) {
-            throw new Exception\RuntimeException('Zend_Tool_Project_Provider_Action::createResource() expects \"controllerName\" is the name of a controller resource to create.');
+            throw new Exception\RuntimeException('Zend\\Tool\\Project\\Provider\\Action::createResource() expects \"controllerName\" is the name of a controller resource to create.');
         }
 
         $controllerFile = self::_getControllerFileResource($profile, $controllerName, $moduleName);
@@ -81,11 +81,11 @@ class Action
     public static function hasResource(ProjectProfile $profile, $actionName, $controllerName, $moduleName = null)
     {
         if (!is_string($actionName)) {
-            throw new Exception\RuntimeException('Zend_Tool_Project_Provider_Action::createResource() expects \"actionName\" is the name of a action resource to create.');
+            throw new Exception\RuntimeException('Zend\\Tool\\Project\\Provider\\Action::createResource() expects \"actionName\" is the name of a action resource to create.');
         }
 
         if (!is_string($controllerName)) {
-            throw new Exception\RuntimeException('Zend_Tool_Project_Provider_Action::createResource() expects \"controllerName\" is the name of a controller resource to create.');
+            throw new Exception\RuntimeException('Zend\\Tool\\Project\\Provider\\Action::createResource() expects \"controllerName\" is the name of a controller resource to create.');
         }
 
         $controllerFile = self::_getControllerFileResource($profile, $controllerName, $moduleName);

--- a/library/Zend/Tool/Project/Provider/Controller.php
+++ b/library/Zend/Tool/Project/Provider/Controller.php
@@ -57,7 +57,7 @@ class Controller
     public static function createResource(ProjectProfile $profile, $controllerName, $moduleName = null)
     {
         if (!is_string($controllerName)) {
-            throw new Exception\RuntimeException('Zend_Tool_Project_Provider_Controller::createResource() expects \"controllerName\" is the name of a controller resource to create.');
+            throw new Exception\RuntimeException('Zend\\Tool\\Project\\Provider\\Controller::createResource() expects \"controllerName\" is the name of a controller resource to create.');
         }
 
         if (!($controllersDirectory = self::_getControllersDirectoryResource($profile, $moduleName))) {
@@ -88,7 +88,7 @@ class Controller
     public static function hasResource(ProjectProfile $profile, $controllerName, $moduleName = null)
     {
         if (!is_string($controllerName)) {
-            throw new Exception\RuntimeException('Zend_Tool_Project_Provider_Controller::createResource() expects \"controllerName\" is the name of a controller resource to create.');
+            throw new Exception\RuntimeException('Zend\\Tool\\Project\\Provider\\Controller::createResource() expects \"controllerName\" is the name of a controller resource to create.');
         }
 
         $controllersDirectory = self::_getControllersDirectoryResource($profile, $moduleName);

--- a/library/Zend/Tool/Project/Provider/DbTable.php
+++ b/library/Zend/Tool/Project/Provider/DbTable.php
@@ -160,7 +160,7 @@ class DbTable
         
         $bootstrapResource = $this->_loadedProfile->search('BootstrapFile');
         
-        /* @var $zendApp Zend_Application */
+        /* @var $zendApp Zend\Application */
         $zendApp = $bootstrapResource->getApplicationInstance();
         
         try {
@@ -170,7 +170,7 @@ class DbTable
             return;
         }
         
-        /* @var $db Zend_Db_Adapter_Abstract */
+        /* @var $db Zend\Db\Adapter\Abstract */
         $db = $zendApp->getBootstrap()->getResource('db');
         
         $tableResources = array();

--- a/library/Zend/Tool/Project/Provider/Form.php
+++ b/library/Zend/Tool/Project/Provider/Form.php
@@ -42,7 +42,7 @@ class Form extends AbstractProvider
     public static function createResource(ProjectProfile $profile, $formName, $moduleName = null)
     {
         if (!is_string($formName)) {
-            throw new Exception\RuntimeException('Zend_Tool_Project_Provider_Form::createResource() expects \"formName\" is the name of a form resource to create.');
+            throw new Exception\RuntimeException('Zend\\Tool\\Project\\Provider\\Form::createResource() expects \"formName\" is the name of a form resource to create.');
         }
 
         if (!($formsDirectory = self::_getFormsDirectoryResource($profile, $moduleName))) {
@@ -73,7 +73,7 @@ class Form extends AbstractProvider
     public static function hasResource(ProjectProfile $profile, $formName, $moduleName = null)
     {
         if (!is_string($formName)) {
-            throw new Exception\RuntimeException('Zend_Tool_Project_Provider_Form::createResource() expects \"formName\" is the name of a form resource to check for existence.');
+            throw new Exception\RuntimeException('Zend\\Tool\\Project\\Provider\\Form::createResource() expects \"formName\" is the name of a form resource to check for existence.');
         }
 
         $formsDirectory = self::_getFormsDirectoryResource($profile, $moduleName);
@@ -129,7 +129,7 @@ class Form extends AbstractProvider
 
             if ($testingEnabled) {
                 $testFormResource = null;
-                // $testFormResource = Zend_Tool_Project_Provider_Test::createApplicationResource($this->_loadedProfile, $name, 'index', $module);
+                // $testFormResource = Zend\Tool\Project\Provider\Test::createApplicationResource($this->_loadedProfile, $name, 'index', $module);
             }
 
         } catch (\Exception $e) {

--- a/library/Zend/Tool/Project/Provider/Model.php
+++ b/library/Zend/Tool/Project/Provider/Model.php
@@ -40,7 +40,7 @@ class Model extends AbstractProvider
     public static function createResource(ProjectProfile $profile, $modelName, $moduleName = null)
     {
         if (!is_string($modelName)) {
-            throw new Exception\RuntimeException('Zend_Tool_Project_Provider_Model::createResource() expects \"modelName\" is the name of a model resource to create.');
+            throw new Exception\RuntimeException('Zend\\Tool\\Project\\Provider\\Model::createResource() expects \"modelName\" is the name of a model resource to create.');
         }
 
         if (!($modelsDirectory = self::_getModelsDirectoryResource($profile, $moduleName))) {
@@ -71,7 +71,7 @@ class Model extends AbstractProvider
     public static function hasResource(ProjectProfile $profile, $modelName, $moduleName = null)
     {
         if (!is_string($modelName)) {
-            throw new Exception\RuntimeException('Zend_Tool_Project_Provider_Model::createResource() expects \"modelName\" is the name of a model resource to check for existence.');
+            throw new Exception\RuntimeException('Zend\\Tool\\Project\\Provider\\Model::createResource() expects \"modelName\" is the name of a model resource to check for existence.');
         }
 
         $modelsDirectory = self::_getModelsDirectoryResource($profile, $moduleName);
@@ -113,7 +113,7 @@ class Model extends AbstractProvider
         $name = ucwords($name);
         
         // determine if testing is enabled in the project
-        $testingEnabled = false; //Zend_Tool_Project_Provider_Test::isTestingEnabled($this->_loadedProfile);
+        $testingEnabled = false; //Zend\Tool\Project\Provider\Test::isTestingEnabled($this->_loadedProfile);
         $testModelResource = null;
 
         // Check that there is not a dash or underscore, return if doesnt match regex
@@ -145,7 +145,7 @@ class Model extends AbstractProvider
             $modelResource = self::createResource($this->_loadedProfile, $name, $module);
 
             if ($testingEnabled) {
-                // $testModelResource = Zend_Tool_Project_Provider_Test::createApplicationResource($this->_loadedProfile, $name, 'index', $module);
+                // $testModelResource = Zend\Tool\Project\Provider\Test::createApplicationResource($this->_loadedProfile, $name, 'index', $module);
             }
 
         } catch (\Exception $e) {

--- a/library/Zend/Tool/Project/Provider/Project.php
+++ b/library/Zend/Tool/Project/Provider/Project.php
@@ -165,7 +165,7 @@ class Project
             <uploadsDirectory enabled="false" />
         </dataDirectory>
         <docsDirectory>
-            <file filesystemName="README.txt" defaultContentCallback="Zend_Tool_Project_Provider_Project::getDefaultReadmeContents"/>
+            <file filesystemName="README.txt" defaultContentCallback="Zend\Tool\Project\Provider\Project::getDefaultReadmeContents"/>
         </docsDirectory>
         <libraryDirectory>
             <zfStandardLibraryDirectory enabled="false" />

--- a/library/Zend/Tool/Project/Provider/ProjectProvider.php
+++ b/library/Zend/Tool/Project/Provider/ProjectProvider.php
@@ -70,9 +70,9 @@ class ProjectProvider extends AbstractProvider
     }
 
     /**
-     * Create stub for Zend_Tool Project Provider
+     * Create stub for Zend\Tool Project Provider
      *
-     * @var string       $name            class name for new Zend_Tool Project Provider
+     * @var string       $name            class name for new Zend\Tool Project Provider
      * @var array|string $actions         list of provider methods
      * @throws \Zend\Tool\Project\Provider\Exception
      */

--- a/library/Zend/Tool/Project/Provider/Test.php
+++ b/library/Zend/Tool/Project/Provider/Test.php
@@ -64,11 +64,11 @@ class Test extends AbstractProvider
     public static function createApplicationResource(ProjectProfile $profile, $controllerName, $actionName, $moduleName = null)
     {
         if (!is_string($controllerName)) {
-            throw new Exception\RuntimeException('Zend_Tool_Project_Provider_View::createApplicationResource() expects \"controllerName\" is the name of a controller resource to create.');
+            throw new Exception\RuntimeException('Zend\\Tool\\Project\\Provider\\View::createApplicationResource() expects \"controllerName\" is the name of a controller resource to create.');
         }
 
         if (!is_string($actionName)) {
-            throw new Exception\RuntimeException('Zend_Tool_Project_Provider_View::createApplicationResource() expects \"actionName\" is the name of a controller resource to create.');
+            throw new Exception\RuntimeException('Zend\\Tool\\Project\\Provider\\View::createApplicationResource() expects \"actionName\" is the name of a controller resource to create.');
         }
 
         $testsDirectoryResource = $profile->search('testsDirectory');

--- a/library/Zend/Tool/Project/Provider/View.php
+++ b/library/Zend/Tool/Project/Provider/View.php
@@ -49,11 +49,11 @@ class View extends AbstractProvider
     public static function createResource(ProjectProfile $profile, $actionName, $controllerName, $moduleName = null)
     {
         if (!is_string($actionName)) {
-            throw new Exception\RuntimeException('Zend_Tool_Project_Provider_View::createResource() expects \"actionName\" is the name of a controller resource to create.');
+            throw new Exception\RuntimeException('Zend\\Tool\\Project\\Provider\\View::createResource() expects \"actionName\" is the name of a controller resource to create.');
         }
 
         if (!is_string($controllerName)) {
-            throw new Exception\RuntimeException('Zend_Tool_Project_Provider_View::createResource() expects \"controllerName\" is the name of a controller resource to create.');
+            throw new Exception\RuntimeException('Zend\\Tool\\Project\\Provider\\View::createResource() expects \"controllerName\" is the name of a controller resource to create.');
         }
 
         $profileSearchParams = array();


### PR DESCRIPTION
I cleaned out the ZF1 classnames in the ZF Tool Component.

This was needed to make the ZF script work again... I got a 'Cannot redeclare Zend\Tool\Project\Provider\Project' error which was caused by the loading of Zend_Tool_Project_Provider_Project somewhere. 

So I just changed all ZF1 classnames to ZF2
