### PR TITLE
Uri\Http changes when getPort is called + missing tests

### DIFF
--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -172,12 +172,20 @@ class Http extends Uri
         $this->setUser($user);
         $this->setPassword($password);
     }
-    
+
+    /**
+     * Return the URI port
+     *
+     * If no port is set, will return the default port according to the scheme
+     *
+     * @return integer
+     * @see    Zend\Uri\Uri::getPort()
+     */
     public function getPort()
     {
         if (empty($this->port)) {
             if (array_key_exists($this->scheme, self::$defaultPorts)) {
-                $this->port= self::$defaultPorts[$this->scheme];
+                return self::$defaultPorts[$this->scheme];
             }
         }
         return $this->port;

--- a/tests/Zend/Uri/HttpTest.php
+++ b/tests/Zend/Uri/HttpTest.php
@@ -199,5 +199,32 @@ class HttpTest extends TestCase
         $this->assertEquals('example.com', $uri->getHost());
     }
 
+    public function testGetPortReturnsDefaultPortHttp()
+    {
+        $uri = new HttpUri('http://www.example.com/');
+        $this->assertEquals(80, $uri->getPort());
+    }
+
+    public function testGetPortReturnsDefaultPortHttps()
+    {
+        $uri = new HttpUri('https://www.example.com/');
+        $this->assertEquals(443, $uri->getPort());
+    }
+
+    public function testGetPortDoesntModifyUrlHttp()
+    {
+        $origUri = 'http://www.example.com/foo';
+        $uri = new HttpUri($origUri);
+        $uri->getPort();
+        $this->assertEquals($origUri, $uri->toString());
+    }
+
+    public function testGetPortDoesntModifyUrlHttps()
+    {
+        $origUri = 'https://www.example.com/foo';
+        $uri = new HttpUri($origUri);
+        $uri->getPort();
+        $this->assertEquals($origUri, $uri->toString());
+    }
 }
 


### PR DESCRIPTION
This commit fixes (and adds some tests) the fact that when getPort() is called on \Zend\Uri\Http which has no port set, the port property is changed to the default port. 

This is problematic because:
1. Nobody expects getSomething() to modify the object
2. It breaks URI normalization, e.g. this code will fail:

``` php
<?php
$uriA = new HttpUri('http://example.com');
$uriA->normalize();
$uriB = clone $uriA;
$uriA->getPort();
if ($uriA->toString() != $uriB->toString()) echo "FAIL!";
```
