### PR TITLE
Throw an exception if there isn't a routematch object

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -258,6 +258,11 @@ class Application implements AppContext
 
         $events     = $this->events();
         $routeMatch = $e->getRouteMatch();
+        if (!$routeMatch) {
+            throw new Exception\MissingRouteMatchException(
+                'Cannot dispatch without a RouteMatch'
+            );
+        }
 
         $controllerName = $routeMatch->getParam('controller', 'not-found');
 

--- a/library/Zend/Mvc/Exception/MissingRouteMatchException.php
+++ b/library/Zend/Mvc/Exception/MissingRouteMatchException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Zend\Mvc\Exception;
+
+use Zend\Mvc\Exception,
+    RuntimeException;
+
+class MissingRouteMatchException extends RuntimeException implements Exception
+{}


### PR DESCRIPTION
This change ensures that we don't fatal with: Fatal error: Call to a member function getParam() on a non-object in /www/zend-framework/zf2/library/Zend/Mvc/Application.php on line 325
