### PR TITLE
Removing PHPUnit warnings

### DIFF
--- a/tests/Zend/Controller/Router/RewriteTest.php
+++ b/tests/Zend/Controller/Router/RewriteTest.php
@@ -60,13 +60,13 @@ class RewriteTest extends \PHPUnit_Framework_TestCase
         $routes = $this->_router->getRoutes();
 
         $this->assertEquals(1, count($routes));
-        $this->assertType('Zend\Controller\Router\Route\Route', $routes['archive']);
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Route', $routes['archive']);
 
         $this->_router->addRoute('register', new Route\Route('register/:action', array('controller' => 'profile', 'action' => 'register')));
         $routes = $this->_router->getRoutes();
 
         $this->assertEquals(2, count($routes));
-        $this->assertType('Zend\Controller\Router\Route\Route', $routes['register']);
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Route', $routes['register']);
     }
 
     public function testAddRoutes()
@@ -80,8 +80,8 @@ class RewriteTest extends \PHPUnit_Framework_TestCase
         $values = $this->_router->getRoutes();
 
         $this->assertEquals(2, count($values));
-        $this->assertType('Zend\Controller\Router\Route\Route', $values['archive']);
-        $this->assertType('Zend\Controller\Router\Route\Route', $values['register']);
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Route', $values['archive']);
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Route', $values['register']);
     }
 
     public function testHasRoute()
@@ -99,7 +99,7 @@ class RewriteTest extends \PHPUnit_Framework_TestCase
 
         $route = $this->_router->getRoute('archive');
 
-        $this->assertType('Zend\Controller\Router\Route\Route', $route);
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Route', $route);
         $this->assertSame($route, $archive);
     }
 
@@ -117,7 +117,7 @@ class RewriteTest extends \PHPUnit_Framework_TestCase
         try {
             $route = $this->_router->removeRoute('archive');
         } catch (Router\Exception $e) {
-            $this->assertType('Zend\Controller\Router\Exception', $e);
+            $this->assertInstanceOf('Zend\Controller\Router\Exception', $e);
             return true;
         }
 
@@ -129,7 +129,7 @@ class RewriteTest extends \PHPUnit_Framework_TestCase
         try {
             $route = $this->_router->getRoute('bogus');
         } catch (Router\Exception $e) {
-            $this->assertType('Zend\Controller\Router\Exception', $e);
+            $this->assertInstanceOf('Zend\Controller\Router\Exception', $e);
             return true;
         }
 
@@ -142,7 +142,7 @@ class RewriteTest extends \PHPUnit_Framework_TestCase
 
         $token = $this->_router->route($request);
 
-        $this->assertType('Zend\Controller\Request\Http', $token);
+        $this->assertInstanceOf('Zend\Controller\Request\Http', $token);
     }
 
     public function testRouteWithIncorrectRequest()
@@ -153,7 +153,7 @@ class RewriteTest extends \PHPUnit_Framework_TestCase
             $token = $this->_router->route($request);
             $this->fail('Should throw an Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Controller\Router\Exception', $e);
+            $this->assertInstanceOf('Zend\Controller\Router\Exception', $e);
         }
     }
 
@@ -164,7 +164,7 @@ class RewriteTest extends \PHPUnit_Framework_TestCase
         $token = $this->_router->route($request);
 
         $routes = $this->_router->getRoutes();
-        $this->assertType('Zend\Controller\Router\Route\Module', $routes['application']);
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Module', $routes['application']);
     }
 
     public function testDefaultRouteWithEmptyAction()
@@ -274,14 +274,14 @@ class RewriteTest extends \PHPUnit_Framework_TestCase
             $route = $this->_router->getCurrentRoute();
             $this->fail();
         } catch (\Exception $e) {
-            $this->assertType('Zend\Controller\Router\Exception', $e);
+            $this->assertInstanceOf('Zend\Controller\Router\Exception', $e);
         }
 
         try {
             $route = $this->_router->getCurrentRouteName();
             $this->fail();
         } catch (\Exception $e) {
-            $this->assertType('Zend\Controller\Router\Exception', $e);
+            $this->assertInstanceOf('Zend\Controller\Router\Exception', $e);
         }
 
         $token = $this->_router->route($request);
@@ -294,7 +294,7 @@ class RewriteTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->assertEquals('application', $name);
-        $this->assertType('Zend\Controller\Router\Route\Module', $route);
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Module', $route);
     }
 
     public function testAddConfig()
