### PR TITLE
The fromString function fail as the http headers returned by $_SERVER variable are of the form HTTP_USER_AGENT

### DIFF
--- a/library/Zend/Http/Header/UserAgent.php
+++ b/library/Zend/Http/Header/UserAgent.php
@@ -16,7 +16,7 @@ class UserAgent implements HeaderDescription
         list($name, $value) = preg_split('#: #', $headerLine, 2);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'user-agent') {
+        if (str_replace(array('_', ' ', '.'), '-', strtolower($name)) !== 'user-agent') {
             throw new Exception\InvalidArgumentException('Invalid header line for User-Agent string');
         }
 


### PR DESCRIPTION
I do not know if this is the right way to do it, but line 19 won't validate as the headers are cleaned up for the HTTP_ prefix but the _ signs are never replaced by -, hence the validation fail.

I took the str_replace(array('_', ' ', '.'), '-', strtolower($name)) idea from the file Zend/Http/Headers.php on line 284 as this is the way the $key variable is created.

If anyone finds a better way to do it please message me.
