### PR TITLE
Fix bug where cached config would prevent the config listener from passing itself to MvcEvent

### DIFF
--- a/library/Zend/Module/Listener/ConfigListener.php
+++ b/library/Zend/Module/Listener/ConfigListener.php
@@ -65,7 +65,7 @@ class ConfigListener extends AbstractListener
      */
     public function __invoke(ModuleEvent $e)
     {
-        $this->loadModule($e);
+        return $this->loadModule($e);
     }
 
     /**

--- a/tests/Zend/Module/Listener/ConfigListenerTest.php
+++ b/tests/Zend/Module/Listener/ConfigListenerTest.php
@@ -127,7 +127,7 @@ class ConfigListenerTest extends TestCase
         $moduleManager = $this->moduleManager;
         $moduleManager->setModules(array('SomeModule'));
         $moduleManager->events()->attach('loadModule', $configListener);
-        $moduleManager->events()->attach('loadModules.post', array($configListener, 'mergeConfigGlobPaths'), 1000);
+        $moduleManager->events()->attach('loadModules.post', array($configListener, 'loadModulesPost'), 1000);
         $moduleManager->loadModules();
     }
 
@@ -244,7 +244,7 @@ class ConfigListenerTest extends TestCase
         $this->assertEquals(1, count($moduleManager->events()->getEvents()));
 
         $configListener->attach($moduleManager->events());
-        $this->assertEquals(3, count($moduleManager->events()->getEvents()));
+        $this->assertEquals(4, count($moduleManager->events()->getEvents()));
 
         $configListener->detach($moduleManager->events());
         $this->assertEquals(1, count($moduleManager->events()->getEvents()));
@@ -263,7 +263,7 @@ class ConfigListenerTest extends TestCase
         $moduleManager->setModules(array('SomeModule'));
 
         $moduleManager->events()->attach('loadModule', $configListener);
-        $moduleManager->events()->attach('loadModules.post', array($configListener, 'mergeConfigGlobPaths'), 1000);
+        $moduleManager->events()->attach('loadModules.post', array($configListener, 'loadModulesPost'), 1000);
 
         $moduleManager->loadModules();
     }


### PR DESCRIPTION
Discovered by @denniswinter. This commit also cleans up the method names in the
config listener to match the event names they are meant to be attached to.

Updated unit tests.
