### PR TITLE
[ZF2-169] Allow only first key/value pair to be used as cookie name/value

### DIFF
--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -96,6 +96,14 @@ class SetCookie implements MultipleHeaderDescription
                         $headerValue = null;
                     }
 
+                    // First K=V pair is always the cookie name and value
+                    if ($header->getName() === NULL) {
+                        $header->setName($headerKey);
+                        $header->setValue($headerValue);
+                        continue;
+                    }
+
+                    // Process the remanining elements
                     switch (str_replace(array('-', '_'), '', strtolower($headerKey))) {
                         case 'expires' : $header->setExpires($headerValue); break;
                         case 'domain'  : $header->setDomain($headerValue); break;
@@ -105,8 +113,7 @@ class SetCookie implements MultipleHeaderDescription
                         case 'version' : $header->setVersion((int) $headerValue); break;
                         case 'maxage'  : $header->setMaxAge((int) $headerValue); break;
                         default:
-                            $header->setName($headerKey);
-                            $header->setValue($headerValue);
+                            // Intentionally omitted 
                     }
                 }
 

--- a/tests/Zend/Http/Header/SetCookieTest.php
+++ b/tests/Zend/Http/Header/SetCookieTest.php
@@ -129,8 +129,7 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
     /** Implmentation specific tests here */
     
     /**
-     * ZF2-169
-     * 
+     * @group ZF2-169
      * @see http://framework.zend.com/issues/browse/ZF2-169
      */
     public function testZF2_169()
@@ -138,6 +137,16 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
         $cookie = 'Set-Cookie: leo_auth_token="example"; Version=1; Max-Age=1799; Expires=Mon, 20-Feb-2012 02:49:57 GMT; Path=/';
         $setCookieHeader = SetCookie::fromString($cookie);
         $this->assertEquals($cookie, $setCookieHeader->toString());
+    }
+
+    /**
+     * @group ZF2-169
+     */
+    public function testDoesNotAcceptCookieNameFromArbitraryLocationInHeaderValue()
+    {
+        $cookie = 'Set-Cookie: Version=1; Max-Age=1799; Expires=Mon, 20-Feb-2012 02:49:57 GMT; Path=/; leo_auth_token="example"';
+        $setCookieHeader = SetCookie::fromString($cookie);
+        $this->assertNotEquals('leo_auth_token', $setCookieHeader->getName());
     }
 }
 


### PR DESCRIPTION
I think that Enrico's fix for [ZF2-169](http://framework.zend.com/issues/browse/ZF2-169) only fixed part of the problem.  [RFC-2109](http://www.ietf.org/rfc/rfc2109.txt) specifies that the name/value pair must be the first K=V pair encountered:

```
   The syntax for the Set-Cookie response header is

   set-cookie      =       "Set-Cookie:" cookies
   cookies         =       1#cookie
   cookie          =       NAME "=" VALUE *(";" cookie-av)
   NAME            =       attr
   VALUE           =       value
   cookie-av       =       "Comment" "=" value
                   |       "Domain" "=" value
                   |       "Max-Age" "=" value
                   |       "Path" "=" value
                   |       "Secure"
                   |       "Version" "=" 1*DIGIT
```

However, the current implementation of `Zend\Http\Header\SetCookie::fromString` allows it to be in any position in the header string.  The switch structure's default case catches any key which isn't pre-defined and makes that key/value pair the cookie name and value. 
