### PR TITLE
Update docs with recently changed view listener

### DIFF
--- a/documentation/manual/en/module_specs/zend.view.quick-start.xml
+++ b/documentation/manual/en/module_specs/zend.view.quick-start.xml
@@ -285,7 +285,9 @@ class BarController extends ActionController
                 associative array from your controller; if so, it will create a
                 view model and inject this associative array as the view
                 variables container; this view model then replaces the MVC
-                event's result. 
+                event's result. It also looks to see if you returned nothing, or
+                null; if so, it will create a view model without any variables
+                attached; this view model also replaces the MVC event's result.
             </para>
                 
             <para>


### PR DESCRIPTION
The Zend\Mvc\View\CreateViewModelListener::createViewModelFromNull()
can create a view model when null is returned. The docs are updated
accordingly.
