### PR TITLE
Fixed misplaced require statement in /bin/zfals.php

### DIFF
--- a/bin/zfals.php
+++ b/bin/zfals.php
@@ -13,8 +13,9 @@ if (!strstr($incPath, $libPath)) {
 }
 
 // Setup autoloading
-$loader = new Zend\Loader\StandardAutoloader();
 require_once 'Zend/Loader/StandardAutoloader.php';
+
+$loader = new Zend\Loader\StandardAutoloader();
 $loader->register();
 
 $rules = array(


### PR DESCRIPTION
Fixed a Class not found error in the classmap autoloader generator.
