### PR TITLE
Remove 'incomplete implementation' exception for static factories via di

### DIFF
--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -175,8 +175,6 @@ class Di implements DependencyInjection
             }
         } elseif (is_callable($instantiator)) {
             $object = $this->createInstanceViaCallback($instantiator, $params, $alias);
-            // @todo make sure we can create via a real object factory
-            throw new \Exception('incomplete implementation');
         } else {
             throw new Exception\RuntimeException('Invalid instantiator');
         }
@@ -191,7 +189,9 @@ class Di implements DependencyInjection
 
         if ($injectionMethods) {
             foreach ($injectionMethods as $injectionMethod => $methodIsRequired) {
-                $this->handleInjectionMethodForObject($object, $injectionMethod, $params, $alias, $methodIsRequired);
+                if ($injectionMethod !== '__construct'){
+                    $this->handleInjectionMethodForObject($object, $injectionMethod, $params, $alias, $methodIsRequired);
+                }
             }
 
             $instanceConfiguration = $instanceManager->getConfiguration($name);

--- a/tests/Zend/Di/ConfigurationTest.php
+++ b/tests/Zend/Di/ConfigurationTest.php
@@ -72,5 +72,52 @@ class ConfigurationTest extends TestCase
         
     }
     
+    public function testCanSetInstantiatorToStaticFactory()
+    {
+        $config = new Configuration(array(
+            'definition' => array(
+                'class' => array(
+                    'ZendTest\Di\TestAsset\DummyParams' => array(
+                        'instantiator' => array('ZendTest\Di\TestAsset\StaticFactory', 'factory'),
+                    ),
+                    'ZendTest\Di\TestAsset\StaticFactory' => array(
+                        'methods' => array(
+                            'factory' => array(
+                                'struct' => array(
+                                    'type' => 'ZendTest\Di\TestAsset\Struct',
+                                    'required' => true,
+                                ),
+                                'params' => array(
+                                    'required' => true,
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            'instance' => array(
+                'ZendTest\Di\TestAsset\DummyParams' => array(
+                    'parameters' => array(
+                        'struct' => 'ZendTest\Di\TestAsset\Struct',
+                        'params' => array(
+                            'foo' => 'bar',
+                        ),
+                    ),
+                ),
+                'ZendTest\Di\TestAsset\Struct' => array(
+                    'parameters' => array(
+                        'param1' => 'hello',
+                        'param2' => 'world',
+                    ),
+                ),
+            ),
+        ));
+        $di = new Di();
+        $di->configure($config);
+        $dummyParams = $di->get('ZendTest\Di\TestAsset\DummyParams');
+        $this->assertEquals($dummyParams->params['param1'], 'hello');
+        $this->assertEquals($dummyParams->params['param2'], 'world');
+        $this->assertEquals($dummyParams->params['foo'], 'bar');
+    }
     
 }


### PR DESCRIPTION
- Added factory unit test to ZendTest\Di\ConfigurationTest
- Made Zend\Di\Di skip handleInjectionMethodForObject() if the method is
  __construct()
