### PR TITLE
Changed error description on no route match

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -294,13 +294,13 @@ class Application implements AppContext
         $routeMatch = $router->match($request);
 
         if (!$routeMatch instanceof Router\RouteMatch) {
-            $e->setError(static::ERROR_CONTROLLER_NOT_FOUND);
+            $e->setError(static::ERROR_ROUTER_NO_MATCH);
 
             $results = $this->events()->trigger('dispatch.error', $e);
             if (count($results)) {
                 $return  = $results->last();
             } else {
-                $return = $error->getParams();
+                $return = $e->getParams();
             }
             return $return;
         }

--- a/library/Zend/Mvc/View/ExceptionStrategy.php
+++ b/library/Zend/Mvc/View/ExceptionStrategy.php
@@ -153,6 +153,7 @@ class ExceptionStrategy implements ListenerAggregate
         switch ($error) {
             case Application::ERROR_CONTROLLER_NOT_FOUND:
             case Application::ERROR_CONTROLLER_INVALID:
+            case Application::ERROR_ROUTER_NO_MATCH:
                 // Specifically not handling these
                 return;
 


### PR DESCRIPTION
Small update to report ERROR_ROUTER_NO_MATCH when the router fails to return a route.
