### PR TITLE
Bug when complex where (included more then one where expression) others expresions doesn't process

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -141,6 +141,7 @@ class Select implements SqlInterface, PreparableSqlInterface
         } else {
             if (is_string($predicate)) {
                 $predicate = new Predicate\Literal($predicate);
+	            $this->where->addPredicate($predicate, $combination);
             } elseif (is_array($predicate)) {
                 foreach ($predicate as $pkey => $pvalue) {
                     if (is_string($pkey) && strpos($pkey, '?') !== false) {
@@ -150,9 +151,9 @@ class Select implements SqlInterface, PreparableSqlInterface
                     } else {
                         $predicate = new Predicate\Literal($pvalue);
                     }
+		            $this->where->addPredicate($predicate, $combination);
                 }
             }
-            $this->where->addPredicate($predicate, $combination);
         }
         return $this;
     }


### PR DESCRIPTION
$rowset = $this->getTableGateway()->select(array('uid' => $uid, 'locale' => $locale));

didn't process second where.

It's my first pull request, sorry if something wrong. 
Thanks if fix it soon. I would use normal coding,
