### PR TITLE
Access the error message and pass that on to the exception. fixes zf2-187

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Statement.php
@@ -215,7 +215,8 @@ class Statement implements StatementInterface
         }
 
         if ($this->resource->execute() === false) {
-            throw new Exception\InvalidQueryException($this->resource->error);
+            $error = $this->resource->errorInfo();
+            throw new Exception\InvalidQueryException($error[2]);
         }
 
         $result = $this->driver->createResult($this->resource);


### PR DESCRIPTION
Hi!

This is a fix for ZF2-187 [1].

I used this approach as similar has been done in the same file here: https://github.com/zendframework/zf2/blob/master/library/Zend/Db/Adapter/Driver/Pdo/Statement.php#L178

[1] http://framework.zend.com/issues/browse/ZF2-187
