### PR TITLE
when the element property 'required' is set to false it is rendered anyway on HTML5 browsers.

### DIFF
--- a/library/Zend/Dojo/Form/Decorator/DijitElement.php
+++ b/library/Zend/Dojo/Form/Decorator/DijitElement.php
@@ -169,8 +169,11 @@ class DijitElement extends ViewHelperDecorator
         $name      = $element->getFullyQualifiedName();
 
         $dijitParams = $this->getDijitParams();
-        $dijitParams['required'] = $element->isRequired();
-
+        
+        if ($element->isRequired()) {
+            $dijitParams['required'] = true;
+        }
+        
         $id = $element->getId();
         if ($view->plugin('dojo')->hasDijit($id)) {
             trigger_error(sprintf('Duplicate dijit ID detected for id "%s; temporarily generating uniqid"', $id), E_USER_NOTICE);


### PR DESCRIPTION
On HTML5 browsers the tag "required" is rendered despise of the fact that is it set to false. With this change the key 'required' is not set, meaning that the function Zend\Dojo\View\Helper\Dojo\Container::registerDijitLoader() will not add it to the zendDijits json array.
