### PR TITLE
added getObjectsAndPrefixesByBucket() to Amazon S3 PHP connection class

### DIFF
--- a/library/Zend/Service/Amazon/S3/S3.php
+++ b/library/Zend/Service/Amazon/S3/S3.php
@@ -299,52 +299,52 @@ class S3 extends \Zend\Service\Amazon\AbstractAmazon
         return $objects;
     }
     
-	/**
-	 * List the objects and common prefixes in a bucket.
-	 *
-	 * Provides the list of object keys and common prefixes that are contained in the bucket.  Valid params include the following.
-	 * prefix - Limits the response to keys which begin with the indicated prefix. You can use prefixes to separate a bucket into different sets of keys in a way similar to how a file system uses folders.
-	 * marker - Indicates where in the bucket to begin listing. The list will only include keys that occur lexicographically after marker. This is convenient for pagination: To get the next page of results use the last key of the current page as the marker.
-	 * max-keys - The maximum number of keys you'd like to see in the response body. The server might return fewer than this many keys, but will not return more.
-	 * delimiter - Causes keys that contain the same string between the prefix and the first occurrence of the delimiter to be rolled up into a single result element in the CommonPrefixes collection. These rolled-up keys are not returned elsewhere in the response.
-	 *
-	 * @param  string $bucket
-	 * @param array $params S3 GET Bucket Paramater
-	 * @return array|false
-	 */
-	public function getObjectsAndPrefixesByBucket($bucket, $params = array())
-	{
-		$response = $this->_makeRequest('GET', $bucket, $params);
+    /**
+     * List the objects and common prefixes in a bucket.
+     *
+     * Provides the list of object keys and common prefixes that are contained in the bucket.  Valid params include the following.
+     * prefix - Limits the response to keys which begin with the indicated prefix. You can use prefixes to separate a bucket into different sets of keys in a way similar to how a file system uses folders.
+     * marker - Indicates where in the bucket to begin listing. The list will only include keys that occur lexicographically after marker. This is convenient for pagination: To get the next page of results use the last key of the current page as the marker.
+     * max-keys - The maximum number of keys you'd like to see in the response body. The server might return fewer than this many keys, but will not return more.
+     * delimiter - Causes keys that contain the same string between the prefix and the first occurrence of the delimiter to be rolled up into a single result element in the CommonPrefixes collection. These rolled-up keys are not returned elsewhere in the response.
+     *
+     * @param  string $bucket
+     * @param array $params S3 GET Bucket Paramater
+     * @return array|false
+     */
+    public function getObjectsAndPrefixesByBucket($bucket, $params = array())
+    {
+        $response = $this->_makeRequest('GET', $bucket, $params);
 
-		if ($response->getStatus() != 200) {
-			return false;
-		}
+        if ($response->getStatus() != 200) {
+            return false;
+        }
 
-		$xml = new \SimpleXMLElement($response->getBody());
+        $xml = new \SimpleXMLElement($response->getBody());
 
-		$objects = array();
-		if (isset($xml->Contents)) {
-			foreach ($xml->Contents as $contents) {
-				foreach ($contents->Key as $object) {
-					$objects[] = (string)$object;
-				}
-			}
-		}
-		$prefixes = array();
-		if (isset($xml->CommonPrefixes)) {
-			foreach ($xml->CommonPrefixes as $prefix) {
-				foreach ($prefix->Prefix as $object) {
-					$prefixes[] = (string)$object;
-				}
-			}
-		}
+        $objects = array();
+        if (isset($xml->Contents)) {
+            foreach ($xml->Contents as $contents) {
+                foreach ($contents->Key as $object) {
+                    $objects[] = (string)$object;
+                }
+            }
+        }
+        $prefixes = array();
+        if (isset($xml->CommonPrefixes)) {
+            foreach ($xml->CommonPrefixes as $prefix) {
+                foreach ($prefix->Prefix as $object) {
+                    $prefixes[] = (string)$object;
+                }
+            }
+        }
 
-		return array(
-			'objects'  => $objects,
-			'prefixes' => $prefixes
-		);
-	}
-
+        return array(
+            'objects'  => $objects,
+            'prefixes' => $prefixes
+        );
+    }
+    
     /**
      * Make sure the object name is valid
      *

--- a/library/Zend/Service/Amazon/S3/S3.php
+++ b/library/Zend/Service/Amazon/S3/S3.php
@@ -298,6 +298,52 @@ class S3 extends \Zend\Service\Amazon\AbstractAmazon
 
         return $objects;
     }
+    
+    /**
+	 * List the objects and common prefixes in a bucket.
+	 *
+	 * Provides the list of object keys and common prefixes that are contained in the bucket.  Valid params include the following.
+	 * prefix - Limits the response to keys which begin with the indicated prefix. You can use prefixes to separate a bucket into different sets of keys in a way similar to how a file system uses folders.
+	 * marker - Indicates where in the bucket to begin listing. The list will only include keys that occur lexicographically after marker. This is convenient for pagination: To get the next page of results use the last key of the current page as the marker.
+	 * max-keys - The maximum number of keys you'd like to see in the response body. The server might return fewer than this many keys, but will not return more.
+	 * delimiter - Causes keys that contain the same string between the prefix and the first occurrence of the delimiter to be rolled up into a single result element in the CommonPrefixes collection. These rolled-up keys are not returned elsewhere in the response.
+	 *
+	 * @param  string $bucket
+	 * @param array $params S3 GET Bucket Paramater
+	 * @return array|false
+	 */
+	public function getObjectsAndPrefixesByBucket($bucket, $params = array())
+	{
+		$response = $this->_makeRequest('GET', $bucket, $params);
+
+		if ($response->getStatus() != 200) {
+			return false;
+		}
+
+		$xml = new \SimpleXMLElement($response->getBody());
+
+		$objects = array();
+		if (isset($xml->Contents)) {
+			foreach ($xml->Contents as $contents) {
+				foreach ($contents->Key as $object) {
+					$objects[] = (string)$object;
+				}
+			}
+		}
+		$prefixes = array();
+		if (isset($xml->CommonPrefixes)) {
+			foreach ($xml->CommonPrefixes as $prefix) {
+				foreach ($prefix->Prefix as $object) {
+					$prefixes[] = (string)$object;
+				}
+			}
+		}
+
+		return array(
+			'objects'  => $objects,
+			'prefixes' => $prefixes
+		);
+	}
 
     /**
      * Make sure the object name is valid

--- a/library/Zend/Service/Amazon/S3/S3.php
+++ b/library/Zend/Service/Amazon/S3/S3.php
@@ -299,7 +299,7 @@ class S3 extends \Zend\Service\Amazon\AbstractAmazon
         return $objects;
     }
     
-    /**
+	/**
 	 * List the objects and common prefixes in a bucket.
 	 *
 	 * Provides the list of object keys and common prefixes that are contained in the bucket.  Valid params include the following.

--- a/tests/Zend/Service/Amazon/S3/OnlineTest.php
+++ b/tests/Zend/Service/Amazon/S3/OnlineTest.php
@@ -540,6 +540,20 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
         $this->_amazon->removeObject("testgetobjectparams1/zftest2", "testdata");
         $this->_amazon->removeBucket("testgetobjectparams1");
     }
+    
+    public function testCommonPrefixes()
+    {
+        $this->_amazon->createBucket($this->_bucket);
+        $this->_amazon->putObject($this->_bucket.'/test-folder/test1','test');
+        $this->_amazon->putObject($this->_bucket.'/test-folder/test2-folder/','');
+        $params= array(
+                    'prefix' => 'test-folder/',
+                    'delimiter' => '/'
+                 );
+        $response= $this->_amazon->getObjectsAndPrefixesByBucket($this->_bucket,$params);
+        $this->assertEquals($response['objects'][0],'test-folder/test1');
+        $this->assertEquals($response['prefixes'][0],'test-folder/test2-folder/');
+    }
 
     public function tearDown()
     {


### PR DESCRIPTION
This is committed into the ZF1 trunk (Rev 24095, see ZF-11401), but hasn't made it's across to ZF2 (it hasn't been merged into 'release1.11' branch in SVN either). Without this additional method, the S3 class is flawed for any use-case where emulation of a standard (non-flat) dirs/files-style filesystem is required.

http://framework.zend.com/issues/browse/ZF-11401
