### PR TITLE
Hotfix/ZF2-61 | Fatal errors on loader tests

### DIFF
--- a/tests/Zend/Loader/AutoloaderFactoryTest.php
+++ b/tests/Zend/Loader/AutoloaderFactoryTest.php
@@ -99,7 +99,7 @@ class AutoloaderFactoryTest extends \PHPUnit_Framework_TestCase
             ),
         ));
         $this->assertEquals(1, count(AutoloaderFactory::getRegisteredAutoloaders()));
-        $this->assertTrue(class_exists('TestNamespace\FallbackCase'));
+        $this->assertTrue(class_exists('TestNamespace\NoDuplicateAutoloadersCase'));
         $this->assertTrue(class_exists('ZendTest\Loader\TestAsset\TestPlugins\Foo'));
     }
 

--- a/tests/Zend/Loader/AutoloaderMultiVersionTest.php
+++ b/tests/Zend/Loader/AutoloaderMultiVersionTest.php
@@ -36,9 +36,14 @@ require_once "PHPUnit/Framework/TestFailure.php";
  */
 class AutoloaderMultiVersionTest extends \PHPUnit_Framework_TestCase
 {
+    protected function isEnabled()
+    {
+        return (bool)constant('TESTS_ZEND_LOADER_AUTOLOADER_MULTIVERSION_ENABLED');
+    }
+    
     public function setUp()
     {
-        if (!constant('TESTS_ZEND_LOADER_AUTOLOADER_MULTIVERSION_ENABLED')) {
+        if (!$this->isEnabled()) {
             $this->markTestSkipped();
         }
 
@@ -49,7 +54,6 @@ class AutoloaderMultiVersionTest extends \PHPUnit_Framework_TestCase
             // autoloaders registered...
             $this->loaders = array();
         }
-
         // Store original include_path
         $this->includePath = get_include_path();
 
@@ -64,12 +68,15 @@ class AutoloaderMultiVersionTest extends \PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
+        if (!$this->isEnabled()) {
+            return;
+        }
         // Restore original autoloaders
         $loaders = spl_autoload_functions();
         foreach ($loaders as $loader) {
             spl_autoload_unregister($loader);
         }
-
+        
         foreach ($this->loaders as $loader) {
             spl_autoload_register($loader);
         }

--- a/tests/Zend/Loader/LoaderTest.php
+++ b/tests/Zend/Loader/LoaderTest.php
@@ -120,7 +120,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(Loader::isReadable(__FILE__ . '.foobaar'));
 
         // test that a file in include_path gets loaded, see ZF-2985
-        $this->assertTrue(Loader::isReadable('Zend/Controller/Front.php'), get_include_path());
+        $this->assertTrue(Loader::isReadable('Zend/Version.php'), get_include_path());
     }
 
     /**

--- a/tests/Zend/Loader/TestAsset/TestNamespace/NoDuplicateAutoloadersCase.php
+++ b/tests/Zend/Loader/TestAsset/TestNamespace/NoDuplicateAutoloadersCase.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Loader
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
+ */
+
+namespace TestNamespace;
+
+/**
+ * @category   Zend
+ * @package    Loader
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Loader
+ */
+class NoDuplicateAutoloadersCase
+{
+}


### PR DESCRIPTION
This patch fixes fatal errors on Zend\Loader tests.
 So... it runs again.

Ticket: http://framework.zend.com/issues/browse/ZF2-61
