### PR TITLE
[#1] Added ability to inject reason for triggering 404

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -27,9 +27,11 @@ use ArrayObject,
  */
 class Application implements AppContext
 {
-    const ERROR_CONTROLLER_NOT_FOUND = 404;
-    const ERROR_CONTROLLER_INVALID   = 404;
-    const ERROR_EXCEPTION            = 500;
+    const ERROR_CONTROLLER_CANNOT_DISPATCH = 'error-controller-cannot-dispatch';
+    const ERROR_CONTROLLER_NOT_FOUND       = 'error-controller-not-found';
+    const ERROR_CONTROLLER_INVALID         = 'error-controller-invalid';
+    const ERROR_EXCEPTION                  = 'error-exception';
+    const ERROR_ROUTER_NO_MATCH            = 'error-router-no-match';
 
     protected $event;
     protected $events;

--- a/library/Zend/Mvc/Bootstrap.php
+++ b/library/Zend/Mvc/Bootstrap.php
@@ -134,6 +134,12 @@ class Bootstrap implements Bootstrapper
                 ),
             ),
             'Zend\Mvc\View\RouteNotFoundStrategy' => array(
+                'setDisplayNotFoundReason' => array(
+                    'displayNotFoundReason' => array(
+                        'required' => false,
+                        'type'     => false,
+                    ),
+                ),
                 'setNotFoundTemplate' => array(
                     'notFoundTemplate' => array(
                         'required' => false,

--- a/library/Zend/Mvc/View/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/RouteNotFoundStrategy.php
@@ -44,6 +44,13 @@ class RouteNotFoundStrategy implements ListenerAggregate
     protected $listeners = array();
 
     /**
+     * Whether or not to display exceptions related to the 404 condition
+     * 
+     * @var bool
+     */
+    protected $displayExceptions = false;
+
+    /**
      * Whether or not to display the reason for a 404
      * 
      * @var bool
@@ -75,6 +82,28 @@ class RouteNotFoundStrategy implements ListenerAggregate
         $this->listeners[] = $events->attach('dispatch', array($this, 'prepareNotFoundViewModel'), -90);
         $this->listeners[] = $events->attach('dispatch.error', array($this, 'detectNotFoundError'));
         $this->listeners[] = $events->attach('dispatch.error', array($this, 'prepareNotFoundViewModel'));
+    }
+
+    /**
+     * Set value indicating whether or not to display exceptions related to a not-found condition
+     *
+     * @param  bool $displayExceptions
+     * @return RouteNotFoundStrategy
+     */
+    public function setDisplayExceptions($displayExceptions)
+    {
+        $this->displayExceptions = (bool) $displayExceptions;
+        return $this;
+    }
+    
+    /**
+     * Should we display exceptions related to a not-found condition?
+     *
+     * @return bool
+     */
+    public function displayExceptions()
+    {
+        return $this->displayExceptions;
     }
 
     /**
@@ -194,11 +223,28 @@ class RouteNotFoundStrategy implements ListenerAggregate
         $model->setTemplate($this->getNotFoundTemplate());
 
         // If displaying reasons, inject the reason
-        $this->injectNotFoundReason($model);
+        $this->injectNotFoundReason($model, $e);
+
+        // If displaying exceptions, inject
+        $this->injectException($model, $e);
+
+        // Inject controller if we're displaying either the reason or the exception
+        $this->injectController($model, $e);
 
         $e->setResult($model);
     }
 
+    /**
+     * Inject the not-found reason into the model
+     *
+     * If $displayNotFoundReason is enabled, checks to see if $reason is set,
+     * and, if so, injects it into the model. If not, it injects
+     * Application::ERROR_CONTROLLER_CANNOT_DISPATCH.
+     * 
+     * @param  ViewModel $model 
+     * @param  MvcEvent $e 
+     * @return void
+     */
     protected function injectNotFoundReason($model)
     {
         if (!$this->displayNotFoundReason()) {
@@ -214,5 +260,66 @@ class RouteNotFoundStrategy implements ListenerAggregate
         // otherwise, must be a case of the controller not being able to 
         // dispatch itself.
         $model->setVariable('reason', Application::ERROR_CONTROLLER_CANNOT_DISPATCH);
+    }
+
+    /**
+     * Inject the exception message into the model
+     *
+     * If $displayExceptions is enabled, and an exception is found in the 
+     * event, inject it into the model.
+     * 
+     * @param  ViewModel $model 
+     * @param  MvcEvent $e 
+     * @return void
+     */
+    protected function injectException($model, $e)
+    {
+        if (!$this->displayExceptions()) {
+            return;
+        }
+
+        $exception = $e->getParam('exception', false);
+        if (!$exception instanceof \Exception) {
+            return;
+        }
+
+        $model->setVariable('exception', $exception);
+    }
+
+    /**
+     * Inject the controller and controller class into the model
+     *
+     * If either $displayExceptions or $displayNotFoundReason are enabled, 
+     * injects the controllerClass from the MvcEvent. It checks to see if a 
+     * controller is present in the MvcEvent, and, if not, grabs it from
+     * the route match if present; if a controller is found, it injects it into 
+     * the model.
+     * 
+     * @param  ViewModel $model 
+     * @param  MvcEvent $e 
+     * @return void
+     */
+    protected function injectController($model, $e)
+    {
+        if (!$this->displayExceptions() && !$this->displayNotFoundReason()) {
+            return;
+        }
+
+        $controller = $e->getController();
+        if (empty($controller)) {
+            $routeMatch = $e->getRouteMatch();
+            if (empty($routeMatch)) {
+                return;
+            }
+
+            $controller = $routeMatch->getParam('controller', false);
+            if (!$controller) {
+                return;
+            }
+        }
+
+        $controllerClass = $e->getControllerClass();
+        $model->setVariable('controller', $controller);
+        $model->setVariable('controller_class', $controllerClass);
     }
 }

--- a/tests/Zend/Mvc/ApplicationTest.php
+++ b/tests/Zend/Mvc/ApplicationTest.php
@@ -499,7 +499,7 @@ class ApplicationTest extends TestCase
         });
 
         $app->run();
-        $this->assertContains('404', $response->getContent());
+        $this->assertContains(Application::ERROR_CONTROLLER_NOT_FOUND, $response->getContent());
         $this->assertContains('bad', $response->getContent());
     }
 
@@ -523,7 +523,7 @@ class ApplicationTest extends TestCase
         });
 
         $app->run();
-        $this->assertContains('404', $response->getContent());
+        $this->assertContains(Application::ERROR_CONTROLLER_INVALID, $response->getContent());
         $this->assertContains('bad', $response->getContent());
         $this->assertContains('stdClass', $response->getContent());
     }
@@ -546,7 +546,7 @@ class ApplicationTest extends TestCase
         });
 
         $app->run();
-        $this->assertContains('404', $response->getContent());
+        $this->assertContains(Application::ERROR_CONTROLLER_NOT_FOUND, $response->getContent());
     }
 
     /**


### PR DESCRIPTION
- if displayNotFoundReason is enabled, will inject a "reason" variable
  into the 404 view model returned, with one of the following constant
  values:
  - Application::ERROR_CONTROLLER_CANNOT_DISPATCH (controller cannot
    dispatch the request)
  - Application::ERROR_CONTROLLER_NOT_FOUND (controller class does not
    exist)
  - Application::ERROR_CONTROLLER_INVALID (controller requested is not
    dispatchable)
  - Application::ERROR_ROUTER_NO_MATCH (routing returned no match, or no
    controller in the matches)
