### PR TITLE
Session Type Hinting Changes

### DIFF
--- a/library/Zend/Session/AbstractManager.php
+++ b/library/Zend/Session/AbstractManager.php
@@ -76,33 +76,6 @@ abstract class AbstractManager implements Manager
      */
     public function __construct(Configuration $config = null, Storage $storage = null, SaveHandler $saveHandler = null)
     {
-        if ($config instanceof \Zend\Config\Config) {
-            $config = $config->toArray();
-        }
-        if (is_array($config)) {
-            foreach ($config as $key => $value) {
-                switch (strtolower($key)) {
-                    case 'storage':
-                        if (null === $storage) {
-                            $storage = $value;
-                        }
-                        unset($config[$key]);
-                        break;
-                    case 'savehandler':
-                        if (null === $saveHandler) {
-                            $saveHandler = $value;
-                        }
-                        unset($config[$key]);
-                        break;
-                }
-            }
-        } elseif (is_string($config)) {
-            if (!class_exists($config)) {
-                throw new Exception\InvalidArgumentException('Configuration class provided is invalid; not found');
-            }
-            $config = new $config;
-        }
-        
         $this->setConfig($config);
         $this->setStorage($storage);
         if ($saveHandler) {

--- a/library/Zend/Session/AbstractManager.php
+++ b/library/Zend/Session/AbstractManager.php
@@ -69,12 +69,12 @@ abstract class AbstractManager implements Manager
      * Allow passing a configuration object or class name, a storage object or 
      * class name, or an array of configuration.
      * 
-     * @param  null|string|Configuration|array $config 
-     * @param  null|string|Storage $storage 
-     * @param  null|string|SaveHandler $saveHandler
+     * @param  Configuration $config 
+     * @param  Storage $storage 
+     * @param  SaveHandler $saveHandler
      * @return void
      */
-    public function __construct($config = null, $storage = null, $saveHandler = null)
+    public function __construct(Configuration $config = null, Storage $storage = null, SaveHandler $saveHandler = null)
     {
         if ($config instanceof \Zend\Config\Config) {
             $config = $config->toArray();
@@ -105,46 +105,26 @@ abstract class AbstractManager implements Manager
         
         $this->setConfig($config);
         $this->setStorage($storage);
-        $this->setSaveHandler($saveHandler);
+        if ($saveHandler) {
+            $this->setSaveHandler($saveHandler);
+        }
     }
 
     /**
      * Set configuration object
      *
-     * Allows lazy-loading a class name, passing an array of configuration to 
-     * the defined default configuration class, or passing in a Configuration 
-     * object. If a null value is passed, an instance of the default 
-     * configuration class is created.
-     * 
-     * @param  null|string|array|Configuration $config 
+     * @param  null|Configuration $config 
      * @return void
      */
-    public function setConfig($config)
+    public function setConfig(Configuration $config = null)
     {
         if (null === $config) {
             $config = new $this->configDefaultClass();
+            if (!$config instanceof Configuration) {
+                throw new Exception\InvalidArgumentException('Default configuration type provided is invalid; must implement Zend\\Session\\Configuration');
+            }
         }
 
-        if (is_array($config)) {
-            $class = $this->configDefaultClass;
-            if (array_key_exists('class', $config)) {
-                $class = $config['class'];
-                unset($config['class']);
-            }
-
-            if (!class_exists($class)) {
-                throw new Exception\InvalidArgumentException('Class provided for configuration is invalid; not found');
-            }
-
-            $options = $config;
-            $config  = new $class();
-            $config->setOptions($options);
-            unset($options);
-        } 
-        
-        if (!$config instanceof Configuration) {
-            throw new Exception\InvalidArgumentException('Configuration type provided is invalid; must implement Zend\\Session\\Configuration');
-        }
         $this->config = $config;
     }
 
@@ -161,27 +141,16 @@ abstract class AbstractManager implements Manager
     /**
      * Set session storage object
      *
-     * Allows passing a null value, string class name, or Storage object. If a 
-     * null value is passed, the default storage class will be used.
-     * 
-     * @param  null|string|Storage $storage 
+     * @param  null|Storage $storage 
      * @return void
      */
-    public function setStorage($storage)
+    public function setStorage(Storage $storage = null)
     {
         if (null === $storage) {
             $storage = new $this->storageDefaultClass();
-        }
-
-        if (is_string($storage)) {
-            if (!class_exists($storage)) {
-                throw new Exception\InvalidArgumentException('Class provided for Storage does not exist');
+            if (!$storage instanceof Storage) {
+                throw new Exception\InvalidArgumentException('Default storage type provided is invalid; must implement Zend\\Session\\Storage');
             }
-            $storage = new $storage();
-        }
-
-        if (!$storage instanceof Storage) {
-            throw new Exception\InvalidArgumentException('Storage type provided is invalid; must implement Zend\\Session\\Storage');
         }
 
         $this->storage = $storage;
@@ -200,29 +169,14 @@ abstract class AbstractManager implements Manager
     /**
      * Set session save handler object
      *
-     * Allows passing a null value, string class name, or SaveHandler object.  If a
-     * null value is passed, no explicit save handler will be used.
-     *
-     * @param null|string|SaveHandler $saveHandler
+     * @param SaveHandler $saveHandler
      * @return void
      */
-    public function setSaveHandler($saveHandler)
+    public function setSaveHandler(SaveHandler $saveHandler)
     {
-        if (null === $saveHandler) {
+        if ($saveHandler === null) {
             return ;
         }
-
-        if (is_string($saveHandler)) {
-            if (!class_exists($saveHandler)) {
-                throw new Exception\InvalidArgumentException('Class provided for SaveHandler does not exist');
-            }
-            $saveHandler = new $saveHandler();
-        }
-
-        if (!$saveHandler instanceof SaveHandler) {
-            throw new Exception\InvalidArgumentException('SaveHandler type provided is invalid; must implement Zend\\Session\\SaveHandler');
-        }
-
         $this->saveHandler = $saveHandler;
     }
 

--- a/library/Zend/Session/Container.php
+++ b/library/Zend/Session/Container.php
@@ -66,10 +66,10 @@ class Container extends ArrayObject
      * Provide a name ('Default' if none provided) and a Manager instance.
      * 
      * @param  null|string $name 
-     * @param  null|Manager $manager 
+     * @param  Manager $manager 
      * @return void
      */
-    public function __construct($name = 'Default', $manager = null)
+    public function __construct($name = 'Default', Manager $manager = null)
     {
         if (!preg_match('/^[a-z][a-z0-9_\\\]+$/i', $name)) {
             throw new Exception\InvalidArgumentException('Name passed to container is invalid; must consist of alphanumerics, backslashes and underscores only');
@@ -108,7 +108,7 @@ class Container extends ArrayObject
         if (null === self::$defaultManager) {
             $manager = new self::$managerDefaultClass();
             if (!$manager instanceof Manager) {
-                throw new Exception\InvalidArgumentException('Invalid manager type provided; must implement Manager');
+                throw new Exception\InvalidArgumentException('Invalid default manager type provided; must implement Manager');
             }
             self::$defaultManager = $manager;
         }
@@ -138,16 +138,16 @@ class Container extends ArrayObject
     /**
      * Set session manager
      * 
-     * @param  null|string|Manager $manager 
+     * @param  null|Manager $manager 
      * @return Container
      */
-    protected function setManager($manager)
+    protected function setManager(Manager $manager = null)
     {
         if (null === $manager) {
             $manager = self::getDefaultManager();
-        }
-        if (!$manager instanceof Manager) {
-            throw new Exception\InvalidArgumentException('Manager provided is invalid; must implement Manager interface');
+            if (!$manager instanceof Manager) {
+                throw new Exception\InvalidArgumentException('Manager provided is invalid; must implement Manager interface');
+            }
         }
         $this->manager = $manager;
         return $this;

--- a/library/Zend/Session/Manager.php
+++ b/library/Zend/Session/Manager.php
@@ -35,7 +35,7 @@ use Zend\EventManager\EventCollection;
  */
 interface Manager
 {
-    public function __construct($config = null, $storage = null, $saveHandler = null);
+    public function __construct(Configuration $config = null, Storage $storage = null, SaveHandler $saveHandler = null);
 
     public function getConfig();
     public function getStorage();

--- a/library/Zend/Session/SaveHandler/Cache.php
+++ b/library/Zend/Session/SaveHandler/Cache.php
@@ -145,10 +145,6 @@ class Cache implements Savable
      */
     public function setStorageAdapter(StorageAdapter $storageAdapter)
     {
-        if (!$storageAdapter instanceof StorageAdapter) {
-            throw new Exception\InvalidArgumentException('StorageAdapter type provided is invalid; must implement Zend\\Cache\\Storage\\Adapter');
-        }
-
         $this->storageAdapter = $storageAdapter;
     }
 

--- a/library/Zend/Session/SaveHandler/Cache.php
+++ b/library/Zend/Session/SaveHandler/Cache.php
@@ -55,11 +55,11 @@ class Cache implements Savable
     /**
      * Constructor
      *
-     * @param  Zend\Cache\Storage\Adapter|null $storageAdapter
+     * @param  Zend\Cache\Storage\Adapter $storageAdapter
      * @return void
      * @throws Zend\Session\Exception
      */
-    public function __construct($storageAdapter)
+    public function __construct(StorageAdapter $storageAdapter)
     {
         $this->setStorageAdapter($storageAdapter);
     }
@@ -140,18 +140,11 @@ class Cache implements Savable
      *
      * Allows passing a string class name or StorageAdapter object.
      *
-     * @param string|Zend\Cache\Storage\Adapter
+     * @param Zend\Cache\Storage\Adapter
      * @return void
      */
-    public function setStorageAdapter($storageAdapter)
+    public function setStorageAdapter(StorageAdapter $storageAdapter)
     {
-        if (is_string($storageAdapter)) {
-            if (!class_exists($storageAdapter)) {
-                throw new Exception\InvalidArgumentException('Class provided for StorageAdapter does not exist');
-            }
-            $storageAdapter = new $storageAdapter;
-        }
-
         if (!$storageAdapter instanceof StorageAdapter) {
             throw new Exception\InvalidArgumentException('StorageAdapter type provided is invalid; must implement Zend\\Cache\\Storage\\Adapter');
         }

--- a/library/Zend/Session/SaveHandler/DbTable.php
+++ b/library/Zend/Session/SaveHandler/DbTable.php
@@ -20,7 +20,8 @@
 
 namespace Zend\Session\SaveHandler;
 
-use Zend\Session\SaveHandler as Savable,
+use Zend\Config\Config as Configuration,
+    Zend\Session\SaveHandler as Savable,
     Zend\Session\Container,
     Zend\Session\Exception,
     Zend\Db\Table\AbstractTable,
@@ -29,10 +30,6 @@ use Zend\Session\SaveHandler as Savable,
 /**
  * DB Table session save handler
  *
- * @uses       Zend\Config
- * @uses       Zend_Db_Table_Abstract
- * @uses       Zend_Db_Table_Row_Abstract
- * @uses       Zend\Session\SaveHandler\Exception
  * @category   Zend
  * @package    Zend_Session
  * @subpackage SaveHandler
@@ -128,9 +125,8 @@ class DbTable
     /**
      * Constructor
      *
-     * $config is an instance of Zend_Config or an array of key/value pairs containing configuration options for
-     * Zend_Session_SaveHandler_DbTable and Zend_Db_Table_Abstract. These are the configuration options for
-     * Zend_Session_SaveHandler_DbTable:
+     * $config is an instance of Zend\Config\Config. These are the configuration options for
+     * Zend\Session\SaveHandler\DbTable:
      *
      * name              => (string) Session table name
      *
@@ -157,19 +153,13 @@ class DbTable
      * overrideLifetime  => (boolean) Whether or not the lifetime of an existing session should be overridden
      *      (optional; default: false)
      *
-     * @param  Zend_Config|array $config      User-provided configuration
+     * @param  Configuration      User-provided configuration
      * @return void
      * @throws Zend_Session_SaveHandler_Exception
      */
-    public function __construct($config)
+    public function __construct(Configuration $config)
     {
-        if ($config instanceof \Zend\Config\Config) {
-            $config = $config->toArray();
-        } else if (!is_array($config)) {
-            throw new Exception\InvalidArgumentException(
-                '$config must be an instance of Zend\\Config or array of key/value pairs containing '
-              . 'configuration options for Zend\\Session\\SaveHandler\\DbTable and Zend\\Db\\Table\\Abstract.');
-        }
+        $config = $config->toArray();
 
         foreach ($config as $key => $value) {
             do {
@@ -515,7 +505,7 @@ class DbTable
     /**
      * Retrieve session lifetime considering DbTable::OVERRIDE_LIFETIME
      *
-     * @param Zend_Db_Table_Row_Abstract $row
+     * @param Zend\Db\Table\Row\Abstract $row
      * @return int
      */
     protected function _getLifetime(AbstractRow $row)
@@ -532,7 +522,7 @@ class DbTable
     /**
      * Retrieve session expiration time
      *
-     * @param Zend_Db_Table_Row_Abstract $row
+     * @param Zend\Db\Table\Row\Abstract $row
      * @return int
      */
     protected function _getExpirationTime(AbstractRow $row)

--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -37,16 +37,6 @@ use Zend\Validator\Alnum as AlnumValidator,
 class SessionManager extends AbstractManager
 {
     /**
-     * @var Configuration
-     */
-    protected $config;
-
-    /**
-     * @var Storage
-     */
-    protected $storage;
-
-    /**
      * Default options when a call to {@link destroy()} is made
      * - send_expire_cookie: whether or not to send a cookie expiring the current session cookie
      * - clear_storage: whether or not to empty the storage object of any stored values

--- a/library/Zend/Session/Storage/ArrayStorage.php
+++ b/library/Zend/Session/Storage/ArrayStorage.php
@@ -149,6 +149,12 @@ class ArrayStorage extends ArrayObject implements Storable
         return array_key_exists($key, $locks);
     }
 
+    /**
+     * Unlock an object or key marked as locked
+     * 
+     * @param  null|int|string $key 
+     * @return ArrayStorage
+     */
     public function unlock($key = null)
     {
         if (null === $key) {

--- a/tests/Zend/Session/ContainerTest.php
+++ b/tests/Zend/Session/ContainerTest.php
@@ -23,6 +23,7 @@
 namespace ZendTest\Session;
 
 use Zend\Session\Container,
+    Zend\Session\Configuration\StandardConfiguration,
     Zend\Session\Manager,
     Zend\Session;
 
@@ -41,10 +42,12 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->forceAutoloader();
         $_SESSION = array();
         Container::setDefaultManager(null);
-        $this->manager = $manager = new TestAsset\TestManager(array(
-            'class'   => 'Zend\\Session\\Configuration\\StandardConfiguration',
+
+        $config = new StandardConfiguration(array(
             'storage' => 'Zend\\Session\\Storage\\ArrayStorage',
         ));
+
+        $this->manager = $manager = new TestAsset\TestManager($config);
         $this->container = new Container('Default', $manager);
     }
 
@@ -185,10 +188,10 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testContainerAllowsInjectingManagerViaConstructor()
     {
-        $manager = new TestAsset\TestManager(array(
-            'class'   => 'Zend\\Session\\Configuration\\StandardConfiguration',
+        $config = new StandardConfiguration(array(
             'storage' => 'Zend\\Session\\Storage\\ArrayStorage',
         ));
+        $manager = new TestAsset\TestManager($config);
         $container = new Container('Foo', $manager);
         $this->assertSame($manager, $container->getManager());
     }

--- a/tests/Zend/Session/SaveHandler/DbTableTest.php
+++ b/tests/Zend/Session/SaveHandler/DbTableTest.php
@@ -47,7 +47,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
     /**
      * @var Zend\Config\Config
      */
-    protected $_saveHandlerTableConfig = array(
+    protected $saveHandlerTableConfig = array(
         'name'              => 'sessions',
         'primary'           => array(
             'id',
@@ -88,7 +88,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Zend\Session\SaveHandler\DbTable tests are not enabled due to missing PDO_Sqlite extension');
         }
 
-        $this->_saveHandlerTableConfig = new Config(array(
+        $this->saveHandlerTableConfig = new Config(array(
             'name'              => 'sessions',
             'primary'           => array(
                 'id',
@@ -108,8 +108,8 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
         // $this->markTestSkipped('Skipped until Zend\Db is refactored, this tests assumptions are generally bad, more assertions are needed');
 
         $this->manager = $manager = new TestManager();
-        $this->_saveHandlerTableConfig['manager'] = $this->manager;
-        $this->_setupDb($this->_saveHandlerTableConfig['primary']);
+        $this->saveHandlerTableConfig['manager'] = $this->manager;
+        $this->setupDb($this->saveHandlerTableConfig['primary']);
     }
 
     /**
@@ -120,26 +120,26 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         if ($this->_db instanceof AbstractAdapter) {
-            $this->_dropTable();
+            $this->dropTable();
         }
     }
 
     public function testConfigPrimaryAssignmentFullConfig()
     {
-        $sh = new DbTable($this->_saveHandlerTableConfig);
+        $sh = new DbTable($this->saveHandlerTableConfig);
         $this->assertInstanceOf('Zend\Db\Table\AbstractTable', $sh);
     }
 
     public function testTableNameSchema()
     {
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         $config['name'] = 'schema.session';
         $this->_usedSaveHandlers[] = $saveHandler = new DbTable($config);
     }
 
     public function testPrimaryAssignmentIdNotSet()
     {
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         $config['primary'] = array('id');
         $config[DbTable::PRIMARY_ASSIGNMENT]
             = DbTable::PRIMARY_ASSIGNMENT_SESSION_SAVE_PATH;
@@ -156,7 +156,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
 
     public function testPrimaryAssignmentNotArray()
     {
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         $config['primary'] = array('id');
         $config[DbTable::PRIMARY_ASSIGNMENT]
             = DbTable::PRIMARY_ASSIGNMENT_SESSION_ID;
@@ -168,7 +168,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
 
     public function testModifiedColumnNotSet()
     {
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         unset($config[DbTable::MODIFIED_COLUMN]);
         $this->setExpectedException(
             'Zend\Session\Exception\RuntimeException',
@@ -182,7 +182,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
 
     public function testLifetimeColumnNotSet()
     {
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         unset($config[DbTable::LIFETIME_COLUMN]);
         
         $this->setExpectedException(
@@ -194,7 +194,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
 
     public function testDataColumnNotSet()
     {
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         unset($config[DbTable::DATA_COLUMN]);
         
         $this->setExpectedException(
@@ -207,7 +207,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
     public function testDifferentArraySize()
     {
         //different number of args between primary and primaryAssignment
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         unset($config[DbTable::PRIMARY_ASSIGNMENT]);
         
         $this->setExpectedException(
@@ -219,7 +219,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
     public function testEmptyPrimaryAssignment()
     {
         //test the default - no primaryAssignment
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         unset($config[DbTable::PRIMARY_ASSIGNMENT]);
         $config['primary'] = $config['primary'][0];
         $this->_usedSaveHandlers[] = $saveHandler = new DbTable($config);
@@ -229,7 +229,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
     {
         //test that the session Id must be in the primary assignment config
         try {
-            $config = $this->_saveHandlerTableConfig;
+            $config = $this->saveHandlerTableConfig;
             $config[DbTable::PRIMARY_ASSIGNMENT] = array(
                 DbTable::PRIMARY_ASSIGNMENT_SESSION_NAME,
             );
@@ -246,7 +246,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
     {
         //test the default - no primaryAssignment
         try {
-            $config = $this->_saveHandlerTableConfig;
+            $config = $this->saveHandlerTableConfig;
             unset($config[DbTable::PRIMARY_ASSIGNMENT]);
             unset($config[DbTable::MODIFIED_COLUMN]);
             $this->_usedSaveHandlers[] =
@@ -263,7 +263,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
     {
         //test the default - no primaryAssignment
         try {
-            $config = $this->_saveHandlerTableConfig;
+            $config = $this->saveHandlerTableConfig;
             unset($config[DbTable::PRIMARY_ASSIGNMENT]);
             unset($config[DbTable::LIFETIME_COLUMN]);
             $this->_usedSaveHandlers[] =
@@ -280,7 +280,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
     {
         //test the default - no primaryAssignment
         try {
-            $config = $this->_saveHandlerTableConfig;
+            $config = $this->saveHandlerTableConfig;
             unset($config[DbTable::PRIMARY_ASSIGNMENT]);
             unset($config[DbTable::DATA_COLUMN]);
             $this->_usedSaveHandlers[] =
@@ -295,7 +295,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
 
     public function testLifetime()
     {
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         unset($config['lifetime']);
         $this->_usedSaveHandlers[] =
             $saveHandler = new DbTable($config);
@@ -303,7 +303,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
             'lifetime must default to session.gc_maxlifetime'
         );
 
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         $lifetime = $config['lifetime'] = 1242;
         $this->_usedSaveHandlers[] =
             $saveHandler = new DbTable($config);
@@ -313,7 +313,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
     public function testOverrideLifetime()
     {
         try {
-            $config = $this->_saveHandlerTableConfig;
+            $config = $this->saveHandlerTableConfig;
             $config['overrideLifetime'] = true;
             $this->_usedSaveHandlers[] =
                 $saveHandler = new DbTable($config);
@@ -328,13 +328,13 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
 
     public function testSessionSaving()
     {
-        $this->_dropTable();
+        $this->dropTable();
 
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         unset($config[DbTable::PRIMARY_ASSIGNMENT]);
         $config['primary'] = array($config['primary'][0]);
 
-        $this->_setupDb($config['primary']);
+        $this->setupDb($config['primary']);
 
         $this->_usedSaveHandlers[] =
             $saveHandler = new DbTable($config);
@@ -346,9 +346,9 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
          */
 
         $session = new \Zend\Session\Container('SaveHandler', $manager);
-        $session->testArray = $this->_saveHandlerTableConfig;
+        $session->testArray = $this->saveHandlerTableConfig;
 
-        $tmp = array('SaveHandler' => serialize(array('testArray' => $this->_saveHandlerTableConfig)));
+        $tmp = array('SaveHandler' => serialize(array('testArray' => $this->saveHandlerTableConfig)));
         $testAgainst = '';
         foreach ($tmp as $key => $val) {
             $testAgainst .= $key . "|" . $val;
@@ -365,10 +365,10 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
 
     public function testReadWrite()
     {
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         unset($config[DbTable::PRIMARY_ASSIGNMENT]);
         $config['primary'] = array($config['primary'][0]);
-        $this->_setupDb($config['primary']);
+        $this->setupDb($config['primary']);
         $this->_usedSaveHandlers[] =
             $saveHandler = new DbTable($config);
 
@@ -382,8 +382,8 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
 
     public function testReadWriteComplex()
     {
-        $config = $this->_saveHandlerTableConfig;
-        $this->_setupDb($config['primary']);
+        $config = $this->saveHandlerTableConfig;
+        $this->setupDb($config['primary']);
         $this->_usedSaveHandlers[] =
             $saveHandler = new DbTable($config);
         $saveHandler->open('savepath', 'sessionname');
@@ -397,10 +397,10 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
 
     public function testReadWriteTwice()
     {
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         unset($config[DbTable::PRIMARY_ASSIGNMENT]);
         $config['primary'] = array($config['primary'][0]);
-        $this->_setupDb($config['primary']);
+        $this->setupDb($config['primary']);
         $this->_usedSaveHandlers[] =
             $saveHandler = new DbTable($config);
 
@@ -417,12 +417,12 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
 
     public function testReadWriteTwiceAndExpire()
     {
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         unset($config[DbTable::PRIMARY_ASSIGNMENT]);
         $config['primary'] = array($config['primary'][0]);
         $config['lifetime'] = 1;
 
-        $this->_setupDb($config['primary']);
+        $this->setupDb($config['primary']);
         $this->_usedSaveHandlers[] =
             $saveHandler = new DbTable($config);
 
@@ -441,12 +441,12 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
 
     public function testReadWriteThreeTimesAndGc()
     {
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         unset($config[DbTable::PRIMARY_ASSIGNMENT]);
         $config['primary'] = array($config['primary'][0]);
         $config['lifetime'] = 1;
 
-        $this->_setupDb($config['primary']);
+        $this->setupDb($config['primary']);
         $this->_usedSaveHandlers[] =
             $saveHandler = new DbTable($config);
 
@@ -482,12 +482,12 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
 
     public function testSetLifetime()
     {
-        $config = $this->_saveHandlerTableConfig;
+        $config = $this->saveHandlerTableConfig;
         unset($config[DbTable::PRIMARY_ASSIGNMENT]);
         $config['primary'] = array($config['primary'][0]);
         $config['lifetime'] = 1;
 
-        $this->_setupDb($config['primary']);
+        $this->setupDb($config['primary']);
         $this->_usedSaveHandlers[] =
             $saveHandler = new DbTable($config);
         $this->assertSame(1, $saveHandler->getLifetime());
@@ -500,7 +500,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
     public function testZendConfig()
     {
         $this->_usedSaveHandlers[] =
-            $saveHandler = new DbTable($this->_saveHandlerTableConfig);
+            $saveHandler = new DbTable($this->saveHandlerTableConfig);
         /**
          * @todo Test something other than that an exception is not thrown
          */
@@ -512,7 +512,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
      * @param  Zend\Config\Config $primary
      * @return void
      */
-    protected function _setupDb(Config $primary)
+    protected function setupDb(Config $primary)
     {
         $primary = $primary->toArray();
         if (!extension_loaded('pdo_sqlite')) {
@@ -543,7 +543,7 @@ class DbTableTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    protected function _dropTable()
+    protected function dropTable()
     {
         if (!$this->_db instanceof AbstractAdapter) {
             return;

--- a/tests/Zend/Session/SessionManagerTest.php
+++ b/tests/Zend/Session/SessionManagerTest.php
@@ -96,61 +96,6 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($config, $manager->getConfig());
     }
 
-    public function testPassingUnknownStringClassForConfigurationRaisesException()
-    {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Configuration class provided is invalid; not found');
-        $manager = new SessionManager('foobarbazbat');
-    }
-
-    public function testPassingInvalidStringClassForConfigurationRaisesException()
-    {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Configuration type provided is invalid; must implement Zend\Session\Configuration');
-        $manager = new SessionManager('Zend\Session\Storage\ArrayStorage');
-    }
-
-    public function testPassingValidStringClassForConfigurationInstantiatesThatConfiguration()
-    {
-        $manager = new SessionManager('Zend\\Session\\Configuration\\StandardConfiguration');
-        $config = $manager->getConfig();
-        $this->assertTrue($config instanceof Session\Configuration\StandardConfiguration);
-    }
-
-    public function testPassingValidStringClassInClassKeyOfArrayConfigurationInstantiatesThatConfiguration()
-    {
-        $manager = new SessionManager(array('class' => 'Zend\\Session\\Configuration\\StandardConfiguration'));
-        $config = $manager->getConfig();
-        $this->assertTrue($config instanceof Session\Configuration\StandardConfiguration);
-    }
-
-    public function testPassingInvalidStringClassInClassKeyOfArrayConfigurationRaisesException()
-    {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Class provided for configuration is invalid; not found');
-        $manager = new SessionManager(array('class' => 'foobarbaz'));
-    }
-
-    public function testPassingValidStringClassInClassKeyOfArrayConfigurationInstantiatesThatConfigurationWithOptionsProvided()
-    {
-        $manager = new SessionManager(array(
-            'class'     => 'Zend\\Session\\Configuration\\StandardConfiguration',
-            'save_path' => __DIR__,
-        ));
-        $config = $manager->getConfig();
-        $this->assertTrue($config instanceof Session\Configuration\StandardConfiguration);
-        $this->assertEquals(__DIR__, $config->getSavePath());
-    }
-
-    public function testPassingZendConfigObjectForConfigurationInstantiatesThatConfiguration()
-    {
-        $config = new \Zend\Config\Config(array(
-            'class'     => 'Zend\\Session\\Configuration\\StandardConfiguration',
-            'save_path' => __DIR__,
-        ));
-        $manager = new SessionManager($config);
-        $config = $manager->getConfig();
-        $this->assertTrue($config instanceof Session\Configuration\StandardConfiguration);
-        $this->assertEquals(__DIR__, $config->getSavePath());
-    }
-
     public function testManagerUsesSessionStorageByDefault()
     {
         $storage = $this->manager->getStorage();
@@ -164,58 +109,10 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($storage, $manager->getStorage());
     }
 
-    public function testCanPassStringStorageNameToConstructor()
-    {
-        $manager = new SessionManager(null, 'Zend\\Session\\Storage\\ArrayStorage');
-        $storage = $manager->getStorage();
-        $this->assertTrue($storage instanceof Session\Storage\ArrayStorage);
-    }
-
-    public function testCanPassStorageClassToConfigurationOptions()
-    {
-        $manager = new SessionManager(array('storage' => 'Zend\\Session\\Storage\\ArrayStorage'));
-        $storage = $manager->getStorage();
-        $this->assertTrue($storage instanceof Session\Storage\ArrayStorage);
-    }
-
-    public function testPassingStorageViaParamOverridesStorageInConfig()
-    {
-        $storage = new Session\Storage\ArrayStorage();
-        $manager = new TestAsset\TestManager(array(
-            'class'   => 'Zend\\Session\\Configuration\\StandardConfiguration',
-            'storage' => 'Zend\\Session\\Storage\\SessionStorage',
-        ), $storage);
-        $this->assertSame($storage, $manager->getStorage());
-    }
-
     public function testCanPassSaveHandlerToConstructor()
     {
         $saveHandler = new TestAsset\TestSaveHandler();
         $manager = new SessionManager(null, null, $saveHandler);
-        $this->assertSame($saveHandler, $manager->getSaveHandler());
-    }
-
-    public function testCanPassStringSessionHandlerNameToConstructor()
-    {
-        $manager = new SessionManager(null, null, 'ZendTest\\Session\\TestAsset\\TestSaveHandler');
-        $sessionHandler = $manager->getSaveHandler();
-        $this->assertTrue($sessionHandler instanceof TestAsset\TestSaveHandler);
-    }
-
-    public function testCanPassSaveHandlerToConfigurationOptions()
-    {
-        $manager = new SessionManager(array('saveHandler' => 'ZendTest\\Session\\TestAsset\\TestSaveHandler'));
-        $saveHandler = $manager->getSaveHandler();
-        $this->assertTrue($saveHandler instanceof TestAsset\TestSaveHandler);
-    }
-    
-    public function testPassingSaveHandlerViaParamOverridesSaveHandlerInConfig()
-    {
-        $saveHandler = new TestAsset\TestSaveHandler();
-        $manager = new TestAsset\TestManager(array(
-            'class' => 'Zend\\Session\\Configuration\\StandardConfiguration',
-            'saveHandler' => 'ZendTest\\Session\\TestAsset\\TestSaveHandler',
-        ), null, $saveHandler);
         $this->assertSame($saveHandler, $manager->getSaveHandler());
     }
 


### PR DESCRIPTION
The goal for this change is really around some of the massive problems you may find around DI when you are not type hinting; additionally the argument can be made that with DI not accepting just an object seems foolish.  This change implements proper type hinting for objects and removes all of the optional types of things.  

Not only does this improve our ability on maintenance and bugs; it also helps to ensure consistency and adaptability of the framework.

Changes:
- Type hint all possible values; remove the possibility of not passing in objects when an object should be necessary.
- Remove unit tests when strings or arrays or the like may have been previously passed instead of an object.
- AbstractManager will no longer accept a saveHandler nor a storage option in the configuration array / object / etc.  This is the largest BC break but did not make sense since the arguments are optional anyhow.

BC Breaks:
- Any attributes that could type hinted values are now type hinted
- 
