### PR TITLE
fromString() in most Zend\Http\Header classes can use explode()

### DIFF
--- a/library/Zend/Http/Header/AbstractAccept.php
+++ b/library/Zend/Http/Header/AbstractAccept.php
@@ -50,7 +50,7 @@ abstract class AbstractAccept implements HeaderDescription
     {
         $acceptHeader = new static();
 
-        list($name, $values) = preg_split('#: #', $headerLine, 2);
+        list($name, $values) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== strtolower($acceptHeader->getFieldName())) {

--- a/library/Zend/Http/Header/AcceptRanges.php
+++ b/library/Zend/Http/Header/AcceptRanges.php
@@ -37,7 +37,7 @@ class AcceptRanges implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'accept-ranges') {

--- a/library/Zend/Http/Header/Age.php
+++ b/library/Zend/Http/Header/Age.php
@@ -15,7 +15,7 @@ class Age implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'age') {

--- a/library/Zend/Http/Header/Allow.php
+++ b/library/Zend/Http/Header/Allow.php
@@ -15,7 +15,7 @@ class Allow implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'allow') {

--- a/library/Zend/Http/Header/AuthenticationInfo.php
+++ b/library/Zend/Http/Header/AuthenticationInfo.php
@@ -13,7 +13,7 @@ class AuthenticationInfo implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'authentication-info') {

--- a/library/Zend/Http/Header/Authorization.php
+++ b/library/Zend/Http/Header/Authorization.php
@@ -13,7 +13,7 @@ class Authorization implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'authorization') {

--- a/library/Zend/Http/Header/CacheControl.php
+++ b/library/Zend/Http/Header/CacheControl.php
@@ -13,7 +13,7 @@ class CacheControl implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'cache-control') {

--- a/library/Zend/Http/Header/Connection.php
+++ b/library/Zend/Http/Header/Connection.php
@@ -13,7 +13,7 @@ class Connection implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'connection') {

--- a/library/Zend/Http/Header/ContentDisposition.php
+++ b/library/Zend/Http/Header/ContentDisposition.php
@@ -13,7 +13,7 @@ class ContentDisposition implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-disposition') {

--- a/library/Zend/Http/Header/ContentEncoding.php
+++ b/library/Zend/Http/Header/ContentEncoding.php
@@ -13,7 +13,7 @@ class ContentEncoding implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-encoding') {

--- a/library/Zend/Http/Header/ContentLanguage.php
+++ b/library/Zend/Http/Header/ContentLanguage.php
@@ -13,7 +13,7 @@ class ContentLanguage implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-language') {

--- a/library/Zend/Http/Header/ContentLength.php
+++ b/library/Zend/Http/Header/ContentLength.php
@@ -13,7 +13,7 @@ class ContentLength implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-length') {

--- a/library/Zend/Http/Header/ContentLocation.php
+++ b/library/Zend/Http/Header/ContentLocation.php
@@ -13,7 +13,7 @@ class ContentLocation implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-location') {

--- a/library/Zend/Http/Header/ContentMD5.php
+++ b/library/Zend/Http/Header/ContentMD5.php
@@ -13,7 +13,7 @@ class ContentMD5 implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-md5') {

--- a/library/Zend/Http/Header/ContentRange.php
+++ b/library/Zend/Http/Header/ContentRange.php
@@ -13,7 +13,7 @@ class ContentRange implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-range') {

--- a/library/Zend/Http/Header/ContentType.php
+++ b/library/Zend/Http/Header/ContentType.php
@@ -13,7 +13,7 @@ class ContentType implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-type') {

--- a/library/Zend/Http/Header/Cookie.php
+++ b/library/Zend/Http/Header/Cookie.php
@@ -57,7 +57,7 @@ class Cookie extends ArrayObject implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'cookie') {

--- a/library/Zend/Http/Header/Date.php
+++ b/library/Zend/Http/Header/Date.php
@@ -13,7 +13,7 @@ class Date implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'date') {

--- a/library/Zend/Http/Header/Etag.php
+++ b/library/Zend/Http/Header/Etag.php
@@ -13,7 +13,7 @@ class Etag implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'etag') {

--- a/library/Zend/Http/Header/Expect.php
+++ b/library/Zend/Http/Header/Expect.php
@@ -13,7 +13,7 @@ class Expect implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'expect') {

--- a/library/Zend/Http/Header/Expires.php
+++ b/library/Zend/Http/Header/Expires.php
@@ -13,7 +13,7 @@ class Expires implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'expires') {

--- a/library/Zend/Http/Header/From.php
+++ b/library/Zend/Http/Header/From.php
@@ -13,7 +13,7 @@ class From implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'from') {

--- a/library/Zend/Http/Header/Host.php
+++ b/library/Zend/Http/Header/Host.php
@@ -13,7 +13,7 @@ class Host implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'host') {

--- a/library/Zend/Http/Header/IfMatch.php
+++ b/library/Zend/Http/Header/IfMatch.php
@@ -13,7 +13,7 @@ class IfMatch implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'if-match') {

--- a/library/Zend/Http/Header/IfModifiedSince.php
+++ b/library/Zend/Http/Header/IfModifiedSince.php
@@ -13,7 +13,7 @@ class IfModifiedSince implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'if-modified-since') {

--- a/library/Zend/Http/Header/IfNoneMatch.php
+++ b/library/Zend/Http/Header/IfNoneMatch.php
@@ -13,7 +13,7 @@ class IfNoneMatch implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'if-none-match') {

--- a/library/Zend/Http/Header/IfRange.php
+++ b/library/Zend/Http/Header/IfRange.php
@@ -13,7 +13,7 @@ class IfRange implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'if-range') {

--- a/library/Zend/Http/Header/IfUnmodifiedSince.php
+++ b/library/Zend/Http/Header/IfUnmodifiedSince.php
@@ -13,7 +13,7 @@ class IfUnmodifiedSince implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'if-unmodified-since') {

--- a/library/Zend/Http/Header/KeepAlive.php
+++ b/library/Zend/Http/Header/KeepAlive.php
@@ -13,7 +13,7 @@ class KeepAlive implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'keep-alive') {

--- a/library/Zend/Http/Header/LastModified.php
+++ b/library/Zend/Http/Header/LastModified.php
@@ -13,7 +13,7 @@ class LastModified implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'last-modified') {

--- a/library/Zend/Http/Header/Location.php
+++ b/library/Zend/Http/Header/Location.php
@@ -15,7 +15,7 @@ class Location implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'location') {

--- a/library/Zend/Http/Header/MaxForwards.php
+++ b/library/Zend/Http/Header/MaxForwards.php
@@ -13,7 +13,7 @@ class MaxForwards implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'max-forwards') {

--- a/library/Zend/Http/Header/Pragma.php
+++ b/library/Zend/Http/Header/Pragma.php
@@ -13,7 +13,7 @@ class Pragma implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'pragma') {

--- a/library/Zend/Http/Header/ProxyAuthenticate.php
+++ b/library/Zend/Http/Header/ProxyAuthenticate.php
@@ -13,7 +13,7 @@ class ProxyAuthenticate implements MultipleHeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'proxy-authenticate') {

--- a/library/Zend/Http/Header/ProxyAuthorization.php
+++ b/library/Zend/Http/Header/ProxyAuthorization.php
@@ -13,7 +13,7 @@ class ProxyAuthorization implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'proxy-authorization') {

--- a/library/Zend/Http/Header/Range.php
+++ b/library/Zend/Http/Header/Range.php
@@ -13,7 +13,7 @@ class Range implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'range') {

--- a/library/Zend/Http/Header/Referer.php
+++ b/library/Zend/Http/Header/Referer.php
@@ -13,7 +13,7 @@ class Referer implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'referer') {

--- a/library/Zend/Http/Header/Refresh.php
+++ b/library/Zend/Http/Header/Refresh.php
@@ -13,7 +13,7 @@ class Refresh implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'refresh') {

--- a/library/Zend/Http/Header/RetryAfter.php
+++ b/library/Zend/Http/Header/RetryAfter.php
@@ -13,7 +13,7 @@ class RetryAfter implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'retry-after') {

--- a/library/Zend/Http/Header/Server.php
+++ b/library/Zend/Http/Header/Server.php
@@ -13,7 +13,7 @@ class Server implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'server') {

--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -114,7 +114,7 @@ class SetCookie implements MultipleHeaderDescription
             };
         }
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'set-cookie') {

--- a/library/Zend/Http/Header/TE.php
+++ b/library/Zend/Http/Header/TE.php
@@ -13,7 +13,7 @@ class TE implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'te') {

--- a/library/Zend/Http/Header/Trailer.php
+++ b/library/Zend/Http/Header/Trailer.php
@@ -13,7 +13,7 @@ class Trailer implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'trailer') {

--- a/library/Zend/Http/Header/TransferEncoding.php
+++ b/library/Zend/Http/Header/TransferEncoding.php
@@ -13,7 +13,7 @@ class TransferEncoding implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'transfer-encoding') {

--- a/library/Zend/Http/Header/Upgrade.php
+++ b/library/Zend/Http/Header/Upgrade.php
@@ -13,7 +13,7 @@ class Upgrade implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'upgrade') {

--- a/library/Zend/Http/Header/UserAgent.php
+++ b/library/Zend/Http/Header/UserAgent.php
@@ -13,7 +13,7 @@ class UserAgent implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (str_replace(array('_', ' ', '.'), '-', strtolower($name)) !== 'user-agent') {

--- a/library/Zend/Http/Header/Vary.php
+++ b/library/Zend/Http/Header/Vary.php
@@ -13,7 +13,7 @@ class Vary implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'vary') {

--- a/library/Zend/Http/Header/Via.php
+++ b/library/Zend/Http/Header/Via.php
@@ -13,7 +13,7 @@ class Via implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'via') {

--- a/library/Zend/Http/Header/WWWAuthenticate.php
+++ b/library/Zend/Http/Header/WWWAuthenticate.php
@@ -13,7 +13,7 @@ class WWWAuthenticate implements MultipleHeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'www-authenticate') {

--- a/library/Zend/Http/Header/Warning.php
+++ b/library/Zend/Http/Header/Warning.php
@@ -13,7 +13,7 @@ class Warning implements HeaderDescription
     {
         $header = new static();
 
-        list($name, $value) = preg_split('#: #', $headerLine, 2);
+        list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'warning') {


### PR DESCRIPTION
Switched a number of fromString() methods in Zend\Http\Header classes to use explode() instead of preg_split() where possible.
