### PR TITLE
Feature/eventmanager convenience api

### DIFF
--- a/library/Zend/EventManager/EventCollection.php
+++ b/library/Zend/EventManager/EventCollection.php
@@ -84,10 +84,10 @@ interface EventCollection
     /**
      * Detach an event listener
      * 
-     * @param  CallbackHandler $listener 
+     * @param  CallbackHandler|ListenerAggregate $listener 
      * @return void
      */
-    public function detach(CallbackHandler $listener);
+    public function detach($listener);
 
     /**
      * Get a list of events for which this collection has listeners

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -257,10 +257,14 @@ class EventManager implements EventCollection
      * @param  string $event
      * @param  callback $callback PHP callback
      * @param  int $priority If provided, the priority at which to register the callback
-     * @return ListenerAggregate (to allow later unsubscribe)
+     * @return CallbackHandler|mixed CallbackHandler if attaching callback (to allow later unsubscribe); mixed if attaching aggregate
      */
-    public function attach($event, $callback, $priority = 1)
+    public function attach($event, $callback = null, $priority = 1)
     {
+        if ($event instanceof ListenerAggregate) {
+            return $this->attachAggregate($event, $callback);
+        }
+
         if (empty($this->events[$event])) {
             $this->events[$event] = new PriorityQueue();
         }
@@ -277,21 +281,38 @@ class EventManager implements EventCollection
      * methods.
      *
      * @param  ListenerAggregate $aggregate
+     * @param  int $priority If provided, a suggested priority for the aggregate to use
      * @return mixed return value of {@link ListenerAggregate::attach()}
      */
-    public function attachAggregate(ListenerAggregate $aggregate)
+    public function attachAggregate(ListenerAggregate $aggregate, $priority = null)
     {
-        return $aggregate->attach($this);
+        if (null === $priority || !is_scalar($priority)) {
+            $priority = 1;
+        }
+        return $aggregate->attach($this, (int) $priority);
     }
 
     /**
      * Unsubscribe a listener from an event
      *
-     * @param  CallbackHandler $listener
+     * @param  CallbackHandler|ListenerAggregate $listener
      * @return bool Returns true if event and listener found, and unsubscribed; returns false if either event or listener not found
+     * @throws Exception\InvalidArgumentException if invalid listener provided
      */
-    public function detach(CallbackHandler $listener)
+    public function detach($listener)
     {
+        if ($listener instanceof ListenerAggregate) {
+            return $this->detachAggregate($listener);
+        }
+
+        if (!$listener instanceof CallbackHandler) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s: expected a ListenerAggregate or CallbackHandler; received "%s"',
+                __METHOD__,
+                (is_object($listener) ? get_class($listener) : gettype($listener))
+            ));
+        }
+
         $event = $listener->getMetadatum('event');
         if (!$event || empty($this->events[$event])) {
             return false;

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -254,8 +254,8 @@ class EventManager implements EventCollection
      * executed. By default, this value is 1; however, you may set it for any
      * integer value. Higher values have higher priority (i.e., execute first).
      *
-     * @param  string $event
-     * @param  callback $callback PHP callback
+     * @param  string|ListenerAggregate $event
+     * @param  callback|int $callback If string $event provided, expects PHP callback; for a ListenerAggregate $event, this will be the priority
      * @param  int $priority If provided, the priority at which to register the callback
      * @return CallbackHandler|mixed CallbackHandler if attaching callback (to allow later unsubscribe); mixed if attaching aggregate
      */
@@ -263,6 +263,13 @@ class EventManager implements EventCollection
     {
         if ($event instanceof ListenerAggregate) {
             return $this->attachAggregate($event, $callback);
+        }
+
+        if (null === $callback) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s: expects a callback; none provided',
+                __METHOD__
+            ));
         }
 
         if (empty($this->events[$event])) {
@@ -281,15 +288,12 @@ class EventManager implements EventCollection
      * methods.
      *
      * @param  ListenerAggregate $aggregate
-     * @param  int $priority If provided, a suggested priority for the aggregate to use
+     * @param  null|int $priority If provided, a suggested priority for the aggregate to use
      * @return mixed return value of {@link ListenerAggregate::attach()}
      */
     public function attachAggregate(ListenerAggregate $aggregate, $priority = null)
     {
-        if (null === $priority || !is_scalar($priority)) {
-            $priority = 1;
-        }
-        return $aggregate->attach($this, (int) $priority);
+        return $aggregate->attach($this, $priority);
     }
 
     /**

--- a/library/Zend/EventManager/ListenerAggregate.php
+++ b/library/Zend/EventManager/ListenerAggregate.php
@@ -42,8 +42,9 @@ interface ListenerAggregate
      * Attach one or more listeners
      *
      * @param EventCollection $events
+     * @param null|int $priority Optional priority "hint" to use when attaching listeners
      */
-    public function attach(EventCollection $events);
+    public function attach(EventCollection $events, $priority = null);
 
     /**
      * Detach all previously attached listeners

--- a/tests/Zend/EventManager/EventManagerTest.php
+++ b/tests/Zend/EventManager/EventManagerTest.php
@@ -312,6 +312,20 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('ZendTest\EventManager\TestAsset\MockAggregate::detach', $method);
     }
 
+    public function testAttachAggregateAcceptsOptionalPriorityValue()
+    {
+        $aggregate = new TestAsset\MockAggregate();
+        $this->events->attachAggregate($aggregate, 1);
+        $this->assertEquals(1, $aggregate->priority);
+    }
+
+    public function testAttachAggregateAcceptsOptionalPriorityValueViaAttachCallbackArgument()
+    {
+        $aggregate = new TestAsset\MockAggregate();
+        $this->events->attach($aggregate, 1);
+        $this->assertEquals(1, $aggregate->priority);
+    }
+
     public function testCallingEventsStopPropagationMethodHaltsEventEmission()
     {
         $this->events->attach('foo.bar', function ($e) { return 'bogus'; }, 4);

--- a/tests/Zend/EventManager/TestAsset/MockAggregate.php
+++ b/tests/Zend/EventManager/TestAsset/MockAggregate.php
@@ -36,9 +36,12 @@ class MockAggregate implements ListenerAggregate
 {
 
     protected $listeners = array();
+    public $priority;
 
-    public function attach(EventCollection $events)
+    public function attach(EventCollection $events, $priority = null)
     {
+        $this->priority = $priority;
+
         $listeners = array();
         $listeners[] = $events->attach('foo.bar', array( $this, 'fooBar' ));
         $listeners[] = $events->attach('foo.baz', array( $this, 'fooBaz' ));


### PR DESCRIPTION
This fulfills story #21 on the board:
- Allow passing a priority "hint" in attachAggregate()
- Allow attach() to proxy to attachAggregate() when the first argument is a ListenerAggregate
- Allow detach() to proxy to detachAggregate() when the argument is a ListenerAggregate
