### PR TITLE
quickfix: app fails to run on non-standard port

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -68,9 +68,14 @@ class Request extends HttpRequest
         }
 
         if ($this->headers()->get('host')) {
-            $uri->setHost($this->headers()->get('host')->getFieldValue());
+            list($name, $port) = explode(':', $this->headers()->get('host')->getFieldValue().':');
+            $uri->setHost($name);
+            if ($port) $uri->setPort($port);
         } elseif (isset($this->serverParams['SERVER_NAME'])) {
             $uri->setHost($this->serverParams['SERVER_NAME']);
+            if (isset($this->serverParams['SERVER_PORT'])) {
+                $uri->setPort($this->serverParams['SERVER_PORT']);
+            }
         }
 
         $this->setUri($uri);

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -68,9 +68,14 @@ class Request extends HttpRequest
         }
 
         if ($this->headers()->get('host')) {
-            list($name, $port) = explode(':', $this->headers()->get('host')->getFieldValue().':');
-            $uri->setHost($name);
-            if ($port) $uri->setPort($port);
+            //TODO handle IPv6 with port
+            if (preg_match('|^([^:]+):([^:]+)$|', $this->headers()->get('host')->getFieldValue(), $match)) {
+                $uri->setHost($match[1]);
+                $uri->setPort($match[2]);
+            }
+            else {
+                $uri->setHost($this->headers()->get('host')->getFieldValue());
+            }
         } elseif (isset($this->serverParams['SERVER_NAME'])) {
             $uri->setHost($this->serverParams['SERVER_NAME']);
             if (isset($this->serverParams['SERVER_PORT'])) {


### PR DESCRIPTION
Hello,

With the standard configuration running \Zend\Mvc\Application will fail on port!=80.

trace:
\Zend\Mvc\Application->getRequest() instantiates \Zend\Http\PhpEnvironment\Request
\Zend\Http\PhpEnvironment\Request->__construct() calls \Zend\Http\PhpEnvironment\Request->setServer()

On line 71 if the hostname is present, it will contain string "mydomain.local:1234".
This will trigger exception in \Zend\Uri\Http->setHost() as the string with name+colon+port fails hostname validation.

I am not quite sure what this string will look like if the url is say http://[1fff:0:a88:85a3::ac1f]:8001/index.html
But at least there wont be a regression, this fix deals with only one colon.

If the hostname can not be obtained from headers, things work fine, only the port is not recorded.
