### PR TITLE
Fixes bogus docblocks in Zend\Acl

### DIFF
--- a/library/Zend/Acl/Acl.php
+++ b/library/Zend/Acl/Acl.php
@@ -61,7 +61,7 @@ class Acl
     /**
      * Role registry
      *
-     * @var \Zend\Acl\Role\Registry
+     * @var Role\Registry
      */
     protected $_roleRegistry = null;
 
@@ -73,17 +73,17 @@ class Acl
     protected $_resources = array();
 
     /**
-     * @var \Zend\Acl\Role
+     * @var Role
      */
     protected $_isAllowedRole     = null;
 
     /**
-     * @var Zend\Acl\Resource
+     * @var Resource
      */
     protected $_isAllowedResource = null;
 
     /**
-     * @var String
+     * @var string
      */
     protected $_isAllowedPrivilege = null;
 
@@ -120,11 +120,11 @@ class Acl
      * will have the least priority, and the last parent added will have the
      * highest priority.
      *
-     * @param  \Zend\Acl\Role              $role
-     * @param  \Zend\Acl\Role|string|array $parents
-     * @uses   \Zend\Acl\Role\Registry::add()
-     * @throws \Zend\Acl\Exception\InvalidArgumentException
-     * @return \Zend\Acl\Acl Provides a fluent interface
+     * @param  Role              $role
+     * @param  Role|string|array $parents
+     * @uses   Role\Registry::add()
+     * @throws Exception\InvalidArgumentException
+     * @return Acl Provides a fluent interface
      */
     public function addRole($role, $parents = null)
     {
@@ -147,9 +147,9 @@ class Acl
      *
      * The $role parameter can either be a Role or Role identifier.
      *
-     * @param  \Zend\Acl\Role|string $role
-     * @uses   \Zend\Acl\Role\Registry::get()
-     * @return \Zend\Acl\Role
+     * @param  Role|string $role
+     * @uses   Role\Registry::get()
+     * @return Role
      */
     public function getRole($role)
     {
@@ -161,8 +161,8 @@ class Acl
      *
      * The $role parameter can either be a Role or a Role identifier.
      *
-     * @param  \Zend\Acl\Role|string $role
-     * @uses   \Zend\Acl\Role\Registry::has()
+     * @param  Role|string $role
+     * @uses   Role\Registry::has()
      * @return boolean
      */
     public function hasRole($role)
@@ -179,10 +179,10 @@ class Acl
      * through the entire inheritance DAG to determine whether $role
      * inherits from $inherit through its ancestor Roles.
      *
-     * @uses   \Zend\Acl\Role\Registry::inherits()
-     * @param  \Zend\Acl\Role|string $role
-     * @param  \Zend\Acl\Role|string $inherit
-     * @param  boolean              $onlyParents
+     * @uses   Role\Registry::inherits()
+     * @param  Role|string $role
+     * @param  Role|string $inherit
+     * @param  boolean     $onlyParents
      * @return boolean
      */
     public function inheritsRole($role, $inherit, $onlyParents = false)
@@ -195,9 +195,9 @@ class Acl
      *
      * The $role parameter can either be a Role or a Role identifier.
      *
-     * @param  \Zend\Acl\Role|string $role
-     * @uses   \Zend\Acl\Role\Registry::remove()
-     * @return \Zend\Acl\Acl Provides a fluent interface
+     * @param  Role|string $role
+     * @uses   Role\Registry::remove()
+     * @return Acl Provides a fluent interface
      */
     public function removeRole($role)
     {
@@ -230,8 +230,8 @@ class Acl
     /**
      * Removes all Roles from the registry
      *
-     * @uses   \Zend\Acl\Role\Registry::removeAll()
-     * @return \Zend\Acl\Acl Provides a fluent interface
+     * @uses   Role\Registry::removeAll()
+     * @return Acl Provides a fluent interface
      */
     public function removeRoleAll()
     {
@@ -255,10 +255,10 @@ class Acl
      * The $parent parameter may be a reference to, or the string identifier for,
      * the existing Resource from which the newly added Resource will inherit.
      *
-     * @param  \Zend\Acl\Resource|string $resource
-     * @param  \Zend\Acl\Resource|string $parent
-     * @throws \Zend\Acl\Exception\InvalidArgumentException
-     * @return \Zend\Acl\Acl Provides a fluent interface
+     * @param  Resource|string $resource
+     * @param  Resource|string $parent
+     * @throws Exception\InvalidArgumentException
+     * @return Acl Provides a fluent interface
      */
     public function addResource($resource, $parent = null)
     {
@@ -306,9 +306,9 @@ class Acl
      *
      * The $resource parameter can either be a Resource or a Resource identifier.
      *
-     * @param  \Zend\Acl\Resource|string $resource
-     * @throws \Zend\Acl\Exception\InvalidArgumentException
-     * @return \Zend\Acl\Resource
+     * @param  Resource|string $resource
+     * @throws Exception\InvalidArgumentException
+     * @return Resource
      */
     public function getResource($resource)
     {
@@ -330,7 +330,7 @@ class Acl
      *
      * The $resource parameter can either be a Resource or a Resource identifier.
      *
-     * @param  \Zend\Acl\Resource|string $resource
+     * @param  Resource|string $resource
      * @return boolean
      */
     public function hasResource($resource)
@@ -353,10 +353,10 @@ class Acl
      * through the entire inheritance tree to determine whether $resource
      * inherits from $inherit through its ancestor Resources.
      *
-     * @param  \Zend\Acl\Resource|string $resource
-     * @param  \Zend\Acl\Resource|string $inherit
-     * @param  boolean                  $onlyParent
-     * @throws \Zend\Acl\Exception\InvalidArgumentException
+     * @param  Resource|string $resource
+     * @param  Resource|string $inherit
+     * @param  boolean         $onlyParent
+     * @throws Exception\InvalidArgumentException
      * @return boolean
      */
     public function inheritsResource($resource, $inherit, $onlyParent = false)
@@ -394,9 +394,9 @@ class Acl
      *
      * The $resource parameter can either be a Resource or a Resource identifier.
      *
-     * @param  \Zend\Acl\Resource|string $resource
-     * @throws \Zend\Acl\Exception\InvalidArgumentException
-     * @return \Zend\Acl\Acl Provides a fluent interface
+     * @param  Resource|string $resource
+     * @throws Exception\InvalidArgumentException
+     * @return Acl Provides a fluent interface
      */
     public function removeResource($resource)
     {
@@ -431,7 +431,7 @@ class Acl
     /**
      * Removes all Resources
      *
-     * @return \Zend\Acl\Acl Provides a fluent interface
+     * @return Acl Provides a fluent interface
      */
     public function removeResourceAll()
     {
@@ -451,12 +451,12 @@ class Acl
     /**
      * Adds an "allow" rule to the ACL
      *
-     * @uses   Zend\Acl\Acl::setRule()
-     * @param  \Zend\Acl\Role|string|array     $roles
-     * @param  \Zend\Acl\Resource|string|array $resources
-     * @param  string|array                   $privileges
-     * @param  \Zend\Acl\Assertion            $assert
-     * @return \Zend\Acl\Acl Provides a fluent interface
+     * @uses   Acl::setRule()
+     * @param  Role|string|array     $roles
+     * @param  Resource|string|array $resources
+     * @param  string|array          $privileges
+     * @param  Assertion             $assert
+     * @return Acl Provides a fluent interface
      */
     public function allow($roles = null, $resources = null, $privileges = null, Assertion $assert = null)
     {
@@ -466,12 +466,12 @@ class Acl
     /**
      * Adds a "deny" rule to the ACL
      *
-     * @uses   Zend\Acl\Acl::setRule()
-     * @param  \Zend\Acl\Role|string|array     $roles
-     * @param  \Zend\Acl\Resource|string|array $resources
-     * @param  string|array                   $privileges
-     * @param  \Zend\Acl\Assertion             $assert
-     * @return \Zend\Acl\Acl Provides a fluent interface
+     * @uses   Acl::setRule()
+     * @param  Role|string|array     $roles
+     * @param  Resource|string|array $resources
+     * @param  string|array          $privileges
+     * @param  Assertion             $assert
+     * @return Acl Provides a fluent interface
      */
     public function deny($roles = null, $resources = null, $privileges = null, Assertion $assert = null)
     {
@@ -481,11 +481,11 @@ class Acl
     /**
      * Removes "allow" permissions from the ACL
      *
-     * @uses   Zend\Acl\Acl::setRule()
-     * @param  \Zend\Acl\Role|string|array     $roles
-     * @param  \Zend\Acl\Resource|string|array $resources
-     * @param  string|array                   $privileges
-     * @return \Zend\Acl\Acl Provides a fluent interface
+     * @uses   Acl::setRule()
+     * @param  Role|string|array     $roles
+     * @param  Resource|string|array $resources
+     * @param  string|array          $privileges
+     * @return Acl Provides a fluent interface
      */
     public function removeAllow($roles = null, $resources = null, $privileges = null)
     {
@@ -495,11 +495,11 @@ class Acl
     /**
      * Removes "deny" restrictions from the ACL
      *
-     * @uses   Zend\Acl\Acl::setRule()
-     * @param  \Zend\Acl\Role|string|array     $roles
-     * @param  \Zend\Acl\Resource|string|array $resources
-     * @param  string|array                   $privileges
-     * @return \Zend\Acl\Acl Provides a fluent interface
+     * @uses   Acl::setRule()
+     * @param  Role|string|array     $roles
+     * @param  Resource|string|array $resources
+     * @param  string|array          $privileges
+     * @return Acl Provides a fluent interface
      */
     public function removeDeny($roles = null, $resources = null, $privileges = null)
     {
@@ -547,16 +547,16 @@ class Acl
      * when the rule's assertion fails. This is because the ACL needs to provide expected
      * behavior when an assertion upon the default ACL rule fails.
      *
-     * @uses   Zend\Acl\Role\Registry::get()
-     * @uses   Zend\Acl\Acl::get()
-     * @param  string                         $operation
-     * @param  string                         $type
-     * @param  \Zend\Acl\Role|string|array     $roles
-     * @param  \Zend\Acl\Resource|string|array $resources
-     * @param  string|array                   $privileges
-     * @param  \Zend\Acl\Assertion             $assert
-     * @throws Zend\Acl\Exception\InvalidArgumentException
-     * @return \Zend\Acl\Acl Provides a fluent interface
+     * @uses   Role\Registry::get()
+     * @uses   Acl::get()
+     * @param  string                $operation
+     * @param  string                $type
+     * @param  Role|string|array     $roles
+     * @param  Resource|string|array $resources
+     * @param  string|array          $privileges
+     * @param  Assertion             $assert
+     * @throws Exception\InvalidArgumentException
+     * @return Acl Provides a fluent interface
      */
     public function setRule($operation, $type, $roles = null, $resources = null,
         $privileges = null, Assertion $assert = null
@@ -701,11 +701,11 @@ class Acl
      * and its respective parents are checked similarly before the lower-priority parents of
      * the Role are checked.
      *
-     * @uses   Zend\Acl\Acl::get()
-     * @uses   Zend\Acl\Role\Registry::get()
-     * @param  \Zend\Acl\Role|string     $role
-     * @param  \Zend\Acl\Resource|string $resource
-     * @param  string                   $privilege
+     * @uses   Acl::get()
+     * @uses   Role\Registry::get()
+     * @param  Role|string     $role
+     * @param  Resource|string $resource
+     * @param  string          $privilege
      * @return boolean
      */
     public function isAllowed($role = null, $resource = null, $privilege = null)
@@ -786,7 +786,7 @@ class Acl
      * If no Role registry has been created yet, a new default Role registry
      * is created and returned.
      *
-     * @return \Zend\Acl\Role\Registry
+     * @return Role\Registry
      */
     protected function _getRoleRegistry()
     {
@@ -837,11 +837,11 @@ class Acl
      *
      * This method is used by the internal depth-first search algorithm and may modify the DFS data structure.
      *
-     * @param  \Zend\Acl\Role     $role
-     * @param  \Zend\Acl\Resource $resource
-     * @param  array             $dfs
+     * @param  Role     $role
+     * @param  Resource $resource
+     * @param  array    $dfs
      * @return boolean|null
-     * @throws \Zend\Acl\Exception\RuntimeException
+     * @throws Exception\RuntimeException
      */
     protected function _roleDFSVisitAllPrivileges(Role $role, Resource $resource = null, &$dfs = null)
     {
@@ -875,11 +875,11 @@ class Acl
      * This method returns true if a rule is found and allows access. If a rule exists and denies access,
      * then this method returns false. If no applicable rule is found, then this method returns null.
      *
-     * @param  \Zend\Acl\Role     $role
-     * @param  \Zend\Acl\Resource $resource
-     * @param  string            $privilege
+     * @param  Role     $role
+     * @param  Resource $resource
+     * @param  string   $privilege
      * @return boolean|null
-     * @throws Zend\Acl\Exception\RuntimeException
+     * @throws Exception\RuntimeException
      */
     protected function _roleDFSOnePrivilege(Role $role, Resource $resource = null, $privilege = null)
     {
@@ -915,12 +915,12 @@ class Acl
      *
      * This method is used by the internal depth-first search algorithm and may modify the DFS data structure.
      *
-     * @param  \Zend\Acl\Role     $role
-     * @param  \Zend\Acl\Resource $resource
-     * @param  string            $privilege
-     * @param  array             $dfs
+     * @param  Role     $role
+     * @param  Resource $resource
+     * @param  string   $privilege
+     * @param  array    $dfs
      * @return boolean|null
-     * @throws Zend\Acl\Exception\RuntimeException
+     * @throws Exception\RuntimeException
      */
     protected function _roleDFSVisitOnePrivilege(Role $role, Resource $resource = null,
         $privilege = null, &$dfs = null
@@ -969,9 +969,9 @@ class Acl
      * If all three parameters are null, then the default ACL rule type is returned,
      * based on whether its assertion method passes.
      *
-     * @param  null|\Zend\Acl\Resource $resource
-     * @param  null|\Zend\Acl\Role     $role
-     * @param  null|string             $privilege
+     * @param  null|Resource $resource
+     * @param  null|Role     $role
+     * @param  null|string   $privilege
      * @return string|null
      */
     protected function _getRuleType(Resource $resource = null, Role $role = null, $privilege = null)
@@ -1024,9 +1024,9 @@ class Acl
      *
      * If the $create parameter is true, then a rule set is first created and then returned to the caller.
      *
-     * @param  \Zend\Acl\Resource $resource
-     * @param  \Zend\Acl\Role     $role
-     * @param  boolean           $create
+     * @param  Resource $resource
+     * @param  Role     $role
+     * @param  boolean  $create
      * @return array|null
      */
     protected function &_getRules(Resource $resource = null, Role $role = null, $create = false)

--- a/library/Zend/Acl/Acl.php
+++ b/library/Zend/Acl/Acl.php
@@ -61,7 +61,7 @@ class Acl
     /**
      * Role registry
      *
-     * @var Zend\Acl\Role\Registry
+     * @var \Zend\Acl\Role\Registry
      */
     protected $_roleRegistry = null;
 
@@ -73,7 +73,7 @@ class Acl
     protected $_resources = array();
 
     /**
-     * @var Zend\Acl\Role
+     * @var \Zend\Acl\Role
      */
     protected $_isAllowedRole     = null;
 
@@ -120,11 +120,11 @@ class Acl
      * will have the least priority, and the last parent added will have the
      * highest priority.
      *
-     * @param  Zend\Acl\Role              $role
-     * @param  Zend\Acl\Role|string|array $parents
-     * @uses   Zend\Acl\Role\Registry::add()
-     * @throws Zend\Acl\Exception\InvalidArgumentException
-     * @return Zend\Acl\Acl Provides a fluent interface
+     * @param  \Zend\Acl\Role              $role
+     * @param  \Zend\Acl\Role|string|array $parents
+     * @uses   \Zend\Acl\Role\Registry::add()
+     * @throws \Zend\Acl\Exception\InvalidArgumentException
+     * @return \Zend\Acl\Acl Provides a fluent interface
      */
     public function addRole($role, $parents = null)
     {
@@ -147,9 +147,9 @@ class Acl
      *
      * The $role parameter can either be a Role or Role identifier.
      *
-     * @param  Zend\Acl\Role|string $role
-     * @uses   Zend\Acl\Role\Registry::get()
-     * @return Zend\Acl\Role
+     * @param  \Zend\Acl\Role|string $role
+     * @uses   \Zend\Acl\Role\Registry::get()
+     * @return \Zend\Acl\Role
      */
     public function getRole($role)
     {
@@ -161,8 +161,8 @@ class Acl
      *
      * The $role parameter can either be a Role or a Role identifier.
      *
-     * @param  Zend\Acl\Role|string $role
-     * @uses   Zend\Acl\Role\Registry::has()
+     * @param  \Zend\Acl\Role|string $role
+     * @uses   \Zend\Acl\Role\Registry::has()
      * @return boolean
      */
     public function hasRole($role)
@@ -179,9 +179,9 @@ class Acl
      * through the entire inheritance DAG to determine whether $role
      * inherits from $inherit through its ancestor Roles.
      *
-     * @uses   Zend\Acl\Role\Registry::inherits()
-     * @param  Zend\Acl\Role|string $role
-     * @param  Zend\Acl\Role|string $inherit
+     * @uses   \Zend\Acl\Role\Registry::inherits()
+     * @param  \Zend\Acl\Role|string $role
+     * @param  \Zend\Acl\Role|string $inherit
      * @param  boolean              $onlyParents
      * @return boolean
      */
@@ -195,9 +195,9 @@ class Acl
      *
      * The $role parameter can either be a Role or a Role identifier.
      *
-     * @param  Zend\Acl\Role|string $role
-     * @uses   Zend\Acl\Role\Registry::remove()
-     * @return Zend\Acl\Acl Provides a fluent interface
+     * @param  \Zend\Acl\Role|string $role
+     * @uses   \Zend\Acl\Role\Registry::remove()
+     * @return \Zend\Acl\Acl Provides a fluent interface
      */
     public function removeRole($role)
     {
@@ -230,8 +230,8 @@ class Acl
     /**
      * Removes all Roles from the registry
      *
-     * @uses   Zend\Acl\Role\Registry::removeAll()
-     * @return Zend\Acl\Acl Provides a fluent interface
+     * @uses   \Zend\Acl\Role\Registry::removeAll()
+     * @return \Zend\Acl\Acl Provides a fluent interface
      */
     public function removeRoleAll()
     {
@@ -255,10 +255,10 @@ class Acl
      * The $parent parameter may be a reference to, or the string identifier for,
      * the existing Resource from which the newly added Resource will inherit.
      *
-     * @param  Zend\Acl\Resource|string $resource
-     * @param  Zend\Acl\Resource|string $parent
-     * @throws Zend\Acl\Exception\InvalidArgumentException
-     * @return Zend\Acl\Acl Provides a fluent interface
+     * @param  \Zend\Acl\Resource|string $resource
+     * @param  \Zend\Acl\Resource|string $parent
+     * @throws \Zend\Acl\Exception\InvalidArgumentException
+     * @return \Zend\Acl\Acl Provides a fluent interface
      */
     public function addResource($resource, $parent = null)
     {
@@ -306,9 +306,9 @@ class Acl
      *
      * The $resource parameter can either be a Resource or a Resource identifier.
      *
-     * @param  Zend\Acl\Resource|string $resource
-     * @throws Zend\Acl\Exception\InvalidArgumentException
-     * @return Zend\Acl\Resource
+     * @param  \Zend\Acl\Resource|string $resource
+     * @throws \Zend\Acl\Exception\InvalidArgumentException
+     * @return \Zend\Acl\Resource
      */
     public function getResource($resource)
     {
@@ -353,10 +353,10 @@ class Acl
      * through the entire inheritance tree to determine whether $resource
      * inherits from $inherit through its ancestor Resources.
      *
-     * @param  Zend\Acl\Resource|string $resource
-     * @param  Zend\Acl\Resource|string $inherit
+     * @param  \Zend\Acl\Resource|string $resource
+     * @param  \Zend\Acl\Resource|string $inherit
      * @param  boolean                  $onlyParent
-     * @throws Zend\Acl\Exception\InvalidArgumentException
+     * @throws \Zend\Acl\Exception\InvalidArgumentException
      * @return boolean
      */
     public function inheritsResource($resource, $inherit, $onlyParent = false)
@@ -394,9 +394,9 @@ class Acl
      *
      * The $resource parameter can either be a Resource or a Resource identifier.
      *
-     * @param  Zend\Acl\Resource|string $resource
-     * @throws Zend\Acl\Exception\InvalidArgumentException
-     * @return Zend\Acl\Acl Provides a fluent interface
+     * @param  \Zend\Acl\Resource|string $resource
+     * @throws \Zend\Acl\Exception\InvalidArgumentException
+     * @return \Zend\Acl\Acl Provides a fluent interface
      */
     public function removeResource($resource)
     {
@@ -431,7 +431,7 @@ class Acl
     /**
      * Removes all Resources
      *
-     * @return Zend\Acl\Acl Provides a fluent interface
+     * @return \Zend\Acl\Acl Provides a fluent interface
      */
     public function removeResourceAll()
     {
@@ -452,11 +452,11 @@ class Acl
      * Adds an "allow" rule to the ACL
      *
      * @uses   Zend\Acl\Acl::setRule()
-     * @param  Zend\Acl\Role|string|array     $roles
-     * @param  Zend\Acl\Resource|string|array $resources
+     * @param  \Zend\Acl\Role|string|array     $roles
+     * @param  \Zend\Acl\Resource|string|array $resources
      * @param  string|array                   $privileges
-     * @param  Zend\Acl\Assertion            $assert
-     * @return Zend\Acl\Acl Provides a fluent interface
+     * @param  \Zend\Acl\Assertion            $assert
+     * @return \Zend\Acl\Acl Provides a fluent interface
      */
     public function allow($roles = null, $resources = null, $privileges = null, Assertion $assert = null)
     {
@@ -467,11 +467,11 @@ class Acl
      * Adds a "deny" rule to the ACL
      *
      * @uses   Zend\Acl\Acl::setRule()
-     * @param  Zend\Acl\Role|string|array     $roles
-     * @param  Zend\Acl\Resource|string|array $resources
+     * @param  \Zend\Acl\Role|string|array     $roles
+     * @param  \Zend\Acl\Resource|string|array $resources
      * @param  string|array                   $privileges
-     * @param  Zend\Acl\Assertion             $assert
-     * @return Zend\Acl\Acl Provides a fluent interface
+     * @param  \Zend\Acl\Assertion             $assert
+     * @return \Zend\Acl\Acl Provides a fluent interface
      */
     public function deny($roles = null, $resources = null, $privileges = null, Assertion $assert = null)
     {
@@ -482,10 +482,10 @@ class Acl
      * Removes "allow" permissions from the ACL
      *
      * @uses   Zend\Acl\Acl::setRule()
-     * @param  Zend\Acl\Role|string|array     $roles
-     * @param  Zend\Acl\Resource|string|array $resources
+     * @param  \Zend\Acl\Role|string|array     $roles
+     * @param  \Zend\Acl\Resource|string|array $resources
      * @param  string|array                   $privileges
-     * @return Zend\Acl\Acl Provides a fluent interface
+     * @return \Zend\Acl\Acl Provides a fluent interface
      */
     public function removeAllow($roles = null, $resources = null, $privileges = null)
     {
@@ -496,10 +496,10 @@ class Acl
      * Removes "deny" restrictions from the ACL
      *
      * @uses   Zend\Acl\Acl::setRule()
-     * @param  Zend\Acl\Role|string|array     $roles
-     * @param  Zend\Acl\Resource|string|array $resources
+     * @param  \Zend\Acl\Role|string|array     $roles
+     * @param  \Zend\Acl\Resource|string|array $resources
      * @param  string|array                   $privileges
-     * @return Zend\Acl\Acl Provides a fluent interface
+     * @return \Zend\Acl\Acl Provides a fluent interface
      */
     public function removeDeny($roles = null, $resources = null, $privileges = null)
     {
@@ -551,14 +551,14 @@ class Acl
      * @uses   Zend\Acl\Acl::get()
      * @param  string                         $operation
      * @param  string                         $type
-     * @param  Zend\Acl\Role|string|array     $roles
-     * @param  Zend\Acl\Resource|string|array $resources
+     * @param  \Zend\Acl\Role|string|array     $roles
+     * @param  \Zend\Acl\Resource|string|array $resources
      * @param  string|array                   $privileges
-     * @param  Zend\Acl\Assertion             $assert
+     * @param  \Zend\Acl\Assertion             $assert
      * @throws Zend\Acl\Exception\InvalidArgumentException
-     * @return Zend\Acl\Acl Provides a fluent interface
+     * @return \Zend\Acl\Acl Provides a fluent interface
      */
-    public function setRule($operation, $type, $roles = null, $resources = null, 
+    public function setRule($operation, $type, $roles = null, $resources = null,
         $privileges = null, Assertion $assert = null
     ) {
         // ensure that the rule type is valid; normalize input to uppercase
@@ -703,8 +703,8 @@ class Acl
      *
      * @uses   Zend\Acl\Acl::get()
      * @uses   Zend\Acl\Role\Registry::get()
-     * @param  Zend\Acl\Role|string     $role
-     * @param  Zend\Acl\Resource|string $resource
+     * @param  \Zend\Acl\Role|string     $role
+     * @param  \Zend\Acl\Resource|string $resource
      * @param  string                   $privilege
      * @return boolean
      */
@@ -786,7 +786,7 @@ class Acl
      * If no Role registry has been created yet, a new default Role registry
      * is created and returned.
      *
-     * @return Zend\Acl\Role\Registry
+     * @return \Zend\Acl\Role\Registry
      */
     protected function _getRoleRegistry()
     {
@@ -803,8 +803,8 @@ class Acl
      * This method returns true if a rule is found and allows access. If a rule exists and denies access,
      * then this method returns false. If no applicable rule is found, then this method returns null.
      *
-     * @param  Zend\Acl\Role     $role
-     * @param  Zend\Acl\Resource $resource
+     * @param  Role     $role
+     * @param  Resource $resource
      * @return boolean|null
      */
     protected function _roleDFSAllPrivileges(Role $role, Resource $resource = null)
@@ -837,8 +837,8 @@ class Acl
      *
      * This method is used by the internal depth-first search algorithm and may modify the DFS data structure.
      *
-     * @param  Zend\Acl\Role     $role
-     * @param  Zend\Acl\Resource $resource
+     * @param  \Zend\Acl\Role     $role
+     * @param  \Zend\Acl\Resource $resource
      * @param  array             $dfs
      * @return boolean|null
      * @throws \Zend\Acl\Exception\RuntimeException
@@ -875,8 +875,8 @@ class Acl
      * This method returns true if a rule is found and allows access. If a rule exists and denies access,
      * then this method returns false. If no applicable rule is found, then this method returns null.
      *
-     * @param  Zend\Acl\Role     $role
-     * @param  Zend\Acl\Resource $resource
+     * @param  \Zend\Acl\Role     $role
+     * @param  \Zend\Acl\Resource $resource
      * @param  string            $privilege
      * @return boolean|null
      * @throws Zend\Acl\Exception\RuntimeException
@@ -915,14 +915,14 @@ class Acl
      *
      * This method is used by the internal depth-first search algorithm and may modify the DFS data structure.
      *
-     * @param  Zend\Acl\Role     $role
-     * @param  Zend\Acl\Resource $resource
+     * @param  \Zend\Acl\Role     $role
+     * @param  \Zend\Acl\Resource $resource
      * @param  string            $privilege
      * @param  array             $dfs
      * @return boolean|null
      * @throws Zend\Acl\Exception\RuntimeException
      */
-    protected function _roleDFSVisitOnePrivilege(Role $role, Resource $resource = null, 
+    protected function _roleDFSVisitOnePrivilege(Role $role, Resource $resource = null,
         $privilege = null, &$dfs = null
     ) {
         if (null === $privilege) {
@@ -969,9 +969,9 @@ class Acl
      * If all three parameters are null, then the default ACL rule type is returned,
      * based on whether its assertion method passes.
      *
-     * @param  Zend\Acl\Resource $resource
-     * @param  Zend\Acl\Role     $role
-     * @param  string            $privilege
+     * @param  null|\Zend\Acl\Resource $resource
+     * @param  null|\Zend\Acl\Role     $role
+     * @param  null|string             $privilege
      * @return string|null
      */
     protected function _getRuleType(Resource $resource = null, Role $role = null, $privilege = null)
@@ -1024,8 +1024,8 @@ class Acl
      *
      * If the $create parameter is true, then a rule set is first created and then returned to the caller.
      *
-     * @param  Zend\Acl\Resource $resource
-     * @param  Zend\Acl\Role     $role
+     * @param  \Zend\Acl\Resource $resource
+     * @param  \Zend\Acl\Role     $role
      * @param  boolean           $create
      * @return array|null
      */

--- a/library/Zend/Acl/Assertion.php
+++ b/library/Zend/Acl/Assertion.php
@@ -41,10 +41,10 @@ interface Assertion
      * $role, $resource, or $privilege parameters are null, it means that the query applies to all Roles, Resources, or
      * privileges, respectively.
      *
-     * @param  \Zend\Acl\Acl      $acl
-     * @param  \Zend\Acl\Role     $role
-     * @param  \Zend\Acl\Resource $resource
-     * @param  string            $privilege
+     * @param  Acl      $acl
+     * @param  Role     $role
+     * @param  Resource $resource
+     * @param  string   $privilege
      * @return boolean
      */
     public function assert(Acl $acl, Role $role = null, Resource $resource = null, $privilege = null);

--- a/library/Zend/Acl/Assertion.php
+++ b/library/Zend/Acl/Assertion.php
@@ -41,9 +41,9 @@ interface Assertion
      * $role, $resource, or $privilege parameters are null, it means that the query applies to all Roles, Resources, or
      * privileges, respectively.
      *
-     * @param  Zend\Acl\Acl      $acl
-     * @param  Zend\Acl\Role     $role
-     * @param  Zend\Acl\Resource $resource
+     * @param  \Zend\Acl\Acl      $acl
+     * @param  \Zend\Acl\Role     $role
+     * @param  \Zend\Acl\Resource $resource
      * @param  string            $privilege
      * @return boolean
      */

--- a/library/Zend/Acl/Role/Registry.php
+++ b/library/Zend/Acl/Role/Registry.php
@@ -62,7 +62,7 @@ class Registry
      * @param  \Zend\Acl\Role              $role
      * @param  \Zend\Acl\Role|string|array $parents
      * @throws \Zend\Acl\Exception\InvalidArgumentException
-     * @return \Zend\Acl\Role\Registry Provides a fluent interface
+     * @return Registry Provides a fluent interface
      */
     public function add(Role $role, $parents = null)
     {
@@ -213,7 +213,7 @@ class Registry
      *
      * @param  \Zend\Acl\Role|string $role
      * @throws \Zend\Acl\Exception\InvalidArgumentException
-     * @return \Zend\Acl\Role\Registry Provides a fluent interface
+     * @return Registry Provides a fluent interface
      */
     public function remove($role)
     {
@@ -238,7 +238,7 @@ class Registry
     /**
      * Removes all Roles from the registry
      *
-     * @return \Zend\Acl\Role\Registry Provides a fluent interface
+     * @return Registry Provides a fluent interface
      */
     public function removeAll()
     {

--- a/library/Zend/Acl/Role/Registry.php
+++ b/library/Zend/Acl/Role/Registry.php
@@ -59,10 +59,10 @@ class Registry
      * will have the least priority, and the last parent added will have the
      * highest priority.
      *
-     * @param  Zend\Acl\Role              $role
-     * @param  Zend\Acl\Role|string|array $parents
-     * @throws Zend\Acl\Exception\InvalidArgumentException
-     * @return Zend\Acl\Role\Registry Provides a fluent interface
+     * @param  \Zend\Acl\Role              $role
+     * @param  \Zend\Acl\Role|string|array $parents
+     * @throws \Zend\Acl\Exception\InvalidArgumentException
+     * @return \Zend\Acl\Role\Registry Provides a fluent interface
      */
     public function add(Role $role, $parents = null)
     {
@@ -108,9 +108,9 @@ class Registry
      *
      * The $role parameter can either be a Role or a Role identifier.
      *
-     * @param  Zend\Acl\Role|string $role
-     * @throws Zend\Acl\Exception\InvalidArgumentException
-     * @return Zend\Acl\Role
+     * @param  \Zend\Acl\Role|string $role
+     * @throws \Zend\Acl\Exception\InvalidArgumentException
+     * @return \Zend\Acl\Role
      */
     public function get($role)
     {
@@ -132,7 +132,7 @@ class Registry
      *
      * The $role parameter can either be a Role or a Role identifier.
      *
-     * @param  Zend\Acl\Role|string $role
+     * @param  \Zend\Acl\Role|string $role
      * @return boolean
      */
     public function has($role)
@@ -157,7 +157,7 @@ class Registry
      * If the Role does not have any parents, then an empty array is returned.
      *
      * @uses   Zend\Acl\Role\Registry::get()
-     * @param  Zend\Acl\Role|string $role
+     * @param  \Zend\Acl\Role|string $role
      * @return array
      */
     public function getParents($role)
@@ -176,10 +176,10 @@ class Registry
      * through the entire inheritance DAG to determine whether $role
      * inherits from $inherit through its ancestor Roles.
      *
-     * @param  Zend\Acl\Role|string $role
-     * @param  Zend\Acl\Role|string $inherit
+     * @param  \Zend\Acl\Role|string $role
+     * @param  \Zend\Acl\Role|string $inherit
      * @param  boolean                        $onlyParents
-     * @throws Zend\Acl\Exception\InvalidArgumentException
+     * @throws \Zend\Acl\Exception\InvalidArgumentException
      * @return boolean
      */
     public function inherits($role, $inherit, $onlyParents = false)
@@ -211,9 +211,9 @@ class Registry
      *
      * The $role parameter can either be a Role or a Role identifier.
      *
-     * @param  Zend\Acl\Role|string $role
-     * @throws Zend\Acl\Exception\InvalidArgumentException
-     * @return Zend\Acl\Role\Registry Provides a fluent interface
+     * @param  \Zend\Acl\Role|string $role
+     * @throws \Zend\Acl\Exception\InvalidArgumentException
+     * @return \Zend\Acl\Role\Registry Provides a fluent interface
      */
     public function remove($role)
     {
@@ -238,7 +238,7 @@ class Registry
     /**
      * Removes all Roles from the registry
      *
-     * @return Zend\Acl\Role\Registry Provides a fluent interface
+     * @return \Zend\Acl\Role\Registry Provides a fluent interface
      */
     public function removeAll()
     {

--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -104,8 +104,8 @@ class Application implements AppContext
 
     /**
      * Set the MVC event instance
-     * 
-     * @param  MvcEvent $event 
+     *
+     * @param  MvcEvent $event
      * @return Application
      */
     public function setMvcEvent(MvcEvent $event)
@@ -165,7 +165,7 @@ class Application implements AppContext
 
     /**
      * Get the MVC event instance
-     * 
+     *
      * @return MvcEvent
      */
     public function getMvcEvent()
@@ -229,13 +229,13 @@ class Application implements AppContext
             }
             return false;
         };
-        
+
         // Trigger route event
-        $result = $events->trigger('route', $event, $shortCircuit);
+        $result = $events->trigger(MvcEvent::EVENT_ROUTE, $event, $shortCircuit);
         if ($result->stopped()) {
             $response = $result->last();
             if ($response instanceof Response) {
-                $events->trigger('finish', $event);
+                $events->trigger(MvcEvent::EVENT_FINISH, $event);
                 return $response;
             }
             if ($event->getError()) {
@@ -248,12 +248,12 @@ class Application implements AppContext
         }
 
         // Trigger dispatch event
-        $result = $events->trigger('dispatch', $event, $shortCircuit);
+        $result = $events->trigger(MvcEvent::EVENT_DISPATCH, $event, $shortCircuit);
 
         // Complete response
         $response = $result->last();
         if ($response instanceof Response) {
-            $events->trigger('finish', $event);
+            $events->trigger(MvcEvent::EVENT_FINISH, $event);
             return $response;
         }
 
@@ -268,15 +268,15 @@ class Application implements AppContext
      *
      * Triggers "render" and "finish" events, and returns response from
      * event object.
-     * 
-     * @param  MvcEvent $event 
+     *
+     * @param  MvcEvent $event
      * @return Response
      */
     protected function completeRequest(MvcEvent $event)
     {
         $events = $this->events();
-        $events->trigger('render', $event);
-        $events->trigger('finish', $event);
+        $events->trigger(MvcEvent::EVENT_RENDER, $event);
+        $events->trigger(MvcEvent::EVENT_FINISH, $event);
         return $event->getResponse();
     }
 
@@ -296,7 +296,7 @@ class Application implements AppContext
         if (!$routeMatch instanceof Router\RouteMatch) {
             $e->setError(static::ERROR_CONTROLLER_NOT_FOUND);
 
-            $results = $this->events()->trigger('dispatch.error', $e);
+            $results = $this->events()->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $e);
             if (count($results)) {
                 $return  = $results->last();
             } else {
@@ -336,7 +336,7 @@ class Application implements AppContext
                   ->setController($controllerName)
                   ->setParam('exception', $exception);
 
-            $results = $events->trigger('dispatch.error', $error);
+            $results = $events->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $error);
             if (count($results)) {
                 $return  = $results->last();
             } else {
@@ -355,7 +355,7 @@ class Application implements AppContext
                   ->setController($controllerName)
                   ->setControllerClass(get_class($controller));
 
-            $results = $events->trigger('dispatch.error', $error);
+            $results = $events->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $error);
             if (count($results)) {
                 $return  = $results->last();
             } else {
@@ -379,7 +379,7 @@ class Application implements AppContext
                   ->setController($controllerName)
                   ->setControllerClass(get_class($controller))
                   ->setParam('exception', $ex);
-            $results = $events->trigger('dispatch.error', $error);
+            $results = $events->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $error);
             if (count($results)) {
                 $return  = $results->last();
             } else {
@@ -407,7 +407,7 @@ class Application implements AppContext
     protected function attachDefaultListeners()
     {
         $events = $this->events();
-        $events->attach('route', array($this, 'route'));
-        $events->attach('dispatch', array($this, 'dispatch'));
+        $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'route'));
+        $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'dispatch'));
     }
 }

--- a/library/Zend/Mvc/Bootstrap.php
+++ b/library/Zend/Mvc/Bootstrap.php
@@ -24,18 +24,18 @@ class Bootstrap implements Bootstrapper
     /**
      * Constructor
      *
-     * @param Config $config 
+     * @param Config $config
      * @return void
      */
     public function __construct(Config $config)
     {
-        $this->config = $config; 
+        $this->config = $config;
     }
 
     /**
      * Set the event manager to use with this object
-     * 
-     * @param  Events $events 
+     *
+     * @param  Events $events
      * @return void
      */
     public function setEventManager(Events $events)
@@ -49,7 +49,7 @@ class Bootstrap implements Bootstrapper
      * If none is initialized, an EventManager instance will be created with
      * the contexts of this class, the current class name (if extending this
      * class), and "bootstrap".
-     * 
+     *
      * @return Events
      */
     public function events()
@@ -69,12 +69,12 @@ class Bootstrap implements Bootstrapper
      *
      * - Initializes the locator, and injects it in the application
      * - Initializes the router, and injects it in the application
-     * - Triggers the "bootstrap" event, passing in the application and modules 
+     * - Triggers the "bootstrap" event, passing in the application and modules
      *   as parameters. This allows module classes to perform arbitrary
-     *   initialization tasks after bootstrapping but before running the 
+     *   initialization tasks after bootstrapping but before running the
      *   application.
-     * 
-     * @param Application $application 
+     *
+     * @param Application $application
      * @return void
      */
     public function bootstrap(AppContext $application)
@@ -88,8 +88,8 @@ class Bootstrap implements Bootstrapper
 
     /**
      * Sets up the locator based on the configuration provided
-     * 
-     * @param  AppContext $application 
+     *
+     * @param  AppContext $application
      * @return void
      */
     protected function setupLocator(AppContext $application)
@@ -228,8 +228,8 @@ class Bootstrap implements Bootstrapper
 
     /**
      * Sets up the router based on the configuration provided
-     * 
-     * @param  Application $application 
+     *
+     * @param  Application $application
      * @return void
      */
     protected function setupRouter(AppContext $application)
@@ -241,11 +241,11 @@ class Bootstrap implements Bootstrapper
     /**
      * Sets up the view integration
      *
-     * Pulls the View object and PhpRenderer strategy from the locator, and 
-     * attaches the former to the latter. Then attaches the 
+     * Pulls the View object and PhpRenderer strategy from the locator, and
+     * attaches the former to the latter. Then attaches the
      * DefaultRenderingStrategy to the application event manager.
-     * 
-     * @param  Application $application 
+     *
+     * @param  Application $application
      * @return void
      */
     protected function setupView($application)
@@ -270,11 +270,11 @@ class Bootstrap implements Bootstrapper
         $createViewModelListener = $locator->get('Zend\Mvc\View\CreateViewModelListener');
         $injectTemplateListener  = $locator->get('Zend\Mvc\View\InjectTemplateListener');
         $injectViewModelListener = $locator->get('Zend\Mvc\View\InjectViewModelListener');
-        $staticEvents->attach('Zend\Stdlib\Dispatchable', 'dispatch', array($createViewModelListener, 'createViewModelFromArray'), -80);
-        $staticEvents->attach('Zend\Stdlib\Dispatchable', 'dispatch', array($createViewModelListener, 'createViewModelFromNull'), -80);
-        $staticEvents->attach('Zend\Stdlib\Dispatchable', 'dispatch', array($injectTemplateListener, 'injectTemplate'), -90);
-        $events->attach('dispatch.error', array($injectViewModelListener, 'injectViewModel'), -100);
-        $staticEvents->attach('Zend\Stdlib\Dispatchable', 'dispatch', array($injectViewModelListener, 'injectViewModel'), -100);
+        $staticEvents->attach('Zend\Stdlib\Dispatchable', MvcEvent::EVENT_DISPATCH, array($createViewModelListener, 'createViewModelFromArray'), -80);
+        $staticEvents->attach('Zend\Stdlib\Dispatchable', MvcEvent::EVENT_DISPATCH, array($createViewModelListener, 'createViewModelFromNull'), -80);
+        $staticEvents->attach('Zend\Stdlib\Dispatchable', MvcEvent::EVENT_DISPATCH, array($injectTemplateListener, 'injectTemplate'), -90);
+        $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($injectViewModelListener, 'injectViewModel'), -100);
+        $staticEvents->attach('Zend\Stdlib\Dispatchable', MvcEvent::EVENT_DISPATCH, array($injectViewModelListener, 'injectViewModel'), -100);
 
         // Inject MVC Event with view model
         $mvcEvent  = $application->getMvcEvent();
@@ -292,8 +292,8 @@ class Bootstrap implements Bootstrapper
      *
      * Triggers with the keys "application" and "config", the latter pointing
      * to the Module Manager attached to the bootstrap.
-     * 
-     * @param  AppContext $application 
+     *
+     * @param  AppContext $application
      * @return void
      */
     protected function setupEvents(AppContext $application)
@@ -302,6 +302,6 @@ class Bootstrap implements Bootstrapper
             'application' => $application,
             'config'      => $this->config,
         );
-        $this->events()->trigger('bootstrap', $this, $params);
+        $this->events()->trigger(MvcEvent::EVENT_BOOTSTRAP, $this, $params);
     }
 }

--- a/library/Zend/Mvc/Controller/ActionController.php
+++ b/library/Zend/Mvc/Controller/ActionController.php
@@ -84,7 +84,7 @@ abstract class ActionController implements Dispatchable, InjectApplicationEvent,
           ->setResponse($response)
           ->setTarget($this);
 
-        $result = $this->events()->trigger('dispatch', $e, function($test) {
+        $result = $this->events()->trigger(MvcEvent::EVENT_DISPATCH, $e, function($test) {
             return ($test instanceof Response);
         });
 
@@ -282,9 +282,9 @@ abstract class ActionController implements Dispatchable, InjectApplicationEvent,
      *
      * If the plugin is a functor, call it, passing the parameters provided.
      * Otherwise, return the plugin instance.
-     * 
-     * @param  string $method 
-     * @param  array $params 
+     *
+     * @param  string $method
+     * @param  array $params
      * @return mixed
      */
     public function __call($method, array $params)
@@ -304,7 +304,7 @@ abstract class ActionController implements Dispatchable, InjectApplicationEvent,
     protected function attachDefaultListeners()
     {
         $events = $this->events();
-        $events->attach('dispatch', array($this, 'execute'));
+        $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'execute'));
     }
 
     /**

--- a/library/Zend/Mvc/Controller/RestfulController.php
+++ b/library/Zend/Mvc/Controller/RestfulController.php
@@ -108,7 +108,7 @@ abstract class RestfulController implements Dispatchable, InjectApplicationEvent
           ->setResponse($response)
           ->setTarget($this);
 
-        $result = $this->events()->trigger('dispatch', $e, function($test) {
+        $result = $this->events()->trigger(MvcEvent::EVENT_DISPATCH, $e, function($test) {
             return ($test instanceof Response);
         });
         if ($result->stopped()) {
@@ -346,9 +346,9 @@ abstract class RestfulController implements Dispatchable, InjectApplicationEvent
      *
      * If the plugin is a functor, call it, passing the parameters provided.
      * Otherwise, return the plugin instance.
-     * 
-     * @param  string $method 
-     * @param  array $params 
+     *
+     * @param  string $method
+     * @param  array $params
      * @return mixed
      */
     public function __call($method, $params)
@@ -368,7 +368,7 @@ abstract class RestfulController implements Dispatchable, InjectApplicationEvent
     protected function attachDefaultListeners()
     {
         $events = $this->events();
-        $events->attach('dispatch', array($this, 'execute'));
+        $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'execute'));
     }
 
     /**

--- a/library/Zend/Mvc/MvcEvent.php
+++ b/library/Zend/Mvc/MvcEvent.php
@@ -9,6 +9,19 @@ use Zend\EventManager\Event,
 
 class MvcEvent extends Event
 {
+    /**#@+
+     * Mvc events triggered by eventmanager
+     */
+    const EVENT_BOOTSTRAP      = 'bootstrap';
+    const EVENT_DISPATCH       = 'dispatch';
+    const EVENT_DISPATCH_ERROR = 'dispatch.error';
+    const EVENT_FINISH         = 'finish';
+    const EVENT_RENDER         = 'render';
+    const EVENT_RENDERER       = 'renderer';
+    const EVENT_RESPONSE       = 'response';
+    const EVENT_ROUTE          = 'route';
+    /**#@-*/
+
     protected $request;
     protected $response;
     protected $result;
@@ -75,7 +88,7 @@ class MvcEvent extends Event
         $this->viewModel = $viewModel;
         return $this;
     }
-    
+
     /**
      * Get value for viewModel
      *

--- a/library/Zend/Mvc/Router/Http/Hostname.php
+++ b/library/Zend/Mvc/Router/Http/Hostname.php
@@ -49,32 +49,31 @@ class Hostname implements Route
 
     /**
      * Constraints for parameters.
-     * 
+     *
      * @var array
      */
     protected $constraints;
-    
+
     /**
      * Default values.
      *
      * @var array
      */
     protected $defaults;
-    
+
     /**
      * List of assembled parameters.
-     * 
+     *
      * @var array
      */
     protected $assembledParams = array();
 
     /**
      * Create a new hostname route.
-     * 
+     *
      * @param  string $route
      * @param  array  $constraints
-     * @param  array  $defaults 
-     * @return void
+     * @param  array  $defaults
      */
     public function __construct($route, array $constraints = array(), array $defaults = array())
     {
@@ -82,13 +81,14 @@ class Hostname implements Route
         $this->constraints = $constraints;
         $this->defaults    = $defaults;
     }
-    
+
     /**
      * factory(): defined by Route interface.
      *
      * @see    Route::factory()
-     * @param  array|Traversable $options
-     * @return void
+     * @param  array|\Traversable $options
+     * @throws \Zend\Mvc\Router\Exception\InvalidArgumentException
+     * @return Hostname
      */
     public static function factory($options = array())
     {
@@ -105,7 +105,7 @@ class Hostname implements Route
         if (!isset($options['constraints'])) {
             $options['constraints'] = array();
         }
-        
+
         if (!isset($options['defaults'])) {
             $options['defaults'] = array();
         }
@@ -133,19 +133,19 @@ class Hostname implements Route
         if (count($hostname) !== count($this->route)) {
             return null;
         }
-        
+
         foreach ($this->route as $index => $routePart) {
             if (preg_match('(^:(?<name>.+)$)', $routePart, $matches)) {
                 if (isset($this->constraints[$matches['name']]) && !preg_match('(^' . $this->constraints[$matches['name']] . '$)', $hostname[$index])) {
                     return null;
                 }
-                
+
                 $params[$matches['name']] = $hostname[$index];
             } elseif ($hostname[$index] !== $routePart) {
                 return null;
             }
         }
-        
+
         return new RouteMatch(array_merge($this->defaults, $params));
     }
 
@@ -161,34 +161,34 @@ class Hostname implements Route
     {
         $mergedParams          = array_merge($this->defaults, $params);
         $this->assembledParams = array();
-        
+
         if (isset($options['uri'])) {
             $parts = array();
-            
+
             foreach ($this->route as $index => $routePart) {
                 if (preg_match('(^:(?<name>.+)$)', $routePart, $matches)) {
                     if (!isset($mergedParams[$matches['name']])) {
                         throw new Exception\InvalidArgumentException(sprintf('Missing parameter "%s"', $matches['name']));
                     }
-                    
+
                     $parts[] = $mergedParams[$matches['name']];
-                    
+
                     $this->assembledParams[] = $matches['name'];
                 } else {
                     $parts[] = $routePart;
                 }
             }
-            
+
             $options['uri']->setHost(implode('.', $parts));
         }
-        
+
         // A hostname does not contribute to the path, thus nothing is returned.
         return '';
     }
-    
+
     /**
      * getAssembledParams(): defined by Route interface.
-     * 
+     *
      * @see    Route::getAssembledParams
      * @return array
      */

--- a/library/Zend/Mvc/Router/Http/Literal.php
+++ b/library/Zend/Mvc/Router/Http/Literal.php
@@ -56,23 +56,23 @@ class Literal implements Route
 
     /**
      * Create a new literal route.
-     * 
+     *
      * @param  string $route
-     * @param  array  $defaults 
-     * @return void
+     * @param  array  $defaults
      */
     public function __construct($route, array $defaults = array())
     {
         $this->route    = $route;
         $this->defaults = $defaults;
     }
-    
+
     /**
      * factory(): defined by Route interface.
      *
      * @see    Route::factory()
-     * @param  array|Traversable $options
-     * @return void
+     * @param  array|\Traversable $options
+     * @throws \Zend\Mvc\Router\Exception\InvalidArgumentException
+     * @return Literal
      */
     public static function factory($options = array())
     {
@@ -97,8 +97,9 @@ class Literal implements Route
      * match(): defined by Route interface.
      *
      * @see    Route::match()
-     * @param  Request $request
-     * @return RouteMatch
+     * @param  Request  $request
+     * @param  int|null $pathOffset
+     * @return RouteMatch|null
      */
     public function match(Request $request, $pathOffset = null)
     {
@@ -115,7 +116,7 @@ class Literal implements Route
                     return new RouteMatch($this->defaults, strlen($this->route));
                 }
             }
-            
+
             return null;
         }
 
@@ -138,10 +139,10 @@ class Literal implements Route
     {
         return $this->route;
     }
-    
+
     /**
      * getAssembledParams(): defined by Route interface.
-     * 
+     *
      * @see    Route::getAssembledParams
      * @return array
      */

--- a/library/Zend/Mvc/Router/Http/Part.php
+++ b/library/Zend/Mvc/Router/Http/Part.php
@@ -69,8 +69,7 @@ class Part extends TreeRouteStack implements Route
      * @param  mixed       $route
      * @param  boolean     $mayTerminate
      * @param  RouteBroker $routeBroker
-     * @param  array       $childRoutes
-     * @return void
+     * @param  array|null  $childRoutes
      */
     public function __construct($route, $mayTerminate, RouteBroker $routeBroker, array $childRoutes = null)
     {
@@ -95,7 +94,8 @@ class Part extends TreeRouteStack implements Route
      *
      * @see    Route::factory()
      * @param  mixed $options
-     * @return void
+     * @throws \Zend\Mvc\Router\Exception\InvalidArgumentException
+     * @return Part
      */
     public static function factory($options = array())
     {
@@ -131,7 +131,8 @@ class Part extends TreeRouteStack implements Route
      * match(): defined by Route interface.
      *
      * @see    Route::match()
-     * @param  Request $request
+     * @param  Request  $request
+     * @param  int|null $pathOffset
      * @return RouteMatch|null
      */
     public function match(Request $request, $pathOffset = null)

--- a/library/Zend/Mvc/Router/Http/Query.php
+++ b/library/Zend/Mvc/Router/Http/Query.php
@@ -42,38 +42,38 @@ use Traversable,
  */
 class Query implements Route
 {
-    
+
     /**
      * Default values.
-     * 
+     *
      * @var array
      */
     protected $defaults;
-    
+
     /**
      * List of assembled parameters.
-     * 
+     *
      * @var array
      */
     protected $assembledParams = array();
 
     /**
      * Create a new wildcard route.
-     * 
-     * @param  array  $defaults
-     * @return void
+     *
+     * @param array $defaults
      */
     public function __construct(array $defaults = array())
     {
         $this->defaults = $defaults;
     }
-    
+
     /**
      * factory(): defined by Route interface.
      *
      * @see    Route::factory()
-     * @param  array|Traversable $options
-     * @return void
+     * @param  array|\Traversable $options
+     * @throws \Zend\Mvc\Router\Exception\InvalidArgumentException
+     * @return Query
      */
     public static function factory($options = array())
     {
@@ -83,7 +83,7 @@ class Query implements Route
             throw new Exception\InvalidArgumentException(__METHOD__ . ' expects an array or Traversable set of options');
         }
 
-        
+
         if (!isset($options['defaults'])) {
             $options['defaults'] = array();
         }
@@ -96,15 +96,16 @@ class Query implements Route
      *
      * @see    Route::match()
      * @param  Request $request
+     * @param  int|null $pathOffset
      * @return RouteMatch
      */
     public function match(Request $request, $pathOffset = null)
     {
         $matches = array();
-        
+
         foreach($_GET as $key=>$value) {
             $matches[urldecode($key)] = urldecode($value);
-            
+
         }
 
         return new RouteMatch(array_merge($this->defaults, $matches));
@@ -126,16 +127,16 @@ class Query implements Route
             foreach ($mergedParams as $key => $value) {
                 $this->assembledParams[] = $key;
             }
-            
+
             return '?' . str_replace('+', '%20', http_build_query($mergedParams));
         }
-        
+
         return null;
     }
-    
+
     /**
      * getAssembledParams(): defined by Route interface.
-     * 
+     *
      * @see    Route::getAssembledParams
      * @return array
      */

--- a/library/Zend/Mvc/Router/Http/Regex.php
+++ b/library/Zend/Mvc/Router/Http/Regex.php
@@ -42,7 +42,7 @@ class Regex implements Route
 {
     /**
      * Regex to match.
-     * 
+     *
      * @var string
      */
     protected $regex;
@@ -58,24 +58,24 @@ class Regex implements Route
      * Specification for URL assembly.
      *
      * Parameters accepting subsitutions should be denoted as "%key%"
-     * 
+     *
      * @var string
      */
     protected $spec;
-    
+
     /**
      * List of assembled parameters.
-     * 
+     *
      * @var array
      */
     protected $assembledParams = array();
-    
+
     /**
      * Create a new regex route.
-     * 
+     *
      * @param  string $regex
      * @param  string $spec
-     * @param  array  $defaults 
+     * @param  array  $defaults
      * @return void
      */
     public function __construct($regex, $spec, array $defaults = array())
@@ -84,12 +84,13 @@ class Regex implements Route
         $this->spec     = $spec;
         $this->defaults = $defaults;
     }
-    
+
     /**
      * factory(): defined by Route interface.
      *
      * @see    Route::factory()
-     * @param  array|Traversable $options
+     * @param  array|\Traversable $options
+     * @throws \Zend\Mvc\Router\Exception\InvalidArgumentException
      * @return void
      */
     public static function factory($options = array())
@@ -103,7 +104,7 @@ class Regex implements Route
         if (!isset($options['regex'])) {
             throw new Exception\InvalidArgumentException('Missing "regex" in options array');
         }
-        
+
         if (!isset($options['spec'])) {
             throw new Exception\InvalidArgumentException('Missing "spec" in options array');
         }
@@ -140,7 +141,7 @@ class Regex implements Route
         if (!$result) {
             return null;
         }
-        
+
         $matchedLength = strlen($matches[0]);
 
         foreach ($matches as $key => $value) {
@@ -167,23 +168,23 @@ class Regex implements Route
         $url                   = $this->spec;
         $mergedParams          = array_merge($this->defaults, $params);
         $this->assembledParams = array();
-        
+
         foreach ($mergedParams as $key => $value) {
             $spec = '%' . $key . '%';
-            
+
             if (strpos($url, $spec) !== false) {
                 $url = str_replace($spec, urlencode($value), $url);
-                
+
                 $this->assembledParams[] = $key;
             }
         }
-        
+
         return $url;
     }
-    
+
     /**
      * getAssembledParams(): defined by Route interface.
-     * 
+     *
      * @see    Route::getAssembledParams
      * @return array
      */

--- a/library/Zend/Mvc/Router/Http/RouteMatch.php
+++ b/library/Zend/Mvc/Router/Http/RouteMatch.php
@@ -38,28 +38,27 @@ class RouteMatch extends BaseRouteMatch
 {
     /**
      * Length of the matched path.
-     * 
+     *
      * @var integer
      */
     protected $length;
-    
+
     /**
      * Create a part RouteMatch with given parameters and length.
-     * 
+     *
      * @param  array   $params
      * @param  integer $length
-     * @return void
      */
     public function __construct(array $params, $length = 0)
     {
         parent::__construct($params);
-        
+
         $this->length = $length;
     }
-    
+
     /**
      * setMatchedRouteName(): defined by BaseRouteMatch.
-     * 
+     *
      * @see    BaseRouteMatch::setMatchedRouteName()
      * @param  string $name
      * @return self
@@ -71,13 +70,13 @@ class RouteMatch extends BaseRouteMatch
         } else {
             $this->matchedRouteName = $name . '/' . $this->matchedRouteName;
         }
-        
+
         return $this;
     }
-    
+
     /**
      * Merge parameters from another match.
-     * 
+     *
      * @param  self $match
      * @return self
      */
@@ -85,15 +84,15 @@ class RouteMatch extends BaseRouteMatch
     {
         $this->params  = array_merge($this->params, $match->getParams());
         $this->length += $match->getLength();
-        
+
         $this->matchedRouteName = $match->getMatchedRouteName();
-        
+
         return $this;
     }
 
     /**
      * Get the matched path length.
-     * 
+     *
      * @return integer
      */
     public function getLength()

--- a/library/Zend/Mvc/Router/Http/Scheme.php
+++ b/library/Zend/Mvc/Router/Http/Scheme.php
@@ -46,7 +46,7 @@ class Scheme implements Route
      * @var array
      */
     protected $scheme;
-    
+
     /**
      * Default values.
      *
@@ -56,23 +56,23 @@ class Scheme implements Route
 
     /**
      * Create a new scheme route.
-     * 
+     *
      * @param  string $scheme
-     * @param  array  $defaults 
-     * @return void
+     * @param  array  $defaults
      */
     public function __construct($scheme, array $defaults = array())
     {
         $this->scheme   = $scheme;
         $this->defaults = $defaults;
     }
-    
+
     /**
      * factory(): defined by Route interface.
      *
      * @see    Route::factory()
-     * @param  array|Traversable $options
-     * @return void
+     * @param  array|\Traversable $options
+     * @throws \Zend\Mvc\Router\Exception\InvalidArgumentException
+     * @return Scheme
      */
     public static function factory($options = array())
     {
@@ -85,7 +85,7 @@ class Scheme implements Route
         if (!isset($options['scheme'])) {
             throw new Exception\InvalidArgumentException('Missing "scheme" in options array');
         }
-        
+
         if (!isset($options['defaults'])) {
             $options['defaults'] = array();
         }
@@ -112,7 +112,7 @@ class Scheme implements Route
         if ($scheme !== $this->scheme) {
             return null;
         }
-        
+
         return new RouteMatch($this->defaults);
     }
 
@@ -129,14 +129,14 @@ class Scheme implements Route
         if (isset($options['uri'])) {
             $options['uri']->setScheme($this->scheme);
         }
-        
+
         // A scheme does not contribute to the path, thus nothing is returned.
         return '';
     }
-    
+
     /**
      * getAssembledParams(): defined by Route interface.
-     * 
+     *
      * @see    Route::getAssembledParams
      * @return array
      */

--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -53,10 +53,10 @@ class Segment implements Route
      * @var string
      */
     protected $regex;
-    
+
     /**
      * Map from regex groups to parameter names.
-     * 
+     *
      * @var array
      */
     protected $paramMap = array();
@@ -95,7 +95,8 @@ class Segment implements Route
      *
      * @see    Route::factory()
      * @param  array|Traversable $options
-     * @return void
+     * @throws \Zend\Mvc\Router\Exception\InvalidArgumentException
+     * @return Segment
      */
     public static function factory($options = array())
     {
@@ -217,7 +218,7 @@ class Segment implements Route
                     } else {
                         $regex .= '([^' . $part[2] . ']+)';
                     }
-                    
+
                     $this->paramMap[$groupIndex++] = $part[1];
                     break;
 

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -99,7 +99,7 @@ class TreeRouteStack extends SimpleRouteStack
      * routeFromArray(): defined by SimpleRouteStack.
      *
      * @see    SimpleRouteStack::routeFromArray()
-     * @param  array|Traversable $specs
+     * @param  array|\Traversable $specs
      * @return Route
      */
     protected function routeFromArray($specs)
@@ -125,7 +125,7 @@ class TreeRouteStack extends SimpleRouteStack
             );
 
             $priority = (isset($route->priority) ? $route->priority : null);
-            
+
             $route = $this->routeBroker->load('part', $options);
             $route->priority = $priority;
         }
@@ -270,7 +270,7 @@ class TreeRouteStack extends SimpleRouteStack
      * Set the request URI.
      *
      * @param  HttpUri $uri
-     * @return self
+     * @return TreeRouteStack
      */
     public function setRequestUri(HttpUri $uri)
     {

--- a/library/Zend/Mvc/Router/Http/Wildcard.php
+++ b/library/Zend/Mvc/Router/Http/Wildcard.php
@@ -53,28 +53,27 @@ class Wildcard implements Route
      * @var array
      */
     protected $paramDelimiter;
-    
+
     /**
      * Default values.
-     * 
+     *
      * @var array
      */
     protected $defaults;
-    
+
     /**
      * List of assembled parameters.
-     * 
+     *
      * @var array
      */
     protected $assembledParams = array();
 
     /**
      * Create a new wildcard route.
-     * 
+     *
      * @param  string $keyValueDelimiter
      * @param  string $paramDelimiter
      * @param  array  $defaults
-     * @return void
      */
     public function __construct($keyValueDelimiter = '/', $paramDelimiter = '/', array $defaults = array())
     {
@@ -82,13 +81,14 @@ class Wildcard implements Route
         $this->paramDelimiter    = $paramDelimiter;
         $this->defaults          = $defaults;
     }
-    
+
     /**
      * factory(): defined by Route interface.
      *
      * @see    Route::factory()
      * @param  array|Traversable $options
-     * @return void
+     * @throws \Zend\Mvc\Router\Exception\InvalidArgumentException
+     * @return Wildcard
      */
     public static function factory($options = array())
     {
@@ -105,7 +105,7 @@ class Wildcard implements Route
         if (!isset($options['param_delimiter'])) {
             $options['param_delimiter'] = '/';
         }
-        
+
         if (!isset($options['defaults'])) {
             $options['defaults'] = array();
         }
@@ -118,6 +118,7 @@ class Wildcard implements Route
      *
      * @see    Route::match()
      * @param  Request $request
+     * @param  int|null $pathOffset
      * @return RouteMatch
      */
     public function match(Request $request, $pathOffset = null)
@@ -139,7 +140,7 @@ class Wildcard implements Route
         if (count($params) > 1 && ($params[0] !== '' || end($params) === '')) {
             return null;
         }
-        
+
         if ($this->keyValueDelimiter === $this->paramDelimiter) {
             $count = count($params);
 
@@ -150,10 +151,10 @@ class Wildcard implements Route
             }
         } else {
             array_shift($params);
-            
+
             foreach ($params as $param) {
                 $param = explode($this->keyValueDelimiter, $param, 2);
-      
+
                 if (isset($param[1])) {
                     $matches[urldecode($param[0])] = urldecode($param[1]);
                 }
@@ -186,13 +187,13 @@ class Wildcard implements Route
 
             return $this->paramDelimiter . implode($this->paramDelimiter, $elements);
         }
-        
+
         return '';
     }
-    
+
     /**
      * getAssembledParams(): defined by Route interface.
-     * 
+     *
      * @see    Route::getAssembledParams
      * @return array
      */

--- a/library/Zend/Mvc/Router/Route.php
+++ b/library/Zend/Mvc/Router/Route.php
@@ -27,7 +27,7 @@ use Zend\Stdlib\RequestDescription as Request;
 
 /**
  * Route interface.
- * 
+ *
  * @package    Zend_Mvc_Router
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -36,30 +36,30 @@ interface Route
 {
     /**
      * Priority used for route stacks.
-     * 
+     *
      * @var integer
      * public $priority;
      */
-    
+
     /**
      * Create a new route with given options.
-     * 
-     * @param  array|Traversable $options
+     *
+     * @param  array|\Traversable $options
      * @return void
      */
     public static function factory($options = array());
-    
+
     /**
      * Match a given request.
-     * 
+     *
      * @param  Request $request
      * @return RouteMatch
      */
     public function match(Request $request);
-    
+
     /**
      * Assemble the route.
-     * 
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed

--- a/library/Zend/Mvc/Router/RouteBroker.php
+++ b/library/Zend/Mvc/Router/RouteBroker.php
@@ -37,15 +37,15 @@ class RouteBroker implements Broker
 {
     /**
      * Default class loader to utilize with this broker.
-     * 
+     *
      * @var string
      */
     protected $defaultClassLoader = 'Zend\Loader\PluginClassLoader';
 
     /**
      * Plugin class loader used by this instance.
-     * 
-     * @var PluginClassLocator 
+     *
+     * @var PluginClassLocator
      */
     protected $classLoader;
 
@@ -53,8 +53,8 @@ class RouteBroker implements Broker
      * Constructor.
      *
      * Allow configuration via options; see {@link setOptions()} for details.
-     * 
-     * @param  null|array|Traversable $options 
+     *
+     * @param  null|array|\Traversable $options
      * @return void
      */
     public function __construct($options = null)
@@ -66,9 +66,9 @@ class RouteBroker implements Broker
 
     /**
      * Configure route broker.
-     * 
-     * @param  mixed $options 
-     * @return PluginBroker
+     *
+     * @param  mixed $options
+     * @return RouteBroker
      */
     public function setOptions($options)
     {
@@ -89,14 +89,14 @@ class RouteBroker implements Broker
                                 $value
                             ));
                         }
-                        
+
                         $value = new $value;
                     }
-                    
+
                     if ($value instanceof ShortNameLocator) {
                         $this->setClassLoader($value);
                         break;
-                    } 
+                    }
 
                     if (!is_array($value) && !$value instanceof \Traversable) {
                         throw new Exception\RuntimeException(sprintf(
@@ -107,7 +107,7 @@ class RouteBroker implements Broker
 
                     $class   = false;
                     $options = null;
-                    
+
                     foreach ($value as $k => $v) {
                         switch (strtolower($k)) {
                             case 'class':
@@ -120,13 +120,13 @@ class RouteBroker implements Broker
                                 break;
                         }
                     }
-                    
+
                     if ($class) {
                         $loader = new $class($options);
                         $this->setClassLoader($loader);
                     }
                     break;
-                    
+
                 default:
                     // ignore unknown options
                     break;
@@ -138,7 +138,7 @@ class RouteBroker implements Broker
 
     /**
      * load(): defined by Broker interface.
-     * 
+     *
      * @see    Broker::load()
      * @param  string $route
      * @param  array  $options
@@ -165,9 +165,9 @@ class RouteBroker implements Broker
 
     /**
      * getPlugins(): defined by Broker interface.
-     * 
+     *
      * Not required in the RouteBroker.
-     * 
+     *
      * @see    Broker::getPlugins()
      * @return array
      */
@@ -177,11 +177,11 @@ class RouteBroker implements Broker
 
     /**
      * isLoaded(): defined by Broker interface.
-     * 
+     *
      * Not required in the RouteBroker.
-     * 
+     *
      * @see    Broker::isLoaded()
-     * @param  string $name 
+     * @param  string $name
      * @return bool
      */
     public function isLoaded($name)
@@ -190,13 +190,13 @@ class RouteBroker implements Broker
 
     /**
      * register(): defined by Broker interface.
-     * 
+     *
      * Not required in the RouteBroker.
-     * 
+     *
      * @see    Broker::register()
-     * @param  string $name 
-     * @param  mixed $plugin 
-     * @return PluginBroker
+     * @param  string $name
+     * @param  mixed $plugin
+     * @return RouteBroker
      */
     public function register($name, $plugin)
     {
@@ -204,11 +204,11 @@ class RouteBroker implements Broker
 
     /**
      * unregister(): defined by Broker interface.
-     * 
+     *
      * Not required in the RouteBroker.
-     * 
+     *
      * @see    Broker::unregister()
-     * @param  string $name 
+     * @param  string $name
      * @return bool
      */
     public function unregister($name)
@@ -217,25 +217,25 @@ class RouteBroker implements Broker
 
     /**
      * setClassLoader(): defined by Broker interface.
-     * 
+     *
      * @see    Broker::setClassLoader()
-     * @param  ShortNameLocator $loader 
-     * @return PluginBroker
+     * @param  ShortNameLocator $loader
+     * @return RouteBroker
      */
     public function setClassLoader(ShortNameLocator $loader)
     {
         if (!$loader instanceof PluginClassLocator) {
             throw new Exception\InvalidArgumentException('Expected instance of PluginClassLocator');
         }
-        
+
         $this->classLoader = $loader;
-        
+
         return $this;
     }
 
     /**
      * getClassLoader(): defined by Broker interface.
-     * 
+     *
      * @see    Broker::getClassLoader()
      * @return ShortNameLocator
      */
@@ -245,7 +245,7 @@ class RouteBroker implements Broker
             $loaderClass = $this->defaultClassLoader;
             $this->setClassLoader(new $loaderClass());
         }
-        
+
         return $this->classLoader;
     }
 }

--- a/library/Zend/Mvc/Router/RouteMatch.php
+++ b/library/Zend/Mvc/Router/RouteMatch.php
@@ -34,77 +34,76 @@ class RouteMatch
 {
     /**
      * Match parameters.
-     * 
+     *
      * @var array
      */
     protected $params = array();
-    
+
     /**
      * Matched route name.
-     * 
+     *
      * @var string
      */
     protected $matchedRouteName;
-    
+
     /**
      * Create a RouteMatch with given parameters.
-     * 
-     * @param  array $params
-     * @return void
+     *
+     * @param array $params
      */
     public function __construct(array $params)
     {
         $this->params = $params;
     }
-    
+
     /**
      * Set name of matched route.
-     * 
+     *
      * @param  string $name
-     * @return self
+     * @return RouteMatch
      */
     public function setMatchedRouteName($name)
     {
         $this->matchedRouteName = $name;
         return $this;
     }
-    
+
     /**
      * Get name of matched route.
-     * 
+     *
      * @return string
      */
     public function getMatchedRouteName()
     {
         return $this->matchedRouteName;
     }
-       
+
     /**
      * Set a parameter.
-     * 
+     *
      * @param  string $name
-     * @param  mixed  $value 
-     * @return self
+     * @param  mixed  $value
+     * @return RouteMatch
      */
     public function setParam($name, $value)
     {
         $this->params[$name] = $value;
         return $this;
     }
-    
+
     /**
      * Get all parameters.
-     * 
+     *
      * @return array
      */
     public function getParams()
     {
         return $this->params;
     }
-    
+
     /**
      * Get a specific parameter.
-     * 
+     *
      * @param  string $name
      * @param  mixed $default
      * @return mixed
@@ -114,7 +113,7 @@ class RouteMatch
         if (array_key_exists($name, $this->params)) {
             return $this->params[$name];
         }
-        
+
         return $default;
     }
 }

--- a/library/Zend/Mvc/Router/RouteStack.php
+++ b/library/Zend/Mvc/Router/RouteStack.php
@@ -32,7 +32,7 @@ interface RouteStack extends Route
 {
     /**
      * Add a route to the stack.
-     * 
+     *
      * @param  string  $name
      * @param  mixed   $route
      * @param  integer $priority
@@ -42,15 +42,15 @@ interface RouteStack extends Route
 
     /**
      * Add multiple routes to the stack.
-     * 
-     * @param  array|Traversable $routes
+     *
+     * @param  array|\Traversable $routes
      * @return RouteStack
      */
     public function addRoutes($routes);
 
     /**
      * Remove a route from the stack.
-     * 
+     *
      * @param  string $name
      * @return RouteStack
      */
@@ -58,8 +58,8 @@ interface RouteStack extends Route
 
     /**
      * Remove all routes from the stack and set new ones.
-     * 
-     * @param  array|Traversable $routes
+     *
+     * @param  array|\Traversable $routes
      * @return RouteStack
      */
     public function setRoutes($routes);

--- a/library/Zend/Mvc/Router/SimpleRouteStack.php
+++ b/library/Zend/Mvc/Router/SimpleRouteStack.php
@@ -51,33 +51,31 @@ class SimpleRouteStack implements RouteStack
      * @var RouteBroker
      */
     protected $routeBroker;
-    
+
     /**
      * Default parameters.
-     * 
+     *
      * @var array
      */
     protected $defaultParams = array();
 
     /**
      * Create a new simple route stack.
-     * 
-     * @return void
      */
     public function __construct()
     {
         $this->routes      = new PriorityList();
         $this->routeBroker = new RouteBroker();
-        
+
         $this->init();
     }
-    
+
     /**
      * factory(): defined by Route interface.
      *
      * @see    Route::factory()
-     * @param  array|Traversable $options
-     * @return void
+     * @param  array|\Traversable $options
+     * @return SimpleRouteStack
      */
     public static function factory($options = array())
     {
@@ -88,22 +86,22 @@ class SimpleRouteStack implements RouteStack
         }
 
         $instance = new static();
-        
+
         if (isset($options['route_broker'])) {
             $instance->setRouteBroker($options['route_broker']);
         }
-        
+
         if (isset($options['routes'])) {
             $instance->addRoutes($options['routes']);
         }
-        
+
         if (isset($options['default_params'])) {
             $instance->setDefaultParams($options['default_params']);
         }
 
         return $instance;
     }
-    
+
     /**
      * Init method for extending classes.
      *
@@ -139,8 +137,8 @@ class SimpleRouteStack implements RouteStack
      * addRoutes(): defined by RouteStack interface.
      *
      * @see    RouteStack::addRoutes()
-     * @param  array|Traversable $routes
-     * @return RouteStack
+     * @param  array|\Traversable $routes
+     * @return SimpleRouteStack
      */
     public function addRoutes($routes)
     {
@@ -162,14 +160,14 @@ class SimpleRouteStack implements RouteStack
      * @param  string  $name
      * @param  mixed   $route
      * @param  integer $priority
-     * @return RouteStack
+     * @return SimpleRouteStack
      */
     public function addRoute($name, $route, $priority = null)
     {
         if (!$route instanceof Route) {
             $route = $this->routeFromArray($route);
         }
-        
+
         if ($priority === null && isset($route->priority)) {
             $priority = $route->priority;
         }
@@ -184,7 +182,7 @@ class SimpleRouteStack implements RouteStack
      *
      * @see    RouteStack::removeRoute()
      * @param  string  $name
-     * @return RouteStack
+     * @return SimpleRouteStack
      */
     public function removeRoute($name)
     {
@@ -196,8 +194,8 @@ class SimpleRouteStack implements RouteStack
     /**
      * setRoutes(): defined by RouteStack interface.
      *
-     * @param  array|Traversable $routes
-     * @return RouteStack
+     * @param  array|\Traversable $routes
+     * @return SimpleRouteStack
      */
     public function setRoutes($routes)
     {
@@ -208,22 +206,22 @@ class SimpleRouteStack implements RouteStack
 
     /**
      * Set a default parameters.
-     * 
+     *
      * @param  array $params
-     * @return RouteStack
+     * @return SimpleRouteStack
      */
     public function setDefaultParams(array $params)
     {
         $this->defaultParams = $params;
         return $this;
     }
-    
+
     /**
      * Set a default parameter.
-     * 
+     *
      * @param  string $name
-     * @param  mixed  $value 
-     * @return RouteStack
+     * @param  mixed  $value
+     * @return SimpleRouteStack
      */
     public function setDefaultParam($name, $value)
     {
@@ -234,7 +232,7 @@ class SimpleRouteStack implements RouteStack
     /**
      * Create a route from array specifications.
      *
-     * @param  array|Traversable $specs
+     * @param  array|\Traversable $specs
      * @return SimpleRouteStack
      */
     protected function routeFromArray($specs)
@@ -256,7 +254,7 @@ class SimpleRouteStack implements RouteStack
         if (isset($specs['priority'])) {
             $route->priority = $specs['priority'];
         }
-        
+
         return $route;
     }
 
@@ -265,20 +263,20 @@ class SimpleRouteStack implements RouteStack
      *
      * @see    Route::match()
      * @param  Request $request
-     * @return RouteMatch
+     * @return RouteMatch|null
      */
     public function match(Request $request)
     {
         foreach ($this->routes as $name => $route) {
             if (($match = $route->match($request)) instanceof RouteMatch) {
                 $match->setMatchedRouteName($name);
-                
+
                 foreach ($this->defaultParams as $name => $value) {
                     if ($match->getParam($name) === null) {
                         $match->setParam($name, $value);
                     }
                 }
-                
+
                 return $match;
             }
         }
@@ -301,7 +299,7 @@ class SimpleRouteStack implements RouteStack
         }
 
         $route = $this->routes->get($options['name']);
-        
+
         if (!$route) {
             throw new Exception\RuntimeException(sprintf('Route with name "%s" not found', $options['name']));
         }

--- a/library/Zend/Mvc/View/CreateViewModelListener.php
+++ b/library/Zend/Mvc/View/CreateViewModelListener.php
@@ -31,27 +31,27 @@ class CreateViewModelListener implements ListenerAggregate
 {
     /**
      * Listeners we've registered
-     * 
+     *
      * @var array
      */
     protected $listeners = array();
 
     /**
      * Attach listeners
-     * 
-     * @param  Events $events 
+     *
+     * @param  Events $events
      * @return void
      */
     public function attach(Events $events)
     {
-        $this->listeners[] = $events->attach('dispatch', array($this, 'createViewModelFromArray'), -80);
-        $this->listeners[] = $events->attach('dispatch', array($this, 'createViewModelFromNull'), -80);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'createViewModelFromArray'), -80);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'createViewModelFromNull'), -80);
     }
 
     /**
      * Detach listeners
-     * 
-     * @param  Events $events 
+     *
+     * @param  Events $events
      * @return void
      */
     public function detach(Events $events)
@@ -66,7 +66,7 @@ class CreateViewModelListener implements ListenerAggregate
     /**
      * Inspect the result, and cast it to a ViewModel if an assoc array is detected
      *
-     * @param  MvcEvent $e 
+     * @param  MvcEvent $e
      * @return void
      */
     public function createViewModelFromArray(MvcEvent $e)

--- a/library/Zend/Mvc/View/DefaultRenderingStrategy.php
+++ b/library/Zend/Mvc/View/DefaultRenderingStrategy.php
@@ -56,8 +56,8 @@ class DefaultRenderingStrategy implements ListenerAggregate
 
     /**
      * Set view
-     * 
-     * @param  View $view 
+     *
+     * @param  View $view
      * @return DefaultRenderingStrategy
      */
     public function __construct(View $view)
@@ -68,19 +68,19 @@ class DefaultRenderingStrategy implements ListenerAggregate
 
     /**
      * Attach the aggregate to the specified event manager
-     * 
-     * @param  EventCollection $events 
+     *
+     * @param  EventCollection $events
      * @return void
      */
     public function attach(EventCollection $events)
     {
-        $this->listeners[] = $events->attach('render', array($this, 'render'), -10000);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER, array($this, 'render'), -10000);
     }
 
     /**
      * Detach aggregate listeners from the specified event manager
-     * 
-     * @param  EventCollection $events 
+     *
+     * @param  EventCollection $events
      * @return void
      */
     public function detach(EventCollection $events)
@@ -103,7 +103,7 @@ class DefaultRenderingStrategy implements ListenerAggregate
         $this->layoutTemplate = (string) $layoutTemplate;
         return $this;
     }
-    
+
     /**
      * Get layout template value
      *
@@ -116,8 +116,8 @@ class DefaultRenderingStrategy implements ListenerAggregate
 
     /**
      * Render the view
-     * 
-     * @param  MvcEvent $e 
+     *
+     * @param  MvcEvent $e
      * @return Response
      */
     public function render(MvcEvent $e)

--- a/library/Zend/Mvc/View/ExceptionStrategy.php
+++ b/library/Zend/Mvc/View/ExceptionStrategy.php
@@ -57,19 +57,19 @@ class ExceptionStrategy implements ListenerAggregate
 
     /**
      * Attach the aggregate to the specified event manager
-     * 
-     * @param  EventCollection $events 
+     *
+     * @param  EventCollection $events
      * @return void
      */
     public function attach(EventCollection $events)
     {
-        $this->listeners[] = $events->attach('dispatch.error', array($this, 'prepareExceptionViewModel'));
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($this, 'prepareExceptionViewModel'));
     }
 
     /**
      * Detach aggregate listeners from the specified event manager
-     * 
-     * @param  EventCollection $events 
+     *
+     * @param  EventCollection $events
      * @return void
      */
     public function detach(EventCollection $events)
@@ -83,8 +83,8 @@ class ExceptionStrategy implements ListenerAggregate
 
     /**
      * Flag: display exceptions in error pages?
-     * 
-     * @param  bool $flag 
+     *
+     * @param  bool $flag
      * @return ExceptionStrategy
      */
     public function setDisplayExceptions($displayExceptions)
@@ -95,7 +95,7 @@ class ExceptionStrategy implements ListenerAggregate
 
     /**
      * Should we display exceptions in error pages?
-     * 
+     *
      * @return bool
      */
     public function displayExceptions()
@@ -105,8 +105,8 @@ class ExceptionStrategy implements ListenerAggregate
 
     /**
      * Set the exception template
-     * 
-     * @param  string $exceptionTemplate 
+     *
+     * @param  string $exceptionTemplate
      * @return ExceptionStrategy
      */
     public function setExceptionTemplate($exceptionTemplate)
@@ -117,7 +117,7 @@ class ExceptionStrategy implements ListenerAggregate
 
     /**
      * Retrieve the exception template
-     * 
+     *
      * @return string
      */
     public function getExceptionTemplate()
@@ -127,13 +127,13 @@ class ExceptionStrategy implements ListenerAggregate
 
     /**
      * Create an exception view model, and set the HTTP status code
-     * 
-     * @todo   dispatch.error does not halt dispatch unless a response is 
+     *
+     * @todo   dispatch.error does not halt dispatch unless a response is
      *         returned. As such, we likely need to trigger rendering as a low
      *         priority dispatch.error event (or goto a render event) to ensure
      *         rendering occurs, and that munging of view models occurs when
      *         expected.
-     * @param  MvcEvent $e 
+     * @param  MvcEvent $e
      * @return void
      */
     public function prepareExceptionViewModel(MvcEvent $e)

--- a/library/Zend/Mvc/View/InjectTemplateListener.php
+++ b/library/Zend/Mvc/View/InjectTemplateListener.php
@@ -32,33 +32,33 @@ class InjectTemplateListener implements ListenerAggregate
 {
     /**
      * Filter/inflector used to normalize names for use as template identifiers
-     * 
+     *
      * @var mixed
      */
     protected $inflector;
 
     /**
      * Listeners we've registered
-     * 
+     *
      * @var array
      */
     protected $listeners = array();
 
     /**
      * Attach listeners
-     * 
-     * @param  Events $events 
+     *
+     * @param  Events $events
      * @return void
      */
     public function attach(Events $events)
     {
-        $this->listeners[] = $events->attach('dispatch', array($this, 'injectTemplate'), -90);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'injectTemplate'), -90);
     }
 
     /**
      * Detach listeners
-     * 
-     * @param  Events $events 
+     *
+     * @param  Events $events
      * @return void
      */
     public function detach(Events $events)
@@ -73,10 +73,10 @@ class InjectTemplateListener implements ListenerAggregate
     /**
      * Inject a template into the view model, if none present
      *
-     * Template is derived from the controller found in the route match, and, 
+     * Template is derived from the controller found in the route match, and,
      * optionally, the action, if present.
      *
-     * @param  MvcEvent $e 
+     * @param  MvcEvent $e
      * @return void
      */
     public function injectTemplate(MvcEvent $e)
@@ -85,7 +85,7 @@ class InjectTemplateListener implements ListenerAggregate
         if (!$model instanceof ViewModel) {
             return;
         }
-        
+
         $template = $model->getTemplate();
         if (!empty($template)) {
             return;
@@ -105,8 +105,8 @@ class InjectTemplateListener implements ListenerAggregate
 
     /**
      * Inflect a name to a normalized value
-     * 
-     * @param  string $name 
+     *
+     * @param  string $name
      * @return string
      */
     protected function inflectName($name)
@@ -122,8 +122,8 @@ class InjectTemplateListener implements ListenerAggregate
      * Determine the name of the controller
      *
      * Strip the namespace, and the suffix "Controller" if present.
-     * 
-     * @param  string $controller 
+     *
+     * @param  string $controller
      * @return string
      */
     protected function deriveControllerClass($controller)
@@ -132,7 +132,7 @@ class InjectTemplateListener implements ListenerAggregate
             $controller = substr($controller, strrpos($controller, '\\') + 1);
         }
 
-        if ((10 < strlen($controller)) 
+        if ((10 < strlen($controller))
             && ('Controller' == substr($controller, -10))
         ) {
             $controller = substr($controller, 0, -10);

--- a/library/Zend/Mvc/View/InjectViewModelListener.php
+++ b/library/Zend/Mvc/View/InjectViewModelListener.php
@@ -31,34 +31,34 @@ class InjectViewModelListener implements ListenerAggregate
 {
     /**
      * Filter/inflector used to normalize names for use as template identifiers
-     * 
+     *
      * @var mixed
      */
     protected $inflector;
 
     /**
      * Listeners we've registered
-     * 
+     *
      * @var array
      */
     protected $listeners = array();
 
     /**
      * Attach listeners
-     * 
-     * @param  Events $events 
+     *
+     * @param  Events $events
      * @return void
      */
     public function attach(Events $events)
     {
-        $this->listeners[] = $events->attach('dispatch', array($this, 'injectViewModel'), -100);
-        $this->listeners[] = $events->attach('dispatch.error', array($this, 'injectViewModel'), -100);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'injectViewModel'), -100);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($this, 'injectViewModel'), -100);
     }
 
     /**
      * Detach listeners
-     * 
-     * @param  Events $events 
+     *
+     * @param  Events $events
      * @return void
      */
     public function detach(Events $events)
@@ -73,11 +73,11 @@ class InjectViewModelListener implements ListenerAggregate
     /**
      * Insert the view model into the event
      *
-     * Inspects the MVC result; if it is a view model, it then either (a) adds 
-     * it as a child to the default, composed view model, or (b) replaces it, 
+     * Inspects the MVC result; if it is a view model, it then either (a) adds
+     * it as a child to the default, composed view model, or (b) replaces it,
      * if the result  is marked as terminable.
-     * 
-     * @param  MvcEvent $e 
+     *
+     * @param  MvcEvent $e
      * @return void
      */
     public function injectViewModel(MvcEvent $e)

--- a/library/Zend/Mvc/View/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/RouteNotFoundStrategy.php
@@ -45,43 +45,43 @@ class RouteNotFoundStrategy implements ListenerAggregate
 
     /**
      * Whether or not to display exceptions related to the 404 condition
-     * 
+     *
      * @var bool
      */
     protected $displayExceptions = false;
 
     /**
      * Whether or not to display the reason for a 404
-     * 
+     *
      * @var bool
      */
     protected $displayNotFoundReason = false;
 
     /**
      * Template to use to report page not found conditions
-     * 
+     *
      * @var string
      */
     protected $notFoundTemplate = 'error';
 
     /**
      * The reason for a not-found condition
-     * 
+     *
      * @var false|string
      */
     protected $reason = false;
 
     /**
      * Attach the aggregate to the specified event manager
-     * 
-     * @param  EventCollection $events 
+     *
+     * @param  EventCollection $events
      * @return void
      */
     public function attach(EventCollection $events)
     {
-        $this->listeners[] = $events->attach('dispatch', array($this, 'prepareNotFoundViewModel'), -90);
-        $this->listeners[] = $events->attach('dispatch.error', array($this, 'detectNotFoundError'));
-        $this->listeners[] = $events->attach('dispatch.error', array($this, 'prepareNotFoundViewModel'));
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'prepareNotFoundViewModel'), -90);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($this, 'detectNotFoundError'));
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($this, 'prepareNotFoundViewModel'));
     }
 
     /**
@@ -95,7 +95,7 @@ class RouteNotFoundStrategy implements ListenerAggregate
         $this->displayExceptions = (bool) $displayExceptions;
         return $this;
     }
-    
+
     /**
      * Should we display exceptions related to a not-found condition?
      *
@@ -108,8 +108,8 @@ class RouteNotFoundStrategy implements ListenerAggregate
 
     /**
      * Detach aggregate listeners from the specified event manager
-     * 
-     * @param  EventCollection $events 
+     *
+     * @param  EventCollection $events
      * @return void
      */
     public function detach(EventCollection $events)
@@ -132,7 +132,7 @@ class RouteNotFoundStrategy implements ListenerAggregate
         $this->displayNotFoundReason = (bool) $displayNotFoundReason;
         return $this;
     }
-    
+
     /**
      * Should we display the reason for a not-found condition?
      *
@@ -154,7 +154,7 @@ class RouteNotFoundStrategy implements ListenerAggregate
         $this->notFoundTemplate = (string) $notFoundTemplate;
         return $this;
     }
-    
+
     /**
      * Get template for not found conditions
      *
@@ -170,8 +170,8 @@ class RouteNotFoundStrategy implements ListenerAggregate
      *
      * If a "controller not found" or "invalid controller" error type is
      * encountered, sets the response status code to 404.
-     * 
-     * @param  MvcEvent $e 
+     *
+     * @param  MvcEvent $e
      * @return void
      */
     public function detectNotFoundError(MvcEvent $e)
@@ -200,8 +200,8 @@ class RouteNotFoundStrategy implements ListenerAggregate
 
     /**
      * Create and return a 404 view model
-     * 
-     * @param  MvcEvent $e 
+     *
+     * @param  MvcEvent $e
      * @return void
      */
     public function prepareNotFoundViewModel(MvcEvent $e)
@@ -240,9 +240,9 @@ class RouteNotFoundStrategy implements ListenerAggregate
      * If $displayNotFoundReason is enabled, checks to see if $reason is set,
      * and, if so, injects it into the model. If not, it injects
      * Application::ERROR_CONTROLLER_CANNOT_DISPATCH.
-     * 
-     * @param  ViewModel $model 
-     * @param  MvcEvent $e 
+     *
+     * @param  ViewModel $model
+     * @param  MvcEvent $e
      * @return void
      */
     protected function injectNotFoundReason($model)
@@ -257,7 +257,7 @@ class RouteNotFoundStrategy implements ListenerAggregate
             return;
         }
 
-        // otherwise, must be a case of the controller not being able to 
+        // otherwise, must be a case of the controller not being able to
         // dispatch itself.
         $model->setVariable('reason', Application::ERROR_CONTROLLER_CANNOT_DISPATCH);
     }
@@ -265,11 +265,11 @@ class RouteNotFoundStrategy implements ListenerAggregate
     /**
      * Inject the exception message into the model
      *
-     * If $displayExceptions is enabled, and an exception is found in the 
+     * If $displayExceptions is enabled, and an exception is found in the
      * event, inject it into the model.
-     * 
-     * @param  ViewModel $model 
-     * @param  MvcEvent $e 
+     *
+     * @param  ViewModel $model
+     * @param  MvcEvent $e
      * @return void
      */
     protected function injectException($model, $e)
@@ -289,14 +289,14 @@ class RouteNotFoundStrategy implements ListenerAggregate
     /**
      * Inject the controller and controller class into the model
      *
-     * If either $displayExceptions or $displayNotFoundReason are enabled, 
-     * injects the controllerClass from the MvcEvent. It checks to see if a 
+     * If either $displayExceptions or $displayNotFoundReason are enabled,
+     * injects the controllerClass from the MvcEvent. It checks to see if a
      * controller is present in the MvcEvent, and, if not, grabs it from
-     * the route match if present; if a controller is found, it injects it into 
+     * the route match if present; if a controller is found, it injects it into
      * the model.
-     * 
-     * @param  ViewModel $model 
-     * @param  MvcEvent $e 
+     *
+     * @param  ViewModel $model
+     * @param  MvcEvent $e
      * @return void
      */
     protected function injectController($model, $e)

--- a/library/Zend/View/View.php
+++ b/library/Zend/View/View.php
@@ -22,6 +22,7 @@ namespace Zend\View;
 
 use Zend\EventManager\EventCollection,
     Zend\EventManager\EventManager,
+    Zend\Mvc\MvcEvent,
     Zend\Stdlib\RequestDescription as Request,
     Zend\Stdlib\ResponseDescription as Response;
 
@@ -50,8 +51,8 @@ class View
 
     /**
      * Set MVC request object
-     * 
-     * @param  Request $request 
+     *
+     * @param  Request $request
      * @return View
      */
     public function setRequest(Request $request)
@@ -61,9 +62,9 @@ class View
     }
 
     /**
-     * Set MVC response object 
-     * 
-     * @param  Response $response 
+     * Set MVC response object
+     *
+     * @param  Response $response
      * @return View
      */
     public function setResponse(Response $response)
@@ -74,7 +75,7 @@ class View
 
     /**
      * Get MVC request object
-     * 
+     *
      * @return null|Request
      */
     public function getRequest()
@@ -84,7 +85,7 @@ class View
 
     /**
      * Get MVC response object
-     * 
+     *
      * @return null|Response
      */
     public function getResponse()
@@ -94,8 +95,8 @@ class View
 
     /**
      * Set the event manager instance
-     * 
-     * @param  EventCollection $events 
+     *
+     * @param  EventCollection $events
      * @return View
      */
     public function setEventManager(EventCollection $events)
@@ -108,7 +109,7 @@ class View
      * Retrieve the event manager instance
      *
      * Lazy-loads a default instance if none available
-     * 
+     *
      * @return EventCollection
      */
     public function events()
@@ -128,11 +129,11 @@ class View
      * Expects a callable. Strategies should accept a ViewEvent object, and should
      * return a Renderer instance if the strategy is selected.
      *
-     * Internally, the callable provided will be subscribed to the "renderer" 
+     * Internally, the callable provided will be subscribed to the "renderer"
      * event, at the priority specified.
-     * 
-     * @param  callable $callable 
-     * @param  int $priority 
+     *
+     * @param  callable $callable
+     * @param  int $priority
      * @return View
      */
     public function addRenderingStrategy($callable, $priority = 1)
@@ -149,11 +150,11 @@ class View
      *
      * Typical usages for a response strategy are to populate the Response object.
      *
-     * Internally, the callable provided will be subscribed to the "response" 
+     * Internally, the callable provided will be subscribed to the "response"
      * event, at the priority specified.
-     * 
-     * @param  callable $callable 
-     * @param  int $priority 
+     *
+     * @param  callable $callable
+     * @param  int $priority
      * @return View
      */
     public function addResponseStrategy($callable, $priority = 1)
@@ -161,7 +162,7 @@ class View
         $this->events()->attach('response', $callable, $priority);
         return $this;
     }
-     
+
     /**
      * Render the provided model.
      *
@@ -181,7 +182,7 @@ class View
         $event   = $this->getEvent();
         $event->setModel($model);
         $events  = $this->events();
-        $results = $events->trigger('renderer', $event, function($result) {
+        $results = $events->trigger(MvcEvent::EVENT_RENDERER, $event, function($result) {
             return ($result instanceof Renderer);
         });
         $renderer = $results->last();
@@ -217,13 +218,13 @@ class View
 
         $event->setResult($rendered);
 
-        $events->trigger('response', $event);
+        $events->trigger(MvcEvent::EVENT_RESPONSE, $event);
     }
 
     /**
      * Loop through children, rendering each
-     * 
-     * @param  Model $model 
+     *
+     * @param  Model $model
      * @return void
      */
     protected function renderChildren(Model $model)
@@ -244,7 +245,7 @@ class View
 
     /**
      * Create and return ViewEvent used by render()
-     * 
+     *
      * @return ViewEvent
      */
     protected function getEvent()


### PR DESCRIPTION
When you are in the namespace "Zend\Acl", docblocks should be relative to this namespace, or should list the full namespace. Otherwise the class mapping will not resolve in most IDE's
