### PR TITLE
ZF2-99 : confirm case-sensitive headers key - passed by Client

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -181,7 +181,7 @@ class Client implements Dispatchable
 
         /** Config Key Normalization */
         foreach ($config as $k => $v) {
-            $this->config[str_replace(array('-', '_', ' ', '.'), '', strtolower($k))] = $v; // replace w/ normalized
+            $this->config[strtolower($k)] = $v; 
         }
 
         // Pass configuration options to the adapter if it exists

--- a/library/Zend/Http/Client/Adapter/Proxy.php
+++ b/library/Zend/Http/Client/Adapter/Proxy.php
@@ -87,7 +87,7 @@ class Proxy extends Socket
         
         /* Url might require stream context even if proxy connection doesn't */
         if ($secure) {
-        	$this->config['sslusecontext'] = true;
+            $this->config['sslusecontext'] = true;
         }
 
         // Connect (a non-secure connection) to the proxy server
@@ -126,8 +126,8 @@ class Proxy extends Socket
         }
 
         // Add Proxy-Authorization header
-        if ($this->config['proxy_user'] && ! isset($headers['proxy-authorization'])) {
-            $headers['proxy-authorization'] = Client::encodeAuthHeader(
+        if ($this->config['proxy_user'] && ! isset($headers['Proxy-Authorization'])) {
+            $headers['Proxy-Authorization'] = Client::encodeAuthHeader(
                 $this->config['proxy_user'], $this->config['proxy_pass'], $this->config['proxy_auth']
             );
         }
@@ -199,9 +199,9 @@ class Proxy extends Socket
 
         // If the proxy-authorization header is set, send it to proxy but remove
         // it from headers sent to target host
-        if (isset($headers['proxy-authorization'])) {
-            $request .= "Proxy-authorization: " . $headers['proxy-authorization'] . "\r\n";
-            unset($headers['proxy-authorization']);
+        if (isset($headers['Proxy-Authorization'])) {
+            $request .= "Proxy-authorization: " . $headers['Proxy-Authorization'] . "\r\n";
+            unset($headers['Proxy-Authorization']);
         }
 
         $request .= "\r\n";

--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -331,16 +331,16 @@ class Socket implements HttpAdapter, Stream
             $this->method == \Zend\Http\Request::METHOD_HEAD) {
 
             // Close the connection if requested to do so by the server
-            if (isset($headers['connection']) && $headers['connection'] == 'close') {
+            if (isset($headers['Connection']) && $headers['Connection'] == 'close') {
                 $this->close();
             }
             return $response;
         }
 
         // If we got a 'transfer-encoding: chunked' header
-        if (isset($headers['transfer-encoding'])) {
+        if (isset($headers['Transfer-Encoding'])) {
             
-            if (strtolower($headers['transfer-encoding']) == 'chunked') {
+            if (strtolower($headers['Transfer-Encoding']) == 'chunked') {
 
                 do {
                     $line  = @fgets($this->socket);
@@ -391,7 +391,7 @@ class Socket implements HttpAdapter, Stream
             } else {
                 $this->close();
                 throw new AdapterException\RuntimeException('Cannot handle "' .
-                    $headers['transfer-encoding'] . '" transfer encoding');
+                    $headers['Transfer-Encoding'] . '" transfer encoding');
             }
             
             // We automatically decode chunked-messages when writing to a stream
@@ -400,14 +400,14 @@ class Socket implements HttpAdapter, Stream
                 $response = str_ireplace("Transfer-Encoding: chunked\r\n", '', $response);
             }
         // Else, if we got the content-length header, read this number of bytes
-        } elseif (isset($headers['content-length'])) {
+        } elseif (isset($headers['Content-Length'])) {
 
             // If we got more than one Content-Length header (see ZF-9404) use
             // the last value sent
-            if (is_array($headers['content-length'])) {
-                $contentLength = $headers['content-length'][count($headers['content-length']) - 1]; 
+            if (is_array($headers['Content-Length'])) {
+                $contentLength = $headers['Content-Length'][count($headers['Content-Length']) - 1]; 
             } else {
-                $contentLength = $headers['content-length'];
+                $contentLength = $headers['Content-Length'];
             }
             
             $current_pos = ftell($this->socket);
@@ -461,7 +461,7 @@ class Socket implements HttpAdapter, Stream
         }
 
         // Close the connection if requested to do so by the server
-        if (isset($headers['connection']) && $headers['connection'] == 'close') {
+        if (isset($headers['Connection']) && $headers['Connection'] == 'close') {
             $this->close();
         }
 

--- a/tests/Zend/Http/Client/ProxyAdapterTest.php
+++ b/tests/Zend/Http/Client/ProxyAdapterTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Http\Client;
-use Zend\Http\Client;
+use Zend\Http\Client,
+    Zend\Http\Request;
 
 /**
  * Zend_Http_Client_Adapter_Proxy test suite.
@@ -50,8 +51,6 @@ class ProxyAdapterTest extends SocketTest
      */
     protected function setUp()
     {
-        $this->markTestIncomplete('Proxy adapter incomplete at the moment');
-
         if (defined('TESTS_ZEND_HTTP_CLIENT_HTTP_PROXY') &&
               TESTS_ZEND_HTTP_CLIENT_HTTP_PROXY) {
 
@@ -77,7 +76,6 @@ class ProxyAdapterTest extends SocketTest
             if (defined('TESTS_ZEND_HTTP_CLIENT_HTTP_PROXY_PASS') &&
                 TESTS_ZEND_HTTP_CLIENT_HTTP_PROXY_PASS)
                     $pass = TESTS_ZEND_HTTP_CLIENT_HTTP_PROXY_PASS;
-
 
             $this->config = array(
                 'adapter'    => '\Zend\Http\Client\Adapter\Proxy',
@@ -105,8 +103,9 @@ class ProxyAdapterTest extends SocketTest
         ));
 
         $this->client->setUri($this->baseuri . 'testGetLastRequest.php');
-        $res = $this->client->request(Client::TRACE);
-        if ($res->getStatus() == 405 || $res->getStatus() == 501) {
+        $this->client->getRequest()->setMethod(Request::METHOD_TRACE);
+        $res = $this->client->send();
+        if ($res->getStatusCode() == 405 || $res->getStatusCode() == 501) {
             $this->markTestSkipped("Server does not allow the TRACE method");
         }
 


### PR DESCRIPTION
fix case-sensitive issue, 
( Because currently HEAD not pass unittests, there is no additional tests. :-\  )
http://framework.zend.com/issues/browse/ZF2-99

.....&, Client setConfig()'s setConfig() 's str_replace(array('-', '_', ' ', '.'), '' is redundant.(ZF2-100)
Because, this str_replace(array('-', '_', ' ', '.') blocks proxy' config setting. 
(so forever cannot use proxy! cannnot unittest!) 
I think --- str_replace(array('-', '_', ' ', '.') --- is overkill.
http://framework.zend.com/issues/browse/ZF2-100

After this patch is applied, tests\Zend\Http 's code-coverage is here.
http://digging.phper.jp/zf2-http-coverage/
