### PR TITLE
[ZF-11819] Zend_Filter_Input

### DIFF
--- a/library/Zend/Filter/InputFilter.php
+++ b/library/Zend/Filter/InputFilter.php
@@ -773,11 +773,13 @@ class InputFilter
                     if (is_array($rule)) {
                         $keys = array_keys($rule);
                         $classKey = array_shift($keys);
-                        $ruleClass = $rule[$classKey];
-                        if ($ruleClass === 'NotEmpty') {
-                            $foundNotEmptyValidator = true;
-                            // field may not be empty, we are ready
-                            break 1;
+                        if (isset($rule[$classKey])) {
+                            $ruleClass = $rule[$classKey];
+                            if ($ruleClass === 'NotEmpty') {
+                                $foundNotEmptyValidator = true;
+                                // field may not be empty, we are ready
+                                break 1;
+                            }
                         }
                     }
 

--- a/tests/Zend/Filter/InputTest.php
+++ b/tests/Zend/Filter/InputTest.php
@@ -1995,6 +1995,23 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
         $messages = $input->getMessages();
         $this->assertSame($messages['field1']['isEmpty'], $customMessage, 'For the NotEmpty validator the custom message is not used');
     }
+    
+    /**
+     * This test doesn't include any assertions as it's purpose is to 
+     * ensure that passing an empty array value into a $validators rule 
+     * doesn't cause a notice to be emitted
+     *  
+     * @group ZF-11819
+     */
+    public function testValidatorRuleCanHaveEmptyArrayAsMetacommandValue()
+    {
+        $validators = array(
+            'perms' => array('Int', 'default' => array()),
+        );
+
+        $validate = new InputFilter(NULL, $validators);
+        $validate->isValid();
+    }
 }
 
 } // end namespace declaration


### PR DESCRIPTION
Fixed case where PHP Notice emitted when validator metacommand value is empty array
