### PR TITLE
Fix fatal error caused by recent changes to Translator resource

### DIFF
--- a/library/Zend/Application/Resource/Translator.php
+++ b/library/Zend/Application/Resource/Translator.php
@@ -25,7 +25,7 @@
 namespace Zend\Application\Resource;
 
 use Zend\Registry,
-    Zend\Translator\Translator;
+    Zend\Translator\Translator as Translate;
 
 /**
  * Resource for setting translation options
@@ -76,7 +76,7 @@ class Translator extends AbstractResource
             }
 
             if (empty($options['adapter'])) {
-                $options['adapter'] = Translator::AN_ARRAY;
+                $options['adapter'] = Translate::AN_ARRAY;
             }
 
             if (!empty($options['data'])) {
@@ -112,7 +112,7 @@ class Translator extends AbstractResource
 
             if(Registry::isRegistered($key)) {
                 $translate = Registry::get($key);
-                if(!$translate instanceof Translator) {
+                if(!$translate instanceof Translate) {
                     throw new Exception\InitializationException($key
                                    . ' already registered in registry but is '
                                    . 'no instance of Zend_Translator');
@@ -121,7 +121,7 @@ class Translator extends AbstractResource
                 $translate->addTranslation($options);
                 $this->_translate = $translate;
             } else {
-                $this->_translate = new Translator($options);
+                $this->_translate = new Translate($options);
                 Registry::set($key, $this->_translate);
             }
         }

--- a/library/Zend/View/Helper/FormText.php
+++ b/library/Zend/View/Helper/FormText.php
@@ -37,6 +37,14 @@ namespace Zend\View\Helper;
 class FormText extends FormElement
 {
     /**
+     * Form field 'type' attribute
+     *
+     * Extending classes can override this value to render HTML5 style form
+     * input fields such as 'url', 'email', etc.
+     */
+    protected $inputType = 'text';
+
+    /**
      * Generates a 'text' element.
      *
      * @access public
@@ -56,11 +64,18 @@ class FormText extends FormElement
         if ($name == null) {
             throw new \InvalidArgumentException('FormText: missing argument. $name is required in formText($name, $value = null, $attribs = null)');
         }
-        
+
         $info = $this->_getInfo($name, $value, $attribs);
         extract($info); // name, value, attribs, options, listsep, disable
 
         // build the element
+        if (isset($attribs['type'])) {
+            $inputType = $attribs['type'];
+            unset($attribs['type']);
+        } else {
+            $inputType = $this->inputType;
+        }
+
         $disabled = '';
         if ($disable) {
             // disabled
@@ -73,7 +88,8 @@ class FormText extends FormElement
             $endTag= '>';
         }
 
-        $xhtml = '<input type="text"'
+        $xhtml = '<input'
+                . ' type="' .  $this->view->vars()->escape($inputType) . '"'
                 . ' name="' . $this->view->vars()->escape($name) . '"'
                 . ' id="' . $this->view->vars()->escape($id) . '"'
                 . ' value="' . $this->view->vars()->escape($value) . '"'


### PR DESCRIPTION
Looks like some of the recent changes that replaced references to "Translate" with "Translator" caused a fatal error of double symbol declaration in this file ("Translator" refers to both the Resource class and \Zend\Translator\Translator). This should fix the problem.

BTW this bug should have been detected very quickly - a mere attempt to compile the file would have detected it, but apparently it wasn't done. 
