### PR TITLE
Zf2-207, ZF2-212

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -1159,7 +1159,7 @@ class Filesystem extends AbstractAdapter
 
         $info = null;
         if ($baseOptions->getReadControl()) {
-            $info['hash'] = Utils::generateHash($this->getReadControlAlgo(), $value, true);
+            $info['hash'] = Utils::generateHash($baseOptions->getReadControlAlgo(), $value, true);
             $info['algo'] = $baseOptions->getReadControlAlgo();
         }
 

--- a/library/Zend/Cache/Utils.php
+++ b/library/Zend/Cache/Utils.php
@@ -179,7 +179,7 @@ abstract class Utils
      *
      * This helper adds the virtual hash algo "strlen".
      *
-     * @param  string $data  Name of selected hashing algorithm
+     * @param  string $algo  Name of selected hashing algorithm
      * @param  string $data  Message to be hashed.
      * @param  bool   $raw   When set to TRUE, outputs raw binary data. FALSE outputs lowercase hexits.
      * @return string        Hash value

--- a/library/Zend/Locale/Data/Cldr.php
+++ b/library/Zend/Locale/Data/Cldr.php
@@ -1654,7 +1654,7 @@ class Cldr extends AbstractLocale
 
         if (self::hasCacheTagSupport()) {
             self::getCache()->setItem($cacheId, self::$_result, array('tags' => array('Zend_Locale')));
-        } else {
+        } elseif (self::hasCache()) {
             self::getCache()->setItem($cacheId, self::$_result);
         }
 

--- a/tests/Zend/Locale/Data/CldrCachedTest.php
+++ b/tests/Zend/Locale/Data/CldrCachedTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Locale
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Locale\Data;
+
+use Zend\Locale\Data\Cldr,
+    Zend\Locale\Exception\InvalidArgumentException,
+    Zend\Locale\Locale,
+    Zend\Cache\StorageFactory as CacheFactory,
+    Zend\Cache\Storage\Adapter as CacheAdapter,
+    ZendTest\Locale\Data\CldrTest;
+
+/**
+ * @category   Zend
+ * @package    Zend_Locale
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Zend_Locale
+ */
+class CldrCachedTest extends CldrTest {
+    
+    private $_cache = null;
+
+    public function setUp()
+    {
+        $this->_cacheDir = sys_get_temp_dir() . '/zend_locale_cldr';
+        $this->_removeRecursive($this->_cacheDir);
+        mkdir($this->_cacheDir);
+
+        $this->_cache = CacheFactory::factory(array(
+            'adapter' => array(
+                'name' => 'Filesystem',
+                'options' => array(
+                    'ttl'       => 1,
+                    'cache_dir' => $this->_cacheDir,
+                )
+            ),
+            'plugins' => array(
+                array(
+                    'name' => 'serializer',
+                    'options' => array(
+                        'serializer' => 'php_serialize',
+                    ),
+                ),
+            ),
+        ));
+
+        Cldr::setCache($this->_cache);
+    }
+
+
+    public function tearDown()
+    {
+        $this->_cache->clear(CacheAdapter::MATCH_ALL);
+        $this->_removeRecursive($this->_cacheDir);
+    }    
+    
+    
+    protected function _removeRecursive($dir)
+    {
+        if (file_exists($dir)) {
+            $dirIt = new \DirectoryIterator($dir);
+            foreach ($dirIt as $entry) {
+                $fname = $entry->getFilename();
+                if ($fname == '.' || $fname == '..') {
+                    continue;
+                }
+
+                if ($entry->isFile()) {
+                    unlink($entry->getPathname());
+                } else {
+                    $this->_removeRecursive($entry->getPathname());
+                }
+            }
+
+            rmdir($dir);
+        }
+    }
+}

--- a/tests/Zend/Locale/Data/CldrTest.php
+++ b/tests/Zend/Locale/Data/CldrTest.php
@@ -38,6 +38,18 @@ use Zend\Locale\Data\Cldr,
 class CldrTest extends \PHPUnit_Framework_TestCase
 {    
     /**
+     * test for reading with cache disabled
+     * @see ZF2-212
+     */
+    public function testNoCache()
+    {
+        Cldr::disableCache(true);
+        $this->testTerritory();
+        Cldr::disableCache(false);
+    }
+    
+    
+    /**
      * test for reading with standard locale
      * expected array
      */

--- a/tests/Zend/Locale/Data/CldrTest.php
+++ b/tests/Zend/Locale/Data/CldrTest.php
@@ -36,64 +36,7 @@ use Zend\Locale\Data\Cldr,
  * @group      Zend_Locale
  */
 class CldrTest extends \PHPUnit_Framework_TestCase
-{
-
-    private $_cache = null;
-
-    public function setUp()
-    {
-        $this->_cacheDir = sys_get_temp_dir() . '/zend_locale_cldr';
-        $this->_removeRecursive($this->_cacheDir);
-        mkdir($this->_cacheDir);
-
-        $this->_cache = CacheFactory::factory(array(
-            'adapter' => array(
-                'name' => 'Filesystem',
-                'options' => array(
-                    'ttl'       => 1,
-                    'cache_dir' => $this->_cacheDir,
-                )
-            ),
-            'plugins' => array(
-                array(
-                    'name' => 'serializer',
-                    'options' => array(
-                        'serializer' => 'php_serialize',
-                    ),
-                ),
-            ),
-        ));
-        Cldr::setCache($this->_cache);
-    }
-
-
-    public function tearDown()
-    {
-        $this->_cache->clear(CacheAdapter::MATCH_ALL);
-        $this->_removeRecursive($this->_cacheDir);
-    }
-
-    protected function _removeRecursive($dir)
-    {
-        if (file_exists($dir)) {
-            $dirIt = new \DirectoryIterator($dir);
-            foreach ($dirIt as $entry) {
-                $fname = $entry->getFilename();
-                if ($fname == '.' || $fname == '..') {
-                    continue;
-                }
-
-                if ($entry->isFile()) {
-                    unlink($entry->getPathname());
-                } else {
-                    $this->_removeRecursive($entry->getPathname());
-                }
-            }
-
-            rmdir($dir);
-        }
-    }
-
+{    
     /**
      * test for reading with standard locale
      * expected array
@@ -112,8 +55,8 @@ class CldrTest extends \PHPUnit_Framework_TestCase
         $locale = new Locale('de');
         $this->assertTrue(is_array(Cldr::getDisplayLanguage($locale)));
     }
-
-
+    
+    
     /**
      * test for reading without type
      * expected empty array


### PR DESCRIPTION
Fixed issues:
- [ZF2-207](http://framework.zend.com/issues/browse/ZF2-207)
- [ZF2-212](http://framework.zend.com/issues/browse/ZF2-212)

We were totally missing `Cldr` behavior without cache. So I added tests.

The only strange thing is that now `ZendTest\Locale\Data\CldrTest::testLanguage` fails,  `Cldr::getDisplayLanguage('de)` returns languages in English. it would be nice if someone can take a look at it.
