### PR TITLE
Adding separators between DSN parameters so both hostname and database c...

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -203,8 +203,8 @@ class Connection implements ConnectionInterface
                     $dsn .= $database;
                     break;
                 default:
-                    $dsn .= (isset($hostname)) ? 'hostname=' . $hostname : '';
-                    $dsn .= (isset($database)) ? 'dbname=' . $database : '';
+                    $dsn .= (isset($hostname)) ? 'hostname=' . $hostname . ';' : '';
+                    $dsn .= (isset($database)) ? 'dbname=' . $database . ';' : '';
             }
         } elseif (!isset($dsn)) {
             throw new \Exception('A dsn was not provided or could not be constructed from your parameters');


### PR DESCRIPTION
When both hostname and databasename are set for a PDO Connection, the DSN settings are not separated resulting in a "no database selected" error.
