### PR TITLE
<!--[if lt IE9]> <![endif]--> printed on web pages in IE9

### DIFF
--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -303,7 +303,7 @@ class HeadLink extends Placeholder\Container\Standalone
             && !empty($attributes['conditionalStylesheet'])
             && is_string($attributes['conditionalStylesheet']))
         {
-            $link = '<!--[if ' . $attributes['conditionalStylesheet'] . ']> ' . $link . '<![endif]-->';
+            $link = '<!-- [if ' . $attributes['conditionalStylesheet'] . ']> ' . $link . '<![endif]-->';
         }
 
         return $link;

--- a/library/Zend/View/Helper/HeadMeta.php
+++ b/library/Zend/View/Helper/HeadMeta.php
@@ -373,7 +373,7 @@ class HeadMeta extends Placeholder\Container\Standalone
             && !empty($item->modifiers['conditional'])
             && is_string($item->modifiers['conditional']))
         {
-            $meta = '<!--[if ' . $this->_escape($item->modifiers['conditional']) . ']>' . $meta . '<![endif]-->';
+            $meta = '<!-- [if ' . $this->_escape($item->modifiers['conditional']) . ']>' . $meta . '<![endif]-->';
         }
 
         return $meta;

--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -437,7 +437,7 @@ class HeadScript extends Placeholder\Container\Standalone
             && !empty($item->attributes['conditional'])
             && is_string($item->attributes['conditional']))
         {
-            $html = $indent . '<!--[if ' . $item->attributes['conditional'] . ']> ' . $html . '<![endif]-->';
+            $html = $indent . '<!-- [if ' . $item->attributes['conditional'] . ']> ' . $html . '<![endif]-->';
         } else {
             $html = $indent . $html;
         }

--- a/library/Zend/View/Helper/HeadStyle.php
+++ b/library/Zend/View/Helper/HeadStyle.php
@@ -371,7 +371,7 @@ class HeadStyle extends Placeholder\Container\Standalone
               . '</style>';
 
         if (null == $escapeStart && null == $escapeEnd) {
-            $html = '<!--[if ' . $item->attributes['conditional'] . ']> ' . $html . '<![endif]-->';
+            $html = '<!-- [if ' . $item->attributes['conditional'] . ']> ' . $html . '<![endif]-->';
         }
 
         return $html;


### PR DESCRIPTION
Quick reproduction of the problem: open IE9 and visit http://zf2test.akrabat.com/ or whatever ZF2-powered site that uses conditional blocks in css or js.
You will see a "<!--[if lt IE9]> <![endif]-->" printed on top left of the page.
It looks like that IE9 behaves unexpectedly if "<!--" isn't separated by at least one space from "[if...."
