### PR TITLE
Zend Json Server error response with result - fix from ZF1.11

### DIFF
--- a/library/Zend/Json/Server/Response.php
+++ b/library/Zend/Json/Server/Response.php
@@ -178,7 +178,6 @@ class Response
     {
         if ($this->isError()) {
             $response = array(
-                'result' => null,
                 'error'  => $this->getError()->toArray(),
                 'id'     => $this->getId(),
             );
@@ -186,7 +185,6 @@ class Response
             $response = array(
                 'result' => $this->getResult(),
                 'id'     => $this->getId(),
-                'error'  => null,
             );
         }
 

--- a/tests/Zend/Json/Server/ResponseTest.php
+++ b/tests/Zend/Json/Server/ResponseTest.php
@@ -118,7 +118,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(is_array($test));
         $this->assertTrue(array_key_exists('result', $test));
-        $this->assertTrue(array_key_exists('error', $test));
+        $this->assertFalse(array_key_exists('error', $test), "'error' may not coexist with 'result'");
         $this->assertTrue(array_key_exists('id', $test));
         $this->assertTrue(array_key_exists('jsonrpc', $test));
 
@@ -139,7 +139,8 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $test = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
 
         $this->assertTrue(is_array($test));
-        $this->assertTrue(array_key_exists('result', $test));
+        $this->assertFalse(array_key_exists('result', $test), "'result' may not coexist with 'error'");
+        $this->assertTrue(array_key_exists('error', $test));
         $this->assertTrue(array_key_exists('id', $test));
         $this->assertFalse(array_key_exists('jsonrpc', $test));
 
@@ -157,7 +158,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(is_array($test));
         $this->assertTrue(array_key_exists('result', $test));
-        $this->assertTrue(array_key_exists('error', $test));
+        $this->assertFalse(array_key_exists('error', $test), "'error' may not coexist with 'result'");
         $this->assertTrue(array_key_exists('id', $test));
         $this->assertFalse(array_key_exists('jsonrpc', $test));
 


### PR DESCRIPTION
Not sure if it's better to wait until you guys try and merge in bugfixes from the 1.x series or to do this now, but here's the fix to better comply with JSON RPC 2.0 standards.

See:
http://framework.zend.com/issues/browse/ZF-11490
