### PR TITLE
Fixes defect segment-routing due to old PCRE-Lib

### DIFF
--- a/library/Zend/Feed/Writer/AbstractFeed.php
+++ b/library/Zend/Feed/Writer/AbstractFeed.php
@@ -41,7 +41,7 @@ class AbstractFeed
      * @var array
      */
     protected $_data = array();
-    
+
     /**
      * Holds the value "atom" or "rss" depending on the feed type set when
      * when last exported.
@@ -49,7 +49,7 @@ class AbstractFeed
      * @var string
      */
     protected $_type = null;
-    
+
     /**
      * Constructor: Primarily triggers the registration of core extensions and
      * loads those appropriate to this data container.
@@ -260,7 +260,7 @@ class AbstractFeed
      */
     public function setId($id)
     {
-        if ((empty($id) || !is_string($id) || !Uri\UriFactory::factory($id)->isValid()) 
+        if ((empty($id) || !is_string($id) || !Uri\UriFactory::factory($id)->isValid())
             && !preg_match("#^urn:[a-zA-Z0-9][a-zA-Z0-9\-]{1,31}:([a-zA-Z0-9\(\)\+\,\.\:\=\@\;\$\_\!\*\-]|%[0-9a-fA-F]{2})*#", $id)
             && !$this->_validateTagUri($id)
         ) {
@@ -268,7 +268,7 @@ class AbstractFeed
         }
         $this->_data['id'] = $id;
     }
-    
+
     /**
      * Validate a URI using the tag scheme (RFC 4151)
      *
@@ -277,7 +277,7 @@ class AbstractFeed
      */
     protected function _validateTagUri($id)
     {
-        if (preg_match('/^tag:(?<name>.*),(?<date>\d{4}-?\d{0,2}-?\d{0,2}):(?<specific>.*)(.*:)*$/', $id, $matches)) {
+        if (preg_match('/^tag:(?P<name>.*),(?P<date>\d{4}-?\d{0,2}-?\d{0,2}):(?P<specific>.*)(.*:)*$/', $id, $matches)) {
             $dvalid = false;
             $nvalid = false;
             $date = $matches['date'];
@@ -317,7 +317,7 @@ class AbstractFeed
             throw new Exception('Invalid parameter: parameter \'uri\''
             . ' must be a non-empty string and valid URI/IRI');
         }
-        $this->_data['image'] = $data;  
+        $this->_data['image'] = $data;
     }
 
     /**
@@ -387,7 +387,7 @@ class AbstractFeed
         }
         $this->_data['encoding'] = $encoding;
     }
-    
+
     /**
      * Set the feed's base URL
      *
@@ -401,7 +401,7 @@ class AbstractFeed
         }
         $this->_data['baseUrl'] = $url;
     }
-    
+
     /**
      * Add a Pubsubhubbub hub endpoint URL
      *
@@ -418,7 +418,7 @@ class AbstractFeed
         }
         $this->_data['hubs'][] = $url;
     }
-    
+
     /**
      * Add Pubsubhubbub hub endpoint URLs
      *
@@ -430,12 +430,12 @@ class AbstractFeed
             $this->addHub($url);
         }
     }
-    
+
     /**
      * Add a feed category
      *
      * @param string $category
-     */ 
+     */
     public function addCategory(array $category)
     {
         if (!isset($category['term'])) {
@@ -444,7 +444,7 @@ class AbstractFeed
             . ' readable category name');
         }
         if (isset($category['scheme'])) {
-            if (empty($category['scheme']) 
+            if (empty($category['scheme'])
                 || !is_string($category['scheme'])
                 || !Uri\UriFactory::factory($category['scheme'])->isValid()
             ) {
@@ -457,7 +457,7 @@ class AbstractFeed
         }
         $this->_data['categories'][] = $category;
     }
-    
+
     /**
      * Set an array of feed categories
      *
@@ -666,7 +666,7 @@ class AbstractFeed
         }
         return $this->_data['encoding'];
     }
-    
+
     /**
      * Get the feed's base url
      *
@@ -679,7 +679,7 @@ class AbstractFeed
         }
         return $this->_data['baseUrl'];
     }
-    
+
     /**
      * Get the URLs used as Pubsubhubbub hubs endpoints
      *
@@ -692,7 +692,7 @@ class AbstractFeed
         }
         return $this->_data['hubs'];
     }
-    
+
     /**
      * Get the feed categories
      *
@@ -715,7 +715,7 @@ class AbstractFeed
     {
         $this->_data = array();
     }
-    
+
     /**
      * Set the current feed type being exported to "rss" or "atom". This allows
      * other objects to gracefully choose whether to execute or not, depending
@@ -727,7 +727,7 @@ class AbstractFeed
     {
         $this->_type = $type;
     }
-    
+
     /**
      * Retrieve the current or last feed type exported.
      *
@@ -737,7 +737,7 @@ class AbstractFeed
     {
         return $this->_type;
     }
-    
+
     /**
      * Unset a specific data point
      *
@@ -749,7 +749,7 @@ class AbstractFeed
             unset($this->_data[$name]);
         }
     }
-    
+
     /**
      * Method overloading: call given method on first extension implementing it
      *

--- a/library/Zend/Feed/Writer/Renderer/Entry/Atom.php
+++ b/library/Zend/Feed/Writer/Renderer/Entry/Atom.php
@@ -42,8 +42,8 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
 {
     /**
      * Constructor
-     * 
-     * @param  Zend_Feed_Writer_Entry $container 
+     *
+     * @param  Zend_Feed_Writer_Entry $container
      * @return void
      */
     public function __construct (Writer\Entry $container)
@@ -53,7 +53,7 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
 
     /**
      * Render atom entry
-     * 
+     *
      * @return Zend_Feed_Writer_Renderer_Entry_Atom
      */
     public function render()
@@ -62,7 +62,7 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
         $this->_dom->formatOutput = true;
         $entry = $this->_dom->createElementNS(Writer\Writer::NAMESPACE_ATOM_10, 'entry');
         $this->_dom->appendChild($entry);
-        
+
         $this->_setSource($this->_dom, $entry);
         $this->_setTitle($this->_dom, $entry);
         $this->_setDescription($this->_dom, $entry);
@@ -81,15 +81,15 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
             $ext->setDOMDocument($this->getDOMDocument(), $entry);
             $ext->render();
         }
-        
+
         return $this;
     }
-    
+
     /**
      * Set entry title
-     * 
-     * @param  DOMDocument $dom 
-     * @param  DOMElement $root 
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
      * @return void
      */
     protected function _setTitle(DOMDocument $dom, DOMElement $root)
@@ -111,12 +111,12 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
         $cdata = $dom->createCDATASection($this->getDataContainer()->getTitle());
         $title->appendChild($cdata);
     }
