### PR TITLE
Increased verbosity of the Invalid Instantiator Di error message.

### DIFF
--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -189,7 +189,11 @@ class Di implements DependencyInjection
                     isset($instantiator[1]) ? $instantiator[1] : 'NoMethodGiven'
                 );
             } else {
-                $msg = 'Invalid instantiator';
+                $msg = sprintf(
+                    'Invalid instantiator of type "%s" for "%s".',
+                    gettype($instantiator),
+                    $name
+                );
             }
             throw new \RuntimeException($msg);
         }


### PR DESCRIPTION
This is a small change that has helped me considerably with debugging.

1) The stack trace that accompanies the error truncates long class names, so this adds the full class name of the class who failed to instantiate to the error message.  

2) This change also adds the invalid instantiator's type to the error message, which may/may-not be necessary, given the possible instantiator types that may come through (frequently Null). I found this comforting, though there's a possibility that some users may find it confusing.
