### PR TITLE
Add consideration of current namespace to get controller and default view...

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -328,7 +328,13 @@ class Application implements AppContext
         }
 
         $routeMatch     = $e->getRouteMatch();
-        $controllerName = $routeMatch->getParam('controller', 'not-found');
+        $namespaceName  = $routeMatch->getParam('namespace');
+        $controllerName = $routeMatch->getParam('controller');
+        if ($controllerName) {
+            if ($namespaceName) $controllerName = $namespaceName . '_' . $controllerName;
+        } else {
+            $controllerName = 'not-found';
+        }
         $events         = $this->events();
 
         try {

--- a/library/Zend/Mvc/View/InjectTemplateListener.php
+++ b/library/Zend/Mvc/View/InjectTemplateListener.php
@@ -92,7 +92,9 @@ class InjectTemplateListener implements ListenerAggregate
         }
 
         $routeMatch = $e->getRouteMatch();
+        $namespace  = $routeMatch->getParam('namespace');
         $controller = $routeMatch->getParam('controller', 'index');
+        if ($namespace) $controller = $namespace . '/' . $controller;
         $controller = $this->deriveControllerClass($controller);
         $template   = $this->inflectName($controller);
 


### PR DESCRIPTION
I have been thinking for long time as would be better to do MVC logic and I met many contradiction. Because of our project not only MVC but and multi-module I had to add consideration of namespaces to MVC.
And I decided that as our project not only MVC but and multi-module, we should add consideration of the namespace to MVC.

Now It more preferable to use https://github.com/VitaliiN/ZendSkeletonApplication as skeleton application (see at module/Application/config/module.config.php at first).

This add some advantages as resolve of identical controller names like IndexController in every module as well as it resolve of render templates with previously identical names.
Also now in your module you can override view of a early included module. As example at application you can override ZfcUser login page by this file structure:

```
module
 |-Application
   |-config
   |-src
   |-view
     |-application
     |-zfcuser
       |-zfcuser
         |-login.phtml   // there is we remake output
         |-register.phtml
    .......
```

Also I added 3 default parameters to default router which we can use to get as example id from url /article/edit/34 where param will be equal 34. And simply can be extracted in action by $id =  $this->getEvent()->getRouteMatch()->getParam('param');
It must help avoid creating additional routers.
