### PR TITLE
Applies patch for ZF-11597 to allow correct single quote escaping in JS c

### DIFF
--- a/library/Zend/View/Helper/HtmlElement.php
+++ b/library/Zend/View/Helper/HtmlElement.php
@@ -98,7 +98,11 @@ abstract class HtmlElement extends AbstractHelper
                     // non-scalar data should be cast to JSON first
                     $val = \Zend\Json\Json::encode($val);
                 }
-                $val = preg_replace('/"([^"]*)":/', '$1:', $val);
+                // Escape single quotes inside event attribute values.
+                // This will create html, where the attribute value has
+                // single quotes around it, and escaped single quotes or
+                // non-escaped double quotes inside of it
+                $val = str_replace('\'', '&#39;', $val);
             } else {
                 if (is_array($val)) {
                     $val = implode(' ', $val);


### PR DESCRIPTION
Applies patch for ZF-11597 to allow correct single quote escaping in JS containing attributes. See ZF-9926 in ZF1 as to why this became necessary. 
