### PR TITLE
[ZF2-146] Fix order of explode arguments in parse method of Zend\Code\Reflection\DocBlock\GenericTag

### DIFF
--- a/library/Zend/Code/Reflection/DocBlock/GenericTag.php
+++ b/library/Zend/Code/Reflection/DocBlock/GenericTag.php
@@ -112,7 +112,7 @@ class GenericTag implements Tag
     
     protected function parse($docblockLine)
     {
-        $this->values = explode($docblockLine, $this->contentSplitCharacter);
+        $this->values = explode($this->contentSplitCharacter, $docblockLine);
     }
     
 }

--- a/tests/Zend/Code/Reflection/DocBlock/Tag/GenericTagTest.php
+++ b/tests/Zend/Code/Reflection/DocBlock/Tag/GenericTagTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Reflection
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+/**
+ * @namespace
+ */
+namespace ZendTest\Code\Reflection\DocBlock\Tag;
+use Zend\Code\Reflection\DocBlock\GenericTag;
+
+/**
+ * @category   Zend
+ * @package    Zend_Reflection
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Zend_Reflection
+ * @group      Zend_Reflection_Docblock
+ */
+class GenericTagTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @group ZF2-146
+     */
+    public function testParse()
+    {
+        $tag = new GenericTag();
+        $tag->initialize('baz zab');
+        $this->assertEquals('baz', $tag->returnValue(0));
+        $this->assertEquals('zab', $tag->returnValue(1));
+    }
+}


### PR DESCRIPTION
See [ZF2-146](http://framework.zend.com/issues/browse/ZF2-146)
