### PR TITLE
Added character \ into Zend\Session\Container name and relevant tests

### DIFF
--- a/library/Zend/Session/Container.php
+++ b/library/Zend/Session/Container.php
@@ -71,7 +71,7 @@ class Container extends ArrayObject
      */
     public function __construct($name = 'Default', $manager = null)
     {
-        if (!preg_match('/^[a-z][a-z0-9_]+$/i', $name)) {
+        if (!preg_match('/^[a-z][a-z0-9_\\\]+$/i', $name)) {
             throw new Exception\InvalidArgumentException('Name passed to container is invalid; must consist of alphanumerics and underscores only');
         }
         $this->_name = $name;

--- a/library/Zend/Session/Container.php
+++ b/library/Zend/Session/Container.php
@@ -72,7 +72,7 @@ class Container extends ArrayObject
     public function __construct($name = 'Default', $manager = null)
     {
         if (!preg_match('/^[a-z][a-z0-9_\\\]+$/i', $name)) {
-            throw new Exception\InvalidArgumentException('Name passed to container is invalid; must consist of alphanumerics and underscores only');
+            throw new Exception\InvalidArgumentException('Name passed to container is invalid; must consist of alphanumerics, backslashes and underscores only');
         }
         $this->_name = $name;
         $this->_setManager($manager);

--- a/tests/Zend/Session/ContainerTest.php
+++ b/tests/Zend/Session/ContainerTest.php
@@ -93,6 +93,18 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $container->getName());
     }
 
+    public function testUsingOldZF1NameIsStillValid()
+    {
+        $container = new Container('Zend_Foo', $this->manager);
+        $this->assertEquals('Zend_Foo', $container->getName());
+    }
+    
+    public function testUsingNewZF2NamespaceIsValid()
+    {
+        $container = new Container('Zend\Foo', $this->manager);
+        $this->assertEquals('Zend\Foo', $container->getName());
+    }
+    
     public function testPassingInvalidNameToConstructorRaisesException()
     {
         $tries = array(
@@ -101,6 +113,8 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
             '_foo',
             '__foo',
             '0foo',
+            '\foo',
+            '\\foo'
         );
         foreach ($tries as $try) {
             try {


### PR DESCRIPTION
Zend\Session\Container only accepted names that start with an alpha, and contain only alpha, numeric, or underscore. In order that ZF2 namespaces are accepted, it needs to have backslash added as a valid name character. The regex in Zend\Session\Container.php has been updated to reflect this (plus suitable tests).