@@ -304,13 +304,13 @@ class RewriteTest extends \PHPUnit_Framework_TestCase
 
         $this->_router->addConfig($config, 'routes');
 
-        $this->assertType('Zend\Controller\Router\Route\StaticRoute', $this->_router->getRoute('news'));
-        $this->assertType('Zend\Controller\Router\Route\Route', $this->_router->getRoute('archive'));
+        $this->assertInstanceOf('Zend\Controller\Router\Route\StaticRoute', $this->_router->getRoute('news'));
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Route', $this->_router->getRoute('archive'));
 
         try {
             $this->_router->addConfig($config, 'database');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Controller\Router\Exception', $e);
+            $this->assertInstanceOf('Zend\Controller\Router\Exception', $e);
             return true;
         }
     }
@@ -322,8 +322,8 @@ class RewriteTest extends \PHPUnit_Framework_TestCase
 
         $this->_router->addConfig($config->routes);
 
-        $this->assertType('Zend\Controller\Router\Route\StaticRoute', $this->_router->getRoute('news'));
-        $this->assertType('Zend\Controller\Router\Route\Route', $this->_router->getRoute('archive'));
+        $this->assertInstanceOf('Zend\Controller\Router\Route\StaticRoute', $this->_router->getRoute('news'));
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Route', $this->_router->getRoute('archive'));
     }
 
     public function testAddConfigWithRootNode()
@@ -333,8 +333,8 @@ class RewriteTest extends \PHPUnit_Framework_TestCase
 
         $this->_router->addConfig($config);
 
-        $this->assertType('Zend\Controller\Router\Route\StaticRoute', $this->_router->getRoute('news'));
-        $this->assertType('Zend\Controller\Router\Route\Route', $this->_router->getRoute('archive'));
+        $this->assertInstanceOf('Zend\Controller\Router\Route\StaticRoute', $this->_router->getRoute('news'));
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Route', $this->_router->getRoute('archive'));
     }
 
     public function testRemoveDefaultRoutes()
@@ -450,8 +450,8 @@ class RewriteTest extends \PHPUnit_Framework_TestCase
         $this->_router->addRoute('req', new Mockup2());
         $routeRequest = $this->_router->getRoute('req')->getRequest();
 
-        $this->assertType('Zend\Controller\Request\AbstractRequest', $request);
-        $this->assertType('Zend\Controller\Request\AbstractRequest', $routeRequest);
+        $this->assertInstanceOf('Zend\Controller\Request\AbstractRequest', $request);
+        $this->assertInstanceOf('Zend\Controller\Request\AbstractRequest', $routeRequest);
         $this->assertSame($request, $routeRequest);
     }
 

--- a/tests/Zend/Controller/Router/Route/ChainTest.php
+++ b/tests/Zend/Controller/Router/Route/ChainTest.php
@@ -50,7 +50,7 @@ class ChainTest extends \PHPUnit_Framework_TestCase
 
         $chain = $foo->addChain($bar);
 
-        $this->assertType('Zend\Controller\Router\Route\Chain', $chain);
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Chain', $chain);
     }
 
     public function testChainingMatch()
@@ -204,7 +204,7 @@ class ChainTest extends \PHPUnit_Framework_TestCase
 
         $res = $chain->match(new Request('http://localhost/foo.bar'));
 
-        $this->assertType('array', $res);
+        $this->assertInternalType('array', $res);
 
         $res = $chain->match(new Request('http://localhost/foo/bar'));
         $this->assertEquals(false, $res);
@@ -212,7 +212,7 @@ class ChainTest extends \PHPUnit_Framework_TestCase
         $chain->addChain($baz, ':');
 
         $res = $chain->match(new Request('http://localhost/foo.bar:baz'));
-        $this->assertType('array', $res);
+        $this->assertInternalType('array', $res);
     }
 
     public function testI18nChaining()
@@ -240,7 +240,7 @@ class ChainTest extends \PHPUnit_Framework_TestCase
         $request = new Request('http://foobar.zend.com/bar');
         $res = $chain->match($request);
 
-        $this->assertType('array', $res);
+        $this->assertInternalType('array', $res);
         $this->assertRegexp('#[^a-z0-9]?foobar\.zend\.com/bar/foo/bar#i', $chain->assemble(array('account' => 'foobar', 'foo' => 'bar')));
     }
 
