### PR TITLE
Session Handling: SaveHandler

### DIFF
--- a/library/Zend/Session/AbstractManager.php
+++ b/library/Zend/Session/AbstractManager.php
@@ -57,6 +57,11 @@ abstract class AbstractManager implements Manager
      */
     protected $_storageDefaultClass = 'Zend\\Session\\Storage\\SessionStorage';
 
+    /**
+     * @var SaveHandler
+     */
+    protected $_saveHandler;
+
 
     /**
      * Constructor
@@ -66,9 +71,10 @@ abstract class AbstractManager implements Manager
      * 
      * @param  null|string|Configuration|array $config 
      * @param  null|string|Storage $storage 
+     * @param  null|string|SaveHandler $saveHandler
      * @return void
      */
-    public function __construct($config = null, $storage = null)
+    public function __construct($config = null, $storage = null, $saveHandler = null)
     {
         if ($config instanceof \Zend\Config\Config) {
             $config = $config->toArray();
@@ -93,6 +99,7 @@ abstract class AbstractManager implements Manager
         
         $this->_setConfig($config);
         $this->_setStorage($storage);
+        $this->_setSaveHandler($saveHandler);
     }
 
     /**
@@ -182,5 +189,44 @@ abstract class AbstractManager implements Manager
     public function getStorage()
     {
         return $this->_storage;
+    }
+
+    /**
+     * Set session save handler object
+     *
+     * Allows passing a null value, string class name, or SaveHandler object.  If a
+     * null value is passed, no explicit save handler will be used.
+     *
+     * @param null|string|SaveHandler $saveHandler
+     * @return void
+     */
+    public function _setSaveHandler($saveHandler)
+    {
+        if (null === $saveHandler) {
+            return ;
+        }
+
+        if (is_string($saveHandler)) {
+            if (!class_exists($saveHandler)) {
+                throw new Exception\InvalidArgumentException('Class provided for SaveHandler does not exist');
+            }
+            $saveHandler = new $saveHandler();
+        }
+
+        if (!$saveHandler instanceof SaveHandler) {
+            throw new Exception\InvalidArgumentException('SaveHandler type provided is invalid; must implement Zend\\Session\\SaveHandler');
+        }
+
+        $this->_saveHandler = $saveHandler;
+    }
+
+    /**
+     * Get SaveHandler Object
+     *
+     * @return SaveHandler
+     */
+    public function getSaveHandler()
+    {
+        return $this->_saveHandler;
     }
 }

--- a/library/Zend/Session/AbstractManager.php
+++ b/library/Zend/Session/AbstractManager.php
@@ -88,6 +88,12 @@ abstract class AbstractManager implements Manager
                         }
                         unset($config[$key]);
                         break;
