### PR TITLE
Feature/module locator registration

### DIFF
--- a/library/Zend/Module/Consumer/LocatorRegistered.php
+++ b/library/Zend/Module/Consumer/LocatorRegistered.php
@@ -2,4 +2,13 @@
 
 namespace Zend\Module\Consumer;
 
+/**
+ * LocatorRegistered 
+ *
+ * By implementing this interface in a Module class, the instance of the Module 
+ * class will be automatically injected into any DI-configured object which has 
+ * a constructor or setter parameter which is type hinted with the Module class 
+ * name. Implementing this interface obviously does not require adding any 
+ * methods to your class.
+ */
 interface LocatorRegistered {}

--- a/library/Zend/Module/Consumer/LocatorRegistered.php
+++ b/library/Zend/Module/Consumer/LocatorRegistered.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Zend\Module\Consumer;
+
+interface LocatorRegistered {}

--- a/library/Zend/Module/Listener/ConfigListener.php
+++ b/library/Zend/Module/Listener/ConfigListener.php
@@ -232,9 +232,6 @@ class ConfigListener extends AbstractListener
      */
     protected function mergeGlobPath($globPath)
     {
-        if (true === $this->skipConfig) {
-            return $this;
-        }
         foreach (glob($globPath, GLOB_BRACE) as $path) {
             $pathInfo = pathinfo($path);
             switch (strtolower($pathInfo['extension'])) {

--- a/library/Zend/Module/Listener/DefaultListenerAggregate.php
+++ b/library/Zend/Module/Listener/DefaultListenerAggregate.php
@@ -29,14 +29,16 @@ class DefaultListenerAggregate extends AbstractListener
     {
         $options = $this->getOptions();
         $configListener = $this->getConfigListener();
+        $locatorRegistrationListener = new LocatorRegistrationListener($options);
         $moduleAutoloader = new ModuleAutoloader($options->getModulePaths());
 
         $this->listeners[] = $events->attach('loadModules.pre', array($moduleAutoloader, 'register'), 1000);
         $this->listeners[] = $events->attach('loadModule.resolve', new ModuleResolverListener, 1000);
         $this->listeners[] = $events->attach('loadModule', new AutoloaderListener($options), 2000);
         $this->listeners[] = $events->attach('loadModule', new InitTrigger($options), 1000);
-        $this->listeners[] = $events->attach('loadModule', new LocatorRegistrationListener($options), 1000);
+        $this->listeners[] = $events->attachAggregate($locatorRegistrationListener);
         $this->listeners[] = $events->attachAggregate($configListener);
+
         return $this;
     }
 

--- a/library/Zend/Module/Listener/DefaultListenerAggregate.php
+++ b/library/Zend/Module/Listener/DefaultListenerAggregate.php
@@ -35,6 +35,7 @@ class DefaultListenerAggregate extends AbstractListener
         $this->listeners[] = $events->attach('loadModule.resolve', new ModuleResolverListener, 1000);
         $this->listeners[] = $events->attach('loadModule', new AutoloaderListener($options), 2000);
         $this->listeners[] = $events->attach('loadModule', new InitTrigger($options), 1000);
+        $this->listeners[] = $events->attach('loadModule', new LocatorRegistrationListener($options), 1000);
         $this->listeners[] = $events->attachAggregate($configListener);
         return $this;
     }

--- a/library/Zend/Module/Listener/LocatorRegistrationListener.php
+++ b/library/Zend/Module/Listener/LocatorRegistrationListener.php
@@ -21,11 +21,28 @@ class LocatorRegistrationListener extends AbstractListener implements ListenerAg
      */
     protected $listeners = array();
 
+    /**
+     * __invoke 
+     *
+     * Convenience method for manually attaching an instance of this class as a listener.
+     * 
+     * @param ModuleEvent $e 
+     * @return void
+     */
     public function __invoke(ModuleEvent $e)
     {
         return $this->loadModule($e);
     }
 
+    /**
+     * loadModule 
+     *
+     * Check each loaded module to see if it implements LocatorRegistered. If it 
+     * does, we add it to an internal array for later.
+     * 
+     * @param ModuleEvent $e 
+     * @return void
+     */
     public function loadModule(ModuleEvent $e)
     {
         if (!$e->getModule() instanceof LocatorRegistered) {
@@ -34,6 +51,14 @@ class LocatorRegistrationListener extends AbstractListener implements ListenerAg
         $this->modules[] = $e->getModule();
     }
 
+    /**
+     * loadModulesPost 
+     *
+     * Once all the modules are loaded, loop 
+     * 
+     * @param Event $e 
+     * @return void
+     */
     public function loadModulesPost(Event $e)
     {
         if (0 === count($this->modules)) {
@@ -45,6 +70,17 @@ class LocatorRegistrationListener extends AbstractListener implements ListenerAg
         $events->attach('bootstrap', 'bootstrap', array($this, 'addTypePreference'), 1000);
     }
 
+    /**
+     * addTypePreference 
+     *
+     * This is ran during the MVC bootstrap event because it requires access to 
+     * the DI container.
+     *
+     * @TODO: Check the application / locator / etc a bit better to make sure 
+     * the env looks how we're expecting it to?
+     * @param Event $e 
+     * @return void
+     */
     public function addTypePreference(Event $e)
     {
         $im = $e->getParam('application')->getLocator()->instanceManager();
@@ -61,7 +97,7 @@ class LocatorRegistrationListener extends AbstractListener implements ListenerAg
      * Attach one or more listeners
      *
      * @param EventCollection $events
-     * @return ConfigListener
+     * @return LocatorRegistrationListener
      */
     public function attach(EventCollection $events)
     {
@@ -74,7 +110,7 @@ class LocatorRegistrationListener extends AbstractListener implements ListenerAg
      * Detach all previously attached listeners
      *
      * @param EventCollection $events
-     * @return void
+     * @return LocatorRegistrationListener
      */
     public function detach(EventCollection $events)
     {

--- a/library/Zend/Module/Listener/LocatorRegistrationListener.php
+++ b/library/Zend/Module/Listener/LocatorRegistrationListener.php
@@ -22,19 +22,6 @@ class LocatorRegistrationListener extends AbstractListener implements ListenerAg
     protected $listeners = array();
 
     /**
-     * __invoke 
-     *
-     * Convenience method for manually attaching an instance of this class as a listener.
-     * 
-     * @param ModuleEvent $e 
-     * @return void
-     */
-    public function __invoke(ModuleEvent $e)
-    {
-        return $this->loadModule($e);
-    }
-
-    /**
      * loadModule 
      *
      * Check each loaded module to see if it implements LocatorRegistered. If it 

--- a/library/Zend/Module/Listener/LocatorRegistrationListener.php
+++ b/library/Zend/Module/Listener/LocatorRegistrationListener.php
@@ -51,11 +51,13 @@ class LocatorRegistrationListener extends AbstractListener implements ListenerAg
     {
         $events = StaticEventManager::getInstance();
         $moduleManager = $e->getTarget();
+
+        // Shared instance for module manager
         $events->attach('bootstrap', 'bootstrap', function ($e) use ($moduleManager) {
             $moduleClassName = get_class($moduleManager);
             $im = $e->getParam('application')->getLocator()->instanceManager();
-            if (!$im->hasTypePreferences($moduleClassName)) {
-                $im->addTypePreference($moduleClassName, $moduleManager);
+            if (!$im->hasSharedInstance($moduleClassName)) {
+                $im->addSharedInstance($moduleManager, $moduleClassName);
             }
         }, 1000);
 
@@ -85,8 +87,8 @@ class LocatorRegistrationListener extends AbstractListener implements ListenerAg
 
         foreach ($this->modules as $module) {
             $moduleClassName = get_class($module);
-            if (!$im->hasTypePreferences($moduleClassName)) {
-                $im->addTypePreference($moduleClassName, $module);
+            if (!$im->hasSharedInstance($moduleClassName)) {
+                $im->addSharedInstance($module, $moduleClassName);
             }
         }
     }

--- a/library/Zend/Module/Listener/LocatorRegistrationListener.php
+++ b/library/Zend/Module/Listener/LocatorRegistrationListener.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Zend\Module\Listener;
+
+use Zend\EventManager\StaticEventManager,
+    Zend\Module\ModuleEvent,
+    Zend\EventManager\Event;
+
+class LocatorRegistrationListener extends AbstractListener
+{
+    protected $moduleEvent;
+
+    public function __invoke(ModuleEvent $e)
+    {
+        $this->moduleEvent = $e;
+        $events = StaticEventManager::getInstance();
+        $events->attach('bootstrap', 'bootstrap', array($this, 'addTypePreference'), 1000);
+    }
+
+    public function addTypePreference(Event $e)
+    {
+        $moduleInstance = $this->moduleEvent->getModule();
+        $moduleClassName = get_class($moduleInstance);
+
+        $di = $e->getParam('application')->getLocator();
+        $im = $di->instanceManager();
+        if ($im->hasTypePreferences($moduleClassName)) return;
+        $im->addTypePreference($moduleClassName, $moduleInstance);
+    }
+}

--- a/library/Zend/Module/Listener/LocatorRegistrationListener.php
+++ b/library/Zend/Module/Listener/LocatorRegistrationListener.php
@@ -3,28 +3,88 @@
 namespace Zend\Module\Listener;
 
 use Zend\EventManager\StaticEventManager,
+    Zend\EventManager\Event,
     Zend\Module\ModuleEvent,
-    Zend\EventManager\Event;
+    Zend\Module\Consumer\LocatorRegistered,
+    Zend\EventManager\EventCollection,
+    Zend\EventManager\ListenerAggregate;
 
-class LocatorRegistrationListener extends AbstractListener
+class LocatorRegistrationListener extends AbstractListener implements ListenerAggregate
 {
-    protected $moduleEvent;
+    /**
+     * @var array
+     */
+    protected $modules = array();
+
+    /**
+     * @var array
+     */
+    protected $listeners = array();
 
     public function __invoke(ModuleEvent $e)
     {
-        $this->moduleEvent = $e;
+        return $this->loadModule($e);
+    }
+
+    public function loadModule(ModuleEvent $e)
+    {
+        if (!$e->getModule() instanceof LocatorRegistered) {
+            return;
+        }
+        $this->modules[] = $e->getModule();
+        $events = StaticEventManager::getInstance();
+        $events->attach('bootstrap', 'bootstrap', array($this, 'addTypePreference'), 1000);
+    }
+
+    public function loadModulesPost(Event $e)
+    {
+        if (0 === count($this->modules)) {
+            return;
+        }
+
+        // Attach to the bootstrap event if there are modules we need to process
         $events = StaticEventManager::getInstance();
         $events->attach('bootstrap', 'bootstrap', array($this, 'addTypePreference'), 1000);
     }
 
     public function addTypePreference(Event $e)
     {
-        $im              = $e->getParam('application')->getLocator()->instanceManager();
-        $moduleInstance  = $this->moduleEvent->getModule();
-        $moduleClassName = get_class($moduleInstance);
+        $im = $e->getParam('application')->getLocator()->instanceManager();
 
-        if (!$im->hasTypePreferences($moduleClassName)) {
-            $im->addTypePreference($moduleClassName, $moduleInstance);
+        foreach ($this->modules as $module) {
+            $moduleClassName = get_class($module);
+            if (!$im->hasTypePreferences($moduleClassName)) {
+                $im->addTypePreference($moduleClassName, $module);
+            }
         }
+    }
+
+    /**
+     * Attach one or more listeners
+     *
+     * @param EventCollection $events
+     * @return ConfigListener
+     */
+    public function attach(EventCollection $events)
+    {
+        $this->listeners[] = $events->attach('loadModule', array($this, 'loadModule'), 1000);
+        $this->listeners[] = $events->attach('loadModules.post', array($this, 'loadModulesPost'), 9000);
+        return $this;
+    }
+
+    /**
+     * Detach all previously attached listeners
+     *
+     * @param EventCollection $events
+     * @return void
+     */
+    public function detach(EventCollection $events)
+    {
+        foreach ($this->listeners as $key => $listener) {
+            $events->detach($listener);
+            unset($this->listeners[$key]);
+        }
+        $this->listeners = array();
+        return $this;
     }
 }

--- a/library/Zend/Module/Listener/LocatorRegistrationListener.php
+++ b/library/Zend/Module/Listener/LocatorRegistrationListener.php
@@ -19,12 +19,12 @@ class LocatorRegistrationListener extends AbstractListener
 
     public function addTypePreference(Event $e)
     {
-        $moduleInstance = $this->moduleEvent->getModule();
+        $im              = $e->getParam('application')->getLocator()->instanceManager();
+        $moduleInstance  = $this->moduleEvent->getModule();
         $moduleClassName = get_class($moduleInstance);
 
-        $di = $e->getParam('application')->getLocator();
-        $im = $di->instanceManager();
-        if ($im->hasTypePreferences($moduleClassName)) return;
-        $im->addTypePreference($moduleClassName, $moduleInstance);
+        if (!$im->hasTypePreferences($moduleClassName)) {
+            $im->addTypePreference($moduleClassName, $moduleInstance);
+        }
     }
 }

--- a/library/Zend/Module/Listener/LocatorRegistrationListener.php
+++ b/library/Zend/Module/Listener/LocatorRegistrationListener.php
@@ -32,8 +32,6 @@ class LocatorRegistrationListener extends AbstractListener implements ListenerAg
             return;
         }
         $this->modules[] = $e->getModule();
-        $events = StaticEventManager::getInstance();
-        $events->attach('bootstrap', 'bootstrap', array($this, 'addTypePreference'), 1000);
     }
 
     public function loadModulesPost(Event $e)

--- a/library/Zend/Module/Manager.php
+++ b/library/Zend/Module/Manager.php
@@ -128,6 +128,20 @@ class Manager implements ModuleHandler
     }
 
     /**
+     * Get an instance of a module class by the module name 
+     * 
+     * @param string $moduleName 
+     * @return mixed
+     */
+    public function getModule($moduleName)
+    {
+        if (!isset($this->loadedModules[$moduleName])) {
+            return null;
+        }
+        return $this->loadedModules[$moduleName];
+    }
+
+    /**
      * Get the array of module names that this manager should load.
      *
      * @return array

--- a/tests/Zend/Module/Listener/DefaultListenerAggregateTest.php
+++ b/tests/Zend/Module/Listener/DefaultListenerAggregateTest.php
@@ -72,9 +72,11 @@ class DefaultListenerAggregateTest extends TestCase
                 'Zend\Module\Listener\AutoloaderListener',
                 'Zend\Module\Listener\InitTrigger',
                 'Zend\Module\Listener\ConfigListener',
+                'Zend\Module\Listener\LocatorRegistrationListener',
             ),
             'loadModules.post' => array(
                 'Zend\Module\Listener\ConfigListener',
+                'Zend\Module\Listener\LocatorRegistrationListener',
             ),
         );
         foreach ($expectedEvents as $event => $expectedListeners) {

--- a/tests/Zend/Module/Listener/LocatorRegistrationListenerTest.php
+++ b/tests/Zend/Module/Listener/LocatorRegistrationListenerTest.php
@@ -79,10 +79,10 @@ class LocatorRegistrationTest extends TestCase
 
         $this->assertEquals(1, count($typePreferences1));
         $this->assertInstanceOf('ListenerTestModule\Module', $typePreferences1[0]);
-        $this->assertEquals(spl_object_hash($this->module), spl_object_hash($locator->get('Foo\Bar')->module));
+        $this->assertSame($this->module, $locator->get('Foo\Bar')->module);
 
         $this->assertEquals(1, count($typePreferences2));
         $this->assertInstanceOf('Zend\Module\Manager', $typePreferences2[0]);
-        $this->assertEquals(spl_object_hash($this->moduleManager), spl_object_hash($locator->get('Foo\Bar')->moduleManager));
+        $this->assertSame($this->moduleManager, $locator->get('Foo\Bar')->moduleManager);
     }
 }

--- a/tests/Zend/Module/Listener/LocatorRegistrationListenerTest.php
+++ b/tests/Zend/Module/Listener/LocatorRegistrationListenerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace ZendTest\Module\Listener;
+
+use ArrayObject,
+    InvalidArgumentException,
+    PHPUnit_Framework_TestCase as TestCase,
+    Zend\Loader\AutoloaderFactory,
+    Zend\Loader\ModuleAutoloader,
+    Zend\Mvc\Bootstrap,
+    Zend\Mvc\Application,
+    Zend\Config\Config,
+    Zend\Module\Listener\LocatorRegistrationListener,
+    Zend\Module\Listener\ModuleResolverListener,
+    Zend\Module\Listener\ListenerOptions,
+    Zend\Module\Manager;
+
+class LocatorRegistrationTest extends TestCase
+{
+    public $module;
+
+    public function setUp()
+    {
+        // Store original autoloaders
+        $this->loaders = spl_autoload_functions();
+        if (!is_array($this->loaders)) {
+            // spl_autoload_functions does not return empty array when no
+            // autoloaders registered...
+            $this->loaders = array();
+        }
+
+        // Store original include_path
+        $this->includePath = get_include_path();
+
+        $autoloader = new ModuleAutoloader(array(
+            dirname(__DIR__) . '/TestAsset',
+        ));
+        $autoloader->register();
+
+        $this->moduleManager = new Manager(array('ListenerTestModule'));
+        $this->moduleManager->events()->attach('loadModule.resolve', new ModuleResolverListener, 1000);
+    }
+
+    public function tearDown()
+    {
+        // Restore original autoloaders
+        AutoloaderFactory::unregisterAutoloaders();
+        $loaders = spl_autoload_functions();
+        if (is_array($loaders)) {
+            foreach ($loaders as $loader) {
+                spl_autoload_unregister($loader);
+            }
+        }
+
+        foreach ($this->loaders as $loader) {
+            spl_autoload_register($loader);
+        }
+
+        // Restore original include_path
+        set_include_path($this->includePath);
+    }
+
+    public function testModuleClassIsRegisteredWithDiAndInjectedWithTypeHints()
+    {
+        $locatorRegistrationListener = new LocatorRegistrationListener;
+        $this->moduleManager->events()->attachAggregate($locatorRegistrationListener);
+        $test = $this;
+        $this->moduleManager->events()->attach('loadModule', function ($e) use ($test) {
+            $test->module = $e->getModule();
+        }, -1000);
+        $this->moduleManager->loadModules();
+
+        $bootstrap       = new Bootstrap(new Config(array('di' => array())));
+        $application     = new Application;
+        $bootstrap->bootstrap($application);
+        $locator         = $application->getLocator();
+        $typePreferences = $locator->instanceManager()->getTypePreferences('ListenerTestModule\Module');
+
+        $this->assertEquals(1, count($typePreferences));
+        $this->assertInstanceOf('ListenerTestModule\Module', $typePreferences[0]);
+        $this->assertEquals(spl_object_hash($this->module), spl_object_hash($locator->get('Foo\Bar')->module));
+    }
+}

--- a/tests/Zend/Module/Listener/LocatorRegistrationListenerTest.php
+++ b/tests/Zend/Module/Listener/LocatorRegistrationListenerTest.php
@@ -74,10 +74,15 @@ class LocatorRegistrationTest extends TestCase
         $application     = new Application;
         $bootstrap->bootstrap($application);
         $locator         = $application->getLocator();
-        $typePreferences = $locator->instanceManager()->getTypePreferences('ListenerTestModule\Module');
+        $typePreferences1 = $locator->instanceManager()->getTypePreferences('ListenerTestModule\Module');
+        $typePreferences2 = $locator->instanceManager()->getTypePreferences('Zend\Module\Manager');
 
-        $this->assertEquals(1, count($typePreferences));
-        $this->assertInstanceOf('ListenerTestModule\Module', $typePreferences[0]);
+        $this->assertEquals(1, count($typePreferences1));
+        $this->assertInstanceOf('ListenerTestModule\Module', $typePreferences1[0]);
         $this->assertEquals(spl_object_hash($this->module), spl_object_hash($locator->get('Foo\Bar')->module));
+
+        $this->assertEquals(1, count($typePreferences2));
+        $this->assertInstanceOf('Zend\Module\Manager', $typePreferences2[0]);
+        $this->assertEquals(spl_object_hash($this->moduleManager), spl_object_hash($locator->get('Foo\Bar')->moduleManager));
     }
 }

--- a/tests/Zend/Module/Listener/LocatorRegistrationListenerTest.php
+++ b/tests/Zend/Module/Listener/LocatorRegistrationListenerTest.php
@@ -60,7 +60,7 @@ class LocatorRegistrationTest extends TestCase
         set_include_path($this->includePath);
     }
 
-    public function testModuleClassIsRegisteredWithDiAndInjectedWithTypeHints()
+    public function testModuleClassIsRegisteredWithDiAndInjectedWithSharedInstances()
     {
         $locatorRegistrationListener = new LocatorRegistrationListener;
         $this->moduleManager->events()->attachAggregate($locatorRegistrationListener);
@@ -74,15 +74,13 @@ class LocatorRegistrationTest extends TestCase
         $application     = new Application;
         $bootstrap->bootstrap($application);
         $locator         = $application->getLocator();
-        $typePreferences1 = $locator->instanceManager()->getTypePreferences('ListenerTestModule\Module');
-        $typePreferences2 = $locator->instanceManager()->getTypePreferences('Zend\Module\Manager');
+        $sharedInstance1 = $locator->instanceManager()->getSharedInstance('ListenerTestModule\Module');
+        $sharedInstance2 = $locator->instanceManager()->getSharedInstance('Zend\Module\Manager');
 
-        $this->assertEquals(1, count($typePreferences1));
-        $this->assertInstanceOf('ListenerTestModule\Module', $typePreferences1[0]);
+        $this->assertInstanceOf('ListenerTestModule\Module', $sharedInstance1);
         $this->assertSame($this->module, $locator->get('Foo\Bar')->module);
 
-        $this->assertEquals(1, count($typePreferences2));
-        $this->assertInstanceOf('Zend\Module\Manager', $typePreferences2[0]);
+        $this->assertInstanceOf('Zend\Module\Manager', $sharedInstance2);
         $this->assertSame($this->moduleManager, $locator->get('Foo\Bar')->moduleManager);
     }
 }

--- a/tests/Zend/Module/ManagerTest.php
+++ b/tests/Zend/Module/ManagerTest.php
@@ -81,6 +81,9 @@ class ManagerTest extends TestCase
         $loadedModules = $moduleManager->getLoadedModules();
         $this->assertInstanceOf('BarModule\Module', $loadedModules['BarModule']);
         $this->assertInstanceOf('BazModule\Module', $loadedModules['BazModule']);
+        $this->assertInstanceOf('BarModule\Module', $moduleManager->getModule('BarModule'));
+        $this->assertInstanceOf('BazModule\Module', $moduleManager->getModule('BazModule'));
+        $this->assertNull($moduleManager->getModule('NotLoaded'));
         $config = $configListener->getMergedConfig();
         $this->assertSame('foo', $config->bar);
         $this->assertSame('bar', $config->baz);

--- a/tests/Zend/Module/TestAsset/ListenerTestModule/Module.php
+++ b/tests/Zend/Module/TestAsset/ListenerTestModule/Module.php
@@ -2,9 +2,10 @@
 
 namespace ListenerTestModule;
 
-use Zend\Module\Consumer\AutoloaderProvider;
+use Zend\Module\Consumer\AutoloaderProvider,
+    Zend\Module\Consumer\LocatorRegistered;
 
-class Module implements AutoloaderProvider
+class Module implements AutoloaderProvider, LocatorRegistered
 {
     public $initCalled = false;
     public $getConfigCalled = false;

--- a/tests/Zend/Module/TestAsset/ListenerTestModule/src/Foo/Bar.php
+++ b/tests/Zend/Module/TestAsset/ListenerTestModule/src/Foo/Bar.php
@@ -2,14 +2,17 @@
 
 namespace Foo;
 
-use ListenerTestModule\Module;
+use ListenerTestModule\Module,
+    Zend\Module\Manager;
 
 class Bar
 {
     public $module;
+    public $moduleManager;
 
-    public function __construct(Module $module)
+    public function __construct(Module $module, Manager $moduleManager)
     {
-        $this->module = $module;
+        $this->module  = $module;
+        $this->moduleManager = $moduleManager;
     }
 }

--- a/tests/Zend/Module/TestAsset/ListenerTestModule/src/Foo/Bar.php
+++ b/tests/Zend/Module/TestAsset/ListenerTestModule/src/Foo/Bar.php
@@ -2,5 +2,14 @@
 
 namespace Foo;
 
+use ListenerTestModule\Module;
+
 class Bar
-{}
+{
+    public $module;
+
+    public function __construct(Module $module)
+    {
+        $this->module = $module;
+    }
+}


### PR DESCRIPTION
- New module listener: you can implement Zend\Module\Consumer\LocatorRegistered in your Module class and the listener will register the module instance as a shared instance in DI.
- In any DI configured class you can add a setter or constructor parameter now that has a typehint of the Module class you want, as long as it implements LocatorRegistered and it will be passed the active instance of that module class. This is very handy for module options.
- Additionally, you can parameter hint Zend\Module\Manager and the module manager will be injected into your class.
- Includes unit tests, 100% coverage.
