### PR TITLE
Addresses issue ZF2-257 "Update all docblocks to use consistent copyrigh...

### DIFF
--- a/demos/Zend/Gdata/BooksBrowser/interface.html
+++ b/demos/Zend/Gdata/BooksBrowser/interface.html
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Gdata
  * @subpackage Demos
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  *
  */

--- a/demos/Zend/Gdata/YouTubeVideoApp/video_app.js
+++ b/demos/Zend/Gdata/YouTubeVideoApp/video_app.js
@@ -13,7 +13,7 @@
  *
  * @category   Zend
  * @package    Zend_Gdata
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 

--- a/demos/Zend/Gdata/YouTubeVideoBrowser/interface.html
+++ b/demos/Zend/Gdata/YouTubeVideoBrowser/interface.html
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Gdata
  * @subpackage Demos
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 -->

--- a/demos/Zend/Gdata/YouTubeVideoBrowser/video_browser.js
+++ b/demos/Zend/Gdata/YouTubeVideoBrowser/video_browser.js
@@ -14,7 +14,7 @@
  * @category   Zend
  * @package    Zend_Gdata
  * @subpackage Demos
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 

--- a/demos/Zend/Service/LiveDocx/DemoConfiguration.php.dist
+++ b/demos/Zend/Service/LiveDocx/DemoConfiguration.php.dist
@@ -16,7 +16,7 @@
  * @category   Zend
  * @package    Zend_Service
  * @subpackage LiveDocx
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 

--- a/documentation/manual/Makefile
+++ b/documentation/manual/Makefile
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/ar/Makefile.in
+++ b/documentation/manual/ar/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/ar/configure.in
+++ b/documentation/manual/ar/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/bg/Makefile.in
+++ b/documentation/manual/bg/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/bg/configure.in
+++ b/documentation/manual/bg/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/cs/Makefile.in
+++ b/documentation/manual/cs/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/cs/configure.in
+++ b/documentation/manual/cs/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/de/Makefile.in
+++ b/documentation/manual/de/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/de/configure.in
+++ b/documentation/manual/de/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 FOP=fop
 XSLTPROC=xsltproc

