### PR TITLE
Made exception messages more accurate

### DIFF
--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -161,7 +161,7 @@ class Di implements DependencyInjection
         if (!$definitions->hasClass($class)) {
             $aliasMsg = ($alias) ? '(specified by alias ' . $alias . ') ' : '';
             throw new Exception\ClassNotFoundException(
-                'Class ' . $aliasMsg . $class . ' could not be located in provided definition.'
+                'Class ' . $aliasMsg . $class . ' could not be located in provided definitions.'
             );
         }
         

--- a/library/Zend/Di/ServiceLocator/DependencyInjectorProxy.php
+++ b/library/Zend/Di/ServiceLocator/DependencyInjectorProxy.php
@@ -143,7 +143,7 @@ class DependencyInjectorProxy extends Di
         if (!$definition->hasClass($class)) {
             $aliasMsg = ($alias) ? '(specified by alias ' . $alias . ') ' : '';
             throw new Exception\ClassNotFoundException(
-                'Class ' . $aliasMsg . $class . ' could not be located in provided definition.'
+                'Class ' . $aliasMsg . $class . ' could not be located in provided definitions.'
             );
         }
 


### PR DESCRIPTION
I've made an minor alteration, making the exception thrown when a class could not be found a bit more accurate.
