### PR TITLE
Navigation must accept routeMatch and urlHelper

### DIFF
--- a/library/Zend/Navigation/Navigation.php
+++ b/library/Zend/Navigation/Navigation.php
@@ -21,9 +21,17 @@
 namespace Zend\Navigation;
 
 use Traversable;
+use Zend\Di\Locator;
+use Zend\Navigation\Container;
+use Zend\Navigation\Page\AbstractPage;
+use Zend\Navigation\Page\Mvc as MvcPage;
+use Zend\Navigation\Exception\InvalidArgumentException;
+use Zend\Mvc\Router\Http\RouteMatch;
+use Zend\View\Helper\Url as UrlHelper;
 
 /**
  * A simple container class for {@link Zend_Navigation_Page} pages
+ *
  *
  * @category  Zend
  * @package   Zend_Navigation
@@ -33,22 +41,211 @@ use Traversable;
 class Navigation extends Container
 {
     /**
-     * Creates a new navigation container
-     *
-     * @param  array|Traversable $pages    [optional] pages to add
-     * @throws Exception\InvalidArgumentException  if $pages is invalid
+     * Service locator instance
+     * @var Zend\Di\Locator
      */
-    public function __construct($pages = null)
+    protected $locator;
+
+    /**
+     * Route match
+     * @var Zend\Mvc\Router\Http\RouteMatch
+     */
+    protected $routeMatch;
+
+    /**
+     * Url view helper
+     * @var Zend\View\Helper\Url
+     */
+    protected $urlHelper;
+
+
+    /**
+     * Construct
+     * Instantiates navigation and injects dependencies to mvc pages.
+     *
+     * @param array|Container $pages
+     * @param Zend\Mvc\Router\Http\RouteMatch $routeMatch
+     * @param Zend\View\Helper\Url $urlHelper
+     * @param Zend\Di\Locator $locator
+     * @return void
+     */
+    public function __construct(
+        $pages = null,
+        $routeMatch = null,
+        $urlHelper = null,
+        Locator $locator = null)
     {
-        if ($pages && (!is_array($pages) && !$pages instanceof Traversable)) {
-            throw new Exception\InvalidArgumentException(
-                'Invalid argument: $pages must be an array, an '
-                . 'instance of Traversable, or null'
-            );
+        //set locator
+        $this->locator = $locator;
+
+        //set route match
+        if($routeMatch)
+            $this->setRouteMatch($routeMatch);
+
+        //set url helper
+        if($urlHelper)
+            $this->setUrlHelper($urlHelper);
+
+        //set default url helper for mvc pages
+        if($locator)
+            MvcPage::setDefaultUrlHelper($locator->get('Zend\View\Helper\Url'));
+
+        //add pages
+        if($pages)
+            $this->addPages($pages);
+    }
+
+
+    /**
+     * Add pages
+     * Adds multiple pages at once.
+     *
+     * @param array|Traversable|Zend\Navigation\Container $pages
+     * @throws Zend\Navigation\Exception\InvalidArgumentException
+     * @return Zend\Navigation\Navigation
+     */
+    public function addPages($pages)
+    {
+        //check pages
+        if(!is_array($pages) && !$pages instanceof Traversable)
+        {
+            $error  = 'Invalid argument: pages must be an array, an ';
+            $error .= 'instance of Traversable or Zend\Navigation\Container';
+            throw new InvalidArgumentException($error);
         }
 
-        if ($pages) {
-            $this->addPages($pages);
-        }
+        //convert pages to array
+        if($pages instanceof Container)
+            $pages = iterator_to_array($pages);
+
+
+        //add pages
+        foreach($pages as $page)
+            $this->addPage($page);
     }
+
+
+    /**
+     * Add page
+     * Adds a page to navigation container. In case MVC page is discovered
+     * injects dependencies.
+     *
+     * @param Zend\Navigation\Page\AbstractPage|array $page
+     * @return Zend\Navigation\Navigation
+     */
+    public function addPage($page)
+    {
+        $routeMatch = $this->getRouteMatch();
+        $urlHelper = $this->getUrlHelper();
+
+        //inject dependencies to mvc page
+        if($this->isMvcPage($page) && $page instanceof MvcPage)
+        {
+            $pageHelper = $page->getUrlHelper();
+            if(!$pageHelper && $urlHelper)
+                $page->setUrlHelper($urlHelper);
+
+            $pageMatch  = $page->getRouteMatch();
+            if(!$pageMatch && $routeMatch)
+                $page->setRouteMatch($routeMatch);
+        }
+
+        //add dependencies to mvc page options
+        if($this->isMvcPage($page) && is_array($page))
+        {
+            if(!isset($page['urlHelper']) && $urlHelper)
+                $page['urlHelper'] = $urlHelper;
+            if(!isset($page['routeMatch']) && $routeMatch)
+                $page['routeMatch'] = $routeMatch;
+        }
+
+        parent::addPage($page);
+        return $this;
+    }
+
+
+    /**
+     * Set url helper
+     * Sets injected url helper instance
+     *
+     * @param Zend\View\Helper\Url $helper
+     * @return Zend\Navigation\Navigation
+     */
+    public function setUrlHelper(UrlHelper $helper)
+    {
+        $this->urlHelper = $helper;
+        return $this;
+    }
+
+
+    /**
+     * Get url helper
+     * Returns currently injected url helper.
+     * @return Zend\View\Helper\Url|null
+     */
+    public function getUrlHelper()
+    {
+        return $this->urlHelper;
+    }
+
+
+    /**
+     * Set route match
+     * Sets injected route match instance
+     *
+     * @param Zend\Mvc\Router\Http\RouteMatch $routeMatch
+     * @return Zend\Navigation\Navigation
+     */
+    public function setRouteMatch(RouteMatch $routeMatch)
+    {
+        $this->routeMatch = $routeMatch;
+        return $this;
+    }
+
+
+    /**
+     * Get route match
+     * Returns current route match instance if present
+     * @return Zend\Mvc\Router\Http\RouteMatch|null
+     */
+    public function getRouteMatch()
+    {
+        return $this->routeMatch;
+    }
+
+
+    /**
+     * Is MVC page
+     * Checks if a page is of MVC type
+     * @param array|Zend\Navigation\Page\AbstractPage
+     * @return bool
+     */
+    protected function isMvcPage($page)
+    {
+        //check page type
+        if(!is_array($page) && !$page instanceof AbstractPage)
+            return false;
+
+        //of mvc type already?
+        if($page instanceof MvcPage)
+            return true;
+
+
+        //detect type for array
+        if(is_array($page))
+        {
+            $hasModule = isset($page['module']);
+            $hasController = isset($page['controller']);
+            $hasAction = isset($page['action']);
+            $hasRoute = isset($page['route']);
+            if($hasModule || $hasController || $hasAction || $hasRoute)
+                return true;
+        }
+
+        //otherwise false
+        return false;
+    }
+
+
+
 }

