### PR TITLE
Zend\Http\Response::$statusCode must be int value

### DIFF
--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -312,7 +312,7 @@ class Response extends Message implements ResponseDescription
                 $code
             ));
         }
-        $this->statusCode = $code;
+        $this->statusCode = (int) $code;
         return $this;
     }
 


### PR DESCRIPTION
Now it's may be string. string(3) '200'
