### PR TITLE
Feature/eventmanager wildcard support

### DIFF
--- a/documentation/manual/en/module_specs/Zend_EventManager-EventManager.xml
+++ b/documentation/manual/en/module_specs/Zend_EventManager-EventManager.xml
@@ -178,6 +178,90 @@ $foo->bar('baz', 'bat');
             values of listeners, test and loop through the results returned by listeners, prioritize
             listeners, and more. Many of these features are detailed in the examples.
         </para>
+        
+        <section xml:id="zend.event-manager.event-manager.quick-start.wildcard">
+            <info><title>Wildcard Listeners</title></info>
+
+            <para>
+                Sometimes you'll want to attach the same listener to many events or to all events of
+                a given instance -- or potentially, with the static manager, many contexts, and many
+                events. The <classname>EventManager</classname> component allows for this.
+            </para>
+
+            <example xml:id="zend.event-manager.event-manager.quick-start.wildcard.many">
+                <info><title>Attaching to many events at once</title></info>
+
+                <programlisting language="php"><![CDATA[
+$events = new EventManager();
+$events->attach(array('these', 'are', 'event', 'names'), $callback);
+]]></programlisting>
+
+                <para>
+                    Note that if you specify a priority, that priority will be used for all events
+                    specified.
+                </para>
+            </example>
+
+            <example xml:id="zend.event-manager.event-manager.quick-start.wildcard.wildcard">
+                <info><title>Attaching using the wildcard</title></info>
+
+                <programlisting language="php"><![CDATA[
+$events = new EventManager();
+$events->attach('*', $callback);
+]]></programlisting>
+
+                <para>
+                    Note that if you specify a priority, that priority will be used for this
+                    listener for any event triggered.
+                </para>
+
+                <para>
+                    What the above specifies is that <emphasis>any</emphasis> event triggered will
+                    result in notification of this particular listener.
+                </para>
+            </example>
+
+            <example xml:id="zend.event-manager.event-manager.quick-start.wildcard.static-many">
+                <info><title>Attaching to many events at once via the StaticEventManager</title></info>
+
+                <programlisting language="php"><![CDATA[
+$events = StaticEventManager::getInstance();
+// Attach to many events on the context "foo"
+$events->attach('foo', array('these', 'are', 'event', 'names'), $callback);
+
+// Attach to many events on the contexts "foo" and "bar"
+$events->attach(array('foo', 'bar'), array('these', 'are', 'event', 'names'), $callback);
+]]></programlisting>
+
+                <para>
+                    Note that if you specify a priority, that priority will be used for all events
+                    specified.
+                </para>
+            </example>
+
+            <example xml:id="zend.event-manager.event-manager.quick-start.wildcard.static-wildcard">
+                <info><title>Attaching to many events at once via the StaticEventManager</title></info>
+
+                <programlisting language="php"><![CDATA[
+$events = StaticEventManager::getInstance();
+// Attach to all events on the context "foo"
+$events->attach('foo', '*', $callback);
+
+// Attach to all events on the contexts "foo" and "bar"
+$events->attach(array('foo', 'bar'), '*', $callback);
+]]></programlisting>
+
+                <para>
+                    Note that if you specify a priority, that priority will be used for all events
+                    specified.
+                </para>
+
+                <para>
+                    The above is specifying that for the contexts "foo" and "bar", the specified
+                    listener should be notified for any event they trigger.
+                </para>
+            </example>
+        </section>
     </section>
  
     <section xml:id="zend.event-manager.event-manager.options">

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -254,6 +254,9 @@ class EventManager implements EventCollection
      * executed. By default, this value is 1; however, you may set it for any
      * integer value. Higher values have higher priority (i.e., execute first).
      *
+     * You can specify "*" for the event name. In such cases, the listener will 
+     * be triggered for every event.
+     *
      * @param  string|array|ListenerAggregate $event An event or array of event names. If a ListenerAggregate, proxies to {@link attachAggregate()}.
      * @param  callback|int $callback If string $event provided, expects PHP callback; for a ListenerAggregate $event, this will be the priority
      * @param  int $priority If provided, the priority at which to register the callback
@@ -261,10 +264,12 @@ class EventManager implements EventCollection
      */
     public function attach($event, $callback = null, $priority = 1)
     {
+        // Proxy ListenerAggregate arguments to attachAggregate()
         if ($event instanceof ListenerAggregate) {
             return $this->attachAggregate($event, $callback);
         }
 
+        // Null callback is invalid
         if (null === $callback) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s: expects a callback; none provided',
@@ -272,6 +277,7 @@ class EventManager implements EventCollection
             ));
         }
 
+        // Array of events should be registered individually, and return an array of all listeners
         if (is_array($event)) {
             $listeners = array();
             foreach ($event as $name) {
@@ -280,10 +286,15 @@ class EventManager implements EventCollection
             return $listeners;
         }
 
+        // If we don't have a priority queue for the event yet, create one
         if (empty($this->events[$event])) {
             $this->events[$event] = new PriorityQueue();
         }
+
+        // Create a callback handler, setting the event and priority in its metadata
         $listener = new CallbackHandler($callback, array('event' => $event, 'priority' => $priority));
+
+        // Inject the callback handler into the queue
         $this->events[$event]->insert($listener, $priority);
         return $listener;
     }
