### PR TITLE
Default $encoding set to UTF-8 in \Zend\Search\Lucene\Document\Field

### DIFF
--- a/library/Zend/Search/Lucene/Document/Field.php
+++ b/library/Zend/Search/Lucene/Document/Field.php
@@ -145,7 +145,7 @@ class Field
      * @param string $encoding
      * @return \Zend\Search\Lucene\Document\Field
      */
-    public static function keyword($name, $value, $encoding = '')
+    public static function keyword($name, $value, $encoding = 'UTF-8')
     {
         return new self($name, $value, $encoding, true, true, false);
     }
@@ -160,7 +160,7 @@ class Field
      * @param string $encoding
      * @return \Zend\Search\Lucene\Document\Field
      */
-    public static function unIndexed($name, $value, $encoding = '')
+    public static function unIndexed($name, $value, $encoding = 'UTF-8')
     {
         return new self($name, $value, $encoding, true, false, false);
     }
@@ -190,7 +190,7 @@ class Field
      * @param string $encoding
      * @return \Zend\Search\Lucene\Document\Field
      */
-    public static function text($name, $value, $encoding = '')
+    public static function text($name, $value, $encoding = 'UTF-8')
     {
         return new self($name, $value, $encoding, true, true, true);
     }
@@ -205,7 +205,7 @@ class Field
      * @param string $encoding
      * @return \Zend\Search\Lucene\Document\Field
      */
-    public static function unStored($name, $value, $encoding = '')
+    public static function unStored($name, $value, $encoding = 'UTF-8')
     {
         return new self($name, $value, $encoding, false, true, true);
     }


### PR DESCRIPTION
There's one problem with having $encoding set to default "" (empty string), because there's a lot of texts that AREN'T in standard 7bit ASCII.

And then iconv() fails with notice (if you're using some debugger that has strict mode to report every notice) about illegal character, because $in_charset was = "";

So there are IMHO two options howto avoid these needless notices when using Field factories.
a) Make $encoding a mandatory parameter (which would cause a BC break)
b) Make $encoding have some fallback value, like UTF-8 (which is widely used anyways) -- will be better for new users and won't BC break old ones, because they're already using some set encoding or having it empty, which is 7bit ASCII (compatible with UTF-8 on their strings).

I chose b).
