### PR TITLE
Zend\CodeGenerator\Php revised.

### DIFF
--- a/library/Zend/CodeGenerator/Php/Docblock/Tag/LicenseTag.php
+++ b/library/Zend/CodeGenerator/Php/Docblock/Tag/LicenseTag.php
@@ -40,11 +40,6 @@ class LicenseTag extends \Zend\CodeGenerator\Php\PhpDocblockTag
     protected $_url = null;
 
     /**
-     * @var string
-     */
-    protected $_description = null;
-
-    /**
      * fromReflection()
      *
      * @param \Zend\Reflection\ReflectionDocblockTag $reflectionTagReturn
@@ -52,7 +47,7 @@ class LicenseTag extends \Zend\CodeGenerator\Php\PhpDocblockTag
      */
     public static function fromReflection(\Zend\Reflection\ReflectionDocblockTag $reflectionTagLicense)
     {
-        $returnTag = new \self();
+        $returnTag = new self();
 
         $returnTag->setName('license');
         $returnTag->setUrl($reflectionTagLicense->getUrl());

--- a/library/Zend/CodeGenerator/Php/Docblock/Tag/ParamTag.php
+++ b/library/Zend/CodeGenerator/Php/Docblock/Tag/ParamTag.php
@@ -45,11 +45,6 @@ class ParamTag extends \Zend\CodeGenerator\Php\PhpDocblockTag
     protected $_paramName = null;
 
     /**
-     * @var string
-     */
-    protected $_description = null;
-
-    /**
      * fromReflection()
      *
      * @param \Zend\Reflection\ReflectionDocblockTag $reflectionTagParam
@@ -57,7 +52,7 @@ class ParamTag extends \Zend\CodeGenerator\Php\PhpDocblockTag
      */
     public static function fromReflection(\Zend\Reflection\ReflectionDocblockTag $reflectionTagParam)
     {
-        $paramTag = new \self();
+        $paramTag = new self();
 
         $paramTag->setName('param');
         $paramTag->setDatatype($reflectionTagParam->getType()); // @todo rename

--- a/library/Zend/CodeGenerator/Php/Docblock/Tag/ReturnTag.php
+++ b/library/Zend/CodeGenerator/Php/Docblock/Tag/ReturnTag.php
@@ -40,11 +40,6 @@ class ReturnTag extends \Zend\CodeGenerator\Php\PhpDocblockTag
     protected $_datatype = null;
 
     /**
-     * @var string
-     */
-    protected $_description = null;
-
-    /**
      * fromReflection()
      *
      * @param \Zend\Reflection\ReflectionDocblockTag $reflectionTagReturn
@@ -52,7 +47,7 @@ class ReturnTag extends \Zend\CodeGenerator\Php\PhpDocblockTag
      */
     public static function fromReflection(\Zend\Reflection\ReflectionDocblockTag $reflectionTagReturn)
     {
-        $returnTag = new \self();
+        $returnTag = new self();
 
         $returnTag->setName('return');
         $returnTag->setDatatype($reflectionTagReturn->getType()); // @todo rename

--- a/library/Zend/CodeGenerator/Php/PhpClass.php
+++ b/library/Zend/CodeGenerator/Php/PhpClass.php
@@ -48,7 +48,7 @@ class PhpClass extends AbstractPhp
      * @var string
      */
     protected $_namespaceName = null;
-    
+
     /**
      * @var \Zend\CodeGenerator\Php\PhpDocblock
      */
@@ -102,14 +102,14 @@ class PhpClass extends AbstractPhp
         }
 
         $class->setAbstract($reflectionClass->isAbstract());
-        
+
         // set the namespace
         if ($reflectionClass->inNamespace()) {
             $class->setNamespaceName($reflectionClass->getNamespaceName());
         }
 
         $class->setName($reflectionClass->getName());
-        
+
         if ($parentClass = $reflectionClass->getParentClass()) {
             $class->setExtendedClass($parentClass->getName());
             $interfaces = array_diff($reflectionClass->getInterfaces(), $parentClass->getInterfaces());
@@ -145,7 +145,7 @@ class PhpClass extends AbstractPhp
 
     /**
      * setPhpFile()
-     * 
+     *
      * @param Zend\CodeGenerator\Php\PhpFile $phpFile
      */
     public function setPhpFile(PhpFile $phpFile)
@@ -153,10 +153,10 @@ class PhpClass extends AbstractPhp
         $this->_phpFile = $phpFile;
         return $this;
     }
-    
+
     /**
      * getPhpFile()
-     * 
+     *
      * @return Zend\CodeGenerator\Php\PhpFile
      */
     public function getPhpFile()
@@ -296,7 +296,7 @@ class PhpClass extends AbstractPhp
      * @param array $implementedInterfaces
      * @return \Zend\CodeGenerator\Php\PhpClass
      */
-    public function setImplementedInterfaces(Array $implementedInterfaces)
+    public function setImplementedInterfaces(array $implementedInterfaces)
     {
         $this->_implementedInterfaces = $implementedInterfaces;
         return $this;
@@ -318,7 +318,7 @@ class PhpClass extends AbstractPhp
      * @param array $properties
      * @return \Zend\CodeGenerator\Php\PhpClass
      */
-    public function setProperties(Array $properties)
+    public function setProperties(array $properties)
     {
         foreach ($properties as $property) {
             $this->setProperty($property);
@@ -337,12 +337,10 @@ class PhpClass extends AbstractPhp
     {
         if (is_array($property)) {
             $property = new PhpProperty($property);
-            $propertyName = $property->getName();
-        } elseif ($property instanceof PhpProperty) {
-            $propertyName = $property->getName();
-        } else {
+        } elseif (!$property instanceof PhpProperty) {
             throw new Exception\InvalidArgumentException('setProperty() expects either an array of property options or an instance of Zend_CodeGenerator_Php_Property');
         }
+        $propertyName = $property->getName();
 
         if (isset($this->_properties[$propertyName])) {
             throw new Exception\InvalidArgumentException('A property by name ' . $propertyName . ' already exists in this class.');
@@ -395,7 +393,7 @@ class PhpClass extends AbstractPhp
      * @param array $methods
      * @return \Zend\CodeGenerator\Php\PhpClass
      */
-    public function setMethods(Array $methods)
+    public function setMethods(array $methods)
     {
         foreach ($methods as $method) {
             $this->setMethod($method);
@@ -413,12 +411,10 @@ class PhpClass extends AbstractPhp
     {
         if (is_array($method)) {
             $method = new PhpMethod($method);
-            $methodName = $method->getName();
-        } elseif ($method instanceof PhpMethod) {
-            $methodName = $method->getName();
-        } else {
+        } elseif (!$method instanceof PhpMethod) {
             throw new Exception\InvalidArgumentException('setMethod() expects either an array of method options or an instance of Zend\CodeGenerator\Php\Method');
         }
+        $methodName = $method->getName();
 
         if (isset($this->_methods[$methodName])) {
             throw new Exception\InvalidArgumentException('A method by name ' . $methodName . ' already exists in this class.');

--- a/library/Zend/CodeGenerator/Php/PhpDocblock.php
+++ b/library/Zend/CodeGenerator/Php/PhpDocblock.php
@@ -128,7 +128,7 @@ class PhpDocblock extends AbstractPhp
      * @param array $tags
      * @return \Zend\CodeGenerator\PhpDocblock
      */
-    public function setTags(Array $tags)
+    public function setTags(array $tags)
     {
         foreach ($tags as $tag) {
             $this->setTag($tag);

--- a/library/Zend/CodeGenerator/Php/PhpDocblockTag.php
+++ b/library/Zend/CodeGenerator/Php/PhpDocblockTag.php
@@ -56,6 +56,11 @@ class PhpDocblockTag extends AbstractPhp
     protected $_name = null;
 
     /**
+     * @var string
+     */
+    protected $_description = null;
+
+    /**
      * fromReflection()
      *
      * @param \Zend\Reflection\ReflectionDocblockTag $reflectionTag

--- a/library/Zend/CodeGenerator/Php/PhpFile.php
+++ b/library/Zend/CodeGenerator/Php/PhpFile.php
@@ -70,12 +70,12 @@ class PhpFile extends AbstractPhp
      * @var string
      */
     protected $_namespace = null;
-    
+
     /**
      * @var array
      */
     protected $_uses = array();
-    
+
     /**
      * @var array
      */
@@ -88,9 +88,9 @@ class PhpFile extends AbstractPhp
 
     /**
      * registerFileCodeGnereator()
-     * 
+     *
      * A file code generator registry
-     * 
+     *
      * @param PhpFile $fileCodeGenerator
      * @param string $fileName
      */
@@ -184,17 +184,16 @@ class PhpFile extends AbstractPhp
             $body = implode("\n", $bodyReturn);
             unset($bodyLines, $bodyReturn, $classStartLine, $classEndLine);
         }
-        
+
         $namespace = $reflectionFile->getNamespace();
         if ($namespace != '') {
             $file->setNamespace($reflectionFile->getNamespace());
         }
-        
+
         $uses = $reflectionFile->getUses();
         if ($uses) {
             $file->setUses($uses);
         }
-        
 
         if (($reflectionFile->getDocComment() != '')) {
             $docblock = $reflectionFile->getDocblock();
@@ -257,7 +256,7 @@ class PhpFile extends AbstractPhp
      * @param array $requiredFiles
      * @return \Zend\CodeGenerator\Php\PhpFile
      */
-    public function setRequiredFiles($requiredFiles)
+    public function setRequiredFiles(array $requiredFiles)
     {
         $this->_requiredFiles = $requiredFiles;
         return $this;
@@ -279,7 +278,7 @@ class PhpFile extends AbstractPhp
      * @param array $classes
      * @return \Zend\CodeGenerator\Php\PhpFile
      */
-    public function setClasses(Array $classes)
+    public function setClasses(array $classes)
     {
         foreach ($classes as $class) {
             $this->setClass($class);
@@ -289,14 +288,14 @@ class PhpFile extends AbstractPhp
 
     /**
      * getNamespace()
-     * 
+     *
      * @return string
      */
     public function getNamespace()
     {
         return $this->_namespace;
     }
-    
+
     /**
      * setNamespace()
      * 
@@ -308,14 +307,14 @@ class PhpFile extends AbstractPhp
         $this->_namespace = $namespace;
         return $this;
     }
-    
+
     /**
      * getUses()
      * 
      * Returns an array with the first element the use statement, second is the as part.
-     * If $withResolvedAs is set to true, there will be a third element that is the 
+     * If $withResolvedAs is set to true, there will be a third element that is the
      * "resolved" as statement, as the second part is not required in use statements
-     * 
+     *
      * @param $withResolvedAs
      * @return array
      */
@@ -337,24 +336,24 @@ class PhpFile extends AbstractPhp
         }
         return $uses;
     }
-    
+
     /**
      * setUses()
-     * 
+     *
      * @param $uses
      * @return Zend\CodeGenerator\Php\PhpFile
      */
-    public function setUses(Array $uses)
+    public function setUses(array $uses)
     {
         foreach ($uses as $use) {
             $this->setUse($use[0], $use[1]);
         }
         return $this;
     }
-    
+
     /**
      * setUse()
-     * 
+     *
      * @param $use
      * @param $as
      * @return Zend\CodeGenerator\Php\PhpFile
@@ -364,7 +363,7 @@ class PhpFile extends AbstractPhp
         $this->_uses[] = array($use, $as);
         return $this;
     }
-    
+
     /**
      * getClass()
      *
@@ -492,12 +491,12 @@ class PhpFile extends AbstractPhp
         $output = '';
 
         // start with the body (if there), or open tag
-        if (preg_match('#(?:\s*)<\?php#', $this->getBody()) == false) {
+        $body = $this->getBody();
+        if (preg_match('#(?:\s*)<\?php#', $body) == false) {
             $output = '<?php' . self::LINE_FEED;
         }
-        
+
         // if there are markers, put the body into the output
-        $body = $this->getBody();
         if (preg_match('#/\* Zend_CodeGenerator_Php_File-(.*?)Marker:#', $body)) {
             $output .= $body;
             $body    = '';
@@ -519,6 +518,7 @@ class PhpFile extends AbstractPhp
 
         // namespace, if any
         if ($namespace = $this->getNamespace()) {
+            $output .= "/** @namespace */" . self::LINE_FEED;
             $output .= sprintf('namespace %s;%s', $namespace, str_repeat(self::LINE_FEED, 2));
         }
 

--- a/library/Zend/CodeGenerator/Php/PhpMember/AbstractMember.php
+++ b/library/Zend/CodeGenerator/Php/PhpMember/AbstractMember.php
@@ -80,7 +80,7 @@ abstract class AbstractMember extends Php\AbstractPhp
      * setDocblock() Set the docblock
      *
      * @param \Zend\CodeGenerator\PhpDocblock|array|string $docblock
-     * @return \Zend\CodeGenerator\Php\PhpFile
+     * @return \Zend\CodeGenerator\Php\PhpMember\AbstractMember
      */
     public function setDocblock($docblock)
     {

--- a/library/Zend/CodeGenerator/Php/PhpMethod.php
+++ b/library/Zend/CodeGenerator/Php/PhpMethod.php
@@ -211,8 +211,7 @@ class PhpMethod extends PhpMember\AbstractMember
         $output .= ')' . self::LINE_FEED . $indent . '{' . self::LINE_FEED;
 
         if ($this->_body) {
-            $output .= '        '
-                    .  str_replace(self::LINE_FEED, self::LINE_FEED . $indent . $indent, trim($this->_body))
+            $output .= preg_replace('#^(.+?)$#m', $indent . $indent . '$1', trim($this->_body))
                     .  self::LINE_FEED;
         }
 

--- a/library/Zend/CodeGenerator/Php/PhpMethod.php
+++ b/library/Zend/CodeGenerator/Php/PhpMethod.php
@@ -112,7 +112,7 @@ class PhpMethod extends PhpMember\AbstractMember
      * @param array $parameters
      * @return \Zend\CodeGenerator\Php\PhpMethod
      */
-    public function setParameters(Array $parameters)
+    public function setParameters(array $parameters)
     {
         foreach ($parameters as $parameter) {
             $this->setParameter($parameter);
@@ -130,12 +130,10 @@ class PhpMethod extends PhpMember\AbstractMember
     {
         if (is_array($parameter)) {
             $parameter = new PhpParameter($parameter);
-            $parameterName = $parameter->getName();
-        } elseif ($parameter instanceof PhpParameter) {
-            $parameterName = $parameter->getName();
-        } else {
+        } elseif (!$parameter instanceof PhpParameter) {
             throw new Exception\InvalidArgumentException('setParameter() expects either an array of method options or an instance of Zend_CodeGenerator_Php_Parameter');
         }
+        $parameterName = $parameter->getName();
 
         $this->_parameters[$parameterName] = $parameter;
         return $this;

--- a/library/Zend/CodeGenerator/Php/PhpParameter.php
+++ b/library/Zend/CodeGenerator/Php/PhpParameter.php
@@ -60,6 +60,11 @@ class PhpParameter extends \Zend\CodeGenerator\Php\AbstractPhp
     protected $_passedByReference = false;
 
     /**
+     * @var array
+     */
+    protected static $_simple = array('int', 'bool', 'string', 'float', 'resource', 'mixed', 'object');
+
+    /**
      * fromReflection()
      *
      * @param \Zend\Reflection\ReflectionParameter $reflectionParameter
@@ -221,7 +226,7 @@ class PhpParameter extends \Zend\CodeGenerator\Php\AbstractPhp
     {
         $output = '';
 
-        if ($this->_type) {
+        if ($this->_type && !in_array($this->_type, self::$_simple)) {
             $output .= $this->_type . ' ';
         }
 
@@ -234,7 +239,7 @@ class PhpParameter extends \Zend\CodeGenerator\Php\AbstractPhp
         if ($this->_defaultValue !== null) {
             $output .= ' = ';
             if (is_string($this->_defaultValue)) {
-                $output .= '\'' . $this->_defaultValue . '\'';
+                $output .= PhpValue::escape($this->_defaultValue);
             } else if($this->_defaultValue instanceof \Zend\CodeGenerator\Php\PhpParameterDefaultValue) {
                 $output .= (string)$this->_defaultValue;
             } else {

--- a/library/Zend/CodeGenerator/Php/PhpValue.php
+++ b/library/Zend/CodeGenerator/Php/PhpValue.php
@@ -47,7 +47,7 @@ class PhpValue extends AbstractPhp
 
     const OUTPUT_MULTIPLE_LINE = 'multipleLine';
     const OUTPUT_SINGLE_LINE = 'singleLine';
-    
+
     /**
      * @var array of reflected constants
      */
@@ -72,12 +72,12 @@ class PhpValue extends AbstractPhp
      * @var string
      */
     protected $_outputMode = self::OUTPUT_MULTIPLE_LINE;
-    
+
     /**
      * @var array
      */
     protected $_allowedTypes = null;
-    
+
     /**
      * _init()
      *
@@ -281,7 +281,7 @@ class PhpValue extends AbstractPhp
                 $output .= ( $value ? 'true' : 'false' );
                 break;
             case self::TYPE_STRING:
-                $output .= "'" . addcslashes($value, "'") . "'";
+                $output .= self::escape($value);
                 break;
             case self::TYPE_NULL:
                 $output .= 'null';
@@ -300,7 +300,7 @@ class PhpValue extends AbstractPhp
                 if (count($value) > 1) {
                     $curArrayMultiblock = true;
                     if ($this->_outputMode == self::OUTPUT_MULTIPLE_LINE) {
-                        $output .= self::LINE_FEED . str_repeat($this->_indentation, $this->_arrayDepth+1);
+                        $output .= self::LINE_FEED . str_repeat($this->_indentation, $this->_arrayDepth + 1);
                     }
                 }
                 $outputParts = array();
@@ -312,15 +312,15 @@ class PhpValue extends AbstractPhp
                         $outputParts[] = $partV;
                         $noKeyIndex++;
                     } else {
-                        $outputParts[] = (is_int($n) ? $n : "'" . addcslashes($n, "'") . "'") . ' => ' . $partV;
+                        $outputParts[] = (is_int($n) ? $n : self::escape($n)) . ' => ' . $partV;
                     }
                 }
                 $padding = ($this->_outputMode == self::OUTPUT_MULTIPLE_LINE)
-                    ? self::LINE_FEED . str_repeat($this->_indentation, $this->_arrayDepth+1)
+                    ? self::LINE_FEED . str_repeat($this->_indentation, $this->_arrayDepth + 1)
                     : ' ';
                 $output .= implode(',' . $padding, $outputParts);
                 if ($curArrayMultiblock == true && $this->_outputMode == self::OUTPUT_MULTIPLE_LINE) {
-                    $output .= self::LINE_FEED . str_repeat($this->_indentation, $this->_arrayDepth+1);
+                    $output .= self::LINE_FEED . str_repeat($this->_indentation, $this->_arrayDepth + 1);
                 }
                 $output .= ')';
                 break;
@@ -329,6 +329,25 @@ class PhpValue extends AbstractPhp
                 throw new Exception\RuntimeException(
                     "Type '".get_class($value)."' is unknown or cannot be used as property default value."
                 );
+        }
+
+        return $output;
+    }
+
+    /**
+     * Quotes value for PHP code.
+     *
+     * @param string $input Raw string.
+     * @param bool $quote Whether add surrounding quotes or not.
+     * @return string PHP-ready code.
+     */
+    public static function escape($input, $quote = true)
+    {
+        $output = addcslashes($input, "'");
+
+        // adds quoting strings
+        if ($quote) {
+            $output = "'" . $output . "'";
         }
 
         return $output;


### PR DESCRIPTION
- A bit of code and formatting fixes (like Array->array).
- Moved PHP escaping code to dedicated method to make it possible to use as standard.
- Preventing from adding type hinting for simple types (and pseudo-types like "mixed", "object", "resource").
- Some fixes in syntax.
