### PR TITLE
[hotfix/ZF-10285] Zend_Validator

### DIFF
--- a/library/Zend/Application/Resource/Session.php
+++ b/library/Zend/Application/Resource/Session.php
@@ -57,7 +57,7 @@ class Session extends AbstractResource
 
     /**
      * Retrieve session manager
-     * 
+     *
      * @return Zend\Session\Manager|null
      */
     public function getManager()
@@ -70,7 +70,7 @@ class Session extends AbstractResource
      *
      * @param  array|string|\Zend\Session\SaveHandler $saveHandler
      * @return \Zend\Application\Resource\Session
-     * @throws \Zend\Application\ResourceException When $saveHandler is no valid save handler
+     * @throws \Zend\Application\ResourceException When $saveHandler is not a valid save handler
      */
     public function setSaveHandler($saveHandler)
     {

--- a/library/Zend/Locale/Data/AbstractLocale.php
+++ b/library/Zend/Locale/Data/AbstractLocale.php
@@ -234,11 +234,13 @@ abstract class AbstractLocale
         throw new UnsupportedMethod('This implementation does not support the selected locale information');
     }
 
-    public static function toInteger();
-    public static function toFloat();
-    public static function toDecimal();
-    public static function toScientific();
-    public static function toCurrency();
-    public static function toArray();
-    public static function toDateString();
+/**
+ *   public static function toInteger();
+ *   public static function toFloat();
+ *   public static function toDecimal();
+ *   public static function toScientific();
+ *   public static function toCurrency();
+ *   public static function toArray();
+ *   public static function toDateString();
+ */
 }

--- a/library/Zend/Locale/Format.php
+++ b/library/Zend/Locale/Format.php
@@ -24,6 +24,8 @@
  */
 namespace Zend\Locale;
 
+use Zend\Locale\Data\Cldr;
+
 /**
  * @uses       \Zend\Locale\Locale
  * @uses       \Zend\Locale\Data\Cldr

--- a/library/Zend/Validator/Isbn.php
+++ b/library/Zend/Validator/Isbn.php
@@ -46,7 +46,7 @@ class Isbn extends AbstractValidator
      */
     protected $_messageTemplates = array(
         self::INVALID => "Invalid type given. String or integer expected",
-        self::NO_ISBN => "'%value%' is no valid ISBN number",
+        self::NO_ISBN => "'%value%' is not a valid ISBN number",
     );
 
     /**

--- a/library/Zend/Validator/Sitemap/Changefreq.php
+++ b/library/Zend/Validator/Sitemap/Changefreq.php
@@ -51,7 +51,7 @@ class Changefreq extends \Zend\Validator\AbstractValidator
      * @var array
      */
     protected $_messageTemplates = array(
-        self::NOT_VALID => "'%value%' is no valid sitemap changefreq",
+        self::NOT_VALID => "'%value%' is not a valid sitemap changefreq",
         self::INVALID   => "Invalid type given. String expected",
     );
 

--- a/library/Zend/Validator/Sitemap/Lastmod.php
+++ b/library/Zend/Validator/Sitemap/Lastmod.php
@@ -57,7 +57,7 @@ class Lastmod extends \Zend\Validator\AbstractValidator
      * @var array
      */
     protected $_messageTemplates = array(
-        self::NOT_VALID => "'%value%' is no valid sitemap lastmod",
+        self::NOT_VALID => "'%value%' is not a valid sitemap lastmod",
         self::INVALID   => "Invalid type given. String expected",
     );
 

--- a/library/Zend/Validator/Sitemap/Loc.php
+++ b/library/Zend/Validator/Sitemap/Loc.php
@@ -53,7 +53,7 @@ class Loc extends \Zend\Validator\AbstractValidator
      * @var array
      */
     protected $_messageTemplates = array(
-        self::NOT_VALID => "'%value%' is no valid sitemap location",
+        self::NOT_VALID => "'%value%' is not a valid sitemap location",
         self::INVALID   => "Invalid type given. String expected",
     );
 

--- a/library/Zend/Validator/Sitemap/Priority.php
+++ b/library/Zend/Validator/Sitemap/Priority.php
@@ -51,7 +51,7 @@ class Priority extends \Zend\Validator\AbstractValidator
      * @var array
      */
     protected $_messageTemplates = array(
-        self::NOT_VALID => "'%value%' is no valid sitemap priority",
+        self::NOT_VALID => "'%value%' is not a valid sitemap priority",
         self::INVALID   => "Invalid type given. Numeric string, integer or float expected",
     );
 

