### PR TITLE
Hotfix/ZF2-62 | Fatal errors on cloud tests

### DIFF
--- a/library/Zend/Cloud/Infrastructure/Adapter.php
+++ b/library/Zend/Cloud/Infrastructure/Adapter.php
@@ -57,7 +57,7 @@ interface Adapter
      * @param  integer $timeout 
      * @return boolean
      */
-    public function waitStatusInstance($id, $status, $timeout = static::TIMEOUT_STATUS_CHANGE);
+    public function waitStatusInstance($id, $status, $timeout = self::TIMEOUT_STATUS_CHANGE);
     
     /**
      * Return the public DNS name of the instance

--- a/library/Zend/Cloud/Infrastructure/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cloud/Infrastructure/Adapter/AbstractAdapter.php
@@ -76,7 +76,7 @@ abstract class AbstractAdapter implements Adapter
      * @param  integer $timeout 
      * @return boolean
      */
-    public function waitStatusInstance($id, $status, $timeout = static::TIMEOUT_STATUS_CHANGE)
+    public function waitStatusInstance($id, $status, $timeout = self::TIMEOUT_STATUS_CHANGE)
     {
         if (empty($id) || empty($status)) {
             return false;

--- a/tests/Zend/Cloud/Infrastructure/Adapter/Ec2OnlineTest.php
+++ b/tests/Zend/Cloud/Infrastructure/Adapter/Ec2OnlineTest.php
@@ -272,7 +272,7 @@ class Ec2OnlineTest extends TestCase
  * @group      Zend\Cloud\Infrastructure
  * @group      Zend\Cloud\Infrastructure\Adapter\Ec2
  */
-class Skip extends TestCase
+class SkipEc2OnlineTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Zend/Cloud/Infrastructure/Adapter/RackspaceOnlineTest.php
+++ b/tests/Zend/Cloud/Infrastructure/Adapter/RackspaceOnlineTest.php
@@ -247,7 +247,7 @@ class RackspaceOnlineTest extends \PHPUnit_Framework_TestCase
  * @group      Zend\Cloud\Infrastructure
  * @group      Zend\Cloud\Infrastructure\Adapter\Rackspace
  */
-class Skip extends \PHPUnit_Framework_TestCase
+class SkipRackspaceOnlineTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {

--- a/tests/Zend/Cloud/Infrastructure/Adapter/RackspaceOnlineTest.php
+++ b/tests/Zend/Cloud/Infrastructure/Adapter/RackspaceOnlineTest.php
@@ -259,4 +259,3 @@ class SkipRackspaceOnlineTest extends \PHPUnit_Framework_TestCase
     {
     }
 }
-

--- a/tests/Zend/Cloud/Infrastructure/Adapter/TestAssets/MockAdapter.php
+++ b/tests/Zend/Cloud/Infrastructure/Adapter/TestAssets/MockAdapter.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend\Cloud\Infrastructure\Adapter\TestAssets
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+/**
+ * @namespace
+ */
+namespace ZendTest\Cloud\Infrastructure\Adapter\TestAssets;
+
+use Zend\Cloud\Infrastructure\Adapter\AbstractAdapter;
+
+class MockAdapter extends AbstractAdapter {
+	/**
+     * Simulate waiting for status $status.
+     * 
+     * @param  string $id
+     * @param  string $status
+     * @param  integer $timeout 
+     * @return boolean
+     */
+    public function waitStatusInstance($id, $status, $timeout = self::TIMEOUT_STATUS_CHANGE)
+    {
+        if (empty($id) || empty($status)) {
+            return false;
+        }
+        
+        return true;
+    }
+    
+    /**
+     * Return the status of an instance
+     *
+     * @param  string $id
+     * @return string
+     */ 
+    public function statusInstance($id) 
+    {
+    	return 'status';
+    }
+    
+    /**
+     * Return the public DNS name of the instance
+     * 
+     * @param  string $id
+     * @return string|boolean 
+     */
+    public function publicDnsInstance($id) 
+    {
+    	return 'public-dns';
+    }
+    
+    /**
+     * Reboot an instance
+     *
+     * @param string $id
+     * @return boolean
+     */ 
+    public function rebootInstance($id) 
+    {
+    	return true;
+    }
+    
+	/**
+     * Create a new instance
+     *
+     * @param  string $name
+     * @param  array $options
+     * @return boolean
+     */ 
+    public function createInstance($name, $options) 
+    {
+    	return true;
+    }
+ 
+    
+    /**
+     * Stop the execution of an instance
+     *
+     * @param  string $id
+     * @return boolean
+     */ 
+    public function stopInstance($id) 
+    {
+    	return true;
+    }
+    
+    /**
+     * Start the execution of an instance
+     *
+     * @param  string $id
+     * @return boolean
+     */ 
+    public function startInstance($id) 
+    {
+    	return true;
+    }
+    
+    /**
+     * Destroy an instance
+     *
+     * @param  string $id
+     * @return boolean
+     */ 
+    public function destroyInstance($id) 
+    {
+    	return true;
+    }
+ 
+    /**
+     * Return all the available instances images
+     *
+     * @return ImageList
+     */ 
+    public function imagesInstance() 
+    {
+    	return array();
+    }
+    
+    /**
+     * Return all the available zones
+     * 
+     * @return array
+     */
+    public function zonesInstance() 
+    {
+    	return array();
+    }
+    
+    /**
+     * Return the system informations about the $metric of an instance
+     *
+     * @param  string $id
+     * @param  string $metric
+     * @param  array $options
+     * @return array
+     */ 
+    public function monitorInstance($id, $metric, $options = null)
+    {
+    	return array();
+    }     
+    
+    /**
+     * Run arbitrary shell script on an instance
+     *
+     * @param  string $id
+     * @param  array $param
+     * @param  string|array $cmd
+     * @return string|array
+     */ 
+    public function deployInstance($id, $params, $cmd) 
+    {
+    	return 'result';
+    }
+    
+    /**
+     * Return a list of the available instances
+     *
+     * @return InstanceList
+     */ 
+    public function listInstances() 
+    {
+    	return array();
+    }
+    
+    /**
+     * Get the adapter instance
+     * 
+     * @return object
+     */
+    public function getAdapter()
+    {
+    	return $this;
+    }
+    
+    /**
+     * Get the adapter result
+     * 
+     * @return array
+     */
+    public function getAdapterResult() 
+    {
+    	return array();
+    }
+    
+    /**
+     * Get the last HTTP response
+     * 
+     * @return Zend\Http\Response
+     */
+    public function getLastHttpResponse()
+    {
+    	return new \Zend\Http\Response();
+    }
+    
+    /**
+     * Get the last HTTP request
+     * 
+     * @return string
+     */
+    public function getLastHttpRequest() 
+    {
+    	return new \Zend\Http\Request();
+    }
+}

--- a/tests/Zend/Cloud/Infrastructure/Adapter/TestAssets/MockAdapter.php
+++ b/tests/Zend/Cloud/Infrastructure/Adapter/TestAssets/MockAdapter.php
@@ -26,7 +26,8 @@ namespace ZendTest\Cloud\Infrastructure\Adapter\TestAssets;
 
 use Zend\Cloud\Infrastructure\Adapter\AbstractAdapter;
 
-class MockAdapter extends AbstractAdapter {
+class MockAdapter extends AbstractAdapter 
+{
     /**
      * Simulate waiting for status $status.
      * 

--- a/tests/Zend/Cloud/Infrastructure/Adapter/TestAssets/MockAdapter.php
+++ b/tests/Zend/Cloud/Infrastructure/Adapter/TestAssets/MockAdapter.php
@@ -27,7 +27,7 @@ namespace ZendTest\Cloud\Infrastructure\Adapter\TestAssets;
 use Zend\Cloud\Infrastructure\Adapter\AbstractAdapter;
 
 class MockAdapter extends AbstractAdapter {
-	/**
+    /**
      * Simulate waiting for status $status.
      * 
      * @param  string $id
@@ -52,7 +52,7 @@ class MockAdapter extends AbstractAdapter {
      */ 
     public function statusInstance($id) 
     {
-    	return 'status';
+        return 'status';
     }
     
     /**
@@ -63,7 +63,7 @@ class MockAdapter extends AbstractAdapter {
      */
     public function publicDnsInstance($id) 
     {
-    	return 'public-dns';
+        return 'public-dns';
     }
     
     /**
@@ -74,10 +74,10 @@ class MockAdapter extends AbstractAdapter {
      */ 
     public function rebootInstance($id) 
     {
-    	return true;
+        return true;
     }
     
-	/**
+    /**
      * Create a new instance
      *
      * @param  string $name
@@ -86,9 +86,9 @@ class MockAdapter extends AbstractAdapter {
      */ 
     public function createInstance($name, $options) 
     {
-    	return true;
+        return true;
     }
- 
+    
     
     /**
      * Stop the execution of an instance
@@ -98,7 +98,7 @@ class MockAdapter extends AbstractAdapter {
      */ 
     public function stopInstance($id) 
     {
-    	return true;
+        return true;
     }
     
     /**
@@ -109,7 +109,7 @@ class MockAdapter extends AbstractAdapter {
      */ 
     public function startInstance($id) 
     {
-    	return true;
+        return true;
     }
     
     /**
@@ -120,9 +120,9 @@ class MockAdapter extends AbstractAdapter {
      */ 
     public function destroyInstance($id) 
     {
-    	return true;
+        return true;
     }
- 
+    
     /**
      * Return all the available instances images
      *
@@ -130,7 +130,7 @@ class MockAdapter extends AbstractAdapter {
      */ 
     public function imagesInstance() 
     {
-    	return array();
+        return array();
     }
     
     /**
@@ -140,7 +140,7 @@ class MockAdapter extends AbstractAdapter {
      */
     public function zonesInstance() 
     {
-    	return array();
+        return array();
     }
     
     /**
@@ -153,7 +153,7 @@ class MockAdapter extends AbstractAdapter {
      */ 
     public function monitorInstance($id, $metric, $options = null)
     {
-    	return array();
+        return array();
     }     
     
     /**
@@ -166,7 +166,7 @@ class MockAdapter extends AbstractAdapter {
      */ 
     public function deployInstance($id, $params, $cmd) 
     {
-    	return 'result';
+        return 'result';
     }
     
     /**
@@ -176,7 +176,7 @@ class MockAdapter extends AbstractAdapter {
      */ 
     public function listInstances() 
     {
-    	return array();
+        return array();
     }
     
     /**
@@ -186,7 +186,7 @@ class MockAdapter extends AbstractAdapter {
      */
     public function getAdapter()
     {
-    	return $this;
+        return $this;
     }
     
     /**
@@ -196,7 +196,7 @@ class MockAdapter extends AbstractAdapter {
      */
     public function getAdapterResult() 
     {
-    	return array();
+        return array();
     }
     
     /**
@@ -206,7 +206,7 @@ class MockAdapter extends AbstractAdapter {
      */
     public function getLastHttpResponse()
     {
-    	return new \Zend\Http\Response();
+        return new \Zend\Http\Response();
     }
     
     /**
@@ -216,6 +216,6 @@ class MockAdapter extends AbstractAdapter {
      */
     public function getLastHttpRequest() 
     {
-    	return new \Zend\Http\Request();
+        return new \Zend\Http\Request();
     }
 }

--- a/tests/Zend/Cloud/Infrastructure/InstanceTest.php
+++ b/tests/Zend/Cloud/Infrastructure/InstanceTest.php
@@ -158,8 +158,8 @@ class InstanceTest extends TestCase
         $instance = new Instance(self::$adapter,self::$data);
         
         $this->assertEquals(
-        	self::$adapter->statusInstance($instance::INSTANCE_ID), 
-        	$instance->getStatus()
+            self::$adapter->statusInstance($instance::INSTANCE_ID), 
+            $instance->getStatus()
         );
         $this->assertEquals('foo', $instance->getAttribute(Instance::INSTANCE_STATUS));
     }
@@ -232,8 +232,8 @@ class InstanceTest extends TestCase
         $instance = new Instance(self::$adapter,self::$data);
         
         $this->assertEquals(
-        	self::$adapter->rebootInstance($instance::INSTANCE_ID), 
-        	$instance->reboot()
+            self::$adapter->rebootInstance($instance::INSTANCE_ID), 
+            $instance->reboot()
         );
     }
 
@@ -245,8 +245,8 @@ class InstanceTest extends TestCase
         $instance = new Instance(self::$adapter,self::$data);
         
         $this->assertEquals(
-        	self::$adapter->stopInstance($instance::INSTANCE_ID), 
-        	$instance->stop()
+            self::$adapter->stopInstance($instance::INSTANCE_ID), 
+            $instance->stop()
         );
     }
 
