### PR TITLE
Fix ZF2-237: The example doesn't mach the description

### DIFF
--- a/documentation/manual/en/module_specs/zend.view.quick-start.xml
+++ b/documentation/manual/en/module_specs/zend.view.quick-start.xml
@@ -320,7 +320,7 @@ use Zend\Mvc\Controller\ActionController;
 
 class BarController extends ActionController
 {
-    public function doSomethingAction()
+    public function doSomethingCrazyAction()
     {
         return array(
             'message' => 'Hello world',


### PR DESCRIPTION
In Example 14.2. Controllers and View Models it says by the example: "As an example, the controller Bar\Controller\BazBatController, with action "doSomethingCrazy","

And in the followeing coding example the function name is:'doSomethingAction()'

http://framework.zend.com/issues/browse/ZF2-237
