### PR TITLE
Corrected test assumption in View test

### DIFF
--- a/library/Zend/View/Model/JsonModel.php
+++ b/library/Zend/View/Model/JsonModel.php
@@ -22,6 +22,7 @@
 namespace Zend\View\Model;
 
 use Traversable,
+    Zend\Json\Json,
     Zend\Stdlib\ArrayUtils;
 
 /**

--- a/tests/Zend/View/ViewTest.php
+++ b/tests/Zend/View/ViewTest.php
@@ -145,6 +145,7 @@ class ViewTest extends TestCase
 
         $child2 = new Model\JsonModel(array('bar' => 'baz'));
         $child2->setCaptureTo('child2');
+        $child2->setTerminal(false);
 
         $this->model->setVariable('parent', 'node');
         $this->model->addChild($child1);


### PR DESCRIPTION
- JsonModel now sets "terminal" flag to true by default, which
  invalidated a test; test now explicity disables it.
- JsonModel was missing an import for Zend\Json\Json, which was exposed
  when the test started working.
