### PR TITLE
ZF-8922 - Adds support for URI fragments (anchors) to Zend\Navigation

### DIFF
--- a/library/Zend/Navigation/AbstractPage.php
+++ b/library/Zend/Navigation/AbstractPage.php
@@ -48,6 +48,20 @@ abstract class AbstractPage extends Container
     protected $_label;
 
     /**
+     * Fragment identifier (anchor identifier)
+     * 
+     * The fragment identifier (anchor identifier) pointing to an anchor within 
+     * a resource that is subordinate to another, primary resource.
+     * The fragment identifier introduced by a hash mark "#".
+     * Example: http://www.example.org/foo.html#bar ("bar" is the fragment identifier)
+     * 
+     * @link http://www.w3.org/TR/html401/intro/intro.html#fragment-uri
+     * 
+     * @var string|null
+     */
+    protected $_fragmentIdentifier;
+
+    /**
      * Page id
      *
      * @var string|null
@@ -317,6 +331,34 @@ abstract class AbstractPage extends Container
     public function getLabel()
     {
         return $this->_label;
+    }
+
+    /**
+     * Sets a fragment identifier
+     *
+     * @param  string $fragmentIdentifier   new fragment identifier
+     * @return Zend_Navigation_Page         fluent interface, returns self
+     * @throws Zend_Navigation_Exception    if empty/no string is given
+     */
+    public function setFragmentIdentifier($fragmentIdentifier)
+    {
+        if (null !== $fragmentIdentifier && !is_string($fragmentIdentifier)) {
+            throw new Exception\InvalidArgumentException(
+                    'Invalid argument: $fragmentIdentifier must be a string or null');
+        }
+ 
+        $this->_fragmentIdentifier = $fragmentIdentifier;
+        return $this;
+    }
+    
+     /**
+     * Returns fragment identifier
+     *
+     * @return string|null  fragment identifier
+     */
+    public function getFragmentIdentifier()
+    {
+        return $this->_fragmentIdentifier;
     }
 
     /**
@@ -1068,7 +1110,8 @@ abstract class AbstractPage extends Container
         return array_merge(
             $this->getCustomProperties(),
             array(
-                'label'     => $this->getlabel(),
+                'label'     => $this->getLabel(),
+                'fragmentIdentifier' => $this->getFragmentIdentifier(),
                 'id'        => $this->getId(),
                 'class'     => $this->getClass(),
                 'title'     => $this->getTitle(),

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -195,6 +195,12 @@ class Mvc extends AbstractPage
                                       $this->getRoute(),
                                       $this->getResetParams());
 
+        // Add the fragment identifier if it is set
+        $fragmentIdentifier = $this->getFragmentIdentifier();       
+        if (null !== $fragmentIdentifier) {
+            $url .= '#' . $fragmentIdentifier;
+        } 
+
         return $this->_hrefCache = $url;
     }
 

--- a/library/Zend/Navigation/Page/Uri.php
+++ b/library/Zend/Navigation/Page/Uri.php
@@ -77,12 +77,25 @@ class Uri extends AbstractPage
 
     /**
      * Returns href for this page
+     * 
+     * Includes the fragment identifier if it is set.
      *
      * @return string
      */
     public function getHref()
     {
-        return $this->getUri();
+        $uri = $this->getUri();
+        
+        $fragmentIdentifier = $this->getFragmentIdentifier();       
+        if (null !== $fragmentIdentifier) {
+            if ('#' == substr($uri, -1)) {
+                return $uri . $fragmentIdentifier;
+            } else {                
+                return $uri . '#' . $fragmentIdentifier;
+            }
+        }
+        
+        return $uri;
     }
 
     // Public methods:

--- a/tests/Zend/Navigation/Page/MvcTest.php
+++ b/tests/Zend/Navigation/Page/MvcTest.php
@@ -108,6 +108,38 @@ class MvcTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/lolcat/myaction/1337', $page->getHref());
     }
 
