### PR TITLE
Fixed basic auth headers for curl adapter

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -324,7 +324,7 @@ class Curl implements HttpAdapter, Stream
                 $curlMethod = CURLOPT_CUSTOMREQUEST;
                 $curlValue = "TRACE";
                 break;
-            
+
             case 'HEAD' :
                 $curlMethod = CURLOPT_CUSTOMREQUEST;
                 $curlValue = "HEAD";
@@ -358,6 +358,13 @@ class Curl implements HttpAdapter, Stream
 
             // ensure actual response is returned
             curl_setopt($this->curl, CURLOPT_RETURNTRANSFER, true);
+        }
+
+        // Treating basic auth headers in a special way
+        if (array_key_exists('Authorization', $headers) && 'Basic' == substr($headers['Authorization'], 0, 5)) {
+        	curl_setopt($this->curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+        	curl_setopt($this->curl, CURLOPT_USERPWD, base64_decode(substr($headers['Authorization'], 6)));
+        	unset($headers['Authorization']);
         }
 
         // set additional headers

--- a/tests/Zend/Http/Client/CurlTest.php
+++ b/tests/Zend/Http/Client/CurlTest.php
@@ -300,7 +300,7 @@ class CurlTest extends CommonHttpTests
 
         $this->assertTrue(is_resource($adapter->getHandle()));
     }
-    
+
     /**
      * @group ZF-9857
      */
@@ -312,5 +312,27 @@ class CurlTest extends CommonHttpTests
         $this->client->setMethod('HEAD');
         $this->client->send();
         $this->assertEquals('', $this->client->getResponse()->getBody());
+    }
+
+    public function testAuthorizeHeader()
+    {
+        // We just need someone to talk to
+        $this->client->setUri($this->baseuri. 'testHttpAuth.php');
+        $adapter = new Adapter\Curl();
+        $this->client->setAdapter($adapter);
+
+        $uid = 'alice';
+        $pwd = 'secret';
+
+        $hash   = base64_encode($uid . ':' . $pwd);
+        $header = 'Authorization: Basic ' . $hash;
+
+        $this->client->setAuth($uid, $pwd);
+        $res = $this->client->send();
+
+        $curlInfo = curl_getinfo($adapter->getHandle());
+        $this->assertArrayHasKey('request_header', $curlInfo, 'Expecting request_header in curl_getinfo() return value');
+
+        $this->assertContains($header, $curlInfo['request_header'], 'Expecting valid basic authorization header');
     }
 }


### PR DESCRIPTION
Auth info needs to be pushed into curl in a special way