@@ -421,12 +432,32 @@ class EventManager implements EventCollection
         $responses = new ResponseCollection;
         $listeners = $this->getListeners($event);
 
-        // add static listeners to the list of listeners
+        // Add static/wildcard listeners to the list of listeners,
         // but don't modify the listeners object
-        $staticListeners = $this->getStaticListeners($event);
-        if (count($staticListeners)) {
+        $staticListeners   = $this->getStaticListeners($event);
+        $wildcardListeners = $this->getListeners('*');
+        if (count($staticListeners) || count($wildcardListeners)) {
             $listeners = clone $listeners;
+        }
+
+        // Add static listeners
+        if (count($staticListeners)) {
             foreach ($staticListeners as $listener) {
+                $priority = $listener->getMetadatum('priority');
+                if (null === $priority) {
+                    $priority = 1;
+                } elseif (is_array($priority)) {
+                    // If we have an array, likely using PriorityQueue. Grab first
+                    // element of the array, as that's the actual priority.
+                    $priority = array_shift($priority);
+                }
+                $listeners->insert($listener, $priority);
+            }
+        }
+
+        // Add wildcard listeners
+        if (count($wildcardListeners)) {
+            foreach ($wildcardListeners as $listener) {
                 $priority = $listener->getMetadatum('priority');
                 if (null === $priority) {
                     $priority = 1;

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -254,7 +254,7 @@ class EventManager implements EventCollection
      * executed. By default, this value is 1; however, you may set it for any
      * integer value. Higher values have higher priority (i.e., execute first).
      *
-     * @param  string|ListenerAggregate $event
+     * @param  string|array|ListenerAggregate $event An event or array of event names. If a ListenerAggregate, proxies to {@link attachAggregate()}.
      * @param  callback|int $callback If string $event provided, expects PHP callback; for a ListenerAggregate $event, this will be the priority
      * @param  int $priority If provided, the priority at which to register the callback
      * @return CallbackHandler|mixed CallbackHandler if attaching callback (to allow later unsubscribe); mixed if attaching aggregate
@@ -270,6 +270,14 @@ class EventManager implements EventCollection
                 '%s: expects a callback; none provided',
                 __METHOD__
             ));
+        }
+
+        if (is_array($event)) {
+            $listeners = array();
+            foreach ($event as $name) {
+                $listeners[] = $this->attach($name, $callback, $priority);
+            }
+            return $listeners;
         }
 
         if (empty($this->events[$event])) {

--- a/tests/Zend/EventManager/EventManagerTest.php
+++ b/tests/Zend/EventManager/EventManagerTest.php
@@ -21,7 +21,9 @@
 
 namespace ZendTest\EventManager;
 
-use Zend\EventManager\Event,
+use ArrayIterator,
+    stdClass,
+    Zend\EventManager\Event,
     Zend\EventManager\EventDescription,
     Zend\EventManager\EventManager,
     Zend\EventManager\ResponseCollection,
@@ -570,11 +572,26 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testIdentifierGetterSettersWorkWithTraversables()
     {
-        $identifiers = new \ArrayIterator(array('foo', 'bar'));
+        $identifiers = new ArrayIterator(array('foo', 'bar'));
         $this->assertInstanceOf('Zend\EventManager\EventManager', $this->events->setIdentifiers($identifiers));
         $this->assertSame($this->events->getIdentifiers(), (array) $identifiers);
-        $identifiers = new \ArrayIterator(array('foo', 'bar', 'baz'));
+        $identifiers = new ArrayIterator(array('foo', 'bar', 'baz'));
         $this->assertInstanceOf('Zend\EventManager\EventManager', $this->events->addIdentifiers($identifiers));
         $this->assertSame($this->events->getIdentifiers(), (array) $identifiers);
+    }
+
+    public function testListenersAttachedWithWildcardAreTriggeredForAllEvents()
+    {
+        $test     = new stdClass;
+        $test->events = array();
+        $callback = function($e) use ($test) {
+            $test->events[] = $e->getName();
+        };
+
+        $this->events->attach('*', $callback);
+        foreach (array('foo', 'bar', 'baz') as $event) {
+            $this->events->trigger($event);
+            $this->assertContains($event, $test->events);
+        }
     }
 }

--- a/tests/Zend/EventManager/EventManagerTest.php
+++ b/tests/Zend/EventManager/EventManagerTest.php
@@ -69,6 +69,37 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('test', $events);
     }
 