@@ -258,8 +258,8 @@ class InstanceTest extends TestCase
         $instance= new Instance(self::$adapter,self::$data);
         
         $this->assertEquals(
-        	self::$adapter->startInstance($instance::INSTANCE_ID), 
-        	$instance->start()
+            self::$adapter->startInstance($instance::INSTANCE_ID), 
+            $instance->start()
         );
     }
 
@@ -271,8 +271,8 @@ class InstanceTest extends TestCase
         $instance = new Instance(self::$adapter, self::$data);
         
         $this->assertEquals(
-        	self::$adapter->destroyInstance($instance::INSTANCE_ID),
-        	$instance->destroy()
+            self::$adapter->destroyInstance($instance::INSTANCE_ID),
+            $instance->destroy()
         );
     }
 
@@ -284,8 +284,8 @@ class InstanceTest extends TestCase
         $instance = new Instance(self::$adapter,self::$data);
         
         $this->assertEquals(
-        	self::$adapter->monitorInstance($instance::INSTANCE_ID, 'foo'), 
-        	$instance->monitor('foo')
+            self::$adapter->monitorInstance($instance::INSTANCE_ID, 'foo'), 
+            $instance->monitor('foo')
         );
     }
 
@@ -297,8 +297,8 @@ class InstanceTest extends TestCase
         $instance = new Instance(self::$adapter,self::$data);
         
         $this->assertEquals(
-        	self::$adapter->deployInstance($instance::INSTANCE_ID, 'foo', 'bar'), 
-        	$instance->deploy('foo','bar')
+            self::$adapter->deployInstance($instance::INSTANCE_ID, 'foo', 'bar'), 
+            $instance->deploy('foo','bar')
         );
     }
 }

