### PR TITLE
Updated checks on setEncoding() to offset two issues

### DIFF
--- a/library/Zend/View/Helper/Escape.php
+++ b/library/Zend/View/Helper/Escape.php
@@ -56,6 +56,21 @@ class Escape extends AbstractHelper
     protected $encoding = 'UTF-8';
 
     /**
+     * @var array Supported encodings used to avoid an illegal call
+     */
+    protected $supportedEncodings = array(
+        'iso-8859-1',   'iso8859-1',    'iso-8859-5',   'iso8859-5',
+        'iso-8859-15',  'iso8859-15',   'utf-8',        'cp866',
+        'ibm866',       '866',          'cp1251',       'windows-1251',
+        'win-1251',     '1251',         'cp1252',       'windows-1252',
+        '1252',         'koi8-r',       'koi8-ru',      'koi8r',
+        'big5',         '950',          'gb2312',       '936',
+        'big5-hkscs',   'shift_jis',    'sjis',         'sjis-win',
+        'cp932',        '932',          'euc-jp',       'eucjp',
+        'eucjp-win',    'macroman'
+    );
+
+    /**
      * Set the encoding to use for escape operations
      * 
      * @param  string $encoding 
@@ -63,6 +78,18 @@ class Escape extends AbstractHelper
      */
     public function setEncoding($encoding)
     {
+        if (empty($encoding)) {
+            throw new Exception\InvalidArgumentException(
+                get_called_class() . '::setEncoding() does not allow a NULL or '
+                . 'blank string value'
+            );
+        }
+        if (!in_array(strtolower($encoding), $this->supportedEncodings)) {
+            throw new Exception\InvalidArgumentException(
+                'Value of \'' . $encoding . '\' passed to ' . get_called_class()
+                . '::setEncoding() is invalid. Provide an encoding supported by htmlspecialchars()'
+            );
+        }
         $this->encoding = $encoding;
         return $this;
     }

--- a/tests/Zend/View/Helper/EscapeTest.php
+++ b/tests/Zend/View/Helper/EscapeTest.php
@@ -8,6 +8,20 @@ use PHPUnit_Framework_TestCase as TestCase,
 
 class EscapeTest extends TestCase
 {
+
+    protected $supportedEncodings = array(
+        'iso-8859-1',   'iso8859-1',    'iso-8859-5',   'iso8859-5',
+        'iso-8859-15',  'iso8859-15',   'utf-8',        'cp866',
+        'ibm866',       '866',          'cp1251',       'windows-1251',
+        'win-1251',     '1251',         'cp1252',       'windows-1252',
+        '1252',         'koi8-r',       'koi8-ru',      'koi8r',
+        'big5',         '950',          'gb2312',       '936',
+        'big5-hkscs',   'shift_jis',    'sjis',         'sjis-win',
+        'cp932',        '932',          'euc-jp',       'eucjp',
+        'eucjp-win',    'macroman'
+    );
+        
+
     public function setUp()
     {
         $this->helper = new EscapeHelper;
@@ -20,8 +34,8 @@ class EscapeTest extends TestCase
 
     public function testEncodingIsMutable()
     {
-        $this->helper->setEncoding('ASCII');
-        $this->assertEquals('ASCII', $this->helper->getEncoding());
+        $this->helper->setEncoding('BIG5-HKSCS');
+        $this->assertEquals('BIG5-HKSCS', $this->helper->getEncoding());
     }
 
     public function testDefaultCallbackIsDefined()
@@ -32,7 +46,7 @@ class EscapeTest extends TestCase
 
     public function testCallbackIsMutable()
     {
-        $this->helper->setCallback('strip_tags');
+        $this->helper->setCallback('strip_tags'); // Don't do this at home ;)
         $this->assertEquals('strip_tags', $this->helper->getCallback());
     }
 
@@ -135,5 +149,38 @@ class EscapeTest extends TestCase
         );
         $test = $this->helper->__invoke($object, EscapeHelper::RECURSE_OBJECT);
         $this->assertEquals($expected, $test);
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     * 
+     * PHP 5.3 instates default encoding on empty string instead of the expected
+     * warning level error for htmlspecialchars() encoding param. PHP 5.4 attempts
+     * to guess the encoding or take it from php.ini default_charset when an empty
+     * string is set. Both are insecure behaviours.
+     */
+    public function testSettingEncodingToEmptyStringShouldThrowException()
+    {
+        $this->helper->setEncoding('');
+    }
+
+    public function testSettingValidEncodingShouldNotThrowExceptions()
+    {
+        foreach ($this->supportedEncodings as $value) {
+            $this->helper->setEncoding($value);
+        }
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     * 
+     * All versions of PHP - when an invalid encoding is set on htmlspecialchars()
+     * a warning level error is issued and escaping continues with the default encoding
+     * for that PHP version. Preventing the continuation behaviour offsets display_errors
+     * off in production env.
+     */
+    public function testSettingEncodingToInvalidValueShouldThrowException()
+    {
+        $this->helper->setEncoding('completely-invalid');
     }
 }


### PR DESCRIPTION
1. htmlspecialchars silently accepts blank strings in PHP 5.3 and uses default encoding (PHP 5.4 guesses or uses php.ini default_charset setting)
2. Setting invalid encoding in htmlspecialchars issues warning level error but continues to escape anyway using default encoding (think if display_errors off...)

This change throws an exception on a blank encoding or an encoding invalid for htmlspecialchars to tighten up this behaviour and discourage insecure coding.
