### PR TITLE
JsonRendererTest - value should be object member variable

### DIFF
--- a/tests/Zend/View/Renderer/TestAsset/JsonModel.php
+++ b/tests/Zend/View/Renderer/TestAsset/JsonModel.php
@@ -36,6 +36,6 @@ class JsonModel implements JsonSerializable
 
     public function jsonSerialize()
     {
-        return $value;
+        return $this->value;
     }
 }


### PR DESCRIPTION
tests/Zend/View/Renderer/JsonRendererTest.php
I met this error

```
There was 1 error:

1) ZendTest\View\Renderer\JsonRendererTest::testRendersJsonSerializableModelsAsJson
Undefined variable: value
```
