### PR TITLE
Fixed calling `getBaseUrl()` instead of `getBaseUrl`

### DIFF
--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -137,7 +137,7 @@ class TreeRouteStack extends SimpleRouteStack
         }
 
         if ($this->baseUrl === null && method_exists($request, 'getBaseUrl')) {
-            $this->setBaseUrl($request->getBaseUrl);
+            $this->setBaseUrl($request->getBaseUrl());
         }
         
         $uri           = $request->uri();


### PR DESCRIPTION
This fixes a Notice