--- a/tests/Zend/Cloud/Infrastructure/InstanceTest.php
+++ b/tests/Zend/Cloud/Infrastructure/InstanceTest.php
@@ -25,14 +25,15 @@
 namespace ZendTest\Cloud\Infrastructure;
 
 use Zend\Cloud\Infrastructure\Instance,
-    PHPUnit_Framework_TestCase as TestCase;
+    PHPUnit_Framework_TestCase as TestCase,
+    ZendTest\Cloud\Infrastructure\Adapter\TestAssets\MockAdapter;
 
 class InstanceTest extends TestCase
 {
     /**
      * Mock class for the Adapter (dummy methods)
      * 
-     * @var ZendTest\Cloud\Infrastructure\TestAsset\MockAdapter
+     * @var MockAdapter
      */
     protected static $adapter;
 
@@ -58,7 +59,7 @@ class InstanceTest extends TestCase
             Instance::INSTANCE_STATUS     => 'foo',        
             Instance::INSTANCE_ZONE       => 'foo',
         );
-        self::$adapter = new TestAsset\MockAdapter();
+        self::$adapter = new MockAdapter();
     }
 
     /**
@@ -102,9 +103,9 @@ class InstanceTest extends TestCase
     {
         $this->setExpectedException(
             'Zend\Cloud\Infrastructure\Exception\InvalidArgumentException',
-            'You must pass an array of params'
+            'You must pass an array of parameters'
         );
-        $instance = new Instance(self::$adapter,array());
+        $instance = new Instance(self::$adapter, array());
     }
 
     /**
@@ -116,7 +117,7 @@ class InstanceTest extends TestCase
             'Zend\Cloud\Infrastructure\Exception\InvalidArgumentException',
             'The param "'.Instance::INSTANCE_ID.'" is a required param for Zend\Cloud\Infrastructure\Instance'
         );
-        $instance = new Instance(self::$adapter,array('foo'=>'bar'));
+        $instance = new Instance(self::$adapter, array('foo'=>'bar'));
     }
 
     /**
@@ -125,8 +126,8 @@ class InstanceTest extends TestCase
     public function testGetId()
     {
         $instance = new Instance(self::$adapter,self::$data);
-        $this->assertEquals('foo',$instance->getId());
-        $this->assertEquals('foo',$instance->getAttribute(Instance::INSTANCE_ID));
+        $this->assertEquals('foo', $instance->getId());
+        $this->assertEquals('foo', $instance->getAttribute(Instance::INSTANCE_ID));
     }
 
     /**
@@ -135,8 +136,8 @@ class InstanceTest extends TestCase
     public function testGetImageId()
     {
         $instance = new Instance(self::$adapter,self::$data);
-        $this->assertEquals('foo',$instance->getImageId());
-        $this->assertEquals('foo',$instance->getAttribute(Instance::INSTANCE_IMAGEID));
+        $this->assertEquals('foo', $instance->getImageId());
+        $this->assertEquals('foo', $instance->getAttribute(Instance::INSTANCE_IMAGEID));
     }
 
     /**
@@ -145,8 +146,8 @@ class InstanceTest extends TestCase
     public function testGetName()
     {
         $instance = new Instance(self::$adapter,self::$data);
-        $this->assertEquals('foo',$instance->getName());
-        $this->assertEquals('foo',$instance->getAttribute(Instance::INSTANCE_NAME));
+        $this->assertEquals('foo', $instance->getName());
+        $this->assertEquals('foo', $instance->getAttribute(Instance::INSTANCE_NAME));
     }
 
     /**
@@ -155,8 +156,12 @@ class InstanceTest extends TestCase
     public function testGetStatus()
     {
         $instance = new Instance(self::$adapter,self::$data);
-        $this->assertEquals('ZendTest\Cloud\Infrastructure\TestAsset\MockAdapter::statusInstance',$instance->getStatus());
-        $this->assertEquals('foo',$instance->getAttribute(Instance::INSTANCE_STATUS));
+        
+        $this->assertEquals(
+        	self::$adapter->statusInstance($instance::INSTANCE_ID), 
+        	$instance->getStatus()
+        );
+        $this->assertEquals('foo', $instance->getAttribute(Instance::INSTANCE_STATUS));
     }
 
     /**
@@ -164,9 +169,9 @@ class InstanceTest extends TestCase
      */
     public function testGetPublicDns()
     {
-        $instance = new Instance(self::$adapter,self::$data);
-        $this->assertEquals('foo',$instance->getPublicDns());
-        $this->assertEquals('foo',$instance->getAttribute(Instance::INSTANCE_PUBLICDNS));
+        $instance = new Instance(self::$adapter, self::$data);
+        $this->assertEquals('foo', $instance->getPublicDns());
+        $this->assertEquals('foo', $instance->getAttribute(Instance::INSTANCE_PUBLICDNS));
     }
 
     /**
@@ -175,8 +180,8 @@ class InstanceTest extends TestCase
     public function testGetCpu()
     {
         $instance = new Instance(self::$adapter,self::$data);
-        $this->assertEquals('foo',$instance->getCpu());
-        $this->assertEquals('foo',$instance->getAttribute(Instance::INSTANCE_CPU));
+        $this->assertEquals('foo', $instance->getCpu());
+        $this->assertEquals('foo', $instance->getAttribute(Instance::INSTANCE_CPU));
     }
 
     /**
@@ -225,7 +230,11 @@ class InstanceTest extends TestCase
     public function testReboot()
     {
         $instance = new Instance(self::$adapter,self::$data);
-        $this->assertEquals('ZendTest\Cloud\Infrastructure\TestAsset\MockAdapter::rebootInstance',$instance->reboot());
+        
+        $this->assertEquals(
+        	self::$adapter->rebootInstance($instance::INSTANCE_ID), 
+        	$instance->reboot()
+        );
     }
 
     /**
@@ -234,7 +243,11 @@ class InstanceTest extends TestCase
     public function testStop()
     {
         $instance = new Instance(self::$adapter,self::$data);
-        $this->assertEquals('ZendTest\Cloud\Infrastructure\TestAsset\MockAdapter::stopInstance',$instance->stop());
+        
+        $this->assertEquals(
+        	self::$adapter->stopInstance($instance::INSTANCE_ID), 
+        	$instance->stop()
+        );
     }
 
     /**
@@ -243,7 +256,11 @@ class InstanceTest extends TestCase
     public function testStart()
     {
         $instance= new Instance(self::$adapter,self::$data);
-        $this->assertEquals('ZendTest\Cloud\Infrastructure\TestAsset\MockAdapter::startInstance',$instance->start());
+        
+        $this->assertEquals(
+        	self::$adapter->startInstance($instance::INSTANCE_ID), 
+        	$instance->start()
+        );
     }
 
     /**
@@ -251,8 +268,12 @@ class InstanceTest extends TestCase
      */
     public function testDestroy()
     {
-        $instance = new Instance(self::$adapter,self::$data);
-        $this->assertEquals('ZendTest\Cloud\Infrastructure\TestAsset\MockAdapter::destroyInstance',$instance->destroy());
+        $instance = new Instance(self::$adapter, self::$data);
+        
+        $this->assertEquals(
+        	self::$adapter->destroyInstance($instance::INSTANCE_ID),
+        	$instance->destroy()
+        );
     }
 
     /**
@@ -261,7 +282,11 @@ class InstanceTest extends TestCase
     public function testMonitor()
     {
         $instance = new Instance(self::$adapter,self::$data);
-        $this->assertEquals('ZendTest\Cloud\Infrastructure\TestAsset\MockAdapter::monitorInstance',$instance->monitor('foo'));
+        
+        $this->assertEquals(
+        	self::$adapter->monitorInstance($instance::INSTANCE_ID, 'foo'), 
+        	$instance->monitor('foo')
+        );
     }
 
     /**
@@ -270,6 +295,10 @@ class InstanceTest extends TestCase
     public function testDeploy()
     {
         $instance = new Instance(self::$adapter,self::$data);
-        $this->assertEquals('ZendTest\Cloud\Infrastructure\TestAsset\MockAdapter::deployInstance',$instance->deploy('foo','bar'));
+        
+        $this->assertEquals(
+        	self::$adapter->deployInstance($instance::INSTANCE_ID, 'foo', 'bar'), 
+        	$instance->deploy('foo','bar')
+        );
     }
 }


### PR DESCRIPTION
This patch makes the cloud tests run again.

solving: http://framework.zend.com/issues/browse/ZF2-62