+                    case 'savehandler':
+                        if (null === $saveHandler) {
+                            $saveHandler = $value;
+                        }
+                        unset($config[$key]);
+                        break;
                 }
             }
         } elseif (is_string($config)) {

--- a/library/Zend/Session/Configuration/SessionConfiguration.php
+++ b/library/Zend/Session/Configuration/SessionConfiguration.php
@@ -170,7 +170,7 @@ class SessionConfiguration extends StandardConfiguration
      * @return SessionConfiguration
      * @throws SessionException
      */
-    public function setSaveHandler($saveHandler)
+    public function setPhpSaveHandler($saveHandler)
     {
         $saveHandler = (string) $saveHandler;
         set_error_handler(array($this, '_handleError'));

--- a/library/Zend/Session/Manager.php
+++ b/library/Zend/Session/Manager.php
@@ -35,10 +35,11 @@ use Zend\EventManager\EventCollection;
  */
 interface Manager
 {
-    public function __construct($config = null, $storage = null);
+    public function __construct($config = null, $storage = null, $saveHandler = null);
 
     public function getConfig();
     public function getStorage();
+    public function getSaveHandler();
     
     public function sessionExists();
     public function start();

--- a/library/Zend/Session/SaveHandler.php
+++ b/library/Zend/Session/SaveHandler.php
@@ -33,21 +33,6 @@ namespace Zend\Session;
 interface SaveHandler
 {
     /**
-     * Set session manager
-     * 
-     * @param  Manager $manager 
-     * @return void
-     */
-    public function setManager(Manager $manager);
-
-    /**
-     * Retrieve session manager
-     * 
-     * @return Manager
-     */
-    public function getManager();
-
-    /**
      * Open Session - retrieve resources
      *
      * @param string $save_path

--- a/library/Zend/Session/SaveHandler/Cache.php
+++ b/library/Zend/Session/SaveHandler/Cache.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-webat this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Session
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Session\SaveHandler;
+
+use Zend\Session\SaveHandler as Savable,
+    Zend\Cache\Storage\Adapter as StorageAdapter;
+
+/**
+ * Cache session save handler
+ *
+ * @uses       Zend\Config
+ * @uses       Zend\Cache\Storage\Adapter
+ * @uses       Zend\Session\SaveHandler\Exception
+ * @category   Zend
+ * @package    Zend_Session
+ * @subpackage SaveHandler
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Cache implements Savable
+{
+    /**
+     * Session Save Path
+     *
+     * @var string
+     */
+    protected $sessionSavePath;
+
+    /**
+     * Session Name
+     *
+     * @var string
+     */
+    protected $sessionName;
+
+    /**
+     * Constructor
+     *
+     * @param  Zend\Cache\Storage\Adapter|null $storageAdapter
+     * @return void
+     * @throws Zend\Session\SaveHandler\Exception
+     */
+    public function __construct($storageAdapter)
+    {
+        $this->_setStorageAdapter($storageAdapter);
+    }
+
+    /**
+     * Open Session
+     *
+     * @param string $save_path
+     * @param string $name
+     * @return boolean
+     */
+    public function open($save_path, $name)
+    {
+        // @todo figure out if we want to use these
+        $this->sessionSavePath = $save_path;
+        $this->sessionName     = $name;
+
+        return true;
+    }
+
+    /**
+     * Close session
+     *
+     * @return boolean
+     */
+    public function close()
+    {
+        return true;
+    }
+
+    /**
+     * Read session data
+     *
+     * @param string $id
+     * @return string
+     */
+    public function read($id)
+    {
+        return $this->getStorageAdapter()->getItem($id);
+    }
+
+    /**
+     * Write session data
+     *
+     * @param string $id
+     * @param string $data
+     * @return boolean
+     */
+    public function write($id, $data)
+    {
+        return $this->getStorageAdapter()->setItem($id, $data);
+    }
+
+    /**
+     * Destroy session
+     *
+     * @param string $id
+     * @return boolean
+     */
+    public function destroy($id)
+    {
+        return $this->getStorageAdapter()->removeItem($id);
+    }
+
+    /**
+     * Garbage Collection
+     *
+     * @param int $maxlifetime
+     * @return true
+     */
+    public function gc($maxlifetime)
+    {
+        return true;
+    }
+
+    /**
+     * Set cache storage adapter
+     *
+     * Allows passing a string class name or StorageAdapter object.
+     *
+     * @param string|Zend\Cache\Storage\Adapter
+     * @return void
+     */
+    public function _setStorageAdapter($storageAdapter)
+    {
+        if (is_string($storageAdapter)) {
+            if (!class_exists($storageAdapter)) {
+                throw new Exception\InvalidArgumentException('Class provided for StorageAdapter does not exist');
+            }
+            $storageAdapter = new $storageAdapter;
+        }
+
+        if (!$storageAdapter instanceof StorageAdapter) {
+            throw new Exception\InvalidArgumentException('StorageAdapter type provided is invalid; must implement Zend\\Cache\\Storage\\Adapter');
+        }
+
+        $this->storageAdapter = $storageAdapter;
+    }
+
+    /**
+     * Get Cache Storage Adapter Object
+     *
+     * @return Zend\Cache\Storage\Adapter
+     */
+    public function getStorageAdapter()
+    {
+        return $this->_storageAdapter;
+    }
+}

--- a/library/Zend/Session/SaveHandler/Cache.php
+++ b/library/Zend/Session/SaveHandler/Cache.php
@@ -165,6 +165,6 @@ class Cache implements Savable
      */
     public function getStorageAdapter()
     {
-        return $this->_storageAdapter;
+        return $this->storageAdapter;
     }
 }

--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -101,6 +101,13 @@ class SessionManager extends AbstractManager
         if ($this->sessionExists()) {
             return;
         }
+
+        $saveHandler = $this->getSaveHandler();
+        if ($saveHandler instanceof SaveHandler) {
+            // register the session handler with ext/session
+            $this->_registerSaveHandler($saveHandler);
+        }
+
         session_start();
         if (!$this->isValid()) {
             throw new Exception\RuntimeException('Session failed validation');
@@ -396,5 +403,26 @@ class SessionManager extends AbstractManager
             // There is a running session so we'll regenerate id to send a new cookie
             $this->regenerateId();
         }
+    }
+
+    /**
+     * Register Save Handler with ext/session
+     *
+     * Since ext/session is coupled to this particular session manager
+     * register the save handler with ext/session.
+     *
+     * @param SaveHandler $saveHandler
+     * @return bool
+     */
+    protected function _registerSaveHandler(SaveHandler $saveHandler)
+    {
+        return session_set_save_handler(
+            array($saveHandler, 'open'),
+            array($saveHandler, 'close'),
+            array($saveHandler, 'read'),
+            array($saveHandler, 'write'),
+            array($saveHandler, 'destroy'),
+            array($saveHandler, 'gc')
+        );
     }
 }

