### PR TITLE
Adding first stub of composer.json to allow zf2 to be used as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,7 @@
     "description": "Zend Framework 2",
     "type": "library",
     "keywords": [
-        "zend framework",
-        "zf",
-        "zf2",
-        "zend"
+        "framework"
     ],
     "homepage": "http://framework.zend.com/",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "zendframework/zf2",
+    "description": "Zend Framework 2",
+    "type": "library",
+    "keywords": [
+        "zend",
+        "framework"
+    ],
+    "homepage": "http://zendframework.com/",
+    "require": {
+        "php": ">=5.3.3"
+    },
+    "autoload": {
+        "psr-0": {
+            "Zend": "library/"
+        },
+        "classmap": [
+            "library/"
+        ]
+    },
+    "config": {
+        "bin-dir": "bin"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
     },
     "config": {
         "bin-dir": "bin"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,12 @@
     "description": "Zend Framework 2",
     "type": "library",
     "keywords": [
-        "zend",
-        "framework"
+        "zend framework",
+        "zf",
+        "zf2",
+        "zend"
     ],
-    "homepage": "http://zendframework.com/",
+    "homepage": "http://framework.zend.com/",
     "require": {
         "php": ">=5.3.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,7 @@
     "autoload": {
         "psr-0": {
             "Zend": "library/"
-        },
-        "classmap": [
-            "library/"
-        ]
+        }
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
Simply adding `composer.json`, this should finally make zf2 an obvious dependency of our modules.
