### PR TITLE
Fix all obvious usage of old Zend\Config readers

### DIFF
--- a/demos/Zend/Service/LiveDocx/MailMerge/constructors/public-zend_config.php
+++ b/demos/Zend/Service/LiveDocx/MailMerge/constructors/public-zend_config.php
@@ -3,7 +3,7 @@
 require_once dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . 'Bootstrap.php';
 
 
-use Zend\Config\Ini;
+use Zend\Config\Factory as ConfigFactory;
 use Zend\Service\LiveDocx\Helper;
 use Zend\Service\LiveDocx\MailMerge;
 
@@ -15,7 +15,7 @@ Helper::printLine(
     PHP_EOL
 );
 
-$options = new Ini('credentials.ini');
+$options = ConfigFactory::fromFile('credentials.ini', true);
 
 $mailMerge = new MailMerge($options);
 

--- a/tests/Zend/Cloud/QueueService/FactoryTest.php
+++ b/tests/Zend/Cloud/QueueService/FactoryTest.php
@@ -26,7 +26,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
     define("PHPUnit_MAIN_METHOD", "Zend\Cloud\StorageService\FactoryTest::main");
 }
 
-use Zend\Config\Ini,
+use Zend\Config\Factory as ConfigFactory,
     Zend\Cloud\QueueService\Factory,
     PHPUnit_Framework_TestCase as PHPUnitTestCase;
 
@@ -61,17 +61,17 @@ class FactoryTest extends PHPUnitTestCase
     public function testGetAdapterWithConfig()
     {
         // SQS adapter
-        $sqsConfig = new Ini(realpath(dirname(__FILE__) . '/_files/config/sqs.ini'));
+        $sqsConfig = ConfigFactory::fromFile(realpath(dirname(__FILE__) . '/_files/config/sqs.ini'), true);
         $sqsAdapter = Factory::getAdapter($sqsConfig);
         $this->assertEquals('Zend\Cloud\QueueService\Adapter\Sqs', get_class($sqsAdapter));
 
         // Zend queue adapter
-        $zqConfig = new Ini(realpath(dirname(__FILE__) . '/_files/config/zendqueue.ini'));
+        $zqConfig = ConfigFactory::fromFile(realpath(dirname(__FILE__) . '/_files/config/zendqueue.ini'), true);
         $zq = Factory::getAdapter($zqConfig);
         $this->assertEquals('Zend\Cloud\QueueService\Adapter\ZendQueue', get_class($zq));
 
         // Azure adapter
-        //$azureConfig = new Ini(realpath(dirname(__FILE__) . '/_files/config/windowsazure.ini'));
+        //$azureConfig = ConfigFactory::fromFile(realpath(dirname(__FILE__) . '/_files/config/windowsazure.ini'), true);
         //$azureAdapter = Factory::getAdapter($azureConfig);
         //$this->assertEquals('Zend\Cloud\QueueService\Adapter\WindowsAzure', get_class($azureAdapter));
     }

--- a/tests/Zend/Cloud/StorageService/FactoryTest.php
+++ b/tests/Zend/Cloud/StorageService/FactoryTest.php
@@ -21,7 +21,7 @@
 
 namespace ZendTest\Cloud\StorageService;
 
-use Zend\Config\Ini,
+use Zend\Config\Factory as ConfigFactory,
     Zend\Cloud\StorageService\Factory,
     Zend\Cloud\StorageService\Adapter\FileSystem,
     Zend\Cloud\StorageService\Adapter\Nirvanix,
@@ -69,7 +69,7 @@ class FactoryTest extends PHPUnitTestCase
         $httptest = new HttpClientTest();
 
         // Nirvanix adapter
-        $nirvanixConfig = new Ini(realpath(dirname(__FILE__) . '/_files/config/nirvanix.ini'));
+        $nirvanixConfig = ConfigFactory::fromFile(realpath(dirname(__FILE__) . '/_files/config/nirvanix.ini'), true);
         $nirvanixConfig = $nirvanixConfig->toArray();
         $nirvanixConfig[Nirvanix::HTTP_ADAPTER] = $httptest;
 
@@ -89,18 +89,18 @@ class FactoryTest extends PHPUnitTestCase
         $this->assertEquals('Zend\Cloud\StorageService\Adapter\Nirvanix', get_class($nirvanixAdapter));
 
         // S3 adapter
-        $s3Config = new Ini(realpath(dirname(__FILE__) . '/_files/config/s3.ini'));
+        $s3Config = ConfigFactory::fromFile(realpath(dirname(__FILE__) . '/_files/config/s3.ini'), true);
         $s3Adapter = Factory::getAdapter($s3Config);
         $this->assertEquals('Zend\Cloud\StorageService\Adapter\S3', get_class($s3Adapter));
 
         // file system adapter
