### PR TITLE
Request must have a body.

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -31,12 +31,26 @@ class Request extends HttpRequest
      */
     protected $requestUri;
 
+    /**
+     * Raw request body
+     * @var string
+     */
+    protected $rawBody;
+
+    /**
+     * Construct
+     *
+     * Instantiates request.
+     *
+     * @return void
+     */
     public function __construct()
     {
         $this->setEnv(new Parameters($_ENV));
         $this->setPost(new Parameters($_POST));
         $this->setQuery(new Parameters($_GET));
         $this->setServer(new Parameters($_SERVER));
+        $this->setRawBody();
 
         if ($_COOKIE) {
             $this->setCookies($_COOKIE);
@@ -47,6 +61,14 @@ class Request extends HttpRequest
         }
     }
 
+    /**
+     * Set cookies
+     *
+     * Instantiate and set cookies.
+     *
+     * @param $cookie
+     * @return Request
+     */
     public function setCookies($cookie)
     {
         $this->headers()->addHeader(new Cookie((array) $cookie));
@@ -364,5 +386,33 @@ class Request extends HttpRequest
 
         // Base path is identical to base URL
         return $baseUrl;
+    }
+
+    /**
+     * Set raw body
+     *
+     * Attempts to capture raw request body if present.
+     *
+     * @return Request
+     */
+    public function setRawBody()
+    {
+        $body = file_get_contents('php://input');
+        if(strlen(trim($body)) > 0){
+            $this->rawBody = $body;
+        }
+        return $this;
+    }
+
+    /**
+     * Get raw body
+     *
+     * Returns raw request body.
+     *
+     * @return string
+     */
+    public function getRawBody()
+    {
+        return $this->rawBody;
     }
 }

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -32,12 +32,6 @@ class Request extends HttpRequest
     protected $requestUri;
 
     /**
-     * Raw request body
-     * @var string
-     */
-    protected $rawBody;
-
-    /**
      * Construct
      *
      * Instantiates request.
@@ -50,7 +44,6 @@ class Request extends HttpRequest
         $this->setPost(new Parameters($_POST));
         $this->setQuery(new Parameters($_GET));
         $this->setServer(new Parameters($_SERVER));
-        $this->setRawBody();
 
         if ($_COOKIE) {
             $this->setCookies($_COOKIE);
@@ -58,6 +51,11 @@ class Request extends HttpRequest
 
         if ($_FILES) {
             $this->setFile(new Parameters($_FILES));
+        }
+
+        $requestBody = file_get_contents('php://input');
+        if(strlen($requestBody) > 0){
+            $this->setContent($requestBody);
         }
     }
 
@@ -386,33 +384,5 @@ class Request extends HttpRequest
 
         // Base path is identical to base URL
         return $baseUrl;
-    }
-
-    /**
-     * Set raw body
-     *
-     * Attempts to capture raw request body if present.
-     *
-     * @return Request
-     */
-    public function setRawBody()
-    {
-        $body = file_get_contents('php://input');
-        if(strlen(trim($body)) > 0){
-            $this->rawBody = $body;
-        }
-        return $this;
-    }
-
-    /**
-     * Get raw body
-     *
-     * Returns raw request body.
-     *
-     * @return string
-     */
-    public function getRawBody()
-    {
-        return $this->rawBody;
     }
 }


### PR DESCRIPTION
The request object now captures raw body and provides accessor to get its content.
