### PR TITLE
ZF-9815: Zend_Navigation allow Container::addPages() accept another Container

### DIFF
--- a/library/Zend/Navigation/Container.php
+++ b/library/Zend/Navigation/Container.php
@@ -150,10 +150,12 @@ abstract class Container implements \RecursiveIterator, \Countable
     /**
      * Adds several pages at once
      *
-     * @param  array|\Zend\Config\Config $pages   pages to add
-     * @return \Zend\Navigation\Container  fluent interface, returns self
-     * @throws \Zend\Navigation\InvalidArgumentException  if $pages is not array
-     *                                                   or \Zend\Config\Config
+     * @param  array|\Zend\Config\Config|\Zend\Navigation\Container $pages pages
+     *                                                                     to add
+     * @return \Zend\Navigation\Container   fluent interface, returns self
+     * @throws \Zend\Navigation\InvalidArgumentException  if $pages is not array,
+     *                                                    \Zend\Config\Config or
+     *                                                    \Zend\Navigation\Container
      */
     public function addPages($pages)
     {
@@ -161,10 +163,16 @@ abstract class Container implements \RecursiveIterator, \Countable
             $pages = $pages->toArray();
         }
 
+        if ($pages instanceof Container) {
+            $pages = iterator_to_array($pages);
+        }
+
         if (!is_array($pages)) {
             throw new Exception\InvalidArgumentException(
-                    'Invalid argument: $pages must be an array or an ' .
-                    'instance of Zend_Config');
+                'Invalid argument: $pages must be an array, an '
+                . 'instance of \Zend\Config\Config or an instance of '
+                . '\Zend\Navigation\Container'
+            );
         }
 
         foreach ($pages as $page) {

--- a/tests/Zend/Navigation/ContainerTest.php
+++ b/tests/Zend/Navigation/ContainerTest.php
@@ -376,6 +376,24 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
                             'Expected 3 pages, found ' . count($nav));
     }
 
+    /**
+     * @group ZF-9815
+     */
+    public function testAddPagesShouldWorkWithNavigationContainer()
+    {
+        $nav = new Navigation\Navigation();
+        $nav->addPages($this->_getFindByNavigation());
+
+        $this->assertEquals(
+            3, count($nav), 'Expected 3 pages, found ' . count($nav)
+        );
+
+        $this->assertEquals(
+            $nav->toArray(),
+            $this->_getFindByNavigation()->toArray()
+        );
+    }
+
     public function testAddPagesShouldThrowExceptionWhenGivenString()
     {
         $nav = new Navigation\Navigation();


### PR DESCRIPTION
ZF-9815: Zend_Navigation allow Container::addPages() accept another Container in addition to array or Zend_Config

See also: https://github.com/zendframework/zf2/pull/419
