### PR TITLE
Http\PhpEnvironment\Request::setServer() fix

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -163,9 +163,6 @@ class Request extends HttpRequest
             $uri->setQuery($this->serverParams['QUERY_STRING']);
         }
 
-        $requestUri = $this->getRequestUri();
-        $uri->setPath(substr($requestUri, 0, strpos($requestUri, '?') ?: strlen($requestUri)));
-
         if ($this->headers()->get('host')) {
             //TODO handle IPv6 with port
             if (preg_match('|^([^:]+):([^:]+)$|', $this->headers()->get('host')->getFieldValue(), $match)) {
@@ -181,6 +178,9 @@ class Request extends HttpRequest
                 $uri->setPort($this->serverParams['SERVER_PORT']);
             }
         }
+
+        $requestUri = $this->getRequestUri();
+        $uri->setPath(substr($requestUri, 0, strpos($requestUri, '?') ?: strlen($requestUri)));
 
         return $this;
     }

--- a/tests/Zend/Http/PhpEnvironment/RequestTest.php
+++ b/tests/Zend/Http/PhpEnvironment/RequestTest.php
@@ -249,6 +249,33 @@ class RequestTest extends TestCase
                 'test.example.com',
                 '/news',
             ),
+            array(
+                array(
+                    'HTTP_HOST' => 'test.example.com',
+                    'REQUEST_URI' => 'http://test.example.com/news',
+                ),
+                'test.example.com',
+                '/news',
+            ),
+            array(
+                array(
+                    'SERVER_NAME' => 'test.example.com',
+                    'SERVER_PORT' => '8080',
+                    'REQUEST_URI' => 'http://test.example.com/news',
+                ),
+                'test.example.com',
+                '/news',
+            ),
+            array(
+                array(
+                    'SERVER_NAME' => 'test.example.com',
+                    'SERVER_PORT' => '443',
+                    'HTTPS'       => 'on',
+                    'REQUEST_URI' => 'https://test.example.com/news',
+                ),
+                'test.example.com',
+                '/news',
+            ),
         );
     }
 

--- a/tests/Zend/Http/PhpEnvironment/RequestTest.php
+++ b/tests/Zend/Http/PhpEnvironment/RequestTest.php
@@ -235,4 +235,38 @@ class RequestTest extends TestCase
         $this->assertEquals($value, $header->getFieldValue($value));
     }
 
+    /**
+     * Data provider for testing server hostname.
+     */
+    public static function serverHostnameProvider()
+    {
+        return array(
+            array(
+                array(
+                    'SERVER_NAME' => 'test.example.com',
+                    'REQUEST_URI' => 'http://test.example.com/news',
+                ),
+                'test.example.com',
+                '/news',
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider serverHostnameProvider
+     * @param array  $server
+     * @param string $name
+     * @param string $value
+     */
+    public function testServerHostnameProvider(array $server, $expectedHost, $expectedRequestUri)
+    {
+        $_SERVER = $server;
+        $request = new Request();
+
+        $host = $request->uri()->getHost();
+        $this->assertEquals($expectedHost, $host);
+
+        $requestUri = $request->getRequestUri();
+        $this->assertEquals($expectedRequestUri, $requestUri);
+    }
 }


### PR DESCRIPTION
Ensure that we determine the requestUri after we have determined the hostname and port
