### PR TITLE
[zen-27] Renamed interfaces in Authentication

### DIFF
--- a/library/Zend/Authentication/Adapter/AdapterInterface.php
+++ b/library/Zend/Authentication/Adapter/AdapterInterface.php
@@ -22,12 +22,19 @@
 namespace Zend\Authentication\Adapter;
 
 /**
- * @uses       Zend\Authentication\Exception
  * @category   Zend
  * @package    Zend_Authentication
  * @subpackage Adapter
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Exception extends \Zend\Authentication\Exception
-{}
+interface AdapterInterface
+{
+    /**
+     * Performs an authentication attempt
+     *
+     * @return Zend\Authentication\Result
+     * @throws Zend\Authentication\Adapter\Exception\ExceptionInterface If authentication cannot be performed
+     */
+    public function authenticate();
+}

--- a/library/Zend/Authentication/Adapter/DbTable.php
+++ b/library/Zend/Authentication/Adapter/DbTable.php
@@ -20,7 +20,7 @@
  */
 
 namespace Zend\Authentication\Adapter;
-use Zend\Authentication\Adapter as AuthenticationAdapter,
+use Zend\Authentication\Adapter\AdapterInterface as AuthenticationAdapter,
     Zend\Authentication\Result as AuthenticationResult,
     Zend\Db\Adapter\Adapter as DbAdapter,
     Zend\Db\Sql\Select as DbSelect,
@@ -352,7 +352,7 @@ class DbTable implements AuthenticationAdapter
      * making sure that this adapter was indeed setup properly with all
      * required pieces of information.
      *
-     * @throws Exception - in the event that setup was not done properly
+     * @throws Exception\ExceptionInterface - in the event that setup was not done properly
      * @return true
      */
     protected function _authenticateSetup()

--- a/library/Zend/Authentication/Adapter/Digest.php
+++ b/library/Zend/Authentication/Adapter/Digest.php
@@ -20,12 +20,10 @@
  */
 
 namespace Zend\Authentication\Adapter;
-use Zend\Authentication\Adapter as AuthenticationAdapter,
+use Zend\Authentication\Adapter\AdapterInterface as AuthenticationAdapter,
     Zend\Authentication\Result as AuthenticationResult;
 
 /**
- * @uses       Zend\Authentication\Adapter\Exception
- * @uses       Zend\Authentication\Adapter
  * @category   Zend
  * @package    Zend_Authentication
  * @subpackage Adapter
@@ -173,7 +171,7 @@ class Digest implements AuthenticationAdapter
     /**
      * Defined by Zend_Auth_Adapter_Interface
      *
-     * @throws Zend\Authentication\Adapter\Exception\RuntimeException
+     * @throws Zend\Authentication\Adapter\Exception\ExceptionInterface
      * @return Zend\Authentication\Result
      */
     public function authenticate()

--- a/library/Zend/Authentication/Adapter/Exception/ExceptionInterface.php
+++ b/library/Zend/Authentication/Adapter/Exception/ExceptionInterface.php
@@ -14,27 +14,20 @@
  *
  * @category   Zend
  * @package    Zend_Authentication
- * @subpackage Adapter
+ * @subpackage Adapter_Exception
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Zend\Authentication;
+namespace Zend\Authentication\Adapter\Exception;
 
 /**
+ * @uses       Zend\Authentication\Exception
  * @category   Zend
  * @package    Zend_Authentication
- * @subpackage Adapter
+ * @subpackage Adapter_Exception
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Adapter
-{
-    /**
-     * Performs an authentication attempt
-     *
-     * @return Zend\Authentication\Result
-     * @throws Zend\Authentication\Adapter\Exception If authentication cannot be performed
-     */
-    public function authenticate();
-}
+interface ExceptionInterface extends \Zend\Authentication\Exception\ExceptionInterface
+{}

--- a/library/Zend/Authentication/Adapter/Exception/InvalidArgumentException.php
+++ b/library/Zend/Authentication/Adapter/Exception/InvalidArgumentException.php
@@ -4,6 +4,6 @@ namespace Zend\Authentication\Adapter\Exception;
 
 class InvalidArgumentException
     extends \InvalidArgumentException
