### PR TITLE
[#1] Remove auto-escaping from PhpRenderer

### DIFF
--- a/library/Zend/View/Helper/Escape.php
+++ b/library/Zend/View/Helper/Escape.php
@@ -106,7 +106,7 @@ class Escape extends AbstractHelper
         if (!is_callable($this->callback)) {
             $encoding = $this->getEncoding();
             $callback = function($value) use ($encoding) {
-                return htmlspecialchars($value, ENT_COMPAT, $encoding, false);
+                return htmlspecialchars($value, ENT_QUOTES, $encoding, false);
             };
             $this->setCallback($callback);
         }

--- a/library/Zend/View/Helper/Fieldset.php
+++ b/library/Zend/View/Helper/Fieldset.php
@@ -50,12 +50,13 @@ class Fieldset extends FormElement
         extract($info);
 
         // get legend
+        $escaper = $this->view->plugin('escape');
         $legend = '';
         if (isset($attribs['legend'])) {
             $legendString = trim($attribs['legend']);
             if (!empty($legendString)) {
                 $legend = '<legend>'
-                        . (($escape) ? $this->view->vars()->escape($legendString) : $legendString)
+                        . (($escape) ? $escaper($legendString) : $legendString)
                         . '</legend>' . PHP_EOL;
             }
             unset($attribs['legend']);
@@ -63,7 +64,7 @@ class Fieldset extends FormElement
 
         // get id
         if (!empty($id)) {
-            $id = ' id="' . $this->view->vars()->escape($id) . '"';
+            $id = ' id="' . $escaper($id) . '"';
         } else {
             $id = '';
         }

--- a/library/Zend/View/Helper/Form.php
+++ b/library/Zend/View/Helper/Form.php
@@ -50,7 +50,8 @@ class Form extends FormElement
         extract($info);
 
         if (!empty($id)) {
-            $id = ' id="' . $this->view->vars()->escape($id) . '"';
+            $escaper = $this->view->plugin('escape');
+            $id      = ' id="' . $escaper($id) . '"';
         } else {
             $id = '';
         }

--- a/library/Zend/View/Helper/FormButton.php
+++ b/library/Zend/View/Helper/FormButton.php
@@ -82,16 +82,17 @@ class FormButton extends FormElement
             $attribs['disabled'] = 'disabled';
         }
 
-        $content = ($escape) ? $this->view->vars()->escape($content) : $content;
+        $escaper = $this->view->plugin('escape');
+        $content = ($escape) ? $escaper($content) : $content;
 
         $xhtml = '<button'
-                . ' name="' . $this->view->vars()->escape($name) . '"'
-                . ' id="' . $this->view->vars()->escape($id) . '"'
-                . ' type="' . $type . '"';
+                . ' name="' . $escaper($name) . '"'
+                . ' id="'   . $escaper($id)   . '"'
+                . ' type="' . $type           . '"';
 
         // add a value if one is given
         if (!empty($value)) {
-            $xhtml .= ' value="' . $this->view->vars()->escape($value) . '"';
+            $xhtml .= ' value="' . $escaper($value) . '"';
         }
 
         // add attributes and close start tag

--- a/library/Zend/View/Helper/FormCheckbox.php
+++ b/library/Zend/View/Helper/FormCheckbox.php
@@ -86,14 +86,15 @@ class FormCheckbox extends FormElement
         }
 
         // build the element
-        $xhtml = '';
+        $xhtml   = '';
+        $escaper = $this->view->plugin('escape');
         if (!$disable && !strstr($name, '[]')) {
             $xhtml = $this->_hidden($name, $checkedOptions['uncheckedValue']);
         }
         $xhtml .= '<input type="checkbox"'
-                . ' name="' . $this->view->vars()->escape($name) . '"'
-                . ' id="' . $this->view->vars()->escape($id) . '"'
-                . ' value="' . $this->view->vars()->escape($checkedOptions['checkedValue']) . '"'
+                . ' name="'  . $escaper($name)                           . '"'
+                . ' id="'    . $escaper($id)                             . '"'
+                . ' value="' . $escaper($checkedOptions['checkedValue']) . '"'
                 . $checkedOptions['checkedString']
                 . $disabled
                 . $this->_htmlAttribs($attribs)

