### PR TITLE
[ZF2-176] Replace all assertType assertions.

### DIFF
--- a/tests/Zend/Db/Statement/Db2Test.php
+++ b/tests/Zend/Db/Statement/Db2Test.php
@@ -95,7 +95,7 @@ class Db2Test extends AbstractTest
             $this->assertTrue($stmt->bindParam('name', $productNameValue), 'Expected bindParam(\'name\') to return true');
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend_Db_Statement_Exception', $e,
+            $this->assertInstanceOf('Zend_Db_Statement_Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->assertEquals("Invalid bind-variable name ':id'", $e->getMessage());
         }
@@ -123,7 +123,7 @@ class Db2Test extends AbstractTest
             $this->assertTrue($stmt->bindParam('name', $productNameValue), 'Expected bindParam(\'name\') to return true');
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend_Db_Statement_Exception', $e,
+            $this->assertInstanceOf('Zend_Db_Statement_Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->assertEquals("Invalid bind-variable name ':id'", $e->getMessage());
         }

--- a/tests/Zend/Db/Statement/MysqliTest.php
+++ b/tests/Zend/Db/Statement/MysqliTest.php
@@ -78,7 +78,7 @@ class MySQLiTest extends AbstractTest
             $this->assertTrue($stmt->bindParam('name', $productNameValue), 'Expected bindParam(\'name\') to return true');
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend_Db_Statement_Exception', $e,
+            $this->assertInstanceOf('Zend_Db_Statement_Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->assertEquals("Invalid bind-variable name ':id'", $e->getMessage());
         }
@@ -101,7 +101,7 @@ class MySQLiTest extends AbstractTest
             $this->assertTrue($stmt->bindParam('name', $productNameValue), 'Expected bindParam(\'name\') to return true');
             $this->fail('Expected to catch Zend_Db_Statement_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend_Db_Statement_Exception', $e,
+            $this->assertInstanceOf('Zend_Db_Statement_Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->assertEquals("Invalid bind-variable name ':id'", $e->getMessage());
         }

--- a/tests/Zend/Db/Statement/MysqliTest.php
+++ b/tests/Zend/Db/Statement/MysqliTest.php
@@ -40,7 +40,7 @@ class MySQLiTest extends AbstractTest
     {
         $this->markTestSkipped('This suite is skipped until Zend\DB can be refactored.');
     }
-    
+
     public function testStatementRowCount()
     {
         $products = $this->_db->quoteIdentifier('zfproducts');
@@ -134,7 +134,7 @@ class MySQLiTest extends AbstractTest
     public function testStatementCanReturnDriverStatement()
     {
         $statement = parent::testStatementCanReturnDriverStatement();
-        $this->assertType('mysqli_stmt', $statement->getDriverStatement());
+        $this->assertInstanceOf('mysqli_stmt', $statement->getDriverStatement());
     }
 
     /**
@@ -149,39 +149,39 @@ class MySQLiTest extends AbstractTest
         $result = $stmt->fetch();
         $this->assertFalse($result);
     }
-    
-	/**
-	 * Test to verify valid report of issue
-	 * 
+
+    /**
+     * Test to verify valid report of issue
+     *
      * @group ZF-8986
      */
     public function testNumberOfBoundParamsDoesNotMatchNumberOfTokens()
     {
-    	$this->_util->createTable('zf_objects', array(
-            'object_id'		=> 'INTEGER NOT NULL',
-    		'object_type'	=> 'INTEGER NOT NULL',
-    		'object_status' => 'INTEGER NOT NULL',
-    		'object_lati'   => 'REAL',
-    		'object_long'   => 'REAL',
+        $this->_util->createTable('zf_objects', array(
+            'object_id'     => 'INTEGER NOT NULL',
+            'object_type'   => 'INTEGER NOT NULL',
+            'object_status' => 'INTEGER NOT NULL',
+            'object_lati'   => 'REAL',
+            'object_long'   => 'REAL',
         ));
         $tableName = $this->_util->getTableName('zf_objects');
-        
+
         $numRows = $this->_db->insert($tableName, array (
-        	'object_id' => 1,
-        	'object_type' => 1,
-        	'object_status' => 1,
-        	'object_lati' => 1.12345,
-        	'object_long' => 1.54321,
+            'object_id'     => 1,
+            'object_type'   => 1,
+            'object_status' => 1,
+            'object_lati'   => 1.12345,
+            'object_long'   => 1.54321,
         ));
-        
+
         $sql = 'SELECT object_id, object_type, object_status,'
-             . ' object_lati, object_long FROM ' . $tableName 
+             . ' object_lati, object_long FROM ' . $tableName
              . ' WHERE object_id = ?';
-             
+
         try {
-        	$stmt = $this->_db->query($sql, 1);
+            $stmt = $this->_db->query($sql, 1);
         } catch (\Exception $e) {
-        	$this->fail('Bounding params failed: ' . $e->getMessage());
+            $this->fail('Bounding params failed: ' . $e->getMessage());
         }
         $result = $stmt->fetch();
         $this->assertInternalType('array', $result);

--- a/tests/Zend/Db/Statement/OracleTest.php
+++ b/tests/Zend/Db/Statement/OracleTest.php
@@ -98,7 +98,7 @@ class OracleTest extends AbstractTest
             $stmt->nextRowset();
             $this->fail('Expected to catch Zend_Db_Statement_Oracle_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend_Db_Statement_Oracle_Exception', $e,
+            $this->assertInstanceOf('Zend_Db_Statement_Oracle_Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Oracle_Exception, got '.get_class($e));
             $this->assertEquals('HYC00 Optional feature not implemented', $e->getMessage());
         }

--- a/tests/Zend/Db/Statement/PdoMysqlTest.php
+++ b/tests/Zend/Db/Statement/PdoMysqlTest.php
@@ -76,7 +76,7 @@ class PdoMysqlTest extends AbstractPdoTest
     public function testStatementCanReturnDriverStatement()
     {
         $statement = parent::testStatementCanReturnDriverStatement();
-        $this->assertType('PDOStatement', $statement->getDriverStatement());
+        $this->assertInstanceOf('PDOStatement', $statement->getDriverStatement());
     }
 
     public function getDriver()

--- a/tests/Zend/Db/Statement/PdoMysqlTest.php
+++ b/tests/Zend/Db/Statement/PdoMysqlTest.php
@@ -45,7 +45,7 @@ class PdoMysqlTest extends AbstractPdoTest
         try {
             $stmt->nextRowset();
         } catch (\Zend\Db\Statement\Exception $e) {
-            $this->assertType('Zend_Db_Statement_Exception', $e,
+            $this->assertInstanceOf('Zend_Db_Statement_Exception', $e,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
             $this->assertEquals('SQLSTATE[HYC00]: Optional feature not implemented', $e->getMessage());
         }

--- a/tests/Zend/Db/Statement/PdoSqliteTest.php
+++ b/tests/Zend/Db/Statement/PdoSqliteTest.php
@@ -40,7 +40,7 @@ class PdoSqliteTest extends AbstractPdoTest
     {
         $this->markTestSkipped('This suite is skipped until Zend\DB can be refactored.');
     }
-    
+
     public function testStatementBindParamByName()
     {
         $this->markTestIncomplete($this->getDriver() . ' is having trouble with binding parameters');
@@ -61,7 +61,7 @@ class PdoSqliteTest extends AbstractPdoTest
     public function testStatementCanReturnDriverStatement()
     {
         $statement = parent::testStatementCanReturnDriverStatement();
-        $this->assertType('PDOStatement', $statement->getDriverStatement());
+        $this->assertInstanceOf('PDOStatement', $statement->getDriverStatement());
     }
 
     public function getDriver()

--- a/tests/Zend/Db/Table/Relationships/AbstractTest.php
+++ b/tests/Zend/Db/Table/Relationships/AbstractTest.php
@@ -48,15 +48,15 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table = $this->_table['bugs'];
 
         $childRows = $table->fetchAll("$bug_id = 1");
-        $this->assertType('Zend\Db\Table\AbstractRowset', $childRows,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $childRows,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($childRows));
 
         $childRow1 = $childRows->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $childRow1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $childRow1,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($childRow1));
 
         $parentRow = $childRow1->findParentRow('\ZendTest\Db\Table\TestAsset\TableAccounts');
-        $this->assertType('Zend\Db\Table\AbstractRow', $parentRow,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $parentRow,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($parentRow));
 
         $this->assertEquals('goofy', $parentRow->$account_name);
@@ -72,15 +72,15 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $select = $table->select()->where($account_name_column . ' = ?', 'goofy');
 
         $childRows = $table->fetchAll("$bug_id = 1");
-        $this->assertType('Zend\Db\Table\AbstractRowset', $childRows,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $childRows,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($childRows));
 
         $childRow1 = $childRows->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $childRow1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $childRow1,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($childRow1));
 
         $parentRow = $childRow1->findParentRow('\ZendTest\Db\Table\TestAsset\TableAccounts', null, $select);
-        $this->assertType('Zend\Db\Table\AbstractRow', $parentRow,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $parentRow,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($parentRow));
 
         $this->assertEquals('goofy', $parentRow->$account_name);
@@ -94,15 +94,15 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 //        $table = $this->_table['bugs'];
 //
 //        $childRows = $table->fetchAll("$bug_id = 1");
-//        $this->assertType('Zend\Db\Table\AbstractRowset', $childRows,
+//        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $childRows,
 //            'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($childRows));
 //
 //        $childRow1 = $childRows->current();
-//        $this->assertType('Zend\Db\Table\AbstractRow', $childRow1,
+//        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $childRow1,
 //            'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($childRow1));
 //
 //        $parentRow = $childRow1->findParentZend_Db_Table_Asset_TableAccounts();
-//        $this->assertType('Zend\Db\Table\AbstractRow', $parentRow,
+//        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $parentRow,
 //            'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($parentRow));
 //
 //        $this->assertEquals('goofy', $parentRow->$account_name);
@@ -118,15 +118,15 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 //        $select = $table->select()->where($account_name_column . ' = ?', 'goofy');
 //
 //        $childRows = $table->fetchAll("$bug_id = 1");
-//        $this->assertType('Zend\Db\Table\AbstractRowset', $childRows,
+//        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $childRows,
 //            'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($childRows));
 //
 //        $childRow1 = $childRows->current();
-//        $this->assertType('Zend\Db\Table\AbstractRow', $childRow1,
+//        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $childRow1,
 //            'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($childRow1));
 //
 //        $parentRow = $childRow1->findParentZend_Db_Table_Asset_TableAccounts($select);
-//        $this->assertType('Zend\Db\Table\AbstractRow', $parentRow,
+//        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $parentRow,
 //            'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($parentRow));
 //
 //        $this->assertEquals('goofy', $parentRow->$account_name);
@@ -144,7 +144,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $result = $parentRow1->nonExistantMethod();
             $this->fail('Expected to catch Zend_Db_Table_Row_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\RowException', $e,
+            $this->assertInstanceOf('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend_Db_Table_Row_Exception got '.get_class($e));
             $this->assertEquals("Unrecognized method 'nonExistantMethod()'", $e->getMessage());
         }
@@ -186,7 +186,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $originRow1 = $originRows->current();
 
         $destRows = $originRow1->findManyToManyRowset('\ZendTest\Db\Table\TestAsset\TableProducts', '\ZendTest\Db\Table\TestAsset\TableBugsProducts');
-        $this->assertType('Zend\Db\Table\AbstractRowset', $destRows,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $destRows,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($destRows));
 
         $this->assertEquals(3, $destRows->count());
@@ -208,7 +208,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 
         $destRows = $originRow1->findManyToManyRowset('\ZendTest\Db\Table\TestAsset\TableProducts', '\ZendTest\Db\Table\TestAsset\TableBugsProducts',
                                                       null, null, $select);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $destRows,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $destRows,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($destRows));
 
         $this->assertEquals(2, $destRows->count());
@@ -225,7 +225,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 //        $originRow1 = $originRows->current();
 //
 //        $destRows = $originRow1->findZend_Db_Table_Asset_TableProductsViaZend_Db_Table_Asset_TableBugsProducts();
-//        $this->assertType('Zend\Db\Table\AbstractRowset', $destRows,
+//        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $destRows,
 //            'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($destRows));
 //
 //        $this->assertEquals(3, $destRows->count());
@@ -246,7 +246,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 //        $originRow1 = $originRows->current();
 //
 //        $destRows = $originRow1->findZend_Db_Table_Asset_TableProductsViaZend_Db_Table_Asset_TableBugsProducts($select);
-//        $this->assertType('Zend\Db\Table\AbstractRowset', $destRows,
+//        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $destRows,
 //            'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($destRows));
 //
 //        $this->assertEquals(2, $destRows->count());
@@ -320,18 +320,18 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $product_id = $this->_db->foldCase('product_id');
 
         $parentRows = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $parentRows,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $parentRows,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($parentRows));
         $parentRow1 = $parentRows->current();
 
         $childRows = $parentRow1->findDependentRowset('\ZendTest\Db\Table\TestAsset\TableBugsProducts');
-        $this->assertType('Zend\Db\Table\AbstractRowset', $childRows,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $childRows,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($childRows));
 
         $this->assertEquals(3, $childRows->count());
 
         $childRow1 = $childRows->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $childRow1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $childRow1,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($childRow1));
 
         $this->assertEquals(1, $childRow1->$bug_id);
@@ -348,16 +348,16 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
                                   ->order($product_id . ' DESC');
 
         $parentRows = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $parentRows,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $parentRows,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($parentRows));
         $parentRow1 = $parentRows->current();
 
         $childRows = $parentRow1->findDependentRowset('\ZendTest\Db\Table\TestAsset\TableBugsProducts', null, $select);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $childRows,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $childRows,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($childRows));
 
         $childRow1 = $childRows->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $childRow1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $childRow1,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($childRow1));
 
         $this->assertEquals(1, $childRow1->$bug_id);
@@ -374,13 +374,13 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 //        $parentRow1 = $parentRows->current();
 //
 //        $childRows = $parentRow1->findZend_Db_Table_Asset_TableBugsProducts();
-//        $this->assertType('Zend\Db\Table\AbstractRowset', $childRows,
+//        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $childRows,
 //            'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($childRows));
 //
 //        $this->assertEquals(3, $childRows->count());
 //
 //        $childRow1 = $childRows->current();
-//        $this->assertType('Zend\Db\Table\AbstractRow', $childRow1,
+//        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $childRow1,
 //            'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($childRow1));
 //
 //        $this->assertEquals(1, $childRow1->$bug_id);
@@ -399,13 +399,13 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 //        $parentRow1 = $parentRows->current();
 //
 //        $childRows = $parentRow1->findZend_Db_Table_Asset_TableBugsProducts($select);
-//        $this->assertType('Zend\Db\Table\AbstractRowset', $childRows,
+//        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $childRows,
 //            'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($childRows));
 //
 //        $this->assertEquals(2, $childRows->count());
 //
 //        $childRow1 = $childRows->current();
-//        $this->assertType('Zend\Db\Table\AbstractRow', $childRow1,
+//        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $childRow1,
 //            'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($childRow1));
 //
 //        $this->assertEquals(1, $childRow1->$bug_id);
@@ -673,7 +673,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $table->getReference('\ZendTest\Db\Table\TestAsset\TableAccounts', 'Nonexistent');
             $this->fail('Expected to catch Zend\Db\Table\Exception for nonexistent reference rule');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\Exception got '.get_class($e));
         }
 
@@ -681,7 +681,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $table->getReference('Nonexistent', 'Reporter');
             $this->fail('Expected to catch Zend\Db\Table\Exception for nonexistent rule tableClass');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\Exception got '.get_class($e));
         }
 
@@ -689,7 +689,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $table->getReference('Nonexistent');
             $this->fail('Expected to catch Zend\Db\Table\Exception for nonexistent rule tableClass');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\Exception got '.get_class($e));
         }
     }
@@ -871,15 +871,15 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table = $this->_table['bugs'];
 
         $childRows = $table->fetchAll("$bug_id = 1");
-        $this->assertType('Zend\Db\Table\AbstractRowset', $childRows,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $childRows,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($childRows));
 
         $childRow1 = $childRows->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $childRow1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $childRow1,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($childRow1));
 
         $parentRow = $childRow1->findParentRow('\ZendTest\Db\Table\TestAsset\TableAccounts');
-        $this->assertType('Zend\Db\Table\AbstractRow', $parentRow,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $parentRow,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($parentRow));
 
         $this->assertEquals('goofy', $parentRow->$account_name);
@@ -911,18 +911,18 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $bug_description = $this->_db->foldCase('bug_description');
 
         $parentRows = $table->find('mmouse');
-        $this->assertType('Zend\Db\Table\AbstractRowset', $parentRows,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $parentRows,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($parentRows));
         $parentRow1 = $parentRows->current();
 
         $childRows = $parentRow1->findDependentRowset('\ZendTest\Db\Table\TestAsset\TableBugs');
-        $this->assertType('Zend\Db\Table\AbstractRowset', $childRows,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $childRows,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($childRows));
 
         $this->assertEquals(1, $childRows->count());
 
         $childRow1 = $childRows->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $childRow1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $childRow1,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($childRow1));
 
         $childRow1->$bug_description = 'Updated description';
@@ -957,7 +957,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $originRow1 = $originRows->current();
 
         $destRows = $originRow1->findManyToManyRowset('\ZendTest\Db\Table\TestAsset\TableProducts', '\ZendTest\Db\Table\TestAsset\TableBugsProducts');
-        $this->assertType('Zend\Db\Table\AbstractRowset', $destRows,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $destRows,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($destRows));
 
         $this->assertEquals(3, $destRows->count());
