### PR TITLE
Fix Zend\Loader\AutoloaderFactory for PHP Versions 5.3.6 and under

### DIFF
--- a/library/Zend/Loader/AutoloaderFactory.php
+++ b/library/Zend/Loader/AutoloaderFactory.php
@@ -105,11 +105,12 @@ abstract class AutoloaderFactory
                 // unfortunately is_subclass_of is broken on some 5.3 versions
                 // additionally instanceof is also broken for this use case
                 if (version_compare(PHP_VERSION, '5.3.6', '>')) {
-                    if (!is_subclass_of($class, 'Zend\Loader\SplAutoloader')) {
-                    require_once 'Exception/InvalidArgumentException.php';
-                    throw new Exception\InvalidArgumentException(
-                                sprintf('Autoloader class %s must implement Zend\\Loader\\SplAutoloader', $class)
-                    );
+                        if (!is_subclass_of($class, 'Zend\Loader\SplAutoloader')) {
+                        require_once 'Exception/InvalidArgumentException.php';
+                        throw new Exception\InvalidArgumentException(
+                                    sprintf('Autoloader class %s must implement Zend\\Loader\\SplAutoloader', $class)
+                        );
+                    }
                 }
 
                 if ($class === static::STANDARD_AUTOLOADER) {

--- a/library/Zend/Loader/AutoloaderFactory.php
+++ b/library/Zend/Loader/AutoloaderFactory.php
@@ -104,7 +104,7 @@ abstract class AutoloaderFactory
 
                 // unfortunately is_subclass_of is broken on some 5.3 versions
                 // additionally instanceof is also broken for this use case
-                if (version_compare(PHP_VERSION, '5.3.6', '>')) {
+                if (version_compare(PHP_VERSION, '5.3.7', '>=')) {
                         if (!is_subclass_of($class, 'Zend\Loader\SplAutoloader')) {
                         require_once 'Exception/InvalidArgumentException.php';
                         throw new Exception\InvalidArgumentException(

--- a/library/Zend/Loader/AutoloaderFactory.php
+++ b/library/Zend/Loader/AutoloaderFactory.php
@@ -102,7 +102,10 @@ abstract class AutoloaderFactory
                     );
                 }
 
-                if (!is_subclass_of($class, 'Zend\Loader\SplAutoloader')) {
+                // unfortunately is_subclass_of is broken on some 5.3 versions
+                // additionally instanceof is also broken for this use case
+                if (version_compare(PHP_VERSION, '5.3.6', '>')) {
+                    if (!is_subclass_of($class, 'Zend\Loader\SplAutoloader')) {
                     require_once 'Exception/InvalidArgumentException.php';
                     throw new Exception\InvalidArgumentException(
                                 sprintf('Autoloader class %s must implement Zend\\Loader\\SplAutoloader', $class)

--- a/tests/Zend/Loader/AutoloaderFactoryTest.php
+++ b/tests/Zend/Loader/AutoloaderFactoryTest.php
@@ -88,6 +88,9 @@ class AutoloaderFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testFactoryCatchesInvalidClasses()
     {
+        if (version_compare(PHP_VERSION, '5.3.6', '<=')) {
+            $this->markTestSkipped('Cannot test invalid interface loader with versions less than or equal to 5.3.6');
+        }
         include __DIR__ . '/_files/InvalidInterfaceAutoloader.php';
         AutoloaderFactory::factory(array(
             'InvalidInterfaceAutoloader' => array()            

--- a/tests/Zend/Loader/AutoloaderFactoryTest.php
+++ b/tests/Zend/Loader/AutoloaderFactoryTest.php
@@ -88,8 +88,8 @@ class AutoloaderFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testFactoryCatchesInvalidClasses()
     {
-        if (version_compare(PHP_VERSION, '5.3.6', '<=')) {
-            $this->markTestSkipped('Cannot test invalid interface loader with versions less than or equal to 5.3.6');
+        if (!version_compare(PHP_VERSION, '5.3.7', '>=')) {
+            $this->markTestSkipped('Cannot test invalid interface loader with versions less than 5.3.7');
         }
         include __DIR__ . '/_files/InvalidInterfaceAutoloader.php';
         AutoloaderFactory::factory(array(


### PR DESCRIPTION
is_subclass_of AND instanceof are broken in PHP versions 5.3.6 for checking of interfaces in some conditions.  

This behavior has broken several peoples instances with errors that state:
Fatal error: Uncaught exception 'Zend\Loader\Exception\InvalidArgumentException' with message 'Autoloader class Zend\Loader\ClassMapAutoloader must implement Zend\Loader\SplAutoloader' in /homer/efi/speck/vendor/ZendFramework/library/Zend/Loader/AutoloaderFactory.php on line 107

This is simply due to the php version.  I can verify that PHP 5.3.9 works and from the PHP changelog for 5.3.7:
Fixed bug #53727 (Inconsistent behavior of is_subclass_of with interfaces) (Ralph Schindler, Dmitry)

So this behavior will happen for all versions under 5.3.7.
The change:
1) Do not validate that the class is a subclass of Zend\Loader\SplAutoloader (nor an instanceof) by using a version check.  - The only real way to check this is with reflection which is VERY expensive
2) Skip the test on using version compare
