### PR TITLE
Broken messages in validator

### DIFF
--- a/library/Zend/Validator/Date.php
+++ b/library/Zend/Validator/Date.php
@@ -106,6 +106,8 @@ class Date extends AbstractValidator
         if (array_key_exists('locale', $options)) {
             $this->setLocale($options['locale']);
         }
+        
+        parent::__construct();
     }
 
     /**

--- a/library/Zend/Validator/Db/AbstractDb.php
+++ b/library/Zend/Validator/Db/AbstractDb.php
@@ -107,6 +107,8 @@ abstract class AbstractDb extends AbstractValidator
      */
     public function __construct($options = null)
     {
+        parent::__construct();
+    
         if ($options instanceof DBSelect) {
             $this->setSelect($options);
             return;

--- a/library/Zend/Validator/GreaterThan.php
+++ b/library/Zend/Validator/GreaterThan.php
@@ -103,6 +103,8 @@ class GreaterThan extends AbstractValidator
 
         $this->setMin($options['min'])
              ->setInclusive($options['inclusive']);
+             
+        parent::__construct();
     }
 
     /**

--- a/library/Zend/Validator/Iban.php
+++ b/library/Zend/Validator/Iban.php
@@ -137,6 +137,8 @@ class Iban extends AbstractValidator
         if ($locale !== null) {
             $this->setLocale($locale);
         }
+        
+        parent::__construct();
     }
 
     /**

--- a/library/Zend/Validator/Identical.php
+++ b/library/Zend/Validator/Identical.php
@@ -84,6 +84,8 @@ class Identical extends AbstractValidator
         } elseif (null !== $token) {
             $this->setToken($token);
         }
+        
+        parent::__construct();
     }
 
     /**

--- a/library/Zend/Validator/InArray.php
+++ b/library/Zend/Validator/InArray.php
@@ -103,6 +103,8 @@ class InArray extends AbstractValidator
         if (array_key_exists('recursive', $options)) {
             $this->setRecursive($options['recursive']);
         }
+        
+        parent::__construct();
     }
 
     /**

--- a/library/Zend/Validator/Int.php
+++ b/library/Zend/Validator/Int.php
@@ -77,6 +77,8 @@ class Int extends AbstractValidator
         if ($locale !== null) {
             $this->setLocale($locale);
         }
+        
+        parent::__construct();
     }
 
     /**

--- a/library/Zend/Validator/Ip.php
+++ b/library/Zend/Validator/Ip.php
@@ -76,6 +76,8 @@ class Ip extends AbstractValidator
 
         $options += $this->_options;
         $this->setOptions($options);
+        
+        parent::__construct();
     }
 
     /**

--- a/library/Zend/Validator/LessThan.php
+++ b/library/Zend/Validator/LessThan.php
@@ -105,6 +105,8 @@ class LessThan extends AbstractValidator
 
         $this->setMax($options['max'])
              ->setInclusive($options['inclusive']);
+             
+        parent::__construct();
     }
 
     /**

--- a/library/Zend/Validator/Regex.php
+++ b/library/Zend/Validator/Regex.php
@@ -82,6 +82,8 @@ class Regex extends AbstractValidator
         }
 
         $this->setPattern($pattern);
+        
+        parent::__construct();
     }
 
     /**

--- a/tests/Zend/Validator/AlnumTest.php
+++ b/tests/Zend/Validator/AlnumTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /**
  * Test helper
@@ -164,5 +165,41 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
     public function testIntegerValidation()
     {
         $this->assertTrue($this->_validator->isValid(1));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/AlphaTest.php
+++ b/tests/Zend/Validator/AlphaTest.php
@@ -24,6 +24,8 @@
  */
 namespace ZendTest\Validator;
 
+use ReflectionClass;
+
 /**
  * Test helper
  */
@@ -130,5 +132,41 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
     public function testNonStringValidation()
     {
         $this->assertFalse($this->_validator->isValid(array(1 => 1)));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/BarcodeTest.php
+++ b/tests/Zend/Validator/BarcodeTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator\Barcode;
+use Zend\Validator\Barcode,
+    ReflectionClass;
 
 /**
  * \Zend\Validator\Barcode
@@ -468,5 +469,41 @@ class BarcodeTest extends \PHPUnit_Framework_TestCase
     {
         $barcode = new Barcode('ean13');
         $this->assertFalse($barcode->isValid('3RH1131-1BB40'));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = new Barcode('code25');
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = new Barcode('code25');
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/BetweenTest.php
+++ b/tests/Zend/Validator/BetweenTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /**
  * Test helper
@@ -117,5 +118,41 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new Validator\Between(array('min' => 1, 'max' => 10));
         $this->assertEquals(true, $validator->getInclusive());
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = new Validator\Between(array('min' => 1, 'max' => 10));
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = new Validator\Between(array('min' => 1, 'max' => 10));
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/CallbackTest.php
+++ b/tests/Zend/Validator/CallbackTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /**
  * @category   Zend
@@ -88,6 +89,42 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $valid = new Validator\Callback(array('callback' => array($this, 'optionsCallback'), 'callbackOptions' => 'options'));
         $this->assertEquals(array('options'), $valid->getCallbackOptions());
         $this->assertTrue($valid->isValid('test', 'something'));
+    }
+
+    public function testEqualsMessageTemplates()
+    {
+        $validator = new Validator\Callback(array($this, 'objectCallback'));
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = new Validator\Callback(array($this, 'objectCallback'));
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 
     public function objectCallback($value)

--- a/tests/Zend/Validator/CreditCardTest.php
+++ b/tests/Zend/Validator/CreditCardTest.php
@@ -23,8 +23,9 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
-use Zend\Config;
+use Zend\Validator,
+    Zend\Config,
+    ReflectionClass;
 
 /**
  * Test helper
@@ -256,6 +257,42 @@ class CreditCardTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($validator->isValid('4111111111111111'));
         $message = $validator->getMessages();
         $this->assertContains('not from an allowed institute', current($message));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = new Validator\CreditCard();
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = new Validator\CreditCard();
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 
     public static function staticCallback($value)

--- a/tests/Zend/Validator/DateTest.php
+++ b/tests/Zend/Validator/DateTest.php
@@ -23,8 +23,9 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
-use Zend\Date;
+use Zend\Validator,
+    Zend\Date,
+    ReflectionClass;
 
 /**
  * Test helper
@@ -263,5 +264,41 @@ class DateTest extends \PHPUnit_Framework_TestCase
     public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
     {
         $this->_errorOccurred = true;
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/Db/NoRecordExistsTest.php
+++ b/tests/Zend/Validator/Db/NoRecordExistsTest.php
@@ -26,7 +26,8 @@ namespace ZendTest\Validator\Db;
 
 use Zend\Db\Table\AbstractTable,
     Zend\Validator\Db\RecordExists as RecordExistsValidator,
-    Zend\Validator\Db\NoRecordExists as NoRecordExistsValidator;
+    Zend\Validator\Db\NoRecordExists as NoRecordExistsValidator,
+    ReflectionClass;
 
 
 /**
@@ -222,5 +223,41 @@ class NoRecordExistsTest extends \PHPUnit_Framework_TestCase
         $validator->isValid('foo');
         $wherePart = $validator->getSelect()->getPart('where');
         $this->assertEquals('("field1" = :value)', $wherePart[0]);
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = new NoRecordExistsValidator('users', 'field1');
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = new NoRecordExistsValidator('users', 'field1');
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/Db/RecordExistsTest.php
+++ b/tests/Zend/Validator/Db/RecordExistsTest.php
@@ -25,7 +25,8 @@
 namespace ZendTest\Validator\Db;
 
 use Zend\Db\Table\AbstractTable,
-    Zend\Validator\Db\RecordExists as RecordExistsValidator;
+    Zend\Validator\Db\RecordExists as RecordExistsValidator,
+    ReflectionClass;
 
 /**
  * @category   Zend
@@ -211,5 +212,41 @@ class RecordExistsTest extends \PHPUnit_Framework_TestCase
         AbstractTable::setDefaultAdapter($this->_adapterHasResult);
         $validator = new RecordExistsValidator('users', 'field1', 'id != 1');
         $this->assertTrue($validator->isValid('value3'));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = new RecordExistsValidator('users', 'field1');
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = new RecordExistsValidator('users', 'field1');
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/DigitsTest.php
+++ b/tests/Zend/Validator/DigitsTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /**
  * Test helper
@@ -126,5 +127,41 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
     public function testNonStringValidation()
     {
         $this->assertFalse($this->_validator->isValid(array(1 => 1)));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/EmailAddressTest.php
+++ b/tests/Zend/Validator/EmailAddressTest.php
@@ -23,8 +23,9 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
-use Zend\Validator\Hostname;
+use Zend\Validator,
+    Zend\Validator\Hostname,
+    ReflectionClass;
 
 /**
  * @category   Zend
@@ -590,5 +591,41 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($validator->isValid('john.doe@gmail.com'));
         $result = $validator->getMXRecord();
         $this->assertTrue(!empty($result));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/FloatTest.php
+++ b/tests/Zend/Validator/FloatTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /**
  * Test helper
@@ -222,5 +223,41 @@ class FloatTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($valid->isValid('1,3'));
         $this->assertFalse($valid->isValid('1000,3'));
         $this->assertFalse($valid->isValid('1.000,3'));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/GreaterThanTest.php
+++ b/tests/Zend/Validator/GreaterThanTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /**
  * Test helper
@@ -107,5 +108,41 @@ class GreaterThanTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new Validator\GreaterThan(10);
         $this->assertEquals(false, $validator->getInclusive());
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = new Validator\GreaterThan(1);
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = new Validator\GreaterThan(1);
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/HexTest.php
+++ b/tests/Zend/Validator/HexTest.php
@@ -24,6 +24,8 @@
  */
 namespace ZendTest\Validator;
 
+use ReflectionClass;
+
 /**
  * Test helper
  */
@@ -99,5 +101,41 @@ class HexTest extends \PHPUnit_Framework_TestCase
     public function testNonStringValidation()
     {
         $this->assertFalse($this->_validator->isValid(array(1 => 1)));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/HostnameTest.php
+++ b/tests/Zend/Validator/HostnameTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator\Hostname;
+use Zend\Validator\Hostname,
+    ReflectionClass;
 
 /**
  * @category   Zend
@@ -461,5 +462,41 @@ class HostnameTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($validator->isValid('tĕst123.si'));
         $this->assertTrue($validator->isValid('tàrø.si'));
         $this->assertFalse($validator->isValid('رات.si'));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/IbanTest.php
+++ b/tests/Zend/Validator/IbanTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /**
  * @category   Zend
@@ -86,5 +87,41 @@ class IbanTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new Validator\Iban(false);
         $this->assertTrue($validator->isValid('AT611904300234573201'));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = new Validator\Iban();
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = new Validator\Iban();
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/IdenticalTest.php
+++ b/tests/Zend/Validator/IdenticalTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /** Zend_Validator_Identical */
 
@@ -131,5 +132,41 @@ class IdenticalTest extends \PHPUnit_Framework_TestCase
 
         $validator->setStrict(true);
         $this->assertFalse($validator->isValid(array('token' => '123')));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = new Validator\Identical();
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = new Validator\Identical();
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/InArrayTest.php
+++ b/tests/Zend/Validator/InArrayTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /**
  * Test helper
@@ -202,5 +203,41 @@ class InArrayTest extends \PHPUnit_Framework_TestCase
 
         $validator->setRecursive(true);
         $this->assertTrue($validator->isValid('A'));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = new Validator\InArray(array());
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = new Validator\InArray(array());
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/IntTest.php
+++ b/tests/Zend/Validator/IntTest.php
@@ -23,8 +23,9 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
-use Zend\Locale;
+use Zend\Validator,
+    Zend\Locale,
+    ReflectionClass;
 
 /**
  * Test helper
@@ -137,5 +138,41 @@ class IntTest extends \PHPUnit_Framework_TestCase
         $valid = new Validator\Int();
         $this->assertTrue($valid->isValid(1200));
         $this->assertFalse($valid->isValid('1,200'));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/IpTest.php
+++ b/tests/Zend/Validator/IpTest.php
@@ -24,6 +24,9 @@
  */
 namespace ZendTest\Validator;
 
+use Zend\Validator,
+    ReflectionClass;
+
 /**
  * Test helper
  */
@@ -259,5 +262,41 @@ class IpTest extends \PHPUnit_Framework_TestCase
             }
         }
 
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/IsbnTest.php
+++ b/tests/Zend/Validator/IsbnTest.php
@@ -22,7 +22,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 
 /**
@@ -232,5 +233,41 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($validator->isValid((float) 1.2345));
         $this->assertFalse($validator->isValid((object) 'Test'));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = new Validator\Isbn();
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = new Validator\Isbn();
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/LessThanTest.php
+++ b/tests/Zend/Validator/LessThanTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /**
  * Test helper
@@ -107,5 +108,41 @@ class LessThanTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new Validator\LessThan(10);
         $this->assertEquals(false, $validator->getInclusive());
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = new Validator\LessThan(10);
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = new Validator\LessThan(10);
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/MessageTest.php
+++ b/tests/Zend/Validator/MessageTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /**
  * @category   Zend
@@ -265,6 +266,42 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->_validator->isValid('abc'));
         $messages = $this->_validator->getMessages();
         $this->assertEquals('variables: %notvar% 4 8 ', current($messages));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 
 }

--- a/tests/Zend/Validator/NotEmptyTest.php
+++ b/tests/Zend/Validator/NotEmptyTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /**
  * @category   Zend
@@ -602,6 +603,42 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($filter->isValid(array()));
         $this->assertTrue($filter->isValid(array('xxx')));
         $this->assertTrue($filter->isValid(null));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }
 

--- a/tests/Zend/Validator/PostCodeTest.php
+++ b/tests/Zend/Validator/PostCodeTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /**
  * @see Zend_Validator_PostCode
@@ -198,5 +199,41 @@ class PostCodeTest extends \PHPUnit_Framework_TestCase
         
         $message = $this->_validator->getMessages();
         $this->assertContains('not appear to be a postal code', $message['postcodeService']);
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/RegexTest.php
+++ b/tests/Zend/Validator/RegexTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /**
  * Test helper
@@ -132,5 +133,41 @@ class RegexTest extends \PHPUnit_Framework_TestCase
                 $this->assertEquals($element[1], $validator->isValid($input));
             }
         }
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = new Validator\Regex('//');
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = new Validator\Regex('//');
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }

--- a/tests/Zend/Validator/StringLengthTest.php
+++ b/tests/Zend/Validator/StringLengthTest.php
@@ -23,7 +23,8 @@
  * @namespace
  */
 namespace ZendTest\Validator;
-use Zend\Validator;
+use Zend\Validator,
+    ReflectionClass;
 
 /**
  * Test helper
@@ -172,5 +173,41 @@ class StringLengthTest extends \PHPUnit_Framework_TestCase
     public function testNonStringValidation()
     {
         $this->assertFalse($this->_validator->isValid(array(1 => 1)));
+    }
+    
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+    
+    public function testEqualsMessageVariables()
+    {
+        $validator = $this->_validator;
+        $reflection = new ReflectionClass($validator);
+        
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+        
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
     }
 }


### PR DESCRIPTION
If not called Zend\Validator\AbstractValidator::__construct, abstractOptions['messageTemplates'] and abstractOptions['messageVariables'] is empty

Sample:

``` php
<?php
$validator = new \Zend\Validator\InArray(array(1, 2, 3, 4, 5));
if(!$validator->isValid(10)) {
    /**
     * output array this empty values
     * array(1) {
     *     ["notInArray"]=>
     *      NULL
     * }
     */
    var_dump($validator->getMessages()); 
}
```

Bad components: Db\RecordExists, Db\NoRecordExists, Date, GreaterThan, Iban, Identical, InArray, Int, Ip, LessThan, Regex
This bug is also present in latest Zend Fremework 1
