### PR TITLE
Zend\Di Shared Support hotfix for type checking of shared configuration status

### DIFF
--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -601,7 +601,7 @@ class Di implements DependencyInjection
                 }
                 array_push($this->currentDependencies, $class);
                 $dConfig = $this->instanceManager->getConfiguration($computedParams['required'][$fqParamPos][0]);
-                if ($dConfig['shared'] == false) {
+                if ($dConfig['shared'] === false) {
                     $resolvedParams[$index] = $this->newInstance($computedParams['required'][$fqParamPos][0], $callTimeUserParams, false);
                 } else {
                     $resolvedParams[$index] = $this->get($computedParams['required'][$fqParamPos][0], $callTimeUserParams);

--- a/library/Zend/Di/InstanceManager.php
+++ b/library/Zend/Di/InstanceManager.php
@@ -244,7 +244,7 @@ class InstanceManager /* implements InstanceCollection */
         $configuration = array(
             'parameters' => isset($configuration['parameters']) ? $configuration['parameters'] : array(),
             'injections' => isset($configuration['injections']) ? $configuration['injections'] : array(),
-            'shared'     => isset($configuration['shared'])     ? $configuration['shared']     : array(),
+            'shared'     => isset($configuration['shared'])     ? $configuration['shared']     : true
         );
         $this->configurations[$key] = array_replace_recursive($this->configurations[$key], $configuration);
     }

--- a/tests/Zend/Di/ConfigurationTest.php
+++ b/tests/Zend/Di/ConfigurationTest.php
@@ -34,11 +34,11 @@ class ConfigurationTest extends TestCase
         $this->assertContains('my-dbAdapter', $im->getTypePreferences('my-mapper'));
 
         $this->assertTrue($im->hasConfiguration('My\DbAdapter'));
-        $expected = array('parameters' => array('username' => 'readonly', 'password' => 'mypassword'), 'injections' => array(), 'shared' => array());
+        $expected = array('parameters' => array('username' => 'readonly', 'password' => 'mypassword'), 'injections' => array(), 'shared' => true);
         $this->assertEquals($expected, $im->getConfiguration('My\DbAdapter'));
         
         $this->assertTrue($im->hasConfiguration('my-dbAdapter'));
-        $expected = array('parameters' => array('username' => 'readwrite'), 'injections' => array(), 'shared' => array());
+        $expected = array('parameters' => array('username' => 'readwrite'), 'injections' => array(), 'shared' => true);
         $this->assertEquals($expected, $im->getConfiguration('my-dbAdapter'));
     }
     

--- a/tests/Zend/Di/InstanceManagerTest.php
+++ b/tests/Zend/Di/InstanceManagerTest.php
@@ -71,7 +71,7 @@ class InstanceManagerTest extends TestCase
         $im->setConfiguration('bar-alias', $config);
 
         $config['injections'] = array();
-        $config['shared'] = array();
+        $config['shared'] = true;
         
         $this->assertEquals($config, $im->getConfiguration('foo-alias'));
     }


### PR DESCRIPTION
This is a fix for the shared support status in configurations with default values (shared = true)
