### PR TITLE
Make Zend\Loader\ClassMapAutoloader prepend itself to the spl autoloader stack...

### DIFF
--- a/library/Zend/Loader/ClassMapAutoloader.php
+++ b/library/Zend/Loader/ClassMapAutoloader.php
@@ -161,7 +161,7 @@ class ClassMapAutoloader implements SplAutoloader
      */
     public function register()
     {
-        spl_autoload_register(array($this, 'autoload'));
+        spl_autoload_register(array($this, 'autoload'), true, true);
     }
 
     /**


### PR DESCRIPTION
As pointed out by SocalNick in IRC, not doing this was causing the
StandardAutoloader to always be used by modules, even if a classmap was
registered. If a user is registering a classmap autoloader, there is probably
no reason for it to be _AFTER_ the StandardAutoloader in a stack; especially if
the StandardAutoloader is serving as a fallback for the classmap.
