### PR TITLE
[Hotfix]Response - fromString isHeader flag should check  first  blank line only

### DIFF
--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -202,7 +202,7 @@ class Response extends Message implements ResponseDescription
         while ($lines) {
             $nextLine = array_shift($lines);
 
-            if ($nextLine == '') {
+            if ($isHeader && $nextLine == '') {
                 $isHeader = false;
                 continue;
             }


### PR DESCRIPTION
if Response is Transfer-Encoding: chunked,
current Zend\Http\Response::fromString() implmentaion causes

```
PHP Fatal error:  Uncaught exception 'Zend\Http\Exception\RuntimeException' with message 'Error parsing body - doesn't seem to be a chunked message'
```
