### PR TITLE
Cache fixes / optimations

### DIFF
--- a/documentation/manual/en/module_specs/zend.cache.storage.adapter.xml
+++ b/documentation/manual/en/module_specs/zend.cache.storage.adapter.xml
@@ -81,7 +81,7 @@ $cache = StorageFactory::factory(array(
 
 // Alternately:
 $cache  = StorageFactory::adapterFactory('apc');
-$plugin = StorageFactory::adapterFactory('exception_handler', array(
+$plugin = StorageFactory::pluginFactory('exception_handler', array(
     'throw_exceptions' => false,
 ));
 $cache->addPlugin($plugin);

--- a/library/Zend/Cache/Exception/OutOfCapacityException.php
+++ b/library/Zend/Cache/Exception/OutOfCapacityException.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Cache
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Cache\Exception;
+
+use Zend\Cache\Exception;
+
+/**
+ * @category   Zend
+ * @package    Zend_Cache
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class OutOfCapacityException extends \OverflowException implements Exception
+{
+}

--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -345,13 +345,8 @@ abstract class AbstractAdapter implements Adapter
         $registry = $this->getPluginRegistry();
         if ($registry->contains($plugin)) {
             $plugin->detach($this->events());
-        } else {
-            throw new Exception\LogicException(sprintf(
-                'Plugin of type "%s" already removed',
-                get_class($plugin)
-            ));
+            $registry->detach($plugin);
         }
-        $registry->detach($plugin);
         return $this;
     }
 

--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -344,11 +344,11 @@ abstract class AbstractAdapter implements Adapter
     /**
      * Get all registered plugins
      *
-     * @return SplObjectStorage
+     * @return Plugin[]
      */
     public function getPlugins()
     {
-        return $this->getPluginRegistry();
+        return iterator_to_array($this->getPluginRegistry(), false);
     }
 
     /* reading */

--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -739,6 +739,19 @@ abstract class AbstractAdapter implements Adapter
     /**
      * Get delayed
      *
+     * Options:
+     *  - ttl <float> optional
+     *    - The time-to-life (Default: ttl of object)
+     *  - namespace <string> optional
+     *    - The namespace to use (Default: namespace of object)
+     *  - select <array> optional
+     *    - An array of the information the returned item contains
+     *      (Default: array('key', 'value'))
+     *  - callback <callback> optional
+     *    - An result callback will be invoked for each item in the result set.
+     *    - The first argument will be the item array.
+     *    - The callback does not have to return anything.
+     *
      * @param  array $keys
      * @param  array $options
      * @return bool
@@ -758,7 +771,6 @@ abstract class AbstractAdapter implements Adapter
         }
 
         $this->normalizeOptions($options);
-
         if (!isset($options['select'])) {
             $options['select'] = array('key', 'value');
         }

--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -101,6 +101,20 @@ abstract class AbstractAdapter implements Adapter
     protected $stmtOptions = null;
 
     /**
+     * Constructor
+     *
+     * @param  null|array|Traversable|AdapterOptions $options
+     * @throws Exception
+     * @return void
+     */
+    public function __construct($options = null)
+    {
+        if ($options) {
+            $this->setOptions($options);
+        }
+    }
+
+    /**
      * Destructor
      *
      * detach all registered plugins to free

--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -566,10 +566,10 @@ abstract class AbstractAdapter implements Adapter
     /**
      * Check and set item
      *
-     * @param  string $token
-     * @param  string|int $key
-     * @param  mixed $value
-     * @param  array $options
+     * @param  mixed  $token
+     * @param  string $key
+     * @param  mixed  $value
+     * @param  array  $options
      * @return bool
      */
     public function checkAndSetItem($token, $key, $value, array $options = array())

--- a/library/Zend/Cache/Storage/Adapter/AdapterOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/AdapterOptions.php
@@ -86,7 +86,7 @@ class AdapterOptions extends Options
 
     /**
      * Cast to array
-     * 
+     *
      * @return array
      */
     public function toArray()
@@ -178,7 +178,7 @@ class AdapterOptions extends Options
      */
     public function setNamespace($namespace)
     {
-        $nameapace = (string)$namespace;
+        $namespace = (string)$namespace;
         if ($namespace === '') {
             throw new Exception\InvalidArgumentException('No namespace given');
         }

--- a/library/Zend/Cache/Storage/Adapter/Apc.php
+++ b/library/Zend/Cache/Storage/Adapter/Apc.php
@@ -64,11 +64,11 @@ class Apc extends AbstractAdapter
     /**
      * Constructor
      *
-     * @param  array $options Option
+     * @param  null|array|Traversable|ApcOptions $options
      * @throws Exception
      * @return void
      */
-    public function __construct()
+    public function __construct($options = null)
     {
         if (version_compare('3.1.6', phpversion('apc')) > 0) {
             throw new Exception\ExtensionNotLoadedException("Missing ext/apc >= 3.1.6");
@@ -103,6 +103,8 @@ class Apc extends AbstractAdapter
                 'internal_key' => \APC_ITER_KEY,
             );
         }
+
+        parent::__construct($options);
     }
 
     /* options */
@@ -116,8 +118,8 @@ class Apc extends AbstractAdapter
      */
     public function setOptions($options)
     {
-        if (!is_array($options) 
-            && !$options instanceof Traversable 
+        if (!is_array($options)
+            && !$options instanceof Traversable
             && !$options instanceof ApcOptions
         ) {
             throw new Exception\InvalidArgumentException(sprintf(

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -75,7 +75,7 @@ class Filesystem extends AbstractAdapter
      * Set options.
      *
      * @param  array|Traversable|FilesystemOptions $options
-     * @return FilesystemAdapter
+     * @return Filesystem
      * @see    getOptions()
      */
     public function setOptions($options)

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -80,8 +80,8 @@ class Filesystem extends AbstractAdapter
      */
     public function setOptions($options)
     {
-        if (!is_array($options) 
-            && !$options instanceof Traversable 
+        if (!is_array($options)
+            && !$options instanceof Traversable
             && !$options instanceof FilesystemOptions
         ) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -648,10 +648,10 @@ class Filesystem extends AbstractAdapter
     /**
      * check and set item
      *
-     * @param $token
-     * @param $key
-     * @param $value
-     * @param array $options
+     * @param string $token
+     * @param string $key
+     * @param mixed  $value
+     * @param array  $options
      * @return bool|mixed
      * @throws ItemNotFoundException
      */
@@ -1320,7 +1320,7 @@ class Filesystem extends AbstractAdapter
      * @return array|bool
      * @throws ItemNotFoundException
      */
-    protected function internalGetMetadata($key, array &$options) 
+    protected function internalGetMetadata($key, array &$options)
     {
         $keyInfo = $this->getKeyInfo($key, $options['namespace']);
         if (!$keyInfo) {
@@ -1537,7 +1537,7 @@ class Filesystem extends AbstractAdapter
 
                 // if MATCH_TAGS mode -> check if all given tags available in current cache
                 if (($mode & self::MATCH_TAGS) == self::MATCH_TAGS ) {
-                    if (!isset($info['tags']) 
+                    if (!isset($info['tags'])
                         || count(array_diff($opts['tags'], $info['tags'])) > 0
                     ) {
                         continue;
@@ -1545,7 +1545,7 @@ class Filesystem extends AbstractAdapter
 
                 // if MATCH_NO_TAGS mode -> check if no given tag available in current cache
                 } elseif(($mode & self::MATCH_NO_TAGS) == self::MATCH_NO_TAGS) {
-                    if (isset($info['tags']) 
+                    if (isset($info['tags'])
                         && count(array_diff($opts['tags'], $info['tags'])) != count($opts['tags'])
                     ) {
                         continue;
@@ -1553,7 +1553,7 @@ class Filesystem extends AbstractAdapter
 
                 // if MATCH_ANY_TAGS mode -> check if any given tag available in current cache
                 } elseif ( ($mode & self::MATCH_ANY_TAGS) == self::MATCH_ANY_TAGS ) {
-                    if (!isset($info['tags']) 
+                    if (!isset($info['tags'])
                         || count(array_diff($opts['tags'], $info['tags'])) == count($opts['tags'])
                     ) {
                         continue;
@@ -1686,7 +1686,7 @@ class Filesystem extends AbstractAdapter
      * @return array|boolean The info array or false if file wasn't found
      * @throws Exception\RuntimeException
      */
-    protected function readInfoFile($file) 
+    protected function readInfoFile($file)
     {
         if (!file_exists($file)) {
             return false;
@@ -1718,10 +1718,10 @@ class Filesystem extends AbstractAdapter
         if ($this->getOptions()->getFileLocking()) {
             set_error_handler(function($errno, $errstr = '', $errfile = '', $errline = 0) use ($file) {
                 $message = sprintf(
-                    'Error getting contents from file "%s" (in %s@%d): %s', 
-                    $file, 
-                    $errfile, 
-                    $errline, 
+                    'Error getting contents from file "%s" (in %s@%d): %s',
+                    $file,
+                    $errfile,
+                    $errline,
                     $errstr
                 );
                 throw new Exception\RuntimeException($message, $errno);
@@ -1730,17 +1730,17 @@ class Filesystem extends AbstractAdapter
             restore_error_handler();
             if ($fp === false) {
                 throw new Exception\RuntimeException(sprintf(
-                    'Unknown error getting contents from file "%s"', 
+                    'Unknown error getting contents from file "%s"',
                     $file
                 ));
             }
 
             set_error_handler(function($errno, $errstr = '', $errfile = '', $errline = 0) use ($file) {
                 $message = sprintf(
-                    'Error locking file "%s" (in %s@%d): %s', 
-                    $file, 
-                    $errfile, 
-                    $errline, 
+                    'Error locking file "%s" (in %s@%d): %s',
+                    $file,
+                    $errfile,
+                    $errline,
                     $errstr
                 );
                 throw new Exception\RuntimeException($message, $errno);
@@ -1859,7 +1859,7 @@ class Filesystem extends AbstractAdapter
      * @return void
      * @throw RuntimeException
      */
-    protected function unlink($file) 
+    protected function unlink($file)
     {
         // If file does not exist, nothing to do
         if (!file_exists($file)) {

--- a/library/Zend/Cache/Storage/Adapter/Memcached.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcached.php
@@ -1030,6 +1030,7 @@ class Memcached extends AbstractAdapter
                         'ttlPrecision'       => 1,
                         'useRequestTime'     => false,
                         'expiredRead'        => false,
+                        'maxKeyLength'       => 255,
                         'namespaceIsPrefix'  => true,
                         'namespaceSeparator' => $this->getOptions()->getNamespaceSeparator(),
                         'iterable'           => false,

--- a/library/Zend/Cache/Storage/Adapter/Memcached.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcached.php
@@ -175,11 +175,11 @@ class Memcached extends AbstractAdapter
                 return $eventRs->last();
             }
 
-            $internalKey = $options['namespace'] . $baseOptions->getNamespaceSeparator() . $key;
+            $this->memcached->setOption(MemcachedResource::OPT_PREFIX_KEY, $options['namespace']);
             if (array_key_exists('token', $options)) {
-                $result = $this->memcached->get($internalKey, null, $options['token']);
+                $result = $this->memcached->get($key, null, $options['token']);
             } else {
-                $result = $this->memcached->get($internalKey);
+                $result = $this->memcached->get($key);
             }
 
             if ($result === false) {
@@ -231,22 +231,10 @@ class Memcached extends AbstractAdapter
                 return $eventRs->last();
             }
 
-            $namespaceSep = $baseOptions->getNamespaceSeparator();
-            $internalKeys = array();
-            foreach ($keys as $key) {
-                $internalKeys[] = $options['namespace'] . $namespaceSep . $key;
-            }
-
-            $fetch = $this->memcached->getMulti($internalKeys);
-            if ($fetch === false) {
+            $this->memcached->setOption(MemcachedResource::OPT_PREFIX_KEY, $options['namespace']);
+            $result = $this->memcached->getMulti($keys);
+            if ($result === false) {
                 throw $this->getExceptionByResultCode($this->memcached->getResultCode());
-            }
-
-            // remove namespace prefix
-            $prefixL = strlen($options['namespace'] . $namespaceSep);
-            $result  = array();
-            foreach ($fetch as $internalKey => &$value) {
-                $result[ substr($internalKey, $prefixL) ] = $value;
             }
 
             return $this->triggerPost(__FUNCTION__, $args, $result);
@@ -293,8 +281,8 @@ class Memcached extends AbstractAdapter
                 return $eventRs->last();
             }
 
-            $internalKey = $options['namespace'] . $baseOptions->getNamespaceSeparator() . $key;
-            $result      = $this->memcached->get($internalKey);
+            $this->memcached->setOption(MemcachedResource::OPT_PREFIX_KEY, $options['namespace']);
+            $result = $this->memcached->get($key);
 
             if ($result === false) {
                 if (($rsCode = $this->memcached->getResultCode()) != 0
@@ -354,9 +342,10 @@ class Memcached extends AbstractAdapter
                 return $eventRs->last();
             }
 
-            $internalKey = $options['namespace'] . $baseOptions->getNamespaceSeparator() . $key;
-            $expiration  = $this->expirationTime($options['ttl']);
-            if (!$this->memcached->set($internalKey, $value, $expiration)) {
+            $this->memcached->setOption(MemcachedResource::OPT_PREFIX_KEY, $options['namespace']);
+
+            $expiration = $this->expirationTime($options['ttl']);
+            if (!$this->memcached->set($key, $value, $expiration)) {
                 throw $this->getExceptionByResultCode($this->memcached->getResultCode());
             }
 
@@ -404,15 +393,10 @@ class Memcached extends AbstractAdapter
                 return $eventRs->last();
             }
 
-            $internalKeyValuePairs = array();
-            $prefix                = $options['namespace'] . $baseOptions->getNamespaceSeparator();
-            foreach ($keyValuePairs as $key => &$value) {
-                $internalKey = $prefix . $key;
-                $internalKeyValuePairs[$internalKey] = &$value;
-            }
+            $this->memcached->setOption(MemcachedResource::OPT_PREFIX_KEY, $options['namespace']);
 
             $expiration = $this->expirationTime($options['ttl']);
-            if (!$this->memcached->setMulti($internalKeyValuePairs, $expiration)) {
+            if (!$this->memcached->setMulti($keyValuePairs, $expiration)) {
                 throw $this->getExceptionByResultCode($this->memcached->getResultCode());
             }
 
@@ -463,9 +447,10 @@ class Memcached extends AbstractAdapter
                 return $eventRs->last();
             }
 
-            $internalKey = $options['namespace'] . $baseOptions->getNamespaceSeparator() . $key;
-            $expiration  = $this->expirationTime($options['ttl']);
-            if (!$this->memcached->add($internalKey, $value, $expiration)) {
+            $this->memcached->setOption(MemcachedResource::OPT_PREFIX_KEY, $options['namespace']);
+
+            $expiration = $this->expirationTime($options['ttl']);
+            if (!$this->memcached->add($key, $value, $expiration)) {
                 throw $this->getExceptionByResultCode($this->memcached->getResultCode());
             }
 
@@ -516,9 +501,10 @@ class Memcached extends AbstractAdapter
                 return $eventRs->last();
             }
 
-            $internalKey = $options['namespace'] . $baseOptions->getNamespaceSeparator() . $key;
-            $expiration  = $this->expirationTime($options['ttl']);
-            if (!$this->memcached->replace($internalKey, $value, $expiration)) {
+            $this->memcached->setOption(MemcachedResource::OPT_PREFIX_KEY, $options['namespace']);
+
+            $expiration = $this->expirationTime($options['ttl']);
+            if (!$this->memcached->replace($key, $value, $expiration)) {
                 throw $this->getExceptionByResultCode($this->memcached->getResultCode());
             }
 
@@ -560,9 +546,10 @@ class Memcached extends AbstractAdapter
                 return $eventRs->last();
             }
 
-            $internalKey = $options['namespace'] . $baseOptions->getNamespaceSeparator() . $key;
-            $expiration  = $this->expirationTime($options['ttl']);
-            $result      = $this->memcached->cas($token, $internalKey, $value, $expiration);
+            $this->memcached->setOption(MemcachedResource::OPT_PREFIX_KEY, $options['namespace']);
+
+            $expiration = $this->expirationTime($options['ttl']);
+            $result     = $this->memcached->cas($token, $key, $value, $expiration);
 
             if ($result === false) {
                 $rsCode = $this->memcached->getResultCode();
@@ -616,8 +603,8 @@ class Memcached extends AbstractAdapter
                 return $eventRs->last();
             }
 
-            $internalKey = $options['namespace'] . $baseOptions->getNamespaceSeparator() . $key;
-            $result = $this->memcached->delete($internalKey);
+            $this->memcached->setOption(MemcachedResource::OPT_PREFIX_KEY, $options['namespace']);
+            $result = $this->memcached->delete($key);
 
             if ($result === false) {
                 if (($rsCode = $this->memcached->getResultCode()) != 0
@@ -664,8 +651,9 @@ class Memcached extends AbstractAdapter
         ));
 
         try {
-            $rsCodes = array();
+            $this->memcached->setOption(MemcachedResource::OPT_PREFIX_KEY, $options['namespace']);
 
+            $rsCodes = array();
             if (static::$extMemcachedMajorVersion >= 2) {
                 $rsCodes = $this->memcached->deleteMulti($keys);
             } else {
@@ -739,9 +727,10 @@ class Memcached extends AbstractAdapter
                 return $eventRs->last();
             }
 
-            $internalKey = $options['namespace'] . $baseOptions->getNamespaceSeparator() . $key;
-            $value       = (int)$value;
-            $newValue    = $this->memcached->increment($internalKey, $value);
+            $this->memcached->setOption(MemcachedResource::OPT_PREFIX_KEY, $options['namespace']);
+
+            $value    = (int)$value;
+            $newValue = $this->memcached->increment($key, $value);
 
             if ($newValue === false) {
                 if (($rsCode = $this->memcached->getResultCode()) != 0
@@ -751,7 +740,7 @@ class Memcached extends AbstractAdapter
                 }
 
                 $expiration = $this->expirationTime($options['ttl']);
-                if (!$this->memcached->add($internalKey, $value, $expiration)) {
+                if (!$this->memcached->add($key, $value, $expiration)) {
                     throw $this->getExceptionByResultCode($this->memcached->getResultCode());
                 }
 
@@ -804,9 +793,10 @@ class Memcached extends AbstractAdapter
                 return $eventRs->last();
             }
 
-            $internalKey = $options['namespace'] . $baseOptions->getNamespaceSeparator() . $key;
-            $value       = (int)$value;
-            $newValue    = $this->memcached->decrement($internalKey, $value);
+            $this->memcached->setOption(MemcachedResource::OPT_PREFIX_KEY, $options['namespace']);
+
+            $value    = (int)$value;
+            $newValue = $this->memcached->decrement($key, $value);
 
             if ($newValue === false) {
                 if (($rsCode = $this->memcached->getResultCode()) != 0
@@ -816,7 +806,7 @@ class Memcached extends AbstractAdapter
                 }
 
                 $expiration = $this->expirationTime($options['ttl']);
-                if (!$this->memcached->add($internalKey, -$value, $expiration)) {
+                if (!$this->memcached->add($key, -$value, $expiration)) {
                     throw $this->getExceptionByResultCode($this->memcached->getResultCode());
                 }
 
@@ -884,16 +874,7 @@ class Memcached extends AbstractAdapter
                 return $eventRs->last();
             }
 
-            $prefix = $options['namespace'] . $baseOptions->getNamespaceSeparator();
-
-            // init search keys
-            $search = array();
-            foreach ($keys as $key) {
-                $search[] = $prefix.$key;
-            }
-
-            // we don't need the CAS token
-            $withCas = false;
+            $this->memcached->setOption(MemcachedResource::OPT_PREFIX_KEY, $options['namespace']);
 
             // redirect callback
             if (isset($options['callback'])) {
@@ -901,11 +882,7 @@ class Memcached extends AbstractAdapter
                     $select = & $options['select'];
 
                     // handle selected key
-                    if (in_array('key', $select)) {
-                        $namespaceSeparator = $baseOptions->getNamespaceSeparator();
-                        $prefixL = strlen($options['namespace'] . $namespaceSeparator);
-                        $item['key'] = substr($item['key'], $prefixL);
-                    } else {
+                    if (!in_array('key', $select)) {
                         unset($item['key']);
                     }
 
@@ -917,11 +894,11 @@ class Memcached extends AbstractAdapter
                     call_user_func($options['callback'], $item);
                 };
 
-                if (!$this->memcached->getDelayed($search, false, $cb)) {
+                if (!$this->memcached->getDelayed($keys, false, $cb)) {
                     throw $this->getExceptionByResultCode($this->memcached->getResultCode());
                 }
             } else {
-                if (!$this->memcached->getDelayed($search)) {
+                if (!$this->memcached->getDelayed($keys)) {
                     throw $this->getExceptionByResultCode($this->memcached->getResultCode());
                 }
 
@@ -965,11 +942,7 @@ class Memcached extends AbstractAdapter
                 $select = & $this->stmtOptions['select'];
 
                 // handle selected key
-                if (in_array('key', $select)) {
-                    $namespaceSeparator = $this->getOptions()->getNamespaceSeparator();
-                    $prefixL = strlen($this->stmtOptions['namespace'] . $namespaceSeparator);
-                    $result['key'] = substr($result['key'], $prefixL);
-                } else {
+                if (!in_array('key', $select)) {
                     unset($result['key']);
                 }
 
@@ -998,10 +971,7 @@ class Memcached extends AbstractAdapter
      */
     public function fetchAll()
     {
-        $prefixL = strlen($this->stmtOptions['namespace'] . $this->getOptions()->getNamespaceSeparator());
-
         $result = $this->memcached->fetchAll();
-
         if ($result === false) {
             throw new Exception\RuntimeException("Memcached::fetchAll() failed");
         }
@@ -1009,9 +979,7 @@ class Memcached extends AbstractAdapter
         $select = $this->stmtOptions['select'];
 
         foreach ($result as &$elem) {
-            if (in_array('key', $select)) {
-                $elem['key'] = substr($elem['key'], $prefixL);
-            } else {
+            if (!in_array('key', $select)) {
                 unset($elem['key']);
             }
         }
@@ -1112,7 +1080,6 @@ class Memcached extends AbstractAdapter
                         'expiredRead'        => false,
                         'maxKeyLength'       => 255,
                         'namespaceIsPrefix'  => true,
-                        'namespaceSeparator' => $this->getOptions()->getNamespaceSeparator(),
                         'iterable'           => false,
                         'clearAllNamespaces' => true,
                         'clearByNamespace'   => false,

--- a/library/Zend/Cache/Storage/Adapter/Memcached.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcached.php
@@ -607,7 +607,6 @@ class Memcached extends AbstractAdapter
         $this->normalizeKey($key);
         $args = new ArrayObject(array(
             'key'     => & $key,
-            'value'   => & $value,
             'options' => & $options,
         ));
 
@@ -667,7 +666,7 @@ class Memcached extends AbstractAdapter
         try {
             $rsCodes = array();
 
-            if (method_exists($this->memcached, 'deleteMulti')) {
+            if (static::$extMemcachedMajorVersion >= 2) {
                 $rsCodes = $this->memcached->deleteMulti($keys);
             } else {
                 foreach ($keys as $key) {
@@ -730,6 +729,7 @@ class Memcached extends AbstractAdapter
         $this->normalizeKey($key);
         $args = new ArrayObject(array(
             'key'     => & $key,
+            'value'   => & $value,
             'options' => & $options,
         ));
 
@@ -794,6 +794,7 @@ class Memcached extends AbstractAdapter
         $this->normalizeKey($key);
         $args = new ArrayObject(array(
             'key'     => & $key,
+            'value'   => & $value,
             'options' => & $options,
         ));
 
@@ -873,7 +874,7 @@ class Memcached extends AbstractAdapter
         }
 
         $args = new ArrayObject(array(
-            'key'     => & $key,
+            'keys'    => & $keys,
             'options' => & $options,
         ));
 

--- a/library/Zend/Cache/Storage/Adapter/Memcached.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcached.php
@@ -125,15 +125,12 @@ class Memcached extends AbstractAdapter
         return $this->options;
     }
 
-
     /* reading */
 
     /**
      * Get an item.
      *
      * Options:
-     *  - ttl <float> optional
-     *    - The time-to-life (Default: ttl of object)
      *  - namespace <string> optional
      *    - The namespace to use (Default: namespace of object)
      *  - ignore_missing_items <boolean> optional
@@ -190,8 +187,6 @@ class Memcached extends AbstractAdapter
      * Get multiple items.
      *
      * Options:
-     *  - ttl <float> optional
-     *    - The time-to-life (Default: ttl of object)
      *  - namespace <string> optional
      *    - The namespace to use (Default: namespace of object)
      *
@@ -252,8 +247,6 @@ class Memcached extends AbstractAdapter
      * Get metadata of an item.
      *
      * Options:
-     *  - ttl <float> optional
-     *    - The time-to-life (Default: ttl of object)
      *  - namespace <string> optional
      *    - The namespace to use (Default: namespace of object)
      *  - ignore_missing_items <boolean> optional
@@ -310,10 +303,10 @@ class Memcached extends AbstractAdapter
      * Store an item.
      *
      * Options:
+     *  - ttl <float> optional
+     *    - The time-to-life (Default: ttl of object)
      *  - namespace <string> optional
      *    - The namespace to use (Default: namespace of object)
-     *  - tags <array> optional
-     *    - An array of tags
      *
      * @param  string $key
      * @param  mixed $value
@@ -365,10 +358,10 @@ class Memcached extends AbstractAdapter
      * Store multiple items.
      *
      * Options:
+     *  - ttl <float> optional
+     *    - The time-to-life (Default: ttl of object)
      *  - namespace <string> optional
      *    - The namespace to use (Default: namespace of object)
-     *  - tags <array> optional
-     *    - An array of tags
      *
      * @param  array $keyValuePairs
      * @param  array $options
@@ -421,10 +414,10 @@ class Memcached extends AbstractAdapter
      * Add an item.
      *
      * Options:
+     *  - ttl <float> optional
+     *    - The time-to-life (Default: ttl of object)
      *  - namespace <string> optional
      *    - The namespace to use (Default: namespace of object)
-     *  - tags <array> optional
-     *    - An array of tags
      *
      * @param  string $key
      * @param  mixed  $value
@@ -480,10 +473,10 @@ class Memcached extends AbstractAdapter
      * Replace an item.
      *
      * Options:
+     *  - ttl <float> optional
+     *    - The time-to-life (Default: ttl of object)
      *  - namespace <string> optional
      *    - The namespace to use (Default: namespace of object)
-     *  - tags <array> optional
-     *    - An array of tags
      *
      * @param  string $key
      * @param  mixed  $value
@@ -916,11 +909,7 @@ class Memcached extends AbstractAdapter
      * Clear items off all namespaces.
      *
      * Options:
-     *  - ttl <float> optional
-     *    - The time-to-life (Default: ttl of object)
-     *  - tags <array> optional
-     *    - Tags to search for used with matching modes of
-     *      Zend\Cache\Storage\Adapter::MATCH_TAGS_*
+     *  - No options available for this adapter
      *
      * @param  int $mode Matching mode (Value of Zend\Cache\Storage\Adapter::MATCH_*)
      * @param  array $options

--- a/library/Zend/Cache/Storage/Adapter/Memcached.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcached.php
@@ -48,7 +48,7 @@ class Memcached extends AbstractAdapter
     /**
      * Constructor
      *
-     * @param  array $options Option
+     * @param  null|array|Traversable|MemcachedOptions $options
      * @throws Exception
      * @return void
      */
@@ -60,11 +60,9 @@ class Memcached extends AbstractAdapter
 
         $this->memcached= new MemcachedResource();
 
-        if (!empty($options)) {
-            $this->setOptions($options);
-        }
+        parent::__construct($options);
 
-        $options= $this->getOptions();
+        $options = $this->getOptions();
         $this->memcached->addServer($options->getServer(), $options->getPort());
 
     }
@@ -74,7 +72,7 @@ class Memcached extends AbstractAdapter
     /**
      * Set options.
      *
-     * @param  string|Traversable|MemcachedOptions $options
+     * @param  array|Traversable|MemcachedOptions $options
      * @return Memcached
      * @see    getOptions()
      */

--- a/library/Zend/Cache/Storage/Adapter/MemcachedOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/MemcachedOptions.php
@@ -37,7 +37,7 @@ class MemcachedOptions extends AdapterOptions
 {
     /**
      * Map of option keys to \Memcached options
-     * 
+     *
      * @var array
      */
     private $optionsMap = array(
@@ -51,7 +51,6 @@ class MemcachedOptions extends AdapterOptions
         'libketama_compatible' => MemcachedResource::OPT_LIBKETAMA_COMPATIBLE,
         'no_block'             => MemcachedResource::OPT_NO_BLOCK,
         'poll_timeout'         => MemcachedResource::OPT_POLL_TIMEOUT,
-        'prefix_key'           => MemcachedResource::OPT_PREFIX_KEY,
         'recv_timeout'         => MemcachedResource::OPT_RECV_TIMEOUT,
         'retry_timeout'        => MemcachedResource::OPT_RETRY_TIMEOUT,
         'send_timeout'         => MemcachedResource::OPT_SEND_TIMEOUT,
@@ -60,176 +59,188 @@ class MemcachedOptions extends AdapterOptions
         'socket_recv_size'     => MemcachedResource::OPT_SOCKET_RECV_SIZE,
         'socket_send_size'     => MemcachedResource::OPT_SOCKET_SEND_SIZE,
         'tcp_nodelay'          => MemcachedResource::OPT_TCP_NODELAY,
+
+        // The prefix_key act as namespace an will be set directly
+        // 'prefix_key'           => MemcachedResource::OPT_PREFIX_KEY,
     );
 
     /**
      * Memcached server address
-     * 
-     * @var string 
+     *
+     * @var string
      */
     protected $server = 'localhost';
-    
+
     /**
      * Memcached port
-     * 
+     *
      * @var integer
      */
     protected $port = 11211;
-    
+
     /**
      * Whether or not to enable binary protocol for communication with server
-     * 
+     *
      * @var bool
      */
     protected $binaryProtocol = false;
 
     /**
      * Enable or disable buffered I/O
-     * 
+     *
      * @var bool
      */
     protected $bufferWrites = false;
 
     /**
      * Whether or not to cache DNS lookups
-     * 
+     *
      * @var bool
      */
     protected $cacheLookups = false;
 
     /**
      * Whether or not to use compression
-     * 
+     *
      * @var bool
      */
     protected $compression = true;
 
     /**
      * Time at which to issue connection timeout, in ms
-     * 
+     *
      * @var int
      */
     protected $connectTimeout = 1000;
 
     /**
      * Server distribution algorithm
-     * 
+     *
      * @var int
      */
     protected $distribution = MemcachedResource::DISTRIBUTION_MODULA;
 
     /**
      * Hashing algorithm to use
-     * 
+     *
      * @var int
      */
     protected $hash = MemcachedResource::HASH_DEFAULT;
 
     /**
      * Whether or not to enable compatibility with libketama-like behavior.
-     * 
+     *
      * @var bool
      */
     protected $libketamaCompatible = false;
 
     /**
-     * Namespace separator
-     *
-     * @var string
-     */
-    protected $namespaceSeparator = ':';
-
-    /**
      * Whether or not to enable asynchronous I/O
-     * 
+     *
      * @var bool
      */
     protected $noBlock = false;
 
     /**
      * Timeout for connection polling, in ms
-     * 
+     *
      * @var int
      */
     protected $pollTimeout = 0;
 
     /**
-     * Prefix to use with keys 
-     * 
-     * @var string
-     */
-    protected $prefixKey = '';
-
-    /**
      * Maximum allowed time for a recv operation, in ms
-     * 
+     *
      * @var int
      */
     protected $recvTimeout = 0;
 
     /**
      * Time to wait before retrying a connection, in seconds
-     * 
+     *
      * @var int
      */
     protected $retryTimeout = 0;
 
     /**
      * Maximum allowed time for a send operation, in ms
-     * 
+     *
      * @var int
      */
     protected $sendTimeout = 0;
 
     /**
      * Serializer to use
-     * 
+     *
      * @var int
      */
     protected $serializer = MemcachedResource::SERIALIZER_PHP;
 
     /**
      * Maximum number of server connection errors
-     * 
+     *
      * @var int
      */
     protected $serverFailureLimit = 0;
 
     /**
      * Maximum socket send buffer in bytes
-     * 
+     *
      * @var int
      */
     protected $socketSendSize;
 
     /**
      * Maximum socket recv buffer in bytes
-     * 
+     *
      * @var int
      */
     protected $socketRecvSize;
 
     /**
      * Whether or not to enable no-delay feature for connecting sockets
-     * 
+     *
      * @var bool
      */
     protected $tcpNodelay = false;
+
+    /**
+     * Set namespace.
+     *
+     * The option Memcached::OPT_PREFIX_KEY will be used as the namespace.
+     * It can't be longer than 128 characters.
+     *
+     * @see AdapterOptions::setNamespace()
+     * @see MemcachedOptions::setPrefixKey()
+     */
+    public function setNamespace($namespace)
+    {
+        $namespace = (string)$namespace;
+
+        if (128 < strlen($namespace)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects a prefix key of no longer than 128 characters',
+                __METHOD__
+            ));
+        }
+
+        return parent::setNamespace($namespace);
+    }
 
     public function setServer($server)
     {
         $this->server= $server;
         return $this;
     }
-    
+
     public function getServer()
     {
         return $this->server;
     }
-    
+
     public function setPort($port)
     {
-        if ((!is_int($port) && !is_numeric($port)) 
+        if ((!is_int($port) && !is_numeric($port))
             || 0 > $port
         ) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -237,18 +248,18 @@ class MemcachedOptions extends AdapterOptions
                 __METHOD__
             ));
         }
-        
+
         $this->port= $port;
         return $this;
     }
-    
+
     public function getPort()
     {
         return $this->port;
     }
-    
+
     /**
-     * Set flag indicating whether or not to enable binary protocol for 
+     * Set flag indicating whether or not to enable binary protocol for
      * communication with server
      *
      * @param  bool $binaryProtocol
@@ -259,7 +270,7 @@ class MemcachedOptions extends AdapterOptions
         $this->binaryProtocol = (bool) $binaryProtocol;
         return $this;
     }
-    
+
     /**
      * Whether or not to enable binary protocol for communication with server
      *
@@ -281,7 +292,7 @@ class MemcachedOptions extends AdapterOptions
         $this->bufferWrites = (bool) $bufferWrites;
         return $this;
     }
-    
+
     /**
      * Whether or not buffered I/O is enabled
      *
@@ -303,7 +314,7 @@ class MemcachedOptions extends AdapterOptions
         $this->cacheLookups = (bool) $cacheLookups;
         return $this;
     }
-    
+
     /**
      * Whether or not to cache DNS lookups
      *
@@ -325,7 +336,7 @@ class MemcachedOptions extends AdapterOptions
         $this->compression = (bool) $compression;
         return $this;
     }
-    
+
     /**
      * Whether or not compression is enabled
      *
@@ -344,7 +355,7 @@ class MemcachedOptions extends AdapterOptions
      */
     public function setConnectTimeout($connectTimeout)
     {
-        if ((!is_int($connectTimeout) && !is_numeric($connectTimeout)) 
+        if ((!is_int($connectTimeout) && !is_numeric($connectTimeout))
             || 0 > $connectTimeout
         ) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -356,7 +367,7 @@ class MemcachedOptions extends AdapterOptions
         $this->connectTimeout = (int) $connectTimeout;
         return $this;
     }
-    
+
     /**
      * Get connection timeout value
      *
@@ -388,7 +399,7 @@ class MemcachedOptions extends AdapterOptions
         $this->distribution = $distribution;
         return $this;
     }
-    
+
     /**
      * Get server distribution algorithm
      *
@@ -427,7 +438,7 @@ class MemcachedOptions extends AdapterOptions
         $this->hash = $hash;
         return $this;
     }
-    
+
     /**
      * Get hash algorithm
      *
@@ -449,7 +460,7 @@ class MemcachedOptions extends AdapterOptions
         $this->libketamaCompatible = (bool) $libketamaCompatible;
         return $this;
     }
-    
+
     /**
      * Whether or not to enable libketama compatibility
      *
@@ -458,28 +469,6 @@ class MemcachedOptions extends AdapterOptions
     public function getLibketamaCompatible()
     {
         return $this->libketamaCompatible;
-    }
-
-    /**
-     * Set namespace separator
-     *
-     * @param  string $separator
-     * @return MemcachedOptions
-     */
-    public function setNamespaceSeparator($separator)
-    {
-        $this->namespaceSeparator = (string) $separator;
-        return $this;
-    }
-
-    /**
-     * Get namespace separator
-     *
-     * @return string
-     */
-    public function getNamespaceSeparator()
-    {
-        return $this->namespaceSeparator;
     }
 
     /**
@@ -493,7 +482,7 @@ class MemcachedOptions extends AdapterOptions
         $this->noBlock = (bool) $noBlock;
         return $this;
     }
-    
+
     /**
      * Whether or not to enable asynchronous I/O
      *
@@ -512,7 +501,7 @@ class MemcachedOptions extends AdapterOptions
      */
     public function setPollTimeout($pollTimeout)
     {
-        if ((!is_int($pollTimeout) && !is_numeric($pollTimeout)) 
+        if ((!is_int($pollTimeout) && !is_numeric($pollTimeout))
             || 0 > $pollTimeout
         ) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -524,7 +513,7 @@ class MemcachedOptions extends AdapterOptions
         $this->pollTimeout = (int) $pollTimeout;
         return $this;
     }
-    
+
     /**
      * Get connection polling timeout value
      *
@@ -538,36 +527,26 @@ class MemcachedOptions extends AdapterOptions
     /**
      * Set prefix for keys
      *
+     * The prefix key act as namespace.
+     *
      * @param  string $prefixKey
      * @return MemcachedOptions
      */
     public function setPrefixKey($prefixKey)
     {
-        if (!is_string($prefixKey)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects a string',
-                __METHOD__
-            ));
-        }
-        if (128 < strlen($prefixKey)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects a prefix key of no longer than 128 characters',
-                __METHOD__
-            ));
-        }
-
-        $this->prefixKey = $prefixKey;
-        return $this;
+        return $this->setNamespace($prefixKey);
     }
-    
+
     /**
      * Get prefix key
+     *
+     * The prefix key act as namespace.
      *
      * @return string
      */
     public function getPrefixKey()
     {
-        return $this->prefixKey;
+        return $this->getNamespace();
     }
 
     /**
@@ -578,7 +557,7 @@ class MemcachedOptions extends AdapterOptions
      */
     public function setRecvTimeout($recvTimeout)
     {
-        if ((!is_int($recvTimeout) && !is_numeric($recvTimeout)) 
+        if ((!is_int($recvTimeout) && !is_numeric($recvTimeout))
             || 0 > $recvTimeout
         ) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -590,7 +569,7 @@ class MemcachedOptions extends AdapterOptions
         $this->recvTimeout = (int) $recvTimeout;
         return $this;
     }
-    
+
     /**
      * Get recv timeout value
      *
@@ -609,7 +588,7 @@ class MemcachedOptions extends AdapterOptions
      */
     public function setRetryTimeout($retryTimeout)
     {
-        if ((!is_int($retryTimeout) && !is_numeric($retryTimeout)) 
+        if ((!is_int($retryTimeout) && !is_numeric($retryTimeout))
             || 0 > $retryTimeout
         ) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -621,7 +600,7 @@ class MemcachedOptions extends AdapterOptions
         $this->retryTimeout = (int) $retryTimeout;
         return $this;
     }
-    
+
     /**
      * Get retry timeout value, in seconds
      *
@@ -640,7 +619,7 @@ class MemcachedOptions extends AdapterOptions
      */
     public function setSendTimeout($sendTimeout)
     {
-        if ((!is_int($sendTimeout) && !is_numeric($sendTimeout)) 
+        if ((!is_int($sendTimeout) && !is_numeric($sendTimeout))
             || 0 > $sendTimeout
         ) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -652,7 +631,7 @@ class MemcachedOptions extends AdapterOptions
         $this->sendTimeout = (int) $sendTimeout;
         return $this;
     }
-    
+
     /**
      * Get send timeout value
      *
@@ -703,7 +682,7 @@ class MemcachedOptions extends AdapterOptions
         $this->serializer = $serializer;
         return $this;
     }
-    
+
     /**
      * Get serializer
      *
@@ -722,7 +701,7 @@ class MemcachedOptions extends AdapterOptions
      */
     public function setServerFailureLimit($serverFailureLimit)
     {
-        if ((!is_int($serverFailureLimit) && !is_numeric($serverFailureLimit)) 
+        if ((!is_int($serverFailureLimit) && !is_numeric($serverFailureLimit))
             || 0 > $serverFailureLimit
         ) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -734,7 +713,7 @@ class MemcachedOptions extends AdapterOptions
         $this->serverFailureLimit = (int) $serverFailureLimit;
         return $this;
     }
-    
+
     /**
      * Get maximum server failures allowed
      *
@@ -756,8 +735,8 @@ class MemcachedOptions extends AdapterOptions
         if ($socketSendSize === null) {
             return $this;
         }
-        
-        if ((!is_int($socketSendSize) && !is_numeric($socketSendSize)) 
+
+        if ((!is_int($socketSendSize) && !is_numeric($socketSendSize))
             || 0 > $socketSendSize
         ) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -769,7 +748,7 @@ class MemcachedOptions extends AdapterOptions
         $this->socketSendSize = (int) $socketSendSize;
         return $this;
     }
-    
+
     /**
      * Get maximum socket send buffer in bytes
      *
@@ -791,8 +770,8 @@ class MemcachedOptions extends AdapterOptions
         if ($socketRecvSize === null) {
             return $this;
         }
-        
-        if ((!is_int($socketRecvSize) && !is_numeric($socketRecvSize)) 
+
+        if ((!is_int($socketRecvSize) && !is_numeric($socketRecvSize))
             || 0 > $socketRecvSize
         ) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -804,7 +783,7 @@ class MemcachedOptions extends AdapterOptions
         $this->socketRecvSize = (int) $socketRecvSize;
         return $this;
     }
-    
+
     /**
      * Get maximum socket recv buffer in bytes
      *
@@ -826,7 +805,7 @@ class MemcachedOptions extends AdapterOptions
         $this->tcpNodelay = (bool) $tcpNodelay;
         return $this;
     }
-    
+
     /**
      * Whether or not to enable no-delay feature when connecting sockets
      *
@@ -839,7 +818,7 @@ class MemcachedOptions extends AdapterOptions
 
     /**
      * Get map of option keys to \Memcached constants
-     * 
+     *
      * @return array
      */
     public function getOptionsMap()

--- a/library/Zend/Cache/Storage/Adapter/Memory.php
+++ b/library/Zend/Cache/Storage/Adapter/Memory.php
@@ -25,6 +25,7 @@ use ArrayObject,
     stdClass,
     Zend\Cache\Exception,
     Zend\Cache\Storage\Capabilities,
+    Zend\Cache\Storage\Adapter\MemoryOptions,
     Zend\Cache\Utils;
 
 /**
@@ -53,6 +54,49 @@ class Memory extends AbstractAdapter
      * @var array
      */
     protected $data = array();
+
+    /**
+     * Set options.
+     *
+     * @param  array|Traversable|MemoryOptions $options
+     * @return Memory
+     * @see    getOptions()
+     */
+    public function setOptions($options)
+    {
+        if (!is_array($options)
+            && !$options instanceof Traversable
+            && !$options instanceof MemoryOptions
+        ) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects an array, a Traversable object, or an MemoryOptions instance; '
+                . 'received "%s"',
+                __METHOD__,
+                (is_object($options) ? get_class($options) : gettype($options))
+            ));
+        }
+
+        if (!$options instanceof MemoryOptions) {
+            $options = new MemoryOptions($options);
+        }
+
+        $this->options = $options;
+        return $this;
+    }
+
+    /**
+     * Get options.
+     *
+     * @return MemoryOptions
+     * @see setOptions()
+     */
+    public function getOptions()
+    {
+        if (!$this->options) {
+            $this->setOptions(new MemoryOptions());
+        }
+        return $this->options;
+    }
 
     /* reading */
 
@@ -332,6 +376,13 @@ class Memory extends AbstractAdapter
                 return $eventRs->last();
             }
 
+            if (!$this->hasFreeCapacity()) {
+                $memoryLimit = $baseOptions->getMemoryLimit();
+                throw new Exception\OutOfCapacityException(
+                    'Memory usage exceeds limit ({$memoryLimit}).'
+                );
+            }
+
             $ns = $options['namespace'];
             $this->data[$ns][$key] = array($value, microtime(true), $options['tags']);
 
@@ -377,6 +428,13 @@ class Memory extends AbstractAdapter
             $eventRs = $this->triggerPre(__FUNCTION__, $args);
             if ($eventRs->stopped()) {
                 return $eventRs->last();
+            }
+
+            if (!$this->hasFreeCapacity()) {
+                $memoryLimit = $baseOptions->getMemoryLimit();
+                throw new Exception\OutOfCapacityException(
+                    'Memory usage exceeds limit ({$memoryLimit}).'
+                );
             }
 
             $ns = $options['namespace'];
@@ -436,6 +494,13 @@ class Memory extends AbstractAdapter
                 return $eventRs->last();
             }
 
+            if (!$this->hasFreeCapacity()) {
+                $memoryLimit = $baseOptions->getMemoryLimit();
+                throw new Exception\OutOfCapacityException(
+                    'Memory usage exceeds limit ({$memoryLimit}).'
+                );
+            }
+
             $ns = $options['namespace'];
             if (isset($this->data[$ns][$key])) {
                 throw new Exception\RuntimeException("Key '{$key}' already exists within namespace '$ns'");
@@ -484,6 +549,13 @@ class Memory extends AbstractAdapter
             $eventRs = $this->triggerPre(__FUNCTION__, $args);
             if ($eventRs->stopped()) {
                 return $eventRs->last();
+            }
+
+            if (!$this->hasFreeCapacity()) {
+                $memoryLimit = $baseOptions->getMemoryLimit();
+                throw new Exception\OutOfCapacityException(
+                    'Memory usage exceeds limit ({$memoryLimit}).'
+                );
             }
 
             $ns = $options['namespace'];
@@ -1276,7 +1348,7 @@ class Memory extends AbstractAdapter
                         'resource' => true,
                     ),
                     'supportedMetadata' => array(
-                        'mtime', 
+                        'mtime',
                         'tags',
                     ),
                     'maxTtl'             => PHP_INT_MAX,
@@ -1319,12 +1391,35 @@ class Memory extends AbstractAdapter
             return $eventRs->last();
         }
 
+        $total = $this->getOptions()->getMemoryLimit();
+        $free  = $total - (float) memory_get_usage(true);
+        $result = array(
+            'total' => $total,
+            'free'  => ($free >= 0) ? $free : 0,
+        );
+
         $result = Utils::getPhpMemoryCapacity();
 
         return $this->triggerPost(__FUNCTION__, $args, $result);
     }
 
     /* internal */
+
+    /**
+     * Has the memory adapter storage free capacity
+     * to store items
+     *
+     * Similar logic as getCapacity() but without triggering
+     * events and returns boolean.
+     *
+     * @return boolean
+     */
+    protected function hasFreeCapacity()
+    {
+        $total = $this->getOptions()->getMemoryLimit();
+        $free  = $total - (float) memory_get_usage(true);
+        return ($free > 0);
+    }
 
     /**
      * Internal method to check if an key exists

--- a/library/Zend/Cache/Storage/Adapter/MemoryOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/MemoryOptions.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Cache
+ * @subpackage Storage
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Cache\Storage\Adapter;
+
+use Zend\Cache\Utils,
+    Zend\Cache\Exception;
+
+/**
+ * These are options specific to the APC adapter
+ *
+ * @category   Zend
+ * @package    Zend_Cache
+ * @subpackage Storage
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class MemoryOptions extends AdapterOptions
+{
+    /**
+     * memory limit
+     *
+     * @var null|int
+     */
+    protected $memoryLimit = null;
+
+    /**
+     * Set memory limit
+     *
+     * If the used memory of PHP exceeds this limit an OutOfCapacityException
+     * will be thrown.
+     *
+     * @param  int $bytes
+     * @return MemoryOptions
+     */
+    public function setMemoryLimit($bytes)
+    {
+        $this->memoryLimit = (int) $bytes;
+        return $this;
+    }
+
+    /**
+     * Get memory limit
+     *
+     * If the used memory of PHP exceeds this limit an OutOfCapacityException
+     * will be thrown.
+     *
+     * @return int
+     */
+    public function getMemoryLimit()
+    {
+        if ($this->memoryLimit === null) {
+            $memoryLimit = Utils::bytesFromString(ini_get('memory_limit'));
+            if ($memoryLimit >= 0) {
+                $this->memoryLimit = floor($memoryLimit / 2);
+            } else {
+                // use a hard memory limit of 32M if php memory limit is disabled
+                $this->memoryLimit = 33554432;
+            }
+        }
+
+        return $this->memoryLimit;
+    }
+}

--- a/library/Zend/Cache/Storage/Adapter/WinCache.php
+++ b/library/Zend/Cache/Storage/Adapter/WinCache.php
@@ -46,7 +46,7 @@ class WinCache extends AbstractAdapter
     /**
      * Constructor
      *
-     * @param  array $options Option
+     * @param  array|Traversable|WinCacheOptions $options
      * @throws Exception
      * @return void
      */
@@ -55,7 +55,7 @@ class WinCache extends AbstractAdapter
         if (!extension_loaded('wincache')) {
             throw new Exception\ExtensionNotLoadedException("WinCache extension is not loaded");
         }
-        
+
         $enabled = ini_get('wincache.ucenabled');
         if (PHP_SAPI == 'cli') {
             $enabled = $enabled && (bool) ini_get('wincache.enablecli');
@@ -66,6 +66,8 @@ class WinCache extends AbstractAdapter
                 "WinCache is disabled - see 'wincache.ucenabled' and 'wincache.enablecli'"
             );
         }
+
+        parent::__construct($options);
     }
 
     /* options */
@@ -73,15 +75,15 @@ class WinCache extends AbstractAdapter
     /**
      * Set options.
      *
-     * @param  stringTraversable|WinCacheOptions $options
+     * @param  array|Traversable|WinCacheOptions $options
      * @return WinCache
      * @see    getOptions()
      */
     public function setOptions($options)
     {
-        if (!is_array($options) 
-            && !$options instanceof Traversable 
-            && !$options instanceof WinCacheOptions    
+        if (!is_array($options)
+            && !$options instanceof Traversable
+            && !$options instanceof WinCacheOptions
         ) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an array, a Traversable object; '
@@ -322,15 +324,15 @@ class WinCache extends AbstractAdapter
             foreach ($keys as $key) {
                 $internalKeys[] = $options['namespace'] . $namespaceSep . $key;
             }
-            
+
             $prefixL = strlen($options['namespace'] . $namespaceSep);
             $result  = array();
             foreach ($internalKeys as $key) {
                 if (wincache_ucache_exists($key)) {
                     $result[] = substr($key, $prefixL);
-                }    
+                }
             }
-            
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             return $this->triggerException(__FUNCTION__, $args, $e);
@@ -382,7 +384,7 @@ class WinCache extends AbstractAdapter
             $info     = wincache_ucache_info(true, $internalKey);
             if (isset($info['ucache_entries'][1])) {
                 $metadata = $info['ucache_entries'][1];
-            }    
+            }
 
             if (empty($metadata)) {
                 if (!$options['ignore_missing_items']) {
@@ -429,9 +431,9 @@ class WinCache extends AbstractAdapter
             if ($eventRs->stopped()) {
                 return $eventRs->last();
             }
-            
+
             $result= array();
-            
+
             foreach ($keys as $key) {
                 $internalKey = $options['namespace'] . $baseOptions->getNamespaceSeparator() . $key;
 
@@ -448,7 +450,7 @@ class WinCache extends AbstractAdapter
                     $result[ substr($internalKey, $prefixL) ] = & $metadata;
                 }
             }
-            
+
             if (!$options['ignore_missing_items']) {
                 if (count($keys) != count($result)) {
                     $missing = implode("', '", array_diff($keys, array_keys($result)));
@@ -860,7 +862,7 @@ class WinCache extends AbstractAdapter
                         "Key '{$internalKey}' not found"
                     );
                 }
-                
+
                 $this->addItem($key, $value, $options);
                 $newValue = $value;
             }
@@ -977,7 +979,7 @@ class WinCache extends AbstractAdapter
             }
 
             $result= wincache_ucache_clear();
-            
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             return $this->triggerException(__FUNCTION__, $args, $e);
@@ -1093,17 +1095,17 @@ class WinCache extends AbstractAdapter
             $metadata['num_hits'] = $metadata['hitcount'];
             unset($metadata['hitcount']);
         }
-        
+
         if (isset($metadata['ttl_seconds'])) {
             $metadata['ttl'] = $metadata['ttl_seconds'];
             unset($metadata['ttl_seconds']);
         }
-        
+
          if (isset($metadata['value_size'])) {
             $metadata['mem_size'] = $metadata['value_size'];
             unset($metadata['value_size']);
         }
-        
+
         // remove namespace prefix
         if (isset($metadata['key_name'])) {
             $pos = strpos($metadata['key_name'], $this->getOptions()->getNamespaceSeparator());

--- a/library/Zend/Cache/Storage/Adapter/WinCache.php
+++ b/library/Zend/Cache/Storage/Adapter/WinCache.php
@@ -50,7 +50,7 @@ class WinCache extends AbstractAdapter
      * @throws Exception
      * @return void
      */
-    public function __construct()
+    public function __construct($options = null)
     {
         if (!extension_loaded('wincache')) {
             throw new Exception\ExtensionNotLoadedException("WinCache extension is not loaded");
@@ -109,7 +109,6 @@ class WinCache extends AbstractAdapter
         }
         return $this->options;
     }
-
 
     /* reading */
 

--- a/library/Zend/Cache/StorageFactory.php
+++ b/library/Zend/Cache/StorageFactory.php
@@ -128,7 +128,7 @@ class StorageFactory
 
         // set adapter or plugin options
         if (isset($cfg['options'])) {
-            if (!is_array($cfg['options']) 
+            if (!is_array($cfg['options'])
                 && !$cfg['options'] instanceof Traversable
             ) {
                 throw new Exception\InvalidArgumentException(
@@ -150,20 +150,23 @@ class StorageFactory
      * Instantiate a storage adapter
      *
      * @param  string|Storage\Adapter $adapterName
-     * @param  array|Traversable|Storage\Adapter\AdapterOptions $options
+     * @param  null|array|Traversable|Storage\Adapter\AdapterOptions $options
      * @return Storage\Adapter
      * @throws Exception\RuntimeException
      */
-    public static function adapterFactory($adapterName, $options = array())
+    public static function adapterFactory($adapterName, $options = null)
     {
         if ($adapterName instanceof Storage\Adapter) {
             // $adapterName is already an adapter object
-            $adapterName->setOptions($options);
-            return $adapterName;
+            $adapter = $adapterName;
+        } else {
+            $adapter = static::getAdapterBroker()->load($adapterName);
         }
 
-        $adapter = static::getAdapterBroker()->load($adapterName);
-        $adapter->setOptions($options);
+        if ($options !== null) {
+            $adapter->setOptions($options);
+        }
+
         return $adapter;
     }
 

--- a/library/Zend/Cache/Utils.php
+++ b/library/Zend/Cache/Utils.php
@@ -224,7 +224,7 @@ abstract class Utils
      * @return float
      * @throws Exception\RuntimeException
      */
-    static protected function bytesFromString($memStr)
+    static public function bytesFromString($memStr)
     {
         if (!preg_match('/\s*([\-\+]?\d+)\s*(\w*)\s*/', $memStr, $matches)) {
             throw new Exception\RuntimeException("Can't detect bytes of string '{$memStr}'");

--- a/library/Zend/Cache/Utils.php
+++ b/library/Zend/Cache/Utils.php
@@ -26,7 +26,7 @@ namespace Zend\Cache;
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Utils
+abstract class Utils
 {
     /**
      * Get disk capacity

--- a/tests/Zend/Cache/Storage/Adapter/MemoryTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/MemoryTest.php
@@ -37,10 +37,19 @@ class MemoryTest extends CommonAdapterTest
     public function setUp()
     {
         // instantiate memory adapter
-        $this->_options = new Cache\Storage\Adapter\AdapterOptions();
+        $this->_options = new Cache\Storage\Adapter\MemoryOptions();
         $this->_storage = new Cache\Storage\Adapter\Memory();
         $this->_storage->setOptions($this->_options);
 
         parent::setUp();
     }
+
+    public function testThrowOutOfCapacityException()
+    {
+        $this->_options->setMemoryLimit(memory_get_usage(true) + 5);
+
+        $this->setExpectedException('Zend\Cache\Exception\OutOfCapacityException');
+        $this->_storage->addItem('test', 'test');
+    }
+
 }

--- a/tests/Zend/Cache/Storage/Adapter/MemoryTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/MemoryTest.php
@@ -46,7 +46,7 @@ class MemoryTest extends CommonAdapterTest
 
     public function testThrowOutOfCapacityException()
     {
-        $this->_options->setMemoryLimit(memory_get_usage(true) + 5);
+        $this->_options->setMemoryLimit(memory_get_usage(true) - 8);
 
         $this->setExpectedException('Zend\Cache\Exception\OutOfCapacityException');
         $this->_storage->addItem('test', 'test');


### PR DESCRIPTION
- fixed AdapterOptions::setNamespace
- fixed quickstart example how to use Zend\Cache\StorageFactory
- make static class Zend\Cache\Utils abstract
- allow to set options on all adapter constructors

plugin handling:
- Don't throw an exception on remove a not registered plug-in (talked with matthiew)
- Now Zend\Cache\Storage\Adapter::getPlugins returns a simple list of plug-ins to not allow editing the plugin registry outside of the adapter
- memcached adapter:
  - Zend\Cache\Storage\Adapter::getMetadata[s] shouldn't throw an exception if the adapter doesn't support metadata. Instead return an empty array.
  - better getDelayed
  - use build-in functionality of CAS
  - added capability 'maxKeyLength' => 255 
  - fixed ttl vs. expiration time
  - use Memcached::getResult[Code|Message] to generate exception and to check if it's an ItemNotFound error
  - use of Memcached::deleteMulti since ext/memcached 2.0.0
  - fixed event params
  - use of Memcached::OPT_PREFIX_KEY as namespace

memory adapter:
- implemented memory limit for memory adapter (Default: PHP memory_limit / 2)
  Why ?

```
- To limit the used PHP memory for cached items
- to have a real "total" for getCapacity if PHP memory limit is disabled
- No need to read /proc/meminfo (*unix) or exec GlobalMemoryStatus.exe (Win) to get the system total
```

filesystem adapter:
- fixed phpdoc of Zend\Cache\Storage\Adapter\Filesystem::setOptions
