### PR TITLE
Fix for Zend\OpenId\OpenId redirect method

### DIFF
--- a/library/Zend/OpenId/OpenId.php
+++ b/library/Zend/OpenId/OpenId.php
@@ -457,7 +457,7 @@ class OpenId
         $response->headers()->addHeaderLine('Location', $url);
 
         if (!headers_sent()) {
-            header($response->renderResponseLine());
+            header($response->renderStatusLine());
             foreach ($response->headers() as $header) {
                 header($header->toString());
             }


### PR DESCRIPTION
Call to Zend\Http\Response renderResponseLine (which doesn't exist anymore) replaced by renderStatusLine
