### PR TITLE
Make StandardAutoloader PSR-0 compliant

### DIFF
--- a/library/Zend/Code/Generator/Docblock/Tag/LicenseTag.php
+++ b/library/Zend/Code/Generator/Docblock/Tag/LicenseTag.php
@@ -25,13 +25,13 @@
 namespace Zend\Code\Generator\Docblock\Tag;
 
 /**
- * @uses       \Zend\Code\Generator\PhpDocblockTag
+ * @uses       \Zend\Code\Generator\Docblock\Tag
  * @category   Zend
  * @package    Zend_CodeGenerator
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class LicenseTag extends \Zend\Code\Generator\PhpDocblockTag
+class LicenseTag extends \Zend\Code\Generator\Docblock\Tag
 {
 
     /**
@@ -42,10 +42,10 @@ class LicenseTag extends \Zend\Code\Generator\PhpDocblockTag
     /**
      * fromReflection()
      *
-     * @param \Zend\Reflection\ReflectionDocblockTag $reflectionTagReturn
+     * @param \Zend\Code\Reflection\ReflectionDocblockTag $reflectionTagReturn
      * @return \Zend\Code\Generator\Docblock\Tag\LicenseTag
      */
-    public static function fromReflection(\Zend\Reflection\ReflectionDocblockTag $reflectionTagLicense)
+    public static function fromReflection(\Zend\Code\Reflection\ReflectionDocblockTag $reflectionTagLicense)
     {
         $returnTag = new self();
 
@@ -86,7 +86,7 @@ class LicenseTag extends \Zend\Code\Generator\PhpDocblockTag
      */
     public function generate()
     {
-        $output = '@license ' . $this->_url . ' ' . $this->_description . self::LINE_FEED;
+        $output = '@license ' . $this->_url . ' ' . $this->description . self::LINE_FEED;
         return $output;
     }
 

--- a/library/Zend/Code/Generator/Docblock/Tag/ParamTag.php
+++ b/library/Zend/Code/Generator/Docblock/Tag/ParamTag.php
@@ -25,13 +25,13 @@
 namespace Zend\Code\Generator\Docblock\Tag;
 
 /**
- * @uses       \Zend\Code\Generator\PhpDocblockTag
+ * @uses       \Zend\Code\Generator\Docblock\Tag
  * @category   Zend
  * @package    Zend_CodeGenerator
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class ParamTag extends \Zend\Code\Generator\PhpDocblockTag
+class ParamTag extends \Zend\Code\Generator\Docblock\Tag
 {
 
     /**
@@ -47,10 +47,10 @@ class ParamTag extends \Zend\Code\Generator\PhpDocblockTag
     /**
      * fromReflection()
      *
-     * @param \Zend\Reflection\ReflectionDocblockTag $reflectionTagParam
+     * @param \Zend\Code\Reflection\ReflectionDocblockTag $reflectionTagParam
      * @return \Zend\Code\Generator\Docblock\Tag\ParamTag
      */
-    public static function fromReflection(\Zend\Reflection\ReflectionDocblockTag $reflectionTagParam)
+    public static function fromReflection(\Zend\Code\Reflection\ReflectionDocblockTag $reflectionTagParam)
     {
         $paramTag = new self();
 
@@ -116,7 +116,7 @@ class ParamTag extends \Zend\Code\Generator\PhpDocblockTag
         $output = '@param '
             . (($this->_datatype  != null) ? $this->_datatype : 'unknown')
             . (($this->_paramName != null) ? ' $' . $this->_paramName : '')
-            . (($this->_description != null) ? ' ' . $this->_description : '');
+            . (($this->description != null) ? ' ' . $this->description : '');
         return $output;
     }
 

--- a/library/Zend/Code/Generator/Docblock/Tag/ReturnTag.php
+++ b/library/Zend/Code/Generator/Docblock/Tag/ReturnTag.php
@@ -25,13 +25,13 @@
 namespace Zend\Code\Generator\Docblock\Tag;
 
 /**
- * @uses       \Zend\Code\Generator\PhpDocblockTag
+ * @uses       \Zend\Code\Generator\Docblock\Tag
  * @category   Zend
  * @package    Zend_CodeGenerator
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class ReturnTag extends \Zend\Code\Generator\PhpDocblockTag
+class ReturnTag extends \Zend\Code\Generator\Docblock\Tag
 {
 
     /**
@@ -42,10 +42,10 @@ class ReturnTag extends \Zend\Code\Generator\PhpDocblockTag
     /**
      * fromReflection()
      *
-     * @param \Zend\Reflection\ReflectionDocblockTag $reflectionTagReturn
+     * @param \Zend\Code\Reflection\ReflectionDocblockTag $reflectionTagReturn
      * @return \Zend\Code\Generator\Docblock\Tag\ReturnTag
      */
-    public static function fromReflection(\Zend\Reflection\ReflectionDocblockTag $reflectionTagReturn)
+    public static function fromReflection(\Zend\Code\Reflection\ReflectionDocblockTag $reflectionTagReturn)
     {
         $returnTag = new self();
 
@@ -86,7 +86,7 @@ class ReturnTag extends \Zend\Code\Generator\PhpDocblockTag
      */
     public function generate()
     {
-        $output = '@return ' . $this->_datatype . ' ' . $this->_description;
+        $output = '@return ' . $this->_datatype . ' ' . $this->description;
         return $output;
     }
 

--- a/library/Zend/Code/Generator/DocblockGenerator.php
+++ b/library/Zend/Code/Generator/DocblockGenerator.php
@@ -27,8 +27,8 @@ namespace Zend\Code\Generator;
 use Zend\Code\Reflection\DocBlockReflection;
 
 /**
- * @uses       \Zend\Code\Generator\AbstractPhp
- * @uses       \Zend\Code\Generator\PhpDocblockTag
+ * @uses       \Zend\Code\Generator\AbstractGenerator
+ * @uses       \Zend\Code\Generator\Docblock\Tag
  * @uses       \Zend\Code\Generator\Exception
  * @category   Zend
  * @package    Zend_CodeGenerator
@@ -156,7 +156,7 @@ class DocblockGenerator extends AbstractGenerator
     /**
      * setTag()
      *
-     * @param array|\Zend\Code\Generator\PhpDocblockTag $tag
+     * @param array|\Zend\Code\Generator\Docblock\Tag $tag
      * @return \Zend\Code\GeneratorDocblock
      */
     public function setTag($tag)
@@ -166,7 +166,7 @@ class DocblockGenerator extends AbstractGenerator
         } elseif (!$tag instanceof Docblock\Tag) {
             throw new Exception\InvalidArgumentException(
                 'setTag() expects either an array of method options or an '
-                . 'instance of Zend_CodeGenerator_Php_Docblock_Tag'
+                . 'instance of Zend\\Code\\Generator\\Docblock\\Tag'
                 );
         }
 

--- a/library/Zend/Code/Generator/MethodGenerator.php
+++ b/library/Zend/Code/Generator/MethodGenerator.php
@@ -61,7 +61,7 @@ class MethodGenerator extends AbstractMemberGenerator
     /**
      * fromReflection()
      *
-     * @param \Zend\Reflection\ReflectionMethod $reflectionMethod
+     * @param \Zend\Code\Reflection\MethodReflection $reflectionMethod
      * @return \MethodGenerator\Code\Generator\PhpMethod
      */
     public static function fromReflection(MethodReflection $reflectionMethod)

--- a/library/Zend/Code/Reflection/MethodReflection.php
+++ b/library/Zend/Code/Reflection/MethodReflection.php
@@ -61,9 +61,6 @@ class MethodReflection extends ReflectionMethod implements Reflection
         }
 
         $instance = new DocBlockReflection($this);
