### PR TITLE
JSON-RPC client and some RPC severs unification 

### DIFF
--- a/library/Zend/Json/Server/Client.php
+++ b/library/Zend/Json/Server/Client.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Json
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+/**
+ * @namespace
+ */
+namespace Zend\Json\Server;
+
+use Zend\Http\Client as HttpClient,
+    Zend\Server\Client as ClientInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Json
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Client implements ClientInterface
+{
+    /**
+     * Full address of the JSON-RPC service.
+     *
+     * @var string
+     */
+    protected $serverAddress;
+
+    /**
+     * HTTP Client to use for requests.
+     *
+     * @var \Zend\Http\Client
+     */
+    protected $httpClient;
+
+    /**
+     * Request of the last method call.
+     *
+     * @var \Zend\Json\Server\Request
+     */
+    protected $lastRequest;
+
+    /**
+     * Response received from the last method call.
+     *
+     * @var \Zend\Json\Server\Response
+     */
+    protected $lastResponse;
+
+    /**
+     * Request ID counter.
+     *
+     * @var int
+     */
+    protected $id = 0;
+
+    /**
+     * Create a new JSON-RPC client to a remote server.
+     *
+     * @param string $server Full address of the JSON-RPC service.
+     * @param \Zend\Http\Client $httpClient HTTP Client to use for requests.
+     */
+    public function __construct($server, HttpClient $httpClient = null)
+    {
+        $this->httpClient = $httpClient ?: new HttpClient();
+        $this->serverAddress = $server;
+    }
+
+    /**
+     * Sets the HTTP client object to use for connecting the JSON-RPC server.
+     *
+     * @param \Zend\Http\Client $httpClient New HTTP client to use.
+     * @return \Zend\Json\Server\Client Self instance.
+     */
+    public function setHttpClient(HttpClient $httpClient)
+    {
+        $this->httpClient = $httpClient;
+
+        return $this;
+    }
+
+    /**
+     * Gets the HTTP client object.
+     *
+     * @return \Zend\Http\Client HTTP client.
+     */
+    public function getHttpClient()
+    {
+        return $this->httpClient;
+    }
+
+    /**
+     * The request of the last method call.
+     *
+     * @return \Zend\Json\Server\Request Request instance.
+     */
+    public function getLastRequest()
+    {
+        return $this->lastRequest;
+    }
+
+    /**
+     * The response received from the last method call.
+     *
+     * @return \Zend\Json\Server\Response Response instance.
+     */
+    public function getLastResponse()
+    {
+        return $this->lastResponse;
+    }
+
+    /**
+     * Perform an JSOC-RPC request and return a response.
+     *
+     * @param \Zend\Json\Server\Request $request Request.
+     * @return \Zend\Json\Server\Response Response.
+     * @throws Exception\HttpException When HTTP communication fails. TODO
+     */
+    public function doRequest($request)
+    {
+        $this->lastRequest = $request;
+
+        $httpRequest = $this->httpClient->getRequest();
+        if ($httpRequest->getUri() === null) {
+            $this->httpClient->setUri($this->serverAddress);
+        }
+
+        $headers = $httpRequest->headers();
+        $headers->addHeaders(array(
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ));
+
+        if (!$headers->get('User-Agent')) {
+            $headers->addHeaderLine('User-Agent', 'Zend_Json_Server_Client');
+        }
+
+        $this->httpClient->setRawBody($request->__toString());
+        $httpResponse = $this->httpClient->setMethod('POST')->send();
+
+        //TODO: this is temporary placeholder from ChilloutFramework's ChillDev\Json\Client - refactor for ZF2 exceptions
+        if (!$httpResponse->isSuccess()) {
+            throw new Exception\HttpException(
+                $httpResponse->getReasonPhrase(),
+                $httpResponse->getStatusCode()
+            );
+        }
+
+        $response = new Response();
+
+        $this->lastResponse = $response;
+
+        // import all response data form JSON HTTP response
+        $response->loadJson($httpResponse->getBody());
+
+        return $response;
+    }
+
+    /**
+     * Send an JSON-RPC request to the service (for a specific method).
+     *
+     * @param string $method Name of the method we want to call.
+     * @param array $params Array of parameters for the method.
+     * @return mixed Method call results.
+     * @throws Exception\RemoteCallException When remote call fails. TODO
+     */
+    public function call($method, $params = array())
+    {
+        $request = $this->createRequest($method, $params);
+
+        $response = $this->doRequest($request);
+
+        //TODO: this is temporary placeholder from ChilloutFramework's ChillDev\Json\Client - refactor for ZF2 exceptions
+        if ($response->isError()) {
+            $error = $response->getError();
+            throw new Exception\RemoteCallException(
+                $request->getMethod(),
+                $fault->getMessage(),
+                $fault->getCode()
+            );
+        }
+
+        return $response->getResult();
+    }
+
+    /**
+     * Create request object.
+     *
+     * @param string $method Method to call.
+     * @param array $params List of arguments.
+     * @return \Zend\Json\Server\Request Created request.
+     */
+    protected function createRequest($method, array $params)
+    {
+        $request = new Request();
+        $request->setMethod($method)
+            ->setParams($params)
+            ->setId(++$this->id);
+        return $request;
+    }
+}

--- a/library/Zend/Json/Server/Client.php
+++ b/library/Zend/Json/Server/Client.php
@@ -129,7 +129,7 @@ class Client implements ClientInterface
      *
      * @param \Zend\Json\Server\Request $request Request.
      * @return \Zend\Json\Server\Response Response.
