### PR TITLE
clone is forbidden for singletons

### DIFF
--- a/library/Zend/EventManager/StaticEventManager.php
+++ b/library/Zend/EventManager/StaticEventManager.php
@@ -56,6 +56,15 @@ class StaticEventManager implements StaticEventCollection
     }
 
     /**
+     * Singleton
+     *
+     * @return void
+     */
+    private function __clone()
+    {
+    }
+
+    /**
      * Retrieve instance
      * 
      * @return EventManager


### PR DESCRIPTION
The StaticEventManager should implement "private function __clone()" because it is a singleton.
