### PR TITLE
 Converting assertType(), to assertInternalType() or assertInstanceOf() s

### DIFF
--- a/tests/Zend/Rest/RouteTest.php
+++ b/tests/Zend/Rest/RouteTest.php
@@ -80,7 +80,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
     	$router = new RewriteRouter();
     	$router->addConfig($config, 'routes');
     	$route = $router->getRoute('rest');
-    	$this->assertType('Zend\\Rest\\Route', $route);
+    	$this->assertInstanceOf('Zend\\Rest\\Route', $route);
     	$this->assertEquals('object', $route->getDefault('controller'));
     	
     	$request = $this->_buildRequest('GET', '/mod/project');
@@ -105,7 +105,9 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request = $this->_buildRequest('GET', '/');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+//        $this->assertInternalType('array', $values);
+        $this->assertInternalType('array', $values);
+
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('default', $values['module']);
         $this->assertEquals('index', $values['controller']);
@@ -120,7 +122,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request = $this->_buildRequest('GET', '/user');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('default', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -132,7 +134,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request = $this->_buildRequest('GET', '/user/index');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('default', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -144,7 +146,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request = $this->_buildRequest('GET', '/user/index/changedSince/123456789/status/active');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('default', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -158,7 +160,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request = $this->_buildRequest('GET', '/user/?changedSince=123456789&status=active');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('default', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -172,7 +174,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request = $this->_buildRequest('GET', '/project/zendframework');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('default', $values['module']);
         $this->assertEquals('project', $values['controller']);
@@ -185,7 +187,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request = $this->_buildRequest('GET', '/project/?id=zendframework');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('default', $values['module']);
         $this->assertEquals('project', $values['controller']);
@@ -198,7 +200,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request = $this->_buildRequest('GET', '/project/zend+framework');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('default', $values['module']);
         $this->assertEquals('project', $values['controller']);
@@ -211,7 +213,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request = $this->_buildRequest('GET', '/project/zendframework/edit');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('default', $values['module']);
         $this->assertEquals('project', $values['controller']);
@@ -224,7 +226,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request = $this->_buildRequest('PUT', '/mod/user/lcrouch');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -237,7 +239,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request = $this->_buildRequest('POST', '/mod/user');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -249,7 +251,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request = $this->_buildRequest('DELETE', '/mod/user/lcrouch');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -262,7 +264,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request = $this->_buildRequest('POST', '/mod/user/lcrouch');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -276,7 +278,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request->setParam('_method', 'PUT');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -289,7 +291,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $request->setHeader('X-HTTP-Method-Override', 'DELETE');
         $values = $this->_invokeRouteMatch($request);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -323,7 +325,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $config = array('mod');
         $values = $this->_invokeRouteMatch($request, $config);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -336,7 +338,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $config = array('mod');
         $values = $this->_invokeRouteMatch($request, $config);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -349,7 +351,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $config = array('mod');
         $values = $this->_invokeRouteMatch($request, $config);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -371,7 +373,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $config = array('mod');
         $values = $this->_invokeRouteMatch($request, $config);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -385,7 +387,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $config = array('mod');
         $values = $this->_invokeRouteMatch($request, $config);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -399,7 +401,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $config = array('mod'=>array('user'));
         $values = $this->_invokeRouteMatch($request, $config);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -430,7 +432,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $config = array('mod'=>array('user'));
         $values = $this->_invokeRouteMatch($request, $config);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -443,7 +445,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $config = array('mod'=>array('user'));
         $values = $this->_invokeRouteMatch($request, $config);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -483,7 +485,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $config = array('mod'=>array('user'));
         $values = $this->_invokeRouteMatch($request, $config);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);
@@ -497,7 +499,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $config = array('mod');
         $values = $this->_invokeRouteMatch($request, $config);
 
-        $this->assertType('array', $values);
+        $this->assertInternalType('array', $values);
         $this->assertTrue(isset($values['module']));
         $this->assertEquals('mod', $values['module']);
         $this->assertEquals('user', $values['controller']);


### PR DESCRIPTION
 Converting assertType(), to assertInternalType() or assertInstanceOf() since assertType is deprecated in newer versions of phpunit.