--- a/documentation/manual/de/ref/coding_standard.xml
+++ b/documentation/manual/de/ref/coding_standard.xml
@@ -1094,7 +1094,7 @@ switch ($numPeople) {
  * @category   Zend
  * @package    Zend_Magic
  * @subpackage Wand
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license   BSD License
  * @version    $Id:$
  * @link       http://framework.zend.com/package/PackageName
@@ -1139,7 +1139,7 @@ switch ($numPeople) {
  * @category   Zend
  * @package    Zend_Magic
  * @subpackage Wand
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license   BSD License
  * @version    Release: @package_version@
  * @link       http://framework.zend.com/package/PackageName

--- a/documentation/manual/en/Makefile.in
+++ b/documentation/manual/en/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/en/configure.in
+++ b/documentation/manual/en/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 FOP=fop
 XSLTPROC=xsltproc

--- a/documentation/manual/en/ref/coding_standard.xml
+++ b/documentation/manual/en/ref/coding_standard.xml
@@ -1068,7 +1068,7 @@ switch ($numPeople) {
  * @category   Zend
  * @package    Zend_Magic
  * @subpackage Wand
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license   BSD License
  * @link       http://framework.zend.com/package/PackageName
  * @since      File available since Release 1.5.0
@@ -1111,7 +1111,7 @@ switch ($numPeople) {
  * @category   Zend
  * @package    Zend_Magic
  * @subpackage Wand
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license   BSD License
  * @version    Release: @package_version@
  * @link       http://framework.zend.com/package/PackageName

--- a/documentation/manual/es/Makefile.in
+++ b/documentation/manual/es/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/es/configure.in
+++ b/documentation/manual/es/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/es/ref/coding_standard.xml
+++ b/documentation/manual/es/ref/coding_standard.xml
@@ -953,7 +953,7 @@ switch ($numPeople) {
  * @category   Zend
  * @package    Zend_Magic
  * @subpackage Wand
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license   BSD License
  * @link       http://framework.zend.com/package/PackageName
  * @since      File available since Release 1.5.0
@@ -992,7 +992,7 @@ switch ($numPeople) {
  * @category   Zend
  * @package    Zend_Magic
  * @subpackage Wand
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license   BSD License
  * @version    Release: @package_version@
  * @link       http://framework.zend.com/package/PackageName

--- a/documentation/manual/fa/Makefile.in
+++ b/documentation/manual/fa/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/fa/configure.in
+++ b/documentation/manual/fa/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/fr/Makefile.in
+++ b/documentation/manual/fr/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/fr/configure.in
+++ b/documentation/manual/fr/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/fr/ref/coding_standard.xml
+++ b/documentation/manual/fr/ref/coding_standard.xml
@@ -1017,7 +1017,7 @@ switch ($numPeople) {
  *
  * LICENSE: Informations sur la licence
  *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license   BSD License
  * @link       http://framework.zend.com/package/PackageName
  * @since      File available since Release 1.5.0
@@ -1037,7 +1037,7 @@ switch ($numPeople) {
  *
  * Description longue de la classe, s'il y en a une
  *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license   BSD License
  * @version    Release: @package_version@
  * @link       http://framework.zend.com/package/PackageName

--- a/documentation/manual/he/Makefile.in
+++ b/documentation/manual/he/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/he/configure.in
+++ b/documentation/manual/he/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/hu/Makefile.in
+++ b/documentation/manual/hu/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/hu/configure.in
+++ b/documentation/manual/hu/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/id/Makefile.in
+++ b/documentation/manual/id/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/id/configure.in
+++ b/documentation/manual/id/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/it/Makefile.in
+++ b/documentation/manual/it/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/it/configure.in
+++ b/documentation/manual/it/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/ja/Makefile.in
+++ b/documentation/manual/ja/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/ja/configure.in
+++ b/documentation/manual/ja/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/ja/ref/coding_standard.xml
+++ b/documentation/manual/ja/ref/coding_standard.xml
@@ -1071,7 +1071,7 @@ switch ($numPeople) {
  * @category   Zend
  * @package    Zend_Magic
  * @subpackage Wand
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license   BSD License
  * @link       http://framework.zend.com/package/PackageName
  * @since      File available since Release 1.5.0
@@ -1113,7 +1113,7 @@ switch ($numPeople) {
  * @category   Zend
  * @package    Zend_Magic
  * @subpackage Wand
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license   BSD License
  * @version    Release: @package_version@
  * @link       http://framework.zend.com/package/PackageName

--- a/documentation/manual/ko/Makefile.in
+++ b/documentation/manual/ko/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/ko/configure.in
+++ b/documentation/manual/ko/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/ko/ref/coding_standard.xml
+++ b/documentation/manual/ko/ref/coding_standard.xml
@@ -694,7 +694,7 @@ switch ($numPeople) {
  *
  * LICENSE: Some license information
  *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://www.zend.com/license/3_0.txt   PHP License 3.0
  * @link       http://dev.zend.com/package/PackageName
  * @since      File available since Release 1.2.0
@@ -715,7 +715,7 @@ switch ($numPeople) {
  *
  * Long description for class (if any)...
  *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://www.zend.com/license/3_0.txt   PHP License 3.0
  * @version    Release: @package_version@
  * @link       http://dev.zend.com/package/PackageName

--- a/documentation/manual/nl/Makefile.in
+++ b/documentation/manual/nl/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/nl/configure.in
+++ b/documentation/manual/nl/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/nl/ref/coding_standard.xml
+++ b/documentation/manual/nl/ref/coding_standard.xml
@@ -589,7 +589,7 @@ switch ($numPeople) {
  *
  * LICENSE: Licentie informatie
  *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://www.zend.com/license/3_0.txt   PHP License 3.0
  * @link       http://dev.zend.com/package/PackageName
  * @since      File available since Release 1.2.0
@@ -606,7 +606,7 @@ switch ($numPeople) {
  *
  * Lange beschrijving van de klasse (indien aanwezig)...
  *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://www.zend.com/license/3_0.txt   PHP License 3.0
  * @version    Release: @package_version@
  * @link       http://dev.zend.com/package/PackageName

--- a/documentation/manual/pl/Makefile.in
+++ b/documentation/manual/pl/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/pl/configure.in
+++ b/documentation/manual/pl/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/pl/ref/coding_standard.xml
+++ b/documentation/manual/pl/ref/coding_standard.xml
@@ -853,7 +853,7 @@ switch ($numPeople) {
  *
  * LICENSE: Some license information
  *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license   BSD License
  * @link       http://framework.zend.com/package/PackageName
  * @since      File available since Release 1.5.0
@@ -876,7 +876,7 @@ switch ($numPeople) {
  *
  * Long description for class (if any)...
  *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license   BSD License
  * @version    Release: @package_version@
  * @link       http://framework.zend.com/package/PackageName

--- a/documentation/manual/pt-br/Makefile.in
+++ b/documentation/manual/pt-br/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/pt-br/configure.in
+++ b/documentation/manual/pt-br/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 FOP=fop
 XSLTPROC=xsltproc

--- a/documentation/manual/ro/Makefile.in
+++ b/documentation/manual/ro/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/ro/configure.in
+++ b/documentation/manual/ro/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/ru/Makefile.in
+++ b/documentation/manual/ru/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/ru/configure.in
+++ b/documentation/manual/ru/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/ru/ref/coding_standard.xml
+++ b/documentation/manual/ru/ref/coding_standard.xml
@@ -777,7 +777,7 @@ switch ($numPeople) {
  *
  * LICENSE: Some license information
  *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://www.zend.com/license/3_0.txt   PHP License 3.0
  * @link       http://dev.zend.com/package/PackageName
  * @since      File available since Release 1.2.0
@@ -798,7 +798,7 @@ switch ($numPeople) {
  *
  * Длинное описание класса (если есть)...
  *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://www.zend.com/license/3_0.txt   PHP License 3.0
  * @version    Release: @package_version@
  * @link       http://dev.zend.com/package/PackageName

--- a/documentation/manual/sk/Makefile.in
+++ b/documentation/manual/sk/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/sk/configure.in
+++ b/documentation/manual/sk/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/sl/Makefile.in
+++ b/documentation/manual/sl/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/sl/configure.in
+++ b/documentation/manual/sl/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/sr/Makefile.in
+++ b/documentation/manual/sr/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/sr/configure.in
+++ b/documentation/manual/sr/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/tr/Makefile.in
+++ b/documentation/manual/tr/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/tr/configure.in
+++ b/documentation/manual/tr/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/tr/ref/coding_standard.xml
+++ b/documentation/manual/tr/ref/coding_standard.xml
@@ -747,7 +747,7 @@ switch ($numPeople) {
  *
  * LİSANS: Lisans bilgisi
  *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://www.zend.com/license/3_0.txt   PHP License 3.0
  * @link       http://dev.zend.com/package/PackageName
  * @since      File available since Release 1.2.0
@@ -769,7 +769,7 @@ switch ($numPeople) {
  *
  * Sınıfın uzun açıklaması (eğer varsa)
  *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://www.zend.com/license/3_0.txt   PHP License 3.0
  * @version    Release: @package_version@
  * @link       http://dev.zend.com/package/PackageName

--- a/documentation/manual/uk/Makefile.in
+++ b/documentation/manual/uk/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/uk/configure.in
+++ b/documentation/manual/uk/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/documentation/manual/uk/ref/coding_standard.xml
+++ b/documentation/manual/uk/ref/coding_standard.xml
@@ -1026,7 +1026,7 @@ switch ($numPeople) {
  * @category   Zend
  * @package    Zend_Magic
  * @subpackage Wand
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license   BSD License
  * @link       http://framework.zend.com/package/PackageName
  * @since      File available since Release 1.5.0
@@ -1069,7 +1069,7 @@ switch ($numPeople) {
  * @category   Zend
  * @package    Zend_Magic
  * @subpackage Wand
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license   BSD License
  * @version    Release: @package_version@
  * @link       http://framework.zend.com/package/PackageName

--- a/documentation/manual/zh/Makefile.in
+++ b/documentation/manual/zh/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/documentation/manual/zh/configure.in
+++ b/documentation/manual/zh/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 FOP=fop
 XSLTPROC=xsltproc

--- a/documentation/manual/zh/ref/coding_standard.xml
+++ b/documentation/manual/zh/ref/coding_standard.xml
@@ -645,7 +645,7 @@ switch ($numPeople) {
  *
  * LICENSE: 一些 license 信息
  *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/3_0.txt   BSD License
  * @link       http://framework.zend.com/package/PackageName
  * @since      File available since Release 1.5.0
@@ -666,7 +666,7 @@ switch ($numPeople) {
  *
  * 类的详细描述 （如果有的话）... ...
  *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/   BSD License
  * @version    Release: @package_version@
  * @link       http://framework.zend.com/package/PackageName

--- a/library/Zend/Config/Exception/InvalidArgumentException.php
+++ b/library/Zend/Config/Exception/InvalidArgumentException.php
@@ -23,7 +23,7 @@ namespace Zend\Config\Exception;
 /**
  * @category  Zend
  * @package   Zend_Config
- * @copyright Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
 class InvalidArgumentException

--- a/library/Zend/Config/Exception/RuntimeException.php
+++ b/library/Zend/Config/Exception/RuntimeException.php
@@ -23,7 +23,7 @@ namespace Zend\Config\Exception;
 /**
  * @category  Zend
  * @package   Zend_Config
- * @copyright Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
 class RuntimeException

--- a/library/Zend/Config/Factory.php
+++ b/library/Zend/Config/Factory.php
@@ -27,7 +27,7 @@ use Zend\Stdlib\ArrayUtils;
  * 
  * @category  Zend
  * @package   Zend_Config
- * @copyright Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
 abstract class Factory

--- a/library/Zend/Config/Processor.php
+++ b/library/Zend/Config/Processor.php
@@ -23,7 +23,7 @@ namespace Zend\Config;
 /**
  * @category   Zend
  * @package    Zend_Config
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 interface Processor

--- a/library/Zend/Config/Processor/Constant.php
+++ b/library/Zend/Config/Processor/Constant.php
@@ -30,7 +30,7 @@ use Zend\Config\Config,
 /**
  * @category   Zend
  * @package    Zend_Config
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Constant extends Token implements Processor

--- a/library/Zend/Config/Processor/Filter.php
+++ b/library/Zend/Config/Processor/Filter.php
@@ -30,7 +30,7 @@ use Zend\Config\Config,
 /**
  * @category   Zend
  * @package    Zend_Config
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Filter implements Processor

--- a/library/Zend/Config/Processor/Queue.php
+++ b/library/Zend/Config/Processor/Queue.php
@@ -28,7 +28,7 @@ use Zend\Config\Config,
 /**
  * @category   Zend
  * @package    Zend_Config
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Queue extends PriorityQueue implements Processor

--- a/library/Zend/Config/Processor/Token.php
+++ b/library/Zend/Config/Processor/Token.php
@@ -29,7 +29,7 @@ use Zend\Config\Config,
 /**
  * @category   Zend
  * @package    Zend_Config
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Token implements Processor

--- a/library/Zend/Config/Processor/Translator.php
+++ b/library/Zend/Config/Processor/Translator.php
@@ -31,7 +31,7 @@ use Zend\Config\Config,
 /**
  * @category   Zend
  * @package    Zend_Config
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Translator implements Processor

--- a/library/Zend/Config/Reader.php
+++ b/library/Zend/Config/Reader.php
@@ -23,7 +23,7 @@ namespace Zend\Config;
 /**
  * @category  Zend
  * @package   Zend_Config
- * @copyright Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
 interface Reader

--- a/library/Zend/Config/Reader/Ini.php
+++ b/library/Zend/Config/Reader/Ini.php
@@ -30,7 +30,7 @@ use Zend\Config\Reader,
  * @category   Zend
  * @package    Zend_Config
  * @subpackage Reader
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Ini implements Reader

--- a/library/Zend/Config/Reader/Json.php
+++ b/library/Zend/Config/Reader/Json.php
@@ -31,7 +31,7 @@ use Zend\Config\Reader,
  * @category   Zend
  * @package    Zend_Config
  * @subpackage Reader
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Json implements Reader

--- a/library/Zend/Config/Reader/Xml.php
+++ b/library/Zend/Config/Reader/Xml.php
@@ -31,7 +31,7 @@ use XMLReader,
  * @category   Zend
  * @package    Zend_Config
  * @subpackage Reader
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Xml implements Reader

--- a/library/Zend/Config/Reader/Yaml.php
+++ b/library/Zend/Config/Reader/Yaml.php
@@ -30,7 +30,7 @@ use Zend\Config\Reader,
  * @category   Zend
  * @package    Zend_Config
  * @subpackage Reader
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Yaml implements Reader

--- a/library/Zend/Config/Writer.php
+++ b/library/Zend/Config/Writer.php
@@ -23,7 +23,7 @@ namespace Zend\Config;
 /**
  * @category  Zend
  * @package   Zend_Config
- * @copyright Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
 interface Writer

--- a/library/Zend/Log/Filter/Regex.php
+++ b/library/Zend/Log/Filter/Regex.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Log
  * @subpackage Filter
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,7 +31,7 @@ use Zend\Log\Exception,
  * @category   Zend
  * @package    Zend_Log
  * @subpackage Filter
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Regex implements Filter

--- a/library/Zend/Log/Formatter/ExceptionHandler.php
+++ b/library/Zend/Log/Formatter/ExceptionHandler.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Log
  * @subpackage Formatter
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -29,7 +29,7 @@ namespace Zend\Log\Formatter;
  * @category   Zend
  * @package    Zend_Log
  * @subpackage Formatter
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class ExceptionHandler extends AbstractFormatter

--- a/library/Zend/Log/Loggable.php
+++ b/library/Zend/Log/Loggable.php
@@ -14,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Log
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -26,7 +26,7 @@ namespace Zend\Log;
 /**
  * @category   Zend
  * @package    Zend_Log
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 interface Loggable

--- a/library/Zend/Log/LoggerAware.php
+++ b/library/Zend/Log/LoggerAware.php
@@ -14,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Log
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -30,7 +30,7 @@ use Zend\Log\Logger;
  *
  * @category   Zend
  * @package    Zend_Log
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 interface LoggerAware

--- a/library/Zend/Log/WriterBroker.php
+++ b/library/Zend/Log/WriterBroker.php
@@ -14,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Log
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -29,7 +29,7 @@ use Zend\Loader\PluginBroker;
  * @uses       \Zend\Loader\PluginBroker
  * @category   Zend
  * @package    Zend_Log
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class WriterBroker extends PluginBroker

--- a/library/Zend/Log/WriterLoader.php
+++ b/library/Zend/Log/WriterLoader.php
@@ -14,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Log
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -29,7 +29,7 @@ use Zend\Loader\PluginClassLoader;
  * @uses       \Zend\Loader\PluginClassLoader
  * @category   Zend
  * @package    Zend_Log
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class WriterLoader extends PluginClassLoader

--- a/library/Zend/Mvc/Router/Http/Hostname.php
+++ b/library/Zend/Mvc/Router/Http/Hostname.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,7 +31,7 @@ use Traversable,
  *
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/library/Zend/Mvc/Router/Http/Literal.php
+++ b/library/Zend/Mvc/Router/Http/Literal.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,7 +31,7 @@ use Traversable,
  *
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/library/Zend/Mvc/Router/Http/Part.php
+++ b/library/Zend/Mvc/Router/Http/Part.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -33,7 +33,7 @@ use Traversable,
  *
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/library/Zend/Mvc/Router/Http/Query.php
+++ b/library/Zend/Mvc/Router/Http/Query.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -33,7 +33,7 @@ use Traversable,
  *
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/library/Zend/Mvc/Router/Http/Regex.php
+++ b/library/Zend/Mvc/Router/Http/Regex.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,7 +31,7 @@ use Traversable,
  *
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/library/Zend/Mvc/Router/Http/Scheme.php
+++ b/library/Zend/Mvc/Router/Http/Scheme.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,7 +31,7 @@ use Traversable,
  *
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,7 +31,7 @@ use Traversable,
  *
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/library/Zend/Mvc/Router/Http/Wildcard.php
+++ b/library/Zend/Mvc/Router/Http/Wildcard.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,7 +31,7 @@ use Traversable,
  *
  * @package    Zend_Mvc_Router
  * @subpackage Http
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/library/Zend/Text/Figlet/zend-framework.flf
+++ b/library/Zend/Text/Figlet/zend-framework.flf
@@ -17,7 +17,7 @@ Version: 1.0
  obtain it through the world-wide-web, please send an email
  to license@zend.com so we can send you a copy immediately.
  
- Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 
 -------------------------------------------------------------------------------
 

--- a/modules/ZendFramework1Mvc/documentation/manual/Makefile
+++ b/modules/ZendFramework1Mvc/documentation/manual/Makefile
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/modules/ZendFramework1Mvc/documentation/manual/de/Makefile.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/de/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/modules/ZendFramework1Mvc/documentation/manual/de/configure.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/de/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 FOP=fop
 XSLTPROC=xsltproc

--- a/modules/ZendFramework1Mvc/documentation/manual/en/Makefile.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/en/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/modules/ZendFramework1Mvc/documentation/manual/en/configure.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/en/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 FOP=fop
 XSLTPROC=xsltproc

--- a/modules/ZendFramework1Mvc/documentation/manual/es/Makefile.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/es/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/modules/ZendFramework1Mvc/documentation/manual/es/configure.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/es/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/modules/ZendFramework1Mvc/documentation/manual/fr/Makefile.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/fr/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/modules/ZendFramework1Mvc/documentation/manual/fr/configure.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/fr/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/modules/ZendFramework1Mvc/documentation/manual/he/Makefile.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/he/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/modules/ZendFramework1Mvc/documentation/manual/he/configure.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/he/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/modules/ZendFramework1Mvc/documentation/manual/hu/Makefile.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/hu/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/modules/ZendFramework1Mvc/documentation/manual/hu/configure.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/hu/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/modules/ZendFramework1Mvc/documentation/manual/ja/Makefile.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/ja/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/modules/ZendFramework1Mvc/documentation/manual/ja/configure.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/ja/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/modules/ZendFramework1Mvc/documentation/manual/pl/Makefile.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/pl/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/modules/ZendFramework1Mvc/documentation/manual/pl/configure.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/pl/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/modules/ZendFramework1Mvc/documentation/manual/pt-br/Makefile.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/pt-br/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/modules/ZendFramework1Mvc/documentation/manual/pt-br/configure.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/pt-br/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 FOP=fop
 XSLTPROC=xsltproc

--- a/modules/ZendFramework1Mvc/documentation/manual/ru/Makefile.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/ru/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/modules/ZendFramework1Mvc/documentation/manual/ru/configure.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/ru/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/modules/ZendFramework1Mvc/documentation/manual/sk/Makefile.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/sk/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/modules/ZendFramework1Mvc/documentation/manual/sk/configure.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/sk/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 XINC=xinc
 XEP=xep

--- a/modules/ZendFramework1Mvc/documentation/manual/zh/Makefile.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/zh/Makefile.in
@@ -11,7 +11,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@zend.com so we can send you a copy immediately.
 #
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 

--- a/modules/ZendFramework1Mvc/documentation/manual/zh/configure.in
+++ b/modules/ZendFramework1Mvc/documentation/manual/zh/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(Makefile.in)
-AC_COPYRIGHT([Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)])
+AC_COPYRIGHT([Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)])
 
 FOP=fop
 XSLTPROC=xsltproc

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/AbstractRouter.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/AbstractRouter.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -33,7 +33,7 @@ use Zend\Controller\Router,
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 abstract class AbstractRouter implements Router

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Exception.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Exception.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -25,7 +25,7 @@ namespace Zend\Controller\Router;
  * @uses       \Zend\Controller\Exception
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Exception extends \Zend\Controller\Exception

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Rewrite.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Rewrite.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -30,7 +30,7 @@ use Zend\Config;
  * @uses       Zend\Loader
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Rewrite/PriorityList.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Rewrite/PriorityList.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @version    $Id$
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -28,7 +28,7 @@ use Zend\Controller\Router\Rewrite\Route\Route;
  *
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Rewrite/Route/Literal.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Rewrite/Route/Literal.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @version    $Id$
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -28,7 +28,7 @@ use Zend\Controller\Request\Http as HttpRequest;
  *
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Rewrite/Route/Part.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Rewrite/Route/Part.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @version    $Id$
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -29,7 +29,7 @@ use Zend\Controller\Request\Http as HttpRequest;
  *
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Rewrite/Route/Regex.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Rewrite/Route/Regex.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @version    $Id$
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -28,7 +28,7 @@ use Zend\Controller\Request\Http as HttpRequest;
  *
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Rewrite/Route/Route.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Rewrite/Route/Route.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @version    $Id$
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -28,7 +28,7 @@ use Zend\Controller\Request\Http as HttpRequest;
  *
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Rewrite/Router.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Rewrite/Router.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @version    $Id$
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -29,7 +29,7 @@ use Zend\Controller\Request\Http as HttpRequest;
  *
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -24,7 +24,7 @@ namespace Zend\Controller\Router;
 /**
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 interface Route {

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route/AbstractRoute.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route/AbstractRoute.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -32,7 +32,7 @@ use Zend\Controller\Router\Route;
  * @uses       \Zend\Controller\Router\Route\Chain
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 abstract class AbstractRoute implements Route

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route/Chain.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route/Chain.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -28,7 +28,7 @@ use Zend\Config;
  * @uses       \Zend\Controller\Router\Route\AbstractRoute
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Chain extends AbstractRoute

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route/Hostname.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route/Hostname.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -30,7 +30,7 @@ use Zend\Config;
  * @uses       \Zend\Controller\Router\Route\AbstractRoute
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route/Module.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route/Module.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -35,7 +35,7 @@ use Zend\Config;
  * @uses       \Zend\Controller\Router\Route\AbstractRoute
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route/Regex.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route/Regex.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -30,7 +30,7 @@ use Zend\Controller\Router;
  * @uses       \Zend\Controller\Router\Route\AbstractRoute
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Regex extends AbstractRoute

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route/Route.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route/Route.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -33,7 +33,7 @@ use Zend\Translator;
  * @uses       \Zend\Registry
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://manuals.rubyonrails.com/read/chapter/65
  */

--- a/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route/StaticRoute.php
+++ b/modules/ZendFramework1Mvc/library/Zend/Controller/Router/Route/StaticRoute.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -30,7 +30,7 @@ use Zend\Config;
  * @uses       \Zend\Controller\Router\Route\AbstractRoute
  * @package    Zend_Controller
  * @subpackage Router
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class StaticRoute extends AbstractRoute

--- a/modules/ZendFramework1Mvc/tests/TestConfiguration.php.dist
+++ b/modules/ZendFramework1Mvc/tests/TestConfiguration.php.dist
@@ -15,7 +15,7 @@
  *
  * @category   Zend
  * @package    UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 

--- a/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/Rewrite/PriorityListTest.php
+++ b/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/Rewrite/PriorityListTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @version    $Id$
  */
@@ -28,7 +28,7 @@ use ZendTest\Controller\Router\Rewrite\TestAsset\DummyRoute;
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Controller
  * @group      Zend_Controller_Router

--- a/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/Rewrite/TestAsset/DummyRoute.php
+++ b/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/Rewrite/TestAsset/DummyRoute.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @version    $Id$
  */
@@ -30,7 +30,7 @@ use Zend\Controller\Request\HTTP as HTTPRequest;
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class DummyRoute implements Route

--- a/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/RewriteTest.php
+++ b/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/RewriteTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,7 +31,7 @@ use Zend\Config,
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Controller
  * @group      Zend_Controller_Router

--- a/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/Route/ChainTest.php
+++ b/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/Route/ChainTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,7 +31,7 @@ use Zend\Config,
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Controller
  * @group      Zend_Controller_Router

--- a/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/Route/HostnameTest.php
+++ b/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/Route/HostnameTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -26,7 +26,7 @@ use Zend\Controller\Router\Route;
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Controller
  * @group      Zend_Controller_Router

--- a/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/Route/ModuleTest.php
+++ b/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/Route/ModuleTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -27,7 +27,7 @@ use Zend\Config;
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Controller
  * @group      Zend_Controller_Router

--- a/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/Route/RegexTest.php
+++ b/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/Route/RegexTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -28,7 +28,7 @@ use Zend\Config\Config,
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Controller
  * @group      Zend_Controller_Router

--- a/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/Route/StaticTest.php
+++ b/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/Route/StaticTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -26,7 +26,7 @@ use Zend\Controller\Router\Route;
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Controller
  * @group      Zend_Controller_Router

--- a/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/RouteTest.php
+++ b/modules/ZendFramework1Mvc/tests/Zend/Controller/Router/RouteTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -27,7 +27,7 @@ use Zend\Controller\Router\Route;
  * @category   Zend
  * @package    Zend_Controller
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Controller
  * @group      Zend_Controller_Router

--- a/tests/Zend/Cache/Pattern/CallbackCacheTest.php
+++ b/tests/Zend/Cache/Pattern/CallbackCacheTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -58,7 +58,7 @@ function bar () {
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Pattern/CaptureCacheTest.php
+++ b/tests/Zend/Cache/Pattern/CaptureCacheTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -26,7 +26,7 @@ use Zend\Cache;
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Pattern/ClassCacheTest.php
+++ b/tests/Zend/Cache/Pattern/ClassCacheTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -49,7 +49,7 @@ class TestClassCache
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Pattern/CommonPatternTest.php
+++ b/tests/Zend/Cache/Pattern/CommonPatternTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -27,7 +27,7 @@ use Zend\Cache;
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Pattern/ObjectCacheTest.php
+++ b/tests/Zend/Cache/Pattern/ObjectCacheTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -56,7 +56,7 @@ class TestObjectCache
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Pattern/OutputCacheTest.php
+++ b/tests/Zend/Cache/Pattern/OutputCacheTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -27,7 +27,7 @@ use Zend\Cache;
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/PatternFactoryTest.php
+++ b/tests/Zend/Cache/PatternFactoryTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -27,7 +27,7 @@ use Zend\Cache,
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Storage/Adapter/AbstractAdapterTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/AbstractAdapterTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -28,7 +28,7 @@ use Zend\Cache,
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Storage/Adapter/AbstractZendServerTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/AbstractZendServerTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -29,7 +29,7 @@ use Zend\Cache\Storage\Adapter,
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Storage/Adapter/ApcTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/ApcTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -26,7 +26,7 @@ use Zend\Cache;
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Storage/Adapter/CommonAdapterTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/CommonAdapterTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -32,7 +32,7 @@ use Zend\Cache\Storage\Adapter,
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Storage/Adapter/FilesystemTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/FilesystemTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -27,7 +27,7 @@ use Zend\Cache;
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Storage/Adapter/MemcachedTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/MemcachedTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -28,7 +28,7 @@ use Zend\Cache,
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Storage/Adapter/MemoryTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/MemoryTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -26,7 +26,7 @@ use Zend\Cache;
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Storage/Adapter/WinCacheTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/WinCacheTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -27,7 +27,7 @@ use \Zend\Cache,
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Storage/Adapter/ZendServerDiskTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/ZendServerDiskTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -28,7 +28,7 @@ use Zend\Cache,
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Storage/Adapter/ZendServerShmTest.php
+++ b/tests/Zend/Cache/Storage/Adapter/ZendServerShmTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -28,7 +28,7 @@ use Zend\Cache,
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Storage/CapabilitiesTest.php
+++ b/tests/Zend/Cache/Storage/CapabilitiesTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -27,7 +27,7 @@ use Zend\Cache\Storage\Capabilities;
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Storage/Plugin/CommonPluginTest.php
+++ b/tests/Zend/Cache/Storage/Plugin/CommonPluginTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -29,7 +29,7 @@ namespace ZendTest\Cache\Storage\Plugin;
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Storage/Plugin/IgnoreUserAbortTest.php
+++ b/tests/Zend/Cache/Storage/Plugin/IgnoreUserAbortTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -30,7 +30,7 @@ use Zend\Cache,
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/Storage/Plugin/SerializerTest.php
+++ b/tests/Zend/Cache/Storage/Plugin/SerializerTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -30,7 +30,7 @@ use Zend\Cache,
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/StorageFactoryTest.php
+++ b/tests/Zend/Cache/StorageFactoryTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -27,7 +27,7 @@ use Zend\Cache,
  * @category   Zend
  * @package    Zend_Cache
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */

--- a/tests/Zend/Cache/UtilsTest.php
+++ b/tests/Zend/Cache/UtilsTest.php
@@ -14,7 +14,7 @@
  *
  * @category   Zend_Cache
  * @package    UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -24,7 +24,7 @@ use Zend\Cache\Utils;
 /**
  * @category   Zend_Cache
  * @package    UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class UtilsTest extends \PHPUnit_Framework_TestCase

--- a/tests/Zend/Config/FactoryTest.php
+++ b/tests/Zend/Config/FactoryTest.php
@@ -27,7 +27,7 @@ use \Zend\Config\Factory;
  * @category   Zend
  * @package    Zend_Config
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */

--- a/tests/Zend/Config/ProcessorTest.php
+++ b/tests/Zend/Config/ProcessorTest.php
@@ -37,7 +37,7 @@ Zend\Filter\PregReplace;
  * @category   Zend
  * @package    Zend_Config
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */

--- a/tests/Zend/Config/Reader/AbstractReaderTestCase.php
+++ b/tests/Zend/Config/Reader/AbstractReaderTestCase.php
@@ -29,7 +29,7 @@ use \PHPUnit_Framework_TestCase as TestCase,
  * @category   Zend
  * @package    Zend_Config
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */

--- a/tests/Zend/Config/Reader/IniTest.php
+++ b/tests/Zend/Config/Reader/IniTest.php
@@ -27,7 +27,7 @@ use \Zend\Config\Reader\Ini;
  * @category   Zend
  * @package    Zend_Config
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */

--- a/tests/Zend/Config/Reader/JsonTest.php
+++ b/tests/Zend/Config/Reader/JsonTest.php
@@ -27,7 +27,7 @@ use \Zend\Config\Reader\Json;
  * @category   Zend
  * @package    Zend_Config
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */

--- a/tests/Zend/Config/Reader/XmlTest.php
+++ b/tests/Zend/Config/Reader/XmlTest.php
@@ -27,7 +27,7 @@ use \Zend\Config\Reader\Xml;
  * @category   Zend
  * @package    Zend_Config
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */

--- a/tests/Zend/Config/Reader/YamlTest.php
+++ b/tests/Zend/Config/Reader/YamlTest.php
@@ -27,7 +27,7 @@ use \Zend\Config\Reader\Yaml as YamlReader;
  * @category   Zend
  * @package    Zend_Config
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */

--- a/tests/Zend/Config/Writer/AbstractWriterTestCase.php
+++ b/tests/Zend/Config/Writer/AbstractWriterTestCase.php
@@ -28,7 +28,7 @@ use \PHPUnit_Framework_TestCase as TestCase,
  * @category   Zend
  * @package    Zend_Config
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */

--- a/tests/Zend/Config/Writer/PhpArrayTest.php
+++ b/tests/Zend/Config/Writer/PhpArrayTest.php
@@ -29,7 +29,7 @@ use \Zend\Config\Writer\PhpArray,
  * @category   Zend
  * @package    Zend_Config
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */

--- a/tests/Zend/GData/GAppsTest.php
+++ b/tests/Zend/GData/GAppsTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_GData_GApps
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -27,7 +27,7 @@ use Zend\GData\GApps;
  * @category   Zend
  * @package    Zend_GData_GApps
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_GData
  * @group      Zend_GData_GApps

--- a/tests/Zend/Log/Filter/ValidatorTest.php
+++ b/tests/Zend/Log/Filter/ValidatorTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Log
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,7 +31,7 @@ use Zend\Log\Logger,
  * @category   Zend
  * @package    Zend_Log
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */

--- a/tests/Zend/Log/Formatter/ExceptionHandlerTest.php
+++ b/tests/Zend/Log/Formatter/ExceptionHandlerTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Log
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -27,7 +27,7 @@ use Zend\Log\Formatter\ExceptionHandler;
  * @category   Zend
  * @package    Zend_Log
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */

--- a/tests/Zend/Log/WriterBrokerTest.php
+++ b/tests/Zend/Log/WriterBrokerTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Log
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -27,7 +27,7 @@ use Zend\Log\WriterBroker;
  * @category   Zend
  * @package    Zend_Log
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */

--- a/tests/Zend/Mvc/Router/Http/TestAsset/DummyRoute.php
+++ b/tests/Zend/Mvc/Router/Http/TestAsset/DummyRoute.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,7 +31,7 @@ use Zend\Mvc\Router\Http\Route,
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class DummyRoute implements Route

--- a/tests/Zend/Mvc/Router/Http/TestAsset/DummyRouteWithParam.php
+++ b/tests/Zend/Mvc/Router/Http/TestAsset/DummyRouteWithParam.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,7 +31,7 @@ use Zend\Mvc\Router\Http\Route,
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class DummyRouteWithParam extends DummyRoute

--- a/tests/Zend/Mvc/Router/PriorityListTest.php
+++ b/tests/Zend/Mvc/Router/PriorityListTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -28,7 +28,7 @@ use Zend\Mvc\Router\PriorityList,
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Router
  */

--- a/tests/Zend/Mvc/Router/RouteBrokerTest.php
+++ b/tests/Zend/Mvc/Router/RouteBrokerTest.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -28,7 +28,7 @@ use Zend\Mvc\Router\RouteBroker,
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Router
  */

--- a/tests/Zend/Mvc/Router/TestAsset/DummyRoute.php
+++ b/tests/Zend/Mvc/Router/TestAsset/DummyRoute.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,7 +31,7 @@ use Zend\Mvc\Router\Route,
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class DummyRoute implements Route

--- a/tests/Zend/Mvc/Router/TestAsset/DummyRouteWithParam.php
+++ b/tests/Zend/Mvc/Router/TestAsset/DummyRouteWithParam.php
@@ -15,7 +15,7 @@
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,7 +31,7 @@ use Zend\Mvc\Router\Route,
  * @category   Zend
  * @package    Zend_Mvc_Router
  * @subpackage UnitTests
- * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class DummyRouteWithParam extends DummyRoute

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -25,7 +25,7 @@
 #
 # @category   Zend
 # @package    UnitTests
-# @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 
 : ${PHPUNIT:="phpunit"}


### PR DESCRIPTION
...t/license header. Version: 2012"

http://framework.zend.com/issues/browse/ZF2-257

Updates existing copyright notices to read 2005-2012
