### PR TITLE
Fixing Zend\Dojo tests

### DIFF
--- a/library/Zend/Dojo/BuildLayer.php
+++ b/library/Zend/Dojo/BuildLayer.php
@@ -25,7 +25,7 @@ namespace Zend\Dojo;
 
 use Zend\Config\Config,
     Zend\Json\Json,
-    Zend\View\ViewEngine;
+    Zend\View\Renderer;
 
 /**
  * Dojo module layer and custom build profile generation support
@@ -91,8 +91,8 @@ class BuildLayer
     protected $_profilePrefixes = array();
 
     /**
-     * Zend_View reference
-     * @var \Zend\View\ViewEngine
+     * Zend\View reference
+     * @var \Zend\View\Renderer
      */
     protected $_view;
 
@@ -138,10 +138,10 @@ class BuildLayer
     /**
      * Set View object
      *
-     * @param  \Zend\View\ViewEngine $view
+     * @param  \Zend\View\Renderer $view
      * @return \Zend\Dojo\BuildLayer
      */
-    public function setView(ViewEngine $view)
+    public function setView(Renderer $view)
     {
         $this->_view = $view;
         return $this;
@@ -183,8 +183,7 @@ class BuildLayer
             if (null === ($view = $this->getView())) {
                 throw new Exception\RuntimeException('View object not registered; cannot retrieve dojo helper');
             }
-            $helper = $view->getHelper('dojo');
-            $this->setDojoHelper($view->dojo());
+            $this->setDojoHelper($view->broker('dojo')->direct());
         }
         return $this->_dojo;
     }

--- a/library/Zend/Dojo/Data.php
+++ b/library/Zend/Dojo/Data.php
@@ -360,7 +360,7 @@ class Data implements \ArrayAccess,\IteratorAggregate,\Countable
         if (!is_string($json)) {
             throw new Exception\InvalidArgumentException('fromJson() expects JSON input');
         }
-        $data = Json::decode($json);
+        $data = Json::decode($json, Json::TYPE_ARRAY);
         return $this->fromArray($data);
     }
 

--- a/library/Zend/Dojo/Form/Decorator/DijitContainer.php
+++ b/library/Zend/Dojo/Form/Decorator/DijitContainer.php
@@ -23,7 +23,7 @@
  */
 namespace Zend\Dojo\Form\Decorator;
 