@@ -1061,7 +1061,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $originRow1 = $originRows->current();
 
         $destRows = $originRow1->findManyToManyRowset('\ZendTest\Db\Table\TestAsset\TableBugs', '\ZendTest\Db\Table\TestAsset\TableBugsProducts');
-        $this->assertType('Zend\Db\Table\AbstractRowset', $destRows,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $destRows,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($destRows));
 
         $this->assertEquals(1, $destRows->count());

--- a/tests/Zend/Db/Table/Relationships/AbstractTest.php
+++ b/tests/Zend/Db/Table/Relationships/AbstractTest.php
@@ -153,7 +153,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     public function testTableRelationshipFindParentRowErrorOnBadString()
     {
         $this->setExpectedException('Zend\Db\Table\Exception');
-        
+
         $bug_id = $this->_db->quoteIdentifier('bug_id', true);
 
         $table = $this->_table['bugs'];
@@ -167,7 +167,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     public function testTableRelationshipFindParentRowExceptionOnBadClass()
     {
         $this->setExpectedException('Zend\Db\Table\Exception');
-        
+
         $bug_id = $this->_db->quoteIdentifier('bug_id', true);
 
         $table = $this->_table['bugs'];
@@ -259,7 +259,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     public function testTableRelationshipFindManyToManyRowsetErrorOnBadClassNameAsString()
     {
         $this->setExpectedException('Zend\Db\Table\Exception');
-        
+
         $table = $this->_table['bugs'];
 
         $originRows = $table->find(1);
@@ -274,7 +274,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     public function testTableRelationshipFindManyToManyRowsetErrorOnBadClassNameAsStringForIntersection()
     {
         $this->setExpectedException('Zend\Db\Table\Exception');
-        
+
         $table = $this->_table['bugs'];
 
         $originRows = $table->find(1);
@@ -287,7 +287,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     public function testTableRelationshipFindManyToManyRowsetExceptionOnBadClassAsString()
     {
         $this->setExpectedException('Zend\Db\Table\Exception');
-        
+
         $table = $this->_table['bugs'];
 
         $originRows = $table->find(1);
@@ -302,7 +302,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     public function testTableRelationshipFindManyToManyRowsetExceptionOnBadClassAsStringForIntersection()
     {
         $this->setExpectedException('Zend\Db\Table\Exception');
-        
+
         $table = $this->_table['bugs'];
 
         $originRows = $table->find(1);
@@ -709,7 +709,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
                         ->current()
                         ->findParentRow($this->_table['accounts']->setRowClass($myRowClass));
 
-        $this->assertType($myRowClass, $bug1Reporter,
+        $this->assertInstanceOf($myRowClass, $bug1Reporter,
             "Expecting object of type $myRowClass, got ".get_class($bug1Reporter));
     }
 
@@ -729,7 +729,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
                         ->current()
                         ->findParentRow(new \ZendTest\Db\Table\TestAsset\TableAccountsCustom(array('db' => $this->_db)));
 
-        $this->assertType($myRowClass, $bug1Reporter,
+        $this->assertInstanceOf($myRowClass, $bug1Reporter,
             "Expecting object of type $myRowClass, got ".get_class($bug1Reporter));
     }
 
@@ -755,13 +755,13 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
                     'Engineer'
                     );
 
-        $this->assertType($myRowsetClass, $bugs,
+        $this->assertInstanceOf($myRowsetClass, $bugs,
             "Expecting object of type $myRowsetClass, got ".get_class($bugs));
 
         $this->assertEquals(3, count($bugs));
 
         foreach ($bugs as $bug) {
-            $this->assertType($myRowClass, $bug,
+            $this->assertInstanceOf($myRowClass, $bug,
                 "Expecting object of type $myRowClass, got ".get_class($bug));
         }
     }
@@ -784,13 +784,13 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
                 ->fetchRow($this->_db->quoteInto("$account_name = ?", 'mmouse'))
                 ->findDependentRowset('\ZendTest\Db\Table\TestAsset\TableBugsCustom', 'Engineer');
 
-        $this->assertType($myRowsetClass, $bugs,
+        $this->assertInstanceOf($myRowsetClass, $bugs,
             "Expecting object of type $myRowsetClass, got ".get_class($bugs));
 
         $this->assertEquals(3, count($bugs));
 
         foreach ($bugs as $bug) {
-            $this->assertType($myRowClass, $bug,
+            $this->assertInstanceOf($myRowClass, $bug,
                 "Expecting object of type $myRowClass, got ".get_class($bug));
         }
     }
@@ -817,13 +817,13 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
                             '\ZendTest\Db\Table\TestAsset\TableBugsProducts'
                             );
 
-        $this->assertType($myRowsetClass, $bug1Products,
+        $this->assertInstanceOf($myRowsetClass, $bug1Products,
             "Expecting object of type $myRowsetClass, got ".get_class($bug1Products));
 
         $this->assertEquals(3, count($bug1Products));
 
         foreach ($bug1Products as $bug1Product) {
-            $this->assertType($myRowClass, $bug1Product,
+            $this->assertInstanceOf($myRowClass, $bug1Product,
                 "Expecting object of type $myRowClass, got ".get_class($bug1Product));
         }
     }
@@ -847,13 +847,13 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
                             '\ZendTest\Db\Table\TestAsset\TableBugsProductsCustom'
                             );
 
-        $this->assertType($myRowsetClass, $bug1Products,
+        $this->assertInstanceOf($myRowsetClass, $bug1Products,
             "Expecting object of type $myRowsetClass, got ".get_class($bug1Products));
 
         $this->assertEquals(3, count($bug1Products));
 
         foreach ($bug1Products as $bug1Product) {
-            $this->assertType($myRowClass, $bug1Product,
+            $this->assertInstanceOf($myRowClass, $bug1Product,
                 "Expecting object of type $myRowClass, got ".get_class($bug1Product));
         }
     }
@@ -1221,11 +1221,11 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table = $this->_getTable('\ZendTest\Db\Table\TestAsset\TableSpecial', $options);
         return $table;
     }
-    
+
     /**
      * Ensure that the related table returned from the ManyToManyRowset only contains
      * the proper columns for the table.
-     * 
+     *
      * @group ZF-3709
      */
     public function testTableRelationshipReturnsOnlyTheColumnsInTargetTable()

--- a/tests/Zend/Db/Table/Row/AbstractTest.php
+++ b/tests/Zend/Db/Table/Row/AbstractTest.php
@@ -872,13 +872,13 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $row = $rowset->current();
         $this->assertTrue($row instanceof \Traversable);
         $this->assertTrue($row instanceof \IteratorAggregate);
-        $this->assertType('ArrayIterator', $row->getIterator());
-        
+        $this->assertInstanceOf('ArrayIterator', $row->getIterator());
+
         $count=0;
         foreach ($row as $columnValue) {
             $count++;
         }
-        
+
         $this->assertEquals(8, $count, 'The row was iterated, there should be 8 columns iterated');
     }
 

--- a/tests/Zend/Db/Table/Row/AbstractTest.php
+++ b/tests/Zend/Db/Table/Row/AbstractTest.php
@@ -78,7 +78,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table = $this->_table['bugs'];
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $this->assertEquals(1, count($rowset));
     }
@@ -96,14 +96,14 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 
         $row1 = new Row($config);
 
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         try {
             $bug_description = $row1->bug_description;
             $this->fail('Expected to catch Zend\Db\Table\RowException');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\RowException', $e,
+            $this->assertInstanceOf('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals("Specified column \"bug_description\" is not in the row", $e->getMessage());
         }
@@ -114,7 +114,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row1 = new Row($config);
             $this->fail('Expected to catch Zend\Db\Table\RowException');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\RowException', $e,
+            $this->assertInstanceOf('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals("Data must be an array", $e->getMessage());
         }
@@ -126,7 +126,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         Table\AbstractTable::setDefaultAdapter($this->_db);
 
         $row = new \ZendTest\Db\Table\TestAsset\Row\TestStandaloneRow();
-        $this->assertType('Zend\Db\Table\AbstractTable', $row->getTable());
+        $this->assertInstanceOf('Zend\Db\Table\AbstractTable', $row->getTable());
 
         Table\AbstractTable::setDefaultAdapter();
     }
@@ -151,10 +151,10 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table = $this->_table['bugs'];
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         $a = $row1->toArray();
@@ -184,14 +184,14 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table = $this->_table['bugs'];
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         $select = $row1->select();
-        $this->assertType('Zend\Db\Table\Select', $select,
+        $this->assertInstanceOf('Zend\Db\Table\Select', $select,
             'Expecting object of type Zend_Db_Table_Select, got '.get_class($select));
     }
 
@@ -203,10 +203,10 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $bug_status = $this->_db->foldCase('bug_status');
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         try {
@@ -247,10 +247,10 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $bug_description = $this->_db->foldCase('bug_description');
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         try {
@@ -270,10 +270,10 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $bug_status = $this->_db->foldCase('bug_status');
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         try {
@@ -292,10 +292,10 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $bug_description = $this->_db->foldCase('bug_description');
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         try {
@@ -315,10 +315,10 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $bug_description = $this->_db->foldCase('bug_description');
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         try {
@@ -342,10 +342,10 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         );
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         $result = $row1->setFromArray($data);
@@ -377,10 +377,10 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         );
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         $row1->setFromArray($data);
@@ -389,7 +389,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $button = $row1->btnAccept;
             $this->fail('Expected to catch Zend\Db\Table\RowException');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\RowException', $e,
+            $this->assertInstanceOf('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals("Specified column \"btnAccept\" is not in the row", $e->getMessage());
         }
@@ -446,10 +446,10 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         );
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         $row1->setFromArray($data);
@@ -475,7 +475,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row->setTable($table);
             $this->fail('Expected to catch Zend\Db\Table\RowException for incorrect parent table');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\RowException got '.get_class($e));
             $this->assertEquals('The specified Table does not have the same columns as the Row', $e->getMessage());
         }
@@ -487,7 +487,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row->setTable($table);
             $this->fail('Expected to catch Zend\Db\Table\RowException for incorrect parent table');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\RowException got '.get_class($e));
             $this->assertEquals('The specified Table \'ZendTest\Db\Table\TestAsset\TableBugs\' does not have the same primary key as the Row', $e->getMessage());
         }
@@ -508,7 +508,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row->save();
             $this->fail('Expected to catch Zend\Db\Table\RowException for incorrect parent table');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\RowException got '.get_class($e));
             $this->assertEquals('The primary key must be set as an array', $e->getMessage());
         }
@@ -519,7 +519,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row->save();
             $this->fail('Expected to catch Zend\Db\Table\RowException for incorrect parent table');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\RowException got '.get_class($e));
             $this->assertEquals('The specified Table \'ZendTest\Db\Table\TestAsset\TableBugs\' does not have the same primary key as the Row', $e->getMessage());
         }
@@ -538,7 +538,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row->save();
             $this->fail('Expected to catch Zend\Db\Table\RowException for missing parent');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\RowException', $e,
+            $this->assertInstanceOf('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException got '.get_class($e));
             $this->assertEquals('Cannot refresh row as parent is missing', $e->getMessage());
         }
@@ -550,10 +550,10 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table2 = $this->_table['products'];
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         $row1->setTable(null);
@@ -563,7 +563,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row1->setTable($table2);
             $this->fail('Expected to catch Zend\Db\Table\Exception for incorrect parent table');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\Exception got '.get_class($e));
             $this->assertEquals('The specified Table is of class ZendTest\Db\Table\TestAsset\TableProducts, expecting class to be instance of ZendTest\Db\Table\TestAsset\TableBugs', $e->getMessage());
         }
@@ -580,7 +580,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row->setTable($table);
             $this->fail('Expected to catch Zend\Db\Table\RowException for incorrect parent table');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\RowException got '.get_class($e));
             $this->assertEquals('The specified Table is of class ZendTest\Db\Table\TestAsset\TableBugs, expecting class to be instance of foo', $e->getMessage());
         }
@@ -591,10 +591,10 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table = $this->_table['bugs'];
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         $column = 'doesNotExist';
@@ -603,7 +603,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $dummy = $row1->$column;
             $this->fail('Expected to catch Zend\Db\Table\RowException');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\RowException', $e,
+            $this->assertInstanceOf('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals("Specified column \"$column\" is not in the row", $e->getMessage());
         }
@@ -614,10 +614,10 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table = $this->_table['bugs'];
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         $column = 'doesNotExist';
@@ -626,7 +626,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row1->$column = 'dummy value';
             $this->fail('Expected to catch Zend\Db\Table\RowException');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\RowException', $e,
+            $this->assertInstanceOf('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals("Specified column \"$column\" is not in the row", $e->getMessage());
         }
@@ -644,7 +644,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $rowsAffected = $row->delete();
             $this->fail('Expected to catch Zend\Db\Table\RowException');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\RowException', $e,
+            $this->assertInstanceOf('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals("The specified Table 'ZendTest\Db\Table\TestAsset\TableBugsProducts' does not have the same primary key as the Row", $e->getMessage());
         }
@@ -656,10 +656,10 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $bug_id = $this->_db->foldCase('bug_id');
 
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type \Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1));
 
         try {
@@ -681,7 +681,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $serRow1 = serialize($row1);
 
         $row1New = unserialize($serRow1);
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1New,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1New,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1New));
         $this->assertEquals($row1->toArray(), $row1New->toArray());
     }
@@ -696,7 +696,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $serRow1 = serialize($row1);
 
         $row1New = unserialize($serRow1);
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1New,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1New,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1New));
         $bug_description = $this->_db->foldCase('bug_description');
         $row1New->$bug_description = 'New description';
@@ -705,7 +705,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row1New->save();
             $this->fail('Expected to catch Zend\Db\Table\RowException');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\RowException', $e,
+            $this->assertInstanceOf('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals("Cannot save a Row unless it is connected", $e->getMessage());
         }
@@ -721,7 +721,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $serRow1 = serialize($row1);
 
         $row1New = unserialize($serRow1);
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1New,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1New,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1New));
 
         try {
@@ -757,7 +757,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $serRow1 = serialize($row1);
 
         $row1New = unserialize($serRow1);
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1New,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1New,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1New));
 
         try {
@@ -785,7 +785,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $serRow1 = serialize($row1);
 
         $row1New = unserialize($serRow1);
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1New,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1New,
             'Expecting object of type \Zend\Db\Table\AbstractRow, got '.get_class($row1New));
 
         $table2 = $this->_table['products'];
@@ -794,7 +794,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $connected = $row1New->setTable($table2);
             $this->fail('Expected to catch Zend\Db\Table\RowException');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\RowException', $e,
+            $this->assertInstanceOf('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals('The specified Table is of class ZendTest\Db\Table\TestAsset\TableProducts, expecting class to be instance of ZendTest\Db\Table\TestAsset\TableBugs', $e->getMessage());
         }
@@ -823,7 +823,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row2->save();
             $this->fail('Expected to catch Zend\Db\Table\RowException');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\RowException', $e,
+            $this->assertInstanceOf('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals('This row has been marked read-only', $e->getMessage());
         }
@@ -838,7 +838,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row2->save();
             $this->fail('Expected to catch Zend\Db\Table\RowException');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\RowException', $e,
+            $this->assertInstanceOf('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend\Db\Table\RowException, got '.get_class($e));
             $this->assertEquals('This row has been marked read-only', $e->getMessage());
         }
@@ -855,7 +855,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row->setInvalidColumn();
             $this->fail('Expected to catch Zend\Db\Table\RowException for invalid column type');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend\Db\Table\RowException got '.get_class($e));
             $this->assertEquals('Specified column is not a string', $e->getMessage());
         }

--- a/tests/Zend/Db/Table/Rowset/AbstractTest.php
+++ b/tests/Zend/Db/Table/Rowset/AbstractTest.php
@@ -44,7 +44,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table = $this->_table['bugs'];
 
         $rows = $table->find(array(1, 2));
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rows,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rows,
             'Expecting object of type Zend_Db_Table_Rowset_Abstract, got '.get_class($rows));
 
         // see if we're at the beginning
@@ -53,7 +53,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 
         // get first row and see if it's the right one
         $row1 = $rows->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type Zend_Db_Table_Row_Abstract, got '.get_class($row1));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(1, $row1->$bug_id);
@@ -65,7 +65,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 
         // get second row and see if it's the right one
         $row2 = $rows->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row2,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row2,
             'Expecting object of type Zend_Db_Table_Row_Abstract, got '.get_class($row2));
         $this->assertEquals(2, $row2->$bug_id);
 
@@ -87,7 +87,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         // get row at beginning and compare it to
         // the one we got earlier
         $row1Copy = $rows->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type Zend_Db_Table_Row_Abstract, got '.get_class($row1));
         $this->assertEquals(1, $row1->$bug_id);
         $this->assertSame($row1, $row1Copy);
@@ -141,7 +141,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $rowset = $table->fetchAll();
 
         $this->assertTrue(isset($rowset[0]));
-        $this->assertType('Zend\Db\Table\Row', $rowset[0]);
+        $this->assertInstanceOf('Zend\Db\Table\Row', $rowset[0]);
     }
 
     public function testTableRowsetEmpty()
@@ -219,11 +219,11 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $rowsNew = unserialize($serRows);
 
         $this->assertFalse($rowsNew->isConnected());
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowsNew,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowsNew,
             'Expecting object of type Zend_Db_Table_Rowset_Abstract, got '.get_class($rowsNew));
 
         $row1New = $rowsNew->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1New,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1New,
             'Expecting object of type Zend_Db_Table_Row_Abstract, got '.get_class($row1New));
     }
 
@@ -244,7 +244,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $serRows = serialize($rows);
 
         $rowsNew = unserialize($serRows);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowsNew,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowsNew,
             'Expecting object of type Zend_Db_Table_Rowset_Abstract, got '.get_class($rowsNew));
 
         $table2 = $this->_table['products'];
