### PR TITLE
fixed problems when using third-party autoloaders

### DIFF
--- a/library/Zend/Feed/Writer/Feed.php
+++ b/library/Zend/Feed/Writer/Feed.php
@@ -246,7 +246,7 @@ class Feed extends AbstractFeed implements \Iterator, \Countable
             throw new Exception('Invalid feed type specified: ' . $type . '.'
             . ' Should be one of "rss" or "atom".');
         }
-        $renderClass = 'Renderer\\Feed\\' . $type;
+        $renderClass = '\\Zend\\Feed\\Writer\\Renderer\\Feed\\' . $type;
         $renderer = new $renderClass($this);
         if ($ignoreExceptions) {
             $renderer->ignoreExceptions();


### PR DESCRIPTION
<pre>Fatal error: Class 'Renderer\Feed\Rss' not found in /var/www/my/stfalcon.com/vendor/zf2/library/Zend/Feed/Writer/Feed.php on line 252</pre>
