### PR TITLE
Fix: bad spelling in Zend\Tool\Framework\Client\Interactive\InputHandler::setClient()

### DIFF
--- a/library/Zend/Tool/Framework/Client/Interactive/InputHandler.php
+++ b/library/Zend/Tool/Framework/Client/Interactive/InputHandler.php
@@ -43,7 +43,7 @@ class InputHandler
 
     protected $_inputRequest = null;
 
-    public function setClient(InteractveInput $client)
+    public function setClient(InteractiveInput $client)
     {
         $this->_client = $client;
         return $this;


### PR DESCRIPTION
The "zf.sh create project" command wouldn't work, this is (part of?) the reason.
