### PR TITLE
Fixes for [Zend\GData\YouTube] and [Zend\Http\Client]

### DIFF
--- a/library/Zend/GData/App.php
+++ b/library/Zend/GData/App.php
@@ -247,7 +247,7 @@ class App
         }
         $userAgent = $applicationId . ' Zend_Framework_Gdata/' .
             \Zend\Version::VERSION;
-        $client->setHeaders(array('User-Agent' => $userAgent));
+        $client->getRequest()->headers()->addHeaderLine('User-Agent', $userAgent);
         $client->setConfig(array(
             'strictredirects' => true
             )

--- a/library/Zend/GData/YouTube.php
+++ b/library/Zend/GData/YouTube.php
@@ -200,11 +200,11 @@ class YouTube extends Media
         }
 
         if ($clientId != null) {
-            $client->setHeaders(array('X-GData-Client' => $clientId));
+            $client->getRequest()->headers()->addHeaderLine('X-GData-Client', $clientId);
         }
 
         if ($developerKey != null) {
-            $client->setHeaders(array('X-GData-Key' => 'key='. $developerKey));
+            $client->getRequest()->headers()->addHeaderLine('X-GData-Key', 'key='. $developerKey);
         }
 
         return parent::setHttpClient($client, $applicationId);

--- a/library/Zend/GData/YouTube.php
+++ b/library/Zend/GData/YouTube.php
@@ -200,11 +200,11 @@ class YouTube extends Media
         }
 
         if ($clientId != null) {
-            $client->setHeaders('X-GData-Client', $clientId);
+            $client->setHeaders(array('X-GData-Client' => $clientId));
         }
 
         if ($developerKey != null) {
-            $client->setHeaders('X-GData-Key', 'key='. $developerKey);
+            $client->setHeaders(array('X-GData-Key' => 'key='. $developerKey));
         }
 
         return parent::setHttpClient($client, $applicationId);

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -536,7 +536,7 @@ class Client implements Dispatchable
     public function setHeaders($headers)
     {
         if (is_array($headers)) {
-            $newHeaders = $this->getRequest()->headers();
+            $newHeaders = new Headers();
             $newHeaders->addHeaders($headers);
             $this->getRequest()->setHeaders($newHeaders);
         } elseif ($headers instanceof Headers) {

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -536,7 +536,7 @@ class Client implements Dispatchable
     public function setHeaders($headers)
     {
         if (is_array($headers)) {
-            $newHeaders = new Headers();
+            $newHeaders = $this->getRequest()->headers();
             $newHeaders->addHeaders($headers);
             $this->getRequest()->setHeaders($newHeaders);
         } elseif ($headers instanceof Headers) {

--- a/tests/Zend/GData/YouTubeTest.php
+++ b/tests/Zend/GData/YouTubeTest.php
@@ -67,6 +67,8 @@ class YouTubeTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($yt instanceOf YouTube);
         $client = $yt->getHttpClient();
 
+        $this->assertEquals($client->getHeader('User-Agent'), 
+                            $applicationId . ' Zend_Framework_Gdata/' . \Zend\Version::VERSION);
         $this->assertEquals($client->getHeader('X-GData-Key'), 'key='. $developerKey);
         $this->assertEquals($client->getHeader('X-GData-Client'), $clientId);
     }


### PR DESCRIPTION
[Zend\GData\YouTube] changes
- Fixed malformed arguments being passed to Client::setHeaders()

[Zend\Http\Client] changes
- Fixed setHeaders() method so that it doesn't instantiate a new Headers object in every call

---

Currently, ZendTest\GData\YouTubeTest::testSetClientIDAndDeveloperKeyHeader fails due to a Zend\Http\Exception\InvalidArgumentException. Two arguments are being passed to Client::setHeaders(); changing to a single Array argument fixes this problem.

Once this is done, the same test fails due to another Zend\Http\Exception\InvalidArgumentException. I noticed that the User-Agent was the last header to be set and the only one that stayed in the object. A new Headers object was being created every time Zend\Http\Client::setHeaders() was called so everything was being overwritten.

After fixing these two issues, the test is passed.
