### PR TITLE
[Zend\Service\Twitter\Search] A fix for the 'double constructor issue'

### DIFF
--- a/library/Zend/Service/Twitter/Search.php
+++ b/library/Zend/Service/Twitter/Search.php
@@ -118,7 +118,7 @@ class Search extends Rest\Client\RestClient
      *
      * @throws Zend_Http_Client_Exception
      */
-    public function search($query, array $params = array())
+    public function execute($query, array $params = array())
     {
 
         $_query = array();

--- a/working/BC-Breaks.txt
+++ b/working/BC-Breaks.txt
@@ -234,3 +234,5 @@ Zend_Queue:
  * 'adapterNamespace' \Zend\Queue\Queue option and adapter name \Zend\Queue\Queue constructor parameter are case sensitive now
  * 'Array' adapter becomes 'ArrayAdapter'
 
+Zend_Service_Twitter:
+ * In the Search class, the method for searching has been renamed for search() to execute(). Method signature is still the same


### PR DESCRIPTION
A fix for the 'double constructor issue', because the classname is now Search and not Zend_Service_Twitter_Search
