### PR TITLE
Zend\Navigation: update isActive from MVC page and remove all relations to module

### DIFF
--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -26,7 +26,7 @@ use Zend\Mvc\Router\RouteMatch,
     Zend\View\Helper\Url as UrlHelper;
 
 /**
- * Represents a page that is defined using module, controller, action, route
+ * Represents a page that is defined using controller, action, route
  * name and route params to assemble the href
  *
  * @category   Zend
@@ -43,11 +43,6 @@ class Mvc extends AbstractPage
      * @var string
      */
     protected $action;
-
-    /**
-     * @var bool
-     */
-    protected $active = false;
 
     /**
      * Controller name to use when assembling URL
@@ -127,11 +122,14 @@ class Mvc extends AbstractPage
             if ($this->routeMatch instanceof RouteMatch) {
                 $reqParams = $this->routeMatch->getParams();
 
-                if ($this->routeMatch->getMatchedRouteName() === $this->getRoute()) {
+                if (null !== $this->getRoute()
+                    && $this->routeMatch->getMatchedRouteName() === $this->getRoute()
+                ) {
                     $this->active = true;
                     return true;
                 }
             }
+
 
             $myParams = $this->params;
 
@@ -282,40 +280,6 @@ class Mvc extends AbstractPage
     public function getController()
     {
         return $this->controller;
-    }
-
-    /**
-     * Sets module name to use when assembling URL
-     *
-     * @see getHref()
-     *
-     * @param  string|null $module        module name
-     * @return Mvc   fluent interface, returns self
-     * @throws Exception\InvalidArgumentException  if invalid module name is given
-     */
-    public function setModule($module)
-    {
-        if (null !== $module && !is_string($module)) {
-            throw new Exception\InvalidArgumentException(
-                'Invalid argument: $module must be a string or null'
-            );
-        }
-
-        $this->module    = $module;
-        $this->hrefCache = null;
-        return $this;
-    }
-
-    /**
-     * Returns module name to use when assembling URL
-     *
-     * @see getHref()
-     *
-     * @return string|null  module name or null
-     */
-    public function getModule()
-    {
-        return $this->module;
     }
 
     /**

--- a/tests/Zend/Navigation/Page/MvcTest.php
+++ b/tests/Zend/Navigation/Page/MvcTest.php
@@ -155,6 +155,18 @@ class MvcTest extends TestCase
         $this->assertEquals(true, $page->isActive());
     }
 
+    public function testIsActiveReturnsFalseWhenNoRouteAndNoMatchedRouteNameIsSet()
+    {
+        $page = new Page\Mvc();
+
+        $routeMatch = new RouteMatch(array());
+        $this->urlHelper->setRouteMatch($routeMatch);
+
+        $page->setRouteMatch($routeMatch);
+
+        $this->assertFalse($page->isActive());
+    }
+
     /**
      * @group ZF-8922
      */
@@ -175,7 +187,6 @@ class MvcTest extends TestCase
             '(lolcat/(?<action>[^/]+)/(?<page>\d+))',
             '/lolcat/%action%/%page%',
             array(
-                'module'     => 'default',
                 'controller' => 'foobar',
                 'action'     => 'bazbat',
                 'page'       => 1,
@@ -190,20 +201,18 @@ class MvcTest extends TestCase
         $this->assertEquals('/lolcat/myaction/1337#qux', $page->getHref());
     }
 
-    public function testIsActiveReturnsTrueOnIdenticalModuleControllerAction()
+    public function testIsActiveReturnsTrueOnIdenticalControllerAction()
     {
         $page = new Page\Mvc(array(
-            'label'      => 'foo',
             'action'     => 'index',
             'controller' => 'index'
         ));
 
         $routeMatch = new RouteMatch(array(
-            'module'     => 'application',
             'controller' => 'index',
             'action'     => 'index',
         ));
-        $routeMatch->setMatchedRouteName('default');
+
         $this->urlHelper->setRouteMatch($routeMatch);
 
         $page->setRouteMatch($routeMatch);
@@ -211,20 +220,18 @@ class MvcTest extends TestCase
         $this->assertTrue($page->isActive());
     }
 