--- a/tests/Zend/Session/SaveHandler/CacheTest.php
+++ b/tests/Zend/Session/SaveHandler/CacheTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Session
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Session\SaveHandler;
+
+use Zend\Session\SaveHandler\Cache,
+    Zend\Session\SaveHandler\Exception as SaveHandlerException,
+    Zend\Session\Manager,
+    Zend\Cache\Storage\Adapter\Memory;
+
+/**
+ * Unit testing for DbTable include all tests for
+ * regular session handling
+ *
+ * @category   Zend
+ * @package    Zend_Session
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Zend_Session
+ * @group      Zend_Cache
+ */
+class CacheTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Zend\Cache\Storage\Adapter\Memory
+     */
+    protected $memory;
+
+    /**
+     * @var string
+     */
+    protected $testArray;
+
+    /**
+     * Array to collect used Cache objects, so they are not
+     * destroyed before all tests are done and session is not closed
+     *
+     * @var array
+     */
+    protected $usedSaveHandlers = array();
+
+    public function setUp()
+    {
+        $this->memory = new Memory();
+        $this->testArray = array('foo' => 'bar', 'bar' => array('foo' => 'bar'));
+    }
+
+    public function testReadWrite()
+    {
+        $this->_usedSaveHandlers[] =
+            $saveHandler = new Cache($this->memory);
+
+        $id = '242';
+
+        $this->assertTrue($saveHandler->write($id, serialize($this->testArray)));
+
+        $data = unserialize($saveHandler->read($id));
+        $this->assertEquals($this->testArray, $data, 'Expected ' . var_export($this->testArray, 1) . "\nbut got: " . var_export($data, 1));
+    }
+
+    public function testReadWriteComplex()
+    {
+        $saveHandler = new Cache($this->memory);
+        $saveHandler->open('savepath', 'sessionname');
+
+        $id = '242';
+
+        $this->assertTrue($saveHandler->write($id, serialize($this->testArray)));
+
+        $this->assertEquals($this->testArray, unserialize($saveHandler->read($id)));
+    }
+
+    public function testReadWriteTwice()
+    {
+        $this->_usedSaveHandlers[] =
+            $saveHandler = new Cache($this->memory);
+
+        $id = '242';
+
+        $this->assertTrue($saveHandler->write($id, serialize($this->testArray)));
+
+        $this->assertEquals($this->testArray, unserialize($saveHandler->read($id)));
+
+        $this->assertTrue($saveHandler->write($id, serialize($this->testArray)));
+
+        $this->assertEquals($this->testArray, unserialize($saveHandler->read($id)));
+    }
+}

--- a/tests/Zend/Session/SaveHandler/DbTableTest.php
+++ b/tests/Zend/Session/SaveHandler/DbTableTest.php
@@ -110,7 +110,6 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
     {
         $sh = new DbTable($this->_saveHandlerTableConfig);
         $this->assertInstanceOf('Zend\Db\Table\AbstractTable', $sh);
-        $this->assertInstanceOf('Zend\Session\Manager', $sh->getManager());
     }
 
     public function testConstructorThrowsExceptionGivenConfigAsNull()
@@ -126,20 +125,6 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
     {
         $config = $this->_saveHandlerTableConfig;
         $config['name'] = 'schema.session';
-        $this->_usedSaveHandlers[] = $saveHandler = new DbTable($config);
-    }
-
-    public function testTableEmptyNamePullFromSavePath()
-    {
-        $config = $this->_saveHandlerTableConfig;
-        unset($config['name']);
-        $savePath = ini_get('session.save_path');
-        $this->manager->getConfig()->setSavePath(__DIR__);
-            
-        $this->setExpectedException(
-            'Zend\Session\SaveHandler\Exception',
-            'path'
-            );
         $this->_usedSaveHandlers[] = $saveHandler = new DbTable($config);
     }
 
@@ -344,8 +329,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
 
         $this->_usedSaveHandlers[] =
             $saveHandler = new DbTable($config);