-    
+
     /**
      * Set entry description
-     * 
-     * @param  DOMDocument $dom 
-     * @param  DOMElement $root 
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
      * @return void
      */
     protected function _setDescription(DOMDocument $dom, DOMElement $root)
@@ -132,12 +132,12 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
         );
         $subtitle->appendChild($cdata);
     }
-    
+
     /**
      * Set date entry was modified
-     * 
-     * @param  DOMDocument $dom 
-     * @param  DOMElement $root 
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
      * @return void
      */
     protected function _setDateModified(DOMDocument $dom, DOMElement $root)
@@ -161,12 +161,12 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
         );
         $updated->appendChild($text);
     }
-    
+
     /**
      * Set date entry was created
-     * 
-     * @param  DOMDocument $dom 
-     * @param  DOMElement $root 
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
      * @return void
      */
     protected function _setDateCreated(DOMDocument $dom, DOMElement $root)
@@ -181,12 +181,12 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
         );
         $el->appendChild($text);
     }
-    
+
     /**
-     * Set entry authors 
-     * 
-     * @param  DOMDocument $dom 
-     * @param  DOMElement $root 
+     * Set entry authors
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
      * @return void
      */
     protected function _setAuthors(DOMDocument $dom, DOMElement $root)
@@ -220,12 +220,12 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
             }
         }
     }
-    
+
     /**
      * Set entry enclosure
-     * 
-     * @param  DOMDocument $dom 
-     * @param  DOMElement $root 
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
      * @return void
      */
     protected function _setEnclosure(DOMDocument $dom, DOMElement $root)
@@ -245,7 +245,7 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
         $enclosure->setAttribute('href', $data['uri']);
         $root->appendChild($enclosure);
     }
-    
+
     protected function _setLink(DOMDocument $dom, DOMElement $root)
     {
         if(!$this->getDataContainer()->getLink()) {
@@ -257,12 +257,12 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
         $link->setAttribute('type', 'text/html');
         $link->setAttribute('href', $this->getDataContainer()->getLink());
     }
-    
+
     /**
-     * Set entry identifier 
-     * 
-     * @param  DOMDocument $dom 
-     * @param  DOMElement $root 
+     * Set entry identifier
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
      * @return void
      */
     protected function _setId(DOMDocument $dom, DOMElement $root)
@@ -286,10 +286,10 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
             $this->getDataContainer()->setId(
                 $this->getDataContainer()->getLink());
         }
