### PR TITLE
Filled map of default headers class.

### DIFF
--- a/library/Zend/Mail/Headers.php
+++ b/library/Zend/Mail/Headers.php
@@ -134,7 +134,17 @@ class Headers implements Iterator, Countable
     {
         if ($this->pluginClassLoader === null) {
             $this->pluginClassLoader = new PluginClassLoader(array(
-                'contenttype'        => 'Zend\Mail\Header\ContentType',
+                'bcc'         => 'Zend\\Mail\\Header\\Bcc',
+                'cc'          => 'Zend\\Mail\\Header\\Cc',
+                'contenttype' => 'Zend\\Mail\\Header\\ContentType',
+                'from'        => 'Zend\\Mail\\Header\\From',
+                'mimeversion' => 'Zend\\Mail\\Header\\MimeVersion',
+                'origdate'    => 'Zend\\Mail\\Header\\OrigDate',
+                'received'    => 'Zend\\Mail\\Header\\Received',
+                'replyto'     => 'Zend\\Mail\\Header\\ReplyTo',
+                'sender'      => 'Zend\\Mail\\Header\\Sender',
+                'subject'     => 'Zend\\Mail\\Header\\Subject',
+                'to'          => 'Zend\\Mail\\Header\\To',
             ));
         }
         return $this->pluginClassLoader;


### PR DESCRIPTION
Maybe there is a reason why there were no plugin classes added to initial map (except for Content-Type header class), but this breaks sending messages - transport classes (at least Sendmail transport) operates on addresses headers using methods of AbstractAddressList that are provided by To, Cc etc. headers. Because of lack of plugin classes provided to PluginClassLoader, they are all instances of GenericHeader and don't provide methods. This causes fatals.

So if that was done this way for some reason, we should rather find new approach. But if it's just left for further filling - here it goes ;).
