### PR TITLE
[Zend\Ldap] Remove code marked as @deprecated

### DIFF
--- a/library/Zend/Ldap/Exception/LdapException.php
+++ b/library/Zend/Ldap/Exception/LdapException.php
@@ -144,27 +144,4 @@ class LdapException extends \Exception implements Exception
 
         parent::__construct($message, $code);
     }
-
-
-    /**
-     * @deprecated not necessary any more - will be removed
-     * @param Ldap $ldap A Zend\Ldap\Ldap object
-     * @return int The current error code for the resource
-     */
-    public static function getLDAPCode(LDAP $ldap = null)
-    {
-        if ($ldap !== null) {
-            return $ldap->getLastErrorCode();
-        }
-        return 0;
-    }
-
-    /**
-     * @deprecated will be removed
-     * @return int The current error code for this exception
-     */
-    public function getErrorCode()
-    {
-        return $this->getCode();
-    }
 }

--- a/library/Zend/Ldap/Ldap.php
+++ b/library/Zend/Ldap/Ldap.php
@@ -73,39 +73,16 @@ class Ldap
     /**
      * Caches the RootDse
      *
-     * @var Node
+     * @var Node\RootDse
      */
     protected $rootDse = null;
 
     /**
      * Caches the schema
      *
-     * @var Node
+     * @var Node\Schema
      */
     protected $schema = null;
-
-    /**
-     * @deprecated will be removed, use {@see Filter\AbstractFilter::escapeValue()}
-     * @param  string $str The string to escape.
-     * @return string The escaped string
-     */
-    public static function filterEscape($str)
-    {
-        return Filter\AbstractFilter::escapeValue($str);
-    }
-
-    /**
-     * @deprecated will be removed, use {@see Dn::checkDn()}
-     * @param  string $dn   The DN to parse
-     * @param  array  $keys An optional array to receive DN keys (e.g. CN, OU, DC, ...)
-     * @param  array  $vals An optional array to receive DN values
-     * @return boolean True if the DN was successfully parsed or false if the string is
-     *             not a valid DN.
-     */
-    public static function explodeDn($dn, array &$keys = null, array &$vals = null)
-    {
-        return Dn::checkDn($dn, $keys, $vals);
-    }
 
     /**
      * Constructor.
@@ -141,6 +118,7 @@ class Ldap
         if (!is_resource($this->resource) || $this->boundUser === false) {
             $this->bind();
         }
+
         return $this->resource;
     }
 
@@ -161,6 +139,7 @@ class Ldap
             }
             return $err;
         }
+
         return 0;
     }
 
@@ -204,6 +183,7 @@ class Ldap
         } else {
             $message .= '(no error message from LDAP)';
         }
+
         return $message;
     }
 
@@ -243,7 +223,7 @@ class Ldap
      *  networkTimeout
      *
      * @param  array|Traversable $options Options used in connecting, binding, etc.
-     * @return Ldap\Ldap Provides a fluent interface
+     * @return Ldap Provides a fluent interface
      * @throws Exception\LdapException
      */
     public function setOptions($options)
@@ -305,6 +285,7 @@ class Ldap
             throw new Exception\LdapException(null, "Unknown Zend\\Ldap\\Ldap option: $key");
         }
         $this->options = $permittedOptions;
+
         return $this;
     }
 
@@ -488,6 +469,7 @@ class Ldap
             // is there a better way to detect this?
             return sprintf("(&(objectClass=user)(sAMAccountName=%s))", $aname);
         }
+
         return sprintf("(&(objectClass=posixAccount)(uid=%s))", $aname);
     }
 
@@ -531,6 +513,7 @@ class Ldap
         }
         $acctname = $this->getCanonicalAccountName($acctname, self::ACCTNAME_FORM_USERNAME);
         $acct     = $this->getAccount($acctname, array('dn'));
+
         return $acct['dn'];
     }
 
@@ -554,6 +537,7 @@ class Ldap
         if (strcasecmp($dname, $accountDomainNameShort) == 0) {
             return true;
         }
+
         return false;
     }
 
@@ -649,6 +633,7 @@ class Ldap
             }
         }
         $accounts->close();
+
         throw new Exception\LdapException($this, $str, $code);
     }
 
@@ -761,6 +746,7 @@ class Ldap
             $this->disconnect();
             throw $zle;
         }