-        $fileSystemConfig = new Ini(realpath(dirname(__FILE__) . '/_files/config/filesystem.ini'));
+        $fileSystemConfig = ConfigFactory::fromFile(realpath(dirname(__FILE__) . '/_files/config/filesystem.ini'), true);
         $fileSystemAdapter = Factory::getAdapter($fileSystemConfig);
         $this->assertEquals('Zend\Cloud\StorageService\Adapter\FileSystem', get_class($fileSystemAdapter));
 
         // Azure adapter
         /*
-        $azureConfig    = new Ini(realpath(dirname(__FILE__) . '/_files/config/windowsazure.ini'));
+        $azureConfig    = ConfigFactory::fromFile(realpath(dirname(__FILE__) . '/_files/config/windowsazure.ini'), true);
         $azureConfig    = $azureConfig->toArray();
         $azureContainer = $azureConfig[WindowsAzure::CONTAINER];
         $azureConfig[WindowsAzure::HTTP_ADAPTER] = $httptest;

--- a/tests/Zend/Di/ConfigurationTest.php
+++ b/tests/Zend/Di/ConfigurationTest.php
@@ -4,13 +4,14 @@ namespace ZendTest\Di;
 
 use Zend\Di\Configuration,
     Zend\Di\Di,
+    Zend\Config\Factory as ConfigFactory,
     PHPUnit_Framework_TestCase as TestCase;
 
 class ConfigurationTest extends TestCase
 {
     public function testConfigurationCanConfigureInstanceManagerWithIniFile()
     {
-        $ini = new \Zend\Config\Ini(__DIR__ . '/_files/sample.ini', 'section-a');
+        $ini = ConfigFactory::fromFile(__DIR__ . '/_files/sample.ini', true)->get('section-a');
         $config = new Configuration($ini->di);
         $di = new Di();
         $di->configure($config);
@@ -44,7 +45,7 @@ class ConfigurationTest extends TestCase
     public function testConfigurationCanConfigureBuilderDefinitionFromIni()
     {
         $this->markTestIncomplete('Builder not updated to new DI yet');
-        $ini = new \Zend\Config\Ini(__DIR__ . '/_files/sample.ini', 'section-b');
+        $ini = ConfigFactory::fromFile(__DIR__ . '/_files/sample.ini', true)->get('section-b');
         $config = new Configuration($ini->di);
         $di = new Di($config);
         $definition = $di->getDefinition();

--- a/tests/Zend/Di/Definition/BuilderDefinitionTest.php
+++ b/tests/Zend/Di/Definition/BuilderDefinitionTest.php
@@ -4,6 +4,7 @@ namespace ZendTest\Di\Definition;
 
 use Zend\Di\Definition\BuilderDefinition,
     Zend\Di\Definition\Builder,
+    Zend\Config\Factory as ConfigFactory,
     PHPUnit_Framework_TestCase as TestCase;
 
 class BuilderDefinitionTest extends TestCase
@@ -44,8 +45,8 @@ class BuilderDefinitionTest extends TestCase
     
     public function testBuilderCanBuildFromArray()
     {
-        $ini = new \Zend\Config\Ini(__DIR__ . '/../_files/sample.ini', 'section-b');
-        $iniAsArray = $ini->toArray();
+        $ini = ConfigFactory::fromFile(__DIR__ . '/../_files/sample.ini');
+        $iniAsArray = $ini['section-b'];
         $definitionArray = $iniAsArray['di']['definitions'][1];
         unset($definitionArray['class']);
         

--- a/tests/Zend/Form/Element/MultiselectTest.php
+++ b/tests/Zend/Form/Element/MultiselectTest.php
@@ -26,8 +26,7 @@ use Zend\Form\Element\Multiselect as MultiselectElement,
     Zend\Form\Element\Xhtml as XhtmlElement,
     Zend\Form\Element,
     Zend\Form\Decorator,
-    Zend\Config\Xml as XMLConfig,
-    Zend\Config\Ini as INIConfig,
+    Zend\Config\Factory as ConfigFactory,
     Zend\Translator\Translator,
     Zend\View\Renderer\PhpRenderer as View;
 
@@ -157,13 +156,13 @@ class MultiselectTest extends \PHPUnit_Framework_TestCase
      */
     public function testCanSetMultiOptionsUsingConfigWithKeyValueKeys()
     {
-        $config = new XMLConfig(__DIR__ . '/../TestAsset/config/multiOptions.xml', 'testing');
+        $config = ConfigFactory::fromFile(__DIR__ . '/../TestAsset/config/multiOptions.xml', true)->get('testing');
         $this->element->setMultiOptions($config->options->toArray());
         $this->assertEquals($config->options->first->value, $this->element->getMultiOption('aa'));
         $this->assertEquals($config->options->second->value, $this->element->getMultiOption(2));
         $this->assertEquals($config->options->third->value, $this->element->getMultiOption('ssss'));
 
-        $config = new INIConfig(__DIR__ . '/../TestAsset/config/multiOptions.ini', 'testing');
+        $config = ConfigFactory::fromFile(__DIR__ . '/../TestAsset/config/multiOptions.ini', true)->get('testing');
         $this->element->setMultiOptions($config->options->toArray());
         $this->assertEquals($config->options->first->value, $this->element->getMultiOption('aa'));
         $this->assertEquals($config->options->second->value, $this->element->getMultiOption(2));

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -27,8 +27,7 @@ use Zend\Form\Form,
     Zend\Form\SubForm,
     Zend\Registry,
     Zend\Config\Config,
-    Zend\Config\Ini as IniConfig,
-    Zend\Config\Xml as XmlConfig,
+    Zend\Config\Factory as ConfigFactory,
     Zend\Loader\PrefixPathLoader,
     Zend\Loader\PrefixPathMapper,
     Zend\Json\Json,
@@ -370,7 +369,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
      */
     public function testDisplayGroupOrderInConfigShouldNotMatter()
     {
-        $config = new XmlConfig(__DIR__ . '/TestAsset/config/zf3250.xml', 'sitearea', true);
+        $config = ConfigFactory::fromFile(__DIR__ . '/TestAsset/config/zf3250.xml', true)->get('sitearea');
         $form = new Form($config->test);
         // no assertions needed; throws error if order matters
     }
@@ -3743,7 +3742,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
      */
     public function testShouldAllowSettingDisplayGroupPrefixPathViaConfigOptions()
     {
-        $config = new IniConfig(__DIR__ . '/TestAsset/config/zf3213.ini', 'form');
+        $config = ConfigFactory::fromFile(__DIR__ . '/TestAsset/config/zf3213.ini', true)->get('form');
         $form   = new Form($config);
         $dg     = $form->foofoo;
         $paths  = $dg->getPluginLoader()->getPaths('My\Decorator');

--- a/tests/Zend/Paginator/PaginatorTest.php
+++ b/tests/Zend/Paginator/PaginatorTest.php
@@ -77,7 +77,7 @@ class PaginatorTest extends TestCase
         $this->_testCollection = range(1, 101);
         $this->_paginator = Paginator\Paginator::factory($this->_testCollection);
 
-        $this->_config = new Config\Xml(__DIR__ . '/_files/config.xml');
+        $this->_config = Config\Factory::fromFile(__DIR__ . '/_files/config.xml', true);
 
         $this->_cache = CacheFactory::factory(array(
             'adapter' => array(

--- a/tests/Zend/Service/Amazon/SimpleDb/OnlineTest.php
+++ b/tests/Zend/Service/Amazon/SimpleDb/OnlineTest.php
@@ -27,8 +27,7 @@ namespace ZendTest\Service\Amazon\SimpleDb;
 
 use Zend\Service\Amazon\SimpleDb,
     Zend\Service\Amazon\SimpleDb\Exception,
-    Zend\Http\Client\Adapter\Socket,
-    Zend\Config\Ini as Config;
+    Zend\Http\Client\Adapter\Socket;
 
 
 /**

--- a/tests/Zend/View/Helper/Navigation/AbstractTest.php
+++ b/tests/Zend/View/Helper/Navigation/AbstractTest.php
@@ -28,8 +28,7 @@ use Zend\Navigation\Navigation,
     Zend\Acl\Acl,
     Zend\Acl\Role\GenericRole,
     Zend\Acl\Resource\GenericResource,
-    Zend\Config\Config,
-    Zend\Config\Reader\Xml as XmlConfig,
+    Zend\Config\Factory as ConfigFactory,
     Zend\Translator\Translator,
     Zend\View\Renderer\PhpRenderer;
 
@@ -95,8 +94,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
 
         // read navigation config
         $this->_files = $cwd . '/_files';
-        $xml    = new XmlConfig();
-        $config = new Config($xml->fromFile($this->_files . '/navigation.xml'));
+        $config = ConfigFactory::fromFile($this->_files . '/navigation.xml', true);
 
         // setup containers from config
         $this->_nav1 = new Navigation($config->get('nav_test1'));


### PR DESCRIPTION
Refactored to use Zend\Config\Factory
