### PR TITLE
[Hotfix]Http Client (add strlen to get length of binary & update testContentTypeAdditionalInfo)

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1080,7 +1080,7 @@ class Client implements Dispatchable
                 $fstat = fstat($body);
                 $headers['Content-Length'] = $fstat['size'];
             } else {
-                $headers['Content-Length'] = strlen($body);
+                $headers['Content-Length'] = static::strlen($body);
             }    
         }
         
@@ -1106,19 +1106,8 @@ class Client implements Dispatchable
             return '';
         }
         
-        // If mbstring overloads substr and strlen functions, we have to
-        // override it's internal encoding
-        if (function_exists('mb_internal_encoding') &&
-           ((int) ini_get('mbstring.func_overload')) & 2) {
-            $mbIntEnc = mb_internal_encoding();
-            mb_internal_encoding('ASCII');
-        }
-        
         $rawBody = $this->getRequest()->getContent();
         if (!empty($rawBody)) {
-            if (isset($mbIntEnc)) {
-                mb_internal_encoding($mbIntEnc);
-            }
             return $rawBody;
         }
 
@@ -1158,11 +1147,6 @@ class Client implements Dispatchable
             } else {
                 throw new Exception\RuntimeException("Cannot handle content type '{$this->encType}' automatically");
             }
-
-        }
-
-        if (isset($mbIntEnc)) {
-            mb_internal_encoding($mbIntEnc);
         }
 
         return $body;
@@ -1238,6 +1222,7 @@ class Client implements Dispatchable
 
         return $ret;
     }
+
     /**
      * Convert an array of parameters into a flat array of (key, value) pairs
      *
@@ -1282,5 +1267,21 @@ class Client implements Dispatchable
         }
 
         return $parameters;
+    }
+    
+    /**
+     * Returns length of binary string in bytes
+     *
+     * @param string $str
+     * @return int the string length
+     */
+    static public function strlen($str)
+    {
+        if (function_exists('mb_internal_encoding') &&
+            (((int)ini_get('mbstring.func_overload')) & 2)) {
+            return mb_strlen($str, 'ASCII');
+        } else {
+            return strlen($str);
+        }
     }
 }

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1279,7 +1279,7 @@ class Client implements Dispatchable
     {
         if (function_exists('mb_internal_encoding') &&
             (((int)ini_get('mbstring.func_overload')) & 2)) {
-            return mb_strlen($str, 'ASCII');
+            return mb_strlen($str, '8bit');
         } else {
             return strlen($str);
         }

--- a/tests/Zend/Http/Client/CommonHttpTests.php
+++ b/tests/Zend/Http/Client/CommonHttpTests.php
@@ -923,18 +923,20 @@ abstract class CommonHttpTests extends \PHPUnit_Framework_TestCase
      */
     public function testContentTypeAdditionlInfo($params)
     {
+        $content_type = 'application/x-www-form-urlencoded; charset=UTF-8';
+
         $this->client->setUri($this->baseuri . 'testPostData.php');
         $this->client->setHeaders(array(
-            'Content-Type' => 'application/x-www-form-urlencoded; charset=UTF-8' 
+            'Content-Type' => $content_type
         ));
         $this->client->setMethod(\Zend\Http\Request::METHOD_POST);
 
         $this->client->setParameterPost($params);
         
         $this->client->send();
-
-        $res = $this->client->send();
-        $this->assertEquals(serialize($params), $res->getBody(), "POST data integrity test failed");
+        $request = Request::fromString($this->client->getLastRawRequest());
+        $this->assertEquals($content_type, 
+                            $request->headers()->get('Content-Type')->getFieldValue());
     }
 
     /**


### PR DESCRIPTION
(1) To get length of binary, add strlen(, 'ASCII') method , & replacing ZF1's mb_internal_encoding hack

Method name "strlen" is Zend\OpenId\OpenId.
but, I didn't sync it OpenId's. 
(Checking mb_internal_encoding was used at ZF1's HttpClient.
 & using 'ASCII' is make more clear  instead of 'latin1') 

To check func_overload simply.

<pre>
$ php -d mbstring.func_overload=2 
      -d mbstring.internal_encoding=UTF-8 
      -r "var_dump((int)ini_get('mbstring.func_overload') & 2);var_dump(strlen('マルチバイト文字列'));"
</pre>


(2)  Update 'testContentTypeAdditionalInfo()' to make it clear.
(This test was added at https://github.com/zendframework/zf2/pull/533 )
