### PR TITLE
[hotfix/ZF-11402] Zend\Form\Element

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -1373,7 +1373,14 @@ class Element implements Validator
             if ($isArray && is_array($value)) {
                 $messages = array();
                 $errors   = array();
-                foreach ($value as $val) {
+                if (empty($value)) {
+                    if ($this->isRequired()
+                        || (!$this->isRequired() && !$this->getAllowEmpty())
+                    ) {
+                        $value = '';
+                    }
+                }
+                foreach ((array)$value as $val) {
                     if (!$validator->isValid($val, $context)) {
                         $result = false;
                         if ($this->_hasErrorMessages()) {
@@ -1381,7 +1388,7 @@ class Element implements Validator
                             $errors   = $messages;
                         } else {
                             $messages = array_merge($messages, $validator->getMessages());
-                            $errors   = array_merge($errors,   $validator->getErrors());
+                            $errors   = $messages;
                         }
                     }
                 }

--- a/tests/Zend/Form/Element/MultiCheckboxTest.php
+++ b/tests/Zend/Form/Element/MultiCheckboxTest.php
@@ -250,4 +250,43 @@ class MultiCheckboxTest extends \PHPUnit_Framework_TestCase
         $this->element->isValid(array('foo', 'bogus'));
         $html = $this->element->render($this->getView());
     }
+ 
+    /**
+     * @group ZF-11402
+    */
+    public function testValidateShouldNotAcceptEmptyArray()
+    {
+        $this->element->addMultiOptions(array(
+            'foo' => 'Foo',
+            'bar' => 'Bar',
+            'baz' => 'Baz',
+        ));
+        $this->element->setRegisterInArrayValidator(true);
+
+        $this->assertTrue($this->element->isValid(array('foo')));
+        $this->assertTrue($this->element->isValid(array('foo','baz')));
+
+        $this->element->setAllowEmpty(true);
+        $this->assertTrue($this->element->isValid(array()));
+ 
+        // Empty value + AllowEmpty=true = no error messages
+        $messages = $this->element->getMessages();
+        $this->assertEquals(0, count($messages), 'Received unexpected error message(s)');
+
+        $this->element->setAllowEmpty(false);
+        $this->assertFalse($this->element->isValid(array()));
+
+        // Empty value + AllowEmpty=false = notInArray error message
+        $messages = $this->element->getMessages();
+        $this->assertTrue(is_array($messages), 'Expected error message');
+        $this->assertArrayHasKey('notInArray', $messages, 'Expected \'notInArray\' error message');
+
+        $this->element->setRequired(true)->setAllowEmpty(false);
+        $this->assertFalse($this->element->isValid(array()));
+
+        // Empty value + Required=true + AllowEmpty=false = isEmpty error message
+        $messages = $this->element->getMessages();
+        $this->assertTrue(is_array($messages), 'Expected error message');
+        $this->assertArrayHasKey('isEmpty', $messages, 'Expected \'isEmpty\' error message');
+    }
 }


### PR DESCRIPTION
Zend\Form\Element\MultiCheckbox does not accept empty array even when AllowEmpty flag is set

svn sync r24197 r24552  (trunk)
