### PR TITLE
make method declaration compatible with the one declared in the interface

### DIFF
--- a/library/Zend/Db/TableGateway/AbstractTableGateway.php
+++ b/library/Zend/Db/TableGateway/AbstractTableGateway.php
@@ -131,7 +131,7 @@ abstract class AbstractTableGateway extends TableGateway
      * @param  string $where
      * @return type 
      */
-    public function update($set, $where)
+    public function update($set, $where = null)
     {
         $this->initialize();
         return parent::update($set, $where);


### PR DESCRIPTION
Hi!

This one fixes zf2-192 http://framework.zend.com/issues/browse/ZF2-192

Set error_reporting to -1 for E_STRICT to kick in to notice it.
