### PR TITLE
Minor improvement: Cleaned up code that was introduced as bugfix to ZF-7289

### DIFF
--- a/library/Zend/Authentication/Adapter/DbTable.php
+++ b/library/Zend/Authentication/Adapter/DbTable.php
@@ -371,18 +371,14 @@ class DbTable implements AuthenticationAdapter
             return $authResult;
         }
 
-        if (true === $this->getAmbiguityIdentity()) {
-            $validIdentities = array ();
-            $zendAuthCredentialMatchColumn = $this->_zendDb->foldCase('zend_auth_credential_match');
-            foreach ($resultIdentities as $identity) {
-                if (1 === (int) $identity[$zendAuthCredentialMatchColumn]) {
-                    $validIdentities[] = $identity;
-                }
+        // At this point, ambiguity is allready done. Loop, check and break on success.
+        foreach ($resultIdentities as $identity) {
+            $authResult = $this->_authenticateValidateResult($identity);
+            if ($authResult->isValid()) {
+                break;
             }
-            $resultIdentities = $validIdentities;
         }
-        
-        $authResult = $this->_authenticateValidateResult(array_shift($resultIdentities));
+
         return $authResult;
     }
 

--- a/tests/Zend/Authentication/Adapter/DbTableTest.php
+++ b/tests/Zend/Authentication/Adapter/DbTableTest.php
@@ -426,8 +426,8 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
         $result2 = $this->_adapter->authenticate();
         $this->assertFalse(in_array('More than one record matches the supplied identity.',
             $result->getMessages()));
-        $this->assertTrue($result->isValid());
-        $this->assertEquals('my_username', $result->getIdentity());
+        $this->assertTrue($result2->isValid());
+        $this->assertEquals('my_username', $result2->getIdentity());
     }
 
 


### PR DESCRIPTION
The code is quite unreadable. This version replaces the double check of
ambiguity. The check and early return is already done by $this->_authenticateValidateResultSet($resultIdentities).

At the point of the check, loop over all identities (most time 1, due default of $_ambiguityIdentity = false) and
check if identity is valid. No need to check other identities.
If no valid identity was found, the latest result (failure) is returned.

Additionally:
- Fixed minor bug in test case. Check of $result2 was not done right. Copy/paste error.
