### PR TITLE
Allow Zend\Cache\Storage\Adapter\Memcached to Handle Multiple Connections

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/Memcached.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcached.php
@@ -84,10 +84,7 @@ class Memcached extends AbstractAdapter
             $options->addServer('localhost', 11211);
             $servers = $options->getServers();
         }
-
-        foreach ($servers as $server) {
-            $this->memcached->addServer($server[0], $server[1]);
-        }
+        $this->memcached->addServers($servers);
     }
 
     /* options */

--- a/library/Zend/Cache/Storage/Adapter/Memcached.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcached.php
@@ -77,9 +77,17 @@ class Memcached extends AbstractAdapter
 
         // It's ok to add server as soon as possible because
         // ext/memcached auto-connects to the server on first use
-        // TODO: Handle multiple servers
         $options = $this->getOptions();
-        $this->memcached->addServer($options->getServer(), $options->getPort());
+
+        $servers = $options->getServers();
+        if (!$servers) {
+            $options->addServer('localhost', 11211);
+            $servers = $options->getServers();
+        }
+
+        foreach ($servers as $server) {
+            $this->memcached->addServer($server[0], $server[1]);
+        }
     }
 
     /* options */

--- a/tests/Zend/Cache/Storage/Adapter/MemcachedTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/MemcachedTest.php
@@ -47,6 +47,48 @@ class MemcachedTest extends CommonAdapterTest
         parent::setUp();
     }
 
+    public function testOptionsAddServer()
+    {
+        $options = new Cache\Storage\Adapter\MemcachedOptions();
+        $options->addServer('127.0.0.1', 11211);
+        $options->addServer('localhost');
+        $options->addServer('domain.com', 11215);
+
+        $servers = array(
+            array('127.0.0.1', 11211),
+            array('localhost', 11211),
+            array('domain.com', 11215),
+        );
+
+        $this->assertEquals($options->getServers(), $servers);
+        $memcached = new Cache\Storage\Adapter\Memcached($options);
+        $this->assertEquals($memcached->getOptions()->getServers(), $servers);
+    }
+
+    public function testOptionsSetServers()
+    {
+        $options = new Cache\Storage\Adapter\MemcachedOptions();
+        $servers = array(
+            array('127.0.0.1', 12345),
+            array('localhost', 54321),
+            array('domain.com')
+        );
+
+        $options->setServers($servers);
+        $servers[2][1] = 11211;
+        $this->assertEquals($options->getServers(), $servers);
+
+        $memcached = new Cache\Storage\Adapter\Memcached($options);
+        $this->assertEquals($memcached->getOptions()->getServers(), $servers);
+    }
+
+    public function testNoOptionsSetsDefaultServer()
+    {
+        $memcached = new Cache\Storage\Adapter\Memcached();
+
+        $this->assertEquals($memcached->getOptions()->getServers(), array(array('localhost', 11211)));
+    }
+
     public function tearDown()
     {
         if (!empty($this->_storage)) {

--- a/tests/Zend/Cache/Storage/Adapter/MemcachedTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/MemcachedTest.php
@@ -42,8 +42,7 @@ class MemcachedTest extends CommonAdapterTest
         }
 
         $this->_options = new Cache\Storage\Adapter\MemcachedOptions();
-        $this->_storage = new Cache\Storage\Adapter\Memcached();
-        $this->_storage->setOptions($this->_options);
+        $this->_storage = new Cache\Storage\Adapter\Memcached($this->_options);
 
         parent::setUp();
     }


### PR DESCRIPTION
This pull request allows for multiple connection handling to memcached; can verify that the added tests pass (there are some existing tests that are broken prior to this change and same amount are broken after this change).

This in particular just adds the options handling to add and modify servers; adds some validation to the hostname.
