### PR TITLE
Errors in Form tests

### DIFF
--- a/library/Zend/Form/Decorator/Image.php
+++ b/library/Zend/Form/Decorator/Image.php
@@ -137,7 +137,7 @@ class Image extends AbstractDecorator
         $attribs       = $this->getAttribs();
         $attribs['id'] = $element->getId();
 
-        $image = $view->formImage($name, $element->getImageValue(), $attribs);
+        $image = $view->broker('formImage')->direct($name, $element->getImageValue(), $attribs);
 
         if (null !== $tag) {
             $decorator = new HtmlTag();

--- a/library/Zend/Form/Decorator/ViewScript.php
+++ b/library/Zend/Form/Decorator/ViewScript.php
@@ -129,7 +129,7 @@ class ViewScript extends AbstractDecorator
         $vars['content']   = $content;
         $vars['decorator'] = $this;
 
-        $renderedContent = $view->partial($viewScript, $vars);
+        $renderedContent = $view->broker('partial')->direct($viewScript, $vars);
 
         // Get placement again to see if it has changed
         $placement = $this->getPlacement();

--- a/tests/Zend/Form/Decorator/AbstractTest.php
+++ b/tests/Zend/Form/Decorator/AbstractTest.php
@@ -26,7 +26,7 @@ use Zend\Form\Decorator,
     Zend\Form\Element,
     Zend\Form\Form,
     Zend\Config\Config,
-    Zend\Loader\PluginLoader;
+    Zend\Loader\PrefixPathLoader;
 
 /**
  * Test class for Zend_Form_Decorator_Abstract
@@ -93,7 +93,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testSetElementAllowsDisplayGroups()
     {
-        $loader = new PluginLoader(array('Zend\Form\Decorator' => 'Zend/Form/Decorator'));
+        $loader = new PrefixPathLoader(array('Zend\Form\Decorator' => 'Zend/Form/Decorator'));
         $group  = new DisplayGroup('foo', $loader);
         $this->decorator->setElement($group);
         $this->assertSame($group, $this->decorator->getElement());

--- a/tests/Zend/Form/Decorator/DescriptionTest.php
+++ b/tests/Zend/Form/Decorator/DescriptionTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Form\Decorator;
 use Zend\Form\Decorator\Description as DescriptionDecorator,
     Zend\Form\Element,
     Zend\Translator\Translator,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Decorator_Description

--- a/tests/Zend/Form/Decorator/ErrorsTest.php
+++ b/tests/Zend/Form/Decorator/ErrorsTest.php
@@ -23,7 +23,7 @@ namespace ZendTest\Form\Decorator;
 
 use Zend\Form\Decorator\Errors as ErrorsDecorator,
     Zend\Form\Element,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Decorator_Errors

--- a/tests/Zend/Form/Decorator/FieldsetTest.php
+++ b/tests/Zend/Form/Decorator/FieldsetTest.php
@@ -25,7 +25,7 @@ use Zend\Form\Decorator\Fieldset as FieldsetDecorator,
     Zend\Form\Element,
     Zend\Form\Form,
     Zend\Form\SubForm,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Decorator_Fieldset

--- a/tests/Zend/Form/Decorator/FileTest.php
+++ b/tests/Zend/Form/Decorator/FileTest.php
@@ -25,7 +25,7 @@ use Zend\Form\Decorator\File as FileDecorator,
     Zend\Form\Decorator\AbstractDecorator,
     Zend\Form\Element\File as FileElement,
     Zend\Form\Element,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Decorator_Errors

--- a/tests/Zend/Form/Decorator/FormDecoratorTest.php
+++ b/tests/Zend/Form/Decorator/FormDecoratorTest.php
@@ -25,7 +25,7 @@ use Zend\Form\Decorator\FormDecorator,
     Zend\Form\DisplayGroup,
     Zend\Form\Form,
     Zend\Loader\PrefixPathLoader,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Decorator_Form

--- a/tests/Zend/Form/Decorator/FormDecoratorTest.php
+++ b/tests/Zend/Form/Decorator/FormDecoratorTest.php
@@ -24,7 +24,7 @@ namespace ZendTest\Form\Decorator;
 use Zend\Form\Decorator\FormDecorator,
     Zend\Form\DisplayGroup,
     Zend\Form\Form,
-    Zend\Loader\PluginLoader,
+    Zend\Loader\PrefixPathLoader,
     Zend\View\View;
 
 /**
@@ -71,7 +71,7 @@ class FormDecoratorTest extends \PHPUnit_Framework_TestCase
             'enctype' => 'ascii',
             'charset' => 'us-ascii'
         );
-        $loader = new PluginLoader(array('Zend\Form\Decorator' => 'Zend/Form/Decorator/'));
+        $loader = new PrefixPathLoader(array('Zend\Form\Decorator' => 'Zend/Form/Decorator/'));
         $displayGroup = new DisplayGroup('foo', $loader, array('attribs' => $attribs));
         $this->decorator->setElement($displayGroup);
         $options = $this->decorator->getOptions();

--- a/tests/Zend/Form/Decorator/ImageTest.php
+++ b/tests/Zend/Form/Decorator/ImageTest.php
@@ -25,7 +25,7 @@ use Zend\Form\Decorator\Image as ImageDecorator,
     Zend\Form\Decorator\AbstractDecorator,
     Zend\Form\Element,
     Zend\Form\Element\Image as ImageElement,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Decorator_Image

--- a/tests/Zend/Form/Decorator/LabelTest.php
+++ b/tests/Zend/Form/Decorator/LabelTest.php
@@ -25,7 +25,7 @@ use Zend\Form\Decorator\Label as LabelDecorator,
     Zend\Form\Decorator\AbstractDecorator,
     Zend\Form\Element,
     Zend\Translator\Translator,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Decorator_Label

--- a/tests/Zend/Form/Decorator/ViewHelperTest.php
+++ b/tests/Zend/Form/Decorator/ViewHelperTest.php
@@ -26,7 +26,7 @@ use Zend\Form\Decorator\ViewHelper as ViewHelperDecorator,
     Zend\Form\Element\Select as SelectElement,
     Zend\Form\Element\Text as TextElement,
     Zend\Translator\Translator,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Decorator_ViewHelper

--- a/tests/Zend/Form/Decorator/ViewScriptTest.php
+++ b/tests/Zend/Form/Decorator/ViewScriptTest.php
@@ -23,7 +23,7 @@ namespace ZendTest\Form\Decorator;
 
 use Zend\Form\Decorator\ViewScript as ViewScriptDecorator,
     Zend\Form\Element\Text as TextElement,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Decorator_ViewScript
@@ -51,7 +51,7 @@ class ViewScriptTest extends \PHPUnit_Framework_TestCase
     public function getView()
     {
         $view = new View();
-        $view->addScriptPath(__DIR__ . '/../TestAsset/views/');
+        $view->resolver()->addPath(__DIR__ . '/../TestAsset/views/');
         return $view;
     }
 

--- a/tests/Zend/Form/Element/ButtonTest.php
+++ b/tests/Zend/Form/Element/ButtonTest.php
@@ -27,7 +27,7 @@ use Zend\Form\Element\Button as ButtonElement,
     Zend\Form\Element,
     Zend\Form\Decorator,
     Zend\Translator\Translator,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Element_Button

--- a/tests/Zend/Form/Element/CheckboxTest.php
+++ b/tests/Zend/Form/Element/CheckboxTest.php
@@ -25,7 +25,7 @@ use Zend\Form\Element\Checkbox as CheckboxElement,
     Zend\Form\Element\Xhtml as XhtmlElement,
     Zend\Form\Element,
     Zend\Form\Decorator,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Element_Checkbox

--- a/tests/Zend/Form/Element/ImageTest.php
+++ b/tests/Zend/Form/Element/ImageTest.php
@@ -26,7 +26,7 @@ use Zend\Form\Element\Image as ImageElement,
     Zend\Form\Element,
     Zend\Form\Decorator,
     Zend\Translator\Adapter\ArrayAdapter as ArrayTranslator,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Element_Image

--- a/tests/Zend/Form/Element/MultiCheckboxTest.php
+++ b/tests/Zend/Form/Element/MultiCheckboxTest.php
@@ -27,7 +27,7 @@ use Zend\Form\Element\MultiCheckbox as MultiCheckboxElement,
     Zend\Form\Element,
     Zend\Form\Decorator,
     Zend\Form\Form,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Element_MultiCheckbox

--- a/tests/Zend/Form/Element/MultiselectTest.php
+++ b/tests/Zend/Form/Element/MultiselectTest.php
@@ -29,7 +29,7 @@ use Zend\Form\Element\Multiselect as MultiselectElement,
     Zend\Config\Xml as XMLConfig,
     Zend\Config\Ini as INIConfig,
     Zend\Translator\Translator,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Element_Multiselect

--- a/tests/Zend/Form/Element/PasswordTest.php
+++ b/tests/Zend/Form/Element/PasswordTest.php
@@ -25,7 +25,7 @@ use Zend\Form\Element\Password as PasswordElement,
     Zend\Form\Element\Xhtml as XhtmlElement,
     Zend\Form\Element,
     Zend\Form\Decorator,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Element_Password

--- a/tests/Zend/Form/Element/RadioTest.php
+++ b/tests/Zend/Form/Element/RadioTest.php
@@ -27,7 +27,7 @@ use Zend\Form\Element\Radio as RadioElement,
     Zend\Form\Element,
     Zend\Form\Form,
     Zend\Form\Decorator,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Element_Radio

--- a/tests/Zend/Form/Element/SelectTest.php
+++ b/tests/Zend/Form/Element/SelectTest.php
@@ -26,7 +26,7 @@ use Zend\Form\Element\Select as SelectElement,
     Zend\Form\Element,
     Zend\Form\Decorator,
     Zend\Translator\Translator,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Element_Select

--- a/tests/Zend/Form/Element/SubmitTest.php
+++ b/tests/Zend/Form/Element/SubmitTest.php
@@ -29,7 +29,7 @@ use Zend\Form\Element\Submit as SubmitElement,
     Zend\Registry,
     Zend\Translator\Translator,
     Zend\Translator\Adapter\ArrayAdapter as ArrayTranslator,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * Test class for Zend_Form_Element_Submit

--- a/tests/Zend/Form/ElementTest.php
+++ b/tests/Zend/Form/ElementTest.php
@@ -1151,7 +1151,7 @@ class ElementTest extends \PHPUnit_Framework_TestCase
         }
         $filter = $this->element->getFilter('Alnum');
         $this->assertTrue($filter instanceof \Zend\Filter\Alnum);
-        $this->assertTrue($filter->allowWhiteSpace);
+        $this->assertTrue($filter->getAllowWhiteSpace());
     }
 
     public function testShouldUseFilterConstructorOptionsAsPassedToAddFilter()

--- a/tests/Zend/Form/SubFormTest.php
+++ b/tests/Zend/Form/SubFormTest.php
@@ -23,7 +23,7 @@ namespace ZendTest\Form;
 
 use Zend\Form\Form,
     Zend\Form\SubForm,
-    Zend\View\View;
+    Zend\View\PhpRenderer as View;
 
 /**
  * @category   Zend

--- a/tests/Zend/Form/TestAsset/views/decorator.phtml
+++ b/tests/Zend/Form/TestAsset/views/decorator.phtml
@@ -1,6 +1,6 @@
 This is content from the view script
 
-<?php foreach ($this->getVars() as $key => $value): 
+<?php foreach ($this->vars() as $key => $value): 
     if ($key == 'decorator') {
         continue;
     }


### PR DESCRIPTION
Fixed import of PluginLoader, and View in Form tests. We can run all tests, but the result is 5 errors, and 12 failures to solve.