-    implements \Zend\Authentication\Adapter\Exception
+    implements \Zend\Authentication\Adapter\Exception\ExceptionInterface
 {
 } 

--- a/library/Zend/Authentication/Adapter/Exception/RuntimeException.php
+++ b/library/Zend/Authentication/Adapter/Exception/RuntimeException.php
@@ -4,7 +4,7 @@ namespace Zend\Authentication\Adapter\Exception;
 
 class RuntimeException 
     extends \RuntimeException 
-    implements \Zend\Authentication\Adapter\Exception
+    implements \Zend\Authentication\Adapter\Exception\ExceptionInterface
 {
 
 }

--- a/library/Zend/Authentication/Adapter/Exception/UnexpectedValueException.php
+++ b/library/Zend/Authentication/Adapter/Exception/UnexpectedValueException.php
@@ -4,6 +4,6 @@ namespace Zend\Authentication\Adapter\Exception;
 
 class UnexpectedValueException
     extends \UnexpectedValueException
-    implements \Zend\Authentication\Adapter\Exception
+    implements \Zend\Authentication\Adapter\Exception\ExceptionInterface
 {
 }

--- a/library/Zend/Authentication/Adapter/Http.php
+++ b/library/Zend/Authentication/Adapter/Http.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Authentication\Adapter;
 
-use Zend\Authentication\Adapter as AuthenticationAdapter,
+use Zend\Authentication\Adapter\AdapterInterface as AuthenticationAdapter,
     Zend\Authentication,
     Zend\Http\Request as HTTPRequest,
     Zend\Http\Response as HTTPResponse,
@@ -32,8 +32,6 @@ use Zend\Authentication\Adapter as AuthenticationAdapter,
  *
  * Implements a pretty good chunk of RFC 2617.
  *
- * @uses       Zend\Authentication\Exception
- * @uses       Zend\Authentication\Adapter
  * @category   Zend
  * @package    Zend_Authentication
  * @subpackage Adapter_Http
@@ -244,10 +242,10 @@ class Http implements AuthenticationAdapter
     /**
      * Setter for the _basicResolver property
      *
-     * @param  Zend\Authentication\Adapter\Http\Resolver $resolver
+     * @param  Zend\Authentication\Adapter\Http\ResolverInterface $resolver
      * @return Zend\Authentication\Adapter\Http Provides a fluent interface
      */
