### PR TITLE
[hotfix/ZF2-46] Definition/Compiler marks all setter-injection method arguments as optional

### DIFF
--- a/library/Zend/Di/Definition/Compiler.php
+++ b/library/Zend/Di/Definition/Compiler.php
@@ -257,8 +257,8 @@ class Compiler
                 $params[$paramName][] = null;
             }
             
-            if ($introspectionType == IntrospectionRuleset::TYPE_SETTER && $rules['paramCanBeOptional']) {
-                $params[$paramName][] = true;
+            if ($introspectionType == IntrospectionRuleset::TYPE_SETTER && !$rules['paramCanBeOptional']) {
+                $params[$paramName][] = false;
             } else {
                 $params[$paramName][] = $p->isOptional(); 
             }

--- a/library/Zend/Di/Definition/RuntimeDefinition.php
+++ b/library/Zend/Di/Definition/RuntimeDefinition.php
@@ -300,8 +300,8 @@ class RuntimeDefinition implements Definition
             $params[$paramName][] = ($pc !== null) ? $pc->getName() : null;
 
             // optional?
-            if ($introspectionType == IntrospectionRuleset::TYPE_SETTER && $rules['paramCanBeOptional']) {
-                $params[$paramName][] = true;
+            if ($introspectionType == IntrospectionRuleset::TYPE_SETTER && !$rules['paramCanBeOptional']) {
+                $params[$paramName][] = false;
             } else {
                 $params[$paramName][] = $p->isOptional(); 
             }

--- a/tests/Zend/Di/Definition/CompilerTest.php
+++ b/tests/Zend/Di/Definition/CompilerTest.php
@@ -38,6 +38,24 @@ class CompilerTest extends TestCase
         $this->assertContains('setB', $definition->getInjectionMethods('ZendTest\Di\TestAsset\CompilerClasses\C'));
         $this->assertTrue($definition->hasInjectionMethod('ZendTest\Di\TestAsset\CompilerClasses\C', 'setB'));
         
-        $this->assertEquals(array('b' => 'ZendTest\Di\TestAsset\CompilerClasses\B'), $definition->getInjectionMethodParameters('ZendTest\Di\TestAsset\CompilerClasses\C', 'setB'));
+        $params = array(
+            'b' => array(
+                'ZendTest\Di\TestAsset\CompilerClasses\B',
+                false, // ZF2-46 
+                true,
+            ),
+        );
+        $this->assertEquals($params, $definition->getInjectionMethodParameters('ZendTest\Di\TestAsset\CompilerClasses\C', 'setB'));
+
+        // I'm not sure there's a use-case for a setter with an optional 
+        // parameter, but we should test that it reflects it accurately.
+        $params = array(
+            'a' => array(
+                'ZendTest\Di\TestAsset\CompilerClasses\A',
+                true,
+                true,
+            ),
+        );
+        $this->assertEquals($params, $definition->getInjectionMethodParameters('ZendTest\Di\TestAsset\CompilerClasses\C', 'setA'));
     }
 }

--- a/tests/Zend/Di/TestAsset/CompilerClasses/C.php
+++ b/tests/Zend/Di/TestAsset/CompilerClasses/C.php
@@ -4,6 +4,11 @@ namespace ZendTest\Di\TestAsset\CompilerClasses;
 
 class C
 {
+    public function setA(A $a = NULL)
+    {
+        
+    }
+
     public function setB(B $b)
     {
         


### PR DESCRIPTION
Suggested fix for ZF2-46
