### PR TITLE
Fixed typo Lucen*c*e to Lucene

### DIFF
--- a/library/Zend/Search/Lucene/Search/Query/MultiTerm.php
+++ b/library/Zend/Search/Lucene/Search/Query/MultiTerm.php
@@ -28,7 +28,7 @@ use Zend\Search\Lucene,
 	Zend\Search\Lucene\Index,
 	Zend\Search\Lucene\Search\Weight,
 	Zend\Search\Lucene\Search\Highlighter,
-	Zend\Search\Lucence\Exception\InvalidArgumentException;
+	Zend\Search\Lucene\Exception\InvalidArgumentException;
 
 /**
  * @uses       \Zend\Search\Lucene\Index

--- a/library/Zend/Search/Lucene/Search/Query/Preprocessing/AbstractPreprocessing.php
+++ b/library/Zend/Search/Lucene/Search/Query/Preprocessing/AbstractPreprocessing.php
@@ -59,7 +59,7 @@ abstract class AbstractPreprocessing extends Query\AbstractQuery
      * Optimize query in the context of specified index
      *
      * @param \Zend\Search\Lucene\SearchIndex $index
-     * @throws \Zend\Search\Lucence\Exception\UnsupportedMethodCallException
+     * @throws \Zend\Search\Lucene\Exception\UnsupportedMethodCallException
      * @return \Zend\Search\Lucene\Search\Query\AbstractQuery
      */
     public function optimize(Lucene\SearchIndex $index)
@@ -71,7 +71,7 @@ abstract class AbstractPreprocessing extends Query\AbstractQuery
      * Constructs an appropriate Weight implementation for this query.
      *
      * @param \Zend\Search\Lucene\SearchIndex $reader
-     * @throws \Zend\Search\Lucence\Exception\UnsupportedMethodCallException
+     * @throws \Zend\Search\Lucene\Exception\UnsupportedMethodCallException
      * @return \Zend\Search\Lucene\Search\Weight\Weight
      */
     public function createWeight(Lucene\SearchIndex $reader)
@@ -85,7 +85,7 @@ abstract class AbstractPreprocessing extends Query\AbstractQuery
      *
      * @param \Zend\Search\Lucene\SearchIndex $reader
      * @param \Zend\Search\Lucene\Index\DocsFilter|null $docsFilter
-     * @throws \Zend\Search\Lucence\Exception\UnsupportedMethodCallException
+     * @throws \Zend\Search\Lucene\Exception\UnsupportedMethodCallException
      */
     public function execute(Lucene\SearchIndex $reader, $docsFilter = null)
     {
@@ -97,7 +97,7 @@ abstract class AbstractPreprocessing extends Query\AbstractQuery
      *
      * It's an array with document ids as keys (performance considerations)
      *
-     * @throws \Zend\Search\Lucence\Exception\UnsupportedMethodCallException
+     * @throws \Zend\Search\Lucene\Exception\UnsupportedMethodCallException
      * @return array
      */
     public function matchedDocs()
@@ -110,7 +110,7 @@ abstract class AbstractPreprocessing extends Query\AbstractQuery
      *
      * @param integer $docId
      * @param \Zend\Search\Lucene\SearchIndex $reader
-     * @throws \Zend\Search\Lucence\Exception\UnsupportedMethodCallException
+     * @throws \Zend\Search\Lucene\Exception\UnsupportedMethodCallException
      * @return float
      */
     public function score($docId, Lucene\SearchIndex $reader)
@@ -121,7 +121,7 @@ abstract class AbstractPreprocessing extends Query\AbstractQuery
     /**
      * Return query terms
      *
-     * @throws \Zend\Search\Lucence\Exception\UnsupportedMethodCallException
+     * @throws \Zend\Search\Lucene\Exception\UnsupportedMethodCallException
      * @return array
      */
     public function getQueryTerms()

--- a/library/Zend/Search/Lucene/Search/Query/Preprocessing/Fuzzy.php
+++ b/library/Zend/Search/Lucene/Search/Query/Preprocessing/Fuzzy.php
@@ -30,7 +30,7 @@ use Zend\Search\Lucene,
 	Zend\Search\Lucene\Search,
 	Zend\Search\Lucene\Analysis\Analyzer,
 	Zend\Search\Lucene\Search\Highlighter,
-	Zend\Search\Lucence\Search\Exception\QueryParserException;
+	Zend\Search\Lucene\Search\Exception\QueryParserException;
 
 /**
  * It's an internal abstract class intended to finalize ase a query processing after query parsing.
@@ -107,7 +107,7 @@ class Fuzzy extends AbstractPreprocessing
      * Re-write query into primitive queries in the context of specified index
      *
      * @param \Zend\Search\Lucene\SearchIndex $index
-     * @throws \Zend\Search\Lucence\Search\Exception\QueryParserException
+     * @throws \Zend\Search\Lucene\Search\Exception\QueryParserException
      * @return \Zend\Search\Lucene\Search\Query\AbstractQuery
      */
     public function rewrite(Lucene\SearchIndex $index)

--- a/library/Zend/Search/Lucene/Search/Query/Preprocessing/Term.php
+++ b/library/Zend/Search/Lucene/Search/Query/Preprocessing/Term.php
@@ -29,7 +29,7 @@ use Zend\Search\Lucene,
 	Zend\Search\Lucene\Search\Query,
 	Zend\Search\Lucene\Analysis\Analyzer,
 	Zend\Search\Lucene\Search\Highlighter,
-	Zend\Search\Lucence\Search\Exception\QueryParserException;
+	Zend\Search\Lucene\Search\Exception\QueryParserException;
 
 /**
  * It's an internal abstract class intended to finalize ase a query processing after query parsing.
@@ -95,7 +95,7 @@ class Term extends AbstractPreprocessing
      * Re-write query into primitive queries in the context of specified index
      *
      * @param \Zend\Search\Lucene\SearchIndex $index
-     * @throws \Zend\Search\Lucence\Search\Exception\QueryParserException
+     * @throws \Zend\Search\Lucene\Search\Exception\QueryParserException
      * @return \Zend\Search\Lucene\Search\Query\AbstractQuery
      */
     public function rewrite(Lucene\SearchIndex $index)

--- a/library/Zend/Search/Lucene/Search/Query/Range.php
+++ b/library/Zend/Search/Lucene/Search/Query/Range.php
@@ -27,10 +27,10 @@ namespace Zend\Search\Lucene\Search\Query;
 use Zend\Search\Lucene,
 	Zend\Search\Lucene\Index,
 	Zend\Search\Lucene\Search\Highlighter,
-	Zend\Search\Lucence\Exception\UnsupportedMethodCallException,
-	Zend\Search\Lucence\Exception\InvalidArgumentException,
-	Zend\Search\Lucence\Exception\RuntimeException,
-	Zend\Search\Lucence\Exception\OutOfBoundsException;
+	Zend\Search\Lucene\Exception\UnsupportedMethodCallException,
+	Zend\Search\Lucene\Exception\InvalidArgumentException,
+	Zend\Search\Lucene\Exception\RuntimeException,
+	Zend\Search\Lucene\Exception\OutOfBoundsException;
 
 /**
  * @uses       \Zend\Search\Lucene\Index


### PR DESCRIPTION
You have typo:
Zend\Search\Lucen_c_e\Exception\
