### PR TITLE
Feature/phprenderer localvars

### DIFF
--- a/library/Zend/View/PhpRenderer.php
+++ b/library/Zend/View/PhpRenderer.php
@@ -412,6 +412,8 @@ class PhpRenderer implements Renderer, Pluggable
 
         unset($vars); // remove $vars from local scope
 
+        extract($this->vars()->getArrayCopy());
+        
         ob_start();
         include $this->file;
         $content = ob_get_clean();

--- a/library/Zend/View/PhpRenderer.php
+++ b/library/Zend/View/PhpRenderer.php
@@ -410,9 +410,14 @@ class PhpRenderer implements Renderer, Pluggable
             $this->setVars($vars);
         }
 
-        unset($vars); // remove $vars from local scope
+        // extract all assigned vars (pre-escaped), but not 'this'
+        $vars = $this->vars()->getArrayCopy();
+        if (array_key_exists('this', $vars)) {
+            unset($vars['this']);
+        }
+        extract($vars);
 
-        extract($this->vars()->getArrayCopy());
+        unset($vars); // remove $vars from local scope
         
         ob_start();
         include $this->file;

--- a/tests/Zend/View/PhpRendererTest.php
+++ b/tests/Zend/View/PhpRendererTest.php
@@ -252,4 +252,13 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
         $foo = $this->renderer->raw('foo');
         $this->assertSame($this->renderer->vars()->getRawValue('foo'), $foo);
     }
+    
+    public function testRenderingLocalVariables()
+    {
+        $expected = '10 &gt; 9';
+        $this->renderer->vars()->assign(array('foo' => '10 > 9'));
+        $this->renderer->resolver()->addPath(__DIR__ . '/_templates');
+        $test = $this->renderer->render('testLocalVars.phtml');
+        $this->assertContains($expected, $test);
+    }    
 }

--- a/tests/Zend/View/_templates/testLocalVars.phtml
+++ b/tests/Zend/View/_templates/testLocalVars.phtml
@@ -1,0 +1,1 @@
+<?php echo $foo; ?>


### PR DESCRIPTION
Allow for the use of $varname within view scripts. Turns out that extract(array('this'=>'test'); actually affects  $this, so I decided to explicitly check for it.