-use Zend\Form\Decorator\Exception as DecoratorException;
+use Zend\Form\Decorator\Exception\RunTimeException as DecoratorException;
 
 /**
  * Zend_Dojo_Form_Decorator_DijitContainer
@@ -190,14 +190,14 @@ abstract class DijitContainer extends \Zend\Form\Decorator\AbstractDecorator
         $helper      = $this->getHelper();
         $id          = $element->getId() . '-' . $helper;
 
-        if ($view->dojo()->hasDijit($id)) {
+        if ($view->broker('dojo')->hasDijit($id)) {
             trigger_error(sprintf('Duplicate dijit ID detected for id "%s; temporarily generating uniqid"', $id), E_USER_WARNING);
             $base = $id;
             do {
                 $id = $base . '-' . uniqid();
-            } while ($view->dojo()->hasDijit($id));
+            } while ($view->broker('dojo')->hasDijit($id));
         }
 
-        return $view->$helper($id, $content, $dijitParams, $attribs);
+        return $view->broker($helper)->direct($id, $content, $dijitParams, $attribs);
     }
 }

--- a/library/Zend/Dojo/Form/Decorator/DijitElement.php
+++ b/library/Zend/Dojo/Form/Decorator/DijitElement.php
@@ -172,12 +172,12 @@ class DijitElement extends ViewHelperDecorator
         $dijitParams['required'] = $element->isRequired();
 
         $id = $element->getId();
-        if ($view->dojo()->hasDijit($id)) {
+        if ($view->broker('dojo')->hasDijit($id)) {
             trigger_error(sprintf('Duplicate dijit ID detected for id "%s; temporarily generating uniqid"', $id), E_USER_NOTICE);
             $base = $id;
             do {
                 $id = $base . '-' . uniqid();
-            } while ($view->dojo()->hasDijit($id));
+            } while ($view->broker('dojo')->hasDijit($id));
         }
         $attribs['id'] = $id;
 
@@ -185,7 +185,7 @@ class DijitElement extends ViewHelperDecorator
                $options = $attribs['options'];
         }
 
-        $elementContent = $view->$helper($name, $value, $dijitParams, $attribs, $options);
+        $elementContent = $view->broker($helper)->direct($name, $value, $dijitParams, $attribs, $options);
         switch ($this->getPlacement()) {
             case self::APPEND:
                 return $content . $separator . $elementContent;

--- a/library/Zend/Dojo/Form/Decorator/DijitElement.php
+++ b/library/Zend/Dojo/Form/Decorator/DijitElement.php
@@ -24,7 +24,7 @@
 namespace Zend\Dojo\Form\Decorator;
 
 use Zend\Form\Decorator\ViewHelper as ViewHelperDecorator,
-    Zend\Form\Decorator\Exception as DecoratorException;
+    Zend\Form\Decorator\Exception\RunTimeException as DecoratorException;
 
 /**
  * Zend_Dojo_Form_Decorator_DijitElement

--- a/library/Zend/Dojo/Form/Decorator/DijitForm.php
+++ b/library/Zend/Dojo/Form/Decorator/DijitForm.php
@@ -58,6 +58,6 @@ class DijitForm extends DijitContainer
         $dijitParams = $this->getDijitParams();
         $attribs     = array_merge($this->getAttribs(), $this->getOptions());
 
-        return $view->form($element->getName(), $attribs, $content);
+        return $view->broker('form')->direct($element->getName(), $attribs, $content);
     }
 }

--- a/library/Zend/Dojo/Form/DisplayGroup.php
+++ b/library/Zend/Dojo/Form/DisplayGroup.php
@@ -65,7 +65,8 @@ class DisplayGroup extends \Zend\Form\DisplayGroup
         if (null !== $view) {
             if(false === $view->broker()->isLoaded('dojo')) {
                 $loader = new \Zend\Dojo\View\HelperLoader();
-                $view->broker()->setClassLoader($loader);
+                $view->broker()->getClassLoader()
+                                ->registerPlugins($loader->getIterator());
             }
         }
         return parent::setView($view);

--- a/library/Zend/Dojo/Form/DisplayGroup.php
+++ b/library/Zend/Dojo/Form/DisplayGroup.php
@@ -25,7 +25,7 @@
 namespace Zend\Dojo\Form;
 
 use Zend\Loader\PrefixPathMapper as PluginLoader,
-    Zend\View\ViewEngine as View;
+    Zend\View\Renderer as View;
 
 /**
  * Dijit-enabled DisplayGroup
@@ -57,14 +57,15 @@ class DisplayGroup extends \Zend\Form\DisplayGroup
      *
      * Ensures that the view object has the dojo view helper path set.
      *
-     * @param  \Zend\View\ViewEngine $view
+     * @param  \Zend\View\Renderer $view
      * @return \Zend\Dojo\Form\Element\Dijit
      */
     public function setView(View $view = null)
     {
         if (null !== $view) {
-            if (false === $view->getPluginLoader('helper')->getPaths('Zend\Dojo\View\Helper')) {
-                $view->addHelperPath('Zend/Dojo/View/Helper', 'Zend\Dojo\View\Helper');
+            if(false === $view->broker()->isLoaded('dojo')) {
+                $loader = new \Zend\Dojo\View\HelperLoader();
+                $view->broker()->setClassLoader($loader);
             }
         }
         return parent::setView($view);

--- a/library/Zend/Dojo/Form/DisplayGroup.php
+++ b/library/Zend/Dojo/Form/DisplayGroup.php
@@ -65,8 +65,7 @@ class DisplayGroup extends \Zend\Form\DisplayGroup
         if (null !== $view) {
             if(false === $view->broker()->isLoaded('dojo')) {
                 $loader = new \Zend\Dojo\View\HelperLoader();
-                $view->broker()->getClassLoader()
-                                ->registerPlugins($loader->getIterator());
+                $view->broker()->getClassLoader()->registerPlugins($loader);
             }
         }
         return parent::setView($view);

--- a/library/Zend/Dojo/Form/Element/CurrencyTextBox.php
+++ b/library/Zend/Dojo/Form/Element/CurrencyTextBox.php
@@ -24,6 +24,8 @@
  */
 namespace Zend\Dojo\Form\Element;
 
+use Zend\Form\Element\Exception;
+
 /**
  * CurrencyTextBox dijit
  *
@@ -77,7 +79,7 @@ class CurrencyTextBox extends NumberTextBox
         $symbol = strtoupper((string) $symbol);
         $length = strlen($symbol);
         if (3 > $length) {
-            throw new \Zend\Form\ElementException('Invalid symbol provided; please provide ISO 4217 alphabetic currency code');
+            throw new Exception\InvalidArgumentException('Invalid symbol provided; please provide ISO 4217 alphabetic currency code');
         }
         if (3 < $length) {
             $symbol = substr($symbol, 0, 3);

--- a/library/Zend/Dojo/Form/Element/DateTextBox.php
+++ b/library/Zend/Dojo/Form/Element/DateTextBox.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace Zend\Dojo\Form\Element;
-use Zend\Form;
+use Zend\Form,
+    Zend\Form\Element\Exception;;
 
 /**
  * DateTextBox dijit
@@ -168,7 +169,7 @@ class DateTextBox extends ValidationTextBox
     {
         $formatLength = strtolower($formatLength);
         if (!in_array($formatLength, $this->_allowedFormatTypes)) {
-            throw new Form\ElementException(sprintf('Invalid formatLength "%s" specified', $formatLength));
+            throw new Exception\InvalidArgumentException(sprintf('Invalid formatLength "%s" specified', $formatLength));
         }
 
         $this->setConstraint('formatLength', $formatLength);
@@ -196,7 +197,7 @@ class DateTextBox extends ValidationTextBox
     {
         $selector = strtolower($selector);
         if (!in_array($selector, $this->_allowedSelectorTypes)) {
-            throw new Form\ElementException(sprintf('Invalid Selector "%s" specified', $selector));
+            throw new Exception\InvalidArgumentException(sprintf('Invalid Selector "%s" specified', $selector));
         }
 
         $this->setConstraint('selector', $selector);

--- a/library/Zend/Dojo/Form/Element/Dijit.php
+++ b/library/Zend/Dojo/Form/Element/Dijit.php
@@ -186,7 +186,8 @@ abstract class Dijit extends \Zend\Form\Element
         if (null !== $view) {
             if(false === $view->broker()->isLoaded('dojo')) {
                 $loader = new \Zend\Dojo\View\HelperLoader();
-                $view->broker()->setClassLoader($loader);
+                $view->broker()->getClassLoader()
+                                ->registerPlugins($loader->getIterator());
             }
         }
         return parent::setView($view);

--- a/library/Zend/Dojo/Form/Element/Dijit.php
+++ b/library/Zend/Dojo/Form/Element/Dijit.php
@@ -24,7 +24,7 @@
  */
 namespace Zend\Dojo\Form\Element;
 
-use Zend\View\ViewEngine as View;
+use Zend\View\Renderer as View;
 
 /**
  * Base element for dijit elements
@@ -178,14 +178,15 @@ abstract class Dijit extends \Zend\Form\Element
      *
      * Ensures that the view object has the dojo view helper path set.
      *
-     * @param  \Zend\View\ViewEngine $view
+     * @param  \Zend\View\Renderer $view
      * @return \Zend\Dojo\Form\Element\Dijit
      */
     public function setView(View $view = null)
     {
         if (null !== $view) {
-            if (false === $view->getPluginLoader('helper')->getPaths('Zend\Dojo\View\Helper')) {
-                $view->addHelperPath('Zend/Dojo/View/Helper', 'Zend\Dojo\View\Helper');
+            if(false === $view->broker()->isLoaded('dojo')) {
+                $loader = new \Zend\Dojo\View\HelperLoader();
+                $view->broker()->setClassLoader($loader);
             }
         }
         return parent::setView($view);

--- a/library/Zend/Dojo/Form/Element/Dijit.php
+++ b/library/Zend/Dojo/Form/Element/Dijit.php
@@ -186,8 +186,7 @@ abstract class Dijit extends \Zend\Form\Element
         if (null !== $view) {
             if(false === $view->broker()->isLoaded('dojo')) {
                 $loader = new \Zend\Dojo\View\HelperLoader();
-                $view->broker()->getClassLoader()
-                                ->registerPlugins($loader->getIterator());
+                $view->broker()->getClassLoader()->registerPlugins($loader);
             }
         }
         return parent::setView($view);

--- a/library/Zend/Dojo/Form/Element/NumberTextBox.php
+++ b/library/Zend/Dojo/Form/Element/NumberTextBox.php
@@ -24,6 +24,8 @@
  */
 namespace Zend\Dojo\Form\Element;
 
+use Zend\Form\Element\Exception;
+
 /**
  * NumberTextBox dijit
  *
@@ -108,7 +110,7 @@ class NumberTextBox extends ValidationTextBox
     {
         $type = strtolower($type);
         if (!in_array($type, $this->_allowedTypes)) {
-            throw new \Zend\Form\ElementException(sprintf('Invalid numeric type "%s" specified', $type));
+            throw new Exception\InvalidArgumentException(sprintf('Invalid numeric type "%s" specified', $type));
         }
 
         $this->setConstraint('type', $type);

--- a/library/Zend/Dojo/Form/Element/TimeTextBox.php
+++ b/library/Zend/Dojo/Form/Element/TimeTextBox.php
@@ -24,6 +24,8 @@
  */
 namespace Zend\Dojo\Form\Element;
 
+use Zend\Form\Element\Exception;
+
 /**
  * TimeTextBox dijit
  *
@@ -52,7 +54,7 @@ class TimeTextBox extends DateTextBox
     protected function _validateIso8601($format)
     {
         if (!preg_match('/^T\d{2}:\d{2}:\d{2}$/', $format)) {
-            throw new \Zend\Form\ElementException(sprintf('Invalid format "%s" provided; must match T:00:00:00 format', $format));
+            throw new Exception\InvalidArgumentException(sprintf('Invalid format "%s" provided; must match T:00:00:00 format', $format));
         }
         return true;
     }

--- a/library/Zend/Dojo/Form/Form.php
+++ b/library/Zend/Dojo/Form/Form.php
@@ -85,8 +85,7 @@ class Form extends \Zend\Form\Form
         if (null !== $view) {
             if(false === $view->broker()->isLoaded('dojo')) {
                 $loader = new \Zend\Dojo\View\HelperLoader();
-                $view->broker()->getClassLoader()
-                                ->registerPlugins($loader->getIterator());
+                $view->broker()->getClassLoader()->registerPlugins($loader);
             }
         }
         return parent::setView($view);

--- a/library/Zend/Dojo/Form/Form.php
+++ b/library/Zend/Dojo/Form/Form.php
@@ -24,7 +24,7 @@
  */
 namespace Zend\Dojo\Form;
 
-use Zend\View\ViewEngine as View;
+use Zend\View\Renderer as View;
 
 /**
  * Dijit-enabled Form
@@ -77,14 +77,15 @@ class Form extends \Zend\Form\Form
      *
      * Ensures that the view object has the dojo view helper path set.
      *
-     * @param  \Zend\View\ViewEngine $view
+     * @param  \Zend\View\Renderer $view
      * @return \Zend\Dojo\Form\Element\Dijit
      */
     public function setView(View $view = null)
     {
         if (null !== $view) {
-            if (false === $view->getPluginLoader('helper')->getPaths('Zend\Dojo\View\Helper')) {
-                $view->addHelperPath('Zend/Dojo/View/Helper', 'Zend\Dojo\View\Helper');
+            if(false === $view->broker()->isLoaded('dojo')) {
+                $loader = new \Zend\Dojo\View\HelperLoader();
+                $view->broker()->setClassLoader($loader);
             }
         }
         return parent::setView($view);

--- a/library/Zend/Dojo/Form/Form.php
+++ b/library/Zend/Dojo/Form/Form.php
@@ -85,7 +85,8 @@ class Form extends \Zend\Form\Form
         if (null !== $view) {
             if(false === $view->broker()->isLoaded('dojo')) {
                 $loader = new \Zend\Dojo\View\HelperLoader();
-                $view->broker()->setClassLoader($loader);
+                $view->broker()->getClassLoader()
+                                ->registerPlugins($loader->getIterator());
             }
         }
         return parent::setView($view);

--- a/library/Zend/Dojo/Form/SubForm.php
+++ b/library/Zend/Dojo/Form/SubForm.php
@@ -87,7 +87,8 @@ class SubForm extends \Zend\Form\SubForm
         if (!$this->_dojoViewPathRegistered) {
             if(false === $view->broker()->isLoaded('dojo')) {
                 $loader = new \Zend\Dojo\View\HelperLoader();
-                $view->broker()->setClassLoader($loader);
+                $view->broker()->getClassLoader()
+                                ->registerPlugins($loader->getIterator());
             }
             $this->_dojoViewPathRegistered = true;
         }

--- a/library/Zend/Dojo/Form/SubForm.php
+++ b/library/Zend/Dojo/Form/SubForm.php
@@ -79,14 +79,15 @@ class SubForm extends \Zend\Form\SubForm
     /**
      * Get view
      *
-     * @return \Zend\View\ViewEngine
+     * @return \Zend\View\Renderer
      */
     public function getView()
     {
         $view = parent::getView();
         if (!$this->_dojoViewPathRegistered) {
-            if (false === $view->getPluginLoader('helper')->getPaths('Zend\Dojo\View\Helper')) {
-                $view->addHelperPath('Zend/Dojo/View/Helper', 'Zend\Dojo\View\Helper');
+            if(false === $view->broker()->isLoaded('dojo')) {
+                $loader = new \Zend\Dojo\View\HelperLoader();
+                $view->broker()->setClassLoader($loader);
             }
             $this->_dojoViewPathRegistered = true;
         }

--- a/library/Zend/Dojo/Form/SubForm.php
+++ b/library/Zend/Dojo/Form/SubForm.php
@@ -87,8 +87,7 @@ class SubForm extends \Zend\Form\SubForm
         if (!$this->_dojoViewPathRegistered) {
             if(false === $view->broker()->isLoaded('dojo')) {
                 $loader = new \Zend\Dojo\View\HelperLoader();
-                $view->broker()->getClassLoader()
-                                ->registerPlugins($loader->getIterator());
+                $view->broker()->getClassLoader()->registerPlugins($loader);
             }
             $this->_dojoViewPathRegistered = true;
         }

--- a/library/Zend/Dojo/View/Helper/BorderContainer.php
+++ b/library/Zend/Dojo/View/Helper/BorderContainer.php
@@ -70,7 +70,7 @@ class BorderContainer extends DijitContainer
 
         // this will ensure that the border container is viewable:
         if (!$this->_styleIsRegistered) {
-            $this->view->headStyle()->appendStyle('html, body { height: 100%; width: 100%; margin: 0; padding: 0; }');
+            $this->view->broker('headStyle')->appendStyle('html, body { height: 100%; width: 100%; margin: 0; padding: 0; }');
             $this->_styleIsRegistered = true;
         }
 

--- a/library/Zend/Dojo/View/Helper/Button.php
+++ b/library/Zend/Dojo/View/Helper/Button.php
@@ -64,6 +64,6 @@ class Button extends Dijit
         }
         $attribs = $this->_prepareDijit($attribs, $params, 'element');
 
-        return $this->view->formButton($id, $value, $attribs);
+        return $this->view->broker('formButton')->direct($id, $value, $attribs);
     }
 }

--- a/library/Zend/Dojo/View/Helper/ComboBox.php
+++ b/library/Zend/Dojo/View/Helper/ComboBox.php
@@ -106,7 +106,7 @@ class ComboBox extends Dijit
 
         // do as normal select
         $attribs = $this->_prepareDijit($attribs, $params, 'element');
-        return $this->view->formSelect($id, $value, $attribs, $options);
+        return $this->view->broker('formSelect')->direct($id, $value, $attribs, $options);
     }
 
     /**

--- a/library/Zend/Dojo/View/Helper/Dojo.php
+++ b/library/Zend/Dojo/View/Helper/Dojo.php
@@ -58,7 +58,7 @@ class Dojo extends AbstractViewHelper
     public $view;
 
     /**
-     * @var \Zend\Dojo\View\Helper\DojoContainer
+     * @var \Zend\Dojo\View\Helper\Dojo\Container
      */
     protected $_container;
 
@@ -101,7 +101,7 @@ class Dojo extends AbstractViewHelper
     /**
      * Return dojo container
      *
-     * @return \Zend\Dojo\View\Helper\DojoContainer
+     * @return \Zend\Dojo\View\Helper\Dojo\Container
      */
     public function direct()
     {

--- a/library/Zend/Dojo/View/Helper/Editor.php
+++ b/library/Zend/Dojo/View/Helper/Editor.php
@@ -120,7 +120,7 @@ class Editor extends Dijit
         // Embed a textarea in a <noscript> tag to allow for graceful 
         // degradation
         $html .= '<noscript>'
-               . $this->view->formTextarea($hiddenId, $value, $attribs)
+               . $this->view->broker('formTextarea')->direct($hiddenId, $value, $attribs)
                . '</noscript>';
 
         return $html;

--- a/library/Zend/Dojo/View/Helper/RadioButton.php
+++ b/library/Zend/Dojo/View/Helper/RadioButton.php
@@ -87,6 +87,6 @@ class RadioButton extends Dijit
             }
         }
 
-        return $this->view->formRadio($id, $value, $attribs, $options, $listsep);
+        return $this->view->broker('formRadio')->direct($id, $value, $attribs, $options, $listsep);
     }
 }

--- a/library/Zend/Dojo/View/Helper/Slider.php
+++ b/library/Zend/Dojo/View/Helper/Slider.php
@@ -248,6 +248,6 @@ abstract class Slider extends Dijit
         $dijit = 'dijit.form.' . ucfirst($this->_sliderType) . 'RuleLabels';
         $attribs = $this->_prepareDijit($attribs, $params, 'layout', $dijit);
 
-        return $this->view->htmlList($labels, true, $attribs);
+        return $this->view->broker('htmlList')->direct($labels, true, $attribs);
     }
 }

--- a/library/Zend/Dojo/View/HelperLoader.php
+++ b/library/Zend/Dojo/View/HelperLoader.php
@@ -45,6 +45,7 @@ class HelperLoader extends PluginClassLoader
         'contentpane'        => 'Zend\Dojo\View\Helper\ContentPane',
         'currencytextbox'    => 'Zend\Dojo\View\Helper\CurrencyTextBox',
         'customdijit'        => 'Zend\Dojo\View\Helper\CustomDijit',
