### PR TITLE
Do not set exception when controller is not Dispatchable

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -283,8 +283,8 @@ class Application implements AppContext
             $error = clone $e;
             $error->setError(static::ERROR_CONTROLLER_INVALID)
                   ->setController($controllerName)
-                  ->setControllerClass(get_class($controller))
-                  ->setParam('exception', $exception);
+                  ->setControllerClass(get_class($controller));
+            
             $results = $events->trigger('dispatch.error', $error);
             if (count($results)) {
                 $return  = $results->last();


### PR DESCRIPTION
In the Zend\Mvc\Application::dispatch() method, there is no exception available when the controller is not a Dispatchable controller. Therefore it makes no sense to set it.
