### PR TITLE
[hotfix/ZF-11513] Zend\CodeGenerator

### DIFF
--- a/tests/Zend/CodeGenerator/Php/PhpClassTest.php
+++ b/tests/Zend/CodeGenerator/Php/PhpClassTest.php
@@ -368,4 +368,34 @@ CODE;
         $received = $codeGenClass->generate();
         $this->assertContains('class FunClass', $received, $received);
     }
+
+    /**
+     * @group ZF-11513
+     */
+    public function testAllowsClassConstantToHaveSameNameAsClassProperty()
+    {
+        $const = new Php\PhpProperty();
+        $const->setName('name')->setDefaultValue('constant')->setConst(true);
+
+        $property = new Php\PhpProperty();
+        $property->setName('name')->setDefaultValue('property');
+
+        $codeGenClass = new Php\PhpClass();
+        $codeGenClass->setName('My_Class')->setProperties(array($const, $property));
+
+        $expected = <<<CODE
+class My_Class
+{
+
+    const name = 'constant';
+
+    public \$name = 'property';
+
+
+}
+
+CODE;
+        $this->assertEquals( $expected, $codeGenClass->generate() );
+    }
+
 }


### PR DESCRIPTION
Support for constants and properties with the same name in a class
