### PR TITLE
Allow module locations to be explicitly defined in paths array given to module autoloader

### DIFF
--- a/tests/Zend/Loader/ModuleAutoloaderTest.php
+++ b/tests/Zend/Loader/ModuleAutoloaderTest.php
@@ -146,4 +146,15 @@ class ManagerTest extends TestCase
         $this->setExpectedException('InvalidArgumentException');
         $loader->registerPaths(123);
     }
+
+    public function testCanLoadModulesFromExplicitLocation()
+    {
+        $loader = new ModuleAutoloader(array(
+            'My\NonmatchingModule' => __DIR__ . '/_files/NonmatchingModule',
+            'PharModule' => __DIR__ . '/_files/PharModule.phar',
+        ));
+        $loader->register();
+        $this->assertTrue(class_exists('My\NonmatchingModule\Module'));
+        $this->assertTrue(class_exists('PharModule\Module'));
+    }
 }

--- a/tests/Zend/Loader/_files/NonmatchingModule/Module.php
+++ b/tests/Zend/Loader/_files/NonmatchingModule/Module.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace My\NonmatchingModule;
+
+class Module
+{
+}


### PR DESCRIPTION
Allow module locations to be explicitly defined in paths array given to module autoloader

Example: array('./modules', 'My\Bar' => '/path/to/barmodule', './other/modules')
