### PR TITLE
Adding failing test for duplicate injections caused by inheritance

### DIFF
--- a/tests/Zend/Di/DiTest.php
+++ b/tests/Zend/Di/DiTest.php
@@ -43,18 +43,18 @@ class DiTest extends \PHPUnit_Framework_TestCase
     public function testPassingInvalidDefinitionRaisesException()
     {
         $di = new Di();
-        
+
         $this->setExpectedException('PHPUnit_Framework_Error');
         $di->setDefinitionList(array('foo'));
     }
-    
+
     public function testGetRetrievesObjectWithMatchingClassDefinition()
     {
         $di = new Di();
         $obj = $di->get('ZendTest\Di\TestAsset\BasicClass');
         $this->assertInstanceOf('ZendTest\Di\TestAsset\BasicClass', $obj);
     }
-    
+
     public function testGetRetrievesSameInstanceOnSubsequentCalls()
     {
         $di = new Di();
@@ -64,23 +64,23 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\BasicClass', $obj2);
         $this->assertSame($obj1, $obj2);
     }
-    
+
     public function testGetThrowsExceptionWhenUnknownClassIsUsed()
     {
         $di = new Di();
-        
+
         $this->setExpectedException('Zend\Di\Exception\ClassNotFoundException', 'could not be located in');
         $obj1 = $di->get('ZendTest\Di\TestAsset\NonExistentClass');
     }
-    
+
     public function testGetThrowsExceptionWhenMissingParametersAreEncountered()
     {
         $di = new Di();
-        
+
         $this->setExpectedException('Zend\Di\Exception\MissingPropertyException', 'Missing instance/object for ');
         $obj1 = $di->get('ZendTest\Di\TestAsset\BasicClassWithParam');
     }
-    
+
     public function testNewInstanceReturnsDifferentInstances()
     {
         $di = new Di();
@@ -90,7 +90,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\BasicClass', $obj2);
         $this->assertNotSame($obj1, $obj2);
     }
-    
+
     public function testNewInstanceReturnsInstanceThatIsSharedWithGet()
     {
         $di = new Di();
@@ -100,7 +100,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\BasicClass', $obj2);
         $this->assertSame($obj1, $obj2);
     }
-    
+
     public function testNewInstanceReturnsInstanceThatIsNotSharedWithGet()
     {
         $di = new Di();
@@ -204,7 +204,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\B', $b);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\A', $b->a);
     }
-    
+
     /**
      * @group ConstructorInjection
      */
@@ -214,15 +214,15 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $b = $di->get('ZendTest\Di\TestAsset\ConstructorInjection\B');
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\B', $b);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\A', $b->a);
-        
+
         $b2 = $di->get('ZendTest\Di\TestAsset\ConstructorInjection\B');
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\B', $b2);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\A', $b2->a);
-        
+
         $this->assertSame($b, $b2);
         $this->assertSame($b->a, $b2->a);
     }
-    
+
     /**
      * @group ConstructorInjection
      */
@@ -233,48 +233,48 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\B', $b);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\A', $b->a);
     }
-    
+
     /**
      * @group ConstructorInjection
      */
     public function testNewInstanceWillResolveConstructorInjectionDependenciesWithProperties()
     {
         $di = new Di();
-        
+
         $im = $di->instanceManager();
         $im->setParameters('ZendTest\Di\TestAsset\ConstructorInjection\X', array('one' => 1, 'two' => 2));
-        
+
         $y = $di->newInstance('ZendTest\Di\TestAsset\ConstructorInjection\Y');
         $this->assertEquals(1, $y->x->one);
         $this->assertEquals(2, $y->x->two);
     }
-    
+
     /**
      * @group ConstructorInjection
      */
     public function testNewInstanceWillThrowExceptionOnConstructorInjectionDependencyWithMissingParameter()
     {
         $di = new Di();
-        
+
         $this->setExpectedException('Zend\Di\Exception\MissingPropertyException', 'Missing instance/object for parameter');
         $b = $di->newInstance('ZendTest\Di\TestAsset\ConstructorInjection\X');
     }
-    
+
     /**
      * @group ConstructorInjection
      */
     public function testNewInstanceWillResolveConstructorInjectionDependenciesWithMoreThan2Dependencies()
     {
         $di = new Di();
-        
+
         $im = $di->instanceManager();
         $im->setParameters('ZendTest\Di\TestAsset\ConstructorInjection\X', array('one' => 1, 'two' => 2));
-        
+
         $z = $di->newInstance('ZendTest\Di\TestAsset\ConstructorInjection\Z');
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\Y', $z->y);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\X', $z->y->x);
     }
-    
+
     /**
      * @group SetterInjection
      */
@@ -290,7 +290,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\B', $b);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\A', $b->a);
     }
-    
+
     /**
      * @group SetterInjection
      */
@@ -306,16 +306,16 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $b = $di->get('ZendTest\Di\TestAsset\SetterInjection\B');
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\B', $b);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\A', $b->a);
-        
+
         $b2 = $di->get('ZendTest\Di\TestAsset\SetterInjection\B');
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\B', $b2);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\A', $b2->a);
-        
+
         $this->assertSame($b, $b2);
         $this->assertSame($b->a, $a);
         $this->assertSame($b2->a, $a);
     }
-    
+
     /**
      * @group SetterInjection
      */
@@ -332,7 +332,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\B', $b);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\A', $b->a);
     }