+    /**
+     * @group ZF-8922
+     */
+    public function testGetHrefWithFragmentIdentifier()
+    {
+        $page = new Page\Mvc(array(
+            'label'              => 'foo',
+            'fragmentIdentifier' => 'qux',
+            'controller'         => 'mycontroller',
+            'action'             => 'myaction',
+            'route'              => 'myroute',
+            'params'             => array(
+                'page' => 1337
+            )
+        ));
+ 
+        $this->_front->getRouter()->addRoute(
+            'myroute',
+            new \Zend\Controller\Router\Route\Route(
+                'lolcat/:action/:page',
+                array(
+                    'module'     => 'default',
+                    'controller' => 'foobar',
+                    'action'     => 'bazbat',
+                    'page'       => 1
+                )
+            )
+        );
+ 
+        $this->assertEquals('/lolcat/myaction/1337#qux', $page->getHref());
+    }
+
     public function testIsActiveReturnsTrueOnIdenticalModuleControllerAction()
     {
         $page = new Page\Mvc(array(
@@ -324,6 +356,7 @@ class MvcTest extends \PHPUnit_Framework_TestCase
             'action' => 'index',
             'controller' => 'index',
             'module' => 'test',
+            'fragmentIdentifier' => 'bar',
             'id' => 'my-id',
             'class' => 'my-class',
             'title' => 'my-title',

--- a/tests/Zend/Navigation/Page/UriTest.php
+++ b/tests/Zend/Navigation/Page/UriTest.php
@@ -104,4 +104,22 @@ class UriTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($uri, $page->getHref());
     }
+
+    /**
+     * @group ZF-8922
+     */
+    public function testGetHrefWithFragmentIdentifier()
+    {
+        $uri = 'http://www.example.com/foo.html';
+        
+        $page = new Page\Uri();
+        $page->setUri($uri);
+        $page->setFragmentIdentifier('bar');
+        
+        $this->assertEquals($uri . '#bar', $page->getHref());
+        
+        $page->setUri('#');
+        
+        $this->assertEquals('#bar', $page->getHref());
+    }
 }

--- a/tests/Zend/Navigation/PageTest.php
+++ b/tests/Zend/Navigation/PageTest.php
@@ -168,6 +168,35 @@ class PageTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @group ZF-8922
+     */
+    public function testSetAndGetFragmentIdentifier()
+    {
+        $page = AbstractPage::factory(array(
+            'uri'                => '#',
+            'fragmentIdentifier' => 'foo',
+        ));
+        
+        $this->assertEquals('foo', $page->getFragmentIdentifier());
+        
+        $page->setFragmentIdentifier('bar');
+        $this->assertEquals('bar', $page->getFragmentIdentifier());
+        
+        $invalids = array(42, (object) null);
+        foreach ($invalids as $invalid) {
+            try {
+                $page->setFragmentIdentifier($invalid);
+                $this->fail('An invalid value was set, but a ' .
+                            'Zend_Navigation_Exception was not thrown');
+            } catch (Navigation\Exception\InvalidArgumentException $e) {
+                $this->assertContains(
+                    'Invalid argument: $fragmentIdentifier', $e->getMessage()
+                );
+            }
+        }
+    }
+
     public function testSetAndGetId()
     {
         $page = AbstractPage::factory(array(
@@ -1099,7 +1128,8 @@ class PageTest extends \PHPUnit_Framework_TestCase
     {
         $options = array(
             'label'    => 'foo',
-            'uri'      => '#',
+            'uri'      => 'http://www.example.com/foo.html',
+            'fragmentIdentifier' => 'bar',
             'id'       => 'my-id',
             'class'    => 'my-class',
             'title'    => 'my-title',
@@ -1119,11 +1149,11 @@ class PageTest extends \PHPUnit_Framework_TestCase
             'pages'    => array(
                 array(
                     'label' => 'foo.bar',
-                    'uri'   => '#'
+                    'uri'   => 'http://www.example.com/foo.html'
                 ),
                 array(
                     'label' => 'foo.baz',
-                    'uri'   => '#'
+                    'uri'   => 'http://www.example.com/foo.html'
                 )
             )
         );
@@ -1145,6 +1175,7 @@ class PageTest extends \PHPUnit_Framework_TestCase
 
         // tweak options to what we expect sub page 1 to be
         $options['label'] = 'foo.bar';
+        $options['fragmentIdentifier'] = null;
         $options['order'] = null;
         $options['id'] = null;
         $options['class'] = null;


### PR DESCRIPTION
This has a single test failure inherited from the master branch that is unrelated to this hotfix:

1) ZendTest\Navigation\Page\MvcTest::testIsActiveReturnsTrueOnIdenticalModuleControllerAction
Failed asserting that boolean:false matches expected boolean:true.