--- a/library/Zend/View/Helper/FormElement.php
+++ b/library/Zend/View/Helper/FormElement.php
@@ -190,9 +190,10 @@ abstract class FormElement extends HtmlElement
      */
     protected function _hidden($name, $value = null, $attribs = null)
     {
+        $escaper = $this->view->plugin('escape');
         return '<input type="hidden"'
-             . ' name="' . $this->view->vars()->escape($name) . '"'
-             . ' value="' . $this->view->vars()->escape($value) . '"'
+             . ' name="' . $escaper($name) . '"'
+             . ' value="' . $escaper($value) . '"'
              . $this->_htmlAttribs($attribs) . $this->getClosingBracket();
     }
 }

--- a/library/Zend/View/Helper/FormErrors.php
+++ b/library/Zend/View/Helper/FormErrors.php
@@ -75,8 +75,9 @@ class FormErrors extends FormElement
         }
 
         if ($escape) {
+            $escaper = $this->view->plugin('escape');
             foreach ($errors as $key => $error) {
-                $errors[$key] = $this->view->vars()->escape($error);
+                $errors[$key] = $escaper($error);
             }
         }
 

--- a/library/Zend/View/Helper/FormFile.php
+++ b/library/Zend/View/Helper/FormFile.php
@@ -67,12 +67,13 @@ class FormFile extends FormElement
         }
 
         // build the element
-        $xhtml = '<input type="file"'
-                . ' name="' . $this->view->vars()->escape($name) . '"'
-                . ' id="' . $this->view->vars()->escape($id) . '"'
-                . $disabled
-                . $this->_htmlAttribs($attribs)
-                . $endTag;
+        $escaper = $this->view->plugin('escape');
+        $xhtml   = '<input type="file"'
+                 . ' name="' . $escaper($name) . '"'
+                 . ' id="' . $escaper($id) . '"'
+                 . $disabled
+                 . $this->_htmlAttribs($attribs)
+                 . $endTag;
 
         return $xhtml;
     }

--- a/library/Zend/View/Helper/FormImage.php
+++ b/library/Zend/View/Helper/FormImage.php
@@ -56,17 +56,18 @@ class FormImage extends FormElement
         extract($info); // name, value, attribs, options, listsep, disable
 
         // Determine if we should use the value or the src attribute
+        $escaper = $this->view->plugin('escape');
         if (isset($attribs['src'])) {
-            $src = ' src="' . $this->view->vars()->escape($attribs['src']) . '"';
+            $src = ' src="' . $escaper($attribs['src']) . '"';
             unset($attribs['src']);
         } else {
-            $src = ' src="' . $this->view->vars()->escape($value) . '"';
+            $src = ' src="' . $escaper($value) . '"';
             unset($value);
         }
 
         // Do we have a value?
         if (isset($value) && !empty($value)) {
-            $value = ' value="' . $this->view->vars()->escape($value) . '"';
+            $value = ' value="' . $escaper($value) . '"';
         } else {
             $value = '';
         }
@@ -85,8 +86,8 @@ class FormImage extends FormElement
 
         // build the element
         $xhtml = '<input type="image"'
-                . ' name="' . $this->view->vars()->escape($name) . '"'
-                . ' id="' . $this->view->vars()->escape($id) . '"'
+                . ' name="' . $escaper($name) . '"'
+                . ' id="'   . $escaper($id)   . '"'
                 . $src
                 . $value
                 . $disabled

--- a/library/Zend/View/Helper/FormLabel.php
+++ b/library/Zend/View/Helper/FormLabel.php
@@ -55,10 +55,11 @@ class FormLabel extends FormElement
             return  '';
         }
 
-        $value = ($escape) ? $this->view->vars()->escape($value) : $value;
-        $for   = (empty($attribs['disableFor']) || !$attribs['disableFor'])
-               ? ' for="' . $this->view->vars()->escape($id) . '"'
-               : '';
+        $escaper = $this->view->plugin('escape');
+        $value   = ($escape) ? $escaper($value) : $value;
+        $for     = (empty($attribs['disableFor']) || !$attribs['disableFor'])
+                 ? ' for="' . $escaper($id) . '"'
+                 : '';
         if (array_key_exists('disableFor', $attribs)) {
             unset($attribs['disableFor']);
         }

--- a/library/Zend/View/Helper/FormPassword.php
+++ b/library/Zend/View/Helper/FormPassword.php
@@ -65,9 +65,10 @@ class FormPassword extends FormElement
 
         // determine the XHTML value
         $valueString = ' value=""';
