### PR TITLE
Don't fall through to class configuration

### DIFF
--- a/library/Zend/Di/Configuration.php
+++ b/library/Zend/Di/Configuration.php
@@ -47,8 +47,10 @@ class Configuration
             switch ($definitionType) {
                 case 'compiler':
                     // @todo
+                    break;
                 case 'runtime':
                     // @todo
+                    break;
                 case 'class':
                     foreach ($definitionData as $className => $classData) {
                         $classDefinitions = $di->definitions()->getDefinitionsByType('Zend\Di\Definition\ClassDefinition');


### PR DESCRIPTION
This allows us to handle runtime configuration (e.g. turning on annotations) in our application manually until this is completed.
