### PR TITLE
Add support for arrays in addCookie

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -464,7 +464,7 @@ class Client implements Dispatchable
     /**
      * Add a cookie
      *
-     * @param ArrayIterator|SetCookie|string $cookie
+     * @param array|ArrayIterator|SetCookie|string $cookie
      * @param string  $value
      * @param string  $domain
      * @param string  $expire

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -43,21 +43,19 @@ use Zend\Config\Config,
  */
 class Client implements Dispatchable
 {
-    /**#@+
+    /**
      * @const string Supported HTTP Authentication methods
      */
     const AUTH_BASIC  = 'basic';
     const AUTH_DIGEST = 'digest';  // not implemented yet
-    /**#@-*/
 
-    /**#@+
+    /**
      * @const string POST data encoding methods
      */
     const ENC_URLENCODED = 'application/x-www-form-urlencoded';
     const ENC_FORMDATA   = 'multipart/form-data';
-    /**#@-*/
 
-    /**#@+
+    /**
      * @const string DIGEST Authentication
      */
     const DIGEST_REALM  = 'realm';
@@ -66,7 +64,6 @@ class Client implements Dispatchable
     const DIGEST_OPAQUE = 'opaque';
     const DIGEST_NC     = 'nc';
     const DIGEST_CNONCE = 'cnonce';
-    /**#@-*/
 
     /**
      * @var Response
@@ -478,7 +475,7 @@ class Client implements Dispatchable
      */
     public function addCookie($cookie, $value = null, $domain = null, $expire = null, $path = null, $secure = false, $httponly = true)
     {
-        if ($cookie instanceof \ArrayIterator) {
+        if (is_array($cookie) || $cookie instanceof \ArrayIterator) {
             foreach ($cookie as $setCookie) {
                 if ($setCookie instanceof SetCookie) {
                     $this->cookies[$this->getCookieId($setCookie)] = $setCookie;

--- a/tests/Zend/Http/ClientTest.php
+++ b/tests/Zend/Http/ClientTest.php
@@ -5,7 +5,8 @@
  */
 namespace ZendTest\Http;
 
-use Zend\Http\Client;
+use Zend\Http\Client,
+    Zend\Http\Header\SetCookie;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
@@ -37,4 +38,44 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client = new Client();
         $client->addCookie("test", null);
     } 
+
+    public function testIfCookieHeaderCanBeSet()
+    {
+        $header = new SetCookie('foo');
+
+        $client = new Client();
+        $client->addCookie($header);
+        
+        $cookies = $client->getCookies();
+        $this->assertEquals(1, count($cookies));
+        $this->assertEquals($header, $cookies['foo']);
+    }
+
+    public function testIfArrayOfHeadersCanBeSet()
+    {
+        $headers = array(
+            new SetCookie('foo'),
+            new SetCookie('bar')
+        );
+
+        $client = new Client();
+        $client->addCookie($headers);
+        
+        $cookies = $client->getCookies();
+        $this->assertEquals(2, count($cookies));
+    }
+
+    public function testIfArrayIteratorOfHeadersCanBeSet()
+    {
+        $headers = new \ArrayIterator(array(
+            new SetCookie('foo'),
+            new SetCookie('bar')
+        ));
+        
+        $client = new Client();
+        $client->addCookie($headers);
+        
+        $cookies = $client->getCookies();
+        $this->assertEquals(2, count($cookies));
+    }
 }


### PR DESCRIPTION
This PR uses the commit of PR #757 with additional unit tests for setting cookies.

The tests for setting cookies with Zend\Http\Header\SetCookie was missing as well as setting with ArrayIterator, so I added those as well.
