### PR TITLE
Add namespace and fix checking supertypes on RuntimeDefinition and CompilerDefinition (fix #ZF2-251)

### DIFF
--- a/library/Zend/Di/Definition/CompilerDefinition.php
+++ b/library/Zend/Di/Definition/CompilerDefinition.php
@@ -5,6 +5,7 @@ namespace Zend\Di\Definition;
 use Zend\Code\Scanner\DerivedClassScanner,
     Zend\Code\Scanner\AggregateDirectoryScanner,
     Zend\Code\Scanner\DirectoryScanner,
+    Zend\Code\Scanner\FileScanner,
     
     Zend\Di\Definition\Annotation,
     Zend\Code\Annotation\AnnotationManager,
@@ -408,7 +409,7 @@ class CompilerDefinition implements Definition
      */
     public function getClassSupertypes($class)
     {
-        if (!array_key_exists($class, $this->classes[$class])) {
+        if (!array_key_exists($class, $this->classes)) {
             $this->processClass($class);
         }
         return $this->classes[$class]['supertypes'];

--- a/library/Zend/Di/Definition/RuntimeDefinition.php
+++ b/library/Zend/Di/Definition/RuntimeDefinition.php
@@ -105,7 +105,7 @@ class RuntimeDefinition implements Definition
      */
     public function getClassSupertypes($class)
     {
-        if (!array_key_exists($class, $this->classes[$class])) {
+        if (!array_key_exists($class, $this->classes)) {
             $this->processClass($class);
         }
         return $this->classes[$class]['supertypes'];

--- a/tests/Zend/Di/Definition/CompilerDefinitionTest.php
+++ b/tests/Zend/Di/Definition/CompilerDefinitionTest.php
@@ -4,6 +4,7 @@ namespace ZendTest\Di\Definition;
 
 use Zend\Di\Definition\CompilerDefinition,
     Zend\Code\Scanner\DirectoryScanner,
+    Zend\Code\Scanner\FileScanner,
     PHPUnit_Framework_TestCase as TestCase;
 
 class CompilerDefinitionTest extends TestCase
@@ -54,5 +55,13 @@ class CompilerDefinitionTest extends TestCase
         $this->assertContains('ZendTest\Di\TestAsset\CompilerClasses\C', $definition->getClassSupertypes('ZendTest\Di\TestAsset\CompilerClasses\D'));
         $this->assertContains('ZendTest\Di\TestAsset\CompilerClasses\C', $definition->getClassSupertypes('ZendTest\Di\TestAsset\CompilerClasses\E'));
         $this->assertContains('ZendTest\Di\TestAsset\CompilerClasses\D', $definition->getClassSupertypes('ZendTest\Di\TestAsset\CompilerClasses\E'));
+    }
+    
+    public function testCompilerDirectoryScannerAndFileScanner()
+    {
+        $definition = new CompilerDefinition;
+        $definition->addDirectoryScanner(new DirectoryScanner(__DIR__ . '/../TestAsset/CompilerClasses'));
+        $definition->addCodeScannerFile(new FileScanner(__DIR__ . '/../TestAsset/CompilerClasses/A.php'));
+        $definition->compile();
     }
 }

--- a/tests/Zend/Di/Definition/CompilerDefinitionTest.php
+++ b/tests/Zend/Di/Definition/CompilerDefinitionTest.php
@@ -63,5 +63,20 @@ class CompilerDefinitionTest extends TestCase
         $definition->addDirectoryScanner(new DirectoryScanner(__DIR__ . '/../TestAsset/CompilerClasses'));
         $definition->addCodeScannerFile(new FileScanner(__DIR__ . '/../TestAsset/CompilerClasses/A.php'));
         $definition->compile();
+        $this->assertContains('ZendTest\Di\TestAsset\CompilerClasses\C', $definition->getClassSupertypes('ZendTest\Di\TestAsset\CompilerClasses\D'));
+        $this->assertContains('ZendTest\Di\TestAsset\CompilerClasses\C', $definition->getClassSupertypes('ZendTest\Di\TestAsset\CompilerClasses\E'));
+        $this->assertContains('ZendTest\Di\TestAsset\CompilerClasses\D', $definition->getClassSupertypes('ZendTest\Di\TestAsset\CompilerClasses\E'));
+    }
+    
+    public function testCompilerFileScanner()
+    {
+        $definition = new CompilerDefinition;
+        $definition->addCodeScannerFile(new FileScanner(__DIR__ . '/../TestAsset/CompilerClasses/C.php'));
+        $definition->addCodeScannerFile(new FileScanner(__DIR__ . '/../TestAsset/CompilerClasses/D.php'));
+        $definition->addCodeScannerFile(new FileScanner(__DIR__ . '/../TestAsset/CompilerClasses/E.php'));
+        $definition->compile();
+        $this->assertContains('ZendTest\Di\TestAsset\CompilerClasses\C', $definition->getClassSupertypes('ZendTest\Di\TestAsset\CompilerClasses\D'));
+        $this->assertContains('ZendTest\Di\TestAsset\CompilerClasses\C', $definition->getClassSupertypes('ZendTest\Di\TestAsset\CompilerClasses\E'));
+        $this->assertContains('ZendTest\Di\TestAsset\CompilerClasses\D', $definition->getClassSupertypes('ZendTest\Di\TestAsset\CompilerClasses\E'));
     }
 }


### PR DESCRIPTION
# ZF-251 :

add namespace for FileScanner to check type in addCodeScannerFile and fix supertype checking
add unit test