+        $escaper     = $this->view->plugin('escape');
         if (array_key_exists('renderPassword', $attribs)) {
             if ($attribs['renderPassword']) {
-                $valueString = ' value="' . $this->view->vars()->escape($value) . '"';
+                $valueString = ' value="' . $escaper($value) . '"';
             }
             unset($attribs['renderPassword']);
         }
@@ -80,8 +81,8 @@ class FormPassword extends FormElement
 
         // render the element
         $xhtml = '<input type="password"'
-                . ' name="' . $this->view->vars()->escape($name) . '"'
-                . ' id="' . $this->view->vars()->escape($id) . '"'
+                . ' name="' . $escaper($name) . '"'
+                . ' id="' . $escaper($id) . '"'
                 . $valueString
                 . $disabled
                 . $this->_htmlAttribs($attribs)

--- a/library/Zend/View/Helper/FormRadio.php
+++ b/library/Zend/View/Helper/FormRadio.php
@@ -112,7 +112,8 @@ class FormRadio extends FormElement
         $list  = array();
 
         // should the name affect an array collection?
-        $name = $this->view->vars()->escape($name);
+        $escaper = $this->view->plugin('escape');
+        $name    = $escaper($name);
         if ($this->_isArray && ('[]' != substr($name, -2))) {
             $name .= '[]';
         }
@@ -132,7 +133,7 @@ class FormRadio extends FormElement
 
             // Should the label be escaped?
             if ($escape) {
-                $opt_label = $this->view->vars()->escape($opt_label);
+                $opt_label = $escaper($opt_label);
             }
 
             // is it disabled?
@@ -159,7 +160,7 @@ class FormRadio extends FormElement
                     . '<input type="' . $this->_inputType . '"'
                     . ' name="' . $name . '"'
                     . ' id="' . $optId . '"'
-                    . ' value="' . $this->view->vars()->escape($opt_value) . '"'
+                    . ' value="' . $escaper($opt_value) . '"'
                     . $checked
                     . $disabled
                     . $this->_htmlAttribs($attribs)

--- a/library/Zend/View/Helper/FormReset.php
+++ b/library/Zend/View/Helper/FormReset.php
@@ -69,14 +69,15 @@ class FormReset extends FormElement
         }
 
         // Render button
+        $escaper = $this->view->plugin('escape');
         $xhtml = '<input type="reset"'
-               . ' name="' . $this->view->vars()->escape($name) . '"'
-               . ' id="' . $this->view->vars()->escape($id) . '"'
+               . ' name="' . $escaper($name) . '"'
+               . ' id="'   . $escaper($id)   . '"'
                . $disabled;
 
         // add a value if one is given
         if (! empty($value)) {
-            $xhtml .= ' value="' . $this->view->vars()->escape($value) . '"';
+            $xhtml .= ' value="' . $escaper($value) . '"';
         }
 
         // add attributes, close, and return

--- a/library/Zend/View/Helper/FormSelect.php
+++ b/library/Zend/View/Helper/FormSelect.php
@@ -100,9 +100,10 @@ class FormSelect extends FormElement
         }
 
         // Build the surrounding select element first.
+        $escaper = $this->view->plugin('escape');
         $xhtml = '<select'
-                . ' name="' . $this->view->vars()->escape($name) . '"'
-                . ' id="' . $this->view->vars()->escape($id) . '"'
+                . ' name="' . $escaper($name) . '"'
+                . ' id="' . $escaper($id) . '"'
                 . $multiple
                 . $disabled
                 . $this->_htmlAttribs($attribs)
@@ -122,7 +123,7 @@ class FormSelect extends FormElement
                 }
                 $list[] = '<optgroup'
                         . $opt_disable
-                        . ' label="' . $this->view->vars()->escape($opt_value) .'">';
+                        . ' label="' . $escaper($opt_value) .'">';
                 foreach ($opt_label as $val => $lab) {
                     $list[] = $this->_build($val, $lab, $value, $disable);
                 }
@@ -153,9 +154,10 @@ class FormSelect extends FormElement
             $disable = array();
         }
 
+        $escaper = $this->view->plugin('escape');
         $opt = '<option'
