### PR TITLE
Fixed addMany() method in Zend\Mail\AddressList.

### DIFF
--- a/library/Zend/Mail/AddressList.php
+++ b/library/Zend/Mail/AddressList.php
@@ -84,7 +84,7 @@ class AddressList implements Countable, Iterator
             if (is_int($key) || is_numeric($key)) {
                 $this->add($value);
             } elseif (is_string($key)) {
-                $this->add($key, value);
+                $this->add($key, $value);
             } else {
                 throw new Exception\RuntimeException(sprintf(
                     'Invalid key type in provided addresses array ("%s")',

--- a/library/Zend/Mail/AddressList.php
+++ b/library/Zend/Mail/AddressList.php
@@ -84,7 +84,7 @@ class AddressList implements Countable, Iterator
             if (is_int($key) || is_numeric($key)) {
                 $this->add($value);
             } elseif (is_string($key)) {
-                $this->add($value, $key);
+                $this->add($key, value);
             } else {
                 throw new Exception\RuntimeException(sprintf(
                     'Invalid key type in provided addresses array ("%s")',

--- a/tests/Zend/Mail/AddressListTest.php
+++ b/tests/Zend/Mail/AddressListTest.php
@@ -98,7 +98,7 @@ class AddressListTest extends TestCase
     {
         $addresses = array(
             'zf-devteam@zend.com',
-            'ZF Contributors List' => 'zf-contributors@lists.zend.com',
+            'zf-contributors@lists.zend.com' => 'ZF Contributors List',
             new Address('fw-announce@lists.zend.com', 'ZF Announce List'),
         );
         $this->list->addMany($addresses);
@@ -112,7 +112,6 @@ class AddressListTest extends TestCase
     {
         $addresses = array(
             'zf-devteam@zend.com',
-            'ZF DevTeam' => 'zf-devteam@zend.com',
             new Address('zf-devteam@zend.com', 'ZF DevTeam'),
         );
         $this->list->addMany($addresses);


### PR DESCRIPTION
Accodring to it's documentation `addMany()` should treat keys as emails (which seems proper to me - multiple emailes can have same name, so they should be array keys).