--- a/library/Zend/Navigation/Navigation.php
+++ b/library/Zend/Navigation/Navigation.php
@@ -79,49 +79,24 @@ class Navigation extends Container
         $this->locator = $locator;
 
         //set route match
-        if($routeMatch)
+        if($routeMatch) {
             $this->setRouteMatch($routeMatch);
-
-        //set url helper
-        if($urlHelper)
-            $this->setUrlHelper($urlHelper);
-
-        //set default url helper for mvc pages
-        if($locator)
-            MvcPage::setDefaultUrlHelper($locator->get('Zend\View\Helper\Url'));
-
-        //add pages
-        if($pages)
-            $this->addPages($pages);
-    }
-
-
-    /**
-     * Add pages
-     * Adds multiple pages at once.
-     *
-     * @param array|Traversable|Zend\Navigation\Container $pages
-     * @throws Zend\Navigation\Exception\InvalidArgumentException
-     * @return Zend\Navigation\Navigation
-     */
-    public function addPages($pages)
-    {
-        //check pages
-        if(!is_array($pages) && !$pages instanceof Traversable)
-        {
-            $error  = 'Invalid argument: pages must be an array, an ';
-            $error .= 'instance of Traversable or Zend\Navigation\Container';
-            throw new InvalidArgumentException($error);
         }
 
-        //convert pages to array
-        if($pages instanceof Container)
-            $pages = iterator_to_array($pages);
+        //set url helper
+        if($urlHelper) {
+            $this->setUrlHelper($urlHelper);
+        }
 
+        //set default url helper for mvc pages
+        if($locator) {
+            MvcPage::setDefaultUrlHelper($locator->get('Zend\View\Helper\Url'));
+        }
 
         //add pages
-        foreach($pages as $page)
-            $this->addPage($page);
+        if($pages) {
+            $this->addPages($pages);
+        }
     }
 
 
@@ -139,24 +114,27 @@ class Navigation extends Container
         $urlHelper = $this->getUrlHelper();
 
         //inject dependencies to mvc page
