### PR TITLE
fixed validation problem, when usin setUri on a request

### DIFF
--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -176,12 +176,10 @@ class Request extends Message implements RequestDescription
     {
         if (is_string($uri)) {
             try {
-                $newuri = new HttpUri;
-                $newuri->parse($uri);
-                $uri = $newuri;
+                $uri = new HttpUri($uri);
             } catch (Exception\InvalidUriPartException $e) {
                 throw new Exception\InvalidArgumentException(
-                        sprintf('Invalid URI passed as string (%s)', $uri),
+                        sprintf('Invalid URI passed as string (%s)', (string) $uri),
                         $e->getCode(),
                         $e
                 );

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -180,7 +180,11 @@ class Request extends Message implements RequestDescription
                 $newuri->parse($uri);
                 $uri = $newuri;
             } catch (Exception\InvalidUriPartException $e) {
-                throw new exception\invalidargumentexception('invalid uri passed as string: ' . $e->getMessage());
+                throw new Exception\InvalidArgumentException(
+                        sprintf('Invalid URI passed as string (%s)', $uri),
+                        $e->getCode(),
+                        $e
+                );
             }
         } elseif (!($uri instanceof \Zend\Uri\Http)) {
             throw new Exception\InvalidArgumentException('URI must be an instance of Zend\Uri\Http or a string');

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -175,8 +175,12 @@ class Request extends Message implements RequestDescription
     public function setUri($uri)
     {
         if (is_string($uri)) {
-            if (!\Zend\Uri\Uri::validateHost($uri)) {
-                throw new Exception\InvalidArgumentException('Invalid URI passed as string');
+            try {
+                $newuri = new \Zend\Uri\Uri;
+                $newuri->parse($uri);
+                $uri = $newuri;
+            } catch (Exception\InvalidUriPartException $e) {
+                throw new exception\invalidargumentexception('invalid uri passed as string: ' . $e->getMessage());
             }
         } elseif (!($uri instanceof \Zend\Uri\Http)) {
             throw new Exception\InvalidArgumentException('URI must be an instance of Zend\Uri\Http or a string');

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -176,7 +176,7 @@ class Request extends Message implements RequestDescription
     {
         if (is_string($uri)) {
             try {
-                $newuri = new \Zend\Uri\Uri;
+                $newuri = new HttpUri;
                 $newuri->parse($uri);
                 $uri = $newuri;
             } catch (Exception\InvalidUriPartException $e) {
@@ -186,7 +186,7 @@ class Request extends Message implements RequestDescription
                         $e
                 );
             }
-        } elseif (!($uri instanceof \Zend\Uri\Http)) {
+        } elseif (!($uri instanceof HttpUri)) {
             throw new Exception\InvalidArgumentException('URI must be an instance of Zend\Uri\Http or a string');
         }
         $this->uri = $uri;

--- a/tests/Zend/Http/RequestTest.php
+++ b/tests/Zend/Http/RequestTest.php
@@ -82,14 +82,26 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('GET', $request->getMethod());
     }
 
-    public function testRequestCanSetAndRetrieveUri()
+    /**
+     * @dataProvider uriDataProvider
+     */
+    public function testRequestCanSetAndRetrieveUri($uri)
     {
         $request = new Request();
-        $request->setUri('/foo');
-        $this->assertEquals('/foo', $request->getUri());
+        $request->setUri($uri);
+        $this->assertEquals($uri, $request->getUri());
         $this->assertInstanceOf('Zend\Uri\Uri', $request->uri());
-        $this->assertEquals('/foo', $request->uri()->toString());
-        $this->assertEquals('/foo', $request->getUri());
+        $this->assertEquals($uri, $request->uri()->toString());
+        $this->assertEquals($uri, $request->getUri());
+    }
+
+    public function uriDataProvider()
+    {
+        return array(
+            array('/foo'),
+            array('/foo#test'),
+            array('/hello?what=true#noway')
+        );
     }
 
     public function testRequestSetUriWillThrowExceptionOnInvalidArgument()


### PR DESCRIPTION
host validation was used on a uri, which failed, when the uri had an anchor set.
now creating a uri object and using its parse method.
