### PR TITLE
Hotfix/zf 27 acl

### DIFF
--- a/library/Zend/Acl/Acl.php
+++ b/library/Zend/Acl/Acl.php
@@ -22,10 +22,10 @@ namespace Zend\Acl;
 
 /**
  * @uses       Zend\Acl\Assertion
- * @uses       Zend\Acl\Exception
- * @uses       Zend\Acl\Resource
+ * @uses       Zend\Acl\Exception\ExceptionInterface
+ * @uses       Zend\Acl\Resource\ResourceInterface
  * @uses       Zend\Acl\Resource\GenericResource
- * @uses       Zend\Acl\Role
+ * @uses       Zend\Acl\Role\RoleInterface
  * @uses       Zend\Acl\Role\GenericRole
  * @uses       Zend\Acl\Role\Registry
  * @category   Zend
@@ -117,8 +117,8 @@ class Acl
      * will have the least priority, and the last parent added will have the
      * highest priority.
      *
-     * @param  Role              $role
-     * @param  Role|string|array $parents
+     * @param  Role\RoleInterface              $role
+     * @param  Role\RoleInterface|string|array $parents
      * @uses   Role\Registry::add()
      * @throws Exception\InvalidArgumentException
      * @return Acl Provides a fluent interface
@@ -129,8 +129,8 @@ class Acl
             $role = new Role\GenericRole($role);
         }
 
-        if (!$role instanceof Role) {
-            throw new Exception\InvalidArgumentException('addRole() expects $role to be of type Zend_Acl_Role_Interface');
+        if (!$role instanceof Role\RoleInterface) {
+            throw new Exception\InvalidArgumentException('addRole() expects $role to be of type Zend_Acl_Role_RoleInterface');
         }
 
 
@@ -144,7 +144,7 @@ class Acl
      *
      * The $role parameter can either be a Role or Role identifier.
      *
-     * @param  Role|string $role
+     * @param  Role\RoleInterface|string $role
      * @uses   Role\Registry::get()
      * @return Role
      */
@@ -158,7 +158,7 @@ class Acl
      *
      * The $role parameter can either be a Role or a Role identifier.
      *
-     * @param  Role|string $role
+     * @param  Role\RoleInterface|string $role
      * @uses   Role\Registry::has()
      * @return boolean
      */
@@ -177,9 +177,9 @@ class Acl
      * inherits from $inherit through its ancestor Roles.
      *
      * @uses   Role\Registry::inherits()
-     * @param  Role|string $role
-     * @param  Role|string $inherit
-     * @param  boolean     $onlyParents
+     * @param  Role\RoleInterface|string    $role
+     * @param  Role\RoleInterface|string    $inherit
+     * @param  boolean                      $onlyParents
      * @return boolean
      */
     public function inheritsRole($role, $inherit, $onlyParents = false)
@@ -192,7 +192,7 @@ class Acl
      *
      * The $role parameter can either be a Role or a Role identifier.
      *
-     * @param  Role|string $role
+     * @param  Role\RoleInterface|string $role
      * @uses   Role\Registry::remove()
      * @return Acl Provides a fluent interface
      */
