### PR TITLE
Removed createDistinctParameterName from Di defintions

### DIFF
--- a/library/Zend/Di/Definition/CompilerDefinition.php
+++ b/library/Zend/Di/Definition/CompilerDefinition.php
@@ -200,8 +200,6 @@ class CompilerDefinition implements Definition
             /** @var $p \ReflectionParameter  */
             $actualParamName = $p->getName();
 
-            $paramName = $this->createDistinctParameterName($actualParamName, $rClass->getName());
-
             $fqName = $rClass->getName() . '::' . $rMethod->getName() . ':' . $p->getPosition();
 
             $def['parameters'][$methodName][$fqName] = array();
@@ -212,30 +210,6 @@ class CompilerDefinition implements Definition
             $def['parameters'][$methodName][$fqName][] = !$p->isOptional();
         }
 
-    }
-
-    protected function createDistinctParameterName($paramName, $class)
-    {
-        $currentParams = array();
-        if ($this->classes[$class]['parameters'] === array()) {
-            return $paramName;
-        }
-        foreach ($this->classes as $cdata) {
-            foreach ($cdata['parameters'] as $mdata) {
-                $currentParams = array_merge($currentParams, array_keys($mdata));
-            }
-        }
-
-        if (!in_array($paramName, $currentParams)) {
-            return $paramName;
-        }
-
-        $alt = 2;
-        while (in_array($paramName . (string) $alt, $currentParams)) {
-            $alt++;
-        }
-
-        return $paramName . (string) $alt;
     }
 
 //    public function processClass($className)

--- a/library/Zend/Di/Definition/RuntimeDefinition.php
+++ b/library/Zend/Di/Definition/RuntimeDefinition.php
@@ -329,29 +329,4 @@ class RuntimeDefinition implements Definition
         }
 
     }
-
-    protected function createDistinctParameterName($paramName, $class)
-    {
-        $currentParams = array();
-        if ($this->classes[$class]['parameters'] === array()) {
-            return $paramName;
-        }
-        foreach ($this->classes as $cdata) {
-            foreach ($cdata['parameters'] as $mdata) {
-                $currentParams = array_merge($currentParams, array_keys($mdata));
-            }
-        }
-
-        if (!in_array($paramName, $currentParams)) {
-            return $paramName;
-        }
-
-        $alt = 2;
-        while (in_array($paramName . (string) $alt, $currentParams)) {
-            $alt++;
-        }
-
-        return $paramName . (string) $alt;
-    }
-    
 }

--- a/library/Zend/Di/Definition/RuntimeDefinition.php
+++ b/library/Zend/Di/Definition/RuntimeDefinition.php
@@ -318,8 +318,6 @@ class RuntimeDefinition implements Definition
             /** @var $p \ReflectionParameter  */
             $actualParamName = $p->getName();
 
-            $paramName = $this->createDistinctParameterName($actualParamName, $rClass->getName());
-
             $fqName = $rClass->getName() . '::' . $rMethod->getName() . ':' . $p->getPosition();
 
             $def['parameters'][$methodName][$fqName] = array();


### PR DESCRIPTION
Removed references to createDistinctParameterName() in RuntimeDefinition and CompilerDefinition. There were superfluous calls to these methods when using Di which were seriously hurting performance. The variables being populated were completely unused, so no behavior was changed. The only effect of these commits is a rather significant performance boost.