-     * @throws Exception\HttpException When HTTP communication fails. TODO
+     * @throws \Zend\Json\Server\Exception\HttpException When HTTP communication fails.
      */
     public function doRequest($request)
     {
@@ -153,7 +153,6 @@ class Client implements ClientInterface
         $this->httpClient->setRawBody($request->__toString());
         $httpResponse = $this->httpClient->setMethod('POST')->send();
 
-        //TODO: this is temporary placeholder from ChilloutFramework's ChillDev\Json\Client - refactor for ZF2 exceptions
         if (!$httpResponse->isSuccess()) {
             throw new Exception\HttpException(
                 $httpResponse->getReasonPhrase(),
@@ -177,7 +176,7 @@ class Client implements ClientInterface
      * @param string $method Name of the method we want to call.
      * @param array $params Array of parameters for the method.
      * @return mixed Method call results.
-     * @throws Exception\RemoteCallException When remote call fails. TODO
+     * @throws \Zend\Json\Server\Exception\ErrorExceptionn When remote call fails.
      */
     public function call($method, $params = array())
     {
@@ -185,13 +184,11 @@ class Client implements ClientInterface
 
         $response = $this->doRequest($request);
 
-        //TODO: this is temporary placeholder from ChilloutFramework's ChillDev\Json\Client - refactor for ZF2 exceptions
         if ($response->isError()) {
             $error = $response->getError();
-            throw new Exception\RemoteCallException(
-                $request->getMethod(),
-                $fault->getMessage(),
-                $fault->getCode()
+            throw new Exception\ErrorException(
+                $error->getMessage(),
+                $error->getCode()
             );
         }
 

--- a/library/Zend/Json/Server/Exception/ErrorException.php
+++ b/library/Zend/Json/Server/Exception/ErrorException.php
@@ -13,8 +13,8 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_XmlRpc
- * @subpackage Client
+ * @package    Zend_Json
+ * @subpackage Server
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -22,19 +22,19 @@
 /**
  * @namespace
  */
-namespace Zend\XmlRpc\Client\Exception;
+namespace Zend\Json\Server\Exception;
 
 /**
- * Thrown by Zend_XmlRpc_Client when an HTTP error occurs during an
- * XML-RPC method call.
+ * Thrown by Zend\Json\Server\Client when an JSON-RPC fault response is returned.
  *
- * @uses       Zend\XmlRpc\Client\Exception
+ * @uses       Zend\Json\Server\Exception
  * @category   Zend
- * @package    Zend_XmlRpc
- * @subpackage Client
+ * @package    Zend_Json
+ * @subpackage Server
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class HttpException
-    extends RuntimeException
+class ErrorException
+    extends \BadMethodCallException
+    implements \Zend\Json\Server\Exception
 {}

--- a/library/Zend/Json/Server/Exception/HttpException.php
+++ b/library/Zend/Json/Server/Exception/HttpException.php
@@ -13,8 +13,8 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_XmlRpc
- * @subpackage Client
+ * @package    Zend_Json
+ * @subpackage Server
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -22,16 +22,16 @@
 /**
  * @namespace
  */
-namespace Zend\XmlRpc\Client\Exception;
+namespace Zend\Json\Server\Exception;
 
 /**
- * Thrown by Zend_XmlRpc_Client when an HTTP error occurs during an
- * XML-RPC method call.
+ * Thrown by Zend_Json_Server_Client when an HTTP error occurs during an
+ * JSON-RPC method call.
  *
- * @uses       Zend\XmlRpc\Client\Exception
+ * @uses       Zend\Json\Server\Exception
  * @category   Zend
- * @package    Zend_XmlRpc
- * @subpackage Client
+ * @package    Zend_Json
+ * @subpackage Server
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */

--- a/library/Zend/Json/Server/Response.php
+++ b/library/Zend/Json/Server/Response.php
@@ -24,6 +24,8 @@
  */
 namespace Zend\Json\Server;
 
+use Zend\Json\Json;
+
 /**
  * @uses       \Zend\Json\Json
  * @category   Zend
@@ -63,6 +65,44 @@ class Response
      * @var string
      */
     protected $_version;
+
+    /**
+     * Set response state
+     *
+     * @param  array $options
+     * @return \Zend\Json\Server\Response
+     */
+    public function setOptions(array $options)
+    {
+        // re-produce error state
+        if (isset($options['error']) && is_array($options['error'])) {
+            $error = $options['error'];
+            $options['error'] = new Error($error['message'], $error['code'], $error['data']);
+        }
+
+        $methods = get_class_methods($this);
+        foreach ($options as $key => $value) {
+            $method = 'set' . ucfirst($key);
+            if (in_array($method, $methods)) {
+                $this->$method($value);
+            } elseif ($key == 'jsonrpc') {
+                $this->setVersion($value);
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * Set response state based on JSON
+     *
+     * @param  string $json
+     * @return void
+     */
+    public function loadJson($json)
+    {
+        $options = Json::decode($json, Json::TYPE_ARRAY);
+        $this->setOptions($options);
+    }
 
     /**
      * Set result

--- a/library/Zend/Json/Server/Server.php
+++ b/library/Zend/Json/Server/Server.php
@@ -49,7 +49,7 @@ class Server extends AbstractServer
      * Flag: whether or not to auto-emit the response
      * @var bool
      */
-    protected $_autoEmitResponse = true;
+    protected $returnResponse = false;
 
     /**
      * @var bool Flag; allow overwriting existing methods when creating server definition
@@ -194,7 +194,7 @@ class Server extends AbstractServer
         $response = $this->_getReadyResponse();
 
         // Emit response?
-        if ($this->autoEmitResponse()) {
+        if (!$this->returnResponse) {
             echo $response;
             return;
         }
@@ -280,21 +280,49 @@ class Server extends AbstractServer
      *
      * @param  bool $flag
      * @return Server
+     * @deprecated Left just for BC, drop it as soon as not used by anyone - use setReturnResponse() with negation instead.
      */
     public function setAutoEmitResponse($flag)
     {
-        $this->_autoEmitResponse = (bool) $flag;
-        return $this;
+        return $this->setReturnResponse(!$flag);
     }
 
     /**
      * Will we auto-emit the response?
      *
      * @return bool
+     * @deprecated Left just for BC, drop it as soon as not used by anyone - use getReturnResponse() with negation instead.
      */
     public function autoEmitResponse()
     {
-        return $this->_autoEmitResponse;
+        return !$this->getReturnResponse();
+    }
+
+    /**
+     * Set return response flag
+     *
+     * If true, {@link handle()} will return the response instead of
+     * automatically sending it back to the requesting client.
+     *
+     * The response is always available via {@link getResponse()}.
+     *
+     * @param boolean $flag
+     * @return \Zend\Json\Server\Server
+     */
+    public function setReturnResponse($flag = true)
+    {
+        $this->returnResponse = ($flag) ? true : false;
+        return $this;
+    }
+
+    /**
+     * Retrieve return response flag
+     *
+     * @return boolean
+     */
+    public function getReturnResponse()
+    {
+        return $this->returnResponse;
     }
 
     // overloading for SMD metadata

--- a/library/Zend/Json/Server/Server.php
+++ b/library/Zend/Json/Server/Server.php
@@ -144,10 +144,9 @@ class Server extends AbstractServer
      */
     public function setClass($class, $namespace = '', $argv = null)
     {
-        $argv = null;
-        if (3 < func_num_args()) {
+        if (2 < func_num_args()) {
             $argv = func_get_args();
-            $argv = array_slice($argv, 3);
+            $argv = array_slice($argv, 2);
         }
 
         $reflection = Reflection::reflectClass($class, $argv, $namespace);

--- a/library/Zend/Server/Client.php
+++ b/library/Zend/Server/Client.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Server
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+/**
+ * @namespace
+ */
+namespace Zend\Server;
+
+/**
+ * Client Interface
+ *
+ * @category   Zend
+ * @package    Zend_Server
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+interface Client
+{
+    /**
+     * Executes remote call
+     *
+     * Unified interface for calling custome remote methods.
+     *
+     * @param string $method Remote call name.
+     * @param array $params Call parameters.
+     * @return mixed Remote call results.
+     */
+    public function call($method, $params = array());
+}

--- a/library/Zend/Server/Server.php
+++ b/library/Zend/Server/Server.php
@@ -119,4 +119,21 @@ interface Server
      * @return void
      */
     public function setPersistence($mode);
+
+    /**
+     * Sets auto-response flag for the server.
+     *
+     * To unify all servers, default behavior should be to auto-emit response.
+     *
+     * @param bool $flag
+     * @return \Zend\Server\Server Self instance.
+     */
+    public function setReturnResponse($flag = true);
+
+    /**
+     * Returns auto-response flag of the server.
+     *
+     * @return bool $flag Current status.
+     */
+    public function getReturnResponse();
 }

--- a/library/Zend/Server/Server.php
+++ b/library/Zend/Server/Server.php
@@ -136,4 +136,12 @@ interface Server
      * @return bool $flag Current status.
      */
     public function getReturnResponse();
+
+    /**
+     * Returns last produced response.
+     *
+     * @return string|object Content of last response, or response object that
+     * implements __toString() methods.
+     */
+    public function getResponse();
 }

--- a/library/Zend/Soap/Client.php
+++ b/library/Zend/Soap/Client.php
@@ -23,6 +23,7 @@
  * @namespace
  */
 namespace Zend\Soap;
+use Zend\Server\Client as ClientInterface;
 
 /**
  * \Zend\Soap\Client\Client
@@ -37,7 +38,7 @@ namespace Zend\Soap;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Client
+class Client implements ClientInterface
 {
     /**
      * Encoding
@@ -1101,6 +1102,17 @@ class Client
         return $this->_preProcessResult($result);
     }
 
+    /**
+     * Send an RPC request to the service for a specific method.
+     *
+     * @param string $method Name of the method we want to call.
+     * @param array $params List of parameters for the method.
+     * @return mixed Returned results.
+     */
+    public function call($method, $params = array())
+    {
+        return call_user_func_array(array($this, '__call'), $params);
+    }
 
     /**
      * Return a list of available functions

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -729,7 +729,7 @@ class Server implements \Zend\Server\Server
      *
      * @return string
      */
-    public function getLastResponse()
+    public function getResponse()
     {
         return $this->_response;
     }

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -559,10 +559,9 @@ class Server implements \Zend\Server\Server
         }
 
         $this->_class = $class;
-        if (1 < func_num_args()) {
+        if (2 < func_num_args()) {
             $argv = func_get_args();
-            array_shift($argv);
-            $this->_classArgs = $argv;
+            $this->_classArgs = array_slice($argv, 2);
         }
 
         return $this;

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -709,7 +709,7 @@ class Server implements \Zend\Server\Server
      * @param boolean $flag
      * @return \Zend\Soap\Server
      */
-    public function setReturnResponse($flag)
+    public function setReturnResponse($flag = true)
     {
         $this->_returnResponse = ($flag) ? true : false;
         return $this;

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -810,7 +810,7 @@ class Server implements \Zend\Server\Server
         ob_start();
         if($setRequestException instanceof \Exception) {
             // Send SOAP fault message if we've catched exception
-            $soap->fault("Sender", $setRequestException->getMessage());
+            $soap->fault('Sender', $setRequestException->getMessage());
         } else {
             try {
                 $soap->handle($this->_request);
@@ -940,6 +940,6 @@ class Server implements \Zend\Server\Server
      */
     public function handlePhpErrors($errno, $errstr, $errfile = null, $errline = null, array $errcontext = null)
     {
-        throw $this->fault($errstr, "Receiver");
+        throw $this->fault($errstr, 'Receiver');
     }
 }

--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -24,6 +24,7 @@
  */
 namespace Zend\XmlRpc;
 use Zend\Http,
+    Zend\Server\Client as ClientInterface,
     Zend\XmlRpc\Value;
 
 /**
@@ -44,7 +45,7 @@ use Zend\Http,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Client
+class Client implements ClientInterface
 {
     /**
      * Full address of the XML-RPC service

--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -288,7 +288,7 @@ class Server extends AbstractServer
      * If true, {@link handle()} will return the response instead of
      * automatically sending it back to the requesting client.
      *
-     * The response is always available via {@link getResponse()}.
+     * The response is always available via {@link getLastResponse()}.
      *
      * @param boolean $flag
      * @return \Zend\XmlRpc\Server

--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -155,6 +155,12 @@ class Server extends AbstractServer
     protected $returnResponse = false;
 
     /**
+     * Last response results.
+     * @var \Zend\XmlRpc\Response
+     */
+    protected $lastResponse;
+
+    /**
      * Constructor
      *
      * Creates system.* methods.
@@ -334,6 +340,7 @@ class Server extends AbstractServer
 
         // Set output encoding
         $response->setEncoding($this->getEncoding());
+        $this->lastResponse = $response;
 
         if (!$this->returnResponse) {
             echo $response;
@@ -443,6 +450,16 @@ class Server extends AbstractServer
     public function getRequest()
     {
         return $this->_request;
+    }
+
+    /**
+     * Last response.
+     *
+     * @return \Zend\XmlRpc\Response
+     */
+    public function getLastResponse()
+    {
+        return $this->lastResponse;
     }
 
     /**

--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -148,6 +148,13 @@ class Server extends AbstractServer
     protected $_sendArgumentsToAllMethods = true;
 
     /**
+     * Flag: whether or not {@link handle()} should return a response instead
+     * of automatically emitting it.
+     * @var boolean
+     */
+    protected $returnResponse = false;
+
+    /**
      * Constructor
      *
      * Creates system.* methods.
@@ -271,6 +278,33 @@ class Server extends AbstractServer
     }
 
     /**
+     * Set return response flag
+     *
+     * If true, {@link handle()} will return the response instead of
+     * automatically sending it back to the requesting client.
+     *
+     * The response is always available via {@link getResponse()}.
+     *
+     * @param boolean $flag
+     * @return \Zend\XmlRpc\Server
+     */
+    public function setReturnResponse($flag = true)
+    {
+        $this->returnResponse = ($flag) ? true : false;
+        return $this;
+    }
+
+    /**
+     * Retrieve return response flag
+     *
+     * @return boolean
+     */
+    public function getReturnResponse()
+    {
+        return $this->returnResponse;
+    }
+
+    /**
      * Handle an xmlrpc call
      *
      * @param Zend\XmlRpc\Request $request Optional
@@ -300,6 +334,11 @@ class Server extends AbstractServer
 
         // Set output encoding
         $response->setEncoding($this->getEncoding());
+
+        if (!$this->returnResponse) {
+            echo $response;
+            return;
+        }
 
         return $response;
     }

--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -158,7 +158,7 @@ class Server extends AbstractServer
      * Last response results.
      * @var \Zend\XmlRpc\Response
      */
-    protected $lastResponse;
+    protected $response;
 
     /**
      * Constructor
@@ -288,7 +288,7 @@ class Server extends AbstractServer
      * If true, {@link handle()} will return the response instead of
      * automatically sending it back to the requesting client.
      *
-     * The response is always available via {@link getLastResponse()}.
+     * The response is always available via {@link getResponse()}.
      *
      * @param boolean $flag
      * @return \Zend\XmlRpc\Server
@@ -339,7 +339,7 @@ class Server extends AbstractServer
 
         // Set output encoding
         $response->setEncoding($this->getEncoding());
-        $this->lastResponse = $response;
+        $this->response = $response;
 
         if (!$this->returnResponse) {
             echo $response;
@@ -456,9 +456,9 @@ class Server extends AbstractServer
      *
      * @return \Zend\XmlRpc\Response
      */
-    public function getLastResponse()
+    public function getResponse()
     {
-        return $this->lastResponse;
+        return $this->response;
     }
 
     /**

--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -251,7 +251,6 @@ class Server extends AbstractServer
             throw new Server\Exception\InvalidArgumentException('Invalid method class', 610);
         }
 
-        $argv = null;
         if (2 < func_num_args()) {
             $argv = func_get_args();
             $argv = array_slice($argv, 2);

--- a/tests/Zend/Json/Server/ClientTest.php
+++ b/tests/Zend/Json/Server/ClientTest.php
@@ -1,0 +1,303 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Json
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+/**
+ * @namespace
+ */
+namespace ZendTest\Json\Server;
+
+use Zend\Http\Client as HttpClient,
+    Zend\Http\Client\Adapter\Test as TestAdapter,
+    Zend\Json\Server\Client,
+    Zend\Json\Server\Error,
+    Zend\Json\Server\Request,
+    Zend\Json\Server\Response;
+
+/**
+ * Test case for Zend\Json\Server\Client
+ *
+ * @category   Zend
+ * @package    Zend_Json
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Zend_XmlRpc
+ */
+class ClientTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Zend\Http\Client\Adapter\Test
+     */
+    protected $httpAdapter;
+
+    /**
+     * @var Zend\Http\Client
+     */
+    protected $httpClient;
+
+    /**
+     * @var Zend\Json\Server\Client
+     */
+    protected $jsonClient;
+
+    public function setUp()
+    {
+        $this->httpAdapter = new TestAdapter();
+        $this->httpClient = new HttpClient('http://foo',
+                                    array('adapter' => $this->httpAdapter));
+
+        $this->jsonClient = new Client('http://foo');
+        $this->jsonClient->setHttpClient($this->httpClient);
+    }
+
+    // HTTP Client
+
+    public function testGettingDefaultHttpClient()
+    {
+        $jsonClient = new Client('http://foo');
+        $httpClient = $jsonClient->getHttpClient();
+        //$this->assertInstanceOf('Zend\\Http\\Client', $httpClient);
+        $this->assertSame($httpClient, $jsonClient->getHttpClient());
+    }
+
+    public function testSettingAndGettingHttpClient()
+    {
+        $jsonClient = new Client('http://foo');
+        $this->assertNotSame($this->httpClient, $jsonClient->getHttpClient());
+
+        $jsonClient->setHttpClient($this->httpClient);
+        $this->assertSame($this->httpClient, $jsonClient->getHttpClient());
+    }
+
+    public function testSettingHttpClientViaContructor()
+    {
+        $jsonClient = new Client('http://foo', $this->httpClient);
+        $httpClient   = $jsonClient->getHttpClient();
+        $this->assertSame($this->httpClient, $httpClient);
+    }
+
+    // Request & Response
+
+    public function testLastRequestAndResponseAreInitiallyNull()
+    {
+        $this->assertNull($this->jsonClient->getLastRequest());
+        $this->assertNull($this->jsonClient->getLastResponse());
+    }
+
+    public function testLastRequestAndResponseAreSetAfterRpcMethodCall()
+    {
+        $this->setServerResponseTo(true);
+        $this->jsonClient->call('foo');
+
+        //$this->assertInstanceOf('Zend\\Json\\Server\\Request', $this->jsonClient->getLastRequest());
+        //$this->assertInstanceOf('Zend\\Json\\Server\\Response', $this->jsonClient->getLastResponse());
+    }
+
+    public function testSuccessfulRpcMethodCallWithNoParameters()
+    {
+        $expectedMethod = 'foo';
+        $expectedReturn = 7;
+
+        $this->setServerResponseTo($expectedReturn);
+        $this->assertSame($expectedReturn, $this->jsonClient->call($expectedMethod));
+
+        $request  = $this->jsonClient->getLastRequest();
+        $response = $this->jsonClient->getLastResponse();
+
+        $this->assertSame($expectedMethod, $request->getMethod());
+        $this->assertSame(array(), $request->getParams());
+        $this->assertSame($expectedReturn, $response->getResult());
+        $this->assertFalse($response->isError());
+    }
+
+    public function testSuccessfulRpcMethodCallWithParameters()
+    {
+        $expectedMethod = 'foobar';
+        $expectedParams = array(1, 1.1, true, 'foo' => 'bar');
+        $expectedReturn = array(7, false, 'foo' => 'bar');
+
+        $this->setServerResponseTo($expectedReturn);
+
+        $actualReturn = $this->jsonClient->call($expectedMethod, $expectedParams);
+        $this->assertSame($expectedReturn, $actualReturn);
+
+        $request  = $this->jsonClient->getLastRequest();
+        $response = $this->jsonClient->getLastResponse();
+
+        $this->assertSame($expectedMethod, $request->getMethod());
+        $params = $request->getParams();
+        $this->assertSame(count($expectedParams), count($params));
+        $this->assertSame($expectedParams[0], $params[0]);
+        $this->assertSame($expectedParams[1], $params[1]);
+        $this->assertSame($expectedParams[2], $params[2]);
+        $this->assertSame($expectedParams['foo'], $params['foo']);
+
+        $this->assertSame($expectedReturn, $response->getResult());
+        $this->assertFalse($response->isError());
+    }
+
+    // Faults
+
+    public function testRpcMethodCallThrowsOnHttpFailure()
+    {
+        $status  = 404;
+        $message = 'Not Found';
+        $body    = 'oops';
+
+        $response = $this->makeHttpResponseFrom($body, $status, $message);
+        $this->httpAdapter->setResponse($response);
+
+        $this->setExpectedException('Zend\\Json\\Server\\Exception\\HttpException', $message, $status);
+        $this->jsonClient->call('foo');
+    }
+
+    public function testRpcMethodCallThrowsOnJsonRpcFault()
+    {
+        $code = -32050;
+        $message = 'foo';
+
+        $error = new Error($message, $code);
+        $response = new Response();
+        $response->setError($error);
+        $json = $response->toJson();
+
+        $response = $this->makeHttpResponseFrom($json);
+        $this->httpAdapter->setResponse($response);
+
+        $this->setExpectedException('Zend\\Json\\Server\\Exception\\ErrorException', $message, $code);
+        $this->jsonClient->call('foo');
+    }
+
+    // HTTP handling
+
+    public function testSettingUriOnHttpClientIsNotOverwrittenByJsonRpcClient()
+    {
+        $changedUri = 'http://bar:80';
+        // Overwrite: http://foo:80
+        $this->setServerResponseTo(null);
+        $this->jsonClient->getHttpClient()->setUri($changedUri);
+        $this->jsonClient->call('foo');
+        $uri = $this->jsonClient->getHttpClient()->getUri()->toString();
+
+        $this->assertEquals($changedUri, $uri);
+    }
+
+    public function testSettingNoHttpClientUriForcesClientToSetUri()
+    {
+        $baseUri = 'http://foo:80';
+        $this->httpAdapter = new TestAdapter();
+        $this->httpClient = new HttpClient(null, array('adapter' => $this->httpAdapter));
+
+        $this->jsonClient = new Client($baseUri);
+        $this->jsonClient->setHttpClient($this->httpClient);
+
+        $this->setServerResponseTo(null);
+        $this->assertNull($this->jsonClient->getHttpClient()->getRequest()->getUri());
+        $this->jsonClient->call('foo');
+        $uri = $this->jsonClient->getHttpClient()->getUri();
+
+        $this->assertEquals($baseUri, $uri->toString());
+    }
+
+    public function testCustomHttpClientUserAgentIsNotOverridden()
+    {
+        $this->assertFalse(
+            $this->httpClient->getHeader('User-Agent'),
+            'UA is null if no request was made'
+        );
+        $this->setServerResponseTo(null);
+        $this->assertNull($this->jsonClient->call('method'));
+        $this->assertSame(
+            'Zend_Json_Server_Client',
+            $this->httpClient->getHeader('User-Agent'),
+            'If no custom UA is set, set Zend_Json_Server_Client'
+        );
+
+        $expectedUserAgent = 'Zend_Json_Server_Client (custom)';
+        $this->httpClient->setHeaders(array('User-Agent' => $expectedUserAgent));
+
+        $this->setServerResponseTo(null);
+        $this->assertNull($this->jsonClient->call('method'));
+        $this->assertSame($expectedUserAgent, $this->httpClient->getHeader('User-Agent'));
+    }
+
+    // Helpers
+    public function setServerResponseTo($nativeVars)
+    {
+        $response = $this->getServerResponseFor($nativeVars);
+        $this->httpAdapter->setResponse($response);
+    }
+
+    public function getServerResponseFor($nativeVars)
+    {
+        $response = new Response();
+        $response->setResult($nativeVars);
+        $json = $response->toJson();
+
+        $response = $this->makeHttpResponseFrom($json);
+        return $response;
+    }
+
+    public function makeHttpResponseFrom($data, $status=200, $message='OK')
+    {
+        $headers = array("HTTP/1.1 $status $message",
+                         "Status: $status",
+                         'Content-Type: application/json',
+                         'Content-Length: ' . strlen($data)
+                         );
+        return implode("\r\n", $headers) . "\r\n\r\n$data\r\n\r\n";
+    }
+
+    //TODO:BEGIN
+    public function makeHttpResponseFor($nativeVars)
+    {
+        $response = $this->getServerResponseFor($nativeVars);
+        return HttpResponse::fromString($response);
+    }
+
+    public function mockHttpClient()
+    {
+        $this->mockedHttpClient = $this->getMock('Zend\\Http\\Client');
+        $this->jsonClient->setHttpClient($this->mockedHttpClient);
+    }
+}
+
+/*
+     * @throws \Zend\Json\Server\Exception\HttpException When HTTP communication fails.
+
+     * @throws \Zend\Json\Server\Exception\ErrorExceptionn When remote call fails.
+    public function call($method, $params = array())
+    {
+        $request = $this->createRequest($method, $params);
+
+        $response = $this->doRequest($request);
+
+        if ($response->isError()) {
+            $error = $response->getError();
+            throw new Exception\ErrorException(
+                $error->getMessage(),
+                $error->getCode()
+            );
+        }
+
+        return $response->getResult();
+    }
+*/

--- a/tests/Zend/Json/Server/ClientTest.php
+++ b/tests/Zend/Json/Server/ClientTest.php
@@ -266,7 +266,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         return implode("\r\n", $headers) . "\r\n\r\n$data\r\n\r\n";
     }
 
-    //TODO:BEGIN
     public function makeHttpResponseFor($nativeVars)
     {
         $response = $this->getServerResponseFor($nativeVars);
@@ -279,25 +278,3 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->jsonClient->setHttpClient($this->mockedHttpClient);
     }
 }
-
-/*
-     * @throws \Zend\Json\Server\Exception\HttpException When HTTP communication fails.
-
-     * @throws \Zend\Json\Server\Exception\ErrorExceptionn When remote call fails.
-    public function call($method, $params = array())
-    {
-        $request = $this->createRequest($method, $params);
-
-        $response = $this->doRequest($request);
-
-        if ($response->isError()) {
-            $error = $response->getError();
-            throw new Exception\ErrorException(
-                $error->getMessage(),
-                $error->getCode()
-            );
-        }
-
-        return $response->getResult();
-    }
-*/

--- a/tests/Zend/Json/Server/ResponseTest.php
+++ b/tests/Zend/Json/Server/ResponseTest.php
@@ -108,6 +108,25 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testShouldBeAbleToLoadResponseFromJSONString()
+    {
+        $options = $this->getOptions();
+        $json    = Json\Json::encode($options);
+        $this->response->loadJSON($json);
+
+        $this->assertEquals('foobar', $this->response->getId());
+        $this->assertEquals($options['result'], $this->response->getResult());
+    }
+
+    public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent()
+    {
+        $options = $this->getOptions();
+        $options['jsonrpc'] = '2.0';
+        $json    = Json\Json::encode($options);
+        $this->response->loadJSON($json);
+        $this->assertEquals('2.0', $this->response->getVersion());
+    }
+
     public function testResponseShouldBeAbleToCastToJSON()
     {
         $this->response->setResult(true)
@@ -164,5 +183,17 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($test['result']);
         $this->assertEquals($this->response->getId(), $test['id']);
+    }
+
+    public function getOptions()
+    {
+        return array(
+            'result' => array(
+                5,
+                'four',
+                true,
+            ),
+            'id'  => 'foobar'
+        );
     }
 }

--- a/tests/Zend/Json/ServerTest.php
+++ b/tests/Zend/Json/ServerTest.php
@@ -189,14 +189,14 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
     public function testResponseShouldBeEmittedAutomaticallyByDefault()
     {
-        $this->assertTrue($this->server->autoEmitResponse());
+        $this->assertFalse($this->server->getReturnResponse());
     }
 
     public function testShouldBeAbleToDisableAutomaticResponseEmission()
     {
         $this->testResponseShouldBeEmittedAutomaticallyByDefault();
-        $this->server->setAutoEmitResponse(false);
-        $this->assertFalse($this->server->autoEmitResponse());
+        $this->server->setReturnResponse(true);
+        $this->assertTrue($this->server->getReturnResponse());
     }
 
     public function testShouldBeAbleToRetrieveSmdObject()
@@ -257,7 +257,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     {
         $this->server->setClass('ZendTest\\Json\\Foo')
                      ->addFunction('ZendTest\\Json\\FooFunc')
-                     ->setAutoEmitResponse(false);
+                     ->setReturnResponse(true);
         $request = $this->server->getRequest();
         $request->setMethod('bar')
                 ->setParams(array(true, 'foo', 'bar'))
@@ -278,7 +278,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     {
         $this->markTestSkipped('Problems with Zend_Server conversion');
         $this->server->setClass('ZendTest\Json\Foo')
-                     ->setAutoEmitResponse(false);
+                     ->setReturnResponse(true);
         $request = $this->server->getRequest();
         $request->setMethod('bar')
                 ->setParams(array(true))
@@ -297,7 +297,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     {
         $this->markTestSkipped('Problems with Zend_Server conversion');
         $this->server->setClass('ZendTest\Json\Foo')
-                     ->setAutoEmitResponse(false);
+                     ->setReturnResponse(true);
         $request = $this->server->getRequest();
         $request->setMethod('bar')
                 ->setParams(array(true, 'foo', 'bar', 'baz'))
@@ -315,7 +315,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function testHandleShouldAllowNamedParamsInAnyOrder1()
     {
         $this->server->setClass('ZendTest\Json\Foo')
-                     ->setAutoEmitResponse( false );
+                     ->setReturnResponse(true);
         $request = $this->server->getRequest();
         $request->setMethod('bar')
                 ->setParams( array( 
@@ -336,7 +336,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function testHandleShouldAllowNamedParamsInAnyOrder2()
     {
         $this->server->setClass('ZendTest\Json\Foo')
-                     ->setAutoEmitResponse( false );
+                     ->setReturnResponse(true);
         $request = $this->server->getRequest();
         $request->setMethod('bar')
                 ->setParams( array( 
@@ -357,7 +357,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function testHandleValidWithoutRequiredParamShouldReturnError()
     {
         $this->server->setClass('ZendTest\Json\Foo')
-                     ->setAutoEmitResponse( false );
+                     ->setReturnResponse(true);
         $request = $this->server->getRequest();
         $request->setMethod('bar')
                 ->setParams( array(
@@ -375,7 +375,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function testHandleRequestWithErrorsShouldReturnErrorResponse()
     {
         $this->server->setClass('ZendTest\Json\Foo')
-                     ->setAutoEmitResponse(false);
+                     ->setReturnResponse(true);
         $response = $this->server->handle();
         $this->assertTrue($response instanceof Response);
         $this->assertTrue($response->isError());
@@ -385,7 +385,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function testHandleRequestWithInvalidMethodShouldReturnErrorResponse()
     {
         $this->server->setClass('ZendTest\Json\Foo')
-                     ->setAutoEmitResponse(false);
+                     ->setReturnResponse(true);
         $request = $this->server->getRequest();
         $request->setMethod('bogus')
                 ->setId('foo');
@@ -399,7 +399,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     {
         $this->markTestSkipped('Problems with Zend_Server conversion');
         $this->server->setClass('ZendTest\Json\Foo')
-                     ->setAutoEmitResponse(false);
+                     ->setReturnResponse(true);
         $request = $this->server->getRequest();
         $request->setMethod('baz')
                 ->setId('foo');

--- a/tests/Zend/Soap/ServerTest.php
+++ b/tests/Zend/Soap/ServerTest.php
@@ -599,7 +599,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         $server->handle($request);
 
-        $this->assertEquals($expectedResponse, $server->getLastResponse());
+        $this->assertEquals($expectedResponse, $server->getResponse());
     }
 
     public function testHandle()

--- a/tests/Zend/Soap/ServerTest.php
+++ b/tests/Zend/Soap/ServerTest.php
@@ -354,7 +354,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $server = new Server();
 
         // Correct class name should pass
-        $r = $server->setClass('\ZendTest\Soap\TestAsset\ServerTestClass', 1, 2, 3, 4);
+        $r = $server->setClass('\ZendTest\Soap\TestAsset\ServerTestClass', null, 1, 2, 3, 4);
         $this->assertSame($server, $r);
     }
 

--- a/tests/Zend/XmlRpc/ClientTest.php
+++ b/tests/Zend/XmlRpc/ClientTest.php
@@ -33,7 +33,7 @@ use Zend\Http\Client\Adapter,
     Zend\XmlRpc;
 
 /**
- * Test case for Zend_XmlRpc_Value
+ * Test case for Zend\XmlRpc\Client
  *
  * @category   Zend
  * @package    Zend_XmlRpc

--- a/tests/Zend/XmlRpc/ClientTest.php
+++ b/tests/Zend/XmlRpc/ClientTest.php
@@ -556,11 +556,11 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testSettingUriOnHttpClientIsNotOverwrittenByXmlRpcClient()
     {
-        $changedUri = "http://bar:80";
+        $changedUri = 'http://bar:80';
         // Overwrite: http://foo:80
         $this->setServerResponseTo(array());
         $this->xmlrpcClient->getHttpClient()->setUri($changedUri);
-        $this->xmlrpcClient->call("foo");
+        $this->xmlrpcClient->call('foo');
         $uri = $this->xmlrpcClient->getHttpClient()->getUri()->toString();
 
         $this->assertEquals($changedUri, $uri);
@@ -571,7 +571,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testSettingNoHttpClientUriForcesClientToSetUri()
     {
-        $baseUri = "http://foo:80";
+        $baseUri = 'http://foo:80';
         $this->httpAdapter = new Adapter\Test();
         $this->httpClient = new Http\Client(null, array('adapter' => $this->httpAdapter));
 
@@ -580,7 +580,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $this->setServerResponseTo(array());
         $this->assertNull($this->xmlrpcClient->getHttpClient()->getRequest()->getUri());
-        $this->xmlrpcClient->call("foo");
+        $this->xmlrpcClient->call('foo');
         $uri = $this->xmlrpcClient->getHttpClient()->getUri();
 
         $this->assertEquals($baseUri, $uri->toString());
@@ -645,7 +645,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $headers = array("HTTP/1.1 $status $message",
                          "Status: $status",
-                         'Content_Type: text/xml; charset=utf-8',
+                         'Content-Type: text/xml; charset=utf-8',
                          'Content-Length: ' . strlen($data)
                          );
         return implode("\r\n", $headers) . "\r\n\r\n$data\r\n\r\n";

--- a/tests/Zend/XmlRpc/ServerTest.php
+++ b/tests/Zend/XmlRpc/ServerTest.php
@@ -54,6 +54,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->_server = new Server();
+        $this->_server->setReturnResponse(true);
     }
 
     /**
@@ -123,6 +124,16 @@ class ServerTest extends \PHPUnit_Framework_TestCase
             ),
             'zsr'
         );
+    }
+
+    /**
+     * getReturnResponse() default value
+     */
+    public function testEmitResponseByDefault()
+    {
+        $server = new Server();
+
+        $this->assertFalse($server->getReturnResponse());
     }
 
     /**
@@ -202,6 +213,29 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * handle() test - default behavior should be to not return the response
+     */
+    public function testHandle()
+    {
+        $request = new Request();
+        $request->setMethod('system.listMethods');
+        $this->_server->setReturnResponse(false);
+        ob_start();
+        $response = $this->_server->handle($request);
+        $output = ob_get_contents();
+        ob_end_clean();
+        $this->_server->setReturnResponse(true);
+
+        $this->assertFalse(isset($response));
+        $response = $this->_server->getLastResponse();
+        $this->assertTrue($response instanceof Response);
+        $this->assertSame($response->__toString(), $output);
+        $return = $response->getReturnValue();
+        $this->assertTrue(is_array($return));
+        $this->assertTrue(in_array('system.multicall', $return));
+    }
+
+    /**
      * handle() test
      *
      * Call as method call
@@ -211,7 +245,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
      *
      * Returns: Zend_XmlRpc_Response|Zend_XmlRpc_Fault
      */
-    public function testHandle()
+    public function testHandleWithReturnResponse()
     {
         $request = new Request();
         $request->setMethod('system.listMethods');

--- a/tests/Zend/XmlRpc/ServerTest.php
+++ b/tests/Zend/XmlRpc/ServerTest.php
@@ -227,7 +227,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->_server->setReturnResponse(true);
 
         $this->assertFalse(isset($response));
-        $response = $this->_server->getLastResponse();
+        $response = $this->_server->getResponse();
         $this->assertTrue($response instanceof Response);
         $this->assertSame($response->__toString(), $output);
         $return = $response->getReturnValue();


### PR DESCRIPTION
It may not be perfect - I didn't want to change too much. For example since there is a JSON client, maybe it would be worth renaming `Zend\Json\Server` to `Zend\Json\Rpc`. But main goals of this pull request are:
- Implement basic JSON-RPC client.
- Implement common minimal interface for clients that describe plain method call.
- Unify response output handling in servers.
- Unify `$argv` argument handling in `setClass()` across all RPC servers.

Changes in existing classes:
- `Zend\Soap\Server::setClass()` now ignores second parameter - it is defined in common RPC server interface as namespace, which is not used by SOAP, but it should not be treated as `$argv` element, since it's against server interface.
- `Zend\Json\Server\Server` class now contains `setReturnResponse()` and `getReturnResponse()` methods. They are equivalent to `setAutoEmitResponse()` and `autoEmitResponse()`, but with negation - implemented to enforce common interface, but since these are redundant old methods were marked as deprecated.
- `Zend\XmlRpc\Server` class now acts like JSON and SOAP servers - can automatically output response, and this is now default behavior - to unify RPC servers.
