### PR TITLE
Stripping trailing slash in Zend\View\Helper\BasePath::setBasePath().

### DIFF
--- a/library/Zend/View/Helper/BasePath.php
+++ b/library/Zend/View/Helper/BasePath.php
@@ -72,7 +72,7 @@ class BasePath extends AbstractHelper
      */
     public function setBasePath($basePath)
     {
-        $this->basePath = $basePath;
+        $this->basePath = rtrim($basePath, '/');
         return $this;
     }
 }

--- a/tests/Zend/View/Helper/BasePathTest.php
+++ b/tests/Zend/View/Helper/BasePathTest.php
@@ -54,6 +54,14 @@ class BasePathTest extends TestCase
         $this->assertEquals('/foo/bar', $helper('bar'));
     }
     
+    public function testBasePathNoDoubleSlashes()
+    {
+        $helper = new BasePath();
+        $helper->setBasePath('/');
+
+        $this->assertEquals('/', $helper('/'));
+    }
+
     public function testBasePathWithFilePrefixedBySlash()
     {
         $helper = new BasePath();


### PR DESCRIPTION
As continuation of #689 and #694 - posting as new PR, since I reverted all previous changed and implemented minimal fix (also test case included.
