### PR TITLE
processArray() now allows Traversables

### DIFF
--- a/library/Zend/Stdlib/Options.php
+++ b/library/Zend/Stdlib/Options.php
@@ -34,31 +34,31 @@ use Traversable;
 abstract class Options implements ParameterObject
 {
     /**
-     * @param array|Traversable|null $config
+     * @param  array|Traversable|null $config
      * @return Options
      * @throws Exception\InvalidArgumentException
      */
     public function __construct($config = null)
     {
-        if (!is_null($config)) {
-            if (is_array($config) || $config instanceof Traversable) {
-                $this->processArray($config);
-            } else {
-                throw new Exception\InvalidArgumentException(
-                    'Parameter to \Zend\Stdlib\Options\'s '
-                    . 'constructor must be an array or implement the '
-                    . 'Traversable interface'
-                );
-            }
+        if (is_null($config)) {
+            return;
         }
+        $this->processArray($config);
     }
 
     /**
-     * @param array $config
+     * @param  array|Traversable $config
      * @return void
      */
-    protected function processArray(array $config)
+    protected function processArray($config)
     {
+        if (!is_array($config) && !$config instanceof Traversable) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Parameter provided to %s must be an array or Traversable',
+                __METHOD__
+            ));
+        }
+
         foreach ($config as $key => $value) {
             $setter = $this->assembleSetterNameFromConfigKey($key);
             $this->{$setter}($value);

--- a/tests/Zend/Stdlib/OptionsTest.php
+++ b/tests/Zend/Stdlib/OptionsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ZendTest\Stdlib;
+
+use ZendTest\Stdlib\TestAsset\TestOptions,
+    ZendTest\Stdlib\TestAsset\TestTraversable,
+    Zend\Stdlib\Exception\InvalidArgumentException;
+
+class OptionsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructionWithArray()
+    {
+        $options = new TestOptions(array('test_field' => 1));
+        
+        $this->assertEquals(1, $options->test_field);
+    }
+    
+    public function testConstructionWithTraversable()
+    {
+        $config = new \ArrayObject(array('test_field' => 1));
+        $options = new TestOptions($config);
+        
+        $this->assertEquals(1, $options->test_field);
+    }
+    
+    public function testConstructionWithNull()
+    {
+        try {
+            $options = new TestOptions(null);
+        } catch(InvalidArgumentException $e) {
+            $this->fail("Unexpected InvalidArgumentException raised");
+        }
+    }
+    
+    public function testUnsetting()
+    {
+        $options = new TestOptions(array('test_field' => 1));
+        
+        $this->assertEquals(true, isset($options->test_field));
+        unset($options->testField);
+        $this->assertEquals(false, isset($options->test_field));
+        
+    }
+}

--- a/tests/Zend/Stdlib/OptionsTest.php
+++ b/tests/Zend/Stdlib/OptionsTest.php
@@ -2,7 +2,8 @@
 
 namespace ZendTest\Stdlib;
 
-use ZendTest\Stdlib\TestAsset\TestOptions,
+use ArrayObject,
+    ZendTest\Stdlib\TestAsset\TestOptions,
     ZendTest\Stdlib\TestAsset\TestTraversable,
     Zend\Stdlib\Exception\InvalidArgumentException;
 
@@ -17,7 +18,7 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
     
     public function testConstructionWithTraversable()
     {
-        $config = new \ArrayObject(array('test_field' => 1));
+        $config = new ArrayObject(array('test_field' => 1));
         $options = new TestOptions($config);
         
         $this->assertEquals(1, $options->test_field);

--- a/tests/Zend/Stdlib/TestAsset/TestOptions.php
+++ b/tests/Zend/Stdlib/TestAsset/TestOptions.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ZendTest\Stdlib\TestAsset;
+
+use Zend\Stdlib\Options;
+
+/**
+ * Dummy TestOptions used to test Stdlib\Options
+ */
+class TestOptions extends Options
+{
+    protected $testField;
+    
+    public function setTestField($value) 
+    {
+        $this->testField = $value;
+    }
+    
+    public function getTestField()
+    {
+        return $this->testField;
+    }
+}


### PR DESCRIPTION
- __construct() previously tested for array|Traversable, and, if
  matched, passed the argument on to processArray(). However,
  processArray() had a typehint of array for its argument, leading to a
  catchable fatal error. Modified to do the check in processArray(),
  removing the typehint.
