### PR TITLE
[Zend\Http] Use setters and change method visibility in PhpEnvironment\Request

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -73,7 +73,7 @@ class Request extends HttpRequest
     public function getRequestUri()
     {
         if ($this->requestUri === null) {
-            $this->requestUri = $this->detectRequestUri();
+            $this->setRequestUri($this->detectRequestUri());
         }
         return $this->requestUri;
     }
@@ -98,7 +98,7 @@ class Request extends HttpRequest
     public function getBaseUrl()
     {
         if ($this->baseUrl === null) {
-            $this->baseUrl = rtrim($this->detectBaseUrl(), '/');
+            $this->setBaseUrl($this->detectBaseUrl());
         }
         return $this->baseUrl;
     }
@@ -123,7 +123,7 @@ class Request extends HttpRequest
     public function getBasePath()
     {
         if ($this->basePath === null) {
-            $this->basePath = rtrim($this->detectBasePath(), '/');
+            $this->setBasePath($this->detectBasePath());
         }
         
         return $this->basePath;
@@ -213,7 +213,7 @@ class Request extends HttpRequest
      * 
      * @return string
      */
-    public function detectRequestUri()
+    protected function detectRequestUri()
     {
         $requestUri = null;
 
@@ -268,7 +268,7 @@ class Request extends HttpRequest
      * 
      * @return string
      */
-    public function detectBaseUrl()
+    protected function detectBaseUrl()
     {
         $baseUrl        = '';
         $filename       = $this->server()->get('SCRIPT_FILENAME', '');
@@ -345,7 +345,7 @@ class Request extends HttpRequest
      * 
      * @return string
      */
-    public function detectBasePath()
+    protected function detectBasePath()
     {
         $filename = basename($this->server()->get('SCRIPT_FILENAME', ''));
         $baseUrl  = $this->getBaseUrl();


### PR DESCRIPTION
- The three detect_() methods were public, but users should be encouraged to use
  the get_() wrappers that cache (as a property) and filter the values.
- The getters were setting the value directly if null, with duplicate calls to
  rtrim. Consolidated by having the getters call the setters instead.