@@ -253,7 +253,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $connected = $rowsNew->setTable($table2);
             $this->fail('Expected to catch Zend_Db_Table_Row_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\RowException', $e,
+            $this->assertInstanceOf('Zend\Db\Table\RowException', $e,
                 'Expecting object of type Zend_Db_Table_Row_Exception, got '.get_class($e));
             $this->assertEquals('The specified Table is of class ZendTest\Db\Table\TestAsset\TableProducts, expecting class to be instance of ZendTest\Db\Table\TestAsset\TableBugs', $e->getMessage());
         }
@@ -271,7 +271,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $rowset[-1];
             $this->fail();
         } catch (Exception $e) {
-            $this->assertType('Zend_Db_Table_Rowset_Exception', $e);
+            $this->assertInstanceOf('Zend_Db_Table_Rowset_Exception', $e);
             $this->assertContains('Illegal index', $e->getMessage());
         }
 
@@ -281,7 +281,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $row = $rowset[count($rowset) + 1];
             $this->fail();
         } catch (Exception $e) {
-            $this->assertType('Zend_Db_Table_Rowset_Exception', $e);
+            $this->assertInstanceOf('Zend_Db_Table_Rowset_Exception', $e);
             $this->assertContains('Illegal index', $e->getMessage());
         }
         $this->assertEquals(0, $rowset->key());

--- a/tests/Zend/Db/Table/Select/AbstractTest.php
+++ b/tests/Zend/Db/Table/Select/AbstractTest.php
@@ -151,7 +151,7 @@ abstract class AbstractTest extends \ZendTest\Db\Select\AbstractTest
             $query = $select->assemble();
             $this->fail('Expected to catch Zend_Db_Table_Select_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend_Db_Table_Select_Exception', $e);
+            $this->assertInstanceOf('Zend_Db_Table_Select_Exception', $e);
             $this->assertEquals('Select query cannot join with another table', $e->getMessage());
         }
     }
@@ -308,7 +308,7 @@ abstract class AbstractTest extends \ZendTest\Db\Select\AbstractTest
 //        try {
 //            $select = $table->select()->columns('product_id');
 //
-//            $this->assertType('Zend_Db_Table_Select', $select);
+//            $this->assertInstanceOf('Zend_Db_Table_Select', $select);
 //        } catch (Zend_Db_Table_Select_Exception $e) {
 //            $this->fail('Exception thrown: ' . $e->getMessage());
 //        }

--- a/tests/Zend/Db/Table/Select/StaticTest.php
+++ b/tests/Zend/Db/Table/Select/StaticTest.php
@@ -66,7 +66,7 @@ class StaticTest extends AbstractTest
         $this->assertEquals('SELECT "zfproducts".* FROM "zfproducts"', $sql);
         $stmt = $select->query();
         \Zend\Loader::loadClass('Zend_Db_Statement_Static');
-        $this->assertType('Zend_Db_Statement_Static', $stmt);
+        $this->assertInstanceOf('Zend_Db_Statement_Static', $stmt);
     }
 
     /**
@@ -82,7 +82,7 @@ class StaticTest extends AbstractTest
 
         $stmt = $select->query();
         \Zend\Loader::loadClass('Zend_Db_Statement_Static');
-        $this->assertType('Zend_Db_Statement_Static', $stmt);
+        $this->assertInstanceOf('Zend_Db_Statement_Static', $stmt);
     }
 
     /**

--- a/tests/Zend/Db/Table/Table/AbstractTest.php
+++ b/tests/Zend/Db/Table/Table/AbstractTest.php
@@ -154,7 +154,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $value = $bugs->info('_non_existent_');
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e);
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e);
             $this->assertEquals('There is no table information for the key "_non_existent_"', $e->getMessage());
         }
     }
@@ -267,7 +267,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     public function testTableGetRowClass()
     {
         $table = $this->_table['products'];
-        $this->assertType('Zend\Db\Table\AbstractTable', $table);
+        $this->assertInstanceOf('Zend\Db\Table\AbstractTable', $table);
 
         $rowClass = $table->getRowClass();
         $this->assertEquals($rowClass, '\Zend\Db\Table\Row');
@@ -323,7 +323,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $ref = $table->getReference('\ZendTest\Db\Table\TestAsset\TableAccounts', 'Verifier');
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e);
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e);
             $this->assertEquals('No reference rule "Verifier" from table ZendTest\Db\Table\TestAsset\TableBugs to table \ZendTest\Db\Table\TestAsset\TableAccounts', $e->getMessage());
         }
 
@@ -331,7 +331,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $ref = $table->getReference('\ZendTest\Db\Table\TestAsset\TableProducts');
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e);
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e);
             $this->assertEquals('No reference from table ZendTest\Db\Table\TestAsset\TableBugs to table \ZendTest\Db\Table\TestAsset\TableProducts', $e->getMessage());
         }
 
@@ -339,7 +339,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $ref = $table->getReference('\ZendTest\Db\Table\TestAsset\TableProducts', 'Product');
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e);
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e);
             $this->assertEquals('No reference rule "Product" from table ZendTest\Db\Table\TestAsset\TableBugs to table \ZendTest\Db\Table\TestAsset\TableProducts', $e->getMessage());
         }
 
@@ -347,7 +347,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $ref = $table->getReference('\ZendTest\Db\Table\TestAsset\TableProducts', 'Reporter');
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e);
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e);
             $this->assertEquals('Reference rule "Reporter" does not reference table \ZendTest\Db\Table\TestAsset\TableProducts', $e->getMessage());
         }
 
@@ -364,7 +364,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     public function testTableSetRowClass()
     {
         $table = $this->_table['products'];
-        $this->assertType('Zend\Db\Table\AbstractTable', $table);
+        $this->assertInstanceOf('Zend\Db\Table\AbstractTable', $table);
 
         $table->setRowClass('stdClass');
         $rowClass = $table->getRowClass();
@@ -397,7 +397,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $table = new \ZendTest\Db\Table\TestAsset\TableBugs();
             $this->fail('Zend_Db_Table_Exception should be thrown');
         }catch(\Exception $e) {
-         $this->assertType('Zend\Db\Table\Exception', $e,
+         $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
         }
     }
@@ -432,7 +432,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             Table\AbstractTable::setDefaultAdapter(new \stdClass());
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals("Argument must be of type Zend_Db_Adapter_Abstract, or a Registry key where a Zend_Db_Adapter_Abstract object is stored", $e->getMessage());
         }
@@ -441,7 +441,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             Table\AbstractTable::setDefaultAdapter(327);
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals("Argument must be of type Zend_Db_Adapter_Abstract, or a Registry key where a Zend_Db_Adapter_Abstract object is stored", $e->getMessage());
         }
@@ -454,7 +454,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $primary = $table->info(Table\AbstractTable::PRIMARY);
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertContains("Primary key column(s)", $e->getMessage());
             $this->assertContains("are not columns in this table", $e->getMessage());
@@ -468,7 +468,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $primary = $table->info(Table\AbstractTable::PRIMARY);
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertContains("Primary key column(s)", $e->getMessage());
             $this->assertContains("are not columns in this table", $e->getMessage());
@@ -487,7 +487,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $primary = $table->info(Table\AbstractTable::PRIMARY);
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals('A table must have a primary key, but none was found', $e->getMessage());
         }
@@ -525,7 +525,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $table = new \ZendTest\Db\Table\TestAsset\TableBugs(array('db' => 327));
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals("Argument must be of type Zend_Db_Adapter_Abstract, or a Registry key where a Zend_Db_Adapter_Abstract object is stored", $e->getMessage());
         }
@@ -538,7 +538,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $table = new \ZendTest\Db\Table\TestAsset\TableBugs(array('db' => 'registered_db'));
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals("Argument must be of type Zend_Db_Adapter_Abstract, or a Registry key where a Zend_Db_Adapter_Abstract object is stored", $e->getMessage());
         }
@@ -548,7 +548,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     {
         $table = $this->_table['bugs'];
         $rowset = $table->find(1);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $this->assertEquals(1, count($rowset));
     }
@@ -557,7 +557,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     {
         $table = $this->_table['bugs'];
         $rowset = $table->find(array(1, 2));
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $this->assertEquals(2, count($rowset));
     }
@@ -569,7 +569,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $table->find(1);
             $this->fail('Expected to catch Zend_Db_Table_Exception for missing key');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals('Too few columns for the primary key', $e->getMessage());
         }
@@ -582,7 +582,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $table->find(1, 2);
             $this->fail('Expected to catch Zend_Db_Table_Exception for incorrect key count');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals('Too many columns for the primary key', $e->getMessage());
         }
@@ -592,7 +592,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     {
         $table = $this->_table['bugs_products'];
         $rowset = $table->find(1, 2);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $this->assertEquals(1, count($rowset));
     }
@@ -601,7 +601,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     {
         $table = $this->_table['bugs_products'];
         $rowset = $table->find(array(1, 1), array(2, 3));
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $this->assertEquals(2, count($rowset));
     }
@@ -613,7 +613,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $rowset = $table->find(array(1, 1), 2);
             $this->fail('Expected to catch Zend_Db_Table_Exception for incorrect key count');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals('Missing value(s) for the primary key', $e->getMessage());
         }
@@ -626,7 +626,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     {
         $table = $this->_table['products'];
         $rowset = $table->find(array(0 => 1, 1 => 2, 99 => 3));
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $this->assertEquals(3, count($rowset));
     }
@@ -639,7 +639,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     {
         $table = $this->_table['products'];
         $rowset = $table->find(array());
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $this->assertEquals(0, count($rowset));
     }
@@ -816,11 +816,11 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 
         // Query the row to see if we have the new values.
         $rowset = $table->find(2);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $this->assertEquals(1, count($rowset), "Expecting rowset count to be 1");
         $row = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(2, $row->$bug_id, "Expecting row->bug_id to be 2");
@@ -935,7 +935,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     {
         $table = $this->_table['bugs'];
         $row = $table->createRow();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row));
         $this->assertTrue(isset($row->bug_description));
         $this->assertEquals($row, $table->fetchNew());
@@ -953,7 +953,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             'assigned_to'     => 'goofy'
         );
         $row = $table->createRow($data);
-        $this->assertType('Zend\Db\Table\AbstractRow', $row,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row));
         $this->assertTrue(isset($row->bug_description));
         $this->assertEquals('New bug', $row->bug_description);
@@ -964,7 +964,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table = $this->_table['bugs'];
         $bug_description = $this->_db->foldCase('bug_description');
         $row = $table->fetchRow();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row));
         $this->assertTrue(isset($row->$bug_description));
     }
@@ -975,7 +975,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 
         $table = $this->_table['bugs'];
         $row = $table->fetchRow("$bug_id = 2");
-        $this->assertType('Zend\Db\Table\AbstractRow', $row,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(2, $row->$bug_id);
@@ -987,7 +987,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 
         $table = $this->_table['bugs'];
         $row = $table->fetchRow(array("$bug_id = ?" => 2));
-        $this->assertType('Zend\Db\Table\AbstractRow', $row,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(2, $row->$bug_id);
@@ -1002,7 +1002,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             ->where("$bug_id = ?", 2);
 
         $row = $table->fetchRow($select);
-        $this->assertType('Zend\Db\Table\AbstractRow', $row,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(2, $row->$bug_id);
@@ -1015,7 +1015,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table = $this->_table['bugs'];
 
         $row = $table->fetchRow("$bug_id > 1", "bug_id ASC");
-        $this->assertType('Zend\Db\Table\AbstractRow', $row,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(2, $row->$bug_id);
@@ -1031,7 +1031,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             ->order("bug_id ASC");
 
         $row = $table->fetchRow($select);
-        $this->assertType('Zend\Db\Table\AbstractRow', $row,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(2, $row->$bug_id);
@@ -1044,7 +1044,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table = $this->_table['bugs'];
 
         $row = $table->fetchRow(null, "bug_id DESC");
-        $this->assertType('Zend\Db\Table\AbstractRow', $row,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(4, $row->$bug_id);
@@ -1060,7 +1060,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             ->order("bug_id DESC");
 
         $row = $table->fetchRow($select);
-        $this->assertType('Zend\Db\Table\AbstractRow', $row,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(4, $row->$bug_id);
@@ -1081,11 +1081,11 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     {
         $table = $this->_table['bugs'];
         $rowset = $table->fetchAll();
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $this->assertEquals(4, count($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row1));
     }
 
@@ -1096,11 +1096,11 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table = $this->_table['bugs'];
 
         $rowset = $table->fetchAll("$bug_id = 2");
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $this->assertEquals(1, count($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row1));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(2, $row1->$bug_id);
@@ -1115,11 +1115,11 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             ->where("$bug_id = ?", 2);
 
         $rowset = $table->fetchAll($select);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $this->assertEquals(1, count($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row1));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(2, $row1->$bug_id);
@@ -1129,11 +1129,11 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     {
         $table = $this->_table['bugs'];
         $rowset = $table->fetchAll(null, 'bug_id DESC');
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $this->assertEquals(4, count($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row1));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(4, $row1->$bug_id);
@@ -1146,11 +1146,11 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             ->order('bug_id DESC');
 
         $rowset = $table->fetchAll($select);
-        $this->assertType('Zend\Db\Table\AbstractRowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRowset', $rowset,
             'Expecting object of type Zend\Db\Table\AbstractRowset, got '.get_class($rowset));
         $this->assertEquals(4, count($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\AbstractRow', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\AbstractRow', $row1,
             'Expecting object of type Zend\Db\Table\AbstractRow, got '.get_class($row1));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(4, $row1->$bug_id);
@@ -1163,11 +1163,11 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $table = $this->_table['bugs'];
 
         $rowset = $table->fetchAll(null, new \Zend\Db\Expr("$bug_id + 1 DESC"));
-        $this->assertType('Zend\Db\Table\Rowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\Rowset', $rowset,
             'Expecting object of type Zend\Db\Table\Rowset, got '.get_class($rowset));
         $this->assertEquals(4, count($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\Row', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\Row', $row1,
             'Expecting object of type Zend\Db\Table\Row, got '.get_class($row1));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(4, $row1->$bug_id);
@@ -1177,11 +1177,11 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     {
         $table = $this->_table['bugs'];
         $rowset = $table->fetchAll(null, 'bug_id ASC', 2, 1);
-        $this->assertType('Zend\Db\Table\Rowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\Rowset', $rowset,
             'Expecting object of type Zend\Db\Table\Rowset, got '.get_class($rowset));
         $this->assertEquals(2, count($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\Row', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\Row', $row1,
             'Expecting object of type Zend\Db\Table\Row, got '.get_class($row1));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(2, $row1->$bug_id);
@@ -1195,11 +1195,11 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             ->limit(2, 1);
 
         $rowset = $table->fetchAll($select);
-        $this->assertType('Zend\Db\Table\Rowset', $rowset,
+        $this->assertInstanceOf('Zend\Db\Table\Rowset', $rowset,
             'Expecting object of type Zend\Db\Table\Rowset, got '.get_class($rowset));
         $this->assertEquals(2, count($rowset));
         $row1 = $rowset->current();
-        $this->assertType('Zend\Db\Table\Row', $row1,
+        $this->assertInstanceOf('Zend\Db\Table\Row', $row1,
             'Expecting object of type Zend\Db\Table\Row, got '.get_class($row1));
         $bug_id = $this->_db->foldCase('bug_id');
         $this->assertEquals(2, $row1->$bug_id);
@@ -1413,7 +1413,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             Table\AbstractTable::setDefaultMetadataCache(new \stdClass());
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals("Argument must be of type Zend_Cache_Core, or a Registry key where a Zend_Cache_Core object is stored", $e->getMessage());
         }
@@ -1422,7 +1422,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             Table\AbstractTable::setDefaultMetadataCache(327);
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals("Argument must be of type Zend_Cache_Core, or a Registry key where a Zend_Cache_Core object is stored", $e->getMessage());
         }
@@ -1439,7 +1439,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $table = new \ZendTest\Db\Table\TestAsset\TableBugs(array('metadataCache' => 327));
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals("Argument must be of type Zend_Cache_Core, or a Registry key where a Zend_Cache_Core object is stored", $e->getMessage());
         }
@@ -1452,7 +1452,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             $table = new \ZendTest\Db\Table\TestAsset\TableBugs(array('metadataCache' => 'registered_metadata_cache'));
             $this->fail('Expected to catch Zend_Db_Table_Exception');
         } catch (\Exception $e) {
-            $this->assertType('Zend\Db\Table\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Table\Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
             $this->assertEquals("Argument must be of type Zend_Cache_Core, or a Registry key where a Zend_Cache_Core object is stored", $e->getMessage());
         }

--- a/tests/Zend/Db/Table/Table/AbstractTest.php
+++ b/tests/Zend/Db/Table/Table/AbstractTest.php
@@ -79,7 +79,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 
     /*
      * @group ZF-2666
-     */ 
+     */
     public function testIsIdentity()
     {
         $bugs = $this->_table['bugs'];
@@ -110,7 +110,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
     public function testTableInfo()
     {
         $bugs = $this->_table['bugs'];
-        $this->assertType('\Zend\Db\Table\AbstractTable', $bugs);
+        $this->assertInstanceOf('\Zend\Db\Table\AbstractTable', $bugs);
         $info = $bugs->info();
 
         $keys = array(
@@ -203,7 +203,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 //    {
 //
 //        $this->markTestSkipped('Test makes no sense with autoloading');
-//        
+//
 //        // TableSpecial.php contains class bugs_products too.
 //        $table = new \zfbugs_products(array('db' => $this->_db));
 //        $info = $table->info();
@@ -1320,7 +1320,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             array('metadataCache' => $cache)
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend\Cache\Frontend\Core',
             $tableBugsCustom1->getMetadataCache()
         );
@@ -1357,7 +1357,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             )
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend\Cache\Frontend\Core',
             $tableBugsCustom1->getMetadataCache()
         );
