### PR TITLE
Fix Zend\Version latest version check

### DIFF
--- a/library/Zend/Version.php
+++ b/library/Zend/Version.php
@@ -23,6 +23,8 @@
  */
 namespace Zend;
 
+use Zend\Json\Json;
+
 /**
  * Class to store and retrieve the version of Zend Framework.
  *
@@ -73,7 +75,7 @@ final class Version
         if (null === self::$latestVersion) {
             self::$latestVersion = 'not available';
             $tags = file_get_contents('https://api.github.com/repos/zendframework/zf2/tags');
-            $tags = json_decode($tags, true);
+            $tags = Json::decode($tags, Json::TYPE_ARRAY);
             $tag  = array_pop($tags);
             self::$latestVersion = str_replace('release-','', $tag['name']);
         }

--- a/library/Zend/Version.php
+++ b/library/Zend/Version.php
@@ -72,14 +72,24 @@ final class Version
     {
         if (null === self::$latestVersion) {
             self::$latestVersion = 'not available';
-
-            $handle = fopen('http://framework.zend.com/api/zf-version', 'r');
-            if (false !== $handle) {
-                self::$latestVersion = stream_get_contents($handle);
-                fclose($handle);
-            }
+            $tags = file_get_contents('https://api.github.com/repos/zendframework/zf2/tags');
+            $tags = json_decode($tags, true);
+            $tag  = array_pop($tags);
+            self::$latestVersion = str_replace('release-','', $tag['name']);
         }
 
         return self::$latestVersion;
+    }
+
+    /**
+     * Returns true if the running version of Zend Framework is
+     * the latest (or newer??) than the latest tag on GitHub,
+     * which is returned by static::getLatest(). 
+     * 
+     * @return boolean
+     */
+    public static function isLatest()
+    {
+        return static::compareVersion(static::getLatest()) < 1;
     }
 }


### PR DESCRIPTION
- Uses GitHub API to get the latest tag (strips 'release-')
- Parses JSON response with Zend\Json
- Added a static isLatest() method to Zend\Version