-    public function setBasicResolver(Http\Resolver $resolver)
+    public function setBasicResolver(Http\ResolverInterface $resolver)
     {
         $this->_basicResolver = $resolver;
 
@@ -257,7 +255,7 @@ class Http implements AuthenticationAdapter
     /**
      * Getter for the _basicResolver property
      *
-     * @return Zend\Authentication\Adapter\Http\Resolver
+     * @return Zend\Authentication\Adapter\Http\ResolverInterface
      */
     public function getBasicResolver()
     {
@@ -267,10 +265,10 @@ class Http implements AuthenticationAdapter
     /**
      * Setter for the _digestResolver property
      *
-     * @param  Zend\Authentication\Adapter\Http\Resolver $resolver
+     * @param  Zend\Authentication\Adapter\Http\ResolverInterface $resolver
      * @return Zend\Authentication\Adapter\Http Provides a fluent interface
      */
-    public function setDigestResolver(Http\Resolver $resolver)
+    public function setDigestResolver(Http\ResolverInterface $resolver)
     {
         $this->_digestResolver = $resolver;
 
@@ -280,7 +278,7 @@ class Http implements AuthenticationAdapter
     /**
      * Getter for the _digestResolver property
      *
-     * @return Zend\Authentication\Adapter\Http\Resolver
+     * @return Zend\Authentication\Adapter\Http\ResolverInterface
      */
     public function getDigestResolver()
     {
@@ -467,7 +465,7 @@ class Http implements AuthenticationAdapter
      * Basic Authentication
      *
      * @param  string $header Client's Authorization header
-     * @throws Zend\Authentication\UnexpectedValueException
+     * @throws Zend\Authentication\Exception\ExceptionInterface
      * @return Zend\Authentication\Result
      */
     protected function _basicAuth($header)
@@ -514,7 +512,7 @@ class Http implements AuthenticationAdapter
      * Digest Authentication
      *
      * @param  string $header Client's Authorization header
-     * @throws Zend\Authentication\Adapter\Exception\UnexpectedValueException
+     * @throws Zend\Authentication\Adapter\Exception\ExceptionInterface
      * @return Zend\Authentication\Result Valid auth result only on successful auth
      */
     protected function _digestAuth($header)

--- a/library/Zend/Authentication/Adapter/Http/Exception/ExceptionInterface.php
+++ b/library/Zend/Authentication/Adapter/Http/Exception/ExceptionInterface.php
@@ -14,12 +14,12 @@
  *
  * @category   Zend
  * @package    Zend_Authentication
- * @subpackage Adapter_HTTP
+ * @subpackage Adapter_HTTP_Exception
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Zend\Authentication\Adapter\Http;
+namespace Zend\Authentication\Adapter\Http\Exception;
 
 /**
  * HTTP Auth Resolver Exception
@@ -27,9 +27,9 @@ namespace Zend\Authentication\Adapter\Http;
  * @uses       Zend\Authentication\Exception
  * @category   Zend
  * @package    Zend_Authentication
- * @subpackage Adapter_Http
+ * @subpackage Adapter_Http_Exception
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Exception extends \Zend\Authentication\Adapter\Exception
+interface ExceptionInterface extends \Zend\Authentication\Adapter\Exception\ExceptionInterface
 {}

--- a/library/Zend/Authentication/Adapter/Http/Exception/InvalidArgumentException.php
+++ b/library/Zend/Authentication/Adapter/Http/Exception/InvalidArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Zend\Authentication\Adapter\Http\Exception;
+
+class InvalidArgumentException
+    extends \InvalidArgumentException
+    implements ExceptionInterface
+{
+}

--- a/library/Zend/Authentication/Adapter/Http/Exception/RuntimeException.php
+++ b/library/Zend/Authentication/Adapter/Http/Exception/RuntimeException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Zend\Authentication\Adapter\Http\Exception;
+
+class RuntimeException
+    extends \RuntimeException
+    implements ExceptionInterface
+{
+}

--- a/library/Zend/Authentication/Adapter/Http/FileResolver.php
+++ b/library/Zend/Authentication/Adapter/Http/FileResolver.php
@@ -24,15 +24,13 @@ namespace Zend\Authentication\Adapter\Http;
 /**
  * HTTP Authentication File Resolver
  *
- * @uses       Zend\Authentication\Adapter\Http\Exception
- * @uses       Zend\Authentication\Adapter\Http\Resolver
  * @category   Zend
  * @package    Zend_Authentication
  * @subpackage Adapter_Http
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class FileResolver implements Resolver
+class FileResolver implements ResolverInterface
 {
     /**
      * Path to credentials file
@@ -59,12 +57,12 @@ class FileResolver implements Resolver
      *
      * @param  string $path
      * @return Zend\Authentication\Adapter\Http\FileResolver Provides a fluent interface
-     * @throws Zend\Authentication\Adapter\Http\Exception
+     * @throws Zend\Authentication\Adapter\Http\Exception\ExceptionInterface
      */
     public function setFile($path)
     {
         if (empty($path) || !is_readable($path)) {
-            throw new InvalidArgumentException('Path not readable: ' . $path);
+            throw new Exception\InvalidArgumentException('Path not readable: ' . $path);
         }
         $this->_file = $path;
 
@@ -100,27 +98,27 @@ class FileResolver implements Resolver
      * @param  string $realm    Authentication Realm
      * @return string|false User's shared secret, if the user is found in the
      *         realm, false otherwise.
-     * @throws Zend\Authentication\Adapter\Http\Exception
+     * @throws Zend\Authentication\Adapter\Http\Exception\ExceptionInterface
      */
     public function resolve($username, $realm)
     {
         if (empty($username)) {
-            throw new InvalidArgumentException('Username is required');
+            throw new Exception\InvalidArgumentException('Username is required');
         } else if (!ctype_print($username) || strpos($username, ':') !== false) {
-            throw new InvalidArgumentException('Username must consist only of printable characters, '
+            throw new Exception\InvalidArgumentException('Username must consist only of printable characters, '
                                                               . 'excluding the colon');
         }
         if (empty($realm)) {
-            throw new InvalidArgumentException('Realm is required');
+            throw new Exception\InvalidArgumentException('Realm is required');
         } else if (!ctype_print($realm) || strpos($realm, ':') !== false) {
-            throw new InvalidArgumentException('Realm must consist only of printable characters, '
+            throw new Exception\InvalidArgumentException('Realm must consist only of printable characters, '
                                                               . 'excluding the colon.');
         }
 
         // Open file, read through looking for matching credentials
         $fp = @fopen($this->_file, 'r');
         if (!$fp) {
-            throw new RuntimeException('Unable to open password file: ' . $this->_file);
+            throw new Exception\RuntimeException('Unable to open password file: ' . $this->_file);
         }
 
         // No real validation is done on the contents of the password file. The

--- a/library/Zend/Authentication/Adapter/Http/InvalidArgumentException.php
+++ b/library/Zend/Authentication/Adapter/Http/InvalidArgumentException.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Zend\Authentication\Adapter\Http;
-
-class InvalidArgumentException
-    extends \InvalidArgumentException
-    implements Exception
-{
-}

--- a/library/Zend/Authentication/Adapter/Http/ResolverInterface.php
+++ b/library/Zend/Authentication/Adapter/Http/ResolverInterface.php
@@ -33,7 +33,7 @@ namespace Zend\Authentication\Adapter\Http;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Resolver
+interface ResolverInterface
 {
     /**
      * Resolve username/realm to password/hash/etc.

--- a/library/Zend/Authentication/Adapter/Http/RuntimeException.php
+++ b/library/Zend/Authentication/Adapter/Http/RuntimeException.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Zend\Authentication\Adapter\Http;
-
-class RuntimeException
-    extends \RuntimeException
-    implements Exception
-{
-}

--- a/library/Zend/Authentication/Adapter/InfoCard.php
+++ b/library/Zend/Authentication/Adapter/InfoCard.php
@@ -20,16 +20,13 @@
  */
 
 namespace Zend\Authentication\Adapter;
-use Zend\Authentication\Adapter as AuthenticationAdapter,
+use Zend\Authentication\Adapter\AdapterInterface as AuthenticationAdapter,
     Zend\Authentication\Result as AuthenticationResult;
 
 /**
  * A Zend_Auth Authentication Adapter allowing the use of Information Cards as an
  * authentication mechanism
  *
- * @uses       Zend\Authentication\Adapter
- * @uses       Zend\Authentication\Result
- * @uses       Zend\InfoCard\InfoCard
  * @category   Zend
  * @package    Zend_Authentication
  * @subpackage Adapter

--- a/library/Zend/Authentication/Adapter/Ldap.php
+++ b/library/Zend/Authentication/Adapter/Ldap.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Authentication\Adapter;
 
-use Zend\Authentication\Adapter as AuthenticationAdapter,
+use Zend\Authentication\Adapter\AdapterInterface as AuthenticationAdapter,
     Zend\Authentication\Result as AuthenticationResult,
     Zend\Ldap as ZendLdap,
     Zend\Ldap\Exception\LdapException;
@@ -237,7 +237,7 @@ class Ldap implements AuthenticationAdapter
      * Authenticate the user
      *
      * @return Zend\Authentication\Result
-     * @throws Zend\Authentication\Adapter\Exception
+     * @throws Zend\Authentication\Adapter\Exception\ExceptionInterface
      */
     public function authenticate()
     {

--- a/library/Zend/Authentication/AuthenticationService.php
+++ b/library/Zend/Authentication/AuthenticationService.php
@@ -21,7 +21,6 @@
 namespace Zend\Authentication;
 
 /**
- * @uses       Zend\Authentication\Storage\Session
  * @category   Zend
  * @package    Zend_Authentication
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
@@ -32,17 +31,17 @@ class AuthenticationService
     /**
      * Persistent storage handler
      *
-     * @var Zend\Authentication\Storage
+     * @var Zend\Authentication\Storage\StorageInterface
      */
     protected $_storage = null;
 
     /**
      * Constructor
      * 
-     * @param  Storage $storage 
+     * @param  Storage\StorageInterface $storage 
      * @return void
      */
-    public function __construct(Storage $storage = null)
+    public function __construct(Storage\StorageInterface $storage = null)
     {
         if (null !== $storage) {
             $this->setStorage($storage);
@@ -54,7 +53,7 @@ class AuthenticationService
      *
      * Session storage is used by default unless a different storage adapter has been set.
      *
-     * @return Zend\Authentication\Storage
+     * @return Zend\Authentication\Storage\StorageInterface
      */
     public function getStorage()
     {
@@ -68,10 +67,10 @@ class AuthenticationService
     /**
      * Sets the persistent storage handler
      *
-     * @param  Zend\Authentication\Storage $storage
+     * @param  Zend\Authentication\Storage\StorageInterface $storage
      * @return Zend\Authentication\AuthenticationService Provides a fluent interface
      */
-    public function setStorage(Storage $storage)
+    public function setStorage(Storage\StorageInterface $storage)
     {
         $this->_storage = $storage;
         return $this;
@@ -80,10 +79,10 @@ class AuthenticationService
     /**
      * Authenticates against the supplied adapter
      *
-     * @param  Zend\Authentication\Adapter $adapter
+     * @param  Zend\Authentication\Adapter\AdapterInterface $adapter
      * @return Zend\Authentication\Result
      */
-    public function authenticate(Adapter $adapter)
+    public function authenticate(Adapter\AdapterInterface $adapter)
     {
         $result = $adapter->authenticate();
 

--- a/library/Zend/Authentication/Exception/ExceptionInterface.php
+++ b/library/Zend/Authentication/Exception/ExceptionInterface.php
@@ -14,18 +14,20 @@
  *
  * @category   Zend
  * @package    Zend_Authentication
+ * @subpackage Exception
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Zend\Authentication;
+namespace Zend\Authentication\Exception;
 
 /**
  * @uses       Zend\Exception
  * @category   Zend
  * @package    Zend_Authentication
+ * @subpackage Exception
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Exception
+interface ExceptionInterface
 {}

--- a/library/Zend/Authentication/Storage/Session.php
+++ b/library/Zend/Authentication/Storage/Session.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Authentication\Storage;
 
-use Zend\Authentication\Storage as AuthenticationStorage,
+use Zend\Authentication\Storage\StorageInterface as AuthenticationStorage,
     Zend\Session\Container as SessionContainer,
     Zend\Session\Manager as SessionManager;
 

--- a/library/Zend/Authentication/Storage/StorageInterface.php
+++ b/library/Zend/Authentication/Storage/StorageInterface.php
@@ -19,7 +19,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Zend\Authentication;
+namespace Zend\Authentication\Storage;
 
 /**
  * @category   Zend
@@ -28,12 +28,12 @@ namespace Zend\Authentication;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Storage
+interface StorageInterface
 {
     /**
      * Returns true if and only if storage is empty
      *
-     * @throws Zend\Authentication\Storage\Exception If it is impossible to determine whether storage is empty
+     * @throws Zend\Authentication\Storage\Exception\ExceptionInterface If it is impossible to determine whether storage is empty
      * @return boolean
      */
     public function isEmpty();
@@ -43,7 +43,7 @@ interface Storage
      *
      * Behavior is undefined when storage is empty.
      *
-     * @throws Zend\Authentication\Storage\Exception If reading contents from storage is impossible
+     * @throws Zend\Authentication\Storage\Exception\ExceptionInterface If reading contents from storage is impossible
      * @return mixed
      */
     public function read();
@@ -52,7 +52,7 @@ interface Storage
      * Writes $contents to storage
      *
      * @param  mixed $contents
-     * @throws Zend\Authentication\Storage\Exception If writing $contents to storage is impossible
+     * @throws Zend\Authentication\Storage\Exception\ExceptionInterface If writing $contents to storage is impossible
      * @return void
      */
     public function write($contents);
@@ -60,7 +60,7 @@ interface Storage
     /**
      * Clears contents from storage
      *
-     * @throws Zend\Authentication\Storage\Exception If clearing contents from storage is impossible
+     * @throws Zend\Authentication\Storage\Exception\ExceptionInterface If clearing contents from storage is impossible
      * @return void
      */
     public function clear();

--- a/tests/Zend/Authentication/Adapter/DigestTest.php
+++ b/tests/Zend/Authentication/Adapter/DigestTest.php
@@ -64,7 +64,7 @@ class DigestTest extends \PHPUnit_Framework_TestCase
             $adapter->authenticate();
             $this->fail('Expected Zend_Auth_Adapter_Exception not thrown upon authentication attempt before setting '
                       . 'a required option');
-        } catch (Adapter\Exception $e) {
+        } catch (Adapter\Exception\ExceptionInterface $e) {
             $this->assertContains('must be set before authentication', $e->getMessage());
         }
     }
@@ -81,7 +81,7 @@ class DigestTest extends \PHPUnit_Framework_TestCase
             $adapter->authenticate();
             $this->fail('Expected Zend_Auth_Adapter_Exception not thrown upon authenticating against nonexistent '
                       . 'file');
-        } catch (Adapter\Exception $e) {
+        } catch (Adapter\Exception\ExceptionInterface $e) {
             $this->assertContains('Cannot open', $e->getMessage());
         }
     }

--- a/tests/Zend/Authentication/Adapter/Http/FileResolverTest.php
+++ b/tests/Zend/Authentication/Adapter/Http/FileResolverTest.php
@@ -93,7 +93,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetFileInvalid()
     {
-        $this->setExpectedException('Zend\\Authentication\\Adapter\\Http\\Exception', 'Path not readable');
+        $this->setExpectedException('Zend\\Authentication\\Adapter\\Http\\Exception\\ExceptionInterface', 'Path not readable');
         $this->_resolver->setFile($this->_badPath);
     }
 
@@ -115,7 +115,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructInvalid()
     {
-        $this->setExpectedException('Zend\\Authentication\\Adapter\\Http\\Exception', 'Path not readable');
+        $this->setExpectedException('Zend\\Authentication\\Adapter\\Http\\Exception\\ExceptionInterface', 'Path not readable');
         $v = new Http\FileResolver($this->_badPath);
     }
 
@@ -126,7 +126,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
      */
     public function testResolveUsernameEmpty()
     {
-        $this->setExpectedException('Zend\\Authentication\\Adapter\\Http\\Exception', 'Username is required');
+        $this->setExpectedException('Zend\\Authentication\\Adapter\\Http\\Exception\\ExceptionInterface', 'Username is required');
         $this->_resolver->resolve('', '');
     }
 
@@ -137,7 +137,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
      */
     public function testResolveRealmEmpty()
     {
-        $this->setExpectedException('Zend\\Authentication\\Adapter\\Http\\Exception', 'Realm is required');
+        $this->setExpectedException('Zend\\Authentication\\Adapter\\Http\\Exception\\ExceptionInterface', 'Realm is required');
         $this->_resolver->resolve('username', '');
     }
 
@@ -151,13 +151,13 @@ class FileTest extends \PHPUnit_Framework_TestCase
         try {
             $this->_resolver->resolve('bad:name', 'realm');
             $this->fail('Accepted malformed username with colon');
-        } catch (Http\Exception $e) {
+        } catch (Http\Exception\ExceptionInterface $e) {
             $this->assertContains('Username must consist', $e->getMessage());
         }
         try {
             $this->_resolver->resolve("badname\n", 'realm');
             $this->fail('Accepted malformed username with newline');
-        } catch (Http\Exception $e) {
+        } catch (Http\Exception\ExceptionInterface $e) {
             $this->assertContains('Username must consist', $e->getMessage());
         }
     }
@@ -172,13 +172,13 @@ class FileTest extends \PHPUnit_Framework_TestCase
         try {
             $this->_resolver->resolve('username', 'bad:realm');
             $this->fail('Accepted malformed realm with colon');
-        } catch (Http\Exception $e) {
+        } catch (Http\Exception\ExceptionInterface $e) {
             $this->assertContains('Realm must consist', $e->getMessage());
         }
         try {
             $this->_resolver->resolve('username', "badrealm\n");
             $this->fail('Accepted malformed realm with newline');
-        } catch (Http\Exception $e) {
+        } catch (Http\Exception\ExceptionInterface $e) {
             $this->assertContains('Realm must consist', $e->getMessage());
         }
     }
@@ -194,7 +194,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
             try {
                 $this->_resolver->resolve('username', 'realm');
                 $this->fail('Expected thrown exception upon resolve() after moving valid file');
-            } catch (Http\Exception $e) {
+            } catch (Http\Exception\ExceptionInterface $e) {
                 $this->assertContains('Unable to open password file', $e->getMessage());
             }
             rename("$this->_filesPath/htdigest.3.renamed", "$this->_filesPath/htdigest.3");

--- a/tests/Zend/Authentication/Adapter/Http/ObjectTest.php
+++ b/tests/Zend/Authentication/Adapter/Http/ObjectTest.php
@@ -112,7 +112,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
     {
         try {
             $t = new Adapter\Http($this->_basicConfig);
-        } catch (Adapter\Exception $e) {
+        } catch (Adapter\Exception\ExceptionInterface $e) {
             $this->fail('Valid config deemed invalid');
         }
         $this->assertFalse(empty($t));
@@ -121,7 +121,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
 
         try {
             $t = new Adapter\Http($this->_digestConfig);
-        } catch (Adapter\Exception $e) {
+        } catch (Adapter\Exception\ExceptionInterface $e) {
             $this->fail('Valid config deemed invalid');
         }
         $this->assertFalse(empty($t));
@@ -130,7 +130,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
 
         try {
             $t = new Adapter\Http($this->_bothConfig);
-        } catch (Adapter\Exception $e) {
+        } catch (Adapter\Exception\ExceptionInterface $e) {
             $this->fail('Valid config deemed invalid');
         }
         $this->assertFalse(empty($t));
@@ -170,7 +170,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
             try {
                 $t = new Adapter\Http($cfg);
                 $this->fail('Accepted an invalid config');
-            } catch (Adapter\Exception $e) {
+            } catch (Adapter\Exception\ExceptionInterface $e) {
                 // Good, it threw an exception
             }
         }
@@ -183,7 +183,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
         try {
             $a->authenticate();
             $this->fail('Attempted authentication without request/response objects');
-        } catch (Adapter\Exception $e) {
+        } catch (Adapter\Exception\ExceptionInterface $e) {
             // Good, it threw an exception
         }
 
@@ -212,7 +212,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
               ->setResponse($response);
             $result = $a->authenticate();
             $this->fail("Tried Basic authentication without a resolver.\n" . \Zend\Debug::dump($result->getMessages(),null,false));
-        } catch (Adapter\Exception $e) {
+        } catch (Adapter\Exception\ExceptionInterface $e) {
             // Good, it threw an exception
             unset($a);
         }
@@ -230,7 +230,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
               ->setResponse($response);
             $result = $a->authenticate();
             $this->fail("Tried Digest authentication without a resolver.\n" . \Zend\Debug::dump($result->getMessages(),null,false));
-        } catch (Adapter\Exception $e) {
+        } catch (Adapter\Exception\ExceptionInterface $e) {
             // Good, it threw an exception
             unset($a);
         }

--- a/tests/Zend/Authentication/TestAsset/SuccessAdapter.php
+++ b/tests/Zend/Authentication/TestAsset/SuccessAdapter.php
@@ -2,7 +2,7 @@
 
 namespace ZendTest\Authentication\TestAsset;
 
-use Zend\Authentication\Adapter as AuthenticationAdapter,
+use Zend\Authentication\Adapter\AdapterInterface as AuthenticationAdapter,
     Zend\Authentication\Result as AuthenticationResult;
 
 class SuccessAdapter implements AuthenticationAdapter


### PR DESCRIPTION
Reworked and renamed interfaces in the Authentication subpackage and moved them into their distinct namespaces as per [zen-27]