+
         throw new Exception\LdapException(null, "Failed to connect to LDAP server: $host:$port");
     }
 
@@ -845,6 +831,7 @@ class Ldap
             $zle = new Exception\LdapException($this, $message);
         }
         $this->disconnect();
+
         throw $zle;
     }
 
@@ -930,6 +917,7 @@ class Ldap
         }
 
         $iterator = new Collection\DefaultIterator($this, $search);
+
         return $this->createCollection($iterator, $collectionClass);
     }
 
@@ -955,6 +943,7 @@ class Ldap
                 throw new Exception\LdapException(null,
                     "Class '$collectionClass' must subclass 'Zend\\Ldap\\Collection'");
             }
+
             return new $collectionClass($iterator);
         }
     }
@@ -979,6 +968,7 @@ class Ldap
                 throw $e;
             }
         }
+
         return $result->count();
     }
 
@@ -1046,6 +1036,7 @@ class Ldap
         if ((bool)$reverseSort === true) {
             $items = array_reverse($items, false);
         }
+
         return $items;
     }
 
@@ -1056,7 +1047,7 @@ class Ldap
      * @param  array     $attributes
      * @param  boolean   $throwOnNotFound
      * @return array
-     * @throws Exception\LdapException
+     * @throws null|Exception\LdapException
      */
     public function getEntry($dn, array $attributes = array(), $throwOnNotFound = false)
     {
@@ -1065,6 +1056,7 @@ class Ldap
                 "(objectClass=*)", $dn, self::SEARCH_SCOPE_BASE,
                 $attributes, null
             );
+
             return $result->getFirst();
         } catch (Exception\LdapException $e) {
             if ($throwOnNotFound !== false) {
@@ -1163,6 +1155,7 @@ class Ldap
         if ($isAdded === false) {
             throw new Exception\LdapException($this, 'adding: ' . $dn->toString());
         }
+
         return $this;
     }
 
@@ -1202,6 +1195,7 @@ class Ldap
                 throw new Exception\LdapException($this, 'updating: ' . $dn->toString());
             }
         }
+
         return $this;
     }
 
@@ -1255,6 +1249,7 @@ class Ldap
         if ($isDeleted === false) {
             throw new Exception\LdapException($this, 'deleting: ' . $dn);
         }
+
         return $this;
     }
 
@@ -1286,6 +1281,7 @@ class Ldap
             $children[] = $childDn;
         }
         @ldap_free_result($search);
+
         return $children;
     }
 
@@ -1315,6 +1311,7 @@ class Ldap
 
         $newDnParts = array_merge(array(array_shift($orgDnParts)), $newParentDnParts);
         $newDn      = Dn::fromArray($newDnParts);
+
         return $this->rename($from, $newDn, $recursively, $alwaysEmulate);
     }
 
@@ -1380,6 +1377,7 @@ class Ldap
             $this->copy($from, $to, $recursively);
             $this->delete($from, $recursively);
         }
+
         return $this;
     }
 
@@ -1408,6 +1406,7 @@ class Ldap
 
         $newDnParts = array_merge(array(array_shift($orgDnParts)), $newParentDnParts);
         $newDn      = Dn::fromArray($newDnParts);
+
         return $this->copy($from, $newDn, $recursively);
     }
 
@@ -1440,6 +1439,7 @@ class Ldap
                 $this->copy($c, $newChild, true);
             }
         }
+
         return $this;
     }
 
@@ -1477,6 +1477,7 @@ class Ldap
         if ($this->rootDse === null) {
             $this->rootDse = Node\RootDse::create($this);
         }
+
         return $this->rootDse;
     }
 
@@ -1491,6 +1492,7 @@ class Ldap
         if ($this->schema === null) {
             $this->schema = Node\Schema::create($this);
         }
+
         return $this->schema;
     }
 }

--- a/tests/Zend/Ldap/BindTest.php
+++ b/tests/Zend/Ldap/BindTest.php
@@ -22,7 +22,7 @@
 namespace ZendTest\Ldap;
 
 use Zend\Ldap,
