### PR TITLE
Fix lack of escaping of values assigned to View\Variables via constructor

### DIFF
--- a/library/Zend/View/Variables.php
+++ b/library/Zend/View/Variables.php
@@ -73,10 +73,16 @@ class Variables extends ArrayObject
     public function __construct(array $variables = array(), array $options = array()) 
     {
         parent::__construct(
-            $variables, 
+            array(), 
             ArrayObject::STD_PROP_LIST|ArrayObject::ARRAY_AS_PROPS, 
             'ArrayIterator'
         );
+        
+        // Load each variable into the object using offsetSet() so that they
+        // are escaped correctly.
+        foreach($variables as $key => $value) {
+            $this->$key = $value;
+        }
         $this->setOptions($options);
     }
 

--- a/tests/Zend/View/VariablesTest.php
+++ b/tests/Zend/View/VariablesTest.php
@@ -130,6 +130,14 @@ class VariablesTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('baz', $this->vars['bar']);
     }
 
+    public function testValuesAssignedViaConstructorAreEscapedByDefault()
+    {
+        $string = '<tag id="foo">\'some string\'</tag>';
+        $vars = new Variables(array('foo'=>$string));
+        $expected = htmlspecialchars($string, ENT_COMPAT, 'UTF-8');
+        $this->assertEquals($expected, $vars['foo']);
+    }
+
     public function testValuesAreEscapedByDefault()
     {
         $string = '<tag id="foo">\'some string\'</tag>';


### PR DESCRIPTION
Variables assigned via the constructor need to be assigned via offsetSet in order to ensure that they are stored in escaped format
