### PR TITLE
[ZF2-11] Loading PEAR's Archive_Tar

### DIFF
--- a/library/Zend/Filter/Compress/Tar.php
+++ b/library/Zend/Filter/Compress/Tar.php
@@ -63,11 +63,9 @@ class Tar extends AbstractCompressionAlgorithm
     public function __construct($options = null)
     {
         if (!class_exists('Archive_Tar')) {
-            try {
-                \Zend\Loader::loadClass('Archive_Tar');
-            } catch (\Exception $e) {
-                throw new Exception\ExtensionNotLoadedException('This filter needs PEARs Archive_Tar', 0, $e);
-            }
+            throw new Exception\ExtensionNotLoadedException(
+                'This filter needs PEARs Archive_Tar.'.
+                'Ensure loading Archive_Tar (registering autoload or require_once)');
         }
 
         parent::__construct($options);

--- a/tests/Zend/Filter/Compress/TarLoadArchiveTarTest.php
+++ b/tests/Zend/Filter/Compress/TarLoadArchiveTarTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Filter
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Filter\Compress;
+
+use Zend\Filter\Compress\Tar as TarCompression,
+    Zend\Filter\Exception\ExtensionNotLoadedException,
+    Zend\Loader\StandardAutoloader;
+
+/**
+ * @category   Zend
+ * @package    Zend_Filter
+ * @subpackage UnitTests
+ * @group      Zend_Filter
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class TarLoadArchveTarTest extends \PHPUnit_Framework_TestCase
+{
+    public function testArchiveTarNotLoaded()
+    {
+        try {
+            $tar = new TarCompression;
+            $this->fail('ExtensionNotLoadedException was expected but not thrown');
+        } catch(ExtensionNotLoadedException $e) {
+        }
+    }
+}

--- a/tests/Zend/Filter/Compress/TarTest.php
+++ b/tests/Zend/Filter/Compress/TarTest.php
@@ -21,7 +21,8 @@
 
 namespace ZendTest\Filter\Compress;
 
-use Zend\Filter\Compress\Tar as TarCompression;
+use Zend\Filter\Compress\Tar as TarCompression,
+    Zend\Loader\StandardAutoloader;
 
 /**
  * @category   Zend
@@ -36,9 +37,9 @@ class TarTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         if (!class_exists('Archive_Tar')) {
-            try {
-                \Zend\Loader::loadClass('Archive_Tar');
-            } catch (\Zend\Loader\Exception $e) {
+            $autoloader = new StandardAutoloader();
+            $autoloader->setFallbackAutoloader(true);
+            if (!$autoloader->autoload('Archive_Tar')) {
                 $this->markTestSkipped('This filter needs PEARs Archive_Tar');
             }
         }


### PR DESCRIPTION
Removing Loader::loadClass.
Not Compatible for ZF1 loadClass - Must use autoload or including.
