### PR TITLE
Mvc router from locator

### DIFF
--- a/library/Zend/Di/Definition/RuntimeDefinition.php
+++ b/library/Zend/Di/Definition/RuntimeDefinition.php
@@ -94,7 +94,7 @@ class RuntimeDefinition implements Definition
             return (array_key_exists($class, $this->classes));
         }
         
-        return class_exists($class, true);
+        return class_exists($class) || interface_exists($class);
     }
 
     /**

--- a/library/Zend/Mvc/Bootstrap.php
+++ b/library/Zend/Mvc/Bootstrap.php
@@ -96,6 +96,23 @@ class Bootstrap implements Bootstrapper
         $di = new Di;
         $di->instanceManager()->addTypePreference('Zend\Di\Locator', $di);
 
+        // default configuration for the router
+        $routerDiConfig = new DiConfiguration(
+            array(
+                'definition' => array(
+                    'class' => array(
+                        'Zend\Mvc\Router\RouteStack' => array(
+                            'instantiator' => array(
+                                'Zend\Mvc\Router\Http\TreeRouteStack',
+                                'factory'
+                            ),
+                        ),
+                    ),
+                )
+            )
+        );
+        $routerDiConfig->configure($di);
+
         $config = new DiConfiguration($this->config->di);
         $config->configure($di);
 
@@ -110,8 +127,7 @@ class Bootstrap implements Bootstrapper
      */
     protected function setupRouter(AppContext $application)
     {
-        $router = new Router();
-        $router->addRoutes($this->config->routes);
+        $router = $application->getLocator()->get('Zend\Mvc\Router\RouteStack');
         $application->setRouter($router);
     }
 

--- a/library/Zend/Mvc/Router/PriorityList.php
+++ b/library/Zend/Mvc/Router/PriorityList.php
@@ -109,6 +109,9 @@ class PriorityList implements Iterator, Countable
     public function clear()
     {
         $this->routes = array();
+        $this->serial = 0;
+        $this->count = 0;
+        $this->sorted = false;
     }
     
     /**

--- a/library/Zend/Mvc/Router/PriorityList.php
+++ b/library/Zend/Mvc/Router/PriorityList.php
@@ -102,6 +102,16 @@ class PriorityList implements Iterator, Countable
     }
     
     /**
+     * Remove all routes.
+     * 
+     * @return void 
+     */
+    public function clear()
+    {
+        $this->routes = array();
+    }
+    
+    /**
      * Get a route.
      * 
      * @param  string $name 

--- a/library/Zend/Mvc/Router/RouteStack.php
+++ b/library/Zend/Mvc/Router/RouteStack.php
@@ -47,7 +47,7 @@ interface RouteStack extends Route
      * @return RouteStack
      */
     public function addRoutes($routes);
-    
+
     /**
      * Remove a route from the stack.
      * 
@@ -55,5 +55,13 @@ interface RouteStack extends Route
      * @return RouteStack
      */
     public function removeRoute($name);
+
+    /**
+     * Remove all routes from the stack and set new ones.
+     * 
+     * @param  array|Traversable $routes
+     * @return RouteStack
+     */
+    public function setRoutes($routes);
 }
 

--- a/library/Zend/Mvc/Router/SimpleRouteStack.php
+++ b/library/Zend/Mvc/Router/SimpleRouteStack.php
@@ -158,7 +158,7 @@ class SimpleRouteStack implements RouteStack
     /**
      * addRoute(): defined by RouteStack interface.
      *
-     * @see    Route::addRoute()
+     * @see    RouteStack::addRoute()
      * @param  string  $name
      * @param  mixed   $route
      * @param  integer $priority
@@ -182,7 +182,7 @@ class SimpleRouteStack implements RouteStack
     /**
      * removeRoute(): defined by RouteStack interface.
      *
-     * @see    Route::removeRoute()
+     * @see    RouteStack::removeRoute()
      * @param  string  $name
      * @return RouteStack
      */