-        if (!Uri\UriFactory::factory($this->getDataContainer()->getId())->isValid() 
+        if (!Uri\UriFactory::factory($this->getDataContainer()->getId())->isValid()
             && !preg_match(
                 "#^urn:[a-zA-Z0-9][a-zA-Z0-9\-]{1,31}:([a-zA-Z0-9\(\)\+\,\.\:\=\@\;\$\_\!\*\-]|%[0-9a-fA-F]{2})*#",
-                $this->getDataContainer()->getId()) 
+                $this->getDataContainer()->getId())
             && !$this->_validateTagUri($this->getDataContainer()->getId())
         ) {
             throw new Exception('Atom 1.0 IDs must be a valid URI/IRI');
@@ -299,7 +299,7 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
         $text = $dom->createTextNode($this->getDataContainer()->getId());
         $id->appendChild($text);
     }
-    
+
     /**
      * Validate a URI using the tag scheme (RFC 4151)
      *
@@ -308,7 +308,7 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
      */
     protected function _validateTagUri($id)
     {
-        if (preg_match('/^tag:(?<name>.*),(?<date>\d{4}-?\d{0,2}-?\d{0,2}):(?<specific>.*)(.*:)*$/', $id, $matches)) {
+        if (preg_match('/^tag:(?P<name>.*),(?P<date>\d{4}-?\d{0,2}-?\d{0,2}):(?P<specific>.*)(.*:)*$/', $id, $matches)) {
             $dvalid = false;
             $nvalid = false;
             $date = $matches['date'];
@@ -331,12 +331,12 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
         }
         return false;
     }
-    
+
     /**
-     * Set entry content 
-     * 
-     * @param  DOMDocument $dom 
-     * @param  DOMElement $root 
+     * Set entry content
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
      * @return void
      */
     protected function _setContent(DOMDocument $dom, DOMElement $root)
@@ -365,7 +365,7 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
         $element->appendChild($xhtml);
         $root->appendChild($element);
     }
-    
+
     /**
      * Load a HTML string and attempt to normalise to XML
      */
@@ -387,19 +387,19 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
             $xhtml = $content;
         }
         $xhtml = preg_replace(array(
-            "/(<[\/]?)([a-zA-Z]+)/"   
+            "/(<[\/]?)([a-zA-Z]+)/"
         ), '$1xhtml:$2', $xhtml);
         $dom = new DOMDocument('1.0', $this->getEncoding());
         $dom->loadXML('<xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml">'
             . $xhtml . '</xhtml:div>');
         return $dom->documentElement;
     }
-    
+
     /**
-     * Set entry cateories 
-     * 
-     * @param  DOMDocument $dom 
-     * @param  DOMElement $root 
+     * Set entry cateories
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
      * @return void
      */
     protected function _setCategories(DOMDocument $dom, DOMElement $root)
@@ -422,12 +422,12 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
             $root->appendChild($category);
         }
     }
-    
+
     /**
      * Append Source element (Atom 1.0 Feed Metadata)
      *
-     * @param  DOMDocument $dom 
-     * @param  DOMElement $root 
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
      * @return void
      */
     protected function _setSource(DOMDocument $dom, DOMElement $root)
@@ -440,6 +440,6 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\Renderer
         $renderer->setType($this->getType());
         $element = $renderer->render()->getElement();
         $imported = $dom->importNode($element, true);
-        $root->appendChild($imported); 
+        $root->appendChild($imported);
     }
 }

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -94,7 +94,7 @@ class Request extends Message implements RequestDescription
             self::METHOD_OPTIONS, self::METHOD_GET, self::METHOD_HEAD, self::METHOD_POST,
             self::METHOD_PUT, self::METHOD_DELETE, self::METHOD_TRACE, self::METHOD_CONNECT
         ));
