### PR TITLE
Module manager event implementation improvements

### DIFF
--- a/library/Zend/Module/Consumer/AutoloaderProvider.php
+++ b/library/Zend/Module/Consumer/AutoloaderProvider.php
@@ -6,7 +6,7 @@ interface AutoloaderProvider
 {
     /**
      * Return an array for passing to Zend\Loader\AutoloaderFactory.
-     * 
+     *
      * @return array
      */
     public function getAutoloaderConfig();

--- a/library/Zend/Module/Exception/InvalidArgumentException.php
+++ b/library/Zend/Module/Exception/InvalidArgumentException.php
@@ -4,7 +4,7 @@ namespace Zend\Module\Exception;
 
 use Zend\Module\Exception;
 
-class InvalidArgumentException 
+class InvalidArgumentException
     extends \InvalidArgumentException
     implements Exception
 {}

--- a/library/Zend/Module/Exception/RuntimeException.php
+++ b/library/Zend/Module/Exception/RuntimeException.php
@@ -3,7 +3,7 @@ namespace Zend\Module\Exception;
 
 use Zend\Module\Exception;
 
-class RuntimeException 
+class RuntimeException
     extends \RuntimeException
     implements Exception
 {}

--- a/library/Zend/Module/Listener/AbstractListener.php
+++ b/library/Zend/Module/Listener/AbstractListener.php
@@ -10,9 +10,9 @@ abstract class AbstractListener
     protected $options;
 
     /**
-     * __construct 
-     * 
-     * @param ListenerOptions $options 
+     * __construct
+     *
+     * @param ListenerOptions $options
      * @return void
      */
     public function __construct(ListenerOptions $options = null)
@@ -23,7 +23,7 @@ abstract class AbstractListener
             $this->setOptions($options);
         }
     }
- 
+
     /**
      * Get options.
      *
@@ -33,7 +33,7 @@ abstract class AbstractListener
     {
         return $this->options;
     }
- 
+
     /**
      * Set options.
      *
@@ -48,9 +48,9 @@ abstract class AbstractListener
 
     /**
      * Write a simple array of scalars to a file
-     * 
-     * @param string $filePath 
-     * @param array $array 
+     *
+     * @param string $filePath
+     * @param array $array
      * @return AbstractListener
      */
     protected function writeArrayToFile($filePath, $array)

--- a/library/Zend/Module/Listener/ConfigListener.php
+++ b/library/Zend/Module/Listener/ConfigListener.php
@@ -33,11 +33,11 @@ class ConfigListener extends AbstractListener implements ConfigMerger
      * @var array
      */
     protected $globPaths = array();
-    
+
     /**
-     * __construct 
-     * 
-     * @param ListenerOptions $options 
+     * __construct
+     *
+     * @param ListenerOptions $options
      * @return void
      */
     public function __construct(ListenerOptions $options = null)
@@ -62,8 +62,8 @@ class ConfigListener extends AbstractListener implements ConfigMerger
 
     /**
      * getMergedConfig
-     * 
-     * @param bool $returnConfigAsObject 
+     *
+     * @param bool $returnConfigAsObject
      * @return mixed
      */
     public function getMergedConfig($returnConfigAsObject = true)
@@ -79,9 +79,9 @@ class ConfigListener extends AbstractListener implements ConfigMerger
     }
 
     /**
-     * setMergedConfig 
-     * 
-     * @param array $config 
+     * setMergedConfig
+     *
+     * @param array $config
      * @return ConfigListener
      */
     public function setMergedConfig(array $config)
@@ -92,16 +92,16 @@ class ConfigListener extends AbstractListener implements ConfigMerger
     }
 
     /**
-     * Add a glob path of config files to merge after loading modules 
-     * 
-     * @param string $globPath 
+     * Add a glob path of config files to merge after loading modules
+     *
+     * @param string $globPath
      * @return ConfigListener
      */
     public function addConfigGlobPath($globPath)
     {
         if (!is_string($globPath)) {
             throw new Exception\InvalidArgumentException(
-                sprintf('Parameter to %s::%s() must be a string; %s given.', 
+                sprintf('Parameter to %s::%s() must be a string; %s given.',
                 __CLASS__, __METHOD__, gettype($globPath))
             );
         }
@@ -110,9 +110,9 @@ class ConfigListener extends AbstractListener implements ConfigMerger
     }
 
     /**
-     * Add an array of glob paths of config files to merge after loading modules 
-     * 
-     * @param mixed $globPaths 
+     * Add an array of glob paths of config files to merge after loading modules
+     *
+     * @param mixed $globPaths
      * @return ConfigListener
      */
     public function addConfigGlobPaths($globPaths)
@@ -125,7 +125,7 @@ class ConfigListener extends AbstractListener implements ConfigMerger
             throw new Exception\InvalidArgumentException(
                 sprintf('Argument passed to %::%s() must be an array, '
                 . 'implement the \Traversable interface, or be an '
-                . 'instance of Zend\Config\Config. %s given.', 
+                . 'instance of Zend\Config\Config. %s given.',
                 __CLASS__, __METHOD__, gettype($globPaths))
             );
         }
@@ -138,10 +138,10 @@ class ConfigListener extends AbstractListener implements ConfigMerger
     }
 
     /**
-     * Merge all config files matched by the given glob()s 
+     * Merge all config files matched by the given glob()s
      *
      * This should really only be called by the module manager.
-     * 
+     *
      * @return ConfigListener
      */
     public function mergeConfigGlobPaths()
@@ -153,9 +153,9 @@ class ConfigListener extends AbstractListener implements ConfigMerger
     }
 
     /**
-     * Merge all config files matching a glob 
-     * 
-     * @param mixed $globPath 
+     * Merge all config files matching a glob
+     *
+     * @param mixed $globPath
      * @return ConfigListener
      */
     protected function mergeGlobPath($globPath)
@@ -205,9 +205,9 @@ class ConfigListener extends AbstractListener implements ConfigMerger
     }
 
     /**
-     * mergeModuleConfig 
-     * 
-     * @param mixed $module 
+     * mergeModuleConfig
+     *
+     * @param mixed $module
      * @return ConfigListener
      */
     protected function mergeModuleConfig($module)
@@ -223,7 +223,7 @@ class ConfigListener extends AbstractListener implements ConfigMerger
                 throw new Exception\InvalidArgumentException(
                     sprintf('getConfig() method of %s must be an array, '
                     . 'implement the \Traversable interface, or be an '
-                    . 'instance of Zend\Config\Config. %s given.', 
+                    . 'instance of Zend\Config\Config. %s given.',
                     get_class($module), gettype($config))
                 );
             }
@@ -248,7 +248,7 @@ class ConfigListener extends AbstractListener implements ConfigMerger
         }
         $this->setMergedConfig(array_replace_recursive($this->mergedConfig, $config));
     }
