### PR TITLE
Patch to TreeRouteStack

### DIFF
--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -136,7 +136,7 @@ class TreeRouteStack extends SimpleRouteStack
             return null;
         }
 
-        if ($this->baseUrl !== null && method_exists($request, 'getBaseUrl')) {
+        if ($this->baseUrl === null && method_exists($request, 'getBaseUrl')) {
             $this->setBaseUrl($request->getBaseUrl);
         }
         


### PR DESCRIPTION
Cannot resolve baseUrl correctly using TreeRouteStack in a project without a virtualhost, this is a patch.

if baseurl is null but the request has a method to obtain it, do getBaseUrl and inside detectBaseUrl
