### PR TITLE
HTTP Client Supporting PATCH Method

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -358,7 +358,8 @@ class Client implements Dispatchable
         $method = $this->getRequest()->setMethod($method)->getMethod();
         
         if (($method == Request::METHOD_POST || $method == Request::METHOD_PUT ||
-             $method == Request::METHOD_DELETE) && empty($this->encType)) {
+             $method == Request::METHOD_DELETE || $method == Request::METHOD_PATCH)
+             && empty($this->encType)) {
             $this->setEncType(self::ENC_URLENCODED);
         } 
         
@@ -1097,7 +1098,7 @@ class Client implements Dispatchable
     
 
     /**
-     * Prepare the request body (for POST and PUT requests)
+     * Prepare the request body (for POST, PUT, and PATCH requests)
      *
      * @return string
      * @throws \Zend\Http\Client\Exception

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -22,6 +22,7 @@ class Request extends Message implements RequestDescription
     const METHOD_DELETE  = 'DELETE';
     const METHOD_TRACE   = 'TRACE';
     const METHOD_CONNECT = 'CONNECT';
+    const METHOD_PATCH   = 'PATCH';
     /**#@-*/
 
     /**#@+
@@ -92,7 +93,8 @@ class Request extends Message implements RequestDescription
         $matches = null;
         $methods = implode('|', array(
             self::METHOD_OPTIONS, self::METHOD_GET, self::METHOD_HEAD, self::METHOD_POST,
-            self::METHOD_PUT, self::METHOD_DELETE, self::METHOD_TRACE, self::METHOD_CONNECT
+            self::METHOD_PUT, self::METHOD_DELETE, self::METHOD_TRACE, self::METHOD_CONNECT,
+            self::METHOD_PATCH
         ));
         $regex = '^(?P<method>' . $methods . ')\s(?<uri>[^ ]*)(?:\sHTTP\/(?<version>\d+\.\d+)){0,1}';
         $firstLine = array_shift($lines);
@@ -489,6 +491,16 @@ class Request extends Message implements RequestDescription
     public function isConnect()
     {
         return ($this->method === self::METHOD_CONNECT);
+    }
+
+    /**
+     * Is this a PATH method request?
+     *
+     * @return bool
+     */
+    public function isPatch()
+    {
+        return ($this->method === self::METHOD_PATCH);
     }
 
     /**

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -494,7 +494,7 @@ class Request extends Message implements RequestDescription
     }
 
     /**
-     * Is this a PATH method request?
+     * Is this a PATCH method request?
      *
      * @return bool
      */


### PR DESCRIPTION
This is a basic update to the supported HTTP methods in the Request and Client libraries to allow PATCH to be used. PATCH differs from PUT in that PATCH signifies only the changes to a resource rather than a complete replacement that PUT calls for. PATCH is typically used in RESTful APIs to signify batch updates to a collection of a resource.

This pull request will allow any implementations using the Zend Client for API requests to start using this method.

PATCH is described here: http://tools.ietf.org/html/rfc5789
