### PR TITLE
Add __isset method for checking existence of a field in lucene document & query hit

### DIFF
--- a/library/Zend/Search/Lucene/Document.php
+++ b/library/Zend/Search/Lucene/Document.php
@@ -55,6 +55,17 @@ class Document
      * @var float
      */
     public $boost = 1.0;
+    
+    /**
+     * Magic method for checking the existence of a field
+     *
+     * @param string $offset
+     * @return boolean TRUE if the field exists else FALSE
+     */
+    public function __isset($offset)
+    {
+        return in_array($offset, $this->getFieldNames());
+    }
 
     /**
      * Proxy method for getFieldValue(), provides more convenient access to

--- a/library/Zend/Search/Lucene/Search/QueryHit.php
+++ b/library/Zend/Search/Lucene/Search/QueryHit.php
@@ -73,7 +73,18 @@ class QueryHit
     {
         $this->_index = $index;
     }
-
+    
+    /**
+     * Magic method for checking the existence of a field
+     *
+     * @param string $offset
+     * @return boolean TRUE if the field exists else FALSE
+     */
+    public function __isset($offset)
+    {
+        return isset($this->getDocument()->$offset);
+    }
+    
 
     /**
      * Convenience function for getting fields from the document


### PR DESCRIPTION
When the __get() method is used, it is usual to implement the __isset() method for checking the existence of the property.

In my case, it is very usefull because I use a PHP template framwork which checks if a property exists before rendering it. So if the __isset() method is not implemented, the template framework can't use the __get() method.
