### PR TITLE
fixed and simplified output cache pattern

### DIFF
--- a/tests/Zend/Cache/Pattern/OutputCacheTest.php
+++ b/tests/Zend/Cache/Pattern/OutputCacheTest.php
@@ -39,6 +39,13 @@ class OutputCacheTest extends CommonPatternTest
      */
     protected $_storage;
 
+    /**
+     * Nesting level of output buffering used to restore on tearDown()
+     *
+     * @var null|int
+     */
+    protected $_obLevel;
+
     public function setUp()
     {
         $this->_storage = new Cache\Storage\Adapter\Memory();
@@ -48,91 +55,61 @@ class OutputCacheTest extends CommonPatternTest
         $this->_pattern = new Cache\Pattern\OutputCache();
         $this->_pattern->setOptions($this->_options);
 
+        // used to reset the level on tearDown
+        $this->_obLevel = ob_get_level();
+
         parent::setUp();
     }
 
     public function tearDown()
     {
+        if ($this->_obLevel > ob_get_Level()) {
+            for ($i = ob_get_level(); $i < $this->_obLevel; $i++) {
+                ob_start();
+            }
+            $this->fail("Nesting level of output buffering to often ended");
+        } elseif ($this->_obLevel < ob_get_level()) {
+            for ($i = ob_get_level(); $i > $this->_obLevel; $i--) {
+                ob_end_clean();
+            }
+            $this->fail("Nesting level of output buffering not well restored");
+        }
+
         parent::tearDown();
     }
 
-    public function testStartEndOutput()
+    public function testStartEndCacheMiss()
     {
         $output = 'foobar';
-        $key    = 'testStartEndOutput';
+        $key    = 'testStartEndCacheMiss';
 
         ob_start();
-        if (!($this->_pattern->start($key))) {
-            echo $output;
-            $this->_pattern->end();
-        }
+        $this->assertFalse($this->_pattern->start($key));
+        echo $output;
+        $this->assertTrue($this->_pattern->end());
         $data = ob_get_clean();
+
         $this->assertEquals($output, $data);
     }
 
-    public function testStartEndReturnOutput()
+    public function testStartEndCacheHit()
     {
         $output = 'foobar';
-        $key    = 'testStartEndReturnOutput';
-        $data   = '';
-        if (!($this->_pattern->start($key))) {
-            echo $output;
-            $data = $this->_pattern->end(array('output' => false));
-        }
-        $this->assertEquals($output, $data);
-    }
+        $key    = 'testStartEndCacheHit';
 
-    public function testStartEndCachedOutput()
-    {
-        $output = 'foobar';
-        $key    = 'testStartEndCachedOutput';
+        // fill cache
+        $this->_pattern->getOptions()->getStorage()->setItem($key, $output);
 
-        // first run to write to cache
         ob_start();
-        if (!($this->_pattern->start($key))) {
-            echo $output;
-            $this->_pattern->end();
-        }
+        $this->assertTrue($this->_pattern->start($key));
         $data = ob_get_clean();
-        $this->assertEquals($output, $data);
 
-        // second run to check if cached
-        // first run to write to cache
-        ob_start();
-        if (!($this->_pattern->start($key))) {
-            ob_end_clean();
-            $this->fail('Second run has to be cached');
-        }
-        $data = ob_get_clean();
-        $this->assertEquals($output, $data);
-    }
-
-    public function testStartEndReturnCachedOutput()
-    {
-        $output = 'foobar';
-        $key    = 'testStartEndReturnCachedOutput';
-
-        // first run to write to cache
-        ob_start();
-        if (!($this->_pattern->start($key))) {
-            echo $output;
-            $this->_pattern->end();
-        }
-        $data = ob_get_clean();
-        ob_implicit_flush(true);
-        $this->assertEquals($output, $data);
-
-        // second run to check if cached
-        // first run to write to cache
-        if ( ($data = $this->_pattern->start($key, array('output' => false))) === false ) {
-            $this->fail('Second run has to be cached');
-        }
-        $this->assertEquals($output, $data);
+        $this->assertSame($output, $data);
     }
 
     public function testThrowMissingKeyException()
     {
-        $this->setExpectedException('Zend\\Cache\\Exception\\MissingKeyException');
+        $this->setExpectedException('Zend\Cache\Exception\MissingKeyException');
         $this->_pattern->start(''); // empty key
     }
 


### PR DESCRIPTION
- removed the option "output" previously used on start() and end() to return the cached/buffered data instead of displaying it. It was only used on unit tests but it's simpler to address it using an own output buffer level.

This fixes the only failed test on Zend\Cache :)
