### PR TITLE
Zend\Db\Sql\Select::join now respects column aliases

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -343,8 +343,12 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 $joinSpecArgArray[$j][] = strtoupper($join['type']); // type
                 $joinSpecArgArray[$j][] = $platform->quoteIdentifier($join['name']); // table
                 $joinSpecArgArray[$j][] = $platform->quoteIdentifierInFragment($join['on'], array('=', 'AND', 'OR', '(', ')')); // on
-                foreach ($join['columns'] as $jColumn) {
-                    $columns[] = $joinSpecArgArray[$j][1] . $separator . $platform->quoteIdentifierInFragment($jColumn);
+                foreach ($join['columns'] as $jColumnAlias => $jColumn) {
+                    if (is_string($jColumnAlias)) {
+                        $columns[] = $joinSpecArgArray[$j][1] . $separator . $platform->quoteIdentifierInFragment($jColumn) . ' AS ' . $platform->quoteIdentifier($jColumnAlias);
+                    } else {
+                        $columns[] = $joinSpecArgArray[$j][1] . $separator . $platform->quoteIdentifierInFragment($jColumn);
+                    }
                 }
             }
         }
@@ -435,9 +439,13 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 $joinSpecArgArray[$j] = array();
                 $joinSpecArgArray[$j][] = strtoupper($join['type']); // type
                 $joinSpecArgArray[$j][] = $platform->quoteIdentifier($join['name']); // table
-                $joinSpecArgArray[$j][] = $platform->quoteIdentifierInFragment($join['on'], array('=', 'AND', 'OR', '(', ')')); // on
-                foreach ($join['columns'] as /* $jColumnKey => */ $jColumn) {
-                    $columns[] = $joinSpecArgArray[$j][1] . $separator . $platform->quoteIdentifierInFragment($jColumn);
+                $joinSpecArgArray[$j][] = $platform->quoteIdentifierInFragment($join['on'], array('=', 'AND', 'OR', '(', ')')); // on 
+                foreach ($join['columns'] as $jColumnAlias => $jColumn) {
+                    if (is_string($jColumnAlias)) {
+                        $columns[] = $joinSpecArgArray[$j][1] . $separator . $platform->quoteIdentifierInFragment($jColumn) . ' AS ' . $platform->quoteIdentifier($jColumnAlias);
+                    } else {
+                        $columns[] = $joinSpecArgArray[$j][1] . $separator . $platform->quoteIdentifierInFragment($jColumn);
+                    }
                 }
             }
         }

--- a/tests/Zend/Db/Sql/SelectTest.php
+++ b/tests/Zend/Db/Sql/SelectTest.php
@@ -322,6 +322,11 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $sql12 = 'SELECT "foo".* FROM "foo" WHERE x = ?';
         $params12 = array(5);
 
+        // join with column aliases
+        $select13 = new Select;
+        $select13->from('foo')->join('zac', 'm = n', array('BAR' => 'bar', 'BAZ' => 'baz'));
+        $sql13 = 'SELECT "foo".*, "zac"."bar" AS "BAR", "zac"."baz" AS "BAZ" FROM "foo" INNER JOIN "zac" ON "m" = "n"';
+
         return array(
             array($select0, $sql0),
             array($select1, $sql1),
@@ -335,7 +340,8 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             array($select9, $sql9),
             array($select10, $sql10),
             array($select11, $sql11),
-            array($select12, $sql12, $params12)
+            array($select12, $sql12, $params12),
+            array($select13, $sql13)
         );
     }
 


### PR DESCRIPTION
Allows column aliases for joined tables in Zend\Db\Sql\Select in the same way that Select::columns does.

Example:
```$select = new Select;
$select->from('foo')->join('zac', 'm = n', array('BAR' => 'bar', 'BAZ' => 'baz'));

``````
Becomes
```SELECT "foo".*, "zac"."bar" AS "BAR", "zac"."baz" AS "BAZ"
FROM "foo" INNER JOIN "zac" ON "m" = "n"```
``````
