### PR TITLE
ClassMapAutoloaderTest fails due to array_pop instead of array_shift

### DIFF
--- a/tests/Zend/Loader/ClassMapAutoloaderTest.php
+++ b/tests/Zend/Loader/ClassMapAutoloaderTest.php
@@ -178,7 +178,7 @@ class ClassMapAutoloaderTest extends \PHPUnit_Framework_TestCase
         $this->loader->register();
         $loaders = spl_autoload_functions();
         $this->assertTrue(count($this->loaders) < count($loaders));
-        $test = array_pop($loaders);
+        $test = array_shift($loaders);
         $this->assertEquals(array($this->loader, 'autoload'), $test);
     }
 


### PR DESCRIPTION
The ClassMapAutoloaderTest is supposed to test that the ClassMapAutoloader was registered; however it was using array_pop instead of array_shift.
