### PR TITLE
Technorati Service refactored.

### DIFF
--- a/library/Zend/Service/Technorati/Author.php
+++ b/library/Zend/Service/Technorati/Author.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -32,7 +32,7 @@ use \DomElement,
  * Represents a weblog Author object. It usually belongs to a Technorati account.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/Author.php
+++ b/library/Zend/Service/Technorati/Author.php
@@ -20,17 +20,22 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a weblog Author object. It usually belongs to a Technorati account.
  *
  * @uses       DOMXPath
- * @uses       Zend_Service_Technorati_Utils
+ * @uses       \Zend\Service\Technorati\Utils
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_Author
+class Author
 {
     /**
      * Author first name
@@ -75,7 +80,7 @@ class Zend_Service_Technorati_Author
     /**
      * Technorati account thumbnail picture URL, if any
      *
-     * @var     null|Zend_Uri_Http
+     * @var     null|\Zend\Uri\Http
      * @access  protected
      */
     protected $_thumbnailPicture;
@@ -86,9 +91,9 @@ class Zend_Service_Technorati_Author
      *
      * @param   DomElement $dom the ReST fragment for this object
      */
-    public function __construct(DomElement $dom)
+    public function __construct(\DomElement $dom)
     {
-        $xpath = new DOMXPath($dom->ownerDocument);
+        $xpath = new \DOMXPath($dom->ownerDocument);
 
         $result = $xpath->query('./firstname/text()', $dom);
         if ($result->length == 1) $this->setFirstName($result->item(0)->data);
@@ -158,7 +163,7 @@ class Zend_Service_Technorati_Author
     /**
      * Returns Technorati account thumbnail picture.
      *
-     * @return  null|Zend_Uri_Http  Technorati account thumbnail picture
+     * @return  null|\Zend\Uri\Http  Technorati account thumbnail picture
      */
     public function getThumbnailPicture() {
         return $this->_thumbnailPicture;
@@ -169,7 +174,7 @@ class Zend_Service_Technorati_Author
      * Sets author first name.
      *
      * @param   string $input   first Name input value
-     * @return  Zend_Service_Technorati_Author  $this instance
+     * @return  \Zend\Service\Technorati\Author  $this instance
      */
     public function setFirstName($input) {
         $this->_firstName = (string) $input;
@@ -180,7 +185,7 @@ class Zend_Service_Technorati_Author
      * Sets author last name.
      *
      * @param   string $input   last Name input value
-     * @return  Zend_Service_Technorati_Author  $this instance
+     * @return  \Zend\Service\Technorati\Author  $this instance
      */
     public function setLastName($input) {
         $this->_lastName = (string) $input;
@@ -191,7 +196,7 @@ class Zend_Service_Technorati_Author
      * Sets Technorati account username.
      *
      * @param   string $input   username input value
-     * @return  Zend_Service_Technorati_Author  $this instance
+     * @return  \Zend\Service\Technorati\Author  $this instance
      */
     public function setUsername($input) {
         $this->_username = (string) $input;
@@ -202,7 +207,7 @@ class Zend_Service_Technorati_Author
      * Sets Technorati account biography.
      *
      * @param   string $input   biography input value
-     * @return  Zend_Service_Technorati_Author  $this instance
+     * @return  \Zend\Service\Technorati\Author  $this instance
      */
     public function setBio($input) {
         $this->_bio = (string) $input;
@@ -213,7 +218,7 @@ class Zend_Service_Technorati_Author
      * Sets Technorati account description.
      *
      * @param   string $input   description input value
-     * @return  Zend_Service_Technorati_Author  $this instance
+     * @return  \Zend\Service\Technorati\Author  $this instance
      */
     public function setDescription($input) {
         $this->_description = (string) $input;
@@ -223,13 +228,13 @@ class Zend_Service_Technorati_Author
     /**
      * Sets Technorati account thumbnail picture.
      *
-     * @param   string|Zend_Uri_Http $input thumbnail picture URI
-     * @return  Zend_Service_Technorati_Author  $this instance
-     * @throws  Zend_Service_Technorati_Exception if $input is an invalid URI
+     * @param   string|\Zend\Uri\Http $input thumbnail picture URI
+     * @return  \Zend\Service\Technorati\Author  $this instance
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if $input is an invalid URI
      *          (via Zend_Service_Technorati_Utils::normalizeUriHttp)
      */
     public function setThumbnailPicture($input) {
-        $this->_thumbnailPicture = Zend_Service_Technorati_Utils::normalizeUriHttp($input);
+        $this->_thumbnailPicture = Utils::normalizeUriHttp($input);
         return $this;
     }
 

--- a/library/Zend/Service/Technorati/Author.php
+++ b/library/Zend/Service/Technorati/Author.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,13 +24,15 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomElement,
+    \DOMXPath,
+    Zend\Uri;
+
 /**
  * Represents a weblog Author object. It usually belongs to a Technorati account.
  *
- * @uses       DOMXPath
- * @uses       \Zend\Service\Technorati\Utils
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -80,7 +82,7 @@ class Author
     /**
      * Technorati account thumbnail picture URL, if any
      *
-     * @var     null|\Zend\Uri\Http
+     * @var     null|Uri\Http
      * @access  protected
      */
     protected $_thumbnailPicture;
@@ -91,9 +93,9 @@ class Author
      *
      * @param   DomElement $dom the ReST fragment for this object
      */
-    public function __construct(\DomElement $dom)
+    public function __construct(DomElement $dom)
     {
-        $xpath = new \DOMXPath($dom->ownerDocument);
+        $xpath = new DOMXPath($dom->ownerDocument);
 
         $result = $xpath->query('./firstname/text()', $dom);
         if ($result->length == 1) $this->setFirstName($result->item(0)->data);
@@ -163,7 +165,7 @@ class Author
     /**
      * Returns Technorati account thumbnail picture.
      *
-     * @return  null|\Zend\Uri\Http  Technorati account thumbnail picture
+     * @return  null|Uri\Http  Technorati account thumbnail picture
      */
     public function getThumbnailPicture() {
         return $this->_thumbnailPicture;
@@ -174,7 +176,7 @@ class Author
      * Sets author first name.
      *
      * @param   string $input   first Name input value
-     * @return  \Zend\Service\Technorati\Author  $this instance
+     * @return  Author  $this instance
      */
     public function setFirstName($input) {
         $this->_firstName = (string) $input;
@@ -185,7 +187,7 @@ class Author
      * Sets author last name.
      *
      * @param   string $input   last Name input value
-     * @return  \Zend\Service\Technorati\Author  $this instance
+     * @return  Author  $this instance
      */
     public function setLastName($input) {
         $this->_lastName = (string) $input;
@@ -196,7 +198,7 @@ class Author
      * Sets Technorati account username.
      *
      * @param   string $input   username input value
-     * @return  \Zend\Service\Technorati\Author  $this instance
+     * @return  Author  $this instance
      */
     public function setUsername($input) {
         $this->_username = (string) $input;
@@ -207,7 +209,7 @@ class Author
      * Sets Technorati account biography.
      *
      * @param   string $input   biography input value
-     * @return  \Zend\Service\Technorati\Author  $this instance
+     * @return  Author  $this instance
      */
     public function setBio($input) {
         $this->_bio = (string) $input;
@@ -218,7 +220,7 @@ class Author
      * Sets Technorati account description.
      *
      * @param   string $input   description input value
-     * @return  \Zend\Service\Technorati\Author  $this instance
+     * @return  Author  $this instance
      */
     public function setDescription($input) {
         $this->_description = (string) $input;
@@ -228,10 +230,10 @@ class Author
     /**
      * Sets Technorati account thumbnail picture.
      *
-     * @param   string|\Zend\Uri\Http $input thumbnail picture URI
-     * @return  \Zend\Service\Technorati\Author  $this instance
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if $input is an invalid URI
-     *          (via Zend_Service_Technorati_Utils::normalizeUriHttp)
+     * @param   string|Uri\Http $input thumbnail picture URI
+     * @return  Author  $this instance
+     * @throws  Exception\RuntimeException if $input is an invalid URI
+     *          (via Utils::normalizeUriHttp)
      */
     public function setThumbnailPicture($input) {
         $this->_thumbnailPicture = Utils::normalizeUriHttp($input);

--- a/library/Zend/Service/Technorati/Author.php
+++ b/library/Zend/Service/Technorati/Author.php
@@ -45,7 +45,7 @@ class Author
      * @var     string
      * @access  protected
      */
-    protected $_firstName;
+    protected $firstName;
 
     /**
      * Author last name
@@ -53,7 +53,7 @@ class Author
      * @var     string
      * @access  protected
      */
-    protected $_lastName;
+    protected $lastName;
 
     /**
      * Technorati account username
@@ -61,7 +61,7 @@ class Author
      * @var     string
      * @access  protected
      */
-    protected $_username;
+    protected $username;
 
     /**
      * Technorati account description
@@ -69,7 +69,7 @@ class Author
      * @var     string
      * @access  protected
      */
-    protected $_description;
+    protected $description;
 
     /**
      * Technorati account biography
@@ -77,7 +77,7 @@ class Author
      * @var     string
      * @access  protected
      */
-    protected $_bio;
+    protected $bio;
 
     /**
      * Technorati account thumbnail picture URL, if any
@@ -85,7 +85,7 @@ class Author
      * @var     null|Uri\Http
      * @access  protected
      */
-    protected $_thumbnailPicture;
+    protected $thumbnailPicture;
 
 
     /**
@@ -123,7 +123,7 @@ class Author
      * @return  string  Author first name
      */
     public function getFirstName() {
-        return $this->_firstName;
+        return $this->firstName;
     }
 
     /**
@@ -132,7 +132,7 @@ class Author
      * @return  string  Author last name
      */
     public function getLastName() {
-        return $this->_lastName;
+        return $this->lastName;
     }
 
     /**
@@ -141,7 +141,7 @@ class Author
      * @return  string  Technorati account username
      */
     public function getUsername() {
-        return $this->_username;
+        return $this->username;
     }
 
     /**
@@ -150,7 +150,7 @@ class Author
      * @return  string  Technorati account description
      */
     public function getDescription() {
-        return $this->_description;
+        return $this->description;
     }
 
     /**
@@ -159,7 +159,7 @@ class Author
      * @return  string  Technorati account biography
      */
     public function getBio() {
-        return $this->_bio;
+        return $this->bio;
     }
 
     /**
@@ -168,7 +168,7 @@ class Author
      * @return  null|Uri\Http  Technorati account thumbnail picture
      */
     public function getThumbnailPicture() {
-        return $this->_thumbnailPicture;
+        return $this->thumbnailPicture;
     }
 
 
@@ -179,7 +179,7 @@ class Author
      * @return  Author  $this instance
      */
     public function setFirstName($input) {
-        $this->_firstName = (string) $input;
+        $this->firstName = (string) $input;
         return $this;
     }
 
@@ -190,7 +190,7 @@ class Author
      * @return  Author  $this instance
      */
     public function setLastName($input) {
-        $this->_lastName = (string) $input;
+        $this->lastName = (string) $input;
         return $this;
     }
 
@@ -201,7 +201,7 @@ class Author
      * @return  Author  $this instance
      */
     public function setUsername($input) {
-        $this->_username = (string) $input;
+        $this->username = (string) $input;
         return $this;
     }
 
@@ -212,7 +212,7 @@ class Author
      * @return  Author  $this instance
      */
     public function setBio($input) {
-        $this->_bio = (string) $input;
+        $this->bio = (string) $input;
         return $this;
     }
 
@@ -223,7 +223,7 @@ class Author
      * @return  Author  $this instance
      */
     public function setDescription($input) {
-        $this->_description = (string) $input;
+        $this->description = (string) $input;
         return $this;
     }
 
@@ -236,7 +236,7 @@ class Author
      *          (via Utils::normalizeUriHttp)
      */
     public function setThumbnailPicture($input) {
-        $this->_thumbnailPicture = Utils::normalizeUriHttp($input);
+        $this->thumbnailPicture = Utils::normalizeUriHttp($input);
         return $this;
     }
 

--- a/library/Zend/Service/Technorati/BlogInfoResult.php
+++ b/library/Zend/Service/Technorati/BlogInfoResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -32,7 +32,7 @@ use \DomDocument,
  * Represents a single Technorati BlogInfo query result object.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/BlogInfoResult.php
+++ b/library/Zend/Service/Technorati/BlogInfoResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,15 +24,15 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomDocument,
+    \DOMXPath,
+    Zend\Uri;
+
 /**
  * Represents a single Technorati BlogInfo query result object.
  *
- * @uses       DOMXPath
- * @uses       \Zend\Service\Technorati\Exception\RuntimeException
- * @uses       \Zend\Service\Technorati\Utils
- * @uses       \Zend\Service\Technorati\Weblog
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -42,7 +42,7 @@ class BlogInfoResult
     /**
      * Technorati weblog url, if queried URL is a valid weblog.
      *
-     * @var     \Zend\Uri\Http
+     * @var     Uri\Http
      * @access  protected
      */
     protected $_url;
@@ -50,7 +50,7 @@ class BlogInfoResult
     /**
      * Technorati weblog, if queried URL is a valid weblog.
      *
-     * @var     \Zend\Service\Technorati\Weblog
+     * @var     Weblog
      * @access  protected
      */
     protected $_weblog;
@@ -77,9 +77,9 @@ class BlogInfoResult
      *
      * @param   DomDocument $dom the ReST fragment for this object
      */
-    public function __construct(\DomDocument $dom)
+    public function __construct(DomDocument $dom)
     {
-        $xpath = new \DOMXPath($dom);
+        $xpath = new DOMXPath($dom);
         $result = $xpath->query('//result/weblog');
         if ($result->length == 1) {
             $this->_weblog = new Weblog($result->item(0));
@@ -115,7 +115,7 @@ class BlogInfoResult
     /**
      * Returns the weblog URL.
      *
-     * @return  \Zend\Uri\Http
+     * @return  Uri\Http
      */
     public function getUrl() {
         return $this->_url;
@@ -124,7 +124,7 @@ class BlogInfoResult
     /**
      * Returns the weblog.
      *
-     * @return  \Zend\Service\Technorati\Weblog
+     * @return  Weblog
      */
     public function getWeblog() {
         return $this->_weblog;

--- a/library/Zend/Service/Technorati/BlogInfoResult.php
+++ b/library/Zend/Service/Technorati/BlogInfoResult.php
@@ -45,7 +45,7 @@ class BlogInfoResult
      * @var     Uri\Http
      * @access  protected
      */
-    protected $_url;
+    protected $url;
 
     /**
      * Technorati weblog, if queried URL is a valid weblog.
@@ -53,7 +53,7 @@ class BlogInfoResult
      * @var     Weblog
      * @access  protected
      */
-    protected $_weblog;
+    protected $weblog;
 
     /**
      * Number of unique blogs linking this blog
@@ -61,7 +61,7 @@ class BlogInfoResult
      * @var     integer
      * @access  protected
      */
-    protected $_inboundBlogs;
+    protected $inboundBlogs;
 
     /**
      * Number of incoming links to this blog
@@ -69,7 +69,7 @@ class BlogInfoResult
      * @var     integer
      * @access  protected
      */
-    protected $_inboundLinks;
+    protected $inboundLinks;
 
 
     /**
@@ -82,7 +82,7 @@ class BlogInfoResult
         $xpath = new DOMXPath($dom);
         $result = $xpath->query('//result/weblog');
         if ($result->length == 1) {
-            $this->_weblog = new Weblog($result->item(0));
+            $this->weblog = new Weblog($result->item(0));
         } else {
             // follow the same behavior of blogPostTags
             // and raise an Exception if the URL is not a valid weblog
@@ -95,19 +95,19 @@ class BlogInfoResult
             try {
                 // fetched URL often doens't include schema
                 // and this issue causes the following line to fail
-                $this->_url = Utils::normalizeUriHttp($result->item(0)->data);
+                $this->url = Utils::normalizeUriHttp($result->item(0)->data);
             } catch(Exception $e) {
                 if ($this->getWeblog() instanceof Weblog) {
-                    $this->_url = $this->getWeblog()->getUrl();
+                    $this->url = $this->getWeblog()->getUrl();
                 }
             }
         }
 
         $result = $xpath->query('//result/inboundblogs/text()');
-        if ($result->length == 1) $this->_inboundBlogs = (int) $result->item(0)->data;
+        if ($result->length == 1) $this->inboundBlogs = (int) $result->item(0)->data;
 
         $result = $xpath->query('//result/inboundlinks/text()');
-        if ($result->length == 1) $this->_inboundLinks = (int) $result->item(0)->data;
+        if ($result->length == 1) $this->inboundLinks = (int) $result->item(0)->data;
 
     }
 
@@ -118,7 +118,7 @@ class BlogInfoResult
      * @return  Uri\Http
      */
     public function getUrl() {
-        return $this->_url;
+        return $this->url;
     }
 
     /**
@@ -127,7 +127,7 @@ class BlogInfoResult
      * @return  Weblog
      */
     public function getWeblog() {
-        return $this->_weblog;
+        return $this->weblog;
     }
 
     /**
@@ -137,7 +137,7 @@ class BlogInfoResult
      */
     public function getInboundBlogs()
     {
-        return (int) $this->_inboundBlogs;
+        return (int) $this->inboundBlogs;
     }
 
     /**
@@ -147,7 +147,7 @@ class BlogInfoResult
      */
     public function getInboundLinks()
     {
-        return (int) $this->_inboundLinks;
+        return (int) $this->inboundLinks;
     }
 
 }

--- a/library/Zend/Service/Technorati/BlogInfoResult.php
+++ b/library/Zend/Service/Technorati/BlogInfoResult.php
@@ -20,24 +20,29 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a single Technorati BlogInfo query result object.
  *
  * @uses       DOMXPath
- * @uses       Zend_Service_Technorati_Exception
- * @uses       Zend_Service_Technorati_Utils
- * @uses       Zend_Service_Technorati_Weblog
+ * @uses       \Zend\Service\Technorati\Exception\RuntimeException
+ * @uses       \Zend\Service\Technorati\Utils
+ * @uses       \Zend\Service\Technorati\Weblog
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_BlogInfoResult
+class BlogInfoResult
 {
     /**
      * Technorati weblog url, if queried URL is a valid weblog.
      *
-     * @var     Zend_Uri_Http
+     * @var     \Zend\Uri\Http
      * @access  protected
      */
     protected $_url;
@@ -45,7 +50,7 @@ class Zend_Service_Technorati_BlogInfoResult
     /**
      * Technorati weblog, if queried URL is a valid weblog.
      *
-     * @var     Zend_Service_Technorati_Weblog
+     * @var     \Zend\Service\Technorati\Weblog
      * @access  protected
      */
     protected $_weblog;
@@ -72,16 +77,16 @@ class Zend_Service_Technorati_BlogInfoResult
      *
      * @param   DomDocument $dom the ReST fragment for this object
      */
-    public function __construct(DomDocument $dom)
+    public function __construct(\DomDocument $dom)
     {
-        $xpath = new DOMXPath($dom);
+        $xpath = new \DOMXPath($dom);
         $result = $xpath->query('//result/weblog');
         if ($result->length == 1) {
-            $this->_weblog = new Zend_Service_Technorati_Weblog($result->item(0));
+            $this->_weblog = new Weblog($result->item(0));
         } else {
             // follow the same behavior of blogPostTags
             // and raise an Exception if the URL is not a valid weblog
-            throw new Zend_Service_Technorati_Exception(
+            throw new Exception\RuntimeException(
                 "Your URL is not a recognized Technorati weblog");
         }
 
@@ -90,9 +95,9 @@ class Zend_Service_Technorati_BlogInfoResult
             try {
                 // fetched URL often doens't include schema
                 // and this issue causes the following line to fail
-                $this->_url = Zend_Service_Technorati_Utils::normalizeUriHttp($result->item(0)->data);
-            } catch(Zend_Service_Technorati_Exception $e) {
-                if ($this->getWeblog() instanceof Zend_Service_Technorati_Weblog) {
+                $this->_url = Utils::normalizeUriHttp($result->item(0)->data);
+            } catch(Exception $e) {
+                if ($this->getWeblog() instanceof Weblog) {
                     $this->_url = $this->getWeblog()->getUrl();
                 }
             }
@@ -110,7 +115,7 @@ class Zend_Service_Technorati_BlogInfoResult
     /**
      * Returns the weblog URL.
      *
-     * @return  Zend_Uri_Http
+     * @return  \Zend\Uri\Http
      */
     public function getUrl() {
         return $this->_url;
@@ -119,7 +124,7 @@ class Zend_Service_Technorati_BlogInfoResult
     /**
      * Returns the weblog.
      *
-     * @return  Zend_Service_Technorati_Weblog
+     * @return  \Zend\Service\Technorati\Weblog
      */
     public function getWeblog() {
         return $this->_weblog;

--- a/library/Zend/Service/Technorati/CosmosResult.php
+++ b/library/Zend/Service/Technorati/CosmosResult.php
@@ -46,7 +46,7 @@ class CosmosResult extends Result
      * @var     Weblog
      * @access  protected
      */
-    protected $_weblog;
+    protected $weblog;
 
     /**
      * The nearest permalink tracked for queried URL.
@@ -54,7 +54,7 @@ class CosmosResult extends Result
      * @var     Uri\Http
      * @access  protected
      */
-    protected $_nearestPermalink;
+    protected $nearestPermalink;
 
     /**
      * The excerpt of the blog/page linking queried URL.
@@ -62,7 +62,7 @@ class CosmosResult extends Result
      * @var     string
      * @access  protected
      */
-    protected $_excerpt;
+    protected $excerpt;
 
     /**
      * The the datetime the link was created.
@@ -70,7 +70,7 @@ class CosmosResult extends Result
      * @var     ZendDate
      * @access  protected
      */
-    protected $_linkCreated;
+    protected $linkCreated;
 
     /**
      * The URL of the specific link target page
@@ -78,7 +78,7 @@ class CosmosResult extends Result
      * @var     Uri\Http
      * @access  protected
      */
-    protected $_linkUrl;
+    protected $linkUrl;
 
 
     /**
@@ -88,19 +88,19 @@ class CosmosResult extends Result
      */
     public function __construct(DomElement $dom)
     {
-        $this->_fields = array( '_nearestPermalink' => 'nearestpermalink',
-                                '_excerpt'          => 'excerpt',
-                                '_linkCreated'      => 'linkcreated',
-                                '_linkUrl'          => 'linkurl');
+        $this->fields = array( 'nearestPermalink' => 'nearestpermalink',
+                               'excerpt'          => 'excerpt',
+                               'linkCreated'      => 'linkcreated',
+                               'linkUrl'          => 'linkurl');
         parent::__construct($dom);
 
         // weblog object field
-        $this->_parseWeblog();
+        $this->parseWeblog();
 
         // filter fields
-        $this->_nearestPermalink = Utils::normalizeUriHttp($this->_nearestPermalink);
-        $this->_linkUrl          = Utils::normalizeUriHttp($this->_linkUrl);
-        $this->_linkCreated      = Utils::normalizeDate($this->_linkCreated);
+        $this->nearestPermalink = Utils::normalizeUriHttp($this->nearestPermalink);
+        $this->linkUrl          = Utils::normalizeUriHttp($this->linkUrl);
+        $this->linkCreated      = Utils::normalizeDate($this->linkCreated);
     }
 
     /**
@@ -109,7 +109,7 @@ class CosmosResult extends Result
      * @return  Weblog
      */
     public function getWeblog() {
-        return $this->_weblog;
+        return $this->weblog;
     }
 
     /**
@@ -118,7 +118,7 @@ class CosmosResult extends Result
      * @return  Uri\Http
      */
     public function getNearestPermalink() {
-        return $this->_nearestPermalink;
+        return $this->nearestPermalink;
     }
 
     /**
@@ -127,7 +127,7 @@ class CosmosResult extends Result
      * @return  string
      */
     public function getExcerpt() {
-        return $this->_excerpt;
+        return $this->excerpt;
     }
 
     /**
@@ -136,7 +136,7 @@ class CosmosResult extends Result
      * @return  ZendDate
      */
     public function getLinkCreated() {
-        return $this->_linkCreated;
+        return $this->linkCreated;
     }
 
     /**
@@ -146,7 +146,7 @@ class CosmosResult extends Result
      * @return  Uri\Http
      */
     public function getLinkUrl() {
-        return $this->_linkUrl;
+        return $this->linkUrl;
     }
 
 }

--- a/library/Zend/Service/Technorati/CosmosResult.php
+++ b/library/Zend/Service/Technorati/CosmosResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,15 +24,16 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomElement,
+    Zend\Uri;
+
 /**
  * Represents a single Technorati Cosmos query result object.
  * It is never returned as a standalone object,
- * but it always belongs to a valid Zend_Service_Technorati_CosmosResultSet object.
+ * but it always belongs to a valid CosmosResultSet object.
  *
- * @uses       \Zend\Service\Technorati\Result
- * @uses       \Zend\Service\Technorati\Utils
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -42,7 +43,7 @@ class CosmosResult extends Result
     /**
      * Technorati weblog object that links queried URL.
      *
-     * @var     \Zend\Service\Technorati\Weblog
+     * @var     Weblog
      * @access  protected
      */
     protected $_weblog;
@@ -50,7 +51,7 @@ class CosmosResult extends Result
     /**
      * The nearest permalink tracked for queried URL.
      *
-     * @var     \Zend\Uri\Http
+     * @var     Uri\Http
      * @access  protected
      */
     protected $_nearestPermalink;
@@ -66,7 +67,7 @@ class CosmosResult extends Result
     /**
      * The the datetime the link was created.
      *
-     * @var     Zend_Date
+     * @var     ZendDate
      * @access  protected
      */
     protected $_linkCreated;
@@ -74,7 +75,7 @@ class CosmosResult extends Result
     /**
      * The URL of the specific link target page
      *
-     * @var     \Zend\Uri\Http
+     * @var     Uri\Http
      * @access  protected
      */
     protected $_linkUrl;
@@ -85,7 +86,7 @@ class CosmosResult extends Result
      *
      * @param   DomElement $dom the ReST fragment for this object
      */
-    public function __construct(\DomElement $dom)
+    public function __construct(DomElement $dom)
     {
         $this->_fields = array( '_nearestPermalink' => 'nearestpermalink',
                                 '_excerpt'          => 'excerpt',
@@ -105,7 +106,7 @@ class CosmosResult extends Result
     /**
      * Returns the weblog object that links queried URL.
      *
-     * @return  \Zend\Service\Technorati\Weblog
+     * @return  Weblog
      */
     public function getWeblog() {
         return $this->_weblog;
@@ -114,7 +115,7 @@ class CosmosResult extends Result
     /**
      * Returns the nearest permalink tracked for queried URL.
      *
-     * @return  \Zend\Uri\Http
+     * @return  Uri\Http
      */
     public function getNearestPermalink() {
         return $this->_nearestPermalink;
@@ -132,7 +133,7 @@ class CosmosResult extends Result
     /**
      * Returns the datetime the link was created.
      *
-     * @return  Zend_Date
+     * @return  ZendDate
      */
     public function getLinkCreated() {
         return $this->_linkCreated;
@@ -142,7 +143,7 @@ class CosmosResult extends Result
      * If queried URL is a valid blog,
      * returns the URL of the specific link target page.
      *
-     * @return  \Zend\Uri\Http
+     * @return  Uri\Http
      */
     public function getLinkUrl() {
         return $this->_linkUrl;

--- a/library/Zend/Service/Technorati/CosmosResult.php
+++ b/library/Zend/Service/Technorati/CosmosResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -33,7 +33,7 @@ use \DomElement,
  * but it always belongs to a valid CosmosResultSet object.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/CosmosResult.php
+++ b/library/Zend/Service/Technorati/CosmosResult.php
@@ -20,24 +20,29 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a single Technorati Cosmos query result object.
  * It is never returned as a standalone object,
  * but it always belongs to a valid Zend_Service_Technorati_CosmosResultSet object.
  *
- * @uses       Zend_Service_Technorati_Result
- * @uses       Zend_Service_Technorati_Utils
+ * @uses       \Zend\Service\Technorati\Result
+ * @uses       \Zend\Service\Technorati\Utils
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_CosmosResult extends Zend_Service_Technorati_Result
+class CosmosResult extends Result
 {
     /**
      * Technorati weblog object that links queried URL.
      *
-     * @var     Zend_Service_Technorati_Weblog
+     * @var     \Zend\Service\Technorati\Weblog
      * @access  protected
      */
     protected $_weblog;
@@ -45,7 +50,7 @@ class Zend_Service_Technorati_CosmosResult extends Zend_Service_Technorati_Resul
     /**
      * The nearest permalink tracked for queried URL.
      *
-     * @var     Zend_Uri_Http
+     * @var     \Zend\Uri\Http
      * @access  protected
      */
     protected $_nearestPermalink;
@@ -69,7 +74,7 @@ class Zend_Service_Technorati_CosmosResult extends Zend_Service_Technorati_Resul
     /**
      * The URL of the specific link target page
      *
-     * @var     Zend_Uri_Http
+     * @var     \Zend\Uri\Http
      * @access  protected
      */
     protected $_linkUrl;
@@ -80,7 +85,7 @@ class Zend_Service_Technorati_CosmosResult extends Zend_Service_Technorati_Resul
      *
      * @param   DomElement $dom the ReST fragment for this object
      */
-    public function __construct(DomElement $dom)
+    public function __construct(\DomElement $dom)
     {
         $this->_fields = array( '_nearestPermalink' => 'nearestpermalink',
                                 '_excerpt'          => 'excerpt',
@@ -92,15 +97,15 @@ class Zend_Service_Technorati_CosmosResult extends Zend_Service_Technorati_Resul
         $this->_parseWeblog();
 
         // filter fields
-        $this->_nearestPermalink = Zend_Service_Technorati_Utils::normalizeUriHttp($this->_nearestPermalink);
-        $this->_linkUrl          = Zend_Service_Technorati_Utils::normalizeUriHttp($this->_linkUrl);
-        $this->_linkCreated      = Zend_Service_Technorati_Utils::normalizeDate($this->_linkCreated);
+        $this->_nearestPermalink = Utils::normalizeUriHttp($this->_nearestPermalink);
+        $this->_linkUrl          = Utils::normalizeUriHttp($this->_linkUrl);
+        $this->_linkCreated      = Utils::normalizeDate($this->_linkCreated);
     }
 
     /**
      * Returns the weblog object that links queried URL.
      *
-     * @return  Zend_Service_Technorati_Weblog
+     * @return  \Zend\Service\Technorati\Weblog
      */
     public function getWeblog() {
         return $this->_weblog;
@@ -109,7 +114,7 @@ class Zend_Service_Technorati_CosmosResult extends Zend_Service_Technorati_Resul
     /**
      * Returns the nearest permalink tracked for queried URL.
      *
-     * @return  Zend_Uri_Http
+     * @return  \Zend\Uri\Http
      */
     public function getNearestPermalink() {
         return $this->_nearestPermalink;
@@ -137,7 +142,7 @@ class Zend_Service_Technorati_CosmosResult extends Zend_Service_Technorati_Resul
      * If queried URL is a valid blog,
      * returns the URL of the specific link target page.
      *
-     * @return  Zend_Uri_Http
+     * @return  \Zend\Uri\Http
      */
     public function getLinkUrl() {
         return $this->_linkUrl;

--- a/library/Zend/Service/Technorati/CosmosResultSet.php
+++ b/library/Zend/Service/Technorati/CosmosResultSet.php
@@ -44,7 +44,7 @@ class CosmosResultSet extends ResultSet
      * @var     Uri\Http
      * @access  protected
      */
-    protected $_url;
+    protected $url;
 
     /**
      * Technorati weblog, if queried URL is a valid weblog.
@@ -52,7 +52,7 @@ class CosmosResultSet extends ResultSet
      * @var     Weblog
      * @access  protected
      */
-    protected $_weblog;
+    protected $weblog;
 
     /**
      * Number of unique blogs linking this blog
@@ -60,7 +60,7 @@ class CosmosResultSet extends ResultSet
      * @var     integer
      * @access  protected
      */
-    protected $_inboundBlogs;
+    protected $inboundBlogs;
 
     /**
      * Number of incoming links to this blog
@@ -68,7 +68,7 @@ class CosmosResultSet extends ResultSet
      * @var     integer
      * @access  protected
      */
-    protected $_inboundLinks;
+    protected $inboundLinks;
 
     /**
      * Parses the search response and retrieve the results for iteration.
@@ -80,40 +80,40 @@ class CosmosResultSet extends ResultSet
     {
         parent::__construct($dom, $options);
 
-        $result = $this->_xpath->query('/tapi/document/result/inboundlinks/text()');
-        if ($result->length == 1) $this->_inboundLinks = (int) $result->item(0)->data;
+        $result = $this->xpath->query('/tapi/document/result/inboundlinks/text()');
+        if ($result->length == 1) $this->inboundLinks = (int) $result->item(0)->data;
 
-        $result = $this->_xpath->query('/tapi/document/result/inboundblogs/text()');
-        if ($result->length == 1) $this->_inboundBlogs = (int) $result->item(0)->data;
+        $result = $this->xpath->query('/tapi/document/result/inboundblogs/text()');
+        if ($result->length == 1) $this->inboundBlogs = (int) $result->item(0)->data;
 
-        $result = $this->_xpath->query('/tapi/document/result/weblog');
+        $result = $this->xpath->query('/tapi/document/result/weblog');
         if ($result->length == 1) {
-            $this->_weblog = new Weblog($result->item(0));
+            $this->weblog = new Weblog($result->item(0));
         }
 
-        $result = $this->_xpath->query('/tapi/document/result/url/text()');
+        $result = $this->xpath->query('/tapi/document/result/url/text()');
         if ($result->length == 1) {
             try {
                 // fetched URL often doens't include schema
                 // and this issue causes the following line to fail
-                $this->_url = Utils::normalizeUriHttp($result->item(0)->data);
+                $this->url = Utils::normalizeUriHttp($result->item(0)->data);
             } catch(Exception $e) {
                 if ($this->getWeblog() instanceof Weblog) {
-                    $this->_url = $this->getWeblog()->getUrl();
+                    $this->url = $this->getWeblog()->getUrl();
                 }
             }
         }
 
-        $this->_totalResultsReturned  = (int) $this->_xpath->evaluate("count(/tapi/document/item)");
+        $this->totalResultsReturned  = (int) $this->xpath->evaluate("count(/tapi/document/item)");
 
         // total number of results depends on query type
         // for now check only getInboundLinks() and getInboundBlogs() value
         if ((int) $this->getInboundLinks() > 0) {
-            $this->_totalResultsAvailable = $this->getInboundLinks();
+            $this->totalResultsAvailable = $this->getInboundLinks();
         } elseif ((int) $this->getInboundBlogs() > 0) {
-            $this->_totalResultsAvailable = $this->getInboundBlogs();
+            $this->totalResultsAvailable = $this->getInboundBlogs();
         } else {
-            $this->_totalResultsAvailable = 0;
+            $this->totalResultsAvailable = 0;
         }
     }
 
@@ -124,7 +124,7 @@ class CosmosResultSet extends ResultSet
      * @return  Uri\Http
      */
     public function getUrl() {
-        return $this->_url;
+        return $this->url;
     }
 
     /**
@@ -133,7 +133,7 @@ class CosmosResultSet extends ResultSet
      * @return  Weblog
      */
     public function getWeblog() {
-        return $this->_weblog;
+        return $this->weblog;
     }
 
     /**
@@ -143,7 +143,7 @@ class CosmosResultSet extends ResultSet
      */
     public function getInboundBlogs()
     {
-        return $this->_inboundBlogs;
+        return $this->inboundBlogs;
     }
 
     /**
@@ -153,7 +153,7 @@ class CosmosResultSet extends ResultSet
      */
     public function getInboundLinks()
     {
-        return $this->_inboundLinks;
+        return $this->inboundLinks;
     }
 
     /**
@@ -163,6 +163,6 @@ class CosmosResultSet extends ResultSet
      */
     public function current()
     {
-        return new CosmosResult($this->_results->item($this->_currentIndex));
+        return new CosmosResult($this->results->item($this->currentIndex));
     }
 }

--- a/library/Zend/Service/Technorati/CosmosResultSet.php
+++ b/library/Zend/Service/Technorati/CosmosResultSet.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -31,7 +31,7 @@ use \DomDocument,
  * Represents a Technorati Cosmos query result set.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/CosmosResultSet.php
+++ b/library/Zend/Service/Technorati/CosmosResultSet.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,15 +24,14 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomDocument,
+    Zend\Uri;
+
 /**
  * Represents a Technorati Cosmos query result set.
  *
- * @uses       \Zend\Service\Technorati\CosmosResult
- * @uses       \Zend\Service\Technorati\ResultSet
- * @uses       \Zend\Service\Technorati\Utils
- * @uses       \Zend\Service\Technorati\Weblog
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -42,7 +41,7 @@ class CosmosResultSet extends ResultSet
     /**
      * Technorati weblog url, if queried URL is a valid weblog.
      *
-     * @var     \Zend\Uri\Http
+     * @var     Uri\Http
      * @access  protected
      */
     protected $_url;
@@ -50,7 +49,7 @@ class CosmosResultSet extends ResultSet
     /**
      * Technorati weblog, if queried URL is a valid weblog.
      *
-     * @var     \Zend\Service\Technorati\Weblog
+     * @var     Weblog
      * @access  protected
      */
     protected $_weblog;
@@ -77,7 +76,7 @@ class CosmosResultSet extends ResultSet
      * @param   DomDocument $dom    the ReST fragment for this object
      * @param   array $options      query options as associative array
      */
-    public function __construct(\DomDocument $dom, $options = array())
+    public function __construct(DomDocument $dom, $options = array())
     {
         parent::__construct($dom, $options);
 
@@ -122,7 +121,7 @@ class CosmosResultSet extends ResultSet
     /**
      * Returns the weblog URL.
      *
-     * @return  \Zend\Uri\Http
+     * @return  Uri\Http
      */
     public function getUrl() {
         return $this->_url;
@@ -131,7 +130,7 @@ class CosmosResultSet extends ResultSet
     /**
      * Returns the weblog.
      *
-     * @return  \Zend\Service\Technorati\Weblog
+     * @return  Weblog
      */
     public function getWeblog() {
         return $this->_weblog;
@@ -158,9 +157,9 @@ class CosmosResultSet extends ResultSet
     }
 
     /**
-     * Implements Zend_Service_Technorati_ResultSet::current().
+     * Implements ResultSet::current().
      *
-     * @return \Zend\Service\Technorati\CosmosResult current result
+     * @return CosmosResult current result
      */
     public function current()
     {

--- a/library/Zend/Service/Technorati/CosmosResultSet.php
+++ b/library/Zend/Service/Technorati/CosmosResultSet.php
@@ -20,24 +20,29 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a Technorati Cosmos query result set.
  *
- * @uses       Zend_Service_Technorati_CosmosResult
- * @uses       Zend_Service_Technorati_ResultSet
- * @uses       Zend_Service_Technorati_Utils
- * @uses       Zend_Service_Technorati_Weblog
+ * @uses       \Zend\Service\Technorati\CosmosResult
+ * @uses       \Zend\Service\Technorati\ResultSet
+ * @uses       \Zend\Service\Technorati\Utils
+ * @uses       \Zend\Service\Technorati\Weblog
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_CosmosResultSet extends Zend_Service_Technorati_ResultSet
+class CosmosResultSet extends ResultSet
 {
     /**
      * Technorati weblog url, if queried URL is a valid weblog.
      *
-     * @var     Zend_Uri_Http
+     * @var     \Zend\Uri\Http
      * @access  protected
      */
     protected $_url;
@@ -45,7 +50,7 @@ class Zend_Service_Technorati_CosmosResultSet extends Zend_Service_Technorati_Re
     /**
      * Technorati weblog, if queried URL is a valid weblog.
      *
-     * @var     Zend_Service_Technorati_Weblog
+     * @var     \Zend\Service\Technorati\Weblog
      * @access  protected
      */
     protected $_weblog;
@@ -72,7 +77,7 @@ class Zend_Service_Technorati_CosmosResultSet extends Zend_Service_Technorati_Re
      * @param   DomDocument $dom    the ReST fragment for this object
      * @param   array $options      query options as associative array
      */
-    public function __construct(DomDocument $dom, $options = array())
+    public function __construct(\DomDocument $dom, $options = array())
     {
         parent::__construct($dom, $options);
 
@@ -84,7 +89,7 @@ class Zend_Service_Technorati_CosmosResultSet extends Zend_Service_Technorati_Re
 
         $result = $this->_xpath->query('/tapi/document/result/weblog');
         if ($result->length == 1) {
-            $this->_weblog = new Zend_Service_Technorati_Weblog($result->item(0));
+            $this->_weblog = new Weblog($result->item(0));
         }
 
         $result = $this->_xpath->query('/tapi/document/result/url/text()');
@@ -92,9 +97,9 @@ class Zend_Service_Technorati_CosmosResultSet extends Zend_Service_Technorati_Re
             try {
                 // fetched URL often doens't include schema
                 // and this issue causes the following line to fail
-                $this->_url = Zend_Service_Technorati_Utils::normalizeUriHttp($result->item(0)->data);
-            } catch(Zend_Service_Technorati_Exception $e) {
-                if ($this->getWeblog() instanceof Zend_Service_Technorati_Weblog) {
+                $this->_url = Utils::normalizeUriHttp($result->item(0)->data);
+            } catch(Exception $e) {
+                if ($this->getWeblog() instanceof Weblog) {
                     $this->_url = $this->getWeblog()->getUrl();
                 }
             }
@@ -117,7 +122,7 @@ class Zend_Service_Technorati_CosmosResultSet extends Zend_Service_Technorati_Re
     /**
      * Returns the weblog URL.
      *
-     * @return  Zend_Uri_Http
+     * @return  \Zend\Uri\Http
      */
     public function getUrl() {
         return $this->_url;
@@ -126,7 +131,7 @@ class Zend_Service_Technorati_CosmosResultSet extends Zend_Service_Technorati_Re
     /**
      * Returns the weblog.
      *
-     * @return  Zend_Service_Technorati_Weblog
+     * @return  \Zend\Service\Technorati\Weblog
      */
     public function getWeblog() {
         return $this->_weblog;
@@ -155,10 +160,10 @@ class Zend_Service_Technorati_CosmosResultSet extends Zend_Service_Technorati_Re
     /**
      * Implements Zend_Service_Technorati_ResultSet::current().
      *
-     * @return Zend_Service_Technorati_CosmosResult current result
+     * @return \Zend\Service\Technorati\CosmosResult current result
      */
     public function current()
     {
-        return new Zend_Service_Technorati_CosmosResult($this->_results->item($this->_currentIndex));
+        return new CosmosResult($this->_results->item($this->_currentIndex));
     }
 }

--- a/library/Zend/Service/Technorati/DailyCountsResult.php
+++ b/library/Zend/Service/Technorati/DailyCountsResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,15 +24,16 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomElement,
+    Zend\Date\Date as ZendDate;
+
 /**
  * Represents a single Technorati DailyCounts query result object.
  * It is never returned as a standalone object,
- * but it always belongs to a valid Zend_Service_Technorati_DailyCountsResultSet object.
+ * but it always belongs to a valid DailyCountsResultSet object.
  *
- * @uses       Zend_Date
- * @uses       \Zend\Service\Technorati\Result
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -42,7 +43,7 @@ class DailyCountsResult extends Result
     /**
      * Date of count.
      *
-     * @var     Zend_Date
+     * @var     ZendDate
      * @access  protected
      */
     protected $_date;
@@ -61,21 +62,21 @@ class DailyCountsResult extends Result
      *
      * @param   DomElement $dom the ReST fragment for this object
      */
-    public function __construct(\DomElement $dom)
+    public function __construct(DomElement $dom)
     {
         $this->_fields = array( '_date'   => 'date',
                                 '_count'  => 'count');
         parent::__construct($dom);
 
         // filter fields
-        $this->_date  = new \Zend\Date\Date(strtotime($this->_date));
+        $this->_date  = new ZendDate(strtotime($this->_date));
         $this->_count = (int) $this->_count;
     }
 
     /**
      * Returns the date of count.
      *
-     * @return  Zend_Date
+     * @return  ZendDate
      */
     public function getDate() {
         return $this->_date;

--- a/library/Zend/Service/Technorati/DailyCountsResult.php
+++ b/library/Zend/Service/Technorati/DailyCountsResult.php
@@ -20,19 +20,24 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a single Technorati DailyCounts query result object.
  * It is never returned as a standalone object,
  * but it always belongs to a valid Zend_Service_Technorati_DailyCountsResultSet object.
  *
  * @uses       Zend_Date
- * @uses       Zend_Service_Technorati_Result
+ * @uses       \Zend\Service\Technorati\Result
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_DailyCountsResult extends Zend_Service_Technorati_Result
+class DailyCountsResult extends Result
 {
     /**
      * Date of count.
@@ -56,14 +61,14 @@ class Zend_Service_Technorati_DailyCountsResult extends Zend_Service_Technorati_
      *
      * @param   DomElement $dom the ReST fragment for this object
      */
-    public function __construct(DomElement $dom)
+    public function __construct(\DomElement $dom)
     {
         $this->_fields = array( '_date'   => 'date',
                                 '_count'  => 'count');
         parent::__construct($dom);
 
         // filter fields
-        $this->_date  = new Zend_Date(strtotime($this->_date));
+        $this->_date  = new \Zend\Date\Date(strtotime($this->_date));
         $this->_count = (int) $this->_count;
     }
 

--- a/library/Zend/Service/Technorati/DailyCountsResult.php
+++ b/library/Zend/Service/Technorati/DailyCountsResult.php
@@ -46,7 +46,7 @@ class DailyCountsResult extends Result
      * @var     ZendDate
      * @access  protected
      */
-    protected $_date;
+    protected $date;
 
     /**
      * Number of posts containing query on given date.
@@ -54,7 +54,7 @@ class DailyCountsResult extends Result
      * @var     int
      * @access  protected
      */
-    protected $_count;
+    protected $count;
 
 
     /**
@@ -64,13 +64,13 @@ class DailyCountsResult extends Result
      */
     public function __construct(DomElement $dom)
     {
-        $this->_fields = array( '_date'   => 'date',
-                                '_count'  => 'count');
+        $this->fields = array( 'date'   => 'date',
+                               'count'  => 'count');
         parent::__construct($dom);
 
         // filter fields
-        $this->_date  = new ZendDate(strtotime($this->_date));
-        $this->_count = (int) $this->_count;
+        $this->date  = new ZendDate(strtotime($this->date));
+        $this->count = (int) $this->count;
     }
 
     /**
@@ -79,7 +79,7 @@ class DailyCountsResult extends Result
      * @return  ZendDate
      */
     public function getDate() {
-        return $this->_date;
+        return $this->date;
     }
 
     /**
@@ -88,6 +88,6 @@ class DailyCountsResult extends Result
      * @return  int
      */
     public function getCount() {
-        return $this->_count;
+        return $this->count;
     }
 }

--- a/library/Zend/Service/Technorati/DailyCountsResult.php
+++ b/library/Zend/Service/Technorati/DailyCountsResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -33,7 +33,7 @@ use \DomElement,
  * but it always belongs to a valid DailyCountsResultSet object.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/DailyCountsResultSet.php
+++ b/library/Zend/Service/Technorati/DailyCountsResultSet.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,15 +24,14 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomDocument,
+    Zend\Uri;
+
 /**
  * Represents a Technorati Tag query result set.
  *
- * @uses       Zend_Date
- * @uses       \Zend\Service\Technorati\DailyCountsResult
- * @uses       \Zend\Service\Technorati\ResultSet
- * @uses       \Zend\Service\Technorati\Utils
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -42,7 +41,7 @@ class DailyCountsResultSet extends ResultSet
     /**
      * Technorati search URL for given query.
      *
-     * @var     \Zend\Uri\Http
+     * @var     Uri\Http
      * @access  protected
      */
     protected $_searchUrl;
@@ -50,7 +49,7 @@ class DailyCountsResultSet extends ResultSet
     /**
      * Number of days for which counts provided.
      *
-     * @var     \Zend\Service\Technorati\Weblog
+     * @var     Weblog
      * @access  protected
      */
     protected $_days;
@@ -61,7 +60,7 @@ class DailyCountsResultSet extends ResultSet
      * @param   DomDocument $dom    the ReST fragment for this object
      * @param   array $options      query options as associative array
      */
-    public function __construct(\DomDocument $dom, $options = array())
+    public function __construct(DomDocument $dom, $options = array())
     {
         parent::__construct($dom, $options);
 
@@ -81,7 +80,7 @@ class DailyCountsResultSet extends ResultSet
     /**
      * Returns the search URL for given query.
      *
-     * @return  \Zend\Uri\Http
+     * @return  Uri\Http
      */
     public function getSearchUrl() {
         return $this->_searchUrl;
@@ -97,9 +96,9 @@ class DailyCountsResultSet extends ResultSet
     }
 
     /**
-     * Implements Zend_Service_Technorati_ResultSet::current().
+     * Implements ResultSet::current().
      *
-     * @return \Zend\Service\Technorati\DailyCountsResult current result
+     * @return DailyCountsResult current result
      */
     public function current()
     {

--- a/library/Zend/Service/Technorati/DailyCountsResultSet.php
+++ b/library/Zend/Service/Technorati/DailyCountsResultSet.php
@@ -20,24 +20,29 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a Technorati Tag query result set.
  *
  * @uses       Zend_Date
- * @uses       Zend_Service_Technorati_DailyCountsResult
- * @uses       Zend_Service_Technorati_ResultSet
- * @uses       Zend_Service_Technorati_Utils
+ * @uses       \Zend\Service\Technorati\DailyCountsResult
+ * @uses       \Zend\Service\Technorati\ResultSet
+ * @uses       \Zend\Service\Technorati\Utils
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_DailyCountsResultSet extends Zend_Service_Technorati_ResultSet
+class DailyCountsResultSet extends ResultSet
 {
     /**
      * Technorati search URL for given query.
      *
-     * @var     Zend_Uri_Http
+     * @var     \Zend\Uri\Http
      * @access  protected
      */
     protected $_searchUrl;
@@ -45,7 +50,7 @@ class Zend_Service_Technorati_DailyCountsResultSet extends Zend_Service_Technora
     /**
      * Number of days for which counts provided.
      *
-     * @var     Zend_Service_Technorati_Weblog
+     * @var     \Zend\Service\Technorati\Weblog
      * @access  protected
      */
     protected $_days;
@@ -56,7 +61,7 @@ class Zend_Service_Technorati_DailyCountsResultSet extends Zend_Service_Technora
      * @param   DomDocument $dom    the ReST fragment for this object
      * @param   array $options      query options as associative array
      */
-    public function __construct(DomDocument $dom, $options = array())
+    public function __construct(\DomDocument $dom, $options = array())
     {
         parent::__construct($dom, $options);
 
@@ -65,7 +70,7 @@ class Zend_Service_Technorati_DailyCountsResultSet extends Zend_Service_Technora
 
         $result = $this->_xpath->query('/tapi/document/result/searchurl/text()');
         if ($result->length == 1) {
-            $this->_searchUrl = Zend_Service_Technorati_Utils::normalizeUriHttp($result->item(0)->data);
+            $this->_searchUrl = Utils::normalizeUriHttp($result->item(0)->data);
         }
 
         $this->_totalResultsReturned  = (int) $this->_xpath->evaluate("count(/tapi/document/items/item)");
@@ -76,7 +81,7 @@ class Zend_Service_Technorati_DailyCountsResultSet extends Zend_Service_Technora
     /**
      * Returns the search URL for given query.
      *
-     * @return  Zend_Uri_Http
+     * @return  \Zend\Uri\Http
      */
     public function getSearchUrl() {
         return $this->_searchUrl;
@@ -94,10 +99,10 @@ class Zend_Service_Technorati_DailyCountsResultSet extends Zend_Service_Technora
     /**
      * Implements Zend_Service_Technorati_ResultSet::current().
      *
-     * @return Zend_Service_Technorati_DailyCountsResult current result
+     * @return \Zend\Service\Technorati\DailyCountsResult current result
      */
     public function current()
     {
-        return new Zend_Service_Technorati_DailyCountsResult($this->_results->item($this->_currentIndex));
+        return new DailyCountsResult($this->_results->item($this->_currentIndex));
     }
 }

--- a/library/Zend/Service/Technorati/DailyCountsResultSet.php
+++ b/library/Zend/Service/Technorati/DailyCountsResultSet.php
@@ -44,7 +44,7 @@ class DailyCountsResultSet extends ResultSet
      * @var     Uri\Http
      * @access  protected
      */
-    protected $_searchUrl;
+    protected $searchUrl;
 
     /**
      * Number of days for which counts provided.
@@ -52,7 +52,7 @@ class DailyCountsResultSet extends ResultSet
      * @var     Weblog
      * @access  protected
      */
-    protected $_days;
+    protected $days;
 
     /**
      * Parses the search response and retrieve the results for iteration.
@@ -64,16 +64,16 @@ class DailyCountsResultSet extends ResultSet
     {
         parent::__construct($dom, $options);
 
-        $result = $this->_xpath->query('/tapi/document/result/days/text()');
-        if ($result->length == 1) $this->_days = (int) $result->item(0)->data;
+        $result = $this->xpath->query('/tapi/document/result/days/text()');
+        if ($result->length == 1) $this->days = (int) $result->item(0)->data;
 
-        $result = $this->_xpath->query('/tapi/document/result/searchurl/text()');
+        $result = $this->xpath->query('/tapi/document/result/searchurl/text()');
         if ($result->length == 1) {
-            $this->_searchUrl = Utils::normalizeUriHttp($result->item(0)->data);
+            $this->searchUrl = Utils::normalizeUriHttp($result->item(0)->data);
         }
 
-        $this->_totalResultsReturned  = (int) $this->_xpath->evaluate("count(/tapi/document/items/item)");
-        $this->_totalResultsAvailable = (int) $this->getDays();
+        $this->totalResultsReturned  = (int) $this->xpath->evaluate("count(/tapi/document/items/item)");
+        $this->totalResultsAvailable = (int) $this->getDays();
     }
 
 
@@ -83,7 +83,7 @@ class DailyCountsResultSet extends ResultSet
      * @return  Uri\Http
      */
     public function getSearchUrl() {
-        return $this->_searchUrl;
+        return $this->searchUrl;
     }
 
     /**
@@ -92,7 +92,7 @@ class DailyCountsResultSet extends ResultSet
      * @return  int
      */
     public function getDays() {
-        return $this->_days;
+        return $this->days;
     }
 
     /**
@@ -102,6 +102,6 @@ class DailyCountsResultSet extends ResultSet
      */
     public function current()
     {
-        return new DailyCountsResult($this->_results->item($this->_currentIndex));
+        return new DailyCountsResult($this->results->item($this->currentIndex));
     }
 }

--- a/library/Zend/Service/Technorati/DailyCountsResultSet.php
+++ b/library/Zend/Service/Technorati/DailyCountsResultSet.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -31,7 +31,7 @@ use \DomDocument,
  * Represents a Technorati Tag query result set.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/Exception.php
+++ b/library/Zend/Service/Technorati/Exception.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -26,7 +26,7 @@ namespace Zend\Service\Technorati;
 
 /**
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/Exception.php
+++ b/library/Zend/Service/Technorati/Exception.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -26,7 +26,7 @@ namespace Zend\Service\Technorati;
 
 /**
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/Exception/RuntimeException.php
+++ b/library/Zend/Service/Technorati/Exception/RuntimeException.php
@@ -12,7 +12,6 @@
  * obtain it through the world-wide-web, please send an email
  * to license@zend.com so we can send you a copy immediately.
  *
- * @uses       \Zend\Service\Technorati\Exception
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati

--- a/library/Zend/Service/Technorati/Exception/RuntimeException.php
+++ b/library/Zend/Service/Technorati/Exception/RuntimeException.php
@@ -24,6 +24,7 @@
  * @namespace
  */
 namespace Zend\Service\Technorati\Exception;
+use Zend\Service\Technorati\Exception as TechnoratiException;
 
 /**
  * @category   Zend
@@ -34,6 +35,6 @@ namespace Zend\Service\Technorati\Exception;
  */
 class RuntimeException
     extends \RuntimeException
-    implements \Zend\Service\Technorati\Exception
+    implements TechnoratiException
 {}
 

--- a/library/Zend/Service/Technorati/Exception/RuntimeException.php
+++ b/library/Zend/Service/Technorati/Exception/RuntimeException.php
@@ -12,6 +12,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@zend.com so we can send you a copy immediately.
  *
+ * @uses       \Zend\Service\Technorati\Exception
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
@@ -22,7 +23,7 @@
 /**
  * @namespace
  */
-namespace Zend\Service\Technorati;
+namespace Zend\Service\Technorati\Exception;
 
 /**
  * @category   Zend
@@ -31,5 +32,8 @@ namespace Zend\Service\Technorati;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Exception
+class RuntimeException
+    extends \RuntimeException
+    implements \Zend\Service\Technorati\Exception
 {}
+

--- a/library/Zend/Service/Technorati/GetInfoResult.php
+++ b/library/Zend/Service/Technorati/GetInfoResult.php
@@ -20,23 +20,28 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a single Technorati GetInfo query result object.
  *
  * @uses       DOMXPath
- * @uses       Zend_Service_Technorati_Author
- * @uses       Zend_Service_Technorati_Weblog
+ * @uses       \Zend\Service\Technorati\Author
+ * @uses       \Zend\Service\Technorati\Weblog
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_GetInfoResult
+class GetInfoResult
 {
     /**
      * Technorati author
      *
-     * @var     Zend_Service_Technorati_Author
+     * @var     \Zend\Service\Technorati\Author
      * @access  protected
      */
     protected $_author;
@@ -55,19 +60,19 @@ class Zend_Service_Technorati_GetInfoResult
      *
      * @param   DomDocument $dom the ReST fragment for this object
      */
-    public function __construct(DomDocument $dom)
+    public function __construct(\DomDocument $dom)
     {
-        $xpath = new DOMXPath($dom);
+        $xpath = new \DOMXPath($dom);
 
         $result = $xpath->query('//result');
         if ($result->length == 1) {
-            $this->_author = new Zend_Service_Technorati_Author($result->item(0));
+            $this->_author = new Author($result->item(0));
         }
 
         $result = $xpath->query('//item/weblog');
         if ($result->length >= 1) {
             foreach ($result as $weblog) {
-                $this->_weblogs[] = new Zend_Service_Technorati_Weblog($weblog);
+                $this->_weblogs[] = new Weblog($weblog);
             }
         }
     }
@@ -76,7 +81,7 @@ class Zend_Service_Technorati_GetInfoResult
     /**
      * Returns the author associated with queried username.
      *
-     * @return  Zend_Service_Technorati_Author
+     * @return  \Zend\Service\Technorati\Author
      */
     public function getAuthor() {
         return $this->_author;
@@ -85,7 +90,7 @@ class Zend_Service_Technorati_GetInfoResult
     /**
      * Returns the collection of weblogs authored by queried username.
      *
-     * @return  array of Zend_Service_Technorati_Weblog
+     * @return  array of \Zend\Service\Technorati\Weblog
      */
     public function getWeblogs() {
         return $this->_weblogs;

--- a/library/Zend/Service/Technorati/GetInfoResult.php
+++ b/library/Zend/Service/Technorati/GetInfoResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -31,7 +31,7 @@ use \DomDocument,
  * Represents a single Technorati GetInfo query result object.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/GetInfoResult.php
+++ b/library/Zend/Service/Technorati/GetInfoResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,14 +24,14 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomDocument,
+    \DOMXPath;
+
 /**
  * Represents a single Technorati GetInfo query result object.
  *
- * @uses       DOMXPath
- * @uses       \Zend\Service\Technorati\Author
- * @uses       \Zend\Service\Technorati\Weblog
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -41,7 +41,7 @@ class GetInfoResult
     /**
      * Technorati author
      *
-     * @var     \Zend\Service\Technorati\Author
+     * @var     Author
      * @access  protected
      */
     protected $_author;
@@ -60,9 +60,9 @@ class GetInfoResult
      *
      * @param   DomDocument $dom the ReST fragment for this object
      */
-    public function __construct(\DomDocument $dom)
+    public function __construct(DomDocument $dom)
     {
-        $xpath = new \DOMXPath($dom);
+        $xpath = new DOMXPath($dom);
 
         $result = $xpath->query('//result');
         if ($result->length == 1) {
@@ -81,7 +81,7 @@ class GetInfoResult
     /**
      * Returns the author associated with queried username.
      *
-     * @return  \Zend\Service\Technorati\Author
+     * @return  Author
      */
     public function getAuthor() {
         return $this->_author;
@@ -90,7 +90,7 @@ class GetInfoResult
     /**
      * Returns the collection of weblogs authored by queried username.
      *
-     * @return  array of \Zend\Service\Technorati\Weblog
+     * @return  array of Weblog
      */
     public function getWeblogs() {
         return $this->_weblogs;

--- a/library/Zend/Service/Technorati/GetInfoResult.php
+++ b/library/Zend/Service/Technorati/GetInfoResult.php
@@ -44,7 +44,7 @@ class GetInfoResult
      * @var     Author
      * @access  protected
      */
-    protected $_author;
+    protected $author;
 
     /**
      * A list of weblogs claimed by this author
@@ -52,7 +52,7 @@ class GetInfoResult
      * @var     array
      * @access  protected
      */
-    protected $_weblogs = array();
+    protected $weblogs = array();
 
 
     /**
@@ -66,13 +66,13 @@ class GetInfoResult
 
         $result = $xpath->query('//result');
         if ($result->length == 1) {
-            $this->_author = new Author($result->item(0));
+            $this->author = new Author($result->item(0));
         }
 
         $result = $xpath->query('//item/weblog');
         if ($result->length >= 1) {
             foreach ($result as $weblog) {
-                $this->_weblogs[] = new Weblog($weblog);
+                $this->weblogs[] = new Weblog($weblog);
             }
         }
     }
@@ -84,7 +84,7 @@ class GetInfoResult
      * @return  Author
      */
     public function getAuthor() {
-        return $this->_author;
+        return $this->author;
     }
 
     /**
@@ -93,7 +93,7 @@ class GetInfoResult
      * @return  array of Weblog
      */
     public function getWeblogs() {
-        return $this->_weblogs;
+        return $this->weblogs;
     }
 
 }

--- a/library/Zend/Service/Technorati/KeyInfoResult.php
+++ b/library/Zend/Service/Technorati/KeyInfoResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,13 +24,15 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomDocument,
+    \DOMXPath;
+
 /**
  * Represents a single Technorati KeyInfo query result object.
  * It provides information about your Technorati API Key daily usage.
  *
- * @uses       DOMXPath
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -69,9 +71,9 @@ class KeyInfoResult
      * @param   DomElement $dom the ReST fragment for this object
      * @param   string $apiKey  the API Key string
      */
-    public function __construct(\DomDocument $dom, $apiKey = null)
+    public function __construct(DomDocument $dom, $apiKey = null)
     {
-        $xpath = new \DOMXPath($dom);
+        $xpath = new DOMXPath($dom);
 
         $this->_apiQueries   = (int) $xpath->query('/tapi/document/result/apiqueries/text()')->item(0)->data;
         $this->_maxQueries   = (int) $xpath->query('/tapi/document/result/maxqueries/text()')->item(0)->data;
@@ -111,7 +113,7 @@ class KeyInfoResult
      * Sets API Key string.
      *
      * @param   string $apiKey  the API Key
-     * @return  \Zend\Service\Technorati\KeyInfoResult $this instance
+     * @return  KeyInfoResult $this instance
      */
     public function setApiKey($apiKey) {
         $this->_apiKey = $apiKey;

--- a/library/Zend/Service/Technorati/KeyInfoResult.php
+++ b/library/Zend/Service/Technorati/KeyInfoResult.php
@@ -20,6 +20,11 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a single Technorati KeyInfo query result object.
  * It provides information about your Technorati API Key daily usage.
  *
@@ -30,7 +35,7 @@
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_KeyInfoResult
+class KeyInfoResult
 {
     /**
      * Technorati API key
@@ -64,9 +69,9 @@ class Zend_Service_Technorati_KeyInfoResult
      * @param   DomElement $dom the ReST fragment for this object
      * @param   string $apiKey  the API Key string
      */
-    public function __construct(DomDocument $dom, $apiKey = null)
+    public function __construct(\DomDocument $dom, $apiKey = null)
     {
-        $xpath = new DOMXPath($dom);
+        $xpath = new \DOMXPath($dom);
 
         $this->_apiQueries   = (int) $xpath->query('/tapi/document/result/apiqueries/text()')->item(0)->data;
         $this->_maxQueries   = (int) $xpath->query('/tapi/document/result/maxqueries/text()')->item(0)->data;
@@ -106,7 +111,7 @@ class Zend_Service_Technorati_KeyInfoResult
      * Sets API Key string.
      *
      * @param   string $apiKey  the API Key
-     * @return  Zend_Service_Technorati_KeyInfoResult $this instance
+     * @return  \Zend\Service\Technorati\KeyInfoResult $this instance
      */
     public function setApiKey($apiKey) {
         $this->_apiKey = $apiKey;

--- a/library/Zend/Service/Technorati/KeyInfoResult.php
+++ b/library/Zend/Service/Technorati/KeyInfoResult.php
@@ -45,7 +45,7 @@ class KeyInfoResult
      * @var     string
      * @access  protected
      */
-    protected $_apiKey;
+    protected $apiKey;
 
     /**
      * Number of queries used today
@@ -53,7 +53,7 @@ class KeyInfoResult
      * @var     int
      * @access  protected
      */
-    protected $_apiQueries;
+    protected $apiQueries;
 
     /**
      * Total number of available queries per day
@@ -61,7 +61,7 @@ class KeyInfoResult
      * @var     int
      * @access  protected
      */
-    protected $_maxQueries;
+    protected $maxQueries;
 
 
     /**
@@ -75,8 +75,8 @@ class KeyInfoResult
     {
         $xpath = new DOMXPath($dom);
 
-        $this->_apiQueries   = (int) $xpath->query('/tapi/document/result/apiqueries/text()')->item(0)->data;
-        $this->_maxQueries   = (int) $xpath->query('/tapi/document/result/maxqueries/text()')->item(0)->data;
+        $this->apiQueries   = (int) $xpath->query('/tapi/document/result/apiqueries/text()')->item(0)->data;
+        $this->maxQueries   = (int) $xpath->query('/tapi/document/result/maxqueries/text()')->item(0)->data;
         $this->setApiKey($apiKey);
     }
 
@@ -87,7 +87,7 @@ class KeyInfoResult
      * @return  string  API Key string
      */
     public function getApiKey() {
-        return $this->_apiKey;
+        return $this->apiKey;
     }
 
     /**
@@ -96,7 +96,7 @@ class KeyInfoResult
      * @return  int     number of queries sent today
      */
     public function getApiQueries() {
-        return $this->_apiQueries;
+        return $this->apiQueries;
     }
 
     /**
@@ -105,7 +105,7 @@ class KeyInfoResult
      * @return  int     maximum number of available queries per day
      */
     public function getMaxQueries() {
-        return $this->_maxQueries;
+        return $this->maxQueries;
     }
 
 
@@ -116,7 +116,7 @@ class KeyInfoResult
      * @return  KeyInfoResult $this instance
      */
     public function setApiKey($apiKey) {
-        $this->_apiKey = $apiKey;
+        $this->apiKey = $apiKey;
         return $this;
     }
 }

--- a/library/Zend/Service/Technorati/KeyInfoResult.php
+++ b/library/Zend/Service/Technorati/KeyInfoResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -32,7 +32,7 @@ use \DomDocument,
  * It provides information about your Technorati API Key daily usage.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/Result.php
+++ b/library/Zend/Service/Technorati/Result.php
@@ -20,12 +20,17 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a single Technorati Search query result object.
  * It is never returned as a standalone object,
  * but it always belongs to a valid Zend_Service_Technorati_SearchResultSet object.
  *
  * @uses       DOMXPath
- * @uses       Zend_Service_Technorati_Weblog
+ * @uses       \Zend\Service\Technorati\Weblog
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
@@ -33,7 +38,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @abstract
  */
-abstract class Zend_Service_Technorati_Result
+abstract class Result
 {
     /**
      * An associative array of 'fieldName' => 'xmlfieldtag'
@@ -67,9 +72,9 @@ abstract class Zend_Service_Technorati_Result
      *
      * @param   DomElement $result  the ReST fragment for this object
      */
-    public function __construct(DomElement $dom)
+    public function __construct(\DomElement $dom)
     {
-        $this->_xpath = new DOMXPath($dom->ownerDocument);
+        $this->_xpath = new \DOMXPath($dom->ownerDocument);
         $this->_dom = $dom;
 
         // default fields for all search results
@@ -98,7 +103,7 @@ abstract class Zend_Service_Technorati_Result
         // weblog object field
         $result = $this->_xpath->query('./weblog', $this->_dom);
         if ($result->length == 1) {
-            $this->_weblog = new Zend_Service_Technorati_Weblog($result->item(0));
+            $this->_weblog = new Weblog($result->item(0));
         } else {
             $this->_weblog = null;
         }

--- a/library/Zend/Service/Technorati/Result.php
+++ b/library/Zend/Service/Technorati/Result.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -33,7 +33,7 @@ use \DomElement,
  * but it always belongs to a valid SearchResultSet object.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/Result.php
+++ b/library/Zend/Service/Technorati/Result.php
@@ -47,7 +47,7 @@ abstract class Result
      * @var     array
      * @access  protected
      */
-    protected $_fields;
+    protected $fields;
 
     /**
      * The ReST fragment for this result object
@@ -55,39 +55,39 @@ abstract class Result
      * @var     DomElement
      * @access  protected
      */
-    protected $_dom;
+    protected $dom;
 
     /**
-     * Object for $this->_dom
+     * Object for $this->dom
      *
      * @var     DOMXpath
      * @access  protected
      */
-    protected $_xpath;
+    protected $xpath;
 
 
     /**
      * Constructs a new object from DOM Element.
      * Properties are automatically fetched from XML
-     * according to array of $_fields to be read.
+     * according to array of $fields to be read.
      *
      * @param   DomElement $result  the ReST fragment for this object
      */
     public function __construct(DomElement $dom)
     {
-        $this->_xpath = new DOMXPath($dom->ownerDocument);
-        $this->_dom = $dom;
+        $this->xpath = new DOMXPath($dom->ownerDocument);
+        $this->dom = $dom;
 
         // default fields for all search results
         $fields = array();
 
         // merge with child's object fields
-        $this->_fields = array_merge($this->_fields, $fields);
+        $this->fields = array_merge($this->fields, $fields);
 
         // add results to appropriate fields
-        foreach($this->_fields as $phpName => $xmlName) {
+        foreach($this->fields as $phpName => $xmlName) {
             $query = "./$xmlName/text()";
-            $node = $this->_xpath->query($query, $this->_dom);
+            $node = $this->xpath->query($query, $this->dom);
             if ($node->length == 1) {
                 $this->{$phpName} = (string) $node->item(0)->data;
             }
@@ -99,14 +99,14 @@ abstract class Result
      *
      * @return  void
      */
-    protected function _parseWeblog()
+    protected function parseWeblog()
     {
         // weblog object field
-        $result = $this->_xpath->query('./weblog', $this->_dom);
+        $result = $this->xpath->query('./weblog', $this->dom);
         if ($result->length == 1) {
-            $this->_weblog = new Weblog($result->item(0));
+            $this->weblog = new Weblog($result->item(0));
         } else {
-            $this->_weblog = null;
+            $this->weblog = null;
         }
     }
 
@@ -118,6 +118,6 @@ abstract class Result
      */
     public function getXml()
     {
-        return $this->_dom->ownerDocument->saveXML($this->_dom);
+        return $this->dom->ownerDocument->saveXML($this->dom);
     }
 }

--- a/library/Zend/Service/Technorati/Result.php
+++ b/library/Zend/Service/Technorati/Result.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,15 +24,16 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomElement,
+    \DOMXPath;
+
 /**
  * Represents a single Technorati Search query result object.
  * It is never returned as a standalone object,
- * but it always belongs to a valid Zend_Service_Technorati_SearchResultSet object.
+ * but it always belongs to a valid SearchResultSet object.
  *
- * @uses       DOMXPath
- * @uses       \Zend\Service\Technorati\Weblog
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -72,9 +73,9 @@ abstract class Result
      *
      * @param   DomElement $result  the ReST fragment for this object
      */
-    public function __construct(\DomElement $dom)
+    public function __construct(DomElement $dom)
     {
-        $this->_xpath = new \DOMXPath($dom->ownerDocument);
+        $this->_xpath = new DOMXPath($dom->ownerDocument);
         $this->_dom = $dom;
 
         // default fields for all search results

--- a/library/Zend/Service/Technorati/ResultSet.php
+++ b/library/Zend/Service/Technorati/ResultSet.php
@@ -20,6 +20,11 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * This is the most essential result set.
  * The scope of this class is to be extended by a query-specific child result set class,
  * and it should never be used to initialize a standalone object.
@@ -30,7 +35,7 @@
  * @uses       DOMDocument
  * @uses       DOMXpath
  * @uses       OutOfBoundsException
- * @uses       Zend_Service_Technorati_Result
+ * @uses       \Zend\Service\Technorati\Result
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
@@ -38,7 +43,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @abstract
  */
-abstract class Zend_Service_Technorati_ResultSet implements SeekableIterator
+abstract class ResultSet implements \SeekableIterator
 {
     /**
      * The total number of results available
@@ -111,7 +116,7 @@ abstract class Zend_Service_Technorati_ResultSet implements SeekableIterator
      * @param   DomDocument $dom    the ReST fragment for this object
      * @param   array $options      query options as associative array
      */
-    public function __construct(DomDocument $dom, $options = array())
+    public function __construct(\DomDocument $dom, $options = array())
     {
         $this->_init($dom, $options);
 
@@ -147,10 +152,10 @@ abstract class Zend_Service_Technorati_ResultSet implements SeekableIterator
      * @param   array $options   query options as associative array
      *      * @return  void
      */
-    protected function _init(DomDocument $dom, $options = array())
+    protected function _init(\DomDocument $dom, $options = array())
     {
         $this->_dom     = $dom;
-        $this->_xpath   = new DOMXPath($dom);
+        $this->_xpath   = new \DOMXPath($dom);
 
         $this->_results = $this->_xpath->query("//item");
     }
@@ -229,7 +234,7 @@ abstract class Zend_Service_Technorati_ResultSet implements SeekableIterator
         if ($indexInt >= 0 && $indexInt < $this->_results->length) {
             $this->_currentIndex = $indexInt;
         } else {
-            throw new OutOfBoundsException("Illegal index '$index'");
+            throw new \OutOfBoundsException("Illegal index '$index'");
         }
     }
 
@@ -277,7 +282,7 @@ abstract class Zend_Service_Technorati_ResultSet implements SeekableIterator
      * @return void
      */
     public function __wakeup() {
-        $dom = new DOMDocument();
+        $dom = new \DOMDocument();
         $dom->loadXml($this->_xml);
         $this->_init($dom);
         $this->_xml = null; // reset XML content

--- a/library/Zend/Service/Technorati/ResultSet.php
+++ b/library/Zend/Service/Technorati/ResultSet.php
@@ -52,7 +52,7 @@ abstract class ResultSet implements SeekableIterator
      * @var     int
      * @access  protected
      */
-    protected $_totalResultsAvailable;
+    protected $totalResultsAvailable;
 
     /**
      * The number of results in this result set
@@ -60,7 +60,7 @@ abstract class ResultSet implements SeekableIterator
      * @var     int
      * @access  protected
      */
-    protected $_totalResultsReturned;
+    protected $totalResultsReturned;
 
     /**
      * The offset in the total result set of this search set
@@ -76,7 +76,7 @@ abstract class ResultSet implements SeekableIterator
      * @var     DomNodeList
      * @access  protected
      */
-    protected $_results;
+    protected $results;
 
     /**
      * Technorati API response document
@@ -84,23 +84,23 @@ abstract class ResultSet implements SeekableIterator
      * @var     DomDocument
      * @access  protected
      */
-    protected $_dom;
+    protected $dom;
 
     /**
-     * Object for $this->_dom
+     * Object for $this->dom
      *
      * @var     DOMXpath
      * @access  protected
      */
-    protected $_xpath;
+    protected $xpath;
 
     /**
-     * XML string representation for $this->_dom
+     * XML string representation for $this->dom
      *
      * @var     string
      * @access  protected
      */
-    protected $_xml;
+    protected $xml;
 
     /**
      * Current Item
@@ -108,7 +108,7 @@ abstract class ResultSet implements SeekableIterator
      * @var     int
      * @access  protected
      */
-    protected $_currentIndex = 0;
+    protected $currentIndex = 0;
 
 
     /**
@@ -119,7 +119,7 @@ abstract class ResultSet implements SeekableIterator
      */
     public function __construct(DomDocument $dom, $options = array())
     {
-        $this->_init($dom, $options);
+        $this->init($dom, $options);
 
         // Technorati loves to make developer's life really hard
         // I must read query options in order to normalize a single way
@@ -138,7 +138,7 @@ abstract class ResultSet implements SeekableIterator
 
         //$start = isset($options['start']) ? $options['start'] : 1;
         //$limit = isset($options['limit']) ? $options['limit'] : 20;
-        //$this->_firstResultPosition = $start;
+        //$this->firstResultPosition = $start;
     }
 
     /**
@@ -153,12 +153,12 @@ abstract class ResultSet implements SeekableIterator
      * @param   array $options   query options as associative array
      *      * @return  void
      */
-    protected function _init(DomDocument $dom, $options = array())
+    protected function init(DomDocument $dom, $options = array())
     {
-        $this->_dom     = $dom;
-        $this->_xpath   = new DOMXPath($dom);
+        $this->dom     = $dom;
+        $this->xpath   = new DOMXPath($dom);
 
-        $this->_results = $this->_xpath->query("//item");
+        $this->results = $this->xpath->query("//item");
     }
 
     /**
@@ -168,7 +168,7 @@ abstract class ResultSet implements SeekableIterator
      */
     public function totalResults()
     {
-        return (int) $this->_totalResultsReturned;
+        return (int) $this->totalResultsReturned;
     }
 
 
@@ -179,7 +179,7 @@ abstract class ResultSet implements SeekableIterator
      */
     public function totalResultsAvailable()
     {
-        return (int) $this->_totalResultsAvailable;
+        return (int) $this->totalResultsAvailable;
     }
 
     /**
@@ -198,7 +198,7 @@ abstract class ResultSet implements SeekableIterator
      */
     public function key()
     {
-        return $this->_currentIndex;
+        return $this->currentIndex;
     }
 
     /**
@@ -208,7 +208,7 @@ abstract class ResultSet implements SeekableIterator
      */
     public function next()
     {
-        $this->_currentIndex += 1;
+        $this->currentIndex += 1;
     }
 
     /**
@@ -218,7 +218,7 @@ abstract class ResultSet implements SeekableIterator
      */
     public function rewind()
     {
-        $this->_currentIndex = 0;
+        $this->currentIndex = 0;
         return true;
     }
 
@@ -232,8 +232,8 @@ abstract class ResultSet implements SeekableIterator
     public function seek($index)
     {
         $indexInt = (int) $index;
-        if ($indexInt >= 0 && $indexInt < $this->_results->length) {
-            $this->_currentIndex = $indexInt;
+        if ($indexInt >= 0 && $indexInt < $this->results->length) {
+            $this->currentIndex = $indexInt;
         } else {
             throw new OutOfBoundsException("Illegal index '$index'");
         }
@@ -246,7 +246,7 @@ abstract class ResultSet implements SeekableIterator
      */
     public function valid()
     {
-        return null !== $this->_results && $this->_currentIndex < $this->_results->length;
+        return null !== $this->results && $this->currentIndex < $this->results->length;
     }
 
     /**
@@ -256,7 +256,7 @@ abstract class ResultSet implements SeekableIterator
      */
     public function getXml()
     {
-        return $this->_dom->saveXML();
+        return $this->dom->saveXML();
     }
 
     /**
@@ -268,7 +268,7 @@ abstract class ResultSet implements SeekableIterator
      * @return void
      */
     public function __sleep() {
-        $this->_xml     = $this->getXml();
+        $this->xml     = $this->getXml();
         $vars = array_keys(get_object_vars($this));
         return array_diff($vars, array('_dom', '_xpath'));
     }
@@ -284,8 +284,8 @@ abstract class ResultSet implements SeekableIterator
      */
     public function __wakeup() {
         $dom = new DOMDocument();
-        $dom->loadXml($this->_xml);
-        $this->_init($dom);
-        $this->_xml = null; // reset XML content
+        $dom->loadXml($this->xml);
+        $this->init($dom);
+        $this->xml = null; // reset XML content
     }
 }

--- a/library/Zend/Service/Technorati/ResultSet.php
+++ b/library/Zend/Service/Technorati/ResultSet.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -38,7 +38,7 @@ use \DomDocument,
  * Result objects.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/ResultSet.php
+++ b/library/Zend/Service/Technorati/ResultSet.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,26 +24,27 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomDocument,
+    \DOMXPath,
+    \SeekableIterator,
+    \OutOfBoundsException;
+
 /**
  * This is the most essential result set.
  * The scope of this class is to be extended by a query-specific child result set class,
  * and it should never be used to initialize a standalone object.
  *
  * Each of the specific result sets represents a collection of query-specific
- * Zend_Service_Technorati_Result objects.
+ * Result objects.
  *
- * @uses       DOMDocument
- * @uses       DOMXpath
- * @uses       OutOfBoundsException
- * @uses       \Zend\Service\Technorati\Result
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @abstract
  */
-abstract class ResultSet implements \SeekableIterator
+abstract class ResultSet implements SeekableIterator
 {
     /**
      * The total number of results available
@@ -116,7 +117,7 @@ abstract class ResultSet implements \SeekableIterator
      * @param   DomDocument $dom    the ReST fragment for this object
      * @param   array $options      query options as associative array
      */
-    public function __construct(\DomDocument $dom, $options = array())
+    public function __construct(DomDocument $dom, $options = array())
     {
         $this->_init($dom, $options);
 
@@ -152,10 +153,10 @@ abstract class ResultSet implements \SeekableIterator
      * @param   array $options   query options as associative array
      *      * @return  void
      */
-    protected function _init(\DomDocument $dom, $options = array())
+    protected function _init(DomDocument $dom, $options = array())
     {
         $this->_dom     = $dom;
-        $this->_xpath   = new \DOMXPath($dom);
+        $this->_xpath   = new DOMXPath($dom);
 
         $this->_results = $this->_xpath->query("//item");
     }
@@ -234,7 +235,7 @@ abstract class ResultSet implements \SeekableIterator
         if ($indexInt >= 0 && $indexInt < $this->_results->length) {
             $this->_currentIndex = $indexInt;
         } else {
-            throw new \OutOfBoundsException("Illegal index '$index'");
+            throw new OutOfBoundsException("Illegal index '$index'");
         }
     }
 
@@ -282,7 +283,7 @@ abstract class ResultSet implements \SeekableIterator
      * @return void
      */
     public function __wakeup() {
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         $dom->loadXml($this->_xml);
         $this->_init($dom);
         $this->_xml = null; // reset XML content

--- a/library/Zend/Service/Technorati/SearchResult.php
+++ b/library/Zend/Service/Technorati/SearchResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,15 +24,16 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomElement,
+    Zend\Uri;
+
 /**
  * Represents a single Technorati Search query result object.
  * It is never returned as a standalone object,
- * but it always belongs to a valid Zend_Service_Technorati_SearchResultSet object.
+ * but it always belongs to a valid SearchResultSet object.
  *
- * @uses       \Zend\Service\Technorati\Result
- * @uses       \Zend\Service\Technorati\Utils
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -42,7 +43,7 @@ class SearchResult extends Result
     /**
      * Technorati weblog object corresponding to queried keyword.
      *
-     * @var     \Zend\Service\Technorati\Weblog
+     * @var     Weblog
      * @access  protected
      */
     protected $_weblog;
@@ -66,7 +67,7 @@ class SearchResult extends Result
     /**
      * The datetime the entry was created.
      *
-     * @var     Zend_Date
+     * @var     ZendDate
      * @access  protected
      */
     protected $_created;
@@ -74,7 +75,7 @@ class SearchResult extends Result
     /**
      * The permalink of the blog entry.
      *
-     * @var     \Zend\Uri\Http
+     * @var     Uri\Http
      * @access  protected
      */
     protected $_permalink;
@@ -85,7 +86,7 @@ class SearchResult extends Result
      *
      * @param   DomElement $dom the ReST fragment for this object
      */
-    public function __construct(\DomElement $dom)
+    public function __construct(DomElement $dom)
     {
         $this->_fields = array( '_permalink'    => 'permalink',
                                 '_excerpt'      => 'excerpt',
@@ -104,7 +105,7 @@ class SearchResult extends Result
     /**
      * Returns the weblog object that links queried URL.
      *
-     * @return  \Zend\Service\Technorati\Weblog
+     * @return  Weblog
      */
     public function getWeblog() {
         return $this->_weblog;
@@ -131,7 +132,7 @@ class SearchResult extends Result
     /**
      * Returns the datetime the entry was created.
      *
-     * @return  Zend_Date
+     * @return  ZendDate
      */
     public function getCreated() {
         return $this->_created;
@@ -140,7 +141,7 @@ class SearchResult extends Result
     /**
      * Returns the permalink of the blog entry.
      *
-     * @return  \Zend\Uri\Http
+     * @return  Uri\Http
      */
     public function getPermalink() {
         return $this->_permalink;

--- a/library/Zend/Service/Technorati/SearchResult.php
+++ b/library/Zend/Service/Technorati/SearchResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -33,7 +33,7 @@ use \DomElement,
  * but it always belongs to a valid SearchResultSet object.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/SearchResult.php
+++ b/library/Zend/Service/Technorati/SearchResult.php
@@ -46,7 +46,7 @@ class SearchResult extends Result
      * @var     Weblog
      * @access  protected
      */
-    protected $_weblog;
+    protected $weblog;
 
     /**
      * The title of the entry.
@@ -54,7 +54,7 @@ class SearchResult extends Result
      * @var     string
      * @access  protected
      */
-    protected $_title;
+    protected $title;
 
     /**
      * The blurb from entry with search term highlighted.
@@ -62,7 +62,7 @@ class SearchResult extends Result
      * @var     string
      * @access  protected
      */
-    protected $_excerpt;
+    protected $excerpt;
 
     /**
      * The datetime the entry was created.
@@ -70,7 +70,7 @@ class SearchResult extends Result
      * @var     ZendDate
      * @access  protected
      */
-    protected $_created;
+    protected $created;
 
     /**
      * The permalink of the blog entry.
@@ -78,7 +78,7 @@ class SearchResult extends Result
      * @var     Uri\Http
      * @access  protected
      */
-    protected $_permalink;
+    protected $permalink;
 
 
     /**
@@ -88,18 +88,18 @@ class SearchResult extends Result
      */
     public function __construct(DomElement $dom)
     {
-        $this->_fields = array( '_permalink'    => 'permalink',
-                                '_excerpt'      => 'excerpt',
-                                '_created'      => 'created',
-                                '_title'        => 'title');
+        $this->fields = array( 'permalink'    => 'permalink',
+                               'excerpt'      => 'excerpt',
+                               'created'      => 'created',
+                               'title'        => 'title');
         parent::__construct($dom);
 
         // weblog object field
-        $this->_parseWeblog();
+        $this->parseWeblog();
 
         // filter fields
-        $this->_permalink = Utils::normalizeUriHttp($this->_permalink);
-        $this->_created   = Utils::normalizeDate($this->_created);
+        $this->permalink = Utils::normalizeUriHttp($this->permalink);
+        $this->created   = Utils::normalizeDate($this->created);
     }
 
     /**
@@ -108,7 +108,7 @@ class SearchResult extends Result
      * @return  Weblog
      */
     public function getWeblog() {
-        return $this->_weblog;
+        return $this->weblog;
     }
 
     /**
@@ -117,7 +117,7 @@ class SearchResult extends Result
      * @return  string
      */
     public function getTitle() {
-        return $this->_title;
+        return $this->title;
     }
 
     /**
@@ -126,7 +126,7 @@ class SearchResult extends Result
      * @return  string
      */
     public function getExcerpt() {
-        return $this->_excerpt;
+        return $this->excerpt;
     }
 
     /**
@@ -135,7 +135,7 @@ class SearchResult extends Result
      * @return  ZendDate
      */
     public function getCreated() {
-        return $this->_created;
+        return $this->created;
     }
 
     /**
@@ -144,7 +144,7 @@ class SearchResult extends Result
      * @return  Uri\Http
      */
     public function getPermalink() {
-        return $this->_permalink;
+        return $this->permalink;
     }
 
 }

--- a/library/Zend/Service/Technorati/SearchResult.php
+++ b/library/Zend/Service/Technorati/SearchResult.php
@@ -20,24 +20,29 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a single Technorati Search query result object.
  * It is never returned as a standalone object,
  * but it always belongs to a valid Zend_Service_Technorati_SearchResultSet object.
  *
- * @uses       Zend_Service_Technorati_Result
- * @uses       Zend_Service_Technorati_Utils
+ * @uses       \Zend\Service\Technorati\Result
+ * @uses       \Zend\Service\Technorati\Utils
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_SearchResult extends Zend_Service_Technorati_Result
+class SearchResult extends Result
 {
     /**
      * Technorati weblog object corresponding to queried keyword.
      *
-     * @var     Zend_Service_Technorati_Weblog
+     * @var     \Zend\Service\Technorati\Weblog
      * @access  protected
      */
     protected $_weblog;
@@ -69,7 +74,7 @@ class Zend_Service_Technorati_SearchResult extends Zend_Service_Technorati_Resul
     /**
      * The permalink of the blog entry.
      *
-     * @var     Zend_Uri_Http
+     * @var     \Zend\Uri\Http
      * @access  protected
      */
     protected $_permalink;
@@ -80,7 +85,7 @@ class Zend_Service_Technorati_SearchResult extends Zend_Service_Technorati_Resul
      *
      * @param   DomElement $dom the ReST fragment for this object
      */
-    public function __construct(DomElement $dom)
+    public function __construct(\DomElement $dom)
     {
         $this->_fields = array( '_permalink'    => 'permalink',
                                 '_excerpt'      => 'excerpt',
@@ -92,14 +97,14 @@ class Zend_Service_Technorati_SearchResult extends Zend_Service_Technorati_Resul
         $this->_parseWeblog();
 
         // filter fields
-        $this->_permalink = Zend_Service_Technorati_Utils::normalizeUriHttp($this->_permalink);
-        $this->_created   = Zend_Service_Technorati_Utils::normalizeDate($this->_created);
+        $this->_permalink = Utils::normalizeUriHttp($this->_permalink);
+        $this->_created   = Utils::normalizeDate($this->_created);
     }
 
     /**
      * Returns the weblog object that links queried URL.
      *
-     * @return  Zend_Service_Technorati_Weblog
+     * @return  \Zend\Service\Technorati\Weblog
      */
     public function getWeblog() {
         return $this->_weblog;
@@ -135,7 +140,7 @@ class Zend_Service_Technorati_SearchResult extends Zend_Service_Technorati_Resul
     /**
      * Returns the permalink of the blog entry.
      *
-     * @return  Zend_Uri_Http
+     * @return  \Zend\Uri\Http
      */
     public function getPermalink() {
         return $this->_permalink;

--- a/library/Zend/Service/Technorati/SearchResultSet.php
+++ b/library/Zend/Service/Technorati/SearchResultSet.php
@@ -43,7 +43,7 @@ class SearchResultSet extends ResultSet
      * @var     int
      * @access  protected
      */
-    protected $_queryCount;
+    protected $queryCount;
 
     /**
      * Parses the search response and retrieve the results for iteration.
@@ -55,11 +55,11 @@ class SearchResultSet extends ResultSet
     {
         parent::__construct($dom, $options);
 
-        $result = $this->_xpath->query('/tapi/document/result/querycount/text()');
-        if ($result->length == 1) $this->_queryCount = (int) $result->item(0)->data;
+        $result = $this->xpath->query('/tapi/document/result/querycount/text()');
+        if ($result->length == 1) $this->queryCount = (int) $result->item(0)->data;
 
-        $this->_totalResultsReturned  = (int) $this->_xpath->evaluate("count(/tapi/document/item)");
-        $this->_totalResultsAvailable = (int) $this->_queryCount;
+        $this->totalResultsReturned  = (int) $this->xpath->evaluate("count(/tapi/document/item)");
+        $this->totalResultsAvailable = (int) $this->queryCount;
     }
 
     /**
@@ -69,6 +69,6 @@ class SearchResultSet extends ResultSet
      */
     public function current()
     {
-        return new SearchResult($this->_results->item($this->_currentIndex));
+        return new SearchResult($this->results->item($this->currentIndex));
     }
 }

--- a/library/Zend/Service/Technorati/SearchResultSet.php
+++ b/library/Zend/Service/Technorati/SearchResultSet.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -30,7 +30,7 @@ use \DomDocument;
  * Represents a Technorati Search query result set.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/SearchResultSet.php
+++ b/library/Zend/Service/Technorati/SearchResultSet.php
@@ -20,17 +20,22 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a Technorati Search query result set.
  *
- * @uses       Zend_Service_Technorati_ResultSet
- * @uses       Zend_Service_Technorati_SearchResult
+ * @uses       \Zend\Service\Technorati\ResultSet
+ * @uses       \Zend\Service\Technorati\SearchResult
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_SearchResultSet extends Zend_Service_Technorati_ResultSet
+class SearchResultSet extends ResultSet
 {
     /**
      * Number of query results.
@@ -46,7 +51,7 @@ class Zend_Service_Technorati_SearchResultSet extends Zend_Service_Technorati_Re
      * @param   DomDocument $dom    the ReST fragment for this object
      * @param   array $options      query options as associative array
      */
-    public function __construct(DomDocument $dom, $options = array())
+    public function __construct(\DomDocument $dom, $options = array())
     {
         parent::__construct($dom, $options);
 
@@ -60,10 +65,10 @@ class Zend_Service_Technorati_SearchResultSet extends Zend_Service_Technorati_Re
     /**
      * Implements Zend_Service_Technorati_ResultSet::current().
      *
-     * @return Zend_Service_Technorati_SearchResult current result
+     * @return \Zend\Service\Technorati\SearchResult current result
      */
     public function current()
     {
-        return new Zend_Service_Technorati_SearchResult($this->_results->item($this->_currentIndex));
+        return new SearchResult($this->_results->item($this->_currentIndex));
     }
 }

--- a/library/Zend/Service/Technorati/SearchResultSet.php
+++ b/library/Zend/Service/Technorati/SearchResultSet.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,13 +24,13 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomDocument;
+
 /**
  * Represents a Technorati Search query result set.
  *
- * @uses       \Zend\Service\Technorati\ResultSet
- * @uses       \Zend\Service\Technorati\SearchResult
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -51,7 +51,7 @@ class SearchResultSet extends ResultSet
      * @param   DomDocument $dom    the ReST fragment for this object
      * @param   array $options      query options as associative array
      */
-    public function __construct(\DomDocument $dom, $options = array())
+    public function __construct(DomDocument $dom, $options = array())
     {
         parent::__construct($dom, $options);
 
@@ -63,9 +63,9 @@ class SearchResultSet extends ResultSet
     }
 
     /**
-     * Implements Zend_Service_Technorati_ResultSet::current().
+     * Implements ResultSet::current().
      *
-     * @return \Zend\Service\Technorati\SearchResult current result
+     * @return SearchResult current result
      */
     public function current()
     {

--- a/library/Zend/Service/Technorati/TagResult.php
+++ b/library/Zend/Service/Technorati/TagResult.php
@@ -46,7 +46,7 @@ class TagResult extends Result
      * @var     Weblog
      * @access  protected
      */
-    protected $_weblog;
+    protected $weblog;
 
     /**
      * The title of the entry.
@@ -54,7 +54,7 @@ class TagResult extends Result
      * @var     string
      * @access  protected
      */
-    protected $_title;
+    protected $title;
 
     /**
      * The blurb from entry with search term highlighted.
@@ -62,7 +62,7 @@ class TagResult extends Result
      * @var     string
      * @access  protected
      */
-    protected $_excerpt;
+    protected $excerpt;
 
     /**
      * The datetime the entry was created.
@@ -70,7 +70,7 @@ class TagResult extends Result
      * @var     ZendDate
      * @access  protected
      */
-    protected $_created;
+    protected $created;
 
     /**
      * The datetime the entry was updated.
@@ -80,7 +80,7 @@ class TagResult extends Result
      * @var     ZendDate
      * @access  protected
      */
-    protected $_updated;
+    protected $updated;
 
     /**
      * The permalink of the blog entry.
@@ -88,7 +88,7 @@ class TagResult extends Result
      * @var     Uri\Http
      * @access  protected
      */
-    protected $_permalink;
+    protected $permalink;
 
 
     /**
@@ -98,20 +98,20 @@ class TagResult extends Result
      */
     public function __construct(DomElement $dom)
     {
-        $this->_fields = array( '_permalink'    => 'permalink',
-                                '_excerpt'      => 'excerpt',
-                                '_created'      => 'created',
-                                '_updated'      => 'postupdate',
-                                '_title'        => 'title');
+        $this->fields = array( 'permalink'    => 'permalink',
+                               'excerpt'      => 'excerpt',
+                               'created'      => 'created',
+                               'updated'      => 'postupdate',
+                               'title'        => 'title');
         parent::__construct($dom);
 
         // weblog object field
-        $this->_parseWeblog();
+        $this->parseWeblog();
 
         // filter fields
-        $this->_permalink = Utils::normalizeUriHttp($this->_permalink);
-        $this->_created   = Utils::normalizeDate($this->_created);
-        $this->_updated   = Utils::normalizeDate($this->_updated);
+        $this->permalink = Utils::normalizeUriHttp($this->permalink);
+        $this->created   = Utils::normalizeDate($this->created);
+        $this->updated   = Utils::normalizeDate($this->updated);
     }
 
     /**
@@ -120,7 +120,7 @@ class TagResult extends Result
      * @return  Weblog
      */
     public function getWeblog() {
-        return $this->_weblog;
+        return $this->weblog;
     }
 
     /**
@@ -129,7 +129,7 @@ class TagResult extends Result
      * @return  string
      */
     public function getTitle() {
-        return $this->_title;
+        return $this->title;
     }
 
     /**
@@ -138,7 +138,7 @@ class TagResult extends Result
      * @return  string
      */
     public function getExcerpt() {
-        return $this->_excerpt;
+        return $this->excerpt;
     }
 
     /**
@@ -147,7 +147,7 @@ class TagResult extends Result
      * @return  ZendDate
      */
     public function getCreated() {
-        return $this->_created;
+        return $this->created;
     }
 
     /**
@@ -156,7 +156,7 @@ class TagResult extends Result
      * @return  ZendDate
      */
     public function getUpdated() {
-        return $this->_updated;
+        return $this->updated;
     }
 
     /**
@@ -165,7 +165,7 @@ class TagResult extends Result
      * @return  Uri\Http
      */
     public function getPermalink() {
-        return $this->_permalink;
+        return $this->permalink;
     }
 
 }

--- a/library/Zend/Service/Technorati/TagResult.php
+++ b/library/Zend/Service/Technorati/TagResult.php
@@ -20,24 +20,29 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a single Technorati Tag query result object.
  * It is never returned as a standalone object,
  * but it always belongs to a valid Zend_Service_Technorati_TagResultSet object.
  *
- * @uses       Zend_Service_Technorati_Result
- * @uses       Zend_Service_Technorati_Utils
+ * @uses       \Zend\Service\Technorati\Result
+ * @uses       \Zend\Service\Technorati\Utils
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_TagResult extends Zend_Service_Technorati_Result
+class TagResult extends Result
 {
     /**
      * Technorati weblog object corresponding to queried keyword.
      *
-     * @var     Zend_Service_Technorati_Weblog
+     * @var     \Zend\Service\Technorati\Weblog
      * @access  protected
      */
     protected $_weblog;
@@ -79,7 +84,7 @@ class Zend_Service_Technorati_TagResult extends Zend_Service_Technorati_Result
     /**
      * The permalink of the blog entry.
      *
-     * @var     Zend_Uri_Http
+     * @var     \Zend\Uri\Http
      * @access  protected
      */
     protected $_permalink;
@@ -90,7 +95,7 @@ class Zend_Service_Technorati_TagResult extends Zend_Service_Technorati_Result
      *
      * @param   DomElement $dom the ReST fragment for this object
      */
-    public function __construct(DomElement $dom)
+    public function __construct(\DomElement $dom)
     {
         $this->_fields = array( '_permalink'    => 'permalink',
                                 '_excerpt'      => 'excerpt',
@@ -103,15 +108,15 @@ class Zend_Service_Technorati_TagResult extends Zend_Service_Technorati_Result
         $this->_parseWeblog();
 
         // filter fields
-        $this->_permalink = Zend_Service_Technorati_Utils::normalizeUriHttp($this->_permalink);
-        $this->_created   = Zend_Service_Technorati_Utils::normalizeDate($this->_created);
-        $this->_updated   = Zend_Service_Technorati_Utils::normalizeDate($this->_updated);
+        $this->_permalink = Utils::normalizeUriHttp($this->_permalink);
+        $this->_created   = Utils::normalizeDate($this->_created);
+        $this->_updated   = Utils::normalizeDate($this->_updated);
     }
 
     /**
      * Returns the weblog object that links queried URL.
      *
-     * @return  Zend_Service_Technorati_Weblog
+     * @return  \Zend\Service\Technorati\Weblog
      */
     public function getWeblog() {
         return $this->_weblog;
@@ -156,7 +161,7 @@ class Zend_Service_Technorati_TagResult extends Zend_Service_Technorati_Result
     /**
      * Returns the permalink of the blog entry.
      *
-     * @return  Zend_Uri_Http
+     * @return  \Zend\Uri\Http
      */
     public function getPermalink() {
         return $this->_permalink;

--- a/library/Zend/Service/Technorati/TagResult.php
+++ b/library/Zend/Service/Technorati/TagResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -33,7 +33,7 @@ use \DomElement,
  * but it always belongs to a valid TagResultSet object.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/TagResult.php
+++ b/library/Zend/Service/Technorati/TagResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,15 +24,16 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomElement,
+    Zend\Uri;
+
 /**
  * Represents a single Technorati Tag query result object.
  * It is never returned as a standalone object,
- * but it always belongs to a valid Zend_Service_Technorati_TagResultSet object.
+ * but it always belongs to a valid TagResultSet object.
  *
- * @uses       \Zend\Service\Technorati\Result
- * @uses       \Zend\Service\Technorati\Utils
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -42,7 +43,7 @@ class TagResult extends Result
     /**
      * Technorati weblog object corresponding to queried keyword.
      *
-     * @var     \Zend\Service\Technorati\Weblog
+     * @var     Weblog
      * @access  protected
      */
     protected $_weblog;
@@ -66,7 +67,7 @@ class TagResult extends Result
     /**
      * The datetime the entry was created.
      *
-     * @var     Zend_Date
+     * @var     ZendDate
      * @access  protected
      */
     protected $_created;
@@ -76,7 +77,7 @@ class TagResult extends Result
      * Called 'postupdate' in original XML response,
      * it has been renamed to provide more coherence.
      *
-     * @var     Zend_Date
+     * @var     ZendDate
      * @access  protected
      */
     protected $_updated;
@@ -84,7 +85,7 @@ class TagResult extends Result
     /**
      * The permalink of the blog entry.
      *
-     * @var     \Zend\Uri\Http
+     * @var     Uri\Http
      * @access  protected
      */
     protected $_permalink;
@@ -95,7 +96,7 @@ class TagResult extends Result
      *
      * @param   DomElement $dom the ReST fragment for this object
      */
-    public function __construct(\DomElement $dom)
+    public function __construct(DomElement $dom)
     {
         $this->_fields = array( '_permalink'    => 'permalink',
                                 '_excerpt'      => 'excerpt',
@@ -116,7 +117,7 @@ class TagResult extends Result
     /**
      * Returns the weblog object that links queried URL.
      *
-     * @return  \Zend\Service\Technorati\Weblog
+     * @return  Weblog
      */
     public function getWeblog() {
         return $this->_weblog;
@@ -143,7 +144,7 @@ class TagResult extends Result
     /**
      * Returns the datetime the entry was created.
      *
-     * @return  Zend_Date
+     * @return  ZendDate
      */
     public function getCreated() {
         return $this->_created;
@@ -152,7 +153,7 @@ class TagResult extends Result
     /**
      * Returns the datetime the entry was updated.
      *
-     * @return  Zend_Date
+     * @return  ZendDate
      */
     public function getUpdated() {
         return $this->_updated;
@@ -161,7 +162,7 @@ class TagResult extends Result
     /**
      * Returns the permalink of the blog entry.
      *
-     * @return  \Zend\Uri\Http
+     * @return  Uri\Http
      */
     public function getPermalink() {
         return $this->_permalink;

--- a/library/Zend/Service/Technorati/TagResultSet.php
+++ b/library/Zend/Service/Technorati/TagResultSet.php
@@ -43,7 +43,7 @@ class TagResultSet extends ResultSet
      * @var     int
      * @access  protected
      */
-    protected $_postsMatched;
+    protected $postsMatched;
 
     /**
      * Number of blogs that match the tag.
@@ -51,7 +51,7 @@ class TagResultSet extends ResultSet
      * @var     int
      * @access  protected
      */
-    protected $_blogsMatched;
+    protected $blogsMatched;
 
     /**
      * Parses the search response and retrieve the results for iteration.
@@ -63,15 +63,15 @@ class TagResultSet extends ResultSet
     {
         parent::__construct($dom, $options);
 
-        $result = $this->_xpath->query('/tapi/document/result/postsmatched/text()');
-        if ($result->length == 1) $this->_postsMatched = (int) $result->item(0)->data;
+        $result = $this->xpath->query('/tapi/document/result/postsmatched/text()');
+        if ($result->length == 1) $this->postsMatched = (int) $result->item(0)->data;
 
-        $result = $this->_xpath->query('/tapi/document/result/blogsmatched/text()');
-        if ($result->length == 1) $this->_blogsMatched = (int) $result->item(0)->data;
+        $result = $this->xpath->query('/tapi/document/result/blogsmatched/text()');
+        if ($result->length == 1) $this->blogsMatched = (int) $result->item(0)->data;
 
-        $this->_totalResultsReturned  = (int) $this->_xpath->evaluate("count(/tapi/document/item)");
+        $this->totalResultsReturned  = (int) $this->xpath->evaluate("count(/tapi/document/item)");
         /** @todo Validate the following assertion */
-        $this->_totalResultsAvailable = (int) $this->getPostsMatched();
+        $this->totalResultsAvailable = (int) $this->getPostsMatched();
     }
 
 
@@ -81,7 +81,7 @@ class TagResultSet extends ResultSet
      * @return  int
      */
     public function getPostsMatched() {
-        return $this->_postsMatched;
+        return $this->postsMatched;
     }
 
     /**
@@ -90,7 +90,7 @@ class TagResultSet extends ResultSet
      * @return  int
      */
     public function getBlogsMatched() {
-        return $this->_blogsMatched;
+        return $this->blogsMatched;
     }
 
     /**
@@ -100,6 +100,6 @@ class TagResultSet extends ResultSet
      */
     public function current()
     {
-        return new TagResult($this->_results->item($this->_currentIndex));
+        return new TagResult($this->results->item($this->currentIndex));
     }
 }

--- a/library/Zend/Service/Technorati/TagResultSet.php
+++ b/library/Zend/Service/Technorati/TagResultSet.php
@@ -20,17 +20,22 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a Technorati Tag query result set.
  *
- * @uses       Zend_Service_Technorati_ResultSet
- * @uses       Zend_Service_Technorati_TagResult
+ * @uses       \Zend\Service\Technorati\ResultSet
+ * @uses       \Zend\Service\Technorati\TagResult
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_TagResultSet extends Zend_Service_Technorati_ResultSet
+class TagResultSet extends ResultSet
 {
     /**
      * Number of posts that match the tag.
@@ -54,7 +59,7 @@ class Zend_Service_Technorati_TagResultSet extends Zend_Service_Technorati_Resul
      * @param   DomDocument $dom    the ReST fragment for this object
      * @param   array $options      query options as associative array
      */
-    public function __construct(DomDocument $dom, $options = array())
+    public function __construct(\DomDocument $dom, $options = array())
     {
         parent::__construct($dom, $options);
 
@@ -91,10 +96,10 @@ class Zend_Service_Technorati_TagResultSet extends Zend_Service_Technorati_Resul
     /**
      * Implements Zend_Service_Technorati_ResultSet::current().
      *
-     * @return Zend_Service_Technorati_TagResult current result
+     * @return \Zend\Service\Technorati\TagResult current result
      */
     public function current()
     {
-        return new Zend_Service_Technorati_TagResult($this->_results->item($this->_currentIndex));
+        return new TagResult($this->_results->item($this->_currentIndex));
     }
 }

--- a/library/Zend/Service/Technorati/TagResultSet.php
+++ b/library/Zend/Service/Technorati/TagResultSet.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,13 +24,13 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomDocument;
+
 /**
  * Represents a Technorati Tag query result set.
  *
- * @uses       \Zend\Service\Technorati\ResultSet
- * @uses       \Zend\Service\Technorati\TagResult
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -59,7 +59,7 @@ class TagResultSet extends ResultSet
      * @param   DomDocument $dom    the ReST fragment for this object
      * @param   array $options      query options as associative array
      */
-    public function __construct(\DomDocument $dom, $options = array())
+    public function __construct(DomDocument $dom, $options = array())
     {
         parent::__construct($dom, $options);
 
@@ -94,9 +94,9 @@ class TagResultSet extends ResultSet
     }
 
     /**
-     * Implements Zend_Service_Technorati_ResultSet::current().
+     * Implements ResultSet::current().
      *
-     * @return \Zend\Service\Technorati\TagResult current result
+     * @return TagResult current result
      */
     public function current()
     {

--- a/library/Zend/Service/Technorati/TagResultSet.php
+++ b/library/Zend/Service/Technorati/TagResultSet.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -30,7 +30,7 @@ use \DomDocument;
  * Represents a Technorati Tag query result set.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/TagsResult.php
+++ b/library/Zend/Service/Technorati/TagsResult.php
@@ -45,7 +45,7 @@ class TagsResult extends Result
      * @var     string
      * @access  protected
      */
-    protected $_tag;
+    protected $tag;
 
     /**
      * Number of posts containing this tag.
@@ -53,7 +53,7 @@ class TagsResult extends Result
      * @var     int
      * @access  protected
      */
-    protected $_posts;
+    protected $posts;
 
 
     /**
@@ -63,13 +63,13 @@ class TagsResult extends Result
      */
     public function __construct(DomElement $dom)
     {
-        $this->_fields = array( '_tag'   => 'tag',
-                                '_posts' => 'posts');
+        $this->fields = array( 'tag'   => 'tag',
+                               'posts' => 'posts');
         parent::__construct($dom);
 
         // filter fields
-        $this->_tag   = (string) $this->_tag;
-        $this->_posts = (int) $this->_posts;
+        $this->tag   = (string) $this->tag;
+        $this->posts = (int) $this->posts;
     }
 
     /**
@@ -78,7 +78,7 @@ class TagsResult extends Result
      * @return  string
      */
     public function getTag() {
-        return $this->_tag;
+        return $this->tag;
     }
 
     /**
@@ -87,6 +87,6 @@ class TagsResult extends Result
      * @return  int
      */
     public function getPosts() {
-        return $this->_posts;
+        return $this->posts;
     }
 }

--- a/library/Zend/Service/Technorati/TagsResult.php
+++ b/library/Zend/Service/Technorati/TagsResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -32,7 +32,7 @@ use \DomElement;
  * but it always belongs to a valid TagsResultSet object.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/TagsResult.php
+++ b/library/Zend/Service/Technorati/TagsResult.php
@@ -20,18 +20,23 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a single Technorati TopTags or BlogPostTags query result object.
  * It is never returned as a standalone object,
  * but it always belongs to a valid Zend_Service_Technorati_TagsResultSet object.
  *
- * @uses       Zend_Service_Technorati_Result
+ * @uses       \Zend\Service\Technorati\Result
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_TagsResult extends Zend_Service_Technorati_Result
+class TagsResult extends Result
 {
     /**
      * Name of the tag.
@@ -55,7 +60,7 @@ class Zend_Service_Technorati_TagsResult extends Zend_Service_Technorati_Result
      *
      * @param   DomElement $dom the ReST fragment for this object
      */
-    public function __construct(DomElement $dom)
+    public function __construct(\DomElement $dom)
     {
         $this->_fields = array( '_tag'   => 'tag',
                                 '_posts' => 'posts');

--- a/library/Zend/Service/Technorati/TagsResult.php
+++ b/library/Zend/Service/Technorati/TagsResult.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,14 +24,15 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomElement;
+
 /**
  * Represents a single Technorati TopTags or BlogPostTags query result object.
  * It is never returned as a standalone object,
- * but it always belongs to a valid Zend_Service_Technorati_TagsResultSet object.
+ * but it always belongs to a valid TagsResultSet object.
  *
- * @uses       \Zend\Service\Technorati\Result
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -60,7 +61,7 @@ class TagsResult extends Result
      *
      * @param   DomElement $dom the ReST fragment for this object
      */
-    public function __construct(\DomElement $dom)
+    public function __construct(DomElement $dom)
     {
         $this->_fields = array( '_tag'   => 'tag',
                                 '_posts' => 'posts');

--- a/library/Zend/Service/Technorati/TagsResultSet.php
+++ b/library/Zend/Service/Technorati/TagsResultSet.php
@@ -46,8 +46,8 @@ class TagsResultSet extends ResultSet
     {
         parent::__construct($dom, $options);
 
-        $this->_totalResultsReturned  = (int) $this->_xpath->evaluate("count(/tapi/document/item)");
-        $this->_totalResultsAvailable = (int) $this->_totalResultsReturned;
+        $this->totalResultsReturned  = (int) $this->xpath->evaluate("count(/tapi/document/item)");
+        $this->totalResultsAvailable = (int) $this->totalResultsReturned;
     }
 
     /**
@@ -57,6 +57,6 @@ class TagsResultSet extends ResultSet
      */
     public function current()
     {
-        return new TagsResult($this->_results->item($this->_currentIndex));
+        return new TagsResult($this->results->item($this->currentIndex));
     }
 }

--- a/library/Zend/Service/Technorati/TagsResultSet.php
+++ b/library/Zend/Service/Technorati/TagsResultSet.php
@@ -20,24 +20,29 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a Technorati TopTags or BlogPostTags queries result set.
  *
- * @uses       Zend_Service_Technorati_ResultSet
- * @uses       Zend_Service_Technorati_TagsResult
+ * @uses       \Zend\Service\Technorati\ResultSet
+ * @uses       \Zend\Service\Technorati\TagsResult
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_TagsResultSet extends Zend_Service_Technorati_ResultSet
+class TagsResultSet extends ResultSet
 {
     /**
      * Constructs a new object object from DOM Document.
      *
      * @param   DomDocument $dom the ReST fragment for this object
      */
-    public function __construct(DomDocument $dom, $options = array())
+    public function __construct(\DomDocument $dom, $options = array())
     {
         parent::__construct($dom, $options);
 
@@ -48,10 +53,10 @@ class Zend_Service_Technorati_TagsResultSet extends Zend_Service_Technorati_Resu
     /**
      * Implements Zend_Service_Technorati_ResultSet::current().
      *
-     * @return Zend_Service_Technorati_TagsResult current result
+     * @return \Zend\Service\Technorati\TagsResult current result
      */
     public function current()
     {
-        return new Zend_Service_Technorati_TagsResult($this->_results->item($this->_currentIndex));
+        return new TagsResult($this->_results->item($this->_currentIndex));
     }
 }

--- a/library/Zend/Service/Technorati/TagsResultSet.php
+++ b/library/Zend/Service/Technorati/TagsResultSet.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,13 +24,13 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomDocument;
+
 /**
  * Represents a Technorati TopTags or BlogPostTags queries result set.
  *
- * @uses       \Zend\Service\Technorati\ResultSet
- * @uses       \Zend\Service\Technorati\TagsResult
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -42,7 +42,7 @@ class TagsResultSet extends ResultSet
      *
      * @param   DomDocument $dom the ReST fragment for this object
      */
-    public function __construct(\DomDocument $dom, $options = array())
+    public function __construct(DomDocument $dom, $options = array())
     {
         parent::__construct($dom, $options);
 
@@ -51,9 +51,9 @@ class TagsResultSet extends ResultSet
     }
 
     /**
-     * Implements Zend_Service_Technorati_ResultSet::current().
+     * Implements ResultSet::current().
      *
-     * @return \Zend\Service\Technorati\TagsResult current result
+     * @return TagsResult current result
      */
     public function current()
     {

--- a/library/Zend/Service/Technorati/TagsResultSet.php
+++ b/library/Zend/Service/Technorati/TagsResultSet.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -30,7 +30,7 @@ use \DomDocument;
  * Represents a Technorati TopTags or BlogPostTags queries result set.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/Technorati.php
+++ b/library/Zend/Service/Technorati/Technorati.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -23,29 +23,19 @@
  * @namespace
  */
 namespace Zend\Service\Technorati;
-use Zend\Http\Response;
+use Zend\Http\Response,
+    Zend\Rest\Client\RestClient,
+    \DomDocument;
 
 /**
- * Zend_Service_Technorati provides an easy, intuitive and object-oriented interface
+ * Zend\Service\Technorati provides an easy, intuitive and object-oriented interface
  * for using the Technorati API.
  *
  * It provides access to all available Technorati API queries
  * and returns the original XML response as a friendly PHP object.
  *
- * @uses       DOMDocument
- * @uses       DOMXPath
- * @uses       Zend_Rest_Client
- * @uses       \Zend\Service\Technorati\BlogInfoResult
- * @uses       \Zend\Service\Technorati\CosmosResultSet
- * @uses       \Zend\Service\Technorati\DailyCountsResultSet
- * @uses       \Zend\Service\Technorati\Exception\RuntimeException
- * @uses       \Zend\Service\Technorati\GetInfoResult
- * @uses       \Zend\Service\Technorati\KeyInfoResult
- * @uses       \Zend\Service\Technorati\SearchResultSet
- * @uses       \Zend\Service\Technorati\TagResultSet
- * @uses       \Zend\Service\Technorati\TagsResultSet
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -83,16 +73,16 @@ class Technorati
     protected $_apiKey;
 
     /**
-     * Zend_Rest_Client instance
+     * RestClient instance
      *
-     * @var     Zend_Rest_Client
+     * @var     RestClient
      * @access  protected
      */
     protected $_restClient;
 
 
     /**
-     * Constructs a new Zend_Service_Technorati instance
+     * Constructs a new Zend\Service\Technorati instance
      * and setup character encoding.
      *
      * @param  string $apiKey  Your Technorati API key
@@ -149,8 +139,8 @@ class Technorati
      *
      * @param   string $url     the URL you are searching for. Prefixes http:// and www. are optional.
      * @param   array $options  additional parameters to refine your query
-     * @return  \Zend\Service\Technorati\CosmosResultSet
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @return  CosmosResultSet
+     * @throws  Exception\RuntimeException
      * @link    http://technorati.com/developers/api/cosmos.html Technorati API: Cosmos Query reference
      */
     public function cosmos($url, $options = null)
@@ -211,8 +201,8 @@ class Technorati
      *
      * @param   string $query   the words you are searching for.
      * @param   array $options  additional parameters to refine your query
-     * @return  \Zend\Service\Technorati\SearchResultSet
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @return  SearchResultSet
+     * @throws  Exception\RuntimeException
      * @link    http://technorati.com/developers/api/search.html Technorati API: Search Query reference
      */
     public function search($query, $options = null)
@@ -254,8 +244,8 @@ class Technorati
      *
      * @param   string $tag     the tag term you are searching posts for.
      * @param   array $options  additional parameters to refine your query
-     * @return  \Zend\Service\Technorati\TagResultSet
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @return  TagResultSet
+     * @throws  Exception\RuntimeException
      *  @link    http://technorati.com/developers/api/tag.html Technorati API: Tag Query reference
      */
     public function tag($tag, $options = null)
@@ -288,8 +278,8 @@ class Technorati
      *
      * @param   string $q       the keyword query
      * @param   array $options  additional parameters to refine your query
-     * @return  \Zend\Service\Technorati\DailyCountsResultSet
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @return  DailyCountsResultSet
+     * @throws  Exception\RuntimeException
      * @link    http://technorati.com/developers/api/dailycounts.html Technorati API: DailyCounts Query reference
      */
     public function dailyCounts($query, $options = null)
@@ -323,8 +313,8 @@ class Technorati
      *      The default start value is 1.
      *
      * @param   array $options  additional parameters to refine your query
-     * @return  \Zend\Service\Technorati\TagsResultSet
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @return  TagsResultSet
+     * @throws  Exception\RuntimeException
      * @link    http://technorati.com/developers/api/toptags.html Technorati API: TopTags Query reference
      */
     public function topTags($options = null)
@@ -348,8 +338,8 @@ class Technorati
      * @param   string $url     the URL you are searching for. Prefixes http:// and www. are optional.
      *                          The URL must be recognized by Technorati as a blog.
      * @param   array $options  additional parameters to refine your query
-     * @return  \Zend\Service\Technorati\BlogInfoResult
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @return  BlogInfoResult
+     * @throws  Exception\RuntimeException
      * @link    http://technorati.com/developers/api/bloginfo.html Technorati API: BlogInfo Query reference
      */
     public function blogInfo($url, $options = null)
@@ -385,8 +375,8 @@ class Technorati
      * @param   string $url     the URL you are searching for. Prefixes http:// and www. are optional.
      *                          The URL must be recognized by Technorati as a blog.
      * @param   array $options  additional parameters to refine your query
-     * @return  \Zend\Service\Technorati\TagsResultSet
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @return  TagsResultSet
+     * @throws  Exception\RuntimeException
      * @link    http://technorati.com/developers/api/blogposttags.html Technorati API: BlogPostTags Query reference
      */
     public function blogPostTags($url, $options = null)
@@ -418,8 +408,8 @@ class Technorati
      *
      * @param   string $username    the Technorati user name you are searching for
      * @param   array $options      additional parameters to refine your query
-     * @return  \Zend\Service\Technorati\GetInfoResult
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @return  GetInfoResult
+     * @throws  Exception\RuntimeException
      * @link    http://technorati.com/developers/api/getinfo.html Technorati API: GetInfo reference
      */
     public function getInfo($username, $options = null)
@@ -442,8 +432,8 @@ class Technorati
      *
      * A day is defined as 00:00-23:59 Pacific time.
      *
-     * @return  \Zend\Service\Technorati\KeyInfoResult
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @return  KeyInfoResult
+     * @throws  Exception\RuntimeException
      * @link    http://developers.technorati.com/wiki/KeyInfo Technorati API: Key Info reference
      */
     public function keyInfo()
@@ -475,14 +465,14 @@ class Technorati
      * Returns a reference to the REST client object in use.
      *
      * If the reference hasn't being inizialized yet,
-     * then a new Zend_Rest_Client instance is created.
+     * then a new Client instance is created.
      *
-     * @return Zend_Rest_Client
+     * @return RestClient
      */
     public function getRestClient()
     {
         if ($this->_restClient === null) {
-            $this->_restClient = new \Zend\Rest\Client\RestClient(self::API_URI_BASE);
+            $this->_restClient = new RestClient(self::API_URI_BASE);
         }
 
         return $this->_restClient;
@@ -494,7 +484,7 @@ class Technorati
      * Be aware that this function doesn't validate the key.
      * The key is validated as soon as the first API request is sent.
      * If the key is invalid, the API request method will throw
-     * a Zend_Service_Technorati_Exception exception with Invalid Key message.
+     * a Exception exception with Invalid Key message.
      *
      * @param   string $key     Technorati API Key
      * @return  void
@@ -512,7 +502,7 @@ class Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @throws  Exception\RuntimeException
      * @access  protected
      */
     protected function _validateCosmos(array $options)
@@ -549,7 +539,7 @@ class Technorati
      *
      * @param   array   $options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @throws  Exception\RuntimeException
      * @access  protected
      */
     protected function _validateSearch(array $options)
@@ -578,7 +568,7 @@ class Technorati
      *
      * @param   array   $options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @throws  Exception\RuntimeException
      * @access  protected
      */
     protected function _validateTag(array $options)
@@ -608,7 +598,7 @@ class Technorati
      *
      * @param   array   $options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @throws  Exception\RuntimeException
      * @access  protected
      */
     protected function _validateDailyCounts(array $options)
@@ -638,7 +628,7 @@ class Technorati
      *
      * @param   array   $options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @throws  Exception\RuntimeException
      * @access  protected
      */
     protected function _validateGetInfo(array $options)
@@ -659,7 +649,7 @@ class Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @throws  Exception\RuntimeException
      * @access  protected
      */
     protected function _validateTopTags(array $options)
@@ -682,7 +672,7 @@ class Technorati
      *
      * @param   array   $options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @throws  Exception\RuntimeException
      * @access  protected
      */
     protected function _validateBlogInfo(array $options)
@@ -703,7 +693,7 @@ class Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @throws  Exception\RuntimeException
      * @access  protected
      */
     protected function _validateBlogPostTags(array $options)
@@ -730,7 +720,7 @@ class Technorati
      * @param   array $options
      * @param   array $array    array of valid options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @throws  Exception\RuntimeException
      * @access  protected
      */
     protected function _validateInArrayOption($name, $options, array $array)
@@ -746,7 +736,7 @@ class Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @throws  Exception\RuntimeException
      * @access  protected
      */
     protected function _validateMandatoryOption($name, $options)
@@ -777,8 +767,8 @@ class Technorati
      *
      * @param   string $path
      * @param   array $options
-     * @return  \Zend\Http\Response
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException on failure
+     * @return  Response
+     * @throws  Exception\RuntimeException on failure
      * @access  protected
      */
     protected function _makeRequest($path, $options = array())
@@ -804,11 +794,11 @@ class Technorati
 
     /**
      * Checks whether 'format' option value is valid.
-     * Be aware that Zend_Service_Technorati supports only XML as format value.
+     * Be aware that Zend\Service\Technorati supports only XML as format value.
      *
      * @param   array $options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if 'format' value != XML
+     * @throws  Exception\RuntimeException if 'format' value != XML
      * @access  protected
      */
     protected function _validateOptionFormat(array $options)
@@ -816,7 +806,7 @@ class Technorati
         if (isset($options['format']) && $options['format'] != 'xml') {
             throw new Exception\RuntimeException(
                         "Invalid value '" . $options['format'] . "' for 'format' option. " .
-                        "Zend_Service_Technorati supports only 'xml'");
+                        "Zend\Service\Technorati supports only 'xml'");
         }
     }
 
@@ -827,7 +817,7 @@ class Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if 'limit' value is invalid
+     * @throws  Exception\RuntimeException if 'limit' value is invalid
      * @access  protected
      */
     protected function _validateOptionLimit(array $options)
@@ -848,7 +838,7 @@ class Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if 'start' value is invalid
+     * @throws  Exception\RuntimeException if 'start' value is invalid
      * @access  protected
      */
     protected function _validateOptionStart(array $options)
@@ -868,9 +858,9 @@ class Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if 'url' value is invalid
+     * @throws  Exception\RuntimeException if 'url' value is invalid
      * @access  protected
-     * @todo    support for Zend_Uri_Http
+     * @todo    support for Zend\Uri\Http
      */
     protected function _validateOptionUrl(array $options)
     {
@@ -882,11 +872,11 @@ class Technorati
      *
      * @param   DomDocument $dom    the XML response as a DOM document
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @throws  Exception\RuntimeException
      * @link    http://technorati.com/developers/api/error.html Technorati API: Error response
      * @access  protected
      */
-    protected static function _checkErrors(\DomDocument $dom)
+    protected static function _checkErrors(DomDocument $dom)
     {
         $xpath = new \DOMXPath($dom);
 
@@ -900,9 +890,9 @@ class Technorati
     /**
      * Converts $response body to a DOM object and checks it.
      *
-     * @param   \Zend\Http\Response $response
+     * @param   Response $response
      * @return  DOMDocument
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if response content contains an error message
+     * @throws  Exception\RuntimeException if response content contains an error message
      * @access  protected
      */
     protected function _convertResponseAndCheckContent(Response $response)
@@ -916,9 +906,9 @@ class Technorati
     /**
      * Checks ReST response for errors.
      *
-     * @param   \Zend\Http\Response $response    the ReST response
+     * @param   Response $response    the ReST response
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @throws  Exception\RuntimeException
      * @access  protected
      */
     protected static function _checkResponse(Response $response)
@@ -936,7 +926,7 @@ class Technorati
      * @param   array $options        user options
      * @param   array $validOptions   valid options
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @throws  Exception\RuntimeException
      * @access  protected
      */
     protected function _compareOptions(array $options, array $validOptions)

--- a/library/Zend/Service/Technorati/Technorati.php
+++ b/library/Zend/Service/Technorati/Technorati.php
@@ -70,7 +70,7 @@ class Technorati
      * @var     string
      * @access  protected
      */
-    protected $_apiKey;
+    protected $apiKey;
 
     /**
      * RestClient instance
@@ -78,7 +78,7 @@ class Technorati
      * @var     RestClient
      * @access  protected
      */
-    protected $_restClient;
+    protected $restClient;
 
 
     /**
@@ -93,7 +93,7 @@ class Technorati
         iconv_set_encoding('input_encoding', 'UTF-8');
         iconv_set_encoding('internal_encoding', 'UTF-8');
 
-        $this->_apiKey = $apiKey;
+        $this->apiKey = $apiKey;
     }
 
 
@@ -156,10 +156,10 @@ class Technorati
 
         $options['url'] = $url;
 
-        $options = $this->_prepareOptions($options, $defaultOptions);
-        $this->_validateCosmos($options);
-        $response = $this->_makeRequest(self::API_PATH_COSMOS, $options);
-        $dom = $this->_convertResponseAndCheckContent($response);
+        $options = $this->prepareOptions($options, $defaultOptions);
+        $this->validateCosmos($options);
+        $response = $this->makeRequest(self::API_PATH_COSMOS, $options);
+        $dom = $this->convertResponseAndCheckContent($response);
 
         return new CosmosResultSet($dom, $options);
     }
@@ -214,10 +214,10 @@ class Technorati
 
         $options['query'] = $query;
 
-        $options = $this->_prepareOptions($options, $defaultOptions);
-        $this->_validateSearch($options);
-        $response = $this->_makeRequest(self::API_PATH_SEARCH, $options);
-        $dom = $this->_convertResponseAndCheckContent($response);
+        $options = $this->prepareOptions($options, $defaultOptions);
+        $this->validateSearch($options);
+        $response = $this->makeRequest(self::API_PATH_SEARCH, $options);
+        $dom = $this->convertResponseAndCheckContent($response);
 
         return new SearchResultSet($dom, $options);
     }
@@ -258,10 +258,10 @@ class Technorati
 
         $options['tag'] = $tag;
 
-        $options = $this->_prepareOptions($options, $defaultOptions);
-        $this->_validateTag($options);
-        $response = $this->_makeRequest(self::API_PATH_TAG, $options);
-        $dom = $this->_convertResponseAndCheckContent($response);
+        $options = $this->prepareOptions($options, $defaultOptions);
+        $this->validateTag($options);
+        $response = $this->makeRequest(self::API_PATH_TAG, $options);
+        $dom = $this->convertResponseAndCheckContent($response);
 
         return new TagResultSet($dom, $options);
     }
@@ -290,10 +290,10 @@ class Technorati
 
         $options['q'] = $query;
 
-        $options = $this->_prepareOptions($options, $defaultOptions);
-        $this->_validateDailyCounts($options);
-        $response = $this->_makeRequest(self::API_PATH_DAILYCOUNTS, $options);
-        $dom = $this->_convertResponseAndCheckContent($response);
+        $options = $this->prepareOptions($options, $defaultOptions);
+        $this->validateDailyCounts($options);
+        $response = $this->makeRequest(self::API_PATH_DAILYCOUNTS, $options);
+        $dom = $this->convertResponseAndCheckContent($response);
 
         return new DailyCountsResultSet($dom);
     }
@@ -324,10 +324,10 @@ class Technorati
                                         'format'    => 'xml'
                                         );
 
-        $options = $this->_prepareOptions($options, $defaultOptions);
-        $this->_validateTopTags($options);
-        $response = $this->_makeRequest(self::API_PATH_TOPTAGS, $options);
-        $dom = $this->_convertResponseAndCheckContent($response);
+        $options = $this->prepareOptions($options, $defaultOptions);
+        $this->validateTopTags($options);
+        $response = $this->makeRequest(self::API_PATH_TOPTAGS, $options);
+        $dom = $this->convertResponseAndCheckContent($response);
 
         return new TagsResultSet($dom);
     }
@@ -349,10 +349,10 @@ class Technorati
 
         $options['url'] = $url;
 
-        $options = $this->_prepareOptions($options, $defaultOptions);
-        $this->_validateBlogInfo($options);
-        $response = $this->_makeRequest(self::API_PATH_BLOGINFO, $options);
-        $dom = $this->_convertResponseAndCheckContent($response);
+        $options = $this->prepareOptions($options, $defaultOptions);
+        $this->validateBlogInfo($options);
+        $response = $this->makeRequest(self::API_PATH_BLOGINFO, $options);
+        $dom = $this->convertResponseAndCheckContent($response);
 
         return new BlogInfoResult($dom);
     }
@@ -388,10 +388,10 @@ class Technorati
 
         $options['url'] = $url;
 
-        $options = $this->_prepareOptions($options, $defaultOptions);
-        $this->_validateBlogPostTags($options);
-        $response = $this->_makeRequest(self::API_PATH_BLOGPOSTTAGS, $options);
-        $dom = $this->_convertResponseAndCheckContent($response);
+        $options = $this->prepareOptions($options, $defaultOptions);
+        $this->validateBlogPostTags($options);
+        $response = $this->makeRequest(self::API_PATH_BLOGPOSTTAGS, $options);
+        $dom = $this->convertResponseAndCheckContent($response);
 
         return new TagsResultSet($dom);
     }
@@ -418,10 +418,10 @@ class Technorati
 
         $options['username'] = $username;
 
-        $options = $this->_prepareOptions($options, $defaultOptions);
-        $this->_validateGetInfo($options);
-        $response = $this->_makeRequest(self::API_PATH_GETINFO, $options);
-        $dom = $this->_convertResponseAndCheckContent($response);
+        $options = $this->prepareOptions($options, $defaultOptions);
+        $this->validateGetInfo($options);
+        $response = $this->makeRequest(self::API_PATH_GETINFO, $options);
+        $dom = $this->convertResponseAndCheckContent($response);
 
         return new GetInfoResult($dom);
     }
@@ -440,14 +440,14 @@ class Technorati
     {
         static $defaultOptions = array();
 
-        $options = $this->_prepareOptions(array(), $defaultOptions);
+        $options = $this->prepareOptions(array(), $defaultOptions);
         // you don't need to validate this request
         // because key is the only mandatory element
         // and it's already set in #_prepareOptions
-        $response = $this->_makeRequest(self::API_PATH_KEYINFO, $options);
-        $dom = $this->_convertResponseAndCheckContent($response);
+        $response = $this->makeRequest(self::API_PATH_KEYINFO, $options);
+        $dom = $this->convertResponseAndCheckContent($response);
 
-        return new KeyInfoResult($dom, $this->_apiKey);
+        return new KeyInfoResult($dom, $this->apiKey);
     }
 
 
@@ -458,7 +458,7 @@ class Technorati
      */
     public function getApiKey()
     {
-        return $this->_apiKey;
+        return $this->apiKey;
     }
 
     /**
@@ -471,11 +471,11 @@ class Technorati
      */
     public function getRestClient()
     {
-        if ($this->_restClient === null) {
-            $this->_restClient = new RestClient(self::API_URI_BASE);
+        if ($this->restClient === null) {
+            $this->restClient = new RestClient(self::API_URI_BASE);
         }
 
-        return $this->_restClient;
+        return $this->restClient;
     }
 
     /**
@@ -492,7 +492,7 @@ class Technorati
      */
     public function setApiKey($key)
     {
-        $this->_apiKey = $key;
+        $this->apiKey = $key;
         return $this;
     }
 
@@ -505,27 +505,27 @@ class Technorati
      * @throws  Exception\RuntimeException
      * @access  protected
      */
-    protected function _validateCosmos(array $options)
+    protected function validateCosmos(array $options)
     {
         static $validOptions = array('key', 'url',
             'type', 'limit', 'start', 'current', 'claim', 'highlight', 'format');
 
         // Validate keys in the $options array
-        $this->_compareOptions($options, $validOptions);
+        $this->compareOptions($options, $validOptions);
         // Validate url (required)
-        $this->_validateOptionUrl($options);
+        $this->validateOptionUrl($options);
         // Validate limit (optional)
-        $this->_validateOptionLimit($options);
+        $this->validateOptionLimit($options);
         // Validate start (optional)
-        $this->_validateOptionStart($options);
+        $this->validateOptionStart($options);
         // Validate format (optional)
-        $this->_validateOptionFormat($options);
+        $this->validateOptionFormat($options);
         // Validate type (optional)
-        $this->_validateInArrayOption('type', $options, array('link', 'weblog'));
+        $this->validateInArrayOption('type', $options, array('link', 'weblog'));
         // Validate claim (optional)
-        $this->_validateOptionClaim($options);
+        $this->validateOptionClaim($options);
         // Validate highlight (optional)
-        $this->_validateIntegerOption('highlight', $options);
+        $this->validateIntegerOption('highlight', $options);
         // Validate current (optional)
         if (isset($options['current'])) {
             $tmp = (int) $options['current'];
@@ -542,25 +542,25 @@ class Technorati
      * @throws  Exception\RuntimeException
      * @access  protected
      */
-    protected function _validateSearch(array $options)
+    protected function validateSearch(array $options)
     {
         static $validOptions = array('key', 'query',
             'language', 'authority', 'limit', 'start', 'claim', 'format');
 
         // Validate keys in the $options array
-        $this->_compareOptions($options, $validOptions);
+        $this->compareOptions($options, $validOptions);
         // Validate query (required)
-        $this->_validateMandatoryOption('query', $options);
+        $this->validateMandatoryOption('query', $options);
         // Validate authority (optional)
-        $this->_validateInArrayOption('authority', $options, array('n', 'a1', 'a4', 'a7'));
+        $this->validateInArrayOption('authority', $options, array('n', 'a1', 'a4', 'a7'));
         // Validate limit (optional)
-        $this->_validateOptionLimit($options);
+        $this->validateOptionLimit($options);
         // Validate start (optional)
-        $this->_validateOptionStart($options);
+        $this->validateOptionStart($options);
         // Validate claim (optional)
-        $this->_validateOptionClaim($options);
+        $this->validateOptionClaim($options);
         // Validate format (optional)
-        $this->_validateOptionFormat($options);
+        $this->validateOptionFormat($options);
     }
 
     /**
@@ -571,25 +571,25 @@ class Technorati
      * @throws  Exception\RuntimeException
      * @access  protected
      */
-    protected function _validateTag(array $options)
+    protected function validateTag(array $options)
     {
         static $validOptions = array('key', 'tag',
             'limit', 'start', 'excerptsize', 'topexcerptsize', 'format');
 
         // Validate keys in the $options array
-        $this->_compareOptions($options, $validOptions);
+        $this->compareOptions($options, $validOptions);
         // Validate query (required)
-        $this->_validateMandatoryOption('tag', $options);
+        $this->validateMandatoryOption('tag', $options);
         // Validate limit (optional)
-        $this->_validateOptionLimit($options);
+        $this->validateOptionLimit($options);
         // Validate start (optional)
-        $this->_validateOptionStart($options);
+        $this->validateOptionStart($options);
         // Validate excerptsize (optional)
-        $this->_validateIntegerOption('excerptsize', $options);
+        $this->validateIntegerOption('excerptsize', $options);
         // Validate excerptsize (optional)
-        $this->_validateIntegerOption('topexcerptsize', $options);
+        $this->validateIntegerOption('topexcerptsize', $options);
         // Validate format (optional)
-        $this->_validateOptionFormat($options);
+        $this->validateOptionFormat($options);
     }
 
 
@@ -601,17 +601,17 @@ class Technorati
      * @throws  Exception\RuntimeException
      * @access  protected
      */
-    protected function _validateDailyCounts(array $options)
+    protected function validateDailyCounts(array $options)
     {
         static $validOptions = array('key', 'q',
             'days', 'format');
 
         // Validate keys in the $options array
-        $this->_compareOptions($options, $validOptions);
+        $this->compareOptions($options, $validOptions);
         // Validate q (required)
-        $this->_validateMandatoryOption('q', $options);
+        $this->validateMandatoryOption('q', $options);
         // Validate format (optional)
-        $this->_validateOptionFormat($options);
+        $this->validateOptionFormat($options);
         // Validate days (optional)
         if (isset($options['days'])) {
             $options['days'] = (int) $options['days'];
@@ -631,17 +631,17 @@ class Technorati
      * @throws  Exception\RuntimeException
      * @access  protected
      */
-    protected function _validateGetInfo(array $options)
+    protected function validateGetInfo(array $options)
     {
         static $validOptions = array('key', 'username',
             'format');
 
         // Validate keys in the $options array
-        $this->_compareOptions($options, $validOptions);
+        $this->compareOptions($options, $validOptions);
         // Validate username (required)
-        $this->_validateMandatoryOption('username', $options);
+        $this->validateMandatoryOption('username', $options);
         // Validate format (optional)
-        $this->_validateOptionFormat($options);
+        $this->validateOptionFormat($options);
     }
 
     /**
@@ -652,19 +652,19 @@ class Technorati
      * @throws  Exception\RuntimeException
      * @access  protected
      */
-    protected function _validateTopTags(array $options)
+    protected function validateTopTags(array $options)
     {
         static $validOptions = array('key',
             'limit', 'start', 'format');
 
         // Validate keys in the $options array
-        $this->_compareOptions($options, $validOptions);
+        $this->compareOptions($options, $validOptions);
         // Validate limit (optional)
-        $this->_validateOptionLimit($options);
+        $this->validateOptionLimit($options);
         // Validate start (optional)
-        $this->_validateOptionStart($options);
+        $this->validateOptionStart($options);
         // Validate format (optional)
-        $this->_validateOptionFormat($options);
+        $this->validateOptionFormat($options);
     }
 
     /**
@@ -675,17 +675,17 @@ class Technorati
      * @throws  Exception\RuntimeException
      * @access  protected
      */
-    protected function _validateBlogInfo(array $options)
+    protected function validateBlogInfo(array $options)
     {
         static $validOptions = array('key', 'url',
             'format');
 
         // Validate keys in the $options array
-        $this->_compareOptions($options, $validOptions);
+        $this->compareOptions($options, $validOptions);
         // Validate url (required)
-        $this->_validateOptionUrl($options);
+        $this->validateOptionUrl($options);
         // Validate format (optional)
-        $this->_validateOptionFormat($options);
+        $this->validateOptionFormat($options);
     }
 
     /**
@@ -696,21 +696,21 @@ class Technorati
      * @throws  Exception\RuntimeException
      * @access  protected
      */
-    protected function _validateBlogPostTags(array $options)
+    protected function validateBlogPostTags(array $options)
     {
         static $validOptions = array('key', 'url',
             'limit', 'start', 'format');
 
         // Validate keys in the $options array
-        $this->_compareOptions($options, $validOptions);
+        $this->compareOptions($options, $validOptions);
         // Validate url (required)
-        $this->_validateOptionUrl($options);
+        $this->validateOptionUrl($options);
         // Validate limit (optional)
-        $this->_validateOptionLimit($options);
+        $this->validateOptionLimit($options);
         // Validate start (optional)
-        $this->_validateOptionStart($options);
+        $this->validateOptionStart($options);
         // Validate format (optional)
-        $this->_validateOptionFormat($options);
+        $this->validateOptionFormat($options);
     }
 
     /**
@@ -723,7 +723,7 @@ class Technorati
      * @throws  Exception\RuntimeException
      * @access  protected
      */
-    protected function _validateInArrayOption($name, $options, array $array)
+    protected function validateInArrayOption($name, $options, array $array)
     {
         if (isset($options[$name]) && !in_array($options[$name], $array)) {
             throw new Exception\RuntimeException(
@@ -739,7 +739,7 @@ class Technorati
      * @throws  Exception\RuntimeException
      * @access  protected
      */
-    protected function _validateMandatoryOption($name, $options)
+    protected function validateMandatoryOption($name, $options)
     {
         if (!isset($options[$name]) || !trim($options[$name])) {
             throw new Exception\RuntimeException(
@@ -754,7 +754,7 @@ class Technorati
      * @return  void
      * @access  protected
      */
-    protected function _validateIntegerOption($name, $options)
+    protected function validateIntegerOption($name, $options)
     {
         if (isset($options[$name])) {
             $options[$name] = (int) $options[$name];
@@ -771,12 +771,12 @@ class Technorati
      * @throws  Exception\RuntimeException on failure
      * @access  protected
      */
-    protected function _makeRequest($path, $options = array())
+    protected function makeRequest($path, $options = array())
     {
         $restClient = $this->getRestClient();
         $restClient->getHttpClient()->resetParameters();
         $response = $restClient->restGet($path, $options);
-        self::_checkResponse($response);
+        self::checkResponse($response);
         return $response;
     }
 
@@ -787,9 +787,9 @@ class Technorati
      * @return  void
      * @access  protected
      */
-    protected function _validateOptionClaim(array $options)
+    protected function validateOptionClaim(array $options)
     {
-        $this->_validateIntegerOption('claim', $options);
+        $this->validateIntegerOption('claim', $options);
     }
 
     /**
@@ -801,7 +801,7 @@ class Technorati
      * @throws  Exception\RuntimeException if 'format' value != XML
      * @access  protected
      */
-    protected function _validateOptionFormat(array $options)
+    protected function validateOptionFormat(array $options)
     {
         if (isset($options['format']) && $options['format'] != 'xml') {
             throw new Exception\RuntimeException(
@@ -820,7 +820,7 @@ class Technorati
      * @throws  Exception\RuntimeException if 'limit' value is invalid
      * @access  protected
      */
-    protected function _validateOptionLimit(array $options)
+    protected function validateOptionLimit(array $options)
     {
         if (!isset($options['limit'])) return;
 
@@ -841,7 +841,7 @@ class Technorati
      * @throws  Exception\RuntimeException if 'start' value is invalid
      * @access  protected
      */
-    protected function _validateOptionStart(array $options)
+    protected function validateOptionStart(array $options)
     {
         if (!isset($options['start'])) return;
 
@@ -862,9 +862,9 @@ class Technorati
      * @access  protected
      * @todo    support for Zend\Uri\Http
      */
-    protected function _validateOptionUrl(array $options)
+    protected function validateOptionUrl(array $options)
     {
-        $this->_validateMandatoryOption('url', $options);
+        $this->validateMandatoryOption('url', $options);
     }
 
     /**
@@ -876,7 +876,7 @@ class Technorati
      * @link    http://technorati.com/developers/api/error.html Technorati API: Error response
      * @access  protected
      */
-    protected static function _checkErrors(DomDocument $dom)
+    protected static function checkErrors(DomDocument $dom)
     {
         $xpath = new \DOMXPath($dom);
 
@@ -895,11 +895,11 @@ class Technorati
      * @throws  Exception\RuntimeException if response content contains an error message
      * @access  protected
      */
-    protected function _convertResponseAndCheckContent(Response $response)
+    protected function convertResponseAndCheckContent(Response $response)
     {
         $dom = new \DOMDocument();
         $dom->loadXML($response->getBody());
-        self::_checkErrors($dom);
+        self::checkErrors($dom);
         return $dom;
     }
 
@@ -911,7 +911,7 @@ class Technorati
      * @throws  Exception\RuntimeException
      * @access  protected
      */
-    protected static function _checkResponse(Response $response)
+    protected static function checkResponse(Response $response)
     {
         if ($response->isServerError() || $response->isClientError()) {
             throw new Exception\RuntimeException(sprintf(
@@ -929,7 +929,7 @@ class Technorati
      * @throws  Exception\RuntimeException
      * @access  protected
      */
-    protected function _compareOptions(array $options, array $validOptions)
+    protected function compareOptions(array $options, array $validOptions)
     {
         $difference = array_diff(array_keys($options), $validOptions);
         if ($difference) {
@@ -947,10 +947,10 @@ class Technorati
      * @return  array Merged array of user and default/required options.
      * @access  protected
      */
-    protected function _prepareOptions($options, array $defaultOptions)
+    protected function prepareOptions($options, array $defaultOptions)
     {
         $options = (array) $options; // force cast to convert null to array()
-        $options['key'] = $this->_apiKey;
+        $options['key'] = $this->apiKey;
         $options = array_merge($defaultOptions, $options);
         return $options;
     }

--- a/library/Zend/Service/Technorati/Technorati.php
+++ b/library/Zend/Service/Technorati/Technorati.php
@@ -20,6 +20,12 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+use Zend\Http\Response;
+
+/**
  * Zend_Service_Technorati provides an easy, intuitive and object-oriented interface
  * for using the Technorati API.
  *
@@ -29,22 +35,22 @@
  * @uses       DOMDocument
  * @uses       DOMXPath
  * @uses       Zend_Rest_Client
- * @uses       Zend_Service_Technorati_BlogInfoResult
- * @uses       Zend_Service_Technorati_CosmosResultSet
- * @uses       Zend_Service_Technorati_DailyCountsResultSet
- * @uses       Zend_Service_Technorati_Exception
- * @uses       Zend_Service_Technorati_GetInfoResult
- * @uses       Zend_Service_Technorati_KeyInfoResult
- * @uses       Zend_Service_Technorati_SearchResultSet
- * @uses       Zend_Service_Technorati_TagResultSet
- * @uses       Zend_Service_Technorati_TagsResultSet
+ * @uses       \Zend\Service\Technorati\BlogInfoResult
+ * @uses       \Zend\Service\Technorati\CosmosResultSet
+ * @uses       \Zend\Service\Technorati\DailyCountsResultSet
+ * @uses       \Zend\Service\Technorati\Exception\RuntimeException
+ * @uses       \Zend\Service\Technorati\GetInfoResult
+ * @uses       \Zend\Service\Technorati\KeyInfoResult
+ * @uses       \Zend\Service\Technorati\SearchResultSet
+ * @uses       \Zend\Service\Technorati\TagResultSet
+ * @uses       \Zend\Service\Technorati\TagsResultSet
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati
+class Technorati
 {
     /** Base Technorati API URI */
     const API_URI_BASE = 'http://api.technorati.com';
@@ -143,8 +149,8 @@ class Zend_Service_Technorati
      *
      * @param   string $url     the URL you are searching for. Prefixes http:// and www. are optional.
      * @param   array $options  additional parameters to refine your query
-     * @return  Zend_Service_Technorati_CosmosResultSet
-     * @throws  Zend_Service_Technorati_Exception
+     * @return  \Zend\Service\Technorati\CosmosResultSet
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @link    http://technorati.com/developers/api/cosmos.html Technorati API: Cosmos Query reference
      */
     public function cosmos($url, $options = null)
@@ -165,7 +171,7 @@ class Zend_Service_Technorati
         $response = $this->_makeRequest(self::API_PATH_COSMOS, $options);
         $dom = $this->_convertResponseAndCheckContent($response);
 
-        return new Zend_Service_Technorati_CosmosResultSet($dom, $options);
+        return new CosmosResultSet($dom, $options);
     }
 
     /**
@@ -205,8 +211,8 @@ class Zend_Service_Technorati
      *
      * @param   string $query   the words you are searching for.
      * @param   array $options  additional parameters to refine your query
-     * @return  Zend_Service_Technorati_SearchResultSet
-     * @throws  Zend_Service_Technorati_Exception
+     * @return  \Zend\Service\Technorati\SearchResultSet
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @link    http://technorati.com/developers/api/search.html Technorati API: Search Query reference
      */
     public function search($query, $options = null)
@@ -223,7 +229,7 @@ class Zend_Service_Technorati
         $response = $this->_makeRequest(self::API_PATH_SEARCH, $options);
         $dom = $this->_convertResponseAndCheckContent($response);
 
-        return new Zend_Service_Technorati_SearchResultSet($dom, $options);
+        return new SearchResultSet($dom, $options);
     }
 
     /**
@@ -248,8 +254,8 @@ class Zend_Service_Technorati
      *
      * @param   string $tag     the tag term you are searching posts for.
      * @param   array $options  additional parameters to refine your query
-     * @return  Zend_Service_Technorati_TagResultSet
-     * @throws  Zend_Service_Technorati_Exception
+     * @return  \Zend\Service\Technorati\TagResultSet
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      *  @link    http://technorati.com/developers/api/tag.html Technorati API: Tag Query reference
      */
     public function tag($tag, $options = null)
@@ -267,7 +273,7 @@ class Zend_Service_Technorati
         $response = $this->_makeRequest(self::API_PATH_TAG, $options);
         $dom = $this->_convertResponseAndCheckContent($response);
 
-        return new Zend_Service_Technorati_TagResultSet($dom, $options);
+        return new TagResultSet($dom, $options);
     }
 
     /**
@@ -282,8 +288,8 @@ class Zend_Service_Technorati
      *
      * @param   string $q       the keyword query
      * @param   array $options  additional parameters to refine your query
-     * @return  Zend_Service_Technorati_DailyCountsResultSet
-     * @throws  Zend_Service_Technorati_Exception
+     * @return  \Zend\Service\Technorati\DailyCountsResultSet
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @link    http://technorati.com/developers/api/dailycounts.html Technorati API: DailyCounts Query reference
      */
     public function dailyCounts($query, $options = null)
@@ -299,7 +305,7 @@ class Zend_Service_Technorati
         $response = $this->_makeRequest(self::API_PATH_DAILYCOUNTS, $options);
         $dom = $this->_convertResponseAndCheckContent($response);
 
-        return new Zend_Service_Technorati_DailyCountsResultSet($dom);
+        return new DailyCountsResultSet($dom);
     }
 
     /**
@@ -317,8 +323,8 @@ class Zend_Service_Technorati
      *      The default start value is 1.
      *
      * @param   array $options  additional parameters to refine your query
-     * @return  Zend_Service_Technorati_TagsResultSet
-     * @throws  Zend_Service_Technorati_Exception
+     * @return  \Zend\Service\Technorati\TagsResultSet
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @link    http://technorati.com/developers/api/toptags.html Technorati API: TopTags Query reference
      */
     public function topTags($options = null)
@@ -333,7 +339,7 @@ class Zend_Service_Technorati
         $response = $this->_makeRequest(self::API_PATH_TOPTAGS, $options);
         $dom = $this->_convertResponseAndCheckContent($response);
 
-        return new Zend_Service_Technorati_TagsResultSet($dom);
+        return new TagsResultSet($dom);
     }
 
     /**
@@ -342,8 +348,8 @@ class Zend_Service_Technorati
      * @param   string $url     the URL you are searching for. Prefixes http:// and www. are optional.
      *                          The URL must be recognized by Technorati as a blog.
      * @param   array $options  additional parameters to refine your query
-     * @return  Zend_Service_Technorati_BlogInfoResult
-     * @throws  Zend_Service_Technorati_Exception
+     * @return  \Zend\Service\Technorati\BlogInfoResult
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @link    http://technorati.com/developers/api/bloginfo.html Technorati API: BlogInfo Query reference
      */
     public function blogInfo($url, $options = null)
@@ -358,7 +364,7 @@ class Zend_Service_Technorati
         $response = $this->_makeRequest(self::API_PATH_BLOGINFO, $options);
         $dom = $this->_convertResponseAndCheckContent($response);
 
-        return new Zend_Service_Technorati_BlogInfoResult($dom);
+        return new BlogInfoResult($dom);
     }
 
     /**
@@ -379,8 +385,8 @@ class Zend_Service_Technorati
      * @param   string $url     the URL you are searching for. Prefixes http:// and www. are optional.
      *                          The URL must be recognized by Technorati as a blog.
      * @param   array $options  additional parameters to refine your query
-     * @return  Zend_Service_Technorati_TagsResultSet
-     * @throws  Zend_Service_Technorati_Exception
+     * @return  \Zend\Service\Technorati\TagsResultSet
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @link    http://technorati.com/developers/api/blogposttags.html Technorati API: BlogPostTags Query reference
      */
     public function blogPostTags($url, $options = null)
@@ -397,7 +403,7 @@ class Zend_Service_Technorati
         $response = $this->_makeRequest(self::API_PATH_BLOGPOSTTAGS, $options);
         $dom = $this->_convertResponseAndCheckContent($response);
 
-        return new Zend_Service_Technorati_TagsResultSet($dom);
+        return new TagsResultSet($dom);
     }
 
     /**
@@ -412,8 +418,8 @@ class Zend_Service_Technorati
      *
      * @param   string $username    the Technorati user name you are searching for
      * @param   array $options      additional parameters to refine your query
-     * @return  Zend_Service_Technorati_GetInfoResult
-     * @throws  Zend_Service_Technorati_Exception
+     * @return  \Zend\Service\Technorati\GetInfoResult
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @link    http://technorati.com/developers/api/getinfo.html Technorati API: GetInfo reference
      */
     public function getInfo($username, $options = null)
@@ -427,7 +433,7 @@ class Zend_Service_Technorati
         $response = $this->_makeRequest(self::API_PATH_GETINFO, $options);
         $dom = $this->_convertResponseAndCheckContent($response);
 
-        return new Zend_Service_Technorati_GetInfoResult($dom);
+        return new GetInfoResult($dom);
     }
 
     /**
@@ -436,8 +442,8 @@ class Zend_Service_Technorati
      *
      * A day is defined as 00:00-23:59 Pacific time.
      *
-     * @return  Zend_Service_Technorati_KeyInfoResult
-     * @throws  Zend_Service_Technorati_Exception
+     * @return  \Zend\Service\Technorati\KeyInfoResult
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @link    http://developers.technorati.com/wiki/KeyInfo Technorati API: Key Info reference
      */
     public function keyInfo()
@@ -451,7 +457,7 @@ class Zend_Service_Technorati
         $response = $this->_makeRequest(self::API_PATH_KEYINFO, $options);
         $dom = $this->_convertResponseAndCheckContent($response);
 
-        return new Zend_Service_Technorati_KeyInfoResult($dom, $this->_apiKey);
+        return new KeyInfoResult($dom, $this->_apiKey);
     }
 
 
@@ -476,7 +482,7 @@ class Zend_Service_Technorati
     public function getRestClient()
     {
         if ($this->_restClient === null) {
-            $this->_restClient = new Zend_Rest_Client(self::API_URI_BASE);
+            $this->_restClient = new \Zend\Rest\Client\RestClient(self::API_URI_BASE);
         }
 
         return $this->_restClient;
@@ -506,7 +512,7 @@ class Zend_Service_Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @access  protected
      */
     protected function _validateCosmos(array $options)
@@ -543,7 +549,7 @@ class Zend_Service_Technorati
      *
      * @param   array   $options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @access  protected
      */
     protected function _validateSearch(array $options)
@@ -572,7 +578,7 @@ class Zend_Service_Technorati
      *
      * @param   array   $options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @access  protected
      */
     protected function _validateTag(array $options)
@@ -602,7 +608,7 @@ class Zend_Service_Technorati
      *
      * @param   array   $options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @access  protected
      */
     protected function _validateDailyCounts(array $options)
@@ -621,7 +627,7 @@ class Zend_Service_Technorati
             $options['days'] = (int) $options['days'];
             if ($options['days'] < self::PARAM_DAYS_MIN_VALUE ||
                 $options['days'] > self::PARAM_DAYS_MAX_VALUE) {
-                throw new Zend_Service_Technorati_Exception(
+                throw new Exception\RuntimeException(
                             "Invalid value '" . $options['days'] . "' for 'days' option");
             }
         }
@@ -632,7 +638,7 @@ class Zend_Service_Technorati
      *
      * @param   array   $options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @access  protected
      */
     protected function _validateGetInfo(array $options)
@@ -653,7 +659,7 @@ class Zend_Service_Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @access  protected
      */
     protected function _validateTopTags(array $options)
@@ -676,7 +682,7 @@ class Zend_Service_Technorati
      *
      * @param   array   $options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @access  protected
      */
     protected function _validateBlogInfo(array $options)
@@ -697,7 +703,7 @@ class Zend_Service_Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @access  protected
      */
     protected function _validateBlogPostTags(array $options)
@@ -724,13 +730,13 @@ class Zend_Service_Technorati
      * @param   array $options
      * @param   array $array    array of valid options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @access  protected
      */
     protected function _validateInArrayOption($name, $options, array $array)
     {
         if (isset($options[$name]) && !in_array($options[$name], $array)) {
-            throw new Zend_Service_Technorati_Exception(
+            throw new Exception\RuntimeException(
                         "Invalid value '{$options[$name]}' for '$name' option");
         }
     }
@@ -740,13 +746,13 @@ class Zend_Service_Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @access  protected
      */
     protected function _validateMandatoryOption($name, $options)
     {
         if (!isset($options[$name]) || !trim($options[$name])) {
-            throw new Zend_Service_Technorati_Exception(
+            throw new Exception\RuntimeException(
                         "Empty value for '$name' option");
         }
     }
@@ -771,8 +777,8 @@ class Zend_Service_Technorati
      *
      * @param   string $path
      * @param   array $options
-     * @return  Zend_Http_Response
-     * @throws  Zend_Service_Technorati_Exception on failure
+     * @return  \Zend\Http\Response
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException on failure
      * @access  protected
      */
     protected function _makeRequest($path, $options = array())
@@ -802,13 +808,13 @@ class Zend_Service_Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception if 'format' value != XML
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if 'format' value != XML
      * @access  protected
      */
     protected function _validateOptionFormat(array $options)
     {
         if (isset($options['format']) && $options['format'] != 'xml') {
-            throw new Zend_Service_Technorati_Exception(
+            throw new Exception\RuntimeException(
                         "Invalid value '" . $options['format'] . "' for 'format' option. " .
                         "Zend_Service_Technorati supports only 'xml'");
         }
@@ -821,7 +827,7 @@ class Zend_Service_Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception if 'limit' value is invalid
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if 'limit' value is invalid
      * @access  protected
      */
     protected function _validateOptionLimit(array $options)
@@ -831,7 +837,7 @@ class Zend_Service_Technorati
         $options['limit'] = (int) $options['limit'];
         if ($options['limit'] < self::PARAM_LIMIT_MIN_VALUE ||
             $options['limit'] > self::PARAM_LIMIT_MAX_VALUE) {
-            throw new Zend_Service_Technorati_Exception(
+            throw new Exception\RuntimeException(
                         "Invalid value '" . $options['limit'] . "' for 'limit' option");
         }
     }
@@ -842,7 +848,7 @@ class Zend_Service_Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception if 'start' value is invalid
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if 'start' value is invalid
      * @access  protected
      */
     protected function _validateOptionStart(array $options)
@@ -851,7 +857,7 @@ class Zend_Service_Technorati
 
         $options['start'] = (int) $options['start'];
         if ($options['start'] < self::PARAM_START_MIN_VALUE) {
-            throw new Zend_Service_Technorati_Exception(
+            throw new Exception\RuntimeException(
                         "Invalid value '" . $options['start'] . "' for 'start' option");
         }
     }
@@ -862,7 +868,7 @@ class Zend_Service_Technorati
      *
      * @param   array $options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception if 'url' value is invalid
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if 'url' value is invalid
      * @access  protected
      * @todo    support for Zend_Uri_Http
      */
@@ -876,32 +882,32 @@ class Zend_Service_Technorati
      *
      * @param   DomDocument $dom    the XML response as a DOM document
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @link    http://technorati.com/developers/api/error.html Technorati API: Error response
      * @access  protected
      */
-    protected static function _checkErrors(DomDocument $dom)
+    protected static function _checkErrors(\DomDocument $dom)
     {
-        $xpath = new DOMXPath($dom);
+        $xpath = new \DOMXPath($dom);
 
         $result = $xpath->query("/tapi/document/result/error");
         if ($result->length >= 1) {
             $error = $result->item(0)->nodeValue;
-            throw new Zend_Service_Technorati_Exception($error);
+            throw new Exception\RuntimeException($error);
         }
     }
 
     /**
      * Converts $response body to a DOM object and checks it.
      *
-     * @param   Zend_Http_Response $response
+     * @param   \Zend\Http\Response $response
      * @return  DOMDocument
-     * @throws  Zend_Service_Technorati_Exception if response content contains an error message
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if response content contains an error message
      * @access  protected
      */
-    protected function _convertResponseAndCheckContent(Zend_Http_Response $response)
+    protected function _convertResponseAndCheckContent(Response $response)
     {
-        $dom = new DOMDocument();
+        $dom = new \DOMDocument();
         $dom->loadXML($response->getBody());
         self::_checkErrors($dom);
         return $dom;
@@ -910,15 +916,15 @@ class Zend_Service_Technorati
     /**
      * Checks ReST response for errors.
      *
-     * @param   Zend_Http_Response $response    the ReST response
+     * @param   \Zend\Http\Response $response    the ReST response
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @access  protected
      */
-    protected static function _checkResponse(Zend_Http_Response $response)
+    protected static function _checkResponse(Response $response)
     {
         if ($response->isError()) {
-            throw new Zend_Service_Technorati_Exception(sprintf(
+            throw new Exception\RuntimeException(sprintf(
                         'Invalid response status code (HTTP/%s %s %s)',
                         $response->getVersion(), $response->getStatus(), $response->getMessage()));
         }
@@ -930,14 +936,14 @@ class Zend_Service_Technorati
      * @param   array $options        user options
      * @param   array $validOptions   valid options
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @access  protected
      */
     protected function _compareOptions(array $options, array $validOptions)
     {
         $difference = array_diff(array_keys($options), $validOptions);
         if ($difference) {
-            throw new Zend_Service_Technorati_Exception(
+            throw new Exception\RuntimeException(
                         "The following parameters are invalid: '" .
                         implode("', '", $difference) . "'");
         }

--- a/library/Zend/Service/Technorati/Technorati.php
+++ b/library/Zend/Service/Technorati/Technorati.php
@@ -923,7 +923,7 @@ class Technorati
      */
     protected static function _checkResponse(Response $response)
     {
-        if ($response->isError()) {
+        if ($response->isServerError() || $response->isClientError()) {
             throw new Exception\RuntimeException(sprintf(
                         'Invalid response status code (HTTP/%s %s %s)',
                         $response->getVersion(), $response->getStatus(), $response->getMessage()));

--- a/library/Zend/Service/Technorati/Technorati.php
+++ b/library/Zend/Service/Technorati/Technorati.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -35,7 +35,7 @@ use Zend\Http\Response,
  * and returns the original XML response as a friendly PHP object.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/Utils.php
+++ b/library/Zend/Service/Technorati/Utils.php
@@ -20,11 +20,17 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+use Zend\Uri;
+
+/**
  * Collection of utilities for various Zend_Service_Technorati classes.
  *
  * @uses       Zend_Date
  * @uses       Zend_Locale
- * @uses       Zend_Service_Technorati_Exception
+ * @uses       \Zend\Service\Technorati\Exception\RuntimeException
  * @uses       Zend_Uri
  * @category   Zend
  * @package    Zend_Service
@@ -32,15 +38,15 @@
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_Utils
+class Utils
 {
     /**
      * Parses, validates and returns a valid Zend_Uri object
      * from given $input.
      *
-     * @param   string|Zend_Uri_Http $input
-     * @return  null|Zend_Uri_Http
-     * @throws  Zend_Service_Technorati_Exception
+     * @param   string|\Zend\Uri\Http $input
+     * @return  null|\Zend\Uri\Http
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @static
      */
     public static function normalizeUriHttp($input)
@@ -50,21 +56,21 @@ class Zend_Service_Technorati_Utils
             return null;
         }
 
-        if ($input instanceof Zend_Uri_Http) {
+        if ($input instanceof Uri\Http) {
             $uri = $input;
         } else {
             try {
-                $uri = Zend_Uri::factory((string) $input);
+                $uri = Uri\UriFactory::factory((string) $input);
             }
             // wrap exception under Zend_Service_Technorati_Exception object
-            catch (Exception $e) {
-                throw new Zend_Service_Technorati_Exception($e->getMessage(), 0, $e);
+            catch (\Exception $e) {
+                throw new Exception\RuntimeException($e->getMessage(), 0, $e);
             }
         }
 
         // allow inly Zend_Uri_Http objects or child classes
-        if (!($uri instanceof Zend_Uri_Http)) {
-            throw new Zend_Service_Technorati_Exception(
+        if (!($uri instanceof Uri\Http)) {
+            throw new Exception\RuntimeException(
                 "Invalid URL $uri, only HTTP(S) protocols can be used");
         }
 
@@ -80,22 +86,22 @@ class Zend_Service_Technorati_Utils
      *
      * @param   mixed|Zend_Date $input
      * @return  null|Zend_Date
-     * @throws  Zend_Service_Technorati_Exception
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      * @static
      */
     public static function normalizeDate($input)
     {
         // allow null as value and return valid Zend_Date objects
-        if (($input === null) || ($input instanceof Zend_Date)) {
+        if (($input === null) || ($input instanceof \Zend\Date)) {
             return $input;
         }
 
-        // due to a BC break as of ZF 1.5 it's not safe to use Zend_Date::isDate() here
+        // due to a BC break as of ZF 1.5 it's not safe to use Zend\Date::isDate() here
         // see ZF-2524, ZF-2334
         if (@strtotime($input) !== FALSE) {
-            return new Zend_Date($input);
+            return new \Zend\Date\Date($input);
         } else {
-            throw new Zend_Service_Technorati_Exception("'$input' is not a valid Date/Time");
+            throw new Exception\RuntimeException("'$input' is not a valid Date/Time");
         }
     }
 

--- a/library/Zend/Service/Technorati/Utils.php
+++ b/library/Zend/Service/Technorati/Utils.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -30,7 +30,7 @@ use Zend\Uri,
  * Collection of utilities for various Zend\Service\Technorati classes.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/Service/Technorati/Utils.php
+++ b/library/Zend/Service/Technorati/Utils.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -23,17 +23,14 @@
  * @namespace
  */
 namespace Zend\Service\Technorati;
-use Zend\Uri;
+use Zend\Uri,
+    Zend\Date\Date as ZendDate;
 
 /**
- * Collection of utilities for various Zend_Service_Technorati classes.
+ * Collection of utilities for various Zend\Service\Technorati classes.
  *
- * @uses       Zend_Date
- * @uses       Zend_Locale
- * @uses       \Zend\Service\Technorati\Exception\RuntimeException
- * @uses       Zend_Uri
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -41,12 +38,12 @@ use Zend\Uri;
 class Utils
 {
     /**
-     * Parses, validates and returns a valid Zend_Uri object
+     * Parses, validates and returns a valid Zend\Uri object
      * from given $input.
      *
-     * @param   string|\Zend\Uri\Http $input
-     * @return  null|\Zend\Uri\Http
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @param   string|Uri\Http $input
+     * @return  null|Uri\Http
+     * @throws  Exception\RuntimeException
      * @static
      */
     public static function normalizeUriHttp($input)
@@ -62,13 +59,13 @@ class Utils
             try {
                 $uri = Uri\UriFactory::factory((string) $input);
             }
-            // wrap exception under Zend_Service_Technorati_Exception object
+            // wrap exception under Exception object
             catch (\Exception $e) {
                 throw new Exception\RuntimeException($e->getMessage(), 0, $e);
             }
         }
 
-        // allow inly Zend_Uri_Http objects or child classes
+        // allow inly Zend\Uri\Http objects or child classes
         if (!($uri instanceof Uri\Http)) {
             throw new Exception\RuntimeException(
                 "Invalid URL $uri, only HTTP(S) protocols can be used");
@@ -77,29 +74,29 @@ class Utils
         return $uri;
     }
     /**
-     * Parses, validates and returns a valid Zend_Date object
+     * Parses, validates and returns a valid ZendDate object
      * from given $input.
      *
-     * $input can be either a string, an integer or a Zend_Date object.
-     * If $input is string or int, it will be provided to Zend_Date as it is.
-     * If $input is a Zend_Date object, the object instance will be returned.
+     * $input can be either a string, an integer or a ZendDate object.
+     * If $input is string or int, it will be provided to ZendDate as it is.
+     * If $input is a ZendDate object, the object instance will be returned.
      *
-     * @param   mixed|Zend_Date $input
-     * @return  null|Zend_Date
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @param   mixed|Date $input
+     * @return  null|Date
+     * @throws  Exception\RuntimeException
      * @static
      */
     public static function normalizeDate($input)
     {
-        // allow null as value and return valid Zend_Date objects
-        if (($input === null) || ($input instanceof \Zend\Date)) {
+        // allow null as value and return valid ZendDate objects
+        if (($input === null) || ($input instanceof ZendDate)) {
             return $input;
         }
 
-        // due to a BC break as of ZF 1.5 it's not safe to use Zend\Date::isDate() here
+        // due to a BC break as of ZF 1.5 it's not safe to use ZendDate::isDate() here
         // see ZF-2524, ZF-2334
         if (@strtotime($input) !== FALSE) {
-            return new \Zend\Date\Date($input);
+            return new ZendDate($input);
         } else {
             throw new Exception\RuntimeException("'$input' is not a valid Date/Time");
         }

--- a/library/Zend/Service/Technorati/Weblog.php
+++ b/library/Zend/Service/Technorati/Weblog.php
@@ -44,7 +44,7 @@ class Weblog
      * @var     string
      * @access  protected
      */
-    protected $_name;
+    protected $name;
 
     /**
      * Base blog URL.
@@ -52,7 +52,7 @@ class Weblog
      * @var     Uri\Http
      * @access  protected
      */
-    protected $_url;
+    protected $url;
 
     /**
      * RSS feed URL, if any.
@@ -60,7 +60,7 @@ class Weblog
      * @var     null|Uri\Http
      * @access  protected
      */
-    protected $_rssUrl;
+    protected $rssUrl;
 
     /**
      * Atom feed URL, if any.
@@ -68,7 +68,7 @@ class Weblog
      * @var     null|Uri\Http
      * @access  protected
      */
-    protected $_atomUrl;
+    protected $atomUrl;
 
     /**
      * Number of unique blogs linking this blog.
@@ -76,7 +76,7 @@ class Weblog
      * @var     integer
      * @access  protected
      */
-    protected $_inboundBlogs;
+    protected $inboundBlogs;
 
     /**
      * Number of incoming links to this blog.
@@ -84,7 +84,7 @@ class Weblog
      * @var     integer
      * @access  protected
      */
-    protected $_inboundLinks;
+    protected $inboundLinks;
 
     /**
      * Last blog update UNIX timestamp.
@@ -92,7 +92,7 @@ class Weblog
      * @var     null|ZendDate
      * @access  protected
      */
-    protected $_lastUpdate;
+    protected $lastUpdate;
 
     /**
      * Technorati rank value for this weblog.
@@ -102,7 +102,7 @@ class Weblog
      * @var     integer
      * @access  protected
      */
-    protected $_rank;
+    protected $rank;
 
     /**
      * Blog latitude coordinate.
@@ -112,7 +112,7 @@ class Weblog
      * @var     float
      * @access  protected
      */
-    protected $_lat;
+    protected $lat;
 
     /**
      * Blog longitude coordinate.
@@ -122,7 +122,7 @@ class Weblog
      * @var     float
      * @access  protected
      */
-    protected $_lon;
+    protected $lon;
 
     /**
      * Whether the author who claimed this weblog has a photo.
@@ -133,7 +133,7 @@ class Weblog
      * @access  protected
      * @see     Author::$thumbnailPicture
      */
-    protected $_hasPhoto = false;
+    protected $hasPhoto = false;
 
     /**
      * An array of Author who claimed this blog
@@ -141,7 +141,7 @@ class Weblog
      * @var     array
      * @access  protected
      */
-    protected $_authors = array();
+    protected $authors = array();
 
 
     /**
@@ -179,7 +179,7 @@ class Weblog
         $result = $xpath->query('./author', $dom);
         if ($result->length >= 1) {
             foreach ($result as $author) {
-                $this->_authors[] = new Author($author);
+                $this->authors[] = new Author($author);
             }
         }
 
@@ -211,7 +211,7 @@ class Weblog
      */
     public function getName()
     {
-        return $this->_name;
+        return $this->name;
     }
 
     /**
@@ -221,7 +221,7 @@ class Weblog
      */
     public function getUrl()
     {
-        return $this->_url;
+        return $this->url;
     }
 
     /**
@@ -231,7 +231,7 @@ class Weblog
      */
     public function getInboundBlogs()
     {
-        return $this->_inboundBlogs;
+        return $this->inboundBlogs;
     }
 
     /**
@@ -241,7 +241,7 @@ class Weblog
      */
     public function getInboundLinks()
     {
-        return $this->_inboundLinks;
+        return $this->inboundLinks;
     }
 
     /**
@@ -252,7 +252,7 @@ class Weblog
      */
     public function getRssUrl()
     {
-        return $this->_rssUrl;
+        return $this->rssUrl;
     }
 
     /**
@@ -263,7 +263,7 @@ class Weblog
      */
     public function getAtomUrl()
     {
-        return $this->_atomUrl;
+        return $this->atomUrl;
     }
 
     /**
@@ -273,7 +273,7 @@ class Weblog
      */
     public function getLastUpdate()
     {
-        return $this->_lastUpdate;
+        return $this->lastUpdate;
     }
 
     /**
@@ -285,7 +285,7 @@ class Weblog
      */
     public function getRank()
     {
-        return $this->_rank;
+        return $this->rank;
     }
 
     /**
@@ -296,7 +296,7 @@ class Weblog
      * @return  float   weblog latitude coordinate
      */
     public function getLat() {
-        return $this->_lat;
+        return $this->lat;
     }
 
     /**
@@ -308,7 +308,7 @@ class Weblog
      */
     public function getLon()
     {
-        return $this->_lon;
+        return $this->lon;
     }
 
     /**
@@ -321,7 +321,7 @@ class Weblog
      */
     public function hasPhoto()
     {
-        return (bool) $this->_hasPhoto;
+        return (bool) $this->hasPhoto;
     }
 
     /**
@@ -331,7 +331,7 @@ class Weblog
      */
     public function getAuthors()
     {
-        return (array) $this->_authors;
+        return (array) $this->authors;
     }
 
 
@@ -343,7 +343,7 @@ class Weblog
      */
     public function setName($name)
     {
-        $this->_name = (string) $name;
+        $this->name = (string) $name;
         return $this;
     }
 
@@ -357,7 +357,7 @@ class Weblog
      */
     public function setUrl($url)
     {
-        $this->_url = Utils::normalizeUriHttp($url);
+        $this->url = Utils::normalizeUriHttp($url);
         return $this;
     }
 
@@ -369,7 +369,7 @@ class Weblog
      */
     public function setInboundBlogs($number)
     {
-        $this->_inboundBlogs = (int) $number;
+        $this->inboundBlogs = (int) $number;
         return $this;
     }
 
@@ -381,7 +381,7 @@ class Weblog
      */
     public function setInboundLinks($number)
     {
-        $this->_inboundLinks = (int) $number;
+        $this->inboundLinks = (int) $number;
         return $this;
     }
 
@@ -395,7 +395,7 @@ class Weblog
      */
     public function setRssUrl($url)
     {
-        $this->_rssUrl = Utils::normalizeUriHttp($url);
+        $this->rssUrl = Utils::normalizeUriHttp($url);
         return $this;
     }
 
@@ -409,7 +409,7 @@ class Weblog
      */
     public function setAtomUrl($url)
     {
-        $this->_atomUrl = Utils::normalizeUriHttp($url);
+        $this->atomUrl = Utils::normalizeUriHttp($url);
         return $this;
     }
 
@@ -426,7 +426,7 @@ class Weblog
      */
     public function setLastUpdate($datetime)
     {
-        $this->_lastUpdate = Utils::normalizeDate($datetime);
+        $this->lastUpdate = Utils::normalizeDate($datetime);
         return $this;
     }
 
@@ -438,7 +438,7 @@ class Weblog
      */
     public function setRank($rank)
     {
-        $this->_rank = (int) $rank;
+        $this->rank = (int) $rank;
         return $this;
     }
 
@@ -450,7 +450,7 @@ class Weblog
      */
     public function setLat($coordinate)
     {
-        $this->_lat = (float) $coordinate;
+        $this->lat = (float) $coordinate;
         return $this;
     }
 
@@ -462,7 +462,7 @@ class Weblog
      */
     public function setLon($coordinate)
     {
-        $this->_lon = (float) $coordinate;
+        $this->lon = (float) $coordinate;
         return $this;
     }
 
@@ -474,7 +474,7 @@ class Weblog
      */
     public function setHasPhoto($hasPhoto)
     {
-        $this->_hasPhoto = (bool) $hasPhoto;
+        $this->hasPhoto = (bool) $hasPhoto;
         return $this;
     }
 

--- a/library/Zend/Service/Technorati/Weblog.php
+++ b/library/Zend/Service/Technorati/Weblog.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,14 +24,14 @@
  */
 namespace Zend\Service\Technorati;
 
+use \DomElement,
+    Zend\Uri;
+
 /**
  * Represents a Weblog object successful recognized by Technorati.
  *
- * @uses       DOMXPath
- * @uses       \Zend\Service\Technorati\Author
- * @uses       \Zend\Service\Technorati\Utils
  * @category   Zend
- * @package    Zend_Service
+ * @package    Zend\Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -49,7 +49,7 @@ class Weblog
     /**
      * Base blog URL.
      *
-     * @var     \Zend\Uri\Http
+     * @var     Uri\Http
      * @access  protected
      */
     protected $_url;
@@ -57,7 +57,7 @@ class Weblog
     /**
      * RSS feed URL, if any.
      *
-     * @var     null|\Zend\Uri\Http
+     * @var     null|Uri\Http
      * @access  protected
      */
     protected $_rssUrl;
@@ -65,7 +65,7 @@ class Weblog
     /**
      * Atom feed URL, if any.
      *
-     * @var     null|\Zend\Uri\Http
+     * @var     null|Uri\Http
      * @access  protected
      */
     protected $_atomUrl;
@@ -89,7 +89,7 @@ class Weblog
     /**
      * Last blog update UNIX timestamp.
      *
-     * @var     null|Zend_Date
+     * @var     null|ZendDate
      * @access  protected
      */
     protected $_lastUpdate;
@@ -131,12 +131,12 @@ class Weblog
      *
      * @var     bool
      * @access  protected
-     * @see     \Zend\Service\Technorati\Author::$thumbnailPicture
+     * @see     Author::$thumbnailPicture
      */
     protected $_hasPhoto = false;
 
     /**
-     * An array of Zend_Service_Technorati_Author who claimed this blog
+     * An array of Author who claimed this blog
      *
      * @var     array
      * @access  protected
@@ -149,7 +149,7 @@ class Weblog
      *
      * @param  DomElement $dom the ReST fragment for this object
      */
-    public function __construct(\DomElement $dom)
+    public function __construct(DomElement $dom)
     {
         $xpath = new \DOMXPath($dom->ownerDocument);
 
@@ -217,7 +217,7 @@ class Weblog
     /**
      * Returns weblog URL.
      *
-     * @return  null|\Zend\Uri\Http object representing weblog base URL
+     * @return  null|Uri\Http object representing weblog base URL
      */
     public function getUrl()
     {
@@ -247,7 +247,7 @@ class Weblog
     /**
      * Returns weblog Rss URL.
      *
-     * @return  null|\Zend\Uri\Http object representing the URL
+     * @return  null|Uri\Http object representing the URL
      *          of the RSS feed for given blog
      */
     public function getRssUrl()
@@ -258,7 +258,7 @@ class Weblog
     /**
      * Returns weblog Atom URL.
      *
-     * @return  null|\Zend\Uri\Http object representing the URL
+     * @return  null|Uri\Http object representing the URL
      *          of the Atom feed for given blog
      */
     public function getAtomUrl()
@@ -327,7 +327,7 @@ class Weblog
     /**
      * Returns the array of weblog authors.
      *
-     * @return  array of \Zend\Service\Technorati\Author authors
+     * @return  array of Author authors
      */
     public function getAuthors()
     {
@@ -339,7 +339,7 @@ class Weblog
      * Sets weblog name.
      *
      * @param   string $name
-     * @return  \Zend\Service\Technorati\Weblog $this instance
+     * @return  Weblog $this instance
      */
     public function setName($name)
     {
@@ -350,10 +350,10 @@ class Weblog
     /**
      * Sets weblog URL.
      *
-     * @param   string|\Zend\Uri\Http $url
+     * @param   string|Uri\Http $url
      * @return  void
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if $input is an invalid URI
-     *          (via Zend_Service_Technorati_Utils::normalizeUriHttp)
+     * @throws  Exception\RuntimeException if $input is an invalid URI
+     *          (via Utils::normalizeUriHttp)
      */
     public function setUrl($url)
     {
@@ -365,7 +365,7 @@ class Weblog
      * Sets number of inbound blogs.
      *
      * @param   integer $number
-     * @return  \Zend\Service\Technorati\Weblog $this instance
+     * @return  Weblog $this instance
      */
     public function setInboundBlogs($number)
     {
@@ -377,7 +377,7 @@ class Weblog
      * Sets number of Iinbound links.
      *
      * @param   integer $number
-     * @return  \Zend\Service\Technorati\Weblog $this instance
+     * @return  Weblog $this instance
      */
     public function setInboundLinks($number)
     {
@@ -388,10 +388,10 @@ class Weblog
     /**
      * Sets weblog Rss URL.
      *
-     * @param   string|\Zend\Uri\Http $url
-     * @return  \Zend\Service\Technorati\Weblog $this instance
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if $input is an invalid URI
-     *          (via Zend_Service_Technorati_Utils::normalizeUriHttp)
+     * @param   string|Uri\Http $url
+     * @return  Weblog $this instance
+     * @throws  Exception\RuntimeException if $input is an invalid URI
+     *          (via Utils::normalizeUriHttp)
      */
     public function setRssUrl($url)
     {
@@ -402,10 +402,10 @@ class Weblog
     /**
      * Sets weblog Atom URL.
      *
-     * @param   string|\Zend\Uri\Http $url
-     * @return  \Zend\Service\Technorati\Weblog $this instance
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if $input is an invalid URI
-     *          (via Zend_Service_Technorati_Utils::normalizeUriHttp)
+     * @param   string|Uri\Http $url
+     * @return  Weblog $this instance
+     * @throws  Exception\RuntimeException if $input is an invalid URI
+     *          (via Utils::normalizeUriHttp)
      */
     public function setAtomUrl($url)
     {
@@ -417,12 +417,12 @@ class Weblog
      * Sets weblog Last Update timestamp.
      *
      * $datetime can be any value supported by
-     * Zend_Service_Technorati_Utils::normalizeDate().
+     * Utils::normalizeDate().
      *
      * @param   mixed $datetime A string representing the last update date time
      *                          in a valid date time format
-     * @return  \Zend\Service\Technorati\Weblog $this instance
-     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
+     * @return  Weblog $this instance
+     * @throws  Exception\RuntimeException
      */
     public function setLastUpdate($datetime)
     {
@@ -434,7 +434,7 @@ class Weblog
      * Sets weblog Rank.
      *
      * @param   integer $rank
-     * @return  \Zend\Service\Technorati\Weblog $this instance
+     * @return  Weblog $this instance
      */
     public function setRank($rank)
     {
@@ -446,7 +446,7 @@ class Weblog
      * Sets weblog latitude coordinate.
      *
      * @param   float $coordinate
-     * @return  \Zend\Service\Technorati\Weblog $this instance
+     * @return  Weblog $this instance
      */
     public function setLat($coordinate)
     {
@@ -458,7 +458,7 @@ class Weblog
      * Sets weblog longitude coordinate.
      *
      * @param   float $coordinate
-     * @return  \Zend\Service\Technorati\Weblog $this instance
+     * @return  Weblog $this instance
      */
     public function setLon($coordinate)
     {
@@ -470,7 +470,7 @@ class Weblog
      * Sets hasPhoto property.
      *
      * @param   bool $hasPhoto
-     * @return  \Zend\Service\Technorati\Weblog $this instance
+     * @return  Weblog $this instance
      */
     public function setHasPhoto($hasPhoto)
     {

--- a/library/Zend/Service/Technorati/Weblog.php
+++ b/library/Zend/Service/Technorati/Weblog.php
@@ -20,18 +20,23 @@
  */
 
 /**
+ * @namespace
+ */
+namespace Zend\Service\Technorati;
+
+/**
  * Represents a Weblog object successful recognized by Technorati.
  *
  * @uses       DOMXPath
- * @uses       Zend_Service_Technorati_Author
- * @uses       Zend_Service_Technorati_Utils
+ * @uses       \Zend\Service\Technorati\Author
+ * @uses       \Zend\Service\Technorati\Utils
  * @category   Zend
  * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Service_Technorati_Weblog
+class Weblog
 {
     /**
      * Blog name as written in the feed.
@@ -44,7 +49,7 @@ class Zend_Service_Technorati_Weblog
     /**
      * Base blog URL.
      *
-     * @var     Zend_Uri_Http
+     * @var     \Zend\Uri\Http
      * @access  protected
      */
     protected $_url;
@@ -52,7 +57,7 @@ class Zend_Service_Technorati_Weblog
     /**
      * RSS feed URL, if any.
      *
-     * @var     null|Zend_Uri_Http
+     * @var     null|\Zend\Uri\Http
      * @access  protected
      */
     protected $_rssUrl;
@@ -60,7 +65,7 @@ class Zend_Service_Technorati_Weblog
     /**
      * Atom feed URL, if any.
      *
-     * @var     null|Zend_Uri_Http
+     * @var     null|\Zend\Uri\Http
      * @access  protected
      */
     protected $_atomUrl;
@@ -126,7 +131,7 @@ class Zend_Service_Technorati_Weblog
      *
      * @var     bool
      * @access  protected
-     * @see     Zend_Service_Technorati_Author::$thumbnailPicture
+     * @see     \Zend\Service\Technorati\Author::$thumbnailPicture
      */
     protected $_hasPhoto = false;
 
@@ -144,9 +149,9 @@ class Zend_Service_Technorati_Weblog
      *
      * @param  DomElement $dom the ReST fragment for this object
      */
-    public function __construct(DomElement $dom)
+    public function __construct(\DomElement $dom)
     {
-        $xpath = new DOMXPath($dom->ownerDocument);
+        $xpath = new \DOMXPath($dom->ownerDocument);
 
         $result = $xpath->query('./name/text()', $dom);
         if ($result->length == 1) $this->setName($result->item(0)->data);
@@ -174,7 +179,7 @@ class Zend_Service_Technorati_Weblog
         $result = $xpath->query('./author', $dom);
         if ($result->length >= 1) {
             foreach ($result as $author) {
-                $this->_authors[] = new Zend_Service_Technorati_Author($author);
+                $this->_authors[] = new Author($author);
             }
         }
 
@@ -212,7 +217,7 @@ class Zend_Service_Technorati_Weblog
     /**
      * Returns weblog URL.
      *
-     * @return  null|Zend_Uri_Http object representing weblog base URL
+     * @return  null|\Zend\Uri\Http object representing weblog base URL
      */
     public function getUrl()
     {
@@ -242,7 +247,7 @@ class Zend_Service_Technorati_Weblog
     /**
      * Returns weblog Rss URL.
      *
-     * @return  null|Zend_Uri_Http object representing the URL
+     * @return  null|\Zend\Uri\Http object representing the URL
      *          of the RSS feed for given blog
      */
     public function getRssUrl()
@@ -253,7 +258,7 @@ class Zend_Service_Technorati_Weblog
     /**
      * Returns weblog Atom URL.
      *
-     * @return  null|Zend_Uri_Http object representing the URL
+     * @return  null|\Zend\Uri\Http object representing the URL
      *          of the Atom feed for given blog
      */
     public function getAtomUrl()
@@ -322,7 +327,7 @@ class Zend_Service_Technorati_Weblog
     /**
      * Returns the array of weblog authors.
      *
-     * @return  array of Zend_Service_Technorati_Author authors
+     * @return  array of \Zend\Service\Technorati\Author authors
      */
     public function getAuthors()
     {
@@ -334,7 +339,7 @@ class Zend_Service_Technorati_Weblog
      * Sets weblog name.
      *
      * @param   string $name
-     * @return  Zend_Service_Technorati_Weblog $this instance
+     * @return  \Zend\Service\Technorati\Weblog $this instance
      */
     public function setName($name)
     {
@@ -345,14 +350,14 @@ class Zend_Service_Technorati_Weblog
     /**
      * Sets weblog URL.
      *
-     * @param   string|Zend_Uri_Http $url
+     * @param   string|\Zend\Uri\Http $url
      * @return  void
-     * @throws  Zend_Service_Technorati_Exception if $input is an invalid URI
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if $input is an invalid URI
      *          (via Zend_Service_Technorati_Utils::normalizeUriHttp)
      */
     public function setUrl($url)
     {
-        $this->_url = Zend_Service_Technorati_Utils::normalizeUriHttp($url);
+        $this->_url = Utils::normalizeUriHttp($url);
         return $this;
     }
 
@@ -360,7 +365,7 @@ class Zend_Service_Technorati_Weblog
      * Sets number of inbound blogs.
      *
      * @param   integer $number
-     * @return  Zend_Service_Technorati_Weblog $this instance
+     * @return  \Zend\Service\Technorati\Weblog $this instance
      */
     public function setInboundBlogs($number)
     {
@@ -372,7 +377,7 @@ class Zend_Service_Technorati_Weblog
      * Sets number of Iinbound links.
      *
      * @param   integer $number
-     * @return  Zend_Service_Technorati_Weblog $this instance
+     * @return  \Zend\Service\Technorati\Weblog $this instance
      */
     public function setInboundLinks($number)
     {
@@ -383,28 +388,28 @@ class Zend_Service_Technorati_Weblog
     /**
      * Sets weblog Rss URL.
      *
-     * @param   string|Zend_Uri_Http $url
-     * @return  Zend_Service_Technorati_Weblog $this instance
-     * @throws  Zend_Service_Technorati_Exception if $input is an invalid URI
+     * @param   string|\Zend\Uri\Http $url
+     * @return  \Zend\Service\Technorati\Weblog $this instance
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if $input is an invalid URI
      *          (via Zend_Service_Technorati_Utils::normalizeUriHttp)
      */
     public function setRssUrl($url)
     {
-        $this->_rssUrl = Zend_Service_Technorati_Utils::normalizeUriHttp($url);
+        $this->_rssUrl = Utils::normalizeUriHttp($url);
         return $this;
     }
 
     /**
      * Sets weblog Atom URL.
      *
-     * @param   string|Zend_Uri_Http $url
-     * @return  Zend_Service_Technorati_Weblog $this instance
-     * @throws  Zend_Service_Technorati_Exception if $input is an invalid URI
+     * @param   string|\Zend\Uri\Http $url
+     * @return  \Zend\Service\Technorati\Weblog $this instance
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException if $input is an invalid URI
      *          (via Zend_Service_Technorati_Utils::normalizeUriHttp)
      */
     public function setAtomUrl($url)
     {
-        $this->_atomUrl = Zend_Service_Technorati_Utils::normalizeUriHttp($url);
+        $this->_atomUrl = Utils::normalizeUriHttp($url);
         return $this;
     }
 
@@ -416,12 +421,12 @@ class Zend_Service_Technorati_Weblog
      *
      * @param   mixed $datetime A string representing the last update date time
      *                          in a valid date time format
-     * @return  Zend_Service_Technorati_Weblog $this instance
-     * @throws  Zend_Service_Technorati_Exception
+     * @return  \Zend\Service\Technorati\Weblog $this instance
+     * @throws  \Zend\Service\Technorati\Exception\RuntimeException
      */
     public function setLastUpdate($datetime)
     {
-        $this->_lastUpdate = Zend_Service_Technorati_Utils::normalizeDate($datetime);
+        $this->_lastUpdate = Utils::normalizeDate($datetime);
         return $this;
     }
 
@@ -429,7 +434,7 @@ class Zend_Service_Technorati_Weblog
      * Sets weblog Rank.
      *
      * @param   integer $rank
-     * @return  Zend_Service_Technorati_Weblog $this instance
+     * @return  \Zend\Service\Technorati\Weblog $this instance
      */
     public function setRank($rank)
     {
@@ -441,7 +446,7 @@ class Zend_Service_Technorati_Weblog
      * Sets weblog latitude coordinate.
      *
      * @param   float $coordinate
-     * @return  Zend_Service_Technorati_Weblog $this instance
+     * @return  \Zend\Service\Technorati\Weblog $this instance
      */
     public function setLat($coordinate)
     {
@@ -453,7 +458,7 @@ class Zend_Service_Technorati_Weblog
      * Sets weblog longitude coordinate.
      *
      * @param   float $coordinate
-     * @return  Zend_Service_Technorati_Weblog $this instance
+     * @return  \Zend\Service\Technorati\Weblog $this instance
      */
     public function setLon($coordinate)
     {
@@ -465,7 +470,7 @@ class Zend_Service_Technorati_Weblog
      * Sets hasPhoto property.
      *
      * @param   bool $hasPhoto
-     * @return  Zend_Service_Technorati_Weblog $this instance
+     * @return  \Zend\Service\Technorati\Weblog $this instance
      */
     public function setHasPhoto($hasPhoto)
     {

--- a/library/Zend/Service/Technorati/Weblog.php
+++ b/library/Zend/Service/Technorati/Weblog.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -31,7 +31,7 @@ use \DomElement,
  * Represents a Weblog object successful recognized by Technorati.
  *
  * @category   Zend
- * @package    Zend\Service
+ * @package    Zend_Service
  * @subpackage Technorati
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/tests/Zend/Service/Technorati/AuthorTest.php
+++ b/tests/Zend/Service/Technorati/AuthorTest.php
@@ -20,10 +20,10 @@
  */
 
 /**
- * @todo: temporary fix because test autoloader doesn't load Zend_* classes
- * from test tree
+ * @namespace
  */
-require_once("Zend/Service/Technorati/TestCase.php");
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * @category   Zend
@@ -34,7 +34,7 @@ require_once("Zend/Service/Technorati/TestCase.php");
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_AuthorTest extends Zend_Service_Technorati_TestCase
+class AuthorTest extends TestCase
 {
     public function setUp()
     {
@@ -43,17 +43,12 @@ class Zend_Service_Technorati_AuthorTest extends Zend_Service_Technorati_TestCas
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_Author', array($this->domElement));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_Author', 'DOMElement');
+        $this->_testConstruct('Zend\Service\Technorati\Author', array($this->domElement));
     }
 
     public function testAuthor()
     {
-        $author = new Zend_Service_Technorati_Author($this->domElement);
+        $author = new Technorati\Author($this->domElement);
 
         $this->assertInternalType('string', $author->getFirstName());
         $this->assertEquals('Cesare', $author->getFirstName());
@@ -70,13 +65,13 @@ class Zend_Service_Technorati_AuthorTest extends Zend_Service_Technorati_TestCas
         $this->assertInternalType('string', $author->getFirstName());
         $this->assertEquals('This is a bio.', $author->getBio());
 
-        $this->assertInstanceOf('Zend_Uri_Http', $author->getThumbnailPicture());
-        $this->assertEquals(Zend_Uri::factory('http://static.technorati.com/progimages/photo.jpg?uid=117217'), $author->getThumbnailPicture());
+        $this->assertInstanceOf('Zend\Uri\Http', $author->getThumbnailPicture());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://static.technorati.com/progimages/photo.jpg?uid=117217'), $author->getThumbnailPicture());
     }
 
     public function testSetGet()
     {
-        $author = new Zend_Service_Technorati_Author($this->domElement);
+        $author = new Technorati\Author($this->domElement);
 
         // check first name
         $set = 'first';
@@ -110,21 +105,21 @@ class Zend_Service_Technorati_AuthorTest extends Zend_Service_Technorati_TestCas
 
         // check thubmnail picture
 
-        $set = Zend_Uri::factory('http://www.simonecarletti.com/');
+        $set = \Zend\Uri\UriFactory::factory('http://www.simonecarletti.com/');
         $get = $author->setThumbnailPicture($set)->getThumbnailPicture();
-        $this->assertInstanceOf('Zend_Uri_Http', $get);
+        $this->assertInstanceOf('Zend\Uri\Http', $get);
         $this->assertEquals($set, $get);
 
         $set = 'http://www.simonecarletti.com/';
         $get = $author->setThumbnailPicture($set)->getThumbnailPicture();
-        $this->assertInstanceOf('Zend_Uri_Http', $get);
-        $this->assertEquals(Zend_Uri::factory($set), $get);
+        $this->assertInstanceOf('Zend\Uri\Http', $get);
+        $this->assertEquals(\Zend\Uri\UriFactory::factory($set), $get);
 
         $set = 'http:::/foo';
         try {
             $author->setThumbnailPicture($set);
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch(Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception\RuntimeException not thrown');
+        } catch(Technorati\Exception\RuntimeException $e) {
             $this->assertContains("Invalid URI", $e->getMessage());
         }
     }

--- a/tests/Zend/Service/Technorati/BlogInfoResultTest.php
+++ b/tests/Zend/Service/Technorati/BlogInfoResultTest.php
@@ -30,7 +30,7 @@ use Zend\Service\Technorati;
  */
 
 /**
- * @see \Zend\Service\Technorati\BlogInfoResult
+ * @see Technorati\BlogInfoResult
  */
 
 

--- a/tests/Zend/Service/Technorati/BlogInfoResultTest.php
+++ b/tests/Zend/Service/Technorati/BlogInfoResultTest.php
@@ -19,13 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_BlogInfoResult
+ * @see \Zend\Service\Technorati\BlogInfoResult
  */
 
 
@@ -38,7 +43,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_BlogInfoResultTest extends Zend_Service_Technorati_TestCase
+class BlogInfoResultTest extends TestCase
 {
     public function setUp()
     {
@@ -47,26 +52,21 @@ class Zend_Service_Technorati_BlogInfoResultTest extends Zend_Service_Technorati
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_BlogInfoResult', array($this->dom));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_BlogInfoResult', 'DOMDocument');
+        $this->_testConstruct('Zend\Service\Technorati\BlogInfoResult', array($this->dom));
     }
 
     public function testBlogInfoResult()
     {
-        $object = new Zend_Service_Technorati_BlogInfoResult($this->dom);
+        $object = new Technorati\BlogInfoResult($this->dom);
 
         // check weblog
         $weblog = $object->getWeblog();
-        $this->assertInstanceOf('Zend_Service_Technorati_Weblog', $weblog);
+        $this->assertInstanceOf('Zend\Service\Technorati\Weblog', $weblog);
         $this->assertEquals('Simone Carletti\'s Blog', $weblog->getName());
 
         // check url
-        $this->assertInstanceOf('Zend_Uri_Http', $object->getUrl());
-        $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com/blog'), $object->getUrl());
+        $this->assertInstanceOf('Zend\Uri\Http', $object->getUrl());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://www.simonecarletti.com/blog'), $object->getUrl());
 
         // check inboundblogs
         $this->assertInternalType('integer', $object->getInboundBlogs());
@@ -80,10 +80,10 @@ class Zend_Service_Technorati_BlogInfoResultTest extends Zend_Service_Technorati
     public function testBlogInfoResultUrlWithInvalidSchemaEqualsToWeblogUrl()
     {
         $dom = self::getTestFileContentAsDom('TestBlogInfoResultUrlWithInvalidSchema.xml');
-        $object = new Zend_Service_Technorati_BlogInfoResult($dom);
+        $object = new Technorati\BlogInfoResult($dom);
 
         // check url
-        $this->assertInstanceOf('Zend_Uri_Http', $object->getUrl());
+        $this->assertInstanceOf('Zend\Uri\Http', $object->getUrl());
         $this->assertEquals($object->getWeblog()->getUrl(), $object->getUrl());
     }
 }

--- a/tests/Zend/Service/Technorati/CosmosResultSetTest.php
+++ b/tests/Zend/Service/Technorati/CosmosResultSetTest.php
@@ -19,13 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_CosmosResultSet
+ * @see \Zend\Service\Technorati\CosmosResultSet
  */
 
 
@@ -38,7 +43,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_CosmosResultSetTest extends Zend_Service_Technorati_TestCase
+class CosmosResultSetTest extends TestCase
 {
     public function setUp()
     {
@@ -47,17 +52,12 @@ class Zend_Service_Technorati_CosmosResultSetTest extends Zend_Service_Technorat
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_CosmosResultSet', array($this->dom));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_CosmosResultSet', 'DOMDocument');
+        $this->_testConstruct('Zend\Service\Technorati\CosmosResultSet', array($this->dom));
     }
 
     public function testCosmosResultSet()
     {
-        $object = new Zend_Service_Technorati_CosmosResultSet($this->dom);
+        $object = new Technorati\CosmosResultSet($this->dom);
 
         // check counts
         $this->assertInternalType('integer', $object->totalResults());
@@ -66,48 +66,48 @@ class Zend_Service_Technorati_CosmosResultSetTest extends Zend_Service_Technorat
         $this->assertEquals(278, $object->totalResultsAvailable());
 
         // check properties
-        $this->assertInstanceOf('Zend_Uri_Http', $object->getUrl());
-        $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com/blog'), $object->getUrl());
+        $this->assertInstanceOf('Zend\Uri\Http', $object->getUrl());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://www.simonecarletti.com/blog'), $object->getUrl());
         $this->assertInternalType('integer', $object->getInboundLinks());
         $this->assertEquals(278, $object->getInboundLinks());
 
         // check weblog
-        $this->assertInstanceOf('Zend_Service_Technorati_Weblog', $object->getWeblog());
+        $this->assertInstanceOf('Zend\Service\Technorati\Weblog', $object->getWeblog());
         $this->assertEquals('Simone Carletti\'s Blog', $object->getWeblog()->getName());
     }
 
     public function testCosmosResultSetItemsInstanceOfResult()
     {
         $this->_testResultSetItemsInstanceOfResult(
-                    'Zend_Service_Technorati_CosmosResultSet',
+                    'Zend\Service\Technorati\CosmosResultSet',
                     array($this->dom),
-                    'Zend_Service_Technorati_CosmosResult');
+                    'Zend\Service\Technorati\CosmosResult');
     }
 
     public function testCosmosResultSetSerialization()
     {
-        $this->_testResultSetSerialization(new Zend_Service_Technorati_CosmosResultSet($this->dom));
+        $this->_testResultSetSerialization(new Technorati\CosmosResultSet($this->dom));
     }
 
     public function testCosmosResultSetSiteLink()
     {
         $dom = self::getTestFileContentAsDom('TestCosmosResultSetSiteLink.xml');
-        $object = new Zend_Service_Technorati_CosmosResultSet($dom);
+        $object = new Technorati\CosmosResultSet($dom);
 
         $this->assertEquals(3, $object->totalResults());
         $this->assertEquals(949, $object->totalResultsAvailable());
-        $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com'), $object->getUrl());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://www.simonecarletti.com'), $object->getUrl());
         $this->assertEquals(949, $object->getInboundLinks());
     }
 
     public function testCosmosResultSetSiteWeblog()
     {
         $dom = self::getTestFileContentAsDom('TestCosmosResultSetSiteWeblog.xml');
-        $object = new Zend_Service_Technorati_CosmosResultSet($dom);
+        $object = new Technorati\CosmosResultSet($dom);
 
         $this->assertEquals(3, $object->totalResults());
         $this->assertEquals(39, $object->totalResultsAvailable());
-        $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com'), $object->getUrl());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://www.simonecarletti.com'), $object->getUrl());
         $this->assertEquals(39, $object->getInboundBlogs());
     }
 
@@ -117,7 +117,7 @@ class Zend_Service_Technorati_CosmosResultSetTest extends Zend_Service_Technorat
         // I only have to ensure the class doens't fail and $object->totalResultsAvailable == 0
 
         $dom = self::getTestFileContentAsDom('TestCosmosResultSetSiteWeblogWithMissingInboundblogs.xml');
-        $object = new Zend_Service_Technorati_CosmosResultSet($dom);
+        $object = new Technorati\CosmosResultSet($dom);
 
         $this->assertEquals(3, $object->totalResults());
         $this->assertEquals(0, $object->totalResultsAvailable());
@@ -138,17 +138,17 @@ class Zend_Service_Technorati_CosmosResultSetTest extends Zend_Service_Technorat
         // $dom = self::getTestFileContentAsDom('TestCosmosResultSetSiteUrlWithInvalidSchema.xml');
         // $object = new Zend_Service_Technorati_CosmosResultSet($dom);
 
-        // $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com'), $object->getUrl());
+        // $this->assertEquals(Zend_UriFactory::factory('http://www.simonecarletti.com'), $object->getUrl());
     }
 
     public function testCosmosResultSetBlogLink()
     {
         $dom = self::getTestFileContentAsDom('TestCosmosResultSetBlogLink.xml');
-        $object = new Zend_Service_Technorati_CosmosResultSet($dom);
+        $object = new Technorati\CosmosResultSet($dom);
 
         $this->assertEquals(20, $object->totalResults());
         $this->assertEquals(298, $object->totalResultsAvailable());
-        $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com/blog'), $object->getUrl());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://www.simonecarletti.com/blog'), $object->getUrl());
         $this->assertEquals(298, $object->getInboundLinks());
         $this->assertEquals('Simone Carletti\'s Blog', $object->getWeblog()->getName());
     }
@@ -156,11 +156,11 @@ class Zend_Service_Technorati_CosmosResultSetTest extends Zend_Service_Technorat
     public function testCosmosResultSetBlogWeblog()
     {
         $dom = self::getTestFileContentAsDom('TestCosmosResultSetBlogWeblog.xml');
-        $object = new Zend_Service_Technorati_CosmosResultSet($dom);
+        $object = new Technorati\CosmosResultSet($dom);
 
         $this->assertEquals(20, $object->totalResults());
         $this->assertEquals(85, $object->totalResultsAvailable());
-        $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com/blog'), $object->getUrl());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://www.simonecarletti.com/blog'), $object->getUrl());
         $this->assertEquals(85, $object->getInboundBlogs());
         $this->assertEquals('Simone Carletti\'s Blog', $object->getWeblog()->getName());
     }

--- a/tests/Zend/Service/Technorati/CosmosResultSetTest.php
+++ b/tests/Zend/Service/Technorati/CosmosResultSetTest.php
@@ -30,7 +30,7 @@ use Zend\Service\Technorati;
  */
 
 /**
- * @see \Zend\Service\Technorati\CosmosResultSet
+ * @see Technorati\CosmosResultSet
  */
 
 

--- a/tests/Zend/Service/Technorati/CosmosResultTest.php
+++ b/tests/Zend/Service/Technorati/CosmosResultTest.php
@@ -19,13 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_CosmosResult
+ * @see \Zend\Service\Technorati\CosmosResult
  */
 
 
@@ -38,7 +43,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_CosmosResultTest extends Zend_Service_Technorati_TestCase
+class CosmosResultTest extends TestCase
 {
     public function setUp()
     {
@@ -47,52 +52,47 @@ class Zend_Service_Technorati_CosmosResultTest extends Zend_Service_Technorati_T
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_CosmosResult', array($this->domElements->item(0)));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_CosmosResult', 'DOMElement');
+        $this->_testConstruct('Zend\Service\Technorati\CosmosResult', array($this->domElements->item(0)));
     }
 
     public function testCosmosResultSerialization()
     {
-        $this->_testResultSerialization(new Zend_Service_Technorati_CosmosResult($this->domElements->item(0)));
+        $this->_testResultSerialization(new Technorati\CosmosResult($this->domElements->item(0)));
     }
 
     public function testCosmosResultSiteLink()
     {
         $domElements = self::getTestFileElementsAsDom('TestCosmosResultSetSiteLink.xml');
-        $object = new Zend_Service_Technorati_CosmosResult($domElements->item(0));
+        $object = new Technorati\CosmosResult($domElements->item(0));
 
-        $this->assertInstanceOf('Zend_Service_Technorati_Weblog', $object->getWeblog());
+        $this->assertInstanceOf('Zend\Service\Technorati\Weblog', $object->getWeblog());
         $this->assertContains('Gioxx', $object->getWeblog()->getName());
 
-        $this->assertInstanceOf('Zend_Uri_Http', $object->getNearestPermalink());
-        $this->assertEquals(Zend_Uri::factory('http://gioxx.org/2007/11/05/il-passaggio-a-mac-le-11-risposte/'), $object->getNearestPermalink());
+        $this->assertInstanceOf('Zend\Uri\Http', $object->getNearestPermalink());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://gioxx.org/2007/11/05/il-passaggio-a-mac-le-11-risposte/'), $object->getNearestPermalink());
 
         $this->assertInternalType('string', $object->getExcerpt());
         $this->assertContains('Ho intenzione di prendere il modello bianco', $object->getExcerpt());
 
-        $this->assertInstanceOf('Zend_Date', $object->getLinkCreated());
-        $this->assertEquals(new Zend_Date('2007-11-11 20:07:11 GMT'), $object->getLinkCreated());
+        $this->assertInstanceOf('Zend\Date\Date', $object->getLinkCreated());
+        $this->assertEquals(new \Zend\Date\Date('2007-11-11 20:07:11 GMT'), $object->getLinkCreated());
 
-        $this->assertInstanceOf('Zend_Uri_Http', $object->getLinkUrl());
-        $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com/blog/2007/04/parallels-desktop-overview.php'), $object->getLinkUrl());
+        $this->assertInstanceOf('Zend\Uri\Http', $object->getLinkUrl());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://www.simonecarletti.com/blog/2007/04/parallels-desktop-overview.php'), $object->getLinkUrl());
 
         // test an other element to prevent cached values
-        $object = new Zend_Service_Technorati_CosmosResult($domElements->item(1));
+        $object = new Technorati\CosmosResult($domElements->item(1));
         $this->assertContains('Progetto-Seo', $object->getWeblog()->getName());
-        $this->assertEquals(Zend_Uri::factory('http://www.progetto-seo.com/motori-di-ricerca/links-interni'), $object->getNearestPermalink());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://www.progetto-seo.com/motori-di-ricerca/links-interni'), $object->getNearestPermalink());
         $this->assertContains('soprattutto Google', $object->getExcerpt());
-        $this->assertEquals(new Zend_Date('2007-11-10 08:57:22 GMT'), $object->getLinkCreated());
-        $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com/blog/2007/04/google-yahoo-ask-nofollow.php'), $object->getLinkUrl());
+        $this->assertEquals(new \Zend\Date\Date('2007-11-10 08:57:22 GMT'), $object->getLinkCreated());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://www.simonecarletti.com/blog/2007/04/google-yahoo-ask-nofollow.php'), $object->getLinkUrl());
     }
 
     public function testCosmosResultSiteLinkNearestPermalinkIsNull()
     {
         $domElements = self::getTestFileElementsAsDom('TestCosmosResultSetSiteLink.xml');
-        $object = new Zend_Service_Technorati_CosmosResult($domElements->item(2));
+        $object = new Technorati\CosmosResult($domElements->item(2));
         $this->assertContains('Controrete', $object->getWeblog()->getName());
         $this->assertNull($object->getNearestPermalink());
     }
@@ -100,18 +100,18 @@ class Zend_Service_Technorati_CosmosResultTest extends Zend_Service_Technorati_T
     public function testCosmosResultSiteWeblog()
     {
         $domElements = self::getTestFileElementsAsDom('TestCosmosResultSetSiteWeblog.xml');
-        $object = new Zend_Service_Technorati_CosmosResult($domElements->item(0));
+        $object = new Technorati\CosmosResult($domElements->item(0));
 
-        $this->assertInstanceOf('Zend_Service_Technorati_Weblog', $object->getWeblog());
+        $this->assertInstanceOf('Zend\Service\Technorati\Weblog', $object->getWeblog());
         $this->assertContains('Simone Carletti', $object->getWeblog()->getName());
 
-        $this->assertInstanceOf('Zend_Uri_Http', $object->getLinkUrl());
-        $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com'), $object->getLinkUrl());
+        $this->assertInstanceOf('Zend\Uri\Http', $object->getLinkUrl());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://www.simonecarletti.com'), $object->getLinkUrl());
 
         // test an other element to prevent cached values
-        $object = new Zend_Service_Technorati_CosmosResult($domElements->item(1));
+        $object = new Technorati\CosmosResult($domElements->item(1));
         $this->assertContains('Gioxx', $object->getWeblog()->getName());
-        $this->assertEquals(Zend_Uri::factory('http://www.simonecarletti.com'), $object->getLinkUrl());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://www.simonecarletti.com'), $object->getLinkUrl());
     }
 
     public function testCosmosResultBlogLink()

--- a/tests/Zend/Service/Technorati/CosmosResultTest.php
+++ b/tests/Zend/Service/Technorati/CosmosResultTest.php
@@ -30,7 +30,7 @@ use Zend\Service\Technorati;
  */
 
 /**
- * @see \Zend\Service\Technorati\CosmosResult
+ * @see Technorati\CosmosResult
  */
 
 

--- a/tests/Zend/Service/Technorati/DailyCountsResultSetTest.php
+++ b/tests/Zend/Service/Technorati/DailyCountsResultSetTest.php
@@ -19,13 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_DailyCountsResultSet
+ * @see \Zend\Service\Technorati\DailyCountsResultSet
  */
 
 
@@ -38,7 +43,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_DailyCountsResultSetTest extends Zend_Service_Technorati_TestCase
+class DailyCountsResultSetTest extends TestCase
 {
     public function setUp()
     {
@@ -47,17 +52,12 @@ class Zend_Service_Technorati_DailyCountsResultSetTest extends Zend_Service_Tech
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_DailyCountsResultSet', array($this->dom));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_DailyCountsResultSet', 'DOMDocument');
+        $this->_testConstruct('Zend\Service\Technorati\DailyCountsResultSet', array($this->dom));
     }
 
     public function testDailyCountsResultSet()
     {
-        $object = new Zend_Service_Technorati_DailyCountsResultSet($this->dom);
+        $object = new Technorati\DailyCountsResultSet($this->dom);
 
         // check counts
         $this->assertInternalType('integer', $object->totalResults());
@@ -66,20 +66,20 @@ class Zend_Service_Technorati_DailyCountsResultSetTest extends Zend_Service_Tech
         $this->assertEquals(5, $object->totalResultsAvailable());
 
         // check properties
-        $this->assertInstanceOf('Zend_Uri_Http', $object->getSearchUrl());
-        $this->assertEquals(Zend_Uri::factory('http://technorati.com/search/google'), $object->getSearchUrl());
+        $this->assertInstanceOf('Zend\Uri\Http', $object->getSearchUrl());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://technorati.com/search/google'), $object->getSearchUrl());
     }
 
     public function testDailyCountsResultSetItemsInstanceOfResult()
     {
         $this->_testResultSetItemsInstanceOfResult(
-                    'Zend_Service_Technorati_DailyCountsResultSet',
+                    'Zend\Service\Technorati\DailyCountsResultSet',
                     array($this->dom),
-                    'Zend_Service_Technorati_DailyCountsResult');
+                    'Zend\Service\Technorati\DailyCountsResult');
     }
 
     public function testDailyCountsResultSetSerialization()
     {
-        $this->_testResultSetSerialization(new Zend_Service_Technorati_DailyCountsResultSet($this->dom));
+        $this->_testResultSetSerialization(new Technorati\DailyCountsResultSet($this->dom));
     }
 }

--- a/tests/Zend/Service/Technorati/DailyCountsResultSetTest.php
+++ b/tests/Zend/Service/Technorati/DailyCountsResultSetTest.php
@@ -30,7 +30,7 @@ use Zend\Service\Technorati;
  */
 
 /**
- * @see \Zend\Service\Technorati\DailyCountsResultSet
+ * @see Technorati\DailyCountsResultSet
  */
 
 

--- a/tests/Zend/Service/Technorati/DailyCountsResultTest.php
+++ b/tests/Zend/Service/Technorati/DailyCountsResultTest.php
@@ -19,13 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_DailyCountsResult
+ * @see \Zend\Service\Technorati\DailyCountsResult
  */
 
 
@@ -38,7 +43,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_DailyCountsResultTest extends Zend_Service_Technorati_TestCase
+class DailyCountsResultTest extends TestCase
 {
     public function setUp()
     {
@@ -47,27 +52,22 @@ class Zend_Service_Technorati_DailyCountsResultTest extends Zend_Service_Technor
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_CosmosResult', array($this->domElements->item(0)));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_DailyCountsResult', 'DOMElement');
+        $this->_testConstruct('Zend\Service\Technorati\CosmosResult', array($this->domElements->item(0)));
     }
 
     public function testDailyCountsResult()
     {
-        $object = new Zend_Service_Technorati_DailyCountsResult($this->domElements->item(1));
+        $object = new Technorati\DailyCountsResult($this->domElements->item(1));
 
         // check properties
-        $this->assertInstanceOf('Zend_Date', $object->getDate());
-        $this->assertEquals(new Zend_Date(strtotime('2007-11-13')), $object->getDate());
+        $this->assertInstanceOf('Zend\Date\Date', $object->getDate());
+        $this->assertEquals(new \Zend\Date\Date(strtotime('2007-11-13')), $object->getDate());
         $this->assertInternalType('integer', $object->getCount());
         $this->assertEquals(54414, $object->getCount());
     }
 
     public function testDailyCountsResultSerialization()
     {
-        $this->_testResultSerialization(new Zend_Service_Technorati_DailyCountsResult($this->domElements->item(0)));
+        $this->_testResultSerialization(new Technorati\DailyCountsResult($this->domElements->item(0)));
     }
 }

--- a/tests/Zend/Service/Technorati/DailyCountsResultTest.php
+++ b/tests/Zend/Service/Technorati/DailyCountsResultTest.php
@@ -30,7 +30,7 @@ use Zend\Service\Technorati;
  */
 
 /**
- * @see \Zend\Service\Technorati\DailyCountsResult
+ * @see Technorati\DailyCountsResult
  */
 
 

--- a/tests/Zend/Service/Technorati/GetInfoResultTest.php
+++ b/tests/Zend/Service/Technorati/GetInfoResultTest.php
@@ -23,13 +23,14 @@
  * @namespace
  */
 namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see \Zend\Service\Technorati\GetInfoResult
+ * @see Technorati\GetInfoResult
  */
 
 
@@ -56,7 +57,7 @@ class GetInfoResultTest extends TestCase
 
     public function testGetInfoResult()
     {
-        $object = new \Zend\Service\Technorati\GetInfoResult($this->dom);
+        $object = new Technorati\GetInfoResult($this->dom);
 
         // check author
         $author = $object->getAuthor();

--- a/tests/Zend/Service/Technorati/GetInfoResultTest.php
+++ b/tests/Zend/Service/Technorati/GetInfoResultTest.php
@@ -19,13 +19,17 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_GetInfoResult
+ * @see \Zend\Service\Technorati\GetInfoResult
  */
 
 
@@ -38,7 +42,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_GetInfoResultTest extends Zend_Service_Technorati_TestCase
+class GetInfoResultTest extends TestCase
 {
     public function setUp()
     {
@@ -47,27 +51,22 @@ class Zend_Service_Technorati_GetInfoResultTest extends Zend_Service_Technorati_
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_GetInfoResult', array($this->dom));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_GetInfoResult', 'DOMDocument');
+        $this->_testConstruct('Zend\Service\Technorati\GetInfoResult', array($this->dom));
     }
 
     public function testGetInfoResult()
     {
-        $object = new Zend_Service_Technorati_GetInfoResult($this->dom);
+        $object = new \Zend\Service\Technorati\GetInfoResult($this->dom);
 
         // check author
         $author = $object->getAuthor();
-        $this->assertInstanceOf('Zend_Service_Technorati_Author', $author);
+        $this->assertInstanceOf('Zend\Service\Technorati\Author', $author);
         $this->assertEquals('weppos', $author->getUsername());
 
         // check weblogs
         $weblogs = $object->getWeblogs();
         $this->assertInternalType('array', $weblogs);
         $this->assertEquals(2, count($weblogs));
-        $this->assertInstanceOf('Zend_Service_Technorati_Weblog', $weblogs[0]);
+        $this->assertInstanceOf('Zend\Service\Technorati\Weblog', $weblogs[0]);
     }
 }

--- a/tests/Zend/Service/Technorati/KeyInfoResultTest.php
+++ b/tests/Zend/Service/Technorati/KeyInfoResultTest.php
@@ -30,7 +30,7 @@ use Zend\Service\Technorati;
  */
 
 /**
- * @see \Zend\Service\Technorati\KeyInfoResult
+ * @see Technorati\KeyInfoResult
  */
 
 

--- a/tests/Zend/Service/Technorati/KeyInfoResultTest.php
+++ b/tests/Zend/Service/Technorati/KeyInfoResultTest.php
@@ -19,13 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_KeyInfoResult
+ * @see \Zend\Service\Technorati\KeyInfoResult
  */
 
 
@@ -38,7 +43,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_KeyInfoResultTest extends Zend_Service_Technorati_TestCase
+class KeyInfoResultTest extends TestCase
 {
     const TEST_API_KEY = 'avalidapikey';
 
@@ -49,17 +54,12 @@ class Zend_Service_Technorati_KeyInfoResultTest extends Zend_Service_Technorati_
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_KeyInfoResult', array($this->dom, self::TEST_API_KEY));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_KeyInfoResult', 'DOMDocument');
+        $this->_testConstruct('Zend\Service\Technorati\KeyInfoResult', array($this->dom, self::TEST_API_KEY));
     }
 
     public function testKeyInfoResult()
     {
-        $object = new Zend_Service_Technorati_KeyInfoResult($this->dom, self::TEST_API_KEY);
+        $object = new Technorati\KeyInfoResult($this->dom, self::TEST_API_KEY);
 
         $this->assertInternalType('string', $object->getApiKey());
         $this->assertEquals(self::TEST_API_KEY, $object->getApiKey());
@@ -71,13 +71,13 @@ class Zend_Service_Technorati_KeyInfoResultTest extends Zend_Service_Technorati_
 
     public function testApiKeyIsNullByDefault()
     {
-        $object = new Zend_Service_Technorati_KeyInfoResult($this->dom);
+        $object = new Technorati\KeyInfoResult($this->dom);
         $this->assertEquals(null, $object->getApiKey());
     }
 
     public function testSetGet()
     {
-        $object = new Zend_Service_Technorati_KeyInfoResult($this->dom, self::TEST_API_KEY);
+        $object = new Technorati\KeyInfoResult($this->dom, self::TEST_API_KEY);
 
         $set = 'anewapikey';
         $get = $object->setApiKey($set)->getApiKey();

--- a/tests/Zend/Service/Technorati/ResultSetTest.php
+++ b/tests/Zend/Service/Technorati/ResultSetTest.php
@@ -19,17 +19,21 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_ResultSet
+ * @see \Zend\Service\Technorati\ResultSet
  */
 
 /**
- * @see Zend_Service_Technorati_SearchResultSet
+ * @see \Zend\Service\Technorati\SearchResultSet
  */
 
 
@@ -42,7 +46,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_ResultSetTest extends Zend_Service_Technorati_TestCase
+class ResultSetTest extends TestCase
 {
     /**
      * Even if Zend_Service_Technorati_ResultSet is an abstract class
@@ -54,10 +58,10 @@ class Zend_Service_Technorati_ResultSetTest extends Zend_Service_Technorati_Test
      */
     public function setUp()
     {
-        $this->ref = new ReflectionClass('Zend_Service_Technorati_ResultSet');
+        $this->ref = new \ReflectionClass('Zend\Service\Technorati\ResultSet');
         $this->dom = self::getTestFileContentAsDom('TestSearchResultSet.xml');
-        $this->object = new Zend_Service_Technorati_SearchResultSet($this->dom);
-        $this->objectRef = new ReflectionObject($this->object);
+        $this->object = new \Zend\Service\Technorati\SearchResultSet($this->dom);
+        $this->objectRef = new \ReflectionObject($this->object);
     }
 
     public function testResultSetIsAbstract()
@@ -91,7 +95,7 @@ class Zend_Service_Technorati_ResultSetTest extends Zend_Service_Technorati_Test
         try {
             $this->object->seek(1000);
             $this->fail('Expected OutOfBoundsException not thrown');
-        } catch (OutOfBoundsException $e) {
+        } catch (\OutOfBoundsException $e) {
             $this->assertContains('Illegal index', $e->getMessage());
         }
     }

--- a/tests/Zend/Service/Technorati/ResultSetTest.php
+++ b/tests/Zend/Service/Technorati/ResultSetTest.php
@@ -23,17 +23,18 @@
  * @namespace
  */
 namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see \Zend\Service\Technorati\ResultSet
+ * @see Technorati\ResultSet
  */
 
 /**
- * @see \Zend\Service\Technorati\SearchResultSet
+ * @see Technorati\SearchResultSet
  */
 
 
@@ -60,7 +61,7 @@ class ResultSetTest extends TestCase
     {
         $this->ref = new \ReflectionClass('Zend\Service\Technorati\ResultSet');
         $this->dom = self::getTestFileContentAsDom('TestSearchResultSet.xml');
-        $this->object = new \Zend\Service\Technorati\SearchResultSet($this->dom);
+        $this->object = new Technorati\SearchResultSet($this->dom);
         $this->objectRef = new \ReflectionObject($this->object);
     }
 

--- a/tests/Zend/Service/Technorati/ResultTest.php
+++ b/tests/Zend/Service/Technorati/ResultTest.php
@@ -23,17 +23,18 @@
  * @namespace
  */
 namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see \Zend\Service\Technorati\Result
+ * @see Technorati\Result
  */
 
 /**
- * @see \Zend\Service\Technorati\SearchResult
+ * @see Technorati\SearchResult
  */
 
 
@@ -56,7 +57,7 @@ class ResultTest extends TestCase
     {
         $this->ref = new \ReflectionClass('Zend\Service\Technorati\Result');
         $this->domElements = self::getTestFileElementsAsDom('TestSearchResultSet.xml');
-        $this->object = new \Zend\Service\Technorati\SearchResult($this->domElements->item(0));
+        $this->object = new Technorati\SearchResult($this->domElements->item(0));
         $this->objectRef = new \ReflectionObject($this->object);
     }
 

--- a/tests/Zend/Service/Technorati/ResultTest.php
+++ b/tests/Zend/Service/Technorati/ResultTest.php
@@ -19,17 +19,21 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_Result
+ * @see \Zend\Service\Technorati\Result
  */
 
 /**
- * @see Zend_Service_Technorati_SearchResult
+ * @see \Zend\Service\Technorati\SearchResult
  */
 
 
@@ -42,7 +46,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_ResultTest extends Zend_Service_Technorati_TestCase
+class ResultTest extends TestCase
 {
     /**
      * Any *Result class should be a child of Result
@@ -50,10 +54,10 @@ class Zend_Service_Technorati_ResultTest extends Zend_Service_Technorati_TestCas
      */
     public function setUp()
     {
-        $this->ref = new ReflectionClass('Zend_Service_Technorati_Result');
+        $this->ref = new \ReflectionClass('Zend\Service\Technorati\Result');
         $this->domElements = self::getTestFileElementsAsDom('TestSearchResultSet.xml');
-        $this->object = new Zend_Service_Technorati_SearchResult($this->domElements->item(0));
-        $this->objectRef = new ReflectionObject($this->object);
+        $this->object = new \Zend\Service\Technorati\SearchResult($this->domElements->item(0));
+        $this->objectRef = new \ReflectionObject($this->object);
     }
 
     public function testResultIsAbstract()

--- a/tests/Zend/Service/Technorati/SearchResultSetTest.php
+++ b/tests/Zend/Service/Technorati/SearchResultSetTest.php
@@ -30,7 +30,7 @@ use Zend\Service\Technorati;
  */
 
 /**
- * @see \Zend\Service\Technorati\SearchResultSet
+ * @see Technorati\SearchResultSet
  */
 
 

--- a/tests/Zend/Service/Technorati/SearchResultSetTest.php
+++ b/tests/Zend/Service/Technorati/SearchResultSetTest.php
@@ -19,13 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_SearchResultSet
+ * @see \Zend\Service\Technorati\SearchResultSet
  */
 
 
@@ -38,7 +43,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_SearchResultSetTest extends Zend_Service_Technorati_TestCase
+class SearchResultSetTest extends TestCase
 {
     public function setUp()
     {
@@ -47,17 +52,12 @@ class Zend_Service_Technorati_SearchResultSetTest extends Zend_Service_Technorat
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_SearchResultSet', array($this->dom));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_SearchResultSet', 'DOMDocument');
+        $this->_testConstruct('Zend\Service\Technorati\SearchResultSet', array($this->dom));
     }
 
     public function testSearchResultSet()
     {
-        $object = new Zend_Service_Technorati_SearchResultSet($this->dom);
+        $object = new Technorati\SearchResultSet($this->dom);
 
         // check counts
         $this->assertInternalType('integer', $object->totalResults());
@@ -69,13 +69,13 @@ class Zend_Service_Technorati_SearchResultSetTest extends Zend_Service_Technorat
     public function testSearchResultSetItemsInstanceOfResult()
     {
         $this->_testResultSetItemsInstanceOfResult(
-                    'Zend_Service_Technorati_SearchResultSet',
+                    'Zend\Service\Technorati\SearchResultSet',
                     array($this->dom),
-                    'Zend_Service_Technorati_SearchResult');
+                    'Zend\Service\Technorati\SearchResult');
     }
 
     public function testSearchResultSetSerialization()
     {
-        $this->_testResultSetSerialization(new Zend_Service_Technorati_SearchResultSet($this->dom));
+        $this->_testResultSetSerialization(new Technorati\SearchResultSet($this->dom));
     }
 }

--- a/tests/Zend/Service/Technorati/SearchResultTest.php
+++ b/tests/Zend/Service/Technorati/SearchResultTest.php
@@ -19,13 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_SearchResult
+ * @see \Zend\Service\Technorati\SearchResult
  */
 
 
@@ -38,7 +43,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_SearchResultTest extends Zend_Service_Technorati_TestCase
+class SearchResultTest extends TestCase
 {
     public function setUp()
     {
@@ -47,41 +52,36 @@ class Zend_Service_Technorati_SearchResultTest extends Zend_Service_Technorati_T
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_SearchResult', array($this->domElements->item(0)));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_SearchResult', 'DOMElement');
+        $this->_testConstruct('Zend\Service\Technorati\SearchResult', array($this->domElements->item(0)));
     }
 
     public function testSearchResult()
     {
-        $object = new Zend_Service_Technorati_SearchResult($this->domElements->item(0));
+        $object = new Technorati\SearchResult($this->domElements->item(0));
 
         // check properties
         $this->assertInternalType('string', $object->getTitle());
         $this->assertContains('El SDK de Android', $object->getTitle());
         $this->assertInternalType('string', $object->getExcerpt());
         $this->assertContains('[ Android]', $object->getExcerpt());
-        $this->assertInstanceOf('Zend_Uri_Http', $object->getPermalink());
-        $this->assertEquals(Zend_Uri_Http::factory('http://blogs.eurielec.etsit.upm.es/miotroblog/?p=271'), $object->getPermalink());
-        $this->assertInstanceOf('Zend_Date', $object->getCreated());
-        $this->assertEquals(new Zend_Date('2007-11-14 22:18:04 GMT'), $object->getCreated());
+        $this->assertInstanceOf('Zend\Uri\Http', $object->getPermalink());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://blogs.eurielec.etsit.upm.es/miotroblog/?p=271'), $object->getPermalink());
+        $this->assertInstanceOf('Zend\Date\Date', $object->getCreated());
+        $this->assertEquals(new \Zend\Date\Date('2007-11-14 22:18:04 GMT'), $object->getCreated());
 
         // check weblog
-        $this->assertInstanceOf('Zend_Service_Technorati_Weblog', $object->getWeblog());
+        $this->assertInstanceOf('Zend\Service\Technorati\Weblog', $object->getWeblog());
         $this->assertContains('Mi otro blog', $object->getWeblog()->getName());
     }
 
     public function testSearchResultSerialization()
     {
-        $this->_testResultSerialization(new Zend_Service_Technorati_SearchResult($this->domElements->item(0)));
+        $this->_testResultSerialization(new Technorati\SearchResult($this->domElements->item(0)));
     }
 
     public function testSearchResultSpecialEncoding()
     {
-        $object = new Zend_Service_Technorati_SearchResult($this->domElements->item(1));
+        $object = new Technorati\SearchResult($this->domElements->item(1));
 
         $this->assertContains('質の超濃い読者をどかんと5000件集めます', $object->getTitle());
     }

--- a/tests/Zend/Service/Technorati/SearchResultTest.php
+++ b/tests/Zend/Service/Technorati/SearchResultTest.php
@@ -30,7 +30,7 @@ use Zend\Service\Technorati;
  */
 
 /**
- * @see \Zend\Service\Technorati\SearchResult
+ * @see Technorati\SearchResult
  */
 
 

--- a/tests/Zend/Service/Technorati/TagResultSetTest.php
+++ b/tests/Zend/Service/Technorati/TagResultSetTest.php
@@ -30,7 +30,7 @@ use Zend\Service\Technorati;
  */
 
 /**
- * @see \Zend\Service\Technorati\TagResultSet
+ * @see Technorati\TagResultSet
  */
 
 

--- a/tests/Zend/Service/Technorati/TagResultSetTest.php
+++ b/tests/Zend/Service/Technorati/TagResultSetTest.php
@@ -19,13 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_TagResultSet
+ * @see \Zend\Service\Technorati\TagResultSet
  */
 
 
@@ -38,7 +43,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_TagResultSetTest extends Zend_Service_Technorati_TestCase
+class TagResultSetTest extends TestCase
 {
     public function setUp()
     {
@@ -47,17 +52,12 @@ class Zend_Service_Technorati_TagResultSetTest extends Zend_Service_Technorati_T
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_TagResultSet', array($this->dom));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_TagResultSet', 'DOMDocument');
+        $this->_testConstruct('Zend\Service\Technorati\TagResultSet', array($this->dom));
     }
 
     public function testTagResultSet()
     {
-        $object = new Zend_Service_Technorati_TagResultSet($this->dom);
+        $object = new Technorati\TagResultSet($this->dom);
 
         // check counts
         $this->assertInternalType('integer', $object->totalResults());
@@ -75,13 +75,13 @@ class Zend_Service_Technorati_TagResultSetTest extends Zend_Service_Technorati_T
     public function testTagResultSetItemsInstanceOfResult()
     {
         $this->_testResultSetItemsInstanceOfResult(
-                    'Zend_Service_Technorati_TagResultSet',
+                    'Zend\Service\Technorati\TagResultSet',
                     array($this->dom),
-                    'Zend_Service_Technorati_TagResult');
+                    'Zend\Service\Technorati\TagResult');
     }
 
     public function testTagResultSetSerialization()
     {
-        $this->_testResultSetSerialization(new Zend_Service_Technorati_TagResultSet($this->dom));
+        $this->_testResultSetSerialization(new Technorati\TagResultSet($this->dom));
     }
 }

--- a/tests/Zend/Service/Technorati/TagResultTest.php
+++ b/tests/Zend/Service/Technorati/TagResultTest.php
@@ -30,7 +30,7 @@ use Zend\Service\Technorati;
  */
 
 /**
- * @see \Zend\Service\Technorati\TagsResult
+ * @see Technorati\TagsResult
  */
 
 

--- a/tests/Zend/Service/Technorati/TagResultTest.php
+++ b/tests/Zend/Service/Technorati/TagResultTest.php
@@ -19,13 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_TagsResult
+ * @see \Zend\Service\Technorati\TagsResult
  */
 
 
@@ -38,7 +43,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_TagResultTest extends Zend_Service_Technorati_TestCase
+class TagResultTest extends TestCase
 {
     public function setUp()
     {
@@ -47,37 +52,32 @@ class Zend_Service_Technorati_TagResultTest extends Zend_Service_Technorati_Test
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_TagResult', array($this->domElements->item(0)));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_TagResult', 'DOMElement');
+        $this->_testConstruct('Zend\Service\Technorati\TagResult', array($this->domElements->item(0)));
     }
 
     public function testTagResult()
     {
-        $object = new Zend_Service_Technorati_TagResult($this->domElements->item(1));
+        $object = new Technorati\TagResult($this->domElements->item(1));
 
         // check properties
         $this->assertInternalType('string', $object->getTitle());
         $this->assertContains('Permalink for : VerveEarth', $object->getTitle());
         $this->assertInternalType('string', $object->getExcerpt());
         $this->assertContains('VerveEarth: Locate Your Blog!', $object->getExcerpt());
-        $this->assertInstanceOf('Zend_Uri_Http', $object->getPermalink());
-        $this->assertEquals(Zend_Uri::factory('http://scienceroll.com/2007/11/14/verveearth-locate-your-blog/'), $object->getPermalink());
-        $this->assertInstanceOf('Zend_Date', $object->getCreated());
-        $this->assertEquals(new Zend_Date('2007-11-14 21:52:11'), $object->getCreated());
-        $this->assertInstanceOf('Zend_Date', $object->getUpdated());
-        $this->assertEquals(new Zend_Date('2007-11-14 21:57:59'), $object->getUpdated());
+        $this->assertInstanceOf('Zend\Uri\Http', $object->getPermalink());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://scienceroll.com/2007/11/14/verveearth-locate-your-blog/'), $object->getPermalink());
+        $this->assertInstanceOf('Zend\Date\Date', $object->getCreated());
+        $this->assertEquals(new \Zend\Date\Date('2007-11-14 21:52:11'), $object->getCreated());
+        $this->assertInstanceOf('Zend\Date\Date', $object->getUpdated());
+        $this->assertEquals(new \Zend\Date\Date('2007-11-14 21:57:59'), $object->getUpdated());
 
         // check weblog
-        $this->assertInstanceOf('Zend_Service_Technorati_Weblog', $object->getWeblog());
+        $this->assertInstanceOf('Zend\Service\Technorati\Weblog', $object->getWeblog());
         $this->assertEquals(' ScienceRoll', $object->getWeblog()->getName());
     }
 
     public function testTagResultSerialization()
     {
-        $this->_testResultSerialization(new Zend_Service_Technorati_TagResult($this->domElements->item(0)));
+        $this->_testResultSerialization(new Technorati\TagResult($this->domElements->item(0)));
     }
 }

--- a/tests/Zend/Service/Technorati/TagsResultSetTest.php
+++ b/tests/Zend/Service/Technorati/TagsResultSetTest.php
@@ -19,13 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_TagsResultSet
+ * @see \Zend\Service\Technorati\TagsResultSet
  */
 
 
@@ -38,27 +43,22 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_TagsResultSetTest extends Zend_Service_Technorati_TestCase
+class TagsResultSetTest extends TestCase
 {
     public function setUp()
     {
         $this->dom = self::getTestFileContentAsDom('TestTagsResultSet.xml');
-        $this->object = new Zend_Service_Technorati_TagsResultSet($this->dom);
+        $this->object = new Technorati\TagsResultSet($this->dom);
     }
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_TagsResultSet', array($this->dom));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_TagsResultSet', 'DOMDocument');
+        $this->_testConstruct('Zend\Service\Technorati\TagsResultSet', array($this->dom));
     }
 
     public function testTagsResultSet()
     {
-        $object = new Zend_Service_Technorati_TagsResultSet($this->dom);
+        $object = new Technorati\TagsResultSet($this->dom);
 
         // check counts
         $this->assertInternalType('integer', $object->totalResults());
@@ -70,13 +70,13 @@ class Zend_Service_Technorati_TagsResultSetTest extends Zend_Service_Technorati_
     public function testTagsResultSetItemsInstanceOfResult()
     {
         $this->_testResultSetItemsInstanceOfResult(
-                    'Zend_Service_Technorati_TagsResultSet',
+                    'Zend\Service\Technorati\TagsResultSet',
                     array($this->dom),
-                    'Zend_Service_Technorati_TagsResult');
+                    'Zend\Service\Technorati\TagsResult');
     }
 
     public function testTagsResultSetSerialization()
     {
-        $this->_testResultSetSerialization(new Zend_Service_Technorati_TagsResultSet($this->dom));
+        $this->_testResultSetSerialization(new Technorati\TagsResultSet($this->dom));
     }
 }

--- a/tests/Zend/Service/Technorati/TagsResultSetTest.php
+++ b/tests/Zend/Service/Technorati/TagsResultSetTest.php
@@ -30,7 +30,7 @@ use Zend\Service\Technorati;
  */
 
 /**
- * @see \Zend\Service\Technorati\TagsResultSet
+ * @see Technorati\TagsResultSet
  */
 
 

--- a/tests/Zend/Service/Technorati/TagsResultTest.php
+++ b/tests/Zend/Service/Technorati/TagsResultTest.php
@@ -19,13 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_TagsResult
+ * @see \Zend\Service\Technorati\TagsResult
  */
 
 
@@ -38,7 +43,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_TagsResultTest extends Zend_Service_Technorati_TestCase
+class TagsResultTest extends TestCase
 {
     public function setUp()
     {
@@ -47,17 +52,12 @@ class Zend_Service_Technorati_TagsResultTest extends Zend_Service_Technorati_Tes
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_TagsResult', array($this->domElements->item(0)));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_TagsResult', 'DOMElement');
+        $this->_testConstruct('Zend\Service\Technorati\TagsResult', array($this->domElements->item(0)));
     }
 
     public function testTagsResult()
     {
-        $object = new Zend_Service_Technorati_TagsResult($this->domElements->item(2));
+        $object = new Technorati\TagsResult($this->domElements->item(2));
 
         // check properties
         $this->assertInternalType('string', $object->getTag());
@@ -68,12 +68,12 @@ class Zend_Service_Technorati_TagsResultTest extends Zend_Service_Technorati_Tes
 
     public function testTagsResultSerialization()
     {
-        $this->_testResultSerialization(new Zend_Service_Technorati_TagsResult($this->domElements->item(0)));
+        $this->_testResultSerialization(new Technorati\TagsResult($this->domElements->item(0)));
     }
 
     public function testTagsResultSpecialEncoding()
     {
-        $object = new Zend_Service_Technorati_TagsResult($this->domElements->item(0));
+        $object = new Technorati\TagsResult($this->domElements->item(0));
         $this->assertEquals('練習用', $object->getTag());
         $this->assertEquals(19655999, $object->getPosts());
     }

--- a/tests/Zend/Service/Technorati/TagsResultTest.php
+++ b/tests/Zend/Service/Technorati/TagsResultTest.php
@@ -30,7 +30,7 @@ use Zend\Service\Technorati;
  */
 
 /**
- * @see \Zend\Service\Technorati\TagsResult
+ * @see Technorati\TagsResult
  */
 
 

--- a/tests/Zend/Service/Technorati/TechnoratiTest.php
+++ b/tests/Zend/Service/Technorati/TechnoratiTest.php
@@ -619,7 +619,7 @@ class TechnoratiTest extends TestCase
      * Do not execute any file validation. Please use this method carefully.
      *
      * @params  string $file
-     * @return  \Zend\Service\Technorati\Technorati
+     * @return  Technorati\Technorati
      */
     private function _setResponseFromFile($file)
     {

--- a/tests/Zend/Service/Technorati/TechnoratiTest.php
+++ b/tests/Zend/Service/Technorati/TechnoratiTest.php
@@ -19,6 +19,11 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
@@ -34,7 +39,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_TestCase
+class TechnoratiTest extends TestCase
 {
     const TEST_APY_KEY = 'somevalidapikey';
     const TEST_PARAM_COSMOS = 'http://www.simonecarletti.com/blog/';
@@ -48,25 +53,25 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     public function setUp()
     {
         /**
-         * @see Zend_Http_Client_Adapter_Test
+         * @see \Zend\Http\Client\Adapter\Test
          */
-        $adapter = new Zend_Http_Client_Adapter_Test();
+        $adapter = new \Zend\Http\Client\Adapter\Test();
 
         /**
-         * @see Zend_Http_Client
+         * @see \Zend\Http\Client
          */
-        $client = new Zend_Http_Client(Zend_Service_Technorati::API_URI_BASE, array(
+        $client = new \Zend\Http\Client(Technorati\Technorati::API_URI_BASE, array(
             'adapter' => $adapter
         ));
 
-        $this->technorati = new Zend_Service_Technorati(self::TEST_APY_KEY);
+        $this->technorati = new Technorati\Technorati(self::TEST_APY_KEY);
         $this->adapter = $adapter;
         $this->technorati->getRestClient()->setHttpClient($client);
     }
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati', array(self::TEST_APY_KEY));
+        $this->_testConstruct('Zend\Service\Technorati\Technorati', array(self::TEST_APY_KEY));
     }
 
     public function testApiKeyMatches()
@@ -88,10 +93,10 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestCosmosSuccess.xml')->cosmos(self::TEST_PARAM_COSMOS);
 
-        $this->assertInstanceOf('Zend_Service_Technorati_CosmosResultSet', $result);
+        $this->assertInstanceOf('Zend\Service\Technorati\CosmosResultSet', $result);
         $this->assertEquals(2, $result->totalResults());
         $result->seek(0);
-        $this->assertInstanceOf('Zend_Service_Technorati_CosmosResult', $result->current());
+        $this->assertInstanceOf('Zend\Service\Technorati\CosmosResult', $result->current());
         // content is validated in Zend_Service_Technorati_CosmosResultSet tests
     }
 
@@ -99,8 +104,8 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         try {
             $this->_setResponseFromFile('TestCosmosError.xml')->cosmos(self::TEST_PARAM_COSMOS);
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch (Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception\RuntimeException not thrown');
+        } catch (Technorati\Exception\RuntimeException $e) {
             $this->assertContains("Invalid request: url is required", $e->getMessage());
         }
     }
@@ -151,10 +156,10 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestSearchSuccess.xml')->search(self::TEST_PARAM_SEARCH);
 
-        $this->assertInstanceOf('Zend_Service_Technorati_SearchResultSet', $result);
+        $this->assertInstanceOf('Zend\Service\Technorati\SearchResultSet', $result);
         $this->assertEquals(2, $result->totalResults());
         $result->seek(0);
-        $this->assertInstanceOf('Zend_Service_Technorati_SearchResult', $result->current());
+        $this->assertInstanceOf('Zend\Service\Technorati\SearchResult', $result->current());
         // content is validated in Zend_Service_Technorati_SearchResultSet tests
     }
 
@@ -165,7 +170,7 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         try {
             $this->_setResponseFromFile('TestSearchError.xml')->cosmos(self::TEST_PARAM_COSMOS);
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
+            $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
         } catch (Zend_Service_Technorati_Exception $e) {
             $this->assertContains("Invalid request: url is required", $e->getMessage());
         }
@@ -214,10 +219,10 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestTagSuccess.xml')->tag(self::TEST_PARAM_TAG);
 
-        $this->assertInstanceOf('Zend_Service_Technorati_TagResultSet', $result);
+        $this->assertInstanceOf('Zend\Service\Technorati\TagResultSet', $result);
         $this->assertEquals(2, $result->totalResults());
         $result->seek(0);
-        $this->assertInstanceOf('Zend_Service_Technorati_TagResult', $result->current());
+        $this->assertInstanceOf('Zend\Service\Technorati\TagResult', $result->current());
         // content is validated in Zend_Service_Technorati_TagResultSet tests
     }
 
@@ -225,8 +230,8 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         try {
             $this->_setResponseFromFile('TestTagError.xml')->tag(self::TEST_PARAM_TAG);
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch (Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
+        } catch (Technorati\Exception\RuntimeException $e) {
             $this->assertContains("Invalid request.", $e->getMessage());
         }
     }
@@ -271,10 +276,10 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestDailyCountsSuccess.xml')->dailyCounts(self::TEST_PARAM_DAILYCOUNT);
 
-        $this->assertInstanceOf('Zend_Service_Technorati_DailyCountsResultSet', $result);
+        $this->assertInstanceOf('Zend\Service\Technorati\DailyCountsResultSet', $result);
         $this->assertEquals(180, $result->totalResults());
         $result->seek(0);
-        $this->assertInstanceOf('Zend_Service_Technorati_DailyCountsResult', $result->current());
+        $this->assertInstanceOf('Zend\Service\Technorati\DailyCountsResult', $result->current());
         // content is validated in Zend_Service_Technorati_DailyCountsResultSet tests
     }
 
@@ -282,8 +287,8 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         try {
             $this->_setResponseFromFile('TestDailyCountsError.xml')->dailyCounts(self::TEST_PARAM_DAILYCOUNT);
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch (Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
+        } catch (Technorati\Exception\RuntimeException $e) {
             $this->assertContains("Missing required parameter", $e->getMessage());
         }
     }
@@ -321,7 +326,7 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestBlogInfoSuccess.xml')->blogInfo(self::TEST_PARAM_BLOGINFO);
 
-        $this->assertInstanceOf('Zend_Service_Technorati_BlogInfoResult', $result);
+        $this->assertInstanceOf('Zend\Service\Technorati\BlogInfoResult', $result);
         // content is validated in Zend_Service_Technorati_BlogInfoResult tests
     }
 
@@ -329,8 +334,8 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         try {
             $this->_setResponseFromFile('TestBlogInfoError.xml')->blogInfo(self::TEST_PARAM_BLOGINFO);
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch (Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
+        } catch (Technorati\Exception\RuntimeException $e) {
             $this->assertContains("Invalid request: url is required", $e->getMessage());
         }
     }
@@ -348,8 +353,8 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
         // when URL is not a recognized weblog
         try {
             $this->_setResponseFromFile('TestBlogInfoErrorUrlNotWeblog.xml')->blogInfo('www.simonecarletti.com');
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch (Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
+        } catch (Technorati\Exception\RuntimeException $e) {
             $this->assertContains("Technorati weblog", $e->getMessage());
         }
     }
@@ -358,7 +363,7 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestBlogPostTagsSuccess.xml')->blogPostTags(self::TEST_PARAM_BLOGPOSTTAGS);
 
-        $this->assertInstanceOf('Zend_Service_Technorati_TagsResultSet', $result);
+        $this->assertInstanceOf('Zend\Service\Technorati\TagsResultSet', $result);
         // content is validated in Zend_Service_Technorati_TagsResultSet tests
     }
 
@@ -366,8 +371,8 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         try {
             $this->_setResponseFromFile('TestBlogPostTagsError.xml')->blogPostTags(self::TEST_PARAM_BLOGPOSTTAGS);
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch (Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
+        } catch (Technorati\Exception\RuntimeException $e) {
             $this->assertContains("Invalid request: url is required", $e->getMessage());
         }
     }
@@ -406,7 +411,7 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestTopTagsSuccess.xml')->topTags();
 
-        $this->assertInstanceOf('Zend_Service_Technorati_TagsResultSet', $result);
+        $this->assertInstanceOf('Zend\Service\Technorati\TagsResultSet', $result);
         // content is validated in Zend_Service_Technorati_TagsResultSet tests
     }
 
@@ -414,8 +419,8 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         try {
             $this->_setResponseFromFile('TestTopTagsError.xml')->topTags();
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch (Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
+        } catch (Technorati\Exception\RuntimeException $e) {
             $this->assertContains("Invalid key.", $e->getMessage());
         }
     }
@@ -447,7 +452,7 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestGetInfoSuccess.xml')->getInfo(self::TEST_PARAM_GETINFO);
 
-        $this->assertInstanceOf('Zend_Service_Technorati_GetInfoResult', $result);
+        $this->assertInstanceOf('Zend\Service\Technorati\GetInfoResult', $result);
         // content is validated in Zend_Service_Technorati_GetInfoResult tests
     }
 
@@ -455,8 +460,8 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         try {
             $this->_setResponseFromFile('TestGetInfoError.xml')->getInfo(self::TEST_PARAM_GETINFO);
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch (Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
+        } catch (Technorati\Exception\RuntimeException $e) {
             $this->assertContains("Username is a required field.", $e->getMessage());
         }
     }
@@ -472,7 +477,7 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         $result = $this->_setResponseFromFile('TestKeyInfoSuccess.xml')->keyInfo();
 
-        $this->assertInstanceOf('Zend_Service_Technorati_KeyInfoResult', $result);
+        $this->assertInstanceOf('Zend\Service\Technorati\KeyInfoResult', $result);
         // content is validated in Zend_Service_Technorati_KeyInfoResult tests
     }
 
@@ -480,8 +485,8 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         try {
             $this->_setResponseFromFile('TestKeyInfoError.xml')->keyInfo();
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch (Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
+        } catch (Technorati\Exception\RuntimeException $e) {
             $this->assertContains("Invalid key.", $e->getMessage());
         }
     }
@@ -504,8 +509,8 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
             $options = array_merge((array) $param, array($invalidFormatOption));
             try {
                 call_user_func_array(array($technorati, $method), $options);
-                $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-            } catch (Zend_Service_Technorati_Exception $e) {
+                $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
+            } catch (Technorati\Exception\RuntimeException $e) {
                 $this->assertContains("'format'", $e->getMessage());
             }
         }
@@ -528,8 +533,8 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
             $options = array_merge((array) $param, array($invalidOption));
             try {
                 call_user_func_array(array($technorati, $method), $options);
-                $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-            } catch (Zend_Service_Technorati_Exception $e) {
+                $this->fail('Expected Zend\Service\Technorati\Exception\RuntimeException not thrown');
+            } catch (Technorati\Exception\RuntimeException $e) {
                 $this->assertContains("'foo'", $e->getMessage());
             }
         }
@@ -545,8 +550,8 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
     {
         try {
             $this->technorati->$callbackMethod('');
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch (Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
+        } catch (Technorati\Exception\RuntimeException $e) {
             $this->assertContains("'$name'", $e->getMessage());
         }
     }
@@ -570,7 +575,7 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
 
             try {
                 call_user_func_array(array($technorati, $callbackMethod), $options);
-            } catch (Zend_Service_Technorati_Exception $e) {
+            } catch (Technorati\Exception\RuntimeException $e) {
                 $this->fail("Exception " . $e->getMessage() . " thrown " .
                             "for option '$option' value '$value'");
             }
@@ -598,7 +603,7 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
                 call_user_func_array(array($technorati, $callbackMethod), $options);
                 $this->fail("Expected Zend_Service_Technorati_Exception not thrown " .
                             "for option '$option' value '$value'");
-            } catch (Zend_Service_Technorati_Exception $e) {
+            } catch (Technorati\Exception\RuntimeException $e) {
                 $this->assertContains("'$option'", $e->getMessage());
             }
         }
@@ -614,7 +619,7 @@ class Zend_Service_Technorati_TechnoratiTest extends Zend_Service_Technorati_Tes
      * Do not execute any file validation. Please use this method carefully.
      *
      * @params  string $file
-     * @return  Zend_Service_Technorati
+     * @return  \Zend\Service\Technorati\Technorati
      */
     private function _setResponseFromFile($file)
     {

--- a/tests/Zend/Service/Technorati/TestCase.php
+++ b/tests/Zend/Service/Technorati/TestCase.php
@@ -20,6 +20,11 @@
  */
 
 /**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+
+/**
  * Patch for default timezone in PHP >= 5.1.0
  */
 if (!ini_get('date.timezone')) {
@@ -35,22 +40,22 @@ if (!ini_get('date.timezone')) {
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_TestCase extends PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit_Framework_TestCase
 {
     protected function _testConstruct($className, $args)
     {
-        $reflection = new ReflectionClass($className);
+        $reflection = new \ReflectionClass($className);
         try {
             $object = $reflection->newInstanceArgs($args);
             $this->assertInstanceOf($className, $object);
-        } catch (Zend_Service_Technorati_Exception $e) {
+        } catch (\Zend\Service\Technorati\Exception\RuntimeException $e) {
             $this->fail("Exception " . $e->getMessage() . " thrown");
         }
     }
 
     protected function _testResultSetItemsInstanceOfResult($resultSetClassName, $args, $resultClassName)
     {
-        $reflection = new ReflectionClass($resultSetClassName);
+        $reflection = new \ReflectionClass($resultSetClassName);
         $resultset = $reflection->newInstanceArgs($args);
         foreach ($resultset as $result) {
             $this->assertInstanceOf($resultClassName, $result);
@@ -68,7 +73,7 @@ class Zend_Service_Technorati_TestCase extends PHPUnit_Framework_TestCase
             try {
                 $unobject->seek($index);
                 $unresult = $unobject->current();
-            } catch(OutOfBoundsException $e) {
+            } catch(\OutOfBoundsException $e) {
                 $this->fail("Missing result index $index");
             }
             $this->assertEquals($result, $unresult);
@@ -108,7 +113,7 @@ class Zend_Service_Technorati_TestCase extends PHPUnit_Framework_TestCase
 
     public static function getTestFileContentAsDom($file)
     {
-        $dom = new DOMDocument();
+        $dom = new \DOMDocument();
         $dom->load(self::getTestFilePath($file));
         return $dom;
     }
@@ -116,14 +121,14 @@ class Zend_Service_Technorati_TestCase extends PHPUnit_Framework_TestCase
     public static function getTestFileElementsAsDom($file, $exp = '//item')
     {
         $dom = self::getTestFileContentAsDom($file);
-        $xpath = new DOMXPath($dom);
+        $xpath = new \DOMXPath($dom);
         return $xpath->query($exp);
     }
 
     public static function getTestFileElementAsDom($file, $exp = '//item', $item = 0)
     {
         $dom = self::getTestFileContentAsDom($file);
-        $xpath = new DOMXPath($dom);
+        $xpath = new \DOMXPath($dom);
         $domElements = $xpath->query($exp);
         return $domElements->item($item);
     }

--- a/tests/Zend/Service/Technorati/TestCase.php
+++ b/tests/Zend/Service/Technorati/TestCase.php
@@ -48,7 +48,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
         try {
             $object = $reflection->newInstanceArgs($args);
             $this->assertInstanceOf($className, $object);
-        } catch (\Zend\Service\Technorati\Exception\RuntimeException $e) {
+        } catch (Technorati\Exception\RuntimeException $e) {
             $this->fail("Exception " . $e->getMessage() . " thrown");
         }
     }

--- a/tests/Zend/Service/Technorati/UtilsTest.php
+++ b/tests/Zend/Service/Technorati/UtilsTest.php
@@ -30,7 +30,7 @@ use Zend\Service\Technorati;
  */
 
 /**
- * @see \Zend\Service\Technorati\Utils
+ * @see Technorati\Utils
  */
 
 

--- a/tests/Zend/Service/Technorati/UtilsTest.php
+++ b/tests/Zend/Service/Technorati/UtilsTest.php
@@ -19,13 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_Utils
+ * @see \Zend\Service\Technorati\Utils
  */
 
 
@@ -38,14 +43,14 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_UtilsTest extends Zend_Service_Technorati_TestCase
+class UtilsTest extends TestCase
 {
     /**
      * @return void
      */
     public function testSetUriHttpInputNullReturnsNull()
     {
-        $this->assertNull(Zend_Service_Technorati_Utils::normalizeUriHttp(null));
+        $this->assertNull(Technorati\Utils::normalizeUriHttp(null));
     }
 
     /**
@@ -56,9 +61,9 @@ class Zend_Service_Technorati_UtilsTest extends Zend_Service_Technorati_TestCase
         $scheme             = 'ftp';
         $inputInvalidScheme = "$scheme://example.com";
         try {
-            Zend_Service_Technorati_Utils::normalizeUriHttp($inputInvalidScheme);
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch (Zend_Service_Technorati_Exception $e) {
+            Technorati\Utils::normalizeUriHttp($inputInvalidScheme);
+            $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
+        } catch (Technorati\Exception\RuntimeException $e) {
             $this->assertContains($scheme, $e->getMessage());
         }
     }
@@ -68,7 +73,7 @@ class Zend_Service_Technorati_UtilsTest extends Zend_Service_Technorati_TestCase
      */
     public function testSetDateInputNullReturnsNull()
     {
-        $this->assertNull(Zend_Service_Technorati_Utils::normalizeDate(null));
+        $this->assertNull(Technorati\Utils::normalizeDate(null));
     }
 
     /**
@@ -76,10 +81,10 @@ class Zend_Service_Technorati_UtilsTest extends Zend_Service_Technorati_TestCase
      */
     public function testSetDateInputDateInstanceReturnsInstance()
     {
-        $date   = new Zend_Date('2007-11-11 08:47:26 GMT');
-        $result = Zend_Service_Technorati_Utils::normalizeDate($date);
+        $date   = new \Zend\Date\Date('2007-11-11 08:47:26 GMT');
+        $result = Technorati\Utils::normalizeDate($date);
 
-        $this->assertInstanceOf('Zend_Date', $result);
+        $this->assertInstanceOf('Zend\Date\Date', $result);
         $this->assertEquals($date, $result);
     }
 
@@ -90,9 +95,9 @@ class Zend_Service_Technorati_UtilsTest extends Zend_Service_Technorati_TestCase
     {
         $inputInvalid = "2007foo";
         try {
-            Zend_Service_Technorati_Utils::normalizeDate($inputInvalid);
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch (Zend_Service_Technorati_Exception $e) {
+            Technorati\Utils::normalizeDate($inputInvalid);
+            $this->fail('Expected Zend\Service\Technorati\Exception\RuntimeException not thrown');
+        } catch (Technorati\Exception\RuntimeException $e) {
             $this->assertContains($inputInvalid, $e->getMessage());
         }
     }

--- a/tests/Zend/Service/Technorati/WeblogTest.php
+++ b/tests/Zend/Service/Technorati/WeblogTest.php
@@ -30,7 +30,7 @@ use Zend\Service\Technorati;
  */
 
 /**
- * @see \Zend\Service\Technorati\Weblog
+ * @see Technorati\Weblog
  */
 
 

--- a/tests/Zend/Service/Technorati/WeblogTest.php
+++ b/tests/Zend/Service/Technorati/WeblogTest.php
@@ -19,13 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+/**
+ * @namespace
+ */
+namespace ZendTest\Service\Technorati;
+use Zend\Service\Technorati;
 
 /**
  * Test helper
  */
 
 /**
- * @see Zend_Service_Technorati_Weblog
+ * @see \Zend\Service\Technorati\Weblog
  */
 
 
@@ -38,7 +43,7 @@
  * @group      Zend_Service
  * @group      Zend_Service_Technorati
  */
-class Zend_Service_Technorati_WeblogTest extends Zend_Service_Technorati_TestCase
+class WeblogTest extends TestCase
 {
     public function setUp()
     {
@@ -47,32 +52,27 @@ class Zend_Service_Technorati_WeblogTest extends Zend_Service_Technorati_TestCas
 
     public function testConstruct()
     {
-        $this->_testConstruct('Zend_Service_Technorati_Weblog', array($this->domElement));
-    }
-
-    public function testConstructThrowsExceptionWithInvalidDom()
-    {
-        $this->_testConstructThrowsExceptionWithInvalidDom('Zend_Service_Technorati_Weblog', 'DOMElement');
+        $this->_testConstruct('Zend\Service\Technorati\Weblog', array($this->domElement));
     }
 
     public function testWeblog()
     {
-        $weblog = new Zend_Service_Technorati_Weblog($this->domElement);
+        $weblog = new Technorati\Weblog($this->domElement);
 
         // check name
         $this->assertEquals('Roby Web World Italia', $weblog->getName());
         // check URL
-        $this->assertEquals(Zend_Uri::factory('http://robyww.blogspot.com'), $weblog->getUrl());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://robyww.blogspot.com'), $weblog->getUrl());
         // check Atom Url
-        $this->assertEquals(Zend_Uri::factory('http://robyww.blogspot.com/feeds/posts/atom'), $weblog->getAtomUrl());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://robyww.blogspot.com/feeds/posts/atom'), $weblog->getAtomUrl());
         // check RSS Url
-        $this->assertEquals(Zend_Uri::factory('http://robyww.blogspot.com/feeds/posts/rss'), $weblog->getRssUrl());
+        $this->assertEquals(\Zend\Uri\UriFactory::factory('http://robyww.blogspot.com/feeds/posts/rss'), $weblog->getRssUrl());
         // check inbound blogs
         $this->assertEquals(71, $weblog->getInboundBlogs());
         // check inbound links
         $this->assertEquals(103, $weblog->getInboundLinks());
         // check last update
-        $this->assertEquals(new Zend_Date('2007-11-11 08:47:26 GMT'), $weblog->getLastUpdate());
+        $this->assertEquals(new \Zend\Date\Date('2007-11-11 08:47:26 GMT'), $weblog->getLastUpdate());
         // check rank
         $this->assertEquals(93473, $weblog->getRank());
         // check authors
@@ -89,7 +89,7 @@ class Zend_Service_Technorati_WeblogTest extends Zend_Service_Technorati_TestCas
     public function testWeblogWithTwoAuthors()
     {
         $domElement = self::getTestFileElementAsDom('TestWeblogTwoAuthors.xml', '//weblog');
-        $weblog = new Zend_Service_Technorati_Weblog($domElement);
+        $weblog = new Technorati\Weblog($domElement);
 
         $authors = $weblog->getAuthors();
 
@@ -99,18 +99,18 @@ class Zend_Service_Technorati_WeblogTest extends Zend_Service_Technorati_TestCas
 
         // check first author
         $author = $authors[0];
-        $this->assertInstanceOf('Zend_Service_Technorati_Author', $author);
+        $this->assertInstanceOf('Zend\Service\Technorati\Author', $author);
         $this->assertEquals('rfilippini', $author->getUsername());
 
         // check second author, be sure it's not the first one
         $author = $authors[1];
-        $this->assertInstanceOf('Zend_Service_Technorati_Author', $author);
+        $this->assertInstanceOf('Zend\Service\Technorati\Author', $author);
         $this->assertEquals('Rinzi', $author->getUsername());
     }
 
     public function testSetGet()
     {
-        $weblog = new Zend_Service_Technorati_Weblog($this->domElement);
+        $weblog = new Technorati\Weblog($this->domElement);
 
         // check name
         $set = 'foo';
@@ -120,61 +120,61 @@ class Zend_Service_Technorati_WeblogTest extends Zend_Service_Technorati_TestCas
 
         // check URL
 
-        $set = Zend_Uri::factory('http://www.simonecarletti.com/');
+        $set = \Zend\Uri\UriFactory::factory('http://www.simonecarletti.com/');
         $get = $weblog->setUrl($set)->getUrl();
-        $this->assertInstanceOf('Zend_Uri_Http', $get);
+        $this->assertInstanceOf('Zend\Uri\Http', $get);
         $this->assertEquals($set, $get);
 
         $set = 'http://www.simonecarletti.com/';
         $get = $weblog->setUrl($set)->getUrl();
-        $this->assertInstanceOf('Zend_Uri_Http', $get);
-        $this->assertEquals(Zend_Uri::factory($set), $get);
+        $this->assertInstanceOf('Zend\Uri\Http', $get);
+        $this->assertEquals(\Zend\Uri\UriFactory::factory($set), $get);
 
         $set = 'http:::/foo';
         try {
             $weblog->setUrl($set);
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch(Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
+        } catch(Technorati\Exception\RuntimeException $e) {
             $this->assertContains("Invalid URI", $e->getMessage());
         }
 
         // check Atom URL
 
-        $set = Zend_Uri::factory('http://www.simonecarletti.com/');
+        $set = \Zend\Uri\UriFactory::factory('http://www.simonecarletti.com/');
         $get = $weblog->setAtomUrl($set)->getAtomUrl();
-        $this->assertInstanceOf('Zend_Uri_Http', $get);
+        $this->assertInstanceOf('Zend\Uri\Http', $get);
         $this->assertEquals($set, $get);
 
         $set = 'http://www.simonecarletti.com/';
         $get = $weblog->setAtomUrl($set)->getAtomUrl();
-        $this->assertInstanceOf('Zend_Uri_Http', $get);
-        $this->assertEquals(Zend_Uri::factory($set), $get);
+        $this->assertInstanceOf('Zend\Uri\Http', $get);
+        $this->assertEquals(\Zend\Uri\UriFactory::factory($set), $get);
 
         $set = 'http:::/foo';
         try {
             $weblog->setAtomUrl($set);
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch(Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
+        } catch(Technorati\Exception\RuntimeException $e) {
             $this->assertContains("Invalid URI", $e->getMessage());
         }
 
         // check RSS Url
 
-        $set = Zend_Uri::factory('http://www.simonecarletti.com/');
+        $set = \Zend\Uri\UriFactory::factory('http://www.simonecarletti.com/');
         $get = $weblog->setRssUrl($set)->getRssUrl();
-        $this->assertInstanceOf('Zend_Uri_Http', $get);
+        $this->assertInstanceOf('Zend\Uri\Http', $get);
         $this->assertEquals($set, $get);
 
         $set = 'http://www.simonecarletti.com/';
         $get = $weblog->setRssUrl($set)->getRssUrl();
-        $this->assertInstanceOf('Zend_Uri_Http', $get);
-        $this->assertEquals(Zend_Uri::factory($set), $get);
+        $this->assertInstanceOf('Zend\Uri\Http', $get);
+        $this->assertEquals(\Zend\Uri\UriFactory::factory($set), $get);
 
         $set = 'http:::/foo';
         try {
             $weblog->setRssUrl($set);
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch(Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception\RuntimeException not thrown');
+        } catch(Technorati\Exception\RuntimeException $e) {
             $this->assertContains("Invalid URI", $e->getMessage());
         }
 
@@ -206,8 +206,8 @@ class Zend_Service_Technorati_WeblogTest extends Zend_Service_Technorati_TestCas
 
         $set = '2007-11-11 08:47:26 GMT';
         $get = $weblog->setLastUpdate($set)->getLastUpdate();
-        $this->assertInstanceOf('Zend_Date', $get);
-        $this->assertEquals(new Zend_Date($set), $get);
+        $this->assertInstanceOf('Zend\Date', $get);
+        $this->assertEquals(new \Zend\Date\Date($set), $get);
 
         /* not supported
         $set = time();
@@ -218,8 +218,8 @@ class Zend_Service_Technorati_WeblogTest extends Zend_Service_Technorati_TestCas
         $set = '200ty';
         try {
             $weblog->setLastUpdate($set);
-            $this->fail('Expected Zend_Service_Technorati_Exception not thrown');
-        } catch(Zend_Service_Technorati_Exception $e) {
+            $this->fail('Expected Zend\Service\Technorati\Exception not thrown');
+        } catch(Technorati\Exception\RuntimeException $e) {
             $this->assertContains("valid Date/Time", $e->getMessage());
         }
 

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -9,7 +9,6 @@
         <exclude>
             <group>disable</group>
             <group>Zend_Search_Lucene</group>
-            <group>Zend_Service_Technorati</group>
         </exclude>
     </groups>
 </phpunit>


### PR DESCRIPTION
I adapted the code for Technorati Service to be compatible with the Framework.

I not made any change in the logic, only I changed classnames and adapt missing functions to the new functions in the framework.

Also I removed the exclusion in the phpunit tests and now ZF-106 is fixed

At this momento only 2 units tests are failling. This tests expects than Zend\Uri\UriFactory throw a Exception if the Uri was mal formatted, but seems that Uri component treats the Uri (http:::/foo) as correct.

``` bash
$ phpunit Zend/Service/Technorati/
PHPUnit 3.6.10 by Sebastian Bergmann.

Configuration read from zf2/tests/phpunit.xml

..F............................................................  63 / 122 ( 51%)
..........................................................F

Time: 5 seconds, Memory: 30,25Mb

There were 2 failures:

1) ZendTest\Service\Technorati\AuthorTest::testSetGet
Expected Zend\Service\Technorati\Exception\RuntimeException not thrown

zf2/tests/Zend/Service/Technorati/AuthorTest.php:121

2) ZendTest\Service\Technorati\WeblogTest::testSetGet
Expected Zend\Service\Technorati\Exception not thrown

zf2/tests/Zend/Service/Technorati/WeblogTest.php:136

FAILURES!
Tests: 122, Assertions: 352, Failures: 2.

```
