### PR TITLE
[Hotfix]Captcha compatiblity for Validator

### DIFF
--- a/library/Zend/Captcha/AbstractAdapter.php
+++ b/library/Zend/Captcha/AbstractAdapter.php
@@ -135,7 +135,7 @@ abstract class AbstractAdapter extends \Zend\Validator\AbstractValidator impleme
      * @param  array $options
      * @return Zend_Form_Element
      */
-    public function setOptions($options = null)
+    public function setOptions(array $options = null)
     {
         foreach ($options as $key => $value) {
             $this->setOption($key, $value);

--- a/library/Zend/Captcha/Word.php
+++ b/library/Zend/Captcha/Word.php
@@ -388,20 +388,20 @@ abstract class Word extends AbstractAdapter
         }
 
         if (!isset($value['input'])) {
-            $this->_error(self::MISSING_VALUE);
+            $this->error(self::MISSING_VALUE);
             return false;
         }
         $input = strtolower($value['input']);
-        $this->_setValue($input);
+        $this->setValue($input);
 
         if (!isset($value['id'])) {
-            $this->_error(self::MISSING_ID);
+            $this->error(self::MISSING_ID);
             return false;
         }
 
         $this->_id = $value['id'];
         if ($input !== $this->getWord()) {
-            $this->_error(self::BAD_CAPTCHA);
+            $this->error(self::BAD_CAPTCHA);
             return false;
         }
 


### PR DESCRIPTION
(1) fix setOptions() for compatiblity in Captcha\AbstractAdapter
(2) remove '_' prefix in Captcha\Word 
    only to pass unit test.... (require updating Captcha's according to ZF2's CS )