-             . ' value="' . $this->view->vars()->escape($value) . '"'
-             . ' label="' . $this->view->vars()->escape($label) . '"';
+             . ' value="' . $escaper($value) . '"'
+             . ' label="' . $escaper($label) . '"';
 
         // selected?
         if (in_array((string) $value, $selected)) {
@@ -167,7 +169,7 @@ class FormSelect extends FormElement
             $opt .= ' disabled="disabled"';
         }
 
-        $opt .= '>' . $this->view->vars()->escape($label) . "</option>";
+        $opt .= '>' . $escaper($label) . "</option>";
 
         return $opt;
     }

--- a/library/Zend/View/Helper/FormSubmit.php
+++ b/library/Zend/View/Helper/FormSubmit.php
@@ -69,10 +69,11 @@ class FormSubmit extends FormElement
         }
 
         // Render the button.
+        $escaper = $this->view->plugin('escape');
         $xhtml = '<input type="submit"'
-               . ' name="' . $this->view->vars()->escape($name) . '"'
-               . ' id="' . $this->view->vars()->escape($id) . '"'
-               . ' value="' . $this->view->vars()->escape($value) . '"'
+               . ' name="'  . $escaper($name)  . '"'
+               . ' id="'    . $escaper($id)    . '"'
+               . ' value="' . $escaper($value) . '"'
                . $disabled
                . $this->_htmlAttribs($attribs)
                . $endTag;

--- a/library/Zend/View/Helper/FormText.php
+++ b/library/Zend/View/Helper/FormText.php
@@ -84,11 +84,12 @@ class FormText extends FormElement
             $endTag= '>';
         }
 
+        $escaper = $this->view->plugin('escape');
         $xhtml = '<input'
-                . ' type="' .  $this->view->vars()->escape($inputType) . '"'
-                . ' name="' . $this->view->vars()->escape($name) . '"'
-                . ' id="' . $this->view->vars()->escape($id) . '"'
-                . ' value="' . $this->view->vars()->escape($value) . '"'
+                . ' type="'  . $escaper($inputType) . '"'
+                . ' name="'  . $escaper($name)      . '"'
+                . ' id="'    . $escaper($id)        . '"'
+                . ' value="' . $escaper($value)     . '"'
                 . $disabled
                 . $this->_htmlAttribs($attribs)
                 . $endTag;

--- a/library/Zend/View/Helper/FormTextarea.php
+++ b/library/Zend/View/Helper/FormTextarea.php
@@ -91,11 +91,12 @@ class FormTextarea extends FormElement
         }
 
         // build the element
-        $xhtml = '<textarea name="' . $this->view->vars()->escape($name) . '"'
-                . ' id="' . $this->view->vars()->escape($id) . '"'
-                . $disabled
-                . $this->_htmlAttribs($attribs) . '>'
-                . $this->view->vars()->escape($value) . '</textarea>';
+        $escaper = $this->view->plugin('escape');
+        $xhtml   = '<textarea name="' . $escaper($name) . '"'
+                 . ' id="' . $escaper($id) . '"'
+                 . $disabled
+                 . $this->_htmlAttribs($attribs) . '>'
+                 . $escaper($value) . '</textarea>';
 
         return $xhtml;
     }

