### PR TITLE
[hotfix/ZF-10517] Zend_Filter_Word

### DIFF
--- a/library/Zend/Filter/Word/SeparatorToCamelCase.php
+++ b/library/Zend/Filter/Word/SeparatorToCamelCase.php
@@ -34,8 +34,8 @@ class SeparatorToCamelCase extends AbstractSeparator
 {
     /**
      * Defined by Zend\Filter\Filter
-     * 
-     * @param  string $value 
+     *
+     * @param  string $value
      * @return string
      */
     public function filter($value)
@@ -44,8 +44,12 @@ class SeparatorToCamelCase extends AbstractSeparator
         $pregQuotedSeparator = preg_quote($this->_separator, '#');
 
         if (self::isUnicodeSupportEnabled()) {
-            parent::setMatchPattern(array('#('.$pregQuotedSeparator.')(\p{L}{1})#e','#(^\p{Ll}{1})#e'));
-            parent::setReplacement(array("strtoupper('\\2')","strtoupper('\\1')"));
+            parent::setMatchPattern(array('#('.$pregQuotedSeparator.')(\p{L}{1})#eu','#(^\p{Ll}{1})#eu'));
+            if (!extension_loaded('mbstring')) {
+                parent::setReplacement(array("strtoupper('\\2')","strtoupper('\\1')"));
+            } else {
+                parent::setReplacement(array("mb_strtoupper('\\2', 'UTF-8')","mb_strtoupper('\\1', 'UTF-8')"));
+            }
         } else {
             parent::setMatchPattern(array('#('.$pregQuotedSeparator.')([A-Za-z]{1})#e','#(^[A-Za-z]{1})#e'));
             parent::setReplacement(array("strtoupper('\\2')","strtoupper('\\1')"));

--- a/tests/Zend/Filter/Word/SeparatorToCamelCaseTest.php
+++ b/tests/Zend/Filter/Word/SeparatorToCamelCaseTest.php
@@ -54,4 +54,38 @@ class SeparatorToCamelCaseTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($string, $filtered);
         $this->assertEquals('CamelCasedWords', $filtered);
     }
+
+    /**
+     * @group ZF-10517
+     */
+    public function testFilterSeparatesUniCodeCamelCasedWordsWithProvidedSeparator()
+    {
+        if (!extension_loaded('mbstring')) {
+            $this->markTestSkipped('Extension mbstring not available');
+        }
+
+        $string   = 'camel:-:cased:-:Words';
+        $filter   = new SeparatorToCamelCaseFilter(':-:');
+        $filtered = $filter($string);
+
+        $this->assertNotEquals($string, $filtered);
+        $this->assertEquals('CamelCasedWords', $filtered);
+    }
+
+    /**
+     * @group ZF-10517
+     */
+    public function testFilterSeparatesUniCodeCamelCasedUserWordsWithProvidedSeparator()
+    {
+        if (!extension_loaded('mbstring')) {
+            $this->markTestSkipped('Extension mbstring not available');
+        }
+
+        $string   = 'test šuma';
+        $filter   = new SeparatorToCamelCaseFilter(' ');
+        $filtered = $filter($string);
+
+        $this->assertNotEquals($string, $filtered);
+        $this->assertEquals('TestŠuma', $filtered);
+    }
 }


### PR DESCRIPTION
- allow usage of mbstr for uppercase when available
