### PR TITLE
StandardAutoloader should always honour the setting of the fallbackAutolo

### DIFF
--- a/library/Zend/Loader/StandardAutoloader.php
+++ b/library/Zend/Loader/StandardAutoloader.php
@@ -223,7 +223,7 @@ class StandardAutoloader implements SplAutoloader
         if (false !== strpos($class, self::NS_SEPARATOR)) {
             if ($this->loadClass($class, self::LOAD_NS)) {
                 return $class;
-            } elseif ($this->isFallbackAutoloader()) {
+            } elseif ($isFallback) {
                 return $this->loadClass($class, self::ACT_AS_FALLBACK);
             }
             return false;
@@ -231,12 +231,14 @@ class StandardAutoloader implements SplAutoloader
         if (false !== strpos($class, self::PREFIX_SEPARATOR)) {
             if ($this->loadClass($class, self::LOAD_PREFIX)) {
                 return $class;
-            } elseif ($this->isFallbackAutoloader()) {
+            } elseif ($isFallback) {
                 return $this->loadClass($class, self::ACT_AS_FALLBACK);
             }
             return false;
         }
-                return $this->loadClass($class, self::ACT_AS_FALLBACK);
+        if ($isFallback) {
+            return $this->loadClass($class, self::ACT_AS_FALLBACK);
+        }
         return false;
     }
 


### PR DESCRIPTION
My branch name is standardautoloader_fix

This patch fixes autoload() in StandardAutoloader so that it doesn't fallback when fallbackAutoloaderFlag is set to false and the class to be loaded doesn't have a namespace or prefix separator.

It also tidies up the use of $isFallback everywhere rather than use $this->isFallbackAutoloader() multiple times.
