### PR TITLE
The declaration of $_knownFlags trigger the error Class 'Zend\Mail\Storage\Storage' not found

### DIFF
--- a/library/Zend/Mail/Storage/Imap.php
+++ b/library/Zend/Mail/Storage/Imap.php
@@ -24,7 +24,8 @@
  */
 namespace Zend\Mail\Storage;
 
-use Zend\Mail\Protocol;
+use Zend\Mail\Protocol,
+    Zend\Mail\Storage;
 
 /**
  * @category   Zend


### PR DESCRIPTION
Changed line 27 from:
use Zend\Mail\Protocol;

to:
use Zend\Mail\Protocol,
    Zend\Mail\Storage;

As the declaration of the static variable $_knownFlags triggered the error:
"Fatal error: Class 'Zend\Mail\Storage\Storage' not found" it happens because the autoloader try to find the class Storage inside the name space Zend\Mail\Storage.
