### PR TITLE
Cache: share EventManager of adapter if it implements EventManagerAware

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -34,7 +34,7 @@ use ArrayObject,
     Zend\Cache\Storage\Plugin,
     Zend\EventManager\EventCollection,
     Zend\EventManager\EventManager,
-    Zend\EventManager\EventsAware;
+    Zend\EventManager\EventsCapableInterface;
 
 /**
  * @category   Zend
@@ -43,7 +43,7 @@ use ArrayObject,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class AbstractAdapter implements Adapter, EventsAware
+abstract class AbstractAdapter implements Adapter, EventsCapableInterface
 {
     /**
      * The used EventManager if any

--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -34,7 +34,7 @@ use ArrayObject,
     Zend\Cache\Storage\Plugin,
     Zend\EventManager\EventCollection,
     Zend\EventManager\EventManager,
-    Zend\EventManager\EventManagerAware;
+    Zend\EventManager\EventsAware;
 
 /**
  * @category   Zend
@@ -43,7 +43,7 @@ use ArrayObject,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class AbstractAdapter implements Adapter, EventManagerAware
+abstract class AbstractAdapter implements Adapter, EventsAware
 {
     /**
      * The used EventManager if any
@@ -223,18 +223,6 @@ abstract class AbstractAdapter implements Adapter, EventManagerAware
     /* Event/Plugin handling */
 
     /**
-     * Set event manager instance
-     *
-     * @param  EventCollection $events
-     * @return AbstractAdapter
-     */
-    public function setEventManager(EventCollection $events)
-    {
-        $this->events = $events;
-        return $this;
-    }
-
-    /**
      * Get the event manager
      *
      * @return EventCollection
@@ -242,10 +230,7 @@ abstract class AbstractAdapter implements Adapter, EventManagerAware
     public function events()
     {
         if ($this->events === null) {
-            $this->setEventManager(new EventManager(array(
-                __CLASS__,
-                get_called_class(),
-            )));
+            $this->events = new EventManager(array(__CLASS__, get_called_class()));
         }
         return $this->events;
     }

--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -48,7 +48,7 @@ abstract class AbstractAdapter implements Adapter, EventManagerAware
     /**
      * The used EventManager if any
      *
-     * @var null|EventManager
+     * @var null|EventCollection
      */
     protected $events = null;
 
