### PR TITLE
Added the support to retrieve informations on who retweeted a tweet

### DIFF
--- a/library/Zend/Service/Twitter.php
+++ b/library/Zend/Service/Twitter.php
@@ -904,6 +904,20 @@ class Twitter extends Rest\Client\RestClient
     }
 
     /**
+     * Returns an array of user objects that retweeted the tweets identified with the given $id
+     *
+     * @param integer $id  The Id of the tweet we want to know who retweeted
+     * @return \Zend\Rest\Client\Result
+     */
+    public function statusRetweetedBy($id)
+    {
+        $this->_init();
+        $path = '/1/statuses/' . $this->_validInteger($id) . '/retweeted_by.xml';
+        $response = $this->_get($path);
+        return new Rest\Client\Result($response->getBody());
+    }
+
+    /**
      * Protected function to validate that the integer is valid or return a 0
      * @param $int
      * @throws \Zend\Http\Client\Exception if HTTP request fails or times out

--- a/tests/Zend/Service/Twitter/TwitterTest.php
+++ b/tests/Zend/Service/Twitter/TwitterTest.php
@@ -600,5 +600,14 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
         $twitter2 = new Service\Twitter(array('username'=>'zftestuser2'));
         $this->assertFalse($twitter1->getLocalHttpClient() === $twitter2->getLocalHttpClient());
     }
+
+    public function testYouCanRetrieveTheUsersWhoRetweetedATweet()
+    {
+        $twitter = new Service\Twitter();
+        $response = $twitter->statusRetweetedBy(85607267692584960);
+
+        $this->assertTrue($response instanceof Rest\Client\Result);
+        $this->assertTrue(in_array('Alessandro Nadalin', $response->name));
+    }
     
 }


### PR DESCRIPTION
Hi there, I just added a new method in the Zend\Service\Twitter in order to retrieve informations about the users of retweeted a given tweet.

http://api.twitter.com/1/statuses/{id}/retweeted_by.json

I updated the PHPUnit related TestCase and everything works fine.

Hope this will help :)
