### PR TITLE
Fixed createInstanceViaConstructor when count($callParameters) is 3

### DIFF
--- a/library/Zend/Di/DependencyInjector.php
+++ b/library/Zend/Di/DependencyInjector.php
@@ -277,7 +277,7 @@ class DependencyInjector implements DependencyInjection
             case 2:
                 return new $class($callParameters[0], $callParameters[1]);
             case 3:
-                return new $class($callParameters[0], $callParameters[1], $callParameters[3]);
+                return new $class($callParameters[0], $callParameters[1], $callParameters[2]);
             default:
                 $r = new \ReflectionClass($class);
                 return $r->newInstanceArgs($callParameters);


### PR DESCRIPTION
Fixed createInstanceViaConstructor when count($callParameters) is 3 (last parameter was wrong).
(I mentioned it here http://framework.zend.com/issues/browse/ZF2-49).
