### PR TITLE
Use DI to collect the PluginBroker

### DIFF
--- a/library/Zend/Mvc/Controller/ActionController.php
+++ b/library/Zend/Mvc/Controller/ActionController.php
@@ -238,7 +238,12 @@ abstract class ActionController implements Dispatchable, InjectApplicationEvent,
     public function getBroker()
     {
         if (!$this->broker) {
-            $this->setBroker(new PluginBroker());
+            $im = $this->getLocator()->instanceManager();
+            $im->setParameters('Zend\Mvc\Controller\PluginBroker', array(
+                'loader' => 'Zend\Mvc\Controller\PluginLoader'
+            ));
+            $broker = $this->getLocator()->get('Zend\Mvc\Controller\PluginBroker');
+            $this->setBroker($broker);
         }
         return $this->broker;
     }


### PR DESCRIPTION
Instead of getting the default broker via new PluginBroker(), we should get it using DI. This way modules can very easily inject controller action helpers into the PluginLoader without app developers having to inject the broker into each and every controller. However in order to inject the action helper into the PluginLoader, we need to ensure that the DI is aware that the PluginBroker also collects its default PluginLoader via DI, otherwise app developers will have to set up this injection themselves. Obviously all this is ignored if the app developer injects their own broker into the controller.

As a result, any module can now register their controller action helpers by simply adding this to the di section of their module.config.php:

```
'Zend\Mvc\Controller\PluginLoader' => array(
    'parameters' => array(
        'map' => array(
            'zfcUserAuthentication' => 'ZfcUser\Controller\Plugin\ZfcUserAuthentication',
        ),
    ),
),
```

Which is a bit more sane than having to do this for every single controller:

```
'album' => array(
    'parameters' => array(
        'broker'       => 'Zend\Mvc\Controller\PluginBroker',
    ),
),
'Zend\Mvc\Controller\PluginBroker' => array(
    'parameters' => array(
        'loader' => 'Zend\Mvc\Controller\PluginLoader',
    ),
),
'Zend\Mvc\Controller\PluginLoader' => array(
    'parameters' => array(
        'map' => array(
            'zfcUserAuthentication' => 'ZfcUser\Controller\Plugin\ZfcUserAuthentication',
        ),
    ),
),
```

(this is just for the album controller, if we had other controllers, we'd have to repeat the "album" section above for every other controller).