-    
+
     /**
      * @todo Setter Injections is not automatic, find a way to test this logically
      *
@@ -341,7 +341,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
     public function testNewInstanceWillResolveSetterInjectionDependenciesWithProperties()
     {
         $di = new Di();
-        
+
         $im = $di->instanceManager();
         $im->setParameters('ZendTest\Di\TestAsset\SetterInjection\X', array('one' => 1, 'two' => 2));
 
@@ -351,10 +351,10 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $y->x->one);
         $this->assertEquals(2, $y->x->two);
     }
-    
+
     /**
      * Test for Circular Dependencies (case 1)
-     * 
+     *
      * A->B, B->A
      * @group CircularDependencyCheck
      */
@@ -365,10 +365,10 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Di\Exception\CircularDependencyException');
         $di->newInstance('ZendTest\Di\TestAsset\CircularClasses\A');
     }
-    
+
     /**
      * Test for Circular Dependencies (case 2)
-     * 
+     *
      * C->D, D->E, E->C
      * @group CircularDependencyCheck
      */
@@ -382,10 +382,10 @@ class DiTest extends \PHPUnit_Framework_TestCase
         );
         $di->newInstance('ZendTest\Di\TestAsset\CircularClasses\C');
     }
-    
+
     /**
      * Test for Circular Dependencies (case 2)
-     * 
+     *
      * C->D, D->E, E->C
      * @group CircularDependencyCheck
      */
@@ -399,10 +399,10 @@ class DiTest extends \PHPUnit_Framework_TestCase
         );
         $di->newInstance('ZendTest\Di\TestAsset\CircularClasses\D');
     }
-    
+
     /**
      * Fix for PHP bug in is_subclass_of
-     * 
+     *
      * @see https://bugs.php.net/bug.php?id=53727
      */
     public function testNewInstanceWillUsePreferredClassForInterfaceHints()
@@ -412,7 +412,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
             'ZendTest\Di\TestAsset\PreferredImplClasses\A',
             'ZendTest\Di\TestAsset\PreferredImplClasses\BofA'
         );
-        
+
         $c = $di->get('ZendTest\Di\TestAsset\PreferredImplClasses\C');
         $a = $c->a;
         $this->assertInstanceOf('ZendTest\Di\TestAsset\PreferredImplClasses\BofA', $a);
@@ -590,7 +590,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\C', $c);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\A', $c->a);
     }
-    
+
     /**
      * @group SharedInstance
      */
@@ -609,5 +609,26 @@ class DiTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotSame($movie->lister, $venue->lister);
         $this->assertSame($movie->lister->sharedLister, $venue->lister->sharedLister);
+    }
+
+    /**
+     * @group SetterInjection
+     * @group SupertypeResolution
+     */
+    public function testSetterInjectionWillNotDuplicateInjectionsForSupertypeDefinition()
+    {
+        $di = new Di();
+        $di->configure(new Configuration(array(
+            'instance' => array(
+                'ZendTest\Di\TestAsset\SetterInjection\DuplicateInjection' => array(
+                    'parameters' => array(
+                        'a' => 'ZendTest\Di\TestAsset\SetterInjection\A',
+                    ),
+                ),
+            ),
+        )));
+
+        $c = $di->get('ZendTest\Di\TestAsset\SetterInjection\DuplicateInjection');
+        $this->assertSame(1, $c->getInjectionsCount());
     }
 }

--- a/tests/Zend/Di/TestAsset/SetterInjection/DuplicateInjection.php
+++ b/tests/Zend/Di/TestAsset/SetterInjection/DuplicateInjection.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ZendTest\Di\TestAsset\SetterInjection;
+
+/**
+ * Test mock used to verify that injections are not duplicated because of class hierarchies
+ */
+class DuplicateInjection extends DuplicateInjectionParent
+{
+    /**
+     * @param \ZendTest\Di\TestAsset\SetterInjection\A $a
+     * @return void
+     */
+    public function setA(A $a) {
+        parent::setA($a);
+    }
+}

--- a/tests/Zend/Di/TestAsset/SetterInjection/DuplicateInjectionParent.php
+++ b/tests/Zend/Di/TestAsset/SetterInjection/DuplicateInjectionParent.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ZendTest\Di\TestAsset\SetterInjection;
+
+/**
+ * Test mock used to verify that injections are not duplicated because of class hierarchies
+ */
+class DuplicateInjectionParent
+{
+    /**
+     * @var int
+     */
+    protected $injectionsCount = 0;
+
+    /**
+     * @param A $a
+     */
+    public function setA(A $a) {
+        $this->injectionsCount += 1;
+    }
+
+    /**
+     * @return int
+     */
+    public function getInjectionsCount()
+    {
+        return $this->injectionsCount;
+    }
+}


### PR DESCRIPTION
This added failing test demonstrates how injections are duplicated when a setter is available both in a retrieved instance and its superclass.

I'm opening the PR to request some suggested fixes. The affected code looks like the the two loops at https://github.com/zendframework/zf2/blob/717082faaffa81bf83857731f9747570b3a39682/library/Zend/Di/Di.php#L210-221
Ideas about how this could be handled? I was thinking about making a subtraction of calls to supertype methods when the supertype method corresponds to the child class method and the parameters are also the same. Something like `when method has already been called with the same parameters, then continue`.

The test is broken without 0c7aa07 . With it applied, it passes.
