### PR TITLE
ZF2-114 - Zend\Http\Request setMethod() should automatically strtoupper the method name

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -355,7 +355,7 @@ class Client implements Dispatchable
      */
     public function setMethod($method)
     {
-        $this->getRequest()->setMethod($method);
+        $method = $this->getRequest()->setMethod($method)->getMethod();
         
         if (($method == Request::METHOD_POST || $method == Request::METHOD_PUT ||
              $method == Request::METHOD_DELETE) && empty($this->encType)) {

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -145,7 +145,8 @@ class Request extends Message implements RequestDescription
      */
     public function setMethod($method)
     {
-        if (!defined('static::METHOD_'.strtoupper($method))) {
+        $method = strtoupper($method);
+        if (!defined('static::METHOD_'.$method)) {
             throw new Exception\InvalidArgumentException('Invalid HTTP method passed');
         }
         $this->method = $method;

--- a/tests/Zend/Http/ClientTest.php
+++ b/tests/Zend/Http/ClientTest.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @namespace
+ */
+namespace ZendTest\Http;
+
+use Zend\Http\Client;
+
+class ClientTest extends \PHPUnit_Framework_TestCase
+{
+    public function testClientRetrievesUppercaseHttpMethodFromRequestObject()
+    {
+        $client = new Client;
+        $client->setMethod('post');
+        $this->assertEquals(Client::ENC_URLENCODED, $client->getEncType());
+    } 
+}

--- a/tests/Zend/Http/RequestTest.php
+++ b/tests/Zend/Http/RequestTest.php
@@ -78,6 +78,13 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('POST', $request->getMethod());
     }
 
+    public function testRequestCanAlwaysForcesUppecaseMethodName()
+    {
+        $request = new Request();
+        $request->setMethod('get');
+        $this->assertEquals('GET', $request->getMethod());
+    }
+
     public function testRequestCanSetAndRetrieveUri()
     {
         $request = new Request();


### PR DESCRIPTION
This fixes [ZF2-114](http://framework.zend.com/issues/browse/ZF2-114). Also contains unit tests covering the change.

This is also the proper fix for [PR 636](https://github.com/zendframework/zf2/pull/636), though I see no reason why that commit could not also be merged.
