### PR TITLE
Feature/event manager improvements

### DIFF
--- a/library/Zend/EventManager/FilterChain.php
+++ b/library/Zend/EventManager/FilterChain.php
@@ -90,7 +90,7 @@ class FilterChain implements Filter
         if (empty($callback)) {
             throw new InvalidCallbackException('No callback provided');
         }
-        $filter = new CallbackHandler(null, $callback, array('priority' => $priority));
+        $filter = new CallbackHandler($callback, array('priority' => $priority));
         $this->filters->insert($filter, $priority);
         return $filter;
     }

--- a/library/Zend/Stdlib/CallbackHandler.php
+++ b/library/Zend/Stdlib/CallbackHandler.php
@@ -24,6 +24,7 @@
 namespace Zend\Stdlib;
 
 use Closure,
+    ReflectionClass,
     WeakRef;
 
 /**
@@ -46,21 +47,16 @@ class CallbackHandler
     protected $callback;
 
     /**
-     * @var string Event to which this handle is subscribed
-     */
-    protected $event;
-
-    /**
      * Until callback has been validated, mark as invalid
      * @var bool
      */
     protected $isValidCallback = false;
 
     /**
-     * Callback options, if any
+     * Callback metadata, if any
      * @var array
      */
-    protected $options;
+    protected $metadata;
 
     /**
      * Constructor
@@ -70,10 +66,9 @@ class CallbackHandler
      * @param  array $options Options used by the callback handler (e.g., priority)
      * @return void
      */
-    public function __construct($event, $callback, array $options = array())
+    public function __construct($callback, array $metadata = array())
     {
-        $this->event    = $event;
-        $this->options  = $options;
+        $this->metadata  = $metadata;
         $this->registerCallback($callback);
     }
 
