### PR TITLE
Feature/url parsing optimization

### DIFF
--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -47,11 +47,6 @@ class Http extends Uri
     );
 
     /**
-     * @see Uri::$validHostTypes
-     */
-    protected $validHostTypes = self::HOST_DNSORIPV4;
-
-    /**
      * User name as provided in authority of URI
      * @var null|string
      */
@@ -62,20 +57,6 @@ class Http extends Uri
      * @var null|string
      */
     protected $password;
-
-    /**
-     * Check if the URI is a valid HTTP URI
-     *
-     * This applys additional HTTP specific validation rules beyond the ones
-     * required by the generic URI syntax
-     *
-     * @return boolean
-     * @see    Uri::isValid()
-     */
-    public function isValid()
-    {
-        return parent::isValid();
-    }
 
     /**
      * Get the username part (before the ':') of the userInfo URI part
@@ -129,21 +110,6 @@ class Http extends Uri
     {
         $this->password = $password;
         return $this;
-    }
-
-    /**
-     * Validate the host part of an HTTP URI
-     *
-     * This overrides the common URI validation method with a DNS or IPv4 only
-     * default. Users may still enforce allowing other host types.
-     *
-     * @param  string  $host
-     * @param  integer $allowed
-     * @return boolean
-     */
-    public static function validateHost($host, $allowed = self::HOST_DNSORIPV4)
-    {
-        return parent::validateHost($host, $allowed);
     }
 
     /**

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -213,7 +213,7 @@ class Uri
      * @param  string $uri
      * @return Uri
      */
