### PR TITLE
Documentation: review documentation generator to create valid DocBook XML

### DIFF
--- a/bin/docbook_skeleton.php
+++ b/bin/docbook_skeleton.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 /**
  * Zend Framework

--- a/library/Zend/Code/Reflection/DocBlockReflection.php
+++ b/library/Zend/Code/Reflection/DocBlockReflection.php
@@ -103,9 +103,9 @@ class DocBlockReflection implements Reflection
      * @param Reflector|string $commentOrReflector
      * @return \Zend\Code\Reflection\DocBlockReflection
      */
-    public function __construct($commentOrReflector, Docblock\TagManager $tagManager = null)
+    public function __construct($commentOrReflector, DocBlock\TagManager $tagManager = null)
     {
-        $this->tagManager = $tagManager ?: new Docblock\TagManager(Docblock\TagManager::USE_DEFAULT_PROTOTYPES);
+        $this->tagManager = $tagManager ?: new DocBlock\TagManager(DocBlock\TagManager::USE_DEFAULT_PROTOTYPES);
 
         if ($commentOrReflector instanceof \Reflector) {
             $this->reflector = $commentOrReflector;

--- a/library/Zend/Docbook/SkeletonGenerator.php
+++ b/library/Zend/Docbook/SkeletonGenerator.php
@@ -95,14 +95,14 @@ class SkeletonGenerator
             $synop->appendChild($mparam);
             $item1->appendChild($synop);
 
-            $item2 = $dom->createElement('listitem');
-            $item2->appendChild($dom->createElement('para', $method->getShortDescription()));
-            $item2->appendChild($dom->createElement('para', $method->getLongDescription()));
-            $item2->appendChild($dom->createElement('para', 'Returns ' . $method->getReturnType()));
+            $item1->appendChild($dom->createElement('para', $method->getShortDescription()));
+            if ($method->getLongDescription()) {
+                $item1->appendChild($dom->createElement('para', $method->getLongDescription()));
+            }
+            $item1->appendChild($dom->createElement('para', 'Returns ' . $method->getReturnType()));
 
             $entry->appendChild($term);
             $entry->appendChild($item1);
-            $entry->appendChild($item2);
 
             $varlist->appendChild($entry);
         }


### PR DESCRIPTION
See PR #779
This will create:

``` xml
            <varlistentry xml:id="zend.barcode.barcode.methods.get-renderer-broker">
                <term>getRendererBroker</term>

                <listitem>
                    <methodsynopsis>
                        <methodname>getRendererBroker</methodname>
                        <methodparam>
                            <funcparams></funcparams>
                        </methodparam>
                    </methodsynopsis>
                    <para>Get the renderer broker</para>
                    <para>Returns Zend\Loader\Broker</para>
                </listitem>
            </varlistentry>
```

Another valid possibility is:

``` xml
            <varlistentry xml:id="zend.barcode.barcode.methods.get-renderer-broker">
                <term>getRendererBroker</term>

                <listitem>
                    <methodsynopsis>
                        <methodname>getRendererBroker</methodname>
                        <methodparam>
                            <funcparams></funcparams>
                        </methodparam>
                    </methodsynopsis>
                </listitem>
                <listitem>
                    <para>Get the renderer broker</para>
                    <para>Returns Zend\Loader\Broker</para>
                </listitem>
            </varlistentry>
```
