### PR TITLE
Bugfixes for Zend\Di\Display\Console

### DIFF
--- a/library/Zend/Di/Display/Console.php
+++ b/library/Zend/Di/Display/Console.php
@@ -48,7 +48,7 @@ class Console
             $this->renderDefinition($definition);
             foreach ($definition->getClasses() as $class) {
                 $knownClasses[] = $class;
-                $this->renderClassDefinition($class);
+                $this->renderClassDefinition($definition, $class);
             }
             if (count($definition->getClasses()) == 0) {
                 echo PHP_EOL .'    No Classes Found' . PHP_EOL . PHP_EOL;
@@ -60,8 +60,8 @@ class Console
 
         $unknownRuntimeClasses = array_diff($this->runtimeClasses, $knownClasses);
         foreach ($unknownRuntimeClasses as $runtimeClass) {
-            //$definition = $this->di->definitions()->getDefinitionForClass($runtimeClass);
-            $this->renderClassDefinition($runtimeClass);
+            $definition = $this->di->definitions()->getDefinitionForClass($runtimeClass);
+            $this->renderClassDefinition($definition, $runtimeClass);
         }
 
 
@@ -122,13 +122,11 @@ class Console
         }
     }
 
-    protected function renderClassDefinition($class)
+    protected function renderClassDefinition($definition, $class)
     {
-        $definitions = $this->di->definitions();
-
         echo PHP_EOL . '    Parameters For Class: ' . $class . PHP_EOL;
-        foreach ($definitions->getMethods($class) as $methodName => $methodIsRequired) {
-            foreach ($definitions->getMethodParameters($class, $methodName) as $fqName => $pData) {
+        foreach ($definition->getMethods($class) as $methodName => $methodIsRequired) {
+            foreach ($definition->getMethodParameters($class, $methodName) as $fqName => $pData) {
                 echo '      ' . $pData[0] . ' [type: ';
                 echo ($pData[1]) ? $pData[1] : 'scalar';
                 echo ($pData[2] === true && $methodIsRequired) ? ', required' : ', not required';


### PR DESCRIPTION
When printing definitions, we should only print the classes, methods, and
parameters provided by the current definition. For example, if a DefinitionList
has two definitions -- a RuntimeDefinition and an ArrayDefinition loaded from
an out-of-date compiled definition -- we should print the good info under the
RuntimeDefinition and the stale info under the ArrayDefinition. Passing the
current definition into renderClassDefinition() makes this possible. The
current implementation (before this patch) ignores the current definition and
always queries the DefinitionList for the first definition that has the class
defined. In the earlier example, this would print the good info under the
ArrayDefinition, which is misleading.

This patch also fixes a subtle bug caused by nested calls to the
SplDoublyLinkedList iterator. In the current implementation, the render()
method iterates over the DefinitionList (which extends SplDoublyLinkedList). In
the loop, it calls renderClassDefinition(), which calls the DefinitionList's
getMethods() and getMethodParameters() methods. These methods also iterate over
the DefinitionList, resetting the current position and causing the outer loop
to lose its place. As a result, render() would fail to print all configured
definitions in some cases. This patch doesn't query the DefinitionList in
renderClassDefinition(), so the outer loop should behave as expected.
