### PR TITLE
Support order() & fetch() in Zend\Db\Sql\Select.

### DIFF
--- a/documentation/manual/en/module_specs/Zend_Db-Sql.xml
+++ b/documentation/manual/en/module_specs/Zend_Db-Sql.xml
@@ -72,6 +72,7 @@ class Zend\Db\Sql\Select
     public function columns(array $columns);
     public function join($name, $on, $columns = self::SQL_WILDCARD, $type = self::JOIN_INNER);
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND);
+    public function order($order);
 
     // methods to generate statement and/or sql
     public function prepareStatement(Adapter $adapter, StatementInterface $statement);
@@ -268,7 +269,8 @@ use Zend\Db\Sql\Select,
 $select = new Select;
 $select->from('artist')
     ->join('album', 'artist.id = album.artist_id')
-    ->where->like('artist.name', 'Foo%');
+    ->where->like('artist.name', 'Foo%')
+    ->order('name ASC');
 
 // create a statement to use
 $statment = $adapter->createStatement();

--- a/documentation/manual/en/module_specs/Zend_Db-Sql.xml
+++ b/documentation/manual/en/module_specs/Zend_Db-Sql.xml
@@ -73,6 +73,7 @@ class Zend\Db\Sql\Select
     public function join($name, $on, $columns = self::SQL_WILDCARD, $type = self::JOIN_INNER);
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND);
     public function order($order);
+    public function fetch($number, $offset);
 
     // methods to generate statement and/or sql
     public function prepareStatement(Adapter $adapter, StatementInterface $statement);
@@ -270,7 +271,8 @@ $select = new Select;
 $select->from('artist')
     ->join('album', 'artist.id = album.artist_id')
     ->where->like('artist.name', 'Foo%')
-    ->order('name ASC');
+    ->order('name ASC')
+    ->fetch(10, 10); // limit to items 11 through 20 only
 
 // create a statement to use
 $statment = $adapter->createStatement();

--- a/library/Zend/Db/Adapter/Platform/Mysql.php
+++ b/library/Zend/Db/Adapter/Platform/Mysql.php
@@ -115,4 +115,57 @@ class Mysql implements PlatformInterface
         }
         return implode('', $parts);
     }
+
+    /**
+     * Given a SQL statement, complete it with limit and order by clauses as 
+     * required.
+     * 
+     * @param string $sql 
+     * @param string $orderSql 
+     * @param int    $number 
+     * @param int    $offset 
+     * 
+     * @return string
+     */
+    public function limitSql($sql, $orderSql, $number, $offset)
+    {
+        $sql = $sql . ' ' . $orderSql;
+
+        if ($number) {
+            $sql .= 'LIMIT ' . $number;
+            if ($offset) {
+                $sql .= ' OFFSET ' . $offset;
+            }
+
+
+        }
+        if ($number == 0) {
+            // no limit required, so just add the order's SQL to the main SQL
+        } else {
+            // limit
+            if (!$orderSql) {
+                $orderSql = 'ORDER BY (SELECT 0)';
+            }
+
+            // remove SELECT from start of $sql as we are going to insert an additional statement
+            $sql = preg_replace('/^SELECT\s/', '', $sql);
+
+            // Build up a SELECT that uses the ROW_NUMBER() window function with
+            // a sub-SELECT for the actual query we're running
+            $sql = 'SELECT * FROM (SELECT ROW_NUMBER() OVER (' . $orderSql 
+                . ') AS ' . $this->quoteIdentifier('zend_db_sql_select_rownumber')
+                . ', ' . $sql . ') AS ' . $this->quoteIdentifier('zend_db_sql_select_table')
+                . ' WHERE ' . $this->quoteIdentifier('zend_db_sql_select_rownumber');
+
+            if ($offset) {
+                $from = $offset + 1;
+                $to = $offset + $number;
+                $sql .= ' BETWEEN ' . $from . ' AND ' . $to;
+            } else {
+                $sql .= ' <= ' . $number;
+            }
+        }
+
+        return trim($sql);
+    }    
 }

--- a/library/Zend/Db/Adapter/Platform/Mysql.php
+++ b/library/Zend/Db/Adapter/Platform/Mysql.php
@@ -136,34 +136,6 @@ class Mysql implements PlatformInterface
             if ($offset) {
                 $sql .= ' OFFSET ' . $offset;
             }
