### PR TITLE
Url ViewHelper update after Di beta1

### DIFF
--- a/library/Zend/View/Helper/Navigation/Sitemap.php
+++ b/library/Zend/View/Helper/Navigation/Sitemap.php
@@ -299,8 +299,8 @@ class Sitemap extends AbstractHelper
             $url = (string) $href;
         } else {
             // href is relative to current document; use url helpers
-            $urlHelper = $this->getView()->plugin('url');
-            $curDoc    = $urlHelper();
+            $baseUrlHelper = $this->getView()->plugin('baseurl');
+            $curDoc    = $baseUrlHelper();
             $curDoc    = ('/' == $curDoc) ? '' : trim($curDoc, '/');
             $url       = rtrim($this->getServerUrl(), '/') . '/'
                        . $curDoc

--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -57,20 +57,20 @@ class Url extends AbstractHelper
      * Generates an url given the name of a route.
      *
      * @see Zend\Mvc\Router\Route::assemble()
-     * @param array $urlParams Parameters for the link
+     * @param array $params Parameters for the link
      * @param string $name Name of the route
-     * @param array $urlOptions Options for the route
+     * @param array $options Options for the route
      * @return string Url for the link href attribute
      * @throws Exception\RuntimeException If no router provided
      */
-    public function __invoke(array $urlParams, $name, array $urlOptions = array())
+    public function __invoke(array $params, $name, array $options = array())
     {
         if (null === $this->router) {
             throw new Exception\RuntimeException('no router instance provided');
         }
 
-        $urlOptions['name'] = $name;
+        $options['name'] = $name;
 
-        return $this->router->assemble($urlParams, $urlOptions);
+        return $this->router->assemble($params, $options);
     }
 }

--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -24,12 +24,12 @@
  */
 namespace Zend\View\Helper;
 
-use Zend\Controller\Front as FrontController;
+use Zend\Mvc\Router\RouteStack,
+    Zend\View\Exception;
 
 /**
  * Helper for making easy links and getting urls that depend on the routes and router
  *
- * @uses       \Zend\Controller\Front
  * @uses       \Zend\View\Helper\AbstractHelper
  * @package    Zend_View
  * @subpackage Helper
@@ -38,26 +38,39 @@ use Zend\Controller\Front as FrontController;
  */
 class Url extends AbstractHelper
 {
-    protected $router = null;
+    /**
+     * @var RouteStack
+     */
+    protected $router;
+
+    /**
+     * @param RouteStack $router
+     * @return Url
+     */
+    public function setRouter(RouteStack $router)
+    {
+        $this->router = $router;
+        return $this;
+    }
 
     /**
      * Generates an url given the name of a route.
      *
-     * @access public
-     *
-     * @param  array $urlOptions Options passed to the assemble method of the Route object.
-     * @param  mixed $name The name of a Route to use. If null it will use the current Route
-     * @param  bool $reset Whether or not to reset the route defaults with those provided
-     * @return string Url for the link href attribute.
+     * @see Zend\Mvc\Router\Route::assemble()
+     * @param array $urlParams Parameters for the link
+     * @param string $name Name of the route
+     * @param array $urlOptions Options for the route
+     * @return string Url for the link href attribute
+     * @throws Exception\RuntimeException If no router provided
      */
-    public function __invoke(array $urlOptions = array(), $name = null, $reset = false, $encode = true)
+    public function __invoke(array $urlParams, $name, array $urlOptions = array())
     {
-        //$router = FrontController::getInstance()->getRouter();
-        return $this->router->assemble($urlOptions, $name, $reset, $encode);
-    }
+        if (null === $this->router) {
+            throw new Exception\RuntimeException('no router instance provided');
+        }
 
-    public function setRouter($router)
-    {
-        $this->router = $router;
+        $urlOptions['name'] = $name;
+
+        return $this->router->assemble($urlParams, $urlOptions);
     }
 }

