### PR TITLE
[ZF-12023] Zend\Feed\Writer\AbstractFeed should accept UNIX timestamps which are <>10 digits

### DIFF
--- a/library/Zend/Feed/Writer/AbstractFeed.php
+++ b/library/Zend/Feed/Writer/AbstractFeed.php
@@ -144,7 +144,7 @@ class AbstractFeed
         $zdate = null;
         if ($date === null) {
             $zdate = new Date\Date;
-        } elseif (ctype_digit($date) && strlen($date) == 10) {
+        } elseif (ctype_digit($date)) {
             $zdate = new Date\Date($date, Date\Date::TIMESTAMP);
         } elseif ($date instanceof Date\Date) {
             $zdate = $date;
@@ -164,7 +164,7 @@ class AbstractFeed
         $zdate = null;
         if ($date === null) {
             $zdate = new Date\Date;
-        } elseif (ctype_digit($date) && strlen($date) == 10) {
+        } elseif (ctype_digit($date)) {
             $zdate = new Date\Date($date, Date\Date::TIMESTAMP);
         } elseif ($date instanceof Date\Date) {
             $zdate = $date;
@@ -184,7 +184,7 @@ class AbstractFeed
         $zdate = null;
         if ($date === null) {
             $zdate = new Date\Date;
-        } elseif (ctype_digit($date) && strlen($date) == 10) {
+        } elseif (ctype_digit($date)) {
             $zdate = new Date\Date($date, Date\Date::TIMESTAMP);
         } elseif ($date instanceof Date\Date) {
             $zdate = $date;

--- a/tests/Zend/Feed/Writer/FeedTest.php
+++ b/tests/Zend/Feed/Writer/FeedTest.php
@@ -203,6 +203,17 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($myDate->equals($writer->getDateCreated()));
     }
 
+    /**
+     * @group ZF-12023
+     */
+    public function testSetDateCreatedUsesGivenUnixTimestampThatIsLessThanTenDigits()
+    {
+        $writer = new Writer\Feed;
+        $writer->setDateCreated(123456789);
+        $myDate = new Date\Date('123456789', Date\Date::TIMESTAMP);
+        $this->assertTrue($myDate->equals($writer->getDateCreated()));
+    }
+
     public function testSetDateCreatedUsesZendDateObject()
     {
         $writer = new Writer\Feed;
@@ -224,6 +235,17 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer\Feed;
         $writer->setDateModified(1234567890);
         $myDate = new Date\Date('1234567890', Date\Date::TIMESTAMP);
+        $this->assertTrue($myDate->equals($writer->getDateModified()));
+    }
+    
+    /**
+     * @group ZF-12023
+     */
+    public function testSetDateModifiedUsesGivenUnixTimestampThatIsLessThanTenDigits()
+    {
+        $writer = new Writer\Feed;
+        $writer->setDateModified(123456789);
+        $myDate = new Date\Date('123456789', Date\Date::TIMESTAMP);
         $this->assertTrue($myDate->equals($writer->getDateModified()));
     }
 
@@ -283,6 +305,17 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($myDate->equals($writer->getLastBuildDate()));
     }
 
+    /**
+     * @group ZF-12023
+     */
+    public function testSetLastBuildDateUsesGivenUnixTimestampThatIsLessThanTenDigits()
+    {
+        $writer = new Writer\Feed;
+        $writer->setLastBuildDate(123456789);
+        $myDate = new Date\Date('123456789', Date\Date::TIMESTAMP);
+        $this->assertTrue($myDate->equals($writer->getLastBuildDate()));
+    }
+    
     public function testSetLastBuildDateUsesZendDateObject()
     {
         $writer = new Writer\Feed;


### PR DESCRIPTION
SVN sync r24639 r24640
