### PR TITLE
Feature/jtai module option cachekey

### DIFF
--- a/library/Zend/Module/ManagerOptions.php
+++ b/library/Zend/Module/ManagerOptions.php
@@ -20,6 +20,11 @@ class ManagerOptions
     /**
      * @var string
      */
+    protected $cacheKey = NULL;
+
+    /**
+     * @var string
+     */
     protected $manifestDir = NULL;
 
     /**
@@ -88,6 +93,29 @@ class ManagerOptions
     }
 
     /**
+     * Get key used to create the cache file name
+     *
+     * @return string
+     */
+    public function getCacheKey() {
+        if ($this->cacheKey !== null) {
+            return $this->cacheKey;
+        }
+        return $this->getApplicationEnv();
+    }
+
+    /**
+     * Set key used to create the cache file name
+     *
+     * @param string $cacheKey the value to be set
+     * @return ManagerOptions
+     */
+    public function setCacheKey($cacheKey) {
+        $this->cacheKey = $cacheKey;
+        return $this;
+    }
+
+    /**
      * Get manifestDir.
      *
      * @return string
@@ -123,7 +151,7 @@ class ManagerOptions
      */
     public function getCacheFilePath()
     {
-        return $this->getCacheDir() . '/module-config-cache.'.$this->getApplicationEnv().'.php';
+        return $this->getCacheDir() . '/module-config-cache.'.$this->getCacheKey().'.php';
     }
 
     /**

--- a/library/Zend/Module/ManagerOptions.php
+++ b/library/Zend/Module/ManagerOptions.php
@@ -20,7 +20,7 @@ class ManagerOptions
     /**
      * @var string
      */
-    protected $cacheKey = NULL;
+    protected $configCacheKey = NULL;
 
     /**
      * @var string
@@ -97,9 +97,9 @@ class ManagerOptions
      *
      * @return string
      */
-    public function getCacheKey() {
-        if ($this->cacheKey !== null) {
-            return $this->cacheKey;
+    public function getConfigCacheKey() {
+        if ($this->configCacheKey !== null) {
+            return $this->configCacheKey;
         }
         return $this->getApplicationEnv();
     }
@@ -107,11 +107,11 @@ class ManagerOptions
     /**
      * Set key used to create the cache file name
      *
-     * @param string $cacheKey the value to be set
+     * @param string $configCacheKey the value to be set
      * @return ManagerOptions
      */
-    public function setCacheKey($cacheKey) {
-        $this->cacheKey = $cacheKey;
+    public function setConfigCacheKey($configCacheKey) {
+        $this->configCacheKey = $configCacheKey;
         return $this;
     }
 
@@ -151,7 +151,7 @@ class ManagerOptions
      */
     public function getCacheFilePath()
     {
-        return $this->getCacheDir() . '/module-config-cache.'.$this->getCacheKey().'.php';
+        return $this->getCacheDir() . '/module-config-cache.'.$this->getConfigCacheKey().'.php';
     }
 
     /**

--- a/library/Zend/Module/ManagerOptions.php
+++ b/library/Zend/Module/ManagerOptions.php
@@ -58,7 +58,7 @@ class ManagerOptions
      * Set if the config cache should be enabled or not
      *
      * @param bool $enabled
-     * @return ManagerConfig
+     * @return ManagerOptions
      */
     public function setEnableConfigCache($enabled)
     {
@@ -80,7 +80,7 @@ class ManagerOptions
      * Set the path where cache files can be stored
      *
      * @param string $cacheDir the value to be set
-     * @return ManagerConfig
+     * @return ManagerOptions
      */
     public function setCacheDir($cacheDir)
     {
@@ -129,7 +129,7 @@ class ManagerOptions
      * Set manifestDir.
      *
      * @param string $manifestDir the value to be set
-     * @return ManagerConfig
+     * @return ManagerOptions
      */
     public function setManifestDir($manifestDir)
     {

--- a/tests/Zend/Module/ManagerOptionsTest.php
+++ b/tests/Zend/Module/ManagerOptionsTest.php
@@ -15,12 +15,14 @@ class ManagerOptionsTest extends TestCase
             'cache_dir'           => __DIR__,
             'enable_config_cache' => true,
             'manifest_dir'        => __DIR__,
+            'config_cache_key'    => 'foo',
         ));
         $this->assertSame($options->getCacheDir(), __DIR__);
         $this->assertTrue($options->getEnableConfigCache());
         $this->assertNotNull(strstr($options->getCacheFilePath(), __DIR__));
         $this->assertNotNull(strstr($options->getCacheFilePath(), '.php'));
         $this->assertSame($options->getManifestDir(), __DIR__);
+        $this->assertSame($options->getConfigCacheKey(), 'foo');
     }
 
     public function testCanAccessKeysAsProperties()


### PR DESCRIPTION
- Add option to module manager for giving the config cache a custom key to save with
- Unit test assertion for new config key
- Fix a few return docblock comments 
