### PR TITLE
Implement new http status codes

### DIFF
--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -14,6 +14,7 @@ class Response extends Message implements ResponseDescription
     const STATUS_CODE_CUSTOM = 0;
     const STATUS_CODE_100 = 100;
     const STATUS_CODE_101 = 101;
+    const STATUS_CODE_102 = 102;
     const STATUS_CODE_200 = 200;
     const STATUS_CODE_201 = 201;
     const STATUS_CODE_202 = 202;
@@ -87,6 +88,7 @@ class Response extends Message implements ResponseDescription
         // INFORMATIONAL CODES
         100 => 'Continue',
         101 => 'Switching Protocols',
+        102 => 'Processing',
         // SUCCESS CODES
         200 => 'OK',
         201 => 'Created',

--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -21,6 +21,7 @@ class Response extends Message implements ResponseDescription
     const STATUS_CODE_204 = 204;
     const STATUS_CODE_205 = 205;
     const STATUS_CODE_206 = 206;
+    const STATUS_CODE_207 = 207
     const STATUS_CODE_300 = 300;
     const STATUS_CODE_301 = 301;
     const STATUS_CODE_302 = 302;
@@ -48,6 +49,9 @@ class Response extends Message implements ResponseDescription
     const STATUS_CODE_416 = 416;
     const STATUS_CODE_417 = 417;
     const STATUS_CODE_418 = 418;
+    const STATUS_CODE_422 = 422;
+    const STATUS_CODE_423 = 423;
+    const STATUS_CODE_424 = 424;
     const STATUS_CODE_428 = 428;
     const STATUS_CODE_429 = 429;
     const STATUS_CODE_431 = 431;
@@ -57,6 +61,7 @@ class Response extends Message implements ResponseDescription
     const STATUS_CODE_503 = 503;
     const STATUS_CODE_504 = 504;
     const STATUS_CODE_505 = 505;
+    const STATUS_CODE_507 = 507;
     const STATUS_CODE_511 = 511;
     
     /**#@-*/
@@ -88,6 +93,7 @@ class Response extends Message implements ResponseDescription
         204 => 'No Content',
         205 => 'Reset Content',
         206 => 'Partial Content',
+        207 => 'Multi-status',
         // REDIRECTION CODES
         300 => 'Multiple Choices',
         301 => 'Moved Permanently',
@@ -117,6 +123,9 @@ class Response extends Message implements ResponseDescription
         416 => 'Requested range not satisfiable',
         417 => 'Expectation Failed',
         418 => 'I\'m a teapot',
+        422 => 'Unprocessable Entity',
+        423 => 'Locked',
+        424 => 'Failed Dependency',
         428 => 'Precondition Required',
         429 => 'Too Many Requests',
         431 => 'Request Header Fields Too Large',
@@ -127,6 +136,7 @@ class Response extends Message implements ResponseDescription
         503 => 'Service Unavailable',
         504 => 'Gateway Time-out',
         505 => 'HTTP Version not supported',
+        507 => 'Insufficient Storage',
         511 => 'Network Authentication Required',
     );
 

--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -22,6 +22,7 @@ class Response extends Message implements ResponseDescription
     const STATUS_CODE_205 = 205;
     const STATUS_CODE_206 = 206;
     const STATUS_CODE_207 = 207;
+    const STATUS_CODE_208 = 208;
     const STATUS_CODE_300 = 300;
     const STATUS_CODE_301 = 301;
     const STATUS_CODE_302 = 302;
@@ -62,6 +63,7 @@ class Response extends Message implements ResponseDescription
     const STATUS_CODE_504 = 504;
     const STATUS_CODE_505 = 505;
     const STATUS_CODE_507 = 507;
+    const STATUS_CODE_508 = 508;
     const STATUS_CODE_511 = 511;
     
     /**#@-*/
@@ -94,6 +96,7 @@ class Response extends Message implements ResponseDescription
         205 => 'Reset Content',
         206 => 'Partial Content',
         207 => 'Multi-status',
+        208 => 'Already Reported',
         // REDIRECTION CODES
         300 => 'Multiple Choices',
         301 => 'Moved Permanently',
@@ -137,6 +140,7 @@ class Response extends Message implements ResponseDescription
         504 => 'Gateway Time-out',
         505 => 'HTTP Version not supported',
         507 => 'Insufficient Storage',
+        508 => 'Loop Detected',
         511 => 'Network Authentication Required',
     );
 

--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -65,6 +65,7 @@ class Response extends Message implements ResponseDescription
     const STATUS_CODE_503 = 503;
     const STATUS_CODE_504 = 504;
     const STATUS_CODE_505 = 505;
+    const STATUS_CODE_506 = 506;
     const STATUS_CODE_507 = 507;
     const STATUS_CODE_508 = 508;
     const STATUS_CODE_511 = 511;
@@ -145,6 +146,7 @@ class Response extends Message implements ResponseDescription
         503 => 'Service Unavailable',
         504 => 'Gateway Time-out',
         505 => 'HTTP Version not supported',
+        506 => 'Variant Also Negotiates',
         507 => 'Insufficient Storage',
         508 => 'Loop Detected',
         511 => 'Network Authentication Required',

--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -54,6 +54,7 @@ class Response extends Message implements ResponseDescription
     const STATUS_CODE_422 = 422;
     const STATUS_CODE_423 = 423;
     const STATUS_CODE_424 = 424;
+    const STATUS_CODE_425 = 425;
     const STATUS_CODE_428 = 428;
     const STATUS_CODE_429 = 429;
     const STATUS_CODE_431 = 431;
@@ -131,6 +132,7 @@ class Response extends Message implements ResponseDescription
         422 => 'Unprocessable Entity',
         423 => 'Locked',
         424 => 'Failed Dependency',
+        425 => 'Unordered Collection',
         428 => 'Precondition Required',
         429 => 'Too Many Requests',
         431 => 'Request Header Fields Too Large',

--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -21,7 +21,7 @@ class Response extends Message implements ResponseDescription
     const STATUS_CODE_204 = 204;
     const STATUS_CODE_205 = 205;
     const STATUS_CODE_206 = 206;
-    const STATUS_CODE_207 = 207
+    const STATUS_CODE_207 = 207;
     const STATUS_CODE_300 = 300;
     const STATUS_CODE_301 = 301;
     const STATUS_CODE_302 = 302;

--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -55,6 +55,7 @@ class Response extends Message implements ResponseDescription
     const STATUS_CODE_423 = 423;
     const STATUS_CODE_424 = 424;
     const STATUS_CODE_425 = 425;
+    const STATUS_CODE_426 = 426;
     const STATUS_CODE_428 = 428;
     const STATUS_CODE_429 = 429;
     const STATUS_CODE_431 = 431;
@@ -133,6 +134,7 @@ class Response extends Message implements ResponseDescription
         423 => 'Locked',
         424 => 'Failed Dependency',
         425 => 'Unordered Collection',
+        426 => 'Upgrade Required',
         428 => 'Precondition Required',
         429 => 'Too Many Requests',
         431 => 'Request Header Fields Too Large',


### PR DESCRIPTION
The Zend\Http\Response has now additional codes so it's compatible with several RFCs:
- RFC 4918
- RFC 5842
- RFC 2518
- RFC 3648
- RFC 2817
