### PR TITLE
Add listener to add RouteMatch to DI instance manager

### DIFF
--- a/library/Zend/Mvc/Bootstrap.php
+++ b/library/Zend/Mvc/Bootstrap.php
@@ -7,7 +7,8 @@ use Zend\Di\Configuration as DiConfiguration,
     Zend\EventManager\EventCollection as Events,
     Zend\EventManager\EventManager,
     Zend\EventManager\StaticEventManager,
-    Zend\Mvc\Router\Http\TreeRouteStack as Router;
+    Zend\Mvc\Router\Http\TreeRouteStack as Router,
+    Zend\Mvc\Router\InjectRouteMatchListener;
 
 class Bootstrap implements Bootstrapper
 {
@@ -238,9 +239,7 @@ class Bootstrap implements Bootstrapper
         $application->setRouter($router);
 
         $events   = $application->events();
-        $locator  = $application->getLocator();
-        $listener = $locator->get('Zend\Mvc\Router\InjectRouteMatchListener');
-        $events->attachAggregate($listener);
+        $events->attach('route', new InjectRouteMatchListener);
     }
 
     /**

--- a/library/Zend/Mvc/Bootstrap.php
+++ b/library/Zend/Mvc/Bootstrap.php
@@ -236,6 +236,11 @@ class Bootstrap implements Bootstrapper
     {
         $router = $application->getLocator()->get('Zend\Mvc\Router\RouteStack');
         $application->setRouter($router);
+
+        $events   = $application->events();
+        $locator  = $application->getLocator();
+        $listener = $locator->get('Zend\Mvc\Router\InjectRouteMatchListener');
+        $events->attachAggregate($listener);
     }
 
     /**

--- a/library/Zend/Mvc/Bootstrap.php
+++ b/library/Zend/Mvc/Bootstrap.php
@@ -7,8 +7,7 @@ use Zend\Di\Configuration as DiConfiguration,
     Zend\EventManager\EventCollection as Events,
     Zend\EventManager\EventManager,
     Zend\EventManager\StaticEventManager,
-    Zend\Mvc\Router\Http\TreeRouteStack as Router,
-    Zend\Mvc\Router\InjectRouteMatchListener;
+    Zend\Mvc\Router\InjectRouteMatch;
 
 class Bootstrap implements Bootstrapper
 {
@@ -239,7 +238,7 @@ class Bootstrap implements Bootstrapper
         $application->setRouter($router);
 
         $events   = $application->events();
-        $events->attach('route', new InjectRouteMatchListener);
+        $events->attach('route', new InjectRouteMatch);
     }
 
     /**

--- a/library/Zend/Mvc/Router/InjectRouteMatch.php
+++ b/library/Zend/Mvc/Router/InjectRouteMatch.php
@@ -40,7 +40,7 @@ class InjectRouteMatch
             return;
         }        
 
-        $im = $e->getParam('application')->getLocator()->instanceManager();
+        $im = $e->getTarget()->getLocator()->instanceManager();
         $className = get_class($routeMatch);
         if (!$im->hasSharedInstance($className)) {
             $im->addSharedInstance($routeMatch, $className);

--- a/library/Zend/Mvc/Router/InjectRouteMatch.php
+++ b/library/Zend/Mvc/Router/InjectRouteMatch.php
@@ -24,7 +24,7 @@ namespace Zend\Mvc\Router;
 use Zend\Mvc\MvcEvent,
     Zend\Mvc\Router\RouteMatch;
 
-class InjectRouteMatchListener
+class InjectRouteMatch
 {
     /**
      * Set the RouteMatch as shared instance in the DI Locator

--- a/library/Zend/Mvc/Router/InjectRouteMatchListener.php
+++ b/library/Zend/Mvc/Router/InjectRouteMatchListener.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Mvc\Router;
+
+use Zend\EventManager\EventCollection as Events,
+    Zend\EventManager\ListenerAggregate,
+    Zend\Mvc\MvcEvent,
+    Zend\Mvc\Router\RouteMatch;
+
+class InjectRouteMatchListener implements ListenerAggregate
+{
+    /**
+     * Listeners we've registered
+     * 
+     * @var array
+     */
+    protected $listeners = array();
+
+    /**
+     * Attach listeners
+     * 
+     * @param  Events $events 
+     * @return void
+     */
+    public function attach(Events $events)
+    {
+        $this->listeners[] = $events->attach('route', array($this, 'injectRouteMatch'), -100);
+    }
+
+    /**
+     * Detach listeners
+     * 
+     * @param  Events $events 
+     * @return void
+     */
+    public function detach(Events $events)
+    {
+        foreach ($this->listeners as $index => $listener) {
+            if ($events->detach($listener)) {
+                unset($this->listeners[$index]);
+            }
+        }
+    }
+
+    /**
+     * Set the RouteMatch as shared instance in the DI Locator
+     *
+     * @param  MvcEvent $e 
+     * @return void
+     */
+    public function injectRouteMatch(MvcEvent $e)
+    {
+        $routeMatch = $e->getRouteMatch();
+
+        if (!$routeMatch instanceof RouteMatch) {
+            return;
+        }        
+
+        $im = $e->getParam('application')->getLocator()->instanceManager();
+        $className = get_class($routeMatch);
+        if (!$im->hasSharedInstance($className)) {
+            $im->addSharedInstance($routeMatch, $className);
+        }
+    }
+}

--- a/library/Zend/Mvc/Router/InjectRouteMatchListener.php
+++ b/library/Zend/Mvc/Router/InjectRouteMatchListener.php
@@ -21,53 +21,18 @@
 
 namespace Zend\Mvc\Router;
 
-use Zend\EventManager\EventCollection as Events,
-    Zend\EventManager\ListenerAggregate,
-    Zend\Mvc\MvcEvent,
+use Zend\Mvc\MvcEvent,
     Zend\Mvc\Router\RouteMatch;
 
-class InjectRouteMatchListener implements ListenerAggregate
+class InjectRouteMatchListener
 {
-    /**
-     * Listeners we've registered
-     * 
-     * @var array
-     */
-    protected $listeners = array();
-
-    /**
-     * Attach listeners
-     * 
-     * @param  Events $events 
-     * @return void
-     */
-    public function attach(Events $events)
-    {
-        $this->listeners[] = $events->attach('route', array($this, 'injectRouteMatch'), -100);
-    }
-
-    /**
-     * Detach listeners
-     * 
-     * @param  Events $events 
-     * @return void
-     */
-    public function detach(Events $events)
-    {
-        foreach ($this->listeners as $index => $listener) {
-            if ($events->detach($listener)) {
-                unset($this->listeners[$index]);
-            }
-        }
-    }
-
     /**
      * Set the RouteMatch as shared instance in the DI Locator
      *
      * @param  MvcEvent $e 
      * @return void
      */
-    public function injectRouteMatch(MvcEvent $e)
+    public function __invoke(MvcEvent $e)
     {
         $routeMatch = $e->getRouteMatch();
 


### PR DESCRIPTION
With this PR, it is possible to inject the routeMatch object in instances pulled from the DIC. For example, you can add the RouteMatch to the url view helper in the application module.config.php:

``` php
'Zend\View\Helper\Url' => array(
  'parameters' => array(
    'router'     => 'Zend\Mvc\Router\RouteStack',
    'routeMatch' => 'Zend\Mvc\Router\Http\RouteMatch'
  ),
)
```

But many other use cases exist. Subject to change perhaps:
1. A separate class, can be a closure instead in `Zend\Mvc\Bootstrap::setupRouter()`
2. Inject during bootstrap, might be in `Zend\Mvc\Application` as well?
