### PR TITLE
Hotfix/method rename

### DIFF
--- a/library/Zend/Mvc/Controller/ActionController.php
+++ b/library/Zend/Mvc/Controller/ActionController.php
@@ -168,7 +168,7 @@ abstract class ActionController implements Dispatchable, EventAware, LocatorAwar
                 __CLASS__, 
                 get_called_class()
             )));
-            $this->registerDefaultEvents();
+            $this->attachDefaultListeners();
         }
         return $this->events;
     }
@@ -292,7 +292,7 @@ abstract class ActionController implements Dispatchable, EventAware, LocatorAwar
      * 
      * @return void
      */
-    protected function registerDefaultEvents()
+    protected function attachDefaultListeners()
     {
         $events = $this->events();
         $events->attach('dispatch', array($this, 'execute'));

--- a/library/Zend/Mvc/Controller/RestfulController.php
+++ b/library/Zend/Mvc/Controller/RestfulController.php
@@ -237,7 +237,7 @@ abstract class RestfulController implements Dispatchable, EventAware, LocatorAwa
                 __CLASS__,
                 get_called_class(),
             )));
-            $this->registerDefaultEvents();
+            $this->attachDefaultListeners();
         }
         return $this->events;
     }
@@ -361,7 +361,7 @@ abstract class RestfulController implements Dispatchable, EventAware, LocatorAwa
      * 
      * @return void
      */
-    protected function registerDefaultEvents()
+    protected function attachDefaultListeners()
     {
         $events = $this->events();
         $events->attach('dispatch', array($this, 'execute'));


### PR DESCRIPTION
Rename method from registerDefaultEvents to attachDefaultListeners so it has the same name as the one in Mvc\Application.

Tests still pass, of course :)
