### PR TITLE
Make sure glob attempt always returns an array.

### DIFF
--- a/library/Zend/Loader/ModuleAutoloader.php
+++ b/library/Zend/Loader/ModuleAutoloader.php
@@ -106,7 +106,7 @@ class ModuleAutoloader implements SplAutoloader
             //$moduleName = substr($class, 0, strpos($class, '\\'));
 
             // Find executable phars
-            $matches = glob($path . '.{' . implode($this->pharExtensions, ',') . '}', GLOB_BRACE);
+            $matches = glob($path . '.{' . implode($this->pharExtensions, ',') . '}', GLOB_BRACE) ?: array();
             foreach ($matches as $phar) {
                 if ($classLoaded = $this->loadModuleFromPhar($phar, $class)) {
                     return $classLoaded;


### PR DESCRIPTION
Noticed by @Danielss89 on IRC, it appears that glob() will return boolean false
in some cases.

To quote a comment from php.net/glob:
"If you have open_basedir set in php.ini to limit which files php can execute,
glob(...) will return false when there are no matching files. If open_basedir is
not set, the very same code will return an empty array in the same situation."
