### PR TITLE
ZF-10465 - Add support for content keys contain / character by passing en

### DIFF
--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -86,6 +86,14 @@ class Mvc extends AbstractPage
     protected $_resetParams = true;
 
     /**
+     * Whether href should be encoded when assembling URL
+     *
+     * @see getHref()
+     * @var bool 
+     */
+    protected $_encodeUrl = true;
+
+    /**
      * Cached href
      *
      * The use of this variable minimizes execution time when getHref() is
@@ -193,7 +201,8 @@ class Mvc extends AbstractPage
         
         $url = self::$_urlHelper->__invoke($params,
                                       $this->getRoute(),
-                                      $this->getResetParams());
+                                      $this->getResetParams(),
+                                      $this->getEncodeUrl());
 
         return $this->_hrefCache = $url;
     }
@@ -393,6 +402,35 @@ class Mvc extends AbstractPage
     }
 
     /**
+     * Sets whether href should be encoded when assembling URL
+     * 
+     * @see getHref()
+     *
+     * @param bool $resetParams         whether href should be encoded when
+     *                                  assembling URL
+     * @return \Zend\Navigation\Page\Mvc fluent interface, returns self
+     */
+    public function setEncodeUrl($encodeUrl)
+    {
+        $this->_encodeUrl = (bool) $encodeUrl;
+        $this->_hrefCache = null;
+        
+        return $this;
+    }
+    
+    /**
+     * Returns whether herf should be encoded when assembling URL
+     * 
+     * @see getHref()
+     *
+     * @return bool whether herf should be encoded when assembling URL 
+     */
+    public function getEncodeUrl()
+    {
+        return $this->_encodeUrl;
+    }
+
+    /**
      * Sets action helper for assembling URLs
      *
      * @see getHref()
@@ -422,7 +460,8 @@ class Mvc extends AbstractPage
                 'module'       => $this->getModule(),
                 'params'       => $this->getParams(),
                 'route'        => $this->getRoute(),
-                'reset_params' => $this->getResetParams()
+                'reset_params' => $this->getResetParams(),
+                'encodeUrl'    => $this->getEncodeUrl(),
             ));
     }
 }

--- a/tests/Zend/Navigation/Page/MvcTest.php
+++ b/tests/Zend/Navigation/Page/MvcTest.php
@@ -317,6 +317,54 @@ class MvcTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $page->getParams());
     }
 
+    /**
+     * @group ZF-10465
+     */
+    public function testSetAndGetEncodeUrl()
+    {
+        $page = new Page\Mvc(array(
+            'label'      => 'foo',
+            'action'     => 'index',
+            'controller' => 'index',
+        ));
+        
+        $page->setEncodeUrl(false);
+        $this->assertEquals(false, $page->getEncodeUrl());
+    }
+    
+    /**
+     * @group ZF-10465
+     */
+    public function testEncodeUrlIsRouteAware()
+    {
+        $page = new Page\Mvc(array(
+            'label'      => 'foo',
+            'route'      => 'myroute',
+            'encodeUrl'  => false,
+            'params'     => array(
+                'contentKey' => 'pagexy/subpage',
+            )
+        ));
+ 
+        $this->_front->getRouter()->addRoute(
+            'myroute',
+            new \Zend\Controller\Router\Route\Regex(
+                '(.+)\.html',
+                array(
+                    'module'     => 'default',
+                    'controller' => 'foobar',
+                    'action'     => 'bazbat',
+                ),
+                array(
+                    1 => 'contentKey'
+                ),
+                '%s.html'
+            )
+        );
+
+        $this->assertEquals('/pagexy/subpage.html', $page->getHref());
+    }
+
     public function testToArrayMethod()
     {
         $options = array(
@@ -331,6 +379,7 @@ class MvcTest extends \PHPUnit_Framework_TestCase
             'order' => 100,
             'active' => true,
             'visible' => false,
+            'encodeUrl'  => false,
 
             'foo' => 'bar',
             'meaning' => 42


### PR DESCRIPTION
ZF-10465 - Add support for content keys contain / character by passing encode flag to view helper

There is 1 failing test in this branch inherited from master that is unrelated to this hotfix.
