### PR TITLE
Fixing outdated references to Translator\Adapter -> Translator\Adapter\AbstractAdapter

### DIFF
--- a/library/Zend/File/Transfer/Adapter/AbstractAdapter.php
+++ b/library/Zend/File/Transfer/Adapter/AbstractAdapter.php
@@ -1093,7 +1093,7 @@ abstract class AbstractAdapter
     {
         if (null === $translator) {
             $this->_translator = null;
-        } elseif ($translator instanceof \Zend\Translator\Adapter\Adapter) {
+        } elseif ($translator instanceof \Zend\Translator\Adapter\AbstractAdapter) {
             $this->_translator = $translator;
         } elseif ($translator instanceof \Zend\Translator\Translator) {
             $this->_translator = $translator->getAdapter();

--- a/library/Zend/Form/DisplayGroup.php
+++ b/library/Zend/Form/DisplayGroup.php
@@ -904,12 +904,12 @@ class DisplayGroup implements \Iterator,\Countable
     /**
      * Set translator object
      *
-     * @param  Zend_Translator|\Zend\Translator\Adapter\Adapter|null $translator
+     * @param  Zend_Translator|\Zend\Translator\Adapter\AbstractAtapter|null $translator
      * @return \Zend\Form\DisplayGroup
      */
     public function setTranslator($translator = null)
     {
-        if ((null === $translator) || ($translator instanceof Translator\Adapter)) {
+        if ((null === $translator) || ($translator instanceof Translator\Adapter\AbstractAdapter)) {
             $this->_translator = $translator;
         } elseif ($translator instanceof Translator\Translator) {
             $this->_translator = $translator->getAdapter();

--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -397,7 +397,7 @@ class Element implements Validator
     {
         if (null === $translator) {
             $this->_translator = null;
-        } elseif ($translator instanceof \Zend\Translator\Adapter) {
+        } elseif ($translator instanceof \Zend\Translator\Adapter\AbstractAdapter) {
             $this->_translator = $translator;
         } elseif ($translator instanceof \Zend\Translator\Translator) {
             $this->_translator = $translator->getAdapter();
@@ -1339,7 +1339,7 @@ class Element implements Validator
         // Find the correct translator. Zend\Validator\AbstractValidator::getDefaultTranslator()
         // will get either the static translator attached to Zend\Validator\AbstractValidator
         // or the 'Zend_Translator' from Zend\Registry.
-        if (AbstractValidator::hasDefaultTranslator() 
+        if (AbstractValidator::hasDefaultTranslator()
             && !Form::hasDefaultTranslator())
         {
             $translator = AbstractValidator::getDefaultTranslator();

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -2933,7 +2933,7 @@ class Form implements \Iterator, \Countable, \Zend\Validator\Validator
     {
         if (null === $translator) {
             $this->_translator = null;
-        } elseif ($translator instanceof Translator\Adapter) {
+        } elseif ($translator instanceof Translator\Adapter\AbstractAdapter) {
             $this->_translator = $translator;
         } elseif ($translator instanceof Translator\Translator) {
             $this->_translator = $translator->getAdapter();
@@ -2954,7 +2954,7 @@ class Form implements \Iterator, \Countable, \Zend\Validator\Validator
     {
         if (null === $translator) {
             self::$_translatorDefault = null;
-        } elseif ($translator instanceof Translator\Adapter) {
+        } elseif ($translator instanceof Translator\Adapter\AbstractAdapter) {
             self::$_translatorDefault = $translator;
         } elseif ($translator instanceof Translator\Translator) {
             self::$_translatorDefault = $translator->getAdapter();
@@ -3001,7 +3001,7 @@ class Form implements \Iterator, \Countable, \Zend\Validator\Validator
         if (null === self::$_translatorDefault) {
             if (Registry::isRegistered('Zend_Translator')) {
                 $translator = Registry::get('Zend_Translator');
-                if ($translator instanceof Translator\Adapter) {
+                if ($translator instanceof Translator\Adapter\AbstractAdapter) {
                     return $translator;
                 } elseif ($translator instanceof Translator\Translator) {
                     return $translator->getAdapter();
@@ -3371,7 +3371,7 @@ class Form implements \Iterator, \Countable, \Zend\Validator\Validator
      * Get a normalized list of decorator prefix paths
      *
      * Returns a list in the form of prefix => path[] pairs.
-     * 
+     *
      * @return array
      */
     protected function getDecoratorPrefixPaths()

--- a/library/Zend/Validator/AbstractValidator.php
+++ b/library/Zend/Validator/AbstractValidator.php
@@ -327,12 +327,12 @@ abstract class AbstractValidator implements Validator
     /**
      * Set translation object
      *
-     * @param  Zend_Translator|\Zend\Translator\Adapter\Adapter|null $translator
+     * @param  Zend_Translator|\Zend\Translator\Adapter\AbstractAdapter|null $translator
      * @return \Zend\Validator\AbstractValidator
      */
     public function setTranslator($translator = null)
     {
-        if ((null === $translator) || ($translator instanceof Translator\Adapter)) {
+        if ((null === $translator) || ($translator instanceof Translator\Adapter\AbstractAdapter)) {
             $this->_translator = $translator;
         } elseif ($translator instanceof Translator\Translator) {
             $this->_translator = $translator->getAdapter();
@@ -378,7 +378,7 @@ abstract class AbstractValidator implements Validator
      */
     public static function setDefaultTranslator($translator = null)
     {
-        if ((null === $translator) || ($translator instanceof Translator\Adapter)) {
+        if ((null === $translator) || ($translator instanceof Translator\Adapter\AbstractAdapter)) {
             self::$_defaultTranslator = $translator;
         } elseif ($translator instanceof Translator\Translator) {
             self::$_defaultTranslator = $translator->getAdapter();
@@ -397,7 +397,7 @@ abstract class AbstractValidator implements Validator
         if (null === self::$_defaultTranslator) {
             if (\Zend\Registry::isRegistered('Zend_Translator')) {
                 $translator = \Zend\Registry::get('Zend_Translator');
-                if ($translator instanceof Translator\Adapter) {
+                if ($translator instanceof Translator\Adapter\AbstractAdapter) {
                     return $translator;
                 } elseif ($translator instanceof Translator\Translator) {
                     return $translator->getAdapter();

--- a/library/Zend/View/Helper/FormElement.php
+++ b/library/Zend/View/Helper/FormElement.php
@@ -62,7 +62,7 @@ abstract class FormElement extends HtmlElement
     {
         if (null === $translator) {
             $this->_translator = null;
-        } elseif ($translator instanceof \Zend\Translator\Adapter) {
+        } elseif ($translator instanceof \Zend\Translator\Adapter\AbstractAdapter) {
             $this->_translator = $translator;
         } elseif ($translator instanceof \Zend\Translator\Translator) {
             $this->_translator = $translator->getAdapter();
@@ -115,7 +115,7 @@ abstract class FormElement extends HtmlElement
                 }
             }
 
-            // If all helper options are passed as an array, attribs may have 
+            // If all helper options are passed as an array, attribs may have
             // been as well
             if (null === $attribs) {
                 $attribs = $info['attribs'];

--- a/library/Zend/View/Helper/HeadTitle.php
+++ b/library/Zend/View/Helper/HeadTitle.php
@@ -129,7 +129,7 @@ class HeadTitle extends Placeholder\Container\Standalone
      */
     public function setTranslator($translate)
     {
-        if ($translate instanceof \Zend\Translator\Adapter) {
+        if ($translate instanceof \Zend\Translator\Adapter\AbstractAdapter) {
             $this->_translator = $translate;
         } elseif ($translate instanceof \Zend\Translator\Translator) {
             $this->_translator = $translate->getAdapter();

--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -295,7 +295,7 @@ abstract class AbstractHelper
     public function setTranslator($translator = null)
     {
         if (null == $translator ||
-            $translator instanceof \Zend\Translator\Adapter) {
+            $translator instanceof \Zend\Translator\Adapter\AbstractAdapter) {
             $this->_translator = $translator;
         } elseif ($translator instanceof \Zend\Translator\Translator) {
             $this->_translator = $translator->getAdapter();

--- a/library/Zend/View/Helper/Translator.php
+++ b/library/Zend/View/Helper/Translator.php
@@ -111,7 +111,7 @@ class Translator extends AbstractHelper
      */
     public function setTranslator($translate)
     {
-        if ($translate instanceof \Zend\Translator\Adapter\Adapter) {
+        if ($translate instanceof \Zend\Translator\Adapter\AbstractAdapter) {
             $this->_translator = $translate;
         } else if ($translate instanceof \Zend\Translator\Translator) {
             $this->_translator = $translate->getAdapter();


### PR DESCRIPTION
bug fix following c073df83: many references to Translator\Adapter\Adapter and Translator\Adapter cause fatal errors
