### PR TITLE
[Zend_Http_Client] fixed double encoding problem about cookie value when...

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -489,9 +489,6 @@ class Client implements Dispatchable
         } elseif ($cookie instanceof SetCookie) {
             $this->cookies[$this->getCookieId($cookie)] = $cookie;
         } elseif (is_string($cookie) && !is_null($value)) {
-            if (!empty($value) && $this->config['encodecookies']) {
-                $value = urlencode($value);
-            }
             $setCookie = new SetCookie($cookie, $value, $domain, $expire, $path, $secure, $httponly);
             $this->cookies[$this->getCookieId($setCookie)] = $setCookie;
         } else {
@@ -1010,8 +1007,9 @@ class Client implements Dispatchable
                 }
             }
         }
-        
+
         $cookies = Cookie::fromSetCookieArray($validCookies);
+        $cookies->setEncodeValue($this->config['encodecookies']);
 
         return $cookies;
     }

--- a/tests/Zend/Http/Client/StaticTest.php
+++ b/tests/Zend/Http/Client/StaticTest.php
@@ -502,6 +502,35 @@ class StaticTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test sending cookie with encoded value
+     *
+     * @group fix-double-encoding-problem-about-cookie-value
+     */
+    public function testEncodedCookiesInRequestHeaders()
+    {
+        $this->_client->addCookie('foo', 'bar=baz');
+        $this->_client->send();
+        $cookieValue = 'Cookie: foo='.urlencode('bar=baz');
+        $this->assertContains($cookieValue, $this->_client->getLastRawRequest(),
+            'Request is expected to contain the entire cookie "keyname=encoded_value"');
+    }
+
+    /**
+     * Test sending cookie header with raw value
+     *
+     * @group fix-double-encoding-problem-about-cookie-value
+     */
+    public function testRawCookiesInRequestHeaders()
+    {
+        $this->_client->setConfig(array('encodecookies' => false));
+        $this->_client->addCookie('foo', 'bar=baz');
+        $this->_client->send();
+        $cookieValue = 'Cookie: foo=bar=baz';
+        $this->assertContains($cookieValue, $this->_client->getLastRawRequest(),
+            'Request is expected to contain the entire cookie "keyname=raw_value"');
+    }
+
+    /**
      * Data providers
      */
 


### PR DESCRIPTION
Currently, Zend_Http_Client has problem with cookie value urlencoding. I think the cookie value should be urlencoded once when "encodecookies" is true. However, current Zend_Http_Client sends twice urlencoded value in request headers.

The same problem is also found when "encodecookies" is false. In this case, the raw value should be sent as cookie value, I think.

I added 2 test cases. For detail, please check them.
