### PR TITLE
[ZF2-172] Properly detect static method validity in PHP 5.4

### DIFF
--- a/tests/Zend/Stdlib/CallbackHandlerTest.php
+++ b/tests/Zend/Stdlib/CallbackHandlerTest.php
@@ -93,7 +93,8 @@ class CallbackHandlerTest extends \PHPUnit_Framework_TestCase
     public function testStringCallbackReferringToClassWithoutDefinedInvokeShouldRaiseException()
     {
         $this->setExpectedException('Zend\Stdlib\Exception\InvalidCallbackException');
-        $handler = new CallbackHandler('ZendTest\\Stdlib\\SignalHandlers\\InstanceMethod');
+        $class   = new SignalHandlers\InstanceMethod();
+        $handler = new CallbackHandler($class);
     }
 
     public function testCallbackConsistingOfStringContextWithNonStaticMethodShouldNotRaiseExceptionButWillRaiseEStrict()
@@ -108,16 +109,22 @@ class CallbackHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($error);
     }
 
-    public function testStringCallbackConsistingOfNonStaticMethodShouldNotRaiseExceptionButWillRaiseEStrict()
+    public function testStringCallbackConsistingOfNonStaticMethodShouldRaiseException()
     {
         $handler = new CallbackHandler('ZendTest\\Stdlib\\SignalHandlers\\InstanceMethod::handler');
-        $error   = false;
-        set_error_handler(function ($errno, $errstr) use (&$error) {
-            $error = true;
-        }, E_STRICT);
-        $handler->call();
-        restore_error_handler();
-        $this->assertTrue($error);
+
+        if (version_compare(PHP_VERSION, '5.4.0rc1', '>=')) {
+            $this->setExpectedException('Zend\Stdlib\Exception\InvalidCallbackException');
+            $handler->call();
+        } else {
+            $error   = false;
+            set_error_handler(function ($errno, $errstr) use (&$error) {
+                $error = true;
+            }, E_STRICT);
+            $handler->call();
+            restore_error_handler();
+            $this->assertTrue($error);
+        }
     }
 
     public function testCallbackToClassImplementingOverloadingButNotInvocableShouldRaiseException()


### PR DESCRIPTION
- PHP 5.4 will return true from is_callable() for 'Class::method', even if it is
  non-static. Added code to detect 5.4 and validate static methods provided by
  strings before executing the callback.
