### PR TITLE
http://framework.zend.com/issues/browse/ZF2-71

### DIFF
--- a/library/Zend/Crypt/Rsa.php
+++ b/library/Zend/Crypt/Rsa.php
@@ -242,11 +242,21 @@ class Rsa
         $this->setCertificateString(file_get_contents($this->_certificatePath));
     }
 
+    /**
+     * @param string $name
+     * @throws \Zend\Crypt\Exception
+     */
     public function setHashAlgorithm($name)
     {
-        switch (strtolower($name)) {
+       switch (strtolower($name)) {
             case 'md2':
-                $this->_hashAlgorithm = OPENSSL_ALGO_MD2;
+                // check if md2 digest is enabled on openssl just for backwards compatibility
+                $digests = openssl_get_md_methods();
+                if (in_array($name, $digests)) {
+                    $this->_hashAlgorithm = OPENSSL_ALGO_MD2;
+                } else {
+                    throw new Zend\Crypt\Exception('Openssl md2 digest is not enabled  (deprecated)');
+                }
                 break;
             case 'md4':
                 $this->_hashAlgorithm = OPENSSL_ALGO_MD4;


### PR DESCRIPTION
fix/ZF2-71 check if md2 digest is enabled on openssl just for backwards compatibility
