### PR TITLE
Pass the exception for ERROR_CONTROLLER_INVALID and ERROR_CONTROLLER_NOT_FOUND through for view listener to use

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -267,7 +267,8 @@ class Application implements AppContext
         } catch (ClassNotFoundException $exception) {
             $error = clone $e;
             $error->setError(static::ERROR_CONTROLLER_NOT_FOUND)
-                  ->setController($controllerName);
+                  ->setController($controllerName)
+                  ->setParam('exception', $exception);
 
             $results = $events->trigger('dispatch.error', $error);
             if (count($results)) {
@@ -282,7 +283,8 @@ class Application implements AppContext
             $error = clone $e;
             $error->setError(static::ERROR_CONTROLLER_INVALID)
                   ->setController($controllerName)
-                  ->setControllerClass(get_class($controller));
+                  ->setControllerClass(get_class($controller))
+                  ->setParam('exception', $exception);
             $results = $events->trigger('dispatch.error', $error);
             if (count($results)) {
                 $return  = $results->last();


### PR DESCRIPTION
Allows for more descriptive 404 pages with exception data in development.
