### PR TITLE
Strip leading backslash from class names in strings in Zend\Mvc

### DIFF
--- a/library/Zend/Mvc/Router/RouteBroker.php
+++ b/library/Zend/Mvc/Router/RouteBroker.php
@@ -40,7 +40,7 @@ class RouteBroker implements Broker
      * 
      * @var string
      */
-    protected $defaultClassLoader = '\Zend\Loader\PluginClassLoader';
+    protected $defaultClassLoader = 'Zend\Loader\PluginClassLoader';
 
     /**
      * Plugin class loader used by this instance.

--- a/tests/Zend/Mvc/Router/Http/HostnameTest.php
+++ b/tests/Zend/Mvc/Router/Http/HostnameTest.php
@@ -119,7 +119,7 @@ class HostnameTest extends TestCase
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
-            '\Zend\Mvc\Router\Http\Hostname',
+            'Zend\Mvc\Router\Http\Hostname',
             array(
                 'route' => 'Missing "route" in options array'
             ),

--- a/tests/Zend/Mvc/Router/Http/LiteralTest.php
+++ b/tests/Zend/Mvc/Router/Http/LiteralTest.php
@@ -112,7 +112,7 @@ class LiteralTest extends TestCase
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
-            '\Zend\Mvc\Router\Http\Literal',
+            'Zend\Mvc\Router\Http\Literal',
             array(
                 'route' => 'Missing "route" in options array'
             ),

--- a/tests/Zend/Mvc/Router/Http/PartTest.php
+++ b/tests/Zend/Mvc/Router/Http/PartTest.php
@@ -245,7 +245,7 @@ class PartTest extends TestCase
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
-            '\Zend\Mvc\Router\Http\Part',
+            'Zend\Mvc\Router\Http\Part',
             array(
                 'route'        => 'Missing "route" in options array',
                 'route_broker' => 'Missing "route_broker" in options array'

--- a/tests/Zend/Mvc/Router/Http/RegexTest.php
+++ b/tests/Zend/Mvc/Router/Http/RegexTest.php
@@ -116,7 +116,7 @@ class RegexTest extends TestCase
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
-            '\Zend\Mvc\Router\Http\Regex',
+            'Zend\Mvc\Router\Http\Regex',
             array(
                 'regex' => 'Missing "regex" in options array',
                 'spec'  => 'Missing "spec" in options array'

--- a/tests/Zend/Mvc/Router/Http/SchemeTest.php
+++ b/tests/Zend/Mvc/Router/Http/SchemeTest.php
@@ -62,7 +62,7 @@ class SchemeTest extends TestCase
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
-            '\Zend\Mvc\Router\Http\Scheme',
+            'Zend\Mvc\Router\Http\Scheme',
             array(
                 'scheme' => 'Missing "scheme" in options array',
             ),

--- a/tests/Zend/Mvc/Router/Http/SegmentTest.php
+++ b/tests/Zend/Mvc/Router/Http/SegmentTest.php
@@ -256,7 +256,7 @@ class SegmentTest extends TestCase
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
-            '\Zend\Mvc\Router\Http\Segment',
+            'Zend\Mvc\Router\Http\Segment',
             array(
                 'route' => 'Missing "route" in options array'
             ),

--- a/tests/Zend/Mvc/Router/Http/TreeRouteStackTest.php
+++ b/tests/Zend/Mvc/Router/Http/TreeRouteStackTest.php
@@ -15,14 +15,14 @@ class TreeRouteStackTest extends TestCase
 {
     public function testAddRouteRequiresHttpSpecificRoute()
     {
-        $this->setExpectedException('\Zend\Mvc\Router\Exception\InvalidArgumentException', 'Route definition must be an array or Traversable object');
+        $this->setExpectedException('Zend\Mvc\Router\Exception\InvalidArgumentException', 'Route definition must be an array or Traversable object');
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', new \ZendTest\Mvc\Router\TestAsset\DummyRoute());
     }
     
     public function testAddRouteViaStringRequiresHttpSpecificRoute()
     {
-        $this->setExpectedException('\Zend\Mvc\Router\Exception\RuntimeException', 'Given route does not implement HTTP route interface');
+        $this->setExpectedException('Zend\Mvc\Router\Exception\RuntimeException', 'Given route does not implement HTTP route interface');
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', array(
             'type' => '\ZendTest\Mvc\Router\TestAsset\DummyRoute'
@@ -220,7 +220,7 @@ class TreeRouteStackTest extends TestCase
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
-            '\Zend\Mvc\Router\Http\TreeRouteStack',
+            'Zend\Mvc\Router\Http\TreeRouteStack',
             array(),
             array()
         );

--- a/tests/Zend/Mvc/Router/Http/WildcardTest.php
+++ b/tests/Zend/Mvc/Router/Http/WildcardTest.php
@@ -142,7 +142,7 @@ class WildcardTest extends TestCase
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
-            '\Zend\Mvc\Router\Http\Wildcard',
+            'Zend\Mvc\Router\Http\Wildcard',
             array(),
             array()
         );

--- a/tests/Zend/Mvc/Router/RouteBrokerTest.php
+++ b/tests/Zend/Mvc/Router/RouteBrokerTest.php
@@ -64,7 +64,7 @@ class RouteBrokerTest extends TestCase
     public function testGetClassLoaderReturnsDefaultLoader()
     {
         $broker = new RouteBroker();
-        $this->assertInstanceOf('\Zend\Loader\PluginClassLoader', $broker->getClassLoader());
+        $this->assertInstanceOf('Zend\Loader\PluginClassLoader', $broker->getClassLoader());
     }
     
     public function testSetClassLoader()
@@ -78,14 +78,14 @@ class RouteBrokerTest extends TestCase
     
     public function testSetClassLoaderOnlyAllowsPluginClassLocator()
     {
-        $this->setExpectedException('\Zend\Mvc\Router\Exception\InvalidArgumentException', 'Expected instance of PluginClassLocator');
+        $this->setExpectedException('Zend\Mvc\Router\Exception\InvalidArgumentException', 'Expected instance of PluginClassLocator');
         $broker = new RouteBroker();
         $broker->setClassLoader(new \Zend\Loader\PrefixPathLoader());
     }
     
     public function testLoadNonExistentRoute()
     {
-        $this->setExpectedException('\Zend\Mvc\Router\Exception\RuntimeException', 'Unable to locate class associated with "foo"');
+        $this->setExpectedException('Zend\Mvc\Router\Exception\RuntimeException', 'Unable to locate class associated with "foo"');
         $broker = new RouteBroker();
         $broker->load('foo');
     }
@@ -102,7 +102,7 @@ class RouteBrokerTest extends TestCase
     
     public function testSetInvalidOptions()
     {
-        $this->setExpectedException('\Zend\Mvc\Router\Exception\InvalidArgumentException', 'Expected an array or Traversable; received "string"');
+        $this->setExpectedException('Zend\Mvc\Router\Exception\InvalidArgumentException', 'Expected an array or Traversable; received "string"');
         $broker = new RouteBroker();
         $broker->setOptions('foo');
     }
@@ -110,15 +110,15 @@ class RouteBrokerTest extends TestCase
     public function testSetClassLoaderViaOptionsAsString()
     {
         $broker = new RouteBroker(array(
-            'class_loader' => '\Zend\Loader\PluginClassLoader'
+            'class_loader' => 'Zend\Loader\PluginClassLoader'
         ));
         
-        $this->assertInstanceOf('\Zend\Loader\PluginClassLoader', $broker->getClassLoader());
+        $this->assertInstanceOf('Zend\Loader\PluginClassLoader', $broker->getClassLoader());
     }
     
     public function testSetClassLoaderViaOptionsAsStringWithInvalidClassname()
     {
-        $this->setExpectedException('\Zend\Mvc\Router\Exception\RuntimeException', 'Unknown class "\Non\Existent\Class\Loader" provided as class loader option');
+        $this->setExpectedException('Zend\Mvc\Router\Exception\RuntimeException', 'Unknown class "\Non\Existent\Class\Loader" provided as class loader option');
         $broker = new RouteBroker(array(
             'class_loader' => '\Non\Existent\Class\Loader'
         ));
@@ -126,7 +126,7 @@ class RouteBrokerTest extends TestCase
     
     public function testSetClassLoaderViaOptionsAsInteger()
     {
-        $this->setExpectedException('\Zend\Mvc\Router\Exception\RuntimeException', 'Option passed for class loader (integer) is of an unknown type');
+        $this->setExpectedException('Zend\Mvc\Router\Exception\RuntimeException', 'Option passed for class loader (integer) is of an unknown type');
         $broker = new RouteBroker(array(
             'class_loader' => 1
         ));
@@ -136,13 +136,13 @@ class RouteBrokerTest extends TestCase
     {
         $broker = new RouteBroker(array(
             'class_loader' => array(
-                'class'   => '\Zend\Loader\PluginClassLoader',
+                'class'   => 'Zend\Loader\PluginClassLoader',
                 'options' => array(),
                 'foo'     => 'bar'
             )
         ));
         
-        $this->assertInstanceOf('\Zend\Loader\PluginClassLoader', $broker->getClassLoader());
+        $this->assertInstanceOf('Zend\Loader\PluginClassLoader', $broker->getClassLoader());
     }
     
     public function testIgnoreUnknownOptions()

--- a/tests/Zend/Mvc/Router/SimpleRouteStackTest.php
+++ b/tests/Zend/Mvc/Router/SimpleRouteStackTest.php
@@ -34,7 +34,7 @@ class SimpleRouteStackTest extends TestCase
             'foo' => new TestAsset\DummyRoute()
         ));
         
-        $this->assertInstanceOf('\Zend\Mvc\Router\RouteMatch', $stack->match(new Request()));
+        $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $stack->match(new Request()));
     }
         
     public function testAddRoutesAsTraversable()
@@ -44,7 +44,7 @@ class SimpleRouteStackTest extends TestCase
             'foo' => new TestAsset\DummyRoute()
         )));
         
-        $this->assertInstanceOf('\Zend\Mvc\Router\RouteMatch', $stack->match(new Request()));
+        $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $stack->match(new Request()));
     }
     
     public function testremoveRouteAsArray()
@@ -72,7 +72,7 @@ class SimpleRouteStackTest extends TestCase
             'type' => '\ZendTest\Mvc\Router\TestAsset\DummyRoute'
         ));
         
-        $this->assertInstanceOf('\Zend\Mvc\Router\RouteMatch', $stack->match(new Request()));
+        $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $stack->match(new Request()));
     }
 
     public function testAddRouteAsArrayWithOptions()
@@ -83,7 +83,7 @@ class SimpleRouteStackTest extends TestCase
             'options' => array()
         ));
         
-        $this->assertInstanceOf('\Zend\Mvc\Router\RouteMatch', $stack->match(new Request()));
+        $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $stack->match(new Request()));
     }
     
     public function testAddRouteAsArrayWithoutType()
@@ -131,7 +131,7 @@ class SimpleRouteStackTest extends TestCase
             'type' => '\ZendTest\Mvc\Router\TestAsset\DummyRoute'
         )));
         
-        $this->assertInstanceOf('\Zend\Mvc\Router\RouteMatch', $stack->match(new Request()));
+        $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $stack->match(new Request()));
     }
 
     public function testAssemble()
@@ -195,7 +195,7 @@ class SimpleRouteStackTest extends TestCase
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
-            '\Zend\Mvc\Router\SimpleRouteStack',
+            'Zend\Mvc\Router\SimpleRouteStack',
             array(),
             array(
                 'route_broker'   => new RouteBroker(),


### PR DESCRIPTION
See http://stackoverflow.com/questions/5072352/instantiating-class-by-string-using-php-5-3-namespaces
