### PR TITLE
Fix form tests for escaping and invalid assumptions

### DIFF
--- a/library/Zend/Form/Decorator/Description.php
+++ b/library/Zend/Form/Decorator/Description.php
@@ -181,7 +181,7 @@ class Description extends AbstractDecorator
         $options   = $this->getOptions();
 
         if ($escape) {
-            $description = $view->vars()->escape($description);
+            $description = $view->escape($description);
         }
 
         if (!empty($tag)) {

--- a/library/Zend/Form/Decorator/FormErrors.php
+++ b/library/Zend/Form/Decorator/FormErrors.php
@@ -424,7 +424,7 @@ class FormErrors extends AbstractDecorator
         }
 
         return $this->getMarkupElementLabelStart()
-             . $view->vars()->escape($label)
+             . $view->escape($label)
              . $this->getMarkupElementLabelEnd();
     }
 

--- a/library/Zend/Validator/File/Upload.php
+++ b/library/Zend/Validator/File/Upload.php
@@ -81,7 +81,7 @@ class Upload extends \Zend\Validator\AbstractValidator
      */
     public function __construct($options = array())
     {
-        if (!array_key_exists('files', $options)) {
+        if (is_array($options) && !array_key_exists('files', $options)) {
             $options = array('files' => $options);
         }
 

--- a/tests/Zend/Form/Decorator/ErrorsTest.php
+++ b/tests/Zend/Form/Decorator/ErrorsTest.php
@@ -77,9 +77,11 @@ class ErrorsTest extends \PHPUnit_Framework_TestCase
     {
         $this->setupElement();
         $content = 'test content';
-        $test = $this->decorator->render($content);
+        $test    = $this->decorator->render($content);
+        $view    = $this->getView();
         $this->assertContains($content, $test);
         foreach ($this->element->getMessages() as $message) {
+            $message = $view->escape($message);
             $this->assertContains($message, $test);
         }
     }

--- a/tests/Zend/Form/Decorator/FormErrorsTest.php
+++ b/tests/Zend/Form/Decorator/FormErrorsTest.php
@@ -116,15 +116,18 @@ class FormErrorsTest extends \PHPUnit_Framework_TestCase
     public function testRenderRendersAllErrorMessages()
     {
         $this->setupForm();
+        $view    = $this->getView();
         $content = 'test content';
-        $test = $this->decorator->render($content);
+        $test    = $this->decorator->render($content);
         $this->assertContains($content, $test);
         foreach ($this->form->getMessages() as $name => $messages) {
             foreach ($messages as $key => $message) {
                 if (is_string($message)) {
+                    $message = $view->escape($message);
                     $this->assertContains($message, $test, var_export($messages, 1));
                 } else {
                     foreach ($message as $m) {
+                        $m = $view->escape($m);
                         $this->assertContains($m, $test, var_export($messages, 1));
                     }
                 }

--- a/tests/Zend/Form/Decorator/LabelTest.php
+++ b/tests/Zend/Form/Decorator/LabelTest.php
@@ -261,11 +261,12 @@ class LabelTest extends \PHPUnit_Framework_TestCase
 
     public function testSettingTagToEmptyValueShouldDisableTag()
     {
+        $this->decorator->setTag('span');
         $element = new Element\Text('foo', array('label' => 'Foo'));
         $this->decorator->setElement($element)
                         ->setTag('');
         $content = $this->decorator->render('');
-        $this->assertTrue(empty($content), $content);
+        $this->assertNotContains('<span', $content);
     }
 
     /**

--- a/tests/Zend/Form/ElementTest.php
+++ b/tests/Zend/Form/ElementTest.php
@@ -652,7 +652,7 @@ class ElementTest extends \PHPUnit_Framework_TestCase
         }
         $validator = $this->element->getValidator('Alnum');
         $this->assertTrue($validator instanceof \Zend\Validator\Alnum);
-        $this->assertTrue($validator->getAllowWhiteSpace());
+        $this->assertFalse($validator->getAllowWhiteSpace());
     }
 
     public function testCanRetrieveSingleValidatorRegisteredAsValidatorObjectUsingShortName()


### PR DESCRIPTION
- Most fixes were to ensure fixes against escaping API
  - escape is now a view helper, not a function of the variables
    container
  - we use ENT_QUOTES now, so some comparisons needed updating
- Label decorator - a test was making the wrong assumption regarding
  setting an empty "tag"
- Element - a test was making an invalid assumption as to a validator
  default