--- a/resources/languages/de/Zend_Validate.php
+++ b/resources/languages/de/Zend_Validate.php
@@ -20,7 +20,7 @@
  */
 
 /**
- * EN-Revision: 06.Jan.2011
+ * EN-Revision: 25.Jul.2011
  */
 return array(
     // Zend_Validate_Alnum
@@ -76,13 +76,13 @@ return array(
 
     // Zend_Validate_EmailAddress
     "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
-    "'%value%' is no valid email address in the basic format local-part@hostname" => "'%value%' ist keine gültige Emailadresse im Basisformat local-part@hostname",
-    "'%hostname%' is no valid hostname for email address '%value%'" => "'%hostname%' ist kein gültiger Hostname für die Emailadresse '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' ist keine gültige Emailadresse im Basisformat local-part@hostname",
+    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' ist kein gültiger Hostname für die Emailadresse '%value%'",
     "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' scheint keinen gültigen MX Eintrag für die Emailadresse '%value%' zu haben",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network" => "'%hostname%' ist in keinem routebaren Netzwerksegment. Die Emailadresse '%value%' sollte nicht vom öffentlichen Netz aus aufgelöst werden",
     "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' passt nicht auf das dot-atom Format",
     "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' passt nicht auf das quoted-string Format",
-    "'%localPart%' is no valid local part for email address '%value%'" => "'%localPart%' ist kein gültiger lokaler Teil für die Emailadresse '%value%'",
+    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' ist kein gültiger lokaler Teil für die Emailadresse '%value%'",
     "'%value%' exceeds the allowed length" => "'%value%' ist länger als erlaubt",
 
     // Zend_Validate_File_Count
@@ -224,7 +224,7 @@ return array(
 
     // Zend_Validate_Isbn
     "Invalid type given. String or integer expected" => "Ungültiger Typ angegeben. String oder Integer erwartet",
-    "'%value%' is no valid ISBN number" => "'%value%' ist keine gültige ISBN Nummer",
+    "'%value%' is not a valid ISBN number" => "'%value%' ist keine gültige ISBN Nummer",
 
     // Zend_Validate_LessThan
     "'%value%' is not less than '%max%'" => "'%value%' ist nicht weniger als '%max%'",
@@ -243,19 +243,19 @@ return array(
     "There was an internal error while using the pattern '%pattern%'" => "Es gab einen internen Fehler bei der Verwendung des Patterns '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is no valid sitemap changefreq" => "'%value%' ist keine gültige Changefreq für Sitemap",
+    "'%value%' is not a valid sitemap changefreq" => "'%value%' ist keine gültige Changefreq für Sitemap",
     "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is no valid sitemap lastmod" => "'%value%' ist keine gültige Lastmod für Sitemap",
+    "'%value%' is not a valid sitemap lastmod" => "'%value%' ist keine gültige Lastmod für Sitemap",
     "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is no valid sitemap location" => "'%value%' ist keine gültige Location für Sitemap",
+    "'%value%' is not a valid sitemap location" => "'%value%' ist keine gültige Location für Sitemap",
     "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is no valid sitemap priority" => "'%value%' ist keine gültige Priority für Sitemap",
+    "'%value%' is not a valid sitemap priority" => "'%value%' ist keine gültige Priority für Sitemap",
     "Invalid type given. Numeric string, integer or float expected" => "Ungültiger Typ angegeben. Nummerischer String, Integer oder Float erwartet",
 
     // Zend_Validate_StringLength

--- a/resources/languages/en/Zend_Validate.php
+++ b/resources/languages/en/Zend_Validate.php
@@ -20,7 +20,7 @@
  */
 
 /**
- * EN-Revision: 06.Jan.2011
+ * EN-Revision: 25.Jul.2011
  */
 return array(
     // Zend_Validate_Alnum
@@ -76,13 +76,13 @@ return array(
 
     // Zend_Validate_EmailAddress
     "Invalid type given. String expected" => "Invalid type given. String expected",
-    "'%value%' is no valid email address in the basic format local-part@hostname" => "'%value%' is no valid email address in the basic format local-part@hostname",
-    "'%hostname%' is no valid hostname for email address '%value%'" => "'%hostname%' is no valid hostname for email address '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' is not a valid email address in the basic format local-part@hostname",
+    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' is not a valid hostname for email address '%value%'",
     "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' does not appear to have a valid MX record for the email address '%value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network" => "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network",
     "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' can not be matched against dot-atom format",
     "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' can not be matched against quoted-string format",
-    "'%localPart%' is no valid local part for email address '%value%'" => "'%localPart%' is no valid local part for email address '%value%'",
+    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' is not a valid local part for email address '%value%'",
     "'%value%' exceeds the allowed length" => "'%value%' exceeds the allowed length",
 
     // Zend_Validate_File_Count
@@ -224,7 +224,7 @@ return array(
 
     // Zend_Validate_Isbn
     "Invalid type given. String or integer expected" => "Invalid type given. String or integer expected",
-    "'%value%' is no valid ISBN number" => "'%value%' is no valid ISBN number",
+    "'%value%' is not a valid ISBN number" => "'%value%' is not a valid ISBN number",
 
     // Zend_Validate_LessThan
     "'%value%' is not less than '%max%'" => "'%value%' is not less than '%max%'",
@@ -243,19 +243,19 @@ return array(
     "There was an internal error while using the pattern '%pattern%'" => "There was an internal error while using the pattern '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is no valid sitemap changefreq" => "'%value%' is no valid sitemap changefreq",
+    "'%value%' is not a valid sitemap changefreq" => "'%value%' is not a valid sitemap changefreq",
     "Invalid type given. String expected" => "Invalid type given. String expected",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is no valid sitemap lastmod" => "'%value%' is no valid sitemap lastmod",
+    "'%value%' is not a valid sitemap lastmod" => "'%value%' is not a valid sitemap lastmod",
     "Invalid type given. String expected" => "Invalid type given. String expected",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is no valid sitemap location" => "'%value%' is no valid sitemap location",
+    "'%value%' is not a valid sitemap location" => "'%value%' is not a valid sitemap location",
     "Invalid type given. String expected" => "Invalid type given. String expected",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is no valid sitemap priority" => "'%value%' is no valid sitemap priority",
+    "'%value%' is not a valid sitemap priority" => "'%value%' is not a valid sitemap priority",
     "Invalid type given. Numeric string, integer or float expected" => "Invalid type given. Numeric string, integer or float expected",
 
     // Zend_Validate_StringLength

--- a/resources/languages/es/Zend_Validate.php
+++ b/resources/languages/es/Zend_Validate.php
@@ -77,13 +77,13 @@ return array(
 
     // Zend_Validate_EmailAddress
     "Invalid type given, value should be a string" => "El tipo especificado no es válido, el valor debe ser una cadena de texto",
-    "'%value%' is no valid email address in the basic format local-part@hostname" => "'%value%' no es una dirección de correo electrónico válido en el formato local-part@hostname",
-    "'%hostname%' is no valid hostname for email address '%value%'" => "'%hostname%' no es un nombre de host válido para la dirección de correo electrónico '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' no es una dirección de correo electrónico válido en el formato local-part@hostname",
+    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' no es un nombre de host válido para la dirección de correo electrónico '%value%'",
     "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' no parece tener un registro MX válido para la dirección de correo electrónico '%value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' no esta en un segmento de red ruteable. La dirección de correo electrónico '%value%' no se debe poder resolver desde una red pública.",
     "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' no es igual al formato dot-atom",
     "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' no es igual al formato quoted-string",
-    "'%localPart%' is no valid local part for email address '%value%'" => "'%localPart%' no es una parte local válida para la dirección de correo electrónico '%value%'",
+    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' no es una parte local válida para la dirección de correo electrónico '%value%'",
     "'%value%' exceeds the allowed length" => "'%value%' excede la longitud permitida",
 
     // Zend_Validate_File_Count

--- a/resources/languages/fi/Zend_Validate.php
+++ b/resources/languages/fi/Zend_Validate.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Translate
+ * @subpackage Ressource
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+/**
+ * EN-Revision: 22075
+ */
+return array(
+    // Zend_Validate_Alnum
+    "Invalid type given. String, integer or float expected" => "Epäkelpo syöte. Pitäisi olla liukuluku, merkkijono tai kokonaisluku",
+    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' on virheelinen, ainoastaan aakkoset ja numerot ovat sallittuja",
+    "'%value%' is an empty string" => "'%value%' on tyhjä merkkijono",
+
+    // Zend_Validate_Alpha
+    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' contains non alphabetic characters" => "'%value%' on virheellinen, ainoastaan aakkoset ovat sallittuja",
+    "'%value%' is an empty string" => "'%value%' on tyhjä merkkijono",
+
+    // Zend_Validate_Barcode
+    "'%value%' failed checksum validation" => "Syötteen '%value%' tarkistusluvun vahvistus epäonnistui",
+    "'%value%' contains invalid characters" => "'%value%' sisältää epäkelpoja merkkejä",
+    "'%value%' should have a length of %length% characters" => "'%value%' pitäisi olla %length% merkkiä pitkä",
+    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+
+    // Zend_Validate_Between
+    "'%value%' is not between '%min%' and '%max%', inclusively" => "'%value%' ei ole luku väliltä %min%-%max%",
+    "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' ei ole luku väliltä %min%-%max%, poislukien ylä- ja alarajat",
+
+    // Zend_Validate_Callback
+    "'%value%' is not valid" => "'%value%' on epäkelpo",
+    "An exception has been raised within the callback" => "Odottamaton virhe, callback-validaattori palautti poikkeuksen",
+
+    // Zend_Validate_Ccnum
+    "'%value%' must contain between 13 and 19 digits" => "'%value%' pitää olla luku väliltä 13-19",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Luhn-algoritmin (mod 10) suoritus syötteelle '%value%' epäonnistui",
+
+    // Zend_Validate_CreditCard
+    "'%value%' seems to contain an invalid checksum" => "Syötteen '%value%' tarkistusluku on viallinen",
+    "'%value%' must contain only digits" => "'%value%' saa sisältää ainoastaan numeroita",
+    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' contains an invalid amount of digits" => "'%value%' sisältää väärän määrän numeroita",
+    "'%value%' is not from an allowed institute" => "'%value%' ei ole sallitun luottolaitoksen alkuosa",
+    "'%value%' seems to be an invalid creditcard number" => "Luottokortin numero '%value%' tulkittiin virheelliseksi",
+    "An exception has been raised while validating '%value%'" => "Kortin '%value%' varmennus epäonnistui, palvelu palautti virheen",
+
+    // Zend_Validate_Date
+    "Invalid type given. String, integer, array or Zend_Date expected" => "Epäkelpo syöte. Pitäisi olla merkkijono, kokonaisluku, taulukko tai Zend_Date",
+    "'%value%' does not appear to be a valid date" => "'%value%' ei ole kelvollinen päivä",
+    "'%value%' does not fit the date format '%format%'" => "'%value%' ei ole muotoa '%format%'",
+
+    // Zend_Validate_Db_Abstract
+    "No record matching '%value%' was found" => "Rekisteristä ei löytynyt arvoa, joka vastaisi syötettä '%value%'",
+    "A record matching '%value%' was found" => "Rekisteristä löytyi syötettä '%value%' vastaava arvo",
+
+    // Zend_Validate_Digits
+    "Invalid type given. String, integer or float expected" => "Epäkelpo syöte. Pitäisi olla merkkijono, kokonaisluku tai liukuluku",
+    "'%value%' must contain only digits" => "'%value%' on virheellinen, ainoastaan numerot ovat sallittuja",
+    "'%value%' is an empty string" => "'%value%' on tyhjä merkkijono",
+
+    // Zend_Validate_EmailAddress
+    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' on virheellinen sähköpostiosoite, ei vastaa muotoa paikallisosa@alue",
+    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' on virheellinen verkkotunnus osoitteelle '%value%'",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "Osoitteen '%value%' verkkotunnukselle '%hostname%' ei löydy MX-tietuetta",
+    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network" => "'%hostname%' ei ole reititettävän verkon osa. Sähköpostiosoitetta '%value%' ei pitäisi selvittää julkisesta verkosta.",
+    "'%localPart%' can not be matched against dot-atom format" => "Virheellinen paikallisosa, '%localPart%' ei ole verrattavissa dot-atom -muotoon",
+    "'%localPart%' can not be matched against quoted-string format" => "Virheellinen paikallisosa, '%localPart%' ei ole verrattavissa quoted-string -muotoon",
+    "'%localPart%' is not a valid local part for email address '%value%'" => "Sähköpostiosoitteen '%value%' paikallisosa '%localPart%' on virheellinen",
+    "'%value%' exceeds the allowed length" => "Osoite '%value%' on liian pitkä",
+
+    // Zend_Validate_File_Count
+    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Virheellinen määrä tiedostoja, maksimimäärä on '%max%', vastaanotettiin '%count%'",
+    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Virheellinen määrä tiedostoja, minimimäärä on '%min%', vastaanotettiin '%count%'",
+
+    // Zend_Validate_File_Crc32
+    "File '%value%' does not match the given crc32 hashes" => "Tiedoston '%value%' crc32-tarkistusluku ei vastaa annettua",
+    "A crc32 hash could not be evaluated for the given file" => "Tarkistuslukua crc32 ei pystytty määrittämään vastaanotetulle tiedostolle",
+    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+
+    // Zend_Validate_File_ExcludeExtension
+    "File '%value%' has a false extension" => "Tiedostolla '%value%' on virheellinen pääte",
+    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+
+    // Zend_Validate_File_ExcludeMimeType
+    "File '%value%' has a false mimetype of '%type%'" => "Tiedoston '%value%' MIME-tyyppi '%type%' on virheellinen",
+    "The mimetype of file '%value%' could not be detected" => "Tiedoston '%value%' MIME-tyyppiä ei pystytty todentamaan",
+    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+
+    // Zend_Validate_File_Exists
+    "File '%value%' does not exist" => "Tiedostoa '%value%' ei ole olemassa",
+
+    // Zend_Validate_File_Extension
+    "File '%value%' has a false extension" => "Tiedostolla '%value%' on virheellinen pääte",
+    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+
+    // Zend_Validate_File_FilesSize
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Kaikkien tiedostojen yhteenlaskettu koko saa olla maksimissaan '%max%', vastaanotettiin '%size%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Kaikkien tiedostojen yhteenlaskettu koko pitää olla vähintään '%min%', vastaanotettiin '%size%'",
+    "One or more files can not be read" => "Yhtä tai useampaa tiedostoa ei voida lukea",
+
+    // Zend_Validate_File_Hash
+    "File '%value%' does not match the given hashes" => "Tiedoston '%value%' tarkastusluku ei vastaa annettua",
+    "A hash could not be evaluated for the given file" => "Tarkistuslukua ei pystytty määrittämään vastaanotetulle tiedostolle",
+    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+
+    // Zend_Validate_File_ImageSize
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Kuvan '%value%' maksimileveys on '%maxwidth%', annettu '%width%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Kuvan '%value%' minimileveys on '%minwidth%', annettu '%width%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Kuvan '%value%' maksimikorkeus on '%maxheight%', annettu '%height%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Kuvan '%value%' minimikorkeus on '%minheight%', annettu '%height%'",
+    "The size of image '%value%' could not be detected" => "Kuvan '%value%' kokoa ei voida todentaa",
+    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+
+    // Zend_Validate_File_IsCompressed
+    "File '%value%' is not compressed, '%type%' detected" => "Tiedosto '%value%' ei ole pakattu, vastaanotettiin tyyppiä '%type%'",
+    "The mimetype of file '%value%' could not be detected" => "Tiedoston '%value%' MIME-tyyppiä ei pystytty todentamaan",
+    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+
+    // Zend_Validate_File_IsImage
+    "File '%value%' is no image, '%type%' detected" => "Tiedosto '%value%' ei ole kuvatiedosto, vastaanotettiin tyyppiä '%type%'",
+    "The mimetype of file '%value%' could not be detected" => "Tiedoston '%value%' MIME-tyyppiä ei pystytty todentamaan",
+    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+
+    // Zend_Validate_File_Md5
+    "File '%value%' does not match the given md5 hashes" => "Tiedoston '%value%' tarkistusluku ei vastaa annettua (md5)",
+    "A md5 hash could not be evaluated for the given file" => "Tiedostolle ei voitu määrittää md5-tarkistuslukua",
+    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+
+    // Zend_Validate_File_MimeType
+    "File '%value%' has a false mimetype of '%type%'" => "Tiedoston '%value%' MIME-tyyppi '%type%' on virheellinen",
+    "The mimetype of file '%value%' could not be detected" => "Tiedoston '%value%' MIME-tyyppiä ei pystytty todentamaan",
+    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+
+    // Zend_Validate_File_NotExists
+    "File '%value%' exists" => "Tiedostoa '%value%' ei ole olemassa",
+
+    // Zend_Validate_File_Sha1
+    "File '%value%' does not match the given sha1 hashes" => "Tiedoston '%value%' tarkistusluku ei vastaa annettua (sha1)",
+    "A sha1 hash could not be evaluated for the given file" => "Tiedostolle ei voitu määrittää sha1-tarkistuslukua",
+    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+
+    // Zend_Validate_File_Size
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Tiedoston '%value%' maksimikoko on '%max%', vastaanotettu '%size%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Tiedoston '%value%' minimikoko on '%min%', vastaanotettu '%size%'",
+    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voidea lukea tai sitä ei ole",
+
+    // Zend_Validate_File_Upload
+    "File '%value%' exceeds the defined ini size" => "Tiedosto '%value%' ylittää ini-tiedostossa määritellyn tiedostokoon",
+    "File '%value%' exceeds the defined form size" => "Tiedosto '%value%' ylittää lomakkeessa määritellyn tiedostokoon",
+    "File '%value%' was only partially uploaded" => "Tiedosto '%value%' vastaanotettiin ainoastaan osittain",
+    "File '%value%' was not uploaded" => "Tiedostoa '%value%' ei lähetetty",
+    "No temporary directory was found for file '%value%'" => "Väliaikaishakemistoa ei löytynyt tiedostolle '%value%'",
+    "File '%value%' can't be written" => "Tiedostoon '%value%' ei voida kirjoittaa",
+    "A PHP extension returned an error while uploading the file '%value%'" => "PHP:n lisäosa palautti virheen kesken tiedoston '%value%' lähetyksen",
+    "File '%value%' was illegally uploaded. This could be a possible attack" => "Tiedoston '%value%' lähetyksessä haivattu laittomuus, mahdollinen hyökkäys",
+    "File '%value%' was not found" => "Tiedostoa '%value%' ei löydy",
+    "Unknown error while uploading file '%value%'" => "Tiedoston '%value%' lähetyksessä tapahtui tunnistamaton virhe",
+
+    // Zend_Validate_File_WordCount
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Virheellinen määrä sanoja, maksimäärä on '%max%', annettu '%count%'",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Virheellinen määrä sanoja, minimimäärä on '%min%', annettu '%count%'",
+    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+
+    // Zend_Validate_Float
+    "Invalid type given. String, integer or float expected" => "Epäkelpo syöte. Pitäisi olla liukuluku, merkkijono tai kokonaisluku",
+    "'%value%' does not appear to be a float" => "'%value%' ei ole liukuluku",
+
+    // Zend_Validate_GreaterThan
+    "'%value%' is not greater than '%min%'" => "'%value%' ei ole suurempi kuin '%min%'",
+
+    // Zend_Validate_Hex
+    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' has not only hexadecimal digit characters" => "'%value%' voi sisältää ainoastaan heksadeslimaalin muotoisia merkkejä",
+
+    // Zend_Validate_Hostname
+    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "'%value%' näyttäisi olevan ip-osoite eikä verkkotunnus",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' verkkotunnuksen TLD-osa ei ole tunnettu",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' näyttäisi olevan käypä verkkotunnus, mutta sisältää viivan väärässä paikassa",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' näyttäisi olevan käypä verkkotunnus, mutta sen TLD-osa '%tld%' on virheellinen",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' verkkotunnuksen TLD-osaa ei pystytty erottamaan",
+    "'%value%' does not match the expected structure for a DNS hostname" => "Verkkotunnus '%value%' on jäsennykseltään virheellinen",
+    "'%value%' does not appear to be a valid local network name" => "'%value%' on epäkelpo paikallisverkkon tunnus",
+    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' tulkittiin paikallisverkon tunnukseksi, jotka eivät ole sallittuja",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "Verkkotunnuksen '%value%' punycode-koodauksen purku epäonnistui",
+
+    // Zend_Validate_Iban
+    "Unknown country within the IBAN '%value%'" => "Maata ei pystytty tunnistamaan IBAN-koodista '%value%'",
+    "'%value%' has a false IBAN format" => "'%value%' on väärän muotoinen IBAN-koodi",
+    "'%value%' has failed the IBAN check" => "'%value%' IBAN-koodin tarkastus epäonnistui",
+
+    // Zend_Validate_Identical
+    "The two given tokens do not match" => "Annetut kaksi arvoa eivät täsmää",
+    "No token was provided to match against" => "Toinen arvoista puuttuu",
+
+    // Zend_Validate_InArray
+    "'%value%' was not found in the haystack" => "'%value%' ei löydy sallittujen syötteiden joukosta",
+
+    // Zend_Validate_Int
+    "Invalid type given. String or integer expected" => "Epäkelpo syöte. Pitäisi olla merkkijono tai kokonaisluku",
+    "'%value%' does not appear to be an integer" => "'%value%' ei ole kokonaisluku",
+
+    // Zend_Validate_Ip
+    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' does not appear to be a valid IP address" => "'%value%' ei ole käypä IP-osoite",
+
+    // Zend_Validate_Isbn
+    "Invalid type given. String or integer expected" => "Epäkelpo syöte. Pitäisi olla merkkijono tai kokonaisluku",
+    "'%value%' is not a valid ISBN number" => "'%value%' ei ole käypä ISBN-numero",
+
+    // Zend_Validate_LessThan
+    "'%value%' is not less than '%max%'" => "'%value%' ei ole pienempi kuin '%max%'",
+
+    // Zend_Validate_NotEmpty
+    "Invalid type given. String, integer, float, boolean or array expected" => "Epäkelpo syöte. Pitäisi olla kokonaisluku, liukuluku, boolean tai taulukko",
+    "Value is required and can't be empty" => "Kenttä ei voi olla tyhjä",
+
+    // Zend_Validate_PostCode
+    "Invalid type given. String or integer expected" => "Epäkelpo syöte. Pitäisi olla merkkijono tai kokonaisluku",
+    "'%value%' does not appear to be a postal code" => "'%value%' ei ole käypä postiosoite",
+
+    // Zend_Validate_Regex
+    "Invalid type given. String, integer or float expected" => "Epäkelpo syöte. Pitäisi olla merkkijono, kokonaisluku tai liukuluku",
+    "'%value%' does not match against pattern '%pattern%'" => "'%value%' ei ole muotoa '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'" => "Sisäinen virhe käytettäessa muotoa '%pattern%'",
+
+    // Zend_Validate_Sitemap_Changefreq
+    "'%value%' is not a valid sitemap changefreq" => "'%value%' ei ole käypä sivukartan muutosnopeus",
+    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+
+    // Zend_Validate_Sitemap_Lastmod
+    "'%value%' is not a valid sitemap lastmod" => "'%value%' ei ole käypä arvo sivukartan viimeksimuokatuksi arvoksi",
+    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+
+    // Zend_Validate_Sitemap_Loc
+    "'%value%' is not a valid sitemap location" => "'%value%' ei ole käypä sivukartan sijainti",
+    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+
+    // Zend_Validate_Sitemap_Priority
+    "'%value%' is not a valid sitemap priority" => "'%value%' ei ole käypä sivukartan prioriteetti",
+    "Invalid type given. Numeric string, integer or float expected" => "Epäkelpo syöte. Pitäisi olla kokonaisluku tai liukuluku",
+
+    // Zend_Validate_StringLength
+    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' is less than %min% characters long" => "'%value%' on lyhyempi kuin vaaditut %min% merkkiä",
+    "'%value%' is more than %max% characters long" => "'%value%' on pidempi kuin sallitut %max% merkkiä",
+);

--- a/resources/languages/fr/Zend_Validate.php
+++ b/resources/languages/fr/Zend_Validate.php
@@ -20,246 +20,115 @@
  */
 
 /**
- * EN-Revision: 22075
+ * EN-Revision: 22668
  */
 return array(
-    // Zend_Validate_Alnum
-    "Invalid type given, value should be float, string, or integer" => "Type de donnée non valide : entier, flottant ou chaîne attendu",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' contient des caractères non alphabétiques et non numériques",
-    "'%value%' is an empty string" => "'%value%' est une chaîne vide",
-
-    // Zend_Validate_Alpha
-    "Invalid type given, value should be a string" => "Type de donnée non valide : chaîne attendue",
-    "'%value%' contains non alphabetic characters" => "'%value%' contient des caractères non alphabétiques",
-    "'%value%' is an empty string" => "'%value%' est une chaîne vide",
-
-    // Zend_Validate_Barcode
-    "'%value%' failed checksum validation" => "'%value%' ne passe pas la validation de somme de contrôle",
-    "'%value%' contains invalid characters" => "'%value%' contient des caractères invalides",
-    "'%value%' should have a length of %length% characters" => "'%value%' devrait avoir une taille de %length% caractères",
-    "Invalid type given, value should be string" => "Type de donnée non valide : chaîne attendue",
-
-    // Zend_Validate_Between
-    "'%value%' is not between '%min%' and '%max%', inclusively" => "'%value%' n'est pas comprise entre '%min%' et '%max%', inclusivement",
-    "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' n'est pas strictement comprise entre '%min%' et '%max%'",
-
-    // Zend_Validate_Callback
-    "'%value%' is not valid" => "'%value%' n'est pas valide",
-    "Failure within the callback, exception returned" => "Echec de la fonction de rappel, exception retournée",
-
-    // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' doit contenir entre 13 et 19 chiffres",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "L'algorithme Luhn (somme de contrôle mod-10) a échoué pour '%value%'",
-
-    // Zend_Validate_CreditCard
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "L'algorithme Luhn (somme de contrôle mod-10) a échoué pour '%value%'",
-    "'%value%' must contain only digits" => "'%value%' ne doit contenir que des chiffres",
-    "Invalid type given, value should be a string" => "Type de donnée non valide : chaîne attendue",
-    "'%value%' contains an invalid amount of digits" => "'%value%' contient un nombre incorrect de chiffres",
-    "'%value%' is not from an allowed institute" => "'%value%' ne provient pas d'une institution autorisée",
-    "Validation of '%value%' has been failed by the service" => "La validation de '%value%' a échoué via le service externe",
-    "The service returned a failure while validating '%value%'" => "Le service externe a retourné un echec lors de la validation de '%value%'",
-
-    // Zend_Validate_Date
-    "Invalid type given, value should be string, integer, array or Zend_Date" => "Type invalide : chaîne, entier, tableau ou Zend_Date requis",
-    "'%value%' does not appear to be a valid date" => "'%value%' ne semble pas être une date valide",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' ne correspond pas au format de date '%format%'",
-
-    // Zend_Validate_Db_Abstract
-    "No record matching %value% was found" => "Aucun enregistrement trouvé pour %value%",
-    "A record matching %value% was found" => "Un enregistrement a été trouvé pour %value%",
-
-    // Zend_Validate_Digits
-    "Invalid type given, value should be string, integer or float" => "Type invalide : chaîne, entier ou flottant attendu",
-    "'%value%' contains characters which are not digits; but only digits are allowed" => "'%value%' contient des caractères qui ne sont pas numériques ; seuls les caractères numériques sont autorisés",
-    "'%value%' contains not only digit characters" => "'%value%' ne contient pas que des chiffres",
-    "'%value%' is an empty string" => "'%value%' est une chaîne vide",
-
-    // Zend_Validate_EmailAddress
-    "Invalid type given, value should be a string" => "Type invalide, chaîne attendue",
-    "'%value%' is no valid email address in the basic format local-part@hostname" => "'%value%' n'est pas un email valide dans le format local-part@hostname",
-    "'%hostname%' is no valid hostname for email address '%value%'" => "'%hostname%' n'est pas un nom d'hôte valide pour l'adresse email '%value%'",
     "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' ne semble pas avoir d'enregistrement MX valide pour l'adresse email '%value%'",
-    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' n'est pas dans un segment réseau routable. L'adresse email '%value%' ne devrait pas être résolue depuis un réseau public.",
+    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' n'est pas un nom d'hôte valide pour l'adresse email '%value%'",
+    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network" => "'%hostname%' n'est pas dans un segment réseau routable. L'adresse email '%value%' ne devrait pas être résolue depuis un réseau public.",
     "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' ne correspond pas au format dot-atom",
     "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' ne correspond pas au format quoted-string",
-    "'%localPart%' is no valid local part for email address '%value%'" => "'%localPart%' n'est pas une partie locale valide pour l'adresse email '%value%'",
-    "'%value%' exceeds the allowed length" => "'%value%' excède la taille autorisée",
-
-    // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Trop de fichiers : un maximum de'%max%' est autorisé mais '%count%' ont été fournis",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Trop peu de fichiers : un minimum de '%min%' est autorisé mais '%count%' ont été fournis",
-
-    // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Le fichier '%value%' ne correspond pas à la somme de contrôle crc32",
-    "A crc32 hash could not be evaluated for the given file" => "La somme de contrôle crc32 n'a pas pu être évaluée pour le fichier",
-    "File '%value%' could not be found" => "Fichier '%value%' introuvable",
-
-    // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Le fichier '%value%' n'a pas la bonne extension",
-    "File '%value%' could not be found" => "Fichier '%value%' introuvable",
-
-    // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Le fichier '%value%' n'a pas le bon type MIME : '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Le type MIME de '%value%' n'a pas pu être détecté",
-    "File '%value%' can not be read" => "Le fichier '%value%' ne peut être lu",
-
-    // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "Le fichier '%value%' n'existe pas",
-
-    // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "Le fichier '%value%' n'a pas la bonne extension",
-    "File '%value%' could not be found" => "Fichier '%value%' introuvable",
-
-    // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Tous les fichiers devraient avoir une taille maximale de '%max%' mais une taille de '%size%' a été détectée",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Tous les fichiers devraient avoir une taille minimale de '%min%' mais une taille de '%size%' a été détectée",
-    "One or more files can not be read" => "Un ou plusieurs fichiers n'est pas lisible",
-
-    // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "Le fichier '%value%' ne correspond pas à la somme de contrôle",
-    "A hash could not be evaluated for the given file" => "Une somme de contrôle n'a pas pu être calculée pour le fichier",
-    "File '%value%' could not be found" => "Fichier '%value%' introuvable",
-
-    // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "La largeur maximale de l'image '%value%' devrait être '%maxwidth%' mais '%width%' a été détectée",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "La largeur minimale de l'image '%value%' devrait être '%minwidth%' mais '%width%' a été détectée",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "La hauteur maximale de l'image '%value%' devrait être '%maxheight%' mais '%height%' a été détectée",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "La hauteur minimale de l'image '%value%' devrait être '%minheight%' mais '%height%' a été détectée",
-    "The size of image '%value%' could not be detected" => "La taille de l'image '%value%' n'a pas pu être détectée",
-    "File '%value%' can not be read" => "Le fichier '%value%' ne peut être lu",
-
-    // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Le fichier '%value%' n'est pas compressé : '%type%' détecté",
-    "The mimetype of file '%value%' could not be detected" => "Le type MIME du fichier '%value%' n'a pu être détecté",
-    "File '%value%' can not be read" => "Le fichier '%value%' ne peut être lu",
-
-    // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Le fichier '%value%' n'est pas une image : '%type%' détecté",
-    "The mimetype of file '%value%' could not be detected" => "Le type MIME du fichier '%value%' n'a pu être détecté",
-    "File '%value%' can not be read" => "Le fichier '%value%' ne peut être lu",
-
-    // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Le fichier '%value%' ne correspond pas à la somme de contrôle MD5",
-    "A md5 hash could not be evaluated for the given file" => "Une somme de contrôle MD5 n'a pas pu être calculée pour le fichier",
-    "File '%value%' could not be found" => "Fichier '%value%' introuvable",
-
-    // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Le fichier '%value%' a un mauvais type MIME : '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Le type MIME du fichier '%value%' n'a pu être détecté",
-    "File '%value%' can not be read" => "Le fichier '%value%' ne peut être lu",
-
-    // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "Le fichier '%value%' existe déja",
-
-    // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Le fichier '%value%' ne correspond pas à la somme de contrôle SHA-1",
-    "A sha1 hash could not be evaluated for the given file" => "La valeur de somme de contrôle SHA-1 n'a pas pu être calculée pour le fichier",
-    "File '%value%' could not be found" => "Fichier '%value%' introuvable",
-
-    // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "La taille maximale requise pour le fichier '%value%' est de '%max%' mais '%size%' a été détecté",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "La taille minimale requise pour le fichier '%value%' est de '%min%' mais '%size%' a été détecté",
-    "File '%value%' could not be found" => "Fichier '%value%' introuvable",
-
-    // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Le fichier '%value%' excède la taille requise par le fichier ini",
-    "File '%value%' exceeds the defined form size" => "Le fichier '%value%' excède la taille requise par le formulaire",
-    "File '%value%' was only partially uploaded" => "Le fichier '%value%' n'a été que partiellement envoyé",
-    "File '%value%' was not uploaded" => "Le fichier '%value%' n'a pas été envoyé",
-    "No temporary directory was found for file '%value%'" => "Pas de dossier temporaire trouvé pour le fichier '%value%'",
-    "File '%value%' can't be written" => "Le fichier '%value%' ne peut être écrit",
-    "A PHP extension returned an error while uploading the file '%value%'" => "Une extension PHP a retourné une erreur lors de l'envoi du fichier '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Fichier '%value%' mal envoyé. Ceci peut être possiblement une attaque",
-    "File '%value%' was not found" => "Fichier '%value%' introuvable",
-    "Unknown error while uploading file '%value%'" => "Erreur inconnue lors de l'envoi du fichier '%value%'",
-
-    // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Trop de mots, un maximum de '%max%' est requis, '%count%' ont été fournis",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Trop peu de mots, un minimum de '%min%' est requis, '%count%' ont été fournis",
-    "File '%value%' could not be found" => "Le fichier '%value%' est introuvable",
-
-    // Zend_Validate_Float
-    "Invalid type given, value should be float, string, or integer" => "Type invalide : chaîne, entier ou flottant attendu",
-    "'%value%' does not appear to be a float" => "'%value%' ne semble pas être de type flottant",
-
-    // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' n'est pas plus grand que '%min%'",
-
-    // Zend_Validate_Hex
-    "Invalid type given, value should be a string" => "Type de donnée non valide : chaîne attendue",
-    "'%value%' has not only hexadecimal digit characters" => "'%value%' ne contient pas uniquement des caractères héxadécimaux",
-
-    // Zend_Validate_Hostname
-    "Invalid type given, value should be a string" => "Type de donnée non valide : chaîne attendue",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "'%value%' semble être une IP valide mais celles-ci ne sont pas autorisées",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' semble être un nom d'hôte DNS mais son extension TLD semble inconnue",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' semble être un nom d'hôte DNS mais il contient un tiret à une position invalide",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' semble être un nom d'hôte DNS valide mais ne correspond pas au schéma de l'extension TLD '%tld%'",
+    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' n'est pas une partie locale valide pour l'adresse email '%value%'",
     "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' semble être un nom d'hôte DNS mais l'extension TLD ne peut être extraite",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' ne correspond pas à la structure d'un nom d'hôte DNS valide",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' ne semble pas être une adresse réseau local valide",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' semble être un nom réseau local mais les noms locaux sont interdits",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' semble être un nom d'hôte DNS mais son extension TLD semble inconnue",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' semble être un nom d'hôte DNS valide mais ne correspond pas au schéma de l'extension TLD '%tld%'",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' semble être un nom d'hôte DNS mais il contient un tiret à une position invalide",
     "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "'%value%' semble être un DNS valide mais le code n'a pu être décodé",
-
-    // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "Pays inconnu pour l'IBAN '%value%'",
+    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' semble être un nom réseau local mais les noms locaux sont interdits",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "'%value%' semble être une IP valide mais celles-ci ne sont pas autorisées",
+    "'%value%' contains an invalid amount of digits" => "'%value%' contient un nombre incorrect de chiffres",
+    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' contient des caractères non alphabétiques et non numériques",
+    "'%value%' contains invalid characters" => "'%value%' contient des caractères invalides",
+    "'%value%' contains non alphabetic characters" => "'%value%' contient des caractères non alphabétiques",
+    "'%value%' does not appear to be a float" => "'%value%' ne semble pas être de type flottant",
+    "'%value%' does not appear to be a postal code" => "'%value%' ne semble pas être un code postal valide",
+    "'%value%' does not appear to be a valid IP address" => "'%value%' n'est pas une IP valide",
+    "'%value%' does not appear to be a valid date" => "'%value%' ne semble pas être une date valide",
+    "'%value%' does not appear to be a valid local network name" => "'%value%' ne semble pas être une adresse réseau local valide",
+    "'%value%' does not appear to be an integer" => "'%value%' n'est pas un entier",
+    "'%value%' does not fit the date format '%format%'" => "'%value%' ne correspond pas au format de date '%format%'",
+    "'%value%' does not match against pattern '%pattern%'" => "'%value%' n'a pas de correspondance avec le motif '%pattern%'",
+    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' ne correspond pas à la structure d'un nom d'hôte DNS valide",
+    "'%value%' exceeds the allowed length" => "'%value%' excède la taille autorisée",
+    "'%value%' failed checksum validation" => "'%value%' ne passe pas la validation de somme de contrôle",
     "'%value%' has a false IBAN format" => "'%value%' n'a pas un format IBAN valide",
     "'%value%' has failed the IBAN check" => "'%value%' n'a pas passé la validation IBAN",
-
-    // Zend_Validate_Identical
-    "The two given tokens do not match" => "Les deux jetons passés ne correspondent pas",
-    "No token was provided to match against" => "Aucun jeton de correspondance n'a été donné",
-
-    // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "'%value%' ne fait pas partie des valeurs attendues",
-
-    // Zend_Validate_Int
-    "Invalid type given, value should be string or integer" => "Type invalide : chaîne ou entier attendu",
-    "'%value%' does not appear to be an integer" => "'%value%' n'est pas un entier",
-
-    // Zend_Validate_Ip
-    "Invalid type given, value should be a string" => "Type invalide : chaîne attendue",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' n'est pas une IP valide",
-
-    // Zend_Validate_Isbn
-    "Invalid type given, value should be string or integer" => "Type invalide : chaîne ou entier attendu",
-    "'%value%' is no valid ISBN number" => "'%value%' n'est pas un ISBN valide",
-
-    // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' n'est pas plus petit que '%max%'",
-
-    // Zend_Validate_NotEmpty
-    "Invalid type given, value should be float, string, array, boolean or integer" => "Type invalide : chaîne, entier, tableau, booléen ou flottant attendu",
-    "Value is required and can't be empty" => "Cette valeur est obligatoire et ne peut être vide",
-
-    // Zend_Validate_PostCode
-    "Invalid type given. The value should be a string or a integer" => "Type invalide : chaîne ou entier attendu",
-    "'%value%' does not appear to be a postal code" => "'%value%' ne semble pas être un code postal valide",
-
-    // Zend_Validate_Regex
-    "Invalid type given, value should be string, integer or float" => "Type invalide : chaîne entier ou flottant attendu",
-    "'%value%' does not match against pattern '%pattern%'" => "'%value%' n'a pas de correspondance avec le motif '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "Il y a eu une erreur interne lors de l'utilisation du motif '%pattern%'",
-
-    // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is no valid sitemap changefreq" => "'%value%' n'est pas une valeur de fréquence de sitemap valide",
-    "Invalid type given, value should be a string" => "Type de donnée non valide : chaîne attendue",
-
-    // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is no valid sitemap lastmod" => "'%value%' n'est pas une date de modification de sitemap valide",
-    "Invalid type given, value should be a string" => "Type de donnée non valide : chaîne attendue",
-
-    // Zend_Validate_Sitemap_Loc
-    "'%value%' is no valid sitemap location" => "'%value%' n'est pas un emplacement valide pour une sitemap",
-    "Invalid type given, value should be a string" => "Type de donnée non valide : chaîne attendue",
-
-    // Zend_Validate_Sitemap_Priority
-    "'%value%' is no valid sitemap priority" => "'%value%' n'est pas une priorité sitemap valide",
-    "Invalid type given, the value should be a integer, a float or a numeric string" => "Type invalide : chaîne numérique, entier ou flottant attendu",
-
-    // Zend_Validate_StringLength
-    "Invalid type given, value should be a string" => "Type de donnée non valide : chaîne de caractères attendue",
+    "'%value%' has not only hexadecimal digit characters" => "'%value%' ne contient pas uniquement des caractères héxadécimaux",
+    "'%value%' is an empty string" => "'%value%' est une chaîne vide",
     "'%value%' is less than %min% characters long" => "La taille de '%value%' est inférieure à %min% caractères",
     "'%value%' is more than %max% characters long" => "La taille de '%value%' est supérieure à %max% caractères",
+    "'%value%' is not a valid ISBN number" => "'%value%' n'est pas un ISBN valide",
+    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' n'est pas un email valide dans le format local-part@hostname",
+    "'%value%' is not a valid sitemap changefreq" => "'%value%' n'est pas une valeur de fréquence de sitemap valide",
+    "'%value%' is not a valid sitemap lastmod" => "'%value%' n'est pas une date de modification de sitemap valide",
+    "'%value%' is not a valid sitemap location" => "'%value%' n'est pas un emplacement valide pour une sitemap",
+    "'%value%' is not a valid sitemap priority" => "'%value%' n'est pas une priorité sitemap valide",
+    "'%value%' is not between '%min%' and '%max%', inclusively" => "'%value%' n'est pas comprise entre '%min%' et '%max%', inclusivement",
+    "'%value%' is not from an allowed institute" => "'%value%' ne provient pas d'une institution autorisée",
+    "'%value%' is not greater than '%min%'" => "'%value%' n'est pas plus grand que '%min%'",
+    "'%value%' is not less than '%max%'" => "'%value%' n'est pas plus petit que '%max%'",
+    "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' n'est pas strictement comprise entre '%min%' et '%max%'",
+    "'%value%' is not valid" => "'%value%' n'est pas valide",
+    "'%value%' must contain between 13 and 19 digits" => "'%value%' doit contenir entre 13 et 19 chiffres",
+    "'%value%' must contain only digits" => "'%value%' ne doit contenir que des chiffres",
+    "'%value%' seems to be an invalid creditcard number" => "'%value%' ne semble pas être une carte de crédit valide",
+    "'%value%' seems to contain an invalid checksum" => "'%value%' semble contenir un somme de vérification invalide",
+    "'%value%' should have a length of %length% characters" => "'%value%' devrait avoir une taille de %length% caractères",
+    "'%value%' was not found in the haystack" => "'%value%' ne fait pas partie des valeurs attendues",
+    "A PHP extension returned an error while uploading the file '%value%'" => "Une extension PHP a retourné une erreur lors de l'envoi du fichier '%value%'",
+    "A crc32 hash could not be evaluated for the given file" => "La somme de contrôle crc32 n'a pas pu être évaluée pour le fichier",
+    "A hash could not be evaluated for the given file" => "Une somme de contrôle n'a pas pu être calculée pour le fichier",
+    "A md5 hash could not be evaluated for the given file" => "Une somme de contrôle MD5 n'a pas pu être calculée pour le fichier",
+    "A record matching '%value%' was found" => "Un enregistrement a été trouvé pour '%value%'",
+    "A sha1 hash could not be evaluated for the given file" => "La valeur de somme de contrôle SHA-1 n'a pas pu être calculée pour le fichier",
+    "An exception has been raised within the callback" => "Une exception a été levée par la fonction de rappel",
+    "An exception has been raised while validating '%value%'" => "Une exception a été levée lors de la validation de '%value%'",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Tous les fichiers devraient avoir une taille maximale de '%max%' mais une taille de '%size%' a été détectée",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Tous les fichiers devraient avoir une taille minimale de '%min%' mais une taille de '%size%' a été détectée",
+    "File '%value%' can't be written" => "Le fichier '%value%' ne peut être écrit",
+    "File '%value%' does not exist" => "Le fichier '%value%' n'existe pas",
+    "File '%value%' does not match the given crc32 hashes" => "Le fichier '%value%' ne correspond pas à la somme de contrôle crc32",
+    "File '%value%' does not match the given hashes" => "Le fichier '%value%' ne correspond pas à la somme de contrôle",
+    "File '%value%' does not match the given md5 hashes" => "Le fichier '%value%' ne correspond pas à la somme de contrôle MD5",
+    "File '%value%' does not match the given sha1 hashes" => "Le fichier '%value%' ne correspond pas à la somme de contrôle SHA-1",
+    "File '%value%' exceeds the defined form size" => "Le fichier '%value%' excède la taille requise par le formulaire",
+    "File '%value%' exceeds the defined ini size" => "Le fichier '%value%' excède la taille requise par le fichier ini",
+    "File '%value%' exists" => "Le fichier '%value%' existe déja",
+    "File '%value%' has a false extension" => "Le fichier '%value%' n'a pas la bonne extension",
+    "File '%value%' has a false mimetype of '%type%'" => "Le fichier '%value%' a un mauvais type MIME : '%type%'",
+    "File '%value%' is no image, '%type%' detected" => "Le fichier '%value%' n'est pas une image : '%type%' détecté",
+    "File '%value%' is not compressed, '%type%' detected" => "Le fichier '%value%' n'est pas compressé : '%type%' détecté",
+    "File '%value%' is not readable or does not exist" => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
+    "File '%value%' was illegally uploaded. This could be a possible attack" => "Fichier '%value%' mal envoyé. Ceci peut être possiblement une attaque",
+    "File '%value%' was not found" => "Fichier '%value%' introuvable",
+    "File '%value%' was not uploaded" => "Le fichier '%value%' n'a pas été envoyé",
+    "File '%value%' was only partially uploaded" => "Le fichier '%value%' n'a été que partiellement envoyé",
+    "Invalid type given. Numeric string, integer or float expected" => "Type invalide. Chaîne numérique, entier ou flottant attendu",
+    "Invalid type given. String expected" => "Type invalide. Chaîne attendue",
+    "Invalid type given. String or integer expected" => "Type invalide. Chaîne ou entier attendu",
+    "Invalid type given. String, integer, array or Zend_Date expected" => "Type invalide. Chaîne, entier, tableau ou Zend_Date attendu",
+    "Invalid type given. String, integer, float, boolean or array expected" => "Type invalide. Chaîne, entier, flottant, booléen ou tableau attendu",
+    "Invalid type given. String, integer or float expected" => "Type invalide. Chaîne, entier ou flottant attendu",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "L'algorithme Luhn (somme de contrôle mod-10) a échoué pour '%value%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "La hauteur maximale de l'image '%value%' devrait être '%maxheight%' mais '%height%' a été détectée",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "La taille maximale requise pour le fichier '%value%' est de '%max%' mais '%size%' a été détecté",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "La largeur maximale de l'image '%value%' devrait être '%maxwidth%' mais '%width%' a été détectée",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "La hauteur minimale de l'image '%value%' devrait être '%minheight%' mais '%height%' a été détectée",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "La taille minimale requise pour le fichier '%value%' est de '%min%' mais '%size%' a été détecté",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "La largeur minimale de l'image '%value%' devrait être '%minwidth%' mais '%width%' a été détectée",
+    "No record matching '%value%' was found" => "Aucun enregistrement trouvé pour '%value%'",
+    "No temporary directory was found for file '%value%'" => "Pas de dossier temporaire trouvé pour le fichier '%value%'",
+    "No token was provided to match against" => "Aucun jeton de correspondance n'a été donné",
+    "One or more files can not be read" => "Un ou plusieurs fichiers n'est pas lisible",
+    "The mimetype of file '%value%' could not be detected" => "Le type MIME du fichier '%value%' n'a pu être détecté",
+    "The size of image '%value%' could not be detected" => "La taille de l'image '%value%' n'a pas pu être détectée",
+    "The two given tokens do not match" => "Les deux jetons passés ne correspondent pas",
+    "There was an internal error while using the pattern '%pattern%'" => "Il y a eu une erreur interne lors de l'utilisation du motif '%pattern%'",
+    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Trop peu de fichiers : un minimum de '%min%' est autorisé mais '%count%' ont été fournis",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Trop peu de mots, un minimum de '%min%' est requis, '%count%' ont été fournis",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Trop de fichiers : un maximum de'%max%' est autorisé mais '%count%' ont été fournis",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Trop de mots, un maximum de '%max%' est requis, '%count%' ont été fournis",
+    "Unknown country within the IBAN '%value%'" => "Pays inconnu pour l'IBAN '%value%'",
+    "Unknown error while uploading file '%value%'" => "Erreur inconnue lors de l'envoi du fichier '%value%'",
+    "Value is required and can't be empty" => "Cette valeur est obligatoire et ne peut être vide",
 );

--- a/resources/languages/hr/Zend_Validate.php
+++ b/resources/languages/hr/Zend_Validate.php
@@ -77,13 +77,13 @@ return array(
 
     // Zend_Validate_EmailAddress
     "Invalid type given, value should be a string" => "Neispravan tip, vrijednost bi trebala biti niz",
-    "'%value%' is no valid email address in the basic format local-part@hostname" => "'%value%' nije ispravna email adresa u osnovnom formatu lokalni-dio@ime-poslužitelja",
-    "'%hostname%' is no valid hostname for email address '%value%'" => "'%hostname%' nije ispravno ime poslužitelja za email adresu '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' nije ispravna email adresa u osnovnom formatu lokalni-dio@ime-poslužitelja",
+    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' nije ispravno ime poslužitelja za email adresu '%value%'",
     "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' nema ispravan MX zapis za email adresu '%value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' nije u rutabilnom mrežnom segmentu. Email adresa '%value%' ne bi smjela biti razlučiva iz javne mreže.",
     "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' se ne podudara s dot-atom formatom",
     "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' se ne podudara s 'quoted-string' formatom",
-    "'%localPart%' is no valid local part for email address '%value%'" => "'%localPart%' nije ispravan lokalni dio za email adresu '%value%'",
+    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' nije ispravan lokalni dio za email adresu '%value%'",
     "'%value%' exceeds the allowed length" => "'%value%' je duža od dozvoljene dužine",
 
     // Zend_Validate_File_Count
@@ -224,7 +224,7 @@ return array(
 
     // Zend_Validate_Isbn
     "Invalid type given, value should be string or integer" => "Neispravan tip, vrijednost mora biti niz ili cijeli broj",
-    "'%value%' is no valid ISBN number" => "'%value%' nije ispravan ISBN broj",
+    "'%value%' is not a valid ISBN number" => "'%value%' nije ispravan ISBN broj",
 
     // Zend_Validate_LessThan
     "'%value%' is not less than '%max%'" => "'%value%' nije manje od '%max%'",
@@ -243,19 +243,19 @@ return array(
     "There was an internal error while using the pattern '%pattern%'" => "Došlo je do interne pogreške prilikom korištenja uzorka '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is no valid sitemap changefreq" => "'%value%' nije ispravna vrijednost za sitemap 'changefreq'",
+    "'%value%' is not a valid sitemap changefreq" => "'%value%' nije ispravna vrijednost za sitemap 'changefreq'",
     "Invalid type given, the value should be a string" => "Neispravan tip, vrijednost mora biti niz",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is no valid sitemap lastmod" => "'%value%' nije ispravna vrijednost za sitemap 'lastmod'",
+    "'%value%' is not a valid sitemap lastmod" => "'%value%' nije ispravna vrijednost za sitemap 'lastmod'",
     "Invalid type given, the value should be a string" => "Neispravan tip, vrijednost mora biti niz",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is no valid sitemap location" => "'%value%' nije ispravna lokacija za 'sitemap'",
+    "'%value%' is not a valid sitemap location" => "'%value%' nije ispravna lokacija za 'sitemap'",
     "Invalid type given, the value should be a string" => "Neispravan tip, vrijednost mora biti niz",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is no valid sitemap priority" => "'%value%' nije ispravna vrijednost za sitemap 'priority'",
+    "'%value%' is not a valid sitemap priority" => "'%value%' nije ispravna vrijednost za sitemap 'priority'",
     "Invalid type given, the value should be a integer, a float or a numeric string" => "Neispravan tip, vrijednost mora biti cijeli broj, realni broj ili niz znamenki",
 
     // Zend_Validate_StringLength

--- a/resources/languages/it/Zend_Validate.php
+++ b/resources/languages/it/Zend_Validate.php
@@ -77,13 +77,13 @@ return array(
 
     // Zend_Validate_EmailAddress
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
-    "'%value%' is no valid email address in the basic format local-part@hostname" => "'%value%' non è un indirizzo email valido nel formato base local-part@hostname",
-    "'%hostname%' is no valid hostname for email address '%value%'" => "'%hostname%' non è un hostname valido nell'indirizzo email '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' non è un indirizzo email valido nel formato base local-part@hostname",
+    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' non è un hostname valido nell'indirizzo email '%value%'",
     "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' non sembra avere un record MX DNS valido nell'indirizzo email %value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' non è in un segmento di rete routabile. L'indirizzo email '%value%' non può essere risolto nella rete pubblica.",
     "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' non può essere validato nel formato dot-atom",
     "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' non può essere validato nel formato quoted-string",
-    "'%localPart%' is no valid local part for email address '%value%'" => "'%localPart%' non è una local part valida nell'indirizzo email '%value%'",
+    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' non è una local part valida nell'indirizzo email '%value%'",
     "'%value%' exceeds the allowed length" => "'%value%' supera la lunghezza consentita",
 
     // Zend_Validate_File_Count
@@ -224,7 +224,7 @@ return array(
 
     // Zend_Validate_Isbn
     "Invalid type given. String or integer expected" => "Tipo di dato non valido. Era atteso un dato di tipo string o integer",
-    "'%value%' is no valid ISBN number" => "'%value%' non è un numero ISBN valido",
+    "'%value%' is not a valid ISBN number" => "'%value%' non è un numero ISBN valido",
 
     // Zend_Validate_LessThan
     "'%value%' is not less than '%max%'" => "'%value%' non è minore di '%max%'",
@@ -243,19 +243,19 @@ return array(
     "There was an internal error while using the pattern '%pattern%'" => "Si è verificato un errore interno usando il pattern '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is no valid sitemap changefreq" => "'%value%' non è una sitemap changefreq valida",
+    "'%value%' is not a valid sitemap changefreq" => "'%value%' non è una sitemap changefreq valida",
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is no valid sitemap lastmod" => "'%value%' non è un sitemap lastmod valido",
+    "'%value%' is not a valid sitemap lastmod" => "'%value%' non è un sitemap lastmod valido",
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is no valid sitemap location" => "'%value%' non è una sitemap location valida",
+    "'%value%' is not a valid sitemap location" => "'%value%' non è una sitemap location valida",
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is no valid sitemap priority" => "'%value%' non è una sitemap priority valida",
+    "'%value%' is not a valid sitemap priority" => "'%value%' non è una sitemap priority valida",
     "Invalid type given. Numeric string, integer or float expected" => "Tipo di dato non valido. Era atteso un dato di tipo stringa numerica, float o integer",
 
     // Zend_Validate_StringLength

--- a/resources/languages/ja/Zend_Validate.php
+++ b/resources/languages/ja/Zend_Validate.php
@@ -76,13 +76,13 @@ return array(
 
     // Zend_Validate_EmailAddress
     "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
-    "'%value%' is no valid email address in the basic format local-part@hostname" => "'%value%' はメールアドレスの基本的な形式 local-part@hostname ではありません",
-    "'%hostname%' is no valid hostname for email address '%value%'" => "メールアドレス '%value%' 内の '%hostname%' は有効なホスト名ではありません",
+    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' はメールアドレスの基本的な形式 local-part@hostname ではありません",
+    "'%hostname%' is not a valid hostname for email address '%value%'" => "メールアドレス '%value%' 内の '%hostname%' は有効なホスト名ではありません",
     "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "メールアドレス '%value%' 内の '%hostname%' は有効な MX レコードではないようです",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network" => "'%hostname%' はネットワークセグメントにありません。メールアドレス '%value%' はパブリックなネットワークから名前解決できませんでした",
     "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' はドットアトム形式ではありません",
     "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' は引用文字列形式ではありません",
-    "'%localPart%' is no valid local part for email address '%value%'" => "メールアドレス '%value%' 内の '%localPart%' は有効なローカルパートではありません",
+    "'%localPart%' is not a valid local part for email address '%value%'" => "メールアドレス '%value%' 内の '%localPart%' は有効なローカルパートではありません",
     "'%value%' exceeds the allowed length" => "'%value%' は許された長さを超えています",
 
     // Zend_Validate_File_Count
@@ -223,7 +223,7 @@ return array(
 
     // Zend_Validate_Isbn
      "Invalid type given. String or integer expected" => "不正な形式です。文字列または整数が期待されています",
-    "'%value%' is no valid ISBN number" => " '%value%' は ISBN 番号ではありません",
+    "'%value%' is not a valid ISBN number" => " '%value%' は ISBN 番号ではありません",
 
     // Zend_Validate_LessThan
     "'%value%' is not less than '%max%'" => " '%value%' は '%max%' 未満ではありません",
@@ -242,19 +242,19 @@ return array(
     "There was an internal error while using the pattern '%pattern%'" => "正規表現パターン '%pattern%' を使用中に内部エラーが発生しました。",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is no valid sitemap changefreq" => " '%value%' は正しいサイトマップの更新頻度ではありません",
+    "'%value%' is not a valid sitemap changefreq" => " '%value%' は正しいサイトマップの更新頻度ではありません",
     "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is no valid sitemap lastmod" => " '%value%' は正しいサイトマップの最終更新日ではありません",
+    "'%value%' is not a valid sitemap lastmod" => " '%value%' は正しいサイトマップの最終更新日ではありません",
     "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is no valid sitemap location" => " '%value%' は正しいサイトマップの位置ではありません",
+    "'%value%' is not a valid sitemap location" => " '%value%' は正しいサイトマップの位置ではありません",
     "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is no valid sitemap priority" => " '%value%' は正しいサイトマップの優先度ではありません",
+    "'%value%' is not a valid sitemap priority" => " '%value%' は正しいサイトマップの優先度ではありません",
     "Invalid type given. Numeric string, integer or float expected" => "不正な形式です。数字、整数もしくは小数が期待されています",
 
     // Zend_Validate_StringLength

--- a/resources/languages/nl/Zend_Validate.php
+++ b/resources/languages/nl/Zend_Validate.php
@@ -76,13 +76,13 @@ return array(
 
     // Zend_Validate_EmailAddress
     "Invalid type given, value should be a string" => "Ongeldig type opgegeven, waarde moet een string zijn",
-    "'%value%' is no valid email address in the basic format local-part@hostname" => "'%value%' is geen geldig e-mail adres in het basis formaat lokaal-gedeelte@hostname",
-    "'%hostname%' is no valid hostname for email address '%value%'" => "'%hostname%' is geen geldige hostnaam voor e-mail adres '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' is geen geldig e-mail adres in het basis formaat lokaal-gedeelte@hostname",
+    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' is geen geldige hostnaam voor e-mail adres '%value%'",
     "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' lijkt geen geldig MX record te hebben voor e-mail adres '%value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' bevindt zich niet in een routeerbaar netwerk segment. Het e-mail adres '%value%' zou niet naar mogen worden verwezen vanaf een publiek netwerk.",
     "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' kan niet worden gematched met het dot-atom formaat",
     "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' kan niet worden gematched met het quoted-string formaat",
-    "'%localPart%' is no valid local part for email address '%value%'" => "'%localPart%' is geen geldig lokaal gedeelte voor e-mail adres '%value%'",
+    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' is geen geldig lokaal gedeelte voor e-mail adres '%value%'",
     "'%value%' exceeds the allowed length" => "'%value%' overschrijdt de toegestane lengte",
 
     // Zend_Validate_File_Count
@@ -223,7 +223,7 @@ return array(
 
     // Zend_Validate_Isbn
     "Invalid type given, value should be string or integer" => "Ongeldig type opgegeven, waarde moet een string of integer zijn",
-    "'%value%' is no valid ISBN number" => "'%value%' is geen geldig ISBN nummer",
+    "'%value%' is not a valid ISBN number" => "'%value%' is geen geldig ISBN nummer",
 
     // Zend_Validate_LessThan
     "'%value%' is not less than '%max%'" => "'%value%' is niet minder dan '%max%'",
@@ -242,19 +242,19 @@ return array(
     "There was an internal error while using the pattern '%pattern%'" => "Er is een interne fout opgetreden tijdens het gebruik van het patroon '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is no valid sitemap changefreq" => "'%value%' is geen geldige sitemap changefreq",
+    "'%value%' is not a valid sitemap changefreq" => "'%value%' is geen geldige sitemap changefreq",
     "Invalid type given, the value should be a string" => "Ongeldig type opgegeven, waarde dient een string te zijn",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is no valid sitemap lastmod" => "'%value%' is geen geldige sitemap lastmod",
+    "'%value%' is not a valid sitemap lastmod" => "'%value%' is geen geldige sitemap lastmod",
     "Invalid type given, the value should be a string" => "Ongeldig type opgegeven, waarde dient een string te zijn",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is no valid sitemap location" => "'%value%' is geen geldige sitemap locatie",
+    "'%value%' is not a valid sitemap location" => "'%value%' is geen geldige sitemap locatie",
     "Invalid type given, the value should be a string" => "Ongeldig type opgegeven, waarde dient een string te zijn",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is no valid sitemap priority" => "'%value%' is geen geldige sitemap prioriteit",
+    "'%value%' is not a valid sitemap priority" => "'%value%' is geen geldige sitemap prioriteit",
     "Invalid type given, the value should be a integer, a float or a numeric string" => "Ongeldig type opgegeven, waarde dient een integer, float of een numerieke string te zijn",
 
     // Zend_Validate_StringLength

--- a/resources/languages/pt_BR/Zend_Validate.php
+++ b/resources/languages/pt_BR/Zend_Validate.php
@@ -76,13 +76,13 @@ return array(
 
     // Zend_Validate_EmailAddress
     "Invalid type given, value should be a string" => "O tipo especificado é inválido, o valor deve ser uma string",
-    "'%value%' is no valid email address in the basic format local-part@hostname" => "'%value%' não é um endereço de e-mail válido no formato local-part@hostname",
-    "'%hostname%' is no valid hostname for email address '%value%'" => "'%hostname%' não é um nome de host válido para o endereço de e-mail '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' não é um endereço de e-mail válido no formato local-part@hostname",
+    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' não é um nome de host válido para o endereço de e-mail '%value%'",
     "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' não parece ter um registro MX válido para o endereço de e-mail '%value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' não é um segmento de rede roteável. O endereço de e-mail '%value%' não deve ser resolvido a partir de um rede pública.",
     "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' não corresponde com o formato dot-atom",
     "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' não corresponde com o formato quoted-string",
-    "'%localPart%' is no valid local part for email address '%value%'" => "'%localPart%' não é uma parte local válida para o endereço de e-mail '%value%'",
+    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' não é uma parte local válida para o endereço de e-mail '%value%'",
     "'%value%' exceeds the allowed length" => "'%value%' excede o comprimento permitido",
 
     // Zend_Validate_File_Count
@@ -223,7 +223,7 @@ return array(
 
     // Zend_Validate_Isbn
     "Invalid type given, value should be string or integer" => "O tipo especificado é inválido, o valor deve ser string ou inteiro",
-    "'%value%' is no valid ISBN number" => "'%value%' não é um número ISBN válido",
+    "'%value%' is not a valid ISBN number" => "'%value%' não é um número ISBN válido",
 
     // Zend_Validate_LessThan
     "'%value%' is not less than '%max%'" => "'%value%' não é menor que '%max%'",
@@ -242,19 +242,19 @@ return array(
     "There was an internal error while using the pattern '%pattern%'" => "Houve um erro interno durante o uso do padrão '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is no valid sitemap changefreq" => "'%value%' não é um changefreq de sitemap válido",
+    "'%value%' is not a valid sitemap changefreq" => "'%value%' não é um changefreq de sitemap válido",
     "Invalid type given, the value should be a string" => "O tipo especificado é inválido, o valor deve ser uma string",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is no valid sitemap lastmod" => "'%value%' não é um lastmod de sitemap válido",
+    "'%value%' is not a valid sitemap lastmod" => "'%value%' não é um lastmod de sitemap válido",
     "Invalid type given, the value should be a string" => "O tipo especificado é inválido, o valor deve ser uma string",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is no valid sitemap location" => "'%value%' não é uma localização de sitemap válida",
+    "'%value%' is not a valid sitemap location" => "'%value%' não é uma localização de sitemap válida",
     "Invalid type given, the value should be a string" => "O tipo especificado é inválido, o valor deve ser uma string",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is no valid sitemap priority" => "'%value%' não é uma prioridade de sitemap válida",
+    "'%value%' is not a valid sitemap priority" => "'%value%' não é uma prioridade de sitemap válida",
     "Invalid type given, the value should be a integer, a float or a numeric string" => "O tipo especificado é inválido, o valor deve ser um inteiro, um float ou uma string numérica",
 
     // Zend_Validate_StringLength

--- a/resources/languages/ru/Zend_Validate.php
+++ b/resources/languages/ru/Zend_Validate.php
@@ -76,13 +76,13 @@ return array(
 
     // Zend_Validate_EmailAddress
     "Invalid type given, value should be a string" => "Недопустимый тип данных, значение должно быть строкой",
-    "'%value%' is no valid email address in the basic format local-part@hostname" => "'%value%' недопустимый адрес электронной почты. Введите его в формате имя@домен",
-    "'%hostname%' is no valid hostname for email address '%value%'" => "'%hostname%' недопустимое имя хоста для адреса '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' недопустимый адрес электронной почты. Введите его в формате имя@домен",
+    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' недопустимое имя хоста для адреса '%value%'",
     "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' не имеет корректной MX-записи об адресе '%value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' не является маршрутизируемым сегментом сети. Адрес электронной почты '%value%' не может быть получен из публичной сети.",
     "'%localPart%' can not be matched against dot-atom format" => "'%localPart% не соответствует формату dot-atom",
     "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' не соответствует формату quoted-string",
-    "'%localPart%' is no valid local part for email address '%value%'" => "'%localPart%' недопустимое имя для адреса '%value%'",
+    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' недопустимое имя для адреса '%value%'",
     "'%value%' exceeds the allowed length" => "'%value%' превышает допустимую длину",
 
     // Zend_Validate_File_Count
@@ -222,7 +222,7 @@ return array(
     "'%value%' does not appear to be a valid IP address" => "'%value%' не является корректным IP-адресом",
 
     // Zend_Validate_Isbn
-    "'%value%' is no valid ISBN number" => "'%value%' не является корректным номером ISBN",
+    "'%value%' is not a valid ISBN number" => "'%value%' не является корректным номером ISBN",
 
     // Zend_Validate_LessThan
     "'%value%' is not less than '%max%'" => "'%value%' не меньше, чем '%max%'",
@@ -240,16 +240,16 @@ return array(
     "'%value%' does not match against pattern '%pattern%'" => "'%value%' не соответствует шаблону '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is no valid sitemap changefreq" => "'%value%' недопустимое значение для sitemap changefreq",
+    "'%value%' is not a valid sitemap changefreq" => "'%value%' недопустимое значение для sitemap changefreq",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is no valid sitemap lastmod" => "'%value%' недопустимое значение для sitemap lastmod",
+    "'%value%' is not a valid sitemap lastmod" => "'%value%' недопустимое значение для sitemap lastmod",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is no valid sitemap location" => "'%value%' недопустимое значение для sitemap location",
+    "'%value%' is not a valid sitemap location" => "'%value%' недопустимое значение для sitemap location",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is no valid sitemap priority" => "'%value%' недопустимое значение для sitemap priority",
+    "'%value%' is not a valid sitemap priority" => "'%value%' недопустимое значение для sitemap priority",
 
     // Zend_Validate_StringLength
     "Invalid type given, value should be a string" => "Недопустимый тип данных, значение должно быть строкой",

--- a/resources/languages/sr/Zend_Validate.php
+++ b/resources/languages/sr/Zend_Validate.php
@@ -77,13 +77,13 @@ return array(
 
     // Zend_Validate_EmailAddress
     "Invalid type given, value should be a string" => "Nevalidan tip, vrednost treba da bude tekst",
-    "'%value%' is no valid email address in the basic format local-part@hostname" => "'%value%' nije validna adresa elektronske pošte u formatu adresa@imehosta",
-    "'%hostname%' is no valid hostname for email address '%value%'" => "'%hostname%' nije validno ime hosta za adresu elektronske pošte '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' nije validna adresa elektronske pošte u formatu adresa@imehosta",
+    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' nije validno ime hosta za adresu elektronske pošte '%value%'",
     "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' nema validan MX zapis za adresu elektronske pošte '%value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' nije rutabilan mrežni segment. Adresa elektronske pošte '%value%' ne treba da bude razrešena sa javne mreže",
     "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' se ne poklapa sa dot-atom formatom",
     "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' se ne poklapa sa quoted-string formatom",
-    "'%localPart%' is no valid local part for email address '%value%'" => "'%localPart%' nije validan deo adrese elektronske pošte '%value%'",
+    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' nije validan deo adrese elektronske pošte '%value%'",
     "'%value%' exceeds the allowed length" => "'%value%' prelazi dozvoljenu dužinu",
 
     // Zend_Validate_File_Count
@@ -224,7 +224,7 @@ return array(
 
     // Zend_Validate_Isbn
     "Invalid type given, value should be string or integer" => "Nevalidan tip, vrednost treba da bude tekst ili ceo broj",
-    "'%value%' is no valid ISBN number" => "'%value%' nije validan ISBN broj",
+    "'%value%' is not a valid ISBN number" => "'%value%' nije validan ISBN broj",
 
     // Zend_Validate_LessThan
     "'%value%' is not less than '%max%'" => "'%value%' je manje od '%max%'",
@@ -243,19 +243,19 @@ return array(
     "There was an internal error while using the pattern '%pattern%'" => "Dogodila se greška pri korišćenju formata '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is no valid sitemap changefreq" => "'%value%' nije validna frekvencija promene mape sajta",
+    "'%value%' is not a valid sitemap changefreq" => "'%value%' nije validna frekvencija promene mape sajta",
     "Invalid type given, the value should be a string" => "Nevalidan tip, vrednost treba da bude tekst",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is no valid sitemap lastmod" => "'%value%' nije validan datum izmene mape sajta",
+    "'%value%' is not a valid sitemap lastmod" => "'%value%' nije validan datum izmene mape sajta",
     "Invalid type given, the value should be a string" => "Nevalidan tip, vrednost treba da bude tekst",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is no valid sitemap location" => "'%value%' nije validna lokacija mape sajta",
+    "'%value%' is not a valid sitemap location" => "'%value%' nije validna lokacija mape sajta",
     "Invalid type given, the value should be a string" => "Nevalidan tip, vrednost treba da bude tekst",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is no valid sitemap priority" => "'%value%' nije validan prioritet mape sajta",
+    "'%value%' is not a valid sitemap priority" => "'%value%' nije validan prioritet mape sajta",
     "Invalid type given, the value should be a integer, a float or a numeric string" => "Nevalidan tip, vrednost treba da bude broj ili numerički niz",
 
     // Zend_Validate_StringLength

--- a/resources/languages/uk/Zend_Validate.php
+++ b/resources/languages/uk/Zend_Validate.php
@@ -76,13 +76,13 @@ return array(
 
     // Zend_Validate_EmailAddress
     "Invalid type given, value should be a string" => "Неприпустимий тип даних, значення повинно рядком",
-    "'%value%' is no valid email address in the basic format local-part@hostname" => "'%value%' неприпустима адреса електронної пошти для формату ім'я@домен",
-    "'%hostname%' is no valid hostname for email address '%value%'" => "'%hostname%' неприпустиме ім'я хоста для адреси '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' неприпустима адреса електронної пошти для формату ім'я@домен",
+    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' неприпустиме ім'я хоста для адреси '%value%'",
     "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' не має коректного MX-запису про адресу '%value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' не є маршрутизованим сегментом мережі. Адреса електронної пошти '%value%' не може бути отримана з публічної мережі.",
     "'%localPart%' can not be matched against dot-atom format" => "'%localPart% не відповідає формату dot-atom",
     "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' не відповідає формату quoted-string",
-    "'%localPart%' is no valid local part for email address '%value%'" => "'%localPart%' неприпустиме ім'я для адреси '%value%'",
+    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' неприпустиме ім'я для адреси '%value%'",
     "'%value%' exceeds the allowed length" => "'%value%' перевищує дозволену довжину",
 
     // Zend_Validate_File_Count
@@ -222,7 +222,7 @@ return array(
     "'%value%' does not appear to be a valid IP address" => "'%value%' - некоректна IP-адреса",
 
     // Zend_Validate_Isbn
-    "'%value%' is no valid ISBN number" => "'%value%' - некоректний номер ISBN",
+    "'%value%' is not a valid ISBN number" => "'%value%' - некоректний номер ISBN",
 
     // Zend_Validate_LessThan
     "'%value%' is not less than '%max%'" => "'%value%' не менше ніж '%max%'",
@@ -240,16 +240,16 @@ return array(
     "'%value%' does not match against pattern '%pattern%'" => "'%value%' не відповідає шаблону '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is no valid sitemap changefreq" => "'%value%' неприпустиме значення для sitemap changefreq",
+    "'%value%' is not a valid sitemap changefreq" => "'%value%' неприпустиме значення для sitemap changefreq",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is no valid sitemap lastmod" => "'%value%' неприпустиме значення для sitemap lastmod",
+    "'%value%' is not a valid sitemap lastmod" => "'%value%' неприпустиме значення для sitemap lastmod",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is no valid sitemap location" => "'%value%' неприпустиме значення для sitemap location",
+    "'%value%' is not a valid sitemap location" => "'%value%' неприпустиме значення для sitemap location",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is no valid sitemap priority" => "'%value%' неприпустиме значення для sitemap priority",
+    "'%value%' is not a valid sitemap priority" => "'%value%' неприпустиме значення для sitemap priority",
 
     // Zend_Validate_StringLength
     "Invalid type given, value should be a string" => "Неприпустимий тип даних, значення повинно бути рядком",

--- a/tests/Zend/Validator/EmailAddressTest.php
+++ b/tests/Zend/Validator/EmailAddressTest.php
@@ -137,7 +137,7 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('quoted-string', current($messages));
 
         $this->assertContains('Some User', next($messages));
-        $this->assertContains('no valid local part', current($messages));
+        $this->assertContains('not a valid local part', current($messages));
     }
 
     /**
@@ -165,7 +165,7 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->_validator->isValid('username@ example . com'));
         $messages = $this->_validator->getMessages();
         $this->assertThat(count($messages), $this->greaterThanOrEqual(1));
-        $this->assertContains('no valid hostname', current($messages));
+        $this->assertContains('not a valid hostname', current($messages));
     }
 
     /**
@@ -200,7 +200,7 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->_validator->isValid('User Name <username@example.com>'));
         $messages = $this->_validator->getMessages();
         $this->assertThat(count($messages), $this->greaterThanOrEqual(3));
-        $this->assertContains('no valid hostname', current($messages));
+        $this->assertContains('not a valid hostname', current($messages));
         $this->assertContains('cannot match TLD', next($messages));
         $this->assertContains('does not appear to be a valid local network name', next($messages));
     }
@@ -501,18 +501,6 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
         $this->_validator->setMessage('TestMessage', Validator\EmailAddress::INVALID);
         $messages = $this->_validator->getMessageTemplates();
         $this->assertEquals('TestMessage', $messages[Validator\EmailAddress::INVALID]);
-    }
-
-    /**
-     * Testing validateMxSupported
-     */
-    public function testValidateMxSupported()
-    {
-        if (function_exists('getmxrr')) {
-            $this->assertTrue($this->_validator->validateMxSupported());
-        } else {
-            $this->assertFalse($this->_validator->validateMxSupported());
-        }
     }
 
     /**

--- a/tests/Zend/Validator/Sitemap/ChangefreqTest.php
+++ b/tests/Zend/Validator/Sitemap/ChangefreqTest.php
@@ -90,7 +90,7 @@ class ChangefreqTest extends \PHPUnit_Framework_TestCase
         foreach ($values as $value) {
             $this->assertSame(false, $this->_validator->isValid($value));
             $messages = $this->_validator->getMessages();
-            $this->assertContains('is no valid', current($messages));
+            $this->assertContains('is not a valid', current($messages));
         }
     }
 

--- a/tests/Zend/Validator/Sitemap/LastmodTest.php
+++ b/tests/Zend/Validator/Sitemap/LastmodTest.php
@@ -102,7 +102,7 @@ class LastmodTest extends \PHPUnit_Framework_TestCase
         foreach ($values as $value) {
             $this->assertSame(false, $this->_validator->isValid($value));
             $messages = $this->_validator->getMessages();
-            $this->assertContains('is no valid', current($messages));
+            $this->assertContains('is not a valid', current($messages));
         }
     }
 

--- a/tests/Zend/Validator/Sitemap/LocTest.php
+++ b/tests/Zend/Validator/Sitemap/LocTest.php
@@ -100,7 +100,7 @@ class LocTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->_validator->isValid($url), $url);
         $messages = $this->_validator->getMessages();
-        $this->assertContains('is no valid', current($messages));
+        $this->assertContains('is not a valid', current($messages));
     }
 
     /**

--- a/tests/Zend/Validator/Sitemap/PriorityTest.php
+++ b/tests/Zend/Validator/Sitemap/PriorityTest.php
@@ -89,7 +89,7 @@ class PriorityTest extends \PHPUnit_Framework_TestCase
         foreach ($values as $value) {
             $this->assertSame(false, $this->_validator->isValid($value));
             $messages = $this->_validator->getMessages();
-            $this->assertContains('is no valid', current($messages));
+            $this->assertContains('is not a valid', current($messages));
         }
     }
 

--- a/tests/Zend/Validator/ValidateTest.php
+++ b/tests/Zend/Validator/ValidateTest.php
@@ -139,7 +139,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     public function testStaticFactoryClassNotFound()
     {
         $this->setExpectedException('Zend\Validate\Exception\RuntimeException', 'foo');
-        Validator\ValidatorChain::execute('1234', 'UnknownValidator');
+        Validator\StaticValidator::execute('1234', 'UnknownValidator');
     }
 
     public function testIsValidWithParameters()


### PR DESCRIPTION
- message corrections for all languages

Note:
Previously existing test failures due to ZF2 migration have not been
addressed by this fix
