### PR TITLE
Zend\Config\Config to use PHP's native array_replace_recursive

### DIFF
--- a/library/Zend/Config/Config.php
+++ b/library/Zend/Config/Config.php
@@ -491,22 +491,9 @@ class Config implements \Countable, \Iterator, \ArrayAccess
     protected function _arrayMergeRecursive($firstArray, $secondArray)
     {
         if (is_array($firstArray) && is_array($secondArray)) {
-            foreach ($secondArray as $key => $value) {
-                if (isset($firstArray[$key])) {
-                    $firstArray[$key] = $this->_arrayMergeRecursive($firstArray[$key], $value);
-                } else {
-                    if($key === 0) {
-                        $firstArray= array(0=>$this->_arrayMergeRecursive($firstArray, $value));
-                    } else {
-                        $firstArray[$key] = $value;
-                    }
-                }
-            }
-        } else {
-            $firstArray = $secondArray;
+            return array_replace_recursive($firstArray, $secondArray);
         }
-
-        return $firstArray;
+        return $secondArray;
     }
 
     /**

--- a/library/Zend/Config/Xml.php
+++ b/library/Zend/Config/Xml.php
@@ -292,4 +292,33 @@ class Xml extends Config
 
         return $config;
     }
+
+    /**
+     * Merge two arrays recursively, overwriting keys of the same name
+     * in $firstArray with the value in $secondArray.
+     *
+     * @param  mixed $firstArray  First array
+     * @param  mixed $secondArray Second array to merge into first array
+     * @return array
+     */
+    protected function _arrayMergeRecursive($firstArray, $secondArray)
+    {
+        if (is_array($firstArray) && is_array($secondArray)) {
+            foreach ($secondArray as $key => $value) {
+                if (isset($firstArray[$key])) {
+                    $firstArray[$key] = $this->_arrayMergeRecursive($firstArray[$key], $value);
+                } else {
+                    if($key === 0) {
+                        $firstArray= array(0=>$this->_arrayMergeRecursive($firstArray, $value));
+                    } else {
+                        $firstArray[$key] = $value;
+                    }
+                }
+            }
+        } else {
+            $firstArray = $secondArray;
+        }
+
+        return $firstArray;
+    }
 }


### PR DESCRIPTION
There is a behavior conflict with Zend\Config\Xml so the old PHP implementation
is retained there pending a better solution. See
ZendTest\Config\Xml->testArrayOfKeysCreatedUsingAttributesAndKeys() / ZF-5800.

All tests still pass!
