### PR TITLE
Zend\Config\Ini should treat values of "true" and "false" the same as true and false

### DIFF
--- a/library/Zend/Config/Ini.php
+++ b/library/Zend/Config/Ini.php
@@ -261,6 +261,11 @@ class Ini extends Config
                 throw new Exception\RuntimeException("Invalid key '$key'");
             }
         } else {
+            if(strtolower(trim($value)) === 'true') {
+                $value = '1';
+            } elseif(strtolower(trim($value)) === 'false') {
+                $value = '';
+            }
             $config[$key] = $value;
         }
         return $config;

--- a/tests/Zend/Config/IniTest.php
+++ b/tests/Zend/Config/IniTest.php
@@ -47,6 +47,7 @@ class IniTest extends \PHPUnit_Framework_TestCase
         $this->_nonReadableConfig = __DIR__ . '/_files/nonreadable.ini';
         $this->_iniFileNoSectionsConfig = __DIR__ . '/_files/nosections.ini';
         $this->_iniFileInvalid = __DIR__ . '/_files/invalid.ini';
+        $this->_iniFileBooleans = __DIR__ . '/_files/booleans.ini';
     }
 
     public function testLoadSingleSection()
@@ -315,6 +316,15 @@ class IniTest extends \PHPUnit_Framework_TestCase
         $config = new Ini($filename, 'all');
         $this->assertEquals(true, isset($config->{1002}));
 
+    }
+
+    public function testBooleans()
+    {
+        $config = new Ini($this->_iniFileBooleans, 'all');
+        $this->assertEquals(true, (bool)$config->trueValue);
+        $this->assertEquals(false, (bool)$config->falseValue);
+        $this->assertEquals(true, (bool)$config->trueString);
+        $this->assertEquals(false, (bool)$config->falseString);
     }
 
 }

--- a/tests/Zend/Config/_files/booleans.ini
+++ b/tests/Zend/Config/_files/booleans.ini
@@ -1,0 +1,6 @@
+[all]
+trueValue = true
+falseValue = false
+trueString = "true"
+falseString = "false"
+


### PR DESCRIPTION
Zend\Config\Ini should treat values of "true" and "false" the same as true and false to reduce confusion as a value of "false" will cast to true, but a value of false will cast to false
