### PR TITLE
[Hotfix] resetParameters() should be return Client for ZF1 API compatiblity

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -710,9 +710,10 @@ class Client implements Dispatchable
         }
         return $response;
     }
+
     /**
      * Reset all the HTTP parameters (auth,cookies,request, response, etc)
-     * 
+     * @return Client
      */
     public function resetParameters()
     {   
@@ -726,6 +727,8 @@ class Client implements Dispatchable
         $this->response   = null;
         
         $this->setUri($uri);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Zend\Rest\Client\RestClient requires this fluent interface at _prepareRest()