-    
+
     protected function hasCachedConfig()
     {
         if (($this->getOptions()->getConfigCacheEnabled())

--- a/library/Zend/Module/Listener/ConfigListener.php
+++ b/library/Zend/Module/Listener/ConfigListener.php
@@ -77,7 +77,7 @@ class ConfigListener extends AbstractListener
     public function attach(EventCollection $events)
     {
         $this->listeners[] = $events->attach('loadModule', $this, 1000);
-        $this->listeners[] = $events->attach('loadModules.post', array($this, 'mergeConfigGlobPaths'), 1000);
+        $this->listeners[] = $events->attach('loadModules.post', array($this, 'mergeConfigGlobPaths'), 9000);
         return $this;
     }
 
@@ -179,12 +179,16 @@ class ConfigListener extends AbstractListener
      *
      * This should really only be called by the module manager.
      *
+     * @param mixed $e 
      * @return ConfigListener
      */
-    public function mergeConfigGlobPaths()
+    public function mergeConfigGlobPaths($e = null)
     {
         foreach ($this->globPaths as $globPath) {
             $this->mergeGlobPath($globPath);
+        }
+        if ($e instanceof ModuleEvent) {
+            $e->setConfigListener($this);
         }
         return $this;
     }

--- a/library/Zend/Module/Listener/ConfigListener.php
+++ b/library/Zend/Module/Listener/ConfigListener.php
@@ -54,7 +54,7 @@ class ConfigListener extends AbstractListener implements ConfigMerger
         if (true === $this->skipConfig) {
             return;
         }
-        $module = $e->getModule();
+        $module = $e->getParam('module');
         if (is_callable(array($module, 'getConfig'))) {
             $this->mergeModuleConfig($module);
         }

--- a/library/Zend/Module/Listener/ConfigMerger.php
+++ b/library/Zend/Module/Listener/ConfigMerger.php
@@ -6,16 +6,16 @@ interface ConfigMerger
 {
     /**
      * getMergedConfig
-     * 
-     * @param bool $returnConfigAsObject 
+     *
+     * @param bool $returnConfigAsObject
      * @return mixed
      */
     public function getMergedConfig($returnConfigAsObject = true);
 
     /**
-     * setMergedConfig 
-     * 
-     * @param array $config 
+     * setMergedConfig
+     *
+     * @param array $config
      * @return Manager
      */
     public function setMergedConfig(array $config);

--- a/library/Zend/Module/Listener/DefaultListenerAggregate.php
+++ b/library/Zend/Module/Listener/DefaultListenerAggregate.php
@@ -48,7 +48,7 @@ class DefaultListenerAggregate extends AbstractListener
     public function detach(EventCollection $events)
     {
         foreach ($this->listeners as $key => $listener) {
-            $events->detach($handler);
+            $events->detach($listener);
             unset($this->listeners[$key]);
         }
         $this->handlers = array();

--- a/library/Zend/Module/Listener/DefaultListenerAggregate.php
+++ b/library/Zend/Module/Listener/DefaultListenerAggregate.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Zend\Module\Listener;
+
+use Zend\EventManager\ListenerAggregate,
+    Zend\EventManager\EventCollection;
+
+class DefaultListenerAggregate extends AbstractListener
+    implements ListenerAggregate
+{
+    /**
+     * @var array
+     */
+    protected $listeners = array();
+
+    /**
+     * @var ConfigMerger
+     */
+    protected $configListener;
+
+    /**
+     * Attach one or more listeners
+     *
+     * @param EventCollection $events
+     * @return void
+     */
+    public function attach(EventCollection $events)
+    {
+        $options = $this->getOptions();
+        $configListener = $this->getConfigListener();
+        $this->listeners[] = $events->attach('loadModule.resolve', new ModuleResolverListener, 1000);
+        $this->listeners[] = $events->attach('loadModule', new AutoloaderListener($options), 2000);
+        $this->listeners[] = $events->attach('loadModule', new InitTrigger($options), 1000);
+        $this->listeners[] = $events->attach('loadModule', $configListener, 1000);
+        $this->listeners[] = $events->attach('loadModules.post', array($configListener, 'mergeConfigGlobPaths'), 1000);
+    }
+
+    /**
+     * Detach all previously attached listeners
+     *
+     * @param EventCollection $events
+     * @return void
+     */
+    public function detach(EventCollection $events)
+    {
+        foreach ($this->listeners as $key => $listener) {
+            $events->detach($handler);
+            unset($this->listeners[$key]);
+        }
+        $this->handlers = array();
+    }
+ 
+    /**
+     * Get the config merger.
+     *
+     * @return ConfigMerger
+     */
+    public function getConfigListener()
+    {
+        if (!$this->configListener instanceof ConfigMerger) {
+            $this->setConfigListener(new ConfigListener($this->getOptions()));
+        }
+        return $this->configListener;
+    }
+ 
+    /**
+     * Set the config merger to use.
+     *
+     * @param ConfigMerger $configListener
+     * @return DefaultListenerAggregate
+     */
+    public function setConfigListener(ConfigMerger $configListener)
+    {
+        $this->configListener = $configListener;
+        return $this;
+    }
+}

--- a/library/Zend/Module/Listener/DefaultListenerAggregate.php
+++ b/library/Zend/Module/Listener/DefaultListenerAggregate.php
@@ -29,7 +29,9 @@ class DefaultListenerAggregate extends AbstractListener
     {
         $options = $this->getOptions();
         $configListener = $this->getConfigListener();
-        $this->listeners[] = $events->attach('loadModules.pre', array(new ModuleAutoloader($options->getModulePaths()), 'register'), 1000);
+        $moduleAutoloader = new ModuleAutoloader($options->getModulePaths());
+
+        $this->listeners[] = $events->attach('loadModules.pre', array($moduleAutoloader, 'register'), 1000);
         $this->listeners[] = $events->attach('loadModule.resolve', new ModuleResolverListener, 1000);
         $this->listeners[] = $events->attach('loadModule', new AutoloaderListener($options), 2000);
         $this->listeners[] = $events->attach('loadModule', new InitTrigger($options), 1000);
@@ -51,7 +53,7 @@ class DefaultListenerAggregate extends AbstractListener
         }
         $this->handlers = array();
     }
- 
+
     /**
      * Get the config merger.
      *
@@ -64,7 +66,7 @@ class DefaultListenerAggregate extends AbstractListener
         }
         return $this->configListener;
     }
- 
+
     /**
      * Set the config merger to use.
      *

--- a/library/Zend/Module/Listener/DefaultListenerAggregate.php
+++ b/library/Zend/Module/Listener/DefaultListenerAggregate.php
@@ -3,7 +3,8 @@
 namespace Zend\Module\Listener;
 
 use Zend\EventManager\ListenerAggregate,
-    Zend\EventManager\EventCollection;
+    Zend\EventManager\EventCollection,
+    Zend\Loader\ModuleAutoloader;
 
 class DefaultListenerAggregate extends AbstractListener
     implements ListenerAggregate
@@ -28,6 +29,7 @@ class DefaultListenerAggregate extends AbstractListener
     {
         $options = $this->getOptions();
         $configListener = $this->getConfigListener();
+        $this->listeners[] = $events->attach('loadModules.pre', array(new ModuleAutoloader($options->getModulePaths()), 'register'), 1000);
         $this->listeners[] = $events->attach('loadModule.resolve', new ModuleResolverListener, 1000);
         $this->listeners[] = $events->attach('loadModule', new AutoloaderListener($options), 2000);
         $this->listeners[] = $events->attach('loadModule', new InitTrigger($options), 1000);

--- a/library/Zend/Module/Listener/DefaultListenerAggregate.php
+++ b/library/Zend/Module/Listener/DefaultListenerAggregate.php
@@ -35,8 +35,8 @@ class DefaultListenerAggregate extends AbstractListener
         $this->listeners[] = $events->attach('loadModule.resolve', new ModuleResolverListener, 1000);
         $this->listeners[] = $events->attach('loadModule', new AutoloaderListener($options), 2000);
         $this->listeners[] = $events->attach('loadModule', new InitTrigger($options), 1000);
-        $this->listeners[] = $events->attach('loadModule', $configListener, 1000);
-        $this->listeners[] = $events->attach('loadModules.post', array($configListener, 'mergeConfigGlobPaths'), 1000);
+        $this->listeners[] = $events->attachAggregate($configListener);
+        return $this;
     }
 
     /**
@@ -48,10 +48,15 @@ class DefaultListenerAggregate extends AbstractListener
     public function detach(EventCollection $events)
     {
         foreach ($this->listeners as $key => $listener) {
-            $events->detach($listener);
+            if ($listener instanceof ListenerAggregate) {
+                $listener->detach($events);
+            } else {
+                $events->detach($listener);
+            }
             unset($this->listeners[$key]);
         }
-        $this->handlers = array();
+        $this->listeners = array();
+        return $this;
     }
 
     /**

--- a/library/Zend/Module/Listener/ListenerOptions.php
+++ b/library/Zend/Module/Listener/ListenerOptions.php
@@ -7,6 +7,11 @@ use Zend\Stdlib\Options;
 class ListenerOptions extends Options
 {
     /**
+     * @var array
+     */
+    protected $modulePaths = array();
+
+    /**
      * @var bool
      */
     protected $configCacheEnabled = false;
@@ -20,6 +25,28 @@ class ListenerOptions extends Options
      * @var string
      */
     protected $cacheDir;
+
+    /**
+     * Get an array of paths where modules reside 
+     * 
+     * @return array
+     */
+    public function getModulePaths()
+    {
+        return $this->modulePaths;
+    }
+
+    /**
+     * Set an array of paths where modules reside 
+     * 
+     * @param array $modulePaths 
+     * @return ListenerOptions
+     */
+    public function setModulePaths(array $modulePaths)
+    {
+        $this->modulePaths = $modulePaths;
+        return $this;
+    }
 
     /**
      * Check if the config cache is enabled

--- a/library/Zend/Module/Listener/ListenerOptions.php
+++ b/library/Zend/Module/Listener/ListenerOptions.php
@@ -27,8 +27,8 @@ class ListenerOptions extends Options
     protected $cacheDir;
 
     /**
-     * Get an array of paths where modules reside 
-     * 
+     * Get an array of paths where modules reside
+     *
      * @return array
      */
     public function getModulePaths()
@@ -37,9 +37,9 @@ class ListenerOptions extends Options
     }
 
     /**
-     * Set an array of paths where modules reside 
-     * 
-     * @param array $modulePaths 
+     * Set an array of paths where modules reside
+     *
+     * @param array $modulePaths
      * @return ListenerOptions
      */
     public function setModulePaths(array $modulePaths)
@@ -57,7 +57,7 @@ class ListenerOptions extends Options
     {
         return $this->configCacheEnabled;
     }
- 
+
     /**
      * Set if the config cache should be enabled or not
      *
@@ -75,7 +75,7 @@ class ListenerOptions extends Options
      *
      * @return string
      */
-    public function getConfigCacheKey() 
+    public function getConfigCacheKey()
     {
         return (string) $this->configCacheKey;
     }
@@ -86,16 +86,16 @@ class ListenerOptions extends Options
      * @param string $configCacheKey the value to be set
      * @return ManagerOptions
      */
-    public function setConfigCacheKey($configCacheKey) 
+    public function setConfigCacheKey($configCacheKey)
     {
         $this->configCacheKey = $configCacheKey;
         return $this;
     }
 
     /**
-     * Get the path to the config cache 
-     * 
-     * Should this be an option, or should the dir option include the 
+     * Get the path to the config cache
+     *
+     * Should this be an option, or should the dir option include the
      * filename, or should it simply remain hard-coded? Thoughts?
      *
      * @return string
@@ -114,7 +114,7 @@ class ListenerOptions extends Options
     {
         return $this->cacheDir;
     }
- 
+
     /**
      * Set the path where cache files can be stored
      *
@@ -133,8 +133,8 @@ class ListenerOptions extends Options
 
     /**
      * Normalize a path for insertion in the stack
-     * 
-     * @param  string $path 
+     *
+     * @param  string $path
      * @return string
      */
     public static function normalizePath($path)

--- a/library/Zend/Module/Listener/ModuleResolverListener.php
+++ b/library/Zend/Module/Listener/ModuleResolverListener.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Zend\Module\Listener;
+
+class ModuleResolverListener extends AbstractListener
+{
+    public function __invoke($e)
+    {
+        $moduleName = $e->getModuleName();
+        $class = $moduleName . '\Module';
+        if (!class_exists($class)) {
+            return false;
+        }
+        $module = new $class;
+        return $module;
+    }
+}

--- a/library/Zend/Module/Manager.php
+++ b/library/Zend/Module/Manager.php
@@ -101,7 +101,7 @@ class Manager implements ModuleHandler
         $module = $result->last();
 
         if (!is_object($module)) {
-            throw new \Exception(sprintf(
+            throw new Exception\RuntimeException(sprintf(
                 'Module (%s) could not be initialized.',
                 $moduleName
             ));
@@ -164,7 +164,7 @@ class Manager implements ModuleHandler
     public function getEvent()
     {
         if (!$this->event instanceof ModuleEvent) {
-            $this->event = new ModuleEvent;
+            $this->setEvent(new ModuleEvent);
         }
         return $this->event;
     }

--- a/library/Zend/Module/Manager.php
+++ b/library/Zend/Module/Manager.php
@@ -24,8 +24,8 @@ class Manager implements ModuleHandler
     protected $event;
 
     /**
-     * modules 
-     * 
+     * modules
+     *
      * @var array|Traversable
      */
     protected $modules = array();
@@ -38,10 +38,10 @@ class Manager implements ModuleHandler
     protected $modulesAreLoaded = false;
 
     /**
-     * __construct 
-     * 
-     * @param array|Traversable $modules 
-     * @param EventCollection $eventManager 
+     * __construct
+     *
+     * @param array|Traversable $modules
+     * @param EventCollection $eventManager
      * @return void
      */
     public function __construct($modules, EventCollection $eventManager = null)
@@ -54,7 +54,7 @@ class Manager implements ModuleHandler
 
     /**
      * Load the provided modules.
-     * 
+     *
      * @triggers loadModules.pre
      * @triggers loadModules.post
      * @return ManagerHandler
@@ -79,8 +79,8 @@ class Manager implements ModuleHandler
 
     /**
      * Load a specific module by name.
-     * 
-     * @param string $moduleName 
+     *
+     * @param string $moduleName
      * @triggers loadModule.resolve
      * @triggers loadModule
      * @return mixed Module's Module class
@@ -90,7 +90,7 @@ class Manager implements ModuleHandler
         if (isset($this->loadedModules[$moduleName])) {
             return $this->loadedModules[$moduleName];
         }
-        
+
         $event = $this->getEvent();
         $event->setModuleName($moduleName);
 
@@ -136,9 +136,9 @@ class Manager implements ModuleHandler
     {
         return $this->modules;
     }
- 
+
     /**
-     * Set an array or Traversable of module names that this module manager should load. 
+     * Set an array or Traversable of module names that this module manager should load.
      *
      * @param mixed $modules array or Traversable of module names
      * @return ModuleHandler
@@ -157,8 +157,8 @@ class Manager implements ModuleHandler
     }
 
     /**
-     * Get the module event 
-     * 
+     * Get the module event
+     *
      * @return ModuleEvent
      */
     public function getEvent()
@@ -170,9 +170,9 @@ class Manager implements ModuleHandler
     }
 
     /**
-     * Set the module event 
-     * 
-     * @param ModuleEvent $event 
+     * Set the module event
+     *
+     * @param ModuleEvent $event
      * @return Manager
      */
     public function setEvent(ModuleEvent $event)
@@ -183,8 +183,8 @@ class Manager implements ModuleHandler
 
     /**
      * Set the event manager instance used by this module manager.
-     * 
-     * @param  EventCollection $events 
+     *
+     * @param  EventCollection $events
      * @return Manager
      */
     public function setEventManager(EventCollection $events)
@@ -197,7 +197,7 @@ class Manager implements ModuleHandler
      * Retrieve the event manager
      *
      * Lazy-loads an EventManager instance if none registered.
-     * 
+     *
      * @return EventCollection
      */
     public function events()

--- a/library/Zend/Module/Manager.php
+++ b/library/Zend/Module/Manager.php
@@ -79,13 +79,14 @@ class Manager implements ModuleHandler
         if (true === $this->modulesAreLoaded) {
             return $this;
         }
+        $this->events()->trigger(__FUNCTION__ . '.pre', $this);
         foreach ($this->getModules() as $moduleName) {
             $this->loadModule($moduleName);
         }
         if ($configListener = $this->getConfigListener()) {
             $configListener->mergeConfigGlobPaths();
         }
-        $this->events()->trigger('init.post', $this);
+        $this->events()->trigger(__FUNCTION__ . '.post', $this);
         $this->modulesAreLoaded = true;
         return $this;
     }

--- a/library/Zend/Module/ModuleEvent.php
+++ b/library/Zend/Module/ModuleEvent.php
@@ -15,6 +15,31 @@ use Zend\EventManager\Event;
 class ModuleEvent extends Event
 {
     /**
+     * Get the name of a given module 
+     * 
+     * @return string
+     */
+    public function getModuleName()
+    {
+        return $this->getParam('moduleName');
+    }
+
+    /**
+     * Set the name of a given module 
+     * 
+     * @param string $moduleName 
+     * @return ModuleEvent
+     */
+    public function setModuleName($moduleName)
+    {
+        if (!is_string($moduleName)) {
+            throw new Exception\InvalidArgumentException(__METHOD__ . ' expects a string as an argument; ' . gettype($moduleName) . ' provided');
+        }
+        $this->setParam('moduleName', $moduleName);
+        return $this;
+    }
+
+    /**
      * Get module object
      * 
      * @return null|object

--- a/library/Zend/Module/ModuleEvent.php
+++ b/library/Zend/Module/ModuleEvent.php
@@ -2,7 +2,8 @@
 
 namespace Zend\Module;
 
-use Zend\EventManager\Event;
+use Zend\EventManager\Event,
+    Zend\Module\Listener\ConfigMerger;
 
 /**
  * Custom event for use with module manager
@@ -67,6 +68,34 @@ class ModuleEvent extends Event
             ));
         }
         $this->setParam('module', $module);
+        return $this;
+    }
+
+    /**
+     * Get the config listner
+     *
+     * @return null|ConfigMerger
+     */
+    public function getConfigListener()
+    {
+        return $this->getParam('configListener');
+    }
+
+    /**
+     * Set module object to compose in this event
+     *
+     * @param  ConfigMerger $listener
+     * @return ModuleEvent
+     */
+    public function setConfigListener($configListener)
+    {
+        if (!$configListener instanceof ConfigMerger) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s::%s() expects an object implementing Zend\Module\Listener\ConfigMerger as an argument; %s provided'
+                ,__CLASS__, __METHOD__, gettype($configListener)
+            ));
+        }
+        $this->setParam('configListener', $configListener);
         return $this;
     }
 }

