### PR TITLE
Fix bug where priority was not passed to wrapping part route

### DIFF
--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -123,7 +123,10 @@ class TreeRouteStack extends SimpleRouteStack
                 'route_broker'  => $this->routeBroker,
             );
 
+            $priority = (isset($route->priority) ? $route->priority : null);
+            
             $route = $this->routeBroker->load('part', $options);
+            $route->priority = $priority;
         }
 
         return $route;

--- a/tests/Zend/Mvc/Router/Http/TreeRouteStackTest.php
+++ b/tests/Zend/Mvc/Router/Http/TreeRouteStackTest.php
@@ -216,6 +216,43 @@ class TreeRouteStackTest extends TestCase
         $this->assertEquals($uri, $stack->getRequestUri());
     }
 
+    public function testPriorityIsPassedToPartRoute()
+    {
+        $stack = new TreeRouteStack();
+        $stack->addRoutes(array(
+            'foo' => array(
+                'type' => 'Literal',
+                'priority' => 1000,
+                'options' => array(
+                    'route' => '/foo',
+                    'defaults' => array(
+                        'controller' => 'foo',
+                    ),
+                ),
+                'may_terminate' => true,
+                'child_routes' => array(
+                    'bar' => array(
+                        'type' => 'Literal',
+                        'options' => array(
+                            'route' => '/bar',
+                            'defaults' => array(
+                                'controller' => 'foo',
+                                'action'     => 'bar',
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ));
+
+        $reflectedClass    = new \ReflectionClass($stack);
+        $reflectedProperty = $reflectedClass->getProperty('routes');
+        $reflectedProperty->setAccessible(true);
+        $routes = $reflectedProperty->getValue($stack);
+
+        $this->assertEquals(1000, $routes->get('foo')->priority);
+    }
+
     public function testFactory()
     {
         $tester = new FactoryTester($this);


### PR DESCRIPTION
When passing a priority for a route which has child routes (part route), it
was not passing the priority along to the wrapping part route. Worked with
@DASPRiD to debug and test this.
