### PR TITLE
Feature/eventmanager di usability

### DIFF
--- a/documentation/manual/en/module_specs/Zend_EventManager-EventManager.xml
+++ b/documentation/manual/en/module_specs/Zend_EventManager-EventManager.xml
@@ -32,9 +32,9 @@
         </itemizedlist>
 
         <para>
-            The basic architecture allows you to attach and detach listeners to named events, both on
-            a per-instance basis as well as statically; trigger events; and interrupt execution of
-            listeners.
+            The basic architecture allows you to attach and detach listeners to named events, both
+            on a per-instance basis as well as via shared collections; trigger events; and interrupt
+            execution of listeners.
         </para>
     </section>
  
@@ -47,18 +47,27 @@
 
         <programlisting language="php"><![CDATA[
 use Zend\EventManager\EventCollection,
-    Zend\EventManager\EventManager;
+use Zend\EventManager\EventManager;
+use Zend\EventManager\EventManagerAware;
 
-class Foo
+class Foo implements EventManagerAware
 {
     protected $events;
 
-    public function events(EventCollection $events = null)
+    public function setEventManager(EventCollection $events)
     {
-        if (null !== $events) {
-            $this->events = $events;
-        } elseif (null === $this->events) {
-            $this->events = new EventManager(__CLASS__);
+        $events->setIdentifiers(array(
+            __CLASS__,
+            get_called_class(),
+        ));
+        $this->events = $events;
+        return $this;
+    }
+
+    public function events()
+    {
+        if (null === $this->events) {
+            $this->setEventManager(new EventManager());
         }
         return $this->events;
     }
@@ -133,23 +142,30 @@ $foo->bar('baz', 'bat');
 
         <para>
             Sometimes you may want to specify listeners without yet having an object instance of the
-            class composing an <classname>EventManager</classname>. The
-            <classname>StaticEventManager</classname> allows you to do this. The call to
+            class composing an <classname>EventManager</classname>. Zend Framework enables this
+            through the concept of a <interfacename>SharedEventCollection</interfacename>. Simply
+            put, you can inject individual <classname>EventManager</classname> instances with a
+            well-known <interfacename>SharedEventCollection</interfacename>, and the
+            <classname>EventManager</classname> instance will query it for additional listeners.
+            Listeners attach to a <interfacename>SharedEventCollection</interfacename> in roughly
+            the same way the do normal event managers; the call to
             <methodname>attach</methodname> is identical to the <classname>EventManager</classname>,
             but expects an additional parameter at the beginning: a named instance. Remember the
             example of composing an <classname>EventManager</classname>, how we passed it
             <constant>__CLASS__</constant>? That value, or any strings you provide in an array to
-            the constructor, may be used to identify an instance when using the
-            <classname>StaticEventManager</classname>. As an example, we could change the above
-            example to attach statically:
+            the constructor, may be used to identify an instance when using a
+            <interfacename>SharedEventCollection</interfacename>. As an example, assuming we have a
+            <classname>SharedEventManager</classname> instance that we know has been injected in our
+            <classname>EventManager</classname> instances (for instance, via dependency injection),
+            we could change the above example to attach via the shared collection:
         </para>
 
         <programlisting language="php"><![CDATA[
-use Zend\EventManager\StaticEventManager,
-    Zend\Log\Factory as LogFactory;
+use Zend\Log\Factory as LogFactory;
+
+// Assume $events is a Zend\EventManager\SharedEventManager instance
 
 $log = LogFactory($someConfig);
-$events = StaticEventManager::getInstance();
 $events->attach('Foo', 'bar', function ($e) use ($log) {
     $event  = $e->getName();
     $target = get_class($e->getTarget());
@@ -165,12 +181,32 @@ $events->attach('Foo', 'bar', function ($e) use ($log) {
 
 // Later, instantiate Foo:
 $foo = new Foo();
+$foo->events()->setSharedEventCollection($events);
 
 // And we can still trigger the above event:
 $foo->bar('baz', 'bat');
 // results in log message: 
 // bar called on Foo, using params {"baz" : "baz", "bat" : "bat"}"
 ]]></programlisting>
+
+        <note>
+            <info><title>StaticEventManager</title></info>
+
+            <para>
+                As of 2.0.0beta3, you can use the <classname>StaticEventManager</classname>
+                singleton as a <interfacename>SharedEventCollection</interfacename>. As such, you do
+                not need to worry about where and how to get access to the
+                <interfacename>SharedEventCollection</interfacename>; it's globally available by
+                simply calling <code>StaticEventManager::getInstance()</code>.
+            </para>
+
+            <para>
+                Be aware, however, that its usage is deprecated within the framework, and starting
+                with 2.0.0beta4, you will instead configure a
+                <classname>SharedEventManager</classname> instance that will be injected by the
+                framework into individual <classname>EventManager</classname> instances.
+            </para>
+        </note>
 
         <para>
             The <classname>EventManager</classname> also provides the ability to detach listeners,
@@ -184,8 +220,8 @@ $foo->bar('baz', 'bat');
 
             <para>
                 Sometimes you'll want to attach the same listener to many events or to all events of
-                a given instance -- or potentially, with the static manager, many contexts, and many
-                events. The <classname>EventManager</classname> component allows for this.
+                a given instance -- or potentially, with a shared event collection, many contexts,
+                and many events. The <classname>EventManager</classname> component allows for this.
             </para>
 
             <example xml:id="zend.event-manager.event-manager.quick-start.wildcard.many">
@@ -221,11 +257,11 @@ $events->attach('*', $callback);
                 </para>
             </example>
 
-            <example xml:id="zend.event-manager.event-manager.quick-start.wildcard.static-many">
-                <title>Attaching to many events at once via the StaticEventManager</title>
+            <example xml:id="zend.event-manager.event-manager.quick-start.wildcard.shared-many">
+                <title>Attaching to many events at once via a SharedEventManager</title>
 
                 <programlisting language="php"><![CDATA[
-$events = StaticEventManager::getInstance();
+$events = new SharedEventManager();
 // Attach to many events on the context "foo"
 $events->attach('foo', array('these', 'are', 'event', 'names'), $callback);
 
@@ -239,11 +275,11 @@ $events->attach(array('foo', 'bar'), array('these', 'are', 'event', 'names'), $c
                 </para>
             </example>
 
-            <example xml:id="zend.event-manager.event-manager.quick-start.wildcard.static-wildcard">
-                <title>Attaching to many events at once via the StaticEventManager</title>
+            <example xml:id="zend.event-manager.event-manager.quick-start.wildcard.shared-wildcard">
+                <title>Attaching to many events at once via a SharedEventManager</title>
 
                 <programlisting language="php"><![CDATA[
-$events = StaticEventManager::getInstance();
+$events = new SharedEventManager();
 // Attach to all events on the context "foo"
 $events->attach('foo', '*', $callback);
 
@@ -277,7 +313,7 @@ $events->attach(array('foo', 'bar'), '*', $callback);
                     <para>
                         A string or array of strings to which the given
                         <classname>EventManager</classname> instance can answer when accessed via
-                        the <classname>StaticEventManager</classname>.
+                        a <interfacename>SharedEventManager</interfacename>.
                     </para>
                 </listitem>
             </varlistentry>
@@ -294,16 +330,12 @@ $events->attach(array('foo', 'bar'), '*', $callback);
             </varlistentry>
 
             <varlistentry>
-                <term>static_connections</term>
+                <term>shared_collections</term>
  
                 <listitem>
                     <para>
-                        An instance of a <interfacename>StaticEventCollection</interfacename>
-                        instance to use when triggering events. By default, this will use
-                        the global <classname>StaticEventManager</classname> instance, but that can
-                        be overridden by passing a value to this method. A <constant>null</constant>
-                        value will prevent the instance from triggering any further statically
-                        attached listeners.
+                        An instance of a <interfacename>SharedEventCollection</interfacename>
+                        instance to use when triggering events. 
                     </para>
                 </listitem>
             </varlistentry>
@@ -325,7 +357,7 @@ $events->attach(array('foo', 'bar'), '*', $callback);
                     </methodsynopsis>
                     <para>
                         Constructs a new <classname>EventManager</classname> instance, using the
-                        given identifier, if provided, for purposes of static attachment.
+                        given identifier, if provided, for purposes of shared collections.
                     </para>
                 </listitem>
             </varlistentry>
@@ -346,42 +378,34 @@ $events->attach(array('foo', 'bar'), '*', $callback);
                 </listitem>
             </varlistentry>
 
-            <varlistentry xml:id="zend.event-manager.event-manager.methods.set-static-connections">
-                <term>setStaticConnections</term>
+            <varlistentry xml:id="zend.event-manager.event-manager.methods.set-shared-collections">
+                <term>setSharedCollections</term>
                 <listitem>
                     <methodsynopsis>
-                        <methodname>setStaticConnections</methodname>
+                        <methodname>setSharedCollections</methodname>
                         <methodparam>
-                            <funcparams>StaticEventCollection $connections = null</funcparams>
+                            <funcparams>SharedEventCollection $collections = null</funcparams>
                         </methodparam>
                     </methodsynopsis>
                     <para>
-                        An instance of a <interfacename>StaticEventCollection</interfacename>
-                        instance to use when triggering events. By default, this will use
-                        the global <classname>StaticEventManager</classname> instance, but that can
-                        be overridden by passing a value to this method. A <constant>null</constant>
-                        value will prevent the instance from triggering any further statically
-                        attached listeners.
+                        An instance of a <interfacename>SharedEventCollection</interfacename>
+                        instance to use when triggering events. 
                     </para>
                 </listitem>
             </varlistentry>
 
-            <varlistentry xml:id="zend.event-manager.event-manager.methods.get-static-connections">
-                <term>getStaticConnections</term>
+            <varlistentry xml:id="zend.event-manager.event-manager.methods.get-shared-collections">
+                <term>getSharedCollections</term>
                 <listitem>
                     <methodsynopsis>
-                        <methodname>getStaticConnections</methodname>
+                        <methodname>getSharedCollections</methodname>
                         <void/>
                     </methodsynopsis>
                     <para>
                         Returns the currently attached
-                        <interfacename>StaticEventCollection</interfacename> instance, lazily
-                        retrieving the global <classname>StaticEventManager</classname> instance if
-                        none is attached and usage of static listeners hasn't been disabled by
-                        passing a <constant>null</constant> value to <link
-                            linkend="zend.event-manager.event-manager.methods.set-static-connections">setStaticConnections()</link>.
-                        Returns either a boolean <constant>false</constant> if static listeners are
-                        disabled, or a <interfacename>StaticEventCollection</interfacename> instance
+                        <interfacename>SharedEventCollection</interfacename> instance.
+                        Returns either a <constant>null</constant> if no collection is attached,
+                        or a <interfacename>SharedEventCollection</interfacename> instance
                         otherwise.
                     </para>
                 </listitem>

--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -33,7 +33,8 @@ use ArrayObject,
     Zend\Cache\Storage\PostEvent,
     Zend\Cache\Storage\Plugin,
     Zend\EventManager\EventCollection,
-    Zend\EventManager\EventManager;
+    Zend\EventManager\EventManager,
+    Zend\EventManager\EventManagerAware;
 
 /**
  * @category   Zend
@@ -42,7 +43,7 @@ use ArrayObject,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class AbstractAdapter implements Adapter
+abstract class AbstractAdapter implements Adapter, EventManagerAware
 {
     /**
      * The used EventManager if any

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -38,7 +38,7 @@ use Zend\Stdlib\CallbackHandler,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class EventManager implements EventCollection, SharedEventManagerAware
+class EventManager implements EventCollection, SharedEventCollectionAware
 {
     /**
      * Subscribed events and their listeners
@@ -52,7 +52,7 @@ class EventManager implements EventCollection, SharedEventManagerAware
     protected $eventClass = 'Zend\EventManager\Event';
 
     /**
-     * Identifiers, used to pull shared signals from SharedEventManager instance
+     * Identifiers, used to pull shared signals from SharedEventCollection instance
      * @var array
      */
     protected $identifiers = array();
@@ -61,13 +61,13 @@ class EventManager implements EventCollection, SharedEventManagerAware
      * Shared connections
      * @var false|null|SharedEventCollection
      */
-    protected $sharedConnections = null;
+    protected $sharedCollections = null;
 
     /**
      * Constructor
      *
      * Allows optionally specifying identifier(s) to use to pull signals from a
-     * SharedEventManager.
+     * SharedEventCollection.
      *
      * @param  null|string|int|array|Traversable $identifiers
      * @return void
@@ -90,35 +90,35 @@ class EventManager implements EventCollection, SharedEventManagerAware
     }
 
     /**
-     * Set shared connections container
+     * Set shared collections container
      *
      * @param  SharedEventCollection $connections
      * @return void
      */
-    public function setSharedConnections(SharedEventCollection $sharedEventManager)
+    public function setSharedCollections(SharedEventCollection $sharedEventCollection)
     {
-        $this->sharedConnections = $sharedEventManager;
+        $this->sharedCollections = $sharedEventCollection;
         return $this;
     }
 
     /**
-     * Remove any shared connections
+     * Remove any shared collections
      * 
      * @return void
      */
-    public function unsetSharedConnections()
+    public function unsetSharedCollections()
     {
-        $this->sharedConnections = null;
+        $this->sharedCollections = null;
     }
 
     /**
-     * Get shared connections container
+     * Get shared collections container
      *
      * @return false|SharedEventCollection
      */
-    public function getSharedConnections()
+    public function getSharedCollections()
     {
-        return $this->sharedConnections;
+        return $this->sharedCollections;
     }
 
     /**
@@ -485,7 +485,7 @@ class EventManager implements EventCollection, SharedEventManagerAware
      */
     protected function getSharedListeners($event)
     {
-        if (!$sharedConnections = $this->getSharedConnections()) {
+        if (!$sharedCollections = $this->getSharedCollections()) {
             return array();
         }
 
@@ -493,7 +493,7 @@ class EventManager implements EventCollection, SharedEventManagerAware
         $sharedListeners = array();
 
         foreach ($identifiers as $id) {
-            if (!$listeners = $sharedConnections->getListeners($id, $event)) {
+            if (!$listeners = $sharedCollections->getListeners($id, $event)) {
                 continue;
             }
 

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -108,7 +108,7 @@ class EventManager implements EventCollection, SharedEventCollectionAware
      */
     public function unsetSharedCollections()
     {
-        $this->sharedCollections = null;
+        $this->sharedCollections = false;
     }
 
     /**
@@ -118,6 +118,9 @@ class EventManager implements EventCollection, SharedEventCollectionAware
      */
     public function getSharedCollections()
     {
+        if (null === $this->sharedCollections) {
+            $this->setSharedCollections(StaticEventManager::getInstance());
+        }
         return $this->sharedCollections;
     }
 

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -38,7 +38,7 @@ use Zend\Stdlib\CallbackHandler,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class EventManager implements EventCollection
+class EventManager implements EventCollection, SharedEventManagerAware
 {
     /**
      * Subscribed events and their listeners
@@ -52,22 +52,22 @@ class EventManager implements EventCollection
     protected $eventClass = 'Zend\EventManager\Event';
 
     /**
-     * Identifiers, used to pull static signals from StaticEventManager
+     * Identifiers, used to pull shared signals from SharedEventManager instance
      * @var array
      */
     protected $identifiers = array();
 
     /**
-     * Static connections
-     * @var false|null|StaticEventCollection
+     * Shared connections
+     * @var false|null|SharedEventCollection
      */
-    protected $staticConnections = null;
+    protected $sharedConnections = null;
 
     /**
      * Constructor
      *
      * Allows optionally specifying identifier(s) to use to pull signals from a
-     * StaticEventManager.
+     * SharedEventManager.
      *
      * @param  null|string|int|array|Traversable $identifiers
      * @return void
@@ -90,32 +90,35 @@ class EventManager implements EventCollection
     }
 
     /**
-     * Set static connections container
+     * Set shared connections container
      *
-     * @param  null|StaticEventCollection $connections
+     * @param  SharedEventCollection $connections
      * @return void
      */
-    public function setStaticConnections(StaticEventCollection $connections = null)
+    public function setSharedConnections(SharedEventCollection $sharedEventManager)
     {
-        if (null === $connections) {
-            $this->staticConnections = false;
-        } else {
-            $this->staticConnections = $connections;
-        }
+        $this->sharedConnections = $sharedEventManager;
         return $this;
     }
 
     /**
-     * Get static connections container
-     *
-     * @return false|StaticEventCollection
+     * Remove any shared connections
+     * 
+     * @return void
      */
-    public function getStaticConnections()
+    public function unsetSharedConnections()
     {
-        if (null === $this->staticConnections) {
-            $this->setStaticConnections(StaticEventManager::getInstance());
-        }
-        return $this->staticConnections;
+        $this->sharedConnections = null;
+    }
+
+    /**
+     * Get shared connections container
+     *
+     * @return false|SharedEventCollection
+     */
+    public function getSharedConnections()
+    {
+        return $this->sharedConnections;
     }
 
     /**
@@ -429,20 +432,20 @@ class EventManager implements EventCollection
         $responses = new ResponseCollection;
         $listeners = $this->getListeners($event);
 
-        // Add static/wildcard listeners to the list of listeners,
+        // Add shared/wildcard listeners to the list of listeners,
         // but don't modify the listeners object
-        $staticListeners         = $this->getStaticListeners($event);
-        $staticWildcardListeners = $this->getStaticListeners('*');
+        $sharedListeners         = $this->getSharedListeners($event);
+        $sharedWildcardListeners = $this->getSharedListeners('*');
         $wildcardListeners       = $this->getListeners('*');
-        if (count($staticListeners) || count($staticWildcardListeners) || count($wildcardListeners)) {
+        if (count($sharedListeners) || count($sharedWildcardListeners) || count($wildcardListeners)) {
             $listeners = clone $listeners;
         }
 
-        // Static listeners on this specific event
-        $this->insertListeners($listeners, $staticListeners);
+        // Shared listeners on this specific event
+        $this->insertListeners($listeners, $sharedListeners);
 
-        // Static wildcard listeners
-        $this->insertListeners($listeners, $staticWildcardListeners);
+        // Shared wildcard listeners
+        $this->insertListeners($listeners, $sharedWildcardListeners);
 
         // Add wildcard listeners
         $this->insertListeners($listeners, $wildcardListeners);
@@ -474,23 +477,23 @@ class EventManager implements EventCollection
     }
 
     /**
-     * Get list of all listeners attached to the static collection for
+     * Get list of all listeners attached to the shared collection for
      * identifiers registered by this instance
      *
      * @param  string $event
      * @return array
      */
-    protected function getStaticListeners($event)
+    protected function getSharedListeners($event)
     {
-        if (!$staticConnections = $this->getStaticConnections()) {
+        if (!$sharedConnections = $this->getSharedConnections()) {
             return array();
         }
 
         $identifiers     = $this->getIdentifiers();
-        $staticListeners = array();
+        $sharedListeners = array();
 
         foreach ($identifiers as $id) {
-            if (!$listeners = $staticConnections->getListeners($id, $event)) {
+            if (!$listeners = $sharedConnections->getListeners($id, $event)) {
                 continue;
             }
 
@@ -502,17 +505,17 @@ class EventManager implements EventCollection
                 if (!$listener instanceof CallbackHandler) {
                     continue;
                 }
-                $staticListeners[] = $listener;
+                $sharedListeners[] = $listener;
             }
         }
 
-        return $staticListeners;
+        return $sharedListeners;
     }
 
     /**
      * Add listeners to the master queue of listeners
      *
-     * Used to inject static listeners and wildcard listeners.
+     * Used to inject shared listeners and wildcard listeners.
      * 
      * @param  PriorityQueue $masterListeners 
      * @param  PriorityQueue $listeners 

--- a/library/Zend/EventManager/EventManagerAware.php
+++ b/library/Zend/EventManager/EventManagerAware.php
@@ -14,27 +14,29 @@
  *
  * @category   Zend
  * @package    Zend_EventManager
- * @subpackage UnitTests
+ * @subpackage UnitTest
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace ZendTest\EventManager\TestAsset;
-
-use Zend\EventManager\SharedEventCollection;
+namespace Zend\EventManager;
 
 /**
+ * Interface to automate setter injection for an EventManager instance
+ *
  * @category   Zend
  * @package    Zend_EventManager
- * @subpackage UnitTests
- * @group      Zend_EventManager
+ * @subpackage UnitTest
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class StaticEventsMock implements SharedEventCollection
+interface EventManagerAware
 {
-    public function getListeners($id, $event)
-    {
-        return array();
-    }
+    /**
+     * Inject an EventManager instance
+     * 
+     * @param  EventCollection $eventManager 
+     * @return void
+     */
+    public function setEventManager(EventCollection $eventManager);
 }

--- a/library/Zend/EventManager/SharedEventCollection.php
+++ b/library/Zend/EventManager/SharedEventCollection.php
@@ -14,27 +14,21 @@
  *
  * @category   Zend
  * @package    Zend_EventManager
- * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace ZendTest\EventManager\TestAsset;
-
-use Zend\EventManager\SharedEventCollection;
+namespace Zend\EventManager;
 
 /**
+ * Interface for shared event listener collections
+ *
  * @category   Zend
  * @package    Zend_EventManager
- * @subpackage UnitTests
- * @group      Zend_EventManager
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class StaticEventsMock implements SharedEventCollection
+interface SharedEventCollection
 {
-    public function getListeners($id, $event)
-    {
-        return array();
-    }
+    public function getListeners($id, $event);
 }

--- a/library/Zend/EventManager/SharedEventCollectionAware.php
+++ b/library/Zend/EventManager/SharedEventCollectionAware.php
@@ -22,7 +22,7 @@
 namespace Zend\EventManager;
 
 /**
- * Interface to automate setter injection for a SharedEventManager instance
+ * Interface to automate setter injection for a SharedEventCollection instance
  *
  * @category   Zend
  * @package    Zend_EventManager
@@ -30,13 +30,13 @@ namespace Zend\EventManager;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface SharedEventManagerAware
+interface SharedEventCollectionAware
 {
     /**
      * Inject an EventManager instance
      * 
-     * @param  SharedEventCollection $sharedEventManager 
-     * @return SharedEventManagerAware
+     * @param  SharedEventCollection $sharedEventCollection 
+     * @return SharedEventCollectionAware
      */
-    public function setSharedConnections(SharedEventCollection $sharedEventManager);
+    public function setSharedCollections(SharedEventCollection $sharedEventCollection);
 }

--- a/library/Zend/EventManager/SharedEventManager.php
+++ b/library/Zend/EventManager/SharedEventManager.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_EventManager
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\EventManager;
+
+use Zend\Stdlib\CallbackHandler;
+
+/**
+ * Shared/contextual EventManager
+ *
+ * Allows attaching to EMs composed by other classes without having an instance first.
+ * The assumption is that the SharedEventManager will be injected into EventManager 
+ * instances, and then queried for additional listeners when triggering an event.
+ *
+ * @category   Zend
+ * @package    Zend_EventManager
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class SharedEventManager implements SharedEventCollection
+{
+    /**
+     * Identifiers with event connections
+     * @var array
+     */
+    protected $identifiers = array();
+
+    /**
+     * Attach a listener to an event
+     *
+     * Allows attaching a callback to an event offerred by one or more 
+     * identifying components. As an example, the following connects to the 
+     * "getAll" event of both an AbstractResource and EntityResource:
+     *
+     * <code>
+     * SharedEventManager::getInstance()->connect(
+     *     array('My\Resource\AbstractResource', 'My\Resource\EntityResource'),
+     *     'getOne',
+     *     function ($e) use ($cache) {
+     *         if (!$id = $e->getParam('id', false)) {
+     *             return;
+     *         }
+     *         if (!$data = $cache->load(get_class($resource) . '::getOne::' . $id )) {
+     *             return;
+     *         }
+     *         return $data;
+     *     }
+     * );
+     * </code>
+     * 
+     * @param  string|array $id Identifier(s) for event emitting component(s)
+     * @param  string $event 
+     * @param  callback $callback PHP Callback
+     * @param  int $priority Priority at which listener should execute
+     * @return void
+     */
+    public function attach($id, $event, $callback, $priority = 1)
+    {
+        $ids = (array) $id;
+        foreach ($ids as $id) {
+            if (!array_key_exists($id, $this->identifiers)) {
+                $this->identifiers[$id] = new EventManager();
+            }
+            $this->identifiers[$id]->attach($event, $callback, $priority);
+        }
+    }
+
+    /**
+     * Detach a listener from an event offered by a given resource
+     * 
+     * @param  string|int $id
+     * @param  CallbackHandler $listener 
+     * @return bool Returns true if event and listener found, and unsubscribed; returns false if either event or listener not found
+     */
+    public function detach($id, CallbackHandler $listener)
+    {
+        if (!array_key_exists($id, $this->identifiers)) {
+            return false;
+        }
+        return $this->identifiers[$id]->detach($listener);
+    }
+
+    /**
+     * Retrieve all registered events for a given resource
+     * 
+     * @param  string|int $id
+     * @return array
+     */
+    public function getEvents($id)
+    {
+        if (!array_key_exists($id, $this->identifiers)) {
+            return false;
+        }
+        return $this->identifiers[$id]->getEvents();
+    }
+
+    /**
+     * Retrieve all listeners for a given identifier and event
+     * 
+     * @param  string|int $id
+     * @param  string|int $event 
+     * @return false|\Zend\Stdlib\PriorityQueue
+     */
+    public function getListeners($id, $event)
+    {
+        if (!array_key_exists($id, $this->identifiers)) {
+            return false;
+        }
+        return $this->identifiers[$id]->getListeners($event);
+    }
+
+    /**
+     * Clear all listeners for a given identifier, optionally for a specific event
+     * 
+     * @param  string|int $id 
+     * @param  null|string $event 
+     * @return bool
+     */
+    public function clearListeners($id, $event = null)
+    {
+        if (!array_key_exists($id, $this->identifiers)) {
+            return false;
+        }
+
+        if (null === $event) {
+            unset($this->identifiers[$id]);
+            return true;
+        }
+
+        return $this->identifiers[$id]->clearListeners($event);
+    }
+}

--- a/library/Zend/EventManager/SharedEventManagerAware.php
+++ b/library/Zend/EventManager/SharedEventManagerAware.php
@@ -14,6 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_EventManager
+ * @subpackage UnitTest
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -21,14 +22,21 @@
 namespace Zend\EventManager;
 
 /**
- * Interface for global (static) event listener collections
+ * Interface to automate setter injection for a SharedEventManager instance
  *
  * @category   Zend
  * @package    Zend_EventManager
+ * @subpackage UnitTest
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface StaticEventCollection
+interface SharedEventManagerAware
 {
-    public function getListeners($id, $event);
+    /**
+     * Inject an EventManager instance
+     * 
+     * @param  SharedEventCollection $sharedEventManager 
+     * @return SharedEventManagerAware
+     */
+    public function setSharedConnections(SharedEventCollection $sharedEventManager);
 }

--- a/library/Zend/EventManager/StaticEventManager.php
+++ b/library/Zend/EventManager/StaticEventManager.php
@@ -30,18 +30,12 @@ use Zend\Stdlib\CallbackHandler;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class StaticEventManager implements StaticEventCollection
+class StaticEventManager extends SharedEventManager
 {
     /**
      * @var StaticEventManager
      */
     protected static $instance;
-
-    /**
-     * Identifiers with event connections
-     * @var array
-     */
-    protected $identifiers = array();
 
     /**
      * Singleton
@@ -82,110 +76,5 @@ class StaticEventManager implements StaticEventCollection
     public static function resetInstance()
     {
         self::$instance = null;
-    }
-
-    /**
-     * Attach a listener to an event
-     *
-     * Allows attaching a callback to an event offerred by one or more 
-     * identifying components. As an example, the following connects to the 
-     * "getAll" event of both an AbstractResource and EntityResource:
-     *
-     * <code>
-     * StaticEventManager::getInstance()->connect(
-     *     array('My\Resource\AbstractResource', 'My\Resource\EntityResource'),
-     *     'getOne',
-     *     function ($e) use ($cache) {
-     *         if (!$id = $e->getParam('id', false)) {
-     *             return;
-     *         }
-     *         if (!$data = $cache->load(get_class($resource) . '::getOne::' . $id )) {
-     *             return;
-     *         }
-     *         return $data;
-     *     }
-     * );
-     * </code>
-     * 
-     * @param  string|array $id Identifier(s) for event emitting component(s)
-     * @param  string $event 
-     * @param  callback $callback PHP Callback
-     * @param  int $priority Priority at which listener should execute
-     * @return void
-     */
-    public function attach($id, $event, $callback, $priority = 1)
-    {
-        $ids = (array) $id;
-        foreach ($ids as $id) {
-            if (!array_key_exists($id, $this->identifiers)) {
-                $this->identifiers[$id] = new EventManager();
-            }
-            $this->identifiers[$id]->attach($event, $callback, $priority);
-        }
-    }
-
-    /**
-     * Detach a listener from an event offered by a given resource
-     * 
-     * @param  string|int $id
-     * @param  CallbackHandler $listener 
-     * @return bool Returns true if event and listener found, and unsubscribed; returns false if either event or listener not found
-     */
-    public function detach($id, CallbackHandler $listener)
-    {
-        if (!array_key_exists($id, $this->identifiers)) {
-            return false;
-        }
-        return $this->identifiers[$id]->detach($listener);
-    }
-
-    /**
-     * Retrieve all registered events for a given resource
-     * 
-     * @param  string|int $id
-     * @return array
-     */
-    public function getEvents($id)
-    {
-        if (!array_key_exists($id, $this->identifiers)) {
-            return false;
-        }
-        return $this->identifiers[$id]->getEvents();
-    }
-
-    /**
-     * Retrieve all listeners for a given identifier and event
-     * 
-     * @param  string|int $id
-     * @param  string|int $event 
-     * @return false|\Zend\Stdlib\PriorityQueue
-     */
-    public function getListeners($id, $event)
-    {
-        if (!array_key_exists($id, $this->identifiers)) {
-            return false;
-        }
-        return $this->identifiers[$id]->getListeners($event);
-    }
-
-    /**
-     * Clear all listeners for a given identifier, optionally for a specific event
-     * 
-     * @param  string|int $id 
-     * @param  null|string $event 
-     * @return bool
-     */
-    public function clearListeners($id, $event = null)
-    {
-        if (!array_key_exists($id, $this->identifiers)) {
-            return false;
-        }
-
-        if (null === $event) {
-            unset($this->identifiers[$id]);
-            return true;
-        }
-
-        return $this->identifiers[$id]->clearListeners($event);
     }
 }

--- a/library/Zend/Module/ModuleHandler.php
+++ b/library/Zend/Module/ModuleHandler.php
@@ -45,14 +45,6 @@ interface ModuleHandler extends EventManagerAware
     public function setModules($modules);
 
     /**
-     * Set the event manager instance used by this module manager.
-     *
-     * @param  EventCollection $events
-     * @return ModuleHandler
-     */
-    public function setEventManager(EventCollection $events);
-
-    /**
      * Retrieve the event manager
      *
      * Lazy-loads an EventManager instance if none registered.

--- a/library/Zend/Module/ModuleHandler.php
+++ b/library/Zend/Module/ModuleHandler.php
@@ -2,9 +2,9 @@
 
 namespace Zend\Module;
 
-use Zend\EventManager\EventCollection;
+use Zend\EventManager\EventManagerAware;
 
-interface ModuleHandler
+interface ModuleHandler extends EventManagerAware
 {
     /**
      * Load the provided modules.

--- a/library/Zend/Mvc/AppContext.php
+++ b/library/Zend/Mvc/AppContext.php
@@ -3,20 +3,12 @@
 namespace Zend\Mvc;
 
 use Zend\Di\Locator,
-    Zend\EventManager\EventCollection,
+    Zend\EventManager\EventManagerAware,
     Zend\Stdlib\RequestDescription as Request,
     Zend\Stdlib\ResponseDescription as Response;
 
-interface AppContext
+interface AppContext extends EventManagerAware
 {
-    /**
-     * Set the event manager instance used by this context
-     * 
-     * @param  EventCollection $events 
-     * @return AppContext
-     */
-    public function setEventManager(EventCollection $events);
-
     /**
      * Set a service locator/DI object
      *

--- a/library/Zend/Mvc/Bootstrap.php
+++ b/library/Zend/Mvc/Bootstrap.php
@@ -6,10 +6,11 @@ use Zend\Di\Configuration as DiConfiguration,
     Zend\Config\Config,
     Zend\EventManager\EventCollection as Events,
     Zend\EventManager\EventManager,
+    Zend\EventManager\EventManagerAware,
     Zend\EventManager\StaticEventManager,
     Zend\Mvc\Router\Http\TreeRouteStack as Router;
 
-class Bootstrap implements Bootstrapper
+class Bootstrap implements Bootstrapper, EventManagerAware
 {
     /**
      * @var \Zend\Config\Config
@@ -218,6 +219,12 @@ class Bootstrap implements Bootstrapper
                 ),
             ),
         )), 'instance' => array(
+            'preferences' => array(
+                // Use EventManager for EventCollection
+                'Zend\EventManager\EventCollection' => 'Zend\EventManager\EventManager',
+                // Use SharedEventManager for SharedEventCollection
+                'Zend\EventManager\SharedEventCollection' => 'Zend\EventManager\SharedEventManager',
+            ),
             'Zend\EventManager\EventManager' => array(
                 'shared' => false, // new instance per class needing an instance
             ),

--- a/library/Zend/Mvc/Bootstrap.php
+++ b/library/Zend/Mvc/Bootstrap.php
@@ -217,7 +217,11 @@ class Bootstrap implements Bootstrapper
                     ),
                 ),
             ),
-        ))));
+        )), 'instance' => array(
+            'Zend\EventManager\EventManager' => array(
+                'shared' => false, // new instance per class needing an instance
+            ),
+        )));
         $diConfig->configure($di);
 
         $config = new DiConfiguration($this->config->di);

--- a/library/Zend/Mvc/Controller/ActionController.php
+++ b/library/Zend/Mvc/Controller/ActionController.php
@@ -6,6 +6,7 @@ use Zend\Di\Locator,
     Zend\EventManager\EventCollection,
     Zend\EventManager\EventDescription as Event,
     Zend\EventManager\EventManager,
+    Zend\EventManager\EventManagerAware,
     Zend\Http\PhpEnvironment\Response as HttpResponse,
     Zend\Loader\Broker,
     Zend\Loader\Pluggable,
@@ -21,7 +22,7 @@ use Zend\Di\Locator,
 /**
  * Basic action controller
  */
-abstract class ActionController implements Dispatchable, InjectApplicationEvent, LocatorAware, Pluggable
+abstract class ActionController implements Dispatchable, EventManagerAware, InjectApplicationEvent, LocatorAware, Pluggable
 {
     //use \Zend\EventManager\ProvidesEvents;
 

--- a/library/Zend/Mvc/Controller/RestfulController.php
+++ b/library/Zend/Mvc/Controller/RestfulController.php
@@ -6,6 +6,7 @@ use Zend\Di\Locator,
     Zend\EventManager\EventCollection,
     Zend\EventManager\EventDescription as Event,
     Zend\EventManager\EventManager,
+    Zend\EventManager\EventManagerAware,
     Zend\Http\Request as HttpRequest,
     Zend\Http\PhpEnvironment\Response as HttpResponse,
     Zend\Loader\Broker,
@@ -21,7 +22,7 @@ use Zend\Di\Locator,
 /**
  * Abstract RESTful controller
  */
-abstract class RestfulController implements Dispatchable, InjectApplicationEvent, LocatorAware, Pluggable
+abstract class RestfulController implements Dispatchable, EventManagerAware, InjectApplicationEvent, LocatorAware, Pluggable
 {
     protected $broker;
     protected $request;

--- a/library/Zend/View/View.php
+++ b/library/Zend/View/View.php
@@ -22,6 +22,7 @@ namespace Zend\View;
 
 use Zend\EventManager\EventCollection,
     Zend\EventManager\EventManager,
+    Zend\EventManager\EventManagerAware,
     Zend\Mvc\MvcEvent,
     Zend\Stdlib\RequestDescription as Request,
     Zend\Stdlib\ResponseDescription as Response;
@@ -32,7 +33,7 @@ use Zend\EventManager\EventCollection,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class View
+class View implements EventManagerAware
 {
     /**
      * @var EventCollection

--- a/tests/Zend/EventManager/EventManagerTest.php
+++ b/tests/Zend/EventManager/EventManagerTest.php
@@ -27,6 +27,7 @@ use ArrayIterator,
     Zend\EventManager\EventDescription,
     Zend\EventManager\EventManager,
     Zend\EventManager\ResponseCollection,
+    Zend\EventManager\StaticEventManager,
     Zend\Stdlib\CallbackHandler;
 
 /**
@@ -41,6 +42,8 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
+        StaticEventManager::resetInstance();
+
         if (isset($this->message)) {
             unset($this->message);
         }

--- a/tests/Zend/EventManager/StaticEventManagerTest.php
+++ b/tests/Zend/EventManager/StaticEventManagerTest.php
@@ -165,7 +165,7 @@ class StaticEventManagerTest extends TestCase
         $staticEvents->attach('bar', '*', $callback);
 
         $events = new EventManager('bar');
-        $events->setSharedConnections($staticEvents);
+        $events->setSharedCollections($staticEvents);
 
         foreach (array('foo', 'bar', 'baz') as $event) {
             $events->trigger($event);
@@ -237,7 +237,7 @@ class StaticEventManagerTest extends TestCase
         $identifiers = array('foo', 'bar');
         $events  = StaticEventManager::getInstance();
         $manager = new EventManager($identifiers);
-        $manager->setSharedConnections($events);
+        $manager->setSharedCollections($events);
 
         $test = new \stdClass;
         $test->triggered = 0;

--- a/tests/Zend/EventManager/StaticEventManagerTest.php
+++ b/tests/Zend/EventManager/StaticEventManagerTest.php
@@ -165,6 +165,7 @@ class StaticEventManagerTest extends TestCase
         $staticEvents->attach('bar', '*', $callback);
 
         $events = new EventManager('bar');
+        $events->setSharedConnections($staticEvents);
 
         foreach (array('foo', 'bar', 'baz') as $event) {
             $events->trigger($event);
@@ -234,9 +235,11 @@ class StaticEventManagerTest extends TestCase
     public function testListenersAttachedToAnyIdentifierProvidedToEventManagerWillBeTriggered()
     {
         $identifiers = array('foo', 'bar');
-        $manager = new EventManager($identifiers);
         $events  = StaticEventManager::getInstance();
-        $test    = new \stdClass;
+        $manager = new EventManager($identifiers);
+        $manager->setSharedConnections($events);
+
+        $test = new \stdClass;
         $test->triggered = 0;
         $events->attach('foo', 'bar', function($e) use ($test) {
             $test->triggered++;

--- a/tests/Zend/EventManager/StaticIntegrationTest.php
+++ b/tests/Zend/EventManager/StaticIntegrationTest.php
@@ -52,7 +52,7 @@ class StaticIntegrationTest extends TestCase
             }
         );
         $class = new TestAsset\ClassWithEvents();
-        $class->events()->setSharedConnections($events);
+        $class->events()->setSharedCollections($events);
         $class->foo();
         $this->assertEquals(1, $counter->count);
     }
@@ -72,7 +72,7 @@ class StaticIntegrationTest extends TestCase
         $class->events()->attach('foo', function ($e) use ($test) {
             $test->results[] = 'local';
         });
-        $class->events()->setSharedConnections($events);
+        $class->events()->setSharedCollections($events);
         $class->foo();
         $this->assertEquals(array('local', 'static'), $test->results);
     }
@@ -99,12 +99,12 @@ class StaticIntegrationTest extends TestCase
         $class->events()->attach('foo', function ($e) use ($test) {
             $test->results[] = 'local3';
         }, 15000); // highest priority
-        $class->events()->setSharedConnections($events);
+        $class->events()->setSharedCollections($events);
         $class->foo();
         $this->assertEquals(array('local3', 'static', 'local2', 'local'), $test->results);
     }
 
-    public function testCallingUnsetSharedConnectionsDisablesStaticConnections()
+    public function testCallingUnsetSharedCollectionsDisablesStaticCollections()
     {
         $counter = (object) array('count' => 0);
         StaticEventManager::getInstance()->attach(
@@ -115,7 +115,7 @@ class StaticIntegrationTest extends TestCase
             }
         );
         $class = new TestAsset\ClassWithEvents();
-        $class->events()->unsetSharedConnections();
+        $class->events()->unsetSharedCollections();
         $class->foo();
         $this->assertEquals(0, $counter->count);
     }
@@ -132,8 +132,8 @@ class StaticIntegrationTest extends TestCase
         );
         $mockStaticEvents = new TestAsset\StaticEventsMock();
         $class = new TestAsset\ClassWithEvents();
-        $class->events()->setSharedConnections($mockStaticEvents);
-        $this->assertSame($mockStaticEvents, $class->events()->getSharedConnections());
+        $class->events()->setSharedCollections($mockStaticEvents);
+        $this->assertSame($mockStaticEvents, $class->events()->getSharedCollections());
         $class->foo();
         $this->assertEquals(0, $counter->count);
     }
@@ -154,7 +154,7 @@ class StaticIntegrationTest extends TestCase
         $class->events()->attach('foo', function ($e) use ($test) {
             $test->results[] = 'local';
         }, -100);
-        $class->events()->setSharedConnections($events);
+        $class->events()->setSharedCollections($events);
         $class->foo();
         $this->assertEquals(array('static', 'local'), $test->results);
     }

--- a/tests/Zend/Mvc/ApplicationTest.php
+++ b/tests/Zend/Mvc/ApplicationTest.php
@@ -8,7 +8,7 @@ use ArrayObject,
     Zend\Di\Di as DependencyInjector,
     Zend\Di\ServiceLocator,
     Zend\EventManager\EventManager,
-    Zend\EventManager\StaticEventManager,
+    Zend\EventManager\SharedEventManager,
     Zend\Http\Request,
     Zend\Http\PhpEnvironment\Response,
     Zend\Mvc\Application,
@@ -17,11 +17,6 @@ use ArrayObject,
 
 class ApplicationTest extends TestCase
 {
-    public function setUp()
-    {
-        StaticEventManager::resetInstance();
-    }
-
     public function testEventManagerIsLazyLoaded()
     {
         $app = new Application();
@@ -405,14 +400,16 @@ class ApplicationTest extends TestCase
         $router  = $app->getRouter();
         $router->addRoute('locator-aware', $route);
 
+        $events  = new SharedEventManager();
         $locator = new TestAsset\Locator();
-        $locator->add('locator-aware', function() {
-            return new TestAsset\LocatorAwareController;
+        $locator->add('locator-aware', function() use ($events) {
+            $controller = new TestAsset\LocatorAwareController;
+            $controller->events()->setSharedConnections($events);
+            return $controller;
         });
         $app->setLocator($locator);
 
         $storage = new ArrayObject();
-        $events  = StaticEventManager::getInstance();
         $events->attach('ZendTest\Mvc\TestAsset\LocatorAwareController', 'dispatch', function ($e) use ($storage) {
             $controller = $e->getTarget();
             $storage['locator'] = $controller->getLocator();
@@ -436,8 +433,10 @@ class ApplicationTest extends TestCase
 
     public function testCanProvideAlternateEventManagerToDisableDefaultRouteAndDispatchEventListeners()
     {
-        $app    = $this->setupActionController();
-        $events = new EventManager();
+        $app          = $this->setupActionController();
+        $events       = new EventManager();
+        $sharedEvents = new SharedEventManager();
+        $events->setSharedConnections($sharedEvents);
         $app->setEventManager($events);
 
         $listener1 = function($e) {
@@ -452,9 +451,8 @@ class ApplicationTest extends TestCase
             $content  = (empty($content) ? 'listener2' : $content . '::' . 'listener2');
             $response->setContent($content);
         };
-        $events = StaticEventManager::getInstance();
-        $events->attach('ZendTest\Mvc\Controller\TestAsset\SampleController', 'dispatch', $listener1, 10);
-        $events->attach('ZendTest\Mvc\Controller\TestAsset\SampleController', 'dispatch', $listener2, -10);
+        $sharedEvents->attach('ZendTest\Mvc\Controller\TestAsset\SampleController', 'dispatch', $listener1, 10);
+        $sharedEvents->attach('ZendTest\Mvc\Controller\TestAsset\SampleController', 'dispatch', $listener2, -10);
 
         $app->run();
         $response = $app->getResponse();

--- a/tests/Zend/Mvc/ApplicationTest.php
+++ b/tests/Zend/Mvc/ApplicationTest.php
@@ -404,7 +404,7 @@ class ApplicationTest extends TestCase
         $locator = new TestAsset\Locator();
         $locator->add('locator-aware', function() use ($events) {
             $controller = new TestAsset\LocatorAwareController;
-            $controller->events()->setSharedConnections($events);
+            $controller->events()->setSharedCollections($events);
             return $controller;
         });
         $app->setLocator($locator);
@@ -436,7 +436,7 @@ class ApplicationTest extends TestCase
         $app          = $this->setupActionController();
         $events       = new EventManager();
         $sharedEvents = new SharedEventManager();
-        $events->setSharedConnections($sharedEvents);
+        $events->setSharedCollections($sharedEvents);
         $app->setEventManager($events);
 
         $listener1 = function($e) {

--- a/tests/Zend/Mvc/Controller/ActionControllerTest.php
+++ b/tests/Zend/Mvc/Controller/ActionControllerTest.php
@@ -3,7 +3,7 @@
 namespace ZendTest\Mvc\Controller;
 
 use PHPUnit_Framework_TestCase as TestCase,
-    Zend\EventManager\StaticEventManager,
+    Zend\EventManager\SharedEventManager,
     Zend\Http\Request,
     Zend\Http\Response,
     Zend\Mvc\Controller\PluginBroker,
@@ -25,8 +25,6 @@ class ActionControllerTest extends TestCase
         $this->event      = new MvcEvent();
         $this->event->setRouteMatch($this->routeMatch);
         $this->controller->setEvent($this->event);
-
-        StaticEventManager::resetInstance();
     }
 
     public function testDispatchInvokesNotFoundActionWhenNoActionPresentInRouteMatch()
@@ -96,10 +94,11 @@ class ActionControllerTest extends TestCase
     {
         $response = new Response();
         $response->setContent('short circuited!');
-        $events = StaticEventManager::getInstance();
+        $events = new SharedEventManager();
         $events->attach('Zend\Stdlib\Dispatchable', 'dispatch', function($e) use ($response) {
             return $response;
         }, 10);
+        $this->controller->events()->setSharedConnections($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }
@@ -108,10 +107,11 @@ class ActionControllerTest extends TestCase
     {
         $response = new Response();
         $response->setContent('short circuited!');
-        $events = StaticEventManager::getInstance();
+        $events = new SharedEventManager();
         $events->attach('Zend\Mvc\Controller\ActionController', 'dispatch', function($e) use ($response) {
             return $response;
         }, 10);
+        $this->controller->events()->setSharedConnections($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }
@@ -120,10 +120,11 @@ class ActionControllerTest extends TestCase
     {
         $response = new Response();
         $response->setContent('short circuited!');
-        $events = StaticEventManager::getInstance();
+        $events = new SharedEventManager();
         $events->attach(get_class($this->controller), 'dispatch', function($e) use ($response) {
             return $response;
         }, 10);
+        $this->controller->events()->setSharedConnections($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }

--- a/tests/Zend/Mvc/Controller/ActionControllerTest.php
+++ b/tests/Zend/Mvc/Controller/ActionControllerTest.php
@@ -98,7 +98,7 @@ class ActionControllerTest extends TestCase
         $events->attach('Zend\Stdlib\Dispatchable', 'dispatch', function($e) use ($response) {
             return $response;
         }, 10);
-        $this->controller->events()->setSharedConnections($events);
+        $this->controller->events()->setSharedCollections($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }
@@ -111,7 +111,7 @@ class ActionControllerTest extends TestCase
         $events->attach('Zend\Mvc\Controller\ActionController', 'dispatch', function($e) use ($response) {
             return $response;
         }, 10);
-        $this->controller->events()->setSharedConnections($events);
+        $this->controller->events()->setSharedCollections($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }
@@ -124,7 +124,7 @@ class ActionControllerTest extends TestCase
         $events->attach(get_class($this->controller), 'dispatch', function($e) use ($response) {
             return $response;
         }, 10);
-        $this->controller->events()->setSharedConnections($events);
+        $this->controller->events()->setSharedCollections($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }

--- a/tests/Zend/Mvc/Controller/RestfulControllerTest.php
+++ b/tests/Zend/Mvc/Controller/RestfulControllerTest.php
@@ -137,7 +137,7 @@ class RestfulControllerTest extends TestCase
         $events->attach('Zend\Stdlib\Dispatchable', 'dispatch', function($e) use ($response) {
             return $response;
         }, 10);
-        $this->controller->events()->setSharedConnections($events);
+        $this->controller->events()->setSharedCollections($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }
@@ -150,7 +150,7 @@ class RestfulControllerTest extends TestCase
         $events->attach('Zend\Mvc\Controller\RestfulController', 'dispatch', function($e) use ($response) {
             return $response;
         }, 10);
-        $this->controller->events()->setSharedConnections($events);
+        $this->controller->events()->setSharedCollections($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }
@@ -163,7 +163,7 @@ class RestfulControllerTest extends TestCase
         $events->attach(get_class($this->controller), 'dispatch', function($e) use ($response) {
             return $response;
         }, 10);
-        $this->controller->events()->setSharedConnections($events);
+        $this->controller->events()->setSharedCollections($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }

--- a/tests/Zend/Mvc/Controller/RestfulControllerTest.php
+++ b/tests/Zend/Mvc/Controller/RestfulControllerTest.php
@@ -4,7 +4,7 @@ namespace ZendTest\Mvc\Controller;
 
 use PHPUnit_Framework_TestCase as TestCase,
     stdClass,
-    Zend\EventManager\StaticEventManager,
+    Zend\EventManager\SharedEventManager,
     Zend\Http\Request,
     Zend\Http\Response,
     Zend\Mvc\MvcEvent,
@@ -26,8 +26,6 @@ class RestfulControllerTest extends TestCase
         $this->event      = new MvcEvent;
         $this->event->setRouteMatch($this->routeMatch);
         $this->controller->setEvent($this->event);
-
-        StaticEventManager::resetInstance();
     }
 
     public function testDispatchInvokesListWhenNoActionPresentAndNoIdentifierOnGet()
@@ -135,10 +133,11 @@ class RestfulControllerTest extends TestCase
     {
         $response = new Response();
         $response->setContent('short circuited!');
-        $events = StaticEventManager::getInstance();
+        $events = new SharedEventManager();
         $events->attach('Zend\Stdlib\Dispatchable', 'dispatch', function($e) use ($response) {
             return $response;
         }, 10);
+        $this->controller->events()->setSharedConnections($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }
@@ -147,10 +146,11 @@ class RestfulControllerTest extends TestCase
     {
         $response = new Response();
         $response->setContent('short circuited!');
-        $events = StaticEventManager::getInstance();
+        $events = new SharedEventManager();
         $events->attach('Zend\Mvc\Controller\RestfulController', 'dispatch', function($e) use ($response) {
             return $response;
         }, 10);
+        $this->controller->events()->setSharedConnections($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }
@@ -159,10 +159,11 @@ class RestfulControllerTest extends TestCase
     {
         $response = new Response();
         $response->setContent('short circuited!');
-        $events = StaticEventManager::getInstance();
+        $events = new SharedEventManager();
         $events->attach(get_class($this->controller), 'dispatch', function($e) use ($response) {
             return $response;
         }, 10);
+        $this->controller->events()->setSharedConnections($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }


### PR DESCRIPTION
Shared Collections support for EventManager

This is a solution for usage of the StaticEventManager. Basically, it
will instead expect the following:
- Classes composing an EventManager will implement EventManagerAware,
  and thus opt-in to setter injection of an EM instance
  - EM instances will _not_ be shared between classes
- The EM implements the SharedEventManagerAware interface, indicating it
  opts-in to setter injection of a SharedEventManager (note: not static)
  - A single "SharedEventManager" will be shared between all instances of
    EventManager

This commit does the following:
- Renames StaticEventCollection to SharedEventCollection
- Creates SharedEventManager, which implements all the functionality of
  StaticEventManager except the singleton aspects.
- StaticEventManager now extends SharedEventManager, and simply
  implements a singleton pattern.
- Introduced EventManagerAware and SharedEventManagerAware interfaces;
  EventManager implements the latter.
- Adds configuration to the Bootstrap in setupLocator() to mark the EventManager
  as an unshared instance.

One issue is known, however:
- Zend\Module\Listener\LocatorRegistration currently fails, as it assumes a StaticEventManager instance. As such, it cannot connect to the bootstrap event. I'm not sure what the solution for this will be -- I assume we'll need to instantiate a SharedEventManager and pass it into the Module\Manager, Mvc\Bootstrap, and potentially Mvc\Application. This will require documentation, and coordination with the skeleton application. Another alternative is to have this listener instead attach directly to the Bootstrap, and loop through the module manager. Ideas are welcome.