-    Zend\Ldap\Exception\LdapException;
+    Zend\Ldap\Exception;
 
 /* Note: The ldap_connect function does not actually try to connect. This
  * is why many tests attempt to bind with invalid credentials. If the
@@ -93,7 +93,7 @@ class BindTest extends \PHPUnit_Framework_TestCase
         try {
             $ldap->bind();
             $this->fail('Expected exception for empty options');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('A host parameter is required', $zle->getMessage());
         }
     }
@@ -106,7 +106,7 @@ class BindTest extends \PHPUnit_Framework_TestCase
         $ldap = new Ldap\Ldap($options);
         try {
             $ldap->bind();
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             // or I guess the server doesn't allow unauthenticated binds
             $this->assertContains('unauthenticated bind', $zle->getMessage());
         }
@@ -122,7 +122,7 @@ class BindTest extends \PHPUnit_Framework_TestCase
         try {
             $ldap->bind('invalid', 'ignored');
             $this->fail('Expected exception for baseDn missing');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Base DN not set', $zle->getMessage());
         }
     }
@@ -138,7 +138,7 @@ class BindTest extends \PHPUnit_Framework_TestCase
         try {
             $ldap->bind('invalid', 'ignored');
             $this->fail('Expected exception for missing accountDomainName');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Option required: accountDomainName', $zle->getMessage());
         }
     }
@@ -181,7 +181,7 @@ class BindTest extends \PHPUnit_Framework_TestCase
         try {
             $ldap->bind($this->altUsername, 'invalid');
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Invalid credentials', $zle->getMessage());
         }
     }
@@ -198,7 +198,7 @@ class BindTest extends \PHPUnit_Framework_TestCase
         try {
             $ldap->bind($this->principalName);
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             /* Note that if your server actually allows anonymous binds this test will fail.
              */
             $this->assertContains('Failed to retrieve DN', $zle->getMessage());
@@ -213,7 +213,7 @@ class BindTest extends \PHPUnit_Framework_TestCase
         try {
             $ldap->bind($this->altUsername, '');
             $this->fail('Expected exception for empty password');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Empty password not allowed - see allowEmptyPassword option.',
                 $zle->getMessage()
             );
