### PR TITLE
Memcached Poll Timeout Default Fix

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/MemcachedOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/MemcachedOptions.php
@@ -141,7 +141,7 @@ class MemcachedOptions extends AdapterOptions
      *
      * @var int
      */
-    protected $pollTimeout = 0;
+    protected $pollTimeout = 1000;
 
     /**
      * Maximum allowed time for a recv operation, in ms


### PR DESCRIPTION
The most annoying bug I have found; took tcpdump + memcached -vv to figure out what the hell was happening followed by going through the options are commenting out one by one until I found the culprit.  Yes; very very frustrating!  With this; you will never be able to keep a connection and will instantly timeout making the adapter worthless :)

Change:
- Set poll_timeout to the correct default.

From: http://www.php.net/manual/en/memcached.constants.php:

> Memcached::OPT_POLL_TIMEOUT
> Timeout for connection polling, in milliseconds.
> 
> Type: integer, default: 1000.