+    public function testAllowsPassingArrayOfEventNamesWhenAttaching()
+    {
+        $callback = function ($e) {
+            return $e->getName();
+        };
+        $this->events->attach(array('foo', 'bar'), $callback);
+
+        foreach (array('foo', 'bar') as $event) {
+            $listeners = $this->events->getListeners($event);
+            $this->assertTrue(count($listeners) > 0);
+            foreach ($listeners as $listener) {
+                $this->assertSame($callback, $listener->getCallback());
+            }
+        }
+    }
+
+    public function testPassingArrayOfEventNamesWhenAttachingReturnsArrayOfCallbackHandlers()
+    {
+        $callback = function ($e) {
+            return $e->getName();
+        };
+        $listeners = $this->events->attach(array('foo', 'bar'), $callback);
+
+        $this->assertInternalType('array', $listeners);
+
+        foreach ($listeners as $listener) {
+            $this->assertInstanceOf('Zend\Stdlib\CallbackHandler', $listener);
+            $this->assertSame($callback, $listener->getCallback());
+        }
+    }
+
     public function testDetachShouldRemoveListenerFromEvent()
     {
         $listener  = $this->events->attach('test', array($this, __METHOD__));

--- a/tests/Zend/EventManager/StaticEventManagerTest.php
+++ b/tests/Zend/EventManager/StaticEventManagerTest.php
@@ -20,9 +20,11 @@
  */
 
 namespace ZendTest\EventManager;
-use Zend\EventManager\StaticEventManager,
+
+use PHPUnit_Framework_TestCase as TestCase,
+    stdClass,
     Zend\EventManager\EventManager,
-    PHPUnit_Framework_TestCase as TestCase;
+    Zend\EventManager\StaticEventManager;
 
 /**
  * @category   Zend
@@ -148,6 +150,25 @@ class StaticEventManagerTest extends TestCase
                 }
                 $this->assertTrue($found, 'Did not find listener!');
             }
+        }
+    }
+
+    public function testListenersAttachedUsingWildcardEventWillBeTriggeredByResource()
+    {
+        $test     = new stdClass;
+        $test->events = array();
+        $callback = function($e) use ($test) {
+            $test->events[] = $e->getName();
+        };
+
+        $staticEvents = StaticEventManager::getInstance();
+        $staticEvents->attach('bar', '*', $callback);
+
+        $events = new EventManager('bar');
+
+        foreach (array('foo', 'bar', 'baz') as $event) {
+            $events->trigger($event);
+            $this->assertContains($event, $test->events);
         }
     }
 

--- a/tests/Zend/EventManager/StaticEventManagerTest.php
+++ b/tests/Zend/EventManager/StaticEventManagerTest.php
@@ -83,6 +83,28 @@ class StaticEventManagerTest extends TestCase
         $this->assertTrue($found, 'Did not find listener!');
     }
 
+    public function testCanAttachCallbackToMultipleEventsAtOnce()
+    {
+        $events = StaticEventManager::getInstance();
+        $events->attach('bar', array('foo', 'test'), array($this, __FUNCTION__));
+        $this->assertContains('foo', $events->getEvents('bar'));
+        $this->assertContains('test', $events->getEvents('bar'));
+        $expected = array($this, __FUNCTION__);
+        foreach (array('foo', 'test') as $event) {
+            $found     = false;
+            $listeners = $events->getListeners('bar', $event);
+            $this->assertInstanceOf('Zend\Stdlib\PriorityQueue', $listeners);
+            $this->assertTrue(0 < count($listeners), 'Empty listeners!');
+            foreach ($listeners as $listener) {
+                if ($expected === $listener->getCallback()) {
+                    $found = true;
+                    break;
+                }
+            }
+            $this->assertTrue($found, 'Did not find listener!');
+        }
+    }
+
     public function testCanAttachSameEventToMultipleResourcesAtOnce()
     {
         $events = StaticEventManager::getInstance();
@@ -102,6 +124,30 @@ class StaticEventManagerTest extends TestCase
                 }
             }
             $this->assertTrue($found, 'Did not find listener!');
+        }
+    }
+
+    public function testCanAttachCallbackToMultipleEventsOnMultipleResourcesAtOnce()
+    {
+        $events = StaticEventManager::getInstance();
+        $events->attach(array('bar', 'baz'), array('foo', 'test'), array($this, __FUNCTION__));
+        $this->assertContains('foo', $events->getEvents('bar'));
+        $this->assertContains('test', $events->getEvents('bar'));
+        $expected = array($this, __FUNCTION__);
+        foreach (array('bar', 'baz') as $resource) {
+            foreach (array('foo', 'test') as $event) {
+                $found     = false;
+                $listeners = $events->getListeners($resource, $event);
+                $this->assertInstanceOf('Zend\Stdlib\PriorityQueue', $listeners);
+                $this->assertTrue(0 < count($listeners), 'Empty listeners!');
+                foreach ($listeners as $listener) {
+                    if ($expected === $listener->getCallback()) {
+                        $found = true;
+                        break;
+                    }
+                }
+                $this->assertTrue($found, 'Did not find listener!');
+            }
         }
     }
 


### PR DESCRIPTION
This request implements https://agilezen.com/project/33552/story/40. It features the following improvements to the EventManager:
- Ability to specify an array of events to which to attach
- Ability to specify a wildcard event to which to attach ($events->attach('*', $listener))
- Both of the above abilities are possible via the StaticEventManager as well, allowing the ability to attach to a well-known instance.
