### PR TITLE
[hotfix/ZF-10738] Zend_Validate_File_Upload

### DIFF
--- a/library/Zend/Validator/File/Upload.php
+++ b/library/Zend/Validator/File/Upload.php
@@ -136,6 +136,10 @@ class Upload extends \Zend\Validator\AbstractValidator
             $this->_files = $files;
         }
 
+        if ($this->_files === NULL) {
+            $this->_files = array();
+        }
+
         foreach($this->_files as $file => $content) {
             if (!isset($content['error'])) {
                 unset($this->_files[$file]);

--- a/tests/Zend/Validator/File/UploadTest.php
+++ b/tests/Zend/Validator/File/UploadTest.php
@@ -232,4 +232,25 @@ class UploadTest extends \PHPUnit_Framework_TestCase
         $validator->setFiles($files);
         $this->assertEquals($files, $validator->getFiles());
     }
+
+    /**
+     * @group ZF-10738
+     */
+    public function testGetFilesReturnsEmptyArrayWhenFilesSuperglobalIsNull()
+    {
+        $_FILES = NULL;
+        $validator = new File\Upload();
+        $validator->setFiles();
+        $this->assertEquals(array(), $validator->getFiles());
+    }
+
+    /**
+     * @group ZF-10738
+     */
+    public function testGetFilesReturnsEmptyArrayAfterSetFilesIsCalledWithNull()
+    {
+        $validator = new File\Upload();
+        $validator->setFiles(NULL);
+        $this->assertEquals(array(), $validator->getFiles());
+    }
 }


### PR DESCRIPTION
- added a fix for environments where $_FILES can contain an invalid NULL
