### PR TITLE
Zend\Loader\AutoloaderFactory::factory() changes

### DIFF
--- a/library/Zend/Loader/AutoloaderFactory.php
+++ b/library/Zend/Loader/AutoloaderFactory.php
@@ -92,6 +92,13 @@ abstract class AutoloaderFactory
                                 sprintf('Autoloader class "%s" not loaded', $class)
                     );
                 }
+
+                if (!is_subclass_of($class, 'Zend\Loader\SplAutoloader')) {
+                    throw new Exception\InvalidArgumentException(
+                        sprintf('Autoloader class %s must implement Zend\\Loader\\SplAutoloader', $class)
+                    );
+                }
+
                 if ($class === 'Zend\Loader\StandardAutoloader') {
                     $autoloader->setOptions($options);
                 } else {

--- a/library/Zend/Loader/AutoloaderFactory.php
+++ b/library/Zend/Loader/AutoloaderFactory.php
@@ -33,6 +33,8 @@ if (class_exists('Zend\Loader\AutoloaderFactory')) return;
  */
 abstract class AutoloaderFactory
 {
+    const STANDARD_AUTOLOADER = 'Zend\Loader\StandardAutoloader';
+
     /**
      * @var array All autoloaders registered using the factory
      */
@@ -73,7 +75,12 @@ abstract class AutoloaderFactory
     public static function factory($options = null)
     {
         if (null === $options) {
-            $options = array('Zend\Loader\StandardAutoloader' => array());
+            if (!isset(static::$loaders[static::STANDARD_AUTOLOADER])) {
+                static::$loaders[STANDARD_AUTOLOADER] = static::getStandardAutoloader();
+            }
+
+            // Return so we don't hit the next check's exception (we're done here anyway)
+            return;
         }
 
         if (!is_array($options) && !($options instanceof \Traversable)) {
@@ -94,12 +101,13 @@ abstract class AutoloaderFactory
                 }
 
                 if (!is_subclass_of($class, 'Zend\Loader\SplAutoloader')) {
+                    require_once 'Exception/InvalidArgumentException.php';
                     throw new Exception\InvalidArgumentException(
-                        sprintf('Autoloader class %s must implement Zend\\Loader\\SplAutoloader', $class)
+                                sprintf('Autoloader class %s must implement Zend\\Loader\\SplAutoloader', $class)
                     );
                 }
 
-                if ($class === 'Zend\Loader\StandardAutoloader') {
+                if ($class === static::STANDARD_AUTOLOADER) {
                     $autoloader->setOptions($options);
                 } else {
                     $autoloader = new $class($options);
@@ -186,9 +194,12 @@ abstract class AutoloaderFactory
         if (null !== static::$standardAutoloader) {
             return static::$standardAutoloader;
         }
+        
+        // Extract the filename from the classname
+        $stdAutoloader = substr(strrchr(static::STANDARD_AUTOLOADER, '\\'), 1);
 
-        if (!class_exists('Zend\Loader\StandardAutoloader')) {
-            require_once __DIR__ . '/StandardAutoloader.php';
+        if (!class_exists(static::STANDARD_AUTOLOADER)) {
+            require_once __DIR__ . "/$stdAutoloader.php";
         }
         $loader = new StandardAutoloader();
         static::$standardAutoloader = $loader;

--- a/library/Zend/Loader/AutoloaderFactory.php
+++ b/library/Zend/Loader/AutoloaderFactory.php
@@ -76,7 +76,7 @@ abstract class AutoloaderFactory
     {
         if (null === $options) {
             if (!isset(static::$loaders[static::STANDARD_AUTOLOADER])) {
-                static::$loaders[STANDARD_AUTOLOADER] = static::getStandardAutoloader();
+                static::$loaders[static::STANDARD_AUTOLOADER] = static::getStandardAutoloader();
             }
 
             // Return so we don't hit the next check's exception (we're done here anyway)

--- a/tests/Zend/Loader/AutoloaderFactoryTest.php
+++ b/tests/Zend/Loader/AutoloaderFactoryTest.php
@@ -81,6 +81,19 @@ class AutoloaderFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($map));
     }
 
+    /**
+     * This tests checks if invalid autoloaders cause exceptions
+     *
+     * @expectedException InvalidArgumentException
+     */
+    public function testFactoryCatchesInvalidClasses()
+    {
+        include __DIR__ . '/_files/InvalidInterfaceAutoloader.php';
+        AutoloaderFactory::factory(array(
+            'InvalidInterfaceAutoloader' => array()            
+        ));
+    }
+
     public function testFactoryDoesNotRegisterDuplicateAutoloaders()
     {
         AutoloaderFactory::factory(array(

--- a/tests/Zend/Loader/_files/InvalidInterfaceAutoloader.php
+++ b/tests/Zend/Loader/_files/InvalidInterfaceAutoloader.php
@@ -1,0 +1,4 @@
+<?php
+class InvalidInterfaceAutoloader
+{
+}


### PR DESCRIPTION
Zend\Loader\AutoloaderFactory::factory() Goes through all supplied options, and registers $class as an autoloader, however we do not check if it has implemented SplAutoloader. I've added this check, as well as a test (which ran successfully: "OK (11 tests, 16 assertions)")

I've also altered some code that caused unnecessary checks and execution. Besides that I've added a cont to make sure that the "standard autoloader" classname was in one place.

Matthew has reviewed this and asked me to mention this.

"This sounds good; feel free to create a PR for it, and indicate I've
reviewed the change already."