-        $regex = '^(?P<method>' . $methods . ')\s(?<uri>[^ ]*)(?:\sHTTP\/(?<version>\d+\.\d+)){0,1}';
+        $regex = '^(?P<method>' . $methods . ')\s(?P<uri>[^ ]*)(?:\sHTTP\/(?P<version>\d+\.\d+)){0,1}';
         $firstLine = array_shift($lines);
         if (!preg_match('#' . $regex . '#', $firstLine, $matches)) {
             throw new Exception\InvalidArgumentException('A valid request line was not found in the provided string');

--- a/library/Zend/Mail/Header/AbstractAddressList.php
+++ b/library/Zend/Mail/Header/AbstractAddressList.php
@@ -47,7 +47,7 @@ abstract class AbstractAddressList implements Header
 
     /**
      * Header encoding
-     * 
+     *
      * @var string
      */
     protected $encoding = 'ASCII';
@@ -59,8 +59,8 @@ abstract class AbstractAddressList implements Header
 
     /**
      * Parse string to create header object
-     * 
-     * @param  string $headerLine 
+     *
+     * @param  string $headerLine
      * @return AbstractAddressList
      */
     public static function fromString($headerLine)
@@ -86,7 +86,7 @@ abstract class AbstractAddressList implements Header
         $addressList = $header->getAddressList();
         foreach ($values as $address) {
             // split values into name/email
-            if (!preg_match('/^((?<name>.*?)<(?<namedEmail>[^>]+)>|(?<email>.+))$/', $address, $matches)) {
+            if (!preg_match('/^((?P<name>.*?)<(?P<namedEmail>[^>]+)>|(?P<email>.+))$/', $address, $matches)) {
                 // Should we raise an exception here?
                 continue;
             }
@@ -117,7 +117,7 @@ abstract class AbstractAddressList implements Header
 
     /**
      * Get field name of this header
-     * 
+     *
      * @return string
      */
     public function getFieldName()
@@ -127,7 +127,7 @@ abstract class AbstractAddressList implements Header
 
     /**
      * Get field value of this header
-     * 
+     *
      * @return string
      */
     public function getFieldValue()
@@ -156,11 +156,11 @@ abstract class AbstractAddressList implements Header
 
     /**
      * Set header encoding
-     * 
-     * @param  string $encoding 
+     *
+     * @param  string $encoding
      * @return AbstractAddressList
      */
-    public function setEncoding($encoding) 
+    public function setEncoding($encoding)
     {
         $this->encoding = $encoding;
         return $this;
@@ -168,7 +168,7 @@ abstract class AbstractAddressList implements Header
 
     /**
      * Get header encoding
-     * 
+     *
      * @return string
      */
     public function getEncoding()
@@ -178,8 +178,8 @@ abstract class AbstractAddressList implements Header
 
     /**
      * Set address list for this header
-     * 
-     * @param  AddressList $addressList 
+     *
+     * @param  AddressList $addressList
      * @return void
      */
     public function setAddressList(AddressList $addressList)
@@ -189,7 +189,7 @@ abstract class AbstractAddressList implements Header
 
     /**
      * Get address list managed by this header
-     * 
+     *
      * @return AddressList
      */
     public function getAddressList()
@@ -202,7 +202,7 @@ abstract class AbstractAddressList implements Header
 
     /**
      * Serialize to string
-     * 
+     *
      * @return string
      */
     public function toString()
@@ -211,4 +211,4 @@ abstract class AbstractAddressList implements Header
         $value = $this->getFieldValue();
         return sprintf("%s: %s\r\n", $name, $value);
     }
-} 
+}

--- a/library/Zend/Mail/Header/MimeVersion.php
+++ b/library/Zend/Mail/Header/MimeVersion.php
@@ -39,8 +39,8 @@ class MimeVersion implements Header
 
     /**
      * Deserialize from string
-     * 
-     * @param  string $headerLine 
+     *
+     * @param  string $headerLine
      * @return MimeVersion
      */
     public static function fromString($headerLine)
@@ -54,16 +54,16 @@ class MimeVersion implements Header
 
         // Check for version, and set if found
         $header = new static();
-        if (preg_match('/^(?<version>\d+\.\d+)$/', $value, $matches)) {
+        if (preg_match('/^(?P<version>\d+\.\d+)$/', $value, $matches)) {
             $header->version = $matches['version'];
         }
-        
+
         return $header;
     }
 
     /**
      * Get the field name
-     * 
+     *
      * @return string
      */
     public function getFieldName()
@@ -73,7 +73,7 @@ class MimeVersion implements Header
 
     /**
      * Get the field value (version string)
-     * 
+     *
      * @return string
      */
     public function getFieldValue()
@@ -83,8 +83,8 @@ class MimeVersion implements Header
 
     /**
      * Set character encoding
-     * 
-     * @param  string $encoding 
+     *
+     * @param  string $encoding
      * @return void
      */
     public function setEncoding($encoding)
@@ -94,7 +94,7 @@ class MimeVersion implements Header
 
     /**
      * Get character encoding
-     * 
+     *
      * @return void
      */
     public function getEncoding()
@@ -104,17 +104,17 @@ class MimeVersion implements Header
 
     /**
      * Serialize to string
-     * 
+     *
      * @return string
      */
     public function toString()
     {
         return 'Mime-Version: ' . $this->getFieldValue();
     }
-    
+
     /**
      * Set the version string used in this header
-     * 
+     *
      * @param  string $version
      * @return MimeVersion
      */
@@ -126,7 +126,7 @@ class MimeVersion implements Header
 
     /**
      * Retrieve the version string for this header
-     * 
+     *
      * @return string
      */
     public function getVersion()

--- a/library/Zend/Mail/Header/Sender.php
+++ b/library/Zend/Mail/Header/Sender.php
@@ -41,15 +41,15 @@ class Sender implements Header
 
     /**
      * Header encoding
-     * 
+     *
      * @var string
      */
     protected $encoding = 'ASCII';
 
     /**
      * Factory: create Sender header object from string
-     * 
-     * @param  string $headerLine 
+     *
+     * @param  string $headerLine
      * @return Sender
      * @throws Exception\InvalidArgumentException on invalid header line
      */
@@ -66,7 +66,7 @@ class Sender implements Header
         $header = new static();
 
         // Check for address, and set if found
-        if (preg_match('^(?<name>.*?)<(?<email>[^>]+)>$', $value, $matches)) {
+        if (preg_match('^(?P<name>.*?)<(?P<email>[^>]+)>$', $value, $matches)) {
             $name = $matches['name'];
             if (empty($name)) {
                 $name = null;
@@ -75,13 +75,13 @@ class Sender implements Header
             }
             $header->setAddress($matches['email'], $name);
         }
-        
+
         return $header;
     }
 
     /**
      * Get header name
-     * 
+     *
      * @return string
      */
     public function getFieldName()
@@ -91,7 +91,7 @@ class Sender implements Header
 
     /**
      * Get header value
-     * 
+     *
      * @return string
      */
     public function getFieldValue()
@@ -114,11 +114,11 @@ class Sender implements Header
 
     /**
      * Set header encoding
-     * 
-     * @param  string $encoding 
+     *
+     * @param  string $encoding
      * @return Sender
      */
-    public function setEncoding($encoding) 
+    public function setEncoding($encoding)
     {
         $this->encoding = $encoding;
         return $this;
@@ -126,7 +126,7 @@ class Sender implements Header
 
     /**
      * Get header encoding
-     * 
+     *
      * @return string
      */
     public function getEncoding()
@@ -136,19 +136,19 @@ class Sender implements Header
 
     /**
      * Serialize to string
-     * 
+     *
      * @return string
      */
     public function toString()
     {
         return 'Sender: ' . $this->getFieldValue();
     }
-    
+
     /**
      * Set the address used in this header
-     * 
-     * @param  string|AddressDescription $emailOrAddress 
-     * @param  null|string $name 
+     *
+     * @param  string|AddressDescription $emailOrAddress
+     * @param  null|string $name
      * @return Sender
      */
     public function setAddress($emailOrAddress, $name = null)
@@ -159,7 +159,7 @@ class Sender implements Header
         if (!$emailOrAddress instanceof AddressDescription) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects a string or AddressDescription object; received "%s"',
-                __METHOD__, 
+                __METHOD__,
                 (is_object($emailOrAddress) ? get_class($emailOrAddress) : gettype($emailOrAddress))
             ));
         }