-        if($this->isMvcPage($page) && $page instanceof MvcPage)
-        {
+        if($this->isMvcPage($page) && $page instanceof MvcPage) {
             $pageHelper = $page->getUrlHelper();
-            if(!$pageHelper && $urlHelper)
+            if(!$pageHelper && $urlHelper) {
                 $page->setUrlHelper($urlHelper);
+            }
 
             $pageMatch  = $page->getRouteMatch();
-            if(!$pageMatch && $routeMatch)
+            if(!$pageMatch && $routeMatch) {
                 $page->setRouteMatch($routeMatch);
+            }
         }
 
         //add dependencies to mvc page options
         if($this->isMvcPage($page) && is_array($page))
         {
-            if(!isset($page['urlHelper']) && $urlHelper)
+            if(!isset($page['urlHelper']) && $urlHelper) {
                 $page['urlHelper'] = $urlHelper;
-            if(!isset($page['routeMatch']) && $routeMatch)
+            }
+            if(!isset($page['routeMatch']) && $routeMatch) {
                 $page['routeMatch'] = $routeMatch;
+            }
         }
 
         parent::addPage($page);
@@ -223,23 +201,26 @@ class Navigation extends Container
     protected function isMvcPage($page)
     {
         //check page type
-        if(!is_array($page) && !$page instanceof AbstractPage)
+        if(!is_array($page) && !$page instanceof AbstractPage) {
             return false;
+        }
 
         //of mvc type already?
-        if($page instanceof MvcPage)
+        if($page instanceof MvcPage) {
             return true;
+        }
 
 
         //detect type for array
-        if(is_array($page))
-        {
+        if(is_array($page)) {
             $hasModule = isset($page['module']);
             $hasController = isset($page['controller']);
             $hasAction = isset($page['action']);
             $hasRoute = isset($page['route']);
-            if($hasModule || $hasController || $hasAction || $hasRoute)
+
+            if($hasModule || $hasController || $hasAction || $hasRoute) {
                 return true;
+            }
         }
 
         //otherwise false

--- a/library/Zend/Navigation/Navigation.php
+++ b/library/Zend/Navigation/Navigation.php
@@ -20,14 +20,14 @@
 
 namespace Zend\Navigation;
 
-use Traversable;
-use Zend\Di\Locator;
-use Zend\Navigation\Container;
-use Zend\Navigation\Page\AbstractPage;
-use Zend\Navigation\Page\Mvc as MvcPage;
-use Zend\Navigation\Exception\InvalidArgumentException;
-use Zend\Mvc\Router\Http\RouteMatch;
-use Zend\View\Helper\Url as UrlHelper;
+use Traversable,
+    Zend\Di\Locator,
+    Zend\Navigation\Container,
+    Zend\Navigation\Page\AbstractPage,
+    Zend\Navigation\Page\Mvc as MvcPage,
+    Zend\Navigation\Exception\InvalidArgumentException,
+    Zend\Mvc\Router\Http\RouteMatch,
+    Zend\View\Helper\Url as UrlHelper;
 
 /**
  * A simple container class for {@link Zend_Navigation_Page} pages

--- a/library/Zend/Navigation/Navigation.php
+++ b/library/Zend/Navigation/Navigation.php
@@ -105,8 +105,8 @@ class Navigation extends Container
      * Adds a page to navigation container. In case MVC page is discovered
      * injects dependencies.
      *
-     * @param Zend\Navigation\Page\AbstractPage|array $page
-     * @return Zend\Navigation\Navigation
+     * @param Page\AbstractPage|array $page
+     * @return Navigation
      */
     public function addPage($page)
     {
@@ -147,7 +147,7 @@ class Navigation extends Container
      * Sets injected url helper instance
      *
      * @param Zend\View\Helper\Url $helper
-     * @return Zend\Navigation\Navigation
+     * @return Navigation
      */
     public function setUrlHelper(UrlHelper $helper)
     {
@@ -172,7 +172,7 @@ class Navigation extends Container
      * Sets injected route match instance
      *
      * @param Zend\Mvc\Router\Http\RouteMatch $routeMatch
-     * @return Zend\Navigation\Navigation
+     * @return Navigation
      */
     public function setRouteMatch(RouteMatch $routeMatch)
     {
@@ -195,7 +195,7 @@ class Navigation extends Container
     /**
      * Is MVC page
      * Checks if a page is of MVC type
-     * @param array|Zend\Navigation\Page\AbstractPage
+     * @param array|Page\AbstractPage
      * @return bool
      */
     protected function isMvcPage($page)


### PR DESCRIPTION
Currently Mvc page objects require urlHelper and routeMatch to be set to render but there are no means to configure or inject those. That makes all navigation objects unrenderable unless you set those dependencies for each page in your navigation individually. That in turn makes it impossible to instantiate navigation from an array or configuration.

That fixes the problem. 
It's minor extension on top of Container to allow those dependencies to be injected or set. Then it will inject those into Mvc pages that do require them to render. 

That's it. Hope you like it.
Dmitry.