+        'datetextbox'        => 'Zend\Dojo\View\Helper\DateTextBox',
         'dijitcontainer'     => 'Zend\Dojo\View\Helper\DijitContainer',
         'dijit'              => 'Zend\Dojo\View\Helper\Dijit',
         'dojo'               => 'Zend\Dojo\View\Helper\Dojo',

--- a/tests/Zend/Dojo/BuildLayerTest.php
+++ b/tests/Zend/Dojo/BuildLayerTest.php
@@ -25,7 +25,7 @@ use Zend\Dojo\BuildLayer,
     Zend\Dojo\View\Helper\Dojo\Container as DojoContainer,
     Zend\Json\Json,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * @category   Zend
@@ -49,7 +49,7 @@ class BuildLayerTest extends \PHPUnit_Framework_TestCase
         if (isset($registry['Zend\Dojo\View\Helper\Dojo'])) {
             unset($registry['Zend\Dojo\View\Helper\Dojo']);
         }
-        $this->view = new View();
+        $this->view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($this->view);
     }
 
@@ -140,7 +140,7 @@ class BuildLayerTest extends \PHPUnit_Framework_TestCase
 
     public function testGeneratingLayerScriptShouldReturnValidLayerMarkup()
     {
-        $this->view->dojo()->requireModule('dijit.form.Form')
+        $this->view->broker('dojo')->requireModule('dijit.form.Form')
                            ->requireModule('dijit.form.TextBox')
                            ->requireModule('dijit.form.Button');
         $build = new BuildLayer(array(
@@ -158,7 +158,7 @@ class BuildLayerTest extends \PHPUnit_Framework_TestCase
 
     public function testGeneratingLayerScriptWithOnLoadsEnabledShouldReturnValidLayerMarkup()
     {
-        $this->view->dojo()->requireModule('dijit.form.Form')
+        $this->view->broker('dojo')->requireModule('dijit.form.Form')
                            ->requireModule('dijit.form.TextBox')
                            ->requireModule('dijit.form.Button')
                            ->addOnLoad('custom.callback');
@@ -178,7 +178,7 @@ class BuildLayerTest extends \PHPUnit_Framework_TestCase
 
     public function testGeneratingLayerScriptWithOnLoadsDisabledShouldNotRenderOnLoadEvents()
     {
-        $this->view->dojo()->requireModule('dijit.form.Form')
+        $this->view->broker('dojo')->requireModule('dijit.form.Form')
                            ->requireModule('dijit.form.TextBox')
                            ->requireModule('dijit.form.Button')
                            ->addOnLoad('custom.callback');
@@ -197,7 +197,7 @@ class BuildLayerTest extends \PHPUnit_Framework_TestCase
 
     public function testGeneratingLayerScriptWithJavascriptsEnabledShouldReturnValidLayerMarkup()
     {
-        $this->view->dojo()->requireModule('dijit.form.Form')
+        $this->view->broker('dojo')->requireModule('dijit.form.Form')
                            ->requireModule('dijit.form.TextBox')
                            ->requireModule('dijit.form.Button')
                            ->addJavascript('custom.callback();');
@@ -217,7 +217,7 @@ class BuildLayerTest extends \PHPUnit_Framework_TestCase
 
     public function testGeneratingLayerScriptWithJavascriptsDisabledShouldNotRenderJavascripts()
     {
-        $this->view->dojo()->requireModule('dijit.form.Form')
+        $this->view->broker('dojo')->requireModule('dijit.form.Form')
                            ->requireModule('dijit.form.TextBox')
                            ->requireModule('dijit.form.Button')
                            ->addJavascript('custom.callback();');
@@ -288,7 +288,7 @@ class BuildLayerTest extends \PHPUnit_Framework_TestCase
 
     public function testProfilePrefixesShouldIncludePrefixesOfAllRequiredModules()
     {
-        $this->view->dojo()->requireModule('dijit.layout.TabContainer')
+        $this->view->broker('dojo')->requireModule('dijit.layout.TabContainer')
                            ->requireModule('dojox.layout.ContentPane');
         $build = new BuildLayer(array('view' => $this->view));
 
@@ -320,7 +320,7 @@ class BuildLayerTest extends \PHPUnit_Framework_TestCase
 
     public function testGeneratedDojoBuildProfileWithLayerDependencies()
     {
-        $this->view->dojo()->requireModule('dijit.layout.BorderContainer')
+        $this->view->broker('dojo')->requireModule('dijit.layout.BorderContainer')
                            ->requireModule('dojox.layout.ContentPane');
         $build = new BuildLayer(array(
             'view' => $this->view,
@@ -364,7 +364,7 @@ class BuildLayerTest extends \PHPUnit_Framework_TestCase
     {
         $profile = preg_replace('/^dependencies = (.*?);$/s', '$1', $profile);
         $profile = preg_replace('/(\b)([^"\':,]+):/', '$1"$2":', $profile);
-        $data    = Json::decode($profile);
+        $data    = Json::decode($profile, JSON::TYPE_ARRAY);
         ksort($data);
         return $data;
     }

--- a/tests/Zend/Dojo/DataTest.php
+++ b/tests/Zend/Dojo/DataTest.php
@@ -364,7 +364,7 @@ class DataTest extends \PHPUnit_Framework_TestCase
     {
         $this->testAddItemsShouldAcceptTraversableObject();
         $json = $this->dojoData->toJson();
-        $this->assertSame($this->dojoData->toArray(), Json::decode($json));
+        $this->assertSame($this->dojoData->toArray(), Json::decode($json, Json::TYPE_ARRAY));
     }
 
     public function testShouldSerializeToStringAsJson()

--- a/tests/Zend/Dojo/DojoTest.php
+++ b/tests/Zend/Dojo/DojoTest.php
@@ -23,7 +23,7 @@ namespace ZendTest\Dojo;
 
 use Zend\Form\Form,
     Zend\Form\SubForm,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo
@@ -51,7 +51,7 @@ class DojoTest extends \PHPUnit_Framework_TestCase
                 ->addElement('text', 'bat');
         $form->addDisplayGroup(array('foo', 'bar'), 'foobar')
              ->addSubForm($subForm, 'sub')
-             ->setView(new View);
+             ->setView(new View\PhpRenderer);
         return $form;
     }
 
@@ -62,27 +62,27 @@ class DojoTest extends \PHPUnit_Framework_TestCase
 
         $decPluginLoader = $form->getPluginLoader('decorator');
         $paths = $decPluginLoader->getPaths('Zend\Dojo\Form\Decorator');
-        $this->assertTrue(is_array($paths));
+        $this->assertInstanceOf('Zend\Stdlib\SplStack', $paths);
 
         $elPluginLoader = $form->getPluginLoader('element');
         $paths = $elPluginLoader->getPaths('Zend\Dojo\Form\Element');
-        $this->assertTrue(is_array($paths));
+        $this->assertInstanceOf('Zend\Stdlib\SplStack', $paths);
 
         $decPluginLoader = $form->baz->getPluginLoader('decorator');
         $paths = $decPluginLoader->getPaths('Zend\Dojo\Form\Decorator');
-        $this->assertTrue(is_array($paths));
+        $this->assertInstanceOf('Zend\Stdlib\SplStack', $paths);
 
         $decPluginLoader = $form->foobar->getPluginLoader();
         $paths = $decPluginLoader->getPaths('Zend\Dojo\Form\Decorator');
-        $this->assertTrue(is_array($paths));
+        $this->assertInstanceOf('Zend\Stdlib\SplStack', $paths);
 
         $decPluginLoader = $form->sub->getPluginLoader('decorator');
         $paths = $decPluginLoader->getPaths('Zend\Dojo\Form\Decorator');
-        $this->assertTrue(is_array($paths));
+        $this->assertInstanceOf('Zend\Stdlib\SplStack', $paths);
 
         $elPluginLoader = $form->sub->getPluginLoader('element');
         $paths = $elPluginLoader->getPaths('Zend\Dojo\Form\Element');
-        $this->assertTrue(is_array($paths));
+        $this->assertInstanceOf('Zend\Stdlib\SplStack', $paths);
     }
 
     public function testEnableFormShouldSetAppropriateDefaultDisplayGroup()
@@ -97,17 +97,17 @@ class DojoTest extends \PHPUnit_Framework_TestCase
         $form = $this->getForm();
         \Zend\Dojo\Dojo::enableForm($form);
         $view = $form->getView();
-        $helperLoader = $view->getPluginLoader('helper');
-        $paths = $helperLoader->getPaths('Zend\Dojo\View\Helper');
-        $this->assertTrue(is_array($paths));
+        $helperLoader = $view->broker()->getClassLoader();
+        $plugins = $helperLoader->getRegisteredPlugins();
+        $this->assertInternalType('array', $plugins);
     }
 
-    public function testEnableViewShouldSetAppropriateViewHelperPaths()
+    public function testEnableViewShouldRegisterDojoViewHelpers()
     {
-        $view = new View;
+        $view = new View\PhpRenderer;
         \Zend\Dojo\Dojo::enableView($view);
-        $helperLoader = $view->getPluginLoader('helper');
-        $paths = $helperLoader->getPaths('Zend\Dojo\View\Helper');
-        $this->assertTrue(is_array($paths));
+        $helperLoader = $view->broker()->getClassLoader();
+        $plugins = $helperLoader->getRegisteredPlugins();
+        $this->assertInternalType('array', $plugins);
     }
 }

--- a/tests/Zend/Dojo/DojoTest.php
+++ b/tests/Zend/Dojo/DojoTest.php
@@ -97,18 +97,15 @@ class DojoTest extends \PHPUnit_Framework_TestCase
         $form = $this->getForm();
         \Zend\Dojo\Dojo::enableForm($form);
         $view = $form->getView();
-        $helperLoader = $view->broker()->getClassLoader();
-        $plugins = $helperLoader->getRegisteredPlugins();
-        $this->assertInternalType('array', $plugins);
+        
+        $this->assertInstanceOf('Zend\Dojo\View\Helper\Dojo', $view->broker('dojo'));
     }
 
     public function testEnableViewShouldRegisterDojoViewHelpers()
     {
         $view = new View\PhpRenderer;
         \Zend\Dojo\Dojo::enableView($view);
-        $helperLoader = $view->broker()->getClassLoader();
-        $plugins = $helperLoader->getRegisteredPlugins();
-
-        $this->assertInternalType('array', $plugins);
+        
+        $this->assertInstanceOf('Zend\Dojo\View\Helper\Dojo', $view->broker('dojo'));
     }
 }

--- a/tests/Zend/Dojo/DojoTest.php
+++ b/tests/Zend/Dojo/DojoTest.php
@@ -108,6 +108,7 @@ class DojoTest extends \PHPUnit_Framework_TestCase
         \Zend\Dojo\Dojo::enableView($view);
         $helperLoader = $view->broker()->getClassLoader();
         $plugins = $helperLoader->getRegisteredPlugins();
+
         $this->assertInternalType('array', $plugins);
     }
 }

--- a/tests/Zend/Dojo/Form/Decorator/AccordionContainerTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/AccordionContainerTest.php
@@ -26,7 +26,7 @@ use Zend\Dojo\Form\Decorator\AccordionContainer as AccordionContainerDecorator,
     Zend\Dojo\Form\Form as DojoForm,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Decorator_AccordionContainer.
@@ -61,7 +61,7 @@ class AccordionContainerTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -84,7 +84,7 @@ class AccordionContainerTest extends \PHPUnit_Framework_TestCase
     public function testRenderingShouldEnableDojo()
     {
         $html = $this->decorator->render('');
-        $this->assertTrue($this->view->dojo()->isEnabled());
+        $this->assertTrue($this->view->broker('dojo')->isEnabled());
     }
 
     public function testRenderingShouldCreateDijit()

--- a/tests/Zend/Dojo/Form/Decorator/AccordionPaneTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/AccordionPaneTest.php
@@ -26,7 +26,7 @@ use Zend\Dojo\Form\Decorator\AccordionPane as AccordionPaneDecorator,
     Zend\Dojo\Form\Form as DojoForm,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Decorator_AccordionPane.
@@ -61,7 +61,7 @@ class AccordionPaneTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -84,7 +84,7 @@ class AccordionPaneTest extends \PHPUnit_Framework_TestCase
     public function testRenderingShouldEnableDojo()
     {
         $html = $this->decorator->render('');
-        $this->assertTrue($this->view->dojo()->isEnabled());
+        $this->assertTrue($this->view->broker('dojo')->isEnabled());
     }
 
     public function testRenderingShouldCreateDijit()

--- a/tests/Zend/Dojo/Form/Decorator/BorderContainerTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/BorderContainerTest.php
@@ -26,7 +26,7 @@ use Zend\Dojo\Form\Decorator\BorderContainer as BorderContainerDecorator,
     Zend\Dojo\Form\Form as DojoForm,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Decorator_BorderContainer.
@@ -61,7 +61,7 @@ class BorderContainerTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -84,7 +84,7 @@ class BorderContainerTest extends \PHPUnit_Framework_TestCase
     public function testRenderingShouldEnableDojo()
     {
         $html = $this->decorator->render('');
-        $this->assertTrue($this->view->dojo()->isEnabled());
+        $this->assertTrue($this->view->broker('dojo')->isEnabled());
     }
 
     public function testRenderingShouldCreateDijit()

--- a/tests/Zend/Dojo/Form/Decorator/DijitContainerTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/DijitContainerTest.php
@@ -27,7 +27,7 @@ use Zend\Dojo\Form\Decorator\DijitContainer as DijitContainerDecorator,
     Zend\Dojo\Form\Form as DojoForm,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Decorator_DijitContainer.
@@ -63,7 +63,7 @@ class DijitContainerTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -134,12 +134,12 @@ class DijitContainerTest extends \PHPUnit_Framework_TestCase
     public function testRenderingShouldEnableDojo()
     {
         $html = $this->decorator->render('');
-        $this->assertTrue($this->view->dojo()->isEnabled());
+        $this->assertTrue($this->view->broker('dojo')->isEnabled());
     }
 
     public function testRenderingShouldTriggerErrorWhenDuplicateDijitDetected()
     {
-        $this->view->dojo()->addDijit('foo-ContentPane', array('dojoType' => 'dijit.layout.ContentPane'));
+        $this->view->broker('dojo')->addDijit('foo-ContentPane', array('dojoType' => 'dijit.layout.ContentPane'));
 
         $handler = set_error_handler(array($this, 'handleError'));
         $html = $this->decorator->render('');

--- a/tests/Zend/Dojo/Form/Decorator/DijitElementTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/DijitElementTest.php
@@ -25,7 +25,7 @@ use Zend\Dojo\Form\Decorator\DijitElement as DijitElementDecorator,
     Zend\Dojo\Form\Element\TextBox as TextBoxElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Decorator_DijitElement.
@@ -61,7 +61,7 @@ class DijitElementTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -116,12 +116,12 @@ class DijitElementTest extends \PHPUnit_Framework_TestCase
     public function testRenderingShouldEnableDojo()
     {
         $html = $this->decorator->render('');
-        $this->assertTrue($this->view->dojo()->isEnabled());
+        $this->assertTrue($this->view->broker('dojo')->isEnabled());
     }
 
     public function testRenderingShouldTriggerErrorWhenDuplicateDijitDetected()
     {
-        $this->view->dojo()->addDijit('foo', array('dojoType' => 'dijit.form.TextBox'));
+        $this->view->broker('dojo')->addDijit('foo', array('dojoType' => 'dijit.form.TextBox'));
 
         $handler = set_error_handler(array($this, 'handleError'));
         $html = $this->decorator->render('');

--- a/tests/Zend/Dojo/Form/Decorator/DijitFormTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/DijitFormTest.php
@@ -26,7 +26,7 @@ use Zend\Dojo\Form\Decorator\DijitForm as DijitFormDecorator,
     Zend\Dojo\Form\Form as DojoForm,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Decorator_DijitForm.
@@ -61,7 +61,7 @@ class DijitFormTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -84,7 +84,7 @@ class DijitFormTest extends \PHPUnit_Framework_TestCase
     public function testRenderingShouldEnableDojo()
     {
         $html = $this->decorator->render('');
-        $this->assertTrue($this->view->dojo()->isEnabled());
+        $this->assertTrue($this->view->broker('dojo')->isEnabled());
     }
 
     public function testRenderingShouldCreateDijit()

--- a/tests/Zend/Dojo/Form/Decorator/SplitContainerTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/SplitContainerTest.php
@@ -26,7 +26,7 @@ use Zend\Dojo\Form\Decorator\SplitContainer as SplitContainerDecorator,
     Zend\Dojo\Form\Form as DojoForm,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Decorator_SplitContainer.
@@ -61,7 +61,7 @@ class SplitContainerTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -84,7 +84,7 @@ class SplitContainerTest extends \PHPUnit_Framework_TestCase
     public function testRenderingShouldEnableDojo()
     {
         $html = $this->decorator->render('');
-        $this->assertTrue($this->view->dojo()->isEnabled());
+        $this->assertTrue($this->view->broker('dojo')->isEnabled());
     }
 
     public function testRenderingShouldCreateDijit()

--- a/tests/Zend/Dojo/Form/Decorator/StackContainerTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/StackContainerTest.php
@@ -26,7 +26,7 @@ use Zend\Dojo\Form\Decorator\StackContainer as StackContainerDecorator,
     Zend\Dojo\Form\Form as DojoForm,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Decorator_StackContainer.
@@ -61,7 +61,7 @@ class StackContainerTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -84,7 +84,7 @@ class StackContainerTest extends \PHPUnit_Framework_TestCase
     public function testRenderingShouldEnableDojo()
     {
         $html = $this->decorator->render('');
-        $this->assertTrue($this->view->dojo()->isEnabled());
+        $this->assertTrue($this->view->broker('dojo')->isEnabled());
     }
 
     public function testRenderingShouldCreateDijit()

--- a/tests/Zend/Dojo/Form/Decorator/TabContainerTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/TabContainerTest.php
@@ -26,7 +26,7 @@ use Zend\Dojo\Form\Decorator\TabContainer as TabContainerDecorator,
     Zend\Dojo\Form\Form as DojoForm,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Decorator_TabContainer.
@@ -61,7 +61,7 @@ class TabContainerTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -84,7 +84,7 @@ class TabContainerTest extends \PHPUnit_Framework_TestCase
     public function testRenderingShouldEnableDojo()
     {
         $html = $this->decorator->render('');
-        $this->assertTrue($this->view->dojo()->isEnabled());
+        $this->assertTrue($this->view->broker('dojo')->isEnabled());
     }
 
     public function testRenderingShouldCreateDijit()

--- a/tests/Zend/Dojo/Form/Element/ButtonTest.php
+++ b/tests/Zend/Dojo/Form/Element/ButtonTest.php
@@ -25,7 +25,7 @@ use Zend\Dojo\Form\Element\Button as ButtonElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
     Zend\Translator\Translator,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_Button.
@@ -58,7 +58,7 @@ class ButtonTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }

--- a/tests/Zend/Dojo/Form/Element/CheckBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/CheckBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\Form\Element;
 use Zend\Dojo\Form\Element\CheckBox as CheckBoxElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_Checkbox.
@@ -57,7 +57,7 @@ class CheckBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -230,7 +230,7 @@ class CheckBoxTest extends \PHPUnit_Framework_TestCase
                     'checkedValue' => 'checkedVal',
                     'unCheckedValue' => 'UNCHECKED',
                 ));
-        $element->setView(new View());
+        $element->setView(new View\PhpRenderer());
         $html = $element->render();
         $this->assertContains('value="checkedVal"', $html, $html);
     }

--- a/tests/Zend/Dojo/Form/Element/ComboBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/ComboBoxTest.php
@@ -25,7 +25,7 @@ use Zend\Dojo\Form\Element\ComboBox as ComboBoxElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Form\SubForm,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_ComboBox.
@@ -58,7 +58,7 @@ class ComboBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }

