### PR TITLE
Navigation: "module" removed from AbstractPage and unit test

### DIFF
--- a/library/Zend/Navigation/Page/AbstractPage.php
+++ b/library/Zend/Navigation/Page/AbstractPage.php
@@ -168,7 +168,7 @@ abstract class AbstractPage extends Container
      * If 'type' is not given, the type of page to construct will be determined
      * by the following rules:
      * - If $options contains either of the keys 'action', 'controller',
-     *   'module', or 'route', a Zend_Navigation_Page_Mvc page will be created.
+     *   or 'route', a Zend_Navigation_Page_Mvc page will be created.
      * - If $options contains the key 'uri', a Zend_Navigation_Page_Uri page
      *   will be created.
      *
@@ -233,7 +233,6 @@ abstract class AbstractPage extends Container
 
         $hasUri = isset($options['uri']);
         $hasMvc = isset($options['action']) || isset($options['controller'])
-                || isset($options['module'])
                 || isset($options['route']);
 
         if ($hasMvc) {

--- a/tests/Zend/Navigation/Page/PageFactoryTest.php
+++ b/tests/Zend/Navigation/Page/PageFactoryTest.php
@@ -55,10 +55,6 @@ class PageFactoryTest extends \PHPUnit_Framework_TestCase
             )),
             AbstractPage::factory(array(
                 'label' => 'MVC Page',
-                'module' => 'index'
-            )),
-            AbstractPage::factory(array(
-                'label' => 'MVC Page',
                 'route' => 'home'
             ))
         );


### PR DESCRIPTION
unneeded "module" option removed from AbstractPage and from unit test
