### PR TITLE
Sql\Predicate\Operator.php

### DIFF
--- a/library/Zend/Db/Sql/Predicate/Operator.php
+++ b/library/Zend/Db/Sql/Predicate/Operator.php
@@ -71,13 +71,13 @@ class Operator implements PredicateInterface
      */
     public function __construct($left = null, $operator = self::OPERATOR_EQUAL_TO, $right = null, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
-        if ($left) {
+        if (null !== $left) {
             $this->setLeft($left);
         }
         if ($operator) {
             $this->setOperator($operator);
         }
-        if ($right) {
+        if (null !== $right) {
             $this->setRight($right);
         }
         if ($leftType) {

--- a/library/Zend/Db/Sql/Predicate/Operator.php
+++ b/library/Zend/Db/Sql/Predicate/Operator.php
@@ -222,7 +222,7 @@ class Operator implements PredicateInterface
     public function getWhereParts()
     {
         return array(array(
-            '%s ' . $this->operator . ' %s', 
+            (is_int($this->left)? '%d ':'%s ') . $this->operator . (is_int($this->right)? ' %d':' %s'), 
             array($this->left, $this->right), 
             array($this->leftType, $this->rightType)
         ));


### PR DESCRIPTION
Regarding commit 164ccc3: $left and $right should be compared to null while validating, because if you try to create a sentence like : where field = 0, $right will be equal to 0 which will make line 80 evaluate to false, never calling $this->setRight($right)

Regarding commit f6d40d0: I don't know if this is the best way to do it, but this kind of validation is necessary because on some RDBMS (like PostgreSQL) you can't compare an integer field to a string value, it will generate an error, as it can't compare different data types.
