### PR TITLE
Add a view helper for generating CSRF token inputs for forms not rendered by Zend\Form

### DIFF
--- a/library/Zend/Form/Element/Hash.php
+++ b/library/Zend/Form/Element/Hash.php
@@ -54,6 +54,13 @@ class Hash extends Xhtml
     protected $_hash;
 
     /**
+     * Static cache of the session names to generated hashes
+     *
+     * @var array 
+     */
+    protected static $_hashCache;
+
+    /**
      * Salt for CSRF token
      * @var string
      */
@@ -253,12 +260,17 @@ class Hash extends Xhtml
      */
     protected function _generateHash()
     {
-        $this->_hash = md5(
-            mt_rand(1,1000000)
-            .  $this->getSalt()
-            .  $this->getName()
-            .  mt_rand(1,1000000)
-        );
+        if (isset(static::$_hashCache[$this->getSessionName()])) {
+            $this->_hash = static::$_hashCache[$this->getSessionName()];
+        } else {
+            $this->_hash = md5(
+                mt_rand(1,1000000)
+                .  $this->getSalt()
+                .  $this->getName()
+                .  mt_rand(1,1000000)
+            );
+            static::$_hashCache[$this->getSessionName()] = $this->_hash;
+        }
         $this->setValue($this->_hash);
     }
 }

--- a/library/Zend/View/Helper/FormCsrf.php
+++ b/library/Zend/View/Helper/FormCsrf.php
@@ -51,6 +51,6 @@ class FormCsrf extends AbstractHelper
             $this->hashElements[$name] = new HashElement($name);
             $this->hashElements[$name]->setDecorators(array('ViewHelper'));
         }
-        return $this->hashElements[$name]->render($this->getView());
+        return trim($this->hashElements[$name]->render($this->getView()));
     }
 }

--- a/library/Zend/View/Helper/FormCsrf.php
+++ b/library/Zend/View/Helper/FormCsrf.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend\View
+ * @subpackage Helper
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\View\Helper;
+
+use Zend\Form\Element\Hash as HashElement;
+
+/**
+ * Helper for rendering CSRF token elements outside of Zend\Form using 
+ * Zend\Form\Element\Hash
+ *
+ * @package    Zend\View
+ * @subpackage Helper
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormCsrf extends AbstractHelper
+{
+    /**
+     * @var array
+     */
+    protected $hashElements;
+
+    /**
+     * __invoke 
+     * 
+     * @param string $name 
+     * @return string
+     */
+    public function __invoke($name = 'csrf')
+    {
+        if (!isset($this->hashElements[$name])) {
+            $this->hashElements[$name] = new HashElement($name);
+            $this->hashElements[$name]->setDecorators(array('ViewHelper'));
+        }
+        return $this->hashElements[$name]->render($this->getView());
+    }
+}

--- a/library/Zend/View/HelperLoader.php
+++ b/library/Zend/View/HelperLoader.php
@@ -47,6 +47,7 @@ class HelperLoader extends PluginClassLoader
         'fieldset'            => 'Zend\View\Helper\Fieldset',
         'formbutton'          => 'Zend\View\Helper\FormButton',
         'formcheckbox'        => 'Zend\View\Helper\FormCheckbox',
+        'formcsrf'            => 'Zend\View\Helper\FormCsrf',
         'formerrors'          => 'Zend\View\Helper\FormErrors',
         'formfile'            => 'Zend\View\Helper\FormFile',
         'formhidden'          => 'Zend\View\Helper\FormHidden',

--- a/tests/Zend/Form/Element/HashTest.php
+++ b/tests/Zend/Form/Element/HashTest.php
@@ -177,4 +177,10 @@ class HashTest extends \PHPUnit_Framework_TestCase
         $html = $this->element->renderViewHelper();
         $this->assertContains($this->element->getHash(), $html, 'Html is: ' . $html);
     }
+
+    public function testMutlipleHashElementsWithSameNameShareSingleHash()
+    {
+        $element = new HashElement('foo');
+        $this->assertSame($this->element->getHash(), $element->getHash());
+    }
 }

--- a/tests/Zend/View/Helper/FormCsrfTest.php
+++ b/tests/Zend/View/Helper/FormCsrfTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zendview
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+/**
+ * @namespace
+ */
+namespace ZendTest\View\Helper;
+
+use PHPUnit_Framework_TestCase as TestCase,
+    Zend\View\PhpRenderer as View,
+    Zend\View\Helper\FormCsrf;
+
+/**
+ * @category   Zend
+ * @package    Zendview
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Zendview
+ * @group      Zendview_Helper
+ */
+class FormCsrfTest extends TestCase
+{
+    /**
+     * @var FormCsrf
+     */
+    protected $helper;
+
+    /**
+     * @var View
+     */
+    protected $view;
+
+    /**
+     * Prepares the environment before running a test.
+     */
+    protected function setUp()
+    {
+        $this->helper = new FormCsrf();
+        $this->view   = new View();
+        $this->view->doctype()->setDoctype(strtoupper("XHTML1_STRICT"));
+        $this->helper->setView($this->view);
+
+        if (isset($_SERVER['HTTPS'])) {
+            unset ($_SERVER['HTTPS']);
+        }
+    }
+
+    /**
+     * Cleans up the environment after running a test.
+     */
+    protected function tearDown()
+    {
+        unset($this->helper, $this->view);
+    }
+
+    public function testCsrfXhtmlDoctype()
+    {
+        $this->assertRegExp(
+            '/\/>$/',
+            $this->helper->__invoke()
+        );
+    }
+
+    public function testCsrfHtmlDoctype()
+    {
+        $object = new FormCsrf();
+        $view   = new View();
+        $view->doctype()->setDoctype(strtoupper("HTML5"));
+        $object->setView($view);
+
+        $this->assertRegExp(
+            '/[^\/]>$/',
+            $object->__invoke()
+        );
+    }
+
+    public function testReturnInputTag()
+    {
+        $this->assertRegExp(
+            "/^<input\s.+/",
+            $this->helper->__invoke()
+        );
+    }
+}


### PR DESCRIPTION
- Uses Zend\Form\Element\Hash
- Updated  Zend\Form\Element\Hash to keep an internal cache of the generated tokens in a given request so that later instances of the same form (or different form with the same name CSRF field) will not invalidate earlier CSRF tokens.
- Updated and added unit tests.

Usage (in your view):

```
<?php echo $this->formcsrf(); ?>
```

or specify the name to use for the input element:

```
<?php echo $this->formcsrf('token'); ?>
```
