### PR TITLE
[zen-27] Renamed interfaces in Zend/Barcode

### DIFF
--- a/library/Zend/Barcode/Barcode.php
+++ b/library/Zend/Barcode/Barcode.php
@@ -147,7 +147,7 @@ class Barcode
         try {
             $barcode  = self::makeBarcode($barcode, $barcodeConfig);
             $renderer = self::makeRenderer($renderer, $rendererConfig);
-        } catch (Exception $e) {
+        } catch (Exception\ExceptionInterface $e) {
             if ($automaticRenderError && !($e instanceof Exception\RendererCreationException)) {
                 $barcode  = self::makeBarcode('error', array( 'text' => $e->getMessage() ));
                 $renderer = self::makeRenderer($renderer, array());
@@ -169,7 +169,7 @@ class Barcode
      */
     public static function makeBarcode($barcode, $barcodeConfig = array())
     {
-        if ($barcode instanceof Object) {
+        if ($barcode instanceof Object\ObjectInterface) {
             return $barcode;
         }
 
@@ -222,7 +222,7 @@ class Barcode
      */
     public static function makeRenderer($renderer = 'image', $rendererConfig = array())
     {
-        if ($renderer instanceof Renderer) {
+        if ($renderer instanceof Renderer\RendererInterface) {
             return $renderer;
         }
 
@@ -267,7 +267,7 @@ class Barcode
     /**
      * Proxy to renderer render() method
      *
-     * @param string | Object | array | Traversable $barcode
+     * @param string | Object\ObjectInterface | array | Traversable $barcode
      * @param string | Renderer $renderer
      * @param array  | Traversable $barcodeConfig
      * @param array  | Traversable $rendererConfig
@@ -283,7 +283,7 @@ class Barcode
     /**
      * Proxy to renderer draw() method
      *
-     * @param string | Object | array | Traversable $barcode
+     * @param string | Object\ObjectInterface | array | Traversable $barcode
      * @param string | Renderer $renderer
      * @param array | Traversable $barcodeConfig
      * @param array | Traversable $rendererConfig

--- a/library/Zend/Barcode/Exception/ExceptionInterface.php
+++ b/library/Zend/Barcode/Exception/ExceptionInterface.php
@@ -18,7 +18,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Zend\Barcode;
+namespace Zend\Barcode\Exception;
 
 /**
  * Exception for Zend_Barcode component.
@@ -26,9 +26,10 @@ namespace Zend\Barcode;
  * @uses       Zend\Exception
  * @category   Zend
  * @package    Zend_Barcode
+ * @subpackage Exception
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Exception
+interface ExceptionInterface
 {
 }

--- a/library/Zend/Barcode/Exception/InvalidArgumentException.php
+++ b/library/Zend/Barcode/Exception/InvalidArgumentException.php
@@ -21,8 +21,6 @@
 
 namespace Zend\Barcode\Exception;
 
-use Zend\Barcode\Exception\ExceptionInterface;
-
 /**
  * Exception for Zend_Barcode component.
  *

--- a/library/Zend/Barcode/Exception/InvalidArgumentException.php
+++ b/library/Zend/Barcode/Exception/InvalidArgumentException.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Barcode\Exception;
 
-use Zend\Barcode\Exception;
+use Zend\Barcode\Exception\ExceptionInterface;
 
 /**
  * Exception for Zend_Barcode component.
@@ -33,6 +33,6 @@ use Zend\Barcode\Exception;
  */
 class InvalidArgumentException
     extends \InvalidArgumentException
-    implements Exception
+    implements ExceptionInterface
 {
 }

--- a/library/Zend/Barcode/Exception/RendererCreationException.php
+++ b/library/Zend/Barcode/Exception/RendererCreationException.php
@@ -21,8 +21,6 @@
 
 namespace Zend\Barcode\Exception;
 
-use Zend\Barcode\Exception\ExceptionInterface;
-
 /**
  * Exception for Zend_Barcode component.
  *

--- a/library/Zend/Barcode/Exception/RendererCreationException.php
+++ b/library/Zend/Barcode/Exception/RendererCreationException.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Barcode\Exception;
 
-use Zend\Barcode\Exception;
+use Zend\Barcode\Exception\ExceptionInterface;
 
 /**
  * Exception for Zend_Barcode component.
@@ -33,6 +33,6 @@ use Zend\Barcode\Exception;
  */
 class RendererCreationException
     extends \InvalidArgumentException
-    implements Exception
+    implements ExceptionInterface
 {
 }

--- a/library/Zend/Barcode/Object/AbstractObject.php
+++ b/library/Zend/Barcode/Object/AbstractObject.php
@@ -23,7 +23,7 @@ namespace Zend\Barcode\Object;
 
 use Traversable,
     Zend\Barcode,
-    Zend\Barcode\Object\Exception,
+    Zend\Barcode\Object\Exception\ExceptionInterface,
     Zend\Validator\Barcode as BarcodeValidator,
     Zend\Stdlib\ArrayUtils;
 
@@ -35,7 +35,7 @@ use Traversable,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class AbstractObject implements Barcode\Object
+abstract class AbstractObject implements Barcode\Object\ObjectInterface
 {
     /**
      * Namespace of the barcode for autoloading
@@ -245,7 +245,7 @@ abstract class AbstractObject implements Barcode\Object
     /**
      * Set barcode state from options array
      * @param  array $options
-     * @return \Zend\Barcode\Object
+     * @return \Zend\Barcode\Object\ObjectInterface
      */
     public function setOptions($options)
     {
@@ -262,7 +262,7 @@ abstract class AbstractObject implements Barcode\Object
      * Set barcode namespace for autoloading
      *
      * @param string $namespace
-     * @return \Zend\Barcode\Object
+     * @return \Zend\Barcode\Object\ObjectInterface
      */
     public function setBarcodeNamespace($namespace)
     {
@@ -292,8 +292,8 @@ abstract class AbstractObject implements Barcode\Object
     /**
      * Set height of the barcode bar
      * @param integer $value
-     * @return \Zend\Barcode\Object
-     * @throw \Zend\Barcode\Object\Exception
+     * @return \Zend\Barcode\Object\ObjectInterface
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarHeight($value)
     {
@@ -318,8 +318,8 @@ abstract class AbstractObject implements Barcode\Object
     /**
      * Set thickness of thin bar
      * @param integer $value
-     * @return \Zend\Barcode\Object
-     * @throw \Zend\Barcode\Object\Exception
+     * @return \Zend\Barcode\Object\ObjectInterface
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarThinWidth($value)
     {
@@ -344,8 +344,8 @@ abstract class AbstractObject implements Barcode\Object
     /**
      * Set thickness of thick bar
      * @param integer $value
-     * @return \Zend\Barcode\Object
-     * @throw \Zend\Barcode\Object\Exception
+     * @return \Zend\Barcode\Object\ObjectInterface
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarThickWidth($value)
     {
@@ -371,8 +371,8 @@ abstract class AbstractObject implements Barcode\Object
      * Set factor applying to
      * thinBarWidth - thickBarWidth - barHeight - fontSize
      * @param float $value
-     * @return \Zend\Barcode\Object
-     * @throw \Zend\Barcode\Object\Exception
+     * @return \Zend\Barcode\Object\ObjectInterface
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFactor($value)
     {
@@ -398,8 +398,8 @@ abstract class AbstractObject implements Barcode\Object
     /**
      * Set color of the barcode and text
      * @param string $value
-     * @return \Zend\Barcode\Object
-     * @throw \Zend\Barcode\Object\Exception
+     * @return \Zend\Barcode\Object\ObjectInterface
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setForeColor($value)
     {
@@ -427,8 +427,8 @@ abstract class AbstractObject implements Barcode\Object
     /**
      * Set the color of the background
      * @param integer $value
-     * @return \Zend\Barcode\Object
-     * @throw \Zend\Barcode\Object\Exception
+     * @return \Zend\Barcode\Object\ObjectInterface
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBackgroundColor($value)
     {
@@ -456,7 +456,7 @@ abstract class AbstractObject implements Barcode\Object
     /**
      * Activate/deactivate drawing of the bar
      * @param boolean $value
-     * @return \Zend\Barcode\Object
+     * @return \Zend\Barcode\Object\ObjectInterface
      */
     public function setWithBorder($value)
     {
@@ -495,7 +495,7 @@ abstract class AbstractObject implements Barcode\Object
 
     /**
      * Allow fast inversion of font/bars color and background color
-     * @return \Zend\Barcode\Object
+     * @return \Zend\Barcode\Object\ObjectInterface
      */
     public function setReverseColor()
     {
@@ -508,8 +508,8 @@ abstract class AbstractObject implements Barcode\Object
     /**
      * Set orientation of barcode and text
      * @param float $value
-     * @return \Zend\Barcode\Object
-     * @throw \Zend\Barcode\Object\Exception
+     * @return \Zend\Barcode\Object\ObjectInterface
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setOrientation($value)
     {
@@ -529,7 +529,7 @@ abstract class AbstractObject implements Barcode\Object
     /**
      * Set text to encode
      * @param string $value
-     * @return \Zend\Barcode\Object
+     * @return \Zend\Barcode\Object\ObjectInterface
      */
     public function setText($value)
     {
@@ -598,7 +598,7 @@ abstract class AbstractObject implements Barcode\Object
     /**
      * Activate/deactivate drawing of text to encode
      * @param boolean $value
-     * @return \Zend\Barcode\Object
+     * @return \Zend\Barcode\Object\ObjectInterface
      */
     public function setDrawText($value)
     {
@@ -619,8 +619,8 @@ abstract class AbstractObject implements Barcode\Object
      * Activate/deactivate the adjustment of the position
      * of the characters to the position of the bars
      * @param boolean $value
-     * @return \Zend\Barcode\Object
-     * @throw \Zend\Barcode\Object\Exception
+     * @return \Zend\Barcode\Object\ObjectInterface
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setStretchText($value)
     {
@@ -643,7 +643,7 @@ abstract class AbstractObject implements Barcode\Object
      * of the checksum character
      * added to the barcode text
      * @param boolean $value
-     * @return \Zend\Barcode\Object
+     * @return \Zend\Barcode\Object\ObjectInterface
      */
     public function setWithChecksum($value)
     {
@@ -668,8 +668,8 @@ abstract class AbstractObject implements Barcode\Object
      * of the checksum character
      * added to the barcode text
      * @param boolean $value
-     * @return \Zend\Barcode\Object
-     * @throw \Zend\Barcode\Object\Exception
+     * @return \Zend\Barcode\Object\ObjectInterface
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setWithChecksumInText($value)
     {
@@ -694,8 +694,8 @@ abstract class AbstractObject implements Barcode\Object
      *  - if integer between 1 and 5, use gd built-in fonts
      *  - if string, $value is assumed to be the path to a TTF font
      * @param integer|string $value
-     * @return \Zend\Barcode\Object
-     * @throw \Zend\Barcode\Object\Exception
+     * @return \Zend\Barcode\Object\ObjectInterface
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFont($value)
     {
@@ -734,8 +734,8 @@ abstract class AbstractObject implements Barcode\Object
     /**
      * Set the size of the font in case of TTF
      * @param float $value
-     * @return \Zend\Barcode\Object
-     * @throw \Zend\Barcode\Object\Exception
+     * @return \Zend\Barcode\Object\ObjectInterface
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFontSize($value)
     {
@@ -863,7 +863,7 @@ abstract class AbstractObject implements Barcode\Object
     /**
      * Check if a text is really provided to barcode
      * @return void
-     * @throw \Zend\Barcode\Object\Exception
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     protected function checkText($value = null)
     {
@@ -883,7 +883,7 @@ abstract class AbstractObject implements Barcode\Object
      * @param integer $min
      * @param integer $max
      * @return void
-     * @throw \Zend\Barcode\Object\Exception
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     protected function checkRatio($min = 2, $max = 3)
     {
@@ -901,7 +901,7 @@ abstract class AbstractObject implements Barcode\Object
     /**
      * Drawing with an angle is just allow TTF font
      * @return void
-     * @throw \Zend\Barcode\Object\Exception
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     protected function checkFontAndOrientation()
     {

--- a/library/Zend/Barcode/Object/AbstractObject.php
+++ b/library/Zend/Barcode/Object/AbstractObject.php
@@ -23,7 +23,6 @@ namespace Zend\Barcode\Object;
 
 use Traversable,
     Zend\Barcode,
-    Zend\Barcode\Object\Exception\ExceptionInterface,
     Zend\Validator\Barcode as BarcodeValidator,
     Zend\Stdlib\ArrayUtils;
 
@@ -35,7 +34,7 @@ use Traversable,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class AbstractObject implements Barcode\Object\ObjectInterface
+abstract class AbstractObject implements ObjectInterface
 {
     /**
      * Namespace of the barcode for autoloading

--- a/library/Zend/Barcode/Object/Ean8.php
+++ b/library/Zend/Barcode/Object/Ean8.php
@@ -21,8 +21,7 @@
 
 namespace Zend\Barcode\Object;
 
-use Zend\Barcode\Object\Exception\ExceptionInterface,
-    Zend\Validator\Barcode as BarcodeValidator;
+use Zend\Validator\Barcode as BarcodeValidator;
 
 /**
  * Class for generate Ean8 barcode

--- a/library/Zend/Barcode/Object/Ean8.php
+++ b/library/Zend/Barcode/Object/Ean8.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Barcode\Object;
 
-use Zend\Barcode\Object\Exception,
+use Zend\Barcode\Object\Exception\ExceptionInterface,
     Zend\Validator\Barcode as BarcodeValidator;
 
 /**

--- a/library/Zend/Barcode/Object/Exception/BarcodeValidationException.php
+++ b/library/Zend/Barcode/Object/Exception/BarcodeValidationException.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Barcode\Object\Exception;
 
-use Zend\Barcode\Object\Exception;
+use Zend\Barcode\Object\Exception\ExceptionInterface;
 
 /**
  * Exception for Zend_Barcode component.
@@ -33,6 +33,6 @@ use Zend\Barcode\Object\Exception;
  */
 class BarcodeValidationException
     extends \Exception
-    implements Exception
+    implements ExceptionInterface
 {
 }

--- a/library/Zend/Barcode/Object/Exception/BarcodeValidationException.php
+++ b/library/Zend/Barcode/Object/Exception/BarcodeValidationException.php
@@ -21,8 +21,6 @@
 
 namespace Zend\Barcode\Object\Exception;
 
-use Zend\Barcode\Object\Exception\ExceptionInterface;
-
 /**
  * Exception for Zend_Barcode component.
  *

--- a/library/Zend/Barcode/Object/Exception/ExceptionInterface.php
+++ b/library/Zend/Barcode/Object/Exception/ExceptionInterface.php
@@ -14,22 +14,24 @@
  *
  * @category   Zend
  * @package    Zend_Barcode
+ * @subpackage Object_Exception
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Zend\Barcode\Object;
+namespace Zend\Barcode\Object\Exception;
 
-use Zend\Barcode\Exception as BarcodeException;
+use Zend\Barcode\Exception\ExceptionInterface as BarcodeException;
 
 /**
  * Base exception interface for barcode objects
  *
  * @category   Zend
  * @package    Zend_Barcode
+ * @subpackage Object_Exception
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Exception extends BarcodeException
+interface ExceptionInterface extends BarcodeException
 {
 }

--- a/library/Zend/Barcode/Object/Exception/ExtensionNotLoadedException.php
+++ b/library/Zend/Barcode/Object/Exception/ExtensionNotLoadedException.php
@@ -21,6 +21,8 @@
 
 namespace Zend\Barcode\Object\Exception;
 
+use Zend\Barcode\Object\Exception\ExceptionInterface;
+
 /**
  * Exception for Zend_Barcode component.
  *
@@ -31,6 +33,6 @@ namespace Zend\Barcode\Object\Exception;
  */
 class ExtensionNotLoadedException
     extends \RuntimeException
-    implements \Zend\Barcode\Object\Exception
+    implements ExceptionInterface
 {
 }

--- a/library/Zend/Barcode/Object/Exception/ExtensionNotLoadedException.php
+++ b/library/Zend/Barcode/Object/Exception/ExtensionNotLoadedException.php
@@ -21,8 +21,6 @@
 
 namespace Zend\Barcode\Object\Exception;
 
-use Zend\Barcode\Object\Exception\ExceptionInterface;
-
 /**
  * Exception for Zend_Barcode component.
  *

--- a/library/Zend/Barcode/Object/Exception/InvalidArgumentException.php
+++ b/library/Zend/Barcode/Object/Exception/InvalidArgumentException.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Barcode\Object\Exception;
 
-use Zend\Barcode\Object\Exception;
+use Zend\Barcode\Object\Exception\ExceptionInterface;
 
 /**
  * Exception for Zend_Barcode component.
@@ -33,6 +33,6 @@ use Zend\Barcode\Object\Exception;
  */
 class InvalidArgumentException
     extends \InvalidArgumentException
-    implements Exception
+    implements ExceptionInterface
 {
 }

--- a/library/Zend/Barcode/Object/Exception/InvalidArgumentException.php
+++ b/library/Zend/Barcode/Object/Exception/InvalidArgumentException.php
@@ -21,8 +21,6 @@
 
 namespace Zend\Barcode\Object\Exception;
 
-use Zend\Barcode\Object\Exception\ExceptionInterface;
-
 /**
  * Exception for Zend_Barcode component.
  *

--- a/library/Zend/Barcode/Object/Exception/OutOfRangeException.php
+++ b/library/Zend/Barcode/Object/Exception/OutOfRangeException.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Barcode\Object\Exception;
 
-use Zend\Barcode\Object\Exception;
+use Zend\Barcode\Object\Exception\ExceptionInterface;
 
 /**
  * Exception for Zend_Barcode component.
@@ -33,6 +33,6 @@ use Zend\Barcode\Object\Exception;
  */
 class OutOfRangeException
     extends \OutOfRangeException
-    implements Exception
+    implements ExceptionInterface
 {
 }

--- a/library/Zend/Barcode/Object/Exception/OutOfRangeException.php
+++ b/library/Zend/Barcode/Object/Exception/OutOfRangeException.php
@@ -21,8 +21,6 @@
 
 namespace Zend\Barcode\Object\Exception;
 
-use Zend\Barcode\Object\Exception\ExceptionInterface;
-
 /**
  * Exception for Zend_Barcode component.
  *

--- a/library/Zend/Barcode/Object/Exception/RuntimeException.php
+++ b/library/Zend/Barcode/Object/Exception/RuntimeException.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Barcode\Object\Exception;
 
-use Zend\Barcode\Object\Exception;
+use Zend\Barcode\Object\Exception\ExceptionInterface;
 
 /**
  * Exception for Zend_Barcode component.
@@ -33,6 +33,6 @@ use Zend\Barcode\Object\Exception;
  */
 class RuntimeException
     extends \RuntimeException
-    implements Exception
+    implements ExceptionInterface
 {
 }

--- a/library/Zend/Barcode/Object/Exception/RuntimeException.php
+++ b/library/Zend/Barcode/Object/Exception/RuntimeException.php
@@ -21,8 +21,6 @@
 
 namespace Zend\Barcode\Object\Exception;
 
-use Zend\Barcode\Object\Exception\ExceptionInterface;
-
 /**
  * Exception for Zend_Barcode component.
  *

--- a/library/Zend/Barcode/Object/ObjectInterface.php
+++ b/library/Zend/Barcode/Object/ObjectInterface.php
@@ -19,17 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Zend\Barcode;
+namespace Zend\Barcode\Object;
 
 /**
  * Interface for generate Barcode
  *
  * @category   Zend
  * @package    Zend_Barcode
+ * @subpackage Object
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Object
+interface ObjectInterface
 {
     /**
      * Constructor
@@ -41,7 +42,7 @@ interface Object
     /**
      * Set barcode state from options array
      * @param  array $options
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setOptions($options);
 
@@ -49,7 +50,7 @@ interface Object
      * Set barcode namespace for autoloading
      *
      * @param string $namespace
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setBarcodeNamespace($namespace);
 
@@ -69,7 +70,7 @@ interface Object
     /**
      * Set height of the barcode bar
      * @param integer $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setBarHeight($value);
 
@@ -82,7 +83,7 @@ interface Object
     /**
      * Set thickness of thin bar
      * @param integer $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setBarThinWidth($value);
 
@@ -95,7 +96,7 @@ interface Object
     /**
      * Set thickness of thick bar
      * @param integer $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setBarThickWidth($value);
 
@@ -109,7 +110,7 @@ interface Object
      * Set factor applying to
      * thinBarWidth - thickBarWidth - barHeight - fontSize
      * @param integer $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setFactor($value);
 
@@ -123,7 +124,7 @@ interface Object
     /**
      * Set color of the barcode and text
      * @param string $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setForeColor($value);
 
@@ -136,7 +137,7 @@ interface Object
     /**
      * Set the color of the background
      * @param integer $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setBackgroundColor($value);
 
@@ -149,7 +150,7 @@ interface Object
     /**
      * Activate/deactivate drawing of the bar
      * @param boolean $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setWithBorder($value);
 
@@ -161,14 +162,14 @@ interface Object
 
     /**
      * Allow fast inversion of font/bars color and background color
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setReverseColor();
 
     /**
      * Set orientation of barcode and text
      * @param float $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setOrientation($value);
 
@@ -181,7 +182,7 @@ interface Object
     /**
      * Set text to encode
      * @param string $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setText($value);
 
@@ -206,7 +207,7 @@ interface Object
     /**
      * Activate/deactivate drawing of text to encode
      * @param boolean $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setDrawText($value);
 
@@ -220,7 +221,7 @@ interface Object
      * Activate/deactivate the adjustment of the position
      * of the characters to the position of the bars
      * @param boolean $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setStretchText($value);
 
@@ -236,7 +237,7 @@ interface Object
      * of the checksum character
      * added to the barcode text
      * @param boolean $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setWithChecksum($value);
 
@@ -252,7 +253,7 @@ interface Object
      * of the checksum character
      * added to the barcode text
      * @param boolean $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setWithChecksumInText($value);
 
@@ -268,7 +269,7 @@ interface Object
      *  - if integer between 1 and 5, use gd built-in fonts
      *  - if string, $value is assumed to be the path to a TTF font
      * @param integer|string $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setFont($value);
 
@@ -281,7 +282,7 @@ interface Object
     /**
      * Set the size of the font in case of TTF
      * @param float $value
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function setFontSize($value);
 

--- a/library/Zend/Barcode/Object/Upce.php
+++ b/library/Zend/Barcode/Object/Upce.php
@@ -22,7 +22,7 @@
 namespace Zend\Barcode\Object;
 
 use Zend\Validator\Barcode as BarcodeValidator,
-    Zend\Barcode\Object\Exception;
+    Zend\Barcode\Object\Exception\ExceptionInterface;
 
 /**
  * Class for generate UpcA barcode

--- a/library/Zend/Barcode/Object/Upce.php
+++ b/library/Zend/Barcode/Object/Upce.php
@@ -21,8 +21,7 @@
 
 namespace Zend\Barcode\Object;
 
-use Zend\Validator\Barcode as BarcodeValidator,
-    Zend\Barcode\Object\Exception\ExceptionInterface;
+use Zend\Validator\Barcode as BarcodeValidator;
 
 /**
  * Class for generate UpcA barcode

--- a/library/Zend/Barcode/Renderer/AbstractRenderer.php
+++ b/library/Zend/Barcode/Renderer/AbstractRenderer.php
@@ -25,7 +25,6 @@ use Traversable,
     Zend\Barcode\Barcode,
     Zend\Barcode\Exception\ExceptionInterface as BarcodeException,
     Zend\Barcode\Object\ObjectInterface,
-    Zend\Barcode\Renderer\RendererInterface,
     Zend\Stdlib\ArrayUtils;
 
 /**

--- a/library/Zend/Barcode/Renderer/AbstractRenderer.php
+++ b/library/Zend/Barcode/Renderer/AbstractRenderer.php
@@ -23,9 +23,9 @@ namespace Zend\Barcode\Renderer;
 
 use Traversable,
     Zend\Barcode\Barcode,
-    Zend\Barcode\Exception as BarcodeException,
-    Zend\Barcode\Object,
-    Zend\Barcode\Renderer,
+    Zend\Barcode\Exception\ExceptionInterface as BarcodeException,
+    Zend\Barcode\Object\ObjectInterface,
+    Zend\Barcode\Renderer\RendererInterface,
     Zend\Stdlib\ArrayUtils;
 
 /**
@@ -36,7 +36,7 @@ use Traversable,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class AbstractRenderer implements Renderer
+abstract class AbstractRenderer implements RendererInterface
 {
     /**
      * Namespace of the renderer for autoloading
@@ -88,7 +88,7 @@ abstract class AbstractRenderer implements Renderer
 
     /**
      * Barcode object
-     * @var Object
+     * @var Object\ObjectInterface
      */
     protected $barcode;
 
@@ -320,7 +320,7 @@ abstract class AbstractRenderer implements Renderer
      */
     public function setBarcode($barcode)
     {
-        if (!$barcode instanceof Object) {
+        if (!$barcode instanceof ObjectInterface) {
             throw new Exception\InvalidArgumentException(
                 'Invalid barcode object provided to setBarcode()'
             );
@@ -331,7 +331,7 @@ abstract class AbstractRenderer implements Renderer
 
     /**
      * Retrieve the barcode object
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function getBarcode()
     {

--- a/library/Zend/Barcode/Renderer/Exception/ExceptionInterface.php
+++ b/library/Zend/Barcode/Renderer/Exception/ExceptionInterface.php
@@ -18,9 +18,9 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Zend\Barcode\Renderer;
+namespace Zend\Barcode\Renderer\Exception;
 
-use Zend\Barcode\Exception as BarcodeException;
+use Zend\Barcode\Exception\ExceptionInterface as BarcodeException;
 
 /**
  * @category   Zend
@@ -28,6 +28,6 @@ use Zend\Barcode\Exception as BarcodeException;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Exception extends BarcodeException
+interface ExceptionInterface extends BarcodeException
 {
 }

--- a/library/Zend/Barcode/Renderer/Exception/InvalidArgumentException.php
+++ b/library/Zend/Barcode/Renderer/Exception/InvalidArgumentException.php
@@ -21,8 +21,6 @@
 
 namespace Zend\Barcode\Renderer\Exception;
 
-use Zend\Barcode\Renderer\Exception;
-
 /**
  * Exception for Zend_Barcode component.
  *

--- a/library/Zend/Barcode/Renderer/Exception/InvalidArgumentException.php
+++ b/library/Zend/Barcode/Renderer/Exception/InvalidArgumentException.php
@@ -33,6 +33,6 @@ use Zend\Barcode\Renderer\Exception;
  */
 class InvalidArgumentException
     extends \InvalidArgumentException
-    implements Exception
+    implements ExceptionInterface
 {
 }

--- a/library/Zend/Barcode/Renderer/Exception/OutOfRangeException.php
+++ b/library/Zend/Barcode/Renderer/Exception/OutOfRangeException.php
@@ -21,8 +21,6 @@
 
 namespace Zend\Barcode\Renderer\Exception;
 
-use Zend\Barcode\Renderer\Exception;
-
 /**
  * Exception for Zend_Barcode component.
  *

--- a/library/Zend/Barcode/Renderer/Exception/OutOfRangeException.php
+++ b/library/Zend/Barcode/Renderer/Exception/OutOfRangeException.php
@@ -33,6 +33,6 @@ use Zend\Barcode\Renderer\Exception;
  */
 class OutOfRangeException
     extends \OutOfRangeException
-    implements Exception
+    implements ExceptionInterface
 {
 }

--- a/library/Zend/Barcode/Renderer/Exception/RuntimeException.php
+++ b/library/Zend/Barcode/Renderer/Exception/RuntimeException.php
@@ -21,8 +21,6 @@
 
 namespace Zend\Barcode\Renderer\Exception;
 
-use Zend\Barcode\Renderer\Exception;
-
 /**
  * Exception for Zend_Barcode component.
  *

--- a/library/Zend/Barcode/Renderer/Exception/RuntimeException.php
+++ b/library/Zend/Barcode/Renderer/Exception/RuntimeException.php
@@ -33,6 +33,6 @@ use Zend\Barcode\Renderer\Exception;
  */
 class RuntimeException
     extends \RuntimeException
-    implements Exception
+    implements ExceptionInterface
 {
 }

--- a/library/Zend/Barcode/Renderer/Exception/UnexpectedValueException.php
+++ b/library/Zend/Barcode/Renderer/Exception/UnexpectedValueException.php
@@ -21,8 +21,6 @@
 
 namespace Zend\Barcode\Renderer\Exception;
 
-use Zend\Barcode\Renderer\Exception;
-
 /**
  * Exception for Zend_Barcode component.
  *

--- a/library/Zend/Barcode/Renderer/Exception/UnexpectedValueException.php
+++ b/library/Zend/Barcode/Renderer/Exception/UnexpectedValueException.php
@@ -33,6 +33,6 @@ use Zend\Barcode\Renderer\Exception;
  */
 class UnexpectedValueException
     extends \UnexpectedValueException
-    implements Exception
+    implements ExceptionInterface
 {
 }

--- a/library/Zend/Barcode/Renderer/Pdf.php
+++ b/library/Zend/Barcode/Renderer/Pdf.php
@@ -21,8 +21,7 @@
 
 namespace Zend\Barcode\Renderer;
 
-use Zend\Barcode\Renderer\Exception\ExceptionInterface,
-    Zend\Pdf\Color,
+use Zend\Pdf\Color,
     Zend\Pdf\Font,
     Zend\Pdf\Page,
     Zend\Pdf\PdfDocument;

--- a/library/Zend/Barcode/Renderer/Pdf.php
+++ b/library/Zend/Barcode/Renderer/Pdf.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Barcode\Renderer;
 
-use Zend\Barcode\Renderer\Exception,
+use Zend\Barcode\Renderer\Exception\ExceptionInterface,
     Zend\Pdf\Color,
     Zend\Pdf\Font,
     Zend\Pdf\Page,

--- a/library/Zend/Barcode/Renderer/RendererInterface.php
+++ b/library/Zend/Barcode/Renderer/RendererInterface.php
@@ -19,17 +19,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Zend\Barcode;
+namespace Zend\Barcode\Renderer;
 
 /**
  * Class for rendering the barcode
  *
  * @category   Zend
  * @package    Zend_Barcode
+ * @subpackage Renderer
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Renderer
+interface RendererInterface
 {
     /**
      * Constructor
@@ -145,14 +146,14 @@ interface Renderer
 
     /**
      * Set the barcode object
-     * @param  Object $barcode
+     * @param  Object\ObjectInterface $barcode
      * @return Renderer
      */
     public function setBarcode($barcode);
 
     /**
      * Retrieve the barcode object
-     * @return Object
+     * @return Object\ObjectInterface
      */
     public function getBarcode();
 

--- a/tests/Zend/Barcode/FactoryTest.php
+++ b/tests/Zend/Barcode/FactoryTest.php
@@ -99,14 +99,14 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testFactoryWithoutAutomaticObjectExceptionRendering()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $options = array('barHeight' => - 1);
         $renderer = Barcode\Barcode::factory('code39', 'image', $options, array(), false);
     }
 
     public function testFactoryWithoutAutomaticRendererExceptionRendering()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $this->checkGDRequirement();
         $options = array('imageType' => 'my');
         $renderer = Barcode\Barcode::factory('code39', 'image', array(), $options, false);
@@ -213,14 +213,14 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testBarcodeObjectFactoryWithBarcodeAsZendConfigButNoBarcodeParameter()
     {
-        $this->setExpectedException('\Zend\Barcode\Exception');
+        $this->setExpectedException('\Zend\Barcode\Exception\ExceptionInterface');
         $config = new Config(array('barcodeParams' => array('barHeight' => 123) ));
         $barcode = Barcode\Barcode::makeBarcode($config);
     }
 
     public function testBarcodeObjectFactoryWithBarcodeAsZendConfigAndBadBarcodeParameters()
     {
-        $this->setExpectedException('\Zend\Barcode\Exception');
+        $this->setExpectedException('\Zend\Barcode\Exception\ExceptionInterface');
         $barcode = Barcode\Barcode::makeBarcode('code25', null);
     }
 
@@ -243,7 +243,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testBarcodeObjectFactoryWithNamespaceButWithoutExtendingObjectAbstract()
     {
-        $this->setExpectedException('\Zend\Barcode\Exception');
+        $this->setExpectedException('\Zend\Barcode\Exception\ExceptionInterface');
         $loader = new PrefixPathLoader(array('ZendTest\Barcode\Object\TestAsset' => __DIR__ . '/Object/TestAsset'));
         Barcode\Barcode::getObjectBroker()->setClassLoader($loader);
         $barcode = Barcode\Barcode::makeBarcode('barcodeNamespaceWithoutExtendingObjectAbstract');
@@ -300,14 +300,14 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testBarcodeRendererFactoryWithBarcodeAsZendConfigButNoBarcodeParameter()
     {
-        $this->setExpectedException('\Zend\Barcode\Exception');
+        $this->setExpectedException('\Zend\Barcode\Exception\ExceptionInterface');
         $config = new Config(array('rendererParams' => array('imageType' => 'gif') ));
         $renderer = Barcode\Barcode::makeRenderer($config);
     }
 
     public function testBarcodeRendererFactoryWithBarcodeAsZendConfigAndBadBarcodeParameters()
     {
-        $this->setExpectedException('\Zend\Barcode\Exception');
+        $this->setExpectedException('\Zend\Barcode\Exception\ExceptionInterface');
         $renderer = Barcode\Barcode::makeRenderer('image', null);
     }
 
@@ -317,12 +317,12 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $loader = new PrefixPathLoader(array('ZendTest\Barcode\Renderer\TestAsset' => __DIR__ . '/Renderer/TestAsset'));
         Barcode\Barcode::getRendererBroker()->setClassLoader($loader);
         $renderer = Barcode\Barcode::makeRenderer('rendererNamespace');
-        $this->assertTrue($renderer instanceof \Zend\Barcode\Renderer);
+        $this->assertTrue($renderer instanceof \Zend\Barcode\Renderer\RendererInterface);
     }
 
     public function testBarcodeFactoryWithNamespaceButWithoutExtendingRendererAbstract()
     {
-        $this->setExpectedException('\Zend\Barcode\Exception');
+        $this->setExpectedException('\Zend\Barcode\Exception\ExceptionInterface');
         $loader = new PrefixPathLoader(array('ZendTest\Barcode\Renderer\TestAsset' => __DIR__ . '/Renderer/TestAsset'));
         Barcode\Barcode::getRendererBroker()->setClassLoader($loader);
         $renderer = Barcode\Barcode::makeRenderer('rendererNamespaceWithoutExtendingRendererAbstract');

--- a/tests/Zend/Barcode/Object/Code25Test.php
+++ b/tests/Zend/Barcode/Object/Code25Test.php
@@ -99,7 +99,7 @@ class Code25Test extends TestCommon
 
     public function testBadTextDetectedIfChecksumWished()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('a');
         $this->object->setWithChecksum(true);
         $this->object->getText();
@@ -113,7 +113,7 @@ class Code25Test extends TestCommon
 
     public function testCheckParamsWithLowRatio()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('0123456789');
         $this->object->setBarThinWidth(21);
         $this->object->setBarThickWidth(40);
@@ -122,7 +122,7 @@ class Code25Test extends TestCommon
 
     public function testCheckParamsWithHighRatio()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('0123456789');
         $this->object->setBarThinWidth(20);
         $this->object->setBarThickWidth(61);

--- a/tests/Zend/Barcode/Object/Code25interleavedTest.php
+++ b/tests/Zend/Barcode/Object/Code25interleavedTest.php
@@ -125,7 +125,7 @@ class Code25interleavedTest extends TestCommon
 
     public function testBadTextDetectedIfChecksumWished()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('a');
         $this->object->setWithChecksum(true);
         $this->object->getText();
@@ -139,7 +139,7 @@ class Code25interleavedTest extends TestCommon
 
     public function testCheckParamsWithLowRatio()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('0123456789');
         $this->object->setBarThinWidth(21);
         $this->object->setBarThickWidth(40);
@@ -148,7 +148,7 @@ class Code25interleavedTest extends TestCommon
 
     public function testCheckParamsWithHighRatio()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('0123456789');
         $this->object->setBarThinWidth(20);
         $this->object->setBarThickWidth(61);

--- a/tests/Zend/Barcode/Object/Code39Test.php
+++ b/tests/Zend/Barcode/Object/Code39Test.php
@@ -92,7 +92,7 @@ class Code39Test extends TestCommon
 
     public function testBadTextDetectedIfChecksumWished()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('&');
         $this->object->setWithChecksum(true);
         $this->object->getText();
@@ -106,7 +106,7 @@ class Code39Test extends TestCommon
 
     public function testCheckParamsWithLowRatio()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('TEST');
         $this->object->setBarThinWidth(21);
         $this->object->setBarThickWidth(40);
@@ -115,7 +115,7 @@ class Code39Test extends TestCommon
 
     public function testCheckParamsWithHighRatio()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('TEST');
         $this->object->setBarThinWidth(20);
         $this->object->setBarThickWidth(61);

--- a/tests/Zend/Barcode/Object/Ean13Test.php
+++ b/tests/Zend/Barcode/Object/Ean13Test.php
@@ -91,7 +91,7 @@ class Ean13Test extends TestCommon
 
     public function testBadTextDetectedIfChecksumWished()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('a');
         $this->object->setWithChecksum(true);
         $this->object->getText();

--- a/tests/Zend/Barcode/Object/Ean8Test.php
+++ b/tests/Zend/Barcode/Object/Ean8Test.php
@@ -91,7 +91,7 @@ class Ean8Test extends TestCommon
 
     public function testBadTextDetectedIfChecksumWished()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('a');
         $this->object->setWithChecksum(true);
         $this->object->getText();

--- a/tests/Zend/Barcode/Object/IdentcodeTest.php
+++ b/tests/Zend/Barcode/Object/IdentcodeTest.php
@@ -91,7 +91,7 @@ class IdentcodeTest extends TestCommon
 
     public function testBadTextDetectedIfChecksumWished()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('a');
         $this->object->setWithChecksum(true);
         $this->object->getText();

--- a/tests/Zend/Barcode/Object/Itf14Test.php
+++ b/tests/Zend/Barcode/Object/Itf14Test.php
@@ -91,7 +91,7 @@ class Itf14Test extends TestCommon
 
     public function testBadTextDetectedIfChecksumWished()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('a');
         $this->object->setWithChecksum(true);
         $this->object->getText();
@@ -105,7 +105,7 @@ class Itf14Test extends TestCommon
 
     public function testCheckParamsWithLowRatio()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('0000123456789');
         $this->object->setBarThinWidth(21);
         $this->object->setBarThickWidth(40);
@@ -114,7 +114,7 @@ class Itf14Test extends TestCommon
 
     public function testCheckParamsWithHighRatio()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('0000123456789');
         $this->object->setBarThinWidth(20);
         $this->object->setBarThickWidth(61);

--- a/tests/Zend/Barcode/Object/LeitcodeTest.php
+++ b/tests/Zend/Barcode/Object/LeitcodeTest.php
@@ -91,7 +91,7 @@ class LeitcodeTest extends TestCommon
 
     public function testBadTextDetectedIfChecksumWished()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('a');
         $this->object->setWithChecksum(true);
         $this->object->getText();

--- a/tests/Zend/Barcode/Object/PlanetTest.php
+++ b/tests/Zend/Barcode/Object/PlanetTest.php
@@ -58,7 +58,7 @@ class PlanetTest extends TestCommon
 
     public function testSetTextWithoutGoodNumberOfCharacters()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('1234');
         $this->object->getText();
     }
@@ -91,7 +91,7 @@ class PlanetTest extends TestCommon
 
     public function testBadTextDetectedIfChecksumWished()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('a');
         $this->object->setWithChecksum(true);
         $this->object->getText();

--- a/tests/Zend/Barcode/Object/PostnetTest.php
+++ b/tests/Zend/Barcode/Object/PostnetTest.php
@@ -58,7 +58,7 @@ class PostnetTest extends TestCommon
 
     public function testSetTextWithoutGoodNumberOfCharacters()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('1234');
         $this->object->getText();
     }
@@ -91,7 +91,7 @@ class PostnetTest extends TestCommon
 
     public function testBadTextDetectedIfChecksumWished()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('a');
         $this->object->setWithChecksum(true);
         $this->object->getText();

--- a/tests/Zend/Barcode/Object/RoyalmailTest.php
+++ b/tests/Zend/Barcode/Object/RoyalmailTest.php
@@ -85,7 +85,7 @@ class RoyalmailTest extends TestCommon
 
     public function testBadTextDetectedIfChecksumWished()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('a');
         $this->object->setWithChecksum(true);
         $this->object->getText();

--- a/tests/Zend/Barcode/Object/TestCommon.php
+++ b/tests/Zend/Barcode/Object/TestCommon.php
@@ -118,7 +118,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testNegativeBarHeight()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setBarHeight(- 1);
     }
 
@@ -134,7 +134,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testNegativeBarThinWidth()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setBarThinWidth(- 1);
     }
 
@@ -150,7 +150,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testNegativeBarThickWidth()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setBarThickWidth(- 1);
     }
 
@@ -168,7 +168,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testNegativeFactor()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setFactor(- 1);
     }
 
@@ -182,13 +182,13 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testNegativeForeColor()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setForeColor(- 1);
     }
 
     public function testTooHighForeColor()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setForeColor(16777126);
     }
 
@@ -202,13 +202,13 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testNegativeBackgroundColor()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setBackgroundColor(- 1);
     }
 
     public function testTooHighBackgroundColor()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setBackgroundColor(16777126);
     }
 
@@ -300,13 +300,13 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testSetLowFontAsNumberForGdImage()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setFont(0);
     }
 
     public function testSetHighFontAsNumberForGdImage()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setFont(6);
     }
 
@@ -318,7 +318,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testSetFontAsBoolean()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setFont(true);
     }
 
@@ -328,7 +328,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped(
                     'GD extension must not be loaded to run this test');
         }
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setFont(1);
     }
 
@@ -351,7 +351,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testStringFontSize()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setFontSize('22a');
     }
 
@@ -442,7 +442,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testCheckParamsFontWithOrientation()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('0');
         $this->object->setFont(1);
         $this->object->setOrientation(45);

--- a/tests/Zend/Barcode/Object/UpcaTest.php
+++ b/tests/Zend/Barcode/Object/UpcaTest.php
@@ -91,7 +91,7 @@ class UpcaTest extends TestCommon
 
     public function testBadTextDetectedIfChecksumWished()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('a');
         $this->object->setWithChecksum(true);
         $this->object->getText();

--- a/tests/Zend/Barcode/Object/UpceTest.php
+++ b/tests/Zend/Barcode/Object/UpceTest.php
@@ -99,7 +99,7 @@ class UpceTest extends TestCommon
 
     public function testBadTextDetectedIfChecksumWished()
     {
-        $this->setExpectedException('\Zend\Barcode\Object\Exception');
+        $this->setExpectedException('\Zend\Barcode\Object\Exception\ExceptionInterface');
         $this->object->setText('a');
         $this->object->setWithChecksum(true);
         $this->object->getText();

--- a/tests/Zend/Barcode/Renderer/ImageTest.php
+++ b/tests/Zend/Barcode/Renderer/ImageTest.php
@@ -60,7 +60,7 @@ class ImageTest extends TestCommon
 
     public function testObjectImageResource()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $imageResource = new \StdClass();
         $this->renderer->setResource($imageResource);
     }
@@ -76,7 +76,7 @@ class ImageTest extends TestCommon
 
     public function testBadHeight()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $this->renderer->setHeight(- 1);
     }
 
@@ -91,7 +91,7 @@ class ImageTest extends TestCommon
 
     public function testBadWidth()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $this->renderer->setWidth(- 1);
     }
 
@@ -108,7 +108,7 @@ class ImageTest extends TestCommon
 
     public function testNonAllowedImageType()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $this->renderer->setImageType('other');
     }
 
@@ -146,7 +146,7 @@ class ImageTest extends TestCommon
 
     public function testBadUserHeightLessThanBarcodeHeight()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $barcode = new Object\Code39(array('text' => '0123456789'));
         $this->assertEquals(62, $barcode->getHeight());
         $this->renderer->setBarcode($barcode);
@@ -165,7 +165,7 @@ class ImageTest extends TestCommon
 
     public function testBadUserWidthLessThanBarcodeWidth()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $barcode = new Object\Code39(array('text' => '0123456789'));
         $this->assertEquals(211, $barcode->getWidth());
         $this->renderer->setBarcode($barcode);
@@ -185,7 +185,7 @@ class ImageTest extends TestCommon
 
     public function testBadHeightOfUserResource()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $barcode = new Object\Code39(array('text' => '0123456789'));
         $this->assertEquals(62, $barcode->getHeight());
         $this->renderer->setBarcode($barcode);
@@ -206,7 +206,7 @@ class ImageTest extends TestCommon
 
     public function testBadWidthOfUserResource()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $barcode = new Object\Code39(array('text' => '0123456789'));
         $this->assertEquals(211, $barcode->getWidth());
         $this->renderer->setBarcode($barcode);
@@ -217,7 +217,7 @@ class ImageTest extends TestCommon
 
     public function testNoFontWithOrientation()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         Barcode\Barcode::setBarcodeFont(null);
         $barcode = new Object\Code39(array('text' => '0123456789'));
         $barcode->setOrientation(1);
@@ -232,7 +232,7 @@ class ImageTest extends TestCommon
 
     public function testRendererWithUnkownInstructionProvideByObject()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         parent::testRendererWithUnkownInstructionProvideByObject();
     }
 