@@ -223,7 +223,7 @@ class BindTest extends \PHPUnit_Framework_TestCase
         $ldap                          = new Ldap\Ldap($options);
         try {
             $ldap->bind($this->altUsername, '');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             if ($zle->getMessage() ===
                 'Empty password not allowed - see allowEmptyPassword option.'
             ) {
@@ -248,7 +248,7 @@ class BindTest extends \PHPUnit_Framework_TestCase
         try {
             $ldap->bind();
             $this->fail('Expected exception for empty password');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Binding requires username in DN form',
                 $zle->getMessage()
             );

--- a/tests/Zend/Ldap/CanonTest.php
+++ b/tests/Zend/Ldap/CanonTest.php
@@ -22,7 +22,7 @@
 namespace ZendTest\Ldap;
 
 use Zend\Ldap,
-    Zend\Ldap\Exception\LdapException;
+    Zend\Ldap\Exception;
 
 /* Note: The ldap_connect function does not actually try to connect. This
  * is why many tests attempt to bind with invalid credentials. If the
@@ -110,7 +110,7 @@ class CanonTest extends \PHPUnit_Framework_TestCase
         try {
             $ldap->bind('invalid', 'invalid');
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $msg = $zle->getMessage();
             $this->assertTrue(strstr($msg, 'Invalid credentials')
                     || strstr($msg, 'No such object')
@@ -132,8 +132,8 @@ class CanonTest extends \PHPUnit_Framework_TestCase
         try {
             $ldap->bind('BOGUS\\doesntmatter', 'doesntmatter');
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
-            $this->assertTrue($zle->getCode() == LdapException::LDAP_X_DOMAIN_MISMATCH);
+        } catch (Exception\LdapException $zle) {
+            $this->assertTrue($zle->getCode() == Exception\LdapException::LDAP_X_DOMAIN_MISMATCH);
         }
     }
 
@@ -216,7 +216,7 @@ class CanonTest extends \PHPUnit_Framework_TestCase
         try {
             $canon = $ldap->getCanonicalAccountName('invalid', Ldap\Ldap::ACCTNAME_FORM_DN);
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('(&(objectClass=posixAccount)(uid=invalid))', $zle->getMessage());
         }
 
@@ -225,7 +225,7 @@ class CanonTest extends \PHPUnit_Framework_TestCase
         try {
             $canon = $ldap->getCanonicalAccountName('invalid', Ldap\Ldap::ACCTNAME_FORM_DN);
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('(&(objectClass=user)(sAMAccountName=invalid))', $zle->getMessage());
         }
     }
@@ -239,7 +239,7 @@ class CanonTest extends \PHPUnit_Framework_TestCase
                 Ldap\Ldap::ACCTNAME_FORM_USERNAME
             );
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Binding domain is not an authority for user: invalid\invalid',
                 $zle->getMessage()
             );
@@ -249,7 +249,7 @@ class CanonTest extends \PHPUnit_Framework_TestCase
                 Ldap\Ldap::ACCTNAME_FORM_USERNAME
             );
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Binding domain is not an authority for user: invalid@invalid.tld',
                 $zle->getMessage()
             );
@@ -266,7 +266,7 @@ class CanonTest extends \PHPUnit_Framework_TestCase
                 Ldap\Ldap::ACCTNAME_FORM_USERNAME
             );
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Binding domain is not an authority for user: invalid@' .
                     TESTS_ZEND_LDAP_ACCOUNT_DOMAIN_NAME,
                 $zle->getMessage()
@@ -281,7 +281,7 @@ class CanonTest extends \PHPUnit_Framework_TestCase
                 Ldap\Ldap::ACCTNAME_FORM_USERNAME
             );
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Binding domain is not an authority for user: ' .
                     TESTS_ZEND_LDAP_ACCOUNT_DOMAIN_NAME_SHORT . '\invalid',
                 $zle->getMessage()
@@ -315,7 +315,7 @@ class CanonTest extends \PHPUnit_Framework_TestCase
                 Ldap\Ldap::ACCTNAME_FORM_USERNAME
             );
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Invalid account name syntax: 0@' .
                     TESTS_ZEND_LDAP_ACCOUNT_DOMAIN_NAME,
                 $zle->getMessage()
@@ -327,7 +327,7 @@ class CanonTest extends \PHPUnit_Framework_TestCase
                 Ldap\Ldap::ACCTNAME_FORM_USERNAME
             );
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Invalid account name syntax: ' .
                     TESTS_ZEND_LDAP_ACCOUNT_DOMAIN_NAME_SHORT . '\\0',
                 $zle->getMessage()
@@ -343,7 +343,7 @@ class CanonTest extends \PHPUnit_Framework_TestCase
         try {
             $canon = $ldap->getCanonicalAccountName(TESTS_ZEND_LDAP_ALT_USERNAME, 99);
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Unknown canonical name form: 99',
                 $zle->getMessage()
             );
@@ -360,7 +360,7 @@ class CanonTest extends \PHPUnit_Framework_TestCase
                 Ldap\Ldap::ACCTNAME_FORM_PRINCIPAL
             );
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Option required: accountDomainName',
                 $zle->getMessage()
             );
@@ -373,7 +373,7 @@ class CanonTest extends \PHPUnit_Framework_TestCase
                 Ldap\Ldap::ACCTNAME_FORM_BACKSLASH
             );
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Option required: accountDomainNameShort',
                 $zle->getMessage()
             );

--- a/tests/Zend/Ldap/ChangePasswordTest.php
+++ b/tests/Zend/Ldap/ChangePasswordTest.php
@@ -22,7 +22,7 @@
 namespace ZendTest\Ldap;
 
 use Zend\Ldap,
-    Zend\Ldap\Exception\LdapException,
+    Zend\Ldap\Exception,
     Zend\Ldap\Node;
 
 /**
@@ -61,7 +61,7 @@ class ChangePasswordTest extends AbstractOnlineTestCase
 
             $this->getLDAP()->bind();
             $this->getLDAP()->delete($dn);
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             $this->getLDAP()->bind();
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
@@ -103,7 +103,7 @@ class ChangePasswordTest extends AbstractOnlineTestCase
             try {
                 $this->getLDAP()->bind($dn, $password);
                 $this->fail('Expected exception not thrown');
-            } catch (LdapException $zle) {
+            } catch (Exception\LdapException $zle) {
                 $message = $zle->getMessage();
                 $this->assertTrue(strstr($message, 'Invalid credentials')
                         || strstr($message, 'Server is unwilling to perform')
@@ -114,7 +114,7 @@ class ChangePasswordTest extends AbstractOnlineTestCase
 
             $this->getLDAP()->bind();
             $this->getLDAP()->delete($dn);
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             $this->getLDAP()->bind();
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
@@ -156,7 +156,7 @@ class ChangePasswordTest extends AbstractOnlineTestCase
 
             $this->getLDAP()->bind();
             $this->getLDAP()->delete($dn);
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             $this->getLDAP()->bind();
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
@@ -204,7 +204,7 @@ class ChangePasswordTest extends AbstractOnlineTestCase
             try {
                 $this->getLDAP()->bind($dn, $password);
                 $this->fail('Expected exception not thrown');
-            } catch (LdapException $zle) {
+            } catch (Exception\LdapException $zle) {
                 $message = $zle->getMessage();
                 $this->assertTrue(strstr($message, 'Invalid credentials')
                         || strstr($message, 'Server is unwilling to perform')
@@ -215,7 +215,7 @@ class ChangePasswordTest extends AbstractOnlineTestCase
 
             $this->getLDAP()->bind();
             $this->getLDAP()->delete($dn);
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             $this->getLDAP()->bind();
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);

--- a/tests/Zend/Ldap/ConnectTest.php
+++ b/tests/Zend/Ldap/ConnectTest.php
@@ -22,7 +22,7 @@
 namespace ZendTest\Ldap;
 
 use Zend\Ldap,
-    Zend\Ldap\Exception\LdapException;
+    Zend\Ldap\Exception;
 
 /* Note: The ldap_connect function does not actually try to connect. This
  * is why many tests attempt to bind with invalid credentials. If the
@@ -63,7 +63,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
         try {
             $ldap->connect();
             $this->fail('Expected exception for empty options');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('host parameter is required', $zle->getMessage());
         }
     }
@@ -75,7 +75,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
             // connect doesn't actually try to connect until bind is called
             $ldap->connect()->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for unknown host');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Can\'t contact LDAP server', $zle->getMessage());
         }
     }
@@ -89,7 +89,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
             // succeeded.
             $ldap->connect()->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for invalid username');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Invalid credentials', $zle->getMessage());
         }
     }
@@ -121,7 +121,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
             $ldap->connect($host, $port, $useSsl)
                 ->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for invalid username');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Invalid credentials', $zle->getMessage());
         }
     }
@@ -141,7 +141,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
             $ldap->connect(null, $port)
                 ->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for invalid username');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Invalid credentials', $zle->getMessage());
         }
     }
@@ -174,7 +174,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
         try {
             $ldap->connect()->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for unknown username');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Can\'t contact LDAP server', $zle->getMessage());
         }
     }
@@ -186,7 +186,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
         try {
             $ldap->connect()->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for invalid username');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Invalid credentials', $zle->getMessage());
         }
     }
@@ -198,7 +198,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
             try {
                 $ldap->connect()->bind('CN=ignored,DC=example,DC=com', 'ignored');
                 $this->fail('Expected exception for unknown username');
-            } catch (LdapException $zle) {
+            } catch (Exception\LdapException $zle) {
                 $this->assertContains('Invalid credentials', $zle->getMessage());
             }
         }
@@ -212,7 +212,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
             try {
                 $ldap->connect()->bind('CN=ignored,DC=example,DC=com', 'ignored');
                 $this->fail('Expected exception for unknown username');
-            } catch (LdapException $zle) {
+            } catch (Exception\LdapException $zle) {
                 $this->assertContains('Invalid credentials', $zle->getMessage());
             }
         }
@@ -227,12 +227,11 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
             // succeeded.
             $ldap->connect()->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for invalid username');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Invalid credentials', $zle->getMessage());
 
             $this->assertEquals(0x31, $zle->getCode());
-            $this->assertEquals(0x0, LdapException::getLDAPCode($ldap));
-            $this->assertEquals(0x0, LdapException::getLDAPCode(null));
+            $this->assertEquals(0x0, $ldap->getLastErrorCode());
         }
     }
 
@@ -264,7 +263,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
             $ldap->connect($host)
                 ->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for invalid username');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains('Invalid credentials', $zle->getMessage());
         }
     }

--- a/tests/Zend/Ldap/CrudTest.php
+++ b/tests/Zend/Ldap/CrudTest.php
@@ -22,7 +22,7 @@
 namespace ZendTest\Ldap;
 
 use Zend\Ldap,
-    Zend\Ldap\Exception\LdapException;
+    Zend\Ldap\Exception;
 
 /**
  * @category   Zend
@@ -46,7 +46,7 @@ class CrudTest extends AbstractOnlineTestCase
             $this->assertEquals(1, $this->getLDAP()->count('ou=TestCreated'));
             $this->getLDAP()->delete($dn);
             $this->assertEquals(0, $this->getLDAP()->count('ou=TestCreated'));
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
             }
@@ -71,7 +71,7 @@ class CrudTest extends AbstractOnlineTestCase
             $entry = $this->getLDAP()->getEntry($dn);
             $this->getLDAP()->delete($dn);
             $this->assertEquals('mylocation2', $entry['l'][0]);
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
             }
@@ -108,16 +108,14 @@ class CrudTest extends AbstractOnlineTestCase
             $exThrown = false;
             try {
                 $this->getLDAP()->update($dn, $entry);
-            }
-            catch (LdapException $e) {
+            } catch (Exception\LdapException $e) {
                 $exThrown = true;
             }
             $this->getLDAP()->delete($dn);
             if (!$exThrown) {
                 $this->fail('no exception thrown while illegaly updating entry');
             }
-        }
-        catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             $this->fail($e->getMessage());
         }
     }
@@ -157,7 +155,7 @@ class CrudTest extends AbstractOnlineTestCase
         $exCaught = false;
         try {
             $this->getLDAP()->delete($topDn, false);
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             $exCaught = true;
         }
         $this->assertTrue($exCaught,
@@ -181,7 +179,7 @@ class CrudTest extends AbstractOnlineTestCase
             $entry = $this->getLDAP()->getEntry($dn);
             $this->getLDAP()->delete($dn);
             $this->assertEquals('mylocation1', $entry['l'][0]);
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
             }
@@ -278,8 +276,7 @@ class CrudTest extends AbstractOnlineTestCase
             $this->getLDAP()->add($dn, $data);
             $this->assertEquals(1, $this->getLDAP()->count('ou=TestCreated'));
             $this->getLDAP()->delete($dn);
-        }
-        catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             $this->fail($e->getMessage());
         }
     }
@@ -301,8 +298,7 @@ class CrudTest extends AbstractOnlineTestCase
             $entry = $this->getLDAP()->getEntry($dn);
             $this->getLDAP()->delete($dn);
             $this->assertEquals('mylocation2', $entry['l'][0]);
-        }
-        catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             $this->fail($e->getMessage());
         }
     }
@@ -321,7 +317,7 @@ class CrudTest extends AbstractOnlineTestCase
             $entry = $this->getLDAP()->getEntry($dn);
             $this->getLDAP()->delete($dn);
             $this->assertEquals('mylocation1', $entry['l'][0]);
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
             }
@@ -349,7 +345,7 @@ class CrudTest extends AbstractOnlineTestCase
             $this->assertEquals('domain', $entry['associateddomain'][0]);
             $this->assertContains('organizationalUnit', $entry['objectclass']);
             $this->assertContains('domainRelatedObject', $entry['objectclass']);
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
             }
@@ -378,7 +374,7 @@ class CrudTest extends AbstractOnlineTestCase
             $this->assertArrayNotHasKey('associateddomain', $entry);
             $this->assertContains('organizationalUnit', $entry['objectclass']);
             $this->assertNotContains('domainRelatedObject', $entry['objectclass']);
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
             }
@@ -401,7 +397,7 @@ class CrudTest extends AbstractOnlineTestCase
             $this->getLdap()->delete($dn);
             $this->assertEquals(array('TestCreated'), $entry['ou']);
 
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             if ($this->getLdap()->exists($dn)) {
                 $this->getLdap()->delete($dn);
             }
@@ -425,7 +421,7 @@ class CrudTest extends AbstractOnlineTestCase
             $this->getLdap()->delete($dn);
             $this->assertEquals(array('TestCreated', 'SecondOu'), $entry['ou']);
 
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             if ($this->getLdap()->exists($dn)) {
                 $this->getLdap()->delete($dn);
             }
@@ -449,7 +445,7 @@ class CrudTest extends AbstractOnlineTestCase
             $this->getLdap()->delete($dn);
             $this->assertEquals(array('TestCreated', 'SecondOu'), $entry['ou']);
 
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             if ($this->getLdap()->exists($dn)) {
                 $this->getLdap()->delete($dn);
             }
@@ -477,7 +473,7 @@ class CrudTest extends AbstractOnlineTestCase
             $this->getLdap()->delete($dn);
             $this->assertEquals(array('TestCreated', 'SecondOu'), $entry['ou']);
 
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             if ($this->getLdap()->exists($dn)) {
                 $this->getLdap()->delete($dn);
             }
@@ -505,7 +501,7 @@ class CrudTest extends AbstractOnlineTestCase
             $this->getLdap()->delete($dn);
             $this->assertEquals(array('TestCreated', 'SecondOu'), $entry['ou']);
 
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             if ($this->getLdap()->exists($dn)) {
                 $this->getLdap()->delete($dn);
             }

--- a/tests/Zend/Ldap/OfflineTest.php
+++ b/tests/Zend/Ldap/OfflineTest.php
@@ -23,7 +23,7 @@ namespace ZendTest\Ldap;
 
 use Zend\Config,
     Zend\Ldap,
-    Zend\Ldap\Exception\LdapException;
+    Zend\Ldap\Exception;
 
 /**
  * @category   Zend
@@ -66,22 +66,20 @@ class OfflineTest extends \PHPUnit_Framework_TestCase
         try {
             $this->ldap->setOptions(array($optionName => 'irrelevant'));
             $this->fail('Expected Zend\Ldap\Exception\LdapException not thrown');
-        } catch (LdapException $e) {
+        } catch (Exception\LdapException $e) {
             $this->assertEquals("Unknown Zend\Ldap\Ldap option: $optionName", $e->getMessage());
         }
     }
 
     public function testException()
     {
-        $e = new LdapException(null, '', 0);
+        $e = new Exception\LdapException(null, '', 0);
         $this->assertEquals('no exception message', $e->getMessage());
         $this->assertEquals(0, $e->getCode());
-        $this->assertEquals(0, $e->getErrorCode());
 
-        $e = new LdapException(null, '', 15);
+        $e = new Exception\LdapException(null, '', 15);
         $this->assertEquals('0xf: no exception message', $e->getMessage());
         $this->assertEquals(15, $e->getCode());
-        $this->assertEquals(15, $e->getErrorCode());
     }
 
     public function testOptionsGetter()

--- a/tests/Zend/Ldap/SearchTest.php
+++ b/tests/Zend/Ldap/SearchTest.php
@@ -22,8 +22,8 @@
 namespace ZendTest\Ldap;
 
 use Zend\Ldap,
-Zend\Ldap\Collection,
-Zend\Ldap\Exception\LdapException;
+    Zend\Ldap\Collection,
+    Zend\Ldap\Exception;
 
 /**
  * @category   Zend
@@ -311,7 +311,7 @@ class SearchTest extends AbstractOnlineTestCase
                 'This_Class_Does_Not_Exist'
             );
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains("Class 'This_Class_Does_Not_Exist' can not be found",
                 $zle->getMessage()
             );
@@ -330,7 +330,7 @@ class SearchTest extends AbstractOnlineTestCase
                 'ZendTest\Ldap\CollectionClassNotSubclassingZendLDAPCollection'
             );
             $this->fail('Expected exception not thrown');
-        } catch (LdapException $zle) {
+        } catch (Exception\LdapException $zle) {
             $this->assertContains(
                 "Class 'ZendTest\\Ldap\\CollectionClassNotSubclassingZendLDAPCollection' must subclass 'Zend\\Ldap\\Collection'",
                 $zle->getMessage()


### PR DESCRIPTION
- Remove the following deprecated methods:
  
  . Ldap::filterEscape() replaced by Filter\AbstractFilter::escapeValue();
  - Ldap::explodeDn() replaced by Dn::checkDn()
  - Exception/LdapException::getLDAPCode() now use  $ldap->getLastErrorCode() from Ldap class
  - Exception/LdapException->getErrorCode() now use  $exception->getCode() for any Exception class
- Adapt Test cases
- Fix some CS issues