-    public function testIsActiveReturnsFalseOnDifferentModuleControllerAction()
+    public function testIsActiveReturnsFalseOnDifferentControllerAction()
     {
         $page = new Page\Mvc(array(
-            'label'      => 'foo',
             'action'     => 'bar',
             'controller' => 'index'
         ));
 
         $routeMatch = new RouteMatch(array(
-            'module'     => 'default',
             'controller' => 'index',
             'action'     => 'index',
         ));
-        $routeMatch->setMatchedRouteName('default');
+
         $this->urlHelper->setRouteMatch($routeMatch);
 
         $page->setRouteMatch($routeMatch);
@@ -238,19 +245,17 @@ class MvcTest extends TestCase
             'label'      => 'foo',
             'action'     => 'view',
             'controller' => 'post',
-            'module'     => 'blog',
             'params'     => array(
                 'id'     => '1337'
             )
         ));
 
         $routeMatch = new RouteMatch(array(
-            'module'     => 'blog',
             'controller' => 'post',
             'action'     => 'view',
             'id'         => '1337'
         ));
-        $routeMatch->setMatchedRouteName('default');
+
         $this->urlHelper->setRouteMatch($routeMatch);
 
         $page->setRouteMatch($routeMatch);
@@ -264,16 +269,14 @@ class MvcTest extends TestCase
             'label'      => 'foo',
             'action'     => 'view',
             'controller' => 'post',
-            'module'     => 'blog'
         ));
 
         $routeMatch = new RouteMatch(array(
-            'module'     => 'blog',
             'controller' => 'post',
             'action'     => 'view',
-            'id'         => '1337'
+            'id'         => '1337',
         ));
-        $routeMatch->setMatchedRouteName('default');
+
         $this->urlHelper->setRouteMatch($routeMatch);
 
         $page->setRouteMatch($routeMatch);
@@ -287,19 +290,17 @@ class MvcTest extends TestCase
             'label'      => 'foo',
             'action'     => 'view',
             'controller' => 'post',
-            'module'     => 'blog',
             'params'     => array(
                 'id'     => '1337'
             )
         ));
 
         $routeMatch = new RouteMatch(array(
-            'module'     => 'blog',
             'controller' => 'post',
             'action'     => 'view',
             'id'         => null
         ));
-        $routeMatch->setMatchedRouteName('default');
+
         $this->urlHelper->setRouteMatch($routeMatch);
 
         $page->setRouteMatch($routeMatch);

--- a/tests/Zend/Navigation/Page/PageTest.php
+++ b/tests/Zend/Navigation/Page/PageTest.php
@@ -813,7 +813,6 @@ class PageTest extends \PHPUnit_Framework_TestCase
             'label' => 'bar',
             'action' => 'baz',
             'controller' => 'bat',
-            'module' => 'test',
             'id' => 'foo-test'
         );
 
@@ -823,7 +822,6 @@ class PageTest extends \PHPUnit_Framework_TestCase
             'label'       => 'bar',
             'action'      => 'baz',
             'controller'  => 'bat',
-            'module'      => 'test',
             'id'          => 'foo-test'
         );
 
@@ -831,7 +829,6 @@ class PageTest extends \PHPUnit_Framework_TestCase
             'label'       => $page->getLabel(),
             'action'      => $page->getAction(),
             'controller'  => $page->getController(),
-            'module'      => $page->getModule(),
             'id'          => $page->getId()
         );
 


### PR DESCRIPTION
- If no route for page is set then don't compare with route from RouteMatch
- Removed unneeded "matched route name" from unit tests
- Removed unneeded "active" property from MVC page
- Removed all relations to module (ZF1) in MVC page and unit tests