--- a/tests/Zend/Dojo/Form/Element/ComboBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/ComboBoxTest.php
@@ -151,7 +151,7 @@ class ComboBoxTest extends \PHPUnit_Framework_TestCase
         $subform = new SubForm(array('name' => 'bar'));
         $subform->addElement($this->element);
         $html = $this->element->render();
-        $dojo = $this->view->dojo()->__toString();
+        $dojo = $this->view->broker('dojo')->__toString();
         $this->assertContains('"store":"foo"', $dojo, $dojo);
     }
 }

--- a/tests/Zend/Dojo/Form/Element/CurrencyTextBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/CurrencyTextBoxTest.php
@@ -25,7 +25,7 @@ use Zend\Dojo\Form\Element\CurrencyTextBox as CurrencyTextBoxElement,
     Zend\Dojo\Form\Element\NumberTextBox as NumberTextBoxElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_CurrencyTextBox.
@@ -58,7 +58,7 @@ class CurrencyTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -118,7 +118,7 @@ class CurrencyTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function testSymbolMutatorShouldRaiseExceptionWhenFewerThan3CharsProvided()
     {
-        $this->setExpectedException('Zend\Form\ElementException');
+        $this->setExpectedException('Zend\Form\Element\Exception\InvalidArgumentException');
         $this->element->setSymbol('$');
     }
 

--- a/tests/Zend/Dojo/Form/Element/DateTextBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/DateTextBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\Form\Element;
 use Zend\Dojo\Form\Element\DateTextBox as DateTextBoxElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_DateTextBox.
@@ -57,7 +57,7 @@ class DateTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -124,7 +124,7 @@ class DateTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function testFormatLengthMutatorShouldThrowExceptionWithInvalidFormatLength()
     {
-        $this->setExpectedException('Zend\Form\ElementException');
+        $this->setExpectedException('Zend\Form\Element\Exception\InvalidArgumentException');
         $this->element->setFormatLength('foobar');
     }
 
@@ -141,7 +141,7 @@ class DateTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function testSelectorMutatorShouldThrowExceptionWithInvalidSelector()
     {
-        $this->setExpectedException('Zend\Form\ElementException');
+        $this->setExpectedException('Zend\Form\Element\Exception\InvalidArgumentException');
         $this->element->setSelector('foobar');
     }
 

--- a/tests/Zend/Dojo/Form/Element/DijitTest.php
+++ b/tests/Zend/Dojo/Form/Element/DijitTest.php
@@ -26,7 +26,7 @@ use Zend\Dojo\Form\Element\TextBox as TextBoxElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Form\Decorator\Description as DescriptionDecorator,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_Dijit.
@@ -59,7 +59,7 @@ class DijitTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -119,10 +119,11 @@ class DijitTest extends \PHPUnit_Framework_TestCase
 
     public function testElementShouldDojoEnableViewObject()
     {
-        $this->element->setView(new View);
+        $this->element->setView(new View\PhpRenderer());
         $view = $this->element->getView();
-        $loader = $view->getPluginLoader('helper');
-        $paths = $loader->getPaths('Zend\Dojo\View\Helper');
-        $this->assertTrue(is_array($paths));
+        $helperLoader = $view->broker()->getClassLoader();
+        $plugins = $helperLoader->getRegisteredPlugins();
+
+        $this->assertInternalType('array', $plugins);
     }
 }

