### PR TITLE
Fixed classmap appending.

### DIFF
--- a/bin/classmap_generator.php
+++ b/bin/classmap_generator.php
@@ -210,7 +210,7 @@ if ($appending) {
     array_pop($existing); 
 
     // Merge
-    $content = implode(PHP_EOL, $existing + $content);
+    $content = implode(PHP_EOL, array_merge($existing, $content));
 } else {
     // Create a file with the class/file map.
     // Stupid syntax highlighters make separating < from PHP declaration necessary


### PR DESCRIPTION
These are indexed arrays, counted from 0 (lines of files) so addition does nothing, since indices of given lines already exists. Used `array_merge()` instead.
