### PR TITLE
ZF2-52: ::regenerateId() fails and ::rememberMe() clears session storage 

### DIFF
--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -84,14 +84,16 @@ class SessionManager extends AbstractManager
     /**
      * Start session
      *
-     * if No sesion currently exists, attempt to start it. Calls 
-     * {@link isValid()} once session_start() is called, and raises an 
+     * if No sesion currently exists, attempt to start it. Calls
+     * {@link isValid()} once session_start() is called, and raises an
      * exception if validation fails.
-     * 
+     *
+     * @param bool $preserveStorage        If set to true, current session storage will not be overwritten by the 
+     *                                     contents of $_SESSION.
      * @return void
      * @throws Exception
      */
-    public function start()
+    public function start($preserveStorage = false)
     {
         if ($this->sessionExists()) {
             return;
@@ -107,7 +109,9 @@ class SessionManager extends AbstractManager
         if ($storage instanceof Storage\SessionStorage
             && $_SESSION !== $storage
         ) {
-            $storage->fromArray($_SESSION);
+            if(!$preserveStorage){
+                $storage->fromArray($_SESSION);
+            }
             $_SESSION = $storage;
         }
     }
@@ -257,9 +261,7 @@ class SessionManager extends AbstractManager
             session_regenerate_id();
             return $this;
         }
-        $this->destroy();
         session_regenerate_id();
-        $this->start();
         return $this;
     }
 
@@ -384,19 +386,12 @@ class SessionManager extends AbstractManager
             return;
         }
 
-        if ($this->sessionExists()) {
-            $this->destroy(array('send_expire_cookie' => false));
-
-            // Since a cookie was destroyed, we should regenerate the ID
-            $this->regenerateId();
-        }
-
-        // Now simply set the cookie TTL
+        // Set new cookie TTL
         $config->setCookieLifetime($ttl);
 
-        if (!$this->sessionExists()) {
-            // Restart session if necessary
-            $this->start();
+        if ($this->sessionExists()) {
+            // There is a running session so we'll regenerate id to send a new cookie
+            $this->regenerateId();
         }
     }
 }

--- a/library/Zend/View/PhpRenderer.php
+++ b/library/Zend/View/PhpRenderer.php
@@ -294,23 +294,4 @@ class PhpRenderer implements Renderer
 
         return $this->getFilterChain()->filter($content); // filter output
     }
-
-    /**
-     * Accesses a helper object from within a script.
-     *
-     * @param string $name The helper name.
-     * @param array $args The parameters for the helper.
-     * @return mixed The result of the helper output.
-     */
-    public function __call($name, $args)
-    {
-        // load the helper
-        $helper = $this->broker($name);
-
-        // call direct() method on the helper
-        return call_user_func_array(
-        	array($helper,'direct'),
-        	$args
-        );
-    }
 }

--- a/library/Zend/View/PhpRenderer.php
+++ b/library/Zend/View/PhpRenderer.php
@@ -294,4 +294,23 @@ class PhpRenderer implements Renderer
 
         return $this->getFilterChain()->filter($content); // filter output
     }
+
+    /**
+     * Accesses a helper object from within a script.
+     *
+     * @param string $name The helper name.
+     * @param array $args The parameters for the helper.
+     * @return mixed The result of the helper output.
+     */
+    public function __call($name, $args)
+    {
+        // load the helper
+        $helper = $this->broker($name);
+
+        // call direct() method on the helper
+        return call_user_func_array(
+        	array($helper,'direct'),
+        	$args
+        );
+    }
 }


### PR DESCRIPTION
Fixes this: http://framework.zend.com/issues/browse/ZF2-52

Also added optional parameter to `SessionManager::start()` to allow starting new session without clearing current session storage.