--- a/library/Zend/Module/ModuleEvent.php
+++ b/library/Zend/Module/ModuleEvent.php
@@ -35,7 +35,7 @@ class ModuleEvent extends Event
         if (!is_string($moduleName)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects a string as an argument; %s provided'
-                ,__METHOD__, gettype($module)
+                ,__METHOD__, gettype($moduleName)
             ));
         }
         $this->setParam('moduleName', $moduleName);

--- a/library/Zend/Module/ModuleEvent.php
+++ b/library/Zend/Module/ModuleEvent.php
@@ -8,15 +8,15 @@ use Zend\EventManager\Event;
  * Custom event for use with module manager
  *
  * Composes Module objects
- * 
+ *
  * @copyright Copyright (C) 2006-Present, Zend Technologies, Inc.
  * @license New BSD {@link http://framework.zend.com/license}
  */
 class ModuleEvent extends Event
 {
     /**
-     * Get the name of a given module 
-     * 
+     * Get the name of a given module
+     *
      * @return string
      */
     public function getModuleName()
@@ -25,15 +25,18 @@ class ModuleEvent extends Event
     }
 
     /**
-     * Set the name of a given module 
-     * 
-     * @param string $moduleName 
+     * Set the name of a given module
+     *
+     * @param string $moduleName
      * @return ModuleEvent
      */
     public function setModuleName($moduleName)
     {
         if (!is_string($moduleName)) {
-            throw new Exception\InvalidArgumentException(__METHOD__ . ' expects a string as an argument; ' . gettype($moduleName) . ' provided');
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects a string as an argument; %s provided'
+                ,__METHOD__, gettype($module)
+            ));
         }
         $this->setParam('moduleName', $moduleName);
         return $this;