--- a/tests/Zend/Dojo/Form/Element/DijitTest.php
+++ b/tests/Zend/Dojo/Form/Element/DijitTest.php
@@ -121,9 +121,7 @@ class DijitTest extends \PHPUnit_Framework_TestCase
     {
         $this->element->setView(new View\PhpRenderer());
         $view = $this->element->getView();
-        $helperLoader = $view->broker()->getClassLoader();
-        $plugins = $helperLoader->getRegisteredPlugins();
-
-        $this->assertInternalType('array', $plugins);
+        
+        $this->assertInstanceOf('Zend\Dojo\View\Helper\Dojo', $view->broker('dojo'));
     }
 }

--- a/tests/Zend/Dojo/Form/Element/EditorTest.php
+++ b/tests/Zend/Dojo/Form/Element/EditorTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\Form\Element;
 use Zend\Dojo\Form\Element\Editor as EditorElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_Editor.
@@ -57,7 +57,7 @@ class EditorTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }

--- a/tests/Zend/Dojo/Form/Element/FilteringSelectTest.php
+++ b/tests/Zend/Dojo/Form/Element/FilteringSelectTest.php
@@ -25,7 +25,7 @@ use Zend\Dojo\Form\Element\FilteringSelect as FilteringSelectElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
     Zend\Validator\InArray as InArrayValidator,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_FilteringSelect.
@@ -58,7 +58,7 @@ class FilteringSelectTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }

--- a/tests/Zend/Dojo/Form/Element/HorizontalSliderTest.php
+++ b/tests/Zend/Dojo/Form/Element/HorizontalSliderTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\Form\Element;
 use Zend\Dojo\Form\Element\HorizontalSlider as HorizontalSliderElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_HorizontalSlider.
@@ -57,7 +57,7 @@ class HorizontalSliderTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }

--- a/tests/Zend/Dojo/Form/Element/NumberSpinnerTest.php
+++ b/tests/Zend/Dojo/Form/Element/NumberSpinnerTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\Form\Element;
 use Zend\Dojo\Form\Element\NumberSpinner as NumberSpinnerElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_NumberSpinner.
@@ -57,7 +57,7 @@ class NumberSpinnerTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }

--- a/tests/Zend/Dojo/Form/Element/NumberTextBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/NumberTextBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\Form\Element;
 use Zend\Dojo\Form\Element\NumberTextBox as NumberTextBoxElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_NumberTextBox.
@@ -57,7 +57,7 @@ class NumberTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -108,7 +108,7 @@ class NumberTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function testTypeMutatorShouldThrowExceptionWithInvalidType()
     {
-        $this->setExpectedException('Zend\Form\ElementException');
+        $this->setExpectedException('Zend\Form\Element\Exception\InvalidArgumentException');
         $this->element->setType('foobar');
     }
 

--- a/tests/Zend/Dojo/Form/Element/PasswordTextBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/PasswordTextBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\Form\Element;
 use Zend\Dojo\Form\Element\PasswordTextBox as PasswordTextBoxElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_PasswordTextBox.
@@ -57,7 +57,7 @@ class PasswordTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }

--- a/tests/Zend/Dojo/Form/Element/RadioButtonTest.php
+++ b/tests/Zend/Dojo/Form/Element/RadioButtonTest.php
@@ -26,7 +26,7 @@ use Zend\Dojo\Form\Element\RadioButton as RadioButtonElement,
     Zend\Registry,
     Zend\Translator\Translator,
     Zend\Validator\InArray as InArrayValidator,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_RadioButton.
@@ -59,7 +59,7 @@ class RadioButtonTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }

--- a/tests/Zend/Dojo/Form/Element/SimpleTextareaTest.php
+++ b/tests/Zend/Dojo/Form/Element/SimpleTextareaTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\Form\Element;
 use Zend\Dojo\Form\Element\SimpleTextarea as SimpleTextareaElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_SimpleTextarea.
@@ -57,7 +57,7 @@ class SimpleTextareaTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }

--- a/tests/Zend/Dojo/Form/Element/SubmitButtonTest.php
+++ b/tests/Zend/Dojo/Form/Element/SubmitButtonTest.php
@@ -25,7 +25,7 @@ use Zend\Dojo\Form\Element\SubmitButton as SubmitButtonElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
     Zend\Translator\Translator,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_SubmitButton.
@@ -58,7 +58,7 @@ class SubmitButtonTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }

--- a/tests/Zend/Dojo/Form/Element/TextBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/TextBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\Form\Element;
 use Zend\Dojo\Form\Element\TextBox as TextBoxElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_TextBox.
@@ -57,7 +57,7 @@ class TextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }

--- a/tests/Zend/Dojo/Form/Element/TextareaTest.php
+++ b/tests/Zend/Dojo/Form/Element/TextareaTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\Form\Element;
 use Zend\Dojo\Form\Element\Textarea as TextareaElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_Textarea.
@@ -57,7 +57,7 @@ class TextareaTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }

--- a/tests/Zend/Dojo/Form/Element/TimeTextBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/TimeTextBoxTest.php
@@ -25,7 +25,7 @@ use Zend\Dojo\Form\Element\TimeTextBox as TimeTextBoxElement,
     Zend\Dojo\Form\Element\DateTextBox as DateTextBoxElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_TimeTextBox.
@@ -58,7 +58,7 @@ class TimeTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -104,7 +104,7 @@ class TimeTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function testClickableIncrementMutatorShouldRaiseExceptionOnInvalidFormat()
     {
-        $this->setExpectedException('Zend\Form\ElementException');
+        $this->setExpectedException('Zend\Form\Element\Exception\InvalidArgumentException');
         $this->element->setClickableIncrement('en-US');
     }
 
@@ -120,7 +120,7 @@ class TimeTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function testVisibleIncrementMutatorShouldRaiseExceptionOnInvalidFormat()
     {
-        $this->setExpectedException('Zend\Form\ElementException');
+        $this->setExpectedException('Zend\Form\Element\Exception\InvalidArgumentException');
         $this->element->setVisibleIncrement('en-US');
     }
 
@@ -136,7 +136,7 @@ class TimeTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function testVisibleRangeMutatorShouldRaiseExceptionOnInvalidFormat()
     {
-        $this->setExpectedException('Zend\Form\ElementException');
+        $this->setExpectedException('Zend\Form\Element\Exception\InvalidArgumentException');
         $this->element->setVisibleRange('en-US');
     }
 

--- a/tests/Zend/Dojo/Form/Element/ValidationTextBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/ValidationTextBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\Form\Element;
 use Zend\Dojo\Form\Element\ValidationTextBox as ValidationTextBoxElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_ValidationTextBox.
@@ -57,7 +57,7 @@ class ValidationTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }

--- a/tests/Zend/Dojo/Form/Element/VerticalSliderTest.php
+++ b/tests/Zend/Dojo/Form/Element/VerticalSliderTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\Form\Element;
 use Zend\Dojo\Form\Element\VerticalSlider as VerticalSliderElement,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form_Element_VerticalSlider.
@@ -57,7 +57,7 @@ class VerticalSliderTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }

--- a/tests/Zend/Dojo/Form/FormTest.php
+++ b/tests/Zend/Dojo/Form/FormTest.php
@@ -85,23 +85,17 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($this->form->getDecorator('DijitForm'));
     }
 
-    public function testShouldRegisterDojoViewHelperPath()
+    public function testShouldRegisterDojoViewHelper()
     {
-        $view   = $this->form->getView();
-        $helperLoader = $view->broker()->getClassLoader();
-        $plugins = $helperLoader->getRegisteredPlugins();
-
-        $this->assertInternalType('array', $plugins);
+        $view = $this->form->getView();
+        $this->assertInstanceOf('Zend\Dojo\View\Helper\Dojo', $view->broker('dojo'));
     }
 
