### PR TITLE
merge driver options array while preserving keys. fixes zf2-188

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -179,7 +179,8 @@ class Connection implements ConnectionInterface
                     break;
                 case 'driver_options':
                 case 'options':
-                    $options = array_merge($options, (array) $value);
+                    $value = (array) $value;
+                    $options = array_diff_key($options, $value) + $value;
                     break;
                 default:
                     $options[$key] = $value;


### PR DESCRIPTION
Hi!

This is a fix for [1], the problem is explained there in detail.

This fix basically does an array_merge, but preserves keys, both numeric and string. The values from the second array will overwrite the values from the first one, if the keys are the same.

[1] http://framework.zend.com/issues/browse/ZF2-188
