### PR TITLE
Zend\Cache\Storage\Adapter\Memcached Default Connection String

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/Memcached.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcached.php
@@ -81,7 +81,7 @@ class Memcached extends AbstractAdapter
 
         $servers = $options->getServers();
         if (!$servers) {
-            $options->addServer('localhost', 11211);
+            $options->addServer('127.0.0.1', 11211);
             $servers = $options->getServers();
         }
         $this->memcached->addServers($servers);

--- a/tests/Zend/Cache/Storage/Adapter/MemcachedTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/MemcachedTest.php
@@ -86,7 +86,7 @@ class MemcachedTest extends CommonAdapterTest
     {
         $memcached = new Cache\Storage\Adapter\Memcached();
 
-        $this->assertEquals($memcached->getOptions()->getServers(), array(array('localhost', 11211)));
+        $this->assertEquals($memcached->getOptions()->getServers(), array(array('127.0.0.1', 11211)));
     }
 
     public function tearDown()


### PR DESCRIPTION
The default connection string is currently "localhost"; by default on most installations when installing from a package manager the configuration will actually lock itself down to 127.0.0.1 (on ubuntu apt-get memcached will have the following in /etc/memcached.conf "-l 127.0.0.1")

This change specifically changes the default value to 127.0.0.1 instead of localhost; in this case now all of the tests for the memcached adapter pass by default on my machine.  When this value is not specified memcached will default to INADDR_ANY.
