### PR TITLE
Fixes issue ZF2-107

### DIFF
--- a/library/Zend/OAuth/Http.php
+++ b/library/Zend/OAuth/Http.php
@@ -175,7 +175,7 @@ class Http
         }
         if ($response !== null) {
             $body   = $response->getBody();
-            $status = $response->getStatus();
+            $status = $response->getStatusCode();
         }
         if ($response === null // Request failure/exception
             || $status == 500  // Internal Server Error
@@ -220,10 +220,10 @@ class Http
     {
         switch ($this->_preferredRequestScheme) {
             case OAuth::REQUEST_SCHEME_HEADER:
-                $this->_preferredRequestScheme = OAuth\OAuth::REQUEST_SCHEME_POSTBODY;
+                $this->_preferredRequestScheme = OAuth::REQUEST_SCHEME_POSTBODY;
                 break;
             case OAuth::REQUEST_SCHEME_POSTBODY:
-                $this->_preferredRequestScheme = OAuth\OAuth::REQUEST_SCHEME_QUERYSTRING;
+                $this->_preferredRequestScheme = OAuth::REQUEST_SCHEME_QUERYSTRING;
                 break;
             default:
                 throw new Exception(


### PR DESCRIPTION
http://framework.zend.com/issues/browse/ZF2-107

`$response->getStatus();`
changed to
`$response->getStatusCode();`

Also at line 223 and 226
`OAuth\OAuth` replaced with `OAuth`
because namespace is Zend\OAuth
