### PR TITLE
Add a context identifier that is the namespace of the controller being executed.

### DIFF
--- a/library/Zend/Mvc/Controller/ActionController.php
+++ b/library/Zend/Mvc/Controller/ActionController.php
@@ -159,7 +159,8 @@ abstract class ActionController implements Dispatchable, EventManagerAware, Inje
         $events->setIdentifiers(array(
             'Zend\Stdlib\Dispatchable',
             __CLASS__,
-            get_class($this)
+            get_class($this),
+            substr(get_class($this), 0, strpos(get_class($this), '\\'))
         ));
         $this->events = $events;
         $this->attachDefaultListeners();


### PR DESCRIPTION
This allows for listening to events (dispatch) only for specific modules (namespaces).