@@ -93,11 +88,18 @@ class CallbackHandler
      */
     protected function registerCallback($callback)
     {
-        // If pecl/weakref is not installed, simply register it
-        if (!class_exists('WeakRef', false)) {
+        if (!is_callable($callback)) {
+            throw new Exception\InvalidCallbackException('Invalid callback provided; not callable');
+        }
+
+        // If pecl/weakref is not installed, simply store the callback and return
+        if (!class_exists('WeakRef')) {
+            $this->validateCallback($callback);
             $this->callback = $callback;
             return;
         }
+
+        // If WeakRef exists, we want to use it.
 
         // If we have a non-closure object, pass it to WeakRef, and then
         // register it.
@@ -117,6 +119,7 @@ class CallbackHandler
         // If we have an array callback, and the first argument is not an 
         // object, register as-is
         if (!is_object($target)) {
+            $this->validateCallback($callback);
             $this->callback = $callback;
             return;
         }
@@ -128,16 +131,6 @@ class CallbackHandler
     }
 
     /**
-     * Get event to which handler is subscribed
-     * 
-     * @return string
-     */
-    public function getEvent()
-    {
-        return $this->event;
-    }
-
-    /**
      * Retrieve registered callback
      * 
      * @return Callback
@@ -145,28 +138,31 @@ class CallbackHandler
      */
     public function getCallback()
     {
-        if (!$this->isValid()) {
-            throw new Exception\InvalidCallbackException('Invalid callback provided; not callable');
-        }
-
         $callback = $this->callback;
+
+        // String callbacks -- simply return
         if (is_string($callback)) {
             return $callback;
         }
 
+        // WeakRef callbacks -- pull it out of the object and return it
         if ($callback instanceof WeakRef) {
             return $callback->get();
         }
 
+        // Non-WeakRef object callback -- return it
         if (is_object($callback)) {
             return $callback;
         }
 
+        // Array callback with WeakRef object -- retrieve the object first, and 
+        // then return
         list($target, $method) = $callback;
         if ($target instanceof WeakRef) {
             return array($target->get(), $method);
         }
 
+        // Otherwise, return it
         return $callback;
     }
 
@@ -179,187 +175,154 @@ class CallbackHandler
     public function call(array $args = array())
     {
         $callback = $this->getCallback();
-        return call_user_func_array($callback, $args);
+
+        $isPhp54 = version_compare(PHP_VERSION, '5.4.0rc1', '>=');
+
+        // Minor performance tweak; use call_user_func() until > 3 arguments 
+        // reached
+        switch (count($args)) {
+            case 0:
+                if ($isPhp54) {
+                    return $callback();
+                }
+                return call_user_func($callback);
+            case 1:
+                if ($isPhp54) {
+                    return $callback(array_shift($args));
+                }
+                return call_user_func($callback, array_shift($args));
+            case 2:
+                $arg1 = array_shift($args);
+                $arg2 = array_shift($args);
+                if ($isPhp54) {
+                    return $callback($arg1, $arg2);
+                }
+                return call_user_func($callback, $arg1, $arg2);
+            case 3:
+                $arg1 = array_shift($args);
+                $arg2 = array_shift($args);
+                $arg3 = array_shift($args);
+                if ($isPhp54) {
+                    return $callback($arg1, $arg2, $arg3);
+                }
+                return call_user_func($callback, $arg1, $arg2, $arg3);
+            default:
+                return call_user_func_array($callback, $args);
+        }
     }
 
     /**
-     * Get all callback options
+     * Get all callback metadata
      * 
      * @return array
      */
-    public function getOptions()
+    public function getMetadata()
     {
-        return $this->options;
+        return $this->metadata;
     }
 
     /**
-     * Retrieve a single option
+     * Retrieve a single metadatum
      * 
      * @param  string $name 
      * @return mixed
      */
-    public function getOption($name)
+    public function getMetadatum($name)
     {
-        if (array_key_exists($name, $this->options)) {
-            return $this->options[$name];
+        if (array_key_exists($name, $this->metadata)) {
+            return $this->metadata[$name];
         }
         return null;
     }
 
     /**
-     * Is the composed callback valid?
+     * Validate a callback
      *
-     * Typically, this method simply checks to see if we have a valid callback. 
-     * In a few situations, it does more.
+     * Attempts to ensure that the provided callback is actually callable.
      *
-     * * If we have a string callback, we pass execution to 
-     *   {@link validateStringCallback()}.
-     * * If we have an object callback, we test to see if that object is a 
-     *   WeakRef {@see http://pecl.php.net/weakref}. If so, we return the value
-     *   of its valid() method. Otherwise, we return the result of is_callable().
-     * * If we have a callback array with a string in the first position, we 
-     *   pass execution to {@link validateArrayCallback()}.
-     * * If we have a callback array with an object in the first position, we 
-     *   test to see if that object is a WeakRef (@see http://pecl.php.net/weakref).
-     *   If so, we return the value of its valid() method. Otherwise, we return 
-     *   the result of is_callable() on the callback.
+     * Interestingly, given a class "Foo" with a non-static method "bar", 
+     * is_callable() still returns true for the following callbacks:
      *
-     * WeakRef is used to allow listeners to go out of scope. This functionality
-     * is turn-key if you have pecl/weakref installed; otherwise, you will have
-     * to manually remove listeners before destroying an object referenced in a
-     * listener.
+     * - array('Foo', 'bar')
+     * - 'Foo::bar'
      *
+     * even though passing these to call_user_func*() will raise an error.
+     * 
+     * @param  string|array|object $callback 
      * @return bool
+     * @throws Exception\InvalidCallbackException
      */
-    public function isValid()
+    protected function validateCallback($callback)
     {
-        // If we've already tested this, we can move on. Note: if a callback
-        // composes a WeakRef, this will never get set, and thus result in
-        // validation on each call.
-        if ($this->isValidCallback) {
-            return $this->callback;
+        if (is_array($callback)) {
+            return $this->validateArrayCallback($callback);
         }
-
-        $callback = $this->callback;
-
         if (is_string($callback)) {
             return $this->validateStringCallback($callback);
         }
-
-        if ($callback instanceof WeakRef) {
-            return $callback->valid();
-        }
-
-        if (is_object($callback) && is_callable($callback)) {
-            $this->isValidCallback = true;
-            return true;
-        }
-
-        if (!is_array($callback)) {
-            return false;
-        }
-
-        list($target, $method) = $callback;
-        if ($target instanceof WeakRef) {
-            if (!$target->valid()) {
-                return false;
-            }
-            $target = $target->get();
-            return is_callable(array($target, $method));
-        }
-        return $this->validateArrayCallback($callback);
-    }
-
-    /**
-     * Validate a string callback
-     *
-     * Check first if the string provided is callable. If not see if it is a 
-     * valid class name; if so, determine if the object is invokable.
-     * 
-     * @param  string $callback 
-     * @return bool
-     */
-    protected function validateStringCallback($callback)
-    {
-        if (is_callable($callback)) {
-            $this->isValidCallback = true;
-            return true;
-        }
-
-        if (!class_exists($callback)) {
-            return false;
-        }
-
-        // check __invoke before instantiating
-        if (!method_exists($callback, '__invoke')) {
-            return false;
-        }
-        $object = new $callback();
-
-        $this->callback        = $object;
-        $this->isValidCallback = true;
         return true;
     }
 
     /**
      * Validate an array callback
-     * 
+     *
+     * If the first argument of the array is an object, simply returns true. 
+     * Otherwise, passes the array arguments off to validateStaticMethod().
+     *
      * @param  array $callback 
-     * @return bool
+     * @return true
+     * @throws Exception\InvalidCallbackException
      */
-    protected function validateArrayCallback(array $callback)
+    protected function validateArrayCallback($callback)
     {
-        $context = $callback[0];
-        $method  = $callback[1];
-
-        if (is_string($context)) {
-            // Dealing with a class/method callback, and class provided is a string classname
-            
-            if (!class_exists($context)) {
-                return false;
-            }
-
-            // We need to determine if we need to instantiate the class first
-            $r = new \ReflectionClass($context);
-            if (!$r->hasMethod($method)) {
-                // Explicit method does not exist
-                if (!$r->hasMethod('__callStatic') && !$r->hasMethod('__call')) {
-                    return false;
-                }
-
-                if ($r->hasMethod('__callStatic')) {
-                    // We have a __callStatic defined, so the original callback is valid
-                    $this->isValidCallback = true;
-                    return $callback;
-                }
-
-                // We have __call defined, so we need to instantiate the class 
-                // first, and redefine the callback
-                $object                 = new $context();
-                $this->callback        = array($object, $method);
-                $this->isValidCallback = true;
-                return $this->callback;
-            }
-
-            // Explicit method exists
-            $rMethod = $r->getMethod($method);
-            if ($rMethod->isStatic()) {
-                // Method is static, so original callback is fine
-                $this->isValidCallback = true;
-                return $callback;
-            }
-
-            // Method is an instance method; instantiate object and redefine callback
-            $object                 = new $context();
-            $this->callback        = array($object, $method);
-            $this->isValidCallback = true;
-            return $this->callback;
-        } elseif (is_callable($callback)) {
-            // The 
-            $this->isValidCallback = true;
-            return $callback;
+        list($target, $method) = $callback;
+        if (is_object($target)) {
+            return true;
         }
 
-        return false;
+        return $this->validateStaticMethod($target, $method);
+    }
+
+    /**
+     * Validate a string callback
+     *
+     * If the callback is a function name, simply returns true. If it refers
+     * to a static method, proxies to validateStaticMethod().
+     * 
+     * @param  string $callback 
+     * @return true
+     * @throws Exception\InvalidCallbackException
+     */
+    protected function validateStringCallback($callback)
+    {
+        if (!strstr($callback, '::')) {
+            return true;
+        }
+
+        list($target, $method) = explode('::', $callback, 2);
+        return $this->validateStaticMethod($target, $method);
+    }
+
+    /**
+     * Validates that a static callback actually exists
+     * 
+     * @param  string $target 
+     * @param  string $method 
+     * @return bool
+     * @throws Exception\InvalidCallbackException
+     */
+    protected function validateStaticMethod($target, $method)
+    {
+        $r = new ReflectionClass($target);
+        if (!$r->hasMethod($method)) {
+            throw new Exception\InvalidCallbackException('Invalid callback; method does not exist');
+        }
+
+        $m = $r->getMethod($method);
+        if (!$m->isStatic()) {
+            throw new Exception\InvalidCallbackException('Invalid callback; method is not static');
+        }
+
+        return true;
     }
 }

--- a/library/Zend/Stdlib/CallbackHandler.php
+++ b/library/Zend/Stdlib/CallbackHandler.php
@@ -212,6 +212,16 @@ class CallbackHandler
     }
 
     /**
+     * Invoke as functor
+     * 
+     * @return mixed
+     */
+    public function __invoke()
+    {
+        return $this->call(func_get_args());
+    }
+
+    /**
      * Get all callback metadata
      * 
      * @return array

--- a/tests/Zend/Stdlib/CallbackHandlerTest.php
+++ b/tests/Zend/Stdlib/CallbackHandlerTest.php
@@ -124,6 +124,13 @@ class CallbackHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $handler->call());
     }
 
+    public function testHandlerShouldBeInvocable()
+    {
+        $handler = new CallbackHandler(array($this, 'handleCall'));
+        $handler('foo', 'bar');
+        $this->assertEquals(array('foo', 'bar'), $this->args);
+    }
+
     public function handleCall()
     {
         $this->args = func_get_args();

--- a/tests/Zend/Stdlib/CallbackHandlerTest.php
+++ b/tests/Zend/Stdlib/CallbackHandlerTest.php
@@ -41,77 +41,84 @@ class CallbackHandlerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testGetEventShouldReturnEvent()
+    public function testCallbackShouldStoreMetadata()
     {
-        $handler = new CallbackHandler('foo', 'rand');
-        $this->assertEquals('foo', $handler->getEvent());
+        $handler = new CallbackHandler('rand', array('event' => 'foo'));
+        $this->assertEquals('foo', $handler->getMetadatum('event'));
+        $this->assertEquals(array('event' => 'foo'), $handler->getMetadata());
     }
 
     public function testCallbackShouldBeStringIfNoHandlerPassedToConstructor()
     {
-        $handler = new CallbackHandler('foo', 'rand');
+        $handler = new CallbackHandler('rand');
         $this->assertSame('rand', $handler->getCallback());
     }
 
     public function testCallbackShouldBeArrayIfHandlerPassedToConstructor()
     {
-        $handler = new CallbackHandler('foo', array('\\ZendTest\\Stdlib\\SignalHandlers\\ObjectCallback', 'test'));
-        $this->assertSame(array('\\ZendTest\\Stdlib\\SignalHandlers\\ObjectCallback', 'test'), $handler->getCallback());
+        $handler = new CallbackHandler(array('ZendTest\\Stdlib\\SignalHandlers\\ObjectCallback', 'test'));
+        $this->assertSame(array('ZendTest\\Stdlib\\SignalHandlers\\ObjectCallback', 'test'), $handler->getCallback());
     }
 
     public function testCallShouldInvokeCallbackWithSuppliedArguments()
     {
-        $handler = new CallbackHandler('foo', array( $this, 'handleCall' ));
+        $handler = new CallbackHandler(array( $this, 'handleCall' ));
         $args   = array('foo', 'bar', 'baz');
         $handler->call($args);
         $this->assertSame($args, $this->args);
     }
 
-    public function testPassingInvalidCallbackShouldRaiseInvalidCallbackExceptionDuringCall()
+    public function testPassingInvalidCallbackShouldRaiseInvalidCallbackExceptionDuringInstantiation()
     {
         $this->setExpectedException('Zend\Stdlib\Exception\InvalidCallbackException');
-        $handler = new CallbackHandler('Invokable', 'boguscallback');
-        $handler->call();
+        $handler = new CallbackHandler('boguscallback');
     }
 
     public function testCallShouldReturnTheReturnValueOfTheCallback()
     {
-        $handler = new CallbackHandler('foo', array('\\ZendTest\\Stdlib\\SignalHandlers\\ObjectCallback', 'test'));
-        if (!is_callable(array('\\ZendTest\\Stdlib\\SignalHandlers\\ObjectCallback', 'test'))) {
-            echo "\nClass exists? " . var_export(class_exists('\\ZendTest\\Stdlib\\SignalHandlers\\ObjectCallback'), 1) . "\n";
+        $handler = new CallbackHandler(array('ZendTest\\Stdlib\\SignalHandlers\\ObjectCallback', 'test'));
+        if (!is_callable(array('ZendTest\\Stdlib\\SignalHandlers\\ObjectCallback', 'test'))) {
+            echo "\nClass exists? " . var_export(class_exists('ZendTest\\Stdlib\\SignalHandlers\\ObjectCallback'), 1) . "\n";
             echo "Include path: " . get_include_path() . "\n";
         }
         $this->assertEquals('bar', $handler->call(array()));
     }
 
-    public function testStringCallbackResolvingToClassNameShouldCallViaInvoke()
+    public function testStringCallbackResolvingToClassDefiningInvokeNameShouldRaiseException()
     {
-        $handler = new CallbackHandler('foo', '\\ZendTest\\Stdlib\\SignalHandlers\\Invokable');
-        $this->assertEquals('__invoke', $handler->call(), var_export($handler->getCallback(), 1));
+        $this->setExpectedException('Zend\Stdlib\Exception\InvalidCallbackException');
+        $handler = new CallbackHandler('ZendTest\\Stdlib\\SignalHandlers\\Invokable');
     }
 
     public function testStringCallbackReferringToClassWithoutDefinedInvokeShouldRaiseException()
     {
         $this->setExpectedException('Zend\Stdlib\Exception\InvalidCallbackException');
-        $handler = new CallbackHandler('foo', '\\ZendTest\\Stdlib\\SignalHandlers\\InstanceMethod');
+        $handler = new CallbackHandler('ZendTest\\Stdlib\\SignalHandlers\\InstanceMethod');
+    }
+
+    public function testCallbackConsistingOfStringContextWithNonStaticMethodShouldRaiseException()
+    {
+        $this->setExpectedException('Zend\Stdlib\Exception\InvalidCallbackException');
+        $handler = new CallbackHandler(array('ZendTest\\Stdlib\\SignalHandlers\\InstanceMethod', 'handler'));
         $handler->call();
     }
 
-    public function testCallbackConsistingOfStringContextWithNonStaticMethodShouldInstantiateContext()
+    public function testStringCallbackConsistingOfNonStaticMethodShouldRaiseException()
     {
-        $handler = new CallbackHandler('foo', array( 'ZendTest\\Stdlib\\SignalHandlers\\InstanceMethod', 'callable' ));
-        $this->assertEquals('callable', $handler->call());
+        $this->setExpectedException('Zend\Stdlib\Exception\InvalidCallbackException');
+        $handler = new CallbackHandler('ZendTest\\Stdlib\\SignalHandlers\\InstanceMethod::handler');
+        $handler->call();
     }
 
-    public function testCallbackToClassImplementingOverloadingShouldSucceed()
+    public function testCallbackToClassImplementingOverloadingButNotInvocableShouldRaiseException()
     {
-        $handler = new CallbackHandler('foo', array( '\\ZendTest\\Stdlib\\SignalHandlers\\Overloadable', 'foo' ));
-        $this->assertEquals('foo', $handler->call());
+        $this->setExpectedException('Zend\Stdlib\Exception\InvalidCallbackException');
+        $handler = new CallbackHandler('foo', array( 'ZendTest\\Stdlib\\SignalHandlers\\Overloadable', 'foo' ));
     }
 
     public function testClosureCallbackShouldBeInvokedByCall()
     {
-        $handler = new CallbackHandler(null, function () {
+        $handler = new CallbackHandler(function () {
             return 'foo';
         });
         $this->assertEquals('foo', $handler->call());

--- a/tests/Zend/Stdlib/CallbackHandlerTest.php
+++ b/tests/Zend/Stdlib/CallbackHandlerTest.php
@@ -96,18 +96,28 @@ class CallbackHandlerTest extends \PHPUnit_Framework_TestCase
         $handler = new CallbackHandler('ZendTest\\Stdlib\\SignalHandlers\\InstanceMethod');
     }
 
-    public function testCallbackConsistingOfStringContextWithNonStaticMethodShouldRaiseException()
+    public function testCallbackConsistingOfStringContextWithNonStaticMethodShouldNotRaiseExceptionButWillRaiseEStrict()
     {
-        $this->setExpectedException('Zend\Stdlib\Exception\InvalidCallbackException');
         $handler = new CallbackHandler(array('ZendTest\\Stdlib\\SignalHandlers\\InstanceMethod', 'handler'));
+        $error   = false;
+        set_error_handler(function ($errno, $errstr) use (&$error) {
+            $error = true;
+        }, E_STRICT);
         $handler->call();
+        restore_error_handler();
+        $this->assertTrue($error);
     }
 
-    public function testStringCallbackConsistingOfNonStaticMethodShouldRaiseException()
+    public function testStringCallbackConsistingOfNonStaticMethodShouldNotRaiseExceptionButWillRaiseEStrict()
     {
-        $this->setExpectedException('Zend\Stdlib\Exception\InvalidCallbackException');
         $handler = new CallbackHandler('ZendTest\\Stdlib\\SignalHandlers\\InstanceMethod::handler');
+        $error   = false;
+        set_error_handler(function ($errno, $errstr) use (&$error) {
+            $error = true;
+        }, E_STRICT);
         $handler->call();
+        restore_error_handler();
+        $this->assertTrue($error);
     }
 
     public function testCallbackToClassImplementingOverloadingButNotInvocableShouldRaiseException()

--- a/tests/Zend/Stdlib/SignalHandlers/InstanceMethod.php
+++ b/tests/Zend/Stdlib/SignalHandlers/InstanceMethod.php
@@ -3,7 +3,7 @@ namespace ZendTest\Stdlib\SignalHandlers;
 
 class InstanceMethod
 {
-    public function callable()
+    public function handler()
     {
         return __FUNCTION__;
     }


### PR DESCRIPTION
This is a first stab at improving performance within the EventManager.

The changes include four BC breaks:
- CallbackHandler::__construct() no longer takes an $event argument; any metadata should now be passed to the $metadata (second) argument.
- Along the same lines, the CallbackHandler::getEvent() method was removed; use getMetadatum('event') instead (more below).
- CallbackHandler::getOptions/getOption were renamed to getMetadata/getMetadatum to provide a more accurate semantic
- The only validation being done on callbacks in CallbackHandler is whether or not they pass is_callable(). Furthermore, the class no longer lazy instantiates objects if the provided callback is declared statically but refers to an instance method. This simplifies logic and provides a performance boost. If such callbacks are encountered, PHP will provide an E_STRICT notice at the least, and an E_FATAL if the method refers to $this.

Also, internally, CallbackHandler::call() now uses call_user_func() for up to 3 arguments, and only results to call_user_func_array() when more than 3 arguments are reached.

Finally, I added __invoke(), which proxies to call(), to simplify usage of the CallbackHandler.

All classes consuming it have been updated at this time.

Performance benefits are not huge, but I measured the following:
- Attaching listeners now takes ~20% longer, as we validate immediately.
- Triggering listeners now takes ~25% less time.
- Overall performance when triggering a given listener only once takes <5% less time.

So, performance gains are not huge, but the code is now simpler and more semantic.
