### PR TITLE
Removed unnecessary status code check in Http\Response::fromString

### DIFF
--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -167,11 +167,6 @@ class Response extends Message implements ResponseDescription
         }
         
         $response->version = $matches['version'];
-
-        if (!defined(get_called_class() . '::STATUS_CODE_' . $matches['status'])) {
-            throw new Exception\InvalidArgumentException('Unknown status code found in provided string');
-        }
-
         $response->setStatusCode($matches['status']);
         $response->setReasonPhrase($matches['reason']);
 


### PR DESCRIPTION
Same thing is done in setStatusCode method (which is used to set status code), and thrown exception IMHO means same thing, so it's duplicate. 
