### PR TITLE
fix classmap generator and autoload example

### DIFF
--- a/bin/autoload_example.php
+++ b/bin/autoload_example.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../library/Zend/Loader/ClassMapAutoloader.php';
 $loader = new Zend\Loader\ClassMapAutoloader();
-$loader->registerAutoloadMap(__DIR__ . '/../library/Zend/Controller/.classmap.php');
+$loader->registerAutoloadMap(__DIR__ . '/../library/Zend/.classmap.php');
 $loader->register();
 
 if (!class_exists('Zend\Controller\Action')) {
@@ -12,5 +12,5 @@ if (!class_exists('Zend\Controller\Action')) {
 if (!class_exists('Zend\Version')) {
     echo "Could not find version class!\n";
 } else {
-    echo "Found version class?\n";
+    echo "Found version class!\n";
 }

--- a/bin/classmap_generator.php
+++ b/bin/classmap_generator.php
@@ -136,9 +136,6 @@ iterator_apply($l, function() use ($l, $map, $strip, $libraryPath){
     $namespace = empty($file->namespace) ? '' : $file->namespace . '\\';
     $filename  = str_replace($strip, '', $file->getPath() . '/' . $file->getFilename());
 
-    // Add in relative path to library
-    $filename  = $libraryPath . $filename;
-
     // Replace directory separators with constant
     $filename  = str_replace(array('/', '\\'), "' . DIRECTORY_SEPARATOR . '", $filename);
 


### PR DESCRIPTION
Hi!

This commit https://github.com/zendframework/zf2/commit/feb25a0f78f93240265c22f87c32ed454022d147 specifically line 140 broke the classmap generator.

It was generating paths like:

/path/to/project/application/application/modules/...
and
/path/to/project/library/Zend/library/Zend/...

I'm running the script like:
# in /path/to/project

prompt> php bin/classmap_generator.php -l library/Zend -w

I've also "fixed" the autoload_example.php which can be used as some sort of test to verify that the classmap generated is valid:

prompt> php bin/autoload_example.php

without the fix, the example will fail, with it it will pass.
