### PR TITLE
hotfix/ZF2-26 Zend\Amf uses undefined Class "Zend\Server\Reflection\Reflection"

### DIFF
--- a/library/Zend/Amf/Adobe/Introspector.php
+++ b/library/Zend/Amf/Adobe/Introspector.php
@@ -105,7 +105,7 @@ class Introspector
         $this->_types = $this->_xml->createElement('types');
         $this->_ops   = $this->_xml->createElement('operations');
 
-        $r = \Zend\Server\Reflection\Reflection::reflectClass($serviceClass);
+        $r = \Zend\Server\Reflection::reflectClass($serviceClass);
         $this->_addService($r, $this->_ops);
 
         $serv->appendChild($this->_types);

--- a/library/Zend/Amf/Server.php
+++ b/library/Zend/Amf/Server.php
@@ -791,7 +791,7 @@ class Server implements \Zend\Server\Server
 
         $this->_classAllowed[is_object($class) ? get_class($class) : $class] = true;
 
-        $this->_methods[] = Reflection\Reflection::reflectClass($class, $argv, $namespace);
+        $this->_methods[] = Reflection::reflectClass($class, $argv, $namespace);
         $this->_buildDispatchTable();
 
         return $this;
@@ -825,7 +825,7 @@ class Server implements \Zend\Server\Server
             if (!is_string($func) || !function_exists($func)) {
                 throw new Exception\InvalidArgumentException('Unable to attach function');
             }
-            $this->_methods[] = Reflection\Reflection::reflectFunction($func, $argv, $namespace);
+            $this->_methods[] = Reflection::reflectFunction($func, $argv, $namespace);
         }
 
         $this->_buildDispatchTable();


### PR DESCRIPTION
updating Amf Reflction ClassName to Valid
http://framework.zend.com/issues/browse/ZF2-26
