### PR TITLE
Added missing method call brackets to Zend\Mvc\Router\Http\TreeRouteStack

### DIFF
--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -137,7 +137,7 @@ class TreeRouteStack extends SimpleRouteStack
         }
 
         if ($this->baseUrl !== null && method_exists($request, 'getBaseUrl')) {
-            $this->setBaseUrl($request->getBaseUrl);
+            $this->setBaseUrl($request->getBaseUrl());
         }
         
         $uri           = $request->uri();


### PR DESCRIPTION
When setting up a base URL in ZendSkeletonApplication, I add this method to my `Application\Module` class and register it to be called on bootstrap:

```
public function registerBaseUrl($e)
{
    $app     = $e->getParam('application');
    $router  = $app->getRouter();
    $router->setBaseUrl($e->getParam('config')->base_url);
} 
```

When I run the app, I get the following notice:

`Notice: Undefined property: Zend\Http\PhpEnvironment\Request::$getBaseUrl in Zend/Mvc/Router/Http/TreeRouteStack.php on line 140`

This is because the call to `getBaseUrl` in TreeRouteStack is missing the ()
