### PR TITLE
only one parameter to mysqli->set_charset. fixes zf2-190

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
@@ -187,7 +187,7 @@ class Connection implements ConnectionInterface
         }
 
         if (!empty($p['charset'])) {
-            $this->resource->set_charset($this->resource, $p['charset']);
+            $this->resource->set_charset($p['charset']);
         }
 
     }


### PR DESCRIPTION
Hi!

mysqli::set_charset expects only one parameter, the charset itself. This is a fix for: http://framework.zend.com/issues/browse/ZF2-190
