### PR TITLE
Removed duplicate class declarations

### DIFF
--- a/library/Zend/Markup/Renderer/Markup/Html/Root.php
+++ b/library/Zend/Markup/Renderer/Markup/Html/Root.php
@@ -37,7 +37,7 @@ use Zend\Markup\Token;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Replace extends AbstractHtml
+class Root extends AbstractHtml
 {
 
     /**

--- a/library/Zend/Service/GoGrid/Exception/OutOfBoundsException.php
+++ b/library/Zend/Service/GoGrid/Exception/OutOfBoundsException.php
@@ -23,7 +23,7 @@
 /**
  * @namespace
  */
-namespace Zend\Service\Amazon\Exception;
+namespace Zend\Service\GoGrid\Exception;
 
 /**
  * @category   Zend

--- a/library/Zend/Service/Rackspace/Servers/Exception/InvalidArgumentException.php
+++ b/library/Zend/Service/Rackspace/Servers/Exception/InvalidArgumentException.php
@@ -23,7 +23,7 @@
 /**
  * @namespace
  */
-namespace Zend\Service\Rackspace\Exception;
+namespace Zend\Service\Rackspace\Servers\Exception;
 
 /**
  * @category   Zend

--- a/library/Zend/Service/Rackspace/Servers/Exception/OutOfBoundsException.php
+++ b/library/Zend/Service/Rackspace/Servers/Exception/OutOfBoundsException.php
@@ -23,7 +23,7 @@
 /**
  * @namespace
  */
-namespace Zend\Service\Rackspace\Exception;
+namespace Zend\Service\Rackspace\Servers\Exception;
 
 /**
  * @category   Zend

--- a/library/Zend/Service/Rackspace/Servers/Exception/RuntimeException.php
+++ b/library/Zend/Service/Rackspace/Servers/Exception/RuntimeException.php
@@ -22,7 +22,7 @@
 /**
  * @namespace
  */
-namespace Zend\Service\Rackspace\Exception;
+namespace Zend\Service\Rackspace\Servers\Exception;
 
 use \Zend\Service\Rackspace\Exception;
 

--- a/library/Zend/XmlRpc/Client/Exception/InvalidArgumentException.php
+++ b/library/Zend/XmlRpc/Client/Exception/InvalidArgumentException.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace Zend\XmlRpc\Exception;
+namespace Zend\XmlRpc\Client\Exception;
 
 class InvalidArgumentException
     extends \InvalidArgumentException
     implements \Zend\XmlRpc\Exception
 {}
-    


### PR DESCRIPTION
When trying to generate API for Zend Framework 2 with ApiGen (http://apigen.org) --  which is very strict and hates multiple class declaration), I've encountered a strange thing in zf2.

Root.php and Replace.php were both having the same class name in their namespace.
So I've renamed class Replace in Root.php to Root, according to PSR-0 standard.

EDIT: Found all bad declarations and fixed them according to PSR-0 or common sense.

I've tried to run tests with "phpunit Zend/Markup/Renderer" and it went "OK (6 tests, 13 assertions)", so I guess this isn't BC break. :)
