### PR TITLE
Add router DI definition to Bootstrap

### DIFF
--- a/library/Zend/Mvc/Bootstrap.php
+++ b/library/Zend/Mvc/Bootstrap.php
@@ -98,7 +98,19 @@ class Bootstrap implements Bootstrapper
         $di->instanceManager()->addTypePreference('Zend\Di\Locator', $di);
 
         // Default configuration for common MVC classes
-        $routerDiConfig = new DiConfiguration(array('definition' => array('class' => array(
+        $diConfig = new DiConfiguration(array('definition' => array('class' => array(
+            'Zend\Mvc\Router\RouteStack' => array(
+                'instantiator' => array(
+                    'Zend\Mvc\Router\Http\TreeRouteStack',
+                    'factory'
+                ),
+            ),
+            'Zend\Mvc\Router\Http\TreeRouteStack' => array(
+                'instantiator' => array(
+                    'Zend\Mvc\Router\Http\TreeRouteStack',
+                    'factory'
+                ),
+            ),
             'Zend\Mvc\View\DefaultRenderingStrategy' => array(
                 'setBaseTemplate' => array(
                     'baseTemplate' => array(
@@ -200,7 +212,7 @@ class Bootstrap implements Bootstrapper
                 ),
             ),
         ))));
-        $routerDiConfig->configure($di);
+        $diConfig->configure($di);
 
         $config = new DiConfiguration($this->config->di);
         $config->configure($di);


### PR DESCRIPTION
- Added the router DI definition to the bootstrap:
  - RouteStack -> instantiator becomes TreeRouteStack::factory
  - TreeRouteStack -> instantiator becomes TreeRouteStack::factory
- Basically, moving this to the skeleton app led to a FAQ situation, and
  if we need a FAQ for common setup, we need to code such that the FAQ
  is no longer necessary. Additionally, you can override the definition
  at any point within your own configuration, as app/module
  configuration is applied after the explicit configuration in the
  bootstrap.
