### PR TITLE
Zend\Pdf\Page - remove one useless "use" statement

### DIFF
--- a/library/Zend/Pdf/Page.php
+++ b/library/Zend/Pdf/Page.php
@@ -35,7 +35,6 @@ namespace Zend\Pdf;
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-use Zend\Pdf\Resource\Font;
 
 use Zend\Pdf\Exception;
 


### PR DESCRIPTION
Statement "use Zend\Pdf\Resource\Font" is useless, class Zend\Pdf\Resource\Font dosn't exist and this use statement is redundant.

By the way in library that uses Zend_Pdf, error that occurs because of this use statement has been raported. Personally I can't reproduce this error, link to this issue: https://github.com/psliwa/PHPPdf/issues/2#issuecomment-2721549
