### PR TITLE
Fix Zend\Uri\Uri::merge to return preferred class using LSB

### DIFF
--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -242,7 +242,7 @@ class Uri
                 $port = substr($authority, $colonPos + 1);
                 if ($port) {
                     $this->setPort((int) $port);
-                } 
+                }
                 $authority = substr($authority, 0, $colonPos);
             }
 
@@ -1063,7 +1063,7 @@ class Uri
      */
     public static function merge($baseUri, $relativeUri)
     {
-        $uri = new self($relativeUri);
+        $uri = new static($relativeUri);
         return $uri->resolve($baseUri);
     }
 


### PR DESCRIPTION
This small fix makes the merge() method return the user's preferred Uri subclass (e.g. HTTP when \Zend\Uri\Http::merge() is used) rather than always return a Uri\Uri object. It utilizes LSB so it's a simple change from self to static call.
