### PR TITLE
Fixes ZF-5570: error on foreach when parameter is not an array

### DIFF
--- a/library/Zend/Amf/Parser/Amf3/Deserializer.php
+++ b/library/Zend/Amf/Parser/Amf3/Deserializer.php
@@ -383,6 +383,7 @@ class Deserializer extends AbstractDeserializer
             }
 
             // Add properties back to the return object.
+            if (!is_array($properties)) $properties = array();
             foreach ($properties as $key => $value) {
                 if($key) {
                     $returnObject->$key = $value;


### PR DESCRIPTION
Zend_Amf fix on a simple foreach error on certain values.
