### PR TITLE
Allow for adding glob paths for config merging BEFORE loading modules

### DIFF
--- a/library/Zend/Module/Manager.php
+++ b/library/Zend/Module/Manager.php
@@ -82,6 +82,9 @@ class Manager implements ModuleHandler
         foreach ($this->getModules() as $moduleName) {
             $this->loadModule($moduleName);
         }
+        if ($configListener = $this->getConfigListener()) {
+            $configListener->mergeConfigGlobPaths();
+        }
         $this->events()->trigger('init.post', $this);
         $this->modulesAreLoaded = true;
         return $this;
@@ -162,10 +165,14 @@ class Manager implements ModuleHandler
     /**
      * Get the listener that's in charge of merging module configs.
      *
+     * @param bool $autoInstantiate 
      * @return ConfigMerger
      */
-    public function getConfigListener()
+    public function getConfigListener($autoInstantiate = true)
     {
+        if (true === $autoInstantiate) {
+            $this->events();
+        }
         return $this->configListener;
     }
  
@@ -255,7 +262,7 @@ class Manager implements ModuleHandler
             return $this;
         }
         $options = $this->getDefaultListenerOptions();
-        if (null === $this->getConfigListener()) {
+        if (null === $this->getConfigListener(false)) {
             $this->setConfigListener(new ConfigListener($options));
         }
         $this->events()->attach('loadModule', new InitTrigger($options), 1000);


### PR DESCRIPTION
This allows for the init.post event to still accurately represent the fully
merged config.

Unit tests updated.

**THIS PR REMOVES THE ConfigListener->mergeGlobDirectory() METHOD!**

Instead, you will now do:

```
$moduleManager->getConfigListener()->addConfigGlobPath('/path/to/configs/*.ini');
```

or...

```
$moduleManager->getConfigListener()->addConfigGlobPaths(array(
    '/path/to/configs/*.ini',
    '/another/path/to/more/configs/*.config.{yaml,php}',
));
```

Also, make sure you add the config glob paths _before_ calling `$moduleManager->loadModules();`.
