### PR TITLE
Topic/authentication service single adapter

### DIFF
--- a/library/Zend/Authentication/AuthenticationService.php
+++ b/library/Zend/Authentication/AuthenticationService.php
@@ -48,10 +48,13 @@ class AuthenticationService
      * @param  Storage $storage 
      * @return void
      */
-    public function __construct(Storage $storage = null)
+    public function __construct(Storage $storage = null, Adapter $adapter = null)
     {
         if (null !== $storage) {
             $this->setStorage($storage);
+        }
+        if (null !== $adapter) {
+            $this->setAdapter($adapter);
         }
     }
 

--- a/library/Zend/Authentication/AuthenticationService.php
+++ b/library/Zend/Authentication/AuthenticationService.php
@@ -21,7 +21,6 @@
 namespace Zend\Authentication;
 
 /**
- * @uses       Zend\Authentication\Storage\Session
  * @category   Zend
  * @package    Zend_Authentication
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
@@ -34,7 +33,14 @@ class AuthenticationService
      *
      * @var Zend\Authentication\Storage
      */
-    protected $_storage = null;
+    protected $storage = null;
+
+    /**
+     * Authentication adapter
+     *
+     * @var Zend\Authentication\Adapter
+     */
+    protected $adapter = null;
 
     /**
      * Constructor
@@ -50,6 +56,30 @@ class AuthenticationService
     }
 
     /**
+     * Returns the authentication adapter
+     *
+     * The adapter does not have a default if the storage adapter has not been set.
+     *
+     * @return Zend\Authentication\Adapter|null
+     */
+    public function getAdapter()
+    {
+        return $this->adapter;
+    }
+
+    /**
+     * Sets the authentication adapter
+     *
+     * @param  Zend\Authentication\Adapter $adapter
+     * @return Zend\Authentication\AuthenticationService Provides a fluent interface
+     */
+    public function setAdapter(Adapter $adapter)
+    {
+        $this->adapter = $adapter;
+        return $this;
+    }
+
+    /**
      * Returns the persistent storage handler
      *
      * Session storage is used by default unless a different storage adapter has been set.
@@ -58,11 +88,11 @@ class AuthenticationService
      */
     public function getStorage()
     {
-        if (null === $this->_storage) {
+        if (null === $this->storage) {
             $this->setStorage(new Storage\Session());
         }
 
-        return $this->_storage;
+        return $this->storage;
     }
 
     /**
@@ -73,7 +103,7 @@ class AuthenticationService
      */
     public function setStorage(Storage $storage)
     {
-        $this->_storage = $storage;
+        $this->storage = $storage;
         return $this;
     }
 
@@ -82,9 +112,15 @@ class AuthenticationService
      *
      * @param  Zend\Authentication\Adapter $adapter
      * @return Zend\Authentication\Result
+     * @throws Zend\Authentication\Exception\RuntimeException
      */
-    public function authenticate(Adapter $adapter)
+    public function authenticate(Adapter $adapter = null)
     {
+        if (!$adapter) {
+            if (!$adapter = $this->getAdapter()) {
+                throw new Exception\RuntimeException('An adapter must be set or passed prior to calling authenticate()');
+            }
+        }
         $result = $adapter->authenticate();
 
         /**

--- a/library/Zend/Authentication/Exception/RuntimeException.php
+++ b/library/Zend/Authentication/Exception/RuntimeException.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Authentication
+ * @subpackage Exception
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Authentication\Exception;
+
+use Zend\Authentication\Exception;
+
+/**
+ * @category   Zend
+ * @package    Zend_Authentication
+ * @subpackage Exception
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class RuntimeException 
+    extends \RuntimeException 
+    implements Exception
+{
+}

--- a/library/Zend/Authentication/Storage/Session.php
+++ b/library/Zend/Authentication/Storage/Session.php
@@ -51,21 +51,21 @@ class Session implements AuthenticationStorage
      *
      * @var Zend\Session\Container
      */
-    protected $_session;
+    protected $session;
 
     /**
      * Session namespace
      *
      * @var mixed
      */
-    protected $_namespace;
+    protected $namespace = self::NAMESPACE_DEFAULT;
 
     /**
      * Session object member
      *
      * @var mixed
      */
-    protected $_member;
+    protected $member = self::MEMBER_DEFAULT;
 
     /**
      * Sets session storage options and initializes session namespace object
@@ -74,12 +74,17 @@ class Session implements AuthenticationStorage
      * @param  mixed $member
      * @return void
      */
-    public function __construct(
-        $namespace = self::NAMESPACE_DEFAULT, $member = self::MEMBER_DEFAULT, SessionManager $manager = null
-    ) {
-        $this->_namespace = $namespace;
-        $this->_member    = $member;
-        $this->_session   = new SessionContainer($this->_namespace, $manager);
+    public function __construct($namespace = null, $member = null, SessionManager $manager = null)
+    {
+        if ($namespace !== null) {
+            $this->namespace = $namespace;
+        }
+        if ($member !== null) {
+            $this->member = $member;
+        }
+        $this->namespace = $namespace;
+        $this->member    = $member;
+        $this->session   = new SessionContainer($this->_namespace, $manager);
     }
 
     /**
@@ -89,7 +94,7 @@ class Session implements AuthenticationStorage
      */
     public function getNamespace()
     {
-        return $this->_namespace;
+        return $this->namespace;
     }
 
     /**
@@ -99,7 +104,7 @@ class Session implements AuthenticationStorage
      */
     public function getMember()
     {
-        return $this->_member;
+        return $this->member;
     }
 
     /**
@@ -109,7 +114,7 @@ class Session implements AuthenticationStorage
      */
     public function isEmpty()
     {
-        return !isset($this->_session->{$this->_member});
+        return !isset($this->session->{$this->member});
     }
 
     /**
@@ -119,7 +124,7 @@ class Session implements AuthenticationStorage
      */
     public function read()
     {
-        return $this->_session->{$this->_member};
+        return $this->session->{$this->member};
     }
 
     /**
@@ -130,7 +135,7 @@ class Session implements AuthenticationStorage
      */
     public function write($contents)
     {
-        $this->_session->{$this->_member} = $contents;
+        $this->session->{$this->member} = $contents;
     }
 
     /**
@@ -140,6 +145,6 @@ class Session implements AuthenticationStorage
      */
     public function clear()
     {
-        unset($this->_session->{$this->_member});
+        unset($this->session->{$this->member});
     }
 }

--- a/library/Zend/Authentication/Storage/Session.php
+++ b/library/Zend/Authentication/Storage/Session.php
@@ -82,9 +82,7 @@ class Session implements AuthenticationStorage
         if ($member !== null) {
             $this->member = $member;
         }
-        $this->namespace = $namespace;
-        $this->member    = $member;
-        $this->session   = new SessionContainer($this->_namespace, $manager);
+        $this->session   = new SessionContainer($this->namespace, $manager);
     }
 
     /**

--- a/tests/Zend/Authentication/AuthenticationServiceTest.php
+++ b/tests/Zend/Authentication/AuthenticationServiceTest.php
@@ -50,6 +50,15 @@ class AuthenticationServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($storage instanceof Auth\Storage\Session);
     }
 
+    public function testAdapter()
+    {
+        $this->assertNull($this->auth->getAdapter());
+        $successAdapter = new TestAsset\SuccessAdapter();
+        $ret = $this->auth->setAdapter($successAdapter);
+        $this->assertSame($ret, $this->auth);
+        $this->assertSame($successAdapter, $this->auth->getAdapter());
+    }
+
     /**
      * Ensures expected behavior for successful authentication
      *
@@ -58,6 +67,14 @@ class AuthenticationServiceTest extends \PHPUnit_Framework_TestCase
     public function testAuthenticate()
     {
         $result = $this->_authenticate();
+        $this->assertTrue($result instanceof Auth\Result);
+        $this->assertTrue($this->auth->hasIdentity());
+        $this->assertEquals('someIdentity', $this->auth->getIdentity());
+    }
+
+    public function testAuthenticateSetAdapter()
+    {
+        $result = $this->_authenticate(new TestAsset\SuccessAdapter());
         $this->assertTrue($result instanceof Auth\Result);
         $this->assertTrue($this->auth->hasIdentity());
         $this->assertEquals('someIdentity', $this->auth->getIdentity());
@@ -76,8 +93,11 @@ class AuthenticationServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(null, $this->auth->getIdentity());
     }
 
-    protected function _authenticate()
+    protected function _authenticate($adapter = null)
     {
-        return $this->auth->authenticate(new TestAsset\SuccessAdapter());
+        if ($adapter === null) {
+            $adapter = new TestAsset\SuccessAdapter();
+        }
+        return $this->auth->authenticate($adapter);
     }
 }

--- a/tests/Zend/Authentication/AuthenticationServiceTest.php
+++ b/tests/Zend/Authentication/AuthenticationServiceTest.php
@@ -66,7 +66,7 @@ class AuthenticationServiceTest extends \PHPUnit_Framework_TestCase
      */
     public function testAuthenticate()
     {
-        $result = $this->_authenticate();
+        $result = $this->authenticate();
         $this->assertTrue($result instanceof Auth\Result);
         $this->assertTrue($this->auth->hasIdentity());
         $this->assertEquals('someIdentity', $this->auth->getIdentity());
@@ -74,7 +74,7 @@ class AuthenticationServiceTest extends \PHPUnit_Framework_TestCase
 
     public function testAuthenticateSetAdapter()
     {
-        $result = $this->_authenticate(new TestAsset\SuccessAdapter());
+        $result = $this->authenticate(new TestAsset\SuccessAdapter());
         $this->assertTrue($result instanceof Auth\Result);
         $this->assertTrue($this->auth->hasIdentity());
         $this->assertEquals('someIdentity', $this->auth->getIdentity());
@@ -87,13 +87,13 @@ class AuthenticationServiceTest extends \PHPUnit_Framework_TestCase
      */
     public function testClearIdentity()
     {
-        $this->_authenticate();
+        $this->authenticate();
         $this->auth->clearIdentity();
         $this->assertFalse($this->auth->hasIdentity());
         $this->assertEquals(null, $this->auth->getIdentity());
     }
 
-    protected function _authenticate($adapter = null)
+    protected function authenticate($adapter = null)
     {
         if ($adapter === null) {
             $adapter = new TestAsset\SuccessAdapter();


### PR DESCRIPTION
_Reasoning:_
Currently the authentication method expects you to send in an adapter; this is great when you support multiple authentication types; however, in many peoples case they support 1 and in that case it would be ideal to be able to set through DI.

Additionally the Storage\Session has been updated for the same reasoning; previously the constructor utilizes defaults that would use the self::CONST_NAME attributes.  Now you can just pass the parameter you need through DI.

_Implementation:_
By changing the method signature of authenticate to allow an option adapter you can now either pass an adapter or set the adapter. In the event that one does not exist it will throw a runtime exception. Additionally the constructor now has an optional adapter argument that has been added on to the constructor signature.

The Session\Storage constructor has changed to default to null and default the constants to their variable counterparts within the class property definition itself.  This allows for a single not null check to assign the change.

_Tests:_
Tests have been updated and pass.

_Additional Remarks:_
Some updates were made to fix some coding standard violations; there are plenty more within the Authentication component but those will be a separate pull request.
