### PR TITLE
[ZF2-68] Fixed variables setting and returning

### DIFF
--- a/library/Zend/View/PhpRenderer.php
+++ b/library/Zend/View/PhpRenderer.php
@@ -172,7 +172,13 @@ class PhpRenderer implements Renderer
                 (is_object($variables) ? get_class($variables) : gettype($variables))
             ));
         }
-        $this->vars = $variables;
+        
+        $variablesAsArray = array();
+        foreach ($variables as $key => $value) {
+            $variablesAsArray[$key] = $value;
+        }
+        
+        $this->vars = new Variables($variablesAsArray);
         return $this;
     }
 

--- a/tests/Zend/View/PhpRendererTest.php
+++ b/tests/Zend/View/PhpRendererTest.php
@@ -73,14 +73,14 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
     {
         $a = new \ArrayObject;
         $this->renderer->setVars($a);
-        $this->assertSame($a, $this->renderer->vars());
+        $this->assertSame($a->getArrayCopy(), $this->renderer->vars()->getArrayCopy());
     }
 
     public function testCanSpecifyArrayForVars()
     {
         $vars = array('foo' => 'bar');
         $this->renderer->setVars($vars);
-        $this->assertEquals($vars, $this->renderer->vars());
+        $this->assertEquals($vars, $this->renderer->vars()->getArrayCopy());
     }
 
     public function testPassingArgumentToVarsReturnsValueFromThatKey()
@@ -178,5 +178,15 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
         foreach (array('foo', 'bar', 'baz') as $value) {
             $this->assertContains("<li>$value</li>", $content);
         }
+    }
+    
+    /**
+     * @group ZF2-68
+     */
+    public function testCanSpecifyArrayForVarsAndGetAlwaysArrayObject()
+    {
+        $vars = array('foo' => 'bar');
+        $this->renderer->setVars($vars);       
+        $this->assertTrue($this->renderer->vars() instanceof \Zend\View\Variables);
     }
 }


### PR DESCRIPTION
Better if PhpRenderer::vars() would return same result type, means \Zend\View\Variables
This patch will do that.