@@ -237,7 +237,7 @@ abstract class AbstractAdapter implements Adapter, EventManagerAware
     /**
      * Get the event manager
      *
-     * @return EventManager
+     * @return EventCollection
      */
     public function events()
     {
@@ -2432,7 +2432,7 @@ abstract class AbstractAdapter implements Adapter, EventManagerAware
     {
         if ($this->capabilities === null) {
             $this->capabilityMarker = new stdClass();
-            $this->capabilities     = new Capabilities($this->capabilityMarker);
+            $this->capabilities     = new Capabilities($this, $this->capabilityMarker);
         }
         return $this->capabilities;
     }

--- a/library/Zend/Cache/Storage/Adapter/AbstractZendServer.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractZendServer.php
@@ -294,6 +294,7 @@ abstract class AbstractZendServer extends AbstractAdapter
         if ($this->capabilities === null) {
             $this->capabilityMarker = new stdClass();
             $this->capabilities     = new Capabilities(
+                $this,
                 $this->capabilityMarker,
                 array(
                     'supportedDatatypes' => array(

--- a/library/Zend/Cache/Storage/Adapter/AdapterOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/AdapterOptions.php
@@ -25,7 +25,7 @@ use ArrayObject,
     Zend\Cache\Exception,
     Zend\Cache\Storage\Adapter,
     Zend\Cache\Storage\Event,
-    Zend\EventManager\EventManagerAware,
+    Zend\EventManager\EventsAware,
     Zend\Stdlib\Options;
 
 /**
@@ -355,7 +355,7 @@ class AdapterOptions extends Options
 
     /**
      * Triggers an option event if this options instance has a connection to
-     * an adapter implements EventManagerAware.
+     * an adapter implements EventsAware.
      *
      * @param string $optionName
      * @param mixed  $optionValue
@@ -363,7 +363,7 @@ class AdapterOptions extends Options
      */
     protected function triggerOptionEvent($optionName, $optionValue)
     {
-        if ($this->adapter instanceof EventManagerAware) {
+        if ($this->adapter instanceof EventsAware) {
             $event = new Event('option', $this->adapter, new ArrayObject(array($optionName => $optionValue)));
             $this->adapter->events()->trigger($event);
         }

--- a/library/Zend/Cache/Storage/Adapter/AdapterOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/AdapterOptions.php
@@ -25,7 +25,7 @@ use ArrayObject,
     Zend\Cache\Exception,
     Zend\Cache\Storage\Adapter,
     Zend\Cache\Storage\Event,
-    Zend\EventManager\EventsAware,
+    Zend\EventManager\EventsCapableInterface,
     Zend\Stdlib\Options;
 
 /**
@@ -355,7 +355,7 @@ class AdapterOptions extends Options
 
     /**
      * Triggers an option event if this options instance has a connection to
-     * an adapter implements EventsAware.
+     * an adapter implements EventsCapableInterface.
      *
      * @param string $optionName
      * @param mixed  $optionValue
@@ -363,7 +363,7 @@ class AdapterOptions extends Options
      */
     protected function triggerOptionEvent($optionName, $optionValue)
     {
-        if ($this->adapter instanceof EventsAware) {
+        if ($this->adapter instanceof EventsCapableInterface) {
             $event = new Event('option', $this->adapter, new ArrayObject(array($optionName => $optionValue)));
             $this->adapter->events()->trigger($event);
         }

--- a/library/Zend/Cache/Storage/Adapter/AdapterOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/AdapterOptions.php
@@ -25,6 +25,7 @@ use ArrayObject,
     Zend\Cache\Exception,
     Zend\Cache\Storage\Adapter,
     Zend\Cache\Storage\Event,
+    Zend\EventManager\EventManagerAware,
     Zend\Stdlib\Options;
 
 /**
@@ -353,8 +354,8 @@ class AdapterOptions extends Options
     }
 
     /**
-     * Triggers an option.change event
-     * if the this options instance has a connection too an adapter instance
+     * Triggers an option event if this options instance has a connection to
+     * an adapter implements EventManagerAware.
      *
      * @param string $optionName
      * @param mixed  $optionValue
@@ -362,12 +363,10 @@ class AdapterOptions extends Options
      */
     protected function triggerOptionEvent($optionName, $optionValue)
     {
-        if (!$this->adapter) {
-            return;
+        if ($this->adapter instanceof EventManagerAware) {
+            $event = new Event('option', $this->adapter, new ArrayObject(array($optionName => $optionValue)));
+            $this->adapter->events()->trigger($event);
         }
-
-        $event = new Event('option', $this->adapter, new ArrayObject(array($optionName => $optionValue)));
-        $this->adapter->events()->trigger($event);
     }
 
     /**

--- a/library/Zend/Cache/Storage/Adapter/Apc.php
+++ b/library/Zend/Cache/Storage/Adapter/Apc.php
@@ -853,6 +853,7 @@ class Apc extends AbstractAdapter
         if ($this->capabilities === null) {
             $marker       = new stdClass();
             $capabilities = new Capabilities(
+                $this,
                 $marker,
                 array(
                     'supportedDatatypes' => array(

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -1287,6 +1287,7 @@ class Filesystem extends AbstractAdapter
             }
 
             $capabilities = new Capabilities(
+                $this,
                 $marker,
                 array(
                     'supportedDatatypes' => array(

--- a/library/Zend/Cache/Storage/Adapter/Memcached.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcached.php
@@ -759,6 +759,7 @@ class Memcached extends AbstractAdapter
         if ($this->capabilities === null) {
             $this->capabilityMarker = new stdClass();
             $this->capabilities     = new Capabilities(
+                $this,
                 $this->capabilityMarker,
                 array(
                     'supportedDatatypes' => array(

--- a/library/Zend/Cache/Storage/Adapter/Memory.php
+++ b/library/Zend/Cache/Storage/Adapter/Memory.php
@@ -820,6 +820,7 @@ class Memory extends AbstractAdapter
         if ($this->capabilities === null) {
             $this->capabilityMarker = new stdClass();
                 $this->capabilities = new Capabilities(
+                $this,
                 $this->capabilityMarker,
                 array(
                     'supportedDatatypes' => array(

--- a/library/Zend/Cache/Storage/Adapter/WinCache.php
+++ b/library/Zend/Cache/Storage/Adapter/WinCache.php
@@ -531,6 +531,7 @@ class WinCache extends AbstractAdapter
         if ($this->capabilities === null) {
             $marker       = new stdClass();
             $capabilities = new Capabilities(
+                $this,
                 $marker,
                 array(
                     'supportedDatatypes' => array(

--- a/library/Zend/Cache/Storage/Capabilities.php
+++ b/library/Zend/Cache/Storage/Capabilities.php
@@ -24,7 +24,7 @@ namespace Zend\Cache\Storage;
 use ArrayObject,
     stdClass,
     Zend\Cache\Exception,
-    Zend\EventManager\EventsAware;
+    Zend\EventManager\EventsCapableInterface;
 
 /**
  * @category   Zend
@@ -572,7 +572,7 @@ class Capabilities
             $this->$property = $value;
 
             // trigger event
-            if ($this->adapter instanceof EventsAware) {
+            if ($this->adapter instanceof EventsCapableInterface) {
                 $this->adapter->events()->trigger('capability', $this->adapter, new ArrayObject(array(
                     $name => $value
                 )));

--- a/library/Zend/Cache/Storage/Capabilities.php
+++ b/library/Zend/Cache/Storage/Capabilities.php
@@ -24,7 +24,6 @@ namespace Zend\Cache\Storage;
 use ArrayObject,
     stdClass,
     Zend\Cache\Exception,
-    Zend\EventManager\EventCollection,
     Zend\EventManager\EventManagerAware;
 
 /**

--- a/library/Zend/Cache/Storage/Capabilities.php
+++ b/library/Zend/Cache/Storage/Capabilities.php
@@ -24,7 +24,7 @@ namespace Zend\Cache\Storage;
 use ArrayObject,
     stdClass,
     Zend\Cache\Exception,
-    Zend\EventManager\EventManagerAware;
+    Zend\EventManager\EventsAware;
 
 /**
  * @category   Zend
@@ -572,7 +572,7 @@ class Capabilities
             $this->$property = $value;
 
             // trigger event
-            if ($this->adapter instanceof EventManagerAware) {
+            if ($this->adapter instanceof EventsAware) {
                 $this->adapter->events()->trigger('capability', $this->adapter, new ArrayObject(array(
                     $name => $value
                 )));

--- a/library/Zend/Cache/Storage/Plugin/Serializer.php
+++ b/library/Zend/Cache/Storage/Plugin/Serializer.php
@@ -332,6 +332,7 @@ class Serializer extends AbstractPlugin
 
         if (!isset($this->capabilities[$index])) {
             $this->capabilities[$index] = new Capabilities(
+                $baseCapabilities->getAdapter(),
                 new stdClass(), // marker
                 array('supportedDatatypes' => array(
                     'NULL'     => true,

--- a/library/Zend/EventManager/EventsAware.php
+++ b/library/Zend/EventManager/EventsAware.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_EventManager
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\EventManager;
+
+/**
+ * Interface to automate setter injection for an EventManager instance
+ *
+ * @category   Zend
+ * @package    Zend_EventManager
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+interface EventsAware
+{
+    /**
+     * Retrieve the event manager
+     *
+     * Lazy-loads an EventManager instance if none registered.
+     *
+     * @return EventCollection
+     */
+    public function events();
+}

--- a/library/Zend/EventManager/EventsCapableInterface.php
+++ b/library/Zend/EventManager/EventsCapableInterface.php
@@ -21,14 +21,14 @@
 namespace Zend\EventManager;
 
 /**
- * Interface to automate setter injection for an EventManager instance
+ * Interface providing events that can be attached, detached and triggered.
  *
  * @category   Zend
  * @package    Zend_EventManager
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface EventsAware
+interface EventsCapableInterface
 {
     /**
      * Retrieve the event manager

--- a/library/Zend/Module/ModuleHandler.php
+++ b/library/Zend/Module/ModuleHandler.php
@@ -2,9 +2,10 @@
 
 namespace Zend\Module;
 
-use Zend\EventManager\EventManagerAware;
+use Zend\EventManager\EventManagerAware,
+    Zend\EventManager\EventsCapableInterface;
 
-interface ModuleHandler extends EventManagerAware
+interface ModuleHandler extends EventManagerAware, EventsCapableInterface
 {
     /**
      * Load the provided modules.
@@ -43,13 +44,4 @@ interface ModuleHandler extends EventManagerAware
      * @return ModuleHandler
      */
     public function setModules($modules);
-
-    /**
-     * Retrieve the event manager
-     *
-     * Lazy-loads an EventManager instance if none registered.
-     *
-     * @return EventCollection
-     */
-    public function events();
 }

--- a/library/Zend/Mvc/AppContext.php
+++ b/library/Zend/Mvc/AppContext.php
@@ -4,31 +4,32 @@ namespace Zend\Mvc;
 
 use Zend\Di\Locator,
     Zend\EventManager\EventManagerAware,
+    Zend\EventManager\EventsCapableInterface,
     Zend\Stdlib\RequestDescription as Request,
     Zend\Stdlib\ResponseDescription as Response;
 
-interface AppContext extends EventManagerAware
+interface AppContext extends EventManagerAware, EventsCapableInterface
 {
     /**
      * Set a service locator/DI object
      *
-     * @param  Locator $locator 
+     * @param  Locator $locator
      * @return AppContext
      */
     public function setLocator(Locator $locator);
 
     /**
      * Set request object that will be consumed
-     * 
-     * @param  Request $request 
+     *
+     * @param  Request $request
      * @return AppContext
      */
     public function setRequest(Request $request);
 
     /**
      * Set response object that will be returned
-     * 
-     * @param  Response $request 
+     *
+     * @param  Response $request
      * @return AppContext
      */
     public function setResponse(Response $response);
@@ -37,52 +38,43 @@ interface AppContext extends EventManagerAware
      * Set the router used to decompose the request
      *
      * A router should return a metadata object containing a controller key.
-     * 
-     * @param  Router\RouteStack $router 
+     *
+     * @param  Router\RouteStack $router
      * @return AppContext
      */
     public function setRouter(Router\RouteStack $router);
 
     /**
      * Get the locator object
-     * 
+     *
      * @return Locator
      */
     public function getLocator();
 
     /**
      * Get the request object
-     * 
+     *
      * @return Request
      */
     public function getRequest();
 
     /**
      * Get the response object
-     * 
+     *
      * @return Response
      */
     public function getResponse();
 
     /**
      * Get the router object
-     * 
+     *
      * @return Router
      */
     public function getRouter();
 
     /**
-     * Retrieve the event manager
-     *
-     * Lazy-loads an EventManager instance if none registered.
-     * 
-     * @return EventCollection
-     */
-    public function events();
-
-    /**
      * Run the application
-     * 
+     *
      * @return \Zend\Http\Response
      */
     public function run();

--- a/library/Zend/Mvc/Bootstrap.php
+++ b/library/Zend/Mvc/Bootstrap.php
@@ -7,9 +7,10 @@ use Zend\Di\Configuration as DiConfiguration,
     Zend\EventManager\EventCollection as Events,
     Zend\EventManager\EventManager,
     Zend\EventManager\EventManagerAware,
+    Zend\EventManager\EventsCapableInterface,
     Zend\Mvc\Router\Http\TreeRouteStack as Router;
 
-class Bootstrap implements Bootstrapper, EventManagerAware
+class Bootstrap implements Bootstrapper, EventManagerAware, EventsCapableInterface
 {
     /**
      * @var \Zend\Config\Config

--- a/library/Zend/Mvc/Controller/ActionController.php
+++ b/library/Zend/Mvc/Controller/ActionController.php
@@ -7,6 +7,7 @@ use Zend\Di\Locator,
     Zend\EventManager\EventDescription as Event,
     Zend\EventManager\EventManager,
     Zend\EventManager\EventManagerAware,
+    Zend\EventManager\EventsCapableInterface,
     Zend\Http\PhpEnvironment\Response as HttpResponse,
     Zend\Loader\Broker,
     Zend\Loader\Pluggable,
@@ -22,7 +23,7 @@ use Zend\Di\Locator,
 /**
  * Basic action controller
  */
-abstract class ActionController implements Dispatchable, EventManagerAware, InjectApplicationEvent, LocatorAware, Pluggable
+abstract class ActionController implements Dispatchable, EventManagerAware, EventsCapableInterface, InjectApplicationEvent, LocatorAware, Pluggable
 {
     //use \Zend\EventManager\ProvidesEvents;
 

--- a/library/Zend/Mvc/Controller/RestfulController.php
+++ b/library/Zend/Mvc/Controller/RestfulController.php
@@ -7,6 +7,7 @@ use Zend\Di\Locator,
     Zend\EventManager\EventDescription as Event,
     Zend\EventManager\EventManager,
     Zend\EventManager\EventManagerAware,
+    Zend\EventManager\EventsCapableInterface,
     Zend\Http\Request as HttpRequest,
     Zend\Http\PhpEnvironment\Response as HttpResponse,
     Zend\Loader\Broker,
@@ -22,7 +23,7 @@ use Zend\Di\Locator,
 /**
  * Abstract RESTful controller
  */
-abstract class RestfulController implements Dispatchable, EventManagerAware, InjectApplicationEvent, LocatorAware, Pluggable
+abstract class RestfulController implements Dispatchable, EventManagerAware, EventsCapableInterface, InjectApplicationEvent, LocatorAware, Pluggable
 {
     protected $broker;
     protected $request;

--- a/library/Zend/View/View.php
+++ b/library/Zend/View/View.php
@@ -23,6 +23,7 @@ namespace Zend\View;
 use Zend\EventManager\EventCollection,
     Zend\EventManager\EventManager,
     Zend\EventManager\EventManagerAware,
+    Zend\EventManager\EventsCapableInterface,
     Zend\Mvc\MvcEvent,
     Zend\Stdlib\RequestDescription as Request,
     Zend\Stdlib\ResponseDescription as Response;
@@ -33,7 +34,7 @@ use Zend\EventManager\EventCollection,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class View implements EventManagerAware
+class View implements EventManagerAware, EventsCapableInterface
 {
     /**
      * @var EventCollection


### PR DESCRIPTION
... because the interface Adapter doesn't implement it

Capabilities:
- connect with the current adapter instance on constructor
- added method getAdapter
- removed methods getEventManager & hasEventManager
- triggers a capability event on a changed capability
  only if the connected adapter implements EventManagerAware
  AdapterOptions:
- Only triggers the option event if the connected adapter
  implements EventManagerAware