@@ -1391,7 +1391,7 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
 
         $this->assertFalse($tableBugsCustom1->isMetadataFromCache);
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend\Cache\Frontend\Core',
             $tableBugsCustom1->getMetadataCache()
         );
@@ -1629,8 +1629,8 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
         $this->assertEquals(1, count($rowset));
         $this->_util->dropTable('thisisaveryverylongtablename');
     }
-    
-    
+
+
      /**
      * @group ZF2-66
      */
@@ -1651,27 +1651,27 @@ abstract class AbstractTest extends \ZendTest\Db\Table\TestSetup
             'Engineer' => $refEngineer
         );
         $table = $this->_getTable('\ZendTest\Db\Table\TestAsset\TableBugs',array('referenceMap' => $refMap));
-        
+
         $this->assertEquals($refReporter, $table->getReference('ZendTest\Db\Table\TestAsset\TableAccounts'));
         $this->assertEquals($refReporter, $table->getReference('ZendTest\Db\Table\TestAsset\TableAccounts', 'Reporter'));
         $this->assertEquals($refEngineer, $table->getReference('ZendTest\Db\Table\TestAsset\TableAccounts', 'Engineer'));
-        
+
         $this->assertEquals(
-                $table->getReference('\ZendTest\Db\Table\TestAsset\TableAccounts'), 
+                $table->getReference('\ZendTest\Db\Table\TestAsset\TableAccounts'),
                 $table->getReference('ZendTest\Db\Table\TestAsset\TableAccounts')
         );
-        
+
         $this->assertEquals(
                 $table->getReference('\ZendTest\Db\Table\TestAsset\TableAccounts', 'Reporter'),
                 $table->getReference('ZendTest\Db\Table\TestAsset\TableAccounts', 'Reporter')
         );
-        
+
         $this->assertEquals(
                 $table->getReference('\ZendTest\Db\Table\TestAsset\TableAccounts', 'Engineer'),
                 $table->getReference('ZendTest\Db\Table\TestAsset\TableAccounts', 'Engineer')
         );
     }
-    
+
 
     protected function _getRowForTableAndIdentityWithVeryLongName()
     {

--- a/tests/Zend/Db/TestSetup.php
+++ b/tests/Zend/Db/TestSetup.php
@@ -83,7 +83,7 @@ abstract class TestSetup extends \PHPUnit_Framework_TestCase
             $conn = $this->_db->getConnection();
         } catch (\Exception $e) {
             $this->_db = null;
-            $this->assertType('Zend\Db\Adapter\Exception', $e,
+            $this->assertInstanceOf('Zend\Db\Adapter\Exception', $e,
                 'Expecting Zend_Db_Adapter_Exception, got ' . get_class($e));
             $this->markTestSkipped($e->getMessage());
         }

--- a/tests/Zend/Feed/PubSubHubbub/PubSubHubbubTest.php
+++ b/tests/Zend/Feed/PubSubHubbub/PubSubHubbubTest.php
@@ -44,7 +44,7 @@ class PubSubHubbubTest extends \PHPUnit_Framework_TestCase
     public function testCanSetCustomHttpClient()
     {
         PubSubHubbub\PubSubHubbub::setHttpClient(new Pubsub());
-        $this->assertType('ZendTest\Feed\PubSubHubbub\Pubsub', PubSubHubbub\PubSubHubbub::getHttpClient());
+        $this->assertInstanceOf('ZendTest\Feed\PubSubHubbub\Pubsub', PubSubHubbub\PubSubHubbub::getHttpClient());
     }
 
     public function testCanDetectHubs()

--- a/tests/Zend/GData/GDataTest.php
+++ b/tests/Zend/GData/GDataTest.php
@@ -81,7 +81,7 @@ class GDataTest extends \PHPUnit_Framework_TestCase
             $feed = $gdata->getFeed(new \stdClass());
             $this->fail('Expecting to catch Zend\GData\App\InvalidArgumentException');
         } catch (\Exception $e) {
-            $this->assertType('Zend\GData\App\InvalidArgumentException', $e,
+            $this->assertInstanceOf('Zend\GData\App\InvalidArgumentException', $e,
                 'Expecting Zend\GData\App\InvalidArgumentException, got '.get_class($e));
             $this->assertEquals('You must specify the location as either a string URI or a child of Zend\GData\Query', $e->getMessage());
         }
@@ -96,7 +96,7 @@ class GDataTest extends \PHPUnit_Framework_TestCase
             $feed = $gdata->getEntry(new \stdClass());
             $this->fail('Expecting to catch Zend\GData\App\InvalidArgumentException');
         } catch (\Exception $e) {
-            $this->assertType('Zend\GData\App\InvalidArgumentException', $e,
+            $this->assertInstanceOf('Zend\GData\App\InvalidArgumentException', $e,
                 'Expecting Zend\GData\App\InvalidArgumentException, got '.get_class($e));
             $this->assertEquals('You must specify the location as either a string URI or a child of Zend\GData\Query', $e->getMessage());
         }

--- a/tests/Zend/GData/Health/ProfileFeedTest.php
+++ b/tests/Zend/GData/Health/ProfileFeedTest.php
@@ -111,7 +111,7 @@ class ProfileFeedTest extends \PHPUnit_Framework_TestCase
         $this->profileFeed->transferFromXML($this->feedText);
 
         $medications = $this->profileFeed->entry[0]->getCcr()->getMedications();
-        $this->assertType('DOMNodeList', $medications);
+        $this->assertInstanceOf('DOMNodeList', $medications);
         $this->assertEquals(1, count($medications));
 
         foreach ($medications as $med) {

--- a/tests/Zend/Http/ResponseTest.php
+++ b/tests/Zend/Http/ResponseTest.php
@@ -28,7 +28,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response->setReasonPhrase('Foo Bar');
         $this->assertEquals('HTTP/1.1 404 Foo Bar', $response->renderStatusLine());
     }
-    
+
     public function testResponseUsesHeadersContainerByDefault()
     {
         $response = new Response();
@@ -270,7 +270,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 //
 //        // Check we get an array if no code is passed
 //        $codes = Response::responseCodeAsText();
-//        $this->assertType('array', $codes);
+//        $this->assertInternalType('array', $codes);
 //        $this->assertEquals('OK', $codes[200]);
 //    }
 //

--- a/tests/Zend/Paginator/Adapter/DbTableSelect/OracleTest.php
+++ b/tests/Zend/Paginator/Adapter/DbTableSelect/OracleTest.php
@@ -49,6 +49,6 @@ class OracleTest extends \ZendTest\Paginator\Adapter\DbSelect\OracleTest
         $adapter = new \Zend\Paginator\Adapter\DbTableSelect($query);
         $items   = $adapter->getItems(0, 10);
 
-        $this->assertType('Zend\Db\Table\Rowset', $items);
+        $this->assertInstanceOf('Zend\Db\Table\Rowset', $items);
     }
 }

--- a/tests/Zend/RegistryTest.php
+++ b/tests/Zend/RegistryTest.php
@@ -54,7 +54,7 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
     {
         // getting instance initializes instance
         $registry = Registry::getInstance();
-        $this->assertType('\\Zend\\Registry', $registry);
+        $this->assertInstanceOf('Zend\Registry', $registry);
     }
 
     public function testRegistryUninitSet()
@@ -62,7 +62,7 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
         // setting value initializes instance
         Registry::set('foo', 'bar');
         $registry = Registry::getInstance();
-        $this->assertType('\\Zend\\Registry', $registry);
+        $this->assertInstanceOf('Zend\Registry', $registry);
     }
 
     public function testRegistryUninitGet()
@@ -77,15 +77,15 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
             $this->assertContains('No entry is registered for key', $e->getMessage());
         }
         $registry = Registry::getInstance();
-        $this->assertType('\\Zend\\Registry', $registry);
+        $this->assertInstanceOf('Zend\Registry', $registry);
     }
 
     public function testRegistrySingletonSameness()
     {
         $registry1 = Registry::getInstance();
         $registry2 = Registry::getInstance();
-        $this->assertType('\\Zend\\Registry', $registry1);
-        $this->assertType('\\Zend\\Registry', $registry2);
+        $this->assertInstanceOf('Zend\Registry', $registry1);
+        $this->assertInstanceOf('Zend\Registry', $registry2);
         $this->assertEquals($registry1, $registry2);
         $this->assertSame($registry1, $registry2);
     }

--- a/tests/Zend/Service/Amazon/Ec2/KeypairTest.php
+++ b/tests/Zend/Service/Amazon/Ec2/KeypairTest.php
@@ -233,7 +233,7 @@ class KeypairTest extends \PHPUnit_Framework_TestCase
         $this->adapter->setResponse($rawHttpResponse);
 
         $response = $this->keypairInstance->delete('myfakekeyname');
-        $this->assertType('boolean', $response);
+        $this->assertInternalType('boolean', $response);
         $this->assertFalse($response);
     }
 
@@ -255,7 +255,7 @@ class KeypairTest extends \PHPUnit_Framework_TestCase
         $this->adapter->setResponse($rawHttpResponse);
 
         $response = $this->keypairInstance->delete('example-key-name');
-        $this->assertType('boolean', $response);
+        $this->assertInternalType('boolean', $response);
         $this->assertTrue($response);
     }
 }

--- a/tests/Zend/Service/Amazon/OfflineTest.php
+++ b/tests/Zend/Service/Amazon/OfflineTest.php
@@ -346,7 +346,7 @@ class OfflineTest extends \PHPUnit_Framework_TestCase
     	} catch (Amazon\Exception $e) {
     		$this->fail('Unexpected exception was triggered');
     	}
-    	$this->assertType('Zend\Service\Amazon\Item', $currentItem);
+    	$this->assertInstanceOf('Zend\Service\Amazon\Item', $currentItem);
     	$this->assertEquals('0754512673', $currentItem->ASIN);
     }
     

--- a/tests/Zend/Service/Delicious/PrivateDataTest.php
+++ b/tests/Zend/Service/Delicious/PrivateDataTest.php
@@ -81,7 +81,7 @@ class PrivateDataTest extends \PHPUnit_Framework_TestCase
      */
     public function testLastUpdate()
     {
-        $this->assertType('\Zend\Date\Date', $this->_delicious->getLastUpdate());
+        $this->assertInstanceOf('Zend\Date\Date', $this->_delicious->getLastUpdate());
     }
 
     /**
@@ -182,7 +182,7 @@ class PrivateDataTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$TEST_POST_NOTES, $savedPost->getNotes());
         $this->assertEquals(self::$TEST_POST_TAGS, $savedPost->getTags());
         $this->assertEquals(self::$TEST_POST_SHARED, $savedPost->getShared());
-        $this->assertType('\Zend\Date\Date', $savedPost->getDate());
+        $this->assertInstanceOf('Zend\Date\Date', $savedPost->getDate());
         $this->assertInternalType('string', $savedPost->getHash());
         $this->assertInternalType('integer', $savedPost->getOthers());
 
@@ -235,7 +235,7 @@ class PrivateDataTest extends \PHPUnit_Framework_TestCase
     public function testGetPosts()
     {
         $posts = $this->_delicious->getPosts('zfSite', new Date(), 'help');
-        $this->assertType('\Zend\Service\Delicious\PostList', $posts);
+        $this->assertInstanceOf('Zend\Service\Delicious\PostList', $posts);
         $this->assertTrue(count($posts) <= 10);
 
         foreach ($posts as $post) {

--- a/tests/Zend/Service/Delicious/PrivateDataTest.php
+++ b/tests/Zend/Service/Delicious/PrivateDataTest.php
@@ -204,7 +204,7 @@ class PrivateDataTest extends \PHPUnit_Framework_TestCase
     public function testGetAllPosts()
     {
         $posts = $this->_delicious->getAllPosts('zfSite');
-        $this->assertType('Zend\Service\Delicious\PostList', $posts);
+        $this->assertInstanceOf('Zend\Service\Delicious\PostList', $posts);
 
         foreach ($posts as $post) {
             $this->assertContains('zfSite', $post->getTags());
@@ -219,7 +219,7 @@ class PrivateDataTest extends \PHPUnit_Framework_TestCase
     public function testGetRecentPosts()
     {
         $posts = $this->_delicious->getRecentPosts('zfSite', 10);
-        $this->assertType('Zend\Service\Delicious\PostList', $posts);
+        $this->assertInstanceOf('Zend\Service\Delicious\PostList', $posts);
         $this->assertTrue(count($posts) <= 10);
 
         foreach ($posts as $post) {

--- a/tests/Zend/Service/Delicious/PublicDataTest.php
+++ b/tests/Zend/Service/Delicious/PublicDataTest.php
@@ -129,12 +129,12 @@ class PublicDataTest extends \PHPUnit_Framework_TestCase
     {
         $posts = $this->_delicious->getUserPosts(self::TEST_UNAME, 10);
 
-        $this->assertType('\Zend\Service\Delicious\PostList', $posts);
+        $this->assertInstanceOf('Zend\Service\Delicious\PostList', $posts);
 
         // check if all objects in returned \Zend\Service\Delicious\PostList
         // are instances of \Zend\Service\Delicious\SimplePost
         foreach ($posts as $post) {
-            $this->assertType('\Zend\Service\Delicious\SimplePost', $post);
+            $this->assertInstanceOf('Zend\Service\Delicious\SimplePost', $post);
         }
 
         // test filtering of Zend_Service_Delicious_PostList by tag name

--- a/tests/Zend/Service/DeveloperGarden/BaseUserServiceTest.php
+++ b/tests/Zend/Service/DeveloperGarden/BaseUserServiceTest.php
@@ -200,7 +200,7 @@ class Zend_Service_DeveloperGarden_BaseUserServiceTest extends PHPUnit_Framework
         $this->assertEquals('0000', $result->getErrorCode());
         $this->assertInternalType('array', $result->Account);
         foreach ($result->Account as $k => $v) {
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_BaseUserService_AccountBalance',
                 $v
             );

--- a/tests/Zend/Service/DeveloperGarden/ConferenceCallTest.php
+++ b/tests/Zend/Service/DeveloperGarden/ConferenceCallTest.php
@@ -82,7 +82,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -116,7 +116,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -143,7 +143,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -151,15 +151,15 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $conferenceId = $result->getConferenceId();
         $this->assertNotNull($conferenceId);
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_ConferenceDetail',
             $conferenceDetails->setName('Marco Kaiser')
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_ConferenceDetail',
             $conferenceDetails->setDescription('Zend Framework')
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_ConferenceDetail',
             $conferenceDetails->setDuration(600)
         );
@@ -171,7 +171,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             $conferenceDetails
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
             $result
         );
@@ -200,7 +200,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -217,7 +217,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -231,7 +231,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -259,7 +259,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -276,7 +276,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -290,7 +290,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
                 $k,
                 $participant
             );
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
                 $result
             );
@@ -321,7 +321,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -338,7 +338,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -374,7 +374,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -391,7 +391,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -404,23 +404,23 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             Zend_Service_DeveloperGarden_ConferenceCall_Mock::PARTICIPANT_MUTE_ON,
             $participant
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
             $result
         );
 
         $result = $this->service->getParticipantStatus($conferenceId, $participantId);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_GetParticipantStatusResponseType',
             $result
         );
         $status = $result->getStatus();
-        $this->assertType(
+        $this->assertInternalType(
             'array',
             $status
         );
         foreach ($status as $k => $v ) {
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_ConferenceCall_ParticipantStatus',
                 $v
             );
@@ -454,7 +454,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -471,7 +471,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -485,14 +485,14 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
         $this->assertNotNull($result->getParticipantId());
 
         $result = $this->service->removeConference($conferenceId);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
             $result
         );
@@ -519,7 +519,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -536,7 +536,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -551,7 +551,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -559,13 +559,13 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $this->assertNotNull($part2Id);
 
         $result = $this->service->removeParticipant($conferenceId, $part1Id);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
             $result
         );
 
         $result = $this->service->removeParticipant($conferenceId, $part2Id);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
             $result
         );
@@ -592,7 +592,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -609,7 +609,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -624,7 +624,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -632,7 +632,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $this->assertNotNull($part2Id);
 
         $result = $this->service->commitConference($conferenceId);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
             $result
         );
@@ -643,7 +643,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
      */
     public function testCommitConferenceWithOutInitiator()
     {
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_Mock',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_ConferenceCall_Mock::ENV_SANDBOX)
         );
@@ -666,7 +666,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -682,7 +682,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -690,7 +690,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $this->assertNotNull($part2Id);
 
         $result = $this->service->commitConference($conferenceId);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
             $result
         );
@@ -701,7 +701,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
      */
     public function testCommitConferenceWithThresholdException()
     {
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_Mock',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_ConferenceCall_Mock::ENV_SANDBOX)
         );
@@ -728,7 +728,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
     public function testGetConferenceList()
     {
         //$this->markTestSkipped('Throws internal error on mock environment');
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_Mock',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_ConferenceCall_Mock::ENV_SANDBOX)
         );
@@ -751,7 +751,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -760,12 +760,12 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $this->assertNotNull($conferenceId);
 
         $result = $this->service->getConferenceList(0, 'My Name');
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_GetConferenceListResponseType',
             $result
         );
 
-        $this->assertType(
+        $this->assertInternalType(
             'array',
             $result->getConferenceIds()
         );
@@ -793,7 +793,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -810,7 +810,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -825,7 +825,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -833,13 +833,13 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $this->assertNotNull($part2Id);
 
         $result = $this->service->commitConference($conferenceId);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
             $result
         );
 
         $result = $this->service->getRunningConference($conferenceId);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_GetRunningConferenceResponseType',
             $result
         );