@@ -256,7 +256,7 @@ class ChainTest extends \PHPUnit_Framework_TestCase
         $request = new Request('http://www.zend.com/bar');
         $res = $chain->match($request);
 
-        $this->assertType('array', $res);
+        $this->assertInternalType('array', $res);
         $this->assertRegexp('#[^a-z0-9]?www\.zend\.com/bar$#i', $chain->assemble());
     }
 
@@ -272,7 +272,7 @@ class ChainTest extends \PHPUnit_Framework_TestCase
         $request = new Request('http://www.zend.com/bar');
         $res = $chain->match($request);
 
-        $this->assertType('array', $res);
+        $this->assertInternalType('array', $res);
         $this->assertRegexp('#[^a-z0-9]?www\.zend\.com/bar$#i', $chain->assemble());
     }
 
@@ -288,13 +288,13 @@ class ChainTest extends \PHPUnit_Framework_TestCase
         $request = new Request('http://www.zend.com/user/1');
         $res = $profileChain->match($request);
 
-        $this->assertType('array', $res);
+        $this->assertInternalType('array', $res);
         $this->assertEquals('prof', $res['controller']);
 
         $request = new Request('http://www.zend.com/article/1');
         $res = $articleChain->match($request);
 
-        $this->assertType('array', $res);
+        $this->assertInternalType('array', $res);
         $this->assertEquals('art', $res['controller']);
         $this->assertEquals('art', $res['action']);
     }
@@ -562,10 +562,10 @@ class ChainTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('index', $token->getControllerName());
         $this->assertEquals('index',   $token->getActionName());
 
-        $this->assertType('Zend\Controller\Router\Route\Chain', $router->getRoute('user-profile'));
-        $this->assertType('Zend\Controller\Router\Route\Chain', $router->getRoute('www-imprint'));
-        $this->assertType('Zend\Controller\Router\Route\Chain', $router->getRoute('www-index'));
-        $this->assertType('Zend\Controller\Router\Route\Chain', $router->getRoute('www-index'));
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Chain', $router->getRoute('user-profile'));
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Chain', $router->getRoute('www-imprint'));
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Chain', $router->getRoute('www-index'));
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Chain', $router->getRoute('www-index'));
     }
 
     public function testChainingWorksWithWildcardAndNoParameters()

--- a/tests/Zend/Controller/Router/Route/ModuleTest.php
+++ b/tests/Zend/Controller/Router/Route/ModuleTest.php
@@ -73,7 +73,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
     {
         $values = $this->route->match('mod');
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
     }
@@ -81,7 +81,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
     public function testModuleAndControllerMatch()
     {
         $values = $this->route->match('mod/con');
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertTrue(isset($values['controller']));
@@ -91,7 +91,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
     public function testModuleControllerAndActionMatch()
     {
         $values = $this->route->match('mod/con/act');
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertTrue(isset($values['controller']));
@@ -103,7 +103,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
     public function testModuleControllerActionAndParamsMatch()
     {
         $values = $this->route->match('mod/con/act/var/val/foo');
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertTrue(isset($values['controller']));
@@ -119,7 +119,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
     public function testControllerOnlyMatch()
     {
         $values = $this->route->match('con');
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['controller']));
         $this->assertEquals('con', $values['controller']);
     }
@@ -127,7 +127,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
     public function testControllerOnlyAndActionMatch()
     {
         $values = $this->route->match('con/act');
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['controller']));
         $this->assertEquals('con', $values['controller']);
         $this->assertTrue(isset($values['action']));
@@ -137,7 +137,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
     public function testControllerOnlyActionAndParamsMatch()
     {
         $values = $this->route->match('con/act/var/val/foo');
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['controller']));
         $this->assertEquals('con', $values['controller']);
         $this->assertTrue(isset($values['action']));
@@ -158,7 +158,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
 
         $values = $this->route->match('mod/ctrl');
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertSame('mod', $values['m']);
         $this->assertSame('ctrl', $values['c']);
         $this->assertSame('index', $values['a']);
@@ -172,7 +172,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
 
         $values = $this->route->match('mod/ctrl');
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertSame('mod', $values['m'], var_export(array_keys($values), 1));
         $this->assertSame('ctrl', $values['c'], var_export(array_keys($values), 1));
         $this->assertSame('index', $values['a'], var_export(array_keys($values), 1));