--- a/tests/Zend/Barcode/Renderer/PdfTest.php
+++ b/tests/Zend/Barcode/Renderer/PdfTest.php
@@ -52,7 +52,7 @@ class PdfTest extends TestCommon
 
     public function testObjectPdfResource()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $pdfResource = new \StdClass();
         $this->renderer->setResource($pdfResource);
     }

--- a/tests/Zend/Barcode/Renderer/SvgTest.php
+++ b/tests/Zend/Barcode/Renderer/SvgTest.php
@@ -56,7 +56,7 @@ class SvgTest extends TestCommon
 
     public function testBadHeight()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $this->renderer->setHeight(-1);
     }
 
@@ -71,7 +71,7 @@ class SvgTest extends TestCommon
 
     public function testBadWidth()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $this->renderer->setWidth(-1);
     }
 
@@ -83,7 +83,7 @@ class SvgTest extends TestCommon
 
     public function testObjectSvgResource()
     {
-        $this->setExpectedException('Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $svgResource = new \StdClass();
         $this->renderer->setResource($svgResource);
     }

--- a/tests/Zend/Barcode/Renderer/TestCommon.php
+++ b/tests/Zend/Barcode/Renderer/TestCommon.php
@@ -76,7 +76,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testSetInvalidBarcodeObject()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $barcode = new \StdClass();
         $this->renderer->setBarcode($barcode);
     }
@@ -89,13 +89,13 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testModuleSizeAsString()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $this->renderer->setModuleSize('abc');
     }
 
     public function testModuleSizeLessThan0()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $this->renderer->setModuleSize(-0.5);
     }
 
@@ -118,7 +118,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testBadHorizontalPosition()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $this->renderer->setHorizontalPosition('none');
     }
 
@@ -133,7 +133,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testBadVerticalPosition()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $this->renderer->setVerticalPosition('none');
     }
 
@@ -148,7 +148,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testBadLeftOffset()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $this->renderer->setLeftOffset(- 1);
     }
 
@@ -163,7 +163,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testBadTopOffset()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $this->renderer->setTopOffset(- 1);
     }
 
@@ -201,7 +201,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testRendererWithUnkownInstructionProvideByObject()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $object = new TestAsset\BarcodeTest();
         $object->setText('test');
         $object->addTestInstruction(array('type' => 'unknown'));
@@ -211,7 +211,7 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
 
     public function testBarcodeObjectProvided()
     {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception');
+        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
         $this->renderer->draw();
     }
 


### PR DESCRIPTION
Reworked and renamed interfaces in the Barcode subpackage and moved them into their distinct namespaces as per [zen-27]