--- a/library/Zend/View/Helper/HtmlElement.php
+++ b/library/Zend/View/Helper/HtmlElement.php
@@ -88,9 +88,10 @@ abstract class HtmlElement extends AbstractHelper
      */
     protected function _htmlAttribs($attribs)
     {
-        $xhtml = '';
+        $xhtml   = '';
+        $escaper = $this->view->plugin('escape');
         foreach ((array) $attribs as $key => $val) {
-            $key = $this->view->vars()->escape($key);
+            $key = $escaper($key);
 
             if (('on' == substr($key, 0, 2)) || ('constraints' == $key)) {
                 // Don't escape event attributes; _do_ substitute double quotes with singles
@@ -107,7 +108,7 @@ abstract class HtmlElement extends AbstractHelper
                 if (is_array($val)) {
                     $val = implode(' ', $val);
                 }
-                $val = $this->view->vars()->escape($val);
+                $val = $escaper($val);
             }
 
             if ('id' == $key) {

--- a/library/Zend/View/Helper/HtmlList.php
+++ b/library/Zend/View/Helper/HtmlList.php
@@ -52,7 +52,8 @@ class HtmlList extends FormElement
         foreach ($items as $item) {
             if (!is_array($item)) {
                 if ($escape) {
-                    $item = $this->view->vars()->escape($item);
+                    $escaper = $this->view->plugin('escape');
+                    $item    = $escaper($item);
                 }
                 $list .= '<li>' . $item . '</li>' . self::EOL;
             } else {

--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -641,8 +641,10 @@ abstract class AbstractHelper extends View\Helper\HtmlElement implements Helper
             'target' => $page->getTarget()
         );
 
+        $escaper = $this->view->plugin('escape');
+
         return '<a' . $this->_htmlAttribs($attribs) . '>'
-             . $this->view->vars()->escape($label)
+             . $escaper($label)
              . '</a>';
     }
 

--- a/library/Zend/View/Helper/Navigation/Breadcrumbs.php
+++ b/library/Zend/View/Helper/Navigation/Breadcrumbs.php
@@ -193,7 +193,8 @@ class Breadcrumbs extends AbstractHelper
             if ($this->getUseTranslator() && $t = $this->getTranslator()) {
                 $html = $t->translate($html);
             }
-            $html = $this->view->vars()->escape($html);
+            $escaper = $this->view->plugin('escape');
+            $html    = $escaper($html);
         }
 
         // walk back to root

--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -235,8 +235,9 @@ class Menu extends AbstractHelper
             $element = 'span';
         }
 
+        $escaper = $this->view->plugin('escape');
         return '<' . $element . $this->_htmlAttribs($attribs) . '>'
-             . $this->view->vars()->escape($label)
+             . $escaper($label)
              . '</' . $element . '>';
     }
 

--- a/tests/Zend/View/Helper/FormLabelTest.php
+++ b/tests/Zend/View/Helper/FormLabelTest.php
@@ -71,7 +71,7 @@ class FormLabelTest extends \PHPUnit_Framework_TestCase
     public function testFormLabelWithInputNeedingEscapesUsesViewEscaping()
     {
         $label = $this->helper->__invoke('<&foo', '</bar>');
-        $expected = '<label for="' . $this->view->vars()->escape('<&foo') . '">' . $this->view->vars()->escape('</bar>') . '</label>';
+        $expected = '<label for="' . $this->view->escape('<&foo') . '">' . $this->view->escape('</bar>') . '</label>';
         $this->assertEquals($expected, $label);
     }
 

--- a/tests/Zend/View/Helper/FormTest.php
+++ b/tests/Zend/View/Helper/FormTest.php
@@ -72,7 +72,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
     public function testFormWithInputNeedingEscapesUsesViewEscaping()
     {
         $form = $this->helper->__invoke('<&foo');
-        $this->assertContains($this->view->vars()->escape('<&foo'), $form);
+        $this->assertContains($this->view->escape('<&foo'), $form);
     }
 
     public function testPassingIdAsAttributeShouldRenderIdAttribAndNotName()

--- a/tests/Zend/View/Helper/HtmlListTest.php
+++ b/tests/Zend/View/Helper/HtmlListTest.php
@@ -163,7 +163,7 @@ class HtmlListTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains('<li>one &lt;small&gt; test</li>', $list);
         $this->assertContains('<li>second &amp; third</li>', $list);
-        $this->assertContains('<li>And \'some\' &quot;final&quot; test</li>', $list);
+        $this->assertContains('<li>And &#039;some&#039; &quot;final&quot; test</li>', $list);
     }
 
     public function testListEscapeSwitchedOffForZF2283()

--- a/tests/Zend/View/PhpRendererTest.php
+++ b/tests/Zend/View/PhpRendererTest.php
@@ -221,7 +221,6 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
     {
         $this->renderer->foo = '<p>Bar</p>';
         $this->assertEquals($this->renderer->vars('foo'), $this->renderer->foo);
-        $this->assertSame('<p>Bar</p>', $this->renderer->vars()->getRawValue('foo'));
     }
 
     /**
@@ -259,33 +258,14 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
     /**
      * @group convenience-api
      */
-    public function testRawMethodShouldRetrieveRawVariableFromVariableContainer()
-    {
-        $this->renderer->foo = '<p>Bar</p>';
-        $foo = $this->renderer->raw('foo');
-        $this->assertSame($this->renderer->vars()->getRawValue('foo'), $foo);
-    }
-    
-    /**
-     * @group convenience-api
-     */
     public function testRenderingLocalVariables()
     {
-        $expected = '10 &gt; 9';
+        $expected = '10 > 9';
         $this->renderer->vars()->assign(array('foo' => '10 > 9'));
         $this->renderer->resolver()->addPath(__DIR__ . '/_templates');
         $test = $this->renderer->render('testLocalVars.phtml');
         $this->assertContains($expected, $test);
     }    
