### PR TITLE
ZF2-243: Removed GLOB_BRACE from ConfigListener

### DIFF
--- a/library/Zend/Module/Listener/ConfigListener.php
+++ b/library/Zend/Module/Listener/ConfigListener.php
@@ -230,7 +230,7 @@ class ConfigListener extends AbstractListener
     protected function mergeGlobPath($globPath)
     {
         // @TODO Use GlobIterator
-        $config = ConfigFactory::fromFiles(glob($globPath, GLOB_BRACE));
+        $config = ConfigFactory::fromFiles(glob($globPath));
         $this->mergeTraversableConfig($config);
         if ($this->getOptions()->getConfigCacheEnabled()) {
             $this->updateCache();


### PR DESCRIPTION
Removed GLOB_BRACE for compatibility with AIX/IBMi
This change requires we update the SkeletonApplication to stack config listeners with separate glob patterns
