### PR TITLE
Hotfix: add base URL to paths assebled by TreeRouteStack 

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/Redirect.php
+++ b/library/Zend/Mvc/Controller/Plugin/Redirect.php
@@ -19,12 +19,12 @@ class Redirect extends AbstractPlugin
 
     /**
      * Generates a URL based on a route
-     * 
+     *
      * @param  string $route Route name
      * @param  array $params Parameters to use in url generation, if any
      * @param  array $options Route-specific options to use in url generation, if any
      * @return Response
-     * @throws Exception\DomainException if composed controller does not implement InjectApplicationEvent, or 
+     * @throws Exception\DomainException if composed controller does not implement InjectApplicationEvent, or
      *         router cannot be found in controller event
      */
     public function toRoute($route, array $params = array(), array $options = array())
@@ -41,8 +41,8 @@ class Redirect extends AbstractPlugin
 
     /**
      * Redirect to the given URL
-     * 
-     * @param  string $url 
+     *
+     * @param  string $url
      * @return Response
      */
     public function toUrl($url)
@@ -55,7 +55,7 @@ class Redirect extends AbstractPlugin
 
     /**
      * Get the router
-     * 
+     *
      * @return RouteStack
      * @throws Exception\DomainException if unable to find router
      */
@@ -76,7 +76,7 @@ class Redirect extends AbstractPlugin
 
     /**
      * Get the response
-     * 
+     *
      * @return Response
      * @throws Exception\DomainException if unable to find response
      */
@@ -97,7 +97,7 @@ class Redirect extends AbstractPlugin
 
     /**
      * Get the event
-     * 
+     *
      * @return MvcEvent
      * @throws Exception\DomainException if unable to find event
      */

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -46,10 +46,10 @@ class TreeRouteStack extends SimpleRouteStack
      * @var string
      */
     protected $baseUrl = '';
-    
+
     /**
      * Request URI.
-     * 
+     *
      * @var HttpUri
      */
     protected $requestUri;
@@ -131,10 +131,10 @@ class TreeRouteStack extends SimpleRouteStack
         if (!method_exists($request, 'uri')) {
             return null;
         }
-        
+
         $uri           = $request->uri();
         $baseUrlLength = strlen($this->baseUrl) ?: null;
-        
+
         if ($this->requestUri === null) {
             $this->setRequestUri($uri);
         }
@@ -167,38 +167,38 @@ class TreeRouteStack extends SimpleRouteStack
         if (!isset($options['name'])) {
             throw new Exception\InvalidArgumentException('Missing "name" option');
         }
-        
+
         $names = explode('/', $options['name'], 2);
         $route = $this->routes->get($names[0]);
-        
+
         if (!$route) {
             throw new Exception\RuntimeException(sprintf('Route with name "%s" not found', $names[0]));
         }
-        
+
         if (isset($names[1])) {
             $options['name'] = $names[1];
         } else {
             unset($options['name']);
         }
-        
-        if (!isset($options['uri'])) {       
+
+        if (!isset($options['uri'])) {
             $uri = new HttpUri();
-            
+
             if (isset($options['absolute']) && $options['absolute']) {
                 if ($this->requestUri === null) {
                     throw new Exception\RuntimeException('Request URI has not been set');
                 }
-            
+
                 $uri->setScheme($this->requestUri->getScheme())
                     ->setHost($this->requestUri->getHost())
                     ->setPort($this->requestUri->getPort());
             }
-            
+
             $options['uri'] = $uri;
         }
-        
-        $path = $route->assemble($params, $options);
-        
+
+        $path = $this->baseUrl . $route->assemble($params, $options);
+
         if (isset($uri)) {
             if (isset($options['absolute']) && $options['absolute']) {
                 return $uri->setPath($path)->toString();
@@ -207,17 +207,17 @@ class TreeRouteStack extends SimpleRouteStack
                     if ($this->requestUri === null) {
                         throw new Exception\RuntimeException('Request URI has not been set');
                     }
-                    
+
                     $uri->setScheme($this->requestUri->getScheme());
                 }
-                
+
                 return $uri->setPath($path)->toString();
             }
         }
-        
+
         return $path;
     }
-    
+
     /**
      * Set the base URL.
      *
@@ -239,10 +239,10 @@ class TreeRouteStack extends SimpleRouteStack
     {
         return $this->baseUrl;
     }
-    
+
     /**
      * Set the request URI.
-     * 
+     *
      * @param  HttpUri $uri
      * @return self
      */
@@ -251,10 +251,10 @@ class TreeRouteStack extends SimpleRouteStack
         $this->requestUri = $uri;
         return $this;
     }
-    
+
     /**
      * Get the request URI.
-     * 
+     *
      * @return HttpUri
      */
     public function getRequestUri()


### PR DESCRIPTION
When using the redirect plugin, I noticed assembled route ignore the baseURL I have set. 
This naive fix prefixes the base URL (if set) to assembled path in TreeRouteStack. 

Again, sorry for the garbage commits, I had some issues with merging git branches so there are a bunch of empty commits here, but in reality we are talking about a dead-simple one liner. 
