### PR TITLE
[hotfix/ZF-11831] Zend_Form

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -2248,7 +2248,8 @@ class Form implements \Iterator, \Countable, \Zend\Validator\Validator
             }
         }
         foreach ($this->getSubForms() as $key => $form) {
-            if (null !== $translator && !$form->hasTranslator()) {
+            if (null !== $translator && $this->hasTranslator()
+                    && !$form->hasTranslator()) {
                 $form->setTranslator($translator);
             }
             if (isset($data[$key]) && !$form->isArray()) {

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -4237,4 +4237,59 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $t2 = $this->form->getDecorators();
         $this->assertEquals($t1, $t2);
     }
+    
+    /**
+     * @group ZF-11831
+     */
+    public function testElementsOfSubFormReceiveCorrectDefaultTranslator()
+    {
+        // Global default translator
+        $trDefault = new \Zend\Translator\Translator(array(
+            'adapter' => 'arrayAdapter',
+            'content' => array(
+                \Zend\Validator\NotEmpty::IS_EMPTY => 'Default'
+            ),
+            'locale' => 'en'
+        ));
+        \Zend\Registry::set('Zend_Translate', $trDefault);
+        
+        // Translator to use for elements
+        $trElement = new \Zend\Translator\Translator(array(
+            'adapter' => 'arrayAdapter',
+            'content' => array(
+                \Zend\Validator\NotEmpty::IS_EMPTY =>'Element'
+            ),
+            'locale' => 'en'
+        ));
+        \Zend\Validator\AbstractValidator::setDefaultTranslator($trElement);
+        
+        // Change the form's translator
+        $form = new Form();
+        $form->addElement(new \Zend\Form\Element\Text('foo', array(
+            'required'   => true,
+            'validators' => array('NotEmpty')
+        )));
+        
+        // Create a subform with it's own validator
+        $sf1 = new SubForm();
+        $sf1->addElement(new \Zend\Form\Element\Text('foosub', array(
+            'required'   => true,
+            'validators' => array('NotEmpty')
+        )));
+        $form->addSubForm($sf1, 'Test1');
+        
+        $form->isValid(array());
+
+        $messages = $form->getMessages();
+        $this->assertEquals(
+            'Element', 
+            @$messages['foo'][\Zend\Validator\NotEmpty::IS_EMPTY], 
+            'Form element received wrong validator'
+        );
+        $this->assertEquals(
+            'Element', 
+            @$messages['Test1']['foosub'][\Zend\Validator\NotEmpty::IS_EMPTY], 
+            'SubForm element received wrong validator'
+        );        
+    }
 }

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -4243,21 +4243,23 @@ class FormTest extends \PHPUnit_Framework_TestCase
      */
     public function testElementsOfSubFormReceiveCorrectDefaultTranslator()
     {
+        $isEmptyKey = \Zend\Validator\NotEmpty::IS_EMPTY;
+        
         // Global default translator
-        $trDefault = new \Zend\Translator\Translator(array(
+        $trDefault = new Translator(array(
             'adapter' => 'arrayAdapter',
             'content' => array(
-                \Zend\Validator\NotEmpty::IS_EMPTY => 'Default'
+                $isEmptyKey => 'Default'
             ),
             'locale' => 'en'
         ));
-        \Zend\Registry::set('Zend_Translate', $trDefault);
+        Registry::set('Zend_Translate', $trDefault);
         
         // Translator to use for elements
-        $trElement = new \Zend\Translator\Translator(array(
+        $trElement = new Translator(array(
             'adapter' => 'arrayAdapter',
             'content' => array(
-                \Zend\Validator\NotEmpty::IS_EMPTY =>'Element'
+                $isEmptyKey =>'Element'
             ),
             'locale' => 'en'
         ));
@@ -4283,12 +4285,12 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $messages = $form->getMessages();
         $this->assertEquals(
             'Element', 
-            @$messages['foo'][\Zend\Validator\NotEmpty::IS_EMPTY], 
+            @$messages['foo'][$isEmptyKey], 
             'Form element received wrong validator'
         );
         $this->assertEquals(
             'Element', 
-            @$messages['Test1']['foosub'][\Zend\Validator\NotEmpty::IS_EMPTY], 
+            @$messages['Test1']['foosub'][$isEmptyKey], 
             'SubForm element received wrong validator'
         );        
     }


### PR DESCRIPTION
Form's default translator incorrectly passed to subforms, causing override of subform elements' default translators
