### PR TITLE
Zend\Cache Refactoring

### DIFF
--- a/documentation/manual/en/module_specs/zend.cache.pattern.xml
+++ b/documentation/manual/en/module_specs/zend.cache.pattern.xml
@@ -79,7 +79,720 @@ $callbackCache->setOptions(new PatternOptions(array(
         </info>
 
         <variablelist>
-            <title/>
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-cache-by-default">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setCacheByDefault</methodname>
+                        <methodparam>
+                            <funcparams>bool $cacheByDefault</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set flag indicating whether or not to cache by default</para>
+                    <para>Used by: - ClassCache - ObjectCache</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-cache-by-default">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getCacheByDefault</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Do we cache by default?</para>
+                    <para>Used by: - ClassCache - ObjectCache</para>
+                    <para>Returns bool</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-cache-output">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setCacheOutput</methodname>
+                        <methodparam>
+                            <funcparams>bool $cacheOutput</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set whether or not to cache output</para>
+                    <para>Used by: - CallbackCache - ClassCache - ObjectCache</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-cache-output">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getCacheOutput</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Will we cache output?</para>
+                    <para>Used by: - CallbackCache - ClassCache - ObjectCache</para>
+                    <para>Returns bool</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-class">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setClass</methodname>
+                        <methodparam>
+                            <funcparams>string $class</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set class name</para>
+                    <para>Used by: - ClassCache</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-class">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getClass</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get class name</para>
+                    <para>Used by: - ClassCache</para>
+                    <para>Returns null|string</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-class-cache-methods">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setClassCacheMethods</methodname>
+                        <methodparam>
+                            <funcparams>array $classCacheMethods</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set list of method return values to cache</para>
+                    <para>Used by: - ClassCache</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-class-cache-methods">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getClassCacheMethods</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get list of methods from which to cache return values</para>
+                    <para>Used by: - ClassCache</para>
+                    <para>Returns array</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-class-non-cache-methods">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setClassNonCacheMethods</methodname>
+                        <methodparam>
+                            <funcparams>array $classNonCacheMethods</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set list of method return values NOT to cache</para>
+                    <para>Used by: - ClassCache</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-class-non-cache-methods">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getClassNonCacheMethods</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get list of methods from which NOT to cache return values</para>
+                    <para>Used by: - ClassCache</para>
+                    <para>Returns array</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-dir-perm">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setDirPerm</methodname>
+                        <methodparam>
+                            <funcparams>string $dirPerm</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set directory permissions</para>
+                    <para>Sets {@link $dirUmask} property to inverse of provided value.</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-dir-perm">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getDirPerm</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Gets directory permissions</para>
+                    <para>Proxies to {@link $dirUmask} property, returning its inverse.</para>
+                    <para>Returns int</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-dir-umask">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setDirUmask</methodname>
+                        <methodparam>
+                            <funcparams>int $dirUmask</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set directory umask</para>
+                    <para>Used by: - CaptureCache</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-dir-umask">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getDirUmask</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get directory umask</para>
+                    <para>Used by: - CaptureCache</para>
+                    <para>Returns int</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-file-locking">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setFileLocking</methodname>
+                        <methodparam>
+                            <funcparams>bool $fileLocking</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set whether or not file locking should be used</para>
+                    <para>Used by: - CaptureCache</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-file-locking">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getFileLocking</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Is file locking enabled?</para>
+                    <para>Used by: - CaptureCache</para>
+                    <para>Returns bool</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-file-perm">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setFilePerm</methodname>
+                        <methodparam>
+                            <funcparams>string $filePerm</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set file permissions</para>
+                    <para>Sets {@link $fileUmask} property to inverse of provided value.</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-file-perm">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getFilePerm</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Gets file permissions</para>
+                    <para>Proxies to {@link $fileUmask} property, returning its inverse.</para>
+                    <para>Returns int</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-file-umask">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setFileUmask</methodname>
+                        <methodparam>
+                            <funcparams>int $fileUmask</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set file umask</para>
+                    <para>Used by: - CaptureCache</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-file-umask">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getFileUmask</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get file umask</para>
+                    <para>Used by: - CaptureCache</para>
+                    <para>Returns int</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-index-filename">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setIndexFilename</methodname>
+                        <methodparam>
+                            <funcparams>string $indexFilename</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set value for index filename</para>
+                    <para></para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-index-filename">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getIndexFilename</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get value for index filename</para>
+                    <para></para>
+                    <para>Returns string</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-object">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setObject</methodname>
+                        <methodparam>
+                            <funcparams>mixed $object</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set object to cache</para>
+                    <para></para>
+                    <para>Returns this</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-object">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getObject</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get object to cache</para>
+                    <para></para>
+                    <para>Returns null|object</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-object-cache-magic-properties">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setObjectCacheMagicProperties</methodname>
+                        <methodparam>
+                            <funcparams>bool $objectCacheMagicProperties</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set flag indicating whether or not to cache magic properties</para>
+                    <para>Used by: - ObjectCache</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-object-cache-magic-properties">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getObjectCacheMagicProperties</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Should we cache magic properties?</para>
+                    <para>Used by: - ObjectCache</para>
+                    <para>Returns bool</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-object-cache-methods">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setObjectCacheMethods</methodname>
+                        <methodparam>
+                            <funcparams>array $objectCacheMethods</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set list of object methods for which to cache return values</para>
+                    <para></para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-object-cache-methods">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getObjectCacheMethods</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get list of object methods for which to cache return values</para>
+                    <para></para>
+                    <para>Returns array</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-object-key">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setObjectKey</methodname>
+                        <methodparam>
+                            <funcparams>mixed $objectKey</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set the object key part.</para>
+                    <para>Used to generate a callback key in order to speed up key generation. Used by: - ObjectCache</para>
+                    <para>Returns this</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-object-key">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getObjectKey</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get object key</para>
+                    <para>Used by: - ObjectCache</para>
+                    <para>Returns mixed</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-object-non-cache-methods">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setObjectNonCacheMethods</methodname>
+                        <methodparam>
+                            <funcparams>array $objectNonCacheMethods</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set list of object methods for which NOT to cache return values</para>
+                    <para></para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-object-non-cache-methods">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getObjectNonCacheMethods</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get list of object methods for which NOT to cache return values</para>
+                    <para></para>
+                    <para>Returns array</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-public-dir">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setPublicDir</methodname>
+                        <methodparam>
+                            <funcparams>string $publicDir</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set location of public directory</para>
+                    <para>Used by: - CaptureCache</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-public-dir">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getPublicDir</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get location of public directory</para>
+                    <para>Used by: - CaptureCache</para>
+                    <para>Returns null|string</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-storage">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setStorage</methodname>
+                        <methodparam>
+                            <funcparams>string|array|Zend\Cache\Storage\Adapter $storage</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set storage adapter</para>
+                    <para>Required for the following Pattern classes: - CallbackCache - ClassCache - ObjectCache - OutputCache</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-storage">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getStorage</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get storage adapter</para>
+                    <para>Used by: - CallbackCache - ClassCache - ObjectCache - OutputCache</para>
+                    <para>Returns null|Zend\Cache\Storage\Adapter</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-tag-key">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setTagKey</methodname>
+                        <methodparam>
+                            <funcparams>string $tagKey</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set tag key</para>
+                    <para></para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-tag-key">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getTagKey</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get tag key</para>
+                    <para></para>
+                    <para>Returns string</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-tags">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setTags</methodname>
+                        <methodparam>
+                            <funcparams>array $tags</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set tags</para>
+                    <para>Used by: - CaptureCache</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-tags">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getTags</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get tags</para>
+                    <para>Used by: - CaptureCache</para>
+                    <para>Returns array</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.set-tag-storage">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setTagStorage</methodname>
+                        <methodparam>
+                            <funcparams>string|array|Zend\Cache\Storage\Adapter $tagStorage</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set storage adapter for tags</para>
+                    <para>Used by: - CaptureCache</para>
+                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.pattern.pattern-options.methods.get-tag-storage">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getTagStorage</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get storage adapter for tags</para>
+                    <para>Used by: - CaptureCache</para>
+                    <para>Returns null|Zend\Cache\Storage\Adapter</para>
+                </listitem>
+            </varlistentry>
+
         </variablelist>
     </section>
 
@@ -89,7 +802,6 @@ $callbackCache->setOptions(new PatternOptions(array(
         </info>
 
         <variablelist>
-
             <varlistentry xml:id="zend.cache.pattern.methods.set-options">
                 <term>
                     <methodsynopsis>
@@ -118,9 +830,9 @@ $callbackCache->setOptions(new PatternOptions(array(
                 </term>
 
                 <listitem>
-                    <para>Get pattern options</para>
+                    <para>Get all pattern options</para>
                     <para></para>
-                    <para>Returns Zend\Cache\Pattern\PatternOptions</para>
+                    <para>Returns array</para>
                 </listitem>
             </varlistentry>
 
@@ -214,7 +926,7 @@ echo 'never cached output';
         </example>
 
         <example xml:id="zend.cache.pattern.examples.capture">
-            <info><title>Using the capture cache pattern (TODO: .htaccess)</title></info>
+            <info><title>Using the capture cache pattern</title></info>
             
             <para>
                 You need to configure your HTTPd to redirect missing content

--- a/documentation/manual/en/module_specs/zend.cache.storage.adapter.xml
+++ b/documentation/manual/en/module_specs/zend.cache.storage.adapter.xml
@@ -21,22 +21,34 @@
         </para>
 
         <para>
-            All adapters implementing the interface
+            All adapters implements the interface
             <classname>Zend\Cache\Storage\Adapter</classname> and extends
             <classname>Zend\Cache\Storage\Adapter\AbstractAdapter</classname>
-            which implements basic logic.
+            which comes with basic logic.
         </para>
 
         <para>
-            Configuration will be done by
-            <classname>Zend\Cache\Storage\Adapter\AdapterOptions</classname>
-            which can simply be instantiated with an associative array of options
-            passing to the constructor. To configure an storage adapter object
-            you can set an instance of
-            <classname>Zend\Cache\StorageAdapter\AdapterOptions</classname> with
-            <methodname>setOptions</methodname> or put it as second argument to the
-            factory.
+            Configuration will be done by one of the adapter options class.
+            Which is the right knows the adapter it self and instantiate it
+            internally if you pass an associative array of options to the
+            <methodname>adapterFactory</methodname>, <methodname>factory</methodname> or the
+            <methodname>setOptions</methodname> method. You can also get the
+            options instance with <methodname>getOptions</methodname> and change
+            it by using setters of it.
         </para>
+
+        <note>
+            <title>Nearly all methods can throw exceptions</title>
+            
+            <para>
+                Because nearly all methods can throw exceptions you need to
+                catch them manually or you can use the plug-in
+                <classname>Zend\Cache\Storage\Plugin\ExceptionHandler</classname>
+                'exception_handler' to automatically catch them and redirect exceptions
+                into a log file using the option 'exception_callback'.
+            </para>
+            
+        </note>
 
     </section>
 
@@ -44,6 +56,46 @@
         <info>
             <title>Quick Start</title>
         </info>
+
+        <para>
+            Caching adapters can either be created from the provided
+            <classname>Zend\Cache\StorageFactory</classname> factory, or by simply
+            instantiating one of the <classname>Zend\Cache\Storage\Adapter\*</classname>classes. 
+        </para>
+
+        <para>
+            To make live easier the <classname>Zend\Cache\StorageFactory</classname>
+            comes with a method <methodname>factory</methodname> to create an adapter
+            and creating/adding all given plug-ins at once.
+        </para>
+
+        <programlisting language="php"><![CDATA[
+use Zend\Cache\StorageFactory;
+
+$cache  = StorageFactory::factory(array(
+    'adapter' => 'apc',
+    'plugins' => array(
+        'exception_handler' => array('throw_exceptions' => false),
+    ),
+));
+
+// OR, the completely equivalent
+
+$cache  = StorageFactory::adapterFactory('apc');
+$plugin = StorageFactory::adapterFactory('exception_handler', array(
+    'throw_exceptions' => false,
+));
+$cache->addPlugin($plugin);
+
+// OR, the completely equivalent
+
+$cache  = new Zend\Cache\Storage\Adapter\Apc();
+$plugin = new Zend\Cache\Storage\Plugin\ExceptionHandler(array(
+    'throw_exceptions' => false,
+));
+$cache->addPlugin($plugin);
+
+]]></programlisting>
 
     </section>
 
@@ -657,7 +709,7 @@
 
     <section xml:id="zend.cache.storage.adapter.examples">
         <info>
-            <title>Examples</title>
+            <title>TODO: Examples</title>
         </info>
 
     </section>

--- a/documentation/manual/en/module_specs/zend.cache.storage.adapter.xml
+++ b/documentation/manual/en/module_specs/zend.cache.storage.adapter.xml
@@ -105,7 +105,261 @@ $cache->addPlugin($plugin);
         </info>
 
         <variablelist>
-            <title/>
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.to-array">
+                <term>
+                    <methodsynopsis>
+                        <methodname>toArray</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Cast to array</para>
+                    <para></para>
+                    <para>Returns array</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.set-ignore-missing-items">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setIgnoreMissingItems</methodname>
+                        <methodparam>
+                            <funcparams>boolean $flag</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Enables or disables ignoring of missing items.</para>
+                    <para>- If enabled and a missing item was requested:     - getItem, getMetadata: return false     - removeItem[s]: return true     - incrementItem[s], decrementItem[s]: add a new item with 0 as base     - touchItem[s]: add new empty item - If disabled and a missing item was requested:     - getItem, getMetadata, incrementItem[s], decrementItem[s], touchItem[s]         throws ItemNotFoundException</para>
+                    <para>Returns Zend\Cache\Storage\Adapter\AdapterOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.get-ignore-missing-items">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getIgnoreMissingItems</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Ignore missing items</para>
+                    <para></para>
+                    <para>Returns boolean</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.set-key-pattern">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setKeyPattern</methodname>
+                        <methodparam>
+                            <funcparams>null|string $pattern</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set key pattern</para>
+                    <para></para>
+                    <para>Returns Zend\Cache\Storage\Adapter\AdapterOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.get-key-pattern">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getKeyPattern</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get key pattern</para>
+                    <para></para>
+                    <para>Returns string</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.set-namespace">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setNamespace</methodname>
+                        <methodparam>
+                            <funcparams>string $namespace</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set namespace.</para>
+                    <para></para>
+                    <para>Returns Zend\Cache\Storage\Adapter\AdapterOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.get-namespace">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getNamespace</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get namespace</para>
+                    <para></para>
+                    <para>Returns string</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.set-namespace-pattern">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setNamespacePattern</methodname>
+                        <methodparam>
+                            <funcparams>null|string $pattern</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set namespace pattern</para>
+                    <para></para>
+                    <para>Returns Zend\Cache\Storage\Adapter\AdapterOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.get-namespace-pattern">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getNamespacePattern</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get namespace pattern</para>
+                    <para></para>
+                    <para>Returns string</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.set-readable">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setReadable</methodname>
+                        <methodparam>
+                            <funcparams>boolean $flag</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Enable/Disable reading data from cache.</para>
+                    <para></para>
+                    <para>Returns Zend\Cache\Storage\Adapter\AbstractAdapter</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.get-readable">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getReadable</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>If reading data from cache enabled.</para>
+                    <para></para>
+                    <para>Returns boolean</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.set-ttl">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setTtl</methodname>
+                        <methodparam>
+                            <funcparams>int|float $ttl</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set time to live.</para>
+                    <para></para>
+                    <para>Returns Zend\Cache\Storage\Adapter\AdapterOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.get-ttl">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getTtl</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get time to live.</para>
+                    <para></para>
+                    <para>Returns float</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.set-writable">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setWritable</methodname>
+                        <methodparam>
+                            <funcparams>boolean $flag</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Enable/Disable writing data to cache.</para>
+                    <para></para>
+                    <para>Returns Zend\Cache\Storage\Adapter\AdapterOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.adapter.adapter-options.methods.get-writable">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getWritable</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>If writing data to cache enabled.</para>
+                    <para></para>
+                    <para>Returns boolean</para>
+                </listitem>
+            </varlistentry>
+
         </variablelist>
     </section>
 
@@ -115,30 +369,12 @@ $cache->addPlugin($plugin);
         </info>
 
         <variablelist>
-            <varlistentry xml:id="zend.cache.storage.adapter.methods.__construct">
-                <term>
-                    <methodsynopsis>
-                        <methodname>__construct</methodname>
-                        <methodparam>
-                            <funcparams>array|Traversable $options = array (
-)</funcparams>
-                        </methodparam>
-                    </methodsynopsis>
-                </term>
-
-                <listitem>
-                    <para>Constructor</para>
-                    <para></para>
-                    <para>Returns void</para>
-                </listitem>
-            </varlistentry>
-
             <varlistentry xml:id="zend.cache.storage.adapter.methods.set-options">
                 <term>
                     <methodsynopsis>
                         <methodname>setOptions</methodname>
                         <methodparam>
-                            <funcparams>array|Traversable $options</funcparams>
+                            <funcparams>array|Traversable|Zend\Cache\Storage\Adapter\AdapterOptions $options</funcparams>
                         </methodparam>
                     </methodsynopsis>
                 </term>
@@ -163,7 +399,7 @@ $cache->addPlugin($plugin);
                 <listitem>
                     <para>Get options</para>
                     <para></para>
-                    <para>Returns array</para>
+                    <para>Returns Zend\Cache\Storage\Adapter\AdapterOptions</para>
                 </listitem>
             </varlistentry>
 

--- a/documentation/manual/en/module_specs/zend.cache.storage.capabilities.xml
+++ b/documentation/manual/en/module_specs/zend.cache.storage.capabilities.xml
@@ -16,14 +16,15 @@
 
         <para>
             To get capabilities of a storage object you can use the method
-            <methodname>getCapabilities</methodname> of the object but only
-            the storage object and it's plug-ins has permissions to change it.
+            <methodname>getCapabilities</methodname> of the storage object but
+            only the storage object and it's plug-ins has permissions to change
+            it.
         </para>
 
         <para>
             Because capabilities can be changed by storage, for example on
-            changing some options, you can get a note by catching the event if
-            it. (TODO: link to example)
+            changing some options, you can get a note by listing the event of
+            it. See the examples how to do that.
         </para>
 
         <para>
@@ -577,7 +578,7 @@ if ($capabilities->getIterable()) {
         </example>
 
         <example xml:id="zend.cache.storage.capabilities.examples.event.change">
-            <info><title>Get note on changed capability</title></info>
+            <info><title>Listen to change event</title></info>
 
             <programlisting language="php"><![CDATA[
 use Zend\Cache\StorageFactory;

--- a/documentation/manual/en/module_specs/zend.cache.storage.plugin.xml
+++ b/documentation/manual/en/module_specs/zend.cache.storage.plugin.xml
@@ -9,12 +9,61 @@
             <title>Overview</title>
         </info>
 
+        <para>
+            Cache storage plug-ins are objects to add missing functionalities
+            or to change influences of a storage adapter. This can be very
+            helpful implement caching into an application.
+        </para>
+
+        <para>
+            The plug-ins listen to events the adapter triggers and can change
+            called method arguments (*.post - events), skipping and directly
+            return a result (using <methodname>stopPropagation</methodname>),
+            changing the result (with <methodname>setResult</methodname> of
+            <classname>Zend\Cache\Storage\PostEvent</classname>) and catching
+            exceptions (with <classname>Zend\Cache\Storage\ExceptionEvent</classname>).
+        </para>
+
     </section>
 
     <section xml:id="zend.cache.storage.plugin.quick-start">
         <info>
             <title>Quick Start</title>
         </info>
+
+        <para>
+            Storage plug-ins can either be created from <classname>Zend\Cache\StorageFactory</classname>
+            with the <methodname>pluginFactory</methodname>, or by simply instantiating
+            one of the <classname>Zend\Cache\Storage\Plugin\*</classname>classes. 
+        </para>
+        
+        <para>
+            To make live easier the <classname>Zend\Cache\StorageFactory</classname>
+            comes with a method <methodname>factory</methodname> to create an adapter
+            and creating/adding all given plug-ins at once.
+        </para>
+
+        <programlisting language="php"><![CDATA[
+use Zend\Cache\StorageFactory;
+
+$cache = StorageFactory::factory(array(
+    'adapter' => 'filesystem',
+    'plugins' => array('serializer'),
+));
+
+// OR, the completely equivalent
+
+$cache  = StorageFactory::adapterFactory('filesystem');
+$plugin = StorageFactory::pluginFactory('serializer');
+$cache->addPlugin($plugin);
+
+// OR, the completely equivalent
+
+$cache  = new Zend\Cache\Storage\Adapter\Filesystem();
+$plugin = new Zend\Cache\Storage\Plugin\Serializer();
+$cache->addPlugin($plugin);
+
+]]></programlisting>
 
     </section>
 
@@ -125,7 +174,7 @@
 
     <section xml:id="zend.cache.storage.plugin.examples">
         <info>
-            <title>Examples</title>
+            <title>TODO: Examples</title>
         </info>
 
     </section>

--- a/documentation/manual/en/module_specs/zend.cache.storage.plugin.xml
+++ b/documentation/manual/en/module_specs/zend.cache.storage.plugin.xml
@@ -72,9 +72,252 @@ $cache->addPlugin($plugin);
             <title>Configuration Options</title>
         </info>
 
+    <section xml:id="zend.cache.storage.plugin.plugin-options.methods">
+        <info>
+            <title>Available Methods</title>
+        </info>
+
         <variablelist>
-            <title/>
+            <varlistentry xml:id="zend.cache.storage.plugin.plugin-options.methods.set-clearing-factor">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setClearingFactor</methodname>
+                        <methodparam>
+                            <funcparams>int $clearingFactor</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set automatic clearing factor</para>
+                    <para>Used by: - ClearByFactor</para>
+                    <para>Returns Zend\Cache\Storage\Plugin\PluginOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.plugin.plugin-options.methods.get-clearing-factor">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getClearingFactor</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get automatic clearing factor</para>
+                    <para>Used by: - ClearByFactor</para>
+                    <para>Returns int</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.plugin.plugin-options.methods.set-clear-by-namespace">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setClearByNamespace</methodname>
+                        <methodparam>
+                            <funcparams>bool $clearByNamespace</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set flag indicating whether or not to clear by namespace</para>
+                    <para>Used by: - ClearByFactor</para>
+                    <para>Returns Zend\Cache\Storage\Plugin\PluginOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.plugin.plugin-options.methods.get-clear-by-namespace">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getClearByNamespace</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Clear items by namespace?</para>
+                    <para>Used by: - ClearByFactor</para>
+                    <para>Returns bool</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.plugin.plugin-options.methods.set-exception-callback">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setExceptionCallback</methodname>
+                        <methodparam>
+                            <funcparams>callable $exceptionCallback</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set callback to call on intercepted exception</para>
+                    <para>Used by: - ExceptionHandler</para>
+                    <para>Returns Zend\Cache\Storage\Plugin\PluginOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.plugin.plugin-options.methods.get-exception-callback">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getExceptionCallback</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get callback to call on intercepted exception</para>
+                    <para>Used by: - ExceptionHandler</para>
+                    <para>Returns null|callable</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.plugin.plugin-options.methods.set-optimizing-factor">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setOptimizingFactor</methodname>
+                        <methodparam>
+                            <funcparams>int $optimizingFactor</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set automatic optimizing factor</para>
+                    <para>Used by: - OptimizeByFactor</para>
+                    <para>Returns Zend\Cache\Storage\Plugin\PluginOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.plugin.plugin-options.methods.get-optimizing-factor">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getOptimizingFactor</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set automatic optimizing factor</para>
+                    <para>Used by: - OptimizeByFactor</para>
+                    <para>Returns int</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.plugin.plugin-options.methods.set-serializer">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setSerializer</methodname>
+                        <methodparam>
+                            <funcparams>string|Zend\Serializer\Adapter $serializer</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set serializer</para>
+                    <para>Used by: - Serializer</para>
+                    <para>Returns Zend\Cache\Storage\Plugin\Serializer</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.plugin.plugin-options.methods.get-serializer">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getSerializer</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get serializer</para>
+                    <para>Used by: - Serializer</para>
+                    <para>Returns Zend\Serializer\Adapter</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.plugin.plugin-options.methods.set-serializer-options">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setSerializerOptions</methodname>
+                        <methodparam>
+                            <funcparams>array $serializerOptions</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set configuration options for instantiating a serializer adapter</para>
+                    <para>Used by: - Serializer</para>
+                    <para>Returns Zend\Cache\Storage\Plugin\PluginOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.plugin.plugin-options.methods.get-serializer-options">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getSerializerOptions</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Get configuration options for instantiating a serializer adapter</para>
+                    <para>Used by: - Serializer</para>
+                    <para>Returns array</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.plugin.plugin-options.methods.set-throw-exceptions">
+                <term>
+                    <methodsynopsis>
+                        <methodname>setThrowExceptions</methodname>
+                        <methodparam>
+                            <funcparams>bool $throwExceptions</funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Set flag indicating we should re-throw exceptions</para>
+                    <para>Used by: - ExceptionHandler</para>
+                    <para>Returns Zend\Cache\Storage\Plugin\PluginOptions</para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry xml:id="zend.cache.storage.plugin.plugin-options.methods.get-throw-exceptions">
+                <term>
+                    <methodsynopsis>
+                        <methodname>getThrowExceptions</methodname>
+                        <methodparam>
+                            <funcparams></funcparams>
+                        </methodparam>
+                    </methodsynopsis>
+                </term>
+
+                <listitem>
+                    <para>Should we re-throw exceptions?</para>
+                    <para>Used by: - ExceptionHandler</para>
+                    <para>Returns bool</para>
+                </listitem>
+            </varlistentry>
+
         </variablelist>
+    </section>
     </section>
 
     <section xml:id="zend.cache.storage.plugin.methods">
@@ -83,30 +326,12 @@ $cache->addPlugin($plugin);
         </info>
 
         <variablelist>
-            <varlistentry xml:id="zend.cache.storage.plugin.methods.__construct">
-                <term>
-                    <methodsynopsis>
-                        <methodname>__construct</methodname>
-                        <methodparam>
-                            <funcparams>array|Traversable $options = array (
-)</funcparams>
-                        </methodparam>
-                    </methodsynopsis>
-                </term>
-
-                <listitem>
-                    <para>Constructor</para>
-                    <para></para>
-                    <para>Returns void</para>
-                </listitem>
-            </varlistentry>
-
             <varlistentry xml:id="zend.cache.storage.plugin.methods.set-options">
                 <term>
                     <methodsynopsis>
                         <methodname>setOptions</methodname>
                         <methodparam>
-                            <funcparams>array|Traversable $options</funcparams>
+                            <funcparams>Zend\Cache\Storage\Plugin\PluginOptions $options</funcparams>
                         </methodparam>
                     </methodsynopsis>
                 </term>
@@ -131,7 +356,7 @@ $cache->addPlugin($plugin);
                 <listitem>
                     <para>Get options</para>
                     <para></para>
-                    <para>Returns array</para>
+                    <para>Returns PluginOptions</para>
                 </listitem>
             </varlistentry>
 


### PR DESCRIPTION
Zend\Cache Refactoring

There are still some functionalities missing but it the initial version to go for ZF-Beta2
There are also some consumers needs to be updated, matthiew is working there.

Adapters coming later:
- Memcached (ext/memcached)
- Memcache (ext/memcache)
- Dba
- XCache
- ZendServer Shm/Disk
- WinCache
- Sqlite
- DbAdapter ?

Plugins coming later:
- IgnoreUserAbort
- Key/Value Filter
- MasterFile
- Reluctant
- Tagging
- WriteControl ?
- WriteBuffer ?
- (Two)Levels ?

Other functionalities coming later:
- Profiler ?
- PageCache ?
- Locking ?