@@ -190,6 +190,19 @@ class SimpleRouteStack implements RouteStack
     {
         $this->routes->remove($name);
         return $this;
+    }
+
+
+    /**
+     * setRoutes(): defined by RouteStack interface.
+     *
+     * @param  array|Traversable $routes
+     * @return RouteStack
+     */
+    public function setRoutes($routes)
+    {
+        $this->routes->clear();
+        $this->addRoutes($routes);
     }
 
     /**

--- a/library/Zend/Mvc/Router/SimpleRouteStack.php
+++ b/library/Zend/Mvc/Router/SimpleRouteStack.php
@@ -203,6 +203,7 @@ class SimpleRouteStack implements RouteStack
     {
         $this->routes->clear();
         $this->addRoutes($routes);
+        return $this;
     }
 
     /**

--- a/tests/Zend/Mvc/Router/PriorityListTest.php
+++ b/tests/Zend/Mvc/Router/PriorityListTest.php
@@ -74,6 +74,19 @@ class PriorityListTest extends TestCase
     {
         $this->list->remove('foo');
     }
+
+    public function testClear()
+    {
+        $this->list->insert('foo', new TestAsset\DummyRoute(), 0);
+        $this->list->insert('bar', new TestAsset\DummyRoute(), 0);
+
+        $this->assertEquals(2, count($this->list));
+
+        $this->list->clear();
+
+        $this->assertEquals(0, count($this->list));
+        $this->assertSame(false, current($this->list));
+    }
     
     public function testGet()
     {

--- a/tests/Zend/Mvc/Router/PriorityListTest.php
+++ b/tests/Zend/Mvc/Router/PriorityListTest.php
@@ -85,7 +85,7 @@ class PriorityListTest extends TestCase
         $this->list->clear();
 
         $this->assertEquals(0, count($this->list));
-        $this->assertSame(false, current($this->list));
+        $this->assertSame(false, $this->list->current());
     }
     
     public function testGet()

--- a/tests/Zend/Mvc/Router/SimpleRouteStackTest.php
+++ b/tests/Zend/Mvc/Router/SimpleRouteStackTest.php
@@ -47,6 +47,42 @@ class SimpleRouteStackTest extends TestCase
         $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $stack->match(new Request()));
     }
     
+    public function testSetRoutesWithInvalidArgument()
+    {
+        $this->setExpectedException('Zend\Mvc\Router\Exception\InvalidArgumentException', 'addRoutes expects an array or Traversable set of routes');
+        $stack = new SimpleRouteStack();
+        $stack->setRoutes('foo');
+    }
+    
+    public function testSetRoutesAsArray()
+    {
+        $stack = new SimpleRouteStack();
+        $stack->setRoutes(array(
+            'foo' => new TestAsset\DummyRoute()
+        ));
+        
+        $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $stack->match(new Request()));
+        
+        $stack->setRoutes(array());
+        
+        $this->assertSame(null, $stack->match(new Request()));
+    }
+        
+    public function testSetRoutesAsTraversable()
+    {
+        $stack = new SimpleRouteStack();
+        $stack->setRoutes(new ArrayIterator(array(
+            'foo' => new TestAsset\DummyRoute()
+        )));
+        
+        $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $stack->match(new Request()));
+        
+        $stack->setRoutes(new ArrayIterator(array()));
+        
+        $this->assertSame(null, $stack->match(new Request()));
+        
+    }
+    
     public function testremoveRouteAsArray()
     {
         $stack = new SimpleRouteStack();


### PR DESCRIPTION
These changes allow the router to be fetched from the locator.

Basically, I'm hereby telling `Zend\Di` that the instantiator for `Zend\Mvc\Router\RouteStack` is `Zend\Mvc\Router\Http\TreeRouteStack::factory`.

This allows us to use the interface FQCN itself to retrieve the router, and gives us more flexibility than just having injections in the router and the router itself injectable.

It is possible to completely replace it by redefining the instantiator definition in configuration.

A change has been applied in the `Zend\Di` namespace to allow using `Di#get($interfaceName)`.

Changes have also been applied to `Zend\Mvc\Router\RouteStack` mainly to allow setter injection, but are also useful regardless of `Zend\Di`.

I have fixed also the configuration for the skeleton application at https://github.com/zendframework/ZendSkeletonApplication/pull/24
