### PR TITLE
Fixed ZF2-153 - renamed Zend\Ldap\Node\RootDSE to RootDse

### DIFF
--- a/library/Zend/Ldap/Ldap.php
+++ b/library/Zend/Ldap/Ldap.php
@@ -30,7 +30,7 @@ namespace Zend\Ldap;
  * @uses       \Zend\Ldap\Exception
  * @uses       \Zend\Ldap\Filter\AbstractFilter
  * @uses       \Zend\Ldap\Node
- * @uses       \Zend\Ldap\Node\RootDSE
+ * @uses       \Zend\Ldap\Node\RootDse
  * @uses       \Zend\Ldap\Node\Schema
  * @category   Zend
  * @package    Zend_Ldap
@@ -79,7 +79,7 @@ class Ldap
     protected $_boundUser = false;
 
     /**
-     * Caches the RootDSE
+     * Caches the RootDse
      *
      * @var \Zend\Ldap\Node
      */
@@ -1416,15 +1416,15 @@ class Ldap
     }
 
     /**
-     * Returns the RootDSE
+     * Returns the RootDse
      *
-     * @return \Zend\Ldap\Node\RootDSE
+     * @return \Zend\Ldap\Node\RootDse
      * @throws \Zend\Ldap\Exception
      */
     public function getRootDse()
     {
         if ($this->_rootDse === null) {
-            $this->_rootDse = Node\RootDSE::create($this);
+            $this->_rootDse = Node\RootDse::create($this);
         }
         return $this->_rootDse;
     }

--- a/library/Zend/Ldap/Node/RootDse.php
+++ b/library/Zend/Ldap/Node/RootDse.php
@@ -26,7 +26,7 @@ namespace Zend\Ldap\Node;
 use Zend\Ldap;
 
 /**
- * Zend_Ldap_Node_RootDse provides a simple data-container for the RootDSE node.
+ * Zend_Ldap_Node_RootDse provides a simple data-container for the RootDse node.
  *
  * @uses       \Zend\Ldap\Dn
  * @uses       \Zend\Ldap\Node\AbstractNode
@@ -47,7 +47,7 @@ class RootDse extends AbstractNode
     const SERVER_TYPE_EDIRECTORY      = 4;
 
     /**
-     * Factory method to create the RootDSE.
+     * Factory method to create the RootDse.
      *
      * @param  \Zend\Ldap\Ldap $ldap
      * @return \Zend\Ldap\Node\RootDse

--- a/library/Zend/Ldap/Node/RootDse/ActiveDirectory.php
+++ b/library/Zend/Ldap/Node/RootDse/ActiveDirectory.php
@@ -27,7 +27,7 @@ namespace Zend\Ldap\Node\RootDse;
 use Zend\Ldap\Node\RootDse;
 
 /**
- * Zend_Ldap_Node_RootDse provides a simple data-container for the RootDSE node of
+ * Zend_Ldap_Node_RootDse provides a simple data-container for the RootDse node of
  * an Active Directory server.
  *
  * @uses       \Zend\Ldap\Dn

--- a/library/Zend/Ldap/Node/RootDse/OpenLdap.php
+++ b/library/Zend/Ldap/Node/RootDse/OpenLdap.php
@@ -27,7 +27,7 @@ namespace Zend\Ldap\Node\RootDse;
 use Zend\Ldap\Node\RootDse;
 
 /**
- * Zend_Ldap_Node_RootDse provides a simple data-container for the RootDSE node of
+ * Zend_Ldap_Node_RootDse provides a simple data-container for the RootDse node of
  * an OpenLDAP server.
  *
  * @uses       \Zend\Ldap\Node\RootDse

--- a/library/Zend/Ldap/Node/RootDse/eDirectory.php
+++ b/library/Zend/Ldap/Node/RootDse/eDirectory.php
@@ -27,7 +27,7 @@ namespace Zend\Ldap\Node\RootDse;
 use Zend\Ldap\Node\RootDse;
 
 /**
- * Zend_Ldap_Node_RootDse provides a simple data-container for the RootDSE node of
+ * Zend_Ldap_Node_RootDse provides a simple data-container for the RootDse node of
  * a Novell eDirectory server.
  *
  * @uses       \Zend\Ldap\Node\RootDse

--- a/library/Zend/Ldap/Node/Schema.php
+++ b/library/Zend/Ldap/Node/Schema.php
@@ -25,14 +25,14 @@
 namespace Zend\Ldap\Node;
 
 use Zend\Ldap;
-use Zend\Ldap\Node\RootDSE;
+use Zend\Ldap\Node\RootDse;
 
 /**
  * Zend_Ldap_Node_Schema provides a simple data-container for the Schema node.
  *
  * @uses       \Zend\Ldap\Node\AbstractNode
- * @uses       \Zend\Ldap\Node\RootDSE\RootDSE
- * @uses       \Zend\Ldap\Node\RootDSE\ActiveDirectory
+ * @uses       \Zend\Ldap\Node\RootDse\RootDse
+ * @uses       \Zend\Ldap\Node\RootDse\ActiveDirectory
  * @uses       \Zend\Ldap\Node\Schema\ActiveDirectory
  * @category   Zend
  * @package    Zend_Ldap
@@ -59,11 +59,11 @@ class Schema extends AbstractNode
         $dn = $ldap->getRootDse()->getSchemaDn();
         $data = $ldap->getEntry($dn, array('*', '+'), true);
         switch ($ldap->getRootDse()->getServerType()) {
-            case RootDSE::SERVER_TYPE_ACTIVEDIRECTORY:
+            case RootDse::SERVER_TYPE_ACTIVEDIRECTORY:
                 return new Schema\ActiveDirectory($dn, $data, $ldap);
-            case RootDSE::SERVER_TYPE_OPENLDAP:
+            case RootDse::SERVER_TYPE_OPENLDAP:
                 return new Schema\OpenLdap($dn, $data, $ldap);
-            case RootDSE::SERVER_TYPE_EDIRECTORY:
+            case RootDse::SERVER_TYPE_EDIRECTORY:
             default:
                 return new self($dn, $data, $ldap);
         }


### PR DESCRIPTION
Renamed RootDSE to RootDse for case sensitive autoloaders.

http://framework.zend.com/issues/browse/ZF2-153
