### PR TITLE
Locator shared instance

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -293,10 +293,6 @@ class Application implements AppContext
             goto complete;
         }
 
-        if ($controller instanceof LocatorAware) {
-            $controller->setLocator($locator);
-        }
-
         $request  = $e->getRequest();
         $response = $this->getResponse();
 

--- a/library/Zend/Mvc/Bootstrap.php
+++ b/library/Zend/Mvc/Bootstrap.php
@@ -94,7 +94,7 @@ class Bootstrap implements Bootstrapper
     protected function setupLocator(AppContext $application)
     {
         $di = new Di;
-        $di->instanceManager()->addTypePreference('Zend\Di\Locator', $di);
+        $di->instanceManager()->addSharedInstance($di, 'Zend\Di\Locator');
 
         // default configuration for the router
         $routerDiConfig = new DiConfiguration(


### PR DESCRIPTION
Fix by @ocramius.

Bootstrap.php:
->addTypePreference was meant to provide the locator in the
locator itself and was not necessary.
Changed to ->addSharedInstance.

Application.php:
Removed check if controller was instanceof locatorAware

Need @ralphschindler review
