### PR TITLE
Fix method name in 7.1.4. Available Methods part

### DIFF
--- a/documentation/manual/en/module_specs/Zend_EventManager-EventManager.xml
+++ b/documentation/manual/en/module_specs/Zend_EventManager-EventManager.xml
@@ -535,7 +535,7 @@ $events->attach(array('foo', 'bar'), '*', $callback);
             </varlistentry>
 
             <varlistentry xml:id="zend.event-manager.event-manager.methods.get-events">
-                <term>detachAggregate</term>
+                <term>getEvents</term>
                 <listitem>
                     <methodsynopsis>
                         <methodname>getEvents</methodname>


### PR DESCRIPTION
Fix copy-paste typo in Zend\EventManager docs
