### PR TITLE
[hotfix/ZF-10185] Zend\Json\Json

### DIFF
--- a/library/Zend/Json/Json.php
+++ b/library/Zend/Json/Json.php
@@ -366,24 +366,32 @@ class Json
             $ind = $options['indent'];
         }
         
+        $inLiteral = false;
         foreach($tokens as $token) {
             if($token == "") continue;
             
             $prefix = str_repeat($ind, $indent);
-            if($token == "{" || $token == "[") {
+            if(!$inLiteral && ($token == "{" || $token == "[")) {
                 $indent++;
                 if($result != "" && $result[strlen($result)-1] == "\n") {
                     $result .= $prefix;
                 }
                 $result .= "$token\n";
-            } else if($token == "}" || $token == "]") {
+            } else if(!$inLiteral && ($token == "}" || $token == "]")) {
                 $indent--;
                 $prefix = str_repeat($ind, $indent);
                 $result .= "\n$prefix$token";                
-            } else if($token == ",") {
+            } else if(!$inLiteral && $token == ",") {
                 $result .= "$token\n";
             } else {
-                $result .= $prefix.$token;
+                $result .= ($inLiteral ?  '' : $prefix) . $token;
+
+                // Count # of unescaped double-quotes in token, subtract # of
+                // escaped double-quotes and if the result is odd then we are
+                // inside a string literal
+                if ((substr_count($token, "\"")-substr_count($token, "\\\"")) % 2 != 0) {
+                    $inLiteral = !$inLiteral;
+                }
             }
         }
         return $result;

--- a/tests/Zend/Json/JsonTest.php
+++ b/tests/Zend/Json/JsonTest.php
@@ -772,6 +772,48 @@ class JsonTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('stdClass', Json\Decoder::decode('{"var":"value"}'));
     }
 
+    /**
+     * @group ZF-10185
+     */
+    public function testJsonPrettyPrintWorksWithArrayNotationInStringLiteral()
+    {
+        $o = new \stdClass();
+        $o->test = 1;
+        $o->faz = 'fubar';
+
+        // The escaped double-quote in item 'stringwithjsonchars' ensures that
+        // escaped double-quotes don't throw off prettyPrint's string literal detection
+        $test = array(
+            'simple'=>'simple test string',
+            'stringwithjsonchars'=>'\"[1,2]',
+            'complex'=>array(
+                'foo'=>'bar',
+                'far'=>'boo',
+                'faz'=>array(
+                    'obj'=>$o
+                )
+            )
+        );
+        $pretty = Json\Json::prettyPrint(Json\Json::encode($test), array("indent"  => " "));
+        $expected = <<<EOB
+{
+ "simple":"simple test string",
+ "stringwithjsonchars":"\\\\\\"[1,2]",
+ "complex":{
+  "foo":"bar",
+  "far":"boo",
+  "faz":{
+   "obj":{
+    "test":1,
+    "faz":"fubar"
+   }
+  }
+ }
+}
+EOB;
+        $this->assertSame($expected, $pretty);
+    }
+
 }
 
 /**


### PR DESCRIPTION
Update Zend\Json\Json::prettyPrint to properly distinguish between array/object notation in string literals and actual encoded arrays/objects
