### PR TITLE
Updated Zend\Navigation to enforce consistency on set/get URI fragment methods

### DIFF
--- a/library/Zend/Navigation/AbstractPage.php
+++ b/library/Zend/Navigation/AbstractPage.php
@@ -59,7 +59,7 @@ abstract class AbstractPage extends Container
      * 
      * @var string|null
      */
-    protected $_fragmentIdentifier;
+    protected $_fragment;
 
     /**
      * Page id
@@ -336,18 +336,18 @@ abstract class AbstractPage extends Container
     /**
      * Sets a fragment identifier
      *
-     * @param  string $fragmentIdentifier   new fragment identifier
+     * @param  string $fragment   new fragment identifier
      * @return Zend_Navigation_Page         fluent interface, returns self
      * @throws Zend_Navigation_Exception    if empty/no string is given
      */
-    public function setFragmentIdentifier($fragmentIdentifier)
+    public function setFragment($fragment)
     {
-        if (null !== $fragmentIdentifier && !is_string($fragmentIdentifier)) {
+        if (null !== $fragment && !is_string($fragment)) {
             throw new Exception\InvalidArgumentException(
-                    'Invalid argument: $fragmentIdentifier must be a string or null');
+                    'Invalid argument: $fragment must be a string or null');
         }
  
-        $this->_fragmentIdentifier = $fragmentIdentifier;
+        $this->_fragment = $fragment;
         return $this;
     }
     
@@ -356,9 +356,9 @@ abstract class AbstractPage extends Container
      *
      * @return string|null  fragment identifier
      */
-    public function getFragmentIdentifier()
+    public function getFragment()
     {
-        return $this->_fragmentIdentifier;
+        return $this->_fragment;
     }
 
     /**
@@ -1114,7 +1114,7 @@ abstract class AbstractPage extends Container
             $this->getCustomProperties(),
             array(
                 'label'     => $this->getLabel(),
-                'fragmentIdentifier' => $this->getFragmentIdentifier(),
+                'fragment' => $this->getFragment(),
                 'id'        => $this->getId(),
                 'class'     => $this->getClass(),
                 'title'     => $this->getTitle(),

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -205,9 +205,9 @@ class Mvc extends AbstractPage
                                       $this->getEncodeUrl());
 
         // Add the fragment identifier if it is set
-        $fragmentIdentifier = $this->getFragmentIdentifier();       
-        if (null !== $fragmentIdentifier) {
-            $url .= '#' . $fragmentIdentifier;
+        $fragment = $this->getFragment();       
+        if (null !== $fragment) {
+            $url .= '#' . $fragment;
         } 
 
         return $this->_hrefCache = $url;

--- a/library/Zend/Navigation/Page/Uri.php
+++ b/library/Zend/Navigation/Page/Uri.php
@@ -86,12 +86,12 @@ class Uri extends AbstractPage
     {
         $uri = $this->getUri();
         
-        $fragmentIdentifier = $this->getFragmentIdentifier();       
-        if (null !== $fragmentIdentifier) {
+        $fragment = $this->getFragment();       
+        if (null !== $fragment) {
             if ('#' == substr($uri, -1)) {
-                return $uri . $fragmentIdentifier;
+                return $uri . $fragment;
             } else {                
-                return $uri . '#' . $fragmentIdentifier;
+                return $uri . '#' . $fragment;
             }
         }
         

--- a/tests/Zend/Navigation/Page/MvcTest.php
+++ b/tests/Zend/Navigation/Page/MvcTest.php
@@ -115,7 +115,7 @@ class MvcTest extends \PHPUnit_Framework_TestCase
     {
         $page = new Page\Mvc(array(
             'label'              => 'foo',
-            'fragmentIdentifier' => 'qux',
+            'fragment' => 'qux',
             'controller'         => 'mycontroller',
             'action'             => 'myaction',
             'route'              => 'myroute',
@@ -404,7 +404,7 @@ class MvcTest extends \PHPUnit_Framework_TestCase
             'action' => 'index',
             'controller' => 'index',
             'module' => 'test',
-            'fragmentIdentifier' => 'bar',
+            'fragment' => 'bar',
             'id' => 'my-id',
             'class' => 'my-class',
             'title' => 'my-title',

--- a/tests/Zend/Navigation/Page/UriTest.php
+++ b/tests/Zend/Navigation/Page/UriTest.php
@@ -114,7 +114,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
         
         $page = new Page\Uri();
         $page->setUri($uri);
-        $page->setFragmentIdentifier('bar');
+        $page->setFragment('bar');
         
         $this->assertEquals($uri . '#bar', $page->getHref());
         

--- a/tests/Zend/Navigation/PageTest.php
+++ b/tests/Zend/Navigation/PageTest.php
@@ -175,23 +175,23 @@ class PageTest extends \PHPUnit_Framework_TestCase
     {
         $page = AbstractPage::factory(array(
             'uri'                => '#',
-            'fragmentIdentifier' => 'foo',
+            'fragment' => 'foo',
         ));
         
-        $this->assertEquals('foo', $page->getFragmentIdentifier());
+        $this->assertEquals('foo', $page->getFragment());
         
-        $page->setFragmentIdentifier('bar');
-        $this->assertEquals('bar', $page->getFragmentIdentifier());
+        $page->setFragment('bar');
+        $this->assertEquals('bar', $page->getFragment());
         
         $invalids = array(42, (object) null);
         foreach ($invalids as $invalid) {
             try {
-                $page->setFragmentIdentifier($invalid);
+                $page->setFragment($invalid);
                 $this->fail('An invalid value was set, but a ' .
                             'Zend_Navigation_Exception was not thrown');
             } catch (Navigation\Exception\InvalidArgumentException $e) {
                 $this->assertContains(
-                    'Invalid argument: $fragmentIdentifier', $e->getMessage()
+                    'Invalid argument: $fragment', $e->getMessage()
                 );
             }
         }
@@ -1137,7 +1137,7 @@ class PageTest extends \PHPUnit_Framework_TestCase
         $options = array(
             'label'    => 'foo',
             'uri'      => 'http://www.example.com/foo.html',
-            'fragmentIdentifier' => 'bar',
+            'fragment' => 'bar',
             'id'       => 'my-id',
             'class'    => 'my-class',
             'title'    => 'my-title',
@@ -1183,7 +1183,7 @@ class PageTest extends \PHPUnit_Framework_TestCase
 
         // tweak options to what we expect sub page 1 to be
         $options['label'] = 'foo.bar';
-        $options['fragmentIdentifier'] = null;
+        $options['fragment'] = null;
         $options['order'] = null;
         $options['id'] = null;
         $options['class'] = null;


### PR DESCRIPTION
Updated Zend\Navigation so that setFragmentIdentifier is replaced with setFragment (+getters) as a better fit for consistency. SVN carries the same change. Refers to an earlier patch not part of a current release (no BC impact).
