### PR TITLE
A View Model is not created when a controller returns an empty array

### DIFF
--- a/library/Zend/Mvc/View/CreateViewModelFromArrayListener.php
+++ b/library/Zend/Mvc/View/CreateViewModelFromArrayListener.php
@@ -71,7 +71,7 @@ class CreateViewModelFromArrayListener implements ListenerAggregate
     public function createViewModelFromArray(MvcEvent $e)
     {
         $result = $e->getResult();
-        if (!IsAssocArray::test($result)) {
+        if (!IsAssocArray::test($result, true)) {
             return;
         }
 

--- a/library/Zend/Stdlib/IsAssocArray.php
+++ b/library/Zend/Stdlib/IsAssocArray.php
@@ -15,12 +15,17 @@ abstract class IsAssocArray
      * We have an associative array if at least one key is a string.
      * 
      * @param  mixed $value 
+     * @param  bool  $allowEmpty
      * @return bool
      */
-    public static function test($value)
+    public static function test($value, $allowEmpty = false)
     {
-        return (is_array($value)
-                && count(array_filter(array_keys($value), 'is_string')) > 0
-        );
+        if (is_array($value)) {
+            if ($allowEmpty && count($value) == 0) {
+                return true;
+            }
+            return count(array_filter(array_keys($value), 'is_string')) > 0;
+        }
+        return false;
     }
 }

--- a/tests/Zend/Mvc/View/CreateViewModelFromArrayListenerTest.php
+++ b/tests/Zend/Mvc/View/CreateViewModelFromArrayListenerTest.php
@@ -117,4 +117,12 @@ class CreateViewModelFromArrayListenerTest extends TestCase
         $listeners = $events->getListeners('dispatch');
         $this->assertEquals(0, count($listeners));
     }
+
+    public function testViewModelCreatesViewModelWithEmptyArray()
+    {
+        $this->event->setResult(array());
+        $this->listener->createViewModelFromArray($this->event);
+        $result = $this->event->getResult();
+        $this->assertInstanceOf('Zend\View\Model\ViewModel', $result);
+    }
 }

--- a/tests/Zend/Stdlib/IsAssocArrayTest.php
+++ b/tests/Zend/Stdlib/IsAssocArrayTest.php
@@ -22,6 +22,13 @@ class IsAssocArrayTest extends TestCase
         );
     }
 
+    public static function validAssocEmptyArrays()
+    {
+        $array = self::validAssocArrays();
+        $array[] = array(array());
+        return $array;
+    }
+
     public static function invalidAssocArrays()
     {
         return array(
@@ -47,10 +54,26 @@ class IsAssocArrayTest extends TestCase
     }
 
     /**
+     * @dataProvider validAssocEmptyArrays
+     */
+    public function testValidAssocEmptyArraysReturnTrue($test)
+    {
+        $this->assertTrue(isAssocArray::test($test, true));
+    }
+
+    /**
      * @dataProvider invalidAssocArrays
      */
     public function testInvalidAssocArraysReturnFalse($test)
     {
         $this->assertFalse(IsAssocArray::test($test));
+    }
+
+    /**
+     * @dataProvider invalidAssocArrays
+     */
+    public function testInvalidAssocEmptyArraysReturnFalse($test)
+    {
+        $this->assertFalse(IsAssocArray::test($test, true));
     }
 }


### PR DESCRIPTION
Prior to the view refactoring you could return an empty array and it would be assigned to the view renderer.  After the view changes if you return an empty array it will skip the view.  This change adds an additional field to the StdLib/IsAssocArray to allow for empty arrays - defined as having a 0 count.  The listener now passes that it will allow empty.

Added new test for behavior and it works as I would have expected now.
