### PR TITLE
Fixed method overriding in Zend\Filter\Decrypt.

### DIFF
--- a/library/Zend/Filter/Decrypt.php
+++ b/library/Zend/Filter/Decrypt.php
@@ -42,7 +42,7 @@ class Decrypt extends Encrypt
      * @param  string $value Content to decrypt
      * @return string The decrypted content
      */
-    public function __invoke($value)
+    public function filter($value)
     {
         return $this->_adapter->decrypt($value);
     }


### PR DESCRIPTION
`__invoke()` maps to `filter()` in AbstractFilter, overriding invoke won't handle direct `filter()` calls as defined by `Zend\Filter\Filter` interface. So the correct flow is to override `filter()` instead of `__invoke()`.
