### PR TITLE
Removed hard requirement on Zend\Config component

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -23,8 +23,7 @@
  */
 namespace Zend\Http;
 
-use Zend\Config\Config,
-    Zend\Uri\Http,
+use Zend\Uri\Http,
     Zend\Http\Header\Cookie,
     Zend\Http\Header\SetCookie,
     Zend\Stdlib\Parameters,
@@ -166,16 +165,13 @@ class Client implements Dispatchable
     /**
      * Set configuration parameters for this HTTP client
      *
-     * @param  Config|array $config
+     * @param  array $config
      * @return Client
      * @throws Client\Exception
      */
     public function setConfig($config = array())
     {
-        if ($config instanceof Config) {
-            $config = $config->toArray();
-
-        } elseif (!is_array($config)) {
+        if (!is_array($config)) {
             throw new Exception\InvalidArgumentException('Config parameter is not valid');
         }
 

--- a/tests/Zend/Http/Client/StaticTest.php
+++ b/tests/Zend/Http/Client/StaticTest.php
@@ -253,7 +253,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
             )
         ));
 
-        $this->_client->setConfig($config);
+        $this->_client->setConfig($config->toArray());
 
         $hasConfig = $this->_client->config;
         $this->assertEquals($config->timeout, $hasConfig['timeout']);


### PR DESCRIPTION
Essentially, this change drops the hard requirement on Zend\Config (in Zend\Http\Client) in order to make the HTTP client more attractive to those that prefer not to use Zend\Config component.

Further, the $config ends up being converted into a hash anyhow, so leaving out Zend\Config handling allows other frameworks/components to employ their own configuration objects as long as they can serialize to a simple hash when constructing an instance of Http\Client.

For example, see the diff for the file named "StaticTest.php" @ line ~256. Originally:

So, instead of calling:
$this->_client->setConfig($config);

the caller now simply does this following:
$this->_client->setConfig($config->toArray());

More predictable, less magic, more interoperability.