@@ -200,7 +200,7 @@ class Acl
     {
         $this->_getRoleRegistry()->remove($role);
 
-        if ($role instanceof Role) {
+        if ($role instanceof Role\RoleInterface) {
             $roleId = $role->getRoleId();
         } else {
             $roleId = $role;
@@ -252,8 +252,8 @@ class Acl
      * The $parent parameter may be a reference to, or the string identifier for,
      * the existing Resource from which the newly added Resource will inherit.
      *
-     * @param  Resource|string $resource
-     * @param  Resource|string $parent
+     * @param  Resource\RoleInterface|string $resource
+     * @param  Resource\RoleInterface|string $parent
      * @throws Exception\InvalidArgumentException
      * @return Acl Provides a fluent interface
      */
@@ -263,8 +263,8 @@ class Acl
             $resource = new Resource\GenericResource($resource);
         }
 
-        if (!$resource instanceof Resource) {
-            throw new Exception\InvalidArgumentException('addResource() expects $resource to be of type Zend_Acl_Resource_Interface');
+        if (!$resource instanceof Resource\ResourceInterface) {
+            throw new Exception\InvalidArgumentException('addResource() expects $resource to be of type Zend_Acl_Resource_ResourceInterface');
         }
 
         $resourceId = $resource->getResourceId();
@@ -277,13 +277,13 @@ class Acl
 
         if (null !== $parent) {
             try {
-                if ($parent instanceof Resource) {
+                if ($parent instanceof Resource\ResourceInterface) {
                     $resourceParentId = $parent->getResourceId();
                 } else {
                     $resourceParentId = $parent;
                 }
                 $resourceParent = $this->getResource($resourceParentId);
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 throw new Exception\InvalidArgumentException("Parent Resource id '$resourceParentId' does not exist", 0, $e);
             }
             $this->_resources[$resourceParentId]['children'][$resourceId] = $resource;
@@ -303,13 +303,13 @@ class Acl
      *
      * The $resource parameter can either be a Resource or a Resource identifier.
      *
-     * @param  Resource|string $resource
+     * @param  Resource\ResourceInterface|string $resource
      * @throws Exception\InvalidArgumentException
      * @return Resource
      */
     public function getResource($resource)
     {
-        if ($resource instanceof Resource) {
+        if ($resource instanceof Resource\ResourceInterface) {
             $resourceId = $resource->getResourceId();
         } else {
             $resourceId = (string) $resource;
@@ -327,12 +327,12 @@ class Acl
      *
      * The $resource parameter can either be a Resource or a Resource identifier.
      *
-     * @param  Resource|string $resource
+     * @param  Resource\ResourceInterface|string $resource
      * @return boolean
      */
     public function hasResource($resource)
     {
-        if ($resource instanceof Resource) {
+        if ($resource instanceof Resource\ResourceInterface) {
             $resourceId = $resource->getResourceId();
         } else {
             $resourceId = (string) $resource;
@@ -350,9 +350,9 @@ class Acl
      * through the entire inheritance tree to determine whether $resource
      * inherits from $inherit through its ancestor Resources.
      *
-     * @param  Resource|string $resource
-     * @param  Resource|string $inherit
-     * @param  boolean         $onlyParent
+     * @param  Resource\ResourceInterface|string    $resource
+     * @param  Resource\ResourceInterface|string    inherit
+     * @param  boolean                              $onlyParent
      * @throws Exception\InvalidArgumentException
      * @return boolean
      */
@@ -391,7 +391,7 @@ class Acl
      *
      * The $resource parameter can either be a Resource or a Resource identifier.
      *
-     * @param  Resource|string $resource
+     * @param  Resource\ResourceInterface|string $resource
      * @throws Exception\InvalidArgumentException
      * @return Acl Provides a fluent interface
      */
@@ -449,10 +449,10 @@ class Acl
      * Adds an "allow" rule to the ACL
      *
      * @uses   Acl::setRule()
-     * @param  Role|string|array     $roles
-     * @param  Resource|string|array $resources
-     * @param  string|array          $privileges
-     * @param  Assertion             $assert
+     * @param  Role\RoleInterface|string|array          $roles
+     * @param  Resource\ResourceInterface|string|array  $resources
+     * @param  string|array                             $privileges
+     * @param  Assertion                                $assert
      * @return Acl Provides a fluent interface
      */
     public function allow($roles = null, $resources = null, $privileges = null, Assertion $assert = null)
@@ -464,10 +464,10 @@ class Acl
      * Adds a "deny" rule to the ACL
      *
      * @uses   Acl::setRule()
-     * @param  Role|string|array     $roles
-     * @param  Resource|string|array $resources
-     * @param  string|array          $privileges
-     * @param  Assertion             $assert
+     * @param  Role\RoleInterface|string|array          $roles
+     * @param  Resource\ResourceInterface|string|array  $resources
+     * @param  string|array                             $privileges
+     * @param  Assertion                                $assert
      * @return Acl Provides a fluent interface
      */
     public function deny($roles = null, $resources = null, $privileges = null, Assertion $assert = null)
@@ -479,9 +479,9 @@ class Acl
      * Removes "allow" permissions from the ACL
      *
      * @uses   Acl::setRule()
-     * @param  Role|string|array     $roles
-     * @param  Resource|string|array $resources
-     * @param  string|array          $privileges
+     * @param  Role\RoleInterface|string|array          $roles
+     * @param  Resource\ResourceInterface|string|array  $resources
+     * @param  string|array                             $privileges
      * @return Acl Provides a fluent interface
      */
     public function removeAllow($roles = null, $resources = null, $privileges = null)
@@ -546,12 +546,12 @@ class Acl
      *
      * @uses   Role\Registry::get()
      * @uses   Acl::get()
-     * @param  string                $operation
-     * @param  string                $type
-     * @param  Role|string|array     $roles
-     * @param  Resource|string|array $resources
-     * @param  string|array          $privileges
-     * @param  Assertion             $assert
+     * @param  string                                   $operation
+     * @param  string                                   $type
+     * @param  Role\RoleInterface|string|array          $roles
+     * @param  Resource\ResourceInterface|string|array  $resources
+     * @param  string|array                             $privileges
+     * @param  Assertion                                $assert
      * @throws Exception\InvalidArgumentException
      * @return Acl Provides a fluent interface
      */
@@ -700,9 +700,9 @@ class Acl
      *
      * @uses   Acl::get()
      * @uses   Role\Registry::get()
-     * @param  Role|string     $role
-     * @param  Resource|string $resource
-     * @param  string          $privilege
+     * @param  Role\RoleInterface|string            $role
+     * @param  Resource\ResourceInterface|string    $resource
+     * @param  string                               $privilege
      * @return boolean
      */
     public function isAllowed($role = null, $resource = null, $privilege = null)
@@ -716,7 +716,7 @@ class Acl
             // keep track of originally called role
             $this->_isAllowedRole = $role;
             $role = $this->_getRoleRegistry()->get($role);
-            if (!$this->_isAllowedRole instanceof Role) {
+            if (!$this->_isAllowedRole instanceof Role\RoleInterface) {
                 $this->_isAllowedRole = $role;
             }
         }
@@ -725,7 +725,7 @@ class Acl
             // keep track of originally called resource
             $this->_isAllowedResource = $resource;
             $resource = $this->getResource($resource);
-            if (!$this->_isAllowedResource instanceof Resource) {
+            if (!$this->_isAllowedResource instanceof Resource\ResourceInterface) {
                 $this->_isAllowedResource = $resource;
             }
         }
@@ -800,11 +800,11 @@ class Acl
      * This method returns true if a rule is found and allows access. If a rule exists and denies access,
      * then this method returns false. If no applicable rule is found, then this method returns null.
      *
-     * @param  Role     $role
-     * @param  Resource $resource
+     * @param  Role\RoleInterface           $role
+     * @param  Resource\ResourceInterface   $resource
      * @return boolean|null
      */
-    protected function _roleDFSAllPrivileges(Role $role, Resource $resource = null)
+    protected function _roleDFSAllPrivileges(Role\RoleInterface $role, Resource\ResourceInterface $resource = null)
     {
         $dfs = array(
             'visited' => array(),
@@ -834,13 +834,13 @@ class Acl
      *
      * This method is used by the internal depth-first search algorithm and may modify the DFS data structure.
      *
-     * @param  Role     $role
-     * @param  Resource $resource
-     * @param  array    $dfs
+     * @param  Role\RoleInterface           $role
+     * @param  Resource\ResourceInterface   $resource
+     * @param  array                        $dfs
      * @return boolean|null
      * @throws Exception\RuntimeException
      */
-    protected function _roleDFSVisitAllPrivileges(Role $role, Resource $resource = null, &$dfs = null)
+    protected function _roleDFSVisitAllPrivileges(Role\RoleInterface $role, Resource\ResourceInterface $resource = null, &$dfs = null)
     {
         if (null === $dfs) {
             throw new Exception\RuntimeException('$dfs parameter may not be null');
@@ -872,13 +872,13 @@ class Acl
      * This method returns true if a rule is found and allows access. If a rule exists and denies access,
      * then this method returns false. If no applicable rule is found, then this method returns null.
      *
-     * @param  Role     $role
-     * @param  Resource $resource
-     * @param  string   $privilege
+     * @param  Role\RoleInterface           $role
+     * @param  Resource\ResourceInterface   $resource
+     * @param  string                       $privilege
      * @return boolean|null
      * @throws Exception\RuntimeException
      */
-    protected function _roleDFSOnePrivilege(Role $role, Resource $resource = null, $privilege = null)
+    protected function _roleDFSOnePrivilege(Role\RoleInterface $role, Resource\ResourceInterface $resource = null, $privilege = null)
     {
         if (null === $privilege) {
             throw new Exception\RuntimeException('$privilege parameter may not be null');
@@ -912,14 +912,14 @@ class Acl
      *
      * This method is used by the internal depth-first search algorithm and may modify the DFS data structure.
      *
-     * @param  Role     $role
-     * @param  Resource $resource
-     * @param  string   $privilege
-     * @param  array    $dfs
+     * @param  Role\RoleInterface           $role
+     * @param  Resource\ResourceInterface   $resource
+     * @param  string                       $privilege
+     * @param  array                        $dfs
      * @return boolean|null
      * @throws Exception\RuntimeException
      */
-    protected function _roleDFSVisitOnePrivilege(Role $role, Resource $resource = null,
+    protected function _roleDFSVisitOnePrivilege(Role\RoleInterface $role, Resource\ResourceInterface $resource = null,
         $privilege = null, &$dfs = null
     ) {
         if (null === $privilege) {
@@ -966,12 +966,12 @@ class Acl
      * If all three parameters are null, then the default ACL rule type is returned,
      * based on whether its assertion method passes.
      *
-     * @param  null|Resource $resource
-     * @param  null|Role     $role
-     * @param  null|string   $privilege
+     * @param  null|Resource\ResourceInterface  $resource
+     * @param  null|Role\RoleInterface          $role
+     * @param  null|string                      $privilege
      * @return string|null
      */
-    protected function _getRuleType(Resource $resource = null, Role $role = null, $privilege = null)
+    protected function _getRuleType(Resource\ResourceInterface $resource = null, Role\RoleInterface $role = null, $privilege = null)
     {
         // get the rules for the $resource and $role
         if (null === ($rules = $this->_getRules($resource, $role))) {
@@ -996,8 +996,8 @@ class Acl
             $assertion = $rule['assert'];
             $assertionValue = $assertion->assert(
                 $this,
-                ($this->_isAllowedRole instanceof Role) ? $this->_isAllowedRole : $role,
-                ($this->_isAllowedResource instanceof Resource) ? $this->_isAllowedResource : $resource,
+                ($this->_isAllowedRole instanceof Role\RoleInterface) ? $this->_isAllowedRole : $role,
+                ($this->_isAllowedResource instanceof Resource\ResourceInterface) ? $this->_isAllowedResource : $resource,
                 $this->_isAllowedPrivilege
             );
         }
@@ -1021,12 +1021,12 @@ class Acl
      *
      * If the $create parameter is true, then a rule set is first created and then returned to the caller.
      *
-     * @param  Resource $resource
-     * @param  Role     $role
+     * @param  Resource\ResourceInterface $resource
+     * @param  Role\RoleInterface     $role
      * @param  boolean  $create
      * @return array|null
      */
-    protected function &_getRules(Resource $resource = null, Role $role = null, $create = false)
+    protected function &_getRules(Resource\ResourceInterface $resource = null, Role\RoleInterface $role = null, $create = false)
     {
         // create a reference to null
         $null = null;

--- a/library/Zend/Acl/Acl.php
+++ b/library/Zend/Acl/Acl.php
@@ -21,13 +21,6 @@
 namespace Zend\Acl;
 
 /**
- * @uses       Zend\Acl\Assertion
- * @uses       Zend\Acl\Exception\ExceptionInterface
- * @uses       Zend\Acl\Resource\ResourceInterface
- * @uses       Zend\Acl\Resource\GenericResource
- * @uses       Zend\Acl\Role\RoleInterface
- * @uses       Zend\Acl\Role\GenericRole
- * @uses       Zend\Acl\Role\Registry
  * @category   Zend
  * @package    Zend_Acl
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
@@ -452,10 +445,10 @@ class Acl
      * @param  Role\RoleInterface|string|array          $roles
      * @param  Resource\ResourceInterface|string|array  $resources
      * @param  string|array                             $privileges
-     * @param  Assertion                                $assert
+     * @param  Assertion\AssertionInterface             $assert
      * @return Acl Provides a fluent interface
      */
-    public function allow($roles = null, $resources = null, $privileges = null, Assertion $assert = null)
+    public function allow($roles = null, $resources = null, $privileges = null, Assertion\AssertionInterface $assert = null)
     {
         return $this->setRule(self::OP_ADD, self::TYPE_ALLOW, $roles, $resources, $privileges, $assert);
     }
@@ -467,10 +460,10 @@ class Acl
      * @param  Role\RoleInterface|string|array          $roles
      * @param  Resource\ResourceInterface|string|array  $resources
      * @param  string|array                             $privileges
-     * @param  Assertion                                $assert
+     * @param  Assertion\AssertionInterface             $assert
      * @return Acl Provides a fluent interface
      */
-    public function deny($roles = null, $resources = null, $privileges = null, Assertion $assert = null)
+    public function deny($roles = null, $resources = null, $privileges = null, Assertion\AssertionInterface $assert = null)
     {
         return $this->setRule(self::OP_ADD, self::TYPE_DENY, $roles, $resources, $privileges, $assert);
     }
@@ -551,12 +544,12 @@ class Acl
      * @param  Role\RoleInterface|string|array          $roles
      * @param  Resource\ResourceInterface|string|array  $resources
      * @param  string|array                             $privileges
-     * @param  Assertion                                $assert
+     * @param  Assertion\AssertionInterface                       $assert
      * @throws Exception\InvalidArgumentException
      * @return Acl Provides a fluent interface
      */
     public function setRule($operation, $type, $roles = null, $resources = null,
-        $privileges = null, Assertion $assert = null
+        $privileges = null, Assertion\AssertionInterface $assert = null
     ) {
         // ensure that the rule type is valid; normalize input to uppercase
         $type = strtoupper($type);

--- a/library/Zend/Acl/Assertion.php
+++ b/library/Zend/Acl/Assertion.php
@@ -44,5 +44,5 @@ interface Assertion
      * @param  string   $privilege
      * @return boolean
      */
-    public function assert(Acl $acl, Role $role = null, Resource $resource = null, $privilege = null);
+    public function assert(Acl $acl, Role\RoleInterface $role = null, Resource\ResourceInterface $resource = null, $privilege = null);
 }

--- a/library/Zend/Acl/Assertion/AssertionInterface.php
+++ b/library/Zend/Acl/Assertion/AssertionInterface.php
@@ -18,18 +18,16 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Zend\Acl;
+namespace Zend\Acl\Assertion;
 
+use Zend\Acl;
 /**
- * @uses       Zend\Acl\Acl
- * @uses       Zend\Acl\Resource
- * @uses       Zend\Acl\Role
  * @category   Zend
  * @package    Zend_Acl
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Assertion
+interface AssertionInterface
 {
     /**
      * Returns true if and only if the assertion conditions are met
@@ -38,11 +36,11 @@ interface Assertion
      * $role, $resource, or $privilege parameters are null, it means that the query applies to all Roles, Resources, or
      * privileges, respectively.
      *
-     * @param  Acl      $acl
-     * @param  Role     $role
-     * @param  Resource $resource
-     * @param  string   $privilege
+     * @param  Acl                           $acl
+     * @param  Role\RoleInterface            $role
+     * @param  Resource\ResourceInterface    $resource
+     * @param  string                        $privilege
      * @return boolean
      */
-    public function assert(Acl $acl, Role\RoleInterface $role = null, Resource\ResourceInterface $resource = null, $privilege = null);
+    public function assert(Acl\Acl $acl, Acl\Role\RoleInterface $role = null, Acl\Resource\ResourceInterface $resource = null, $privilege = null);
 }

--- a/library/Zend/Acl/Exception/ExceptionInterface.php
+++ b/library/Zend/Acl/Exception/ExceptionInterface.php
@@ -21,7 +21,6 @@
 namespace Zend\Acl\Exception;
 
 /**
- * @uses       Zend\Exception
  * @category   Zend
  * @package    Zend_Acl
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Acl/Exception/ExceptionInterface.php
+++ b/library/Zend/Acl/Exception/ExceptionInterface.php
@@ -18,20 +18,14 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Zend\Acl;
+namespace Zend\Acl\Exception;
 
 /**
+ * @uses       Zend\Exception
  * @category   Zend
  * @package    Zend_Acl
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Role
-{
-    /**
-     * Returns the string identifier of the Role
-     *
-     * @return string
-     */
-    public function getRoleId();
-}
+interface ExceptionInterface
+{}

--- a/library/Zend/Acl/Exception/InvalidArgumentException.php
+++ b/library/Zend/Acl/Exception/InvalidArgumentException.php
@@ -4,7 +4,7 @@ namespace Zend\Acl\Exception;
 
 class InvalidArgumentException
     extends \InvalidArgumentException
-    implements \Zend\Acl\Exception
+    implements \Zend\Acl\Exception\ExceptionInterface
 {
     
 }

--- a/library/Zend/Acl/Exception/RuntimeException.php
+++ b/library/Zend/Acl/Exception/RuntimeException.php
@@ -4,7 +4,7 @@ namespace Zend\Acl\Exception;
 
 class RuntimeException
     extends \RuntimeException
-    implements \Zend\Acl\Exception
+    implements \Zend\Acl\Exception\ExceptionInterface
 {
     
 }

--- a/library/Zend/Acl/Resource/GenericResource.php
+++ b/library/Zend/Acl/Resource/GenericResource.php
@@ -20,7 +20,7 @@
 
 namespace Zend\Acl\Resource;
 
-use Zend\Acl\Resource;
+use Zend\Acl\Resource\ResourceInterface;
 
 /**
  * @uses       \Zend\Acl\Resource\ResourceInterface
@@ -29,7 +29,7 @@ use Zend\Acl\Resource;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class GenericResource implements Resource
+class GenericResource implements ResourceInterface
 {
     /**
      * Unique id of Resource

--- a/library/Zend/Acl/Resource/GenericResource.php
+++ b/library/Zend/Acl/Resource/GenericResource.php
@@ -23,7 +23,6 @@ namespace Zend\Acl\Resource;
 use Zend\Acl\Resource\ResourceInterface;
 
 /**
- * @uses       \Zend\Acl\Resource\ResourceInterface
  * @category   Zend
  * @package    Zend_Acl
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Acl/Resource/ResourceInterface.php
+++ b/library/Zend/Acl/Resource/ResourceInterface.php
@@ -18,7 +18,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Zend\Acl;
+namespace Zend\Acl\Resource;
 
 /**
  * @category   Zend
@@ -26,7 +26,7 @@ namespace Zend\Acl;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Resource
+interface ResourceInterface
 {
     /**
      * Returns the string identifier of the Resource

--- a/library/Zend/Acl/Role/GenericRole.php
+++ b/library/Zend/Acl/Role/GenericRole.php
@@ -23,7 +23,6 @@ namespace Zend\Acl\Role;
 use Zend\Acl\Role\RoleInterface;
 
 /**
- * @uses       Zend\Acl\Role
  * @category   Zend
  * @package    Zend_Acl
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Acl/Role/GenericRole.php
+++ b/library/Zend/Acl/Role/GenericRole.php
@@ -20,7 +20,7 @@
 
 namespace Zend\Acl\Role;
 
-use Zend\Acl\Role;
+use Zend\Acl\Role\RoleInterface;
 
 /**
  * @uses       Zend\Acl\Role
@@ -29,7 +29,7 @@ use Zend\Acl\Role;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class GenericRole implements Role
+class GenericRole implements RoleInterface
 {
     /**
      * Unique id of Role
@@ -50,7 +50,7 @@ class GenericRole implements Role
     }
 
     /**
-     * Defined by Zend\Acl\Role; returns the Role identifier
+     * Defined by Zend\Acl\Role\RoleInterface; returns the Role identifier
      *
      * @return string
      */
@@ -60,7 +60,7 @@ class GenericRole implements Role
     }
 
     /**
-     * Defined by Zend\Acl\Role; returns the Role identifier
+     * Defined by Zend\Acl\Role\RoleInterface; returns the Role identifier
      * Proxies to getRoleId()
      *
      * @return string

--- a/library/Zend/Acl/Role/Registry.php
+++ b/library/Zend/Acl/Role/Registry.php
@@ -26,8 +26,6 @@ use Zend\Acl,
 
 
 /**
- * @uses       Zend\Acl\Role
- * @uses       Zend\Acl\Role\Exception
  * @category   Zend
  * @package    Zend_Acl
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)

--- a/library/Zend/Acl/Role/Registry.php
+++ b/library/Zend/Acl/Role/Registry.php
@@ -56,12 +56,12 @@ class Registry
      * will have the least priority, and the last parent added will have the
      * highest priority.
      *
-     * @param  \Zend\Acl\Role              $role
-     * @param  \Zend\Acl\Role|string|array $parents
+     * @param  \Zend\Acl\Role\RoleInterface              $role
+     * @param  \Zend\Acl\Role\RoleInterface|string|array $parents
      * @throws \Zend\Acl\Exception\InvalidArgumentException
      * @return Registry Provides a fluent interface
      */
-    public function add(Role $role, $parents = null)
+    public function add(Role\RoleInterface $role, $parents = null)
     {
         $roleId = $role->getRoleId();
 
@@ -77,13 +77,13 @@ class Registry
             }
             foreach ($parents as $parent) {
                 try {
-                    if ($parent instanceof Role) {
+                    if ($parent instanceof Role\RoleInterface) {
                         $roleParentId = $parent->getRoleId();
                     } else {
                         $roleParentId = $parent;
                     }
                     $roleParent = $this->get($roleParentId);
-                } catch (Exception $e) {
+                } catch (\Exception $e) {
                     throw new Acl\Exception\InvalidArgumentException("Parent Role id '$roleParentId' does not exist", 0, $e);
                 }
                 $roleParents[$roleParentId] = $roleParent;
@@ -111,7 +111,7 @@ class Registry
      */
     public function get($role)
     {
-        if ($role instanceof Role) {
+        if ($role instanceof Role\RoleInterface) {
             $roleId = $role->getRoleId();
         } else {
             $roleId = (string) $role;
@@ -134,7 +134,7 @@ class Registry
      */
     public function has($role)
     {
-        if ($role instanceof Role) {
+        if ($role instanceof Role\RoleInterface) {
             $roleId = $role->getRoleId();
         } else {
             $roleId = (string) $role;
@@ -154,7 +154,7 @@ class Registry
      * If the Role does not have any parents, then an empty array is returned.
      *
      * @uses   Zend\Acl\Role\Registry::get()
-     * @param  \Zend\Acl\Role|string $role
+     * @param  \Zend\Acl\Role\RoleInterface|string $role
      * @return array
      */
     public function getParents($role)
@@ -173,9 +173,9 @@ class Registry
      * through the entire inheritance DAG to determine whether $role
      * inherits from $inherit through its ancestor Roles.
      *
-     * @param  \Zend\Acl\Role|string $role
-     * @param  \Zend\Acl\Role|string $inherit
-     * @param  boolean                        $onlyParents
+     * @param  \Zend\Acl\Role\RoleInterface|string  $role
+     * @param  \Zend\Acl\Role\RoleInterface|string  $inherit
+     * @param  boolean                              $onlyParents
      * @throws \Zend\Acl\Exception\InvalidArgumentException
      * @return boolean
      */
@@ -208,7 +208,7 @@ class Registry
      *
      * The $role parameter can either be a Role or a Role identifier.
      *
-     * @param  \Zend\Acl\Role|string $role
+     * @param  \Zend\Acl\Role\RoleInterface|string $role
      * @throws \Zend\Acl\Exception\InvalidArgumentException
      * @return Registry Provides a fluent interface
      */

--- a/library/Zend/Acl/Role/RoleInterface.php
+++ b/library/Zend/Acl/Role/RoleInterface.php
@@ -18,14 +18,20 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Zend\Acl;
+namespace Zend\Acl\Role;
 
 /**
- * @uses       Zend\Exception
  * @category   Zend
  * @package    Zend_Acl
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Exception
-{}
+interface RoleInterface
+{
+    /**
+     * Returns the string identifier of the Role
+     *
+     * @return string
+     */
+    public function getRoleId();
+}

--- a/tests/Zend/Acl/AclTest.php
+++ b/tests/Zend/Acl/AclTest.php
@@ -75,7 +75,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
     {
         $role = $this->_acl->addRole('area')
                           ->getRole('area');
-        $this->assertInstanceOf('Zend\Acl\Role', $role);
+        $this->assertInstanceOf('Zend\Acl\Role\RoleInterface', $role);
         $this->assertEquals('area', $role->getRoleId());
     }
 
@@ -263,7 +263,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
     {
         $resource = $this->_acl->addResource('area')
                           ->getResource('area');
-        $this->assertInstanceOf('Zend\Acl\Resource', $resource);
+        $this->assertInstanceOf('Zend\Acl\Resource\ResourceInterface', $resource);
         $this->assertEquals('area', $resource->getResourceId());
     }
 
@@ -302,7 +302,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      */
     public function testResourceRemoveOneNonExistent()
     {
-        $this->setExpectedException('Zend\Acl\Exception', 'not found');
+        $this->setExpectedException('Zend\Acl\Exception\ExceptionInterface', 'not found');
         $this->_acl->removeResource('nonexistent');
     }
 
@@ -341,14 +341,14 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->_acl->addResource($resourceArea);
         try {
             $this->_acl->inheritsResource('nonexistent', $resourceArea);
-            $this->fail('Expected Zend\Acl\Exception not thrown upon specifying a non-existent child Resource');
-        } catch (Acl\Exception $e) {
+            $this->fail('Expected Zend\Acl\Exception\ExceptionInterface not thrown upon specifying a non-existent child Resource');
+        } catch (Acl\Exception\ExceptionInterface $e) {
             $this->assertContains('not found', $e->getMessage());
         }
         try {
             $this->_acl->inheritsResource($resourceArea, 'nonexistent');
-            $this->fail('Expected Zend\Acl\Exception not thrown upon specifying a non-existent parent Resource');
-        } catch (Acl\Exception $e) {
+            $this->fail('Expected Zend\Acl\Exception\ExceptionInterface not thrown upon specifying a non-existent parent Resource');
+        } catch (Acl\Exception\ExceptionInterface $e) {
             $this->assertContains('not found', $e->getMessage());
         }
     }
@@ -383,7 +383,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      */
     public function testResourceDuplicate()
     {
-        $this->setExpectedException('Zend\Acl\Exception', 'already exists');
+        $this->setExpectedException('Zend\Acl\Exception\ExceptionInterface', 'already exists');
         $resourceArea = new Resource\GenericResource('area');
         $this->_acl->addResource($resourceArea)
                    ->addResource($resourceArea);
@@ -396,7 +396,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      */
     public function testResourceDuplicateId()
     {
-        $this->setExpectedException('Zend\Acl\Exception', 'already exists');
+        $this->setExpectedException('Zend\Acl\Exception\ExceptionInterface', 'already exists');
         $resourceArea1 = new Resource\GenericResource('area');
         $resourceArea2 = new Resource\GenericResource('area');
         $this->_acl->addResource($resourceArea1)
@@ -412,13 +412,13 @@ class AclTest extends \PHPUnit_Framework_TestCase
     {
         try {
             $this->_acl->isAllowed('nonexistent');
-            $this->fail('Expected Zend\Acl\Role\Exception not thrown upon non-existent Role');
+            $this->fail('Expected Zend\Acl\Role\Exception\ExceptionInterface not thrown upon non-existent Role');
         } catch (Acl\Exception\InvalidArgumentException $e) {
             $this->assertContains('not found', $e->getMessage());
         }
         try {
             $this->_acl->isAllowed(null, 'nonexistent');
-            $this->fail('Expected Zend\Acl\Exception not thrown upon non-existent Resource');
+            $this->fail('Expected Zend\Acl\Exception\ExceptionInterface not thrown upon non-existent Resource');
         } catch (Acl\Exception\InvalidArgumentException $e) {
             $this->assertContains('not found', $e->getMessage());
         }
@@ -821,7 +821,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
         try {
             $this->_acl->isAllowed(null, 'area');
             $this->fail('Expected Zend\Acl\Exception not thrown upon isAllowed() on non-existent Resource');
-        } catch (Acl\Exception $e) {
+        } catch (Acl\Exception\ExceptionInterface $e) {
             $this->assertContains('not found', $e->getMessage());
         }
         $this->_acl->addResource(new Resource\GenericResource('area'));
@@ -841,8 +841,8 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->_acl->removeResourceAll();
         try {
             $this->_acl->isAllowed(null, 'area');
-            $this->fail('Expected Zend\Acl\Exception not thrown upon isAllowed() on non-existent Resource');
-        } catch (Acl\Exception $e) {
+            $this->fail('Expected Zend\Acl\Exception\ExceptionInterface not thrown upon isAllowed() on non-existent Resource');
+        } catch (Acl\Exception\ExceptionInterface $e) {
             $this->assertContains('not found', $e->getMessage());
         }
         $this->_acl->addResource(new Resource\GenericResource('area'));
@@ -1052,28 +1052,28 @@ class AclTest extends \PHPUnit_Framework_TestCase
         try {
             $acl->roleDFSVisitAllPrivileges($someRole, $someResource, $nullReference);
             $this->fail('Expected Zend\Acl\Exception not thrown');
-        } catch (Acl\Exception $e) {
+        } catch (Acl\Exception\ExceptionInterface $e) {
             $this->assertEquals('$dfs parameter may not be null', $e->getMessage());
         }
 
         try {
             $acl->roleDFSOnePrivilege($someRole, $someResource, null);
             $this->fail('Expected Zend\Acl\Exception not thrown');
-        } catch (Acl\Exception $e) {
+        } catch (Acl\Exception\ExceptionInterface $e) {
             $this->assertEquals('$privilege parameter may not be null', $e->getMessage());
         }
 
         try {
             $acl->roleDFSVisitOnePrivilege($someRole, $someResource, null);
             $this->fail('Expected Zend\Acl\Exception not thrown');
-        } catch (Acl\Exception $e) {
+        } catch (Acl\Exception\ExceptionInterface $e) {
             $this->assertEquals('$privilege parameter may not be null', $e->getMessage());
         }
 
         try {
             $acl->roleDFSVisitOnePrivilege($someRole, $someResource, 'somePrivilege', $nullReference);
             $this->fail('Expected Zend\\Acl\\Exception not thrown');
-        } catch (Acl\Exception $e) {
+        } catch (Acl\Exception\ExceptionInterface $e) {
             $this->assertEquals('$dfs parameter may not be null', $e->getMessage());
         }
     }

--- a/tests/Zend/Acl/TestAsset/AssertionZF7973.php
+++ b/tests/Zend/Acl/TestAsset/AssertionZF7973.php
@@ -6,7 +6,7 @@ use Zend\Acl\Assertion,
     Zend\Acl;
 
 class AssertionZF7973 implements Assertion {
-    public function assert(Acl\Acl $acl, Acl\Role $role = null, Acl\Resource $resource = null, $privilege = null)
+    public function assert(Acl\Acl $acl, Acl\Role\RoleInterface $role = null, Acl\Resource\ResourceInterface $resource = null, $privilege = null)
     {
         if($privilege != 'privilege') {
             return false;

--- a/tests/Zend/Acl/TestAsset/AssertionZF7973.php
+++ b/tests/Zend/Acl/TestAsset/AssertionZF7973.php
@@ -2,10 +2,10 @@
 
 namespace ZendTest\Acl\TestAsset;
 
-use Zend\Acl\Assertion,
+use Zend\Acl\Assertion\AssertionInterface,
     Zend\Acl;
 
-class AssertionZF7973 implements Assertion {
+class AssertionZF7973 implements AssertionInterface {
     public function assert(Acl\Acl $acl, Acl\Role\RoleInterface $role = null, Acl\Resource\ResourceInterface $resource = null, $privilege = null)
     {
         if($privilege != 'privilege') {

--- a/tests/Zend/Acl/TestAsset/ExtendedAclZF2234.php
+++ b/tests/Zend/Acl/TestAsset/ExtendedAclZF2234.php
@@ -5,19 +5,19 @@ use Zend\Acl;
 
 class ExtendedAclZF2234 extends Acl\Acl
 {
-    public function roleDFSVisitAllPrivileges(Acl\Role $role, Acl\Resource $resource = null,
+    public function roleDFSVisitAllPrivileges(Acl\Role\RoleInterface $role, Acl\Resource\ResourceInterface $resource = null,
                                               &$dfs = null)
     {
         return $this->_roleDFSVisitAllPrivileges($role, $resource, $dfs);
     }
 
-    public function roleDFSOnePrivilege(Acl\Role $role, Acl\Resource $resource = null,
+    public function roleDFSOnePrivilege(Acl\Role\RoleInterface $role, Acl\Resource\ResourceInterface $resource = null,
                                         $privilege = null)
     {
         return $this->_roleDFSOnePrivilege($role, $resource, $privilege);
     }
 
-    public function roleDFSVisitOnePrivilege(Acl\Role $role, Acl\Resource $resource = null,
+    public function roleDFSVisitOnePrivilege(Acl\Role\RoleInterface $role, Acl\Resource\ResourceInterface $resource = null,
                                              $privilege = null, &$dfs = null)
     {
         return $this->_roleDFSVisitOnePrivilege($role, $resource, $privilege, $dfs);

--- a/tests/Zend/Acl/TestAsset/MockAssertion.php
+++ b/tests/Zend/Acl/TestAsset/MockAssertion.php
@@ -13,7 +13,7 @@ class MockAssertion implements Acl\Assertion
         $this->_returnValue = (bool) $returnValue;
     }
 
-    public function assert(Acl\Acl $acl, Acl\Role $role = null, Acl\Resource $resource = null,
+    public function assert(Acl\Acl $acl, Acl\Role\RoleInterface $role = null, Acl\Resource\ResourceInterface $resource = null,
                            $privilege = null)
     {
        return $this->_returnValue;

--- a/tests/Zend/Acl/TestAsset/MockAssertion.php
+++ b/tests/Zend/Acl/TestAsset/MockAssertion.php
@@ -4,7 +4,7 @@ namespace ZendTest\Acl\TestAsset;
 
 use Zend\Acl;
 
-class MockAssertion implements Acl\Assertion
+class MockAssertion implements Acl\Assertion\AssertionInterface
 {
     protected $_returnValue;
 

--- a/tests/Zend/Acl/TestAsset/UseCase1/BlogPost.php
+++ b/tests/Zend/Acl/TestAsset/UseCase1/BlogPost.php
@@ -4,7 +4,7 @@ namespace ZendTest\Acl\TestAsset\UseCase1;
 
 use Zend\Acl\Resource;
 
-class BlogPost implements Resource
+class BlogPost implements Resource\ResourceInterface
 {
     public $owner = null;
     public function getResourceId()

--- a/tests/Zend/Acl/TestAsset/UseCase1/User.php
+++ b/tests/Zend/Acl/TestAsset/UseCase1/User.php
@@ -4,7 +4,7 @@ namespace ZendTest\Acl\TestAsset\UseCase1;
 
 use Zend\Acl\Role;
 
-class User implements Role
+class User implements Role\RoleInterface
 {
     public $role = 'guest';
     public function getRoleId()

--- a/tests/Zend/Acl/TestAsset/UseCase1/UserIsBlogPostOwnerAssertion.php
+++ b/tests/Zend/Acl/TestAsset/UseCase1/UserIsBlogPostOwnerAssertion.php
@@ -2,10 +2,10 @@
 
 namespace ZendTest\Acl\TestAsset\UseCase1;
 
-use Zend\Acl\Assertion,
+use Zend\Acl\Assertion\AssertionInterface,
     Zend\Acl as ZendAcl;
 
-class UserIsBlogPostOwnerAssertion implements Assertion
+class UserIsBlogPostOwnerAssertion implements AssertionInterface
 {
 
     public $lastAssertRole = null;

--- a/tests/Zend/Acl/TestAsset/UseCase1/UserIsBlogPostOwnerAssertion.php
+++ b/tests/Zend/Acl/TestAsset/UseCase1/UserIsBlogPostOwnerAssertion.php
@@ -13,7 +13,7 @@ class UserIsBlogPostOwnerAssertion implements Assertion
     public $lastAssertPrivilege = null;
     public $assertReturnValue = true;
 
-    public function assert(ZendAcl\Acl $acl, ZendAcl\Role $user = null, ZendAcl\Resource $blogPost = null, $privilege = null)
+    public function assert(ZendAcl\Acl $acl, ZendAcl\Role\RoleInterface $user = null, ZendAcl\Resource\ResourceInterface $blogPost = null, $privilege = null)
     {
         $this->lastAssertRole      = $user;
         $this->lastAssertResource  = $blogPost;


### PR DESCRIPTION
Reworked and renamed interfaces in the acl subpackage and moved them into their distinct namespaces as per
[zen-27] 