-
-    public function testInjectsVariablesContainerWithEscapeHelperAsEscapeCallbackWhenPresent()
-    {
-        if (!$this->renderer->getBroker()->getClassLoader()->isLoaded('escape')) {
-            $this->markTestSkipped('Cannot test as escape helper is not loaded');
-        }
-        $escapeHelper = $this->renderer->plugin('escape');
-        $this->assertSame($escapeHelper, $this->renderer->vars()->getEscapeCallback());
-    }
 
     public function testRendersTemplatesInAStack()
     {
@@ -398,9 +378,6 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
         $model = new ViewModel();
         $model->setTemplate('template');
         $vars  = $model->getVariables();
-        $vars->setEscapeCallback(function ($value) {
-            return strtolower($value);
-        });
         $vars['foo'] = 'BAR-BAZ-BAT';
 
         $resolver = new TemplateMapResolver(array(
@@ -408,6 +385,6 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
         ));
         $this->renderer->setResolver($resolver);
         $test = $this->renderer->render($model);
-        $this->assertContains('bar-baz-bat', $test);
+        $this->assertContains('BAR-BAZ-BAT', $test);
     }
 }

--- a/tests/Zend/View/VariablesTest.php
+++ b/tests/Zend/View/VariablesTest.php
@@ -40,59 +40,15 @@ class VariablesTest extends \PHPUnit_Framework_TestCase
         $this->vars = new Variables;
     }
 
-    public function testEncodingIsUtf8ByDefault()
-    {
-        $this->assertEquals('UTF-8', $this->vars->getEncoding());
-    }
-
-    public function testRawValuesAreEmptyByDefault()
-    {
-        $rawValues = $this->vars->getRawValues();
-        $this->assertTrue(empty($rawValues));
-    }
-
     public function testStrictVarsAreDisabledByDefault()
     {
         $this->assertFalse($this->vars->isStrict());
-    }
-
-    public function testHasDefaultEscapeCallback()
-    {
-        $callback = $this->vars->getEscapeCallback();
-        $this->assertTrue(is_callable($callback));
-    }
-
-    public function testEscapeUsesHtmlSpecialCharsByDefault()
-    {
-        $string   = '<tag foo="bar">\'some string\'</tag>';
-        $expected = htmlspecialchars($string, ENT_COMPAT, 'UTF-8');
-        $test     = $this->vars->escape($string);
-        $this->assertEquals($expected, $test);
-    }
-
-    public function testCanSetEncoding()
-    {
-        $this->vars->setEncoding('iso-8859-1');
-        $this->assertEquals('iso-8859-1', $this->vars->getEncoding());
     }
 
     public function testCanSetStrictFlag()
     {
         $this->vars->setStrictVars(true);
         $this->assertTrue($this->vars->isStrict());
-    }
-
-    public function testPassingNonCallableArgumentToEscapeCallbackRaisesException()
-    {
-        $this->setExpectedException('Zend\View\Exception', 'callable');
-        $this->vars->setEscapeCallback('__foo__');
-    }
-
-    public function testCanSetEscapeCallback()
-    {
-        $callback = 'htmlspecialchars';
-        $this->vars->setEscapeCallback($callback);
-        $this->assertEquals($callback, $this->vars->getEscapeCallback());
     }
 
     public function testAssignMergesValuesWithObject()
@@ -130,38 +86,6 @@ class VariablesTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('baz', $this->vars['bar']);
     }
 