@@ -849,7 +849,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
     public function testGetConferenceStatusSandBox()
     {
         //$this->markTestSkipped('Throws internal error on mock environment');
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_Mock',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_ConferenceCall_Mock::ENV_SANDBOX)
         );
@@ -872,7 +872,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -889,7 +889,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -904,7 +904,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -912,13 +912,13 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $this->assertNotNull($part2Id);
 
         $result = $this->service->getConferenceStatus($conferenceId);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_GetConferenceStatusResponseType',
             $result
         );
 
         $detail = $result->getDetail();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_ConferenceDetail',
             $detail
         );
@@ -932,14 +932,14 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $this->assertInternalType('array', $result->getParticipants());
         $this->assertTrue(count($result->getParticipants()) === 2);
         foreach ($result->getParticipants() as $v) {
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_ConferenceCall_Participant',
                 $v
             );
         }
 
         if ($this->service->getEnvironment() === Zend_Service_DeveloperGarden_ConferenceCall::ENV_PRODUCTION) {
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_ConferenceCall_ConferenceAccount',
                 $result->getAccount()
             );
@@ -968,7 +968,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -985,7 +985,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -1000,7 +1000,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -1014,13 +1014,13 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
                 $this->markTestSkipped('Internal Error still exists on MOCK!');
             }
         }
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_GetConferenceStatusResponseType',
             $result
         );
 
         $detail = $result->getDetail();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_ConferenceDetail',
             $detail
         );
@@ -1034,14 +1034,14 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $this->assertInternalType('array', $result->getParticipants());
         $this->assertTrue(count($result->getParticipants()) === 2);
         foreach ($result->getParticipants() as $v) {
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_ConferenceCall_Participant',
                 $v
             );
         }
 
         if ($this->service->getEnvironment() === Zend_Service_DeveloperGarden_ConferenceCall::ENV_PRODUCTION) {
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_ConferenceCall_ConferenceAccount',
                 $result->getAccount()
             );
@@ -1054,7 +1054,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
     public function testGetConferenceStatusException()
     {
         //$this->markTestSkipped('Throws internal error on mock environment');
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_Mock',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_ConferenceCall_Mock::ENV_SANDBOX)
         );
@@ -1101,7 +1101,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             }
         }
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceResponseType',
             $result
         );
@@ -1118,7 +1118,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -1133,7 +1133,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->newParticipant($conferenceId, $participant);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_NewParticipantResponseType',
             $result
         );
@@ -1141,13 +1141,13 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $this->assertNotNull($part2Id);
 
         $result = $this->service->getParticipantStatus($conferenceId, $part1Id);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_GetParticipantStatusResponseType',
             $result
         );
         $this->assertInternalType('array', $result->getStatus());
         foreach ($result->getStatus() as $v) {
-            $this->assertType('Zend_Service_DeveloperGarden_ConferenceCall_ParticipantStatus', $v);
+            $this->assertInstanceOf('Zend_Service_DeveloperGarden_ConferenceCall_ParticipantStatus', $v);
             $this->assertNotNull($v->getName());
             $this->assertNotNull($v->getValue());
         }
@@ -1156,14 +1156,14 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
     public function testRemoveConferenceLooped()
     {
         //$this->markTestSkipped('Throws internal error on mock environment');
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_Mock',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_ConferenceCall_Mock::ENV_SANDBOX)
         );
         $result = $this->service->getConferenceList(0, 'My Name');
         foreach ($result->getConferenceIds() as $k => $v) {
             $this->assertNotNull($v);
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
                 $this->service->removeConference($v)
             );
@@ -1203,7 +1203,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             $conferenceDetails,
             $participants
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceTemplateResponseType',
             $result
         );
@@ -1241,7 +1241,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             $conferenceDetails,
             $participants
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceTemplateResponseType',
             $result
         );
@@ -1250,7 +1250,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $this->assertNotNull($templateId);
 
         $result = $this->service->removeConferenceTemplate($templateId);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
             $result
         );
@@ -1286,7 +1286,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             $conferenceDetails,
             $participants
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceTemplateResponseType',
             $result
         );
@@ -1294,17 +1294,17 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $templateId = $result->getTemplateId();
         $this->assertNotNull($templateId);
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_ConferenceDetail',
             $conferenceDetails->setDescription('Some Description')
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_ConferenceDetail',
             $conferenceDetails->setDuration(123)
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_ConferenceDetail',
             $conferenceDetails->setName('Marco Kaiser')
         );
@@ -1314,7 +1314,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             null,
             $conferenceDetails
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
             $result
         );
@@ -1350,7 +1350,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             $conferenceDetails,
             $participants
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceTemplateResponseType',
             $result
         );
@@ -1358,17 +1358,17 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $templateId = $result->getTemplateId();
         $this->assertNotNull($templateId);
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_ConferenceDetail',
             $conferenceDetails->setDescription('Some Description')
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_ConferenceDetail',
             $conferenceDetails->setDuration(123)
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_ConferenceDetail',
             $conferenceDetails->setName('Marco Kaiser')
         );
@@ -1378,7 +1378,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             null,
             $conferenceDetails
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
             $result
         );
@@ -1387,7 +1387,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $result = $this->service->getConferenceTemplate($templateId);
 
         $detail = $result->getDetail();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_ConferenceDetail',
             $detail
         );
@@ -1398,28 +1398,28 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $this->assertInternalType('array', $result->getParticipants());
         $this->assertTrue(count($result->getParticipants()) > 0);
         foreach ($result->getParticipants() as $k => $v) {
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_ConferenceCall_Participant',
                 $v
             );
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_ConferenceCall_ParticipantDetail',
                 $v->getDetail()
             );
-            $this->assertType(
+            $this->assertInternalType(
                 'array',
                 $v->getStatus()
             );
         }
 
         $pid1 = $result->getParticipantById('pid1');
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_Participant',
             $pid1
         );
 
         $this->assertEquals('pid1', $pid1->getParticipantId());
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_ParticipantDetail',
             $pid1->getDetail()
         );
@@ -1455,7 +1455,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             $conferenceDetails,
             $participants
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceTemplateResponseType',
             $result
         );
@@ -1464,7 +1464,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $this->assertNotNull($templateId);
 
         $result = $this->service->getConferenceTemplateList('My Name');
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_GetConferenceTemplateListResponseType',
             $result
         );
@@ -1503,7 +1503,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             $conferenceDetails->getName(),
             $conferenceDetails
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceTemplateResponseType',
             $result
         );
@@ -1514,7 +1514,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $this->assertInternalType('array', $participants);
         foreach ($participants as $k => $v) {
             $result = $this->service->addConferenceTemplateParticipant($templateId, $v);
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_Response_ConferenceCall_AddConferenceTemplateParticipantResponseType',
                 $result
             );
@@ -1552,7 +1552,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             $conferenceDetails,
             $participants
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceTemplateResponseType',
             $result
         );
@@ -1563,14 +1563,14 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $pidArray = array('pid1', 'pid2');
         foreach ($pidArray as $k => $v) {
             $result = $this->service->removeConferenceTemplateParticipant($templateId, $v);
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
                 $result
             );
             $this->assertEquals('0000', $result->getStatusCode());
         }
         $result = $this->service->getConferenceTemplate($templateId);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_GetConferenceTemplateResponseType',
             $result
         );
@@ -1606,7 +1606,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             $conferenceDetails,
             $participants
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceTemplateResponseType',
             $result
         );
@@ -1617,11 +1617,11 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $pidArray = array('pid1', 'pid2');
         foreach ($pidArray as $k => $v) {
             $result = $this->service->getConferenceTemplateParticipant($templateId, $v);
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_Response_ConferenceCall_GetConferenceTemplateParticipantResponseType',
                 $result
             );
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_ConferenceCall_ParticipantDetail',
                 $result->getParticipant()
             );
@@ -1632,7 +1632,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
     public function testUpdateConferenceTemplateParticipant()
     {
         // works only on sandbox
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_Mock',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_ConferenceCall_Mock::ENV_SANDBOX)
         );
@@ -1664,7 +1664,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             $conferenceDetails,
             $participants
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_CreateConferenceTemplateResponseType',
             $result
         );
@@ -1673,7 +1673,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         $this->assertNotNull($templateId);
 
         $result = $this->service->getConferenceTemplate($templateId);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_GetConferenceTemplateResponseType',
             $result
         );
@@ -1683,15 +1683,15 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         foreach ($list as $k => $v) {
             $participantId = $v->getParticipantId();
             $detail = $v->getDetail();
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_ConferenceCall_ParticipantDetail',
                 $detail
             );
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_ConferenceCall_ParticipantDetail',
                 $detail->setFirstName('Zend')
             );
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_ConferenceCall_ParticipantDetail',
                 $detail->setLastName('Framework')
             );
@@ -1701,7 +1701,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
                 $participantId,
                 $detail
             );
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
                 $result
             );
@@ -1709,12 +1709,12 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
 
             // ask for part
             $result = $this->service->getConferenceTemplateParticipant($templateId, $participantId);
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_Response_ConferenceCall_GetConferenceTemplateParticipantResponseType',
                 $result
             );
             $newPart = $result->getParticipant();
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_ConferenceCall_ParticipantDetail',
                 $newPart
             );
@@ -1750,7 +1750,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->getConferenceTemplateList('My Name');
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_GetConferenceTemplateListResponseType',
             $result
         );
@@ -1760,7 +1760,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             $templateId = $v;
             $this->assertNotNull($templateId);
             $result = $this->service->removeConferenceTemplate($templateId);
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
                 $result
             );
@@ -1770,7 +1770,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
 
     public function testRemoveConferenceTemplateLoopedSandbox()
     {
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_ConferenceCall_Mock',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_ConferenceCall_Mock::ENV_SANDBOX)
         );
@@ -1797,7 +1797,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
         );
 
         $result = $this->service->getConferenceTemplateList('My Name');
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_ConferenceCall_GetConferenceTemplateListResponseType',
             $result
         );
@@ -1807,7 +1807,7 @@ class Zend_Service_DeveloperGarden_ConferenceCallTest extends PHPUnit_Framework_
             $templateId = $v;
             $this->assertNotNull($templateId);
             $result = $this->service->removeConferenceTemplate($templateId);
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_Response_ConferenceCall_CCSResponseType',
                 $result
             );

--- a/tests/Zend/Service/DeveloperGarden/LocalSearchTest.php
+++ b/tests/Zend/Service/DeveloperGarden/LocalSearchTest.php
@@ -68,7 +68,7 @@ class Zend_Service_DeveloperGarden_LocalSearchTest extends PHPUnit_Framework_Tes
                          ->setHits(3);
         try {
             $result = $this->service->localSearch($searchParameters);
-            $this->assertType('Zend_Service_DeveloperGarden_Response_LocalSearch_LocalSearchResponseType',
+            $this->assertInstanceOf('Zend_Service_DeveloperGarden_Response_LocalSearch_LocalSearchResponseType',
                               $result->getSearchResult());
             $this->assertEquals('0000', $result->getErrorCode());
         } catch (Exception $e) {

--- a/tests/Zend/Service/DeveloperGarden/OfflineBaseUserServiceTest.php
+++ b/tests/Zend/Service/DeveloperGarden/OfflineBaseUserServiceTest.php
@@ -145,7 +145,7 @@ class Zend_Service_DeveloperGarden_OfflineBaseUserServiceTest extends PHPUnit_Fr
 
     public function testGetCredentialOnSoapObject()
     {
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Credential',
             $this->service->getSoapClient()->getCredential()
         );
@@ -153,7 +153,7 @@ class Zend_Service_DeveloperGarden_OfflineBaseUserServiceTest extends PHPUnit_Fr
 
     public function testGetTokenServiceOnSoapObject()
     {
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_SecurityTokenServer',
             $this->service->getSoapClient()->getTokenService()
         );

--- a/tests/Zend/Service/DeveloperGarden/OfflineClientTest.php
+++ b/tests/Zend/Service/DeveloperGarden/OfflineClientTest.php
@@ -100,7 +100,7 @@ class Zend_Service_DeveloperGarden_OfflineClientTest extends PHPUnit_Framework_T
         $this->assertNull($this->service->getOption('not_existing'));
         foreach ($options as $key => $value) {
             $this->assertNull($this->service->getOption($key));
-            $this->assertType(
+            $this->assertInstanceOf(
                 'Zend_Service_DeveloperGarden_Client_AbstractClient',
                 $this->service->setOption($key, $value)
             );
@@ -127,11 +127,11 @@ class Zend_Service_DeveloperGarden_OfflineClientTest extends PHPUnit_Framework_T
         );
 
         $this->service = new Zend_Service_DeveloperGarden_OfflineClient_Mock($options);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_OfflineClient_Mock',
             $this->service
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Client_Soap',
             $this->service->getSoapClient()
         );
@@ -139,7 +139,7 @@ class Zend_Service_DeveloperGarden_OfflineClientTest extends PHPUnit_Framework_T
 
     public function testOnlineWsdl()
     {
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Client_AbstractClient',
             $this->service->setUseLocalWsdl(false)
         );
@@ -151,7 +151,7 @@ class Zend_Service_DeveloperGarden_OfflineClientTest extends PHPUnit_Framework_T
 
     public function testSetLocalWsdl()
     {
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Client_AbstractClient',
             $this->service->setLocalWsdl('my.wsdl')
         );
@@ -164,12 +164,12 @@ class Zend_Service_DeveloperGarden_OfflineClientTest extends PHPUnit_Framework_T
 
     public function testSetWsdl()
     {
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Client_AbstractClient',
             $this->service->setWsdl('http://my.wsdl')
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Client_AbstractClient',
             $this->service->setUseLocalWsdl(false)
         );
@@ -207,7 +207,7 @@ class Zend_Service_DeveloperGarden_OfflineClientTest extends PHPUnit_Framework_T
     public function testParticipantsAction()
     {
         $actions = $this->service->getParticipantActions();
-        $this->assertType(
+        $this->assertInternalType(
             'array',
             $actions
         );
@@ -236,7 +236,7 @@ class Zend_Service_DeveloperGarden_OfflineClientTest extends PHPUnit_Framework_T
             Zend_Service_DeveloperGarden_SecurityTokenServer_Cache::setWsdlCache(WSDL_CACHE_BOTH)
         );
         $options = $this->service->getClientOptions();
-        $this->assertType(
+        $this->assertInternalType(
             'array',
             $options
         );

--- a/tests/Zend/Service/DeveloperGarden/OfflineLocalSearchParametersTest.php
+++ b/tests/Zend/Service/DeveloperGarden/OfflineLocalSearchParametersTest.php
@@ -90,7 +90,7 @@ class Zend_Service_DeveloperGarden_OfflineLocalSearchParametersTest extends PHPU
     public function testSetHits()
     {
         $param = new Zend_Service_DeveloperGarden_LocalSearch_SearchParameters();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_LocalSearch_SearchParameters',
             $param->setHits(1000)
         );
@@ -102,7 +102,7 @@ class Zend_Service_DeveloperGarden_OfflineLocalSearchParametersTest extends PHPU
     public function testCollapseValuesWrong()
     {
         $param = new Zend_Service_DeveloperGarden_LocalSearch_SearchParameters();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_LocalSearch_SearchParameters',
             $param->setCollapse('SomeStrangeValue')
         );
@@ -111,7 +111,7 @@ class Zend_Service_DeveloperGarden_OfflineLocalSearchParametersTest extends PHPU
     public function testCollapseValuesTrue()
     {
         $param = new Zend_Service_DeveloperGarden_LocalSearch_SearchParameters();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_LocalSearch_SearchParameters',
             $param->setCollapse(true)
         );
@@ -120,7 +120,7 @@ class Zend_Service_DeveloperGarden_OfflineLocalSearchParametersTest extends PHPU
     public function testCollapseValuesFalse()
     {
         $param = new Zend_Service_DeveloperGarden_LocalSearch_SearchParameters();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_LocalSearch_SearchParameters',
             $param->setCollapse(false)
         );
@@ -129,7 +129,7 @@ class Zend_Service_DeveloperGarden_OfflineLocalSearchParametersTest extends PHPU
     public function testCollapseValuesAddressCompany()
     {
         $param = new Zend_Service_DeveloperGarden_LocalSearch_SearchParameters();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_LocalSearch_SearchParameters',
             $param->setCollapse('ADDRESS_COMPANY')
         );
@@ -138,7 +138,7 @@ class Zend_Service_DeveloperGarden_OfflineLocalSearchParametersTest extends PHPU
     public function testCollapseValuesDomain()
     {
         $param = new Zend_Service_DeveloperGarden_LocalSearch_SearchParameters();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_LocalSearch_SearchParameters',
             $param->setCollapse('DOMAIN')
         );
@@ -150,7 +150,7 @@ class Zend_Service_DeveloperGarden_OfflineLocalSearchParametersTest extends PHPU
     public function testWhereEmpty()
     {
         $param = new Zend_Service_DeveloperGarden_LocalSearch_SearchParameters();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_LocalSearch_SearchParameters',
             $param->setWhere(null)
         );
@@ -162,7 +162,7 @@ class Zend_Service_DeveloperGarden_OfflineLocalSearchParametersTest extends PHPU
     public function testRadiusWithString()
     {
         $param = new Zend_Service_DeveloperGarden_LocalSearch_SearchParameters();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_LocalSearch_SearchParameters',
             $param->setRadius('foobar')
         );
@@ -174,7 +174,7 @@ class Zend_Service_DeveloperGarden_OfflineLocalSearchParametersTest extends PHPU
     public function testRadiusWithStringAndInteger()
     {
         $param = new Zend_Service_DeveloperGarden_LocalSearch_SearchParameters();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_LocalSearch_SearchParameters',
             $param->setRadius('1a')
         );
@@ -183,7 +183,7 @@ class Zend_Service_DeveloperGarden_OfflineLocalSearchParametersTest extends PHPU
     public function testRadiusWithIntegerAsString()
     {
         $param = new Zend_Service_DeveloperGarden_LocalSearch_SearchParameters();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_LocalSearch_SearchParameters',
             $param->setRadius('-100')
         );

--- a/tests/Zend/Service/DeveloperGarden/OfflineSecurityTokenServerTest.php
+++ b/tests/Zend/Service/DeveloperGarden/OfflineSecurityTokenServerTest.php
@@ -220,8 +220,8 @@ class Zend_Service_DeveloperGarden_OfflineSecurityTokenServerTest extends PHPUni
         $this->assertNull(
             Zend_Service_DeveloperGarden_SecurityTokenServer_Cache::setCache($cache)
         );
-        $this->assertType(
-            'Zend\\Cache\\Frontend\\Core',
+        $this->assertInstanceOf(
+            'Zend\Cache\Frontend\Core',
             Zend_Service_DeveloperGarden_SecurityTokenServer_Cache::getCache()
         );
     }
@@ -232,8 +232,8 @@ class Zend_Service_DeveloperGarden_OfflineSecurityTokenServerTest extends PHPUni
         $this->assertNull(
             Zend_Service_DeveloperGarden_SecurityTokenServer_Cache::setCache($cache)
         );
-        $this->assertType(
-            'Zend\\Cache\\Frontend\\Core',
+        $this->assertInstanceOf(
+            'Zend\Cache\Frontend\Core',
             Zend_Service_DeveloperGarden_SecurityTokenServer_Cache::getCache()
         );
 
@@ -249,8 +249,8 @@ class Zend_Service_DeveloperGarden_OfflineSecurityTokenServerTest extends PHPUni
         $this->assertNull(
             Zend_Service_DeveloperGarden_SecurityTokenServer_Cache::setCache($cache)
         );
-        $this->assertType(
-            'Zend\\Cache\\Frontend\\Core',
+        $this->assertInstanceOf(
+            'Zend\Cache\Frontend\Core',
             Zend_Service_DeveloperGarden_SecurityTokenServer_Cache::getCache()
         );
 
@@ -268,8 +268,8 @@ class Zend_Service_DeveloperGarden_OfflineSecurityTokenServerTest extends PHPUni
         $this->assertNull(
             Zend_Service_DeveloperGarden_SecurityTokenServer_Cache::setCache($cache)
         );
-        $this->assertType(
-            'Zend\\Cache\\Frontend\\Core',
+        $this->assertInstanceOf(
+            'Zend\Cache\Frontend\Core',
             Zend_Service_DeveloperGarden_SecurityTokenServer_Cache::getCache()
         );
 

--- a/tests/Zend/Service/DeveloperGarden/SecurityTokenServerTest.php
+++ b/tests/Zend/Service/DeveloperGarden/SecurityTokenServerTest.php
@@ -68,18 +68,18 @@ class Zend_Service_DeveloperGarden_SecurityTokenServerTest extends PHPUnit_Frame
     public function testGetTokens()
     {
         $soap = $this->service->getSoapClient();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Client_Soap',
             $soap
         );
 
         $tokens = $this->service->getTokens();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_SecurityTokenServer_GetTokensResponse',
             $tokens
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_SecurityTokenServer_SecurityTokenResponse',
             $tokens->securityToken
         );
@@ -105,7 +105,7 @@ class Zend_Service_DeveloperGarden_SecurityTokenServerTest extends PHPUnit_Frame
         $this->assertNull(
             Zend_Service_DeveloperGarden_SecurityTokenServer_Cache::setCache($cache)
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Cache_Core',
             Zend_Service_DeveloperGarden_SecurityTokenServer_Cache::getCache()
         );
@@ -114,12 +114,12 @@ class Zend_Service_DeveloperGarden_SecurityTokenServerTest extends PHPUnit_Frame
         Zend_Service_DeveloperGarden_SecurityTokenServer_Cache::clearCache();
 
         $tokens = $this->service->getTokens();
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_SecurityTokenServer_GetTokensResponse',
             $tokens
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_SecurityTokenServer_SecurityTokenResponse',
             $tokens->securityToken
         );

--- a/tests/Zend/Service/DeveloperGarden/SendSmsTest.php
+++ b/tests/Zend/Service/DeveloperGarden/SendSmsTest.php
@@ -60,7 +60,7 @@ class Zend_Service_DeveloperGarden_SendSmsTest extends PHPUnit_Framework_TestCas
         );
         $this->service = new Zend_Service_DeveloperGarden_SendSms_Mock($config);
         // limit to mock env
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_SendSms_Mock',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_SendSms_Mock::ENV_MOCK)
         );
@@ -77,12 +77,12 @@ class Zend_Service_DeveloperGarden_SendSmsTest extends PHPUnit_Framework_TestCas
             'Zend.Framework'
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_SendSms_SendSMS',
             $sms
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_SendSms_SendSMSResponse',
             $this->service->send($sms)
         );
@@ -100,12 +100,12 @@ class Zend_Service_DeveloperGarden_SendSmsTest extends PHPUnit_Framework_TestCas
             'Zend.Framework'
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_SendSms_SendFlashSMS',
             $sms
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_SendSms_SendFlashSMSResponse',
             $this->service->send($sms)
         );
@@ -119,13 +119,13 @@ class Zend_Service_DeveloperGarden_SendSmsTest extends PHPUnit_Framework_TestCas
             'ZFTest'
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_SendSms_SendSMS',
             $sms
         );
 
         $result = $this->service->send($sms);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_SendSms_SendSMSResponse',
             $result
         );
