### PR TITLE
[Zend\View\Helper\Translator] fixes for #ZF2-140

### DIFF
--- a/library/Zend/View/Helper/Translator.php
+++ b/library/Zend/View/Helper/Translator.php
@@ -133,7 +133,7 @@ class Translator extends AbstractHelper
     public function setTranslator($translator)
     {
         if ($translator instanceof TranslationAdapter) {
-            $this->translator = $translate;
+            $this->translator = $translator;
         } else if ($translator instanceof Translation) {
             $this->translator = $translator->getAdapter();
         } else {

--- a/tests/Zend/View/Helper/TranslatorTest.php
+++ b/tests/Zend/View/Helper/TranslatorTest.php
@@ -243,4 +243,24 @@ class TranslateTest extends \PHPUnit_Framework_TestCase
         $result = $this->helper->__invoke("test %1\$s", "100");
         $this->assertEquals('test 100', $result);
     }
+
+    /**
+     * @group ZF2-140
+     */
+    public function testSetTranslatorWithTranslationAdapter()
+    {
+        $trans = new Translator\Adapter\ArrayAdapter(array('one' => 'eins', "two %1\$s" => "zwei %1\$s",
+            "three %1\$s %2\$s" => "drei %1\$s %2\$s", 'vier%ig' => 'four%'), 'de');
+        $this->helper->setTranslator($trans);
+    }
+
+    /**
+     * @group ZF2-140
+     */
+    public function testSetTranslatorWithTranslation()
+    {
+        $trans = new Translator\Translator('arrayAdapter', array('one' => 'eins', "two %1\$s" => "zwei %1\$s",
+            "three %1\$s %2\$s" => "drei %1\$s %2\$s", 'vier%ig' => 'four%'), 'de');
+        $this->helper->setTranslator($trans);
+    }
 }


### PR DESCRIPTION
- Changed $translate to $translator in setTranslator()
- Added tests for setTranslator() using [Zend\Translator\Translator] and [Zend\Translator\Adapter\AbstractAdapter] as arguments

And [the issue on JIRA here](http://framework.zend.com/issues/browse/ZF2-140).
