### PR TITLE
partial view helper vars reset fix

### DIFF
--- a/library/Zend/View/Helper/Partial.php
+++ b/library/Zend/View/Helper/Partial.php
@@ -115,7 +115,7 @@ class Partial extends AbstractHelper
     public function cloneView()
     {
         $view = clone $this->view;
-        $view->vars()->clear();
+        $view->setVars(array());
         return $view;
     }
 


### PR DESCRIPTION
The partial view helper clones the view object and resets the vars() object but along the way it resets the vars of the original object too. This is because the clone is not a deep clone - so calling $view->vars() actually returns the vars object shared between the original and clone objects.

This small fix calls setVars() on the cloned object instead of accessing the shared vars() object, thus avoiding the problem. 
