### PR TITLE
ZF2-173 Ldap classnames references in tests

### DIFF
--- a/tests/Zend/Ldap/AttributeTest.php
+++ b/tests/Zend/Ldap/AttributeTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -27,11 +27,11 @@ use Zend\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
+ * @group      Zend_Ldap
  */
 class AttributeTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Zend/Ldap/BindTest.php
+++ b/tests/Zend/Ldap/BindTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -33,11 +33,11 @@ use Zend\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
+ * @group      Zend_Ldap
  */
 class BindTest extends \PHPUnit_Framework_TestCase
 {
@@ -49,7 +49,7 @@ class BindTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         if (!constant('TESTS_ZEND_LDAP_ONLINE_ENABLED')) {
-            $this->markTestSkipped("Zend_LDAP online tests are not enabled");
+            $this->markTestSkipped("Zend_Ldap online tests are not enabled");
         }
 
         $this->_options = array(

--- a/tests/Zend/Ldap/CanonTest.php
+++ b/tests/Zend/Ldap/CanonTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -33,11 +33,11 @@ use Zend\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
+ * @group      Zend_Ldap
  */
 class CanonTest extends \PHPUnit_Framework_TestCase
 {
@@ -46,7 +46,7 @@ class CanonTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         if (!constant('TESTS_ZEND_LDAP_ONLINE_ENABLED')) {
-            $this->markTestSkipped("Zend_LDAP online tests are not enabled");
+            $this->markTestSkipped("Zend_Ldap online tests are not enabled");
         }
 
         $this->_options = array(

--- a/tests/Zend/Ldap/ChangePasswordTest.php
+++ b/tests/Zend/Ldap/ChangePasswordTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -28,9 +28,9 @@ use Zend\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
- * @group      Zend_LDAP
+ * @group      Zend_Ldap
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -56,7 +56,7 @@ class ChangePasswordTest extends OnlineTestCase
         try {
             $this->_getLDAP()->add($dn, $data);
 
-            $this->assertType('Zend\Ldap\Ldap', $this->_getLDAP()->bind($dn, $password));
+            $this->assertInstanceOf('Zend\Ldap\Ldap', $this->_getLDAP()->bind($dn, $password));
 
             $this->_getLDAP()->bind();
             $this->_getLDAP()->delete($dn);
@@ -105,7 +105,7 @@ class ChangePasswordTest extends OnlineTestCase
                     strstr($message, 'Server is unwilling to perform'));
             }
 
-            $this->assertType('Zend\Ldap\Ldap', $this->_getLDAP()->bind($dn, $newPasswd));
+            $this->assertInstanceOf('Zend\Ldap\Ldap', $this->_getLDAP()->bind($dn, $newPasswd));
 
             $this->_getLDAP()->bind();
             $this->_getLDAP()->delete($dn);
@@ -145,7 +145,7 @@ class ChangePasswordTest extends OnlineTestCase
         try {
             $this->_getLDAP()->add($dn, $data);
 
-            $this->assertType('Zend_LDAP', $this->_getLDAP()->bind($dn, $password));
+            $this->assertInstanceOf('Zend\Ldap', $this->_getLDAP()->bind($dn, $password));
 
             $this->_getLDAP()->bind();
             $this->_getLDAP()->delete($dn);
@@ -201,7 +201,7 @@ class ChangePasswordTest extends OnlineTestCase
                     strstr($message, 'Server is unwilling to perform'));
             }
 
-            $this->assertType('Zend_LDAP', $this->_getLDAP()->bind($dn, $newPasswd));
+            $this->assertInstanceOf('Zend\Ldap', $this->_getLDAP()->bind($dn, $newPasswd));
 
             $this->_getLDAP()->bind();
             $this->_getLDAP()->delete($dn);

--- a/tests/Zend/Ldap/ConnectTest.php
+++ b/tests/Zend/Ldap/ConnectTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -33,11 +33,11 @@ use Zend\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
+ * @group      Zend_Ldap
  */
 class ConnectTest extends \PHPUnit_Framework_TestCase
 {
@@ -46,7 +46,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         if (!constant('TESTS_ZEND_LDAP_ONLINE_ENABLED')) {
-            $this->markTestSkipped("Zend_LDAP online tests are not enabled");
+            $this->markTestSkipped("Zend_Ldap online tests are not enabled");
         }
 
         $this->_options = array('host' => TESTS_ZEND_LDAP_HOST);

--- a/tests/Zend/Ldap/ConverterTest.php
+++ b/tests/Zend/Ldap/ConverterTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -28,11 +28,11 @@ use Zend\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
+ * @group      Zend_Ldap
  */
 class ConverterTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Zend/Ldap/CopyRenameTest.php
+++ b/tests/Zend/Ldap/CopyRenameTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -28,11 +28,11 @@ use Zend\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
+ * @group      Zend_Ldap
  */
 class CopyRenameTest extends OnlineTestCase
 {

--- a/tests/Zend/Ldap/CrudTest.php
+++ b/tests/Zend/Ldap/CrudTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -27,11 +27,11 @@ use Zend\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
+ * @group      Zend_Ldap
  */
 class CrudTest extends OnlineTestCase
 {

--- a/tests/Zend/Ldap/Dn/CreationTest.php
+++ b/tests/Zend/Ldap/Dn/CreationTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -29,17 +29,17 @@ use Zend\Ldap;
  * Test helper
  */
 /**
- * Zend_LDAP_Dn
+ * Zend_Ldap_Dn
  */
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Dn
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Dn
  */
 class CreationTest extends \PHPUnit_Framework_TestCase
 {
@@ -119,7 +119,7 @@ class CreationTest extends \PHPUnit_Framework_TestCase
 
         try {
             $dn=Ldap\Dn::factory(1);
-            $this->fail('Expected Zend_LDAP_Exception not thrown');
+            $this->fail('Expected Zend_Ldap_Exception not thrown');
         } catch (Ldap\Exception $e) {
             $this->assertEquals('Invalid argument type for $dn', $e->getMessage());
         }
@@ -195,13 +195,13 @@ class CreationTest extends \PHPUnit_Framework_TestCase
 
         try {
             $dn->getParentDn(0)->toString();
-            $this->fail('Expected Zend_LDAP_Exception not thrown');
+            $this->fail('Expected Zend_Ldap_Exception not thrown');
         } catch (Ldap\Exception $e) {
             $this->assertEquals('Cannot retrieve parent DN with given $levelUp', $e->getMessage());
         }
         try {
             $dn->getParentDn(4)->toString();
-            $this->fail('Expected Zend_LDAP_Exception not thrown');
+            $this->fail('Expected Zend_Ldap_Exception not thrown');
         } catch (Ldap\Exception $e) {
             $this->assertEquals('Cannot retrieve parent DN with given $levelUp', $e->getMessage());
         }

--- a/tests/Zend/Ldap/Dn/EscapingTest.php
+++ b/tests/Zend/Ldap/Dn/EscapingTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -29,17 +29,17 @@ use Zend\Ldap;
  * Test helper
  */
 /**
- * Zend_LDAP_Dn
+ * Zend_Ldap_Dn
  */
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Dn
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Dn
  */
 class EscapingTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Zend/Ldap/Dn/ExplodingTest.php
+++ b/tests/Zend/Ldap/Dn/ExplodingTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -28,12 +28,12 @@ use Zend\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Dn
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Dn
  */
 class ExplodingTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Zend/Ldap/Dn/ImplodingTest.php
+++ b/tests/Zend/Ldap/Dn/ImplodingTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -27,12 +27,12 @@ use Zend\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Dn
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Dn
  */
 class ImplodingTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Zend/Ldap/Dn/MiscTest.php
+++ b/tests/Zend/Ldap/Dn/MiscTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -29,17 +29,17 @@ use Zend\Ldap;
  * Test helper
  */
 /**
- * Zend_LDAP_Dn
+ * Zend_Ldap_Dn
  */
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Dn
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Dn
  */
 class MiscTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Zend/Ldap/Dn/ModificationTest.php
+++ b/tests/Zend/Ldap/Dn/ModificationTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -29,17 +29,17 @@ use Zend\Ldap;
  * Test helper
  */
 /**
- * Zend_LDAP_Dn
+ * Zend_Ldap_Dn
  */
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Dn
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Dn
  */
 class ModificationTest extends \PHPUnit_Framework_TestCase
 {
@@ -54,19 +54,19 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('dc' => 'com'), $dn->get(3));
         try {
             $this->assertEquals(array('dc' => 'com'), $dn->get('string'));
-            $this->fail('Expected Zend_LDAP_Exception not thrown');
+            $this->fail('Expected Zend_Ldap_Exception not thrown');
         } catch (Ldap\Exception $e) {
             $this->assertEquals('Parameter $index must be an integer', $e->getMessage());
         }
         try {
             $this->assertEquals(array('cn' => 'Baker, Alice'), $dn->get(-1));
-            $this->fail('Expected Zend_LDAP_Exception not thrown');
+            $this->fail('Expected Zend_Ldap_Exception not thrown');
         } catch (Ldap\Exception $e) {
             $this->assertEquals('Parameter $index out of bounds', $e->getMessage());
         }
         try {
             $this->assertEquals(array('dc' => 'com'), $dn->get(4));
-            $this->fail('Expected Zend_LDAP_Exception not thrown');
+            $this->fail('Expected Zend_Ldap_Exception not thrown');
         } catch (Ldap\Exception $e) {
             $this->assertEquals('Parameter $index out of bounds', $e->getMessage());
         }
@@ -138,13 +138,13 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
 
         try {
             $dn->set(4, array('dc' => 'de'));
-            $this->fail('Expected Zend_LDAP_Exception not thrown');
+            $this->fail('Expected Zend_Ldap_Exception not thrown');
         } catch (Ldap\Exception $e) {
             $this->assertEquals('Parameter $index out of bounds', $e->getMessage());
         }
         try {
             $dn->set(3, array('dc' => 'de', 'ou'));
-            $this->fail('Expected Zend_LDAP_Exception not thrown');
+            $this->fail('Expected Zend_Ldap_Exception not thrown');
         } catch (Ldap\Exception $e) {
             $this->assertEquals('RDN Array is malformed: it must use string keys', $e->getMessage());
         }
@@ -170,7 +170,7 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         try {
             $dn=Ldap\Dn::fromString($dnString);
             $dn->remove(4);
-            $this->fail('Expected Zend_LDAP_Exception not thrown');
+            $this->fail('Expected Zend_Ldap_Exception not thrown');
         } catch (Ldap\Exception $e) {
             $this->assertEquals('Parameter $index out of bounds', $e->getMessage());
         }
@@ -201,13 +201,13 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
 
         try {
             $dn->append(array('dc' => 'de', 'ou'));
-            $this->fail('Expected Zend_LDAP_Exception not thrown');
+            $this->fail('Expected Zend_Ldap_Exception not thrown');
         } catch (Ldap\Exception $e) {
             $this->assertEquals('RDN Array is malformed: it must use string keys', $e->getMessage());
         }
         try {
             $dn->prepend(array('dc' => 'de', 'ou'));
-            $this->fail('Expected Zend_LDAP_Exception not thrown');
+            $this->fail('Expected Zend_Ldap_Exception not thrown');
         } catch (Ldap\Exception $e) {
             $this->assertEquals('RDN Array is malformed: it must use string keys', $e->getMessage());
         }
@@ -236,14 +236,14 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         try {
             $dn=Ldap\Dn::fromString($dnString);
             $dn->insert(4, array('dc' => 'de'));
-            $this->fail('Expected Zend_LDAP_Exception not thrown');
+            $this->fail('Expected Zend_Ldap_Exception not thrown');
         } catch (Ldap\Exception $e) {
             $this->assertEquals('Parameter $index out of bounds', $e->getMessage());
         }
         try {
             $dn=Ldap\Dn::fromString($dnString);
             $dn->insert(3, array('dc' => 'de', 'ou'));
-            $this->fail('Expected Zend_LDAP_Exception not thrown');
+            $this->fail('Expected Zend_Ldap_Exception not thrown');
         } catch (Ldap\Exception $e) {
             $this->assertEquals('RDN Array is malformed: it must use string keys', $e->getMessage());
         }

--- a/tests/Zend/Ldap/FilterTest.php
+++ b/tests/Zend/Ldap/FilterTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -27,11 +27,11 @@ use Zend\Ldap\Filter;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
+ * @group      Zend_Ldap
  */
 class FilterTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Zend/Ldap/Ldif/SimpleDecoderTest.php
+++ b/tests/Zend/Ldap/Ldif/SimpleDecoderTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -28,12 +28,12 @@ use Zend\Ldap\Ldif;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Ldif
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Ldif
  */
 class SimpleDecoderTest extends \ZendTest\Ldap\TestCase
 {

--- a/tests/Zend/Ldap/Ldif/SimpleEncoderTest.php
+++ b/tests/Zend/Ldap/Ldif/SimpleEncoderTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -28,12 +28,12 @@ use Zend\Ldap\Ldif;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Ldif
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Ldif
  */
 class SimpleEncoderTest extends \ZendTest\Ldap\TestCase
 {

--- a/tests/Zend/Ldap/Node/AttributeIterationTest.php
+++ b/tests/Zend/Ldap/Node/AttributeIterationTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -27,12 +27,12 @@ namespace ZendTest\Ldap\Node;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Node
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Node
  */
 class AttributeIterationTest extends \ZendTest\Ldap\TestCase
 {

--- a/tests/Zend/Ldap/Node/ChildrenIterationTest.php
+++ b/tests/Zend/Ldap/Node/ChildrenIterationTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -26,20 +26,20 @@ namespace ZendTest\Ldap\Node;
 use Zend\Ldap;
 
 /**
- * Zend_LDAP_OnlineTestCase
+ * Zend_Ldap_OnlineTestCase
  */
 /**
- * @see Zend_LDAP_Node
+ * @see Zend_Ldap_Node
  */
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Node
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Node
  */
 class ChildrenIterationTest extends \ZendTest\Ldap\OnlineTestCase
 {
@@ -113,7 +113,7 @@ class ChildrenIterationTest extends \ZendTest\Ldap\OnlineTestCase
 
     /**
      * Test issue reported by Lance Hendrix on
-     * http://framework.zend.com/wiki/display/ZFPROP/Zend_LDAP+-+Extended+support+-+Stefan+Gehrig?
+     * http://framework.zend.com/wiki/display/ZFPROP/Zend_Ldap+-+Extended+support+-+Stefan+Gehrig?
      *      focusedCommentId=13107431#comment-13107431
      */
     public function testCallingNextAfterIterationShouldNotThrowException()

--- a/tests/Zend/Ldap/Node/ChildrenTest.php
+++ b/tests/Zend/Ldap/Node/ChildrenTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -27,12 +27,12 @@ namespace ZendTest\Ldap\Node;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Node
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Node
  */
 class ChildrenTest extends \ZendTest\Ldap\OnlineTestCase
 {
@@ -52,9 +52,9 @@ class ChildrenTest extends \ZendTest\Ldap\OnlineTestCase
     {
         $node=$this->_getLDAP()->getBaseNode();
         $children=$node->getChildren();
-        $this->assertType('Zend\Ldap\Node\ChildrenIterator', $children);
+        $this->assertInstanceOf('Zend\Ldap\Node\ChildrenIterator', $children);
         $this->assertEquals(6, count($children));
-        $this->assertType('Zend\Ldap\Node', $children['ou=Node']);
+        $this->assertInstanceOf('Zend\Ldap\Node', $children['ou=Node']);
     }
 
     public function testGetChildrenOnDetachedNode()
@@ -62,16 +62,16 @@ class ChildrenTest extends \ZendTest\Ldap\OnlineTestCase
         $node=$this->_getLDAP()->getBaseNode();
         $node->detachLDAP();
         $children=$node->getChildren();
-        $this->assertType('Zend\Ldap\Node\ChildrenIterator', $children);
+        $this->assertInstanceOf('Zend\Ldap\Node\ChildrenIterator', $children);
         $this->assertEquals(0, count($children));
 
         $node->attachLDAP($this->_getLDAP());
         $node->reload();
         $children=$node->getChildren();
 
-        $this->assertType('Zend\Ldap\Node\ChildrenIterator', $children);
+        $this->assertInstanceOf('Zend\Ldap\Node\ChildrenIterator', $children);
         $this->assertEquals(6, count($children));
-        $this->assertType('Zend\Ldap\Node', $children['ou=Node']);
+        $this->assertInstanceOf('Zend\Ldap\Node', $children['ou=Node']);
     }
 
     public function testHasChildrenOnAttachedNode()

--- a/tests/Zend/Ldap/Node/OfflineTest.php
+++ b/tests/Zend/Ldap/Node/OfflineTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -28,12 +28,12 @@ use Zend\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Node
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Node
  */
 class OfflineTest extends \ZendTest\Ldap\TestCase
 {

--- a/tests/Zend/Ldap/Node/OnlineTest.php
+++ b/tests/Zend/Ldap/Node/OnlineTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -28,12 +28,12 @@ use Zend\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Node
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Node
  */
 class OnlineTest extends \ZendTest\Ldap\OnlineTestCase
 {
@@ -53,7 +53,7 @@ class OnlineTest extends \ZendTest\Ldap\OnlineTestCase
     {
         $dn=$this->_createDn('ou=Test1,');
         $node=Node::fromLDAP($dn, $this->_getLDAP());
-        $this->assertType('Zend\Ldap\Node', $node);
+        $this->assertInstanceOf('Zend\Ldap\Node', $node);
         $this->assertTrue($node->isAttached());
     }
 
@@ -107,7 +107,7 @@ class OnlineTest extends \ZendTest\Ldap\OnlineTestCase
     {
         $dn=$this->_createDn('ou=Test1,');
         $node=Node::fromLDAP($dn, $this->_getLDAP());
-        $this->assertType('Zend\Ldap\Node', $node);
+        $this->assertInstanceOf('Zend\Ldap\Node', $node);
         $this->assertTrue($node->isAttached());
         $node->detachLDAP();
         $this->assertFalse($node->isAttached());
@@ -213,7 +213,7 @@ class OnlineTest extends \ZendTest\Ldap\OnlineTestCase
         $node=$this->_getLDAP()->getNode($this->_createDn('ou=Node,'));
         $items=$node->searchSubtree('(objectClass=organizationalUnit)', Ldap\Ldap::SEARCH_SCOPE_SUB,
             array(), 'ou');
-        $this->assertType('Zend\Ldap\Node\Collection', $items);
+        $this->assertInstanceOf('Zend\Ldap\Node\Collection', $items);
         $this->assertEquals(3, $items->count());
 
         $i=0;
@@ -280,7 +280,7 @@ class OnlineTest extends \ZendTest\Ldap\OnlineTestCase
     {
         $dn=Ldap\Dn::fromString($this->_createDn('ou=Test1,'));
         $node=Node::fromLDAP($dn, $this->_getLDAP());
-        $this->assertType('Zend\Ldap\Node', $node);
+        $this->assertInstanceOf('Zend\Ldap\Node', $node);
         $this->assertTrue($node->isAttached());
     }
 }

--- a/tests/Zend/Ldap/Node/RootDseTest.php
+++ b/tests/Zend/Ldap/Node/RootDseTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -26,17 +26,17 @@ namespace ZendTest\Ldap\Node;
 use Zend\Ldap\Node\RootDse;
 
 /**
- * Zend_LDAP_OnlineTestCase
+ * Zend_Ldap_OnlineTestCase
  */
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Node
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Node
  */
 class RootDseTest extends \ZendTest\Ldap\OnlineTestCase
 {
@@ -53,38 +53,38 @@ class RootDseTest extends \ZendTest\Ldap\OnlineTestCase
     {
         $root=$this->_getLDAP()->getRootDse();
 
-        $this->assertType('boolean', $root->supportsSaslMechanism('GSSAPI'));
-        $this->assertType('boolean', $root->supportsSaslMechanism(array('GSSAPI', 'DIGEST-MD5')));
-        $this->assertType('boolean', $root->supportsVersion('3'));
-        $this->assertType('boolean', $root->supportsVersion(3));
-        $this->assertType('boolean', $root->supportsVersion(array('3', '2')));
-        $this->assertType('boolean', $root->supportsVersion(array(3, 2)));
+        $this->assertInternalType('boolean', $root->supportsSaslMechanism('GSSAPI'));
+        $this->assertInternalType('boolean', $root->supportsSaslMechanism(array('GSSAPI', 'DIGEST-MD5')));
+        $this->assertInternalType('boolean', $root->supportsVersion('3'));
+        $this->assertInternalType('boolean', $root->supportsVersion(3));
+        $this->assertInternalType('boolean', $root->supportsVersion(array('3', '2')));
+        $this->assertInternalType('boolean', $root->supportsVersion(array(3, 2)));
 
         switch ($root->getServerType()) {
             case RootDse::SERVER_TYPE_ACTIVEDIRECTORY:
-                $this->assertType('boolean', $root->supportsControl('1.2.840.113556.1.4.319'));
-                $this->assertType('boolean', $root->supportsControl(array('1.2.840.113556.1.4.319',
+                $this->assertInternalType('boolean', $root->supportsControl('1.2.840.113556.1.4.319'));
+                $this->assertInternalType('boolean', $root->supportsControl(array('1.2.840.113556.1.4.319',
                     '1.2.840.113556.1.4.473')));
-                $this->assertType('boolean', $root->supportsCapability('1.3.6.1.4.1.4203.1.9.1.1'));
-                $this->assertType('boolean', $root->supportsCapability(array('1.3.6.1.4.1.4203.1.9.1.1',
+                $this->assertInternalType('boolean', $root->supportsCapability('1.3.6.1.4.1.4203.1.9.1.1'));
+                $this->assertInternalType('boolean', $root->supportsCapability(array('1.3.6.1.4.1.4203.1.9.1.1',
                     '2.16.840.1.113730.3.4.18')));
-                $this->assertType('boolean', $root->supportsPolicy('unknown'));
-                $this->assertType('boolean', $root->supportsPolicy(array('unknown', 'unknown')));
+                $this->assertInternalType('boolean', $root->supportsPolicy('unknown'));
+                $this->assertInternalType('boolean', $root->supportsPolicy(array('unknown', 'unknown')));
                 break;
             case RootDse::SERVER_TYPE_EDIRECTORY:
-                $this->assertType('boolean', $root->supportsExtension('1.3.6.1.4.1.1466.20037'));
-                $this->assertType('boolean', $root->supportsExtension(array('1.3.6.1.4.1.1466.20037',
+                $this->assertInternalType('boolean', $root->supportsExtension('1.3.6.1.4.1.1466.20037'));
+                $this->assertInternalType('boolean', $root->supportsExtension(array('1.3.6.1.4.1.1466.20037',
                     '1.3.6.1.4.1.4203.1.11.1')));
                 break;
             case RootDse::SERVER_TYPE_OPENLDAP:
-                $this->assertType('boolean', $root->supportsControl('1.3.6.1.4.1.4203.1.9.1.1'));
-                $this->assertType('boolean', $root->supportsControl(array('1.3.6.1.4.1.4203.1.9.1.1',
+                $this->assertInternalType('boolean', $root->supportsControl('1.3.6.1.4.1.4203.1.9.1.1'));
+                $this->assertInternalType('boolean', $root->supportsControl(array('1.3.6.1.4.1.4203.1.9.1.1',
                     '2.16.840.1.113730.3.4.18')));
-                $this->assertType('boolean', $root->supportsExtension('1.3.6.1.4.1.1466.20037'));
-                $this->assertType('boolean', $root->supportsExtension(array('1.3.6.1.4.1.1466.20037',
+                $this->assertInternalType('boolean', $root->supportsExtension('1.3.6.1.4.1.1466.20037'));
+                $this->assertInternalType('boolean', $root->supportsExtension(array('1.3.6.1.4.1.1466.20037',
                     '1.3.6.1.4.1.4203.1.11.1')));
-                $this->assertType('boolean', $root->supportsFeature('1.3.6.1.1.14'));
-                $this->assertType('boolean', $root->supportsFeature(array('1.3.6.1.1.14',
+                $this->assertInternalType('boolean', $root->supportsFeature('1.3.6.1.1.14'));
+                $this->assertInternalType('boolean', $root->supportsFeature(array('1.3.6.1.1.14',
                     '1.3.6.1.4.1.4203.1.5.1')));
                 break;
         }
@@ -108,8 +108,8 @@ class RootDseTest extends \ZendTest\Ldap\OnlineTestCase
                 $this->assertInternalType('string', $root->getDsServiceName());
                 $this->assertInternalType('string', $root->getForestFunctionality());
                 $this->assertInternalType('string', $root->getHighestCommittedUSN());
-                $this->assertType('boolean', $root->getIsGlobalCatalogReady());
-                $this->assertType('boolean', $root->getIsSynchronized());
+                $this->assertInternalType('boolean', $root->getIsGlobalCatalogReady());
+                $this->assertInternalType('boolean', $root->getIsSynchronized());
                 $this->assertInternalType('string', $root->getLDAPServiceName());
                 $this->assertInternalType('string', $root->getRootDomainNamingContext());
                 $this->assertInternalType('string', $root->getSchemaNamingContext());

--- a/tests/Zend/Ldap/Node/SchemaTest.php
+++ b/tests/Zend/Ldap/Node/SchemaTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -26,22 +26,22 @@ namespace ZendTest\Ldap\Node;
 use Zend\Ldap\Node\RootDse;
 
 /**
- * Zend_LDAP_OnlineTestCase
+ * Zend_Ldap_OnlineTestCase
  */
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Node
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Node
  */
 class SchemaTest extends \ZendTest\Ldap\OnlineTestCase
 {
     /**
-     * @var Zend_LDAP_Node_Schema
+     * @var Zend_Ldap_Node_Schema
      */
     private $_schema;
 
@@ -126,7 +126,7 @@ class SchemaTest extends \ZendTest\Ldap\OnlineTestCase
 
         $this->assertArrayHasKey('organizationalUnit', $objectClasses);
         $ou=$objectClasses['organizationalUnit'];
-        $this->assertType('\Zend\Ldap\Node\Schema\ObjectClassOpenLdap', $ou);
+        $this->assertInstanceOf('\Zend\Ldap\Node\Schema\ObjectClassOpenLdap', $ou);
         $this->assertEquals('organizationalUnit', $ou->getName());
         $this->assertEquals('2.5.6.5', $ou->getOid());
         $this->assertEquals(array('objectClass', 'ou'), $ou->getMustContain());
@@ -167,7 +167,7 @@ class SchemaTest extends \ZendTest\Ldap\OnlineTestCase
 
         $this->assertArrayHasKey('ou', $attributeTypes);
         $ou=$attributeTypes['ou'];
-        $this->assertType('\Zend\Ldap\Node\Schema\AttributeTypeOpenLdap', $ou);
+        $this->assertInstanceOf('\Zend\Ldap\Node\Schema\AttributeTypeOpenLdap', $ou);
         $this->assertEquals('ou', $ou->getName());
         $this->assertEquals('2.5.4.11', $ou->getOid());
         $this->assertEquals('1.3.6.1.4.1.1466.115.121.1.15', $ou->getSyntax());

--- a/tests/Zend/Ldap/Node/SchemaTest.php
+++ b/tests/Zend/Ldap/Node/SchemaTest.php
@@ -126,7 +126,7 @@ class SchemaTest extends \ZendTest\Ldap\OnlineTestCase
 
         $this->assertArrayHasKey('organizationalUnit', $objectClasses);
         $ou=$objectClasses['organizationalUnit'];
-        $this->assertInstanceOf('\Zend\Ldap\Node\Schema\ObjectClassOpenLdap', $ou);
+        $this->assertInstanceOf('Zend\Ldap\Node\Schema\ObjectClass\OpenLdap', $ou);
         $this->assertEquals('organizationalUnit', $ou->getName());
         $this->assertEquals('2.5.6.5', $ou->getOid());
         $this->assertEquals(array('objectClass', 'ou'), $ou->getMustContain());
@@ -167,7 +167,7 @@ class SchemaTest extends \ZendTest\Ldap\OnlineTestCase
 
         $this->assertArrayHasKey('ou', $attributeTypes);
         $ou=$attributeTypes['ou'];
-        $this->assertInstanceOf('\Zend\Ldap\Node\Schema\AttributeTypeOpenLdap', $ou);
+        $this->assertInstanceOf('Zend\Ldap\Node\Schema\AttributeType\OpenLdap', $ou);
         $this->assertEquals('ou', $ou->getName());
         $this->assertEquals('2.5.4.11', $ou->getOid());
         $this->assertEquals('1.3.6.1.4.1.1466.115.121.1.15', $ou->getSyntax());

--- a/tests/Zend/Ldap/Node/UpdateTest.php
+++ b/tests/Zend/Ldap/Node/UpdateTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -28,12 +28,12 @@ use Zend\Ldap\Node;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
- * @group      Zend_LDAP_Node
+ * @group      Zend_Ldap
+ * @group      Zend_Ldap_Node
  */
 class UpdateTest extends \ZendTest\Ldap\OnlineTestCase
 {

--- a/tests/Zend/Ldap/OfflineTest.php
+++ b/tests/Zend/Ldap/OfflineTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -27,25 +27,25 @@ use Zend\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
+ * @group      Zend_Ldap
  */
 class OfflineTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * Zend_LDAP instance
+     * Zend_Ldap instance
      *
-     * @var Zend_LDAP
+     * @var Zend_Ldap
      */
     protected $_ldap = null;
 
     /**
      * Setup operations run prior to each test method:
      *
-     * * Creates an instance of Zend_LDAP
+     * * Creates an instance of Zend_Ldap
      *
      * @return void
      */
@@ -65,9 +65,9 @@ class OfflineTest extends \PHPUnit_Framework_TestCase
         $optionName = 'invalid';
         try {
             $this->_ldap->setOptions(array($optionName => 'irrelevant'));
-            $this->fail('Expected Zend_LDAP_Exception not thrown');
+            $this->fail('Expected Zend_Ldap_Exception not thrown');
         } catch (Ldap\Exception $e) {
-            $this->assertEquals("Unknown Zend_LDAP option: $optionName", $e->getMessage());
+            $this->assertEquals("Unknown Zend_Ldap option: $optionName", $e->getMessage());
         }
     }
 

--- a/tests/Zend/Ldap/OnlineTestCase.php
+++ b/tests/Zend/Ldap/OnlineTestCase.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -27,16 +27,16 @@ use Zend\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
+ * @group      Zend_Ldap
  */
 abstract class OnlineTestCase extends TestCase
 {
     /**
-     * @var Zend_LDAP
+     * @var Zend_Ldap
      */
     private $_ldap;
 
@@ -56,7 +56,7 @@ abstract class OnlineTestCase extends TestCase
     protected function setUp()
     {
         if (!constant('TESTS_ZEND_LDAP_ONLINE_ENABLED')) {
-            $this->markTestSkipped("Zend_LDAP online tests are not enabled");
+            $this->markTestSkipped("Zend_Ldap online tests are not enabled");
         }
 
         $options = array(

--- a/tests/Zend/Ldap/SearchTest.php
+++ b/tests/Zend/Ldap/SearchTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -30,11 +30,11 @@ use Zend\Ldap\Collection;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
+ * @group      Zend_Ldap
  */
 class SearchTest extends OnlineTestCase
 {
@@ -284,7 +284,7 @@ class SearchTest extends OnlineTestCase
 
     /**
      * Test issue reported by Lance Hendrix on
-     * http://framework.zend.com/wiki/display/ZFPROP/Zend_LDAP+-+Extended+support+-+Stefan+Gehrig?
+     * http://framework.zend.com/wiki/display/ZFPROP/Zend_Ldap+-+Extended+support+-+Stefan+Gehrig?
      *      focusedCommentId=13107431#comment-13107431
      */
     public function testCallingNextAfterIterationShouldNotThrowException()

--- a/tests/Zend/Ldap/TestCase.php
+++ b/tests/Zend/Ldap/TestCase.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -27,11 +27,11 @@ namespace ZendTest\Ldap;
 
 /**
  * @category   Zend
- * @package    Zend_LDAP
+ * @package    Zend_Ldap
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @group      Zend_LDAP
+ * @group      Zend_Ldap
  */
 abstract class TestCase extends \PHPUnit_Framework_TestCase
 {
@@ -52,7 +52,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return Zend_LDAP_Node
+     * @return Zend_Ldap_Node
      */
     protected function _createTestNode()
     {


### PR DESCRIPTION
Fix testInvalidOptionResultsInException() fail because classname was wrong.

Fix all PHP Fatal error: Call to undefined method ZendTest\Ldap****Test::assertType() (See #313)

Change old Zend_LDAP references to Zend_Ldap, also some typo on classnames like Zenda_Ldap was fixed too.