-    public function testDisplayGroupShouldRegisterDojoViewHelperPath()
+    public function testDisplayGroupShouldRegisterDojoViewHelper()
     {
         $this->form->dg->setView(new View\PhpRenderer());
         $view   = $this->form->dg->getView();
-        $helperLoader = $view->broker()->getClassLoader();
-        $plugins = $helperLoader->getRegisteredPlugins();
-
-        $this->assertInternalType('array', $plugins);
+        $this->assertInstanceOf('Zend\Dojo\View\Helper\Dojo', $view->broker('dojo'));
     }
 
     /**

--- a/tests/Zend/Dojo/Form/FormTest.php
+++ b/tests/Zend/Dojo/Form/FormTest.php
@@ -22,7 +22,7 @@
 namespace ZendTest\Dojo\Form;
 
 use Zend\Dojo\Form\Form as DojoForm,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_Form and Zend_Dojo_Form_DisplayGroup
@@ -48,31 +48,31 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->form = new DojoForm();
         $this->form->addElement('TextBox', 'foo')
                    ->addDisplayGroup(array('foo'), 'dg')
-                   ->setView(new View());
+                   ->setView(new View\PhpRenderer());
     }
 
     public function testDojoFormDecoratorPathShouldBeRegisteredByDefault()
     {
         $paths = $this->form->getPluginLoader('decorator')->getPaths('Zend\Dojo\Form\Decorator');
-        $this->assertTrue(is_array($paths));
+        $this->assertInstanceOf('Zend\Stdlib\SplStack', $paths);
     }
 
     public function testDojoFormElementPathShouldBeRegisteredByDefault()
     {
         $paths = $this->form->getPluginLoader('element')->getPaths('Zend\Dojo\Form\Element');
-        $this->assertTrue(is_array($paths));
+        $this->assertInstanceOf('Zend\Stdlib\SplStack', $paths);
     }
 
     public function testDojoFormElementDecoratorPathShouldBeRegisteredByDefault()
     {
         $paths = $this->form->foo->getPluginLoader('decorator')->getPaths('Zend\Dojo\Form\Decorator');
-        $this->assertTrue(is_array($paths));
+        $this->assertInstanceOf('Zend\Stdlib\SplStack', $paths);
     }
 
     public function testDojoFormDisplayGroupDecoratorPathShouldBeRegisteredByDefault()
     {
         $paths = $this->form->dg->getPluginLoader()->getPaths('Zend\Dojo\Form\Decorator');
-        $this->assertTrue(is_array($paths));
+        $this->assertInstanceOf('Zend\Stdlib\SplStack', $paths);
     }
 
     public function testDefaultDisplayGroupClassShouldBeDojoDisplayGroupByDefault()
@@ -88,18 +88,20 @@ class FormTest extends \PHPUnit_Framework_TestCase
     public function testShouldRegisterDojoViewHelperPath()
     {
         $view   = $this->form->getView();
-        $loader = $view->getPluginLoader('helper');
-        $paths  = $loader->getPaths('Zend\Dojo\View\Helper');
-        $this->assertTrue(is_array($paths));
+        $helperLoader = $view->broker()->getClassLoader();
+        $plugins = $helperLoader->getRegisteredPlugins();
+
+        $this->assertInternalType('array', $plugins);
     }
 
     public function testDisplayGroupShouldRegisterDojoViewHelperPath()
     {
-        $this->form->dg->setView(new View());
+        $this->form->dg->setView(new View\PhpRenderer());
         $view   = $this->form->dg->getView();
-        $loader = $view->getPluginLoader('helper');
-        $paths  = $loader->getPaths('Zend\Dojo\View\Helper');
-        $this->assertTrue(is_array($paths));
+        $helperLoader = $view->broker()->getClassLoader();
+        $plugins = $helperLoader->getRegisteredPlugins();
+
+        $this->assertInternalType('array', $plugins);
     }
 
     /**

--- a/tests/Zend/Dojo/Form/SubFormTest.php
+++ b/tests/Zend/Dojo/Form/SubFormTest.php
@@ -85,12 +85,10 @@ class SubFormTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($this->form->getDecorator('ContentPane'));
     }
 
-    public function testShouldRegisterDojoViewHelperPath()
+    public function testShouldRegisterDojoViewHelper()
     {
-        $view   = $this->form->getView();
-        $helperLoader = $view->broker()->getClassLoader();
-        $plugins = $helperLoader->getRegisteredPlugins();
-
-        $this->assertInternalType('array', $plugins);
+        $view = $this->form->getView();
+        
+        $this->assertInstanceOf('Zend\Dojo\View\Helper\Dojo', $view->broker('dojo'));
     }
 }

--- a/tests/Zend/Dojo/Form/SubFormTest.php
+++ b/tests/Zend/Dojo/Form/SubFormTest.php
@@ -22,7 +22,7 @@
 namespace ZendTest\Dojo\Form;
 
 use Zend\Dojo\Form\SubForm as DojoSubForm,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_SubForm
@@ -48,31 +48,31 @@ class SubFormTest extends \PHPUnit_Framework_TestCase
         $this->form = new DojoSubForm();
         $this->form->addElement('TextBox', 'foo')
                    ->addDisplayGroup(array('foo'), 'dg')
-                   ->setView(new View());
+                   ->setView(new View\PhpRenderer());
     }
 
     public function testDojoFormDecoratorPathShouldBeRegisteredByDefault()
     {
         $paths = $this->form->getPluginLoader('decorator')->getPaths('Zend\Dojo\Form\Decorator');
-        $this->assertTrue(is_array($paths));
+        $this->assertInstanceOf('Zend\Stdlib\SplStack', $paths);
     }
 
     public function testDojoFormElementPathShouldBeRegisteredByDefault()
     {
         $paths = $this->form->getPluginLoader('element')->getPaths('Zend\Dojo\Form\Element');
-        $this->assertTrue(is_array($paths));
+        $this->assertInstanceOf('Zend\Stdlib\SplStack', $paths);
     }
 
     public function testDojoFormElementDecoratorPathShouldBeRegisteredByDefault()
     {
         $paths = $this->form->foo->getPluginLoader('decorator')->getPaths('Zend\Dojo\Form\Decorator');
-        $this->assertTrue(is_array($paths));
+        $this->assertInstanceOf('Zend\Stdlib\SplStack', $paths);
     }
 
     public function testDojoFormDisplayGroupDecoratorPathShouldBeRegisteredByDefault()
     {
         $paths = $this->form->dg->getPluginLoader()->getPaths('Zend\Dojo\Form\Decorator');
-        $this->assertTrue(is_array($paths));
+        $this->assertInstanceOf('Zend\Stdlib\SplStack', $paths);
     }
 
     public function testDefaultDisplayGroupClassShouldBeDojoDisplayGroupByDefault()
@@ -88,8 +88,9 @@ class SubFormTest extends \PHPUnit_Framework_TestCase
     public function testShouldRegisterDojoViewHelperPath()
     {
         $view   = $this->form->getView();
-        $loader = $view->getPluginLoader('helper');
-        $paths  = $loader->getPaths('Zend\Dojo\View\Helper');
-        $this->assertTrue(is_array($paths));
+        $helperLoader = $view->broker()->getClassLoader();
+        $plugins = $helperLoader->getRegisteredPlugins();
+
+        $this->assertInternalType('array', $plugins);
     }
 }

--- a/tests/Zend/Dojo/View/Helper/AccordionContainerTest.php
+++ b/tests/Zend/Dojo/View/Helper/AccordionContainerTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\AccordionContainer as AccordionContainerHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_AccordionContainer.
@@ -57,7 +57,7 @@ class AccordionContainerTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -69,7 +69,7 @@ class AccordionContainerTest extends \PHPUnit_Framework_TestCase
             $id      = 'pane' . $i;
             $title   = 'Pane ' . $i;
             $content = 'This is the content of pane ' . $i;
-            $html   .= $this->view->accordionPane($id, $content, array('title' => $title));
+            $html   .= $this->view->broker('accordionPane')->direct($id, $content, array('title' => $title));
         }
         return $this->helper->direct('container', $html, array(), array('style' => 'height: 200px; width: 100px;'));
     }
@@ -85,19 +85,19 @@ class AccordionContainerTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getContainer();
         $this->assertNotRegexp('/<div[^>]*(dojoType="dijit.layout.AccordionContainer")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('container'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('container'));
     }
 
     public function testShouldAllowCapturingNestedContent()
     {
         $this->helper->captureStart('foo', array(), array('style' => 'height: 200px; width: 100px;'));
-        $this->view->accordionPane()->captureStart('bar', array('title' => 'Captured Pane'));
+        $this->view->broker('accordionPane')->captureStart('bar', array('title' => 'Captured Pane'));
         echo "Captured content started\n";
-        $this->view->accordionPane()->captureStart('baz', array('title' => 'Nested Pane'));
+        $this->view->broker('accordionPane')->captureStart('baz', array('title' => 'Nested Pane'));
         echo 'Nested Content';
-        echo $this->view->accordionPane()->captureEnd('baz');
+        echo $this->view->broker('accordionPane')->captureEnd('baz');
         echo "Captured content ended\n";
-        echo $this->view->accordionPane()->captureEnd('bar');
+        echo $this->view->broker('accordionPane')->captureEnd('bar');
         $html = $this->helper->captureEnd('foo');
         $this->assertRegexp('/<div[^>]*(id="bar")/', $html);
         $this->assertRegexp('/<div[^>]*(id="baz")/', $html);
@@ -112,10 +112,10 @@ class AccordionContainerTest extends \PHPUnit_Framework_TestCase
     public function testCapturingShouldRaiseErrorWhenDuplicateIdDiscovered()
     {
         $this->helper->captureStart('foo', array(), array('style' => 'height: 200px; width: 100px;'));
-        $this->view->accordionPane()->captureStart('bar', array('title' => 'Captured Pane'));
+        $this->view->broker('accordionPane')->captureStart('bar', array('title' => 'Captured Pane'));
         
         $this->setExpectedException('Zend\Dojo\View\Exception\RuntimeException', 'Lock already exists for id ');
-        $this->view->accordionPane()->captureStart('bar', array('title' => 'Captured Pane'));
+        $this->view->broker('accordionPane')->captureStart('bar', array('title' => 'Captured Pane'));
     }
 
     public function testCapturingShouldRaiseErrorWhenNonexistentIdPassedToEnd()

--- a/tests/Zend/Dojo/View/Helper/AccordionPaneTest.php
+++ b/tests/Zend/Dojo/View/Helper/AccordionPaneTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\AccordionPane as AccordionPaneHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_AccordionPane.
@@ -57,14 +57,14 @@ class AccordionPaneTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
 
     public function getContainer()
     {
-        return $this->view->accordionPane('pane1', 'This is the pane content', array('title' => 'Pane 1'));
+        return $this->view->broker('accordionPane')->direct('pane1', 'This is the pane content', array('title' => 'Pane 1'));
     }
 
     public function testShouldAllowDeclarativeDijitCreation()
@@ -78,6 +78,6 @@ class AccordionPaneTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getContainer();
         $this->assertNotRegexp('/<div[^>]*(dojoType="dijit.layout.AccordionPane")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('pane1'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('pane1'));
     }
 }

--- a/tests/Zend/Dojo/View/Helper/BorderContainerTest.php
+++ b/tests/Zend/Dojo/View/Helper/BorderContainerTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\BorderContainer as BorderContainerHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_BorderContainer.
@@ -57,7 +57,7 @@ class BorderContainerTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -68,7 +68,7 @@ class BorderContainerTest extends \PHPUnit_Framework_TestCase
         foreach (array('top', 'bottom', 'center', 'left', 'right') as $pane) {
             $id      = $pane . 'Pane';
             $content = 'This is the content of pane ' . $pane;
-            $html   .= $this->view->contentPane($id, $content, array('region' => $pane));
+            $html   .= $this->view->broker('contentPane')->direct($id, $content, array('region' => $pane));
         }
         return $this->helper->direct('container', $html, array('design' => 'headline'));
     }
@@ -84,7 +84,7 @@ class BorderContainerTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getContainer();
         $this->assertNotRegexp('/<div[^>]*(dojoType="dijit.layout.BorderContainer")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('container'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('container'));
     }
 
     /**
@@ -95,7 +95,7 @@ class BorderContainerTest extends \PHPUnit_Framework_TestCase
         $this->getContainer();
         $this->getContainer();
         $style  = 'html, body { height: 100%; width: 100%; margin: 0; padding: 0; }';
-        $styles = $this->helper->view->headStyle()->toString();
+        $styles = $this->helper->getView()->broker('headStyle')->toString();
         $this->assertEquals(1, substr_count($styles, $style), $styles);
     }
 }

--- a/tests/Zend/Dojo/View/Helper/ButtonTest.php
+++ b/tests/Zend/Dojo/View/Helper/ButtonTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\Button as ButtonHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_Button.
@@ -57,7 +57,7 @@ class ButtonTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -87,6 +87,6 @@ class ButtonTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<button[^>]*(dojoType="dijit.form.Button")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 }

--- a/tests/Zend/Dojo/View/Helper/CheckBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/CheckBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\CheckBox as CheckBoxHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_CheckBox.
@@ -57,7 +57,7 @@ class CheckBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -87,7 +87,7 @@ class CheckBoxTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<input[^>]*(dojoType="dijit.form.CheckBox")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 
     public function testShouldCreateHiddenElementWithUncheckedValue()

--- a/tests/Zend/Dojo/View/Helper/ComboBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/ComboBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\ComboBox as ComboBoxHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_ComboBox.
@@ -57,7 +57,7 @@ class ComboBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -110,7 +110,7 @@ class ComboBoxTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElementAsSelect();
         $this->assertNotRegexp('/<select[^>]*(dojoType="dijit.form.ComboBox")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 
     public function testShouldAllowDeclarativeDijitCreationAsRemoter()
@@ -128,12 +128,12 @@ class ComboBoxTest extends \PHPUnit_Framework_TestCase
         $html = $this->getElementAsRemoter();
         $this->assertNotRegexp('/<input[^>]*(dojoType="dijit.form.ComboBox")/', $html);
         $this->assertRegexp('/<input[^>]*(type="text")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
 
         $found = false;
-        $this->assertContains('var stateStore;', $this->view->dojo()->getJavascript());
+        $this->assertContains('var stateStore;', $this->view->broker('dojo')->getJavascript());
 
-        $scripts = $this->view->dojo()->_getZendLoadActions();
+        $scripts = $this->view->broker('dojo')->_getZendLoadActions();
         foreach ($scripts as $js) {
             if (strstr($js, 'stateStore = new ')) {
                 $found = true;
@@ -174,10 +174,10 @@ class ComboBoxTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic(true);
         $html = $this->getElementAsRemoter();
 
-        $js   = $this->view->dojo()->getJavascript();
+        $js   = $this->view->broker('dojo')->getJavascript();
         $this->assertContains('var stateStore;', $js);
 
-        $onLoad = $this->view->dojo()->_getZendLoadActions();
+        $onLoad = $this->view->broker('dojo')->_getZendLoadActions();
         $storeDeclarationFound = false;
         foreach ($onLoad as $statement) {
             if (strstr($statement, 'stateStore = new ')) {

--- a/tests/Zend/Dojo/View/Helper/ContentPaneTest.php
+++ b/tests/Zend/Dojo/View/Helper/ContentPaneTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\ContentPane as ContentPaneHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_ContentPane.
@@ -57,14 +57,14 @@ class ContentPaneTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
 
     public function getContainer()
     {
-        return $this->view->contentPane('pane1', 'This is the pane content', array('title' => 'Pane 1'));
+        return $this->view->broker('contentPane')->direct('pane1', 'This is the pane content', array('title' => 'Pane 1'));
     }
 
     public function testShouldAllowDeclarativeDijitCreation()
@@ -78,7 +78,7 @@ class ContentPaneTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getContainer();
         $this->assertNotRegexp('/<div[^>]*(dojoType="dijit.layout.ContentPane")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('pane1'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('pane1'));
     }
 
     /**
@@ -86,11 +86,11 @@ class ContentPaneTest extends \PHPUnit_Framework_TestCase
      */
     public function testContentPaneMarkupShouldNotContainNameAttribute()
     {
-        $html = $this->view->contentPane('pane1', 'This is the pane content', array('id' => 'pane', 'title' => 'Pane 1'));
+        $html = $this->view->broker('contentPane')->direct('pane1', 'This is the pane content', array('id' => 'pane', 'title' => 'Pane 1'));
         $this->assertNotContains('name="/', $html, $html);
 
         DojoHelper::setUseProgrammatic();
-        $html = $this->view->contentPane('pane1', 'This is the pane content', array('id' => 'pane', 'title' => 'Pane 1'));
+        $html = $this->view->broker('contentPane')->direct('pane1', 'This is the pane content', array('id' => 'pane', 'title' => 'Pane 1'));
         $this->assertNotContains('name="/', $html, $html);
     }
 
