### PR TITLE
Added filter for Oauth StandardConfig URLs

### DIFF
--- a/library/Zend/OAuth/Config/StandardConfig.php
+++ b/library/Zend/OAuth/Config/StandardConfig.php
@@ -442,7 +442,7 @@ class StandardConfig implements OAuthConfig
     public function getRequestTokenUrl()
     {
         if (!$this->_requestTokenUrl && $this->_siteUrl) {
-            return $this->_siteUrl . '/request_token';
+            return rtrim($this->_siteUrl, '/') . '/request_token';
         }
         return $this->_requestTokenUrl;
     }
@@ -472,7 +472,7 @@ class StandardConfig implements OAuthConfig
     public function getAccessTokenUrl()
     {
         if (!$this->_accessTokenUrl && $this->_siteUrl) {
-            return $this->_siteUrl . '/access_token';
+            return rtrim($this->_siteUrl, '/') . '/access_token';
         }
         return $this->_accessTokenUrl;
     }
@@ -524,7 +524,7 @@ class StandardConfig implements OAuthConfig
     public function getAuthorizeUrl()
     {
         if (!$this->_authorizeUrl && $this->_siteUrl) {
-            return $this->_siteUrl . '/authorize';
+            return rtrim($this->_siteUrl, '/') . '/authorize';
         }
         return $this->_authorizeUrl;
     }

--- a/tests/Zend/OAuth/Config/StandardConfigurationTest.php
+++ b/tests/Zend/OAuth/Config/StandardConfigurationTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_OAuth
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id:$
+ */
+
+namespace ZendTest\OAuth\Config;
+
+
+/**
+ * @category   Zend
+ * @package    Zend_OAuth
+ * @subpackage UnitTests
+ * @group      Zend_OAuth
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+use Zend\OAuth\Config\StandardConfig;
+
+class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testSiteUrlArePropertlyBuiltFromDefaultPaths()
+    {
+    	$config = new StandardConfig(
+    		array(
+    			'siteUrl'	=> 'https://example.com/oauth/'
+    		)
+    	);
+    	$this->assertEquals('https://example.com/oauth/authorize', $config->getAuthorizeUrl());
+    	$this->assertEquals('https://example.com/oauth/request_token', $config->getRequestTokenUrl());
+    	$this->assertEquals('https://example.com/oauth/access_token', $config->getAccessTokenUrl());
+    	
+    }
+
+}
+


### PR DESCRIPTION
Changed StandardConfig in the OAuth namespace so that URLs that
    had a trailing slash provided would have that slash removed since it
    is technically an invalid URL.  Twitter fails monstrously with an
    extra slash in the path.

Change-Id: I2dbaafb7ecc8ec6a09c00a35ba7d893084ad0fcd