@@ -141,13 +141,13 @@ class Zend_Service_DeveloperGarden_SendSmsTest extends PHPUnit_Framework_TestCas
             'ZFTest'
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_SendSms_SendFlashSMS',
             $sms
         );
 
         $result = $this->service->send($sms);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_SendSms_SendFlashSMSResponse',
             $result
         );
@@ -163,20 +163,20 @@ class Zend_Service_DeveloperGarden_SendSmsTest extends PHPUnit_Framework_TestCas
         $sms = new Zend_Service_DeveloperGarden_Request_SendSms_WrongSmsType(
             $this->service->getEnvironment()
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_SendSms_WrongSmsType',
             $sms->setNumber('+49-171-2345678')
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_SendSms_WrongSmsType',
             $sms->setMessage('Zend Framework is very cool')
         );
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_SendSms_WrongSmsType',
             $sms->setOriginator('ZFTest')
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_SendSms_WrongSmsType',
             $sms
         );

--- a/tests/Zend/Service/DeveloperGarden/VoiceCallTest.php
+++ b/tests/Zend/Service/DeveloperGarden/VoiceCallTest.php
@@ -67,13 +67,13 @@ class Zend_Service_DeveloperGarden_VoiceCallTest extends PHPUnit_Framework_TestC
         $bNumber = '+4932-000002';
 
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Client_AbstractClient',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_VoiceCall_Mock::ENV_MOCK)
         );
 
         $result = $this->service->newCall($aNumber, $bNumber, 30, 30);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_VoiceButler_NewCallResponse',
             $result
         );
@@ -97,19 +97,19 @@ class Zend_Service_DeveloperGarden_VoiceCallTest extends PHPUnit_Framework_TestC
         );
 
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Client_AbstractClient',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_VoiceCall_Mock::ENV_MOCK)
         );
 
         $result = $this->service->newCallSequenced($aNumber, $bNumber, 30, 30, 5);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_VoiceButler_NewCallSequencedResponse',
             $result
         );
 
         // test getReturn specially here
-        $this->assertType(
+        $this->assertInstanceOf(
             'stdClass',
             $result->getReturn()
         );
@@ -129,7 +129,7 @@ class Zend_Service_DeveloperGarden_VoiceCallTest extends PHPUnit_Framework_TestC
         );
 
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Client_AbstractClient',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_VoiceCall_Mock::ENV_MOCK)
         );
@@ -143,13 +143,13 @@ class Zend_Service_DeveloperGarden_VoiceCallTest extends PHPUnit_Framework_TestC
         $bNumber = '+4932-000001';
 
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Client_AbstractClient',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_VoiceCall_Mock::ENV_MOCK)
         );
 
         $result = $this->service->newCall($aNumber, $bNumber, 30, 30);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_VoiceButler_NewCallResponse',
             $result
         );
@@ -161,7 +161,7 @@ class Zend_Service_DeveloperGarden_VoiceCallTest extends PHPUnit_Framework_TestC
         $this->assertNotNull($sessionId);
 
         $result = $this->service->tearDownCall($sessionId);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_VoiceButler_TearDownCallResponse',
             $result
         );
@@ -178,7 +178,7 @@ class Zend_Service_DeveloperGarden_VoiceCallTest extends PHPUnit_Framework_TestC
      */
     public function testTearDownCallException()
     {
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Client_AbstractClient',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_VoiceCall_Mock::ENV_MOCK)
         );
@@ -192,13 +192,13 @@ class Zend_Service_DeveloperGarden_VoiceCallTest extends PHPUnit_Framework_TestC
         $bNumber = '+4932-000001';
 
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Client_AbstractClient',
             $this->service->setEnvironment(Zend_Service_DeveloperGarden_VoiceCall_Mock::ENV_MOCK)
         );
 
         $result = $this->service->newCall($aNumber, $bNumber, 30, 30);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_VoiceButler_NewCallResponse',
             $result
         );
@@ -210,7 +210,7 @@ class Zend_Service_DeveloperGarden_VoiceCallTest extends PHPUnit_Framework_TestC
         $this->assertNotNull($sessionId);
 
         $result = $this->service->callStatus($sessionId, 30);
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Response_VoiceButler_CallStatusResponse',
             $result
         );
@@ -302,61 +302,61 @@ class Zend_Service_DeveloperGarden_VoiceCallTest extends PHPUnit_Framework_TestC
             $request->getEnvironment()
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_NewCall',
             $request->setAccount(999999)
         );
         $this->assertEquals(999999, $request->getAccount());
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_NewCall',
             $request->setANumber('+49-123456')
         );
         $this->assertEquals('+49-123456', $request->getANumber());
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_NewCall',
             $request->setBNumber('+49-654321')
         );
         $this->assertEquals('+49-654321', $request->getBNumber());
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_NewCall',
             $request->setBNumber('+49-654321')
         );
         $this->assertEquals('+49-654321', $request->getBNumber());
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_NewCall',
             $request->setPrivacyA(true)
         );
         $this->assertEquals(true, $request->getPrivacyA());
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_NewCall',
             $request->setPrivacyB(true)
         );
         $this->assertEquals(true, $request->getPrivacyB());
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_NewCall',
             $request->setExpiration(30)
         );
         $this->assertEquals(30, $request->getExpiration());
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_NewCall',
             $request->setMaxDuration(60)
         );
         $this->assertEquals(60, $request->getMaxDuration());
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_NewCall',
             $request->setGreeter('49-999999')
         );
         $this->assertEquals('49-999999', $request->getGreeter());
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_NewCall',
             $request->setEnvironment(Zend_Service_DeveloperGarden_VoiceCall_Mock::ENV_MOCK)
         );
@@ -376,7 +376,7 @@ class Zend_Service_DeveloperGarden_VoiceCallTest extends PHPUnit_Framework_TestC
             $request->getEnvironment()
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_NewCallSequenced',
             $request->setBNumber(array('+49-654321','+49-123456'))
         );
@@ -391,7 +391,7 @@ class Zend_Service_DeveloperGarden_VoiceCallTest extends PHPUnit_Framework_TestC
         $this->assertArrayHasKey(0, array('+49-654321','+49-123456'));
         $this->assertArrayHasKey(1, array('+49-654321','+49-123456'));
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_NewCallSequenced',
             $request->setMaxWait(9)
         );
@@ -415,7 +415,7 @@ class Zend_Service_DeveloperGarden_VoiceCallTest extends PHPUnit_Framework_TestC
             $request->getSessionId()
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_TearDownCall',
             $request->setSessionId('SESSIONID-8888888888')
         );
@@ -448,7 +448,7 @@ class Zend_Service_DeveloperGarden_VoiceCallTest extends PHPUnit_Framework_TestC
         );
 
         // value changes
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_CallStatus',
             $request->setSessionId('SESSIONID-8888888888')
         );
@@ -458,7 +458,7 @@ class Zend_Service_DeveloperGarden_VoiceCallTest extends PHPUnit_Framework_TestC
             $request->getSessionId()
         );
 
-        $this->assertType(
+        $this->assertInstanceOf(
             'Zend_Service_DeveloperGarden_Request_VoiceButler_CallStatus',
             $request->setKeepAlive(15)
         );

--- a/tests/Zend/Service/StrikeIron/BaseTest.php
+++ b/tests/Zend/Service/StrikeIron/BaseTest.php
@@ -70,7 +70,7 @@ class Zend_Service_StrikeIron_BaseTest extends PHPUnit_Framework_TestCase
         // soapclient instance without hitting the network
         $base = new Zend_Service_StrikeIron_Base(array('options' => array('location' => '',
                                                                           'uri'      => '')));
-        $this->assertType('SOAPClient', $base->getSoapClient());
+        $this->assertInstanceOf('SOAPClient', $base->getSoapClient());
     }
 
     public function testDefaultSoapHeadersHasTheLicenseInfoHeader()
@@ -82,7 +82,7 @@ class Zend_Service_StrikeIron_BaseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($headers));
         $header = $headers[0];
 
-        $this->assertType('SoapHeader', $header);
+        $this->assertInstanceOf('SoapHeader', $header);
         $this->assertEquals('LicenseInfo', $header->name);
         $this->assertEquals('user', $header->data['RegisteredUser']['UserID']);
         $this->assertEquals('pass', $header->data['RegisteredUser']['Password']);
@@ -141,7 +141,7 @@ class Zend_Service_StrikeIron_BaseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($headers));
         $header = $headers[0];
 
-        $this->assertType('SoapHeader', $header);
+        $this->assertInstanceOf('SoapHeader', $header);
         $this->assertEquals('LicenseInfo', $header->name);
         $this->assertEquals('foo', $header->data['RegisteredUser']['UserID']);
         $this->assertEquals('bar', $header->data['RegisteredUser']['Password']);

--- a/tests/Zend/Service/StrikeIron/BaseTest.php
+++ b/tests/Zend/Service/StrikeIron/BaseTest.php
@@ -175,7 +175,7 @@ class Zend_Service_StrikeIron_BaseTest extends PHPUnit_Framework_TestCase
 
     public function testMethodResultWrappingAnyObject()
     {
-        $this->assertType('Zend_Service_StrikeIron_Decorator',
+        $this->assertInstanceOf('Zend_Service_StrikeIron_Decorator',
                           $this->base->returnTheObject());
     }
 
@@ -190,7 +190,7 @@ class Zend_Service_StrikeIron_BaseTest extends PHPUnit_Framework_TestCase
             $this->base->throwTheException();
             $this->fail();
         } catch (Exception $e) {
-            $this->assertType('Zend_Service_StrikeIron_Exception', $e);
+            $this->assertInstanceOf('Zend_Service_StrikeIron_Exception', $e);
             $this->assertEquals('Exception: foo', $e->getMessage());
             $this->assertEquals(43, $e->getCode());
         }

--- a/tests/Zend/Service/StrikeIron/DecoratorTest.php
+++ b/tests/Zend/Service/StrikeIron/DecoratorTest.php
@@ -81,7 +81,7 @@ class Zend_Service_StrikeIron_DecoratorTest extends PHPUnit_Framework_TestCase
     {
         $object = (object)array('Foo' => new stdclass);
         $decorator = new Zend_Service_StrikeIron_Decorator($object);
-        $this->assertType(get_class($decorator), $decorator->Foo);
+        $this->assertInstanceOf(get_class($decorator), $decorator->Foo);
     }
 
     public function testDecoratorProxiesMethodCalls()

--- a/tests/Zend/Service/StrikeIron/ExceptionTest.php
+++ b/tests/Zend/Service/StrikeIron/ExceptionTest.php
@@ -43,6 +43,6 @@ class Zend_Service_StrikeIron_ExceptionTest extends PHPUnit_Framework_TestCase
     public function testInheritsFromZendException()
     {
         $exception = new Zend_Service_StrikeIron_Exception();
-        $this->assertType('Zend_Exception', $exception);
+        $this->assertInstanceOf('Zend_Exception', $exception);
     }
 }

--- a/tests/Zend/Service/StrikeIron/NoSoapTest.php
+++ b/tests/Zend/Service/StrikeIron/NoSoapTest.php
@@ -57,7 +57,7 @@ class Zend_Service_StrikeIron_NoSoapTest extends PHPUnit_Framework_TestCase
                                                              'password' => 'pass'));
             $this->fail('Expecting exception of type Zend_Service_StrikeIron_Exception');
         } catch (Zend_Exception $e) {
-            $this->assertType('Zend_Service_StrikeIron_Exception', $e,
+            $this->assertInstanceOf('Zend_Service_StrikeIron_Exception', $e,
                 'Expecting exception of type Zend_Service_StrikeIron_Exception, got '.get_class($e));
             $this->assertEquals('SOAP extension is not enabled', $e->getMessage());
         }

--- a/tests/Zend/Service/StrikeIron/SalesUseTaxBasicTest.php
+++ b/tests/Zend/Service/StrikeIron/SalesUseTaxBasicTest.php
@@ -52,7 +52,7 @@ class Zend_Service_StrikeIron_SalesUseTaxBasicTest extends PHPUnit_Framework_Tes
 
     public function testInheritsFromBase()
     {
-        $this->assertType('Zend_Service_StrikeIron_Base', $this->service);
+        $this->assertInstanceOf('Zend_Service_StrikeIron_Base', $this->service);
     }
 
     public function testWsdl()
@@ -66,6 +66,6 @@ class Zend_Service_StrikeIron_SalesUseTaxBasicTest extends PHPUnit_Framework_Tes
         $strikeIron = new Zend_Service_StrikeIron(array('client' => $this->soapClient));
         $client = $strikeIron->getService(array('class' => 'SalesUseTaxBasic'));
 
-        $this->assertType('Zend_Service_StrikeIron_SalesUseTaxBasic', $client);
+        $this->assertInstanceOf('Zend_Service_StrikeIron_SalesUseTaxBasic', $client);
     }
 }

