### PR TITLE
ZF-10871: errno/errstr may be undefined

### DIFF
--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -207,7 +207,9 @@ class Socket implements HttpAdapter, Stream
 
             $flags = STREAM_CLIENT_CONNECT;
             if ($this->config['persistent']) $flags |= STREAM_CLIENT_PERSISTENT;
-            
+
+            $errno = null;
+            $errstr = '';
             $this->socket = @stream_socket_client($host . ':' . $port,
                                                   $errno,
                                                   $errstr,


### PR DESCRIPTION
initialized variables in the event the socket functions are disabled by php config