-
-
-        }
-        if ($number == 0) {
-            // no limit required, so just add the order's SQL to the main SQL
-        } else {
-            // limit
-            if (!$orderSql) {
-                $orderSql = 'ORDER BY (SELECT 0)';
-            }
-
-            // remove SELECT from start of $sql as we are going to insert an additional statement
-            $sql = preg_replace('/^SELECT\s/', '', $sql);
-
-            // Build up a SELECT that uses the ROW_NUMBER() window function with
-            // a sub-SELECT for the actual query we're running
-            $sql = 'SELECT * FROM (SELECT ROW_NUMBER() OVER (' . $orderSql 
-                . ') AS ' . $this->quoteIdentifier('zend_db_sql_select_rownumber')
-                . ', ' . $sql . ') AS ' . $this->quoteIdentifier('zend_db_sql_select_table')
-                . ' WHERE ' . $this->quoteIdentifier('zend_db_sql_select_rownumber');
-
-            if ($offset) {
-                $from = $offset + 1;
-                $to = $offset + $number;
-                $sql .= ' BETWEEN ' . $from . ' AND ' . $to;
-            } else {
-                $sql .= ' <= ' . $number;
-            }
         }
 
         return trim($sql);

--- a/library/Zend/Db/Adapter/Platform/SqlServer.php
+++ b/library/Zend/Db/Adapter/Platform/SqlServer.php
@@ -115,4 +115,51 @@ class SqlServer implements PlatformInterface
         }
         return implode('', $parts);
     }
+
+    /**
+     * Given a SQL statement, complete it with limit and order by clauses as 
+     * required.
+     * 
+     * @param string $sql 
+     * @param string $orderSql 
+     * @param int    $number 
+     * @param int    $offset 
+     * 
+     * @return string
+     */
+    public function limitSql($sql, $orderSql, $number, $offset)
+    {
+        if ($number == 0) {
+            // no limit required, so just add the order's SQL to the main SQL
+            $sql = $sql . ' ' . $orderSql;
+        } else {
+            // limit
+            if ($offset == 0) {
+                // Can just use TOP
+                $sql = preg_replace('/^(SELECT\s(DISTINCT\s)?)/i', '$1 TOP ' . $number . ' ', $sql);
+            } else {
+                // we have an offset, so use the ROW_NUMBER() window function
+                if (!$orderSql) {
+                    // We need an order by statement
+                    $orderSql = 'ORDER BY (SELECT 0)';
+                }
+
+                // remove SELECT from start of $sql as we are going to insert an additional statement
+                $sql = preg_replace('/^SELECT\s/', '', $sql);
+
+                // Build up a SELECT that uses the ROW_NUMBER() window function with
+                // a sub-SELECT for the actual query we're running
+                $sql = 'SELECT * FROM (SELECT ROW_NUMBER() OVER (' . $orderSql 
+                    . ') AS ' . $this->quoteIdentifier('zend_db_sql_select_rownumber')
+                    . ', ' . $sql . ') AS ' . $this->quoteIdentifier('zend_db_sql_select_table')
+                    . ' WHERE ' . $this->quoteIdentifier('zend_db_sql_select_rownumber');
+
+                $from = $offset + 1;
+                $to = $offset + $number;
+                $sql .= ' BETWEEN ' . $from . ' AND ' . $to;
+            }
+        }
+
+        return trim($sql);
+    }
 }

--- a/library/Zend/Db/Adapter/Platform/Sqlite.php
+++ b/library/Zend/Db/Adapter/Platform/Sqlite.php
@@ -115,4 +115,29 @@ class Sqlite implements PlatformInterface
         }
         return implode('', $parts);
     }
+
+    /**
+     * Given a SQL statement, complete it with limit and order by clauses as 
+     * required.
+     * 
+     * @param string $sql 
+     * @param string $orderSql 
+     * @param int    $number 
+     * @param int    $offset 
+     * 
+     * @return string
+     */
+    public function limitSql($sql, $orderSql, $number, $offset)
+    {
+        $sql = $sql . ' ' . $orderSql;
+
+        if ($number) {
+            $sql .= 'LIMIT ' . $number;
+            if ($offset) {
+                $sql .= ' OFFSET ' . $offset;
+            }
+        }
+
+        return trim($sql);
+    }      
 }

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -104,9 +104,9 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     protected $where = null;
 
     /**
-     * @var null|string
+     * @var array
      */
