### PR TITLE
ClassMapAutoloaderTest fails due to array_pop instead of array_shift

### DIFF
--- a/library/Zend/Loader/AutoloaderFactory.php
+++ b/library/Zend/Loader/AutoloaderFactory.php
@@ -105,11 +105,12 @@ abstract class AutoloaderFactory
                 // unfortunately is_subclass_of is broken on some 5.3 versions
                 // additionally instanceof is also broken for this use case
                 if (version_compare(PHP_VERSION, '5.3.6', '>')) {
-                    if (!is_subclass_of($class, 'Zend\Loader\SplAutoloader')) {
-                    require_once 'Exception/InvalidArgumentException.php';
-                    throw new Exception\InvalidArgumentException(
-                                sprintf('Autoloader class %s must implement Zend\\Loader\\SplAutoloader', $class)
-                    );
+                        if (!is_subclass_of($class, 'Zend\Loader\SplAutoloader')) {
+                        require_once 'Exception/InvalidArgumentException.php';
+                        throw new Exception\InvalidArgumentException(
+                                    sprintf('Autoloader class %s must implement Zend\\Loader\\SplAutoloader', $class)
+                        );
+                    }
                 }
 
                 if ($class === static::STANDARD_AUTOLOADER) {

--- a/library/Zend/Loader/AutoloaderFactory.php
+++ b/library/Zend/Loader/AutoloaderFactory.php
@@ -102,7 +102,10 @@ abstract class AutoloaderFactory
                     );
                 }
 
-                if (!is_subclass_of($class, 'Zend\Loader\SplAutoloader')) {
+                // unfortunately is_subclass_of is broken on some 5.3 versions
+                // additionally instanceof is also broken for this use case
+                if (version_compare(PHP_VERSION, '5.3.6', '>')) {
+                    if (!is_subclass_of($class, 'Zend\Loader\SplAutoloader')) {
                     require_once 'Exception/InvalidArgumentException.php';
                     throw new Exception\InvalidArgumentException(
                                 sprintf('Autoloader class %s must implement Zend\\Loader\\SplAutoloader', $class)

--- a/tests/Zend/Loader/AutoloaderFactoryTest.php
+++ b/tests/Zend/Loader/AutoloaderFactoryTest.php
@@ -88,6 +88,9 @@ class AutoloaderFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testFactoryCatchesInvalidClasses()
     {
+        if (version_compare(PHP_VERSION, '5.3.6', '<=')) {
+            $this->markTestSkipped('Cannot test invalid interface loader with versions less than or equal to 5.3.6');
+        }
         include __DIR__ . '/_files/InvalidInterfaceAutoloader.php';
         AutoloaderFactory::factory(array(
             'InvalidInterfaceAutoloader' => array()            

--- a/tests/Zend/Loader/ClassMapAutoloaderTest.php
+++ b/tests/Zend/Loader/ClassMapAutoloaderTest.php
@@ -178,7 +178,7 @@ class ClassMapAutoloaderTest extends \PHPUnit_Framework_TestCase
         $this->loader->register();
         $loaders = spl_autoload_functions();
         $this->assertTrue(count($this->loaders) < count($loaders));
-        $test = array_pop($loaders);
+        $test = array_shift($loaders);
         $this->assertEquals(array($this->loader, 'autoload'), $test);
     }
 


### PR DESCRIPTION
The classmap autoloader is testing that it has registered; although this fails since array_pop was used instead of array_shift.  This change fixes this,
