### PR TITLE
[ZF2-171] trigger 'finish' before returning response

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -233,6 +233,7 @@ class Application implements AppContext
         if ($result->stopped()) {
             $response = $result->last();
             if ($response instanceof Response) {
+                $events->trigger('finish', $event);
                 return $response;
             }
             if ($event->getError()) {
@@ -250,6 +251,7 @@ class Application implements AppContext
         // Complete response
         $response = $result->last();
         if ($response instanceof Response) {
+            $events->trigger('finish', $event);
             return $response;
         }
 

--- a/tests/Zend/Mvc/ApplicationTest.php
+++ b/tests/Zend/Mvc/ApplicationTest.php
@@ -588,4 +588,50 @@ class ApplicationTest extends TestCase
         $event = $app->getMvcEvent();
         $this->assertEquals(Application::ERROR_CONTROLLER_NOT_FOUND, $event->getError());
     }
+
+    /**
+     * @group ZF2-171
+     */
+    public function testFinishShouldRunEvenIfRouteEventReturnsResponse()
+    {
+        $app      = new Application();
+        $response = $app->getResponse();
+        $events   = $app->events();
+        $events->attach('route', function($e) use ($response) {
+            return $response;
+        }, 100);
+
+        $token = new stdClass;
+        $events->attach('finish', function($e) use ($token) {
+            $token->foo = 'bar';
+        });
+
+        $app->run();
+        $this->assertTrue(isset($token->foo));
+        $this->assertEquals('bar',$token->foo);
+    }
+
+    /**
+     * @group ZF2-171
+     */
+    public function testFinishShouldRunEvenIfDispatchEventReturnsResponse()
+    {
+        $this->markTestSkipped();
+        $app      = new Application();
+        $response = $app->getResponse();
+        $events   = $app->events();
+        $events->clearListeners('route');
+        $events->attach('dispatch', function($e) use ($response) {
+            return $response;
+        }, 100);
+
+        $token = new stdClass;
+        $events->attach('finish', function($e) use ($token) {
+            $token->foo = 'bar';
+        });
+
+        $app->run();
+        $this->assertTrue(isset($token->foo));
+        $this->assertEquals('bar',$token->foo);
+    }
 }

--- a/tests/Zend/Mvc/ApplicationTest.php
+++ b/tests/Zend/Mvc/ApplicationTest.php
@@ -616,7 +616,6 @@ class ApplicationTest extends TestCase
      */
     public function testFinishShouldRunEvenIfDispatchEventReturnsResponse()
     {
-        $this->markTestSkipped();
         $app      = new Application();
         $response = $app->getResponse();
         $events   = $app->events();


### PR DESCRIPTION
- Identified two locations in run() where a response was being returned
  without triggering the "finish" event
