### PR TITLE
Cache fixes + simplified methods setOptions 

### DIFF
--- a/library/Zend/Cache/Pattern/AbstractPattern.php
+++ b/library/Zend/Cache/Pattern/AbstractPattern.php
@@ -48,18 +48,6 @@ abstract class AbstractPattern implements Pattern
      */
     public function setOptions(PatternOptions $options)
     {
-        if (!is_array($options)
-            && !$options instanceof Traversable
-            && !$options instanceof PatternOptions
-        ) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects an array, a Traversable object, or an PatternOptions instance; '
-                    . 'received "%s"',
-                __METHOD__,
-                (is_object($options) ? get_class($options) : gettype($options))
-            ));
-        }
-
         if (!$options instanceof PatternOptions) {
             $options = new PatternOptions($options);
         }
@@ -67,8 +55,6 @@ abstract class AbstractPattern implements Pattern
         $this->options = $options;
         return $this;
     }
-
-
 
     /**
      * Get all pattern options

--- a/library/Zend/Cache/Pattern/CallbackCache.php
+++ b/library/Zend/Cache/Pattern/CallbackCache.php
@@ -36,14 +36,15 @@ class CallbackCache extends AbstractPattern
 {
     /**
      * Set options
-     * 
-     * @param  PatternOptions $options 
+     *
+     * @param  PatternOptions $options
      * @return CallbackCache
      * @throws Exception\InvalidArgumentException if missing storage option
      */
     public function setOptions(PatternOptions $options)
     {
         parent::setOptions($options);
+
         if (!$options->getStorage()) {
             throw new Exception\InvalidArgumentException("Missing option 'storage'");
         }

--- a/library/Zend/Cache/Pattern/CallbackCache.php
+++ b/library/Zend/Cache/Pattern/CallbackCache.php
@@ -73,7 +73,8 @@ class CallbackCache extends AbstractPattern
             return $rs[0];
         }
 
-        if ( ($cacheOutput = $classOptions->getCacheOutput()) ) {
+        $cacheOutput = $classOptions->getCacheOutput();
+        if ($cacheOutput) {
             ob_start();
             ob_implicit_flush(false);
         }

--- a/library/Zend/Cache/Pattern/CaptureCache.php
+++ b/library/Zend/Cache/Pattern/CaptureCache.php
@@ -69,7 +69,7 @@ class CaptureCache extends AbstractPattern
         }
 
         ob_start(array($this, 'flush'));
-        ob_implicitflush(false);
+        ob_implicit_flush(false);
         $this->pageId = $pageId;
 
         return false;

--- a/library/Zend/Cache/Pattern/PatternOptions.php
+++ b/library/Zend/Cache/Pattern/PatternOptions.php
@@ -189,7 +189,7 @@ class PatternOptions extends Options
         $this->cacheByDefault = $cacheByDefault;
         return $this;
     }
-    
+
     /**
      * Do we cache by default?
      *
@@ -220,7 +220,7 @@ class PatternOptions extends Options
         $this->cacheOutput = (bool) $cacheOutput;
         return $this;
     }
-    
+
     /**
      * Will we cache output?
      *
@@ -253,7 +253,7 @@ class PatternOptions extends Options
         $this->class = $class;
         return $this;
     }
-    
+
     /**
      * Get class name
      *
@@ -281,7 +281,7 @@ class PatternOptions extends Options
         $this->classCacheMethods = $this->recursiveStrtolower($classCacheMethods);
         return $this;
     }
-    
+
     /**
      * Get list of methods from which to cache return values
      *
@@ -309,7 +309,7 @@ class PatternOptions extends Options
         $this->classNonCacheMethods = $this->recursiveStrtolower($classNonCacheMethods);
         return $this;
     }
-    
+
     /**
      * Get list of methods from which NOT to cache return values
      *
@@ -327,8 +327,8 @@ class PatternOptions extends Options
      * Set directory permissions
      *
      * Sets {@link $dirUmask} property to inverse of provided value.
-     * 
-     * @param  string $dirPerm 
+     *
+     * @param  string $dirPerm
      * @return PatternOptions
      */
     public function setDirPerm($dirPerm)
