### PR TITLE
Allow to pass object instances to \Zend\Soap\Server::setClass().

### DIFF
--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -535,7 +535,7 @@ class Server implements \Zend\Server\Server
      *
      * See {@link setObject()} to set preconfigured object instances as request handlers.
      *
-     * @param string $class Class Name which executes SOAP Requests at endpoint.
+     * @param string|object $class Class name or object instance which executes SOAP Requests at endpoint.
      * @return \Zend\Soap\Server
      * @throws \Zend\Soap\ServerException if called more than once, or if class
      * does not exist
@@ -544,6 +544,10 @@ class Server implements \Zend\Server\Server
     {
         if (isset($this->_class)) {
             throw new Exception\InvalidArgumentException('A class has already been registered with this soap server instance');
+        }
+
+        if (is_object($class)) {
+            return $this->setObject($class);
         }
 
         if (!is_string($class)) {

--- a/tests/Zend/Soap/ServerTest.php
+++ b/tests/Zend/Soap/ServerTest.php
@@ -324,6 +324,17 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($server, $r);
     }
 
+    // GitHub PR #706
+    public function testSetClassWithObject()
+    {
+        $server = new Server();
+
+        // Correct class name should pass
+        $object = new \ZendTest\Soap\TestAsset\ServerTestClass();
+        $r = $server->setClass($object);
+        $this->assertSame($server, $r);
+    }
+
     public function testSetClassTwiceThrowsException()
     {
         $server = new Server();


### PR DESCRIPTION
According to `$class` parameter docblock in `Zend\Server\Server` interface this can be either a class name string or existing object instance and both `Zend\XmlRpc\Server` and `Zend\Json\Server\Server` implement `setClass()` this way, only SOAP server doesn't support such use case.

This fix allows to have same flow for all servers.
