### PR TITLE
RegenerateId must remove old session.

### DIFF
--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -252,19 +252,21 @@ class SessionManager extends AbstractManager
     }
 
     /**
-     * Regenerate the session ID, using session save handler's native ID generation
+     * Regenerate id
      *
-     * Can safely be called in the middle of a session.
-     * 
+     * Regenerate the session ID, using session save handler's 
+     * native ID generation Can safely be called in the middle of a session.
+     *
+     * @param bool $deleteOldSession
      * @return SessionManager
      */
-    public function regenerateId()
+    public function regenerateId($deleteOldSession = true)
     {
         if (!$this->sessionExists()) {
-            session_regenerate_id();
+            session_regenerate_id($deleteOldSession);
             return $this;
         }
-        session_regenerate_id();
+        session_regenerate_id($deleteOldSession);
         return $this;
     }
 


### PR DESCRIPTION
Here's a quick fix to remove old session when doing regenerateId().
It was there in zf1 but somehow was left out when refactoring for zf2.

In its current state if you choose to regenerateId() on each request or do a rememberMe()/forgetMe() it causes new session to be created that results in sessions proliferation quite quickly.

This fix makes old session to be removed.