--- a/tests/Zend/Service/StrikeIron/StrikeIronTest.php
+++ b/tests/Zend/Service/StrikeIron/StrikeIronTest.php
@@ -62,7 +62,7 @@ class Zend_Service_StrikeIron_StrikeIronTest extends PHPUnit_Framework_TestCase
     {
         $class = 'Zend_Service_StrikeIron_StrikeIronTest_StubbedBase';
         $stub = $this->strikeIron->getService(array('class' => $class));
-        $this->assertType($class, $stub);
+        $this->assertInstanceOf($class, $stub);
     }
 
     public function testFactoryReturnsServiceByWsdl()

--- a/tests/Zend/Service/StrikeIron/StrikeIronTest.php
+++ b/tests/Zend/Service/StrikeIron/StrikeIronTest.php
@@ -53,7 +53,7 @@ class Zend_Service_StrikeIron_StrikeIronTest extends PHPUnit_Framework_TestCase
     public function testFactoryReturnsServiceByStrikeIronClass()
     {
         $base = $this->strikeIron->getService(array('class' => 'Base'));
-        $this->assertType('Zend_Service_StrikeIron_Base', $base);
+        $this->assertInstanceOf('Zend_Service_StrikeIron_Base', $base);
         $this->assertSame(null, $base->getWsdl());
         $this->assertSame($this->soapClient, $base->getSoapClient());
     }

--- a/tests/Zend/Service/StrikeIron/USAddressVerificationTest.php
+++ b/tests/Zend/Service/StrikeIron/USAddressVerificationTest.php
@@ -52,7 +52,7 @@ class Zend_Service_StrikeIron_USAddressVerificationTest extends PHPUnit_Framewor
 
     public function testInheritsFromBase()
     {
-        $this->assertType('Zend_Service_StrikeIron_Base', $this->service);
+        $this->assertInstanceOf('Zend_Service_StrikeIron_Base', $this->service);
     }
 
     public function testHasCorrectWsdl()
@@ -66,6 +66,6 @@ class Zend_Service_StrikeIron_USAddressVerificationTest extends PHPUnit_Framewor
         $strikeIron = new Zend_Service_StrikeIron(array('client' => $this->soapClient));
         $client = $strikeIron->getService(array('class' => 'USAddressVerification'));
 
-        $this->assertType('Zend_Service_StrikeIron_USAddressVerification', $client);
+        $this->assertInstanceOf('Zend_Service_StrikeIron_USAddressVerification', $client);
     }
 }

--- a/tests/Zend/Service/StrikeIron/ZipCodeInfoTest.php
+++ b/tests/Zend/Service/StrikeIron/ZipCodeInfoTest.php
@@ -52,7 +52,7 @@ class Zend_Service_StrikeIron_ZipCodeInfoTest extends PHPUnit_Framework_TestCase
 
     public function testInheritsFromBase()
     {
-        $this->assertType('Zend_Service_StrikeIron_Base', $this->service);
+        $this->assertInstanceOf('Zend_Service_StrikeIron_Base', $this->service);
     }
 
     public function testHasCorrectWsdl()
@@ -66,7 +66,7 @@ class Zend_Service_StrikeIron_ZipCodeInfoTest extends PHPUnit_Framework_TestCase
         $strikeIron = new Zend_Service_StrikeIron(array('client' => $this->soapClient));
         $client = $strikeIron->getService(array('class' => 'ZipCodeInfo'));
 
-        $this->assertType('Zend_Service_StrikeIron_ZipCodeInfo', $client);
+        $this->assertInstanceOf('Zend_Service_StrikeIron_ZipCodeInfo', $client);
     }
 
 }

--- a/tests/Zend/Service/Technorati/AuthorTest.php
+++ b/tests/Zend/Service/Technorati/AuthorTest.php
@@ -70,7 +70,7 @@ class Zend_Service_Technorati_AuthorTest extends Zend_Service_Technorati_TestCas
         $this->assertInternalType('string', $author->getFirstName());
         $this->assertEquals('This is a bio.', $author->getBio());
 
-        $this->assertType('Zend_Uri_Http', $author->getThumbnailPicture());
+        $this->assertInstanceOf('Zend_Uri_Http', $author->getThumbnailPicture());
         $this->assertEquals(Zend_Uri::factory('http://static.technorati.com/progimages/photo.jpg?uid=117217'), $author->getThumbnailPicture());
     }
 
@@ -112,12 +112,12 @@ class Zend_Service_Technorati_AuthorTest extends Zend_Service_Technorati_TestCas
 
         $set = Zend_Uri::factory('http://www.simonecarletti.com/');
         $get = $author->setThumbnailPicture($set)->getThumbnailPicture();
-        $this->assertType('Zend_Uri_Http', $get);
+        $this->assertInstanceOf('Zend_Uri_Http', $get);
         $this->assertEquals($set, $get);
 
         $set = 'http://www.simonecarletti.com/';
         $get = $author->setThumbnailPicture($set)->getThumbnailPicture();
-        $this->assertType('Zend_Uri_Http', $get);
+        $this->assertInstanceOf('Zend_Uri_Http', $get);
         $this->assertEquals(Zend_Uri::factory($set), $get);
 
         $set = 'http:::/foo';

--- a/tests/Zend/Service/Technorati/BlogInfoResultTest.php
+++ b/tests/Zend/Service/Technorati/BlogInfoResultTest.php
@@ -61,11 +61,11 @@ class Zend_Service_Technorati_BlogInfoResultTest extends Zend_Service_Technorati
 
         // check weblog
         $weblog = $object->getWeblog();
-        $this->assertType('Zend_Service_Technorati_Weblog', $weblog);
+        $this->assertInstanceOf('Zend_Service_Technorati_Weblog', $weblog);
         $this->assertEquals('Simone Carletti\'s Blog', $weblog->getName());
 
         // check url
-        $this->assertType('Zend_Uri_Http', $object->getUrl());
+        $this->assertInstanceOf('Zend_Uri_Http', $object->getUrl());
         $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com/blog'), $object->getUrl());
 
         // check inboundblogs
@@ -83,7 +83,7 @@ class Zend_Service_Technorati_BlogInfoResultTest extends Zend_Service_Technorati
         $object = new Zend_Service_Technorati_BlogInfoResult($dom);
 
         // check url
-        $this->assertType('Zend_Uri_Http', $object->getUrl());
+        $this->assertInstanceOf('Zend_Uri_Http', $object->getUrl());
         $this->assertEquals($object->getWeblog()->getUrl(), $object->getUrl());
     }
 }

--- a/tests/Zend/Service/Technorati/CosmosResultSetTest.php
+++ b/tests/Zend/Service/Technorati/CosmosResultSetTest.php
@@ -66,13 +66,13 @@ class Zend_Service_Technorati_CosmosResultSetTest extends Zend_Service_Technorat
         $this->assertEquals(278, $object->totalResultsAvailable());
 
         // check properties
-        $this->assertType('Zend_Uri_Http', $object->getUrl());
+        $this->assertInstanceOf('Zend_Uri_Http', $object->getUrl());
         $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com/blog'), $object->getUrl());
         $this->assertInternalType('integer', $object->getInboundLinks());
         $this->assertEquals(278, $object->getInboundLinks());
 
         // check weblog
-        $this->assertType('Zend_Service_Technorati_Weblog', $object->getWeblog());
+        $this->assertInstanceOf('Zend_Service_Technorati_Weblog', $object->getWeblog());
         $this->assertEquals('Simone Carletti\'s Blog', $object->getWeblog()->getName());
     }
 

--- a/tests/Zend/Service/Technorati/CosmosResultTest.php
+++ b/tests/Zend/Service/Technorati/CosmosResultTest.php
@@ -65,19 +65,19 @@ class Zend_Service_Technorati_CosmosResultTest extends Zend_Service_Technorati_T
         $domElements = self::getTestFileElementsAsDom('TestCosmosResultSetSiteLink.xml');
         $object = new Zend_Service_Technorati_CosmosResult($domElements->item(0));
 
-        $this->assertType('Zend_Service_Technorati_Weblog', $object->getWeblog());
+        $this->assertInstanceOf('Zend_Service_Technorati_Weblog', $object->getWeblog());
         $this->assertContains('Gioxx', $object->getWeblog()->getName());
 
-        $this->assertType('Zend_Uri_Http', $object->getNearestPermalink());
+        $this->assertInstanceOf('Zend_Uri_Http', $object->getNearestPermalink());
         $this->assertEquals(Zend_Uri::factory('http://gioxx.org/2007/11/05/il-passaggio-a-mac-le-11-risposte/'), $object->getNearestPermalink());
 
         $this->assertInternalType('string', $object->getExcerpt());
         $this->assertContains('Ho intenzione di prendere il modello bianco', $object->getExcerpt());
 
-        $this->assertType('Zend_Date', $object->getLinkCreated());
+        $this->assertInstanceOf('Zend_Date', $object->getLinkCreated());
         $this->assertEquals(new Zend_Date('2007-11-11 20:07:11 GMT'), $object->getLinkCreated());
 
-        $this->assertType('Zend_Uri_Http', $object->getLinkUrl());
+        $this->assertInstanceOf('Zend_Uri_Http', $object->getLinkUrl());
         $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com/blog/2007/04/parallels-desktop-overview.php'), $object->getLinkUrl());
 
         // test an other element to prevent cached values
@@ -102,10 +102,10 @@ class Zend_Service_Technorati_CosmosResultTest extends Zend_Service_Technorati_T
         $domElements = self::getTestFileElementsAsDom('TestCosmosResultSetSiteWeblog.xml');
         $object = new Zend_Service_Technorati_CosmosResult($domElements->item(0));
 
-        $this->assertType('Zend_Service_Technorati_Weblog', $object->getWeblog());
+        $this->assertInstanceOf('Zend_Service_Technorati_Weblog', $object->getWeblog());
         $this->assertContains('Simone Carletti', $object->getWeblog()->getName());
 
-        $this->assertType('Zend_Uri_Http', $object->getLinkUrl());
+        $this->assertInstanceOf('Zend_Uri_Http', $object->getLinkUrl());
         $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com'), $object->getLinkUrl());
 
         // test an other element to prevent cached values

--- a/tests/Zend/Service/Technorati/DailyCountsResultSetTest.php
+++ b/tests/Zend/Service/Technorati/DailyCountsResultSetTest.php
@@ -66,7 +66,7 @@ class Zend_Service_Technorati_DailyCountsResultSetTest extends Zend_Service_Tech
         $this->assertEquals(5, $object->totalResultsAvailable());
 
         // check properties
-        $this->assertType('Zend_Uri_Http', $object->getSearchUrl());
+        $this->assertInstanceOf('Zend_Uri_Http', $object->getSearchUrl());
         $this->assertEquals(Zend_Uri::factory('http://technorati.com/search/google'), $object->getSearchUrl());
     }
 

--- a/tests/Zend/Service/Technorati/DailyCountsResultTest.php
+++ b/tests/Zend/Service/Technorati/DailyCountsResultTest.php
@@ -60,7 +60,7 @@ class Zend_Service_Technorati_DailyCountsResultTest extends Zend_Service_Technor
         $object = new Zend_Service_Technorati_DailyCountsResult($this->domElements->item(1));
 
         // check properties
-        $this->assertType('Zend_Date', $object->getDate());
+        $this->assertInstanceOf('Zend_Date', $object->getDate());
         $this->assertEquals(new Zend_Date(strtotime('2007-11-13')), $object->getDate());
         $this->assertInternalType('integer', $object->getCount());
         $this->assertEquals(54414, $object->getCount());

--- a/tests/Zend/Service/Technorati/GetInfoResultTest.php
+++ b/tests/Zend/Service/Technorati/GetInfoResultTest.php
@@ -61,13 +61,13 @@ class Zend_Service_Technorati_GetInfoResultTest extends Zend_Service_Technorati_
 
         // check author
         $author = $object->getAuthor();
-        $this->assertType('Zend_Service_Technorati_Author', $author);
+        $this->assertInstanceOf('Zend_Service_Technorati_Author', $author);
         $this->assertEquals('weppos', $author->getUsername());
 
         // check weblogs
         $weblogs = $object->getWeblogs();
         $this->assertInternalType('array', $weblogs);
         $this->assertEquals(2, count($weblogs));
-        $this->assertType('Zend_Service_Technorati_Weblog', $weblogs[0]);
+        $this->assertInstanceOf('Zend_Service_Technorati_Weblog', $weblogs[0]);
     }
 }

--- a/tests/Zend/Service/Technorati/SearchResultTest.php
+++ b/tests/Zend/Service/Technorati/SearchResultTest.php
@@ -64,13 +64,13 @@ class Zend_Service_Technorati_SearchResultTest extends Zend_Service_Technorati_T
         $this->assertContains('El SDK de Android', $object->getTitle());
         $this->assertInternalType('string', $object->getExcerpt());
         $this->assertContains('[ Android]', $object->getExcerpt());
-        $this->assertType('Zend_Uri_Http', $object->getPermalink());
+        $this->assertInstanceOf('Zend_Uri_Http', $object->getPermalink());
         $this->assertEquals(Zend_Uri_Http::factory('http://blogs.eurielec.etsit.upm.es/miotroblog/?p=271'), $object->getPermalink());
-        $this->assertType('Zend_Date', $object->getCreated());
+        $this->assertInstanceOf('Zend_Date', $object->getCreated());
         $this->assertEquals(new Zend_Date('2007-11-14 22:18:04 GMT'), $object->getCreated());
 
         // check weblog
-        $this->assertType('Zend_Service_Technorati_Weblog', $object->getWeblog());
+        $this->assertInstanceOf('Zend_Service_Technorati_Weblog', $object->getWeblog());
         $this->assertContains('Mi otro blog', $object->getWeblog()->getName());
     }
 

--- a/tests/Zend/Service/Technorati/TagResultTest.php
+++ b/tests/Zend/Service/Technorati/TagResultTest.php
@@ -64,15 +64,15 @@ class Zend_Service_Technorati_TagResultTest extends Zend_Service_Technorati_Test
         $this->assertContains('Permalink for : VerveEarth', $object->getTitle());
         $this->assertInternalType('string', $object->getExcerpt());
         $this->assertContains('VerveEarth: Locate Your Blog!', $object->getExcerpt());
-        $this->assertType('Zend_Uri_Http', $object->getPermalink());
+        $this->assertInstanceOf('Zend_Uri_Http', $object->getPermalink());
         $this->assertEquals(Zend_Uri::factory('http://scienceroll.com/2007/11/14/verveearth-locate-your-blog/'), $object->getPermalink());
-        $this->assertType('Zend_Date', $object->getCreated());
+        $this->assertInstanceOf('Zend_Date', $object->getCreated());
         $this->assertEquals(new Zend_Date('2007-11-14 21:52:11'), $object->getCreated());
-        $this->assertType('Zend_Date', $object->getUpdated());
+        $this->assertInstanceOf('Zend_Date', $object->getUpdated());
         $this->assertEquals(new Zend_Date('2007-11-14 21:57:59'), $object->getUpdated());
 
         // check weblog
-        $this->assertType('Zend_Service_Technorati_Weblog', $object->getWeblog());
+        $this->assertInstanceOf('Zend_Service_Technorati_Weblog', $object->getWeblog());
         $this->assertEquals(' ScienceRoll', $object->getWeblog()->getName());
     }
 

--- a/tests/Zend/Service/Technorati/TechnoratiTest.php
+++ b/tests/Zend/Service/Technorati/TechnoratiTest.php
@@ -88,10 +88,10 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestCosmosSuccess.xml')->cosmos(self::TEST_PARAM_COSMOS);
 
-        $this->assertType('Zend_Service_Technorati_CosmosResultSet', $result);
+        $this->assertInstanceOf('Zend_Service_Technorati_CosmosResultSet', $result);
         $this->assertEquals(2, $result->totalResults());
         $result->seek(0);
-        $this->assertType('Zend_Service_Technorati_CosmosResult', $result->current());
+        $this->assertInstanceOf('Zend_Service_Technorati_CosmosResult', $result->current());
         // content is validated in Zend_Service_Technorati_CosmosResultSet tests
     }
 
@@ -151,10 +151,10 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestSearchSuccess.xml')->search(self::TEST_PARAM_SEARCH);
 
-        $this->assertType('Zend_Service_Technorati_SearchResultSet', $result);
+        $this->assertInstanceOf('Zend_Service_Technorati_SearchResultSet', $result);
         $this->assertEquals(2, $result->totalResults());
         $result->seek(0);
-        $this->assertType('Zend_Service_Technorati_SearchResult', $result->current());
+        $this->assertInstanceOf('Zend_Service_Technorati_SearchResult', $result->current());
         // content is validated in Zend_Service_Technorati_SearchResultSet tests
     }
 
@@ -214,10 +214,10 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestTagSuccess.xml')->tag(self::TEST_PARAM_TAG);
 
-        $this->assertType('Zend_Service_Technorati_TagResultSet', $result);
+        $this->assertInstanceOf('Zend_Service_Technorati_TagResultSet', $result);
         $this->assertEquals(2, $result->totalResults());
         $result->seek(0);
