### PR TITLE
Adding a test that shows filesystem cache is broken

### DIFF
--- a/tests/Zend/Cache/Storage/Adapter/FilesystemTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/FilesystemTest.php
@@ -356,4 +356,19 @@ class FilesystemTest extends CommonAdapterTest
         $expectedAtime = fileatime($meta['filespec'] . '.dat');
         $this->assertEquals($expectedAtime, $meta['atime']);
     }
+
+    public function testSetItemWithSerializer()
+    {
+        $key = 'test';
+        $value = array(
+            'a' => 'foo',
+            'b' => 'bar',
+        );
+        $storage = $this->getMock('Zend\Cache\Storage\Adapter\Filesystem', array('putFileContent'));
+        $storage->addPlugin(new \Zend\Cache\Storage\Plugin\Serializer());
+        $storage->expects($this->once())
+                       ->method('putFileContent')
+                       ->with($this->stringEndsWith('zfcache-test.dat'), serialize($value));
+        $storage->setItem($key, $value);
+    }
 }


### PR DESCRIPTION
Filesystem cache (possibly others) are broken since SHA: e8084e378dd4a5fe477d3769bbc91762fdc5772b