-    protected $order = null;
+    protected $order = array();
 
     /**
      * @var int|null
@@ -235,17 +235,29 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     }
 
     /**
-     * $order can be an array of:
+     * $order can be an array or string of order clauses:
+     * e.g:
+     *  $order = 'id DESC';
+     * or
+     *  $order = array('name ASC', 'id DESC');
+     * 
      *
-     * @todo
-     *
-     *
-     * @param string|array $order
+     * @param string|array\Expression $order
      * @return Select
      */
     public function order($order)
     {
-        $this->order = $order;
+        if (is_string($order)) {
+            $order = explode(',', $order);
+        } 
+
+        if ($order instanceof Expression) {
+            $this->order[] = $order;
+        } else {
+            foreach ($order as $item) {
+                $this->order[] = trim($item);
+            }
+        }
         return $this;
     }
 
@@ -375,14 +387,25 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $sql .= ' ' . sprintf($this->specifications[self::SPECIFICATION_WHERE], $whereParts['sql']);
         }
 
-        if (is_string($this->order) && $this->order != '') {
-            $sql .= $this->applySpecification(self::SPECIFICATION_ORDER, $this->order);
+        // process order
+        if (count($this->order)) {
+            $order = array();
+            foreach ($this->order as $item) {
+                if ($item instanceof Expression) {
+                    $orderParts = $this->processExpression($item, $platform, $adapter->getDriver(), 'orderby');
+                    if (count($orderParts['parameters']) > 0) {
+                        $parameterContainer->merge($orderParts['parameters']);
+                    }
+                    $order[] = $orderParts['sql'];
+                } else {
+                    $order[] = $platform->quoteIdentifierInFragment($item, array('ASC', 'DESC', 'asc', 'desc', 'Asc', 'Desc'));
+                }
+            }
+            $sql .= ' ' . sprintf($this->specifications[self::SPECIFICATION_ORDER], implode(', ', $order));
         }
 
         // @todo Order and Fetch/Limit in prepare for Sql object
-        $order = null;
         $limit = null;
-
         $sql .= (isset($limit)) ? sprintf($this->specifications[self::SPECIFICATION_FETCH], $limit) : '';
 
         $statement->setSql($sql);
@@ -469,9 +492,21 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $sql .= ' ' . sprintf($this->specifications[self::SPECIFICATION_WHERE], $whereParts['sql']);
         }
 
-        // process order & limit
-        // @todo this is too basic, but good for now
-        //$sql .= (isset($this->order)) ? sprintf($this->specifications[self::SPECIFICATION_ORDER], $this->order) : '';
+        // process order
+        if (count($this->order)) {
+            $order = array();
+            foreach ($this->order as $item) {
+                if ($item instanceof Expression) {
+                    $orderParts = $this->processExpression($item, $platform, null, 'orderby');
+                    $order[] = $orderParts['sql'];
+                } else {
+                    $order[] = $platform->quoteIdentifierInFragment($item, array('ASC', 'DESC', 'asc', 'desc', 'Asc', 'Desc'));
+                }
+            }
+            $sql .= ' ' . sprintf($this->specifications[self::SPECIFICATION_ORDER], implode(', ', $order));
+        }
+
+        // @todo process limit
         //$sql .= (isset($this->limit)) ? sprintf($this->specifications[self::SPECIFICATION_FETCH], $this->limit) : '';
 
         return $sql;

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -265,6 +265,8 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     {
         $this->fetchNumber = $number;
         $this->fetchOffset = $offset;
+
+        return $this;
     }
 
     public function setSpecification($index, $specification)

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -389,7 +389,8 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $sql .= ' ' . sprintf($this->specifications[self::SPECIFICATION_WHERE], $whereParts['sql']);
         }
 
-        // process order
+        // process order & limit
+        $orderString = '';
         if (count($this->order)) {
             $order = array();
             foreach ($this->order as $item) {
@@ -403,12 +404,12 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                     $order[] = $platform->quoteIdentifierInFragment($item, array('ASC', 'DESC', 'asc', 'desc', 'Asc', 'Desc'));
                 }
             }
-            $sql .= ' ' . sprintf($this->specifications[self::SPECIFICATION_ORDER], implode(', ', $order));
+
+            $orderString = sprintf($this->specifications[self::SPECIFICATION_ORDER], implode(', ', $order));
         }
 
