### PR TITLE
[Travis] Add the minimum PHP version supported.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3.3
   - 5.3
   - 5.4
 


### PR DESCRIPTION
Add PHP version 5.3.3 to run tests with the minimun version required by ZF2
