### PR TITLE
Handle duplicate identifiers and add identifier accessors in EventManager

### DIFF
--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -55,10 +55,10 @@ class EventManager implements EventCollection
     protected $eventClass = 'Zend\EventManager\Event';
 
     /**
-     * Identifier, used to pull static signals from StaticEventManager
-     * @var null|string
+     * Identifiers, used to pull static signals from StaticEventManager
+     * @var array
      */
-    protected $identifier;
+    protected $identifiers = array();
 
     /**
      * Static connections
@@ -69,15 +69,15 @@ class EventManager implements EventCollection
     /**
      * Constructor
      *
-     * Allows optionally specifying an identifier to use to pull signals from a
+     * Allows optionally specifying identifier(s) to use to pull signals from a
      * StaticEventManager.
      *
-     * @param  null|string|int $identifier
+     * @param  null|string|int|array $identifiers
      * @return void
      */
-    public function __construct($identifier = null)
+    public function __construct($identifiers = null)
     {
-        $this->identifier = $identifier;
+        $this->setIdentifiers($identifiers);
     }
 
     /**
@@ -119,6 +119,48 @@ class EventManager implements EventCollection
             $this->setStaticConnections(StaticEventManager::getInstance());
         }
         return $this->staticConnections;
+    }
+
+    /**
+     * Get the identifier(s) for this EventManager 
+     * 
+     * @return null|string|int|array
+     */
+    public function getIdentifiers()
+    {
+        return $this->identifiers;
+    }
+
+    /**
+     * Set the identifiers (overrides any currently set identifiers) 
+     * 
+     * @param string|int|array $identifiers 
+     * @return ModuleManager
+     */
+    public function setIdentifiers($identifiers)
+    {
+        if (is_array($identifiers)) {
+            $this->identifiers = array_unique($identifiers);
+        } elseif ($identifiers !== null) {
+            $this->identifiers = array($identifiers);
+        }
+        return $this;
+    }
+
+    /**
+     * Add some identifier(s) (appends to any currently set identifiers) 
+     * 
+     * @param string|int|array $identifiers 
+     * @return ModuleManager
+     */
+    public function addIdentifiers($identifiers)
+    {
+        if (is_array($identifiers)) {
+            $this->identifiers = array_unique($this->identifiers + $identifiers);
+        } elseif ($identifiers !== null) {
+            $this->identifiers = array_unique($this->identifiers + array($identifiers));
+        }
+        return $this;
     }
 
     /**
@@ -405,7 +447,7 @@ class EventManager implements EventCollection
             return array();
         }
 
-        $identifiers     = (array) $this->identifier;
+        $identifiers     = $this->getIdentifiers();
         $staticListeners = array();
 
         foreach ($identifiers as $id) {

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -124,7 +124,7 @@ class EventManager implements EventCollection
     /**
      * Get the identifier(s) for this EventManager 
      * 
-     * @return null|string|int|array
+     * @return array
      */
     public function getIdentifiers()
     {

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -72,7 +72,7 @@ class EventManager implements EventCollection
      * Allows optionally specifying identifier(s) to use to pull signals from a
      * StaticEventManager.
      *
-     * @param  null|string|int|array $identifiers
+     * @param  null|string|int|array|Traversable $identifiers
      * @return void
      */
     public function __construct($identifiers = null)
@@ -134,13 +134,13 @@ class EventManager implements EventCollection
     /**
      * Set the identifiers (overrides any currently set identifiers) 
      * 
-     * @param string|int|array $identifiers 
+     * @param string|int|array|Traversable $identifiers 
      * @return ModuleManager
      */
     public function setIdentifiers($identifiers)
     {
-        if (is_array($identifiers)) {
-            $this->identifiers = array_unique($identifiers);
+        if (is_array($identifiers) || $identifiers instanceof \Traversable) {
+            $this->identifiers = array_unique((array) $identifiers);
         } elseif ($identifiers !== null) {
             $this->identifiers = array($identifiers);
         }
@@ -150,13 +150,13 @@ class EventManager implements EventCollection
     /**
      * Add some identifier(s) (appends to any currently set identifiers) 
      * 
-     * @param string|int|array $identifiers 
+     * @param string|int|array|Traversable $identifiers 
      * @return ModuleManager
      */
     public function addIdentifiers($identifiers)
     {
-        if (is_array($identifiers)) {
-            $this->identifiers = array_unique($this->identifiers + $identifiers);
+        if (is_array($identifiers) || $identifiers instanceof \Traversable) {
+            $this->identifiers = array_unique($this->identifiers + (array) $identifiers);
         } elseif ($identifiers !== null) {
             $this->identifiers = array_unique($this->identifiers + array($identifiers));
         }

--- a/tests/Zend/EventManager/EventManagerTest.php
+++ b/tests/Zend/EventManager/EventManagerTest.php
@@ -473,7 +473,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($identifiers[0], __CLASS__);
     }
 
-    public function testIdentifierGetterSettersWork()
+    public function testIdentifierGetterSettersWorkWithArrays()
     {
         $identifiers = array('foo', 'bar');
         $this->assertInstanceOf('Zend\EventManager\EventManager', $this->events->setIdentifiers($identifiers));
@@ -481,5 +481,15 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $identifiers[] = 'baz';
         $this->assertInstanceOf('Zend\EventManager\EventManager', $this->events->addIdentifiers($identifiers));
         $this->assertSame($this->events->getIdentifiers(), $identifiers);
+    }
+
+    public function testIdentifierGetterSettersWorkWithTraversables()
+    {
+        $identifiers = new \ArrayIterator(array('foo', 'bar'));
+        $this->assertInstanceOf('Zend\EventManager\EventManager', $this->events->setIdentifiers($identifiers));
+        $this->assertSame($this->events->getIdentifiers(), (array) $identifiers);
+        $identifiers = new \ArrayIterator(array('foo', 'bar', 'baz'));
+        $this->assertInstanceOf('Zend\EventManager\EventManager', $this->events->addIdentifiers($identifiers));
+        $this->assertSame($this->events->getIdentifiers(), (array) $identifiers);
     }
 }

--- a/tests/Zend/EventManager/EventManagerTest.php
+++ b/tests/Zend/EventManager/EventManagerTest.php
@@ -461,4 +461,25 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $message = $result->last();
         $this->assertNull($message);
     }
+
+    public function testDuplicateIdentifiersAreNotRegistered()
+    {
+        $events = new EventManager(array(__CLASS__, get_class($this)));
+        $identifiers = $events->getIdentifiers();
+        $this->assertSame(count($identifiers), 1);
+        $this->assertSame($identifiers[0], __CLASS__);
+        $events->addIdentifiers(__CLASS__);
+        $this->assertSame(count($identifiers), 1);
+        $this->assertSame($identifiers[0], __CLASS__);
+    }
+
+    public function testIdentifierGetterSettersWork()
+    {
+        $identifiers = array('foo', 'bar');
+        $this->assertInstanceOf('Zend\EventManager\EventManager', $this->events->setIdentifiers($identifiers));
+        $this->assertSame($this->events->getIdentifiers(), $identifiers);
+        $identifiers[] = 'baz';
+        $this->assertInstanceOf('Zend\EventManager\EventManager', $this->events->addIdentifiers($identifiers));
+        $this->assertSame($this->events->getIdentifiers(), $identifiers);
+    }
 }


### PR DESCRIPTION
Handle duplicate identifiers and add identifier accessors in EventManager
- Run identifiers through array_unique to always ensure there are no duplicates
  registered.
- addIdentifiers(), setIdentifiers(), and getIdentifiers() methods added
- s/identifier/identifiers and normlized property to always be an array
- Unit tests updated and pass
