### PR TITLE
During View object cloning its Variables object remains the same

### DIFF
--- a/library/Zend/View/Helper/Partial.php
+++ b/library/Zend/View/Helper/Partial.php
@@ -24,7 +24,8 @@
  */
 namespace Zend\View\Helper;
 
-use Zend\View\Exception;
+use Zend\View\Exception,
+    Zend\View\Variables;
 
 /**
  * Helper for rendering a template fragment in its own variable scope.
@@ -116,7 +117,7 @@ class Partial extends AbstractHelper
     public function cloneView()
     {
         $view = clone $this->view;
-        $view->vars()->clear();
+        $view->setVars(new Variables());
         return $view;
     }
 


### PR DESCRIPTION
During View object cloning its Variables object remains the same and $this->vars()->clear() deletes all the vars of initial View object

In phtml file

``` php
<?php isset($this->test); ?> // true
<?php echo $this->partial('course.phtml'); ?>
<?php isset($this->test); ?> // false
```
