### PR TITLE
[ZF2-254] Zend\Http\Header\SetCookie constructor does not call all necessary setters

### DIFF
--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -155,7 +155,7 @@ class SetCookie implements MultipleHeaderDescription
      * @param bool $httponly
      * @return SetCookie
      */
-    public function __construct($name = null, $value = null, $version = null, $maxAge = null, $domain = null, $expires = null, $path = null, $secure = false, $httponly = true)
+    public function __construct($name = null, $value = null, $version = null, $maxAge = null, $domain = null, $expires = null, $path = null, $secure = false, $httponly = false)
     {
         $this->type = 'Cookie';
 
@@ -183,8 +183,16 @@ class SetCookie implements MultipleHeaderDescription
             $this->setExpires($expires);
         }
 
+        if ($path) {
+            $this->setPath($path);
+        }
+
         if ($secure) {
             $this->setSecure($secure);
+        }
+
+        if ($httponly) {
+            $this->setHttpOnly($httponly);
         }
     }
 

--- a/tests/Zend/Http/Header/SetCookieTest.php
+++ b/tests/Zend/Http/Header/SetCookieTest.php
@@ -6,6 +6,25 @@ use Zend\Http\Header\SetCookie;
 
 class SetCookieTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @group ZF2-254
+     */
+    public function testSetCookieConstructor()
+    {
+        $setCookieHeader = new SetCookie(
+            'myname', 'myvalue', 9, 99, 'docs.foo.com', 
+            'Wed, 13-Jan-2021 22:23:01 GMT', '/accounts', true, true
+        );
+        $this->assertEquals('myname', $setCookieHeader->getName());
+        $this->assertEquals('myvalue', $setCookieHeader->getValue());
+        $this->assertEquals(9, $setCookieHeader->getVersion());
+        $this->assertEquals(99, $setCookieHeader->getMaxAge());
+        $this->assertEquals('docs.foo.com', $setCookieHeader->getDomain());
+        $this->assertEquals('Wed, 13-Jan-2021 22:23:01 GMT', $setCookieHeader->getExpires());
+        $this->assertEquals('/accounts', $setCookieHeader->getPath());
+        $this->assertTrue($setCookieHeader->isSecure());
+        $this->assertTrue($setCookieHeader->isHttpOnly());
+    }
 
     public function testSetCookieFromStringCreatesValidSetCookieHeader()
     {


### PR DESCRIPTION
Fixes [ZF2-254](http://framework.zend.com/issues/browse/ZF2-254)
- Add calls to setPath and setHttpOnly in constructor
- Change default value of $httponly from true to false
- Add unit test to enforce expected behavior