@@ -99,8 +99,8 @@ class ContentPaneTest extends \PHPUnit_Framework_TestCase
      */
     public function testCaptureStartShouldReturnVoid()
     {
-        $test = $this->view->contentPane()->captureStart('pane1');
-        $this->view->contentPane()->captureEnd('pane1');
+        $test = $this->view->broker('contentPane')->captureStart('pane1');
+        $this->view->broker('contentPane')->captureEnd('pane1');
         $this->assertNull($test);
     }
 }

--- a/tests/Zend/Dojo/View/Helper/CurrencyTextBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/CurrencyTextBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\CurrencyTextBox as CurrencyTextBoxHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_CurrencyTextBox.
@@ -57,7 +57,7 @@ class CurrencyTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -87,7 +87,7 @@ class CurrencyTextBoxTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<input[^>]*(dojoType="dijit.form.CurrencyTextBox")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 
     public function testShouldCreateTextInput()

--- a/tests/Zend/Dojo/View/Helper/CustomDijitTest.php
+++ b/tests/Zend/Dojo/View/Helper/CustomDijitTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\CustomDijit as CustomDijitHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_CustomDijit
@@ -55,7 +55,7 @@ class CustomDijitTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -63,19 +63,19 @@ class CustomDijitTest extends \PHPUnit_Framework_TestCase
     public function testHelperShouldRaiseExceptionIfNoDojoTypePassed()
     {
         $this->setExpectedException('Zend\Dojo\View\Exception\InvalidArgumentException', 'No dojoType specified; cannot create dijit');
-        $this->view->customDijit('foo');
+        $this->view->broker('customDijit')->direct('foo');
     }
 
     public function testHelperInDeclarativeModeShouldGenerateDivWithPassedDojoType()
     {
-        $content = $this->view->customDijit('foo', 'content', array('dojoType' => 'custom.Dijit'));
+        $content = $this->view->broker('customDijit')->direct('foo', 'content', array('dojoType' => 'custom.Dijit'));
         $this->assertContains('dojoType="custom.Dijit"', $content);
     }
 
     public function testHelperInDeclarativeModeShouldRegisterDojoTypeAsModule()
     {
-        $content = $this->view->customDijit('foo', 'content', array('dojoType' => 'custom.Dijit'));
-        $dojo    = $this->view->dojo();
+        $content = $this->view->broker('customDijit')->direct('foo', 'content', array('dojoType' => 'custom.Dijit'));
+        $dojo    = $this->view->broker('dojo');
         $modules = $dojo->getModules();
         $this->assertContains('custom.Dijit', $modules);
     }
@@ -83,8 +83,8 @@ class CustomDijitTest extends \PHPUnit_Framework_TestCase
     public function testHelperInProgrammaticModeShouldRegisterDojoTypeAsModule()
     {
         DojoHelper::setUseProgrammatic();
-        $content = $this->view->customDijit('foo', 'content', array('dojoType' => 'custom.Dijit'));
-        $dojo    = $this->view->dojo();
+        $content = $this->view->broker('customDijit')->direct('foo', 'content', array('dojoType' => 'custom.Dijit'));
+        $dojo    = $this->view->broker('dojo');
         $modules = $dojo->getModules();
         $this->assertContains('custom.Dijit', $modules);
     }
@@ -92,15 +92,15 @@ class CustomDijitTest extends \PHPUnit_Framework_TestCase
     public function testHelperInProgrammaticModeShouldGenerateDivWithoutPassedDojoType()
     {
         DojoHelper::setUseProgrammatic();
-        $content = $this->view->customDijit('foo', 'content', array('dojoType' => 'custom.Dijit'));
+        $content = $this->view->broker('customDijit')->direct('foo', 'content', array('dojoType' => 'custom.Dijit'));
         $this->assertNotContains('dojoType="custom.Dijit"', $content);
     }
 
     public function testHelperShouldAllowCapturingContent()
     {
-        $this->view->customDijit()->captureStart('foo', array('dojoType' => 'custom.Dijit'));
+        $this->view->broker('customDijit')->captureStart('foo', array('dojoType' => 'custom.Dijit'));
         echo "Captured content started\n";
-        $content = $this->view->customDijit()->captureEnd('foo');
+        $content = $this->view->broker('customDijit')->captureEnd('foo');
         $this->assertContains(">Captured content started\n<", $content);
     }
 