-        // @todo Order and Fetch/Limit in prepare for Sql object
-        $limit = null;
-        $sql .= (isset($limit)) ? sprintf($this->specifications[self::SPECIFICATION_FETCH], $limit) : '';
+        $sql = $platform->limitSql($sql, $orderString, $this->fetchNumber, $this->fetchOffset);
+        
 
         $statement->setSql($sql);
     }
@@ -494,7 +495,8 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $sql .= ' ' . sprintf($this->specifications[self::SPECIFICATION_WHERE], $whereParts['sql']);
         }
 
-        // process order
+        // process order & limit
+        $orderString = '';
         if (count($this->order)) {
             $order = array();
             foreach ($this->order as $item) {
@@ -505,11 +507,11 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                     $order[] = $platform->quoteIdentifierInFragment($item, array('ASC', 'DESC', 'asc', 'desc', 'Asc', 'Desc'));
                 }
             }
-            $sql .= ' ' . sprintf($this->specifications[self::SPECIFICATION_ORDER], implode(', ', $order));
+
+            $orderString = sprintf($this->specifications[self::SPECIFICATION_ORDER], implode(', ', $order));
         }
 
-        // @todo process limit
-        //$sql .= (isset($this->limit)) ? sprintf($this->specifications[self::SPECIFICATION_FETCH], $this->limit) : '';
+        $sql = $platform->limitSql($sql, $orderString, $this->fetchNumber, $this->fetchOffset);
 
         return $sql;
     }

--- a/tests/Zend/Db/Sql/SelectTest.php
+++ b/tests/Zend/Db/Sql/SelectTest.php
@@ -419,7 +419,8 @@ class SelectTest extends \PHPUnit_Framework_TestCase
     public function testOrder()
     {
         $select = new Select;
-        $select->order('id DESC');
+        $return = $select->order('id DESC');
+        $this->assertSame($select, $return);
         $this->assertEquals(array('id DESC'), $select->getRawState('order'));
 
         $select = new Select;

--- a/tests/Zend/Db/Sql/SelectTest.php
+++ b/tests/Zend/Db/Sql/SelectTest.php
@@ -433,4 +433,16 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('name ASC', 'age DESC'), $select->getRawState('order'));
 
     }
+
+    /**
+     * @testdox unit test: Test fetch()
+     * @covers Zend\Db\Sql\Select::fetch
+     */
+    public function testFetch()
+    {
+        $select = new Select;
+        $return = $select->fetch(10, 5);
+        $this->assertSame($select, $return);
+        $this->assertEquals(array(10, 5), $select->getRawState('fetch'));
+    }    
 }

--- a/tests/Zend/Db/Sql/SelectTest.php
+++ b/tests/Zend/Db/Sql/SelectTest.php
@@ -340,6 +340,18 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $sql15 = 'SELECT "foo".* FROM "foo" ORDER BY CASE "acolumn" WHEN ? THEN bcolumn ELSE ccolumn END';
         $params15 = array('bar');
 
+        // fetch
+        $select16 = new Select;
+        $select16->from('foo');
+        $select16->fetch(10, 5);
+        $sql16 = 'SELECT * FROM (SELECT ROW_NUMBER() OVER (ORDER BY (SELECT 0)) AS "zend_db_sql_select_rownumber", "foo".* FROM "foo") AS "zend_db_sql_select_table" WHERE "zend_db_sql_select_rownumber" BETWEEN 6 AND 15';
+
+        $select17 = new Select;
+        $select17->from('foo');
+        $select17->order('id');
+        $select17->fetch(10, 5);
+        $sql17 = 'SELECT * FROM (SELECT ROW_NUMBER() OVER (ORDER BY "id") AS "zend_db_sql_select_rownumber", "foo".* FROM "foo") AS "zend_db_sql_select_table" WHERE "zend_db_sql_select_rownumber" BETWEEN 6 AND 15';
+        
         return array(
             array($select0, $sql0),
             array($select1, $sql1),
@@ -357,6 +369,8 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             array($select13, $sql13),
             array($select14, $sql14),
             array($select15, $sql15, $params15),
+            array($select16, $sql16),
+            array($select17, $sql17),
         );
     }
 


### PR DESCRIPTION
Supports:
- `$select->order('id ASC, name DESC');`
- `$select->order(array('id ASC', 'name DESC'));`
- `$select->order(new Expression('CASE "foo" WHEN ? THEN name ELSE id END', array('bar')));`

Also supports LIMIT...OFFSET for MySQL & Sqlite and the ROW_NUMBER() window function for Sql92 and SQL Server.
