### PR TITLE
Fix module config listener bug

### DIFF
--- a/library/Zend/Module/Listener/ConfigListener.php
+++ b/library/Zend/Module/Listener/ConfigListener.php
@@ -171,7 +171,7 @@ class ConfigListener extends AbstractListener implements ConfigMerger
                 . 'instance of Zend\Config\Config. %s given.', gettype($config))
             );
         }
-        $this->mergedConfig = array_replace_recursive($this->mergedConfig, $config);
+        $this->setMergedConfig(array_replace_recursive($this->mergedConfig, $config));
     }
     
     protected function hasCachedConfig()

--- a/tests/Zend/Module/Listener/ConfigListenerTest.php
+++ b/tests/Zend/Module/Listener/ConfigListenerTest.php
@@ -108,8 +108,19 @@ class ConfigListenerTest extends TestCase
     {
         $moduleManager = new Manager(array('SomeModule'));
         $moduleManager->loadModules();
+        $moduleManager->getMergedConfig(); // 'cache' the config object
         $moduleManager->getConfigListener()->mergeGlobDirectory(dirname(__DIR__) . '/_files/*.{ini,json,php,xml,yaml}');
+        $configObject = $moduleManager->getMergedConfig()->all;
+        $this->assertSame('yes', $configObject->ini);
+        $this->assertSame('yes', $configObject->php);
+        $this->assertSame('yes', $configObject->json);
+        $this->assertSame('yes', $configObject->xml);
+        $this->assertTrue($configObject->yaml);
         $config = $moduleManager->getMergedConfig(false);
-        $this->assertTrue($config['php']);
+        $this->assertSame('yes', $config['all']['ini']);
+        $this->assertSame('yes', $config['all']['json']);
+        $this->assertSame('yes', $config['all']['php']);
+        $this->assertSame('yes', $config['all']['xml']);
+        $this->assertTrue($config['all']['yaml']); // stupid yaml
     }
 }

--- a/tests/Zend/Module/_files/config.ini
+++ b/tests/Zend/Module/_files/config.ini
@@ -1,2 +1,2 @@
 [all]
-ini = true
+ini = "yes"

--- a/tests/Zend/Module/_files/config.json
+++ b/tests/Zend/Module/_files/config.json
@@ -1,1 +1,1 @@
-{"all":{"json":true}}
+{"all":{"json":"yes"}}

--- a/tests/Zend/Module/_files/config.php
+++ b/tests/Zend/Module/_files/config.php
@@ -1,4 +1,6 @@
 <?php
 return array(
-    'php' => true
+    'all' => array(
+        'php' => 'yes'
+    ),
 );

--- a/tests/Zend/Module/_files/config.xml
+++ b/tests/Zend/Module/_files/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config>
     <all>
-        <xml>true</xml>
+        <xml>yes</xml>
     </all>
 </config>

--- a/tests/Zend/Module/_files/config.yaml
+++ b/tests/Zend/Module/_files/config.yaml
@@ -1,2 +1,2 @@
 all: 
-  yaml: 1
+  yaml: true


### PR DESCRIPTION
Merged module config object would not be updated after merging a glob() path.
- Added unit test assertions to illustrate bug (which now passes)
- Updated unit tests with a couple of other missing assertions as well