@@ -403,7 +403,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
         $config = new Config\Config($routeConf);
         $route = Route\Module::getInstance($config);
 
-        $this->assertType('Zend\Controller\Router\Route\Module', $route);
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Module', $route);
     }
 
     public function testEncode()
@@ -444,7 +444,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
 
         $values = $this->route->match('mod/ctrl');
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertSame('mod', $values['m'], var_export(array_keys($values), 1));
         $this->assertSame('ctrl', $values['c'], var_export(array_keys($values), 1));
         $this->assertSame('index', $values['a'], var_export(array_keys($values), 1));

--- a/tests/Zend/Controller/Router/Route/RegexTest.php
+++ b/tests/Zend/Controller/Router/Route/RegexTest.php
@@ -400,7 +400,7 @@ class RegexTest extends \PHPUnit_Framework_TestCase
         $config = new \Zend\Config\Config($routeConf);
         $route = Route\Regex::getInstance($config);
 
-        $this->assertType('Zend\Controller\Router\Route\Regex', $route);
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Regex', $route);
 
         $values = $route->match('forum/1');
 

--- a/tests/Zend/Controller/Router/Route/StaticTest.php
+++ b/tests/Zend/Controller/Router/Route/StaticTest.php
@@ -42,7 +42,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         $route = new Route\StaticRoute('users/all');
         $values = $route->match('users/all');
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
     }
 
     public function testStaticMatchFailure()
@@ -59,7 +59,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
                     array('controller' => 'ctrl', 'action' => 'act'));
         $values = $route->match('users/all');
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertSame('ctrl', $values['controller']);
         $this->assertSame('act', $values['action']);
     }
@@ -69,7 +69,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         $route = new Route\StaticRoute('żółć');
         $values = $route->match('żółć');
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
     }
 
     public function testRootRoute()
@@ -95,7 +95,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
 
         $values = $route->getDefaults();
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertSame('ctrl', $values['controller']);
         $this->assertSame('act', $values['action']);
     }
@@ -122,7 +122,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         $config = new \Zend\Config\Config($routeConf);
         $route = Route\StaticRoute::getInstance($config);
 
-        $this->assertType('Zend\Controller\Router\Route\StaticRoute', $route);
+        $this->assertInstanceOf('Zend\Controller\Router\Route\StaticRoute', $route);
 
         $values = $route->match('users/all');
 

--- a/tests/Zend/Controller/Router/RouteTest.php
+++ b/tests/Zend/Controller/Router/RouteTest.php
@@ -417,7 +417,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
     {
         $route = new Route\Route('archives/:year/:month');
         $values = $route->match('archives/2006/07');
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
 
         $url = $route->assemble(array('month' => '03'));
         $this->assertEquals('archives/2006/03', $url);
@@ -445,7 +445,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
     {
         $route = new Route\Route('archives/:year/:month/*', array('controller' => 'archive'));
         $values = $route->match('archives/2006/07/controller/test/year/10000/sort/author');
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
 
         $this->assertEquals('archive', $values['controller']);
         $this->assertEquals('2006', $values['year']);
@@ -460,7 +460,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
 
         $values = $route->getDefaults();
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertEquals('ctrl', $values['controller']);
         $this->assertEquals('act', $values['action']);
     }
@@ -487,7 +487,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $config = new \Zend\Config\Config($routeConf);
         $route = Route\Route::getInstance($config);
 
-        $this->assertType('Zend\Controller\Router\Route\Route', $route);
+        $this->assertInstanceOf('Zend\Controller\Router\Route\Route', $route);
 
         $values = $route->match('users/all');
 
@@ -589,7 +589,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('families', $route->assemble());
 
         $values = $route->match('families/edit/id/4');
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
 
         $this->assertEquals('families/edit/id/4', $route->assemble());
     }
@@ -629,7 +629,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
 
         $values = $route->match('en/tmp/ctrl/action/id/1', true);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertEquals('en', $values['lang']);
         $this->assertEquals('tmp', $values['temp']);
         $this->assertEquals('en/tmp', $route->getMatchedPath());


### PR DESCRIPTION
Hello!

This patch removes the warnings that PHPUnit throws on using assertType on the Zend\Controller\Router* tests. I changed those calls to assertInternalType and assertInstanceOf.

HTH :)