@@ -347,7 +347,7 @@ class PatternOptions extends Options
      * Gets directory permissions
      *
      * Proxies to {@link $dirUmask} property, returning its inverse.
-     * 
+     *
      * @return int
      */
     public function getDirPerm()
@@ -377,7 +377,7 @@ class PatternOptions extends Options
         $this->dirUmask = $dirUmask;
         return $this;
     }
-    
+
     /**
      * Get directory umask
      *
@@ -405,7 +405,7 @@ class PatternOptions extends Options
         $this->fileLocking = (bool) $fileLocking;
         return $this;
     }
-    
+
     /**
      * Is file locking enabled?
      *
@@ -423,8 +423,8 @@ class PatternOptions extends Options
      * Set file permissions
      *
      * Sets {@link $fileUmask} property to inverse of provided value.
-     * 
-     * @param  string $filePerm 
+     *
+     * @param  string $filePerm
      * @return PatternOptions
      */
     public function setFilePerm($filePerm)
@@ -443,7 +443,7 @@ class PatternOptions extends Options
      * Gets file permissions
      *
      * Proxies to {@link $fileUmask} property, returning its inverse.
-     * 
+     *
      * @return int
      */
     public function getFilePerm()
@@ -478,7 +478,7 @@ class PatternOptions extends Options
         $this->fileUmask = $fileUmask;
         return $this;
     }
-    
+
     /**
      * Get file umask
      *
@@ -503,7 +503,7 @@ class PatternOptions extends Options
         $this->indexFilename = (string) $indexFilename;
         return $this;
     }
-    
+
     /**
      * Get value for index filename
      *
@@ -530,7 +530,7 @@ class PatternOptions extends Options
         $this->object = $object;
         return $this;
     }
-    
+
     /**
      * Get object to cache
      *
@@ -555,7 +555,7 @@ class PatternOptions extends Options
         $this->objectCacheMagicProperties = (bool) $objectCacheMagicProperties;
         return $this;
     }
-    
+
     /**
      * Should we cache magic properties?
      *
@@ -581,7 +581,7 @@ class PatternOptions extends Options
         $this->objectCacheMethods = $this->normalizeObjectMethods($objectCacheMethods);
         return $this;
     }
-    
+
     /**
      * Get list of object methods for which to cache return values
      *
@@ -612,7 +612,7 @@ class PatternOptions extends Options
         }
         return $this;
     }
-    
+
     /**
      * Get object key
      *
@@ -638,7 +638,7 @@ class PatternOptions extends Options
         $this->objectNonCacheMethods = $this->normalizeObjectMethods($objectNonCacheMethods);
         return $this;
     }
-    
+
     /**
      * Get list of object methods for which NOT to cache return values
      *
@@ -663,7 +663,7 @@ class PatternOptions extends Options
         $this->publicDir = (string) $publicDir;
         return $this;
     }
-    
+
     /**
      * Get location of public directory
      *
@@ -695,7 +695,7 @@ class PatternOptions extends Options
         $this->storage = $storage;
         return $this;
     }
-    
+
     /**
      * Get storage adapter
      *
@@ -727,7 +727,7 @@ class PatternOptions extends Options
         $this->tagKey = $tagKey;
         return $this;
     }
-    
+
     /**
      * Get tag key
      *
@@ -752,7 +752,7 @@ class PatternOptions extends Options
         $this->tags = $tags;
         return $this;
     }
-    
+
     /**
      * Get tags
      *
@@ -781,7 +781,7 @@ class PatternOptions extends Options
         $this->tagStorage = $tagStorage;
         return $this;
     }
-    
+
     /**
      * Get storage adapter for tags
      *
@@ -798,8 +798,8 @@ class PatternOptions extends Options
     /**
      * Recursively apply strtolower on all values of an array, and return as a
      * list of unique values
-     * 
-     * @param  array $array 
+     *
+     * @param  array $array
      * @return array
      */
     protected function recursiveStrtolower(array $array)
@@ -811,11 +811,11 @@ class PatternOptions extends Options
 
     /**
      * Normalize object methods
-     * 
-     * Recursively casts values to lowercase, then determines if any are in a 
+     *
+     * Recursively casts values to lowercase, then determines if any are in a
      * list of methods not handled, raising an exception if so.
      *
-     * @param  array $methods 
+     * @param  array $methods
      * @return array
      * @throws Exception\InvalidArgumentException
      */