@@ -128,7 +128,7 @@ class CustomDijitTest extends \PHPUnit_Framework_TestCase
      */
     public function testHelperShouldAllowSpecifyingRootNode()
     {
-        $content = $this->view->customDijit('foo', 'content', array(
+        $content = $this->view->broker('customDijit')->direct('foo', 'content', array(
             'dojoType' => 'custom.Dijit',
             'rootNode' => 'select',
         ));

--- a/tests/Zend/Dojo/View/Helper/DateTextBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/DateTextBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\DateTextBox as DateTextBoxHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_DateTextBox.
@@ -57,7 +57,7 @@ class DateTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -85,7 +85,7 @@ class DateTextBoxTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<input[^>]*(dojoType="dijit.form.DateTextBox")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 
     public function testShouldCreateTextInput()

--- a/tests/Zend/Dojo/View/Helper/EditorTest.php
+++ b/tests/Zend/Dojo/View/Helper/EditorTest.php
@@ -25,7 +25,7 @@ use Zend\Dojo\View\Helper\Editor as EditorHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Json\Json,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_Editor.
@@ -58,7 +58,7 @@ class EditorTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -87,7 +87,7 @@ class EditorTest extends \PHPUnit_Framework_TestCase
     public function testHelperShouldRegisterDijitModule()
     {
         $html = $this->helper->direct('foo');
-        $modules = $this->view->dojo()->getModules();
+        $modules = $this->view->broker('dojo')->getModules();
         $this->assertContains('dijit.Editor', $modules);
     }
 
@@ -112,7 +112,7 @@ class EditorTest extends \PHPUnit_Framework_TestCase
     public function testHelperShouldCreateJavascriptToConnectEditorToHiddenValue()
     {
         $this->helper->direct('foo');
-        $onLoadActions = $this->view->dojo()->getOnLoadActions();
+        $onLoadActions = $this->view->broker('dojo')->getOnLoadActions();
         $found = false;
         foreach ($onLoadActions as $action) {
             if (strstr($action, "dojo.byId('foo').value = dijit.byId('foo-Editor').getValue(false);")) {
@@ -126,7 +126,7 @@ class EditorTest extends \PHPUnit_Framework_TestCase
     public function testHelperShouldCreateJavascriptToFindParentForm()
     {
         $this->helper->direct('foo');
-        $javascript = $this->view->dojo()->getJavascript();
+        $javascript = $this->view->broker('dojo')->getJavascript();
         $found = false;
         foreach ($javascript as $action) {
             if (strstr($action, "zend.findParentForm = function")) {
@@ -140,7 +140,7 @@ class EditorTest extends \PHPUnit_Framework_TestCase
     public function testHelperShouldNotRegisterDojoStylesheet()
     {
         $this->helper->direct('foo');
-        $this->assertFalse($this->view->dojo()->registerDojoStylesheet());
+        $this->assertFalse($this->view->broker('dojo')->registerDojoStylesheet());
     }
 
     /**
@@ -154,7 +154,7 @@ class EditorTest extends \PHPUnit_Framework_TestCase
         );
         $html = $this->helper->direct('foo', '', array('plugins' => array_keys($plugins)));
 
-        $dojo = $this->view->dojo()->__toString();
+        $dojo = $this->view->broker('dojo')->__toString();
         foreach (array_values($plugins) as $plugin) {
             $this->assertContains('dojo.require("dijit._editor.plugins.' . $plugin . '")', $dojo, $dojo);
         }

--- a/tests/Zend/Dojo/View/Helper/FilteringSelectTest.php
+++ b/tests/Zend/Dojo/View/Helper/FilteringSelectTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\FilteringSelect as FilteringSelectHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_FilteringSelect.
@@ -57,7 +57,7 @@ class FilteringSelectTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -110,7 +110,7 @@ class FilteringSelectTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElementAsSelect();
         $this->assertNotRegexp('/<select[^>]*(dojoType="dijit.form.FilteringSelect")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 
     public function testShouldAllowDeclarativeDijitCreationAsRemoter()
@@ -128,12 +128,12 @@ class FilteringSelectTest extends \PHPUnit_Framework_TestCase
         $html = $this->getElementAsRemoter();
         $this->assertNotRegexp('/<input[^>]*(dojoType="dijit.form.FilteringSelect")/', $html);
         $this->assertRegexp('/<input[^>]*(type="text")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
 
-        $this->assertContains('var stateStore;', $this->view->dojo()->getJavascript());
+        $this->assertContains('var stateStore;', $this->view->broker('dojo')->getJavascript());
 
         $found = false;
-        $scripts = $this->view->dojo()->_getZendLoadActions();
+        $scripts = $this->view->broker('dojo')->_getZendLoadActions();
         foreach ($scripts as $js) {
             if (strstr($js, 'stateStore = new ')) {
                 $found = true;

--- a/tests/Zend/Dojo/View/Helper/FormTest.php
+++ b/tests/Zend/Dojo/View/Helper/FormTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\Form as FormHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_Form.
@@ -57,7 +57,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -78,13 +78,13 @@ class FormTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getForm();
         $this->assertNotRegexp('/<form[^>]*(dojoType="dijit.form.Form")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('myForm'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('myForm'));
     }
 
     public function testOnlyIdShouldBeNecessary()
     {
         DojoHelper::setUseDeclarative();
-        $html = $this->view->form('foo');
+        $html = $this->view->broker('form')->direct('foo');
         $this->assertRegexp('/<form[^>]*(dojoType="dijit.form.Form")/', $html, $html);
         $this->assertRegexp('/<form[^>]*(id="foo")/', $html, $html);
     }

--- a/tests/Zend/Dojo/View/Helper/HorizontalSliderTest.php
+++ b/tests/Zend/Dojo/View/Helper/HorizontalSliderTest.php
@@ -230,7 +230,6 @@ class HorizontalSliderTest extends \PHPUnit_Framework_TestCase
      */
     public function testShouldCreateAppropriateIdsForElementsInSubForms()
     {
-        $this->markTestSkipped();
         $form = new DojoForm;
         $form->setDecorators(array(
             'FormElements',

--- a/tests/Zend/Dojo/View/Helper/HorizontalSliderTest.php
+++ b/tests/Zend/Dojo/View/Helper/HorizontalSliderTest.php
@@ -26,7 +26,7 @@ use Zend\Dojo\View\Helper\HorizontalSlider as HorizontalSliderHelper,
     Zend\Dojo\Form\Form as DojoForm,
     Zend\Dojo\Form\SubForm as DojoSubForm,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_HorizontalSlider.
@@ -59,7 +59,7 @@ class HorizontalSliderTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -152,7 +152,7 @@ class HorizontalSliderTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<div[^>]*(dojoType="dijit.form.HorizontalSlider")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId-slider'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId-slider'));
     }
 
     public function testShouldCreateOnChangeAttributeByDefault()
@@ -230,6 +230,7 @@ class HorizontalSliderTest extends \PHPUnit_Framework_TestCase
      */
     public function testShouldCreateAppropriateIdsForElementsInSubForms()
     {
+        $this->markTestSkipped();
         $form = new DojoForm;
         $form->setDecorators(array(
             'FormElements',

--- a/tests/Zend/Dojo/View/Helper/NumberSpinnerTest.php
+++ b/tests/Zend/Dojo/View/Helper/NumberSpinnerTest.php
@@ -25,7 +25,7 @@ use Zend\Dojo\View\Helper\NumberSpinner as NumberSpinnerHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Json\Json,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_NumberSpinner.
@@ -58,7 +58,7 @@ class NumberSpinnerTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -90,7 +90,7 @@ class NumberSpinnerTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<input[^>]*(dojoType="dijit.form.NumberSpinner")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 
     public function testShouldCreateTextInput()
@@ -106,7 +106,7 @@ class NumberSpinnerTest extends \PHPUnit_Framework_TestCase
             $this->fail('Did not serialize constraints');
         }
         $constraints = str_replace("'", '"', $m[1]);
-        $constraints = Json::decode($constraints);
+        $constraints = Json::decode($constraints, JSON::TYPE_ARRAY);
         $this->assertTrue(is_array($constraints), var_export($m[1], 1));
         $this->assertTrue(array_key_exists('min', $constraints));
         $this->assertTrue(array_key_exists('max', $constraints));

--- a/tests/Zend/Dojo/View/Helper/NumberTextBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/NumberTextBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\NumberTextBox as NumberTextBoxHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_NumberTextBox.
@@ -57,7 +57,7 @@ class NumberTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -86,7 +86,7 @@ class NumberTextBoxTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<input[^>]*(dojoType="dijit.form.NumberTextBox")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 
     public function testShouldCreateTextInput()

--- a/tests/Zend/Dojo/View/Helper/PasswordTextBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/PasswordTextBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\PasswordTextBox as PasswordTextBoxHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_PasswordTextBox.
@@ -57,7 +57,7 @@ class PasswordTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -85,7 +85,7 @@ class PasswordTextBoxTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<input[^>]*(dojoType="dijit.form.ValidationTextBox")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 
     public function testShouldCreatePasswordInput()

--- a/tests/Zend/Dojo/View/Helper/RadioButtonTest.php
+++ b/tests/Zend/Dojo/View/Helper/RadioButtonTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\RadioButton as RadioButtonHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_RadioButton.
@@ -57,7 +57,7 @@ class RadioButtonTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -87,6 +87,6 @@ class RadioButtonTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<input[^>]*(dojoType="dijit.form.RadioButton")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 }

--- a/tests/Zend/Dojo/View/Helper/SplitContainerTest.php
+++ b/tests/Zend/Dojo/View/Helper/SplitContainerTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\SplitContainer as SplitContainerHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_SplitContainer.
@@ -57,7 +57,7 @@ class SplitContainerTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -68,7 +68,7 @@ class SplitContainerTest extends \PHPUnit_Framework_TestCase
         foreach (array('top', 'bottom', 'center', 'left', 'right') as $pane) {
             $id      = $pane . 'Pane';
             $content = 'This is the content of pane ' . $pane;
-            $html   .= $this->view->contentPane($id, $content, array('region' => $pane));
+            $html   .= $this->view->broker('contentPane')->direct($id, $content, array('region' => $pane));
         }
         return $this->helper->direct('container', $html, array('design' => 'headline'));
     }
@@ -84,6 +84,6 @@ class SplitContainerTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getContainer();
         $this->assertNotRegexp('/<div[^>]*(dojoType="dijit.layout.SplitContainer")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('container'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('container'));
     }
 }

--- a/tests/Zend/Dojo/View/Helper/StackContainerTest.php
+++ b/tests/Zend/Dojo/View/Helper/StackContainerTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\StackContainer as StackContainerHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_StackContainer.
@@ -57,7 +57,7 @@ class StackContainerTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -68,7 +68,7 @@ class StackContainerTest extends \PHPUnit_Framework_TestCase
         foreach (array('top', 'bottom', 'center', 'left', 'right') as $pane) {
             $id      = $pane . 'Pane';
             $content = 'This is the content of pane ' . $pane;
-            $html   .= $this->view->contentPane($id, $content, array('region' => $pane));
+            $html   .= $this->view->broker('contentPane')->direct($id, $content, array('region' => $pane));
         }
         return $this->helper->direct('container', $html, array('design' => 'headline'));
     }
@@ -84,6 +84,6 @@ class StackContainerTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getContainer();
         $this->assertNotRegexp('/<div[^>]*(dojoType="dijit.layout.StackContainer")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('container'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('container'));
     }
 }

--- a/tests/Zend/Dojo/View/Helper/SubmitButtonTest.php
+++ b/tests/Zend/Dojo/View/Helper/SubmitButtonTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\SubmitButton as SubmitButtonHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_SubmitButton.
@@ -57,7 +57,7 @@ class SubmitButtonTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -85,7 +85,7 @@ class SubmitButtonTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<input[^>]*(dojoType="dijit.form.Button")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 
     /**

--- a/tests/Zend/Dojo/View/Helper/TabContainerTest.php
+++ b/tests/Zend/Dojo/View/Helper/TabContainerTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\TabContainer as TabContainerHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_TabContainer.
@@ -57,7 +57,7 @@ class TabContainerTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -68,7 +68,7 @@ class TabContainerTest extends \PHPUnit_Framework_TestCase
         foreach (array('top', 'bottom', 'center', 'left', 'right') as $pane) {
             $id      = $pane . 'Pane';
             $content = 'This is the content of pane ' . $pane;
-            $html   .= $this->view->contentPane($id, $content, array('region' => $pane));
+            $html   .= $this->view->broker('contentPane')->direct($id, $content, array('region' => $pane));
         }
         return $this->helper->direct('container', $html, array('design' => 'headline'));
     }
@@ -84,6 +84,6 @@ class TabContainerTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getContainer();
         $this->assertNotRegexp('/<div[^>]*(dojoType="dijit.layout.TabContainer")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('container'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('container'));
     }
 }

--- a/tests/Zend/Dojo/View/Helper/TextBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/TextBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\TextBox as TextBoxHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_TextBox.
@@ -57,7 +57,7 @@ class TextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -87,7 +87,7 @@ class TextBoxTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<input[^>]*(dojoType="dijit.form.TextBox")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 
     public function testShouldCreateTextInput()

--- a/tests/Zend/Dojo/View/Helper/TextareaTest.php
+++ b/tests/Zend/Dojo/View/Helper/TextareaTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\Textarea as TextareaHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_Textarea.
@@ -57,7 +57,7 @@ class TextareaTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -83,7 +83,7 @@ class TextareaTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<textarea[^>]*(dojoType="dijit.form.Textarea")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 
     public function testPassingIdAsAttributeShouldOverrideUsingNameAsId()

--- a/tests/Zend/Dojo/View/Helper/TimeTextBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/TimeTextBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\TimeTextBox as TimeTextBoxHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_TimeTextBox.
@@ -57,7 +57,7 @@ class TimeTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -85,7 +85,7 @@ class TimeTextBoxTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<input[^>]*(dojoType="dijit.form.TimeTextBox")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 
     public function testShouldCreateTextInput()

--- a/tests/Zend/Dojo/View/Helper/ValidationTextBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/ValidationTextBoxTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\ValidationTextBox as ValidationTextBoxHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_ValidationTextBox.
@@ -57,7 +57,7 @@ class ValidationTextBoxTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -86,7 +86,7 @@ class ValidationTextBoxTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<input[^>]*(dojoType="dijit.form.ValidationTextBox")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId'));
     }
 
     public function testShouldCreateTextInput()

--- a/tests/Zend/Dojo/View/Helper/VerticalSliderTest.php
+++ b/tests/Zend/Dojo/View/Helper/VerticalSliderTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Dojo\View\Helper;
 use Zend\Dojo\View\Helper\VerticalSlider as VerticalSliderHelper,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
     Zend\Registry,
-    Zend\View\View;
+    Zend\View;
 
 /**
  * Test class for Zend_Dojo_View_Helper_VerticalSlider.
@@ -57,7 +57,7 @@ class VerticalSliderTest extends \PHPUnit_Framework_TestCase
 
     public function getView()
     {
-        $view = new View();
+        $view = new View\PhpRenderer();
         \Zend\Dojo\Dojo::enableView($view);
         return $view;
     }
@@ -149,7 +149,7 @@ class VerticalSliderTest extends \PHPUnit_Framework_TestCase
         DojoHelper::setUseProgrammatic();
         $html = $this->getElement();
         $this->assertNotRegexp('/<div[^>]*(dojoType="dijit.form.VerticalSlider")/', $html);
-        $this->assertNotNull($this->view->dojo()->getDijit('elementId-slider'));
+        $this->assertNotNull($this->view->broker('dojo')->getDijit('elementId-slider'));
     }
 
     public function testShouldCreateOnChangeAttributeByDefault()


### PR DESCRIPTION
Hi!

I've made all the Zend\Dojo tests pass. I know there will most likely be changes that will make these tests break again, but it should be easier to fix then :)

With one type of tests I'm not satisfied and those are the tests which test are the Dojo view helpers actually registered, for example: https://github.com/robertbasic/zf2/blob/dojo/tests/Zend/Dojo/DojoTest.php#L105 and that's because I couldn't figure out the way to tests for all helpers from a given path, like here: https://github.com/robertbasic/zf2/blob/master/tests/Zend/Dojo/DojoTest.php#L109

Would testing is the Zend\Dojo\View\Helper\Dojo view helper loaded be sufficient? If yes, then I'll update tests to test that.

Or some third way I'm not seeing :)
