### PR TITLE
[hotfix/ZF-11739] DOCUMENTATION

### DIFF
--- a/documentation/manual/de/module_specs/Zend_Markup-Renderers.xml
+++ b/documentation/manual/de/module_specs/Zend_Markup-Renderers.xml
@@ -100,7 +100,7 @@ $bbcode = Zend_Markup::factory('Bbcode');
 // Markup
 $bbcode->addMarkup(
     'upper',
-    Zend_Markup_Renderer_RendererAbstract::TYPE_REPLACE,
+    Zend_Markup_Renderer_RendererAbstract::TYPE_CALLBACK,
     array(
         'callback' => new My_Markup_Renderer_Html_Upper(),
         'group'    => 'inline'

--- a/documentation/manual/en/module_specs/Zend_Markup-Renderers.xml
+++ b/documentation/manual/en/module_specs/Zend_Markup-Renderers.xml
@@ -100,7 +100,7 @@ $bbcode = Zend_Markup::factory('Bbcode');
 // markup, like the markup's group, and (in this case) a start and end markup.
 $bbcode->addMarkup(
     'upper',
-    Zend_Markup_Renderer_RendererAbstract::TYPE_REPLACE,
+    Zend_Markup_Renderer_RendererAbstract::TYPE_CALLBACK,
     array(
         'callback' => new My_Markup_Renderer_Html_Upper(),
         'group'    => 'inline'

--- a/documentation/manual/fr/module_specs/Zend_Markup-Renderers.xml
+++ b/documentation/manual/fr/module_specs/Zend_Markup-Renderers.xml
@@ -100,7 +100,7 @@ $bbcode = Zend_Markup::factory('Bbcode');
 // du markup comme son groupe et (dans ce cas) les markups de début et de fin
 $bbcode->addMarkup(
     'upper',
-    Zend_Markup_Renderer_RendererAbstract::TYPE_REPLACE,
+    Zend_Markup_Renderer_RendererAbstract::TYPE_CALLBACK,
     array(
         'callback' => new My_Markup_Renderer_Html_Upper(),
         'group'    => 'inline'

--- a/documentation/manual/ja/module_specs/Zend_Markup-Renderers.xml
+++ b/documentation/manual/ja/module_specs/Zend_Markup-Renderers.xml
@@ -100,7 +100,7 @@ $bbcode = Zend_Markup::factory('Bbcode');
 // tag, like the tag's group, and (in this case) a start and end tag.
 $bbcode->addTag(
     'upper',
-    Zend_Markup_Renderer_RendererAbstract::TYPE_REPLACE,
+    Zend_Markup_Renderer_RendererAbstract::TYPE_CALLBACK,
     array(
         'callback' => new My_Markup_Renderer_Html_Upper(),
         'group'    => 'inline'


### PR DESCRIPTION
Fixed typo in "Renderers" manual page for Zend_Markup