-        $this->assertType('Zend_Service_Technorati_TagResult', $result->current());
+        $this->assertInstanceOf('Zend_Service_Technorati_TagResult', $result->current());
         // content is validated in Zend_Service_Technorati_TagResultSet tests
     }
 
@@ -271,10 +271,10 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestDailyCountsSuccess.xml')->dailyCounts(self::TEST_PARAM_DAILYCOUNT);
 
-        $this->assertType('Zend_Service_Technorati_DailyCountsResultSet', $result);
+        $this->assertInstanceOf('Zend_Service_Technorati_DailyCountsResultSet', $result);
         $this->assertEquals(180, $result->totalResults());
         $result->seek(0);
-        $this->assertType('Zend_Service_Technorati_DailyCountsResult', $result->current());
+        $this->assertInstanceOf('Zend_Service_Technorati_DailyCountsResult', $result->current());
         // content is validated in Zend_Service_Technorati_DailyCountsResultSet tests
     }
 
@@ -321,7 +321,7 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestBlogInfoSuccess.xml')->blogInfo(self::TEST_PARAM_BLOGINFO);
 
-        $this->assertType('Zend_Service_Technorati_BlogInfoResult', $result);
+        $this->assertInstanceOf('Zend_Service_Technorati_BlogInfoResult', $result);
         // content is validated in Zend_Service_Technorati_BlogInfoResult tests
     }
 
@@ -358,7 +358,7 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestBlogPostTagsSuccess.xml')->blogPostTags(self::TEST_PARAM_BLOGPOSTTAGS);
 
-        $this->assertType('Zend_Service_Technorati_TagsResultSet', $result);
+        $this->assertInstanceOf('Zend_Service_Technorati_TagsResultSet', $result);
         // content is validated in Zend_Service_Technorati_TagsResultSet tests
     }
 
@@ -406,7 +406,7 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestTopTagsSuccess.xml')->topTags();
 
-        $this->assertType('Zend_Service_Technorati_TagsResultSet', $result);
+        $this->assertInstanceOf('Zend_Service_Technorati_TagsResultSet', $result);
         // content is validated in Zend_Service_Technorati_TagsResultSet tests
     }
 
@@ -447,7 +447,7 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestGetInfoSuccess.xml')->getInfo(self::TEST_PARAM_GETINFO);
 
-        $this->assertType('Zend_Service_Technorati_GetInfoResult', $result);
+        $this->assertInstanceOf('Zend_Service_Technorati_GetInfoResult', $result);
         // content is validated in Zend_Service_Technorati_GetInfoResult tests
     }
 
@@ -472,7 +472,7 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestKeyInfoSuccess.xml')->keyInfo();
 
-        $this->assertType('Zend_Service_Technorati_KeyInfoResult', $result);
+        $this->assertInstanceOf('Zend_Service_Technorati_KeyInfoResult', $result);
         // content is validated in Zend_Service_Technorati_KeyInfoResult tests
     }
 

--- a/tests/Zend/Service/Technorati/TestCase.php
+++ b/tests/Zend/Service/Technorati/TestCase.php
@@ -42,7 +42,7 @@ class Zend_Service_Technorati_TestCase extends PHPUnit_Framework_TestCase
         $reflection = new ReflectionClass($className);
         try {
             $object = $reflection->newInstanceArgs($args);
-            $this->assertType($className, $object);
+            $this->assertInstanceOf($className, $object);
         } catch (Zend_Service_Technorati_Exception $e) {
             $this->fail("Exception " . $e->getMessage() . " thrown");
         }
@@ -53,7 +53,7 @@ class Zend_Service_Technorati_TestCase extends PHPUnit_Framework_TestCase
         $reflection = new ReflectionClass($resultSetClassName);
         $resultset = $reflection->newInstanceArgs($args);
         foreach ($resultset as $result) {
-            $this->assertType($resultClassName, $result);
+            $this->assertInstanceOf($resultClassName, $result);
         }
     }
 
@@ -62,7 +62,7 @@ class Zend_Service_Technorati_TestCase extends PHPUnit_Framework_TestCase
         $unobject = unserialize(serialize($resultSet));
         $unresult = null;
 
-        $this->assertType(get_class($resultSet), $unobject);
+        $this->assertInstanceOf(get_class($resultSet), $unobject);
 
         foreach ($resultSet as $index => $result) {
             try {
@@ -97,7 +97,7 @@ class Zend_Service_Technorati_TestCase extends PHPUnit_Framework_TestCase
          */
         $unresult = unserialize(serialize($result));
 
-        $this->assertType(get_class($result), $unresult);
+        $this->assertInstanceOf(get_class($result), $unresult);
         $this->assertEquals($result, $unresult);
     }
 

--- a/tests/Zend/Service/Technorati/UtilsTest.php
+++ b/tests/Zend/Service/Technorati/UtilsTest.php
@@ -79,7 +79,7 @@ class Zend_Service_Technorati_UtilsTest extends Zend_Service_Technorati_TestCase
         $date   = new Zend_Date('2007-11-11 08:47:26 GMT');
         $result = Zend_Service_Technorati_Utils::normalizeDate($date);
 
-        $this->assertType('Zend_Date', $result);
+        $this->assertInstanceOf('Zend_Date', $result);
         $this->assertEquals($date, $result);
     }
 

--- a/tests/Zend/Service/Technorati/WeblogTest.php
+++ b/tests/Zend/Service/Technorati/WeblogTest.php
@@ -99,12 +99,12 @@ class Zend_Service_Technorati_WeblogTest extends Zend_Service_Technorati_TestCas
 
         // check first author
         $author = $authors[0];
-        $this->assertType('Zend_Service_Technorati_Author', $author);
+        $this->assertInstanceOf('Zend_Service_Technorati_Author', $author);
         $this->assertEquals('rfilippini', $author->getUsername());
 
         // check second author, be sure it's not the first one
         $author = $authors[1];
-        $this->assertType('Zend_Service_Technorati_Author', $author);
+        $this->assertInstanceOf('Zend_Service_Technorati_Author', $author);
         $this->assertEquals('Rinzi', $author->getUsername());
     }
 
@@ -122,12 +122,12 @@ class Zend_Service_Technorati_WeblogTest extends Zend_Service_Technorati_TestCas
 
         $set = Zend_Uri::factory('http://www.simonecarletti.com/');
         $get = $weblog->setUrl($set)->getUrl();
-        $this->assertType('Zend_Uri_Http', $get);
+        $this->assertInstanceOf('Zend_Uri_Http', $get);
         $this->assertEquals($set, $get);
 
         $set = 'http://www.simonecarletti.com/';
         $get = $weblog->setUrl($set)->getUrl();
-        $this->assertType('Zend_Uri_Http', $get);
+        $this->assertInstanceOf('Zend_Uri_Http', $get);
         $this->assertEquals(Zend_Uri::factory($set), $get);
 
         $set = 'http:::/foo';
@@ -142,12 +142,12 @@ class Zend_Service_Technorati_WeblogTest extends Zend_Service_Technorati_TestCas
 
         $set = Zend_Uri::factory('http://www.simonecarletti.com/');
         $get = $weblog->setAtomUrl($set)->getAtomUrl();
-        $this->assertType('Zend_Uri_Http', $get);
+        $this->assertInstanceOf('Zend_Uri_Http', $get);
         $this->assertEquals($set, $get);
 
         $set = 'http://www.simonecarletti.com/';
         $get = $weblog->setAtomUrl($set)->getAtomUrl();
-        $this->assertType('Zend_Uri_Http', $get);
+        $this->assertInstanceOf('Zend_Uri_Http', $get);
         $this->assertEquals(Zend_Uri::factory($set), $get);
 
         $set = 'http:::/foo';
@@ -162,12 +162,12 @@ class Zend_Service_Technorati_WeblogTest extends Zend_Service_Technorati_TestCas
 
         $set = Zend_Uri::factory('http://www.simonecarletti.com/');
         $get = $weblog->setRssUrl($set)->getRssUrl();
-        $this->assertType('Zend_Uri_Http', $get);
+        $this->assertInstanceOf('Zend_Uri_Http', $get);
         $this->assertEquals($set, $get);
 
         $set = 'http://www.simonecarletti.com/';
         $get = $weblog->setRssUrl($set)->getRssUrl();
-        $this->assertType('Zend_Uri_Http', $get);
+        $this->assertInstanceOf('Zend_Uri_Http', $get);
         $this->assertEquals(Zend_Uri::factory($set), $get);
 
         $set = 'http:::/foo';
@@ -206,7 +206,7 @@ class Zend_Service_Technorati_WeblogTest extends Zend_Service_Technorati_TestCas
 
         $set = '2007-11-11 08:47:26 GMT';
         $get = $weblog->setLastUpdate($set)->getLastUpdate();
-        $this->assertType('Zend_Date', $get);
+        $this->assertInstanceOf('Zend_Date', $get);
         $this->assertEquals(new Zend_Date($set), $get);
 
         /* not supported
@@ -239,36 +239,36 @@ class Zend_Service_Technorati_WeblogTest extends Zend_Service_Technorati_TestCas
 
         $set = false;
         $get = $weblog->setHasPhoto($set)->hasPhoto();
-        $this->assertType('boolean', $get);
+        $this->assertInternalType('boolean', $get);
         $this->assertEquals($set, $get);
 
         $set = 0;
         $get = $weblog->setHasPhoto($set)->hasPhoto();
-        $this->assertType('boolean', $get);
+        $this->assertInternalType('boolean', $get);
         $this->assertEquals((bool) $set, $get);
 
         // check lat
 
         $set = 1.3;
         $get = $weblog->setLat($set)->getLat();
-        $this->assertType('float', $get);
+        $this->assertInternalType('float', $get);
         $this->assertEquals($set, $get);
 
         $set = '1.3';
         $get = $weblog->setLat($set)->getLat();
-        $this->assertType('float', $get);
+        $this->assertInternalType('float', $get);
         $this->assertEquals((float) $set, $get);
 
         // check lon
 
         $set = 1.3;
         $get = $weblog->setLon($set)->getLon();
-        $this->assertType('float', $get);
+        $this->assertInternalType('float', $get);
         $this->assertEquals($set, $get);
 
         $set = '1.3';
         $get = $weblog->setLon($set)->getLon();
-        $this->assertType('float', $get);
+        $this->assertInternalType('float', $get);
         $this->assertEquals((float) $set, $get);
     }
 }

--- a/tests/Zend/Service/WindowsAzure/TableStorageTest.php
+++ b/tests/Zend/Service/WindowsAzure/TableStorageTest.php
@@ -270,7 +270,7 @@ class Zend_Service_WindowsAzure_TableStorageTest extends PHPUnit_Framework_TestC
 
         $result = $storageClient->retrieveEntityById($tableName, $entity->getPartitionKey(), $entity->getRowKey());
         $this->assertEquals($entity->FullName, $result->Name);
-        $this->assertType('Zend_Service_WindowsAzure_Storage_DynamicTableEntity', $result);
+        $this->assertInstanceOf('Zend_Service_WindowsAzure_Storage_DynamicTableEntity', $result);
     }
 
     /**
@@ -421,7 +421,7 @@ class Zend_Service_WindowsAzure_TableStorageTest extends PHPUnit_Framework_TestC
         $this->assertEquals(20, count($result));
 
         foreach ($result as $item) {
-            $this->assertType('Zend_Service_WindowsAzure_Storage_DynamicTableEntity', $item);
+            $this->assertInstanceOf('Zend_Service_WindowsAzure_Storage_DynamicTableEntity', $item);
         }
     }
 
@@ -538,7 +538,7 @@ class Zend_Service_WindowsAzure_TableStorageTest extends PHPUnit_Framework_TestC
 
         // Start batch
         $batch = $storageClient->startBatch();
-        $this->assertType('Zend_Service_WindowsAzure_Storage_Batch', $batch);
+        $this->assertInstanceOf('Zend_Service_WindowsAzure_Storage_Batch', $batch);
 
         // Insert entities in batch
         foreach ($entities2 as $entity) {
@@ -571,7 +571,7 @@ class Zend_Service_WindowsAzure_TableStorageTest extends PHPUnit_Framework_TestC
 
         // Start batch
         $batch = $storageClient->startBatch();
-        $this->assertType('Zend_Service_WindowsAzure_Storage_Batch', $batch);
+        $this->assertInstanceOf('Zend_Service_WindowsAzure_Storage_Batch', $batch);
 
         // Insert entities in batch
         foreach ($entities as $entity) {
@@ -609,7 +609,7 @@ class Zend_Service_WindowsAzure_TableStorageTest extends PHPUnit_Framework_TestC
 
         // Start batch
         $batch = $storageClient->startBatch();
-        $this->assertType('Zend_Service_WindowsAzure_Storage_Batch', $batch);
+        $this->assertInstanceOf('Zend_Service_WindowsAzure_Storage_Batch', $batch);
 
         // Update entities in batch
         $storageClient->updateEntity($tableName, $entities[0], true);
@@ -639,7 +639,7 @@ class Zend_Service_WindowsAzure_TableStorageTest extends PHPUnit_Framework_TestC
 
         // Start batch
         $batch = $storageClient->startBatch();
-        $this->assertType('Zend_Service_WindowsAzure_Storage_Batch', $batch);
+        $this->assertInstanceOf('Zend_Service_WindowsAzure_Storage_Batch', $batch);
 
         // Insert entities in batch
         foreach ($entities as $entity) {

--- a/tests/Zend/Test/DbStatementTest.php
+++ b/tests/Zend/Test/DbStatementTest.php
@@ -54,7 +54,7 @@ class DbStatementTest extends \PHPUnit_Framework_TestCase
 
         $stmt = Test\DbStatement::createSelectStatement($rows);
 
-        $this->assertType('Zend\Test\DbStatement', $stmt);
+        $this->assertInstanceOf('Zend\Test\DbStatement', $stmt);
         $this->assertEquals($rows, $stmt->fetchAll());
     }
 
@@ -62,7 +62,7 @@ class DbStatementTest extends \PHPUnit_Framework_TestCase
     {
         $stmt = Test\DbStatement::createInsertStatement(1234);
 
-        $this->assertType('Zend\Test\DbStatement', $stmt);
+        $this->assertInstanceOf('Zend\Test\DbStatement', $stmt);
         $this->assertEquals(1234, $stmt->rowCount());
     }
 
@@ -70,7 +70,7 @@ class DbStatementTest extends \PHPUnit_Framework_TestCase
     {
         $stmt = Test\DbStatement::createUpdateStatement(1234);
 
-        $this->assertType('Zend\Test\DbStatement', $stmt);
+        $this->assertInstanceOf('Zend\Test\DbStatement', $stmt);
         $this->assertEquals(1234, $stmt->rowCount());
     }
 
@@ -78,7 +78,7 @@ class DbStatementTest extends \PHPUnit_Framework_TestCase
     {
         $stmt = Test\DbStatement::createDeleteStatement(1234);
 
-        $this->assertType('Zend\Test\DbStatement', $stmt);
+        $this->assertInstanceOf('Zend\Test\DbStatement', $stmt);
         $this->assertEquals(1234, $stmt->rowCount());
     }
 

--- a/tests/Zend/Test/PHPUnit/Db/ConnectionTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/ConnectionTest.php
@@ -65,7 +65,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $connection = $this->createConnection();
         $ret = $connection->createQueryTable("foo", "foo");
 
-        $this->assertType('Zend\Test\PHPUnit\Db\DataSet\QueryTable', $ret);
+        $this->assertInstanceOf('Zend\Test\PHPUnit\Db\DataSet\QueryTable', $ret);
     }
 
     public function testGetSchema()
@@ -81,7 +81,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $connection = $this->createConnection();
         $metadata = $connection->getMetaData();
 
-        $this->assertType('Zend\Test\PHPUnit\Db\Metadata\Generic', $metadata);
+        $this->assertInstanceOf('Zend\Test\PHPUnit\Db\Metadata\Generic', $metadata);
     }
 
     public function testGetTruncateCommand()

--- a/tests/Zend/Test/PHPUnit/Db/DataSet/DbTableDataSetTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/DataSet/DbTableDataSetTest.php
@@ -62,7 +62,7 @@ class DbTableDataSetTest extends \PHPUnit_Framework_TestCase
         $dataSet = new DataSet\DbTableDataSet();
         $dataSet->addTable($table);
 
-        $this->assertType('Zend\Test\PHPUnit\Db\DataSet\DbTable', $dataSet->getTable($fixtureTable));
+        $this->assertInstanceOf('Zend\Test\PHPUnit\Db\DataSet\DbTable', $dataSet->getTable($fixtureTable));
     }
 
     public function testGetUnknownTableThrowsException()

--- a/tests/Zend/Test/PHPUnit/Db/DataSet/QueryTableTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/DataSet/QueryTableTest.php
@@ -113,7 +113,7 @@ class QueryTableTest extends DataSetTestCase
         $queryTable = new DataSet\QueryTable("foo", null, $this->connectionMock);
 
         $metadata = $queryTable->getTableMetaData();
-        $this->assertType('PHPUnit_Extensions_Database_DataSet_ITableMetaData', $metadata);
+        $this->assertInstanceOf('PHPUnit_Extensions_Database_DataSet_ITableMetaData', $metadata);
         $this->assertEquals(array(), $metadata->getColumns());
         $this->assertEquals(array(), $metadata->getPrimaryKeys());
         $this->assertEquals("foo", $metadata->getTableName());


### PR DESCRIPTION
I replaced every assertType ocurrence in the code with assertInstanceOf or assertInternalType depending if was asserting a class or a PHP's primitive type

This change is according to the PHPUnit's API changes where assertType was declared as deprecated in PHPUnit 3.5 and finally was removed in 3.6 
