### PR TITLE
A set of Zend\Db\Adapter\Driver fixes whilst reviewing

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -149,7 +149,7 @@ class Connection implements ConnectionInterface
 
         // @todo method createKnownDsn
 
-        $dsn = $username = $password = $database = null;
+        $dsn = $username = $password = $hostname = $database = null;
         $options = array();
         foreach ($this->connectionParameters as $key => $value) {
             switch (strtolower($key)) {
@@ -173,6 +173,10 @@ class Connection implements ConnectionInterface
                 case 'password':
                     $password = (string) $value;
                     break;
+                case 'host':
+                case 'hostname':
+                    $hostname = (string) $value;
+                    break;
                 case 'database':
                 case 'dbname':
                     $database = (string) $value;
@@ -190,8 +194,11 @@ class Connection implements ConnectionInterface
 
         if (!isset($dsn) && isset($pdoDriver)) {
             $dsn = $pdoDriver . ':';
+            if (isset($hostname)) {
+                $dsn .= "hostname=$hostname;";
+            }
             if (isset($database)) {
-                $dsn .= $database;
+                $dsn .= "dbname=$database;";
             }
         } elseif (!isset($dsn)) {
             throw new \Exception('A dsn was not provided or could not be constructed from your parameters');

--- a/library/Zend/Db/Adapter/Driver/Pdo/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Statement.php
@@ -250,8 +250,9 @@ class Statement implements StatementInterface
                 }
             }
 
-            // position is named or positional, value is reference
-            $this->resource->bindParam((is_int($position) ? ($position + 1) : $position), $value, $type);
+            // parameter is named or positional, value is reference
+            $parameter = is_int($position) ? ($position + 1) : $position;
+            $this->resource->bindParam($parameter, $value, $type);
         }
     }
 

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Connection.php
@@ -173,6 +173,11 @@ class Connection implements ConnectionInterface
                 case 'dbname':
                     $params['Database'] = (string) $value;
                     break;
+                case 'driver_options':
+                case 'options':
+                    $params = array_merge($params, (array) $value);
+                    break;
+
             }
         }
 

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Connection.php
@@ -155,23 +155,23 @@ class Connection implements ConnectionInterface
         
         $serverName = '.';
         $params = array();
-        foreach ($this->connectionParameters as $cpName => $cpValue) {
-            switch (strtolower($cpName)) {
+        foreach ($this->connectionParameters as $key => $value) {
+            switch (strtolower($key)) {
                 case 'hostname':
                 case 'servername':
-                    $serverName = $cpValue;
+                    $serverName = (string) $value;
                     break;
                 case 'username':
                 case 'uid':
-                    $params['UID'] = $cpValue;
+                    $params['UID'] = (string) $value;
                     break;
                 case 'password':
                 case 'pwd':
-                    $params['PWD'] = $cpValue;
+                    $params['PWD'] = (string) $value;
                     break;
                 case 'database':
                 case 'dbname':
-                    $params['Database'] = $cpValue;
+                    $params['Database'] = (string) $value;
                     break;
             }
         }


### PR DESCRIPTION
1. Fix Pdo\Connection so that it works properly without a dsn parameter
2. Make Sqlsrv detection of configuration parameters consistent with the same code for Pdo
3. Simplify bindParam() call
4. Support additional Sqlsrv driver_options for things like the CharacterSet option
