### PR TITLE
[hotfix/ZF-11356] Zend\Json\Encoder

### DIFF
--- a/library/Zend/Json/Encoder.php
+++ b/library/Zend/Json/Encoder.php
@@ -165,8 +165,9 @@ class Encoder
             }
         }
 
-        return '{"__className":"' 
-            . str_replace('\\', '\\\\', get_class($value)) . '"'
+        $className = get_class($value);
+        return '{"__className":' 
+            . $this->_encodeString($className)
             . $props . '}';
     }
 


### PR DESCRIPTION
Update Zend\Json\Encoder::_encodeObject to encode the object's class name using _encodeString
I did not provide any unit test, as tests covering the encoding of class names is already in place to ensure that the switch proposed in this patch works properly. 
