### PR TITLE
Modified addRoute procedure

### DIFF
--- a/library/Zend/Mvc/Router/SimpleRouteStack.php
+++ b/library/Zend/Mvc/Router/SimpleRouteStack.php
@@ -162,7 +162,7 @@ class SimpleRouteStack implements RouteStack
             $route = $this->routeFromArray($route);
         }
         
-        if ($priority !== null && isset($route->priority)) {
+        if ($priority === null && isset($route->priority)) {
             $priority = $route->priority;
         }
 


### PR DESCRIPTION
It is impossible to set priority through the addRoutes method because it does not pass the route priority property and the $priority parameter will always be null