@@ -41,7 +44,7 @@ class ModuleEvent extends Event
 
     /**
      * Get module object
-     * 
+     *
      * @return null|object
      */
     public function getModule()
@@ -51,14 +54,17 @@ class ModuleEvent extends Event
 
     /**
      * Set module object to compose in this event
-     * 
-     * @param  object $module 
+     *
+     * @param  object $module
      * @return ModuleEvent
      */
     public function setModule($module)
     {
         if (!is_object($module)) {
-            throw new Exception\InvalidArgumentException(__METHOD__ . ' expects a module object as an argument; ' . gettype($module) . ' provided');
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects a module object as an argument; %s provided'
+                ,__METHOD__, gettype($module)
+            ));
         }
         $this->setParam('module', $module);
         return $this;

--- a/library/Zend/Module/ModuleHandler.php
+++ b/library/Zend/Module/ModuleHandler.php
@@ -8,15 +8,15 @@ interface ModuleHandler
 {
     /**
      * Load the provided modules.
-     * 
+     *
      * @return ManagerHandler
      */
     public function loadModules();
 
     /**
      * Load a specific module by name.
-     * 
-     * @param string $moduleName 
+     *
+     * @param string $moduleName
      * @return mixed Module's Module class
      */
     public function loadModule($moduleName);
@@ -35,9 +35,9 @@ interface ModuleHandler
      * @return array
      */
     public function getModules();
- 
+
     /**
-     * Set an array or Traversable of module names that this module manager should load. 
+     * Set an array or Traversable of module names that this module manager should load.
      *
      * @param mixed $modules array or Traversable of module names
      * @return ModuleHandler
@@ -46,17 +46,17 @@ interface ModuleHandler
 
     /**
      * Set the event manager instance used by this module manager.
-     * 
-     * @param  EventCollection $events 
+     *
+     * @param  EventCollection $events
      * @return ManagerHandler
      */
     public function setEventManager(EventCollection $events);
-    
+
     /**
      * Retrieve the event manager
      *
      * Lazy-loads an EventManager instance if none registered.
-     * 
+     *
      * @return EventCollection
      */
     public function events();

--- a/library/Zend/Module/ModuleHandler.php
+++ b/library/Zend/Module/ModuleHandler.php
@@ -2,8 +2,7 @@
 
 namespace Zend\Module;
 
-use Zend\EventManager\EventCollection,
-    Zend\Module\Listener\ConfigMerger;
+use Zend\EventManager\EventCollection;
 
 interface ModuleHandler
 {
@@ -44,31 +43,6 @@ interface ModuleHandler
      * @return ModuleHandler
      */
     public function setModules($modules);
-
-    /**
-     * Get the listener that's in charge of merging module configs.
-     *
-     * @return ConfigMerger
-     */
-    public function getConfigListener();
- 
-    /**
-     * Set the listener that's in charge of merging module configs.
-     *
-     * @param ConfigMerger $configListener
-     * @return ModuleHandler
-     */
-    public function setConfigListener(ConfigMerger $configListener);
-
-    /**
-     * A convenience method that proxies through to:
-     *
-     * $this->getConfigListener()->getMergedConfig();
-     * 
-     * @param bool $returnConfigAsObject 
-     * @return mixed
-     */
-    public function getMergedConfig($returnConfigAsObject = true);
 
     /**
      * Set the event manager instance used by this module manager.

--- a/tests/Zend/Module/Listener/ConfigListenerTest.php
+++ b/tests/Zend/Module/Listener/ConfigListenerTest.php
@@ -153,8 +153,8 @@ class ConfigListenerTest extends TestCase
         $moduleManager = $this->moduleManager;
         $moduleManager->setModules(array('SomeModule'));
 
-        $moduleManager->events()->attach('loadModule', $configListener);
-        $moduleManager->events()->attach('loadModules.post', array($configListener, 'mergeConfigGlobPaths'), 1000);
+        $moduleManager->events()->attachAggregate($configListener);
+
         $moduleManager->loadModules();
         $configObjectCheck = $configListener->getMergedConfig();
 
@@ -189,8 +189,7 @@ class ConfigListenerTest extends TestCase
         $moduleManager = $this->moduleManager;
         $moduleManager->setModules(array('SomeModule'));
 
-        $moduleManager->events()->attach('loadModule', $configListener);
-        $moduleManager->events()->attach('loadModules.post', array($configListener, 'mergeConfigGlobPaths'), 1000);
+        $moduleManager->events()->attachAggregate($configListener);
         $moduleManager->loadModules();
 
         // Test as object
@@ -200,6 +199,20 @@ class ConfigListenerTest extends TestCase
         $this->assertSame('loaded', $configObject->json);
         $this->assertSame('loaded', $configObject->xml);
         $this->assertSame('loaded', $configObject->yml);
+    }
+
+    public function testConfigListenerFunctionsAsAggregateListener()
+    {
+        $configListener = new ConfigListener;
+
+        $moduleManager = $this->moduleManager;
+        $this->assertEquals(1, count($moduleManager->events()->getEvents()));
+
+        $configListener->attach($moduleManager->events());
+        $this->assertEquals(3, count($moduleManager->events()->getEvents()));
+
+        $configListener->detach($moduleManager->events());
+        $this->assertEquals(1, count($moduleManager->events()->getEvents()));
     }
 
     public function testPhpConfigFileReturningInvalidConfigRaisesException()

--- a/tests/Zend/Module/Listener/ConfigListenerTest.php
+++ b/tests/Zend/Module/Listener/ConfigListenerTest.php
@@ -8,6 +8,7 @@ use ArrayObject,
     Zend\Loader\AutoloaderFactory,
     Zend\Loader\ModuleAutoloader,
     Zend\Module\Listener\ConfigListener,
+    Zend\Module\Listener\ModuleResolverListener,
     Zend\Module\Listener\ListenerOptions,
     Zend\Module\Manager;
 
@@ -33,13 +34,16 @@ class ConfigListenerTest extends TestCase
             dirname(__DIR__) . '/TestAsset',
         ));
         $autoloader->register();
+
+        $this->moduleManager = new Manager(array());
+        $this->moduleManager->events()->attach('loadModule.resolve', new ModuleResolverListener, 1000);
     }
 
     public function tearDown()
     {
         $file = glob($this->tmpdir . DIRECTORY_SEPARATOR . '*');
-        //@unlink($file[0]); // change this if there's ever > 1 file 
-        //@rmdir($this->tmpdir);
+        @unlink($file[0]); // change this if there's ever > 1 file 
+        @rmdir($this->tmpdir);
         // Restore original autoloaders
         AutoloaderFactory::unregisterAutoloaders();
         $loaders = spl_autoload_functions();
@@ -59,32 +63,43 @@ class ConfigListenerTest extends TestCase
 
     public function testMultipleConfigsAreMerged()
     {
-        $moduleManager = new Manager(array('SomeModule', 'ListenerTestModule'));
+        $configListener = new ConfigListener;
+
+        $moduleManager = $this->moduleManager;
+        $moduleManager->events()->attach('loadModule', $configListener);
+        $moduleManager->setModules(array('SomeModule', 'ListenerTestModule'));
         $moduleManager->loadModules();
-        $config = $moduleManager->getConfigListener()->getMergedConfig(false);
+
+        $config = $configListener->getMergedConfig(false);
         $this->assertSame(2, count($config));
         $this->assertSame('test', $config['listener']);
         $this->assertSame('thing', $config['some']);
-        $configObject = $moduleManager->getConfigListener()->getMergedConfig();
+        $configObject = $configListener->getMergedConfig();
         $this->assertInstanceOf('Zend\Config\Config', $configObject);
     }
 
     public function testCanCacheMergedConfig()
     {
-        $moduleManager = new Manager(array('SomeModule', 'ListenerTestModule'));
         $options = new ListenerOptions(array(
             'cache_dir'            => $this->tmpdir,
             'config_cache_enabled' => true,
         ));
-        $moduleManager->setDefaultListenerOptions($options);
+        $configListener = new ConfigListener($options);
+
+        $moduleManager = $this->moduleManager;
+        $moduleManager->setModules(array('SomeModule', 'ListenerTestModule'));
+        $moduleManager->events()->attach('loadModule', $configListener);
         $moduleManager->loadModules(); // This should cache the config
+
         $modules = $moduleManager->getLoadedModules();
         $this->assertTrue($modules['ListenerTestModule']->getConfigCalled);
 
         // Now we check to make sure it uses the config and doesn't hit 
         // the module objects getConfig() method(s)
         $moduleManager = new Manager(array('SomeModule', 'ListenerTestModule'));
-        $moduleManager->setDefaultListenerOptions($options);
+        $moduleManager->events()->attach('loadModule.resolve', new ModuleResolverListener, 1000);
+        $configListener = new ConfigListener($options);
+        $moduleManager->events()->attach('loadModule', $configListener);
         $moduleManager->loadModules();
         $modules = $moduleManager->getLoadedModules();
         $this->assertFalse($modules['ListenerTestModule']->getConfigCalled);
@@ -93,51 +108,66 @@ class ConfigListenerTest extends TestCase
     public function testBadConfigValueThrowsInvalidArgumentException()
     {
         $this->setExpectedException('InvalidArgumentException');
-        $moduleManager = new Manager(array('BadConfigModule', 'SomeModule'));
+
+        $configListener = new ConfigListener;
+
+        $moduleManager = $this->moduleManager;
+        $moduleManager->setModules(array('BadConfigModule', 'SomeModule'));
+        $moduleManager->events()->attach('loadModule', $configListener);
         $moduleManager->loadModules();
     }
     
     public function testBadConfigFileExtensionThrowsRuntimeException()
     {
         $this->setExpectedException('RuntimeException');
-        $moduleManager = new Manager(array('SomeModule'));
-        $moduleManager->getConfigListener()->addConfigGlobPath(__DIR__ . '/_files/bad/*.badext');
+
+        $configListener = new ConfigListener;
+        $configListener->addConfigGlobPath(__DIR__ . '/_files/bad/*.badext');
+
+        $moduleManager = $this->moduleManager;
+        $moduleManager->setModules(array('SomeModule'));
+        $moduleManager->events()->attach('loadModule', $configListener);
+        $moduleManager->events()->attach('loadModules.post', array($configListener, 'mergeConfigGlobPaths'), 1000);
         $moduleManager->loadModules();
     }
 
     public function testBadGlobPathTrowsInvalidArgumentException()
     {
         $this->setExpectedException('InvalidArgumentException');
-        $moduleManager = new Manager(array('SomeModule'));
-        $moduleManager->getConfigListener()->addConfigGlobPath(array('asd'));
-        $moduleManager->loadModules();
+        $configListener = new ConfigListener;
+        $configListener->addConfigGlobPath(array('asd'));
     }
 
     public function testBadGlobPathArrayTrowsInvalidArgumentException()
     {
         $this->setExpectedException('InvalidArgumentException');
-        $moduleManager = new Manager(array('SomeModule'));
-        $moduleManager->getConfigListener()->addConfigGlobPaths('asd');
-        $moduleManager->loadModules();
+        $configListener = new ConfigListener;
+        $configListener->addConfigGlobPaths('asd');
     }
 
     public function testCanMergeConfigFromGlob()
     {
-        $moduleManager = new Manager(array('SomeModule'));
-        $options = new ListenerOptions;
-        $moduleManager->setDefaultListenerOptions($options);
-        $moduleManager->getConfigListener()->addConfigGlobPath(__DIR__ . '/_files/good/*.{ini,json,php,xml,yml}');
+        $configListener = new ConfigListener;
+        $configListener->addConfigGlobPath(__DIR__ . '/_files/good/*.{ini,json,php,xml,yml}');
+
+        $moduleManager = $this->moduleManager;
+        $moduleManager->setModules(array('SomeModule'));
+
+        $moduleManager->events()->attach('loadModule', $configListener);
+        $moduleManager->events()->attach('loadModules.post', array($configListener, 'mergeConfigGlobPaths'), 1000);
         $moduleManager->loadModules();
-        $moduleManager->getMergedConfig(); 
+        $configObjectCheck = $configListener->getMergedConfig();
+
         // Test as object
-        $configObject = $moduleManager->getMergedConfig();
+        $configObject = $configListener->getMergedConfig();
+        $this->assertSame(spl_object_hash($configObjectCheck), spl_object_hash($configObject));
         $this->assertSame('loaded', $configObject->ini);
         $this->assertSame('loaded', $configObject->php);
         $this->assertSame('loaded', $configObject->json);
         $this->assertSame('loaded', $configObject->xml);
         $this->assertSame('loaded', $configObject->yml);
         // Test as array
-        $config = $moduleManager->getMergedConfig(false);
+        $config = $configListener->getMergedConfig(false);
         $this->assertSame('loaded', $config['ini']);
         $this->assertSame('loaded', $config['json']);
         $this->assertSame('loaded', $config['php']);
@@ -147,19 +177,24 @@ class ConfigListenerTest extends TestCase
 
     public function testCanMergeConfigFromArrayOfGlobs()
     {
-        $moduleManager = new Manager(array('SomeModule'));
-        $options = new ListenerOptions;
-        $moduleManager->setDefaultListenerOptions($options);
-        $moduleManager->getConfigListener()->addConfigGlobPaths(new ArrayObject(array(
+        $configListener = new ConfigListener;
+        $configListener->addConfigGlobPaths(new ArrayObject(array(
             __DIR__ . '/_files/good/*.ini',
             __DIR__ . '/_files/good/*.json',
             __DIR__ . '/_files/good/*.php',
             __DIR__ . '/_files/good/*.xml',
             __DIR__ . '/_files/good/*.yml',
         )));
+
+        $moduleManager = $this->moduleManager;
+        $moduleManager->setModules(array('SomeModule'));
+
+        $moduleManager->events()->attach('loadModule', $configListener);
+        $moduleManager->events()->attach('loadModules.post', array($configListener, 'mergeConfigGlobPaths'), 1000);
         $moduleManager->loadModules();
+
         // Test as object
-        $configObject = $moduleManager->getMergedConfig();
+        $configObject = $configListener->getMergedConfig();
         $this->assertSame('loaded', $configObject->ini);
         $this->assertSame('loaded', $configObject->php);
         $this->assertSame('loaded', $configObject->json);
@@ -169,12 +204,19 @@ class ConfigListenerTest extends TestCase
 
     public function testPhpConfigFileReturningInvalidConfigRaisesException()
     {
-        $moduleManager  = new Manager(array('SomeModule'));
-        $configListener = $moduleManager->getConfigListener();
+        $this->setExpectedException('Zend\Module\Listener\Exception\RuntimeException', 'Invalid configuration');
+
+        $configListener = new ConfigListener;
         $configListener->addConfigGlobPaths(new ArrayObject(array(
             __DIR__ . '/_files/bad/*.php',
         )));
-        $this->setExpectedException('Zend\Module\Listener\Exception\RuntimeException', 'Invalid configuration');
+
+        $moduleManager  = $this->moduleManager;
+        $moduleManager->setModules(array('SomeModule'));
+
+        $moduleManager->events()->attach('loadModule', $configListener);
+        $moduleManager->events()->attach('loadModules.post', array($configListener, 'mergeConfigGlobPaths'), 1000);
+
         $moduleManager->loadModules();
     }
 }

--- a/tests/Zend/Module/Listener/DefaultListenerAggregateTest.php
+++ b/tests/Zend/Module/Listener/DefaultListenerAggregateTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace ZendTest\Module\Listener;
+
+use PHPUnit_Framework_TestCase as TestCase,
+    Zend\Loader\ModuleAutoloader,
+    Zend\Loader\AutoloaderFactory,
+    Zend\Module\Manager,
+    Zend\Module\Listener\ListenerOptions,
+    Zend\EventManager\EventManager,
+    Zend\Module\Listener\DefaultListenerAggregate,
+    InvalidArgumentException;
+
+class DefaultListenerAggregateTest extends TestCase
+{
+    public function setUp()
+    {
+        // Store original autoloaders
+        $this->loaders = spl_autoload_functions();
+        if (!is_array($this->loaders)) {
+            // spl_autoload_functions does not return empty array when no
+            // autoloaders registered...
+            $this->loaders = array();
+        }
+
+        // Store original include_path
+        $this->includePath = get_include_path();
+
+        $this->defaultListeners = new DefaultListenerAggregate(
+            new ListenerOptions(array( 
+                'module_paths'         => array(
+                    realpath(__DIR__ . '/TestAsset'),
+                ),
+            ))
+        );
+    }
+
+    public function tearDown()
+    {
+        // Restore original autoloaders
+        AutoloaderFactory::unregisterAutoloaders();
+        $loaders = spl_autoload_functions();
+        if (is_array($loaders)) {
+            foreach ($loaders as $loader) {
+                spl_autoload_unregister($loader);
+            }
+        }
+
+        foreach ($this->loaders as $loader) {
+            spl_autoload_register($loader);
+        }
+
+        // Restore original include_path
+        set_include_path($this->includePath);
+    }
+
+    public function testDefaultListenerAggregateCanAttachItself()
+    {
+        $moduleManager = new Manager(array('ListenerTestModule'));
+        $moduleManager->events()->attachAggregate(new DefaultListenerAggregate);
+
+        $events = $moduleManager->events()->getEvents();
+        $expectedEvents = array(
+            'loadModules.pre' => array(
+                'Zend\Loader\ModuleAutoloader',
+            ),
+            'loadModule.resolve' => array(
+                'Zend\Module\Listener\ModuleResolverListener',
+            ),
+            'loadModule' => array(
+                'Zend\Module\Listener\AutoloaderListener',
+                'Zend\Module\Listener\InitTrigger',
+                'Zend\Module\Listener\ConfigListener',
+            ),
+            'loadModules.post' => array(
+                'Zend\Module\Listener\ConfigListener',
+            ),
+        );
+        foreach ($expectedEvents as $event => $expectedListeners) {
+            $this->assertContains($event, $events);
+            $listeners = $moduleManager->events()->getListeners($event);
+            $this->assertSame(count($expectedListeners), count($listeners));
+            foreach ($listeners as $listener) {
+                $callback = $listener->getCallback();
+                if (is_array($callback)) {
+                    $callback = $callback[0];
+                }
+                $listenerClass = get_class($callback);
+                $this->assertContains($listenerClass, $expectedListeners);
+            }
+        }
+    }
+
+    public function testDefaultListenerAggregateCanDetachItself()
+    {
+        $listenerAggregate = new DefaultListenerAggregate;
+        $moduleManager = new Manager(array('ListenerTestModule'));
+
+        $listenerAggregate->attach($moduleManager->events());
+        $this->assertEquals(4, count($moduleManager->events()->getEvents()));
+
+        $listenerAggregate->detach($moduleManager->events());
+        $this->assertEquals(0, count($moduleManager->events()->getEvents()));
+    }
+}

--- a/tests/Zend/Module/Listener/ListenerOptionsTest.php
+++ b/tests/Zend/Module/Listener/ListenerOptionsTest.php
@@ -15,12 +15,14 @@ class ListenerOptionsTest extends TestCase
             'cache_dir'               => __DIR__,
             'config_cache_enabled'    => true,
             'config_cache_key'        => 'foo',
+            'module_paths'            => array('foo','bar'),
         ));
         $this->assertSame($options->getCacheDir(), __DIR__);
         $this->assertTrue($options->getConfigCacheEnabled());
         $this->assertNotNull(strstr($options->getConfigCacheFile(), __DIR__));
         $this->assertNotNull(strstr($options->getConfigCacheFile(), '.php'));
         $this->assertSame('foo', $options->getConfigCacheKey());
+        $this->assertSame(array('foo', 'bar'), $options->getModulePaths());
     }
 
     public function testCanAccessKeysAsProperties()
@@ -29,6 +31,7 @@ class ListenerOptionsTest extends TestCase
             'cache_dir'               => __DIR__,
             'config_cache_enabled'    => true,
             'config_cache_key'        => 'foo',
+            'module_paths'            => array('foo','bar'),
         ));
         $this->assertSame($options->cache_dir, __DIR__);
         $options->cache_dir = 'foo';
@@ -42,5 +45,6 @@ class ListenerOptionsTest extends TestCase
         $this->assertFalse($options->config_cache_enabled);
 
         $this->assertEquals('foo', $options->config_cache_key);
+        $this->assertSame(array('foo', 'bar'), $options->module_paths);
     }
 }

--- a/tests/Zend/Module/Listener/ModuleResolverListenerTest.php
+++ b/tests/Zend/Module/Listener/ModuleResolverListenerTest.php
@@ -5,11 +5,10 @@ namespace ZendTest\Module\Listener;
 use PHPUnit_Framework_TestCase as TestCase,
     Zend\Loader\ModuleAutoloader,
     Zend\Loader\AutoloaderFactory,
-    Zend\Module\Listener\InitTrigger,
     Zend\Module\Listener\ModuleResolverListener,
-    Zend\Module\Manager;
+    Zend\Module\ModuleEvent;
 
-class InitTriggerTest extends TestCase
+class ModuleResolverListenerTest extends TestCase
 {
 
     public function setUp()
@@ -28,10 +27,6 @@ class InitTriggerTest extends TestCase
             dirname(__DIR__) . '/TestAsset',
         ));
         $autoloader->register();
-
-        $this->moduleManager = new Manager(array());
-        $this->moduleManager->events()->attach('loadModule.resolve', new ModuleResolverListener, 1000);
-        $this->moduleManager->events()->attach('loadModule', new InitTrigger, 2000);
     }
 
     public function tearDown()
@@ -53,12 +48,15 @@ class InitTriggerTest extends TestCase
         set_include_path($this->includePath);
     }
 
-    public function testInitMethodCalledByInitTriggerListener()
+    public function testModuleResolverListenerCanResolveModuleClasses()
     {
-        $moduleManager = $this->moduleManager;
-        $moduleManager->setModules(array('ListenerTestModule'));
-        $moduleManager->loadModules();
-        $modules = $moduleManager->getLoadedModules();
-        $this->assertTrue($modules['ListenerTestModule']->initCalled);
+        $moduleResolver = new ModuleResolverListener;
+        $e = new ModuleEvent;
+
+        $e->setModuleName('ListenerTestModule');
+        $this->assertInstanceOf('ListenerTestModule\Module', $moduleResolver($e));
+
+        $e->setModuleName('DoesNotExist');
+        $this->assertFalse($moduleResolver($e));
     }
 }

--- a/tests/Zend/Module/ManagerTest.php
+++ b/tests/Zend/Module/ManagerTest.php
@@ -7,6 +7,8 @@ use PHPUnit_Framework_TestCase as TestCase,
     Zend\Loader\AutoloaderFactory,
     Zend\Module\Manager,
     Zend\Module\Listener\ListenerOptions,
+    Zend\EventManager\EventManager,
+    Zend\Module\Listener\DefaultListenerAggregate,
     InvalidArgumentException;
 
 class ManagerTest extends TestCase
@@ -27,10 +29,18 @@ class ManagerTest extends TestCase
         // Store original include_path
         $this->includePath = get_include_path();
 
-        $autoloader = new ModuleAutoloader(array(
-            __DIR__ . '/TestAsset',
-        ));
-        $autoloader->register();
+
+        $this->defaultListeners = new DefaultListenerAggregate(
+            new ListenerOptions(array( 
+                'module_paths'         => array(
+                    realpath(__DIR__ . '/TestAsset'),
+                ),
+            ))
+        );
+        //$autoloader = new ModuleAutoloader(array(
+        //    __DIR__ . '/TestAsset',
+        //));
+        //$autoloader->register();
     }
 
     public function tearDown()
@@ -55,60 +65,36 @@ class ManagerTest extends TestCase
         set_include_path($this->includePath);
     }
 
-    public function testDefaultListenerOptions()
-    {
-        $moduleManager = new Manager(array());
-        $this->assertInstanceOf('Zend\Module\Listener\ListenerOptions', $moduleManager->getDefaultListenerOptions());
-    }
-
-    public function testCanSetDefaultListenerOptions()
-    {
-        $options = new ListenerOptions(array('cache_dir' => __DIR__));
-        $moduleManager = new Manager(array());
-        $moduleManager->setDefaultListenerOptions($options);
-        $this->assertSame(__DIR__, $moduleManager->getDefaultListenerOptions()->cache_dir);
-    }
-
     public function testCanLoadSomeModule()
     {
-        $moduleManager = new Manager(array('SomeModule'));
+        $configListener = $this->defaultListeners->getConfigListener();
+        $moduleManager  = new Manager(array('SomeModule'), new EventManager);
+        $moduleManager->events()->attachAggregate($this->defaultListeners);
         $moduleManager->loadModules();
         $loadedModules = $moduleManager->getLoadedModules();
         $this->assertInstanceOf('SomeModule\Module', $loadedModules['SomeModule']);
-        $config = $moduleManager->getConfigListener()->getMergedConfig();
+        $config = $configListener->getMergedConfig();
         $this->assertSame($config->some, 'thing');
     }
 
     public function testCanLoadMultipleModules()
     {
-        $moduleManager = new Manager(array('BarModule', 'BazModule'));
+        $configListener = $this->defaultListeners->getConfigListener();
+        $moduleManager  = new Manager(array('BarModule', 'BazModule'));
+        $moduleManager->events()->attachAggregate($this->defaultListeners);
         $moduleManager->loadModules();
         $loadedModules = $moduleManager->getLoadedModules();
         $this->assertInstanceOf('BarModule\Module', $loadedModules['BarModule']);
         $this->assertInstanceOf('BazModule\Module', $loadedModules['BazModule']);
-        $config = $moduleManager->getMergedConfig(); // use convenience method
+        $config = $configListener->getMergedConfig();
         $this->assertSame('foo', $config->bar);
         $this->assertSame('bar', $config->baz);
-    }
-
-    public function testDefaultModuleListenersAreLoaded()
-    {
-        $moduleManager = new Manager(array());
-        $listeners = $moduleManager->events()->getListeners('loadModule');
-        $this->assertSame(3, count($listeners));
-    }
-
-    public function testCanSkipDefaultModuleListeners()
-    {
-        $moduleManager = new Manager(array());
-        $moduleManager->setDisableLoadDefaultListeners(true);
-        $listeners = $moduleManager->events()->getListeners('loadModule');
-        $this->assertSame(0, count($listeners));
     }
 
     public function testModuleLoadingBehavior()
     {
         $moduleManager = new Manager(array('BarModule'));
+        $moduleManager->events()->attachAggregate($this->defaultListeners);
         $modules = $moduleManager->getLoadedModules();
         $this->assertSame(0, count($modules));
         $modules = $moduleManager->getLoadedModules(true);
@@ -117,7 +103,6 @@ class ManagerTest extends TestCase
         $moduleManager->loadModule('BarModule'); // should not cause any problems
         $modules = $moduleManager->getLoadedModules(true); // BarModule already loaded so nothing happens
         $this->assertSame(1, count($modules));
-
     }
 
     public function testConstructorThrowsInvalidArgumentException()

--- a/tests/Zend/Module/ManagerTest.php
+++ b/tests/Zend/Module/ManagerTest.php
@@ -29,7 +29,6 @@ class ManagerTest extends TestCase
         // Store original include_path
         $this->includePath = get_include_path();
 
-
         $this->defaultListeners = new DefaultListenerAggregate(
             new ListenerOptions(array( 
                 'module_paths'         => array(
@@ -37,10 +36,6 @@ class ManagerTest extends TestCase
                 ),
             ))
         );
-        //$autoloader = new ModuleAutoloader(array(
-        //    __DIR__ . '/TestAsset',
-        //));
-        //$autoloader->register();
     }
 
     public function tearDown()

--- a/tests/Zend/Module/ModuleEventTest.php
+++ b/tests/Zend/Module/ModuleEventTest.php
@@ -34,4 +34,26 @@ class ModuleEventTest extends TestCase
         $this->setExpectedException('Zend\Module\Exception\InvalidArgumentException');
         $this->event->setModule('foo');
     }
+
+    public function testSettingModuleNameProxiesToParameters()
+    {
+        $moduleName = 'MyModule';
+        $this->event->setModuleName($moduleName);
+        $test = $this->event->getParam('moduleName');
+        $this->assertSame($moduleName, $test);
+    }
+
+    public function testCanRetrieveModuleNameViaGetter()
+    {
+        $moduleName = 'MyModule';
+        $this->event->setModuleName($moduleName);
+        $test = $this->event->getModuleName();
+        $this->assertSame($moduleName, $test);
+    }
+
+    public function testPassingNonStringToSetModuleNameRaisesException()
+    {
+        $this->setExpectedException('Zend\Module\Exception\InvalidArgumentException');
+        $this->event->setModuleName(new StdClass);
+    }
 }

--- a/tests/Zend/Module/ModuleEventTest.php
+++ b/tests/Zend/Module/ModuleEventTest.php
@@ -4,7 +4,8 @@ namespace ZendTest\Module;
 
 use PHPUnit_Framework_TestCase as TestCase,
     stdClass,
-    Zend\Module\ModuleEvent;
+    Zend\Module\ModuleEvent,
+    Zend\Module\Listener\ConfigListener;
 
 class ModuleEventTest extends TestCase
 {
@@ -55,5 +56,27 @@ class ModuleEventTest extends TestCase
     {
         $this->setExpectedException('Zend\Module\Exception\InvalidArgumentException');
         $this->event->setModuleName(new StdClass);
+    }
+
+    public function testSettingConfigListenerProxiesToParameters()
+    {
+        $configListener = new ConfigListener;
+        $this->event->setConfigListener($configListener);
+        $test = $this->event->getParam('configListener');
+        $this->assertSame($configListener, $test);
+    }
+
+    public function testCanRetrieveConfigListenerViaGetter()
+    {
+        $configListener = new ConfigListener;
+        $this->event->setConfigListener($configListener);
+        $test = $this->event->getConfigListener();
+        $this->assertSame($configListener, $test);
+    }
+
+    public function testPassingNonConfigMergerToSetConfigListenerRaisesException()
+    {
+        $this->setExpectedException('Zend\Module\Exception\InvalidArgumentException');
+        $this->event->setConfigListener(new StdClass);
     }
 }

--- a/tests/Zend/Module/TestAsset/NotAutoloaderModule/Module.php
+++ b/tests/Zend/Module/TestAsset/NotAutoloaderModule/Module.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace NotAutoloaderModule;
+
+class Module
+{
+    public $getAutoloaderConfigCalled = false;
+
+    public function getAutoloaderConfig()
+    {
+        $this->getAutoloaderConfigCalled = true;
+        return array(
+            'Zend\Loader\StandardAutoloader' => array(
+                'namespaces' => array(
+                    'Foo' => __DIR__ . '/src/Foo',
+                ),
+            ),
+        );
+    }
+}

--- a/tests/Zend/Module/TestAsset/NotAutoloaderModule/src/Foo/Bar.php
+++ b/tests/Zend/Module/TestAsset/NotAutoloaderModule/src/Foo/Bar.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Foo;
+
+class Baz
+{}


### PR DESCRIPTION
## THIS PR BREAKS BC! SEE BELOW.
### Included in this PR:
- The init.post event has been renamed to 'loadModules.post'
- New event addded to module manager: 'loadModules.pre'
- New event addded to module manager: 'loadModule.resolve' -- You can attach events to this and provide alternative ways of loading and resolving modules (or even supplement the existing one)
- Module resolving has been moved from the module manager to the new `ModuleResolverListener` which listens to 'loadModule.resolve'
- `ConfigListener` can now be attached as an aggregate listener
- All 'default listener' logic has been removed from the module manager
- `DefaultListenerAggregate` added which aggregates default listeners (init, config, autoloader), and attaches the module autoloader to the 'loadModules.pre' event.
- All unit tests updated: 100% code coverage.
### BC breaks explained:
#### index.php

You need to update index.php for the API changes in the module manager / listeners. Here is an example updated `index.php`:

```
<?php
chdir(dirname(__DIR__));
require_once 'vendor/ZendFramework/library/Zend/Loader/AutoloaderFactory.php';
Zend\Loader\AutoloaderFactory::factory(array('Zend\Loader\StandardAutoloader' => array()));

$appConfig = include 'config/application.config.php';

$moduleManager    = new Zend\Module\Manager($appConfig['modules']);
$listenerOptions  = new Zend\Module\Listener\ListenerOptions($appConfig['module_listener_options']);
$defaultListeners = new Zend\Module\Listener\DefaultListenerAggregate($listenerOptions);

$defaultListeners->getConfigListener()->addConfigGlobPath('config/autoload/*.config.php');
$moduleManager->events()->attachAggregate($defaultListeners);
$moduleManager->loadModules();

// Create application, bootstrap, and run
$bootstrap   = new Zend\Mvc\Bootstrap($defaultListeners->getConfigListener()->getMergedConfig());
$application = new Zend\Mvc\Application;
$bootstrap->bootstrap($application);
$application->run()->send();
```
#### application.config.php

In `application.config.php`, you will need to move the 'module_paths' array into the 'module_listener_options' array like this:

```
<?php
return array(
    'modules' => array(
        'Application',
    ),
    'module_listener_options' => array( 
        'config_cache_enabled' => false,
        'cache_dir'            => realpath(dirname(__DIR__) . '/data/cache'),
        'module_paths' => array(
            realpath(dirname(__DIR__) . '/module'),
            realpath(dirname(__DIR__) . '/vendor'),
        ),
    ),
);
```
#### In your modules:
- Anywhere in your `Module.php` you attach to the 'init.post' event, you will need to change it to 'loadModules.post'.
- In your 'init.post' (now 'loadModules.post') listener(s), if you retrieve the config via `$e->getTarget()->getMergedConfig();`, you will need to change that to `$e->getConfigListener()->getMergedConfig();`. If your 'loadModules.post' listener has a priority set which is > 9000, it will not have access to the config listener (nor the merged config).