@@ -836,13 +836,13 @@ class PatternOptions extends Options
      *
      * Allows specifying a umask as either an octal or integer. If the umask
      * fails required permissions, raises an exception.
-     * 
-     * @param  int|string $mask 
-     * @param  callable Callback used to verify the umask is acceptable for the given purpose
+     *
+     * @param  int|string $umask
+     * @param  callable   $comparison Callback used to verify the umask is acceptable for the given purpose
      * @return int
      * @throws Exception\InvalidArgumentException
      */
-    protected function normalizeUmask($mask, $comparison)
+    protected function normalizeUmask($umask, $comparison)
     {
         if (is_string($umask)) {
             $umask = octdec($umask);
@@ -857,8 +857,8 @@ class PatternOptions extends Options
 
     /**
      * Create a storage object from a given specification
-     * 
-     * @param  array|string|StorageAdapter $storage 
+     *
+     * @param  array|string|StorageAdapter $storage
      * @return StorageAdapter
      */
     protected function storageFactory($storage)

--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -141,18 +141,6 @@ abstract class AbstractAdapter implements Adapter
      */
     public function setOptions($options)
     {
-        if (!is_array($options)
-            && !$options instanceof Traversable
-            && !$options instanceof AdapterOptions
-        ) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects an array, a Traversable object, or an AdapterOptions instance; '
-                . 'received "%s"',
-                __METHOD__,
-                (is_object($options) ? get_class($options) : gettype($options))
-            ));
-        }
-
         if (!$options instanceof AdapterOptions) {
             $options = new AdapterOptions($options);
         }

--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -726,7 +726,7 @@ abstract class AbstractAdapter implements Adapter
 
         $ret = true;
         foreach ($keyValuePairs as $key => $value) {
-            $ret = $this->decrementMulti($key, $value, $options) && $ret;
+            $ret = $this->decrementItem($key, $value, $options) && $ret;
         }
         return $ret;
     }

--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -684,7 +684,7 @@ abstract class AbstractAdapter implements Adapter
 
         $ret = true;
         foreach ($keyValuePairs as $key => $value) {
-            $ret = $this->incrementItems($key, $value, $options) && $ret;
+            $ret = $this->incrementItem($key, $value, $options) && $ret;
         }
         return $ret;
     }

--- a/library/Zend/Cache/Storage/Adapter/AbstractZendServer.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractZendServer.php
@@ -427,7 +427,6 @@ abstract class AbstractZendServer extends AbstractAdapter
         $this->normalizeOptions($options);
         $args = new ArrayObject(array(
             'key'     => & $key,
-            'value'   => & $value,
             'options' => & $options,
         ));
 

--- a/library/Zend/Cache/Storage/Adapter/AbstractZendServer.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractZendServer.php
@@ -287,7 +287,14 @@ abstract class AbstractZendServer extends AbstractAdapter
             }
 
             $internalKey = $options['namespace'] . self::NAMESPACE_SEPARATOR . $key;
-            $result      = ($this->zdcFetch($internalKey) !== false) ? array() : false;
+            if ($this->zdcFetch($internalKey) === false) {
+                if (!$options['ignore_missing_items']) {
+                    throw new Exception\ItemNotFoundException("Key '{$internalKey}' not found");
+                }
+                $result = false;
+            } else {
+                $result = array();
+            }
 
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {

--- a/library/Zend/Cache/Storage/Adapter/Apc.php
+++ b/library/Zend/Cache/Storage/Adapter/Apc.php
@@ -834,7 +834,6 @@ class Apc extends AbstractAdapter
         $this->normalizeKey($key);
         $args = new ArrayObject(array(
             'key'     => & $key,
-            'value'   => & $value,
             'options' => & $options,
         ));
 
@@ -1076,7 +1075,7 @@ class Apc extends AbstractAdapter
         }
 
         $args = new ArrayObject(array(
-            'key'     => & $key,
+            'keys'    => & $keys,
             'options' => & $options,
         ));
 