--- a/tests/Zend/View/Helper/Navigation/SitemapTest.php
+++ b/tests/Zend/View/Helper/Navigation/SitemapTest.php
@@ -39,9 +39,6 @@ use Zend\View;
  */
 class SitemapTest extends AbstractTest
 {
-    protected $_front;
-    protected $_oldRequest;
-    protected $_oldRouter;
     protected $_oldServer = array();
 
     /**
@@ -85,14 +82,6 @@ class SitemapTest extends AbstractTest
         $_SERVER['SERVER_PORT'] = 80;
         $_SERVER['REQUEST_URI'] = '/';
 
-        $this->_front = \Zend\Controller\Front::getInstance();
-        $this->_oldRequest = $this->_front->getRequest();
-        $this->_oldRouter = $this->_front->getRouter();
-
-        $this->_front->resetInstance();
-        $this->_front->setRequest(new Request\Http());
-        $this->_front->getRouter()->addDefaultRoutes();
-
         parent::setUp();
 
         $this->_helper->setFormatOutput(true);
@@ -100,13 +89,6 @@ class SitemapTest extends AbstractTest
 
     protected function tearDown()
     {
-        if (null !== $this->_oldRequest) {
-            $this->_front->setRequest($this->_oldRequest);
-        } else {
-            $this->_front->setRequest(new Request\Http());
-        }
-        $this->_front->setRouter($this->_oldRouter);
-
         foreach ($this->_oldServer as $key => $value) {
             $_SERVER[$key] = $value;
         }

--- a/tests/Zend/View/Helper/UrlTest.php
+++ b/tests/Zend/View/Helper/UrlTest.php
@@ -24,6 +24,9 @@
  */
 namespace ZendTest\View\Helper;
 
+use Zend\View\Helper\Url as UrlHelper,
+    Zend\Mvc\Router\SimpleRouteStack as Router;
+
 /**
  * Zend_View_Helper_UrlTest
  *
@@ -39,33 +42,46 @@ namespace ZendTest\View\Helper;
  */
 class UrlTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
-     *
-     * @access protected
      */
     protected function setUp()
     {
-        $this->front = \Zend\Controller\Front::getInstance();
-        $this->front->getRouter()->addDefaultRoutes();
+        $router = new Router();
+        $router->addRoute('home', array(
+            'type' => 'Zend\Mvc\Router\Http\Literal',
+            'options' => array(
+                'route' => '/',
+            )
+        ));
+        $router->addRoute('default', array(
+                'type' => 'Zend\Mvc\Router\Http\Segment',
+                'options' => array(
+                    'route' => '/:controller[/:action]',
+                )
+        ));
 
-        // $this->view = new Zend_View();
-        $this->helper = new \Zend\View\Helper\Url();
-        // $this->helper->setView($this->view);
+        $this->url = new UrlHelper;
+        $this->url->setRouter($router);
     }
 
-    public function testDefaultEmpty()
+    public function testHelperHasHardDependencyWithRouter()
     {
-        $url = $this->helper->__invoke();
+        $this->setExpectedException('Zend\View\Exception\RuntimeException', 'no router');
+        $url = new UrlHelper;
+        $url(array(), 'home');
+    }
+
+    public function testHomeRoute()
+    {
+        $url = $this->url->__invoke(array(), 'home');
         $this->assertEquals('/', $url);
     }
 
-    public function testDefault()
+    public function testModuleRoute()
     {
-        $url = $this->helper->__invoke(array('controller' => 'ctrl', 'action' => 'act'));
+        $url = $this->url->__invoke(array('controller' => 'ctrl', 'action' => 'act'), 'default');
         $this->assertEquals('/ctrl/act', $url);
     }
-
 }


### PR DESCRIPTION
## Url

I choose the signature of ZF1 for parameters order. I know that Url ControllerPlugin has another order. I think we need an harmony between ViewHelper and ControllerPlugin with the same role.
## Update Sitemap ViewHelper

Sitemap ViewHelper has a dependency to Url ViewHelper in url() method. It calls with defaults parameters. In ZF1, a route keep values between match() and assemble() methods in the same instance.

This behavior is broken in ZF2 (at this time). We don't have a default route or a current route in Mvc\Router: we must define route to call Url ViewHelper. Why Sitemap ViewHelper need the "current document"? I try to replace this behavior with BaseUrl ViewHelper. Wait & see...
