### PR TITLE
[ZF-11946] Zend_Ldap_Collection::toArray throws exception instead of ret...

### DIFF
--- a/library/Zend/Ldap/Collection/DefaultIterator.php
+++ b/library/Zend/Ldap/Collection/DefaultIterator.php
@@ -262,7 +262,7 @@ class DefaultIterator implements \Iterator, \Countable
      */
     public function next()
     {
-        if (is_resource($this->_current)) {
+        if (is_resource($this->_current) && $this->_itemCount > 0) {
             $this->_current = @ldap_next_entry($this->_ldap->getResource(), $this->_current);
             if ($this->_current === false) {
                 $msg = $this->_ldap->getLastError($code);
@@ -273,6 +273,8 @@ class DefaultIterator implements \Iterator, \Countable
                      throw new Ldap\Exception($this->_ldap, 'getting next entry (' . $msg . ')');
                 }
             }
+        } else {
+            $this->_current = false;
         }
     }
 

--- a/tests/Zend/Ldap/OnlineTestCase.php
+++ b/tests/Zend/Ldap/OnlineTestCase.php
@@ -46,7 +46,7 @@ abstract class OnlineTestCase extends TestCase
     private $_nodes;
 
     /**
-     * @return Zend_LDAP
+     * @return \Zend\Ldap\Ldap
      */
     protected function _getLDAP()
     {

--- a/tests/Zend/Ldap/SearchTest.php
+++ b/tests/Zend/Ldap/SearchTest.php
@@ -133,7 +133,7 @@ class SearchTest extends OnlineTestCase
     {
         $entries=$this->_getLDAP()->searchEntries('(objectClass=organizationalUnit)',
             TESTS_ZEND_LDAP_WRITEABLE_SUBTREE, Ldap\Ldap::SEARCH_SCOPE_SUB);
-        $this->assertType("array", $entries);
+        $this->assertInternalType("array", $entries);
         $this->assertEquals(9, count($entries));
     }
 
@@ -232,7 +232,7 @@ class SearchTest extends OnlineTestCase
         $filter=Filter::equals('objectClass', 'organizationalUnit');
 
         $entries=$this->_getLDAP()->searchEntries($filter, $dn, Ldap\Ldap::SEARCH_SCOPE_SUB);
-        $this->assertType("array", $entries);
+        $this->assertInternalType("array", $entries);
         $this->assertEquals(9, count($entries));
     }
 
@@ -442,7 +442,7 @@ class SearchTest extends OnlineTestCase
     {
         $items = $this->_getLDAP()->search('(objectClass=organizationalUnit)',
             TESTS_ZEND_LDAP_WRITEABLE_SUBTREE, Ldap\Ldap::SEARCH_SCOPE_SUB);
-        $this->assertType('\Zend\Ldap\Collection\DefaultIterator', $items->getInnerIterator());
+        $this->assertInstanceOf('\Zend\Ldap\Collection\DefaultIterator', $items->getInnerIterator());
     }
 
     /**


### PR DESCRIPTION
...urning array

Could not reproduce the issue - but implemented a second safe-guard.
Test fixed for use with PHPUnit 3.6
