### PR TITLE
[pdf][ZF-11906] constructor, destructor abstract method define is no meaning 

### DIFF
--- a/library/Zend/Pdf/BinaryParser/DataSource/AbstractDataSource.php
+++ b/library/Zend/Pdf/BinaryParser/DataSource/AbstractDataSource.php
@@ -82,14 +82,14 @@ abstract class AbstractDataSource
      *
      * @throws \Zend\Pdf\Exception
      */
-    abstract public function __construct();
+    //abstract public function __construct();
 
     /**
      * Object destructor. Closes the data source.
      *
      * May also perform cleanup tasks such as deleting temporary files.
      */
-    abstract public function __destruct();
+    //abstract public function __destruct();
 
     /**
      * Returns the specified number of raw bytes from the data source at the


### PR DESCRIPTION
In PHP 5.4

```
Fatal error: Declaration of Zend\Pdf\BinaryParser\DataSource\File::__construct() must be compatible with Zend\Pdf\BinaryParser\DataSource\AbstractDataSource::__construct() 
```
