### PR TITLE
Added __clone function in Update class to reset the Where instance.

### DIFF
--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -274,4 +274,16 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 return $this->where;
         }
     }
+	
+	/**
+     * __clone
+     *
+     * Resets the where object each time the Update is cloned.
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        $this->where = clone $this->where;
+    }
 }

--- a/tests/Zend/Db/Sql/UpdateTest.php
+++ b/tests/Zend/Db/Sql/UpdateTest.php
@@ -118,4 +118,23 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('UPDATE "foo" SET "bar" = \'baz\' WHERE x = y', $this->update->getSqlString());
     }
+
+    /**
+     * @covers Zend\Db\Sql\Update::__clone
+     */
+    public function testCloneUpdate()
+    {
+        $update1 = clone $this->update;
+        $update1->table('foo')
+                ->set(array('bar' => 'baz'))
+                ->where('x = y');
+
+        $update2 = clone $this->update;
+        $update2->table('foo')
+            ->set(array('bar' => 'baz'))
+            ->where(array(
+                'id = ?'=>1
+            ));
+        $this->assertEquals('UPDATE "foo" SET "bar" = \'baz\' WHERE id = \'1\'', $update2->getSqlString());
+    }
 }


### PR DESCRIPTION
There was a problem when trying to update multiple rows one after the other. The first update would have succeeded, but the following updated would have kept adding conditions for the update without clearing the previous ones.

I've added a __clone function to clear the Where instance before new conditions are added, exactly like in the Select class. 
