### PR TITLE
Remove an IDE warning about invoking a variable that may not be invokable.

### DIFF
--- a/library/Zend/Cache/Cache.php
+++ b/library/Zend/Cache/Cache.php
@@ -210,6 +210,9 @@ abstract class Cache
         throw new Exception($msg, 0, $e);
     }
 
+    /**
+     * @return \Zend\Filter\AbstractFilter
+     */
     protected static function _getCamelCaseFilter()
     {
         if (null === self::$_camelCaseFilter) {


### PR DESCRIPTION
Before this change, PhpStorm could not tell that _getCamelCaseFilter() returned an invokable, so it marked as a potential error the 2nd line of _normalizeName() where $filter is invoked as a function.
