### PR TITLE
Adding missing break to the method/methods case

### DIFF
--- a/library/Zend/Di/Configuration.php
+++ b/library/Zend/Di/Configuration.php
@@ -80,6 +80,7 @@ class Configuration
                                             $classDefinition->addMethodParameter($methodName, $paramName, $paramInfo);
                                         }
                                     }
+                                    break;
                                 default:
                                     $methodName = $classDefKey;
                                     $methodInfo = $classDefData;

--- a/tests/Zend/Di/ConfigurationTest.php
+++ b/tests/Zend/Di/ConfigurationTest.php
@@ -118,6 +118,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($dummyParams->params['param1'], 'hello');
         $this->assertEquals($dummyParams->params['param2'], 'world');
         $this->assertEquals($dummyParams->params['foo'], 'bar');
+        $this->assertArrayNotHasKey('methods', $di->definitions()->hasMethods('ZendTest\Di\TestAsset\StaticFactory'));
     }
     
 }


### PR DESCRIPTION
Without the break, a miscellaneous "methods" entry is added to the definitions. Added an assertion to the ConfigurationTest to check for this.