@@ -169,7 +169,7 @@ class Sender implements Header
 
     /**
      * Retrieve the internal address from this header
-     * 
+     *
      * @return AddressDescription|null
      */
     public function getAddress()

--- a/library/Zend/Markup/Parser/Bbcode.php
+++ b/library/Zend/Markup/Parser/Bbcode.php
@@ -463,7 +463,7 @@ class Bbcode implements Parser
             }
 
             $matches = array();
-            $regex   = '#\G(?<text>[^\[]*)(?<open>\[(?<name>[' . self::NAME_CHARSET . ']+)?)?#';
+            $regex   = '#\G(?P<text>[^\[]*)(?P<open>\[(?P<name>[' . self::NAME_CHARSET . ']+)?)?#';
             if (!preg_match($regex, $value, $matches, null, $pointer)) {
                 goto end;
             }
@@ -508,7 +508,7 @@ class Bbcode implements Parser
 
         scanattrs: {
             $matches = array();
-            $regex   = '#\G((?<end>\s*\])|\s+(?<attribute>[' . self::NAME_CHARSET . ']+)(?<eq>=?))#';
+            $regex   = '#\G((?P<end>\s*\])|\s+(?P<attribute>[' . self::NAME_CHARSET . ']+)(?P<eq>=?))#';
             if (!preg_match($regex, $value, $matches, null, $pointer)) {
                 goto end;
             }
@@ -547,7 +547,7 @@ class Bbcode implements Parser
 
         parsevalue: {
             $matches = array();
-            $regex   = '#\G((?<quote>"|\')(?<valuequote>.*?)\\2|(?<value>[^\]\s]+))#';
+            $regex   = '#\G((?P<quote>"|\')(?P<valuequote>.*?)\\2|(?P<value>[^\]\s]+))#';
             if (!preg_match($regex, $value, $matches, null, $pointer)) {
                 goto scanattrs;
             }

--- a/library/Zend/Mvc/Router/Http/Hostname.php
+++ b/library/Zend/Mvc/Router/Http/Hostname.php
@@ -135,7 +135,7 @@ class Hostname implements Route
         }
 
         foreach ($this->route as $index => $routePart) {
-            if (preg_match('(^:(?<name>.+)$)', $routePart, $matches)) {
+            if (preg_match('(^:(?P<name>.+)$)', $routePart, $matches)) {
                 if (isset($this->constraints[$matches['name']]) && !preg_match('(^' . $this->constraints[$matches['name']] . '$)', $hostname[$index])) {
                     return null;
                 }
@@ -166,7 +166,7 @@ class Hostname implements Route
             $parts = array();
 
             foreach ($this->route as $index => $routePart) {
-                if (preg_match('(^:(?<name>.+)$)', $routePart, $matches)) {
+                if (preg_match('(^:(?P<name>.+)$)', $routePart, $matches)) {
                     if (!isset($mergedParams[$matches['name']])) {
                         throw new Exception\InvalidArgumentException(sprintf('Missing parameter "%s"', $matches['name']));
                     }

--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -136,7 +136,7 @@ class Segment implements Route
         $level      = 0;
 
         while ($currentPos < $length) {
-            preg_match('(\G(?<literal>[^:{\[\]]*)(?<token>[:{\[\]]|$))', $def, $matches, 0, $currentPos);
+            preg_match('(\G(?P<literal>[^:{\[\]]*)(?P<token>[:{\[\]]|$))', $def, $matches, 0, $currentPos);
 
             $currentPos += strlen($matches[0]);
 
@@ -146,13 +146,13 @@ class Segment implements Route
 
             if ($matches['token'] === ':') {
                 if (isset($def[$currentPos]) && $def[$currentPos] === '{') {
-                    if (!preg_match('(\G\{(?<name>[^}]+)\}:?)', $def, $matches, 0, $currentPos)) {
+                    if (!preg_match('(\G\{(?P<name>[^}]+)\}:?)', $def, $matches, 0, $currentPos)) {
                         throw new Exception\RuntimeException('Translated parameter missing closing bracket');
                     }
 
                     $levelParts[$level][] = array('translated-parameter', $matches['name']);
                 } else {
-                    if (!preg_match('(\G(?<name>[^:/{\[\]]+)(?:{(?<delimiters>[^}]+)})?:?)', $def, $matches, 0, $currentPos)) {
+                    if (!preg_match('(\G(?P<name>[^:/{\[\]]+)(?:{(?P<delimiters>[^}]+)})?:?)', $def, $matches, 0, $currentPos)) {
                         throw new Exception\RuntimeException('Found empty parameter name');
                     }
 
@@ -161,7 +161,7 @@ class Segment implements Route
 
                 $currentPos += strlen($matches[0]);
             } elseif ($matches['token'] === '{') {
-                if (!preg_match('(\G(?<literal>[^}]+)\})', $def, $matches, 0, $currentPos)) {
+                if (!preg_match('(\G(?P<literal>[^}]+)\})', $def, $matches, 0, $currentPos)) {
                     throw new Exception\RuntimeException('Translated literal missing closing bracket');
                 }
 


### PR DESCRIPTION
Due to a pre 7.0 PCRE-lib PHP only understand named patterns using the
"(?P<"-notation and not the "(?<" notation that was used for determining
the segments for routing.

This is a fix for issue  ZF2-241 - http://framework.zend.com/issues/browse/ZF2-241

As long as no speed-issues stand against it, we should use the "old" syntax for named subpatterns as it's not a PHP but a library issue.