-    public function parse($uri)
+    protected function parse($uri)
     {
         // Capture scheme
         if (($scheme = self::parseScheme($uri)) !== null) {
@@ -733,6 +733,44 @@ class Uri
     public function setFragment($fragment)
     {
         $this->fragment = $fragment;
+        return $this;
+    }
+
+    /**
+     * Sets this Uri to match Uri string representation
+     *
+     * @param  string $uri
+     * @return Uri
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setFromString($uri)
+    {
+        if (!is_string($uri)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Expecting a string, received "%s"',
+                (is_object($uri) ? get_class($uri) : gettype($uri))
+            ));
+        }
+
+        $this->clear();
+        $this->parse($uri);
+        return $this;
+    }
+
+    /**
+     * Clear all the parts of this Uri
+     *
+     * @return Uri
+     */
+    public function clear()
+    {
+        $this->setScheme(null);
+        $this->setUserInfo(null);
+        $this->setHost(null);
+        $this->setPort(null);
+        $this->setPath(null);
+        $this->setQuery(null);
+        $this->setFragment(null);
         return $this;
     }
 

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -208,17 +208,16 @@ class Uri
      */
     protected function parseAuthority($authority)
     {
-        // Split authority into userInfo and host
-        if (strpos($authority, '@') !== false) {
-            // The userInfo can also contain '@' symbols; split $authority
-            // into segments, and set it to the last segment.
-            $segments  = explode('@', $authority);
-            $authority = array_pop($segments);
-            $userInfo  = implode('@', $segments);
-            unset($segments);
+        // capture userInfo
+        // The userInfo can also contain '@' symbols; use rightmost
+        $atPos = strrpos($authority, '@');
+        if ($atPos !== false) {
+            $userInfo = substr($authority, 0, $atPos);
             $this->setUserInfo($userInfo);
+            $authority = substr($authority, $atPos + 1);
         }
 
+        // capture port
         $colonPos = strrpos($authority, ':');
         if ($colonPos !== false) {
             $port = substr($authority, $colonPos + 1);
@@ -228,6 +227,7 @@ class Uri
             $authority = substr($authority, 0, $colonPos);
         }
 
+        // only the host remains.
         $this->setHost($authority);
     }
 

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -144,15 +144,9 @@ class Uri
     {
         if (is_string($uri)) {
             $this->parse($uri);
-        } elseif ($uri instanceof Uri) {
+        } elseif ($uri instanceof self) {
             // Copy constructor
-            $this->setScheme($uri->getScheme());
-            $this->setUserInfo($uri->getUserInfo());
-            $this->setHost($uri->getHost());
-            $this->setPort($uri->getPort());
-            $this->setPath($uri->getPath());
-            $this->setQuery($uri->getQuery());
-            $this->setFragment($uri->getFragment());
+            $this->setFromUri($uri);
         } elseif ($uri !== null) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Expecting a string or a URI object, received "%s"',
@@ -733,6 +727,24 @@ class Uri
     public function setFragment($fragment)
     {
         $this->fragment = $fragment;
+        return $this;
+    }
+
+    /**
+     * Sets this Uri to match the Uri passed
+     *
+     * @param  \Zend\Uri\Uri $uri
+     * @return Uri
+     */
+    public function setFromUri(Uri $uri)
+    {
+        $this->setScheme($uri->getScheme());
+        $this->setUserInfo($uri->getUserInfo());
+        $this->setHost($uri->getHost());
+        $this->setPort($uri->getPort());
+        $this->setPath($uri->getPath());
+        $this->setQuery($uri->getQuery());
+        $this->setFragment($uri->getFragment());
         return $this;
     }
 

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -1008,36 +1008,6 @@ class Uri
     }
 
     /**
-     * Extract only the scheme part out of a URI string.
-     *
-     * This is used by the parse() method, but is useful as a standalone public
-     * method if one wants to test a URI string for it's scheme before doing
-     * anything with it.
-     *
-     * Will return the scmeme if found, or NULL if no scheme found (URI may
-     * still be valid, but not full)
-     *
-     * @param  string $uriString
-     * @return string|null
-     * @throws InvalidArgumentException
-     */
-    public static function parseScheme($uriString)
-    {
-        if (! is_string($uriString)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'Expecting a string, got %s',
-                (is_object($uriString) ? get_class($uriString) : gettype($uriString))
-            ));
-        }
-
-        if (preg_match('/^([A-Za-z][A-Za-z0-9\.\+\-]*):/', $uriString, $match)) {
-            return $match[1];
-        }
-
-        return null;
-    }
-
-    /**
      * Remove any extra dot segments (/../, /./) from a path
      *
      * Algorithm is adapted from RFC-3986 section 5.2.4

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -249,13 +249,15 @@ class Uri
             return;
         }
 
+        // See RFC-3986, Appendix B for a guide to the resulting subexpressions
+
         if (!empty($match[2])) {
             $this->setScheme($match[2]);
         }
 
         if (!empty($match[3])) {
-            // expression 3 determines the authority exists
-            // expression 4 is the actual authority value
+            // subexpression 3 determines the authority exists
+            // subexpression 4 is the actual authority value
             $this->parseAuthority($match[4]);
         }
         

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -202,6 +202,36 @@ class Uri
     }
 
     /**
+     * Parse a authority string into the fragments of this uri
+     *
+     * @param  string $authority
+     */
+    protected function parseAuthority($authority)
+    {
+        // Split authority into userInfo and host
+        if (strpos($authority, '@') !== false) {
+            // The userInfo can also contain '@' symbols; split $authority
+            // into segments, and set it to the last segment.
+            $segments  = explode('@', $authority);
+            $authority = array_pop($segments);
+            $userInfo  = implode('@', $segments);
+            unset($segments);
+            $this->setUserInfo($userInfo);
+        }
+
+        $colonPos = strrpos($authority, ':');
+        if ($colonPos !== false) {
+            $port = substr($authority, $colonPos + 1);
+            if ($port) {
+                $this->setPort((int) $port);
+            }
+            $authority = substr($authority, 0, $colonPos);
+        }
+
+        $this->setHost($authority);
+    }
+
+    /**
      * Parse a URI string
      *
      * @param  string $uri
@@ -217,30 +247,8 @@ class Uri
 
         // Capture authority part
         if (preg_match('|^//([^/\?#]*)|', $uri, $match)) {
-            $authority = $match[1];
-            $uri       = substr($uri, strlen($match[0]));
-
-            // Split authority into userInfo and host
-            if (strpos($authority, '@') !== false) {
-                // The userInfo can also contain '@' symbols; split $authority
-                // into segments, and set it to the last segment.
-                $segments  = explode('@', $authority);
-                $authority = array_pop($segments);
-                $userInfo  = implode('@', $segments);
-                unset($segments);
-                $this->setUserInfo($userInfo);
-            }
-
-            $colonPos = strrpos($authority, ':');
-            if ($colonPos !== false) {
-                $port = substr($authority, $colonPos + 1);
-                if ($port) {
-                    $this->setPort((int) $port);
-                }
-                $authority = substr($authority, 0, $colonPos);
-            }
-
-            $this->setHost($authority);
+            $uri = substr($uri, strlen($match[0]));
+            $this->parseAuthority($match[1]);
         }
 
         if (!$uri) {

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -301,17 +301,17 @@ class Uri
         }
 
         if ($this->path) {
-            $uri .= self::encodePath($this->path);
+            $uri .= $this->path;
         } elseif ($this->host && ($this->query || $this->fragment)) {
             $uri .= '/';
         }
 
         if ($this->query) {
-            $uri .= "?" . self::encodeQueryFragment($this->query);
+            $uri .= "?" . $this->query;
         }
 
         if ($this->fragment) {
-            $uri .= "#" . self::encodeQueryFragment($this->fragment);
+            $uri .= "#" . $this->fragment;
         }
 
         return $uri;
@@ -691,6 +691,9 @@ class Uri
      */
     public function setPath($path)
     {
+        if ($path !== null) {
+            $path = static::encodePath($path);
+        }
         $this->path = $path;
         return $this;
     }
@@ -712,7 +715,9 @@ class Uri
             // more standard %20.
             $query = str_replace('+', '%20', http_build_query($query));
         }
-
+        if ($query !== null) {
+            $query = static::encodeQueryFragment($query);
+        }
         $this->query = $query;
         return $this;
     }
