### PR TITLE
Allow DI instantiation of Zend\Mail & Zend\Mail\Transport\Smtp

### DIFF
--- a/library/Zend/Mail/Mail.php
+++ b/library/Zend/Mail/Mail.php
@@ -157,11 +157,17 @@ class Mail extends Mime\Message
     /**#@-*/
 
     /**
+     * Mail transport object
+     *
+     * @var \Zend\Mail\AbstractTransport
+     */
+    protected $transport = null;
+
+    /**
      * Flag: whether or not email has attachments
      * @var boolean
      */
     public $hasAttachments = false;
-
 
     /**
      * Sets the default mail transport for all following uses of
@@ -185,6 +191,10 @@ class Mail extends Mime\Message
      */
     public static function getDefaultTransport()
     {
+        if (! self::$_defaultTransport instanceof AbstractTransport) {
+            $transport = new Transport\Sendmail();
+        }
+
         return self::$_defaultTransport;
     }
 
@@ -207,6 +217,35 @@ class Mail extends Mime\Message
         if ($charset != null) {
             $this->_charset = $charset;
         }
+    }
+
+    /**
+     * Set the transport object
+     *
+     * @param  AbstractTransport $transport
+     * @return \Zend\Mail\Mail
+     */
+    public function setTransport(AbstractTransport $transport)
+    {
+        $this->transport = $transport;
+        return $this;
+    }
+
+    /**
+     * Get transport object
+     *
+     * If no transport object is set, will set and return the global default
+     * transport object
+     *
+     * @return \Zend\Mail\AbstractTransport
+     */
+    public function getTransport()
+    {
+        if (! $this->transport) {
+            $this->transport = self::getDefaultTransport();
+        }
+
+        return $this->transport;
     }
 
     /**
@@ -1086,11 +1125,7 @@ class Mail extends Mime\Message
     public function send($transport = null)
     {
         if ($transport === null) {
-            if (! self::$_defaultTransport instanceof AbstractTransport) {
-                $transport = new Transport\Sendmail();
-            } else {
-                $transport = self::$_defaultTransport;
-            }
+            $transport = $this->getTransport();
         }
 
         if ($this->_date === null) {

--- a/library/Zend/Mail/Transport/Smtp.php
+++ b/library/Zend/Mail/Transport/Smtp.php
@@ -115,6 +115,21 @@ class Smtp extends AbstractTransport
      */
     public function __construct($host = '127.0.0.1', Array $config = array())
     {
+        if ($host) {
+            $config['host'] = $host;
+        }
+
+        $this->setConfig($config);
+    }
+
+    /**
+     * Set configuration
+     *
+     * @param  array $config
+     * @return \Zend\Mail\Transport\Smtp
+     */
+    public function setConfig(array $config)
+    {
         if (isset($config['name'])) {
             $this->_name = $config['name'];
         }
@@ -124,11 +139,14 @@ class Smtp extends AbstractTransport
         if (isset($config['auth'])) {
             $this->_auth = $config['auth'];
         }
+        if (isset($config['host'])) {
+            $this->_host = $config['host'];
+        }
 
-        $this->_host = $host;
         $this->_config = $config;
-    }
 
+        return $this;
+    }
 
     /**
      * Class destructor to ensure all open connections are closed

--- a/tests/Zend/Mail/MessageTest.php
+++ b/tests/Zend/Mail/MessageTest.php
@@ -26,6 +26,7 @@ namespace ZendTest\Mail;
 use Zend\Mail\Message;
 use Zend\Mime;
 use Zend\Mail\Storage;
+use Zend\Mail\Exception;
 
 /**
  * @category   Zend
@@ -173,7 +174,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     {
         try {
             $message = new Message(array('handler' => 1));
-        } catch (\Zend\Mime\Exception $e) {
+        } catch (Exception\InvalidArgumentException $e) {
             return; // ok
         }
 
@@ -187,7 +188,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         try {
             $message = new Message(array('handler' => $mail));
-        } catch (\Zend\Mime\Exception $e) {
+        } catch (Exception\InvalidArgumentException $e) {
             return; // ok
         }
 
@@ -268,7 +269,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         try {
             $message->getContent();
-        } catch (\Zend\Mime\Exception $e) {
+        } catch (Exception\RuntimeException $e) {
             return; // ok
         }
 
@@ -284,7 +285,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $subject = null;
         try {
             $subject = $message->subject;
-        } catch (\Zend\Mime\Exception $e) {
+        } catch (Exception\InvalidArgumentException $e) {
             // ok
         }
         if ($subject) {
@@ -298,7 +299,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $part = null;
         try {
             $part = $message->getPart(1);
-        } catch (\Zend\Mime\Exception $e) {
+        } catch (Exception\RuntimeException $e) {
             // ok
         }
         if ($part) {
@@ -329,7 +330,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         try {
             $message->getPart(1);
-        } catch (\Zend\Mime\Exception $e) {
+        } catch (Exception\RuntimeException $e) {
             return; // ok
         }
         $this->fail('no exception raised while getting part from message without boundary');


### PR DESCRIPTION
This is not an attempt to rewrite Zend\Mail, but to make the minimal changes needed in order to allow easy instantiation of Zend\Mail and related transport class Zend\Mail\Transport\Smtp through DI. 

In addition, I've fixed some of the broken Zend\Mail unit tests that expected wrong exception types (trivial fixes). Still not all unit tests pass but situation is better than before. 