--- a/library/Zend/Cache/Storage/Adapter/Apc.php
+++ b/library/Zend/Cache/Storage/Adapter/Apc.php
@@ -118,18 +118,6 @@ class Apc extends AbstractAdapter
      */
     public function setOptions($options)
     {
-        if (!is_array($options)
-            && !$options instanceof Traversable
-            && !$options instanceof ApcOptions
-        ) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects an array, a Traversable object, or an ApcOptions instance; '
-                . 'received "%s"',
-                __METHOD__,
-                (is_object($options) ? get_class($options) : gettype($options))
-            ));
-        }
-
         if (!$options instanceof ApcOptions) {
             $options = new ApcOptions($options);
         }

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -79,18 +79,6 @@ class Filesystem extends AbstractAdapter
      */
     public function setOptions($options)
     {
-        if (!is_array($options)
-            && !$options instanceof Traversable
-            && !$options instanceof FilesystemOptions
-        ) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects an array, a Traversable object, or an FilesystemOptions instance; '
-                . 'received "%s"',
-                __METHOD__,
-                (is_object($options) ? get_class($options) : gettype($options))
-            ));
-        }
-
         if (!$options instanceof FilesystemOptions) {
             $options = new FilesystemOptions($options);
         }

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -1023,7 +1023,7 @@ class Filesystem extends AbstractAdapter
                 return $eventRs->last();
             }
 