@@ -725,6 +730,9 @@ class Uri
      */
     public function setFragment($fragment)
     {
+        if ($fragment !== null) {
+            $fragment = static::encodeQueryFragment($fragment);
+        }
         $this->fragment = $fragment;
         return $this;
     }

--- a/tests/Zend/Uri/UriTest.php
+++ b/tests/Zend/Uri/UriTest.php
@@ -379,6 +379,22 @@ class UriTest extends \PHPUnit_Framework_TestCase
      * @param        string $uriString
      * @dataProvider validUriStringProvider
      */
+    public function testSetFromUri($uriString)
+    {
+        // start with all parts set
+        $uri = new Uri('https://joe:secret@example.com:8443/foo/bar?query#foo');
+
+        $uri->setFromUri(new Uri($uriString));
+        
+        $this->assertEquals($uriString, $uri->toString());
+    }
+
+    /**
+     * Test that setting the uri from a string returns the same URI
+     *
+     * @param        string $uriString
+     * @dataProvider validUriStringProvider
+     */
     public function testSetFromString($uriString)
     {
         // start with all parts set

--- a/tests/Zend/Uri/UriTest.php
+++ b/tests/Zend/Uri/UriTest.php
@@ -834,6 +834,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
             array('a:b'),
             array('http://www.zend.com'),
             array('https://example.com:10082/foo/bar?query'),
+            array('https://example.com/foo%20bar'),
             array('../relative/path'),
             array('?queryOnly'),
             array('#fragmentOnly'),

--- a/tests/Zend/Uri/UriTest.php
+++ b/tests/Zend/Uri/UriTest.php
@@ -75,35 +75,6 @@ class UriTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test the parseScheme static method to extract the scheme part
-     *
-     * @param string $uriString
-     * @param array  $parts
-     * @dataProvider uriWithPartsProvider
-     */
-    public function testParseScheme($uriString, $parts)
-    {
-        $scheme = Uri::parseScheme($uriString);
-        if (! isset($parts['scheme'])) {
-            $parts['scheme'] = null;
-        }
-
-        $this->assertEquals($parts['scheme'], $scheme);
-    }
-
-    /**
-     * Test that parseScheme throws an exception in case of invalid input
-
-     * @param  mixed $input
-     * @dataProvider notStringInputProvider
-     */
-    public function testParseSchemeInvalidInput($input)
-    {
-        $this->setExpectedException('Zend\Uri\Exception\InvalidArgumentException');
-        $scheme = Uri::parseScheme($input);
-    }
-
-    /**
      * Test that __toString() (magic) returns an empty string if URI is invalid
      *
      * @dataProvider invalidUriObjectProvider

--- a/tests/Zend/Uri/UriTest.php
+++ b/tests/Zend/Uri/UriTest.php
@@ -374,6 +374,39 @@ class UriTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test that setting the uri from a string returns the same URI
+     *
+     * @param        string $uriString
+     * @dataProvider validUriStringProvider
+     */
+    public function testSetFromString($uriString)
+    {
+        // start with all parts set
+        $uri = new Uri('https://joe:secret@example.com:8443/foo/bar?query#foo');
+
+        $uri->setFromString($uriString);
+        
+        $this->assertEquals($uriString, $uri->toString());
+    }
+
+    /**
+     * Test that clear clears all parts of the Uri
+     */
+    public function testClear()
+    {
+        $uri = new Uri('https://joe:secret@example.com:8443/foo/bar?query#foo');
+        $uri->clear();
+
+        $this->assertNull($uri->getScheme());
+        $this->assertNull($uri->getUserInfo());
+        $this->assertNull($uri->getHost());
+        $this->assertNull($uri->getPort());
+        $this->assertNull($uri->getPath());
+        $this->assertNull($uri->getQuery());
+        $this->assertNull($uri->getFragment());
+    }
+
+    /**
      * Validation and encoding tests
      */
 
@@ -1095,6 +1128,8 @@ class UriTest extends \PHPUnit_Framework_TestCase
             array('setPath',      array('/baz/baz')),
             array('setQuery',     array('foo=bar')),
             array('setFragment',  array('part2')),
+            array('setFromString',array('')),
+            array('clear',        array()),
             array('makeRelative', array('http://foo.bar/')),
             array('resolve',      array('http://foo.bar/')),
             array('normalize',    array())


### PR DESCRIPTION
These changes center around the \Zend\Uri\Uri parse method.

Replaced parse method in public interface with setFromString method.  parse would not clear previous url parts before setting new ones, setFromString does.  Other Uri part setting methods use the set\* naming convention, the name change is to highlight that parts are being set.

Added setFromUri and clear utility methods, used by the constructor and setFromString, respectively.

Consolidated regular expressions and string processing in parse method to more clearly correspond to regexp parsing description in RFC and improve performance.

Remove no-longer used public parseScheme method.  (No other Uri parts get their own public parse method)