-    public function testValuesAssignedViaConstructorAreEscapedByDefault()
-    {
-        $string = '<tag id="foo">\'some string\'</tag>';
-        $vars = new Variables(array('foo'=>$string));
-        $expected = htmlspecialchars($string, ENT_COMPAT, 'UTF-8');
-        $this->assertEquals($expected, $vars['foo']);
-    }
-
-    public function testValuesAreEscapedByDefault()
-    {
-        $string = '<tag id="foo">\'some string\'</tag>';
-        $this->vars['foo'] = $string;
-        $expected = htmlspecialchars($string, ENT_COMPAT, 'UTF-8');
-        $this->assertEquals($expected, $this->vars['foo']);
-    }
-
-    public function testNonStringValuesAreNotEscaped()
-    {
-        $value = array(
-            '<tag id="foo">\'some string\'</tag>',
-        );
-        $this->vars['foo'] = $value;
-        $this->assertEquals($value[0], $this->vars['foo'][0]);
-    }
-
-    public function testCanForceUsingUnsanitizedStringsPerVariable()
-    {
-        $string = '<tag id="foo">\'some string\'</tag>';
-        $this->vars->setCleanValue('foo', $string);
-        $this->assertEquals($string, $this->vars['foo']);
-    }
-
     public function testNullIsReturnedForUndefinedVariables()
     {
         $this->assertNull($this->vars['foo']);
@@ -181,34 +105,12 @@ class VariablesTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('does not exist', $this->error);
     }
 
-    public function testRetrievingUndefinedRawValueRaisesErrorWhenStrictVarsIsRequested()
-    {
-        $this->vars->setStrictVars(true);
-        set_error_handler(array($this, 'handleErrors'), E_USER_NOTICE);
-        $this->assertNull($this->vars->getRawValue('foo'));
-        restore_error_handler();
-        $this->assertContains('does not exist', $this->error);
-    }
-
     public function values()
     {
         return array(
             array('foo', 'bar'),
             array('xss', '<tag id="foo">\'value\'</tag>'),
         );
-    }
-
-    /**
-     * @dataProvider values
-     */
-    public function testRawValueIsStoredForEachValue($key, $arg)
-    {
-        $this->vars[$key] = $arg;
-        $this->assertEquals($arg, $this->vars->getRawValue($key));
-        $this->assertNotNull($this->vars[$key]);
-
-        $rawValues = $this->vars->getRawValues();
-        $this->assertEquals(count($this->vars), count($rawValues));
     }
 
     public function testCallingClearEmptiesObject()
@@ -220,8 +122,6 @@ class VariablesTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($this->vars));
         $this->vars->clear();
         $this->assertEquals(0, count($this->vars));
-        $rawValues = $this->vars->getRawValues();
-        $this->assertEquals(0, count($rawValues));
     }
 
     public function testAllowsSpecifyingClosureValuesAndReturningTheValue()
@@ -237,40 +137,5 @@ class VariablesTest extends \PHPUnit_Framework_TestCase
     {
         $this->vars->foo = new TestAsset\VariableFunctor('bar');
         $this->assertEquals('bar', $this->vars->foo);
-    }
-
-    public function testClosureValuesAreEscaped()
-    {
-        $this->vars->foo = function () {
-            return '<a href="foo">bar</a>';
-        };
-
-        $expected = $this->vars->escape('<a href="foo">bar</a>');
-        $this->assertEquals($expected, $this->vars->foo);
-    }
-
-    public function testFunctorValuesAreEscaped()
-    {
-        $this->vars->foo = new TestAsset\VariableFunctor('<a href="foo">bar</a>');
-        $expected = $this->vars->escape('<a href="foo">bar</a>');
-        $this->assertEquals($expected, $this->vars->foo);
-    }
-
-    public function testCallbackValuesAreReturnedAsIsWhenRetrievedAsRawValue()
-    {
-        $value = function () {
-            return '<a href="foo">bar</a>';
-        };
-        $this->vars->foo = $value;
-
-        $this->assertSame($value, $this->vars->getRawValue('foo'));
-    }
-
-    public function testFunctorValuesAreReturnedAsIsWhenRetrievedAsRawValue()
-    {
-        $value = new TestAsset\VariableFunctor('<a href="foo">bar</a>');
-        $this->vars->foo = $value;
-
-        $this->assertSame($value, $this->vars->getRawValue('foo'));
     }
 }

--- a/tests/Zend/View/_templates/testNestedOuter.phtml
+++ b/tests/Zend/View/_templates/testNestedOuter.phtml
@@ -1,4 +1,4 @@
 <?php
 ?>
 <?php echo $this->render('testNestedInner.phtml') ?>
-<?php echo $this->raw('content') ?>
+<?php echo $this->content ?>


### PR DESCRIPTION
- Feedback indicates the current solution is incomplete and/or misleading and/or
  confusing to end-users. Removed all auto-escaping from the Variables
  container, and updated helpers to use the Escape helper instead.