-            if ( ($dirLevel = $baseOptions->getDirLevel()) ) {
+            if ($baseOptions->getDirLevel()) {
                 // removes only empty directories
                 $this->rmDir(
                     $baseOptions->getCacheDir(),
@@ -1323,7 +1323,8 @@ class Filesystem extends AbstractAdapter
             $keyInfo['atime'] = fileatime($keyInfo['filespec'] . '.dat');
         }
 
-        if ( ($info = $this->readInfoFile($keyInfo['filespec'] . '.ifo')) ) {
+        $info = $this->readInfoFile($keyInfo['filespec'] . '.ifo');
+        if ($info) {
             return $keyInfo + $info;
         }
 

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -1162,7 +1162,7 @@ class Filesystem extends AbstractAdapter
                     $error = ErrorHandler::stop();
                     if (!$mkdir) {
                         throw new Exception\RuntimeException(
-                            "Error creating directory '{$file}'", 0, $error
+                            "Error creating directory '{$path}'", 0, $error
                         );
                     }
                 }
@@ -1171,7 +1171,7 @@ class Filesystem extends AbstractAdapter
 
         $info = null;
         if ($baseOptions->getReadControl()) {
-            $info['hash'] = Utils::generateHash($this->getReadControlAlgo(), $data, true);
+            $info['hash'] = Utils::generateHash($this->getReadControlAlgo(), $value, true);
             $info['algo'] = $baseOptions->getReadControlAlgo();
         }
 
@@ -1368,7 +1368,7 @@ class Filesystem extends AbstractAdapter
         $error = ErrorHandler::stop();
         if (!$touch) {
             throw new Exception\RuntimeException(
-                "Error touching file '{$file}'", 0, $error
+                "Error touching file '{$keyInfo['filespec']}.dat'", 0, $error
             );
         }
     }
@@ -1443,19 +1443,19 @@ class Filesystem extends AbstractAdapter
 
                 // if MATCH_TAGS mode -> check if all given tags available in current cache
                 if (($mode & self::MATCH_TAGS_AND) == self::MATCH_TAGS_AND ) {
-                    if (!isset($meta['tags']) || count(array_diff($opts['tags'], $meta['tags'])) > 0) {
+                    if (!isset($meta['tags']) || count(array_diff($options['tags'], $meta['tags'])) > 0) {
                         continue;
                     }
 
                 // if MATCH_NO_TAGS mode -> check if no given tag available in current cache
                 } elseif( ($mode & self::MATCH_TAGS_NEGATE) == self::MATCH_TAGS_NEGATE ) {
-                    if (isset($meta['tags']) && count(array_diff($opts['tags'], $meta['tags'])) != count($opts['tags'])) {
+                    if (isset($meta['tags']) && count(array_diff($options['tags'], $meta['tags'])) != count($options['tags'])) {
                         continue;
                     }
 
                 // if MATCH_ANY_TAGS mode -> check if any given tag available in current cache
                 } elseif ( ($mode & self::MATCH_TAGS_OR) == self::MATCH_TAGS_OR ) {
-                    if (!isset($meta['tags']) || count(array_diff($opts['tags'], $meta['tags'])) == count($opts['tags'])) {
+                    if (!isset($meta['tags']) || count(array_diff($options['tags'], $meta['tags'])) == count($options['tags'])) {
                         continue;
                     }
 
@@ -1541,7 +1541,7 @@ class Filesystem extends AbstractAdapter
             // check tags only if one of the tag matching mode is selected
             if (($mode & 070) > 0) {
 
-                $info = $this->readInfoFile($filespec . '.ifo');
+                $info = $this->readInfoFile($pathnameSpec . '.ifo');
 
                 // if MATCH_TAGS mode -> check if all given tags available in current cache
                 if (($mode & self::MATCH_TAGS) == self::MATCH_TAGS ) {

--- a/library/Zend/Cache/Storage/Adapter/Memcached.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcached.php
@@ -93,18 +93,6 @@ class Memcached extends AbstractAdapter
      */
     public function setOptions($options)
     {
-        if (!is_array($options)
-            && !$options instanceof Traversable
-            && !$options instanceof MemcachedOptions
-        ) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects an array, a Traversable object, or a MemcachedOptions object; '
-                . 'received "%s"',
-                __METHOD__,
-                (is_object($options) ? get_class($options) : gettype($options))
-            ));
-        }
-
         if (!$options instanceof MemcachedOptions) {
             $options = new MemcachedOptions($options);
         }

--- a/library/Zend/Cache/Storage/Adapter/Memory.php
+++ b/library/Zend/Cache/Storage/Adapter/Memory.php
@@ -64,18 +64,6 @@ class Memory extends AbstractAdapter
      */
     public function setOptions($options)
     {
-        if (!is_array($options)
-            && !$options instanceof Traversable
-            && !$options instanceof MemoryOptions
-        ) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects an array, a Traversable object, or an MemoryOptions instance; '
-                . 'received "%s"',
-                __METHOD__,
-                (is_object($options) ? get_class($options) : gettype($options))
-            ));
-        }
-
         if (!$options instanceof MemoryOptions) {
             $options = new MemoryOptions($options);
         }

--- a/library/Zend/Cache/Storage/Adapter/Memory.php
+++ b/library/Zend/Cache/Storage/Adapter/Memory.php
@@ -657,7 +657,7 @@ class Memory extends AbstractAdapter
         }
 
         $this->normalizeOptions($options);
-        $args = ArrayObject(array(
+        $args = new ArrayObject(array(
             'keyValuePairs' => & $keyValuePairs,
             'options'       => & $options,
         ));

--- a/library/Zend/Cache/Storage/Adapter/WinCache.php
+++ b/library/Zend/Cache/Storage/Adapter/WinCache.php
@@ -81,17 +81,10 @@ class WinCache extends AbstractAdapter
      */
     public function setOptions($options)
     {
-        if (!is_array($options)
-            && !$options instanceof Traversable
-            && !$options instanceof WinCacheOptions
-        ) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects an array, a Traversable object; '
-                . 'received "%s"',
-                __METHOD__,
-                (is_object($options) ? get_class($options) : gettype($options))
-            ));
+        if (!$options instanceof WinCacheOptions) {
+            $options = new WinCacheOptions($options);
         }
+
         $this->options = $options;
         return $this;
     }

--- a/library/Zend/Cache/Storage/Adapter/WinCache.php
+++ b/library/Zend/Cache/Storage/Adapter/WinCache.php
@@ -780,7 +780,6 @@ class WinCache extends AbstractAdapter
         $this->normalizeKey($key);
         $args = new ArrayObject(array(
             'key'     => & $key,
-            'value'   => & $value,
             'options' => & $options,
         ));
 

--- a/library/Zend/Cache/Storage/Adapter/WinCache.php
+++ b/library/Zend/Cache/Storage/Adapter/WinCache.php
@@ -380,7 +380,7 @@ class WinCache extends AbstractAdapter
 
             $internalKey = $options['namespace'] . $baseOptions->getNamespaceSeparator() . $key;
 
-            $info     = wincache_ucache_info(true, $internalKey);
+            $info = wincache_ucache_info(true, $internalKey);
             if (isset($info['ucache_entries'][1])) {
                 $metadata = $info['ucache_entries'][1];
             }
@@ -620,7 +620,7 @@ class WinCache extends AbstractAdapter
             }
 
             $internalKey = $options['namespace'] . $baseOptions->getNamespaceSeparator() . $key;
-            if (!@wincache_ucache_add($internalKey, $value, $options['ttl'])) {
+            if (!wincache_ucache_add($internalKey, $value, $options['ttl'])) {
                 if (wincache_ucache_exists($internalKey)) {
                     throw new Exception\RuntimeException("Key '{$internalKey}' already exists");
                 }
@@ -977,8 +977,7 @@ class WinCache extends AbstractAdapter
                 return $eventRs->last();
             }
 
-            $result= wincache_ucache_clear();
-
+            $result = wincache_ucache_clear();
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             return $this->triggerException(__FUNCTION__, $args, $e);

--- a/library/Zend/Cache/Storage/Adapter/ZendServerDisk.php
+++ b/library/Zend/Cache/Storage/Adapter/ZendServerDisk.php
@@ -91,12 +91,12 @@ class ZendServerDisk extends AbstractZendServer
      * @return void
      * @throws Exception\RuntimeException
      */
-    protected function zdcStore($key, $value, $ttl)
+    protected function zdcStore($internalKey, $value, $ttl)
     {
-        if (!zend_disk_cache_store($key, $value, $ttl)) {
+        if (!zend_disk_cache_store($internalKey, $value, $ttl)) {
             $valueType = gettype($value);
             throw new Exception\RuntimeException(
-                "zend_disk_cache_store($internalKey, <{$valueType}>, {$options['ttl']}) failed"
+                "zend_disk_cache_store($internalKey, <{$valueType}>, {$ttl}) failed"
             );
         }
     }
@@ -108,9 +108,9 @@ class ZendServerDisk extends AbstractZendServer
      * @return mixed The stored value or FALSE if item wasn't found
      * @throws Exception\RuntimeException
      */
-    protected function zdcFetch($key)
+    protected function zdcFetch($internalKey)
     {
-        return zend_disk_cache_fetch((string)$key);
+        return zend_disk_cache_fetch((string)$internalKey);
     }
 
     /**
@@ -136,9 +136,9 @@ class ZendServerDisk extends AbstractZendServer
      * @return boolean
      * @throws Exception\RuntimeException
      */
-    protected function zdcDelete($key)
+    protected function zdcDelete($internalKey)
     {
-        return zend_disk_cache_delete($key);
+        return zend_disk_cache_delete($internalKey);
     }
 
     /**

--- a/library/Zend/Cache/Storage/Adapter/ZendServerDisk.php
+++ b/library/Zend/Cache/Storage/Adapter/ZendServerDisk.php
@@ -21,7 +21,8 @@
 
 namespace Zend\Cache\Storage\Adapter;
 
-use Zend\Cache\Utils,
+use ArrayObject,
+    Zend\Cache\Utils,
     Zend\Cache\Exception;
 
 /**

--- a/library/Zend/Cache/Storage/Adapter/ZendServerShm.php
+++ b/library/Zend/Cache/Storage/Adapter/ZendServerShm.php
@@ -21,7 +21,8 @@
 
 namespace Zend\Cache\Storage\Adapter;
 
-use Zend\Cache\Exception;
+use ArrayObject,
+    Zend\Cache\Exception;
 
 /**
  * @category   Zend

--- a/library/Zend/Cache/Storage/Adapter/ZendServerShm.php
+++ b/library/Zend/Cache/Storage/Adapter/ZendServerShm.php
@@ -96,12 +96,12 @@ class ZendServerShm extends AbstractZendServer
      * @return void
      * @throws Exception\RuntimeException
      */
-    protected function zdcStore($key, $value, $ttl)
+    protected function zdcStore($internalKey, $value, $ttl)
     {
-        if (!zend_shm_cache_store($key, $value, $ttl)) {
+        if (!zend_shm_cache_store($internalKey, $value, $ttl)) {
             $valueType = gettype($value);
             throw new Exception\RuntimeException(
-                "zend_disk_cache_store($internalKey, <{$valueType}>, {$options['ttl']}) failed"
+                "zend_disk_cache_store($internalKey, <{$valueType}>, {$ttl}) failed"
             );
         }
     }
@@ -113,9 +113,9 @@ class ZendServerShm extends AbstractZendServer
      * @return mixed The stored value or FALSE if item wasn't found
      * @throws Exception\RuntimeException
      */
-    protected function zdcFetch($key)
+    protected function zdcFetch($internalKey)
     {
-        return zend_shm_cache_fetch((string)$key);
+        return zend_shm_cache_fetch((string)$internalKey);
     }
 
     /**
@@ -141,9 +141,9 @@ class ZendServerShm extends AbstractZendServer
      * @return boolean
      * @throws Exception\RuntimeException
      */
-    protected function zdcDelete($key)
+    protected function zdcDelete($internalKey)
     {
-        return zend_shm_cache_delete($key);
+        return zend_shm_cache_delete($internalKey);
     }
 
     /**

--- a/library/Zend/Cache/Storage/Plugin/ExceptionHandler.php
+++ b/library/Zend/Cache/Storage/Plugin/ExceptionHandler.php
@@ -145,8 +145,9 @@ class ExceptionHandler extends AbstractPlugin
      */
     public function onException(ExceptionEvent $event)
     {
-        $options = $this->getOptions();
-        if (($callback = $options->getExceptionCallback())) {
+        $options  = $this->getOptions();
+        $callback = $options->getExceptionCallback();
+        if ($callback) {
             call_user_func($callback, $event->getException());
         }
 

--- a/library/Zend/Cache/Storage/Plugin/IgnoreUserAbort.php
+++ b/library/Zend/Cache/Storage/Plugin/IgnoreUserAbort.php
@@ -21,7 +21,8 @@
 
 namespace Zend\Cache\Storage\Plugin;
 
-use Zend\Cache\Storage\Adapter,
+use Zend\Cache\Exception,
+    Zend\Cache\Storage\Adapter,
     Zend\Cache\Storage\Event,
     Zend\EventManager\EventCollection;
 

--- a/tests/Zend/Cache/Storage/Adapter/CommonAdapterTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/CommonAdapterTest.php
@@ -980,7 +980,7 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->_storage->setItem('key', 'value'));
 
         // sleep 1 times before expire to touch the item
-        usleep($capabilities->getTtlPrecision() * 2000000);
+        usleep($capabilities->getTtlPrecision() * 1000000);
         $this->assertTrue($this->_storage->touchItem('key'));
 
         usleep($capabilities->getTtlPrecision() * 1000000);

--- a/tests/Zend/Cache/Storage/Adapter/ZendServerDiskTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/ZendServerDiskTest.php
@@ -46,7 +46,8 @@ class ZendServerDiskTest extends CommonAdapterTest
             }
         }
 
-        $this->_storage = new Cache\Storage\Adapter\ZendServerDisk();
+        $this->_options = new Cache\Storage\Adapter\AdapterOptions();
+        $this->_storage = new Cache\Storage\Adapter\ZendServerDisk($this->_options);
         parent::setUp();
     }
 

--- a/tests/Zend/Cache/Storage/Adapter/ZendServerShmTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/ZendServerShmTest.php
@@ -51,7 +51,8 @@ class ZendServerShmTest extends CommonAdapterTest
             }
         }
 
-        $this->_storage = new Cache\Storage\Adapter\ZendServerShm();
+        $this->_options = new Cache\Storage\Adapter\AdapterOptions();
+        $this->_storage = new Cache\Storage\Adapter\ZendServerShm($this->_options);
         parent::setUp();
     }
 


### PR DESCRIPTION
- tons of small fixes
- Now all tests of Zend\Cache\Storage\Adapter\ZendServer*-Adapters pass
- removed type check of options on setOptions because it will already done by Zend\Stdlib\Options
