### PR TITLE
[ZF-12070] Fix remaining classes in Zend\Feed\Writer to accept UNIX timestamps which are <>10 digits

### DIFF
--- a/library/Zend/Feed/Writer/Deleted.php
+++ b/library/Zend/Feed/Writer/Deleted.php
@@ -131,7 +131,7 @@ class Deleted
         $zdate = null;
         if ($date === null) {
             $zdate = new Date\Date;
-        } elseif (ctype_digit($date) && strlen($date) == 10) {
+        } elseif (ctype_digit($date)) {
             $zdate = new Date\Date($date, Date\Date::TIMESTAMP);
         } elseif ($date instanceof Date\Date) {
             $zdate = $date;

--- a/library/Zend/Feed/Writer/Entry.php
+++ b/library/Zend/Feed/Writer/Entry.php
@@ -197,7 +197,7 @@ class Entry
         $zdate = null;
         if ($date === null) {
             $zdate = new Date\Date;
-        } elseif (ctype_digit($date) && strlen($date) == 10) {
+        } elseif (ctype_digit($date)) {
             $zdate = new Date\Date($date, Date\Date::TIMESTAMP);
         } elseif ($date instanceof Date\Date) {
             $zdate = $date;
@@ -217,7 +217,7 @@ class Entry
         $zdate = null;
         if ($date === null) {
             $zdate = new Date\Date;
-        } elseif (ctype_digit($date) && strlen($date) == 10) {
+        } elseif (ctype_digit($date)) {
             $zdate = new Date\Date($date, Date\Date::TIMESTAMP);
         } elseif ($date instanceof Date\Date) {
             $zdate = $date;

--- a/tests/Zend/Feed/Writer/DeletedTest.php
+++ b/tests/Zend/Feed/Writer/DeletedTest.php
@@ -76,7 +76,18 @@ class DeletedTest extends \PHPUnit_Framework_TestCase
         $myDate = new Date\Date('1234567890', Date\Date::TIMESTAMP);
         $this->assertTrue($myDate->equals($entry->getWhen()));
     }
-
+ 
+    /**
+     * @group ZF-12070
+     */
+    public function testSetWhenUsesGivenUnixTimestampWhenItIsLessThanTenDigits()
+    {
+        $entry = new Writer\Deleted;
+        $entry->setWhen(123456789);
+        $myDate = new Date\Date('123456789', Date\Date::TIMESTAMP);
+        $this->assertTrue($myDate->equals($entry->getWhen()));
+    }
+    
     public function testSetWhenUsesZendDateObject()
     {
         $entry = new Writer\Deleted;

--- a/tests/Zend/Feed/Writer/EntryTest.php
+++ b/tests/Zend/Feed/Writer/EntryTest.php
@@ -266,6 +266,17 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($myDate->equals($entry->getDateCreated()));
     }
 
+    /**
+     * @group ZF-12070
+     */
+    public function testSetDateCreatedUsesGivenUnixTimestampWhenItIsLessThanTenDigits()
+    {
+        $entry = new Writer\Entry;
+        $entry->setDateCreated(123456789);
+        $myDate = new Date\Date('123456789', Date\Date::TIMESTAMP);
+        $this->assertTrue($myDate->equals($entry->getDateCreated()));
+    }
+    
     public function testSetDateCreatedUsesZendDateObject()
     {
         $entry = new Writer\Entry;
@@ -287,6 +298,17 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $entry = new Writer\Entry;
         $entry->setDateModified(1234567890);
         $myDate = new Date\Date('1234567890', Date\Date::TIMESTAMP);
+        $this->assertTrue($myDate->equals($entry->getDateModified()));
+    }
+
+    /**
+     * @group ZF-12070
+     */
+    public function testSetDateModifiedUsesGivenUnixTimestampWhenItIsLessThanTenDigits()
+    {
+        $entry = new Writer\Entry;
+        $entry->setDateModified(123456789);
+        $myDate = new Date\Date('123456789', Date\Date::TIMESTAMP);
         $this->assertTrue($myDate->equals($entry->getDateModified()));
     }
 


### PR DESCRIPTION
SVN sync r24641 r24642
