### PR TITLE
Support appending to a previously generated classmap file

### DIFF
--- a/bin/classmap_generator.php
+++ b/bin/classmap_generator.php
@@ -126,7 +126,7 @@ $l = new \Zend\File\ClassFileLocator($path);
 
 // Iterate over each element in the path, and create a map of 
 // classname => filename, where the filename is relative to the library path
-$map = new \stdClass;
+$map    = new \stdClass;
 $strip .= DIRECTORY_SEPARATOR;
 iterator_apply($l, function() use ($l, $map, $strip){
     $file      = $l->current();

--- a/bin/classmap_generator.php
+++ b/bin/classmap_generator.php
@@ -159,9 +159,8 @@ if ($appending) {
     $existing = file($output, FILE_IGNORE_NEW_LINES);
     array_pop($existing); 
 
-    // Merge and write to disk
-    $existing += $content;
-    file_put_contents($output, implode(PHP_EOL, $existing));
+    // Merge
+    $content = implode(PHP_EOL, $existing + $content);
 } else {
     // Create a file with the class/file map.
     // Stupid syntax highlighters make separating < from PHP declaration necessary
@@ -173,10 +172,10 @@ if ($appending) {
 
     // Fix \' strings from injected DIRECTORY_SEPARATOR usage in iterator_apply op
     $content = str_replace("\\'", "'", $content);
-
-    // Write the contents to disk
-    file_put_contents($output, $content);
 }
+
+// Write the contents to disk
+file_put_contents($output, $content);
 
 if (!$usingStdout) {
     echo "Wrote classmap file to '" . realpath($output) . "'" . PHP_EOL;


### PR DESCRIPTION
This patch allows for appending multiple class map generations into one file.  Typical usage:

```
$ php /zf2/bin/classmap_generator.php -o .classmap.php -w
Creating class file map for library in '/www/akrabat/zf2-tutorial/library'...
Wrote classmap file to '/www/akrabat/zf2-tutorial/library/.classmap.php'

$ php /zf2/bin/classmap_generator.php -l Zend -o .classmap.php -a
Appending to class file map '.classmap.php' for library in '/www/zend-framework/zf2/library/Zend'...
Wrote classmap file to '/www/akrabat/zf2-tutorial/library/.classmap.php'

$ php /zf2/bin/classmap_generator.php -l Zf2 -o .classmap.php -a
Appending to class file map '.classmap.php' for library in '/www/thirdparty/zf2/zf-quickstart/library/Zf2'...
Wrote classmap file to '/www/akrabat/zf2-tutorial/library/.classmap.php'
```