-        if ($this->annotationManager) {
-            $instance->setAnnotationManager($this->annotationManager);
-        }
         return $instance;
     }
 

--- a/library/Zend/Loader/StandardAutoloader.php
+++ b/library/Zend/Loader/StandardAutoloader.php
@@ -261,7 +261,20 @@ class StandardAutoloader implements SplAutoloader
      */
     protected function transformClassNameToFilename($class, $directory)
     {
+        // $class may contain a namespace portion, in  which case we need
+        // to preserve any underscores in that portion.
+        $ns  = '';
+        $pos = strrpos($class, self::NS_SEPARATOR);
+        if ($pos) {
+            $ns = substr($class, 0, $pos);
+            $class = substr($class, $pos);
+        }
         return $directory
+            . str_replace(
+                self::NS_SEPARATOR,
+                DIRECTORY_SEPARATOR,
+                $ns
+            )
             . str_replace(
                 array(self::NS_SEPARATOR, self::PREFIX_SEPARATOR),
                 DIRECTORY_SEPARATOR,

--- a/tests/Zend/Loader/ModuleAutoloaderTest.php
+++ b/tests/Zend/Loader/ModuleAutoloaderTest.php
@@ -146,4 +146,15 @@ class ManagerTest extends TestCase
         $this->setExpectedException('InvalidArgumentException');
         $loader->registerPaths(123);
     }
+
+    public function testCanLoadModulesFromExplicitLocation()
+    {
+        $loader = new ModuleAutoloader(array(
+            'My\NonmatchingModule' => __DIR__ . '/_files/NonmatchingModule',
+            'PharModule' => __DIR__ . '/_files/PharModule.phar',
+        ));
+        $loader->register();
+        $this->assertTrue(class_exists('My\NonmatchingModule\Module'));
+        $this->assertTrue(class_exists('PharModule\Module'));
+    }
 }

--- a/tests/Zend/Loader/StandardAutoloaderTest.php
+++ b/tests/Zend/Loader/StandardAutoloaderTest.php
@@ -175,4 +175,12 @@ class StandardAutoloaderTest extends \PHPUnit_Framework_TestCase
         $test = array_pop($loaders);
         $this->assertEquals(array($loader, 'autoload'), $test);
     }
+
+    public function testAutoloadsNamespacedClassesWithUnderscores()
+    {
+        $loader = new StandardAutoloader();
+        $loader->registerNamespace('ZendTest\UnusualNamespace', __DIR__ . '/TestAsset');
+        $loader->autoload('ZendTest\UnusualNamespace\Name_Space\Namespaced_Class');
+        $this->assertTrue(class_exists('ZendTest\UnusualNamespace\Name_Space\Namespaced_Class', false));
+    }
 }

--- a/tests/Zend/Loader/TestAsset/Name_Space/Namespaced/Class.php
+++ b/tests/Zend/Loader/TestAsset/Name_Space/Namespaced/Class.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Loader
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
+ */
+
+namespace ZendTest\UnusualNamespace\Name_Space;
+
+/**
+ * @category   Zend
+ * @package    Loader
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Loader
+ */
+class Namespaced_Class
+{
+}

--- a/tests/Zend/Loader/_files/NonmatchingModule/Module.php
+++ b/tests/Zend/Loader/_files/NonmatchingModule/Module.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace My\NonmatchingModule;
+
+class Module
+{
+}


### PR DESCRIPTION
Make the StandardAutoloader PSR-0 compliant, by nhonouring the the underscore in the namespace portion and not replacing it with a directory separator