-        $manager = new TestManager();
-        $saveHandler->setManager($manager);
+        $manager = new TestManager(null, null, $saveHandler);
         $manager->start();
 
         /**

--- a/tests/Zend/Session/SessionConfigurationTest.php
+++ b/tests/Zend/Session/SessionConfigurationTest.php
@@ -105,7 +105,7 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
     public function testSettingInvalidSaveHandlerRaisesException()
     {
         $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid save handler specified');
-        $this->config->setSaveHandler('foobar_bogus');
+        $this->config->setPhpSaveHandler('foobar_bogus');
     }
 
     // session.gc_probability

--- a/tests/Zend/Session/SessionManagerTest.php
+++ b/tests/Zend/Session/SessionManagerTest.php
@@ -188,6 +188,37 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($storage, $manager->getStorage());
     }
 
+    public function testCanPassSaveHandlerToConstructor()
+    {
+        $saveHandler = new TestAsset\TestSaveHandler();
+        $manager = new SessionManager(null, null, $saveHandler);
+        $this->assertSame($saveHandler, $manager->getSaveHandler());
+    }
+
+    public function testCanPassStringSessionHandlerNameToConstructor()
+    {
+        $manager = new SessionManager(null, null, 'ZendTest\\Session\\TestAsset\\TestSaveHandler');
+        $sessionHandler = $manager->getSaveHandler();
+        $this->assertTrue($sessionHandler instanceof TestAsset\TestSaveHandler);
+    }
+
+    public function testCanPassSaveHandlerToConfigurationOptions()
+    {
+        $manager = new SessionManager(array('saveHandler' => 'ZendTest\\Session\\TestAsset\\TestSaveHandler'));
+        $saveHandler = $manager->getSaveHandler();
+        $this->assertTrue($saveHandler instanceof TestAsset\TestSaveHandler);
+    }
+    
+    public function testPassingSaveHandlerViaParamOverridesSaveHandlerInConfig()
+    {
+        $saveHandler = new TestAsset\TestSaveHandler();
+        $manager = new TestAsset\TestManager(array(
+            'class' => 'Zend\\Session\\Configuration\\StandardConfiguration',
+            'saveHandler' => 'ZendTest\\Session\\TestAsset\\TestSaveHandler',
+        ), null, $saveHandler);
+        $this->assertSame($saveHandler, $manager->getSaveHandler());
+    }
+
     // Session-related functionality
 
     /**

--- a/tests/Zend/Session/TestAsset/TestManager.php
+++ b/tests/Zend/Session/TestAsset/TestManager.php
@@ -4,6 +4,7 @@ namespace ZendTest\Session\TestAsset;
 use Zend\Session\AbstractManager,
     Zend\Session\Configuration as SessionConfiguration,
     Zend\Session\Storage as SessionStorage,
+    Zend\Session\SaveHandler as SessionSaveHandler,
     Zend\EventManager\EventCollection;
 
 class TestManager extends AbstractManager
@@ -78,5 +79,10 @@ class TestManager extends AbstractManager
     public function setStorage(SessionStorage $storage)
     {
         $this->_setStorage($storage);
+    }
+
+    public function setSaveHandler(SessionSaveHandler $saveHandler)
+    {
+        $this->_setSaveHandler($saveHandler);
     }
 }

--- a/tests/Zend/Session/TestAsset/TestSaveHandler.php
+++ b/tests/Zend/Session/TestAsset/TestSaveHandler.php
@@ -1,0 +1,25 @@
+<?php
+namespace ZendTest\Session\TestAsset;
+
+use Zend\Session\SaveHandler;
+
+class TestSaveHandler implements SaveHandler
+{
+    public function open($save_path, $name)
+    {}
+
+    public function close()
+    {}
+
+    public function read($id)
+    {}
+
+    public function write($id, $data)
+    {}
+
+    public function destroy($id)
+    {}
+
+    public function gc($maxlifetime)
+    {}
+}


### PR DESCRIPTION
Session Handling Current State:
- Currently; there is a setManager method on the SaveHandler; unfortunately the design of the current SessionManager does not allow this to function.
- Custom session handlers are confusing and are coupling themselves to configuration of the SessionManager
- Configuration option "saveHandler" attempts to set PHP's internal save handler ini option.

Session Handling Changes:
- Removal of setManager/getManager from SaveHandler (complete decoupling)
- Addition of _setSaveHandler, getSaveHandler and $saveHandler parameter to the AbstractManager
- Change from setSaveHandler in the configuration to setPhpSaveHandler
- Change to SaveHandler/DbTable to take the table name from a configuration option "name" rather than attempting to get a configuration option from the manager.
- SessionManager now provides a method to register with ext/session

Session Handling Additions:
- Cache Save Handler which can leverage a Zend\Cache\Storage\Adapter
