### PR TITLE
Fixed "no database selected" exception

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -204,6 +204,7 @@ class Connection implements ConnectionInterface
                     break;
                 default:
                     $dsn .= (isset($hostname)) ? 'hostname=' . $hostname : '';
+                    $dsn .= (isset($hostname) && isset($database)) ? ';' : '';
                     $dsn .= (isset($database)) ? 'dbname=' . $database : '';
             }
         } elseif (!isset($dsn)) {


### PR DESCRIPTION
when hostname and database are both set when using PDO adapter by adding separator
