### PR TITLE
Hotfix/di parent duplicate injections and parameters resolution order

### DIFF
--- a/library/Zend/Di/DefinitionList.php
+++ b/library/Zend/Di/DefinitionList.php
@@ -16,7 +16,7 @@ class DefinitionList extends SplDoublyLinkedList implements Definition\Definitio
             $this->push($definition);
         }
     }
-    
+
     public function addDefinition(Definition\Definition $definition, $addToBackOfList = true)
     {
         if ($addToBackOfList) {
@@ -81,7 +81,7 @@ class DefinitionList extends SplDoublyLinkedList implements Definition\Definitio
         }
         return $classes;
     }
-    
+
     public function hasClass($class)
     {
         /** @var $definition Definition\Definition */
@@ -92,7 +92,8 @@ class DefinitionList extends SplDoublyLinkedList implements Definition\Definitio
         }
         return false;
     }
-    
+
+    // @todo sorting of supertypes should be guaranteed
     public function getClassSupertypes($class)
     {
         $supertypes = array();
@@ -103,7 +104,7 @@ class DefinitionList extends SplDoublyLinkedList implements Definition\Definitio
         // @todo remove duplicates?
         return $supertypes;
     }
-    
+
     public function getInstantiator($class)
     {
         /** @var $definition Definition\Definition */
@@ -119,7 +120,7 @@ class DefinitionList extends SplDoublyLinkedList implements Definition\Definitio
         }
         return false;
     }
-    
+
     public function hasMethods($class)
     {
         /** @var $definition Definition\Definition */
@@ -134,7 +135,7 @@ class DefinitionList extends SplDoublyLinkedList implements Definition\Definitio
         }
         return false;
     }
-    
+
     public function hasMethod($class, $method)
     {
         /** @var $definition Definition\Definition */
@@ -149,7 +150,7 @@ class DefinitionList extends SplDoublyLinkedList implements Definition\Definitio
         }
         return false;
     }
-    
+
     public function getMethods($class)
     {
         /** @var $definition Definition\Definition */
@@ -182,5 +183,5 @@ class DefinitionList extends SplDoublyLinkedList implements Definition\Definitio
         }
         return array();
     }
-    
+
 }

--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -207,16 +207,18 @@ class Di implements DependencyInjection
         }
 
         if ($injectionMethods || $supertypeInjectionMethods) {
-            foreach ($injectionMethods as $injectionMethod => $methodIsRequired) {
-                if ($injectionMethod !== '__construct') {
-                    $this->handleInjectionMethodForInstance($instance, $injectionMethod, $params, $alias, $methodIsRequired);
-                }
-            }
-            foreach ($supertypeInjectionMethods as $supertype => $supertypeInjectionMethod) {
+            // supertype injections should be handled before as overrides may happen later
+            // @todo verify the effective order of supertypes. This array_reverse should be removed and order guaranteed
+            foreach (array_reverse($supertypeInjectionMethods) as $supertype => $supertypeInjectionMethod) {
                 foreach ($supertypeInjectionMethod as $injectionMethod => $methodIsRequired) {
                     if ($injectionMethod !== '__construct') {
                         $this->handleInjectionMethodForInstance($instance, $injectionMethod, $params, $alias, $methodIsRequired, $supertype);
                     }
+                }
+            }
+            foreach ($injectionMethods as $injectionMethod => $methodIsRequired) {
+                if ($injectionMethod !== '__construct'){
+                    $this->handleInjectionMethodForInstance($instance, $injectionMethod, $params, $alias, $methodIsRequired);
                 }
             }
 

--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -209,16 +209,50 @@ class Di implements DependencyInjection
         if ($injectionMethods || $supertypeInjectionMethods) {
             // supertype injections should be handled before as overrides may happen later
             // @todo verify the effective order of supertypes. This array_reverse should be removed and order guaranteed
+            $handledInjections = array();
+
             foreach (array_reverse($supertypeInjectionMethods) as $supertype => $supertypeInjectionMethod) {
                 foreach ($supertypeInjectionMethod as $injectionMethod => $methodIsRequired) {
                     if ($injectionMethod !== '__construct') {
-                        $this->handleInjectionMethodForInstance($instance, $injectionMethod, $params, $alias, $methodIsRequired, $supertype);
+                        $injectionResult = $this->handleInjectionMethodForInstance(
+                            $instance,
+                            $injectionMethod,
+                            $params,
+                            $alias,
+                            $methodIsRequired,
+                            $supertype,
+                            $handledInjections
+                        );
+
+                        if ($injectionResult) {
+                            if (!isset($handledInjections[$injectionMethod])) {
+                                $handledInjections[$injectionMethod] = array();
+                            }
+
+                            $handledInjections[$injectionMethod][] = $injectionResult;
+                        }
                     }
                 }
             }
             foreach ($injectionMethods as $injectionMethod => $methodIsRequired) {
-                if ($injectionMethod !== '__construct'){
-                    $this->handleInjectionMethodForInstance($instance, $injectionMethod, $params, $alias, $methodIsRequired);
+                if ($injectionMethod !== '__construct') {
+                    $injectionResult = $this->handleInjectionMethodForInstance(
+                        $instance,
+                        $injectionMethod,
+                        $params,
+                        $alias,
+                        $methodIsRequired,
+                        $class,
+                        $handledInjections
+                    );
+
+                    if ($injectionResult) {
+                        if (!isset($handledInjections[$injectionMethod])) {
+                            $handledInjections[$injectionMethod] = array();
+                        }
+
+                        $handledInjections[$injectionMethod][] = $injectionResult;
+                    }
                 }
             }
 
@@ -381,17 +415,33 @@ class Di implements DependencyInjection
      * @param string $method
      * @param array $params
      * @param string $alias
+     * @return array|null the generated parameters or null if no method will be called
      */
-    protected function handleInjectionMethodForInstance($instance, $method, $params, $alias, $methodIsRequired, $methodClass = null)
+    protected function handleInjectionMethodForInstance($instance, $method, $params, $alias, $methodIsRequired, $methodClass = null, $handledInjections = array())
     {
         $methodClass = ($methodClass) ?: get_class($instance);
         // @todo make sure to resolve the supertypes for both the object & definition
         $callParameters = $this->resolveMethodParameters($methodClass, $method, $params, false, $alias, $methodIsRequired);
+
         if ($callParameters == false) {
             return;
         }
+
+        if (isset($handledInjections[$method])) {
+            foreach ($handledInjections[$method] as $handledCallParameters) {
+                foreach ($handledCallParameters as $key => $handledCallParameter) {
+                    if ($callParameters[$key] !== $handledCallParameter) {
+                        continue;
+                    }
+
+                    return; // if a call with the same parameters is found, return without invoking the method
+                }
+            }
+        }
+
         if ($callParameters !== array_fill(0, count($callParameters), null)) {
             call_user_func_array(array($instance, $method), $callParameters);
+            return $callParameters;
         }
     }
 

--- a/tests/Zend/Di/DiTest.php
+++ b/tests/Zend/Di/DiTest.php
@@ -634,4 +634,25 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertNotSame($movie->lister, $venue->lister);
         $this->assertSame($movie->lister->sharedLister, $venue->lister->sharedLister);
     }
+
+    /**
+     * @group SetterInjection
+     * @group SupertypeResolution
+     */
+    public function testSetterInjectionWillNotDuplicateInjectionsForSupertypeDefinition()
+    {
+        $di = new Di();
+        $di->configure(new Configuration(array(
+            'instance' => array(
+                'ZendTest\Di\TestAsset\SetterInjection\DuplicateInjection' => array(
+                    'parameters' => array(
+                        'a' => 'ZendTest\Di\TestAsset\SetterInjection\A',
+                    ),
+                ),
+            ),
+        )));
+
+        $c = $di->get('ZendTest\Di\TestAsset\SetterInjection\DuplicateInjection');
+        $this->assertSame(1, $c->getInjectionsCount());
+    }
 }

--- a/tests/Zend/Di/DiTest.php
+++ b/tests/Zend/Di/DiTest.php
@@ -642,17 +642,60 @@ class DiTest extends \PHPUnit_Framework_TestCase
     public function testSetterInjectionWillNotDuplicateInjectionsForSupertypeDefinition()
     {
         $di = new Di();
-        $di->configure(new Configuration(array(
-            'instance' => array(
-                'ZendTest\Di\TestAsset\SetterInjection\DuplicateInjection' => array(
-                    'parameters' => array(
-                        'a' => 'ZendTest\Di\TestAsset\SetterInjection\A',
-                    ),
-                ),
-            ),
-        )));
 
-        $c = $di->get('ZendTest\Di\TestAsset\SetterInjection\DuplicateInjection');
+        $di->instanceManager()->setParameters(
+            'ZendTest\Di\TestAsset\SetterInjection\DuplicateInjection',
+            array('a' => 'hi!')
+        );
+        $c = $di->newInstance('ZendTest\Di\TestAsset\SetterInjection\DuplicateInjection');
         $this->assertSame(1, $c->getInjectionsCount());
+
+        // When the parameters are different, injections should be called first for the parent, then for the child
+        $di->instanceManager()->setParameters(
+            'ZendTest\Di\TestAsset\SetterInjection\DuplicateInjectionParent',
+            array('a' => 'hello!')
+        );
+        $c = $di->newInstance('ZendTest\Di\TestAsset\SetterInjection\DuplicateInjection');
+        $this->assertSame(2, $c->getInjectionsCount());
+    }
+
+    /**
+     * @group SetterInjection
+     * @group SupertypeResolution
+     */
+    public function testSetterInjectionWillNotDuplicateInjectionsForSupertypeDefinitionWithSameParameters()
+    {
+        $di = new Di();
+
+        $di->instanceManager()->setParameters(
+            'ZendTest\Di\TestAsset\SetterInjection\DuplicateInjection',
+            array('a' => 'hi!')
+        );
+        $di->instanceManager()->setParameters(
+            'ZendTest\Di\TestAsset\SetterInjection\DuplicateInjectionParent',
+            array('a' => 'hi!')
+        );
+        $c = $di->newInstance('ZendTest\Di\TestAsset\SetterInjection\DuplicateInjection');
+        $this->assertSame(1, $c->getInjectionsCount());
+    }
+
+    /**
+     * @group SetterInjection
+     * @group SupertypeResolution
+     */
+    public function testSetterInjectionWillFirstCallParentSettersThenChildSettersWhenDifferentParametersAreDefined()
+    {
+        $di = new Di();
+
+        $di->instanceManager()->setParameters(
+            'ZendTest\Di\TestAsset\SetterInjection\DuplicateInjection',
+            array('a' => 'hi!')
+        );
+        $di->instanceManager()->setParameters(
+            'ZendTest\Di\TestAsset\SetterInjection\DuplicateInjectionParent',
+            array('a' => 'hello!')
+        );
+        $c = $di->newInstance('ZendTest\Di\TestAsset\SetterInjection\DuplicateInjection');
+        $this->assertSame(array('hello!', 'hi!'), $c->injections);
     }
 }

--- a/tests/Zend/Di/DiTest.php
+++ b/tests/Zend/Di/DiTest.php
@@ -43,18 +43,18 @@ class DiTest extends \PHPUnit_Framework_TestCase
     public function testPassingInvalidDefinitionRaisesException()
     {
         $di = new Di();
-        
+
         $this->setExpectedException('PHPUnit_Framework_Error');
         $di->setDefinitionList(array('foo'));
     }
-    
+
     public function testGetRetrievesObjectWithMatchingClassDefinition()
     {
         $di = new Di();
         $obj = $di->get('ZendTest\Di\TestAsset\BasicClass');
         $this->assertInstanceOf('ZendTest\Di\TestAsset\BasicClass', $obj);
     }
-    
+
     public function testGetRetrievesSameInstanceOnSubsequentCalls()
     {
         $di = new Di();
@@ -64,23 +64,23 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\BasicClass', $obj2);
         $this->assertSame($obj1, $obj2);
     }
-    
+
     public function testGetThrowsExceptionWhenUnknownClassIsUsed()
     {
         $di = new Di();
-        
+
         $this->setExpectedException('Zend\Di\Exception\ClassNotFoundException', 'could not be located in');
         $obj1 = $di->get('ZendTest\Di\TestAsset\NonExistentClass');
     }
-    
+
     public function testGetThrowsExceptionWhenMissingParametersAreEncountered()
     {
         $di = new Di();
-        
+
         $this->setExpectedException('Zend\Di\Exception\MissingPropertyException', 'Missing instance/object for ');
         $obj1 = $di->get('ZendTest\Di\TestAsset\BasicClassWithParam');
     }
-    
+
     public function testNewInstanceReturnsDifferentInstances()
     {
         $di = new Di();
@@ -90,7 +90,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\BasicClass', $obj2);
         $this->assertNotSame($obj1, $obj2);
     }
-    
+
     public function testNewInstanceReturnsInstanceThatIsSharedWithGet()
     {
         $di = new Di();
@@ -100,7 +100,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\BasicClass', $obj2);
         $this->assertSame($obj1, $obj2);
     }
-    
+
     public function testNewInstanceReturnsInstanceThatIsNotSharedWithGet()
     {
         $di = new Di();
@@ -204,7 +204,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\B', $b);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\A', $b->a);
     }
-    
+
     /**
      * @group ConstructorInjection
      */
@@ -214,15 +214,15 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $b = $di->get('ZendTest\Di\TestAsset\ConstructorInjection\B');
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\B', $b);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\A', $b->a);
-        
+
         $b2 = $di->get('ZendTest\Di\TestAsset\ConstructorInjection\B');
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\B', $b2);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\A', $b2->a);
-        
+
         $this->assertSame($b, $b2);
         $this->assertSame($b->a, $b2->a);
     }
-    
+
     /**
      * @group ConstructorInjection
      */
@@ -233,48 +233,48 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\B', $b);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\A', $b->a);
     }
-    
+
     /**
      * @group ConstructorInjection
      */
     public function testNewInstanceWillResolveConstructorInjectionDependenciesWithProperties()
     {
         $di = new Di();
-        
+
         $im = $di->instanceManager();
         $im->setParameters('ZendTest\Di\TestAsset\ConstructorInjection\X', array('one' => 1, 'two' => 2));
-        
+
         $y = $di->newInstance('ZendTest\Di\TestAsset\ConstructorInjection\Y');
         $this->assertEquals(1, $y->x->one);
         $this->assertEquals(2, $y->x->two);
     }
-    
+
     /**
      * @group ConstructorInjection
      */
     public function testNewInstanceWillThrowExceptionOnConstructorInjectionDependencyWithMissingParameter()
     {
         $di = new Di();
-        
+
         $this->setExpectedException('Zend\Di\Exception\MissingPropertyException', 'Missing instance/object for parameter');
         $b = $di->newInstance('ZendTest\Di\TestAsset\ConstructorInjection\X');
     }
-    
+
     /**
      * @group ConstructorInjection
      */
     public function testNewInstanceWillResolveConstructorInjectionDependenciesWithMoreThan2Dependencies()
     {
         $di = new Di();
-        
+
         $im = $di->instanceManager();
         $im->setParameters('ZendTest\Di\TestAsset\ConstructorInjection\X', array('one' => 1, 'two' => 2));
-        
+
         $z = $di->newInstance('ZendTest\Di\TestAsset\ConstructorInjection\Z');
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\Y', $z->y);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\ConstructorInjection\X', $z->y->x);
     }
-    
+
     /**
      * @group SetterInjection
      */
@@ -290,7 +290,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\B', $b);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\A', $b->a);
     }
-    
+
     /**
      * @group SetterInjection
      */
@@ -306,16 +306,16 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $b = $di->get('ZendTest\Di\TestAsset\SetterInjection\B');
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\B', $b);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\A', $b->a);
-        
+
         $b2 = $di->get('ZendTest\Di\TestAsset\SetterInjection\B');
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\B', $b2);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\A', $b2->a);
-        
+
         $this->assertSame($b, $b2);
         $this->assertSame($b->a, $a);
         $this->assertSame($b2->a, $a);
     }
-    
+
     /**
      * @group SetterInjection
      */
@@ -332,7 +332,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\B', $b);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\A', $b->a);
     }
-    
+
     /**
      * @todo Setter Injections is not automatic, find a way to test this logically
      *
@@ -341,7 +341,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
     public function testNewInstanceWillResolveSetterInjectionDependenciesWithProperties()
     {
         $di = new Di();
-        
+
         $im = $di->instanceManager();
         $im->setParameters('ZendTest\Di\TestAsset\SetterInjection\X', array('one' => 1, 'two' => 2));
 
@@ -351,10 +351,10 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $y->x->one);
         $this->assertEquals(2, $y->x->two);
     }
-    
+
     /**
      * Test for Circular Dependencies (case 1)
-     * 
+     *
      * A->B, B->A
      * @group CircularDependencyCheck
      */
@@ -365,10 +365,10 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Di\Exception\CircularDependencyException');
         $di->newInstance('ZendTest\Di\TestAsset\CircularClasses\A');
     }
-    
+
     /**
      * Test for Circular Dependencies (case 2)
-     * 
+     *
      * C->D, D->E, E->C
      * @group CircularDependencyCheck
      */
@@ -382,10 +382,10 @@ class DiTest extends \PHPUnit_Framework_TestCase
         );
         $di->newInstance('ZendTest\Di\TestAsset\CircularClasses\C');
     }
-    
+
     /**
      * Test for Circular Dependencies (case 2)
-     * 
+     *
      * C->D, D->E, E->C
      * @group CircularDependencyCheck
      */
@@ -399,10 +399,10 @@ class DiTest extends \PHPUnit_Framework_TestCase
         );
         $di->newInstance('ZendTest\Di\TestAsset\CircularClasses\D');
     }
-    
+
     /**
      * Fix for PHP bug in is_subclass_of
-     * 
+     *
      * @see https://bugs.php.net/bug.php?id=53727
      */
     public function testNewInstanceWillUsePreferredClassForInterfaceHints()
@@ -412,7 +412,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
             'ZendTest\Di\TestAsset\PreferredImplClasses\A',
             'ZendTest\Di\TestAsset\PreferredImplClasses\BofA'
         );
-        
+
         $c = $di->get('ZendTest\Di\TestAsset\PreferredImplClasses\C');
         $a = $c->a;
         $this->assertInstanceOf('ZendTest\Di\TestAsset\PreferredImplClasses\BofA', $a);
@@ -614,7 +614,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $c = $di->get('ZendTest\Di\TestAsset\InheritanceClasses\C');
         $this->assertEquals('b', $c->test);
     }
-    
+
     /**
      * @group SharedInstance
      */

--- a/tests/Zend/Di/DiTest.php
+++ b/tests/Zend/Di/DiTest.php
@@ -590,6 +590,26 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\C', $c);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\SetterInjection\A', $c->a);
     }
+
+    /**
+     * @group SetterInjection
+     * @group SupertypeResolution
+     */
+    public function testInjectionForSetterInjectionWillNotUseSupertypeWhenChildParamIsExplicitlyDefined()
+    {
+        $di = new Di();
+        // for setter injection, the dependency is not required, thus it must be forced
+        $di->instanceManager()->setParameters(
+            'ZendTest\Di\TestAsset\InheritanceClasses\A',
+            array('test' => 'a')
+        );
+        $di->instanceManager()->setParameters(
+            'ZendTest\Di\TestAsset\InheritanceClasses\B',
+            array('test' => 'b')
+        );
+        $b = $di->get('ZendTest\Di\TestAsset\InheritanceClasses\B');
+        $this->assertEquals('b', $b->test);
+    }
     
     /**
      * @group SharedInstance

--- a/tests/Zend/Di/DiTest.php
+++ b/tests/Zend/Di/DiTest.php
@@ -600,15 +600,19 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $di = new Di();
         // for setter injection, the dependency is not required, thus it must be forced
         $di->instanceManager()->setParameters(
-            'ZendTest\Di\TestAsset\InheritanceClasses\A',
-            array('test' => 'a')
-        );
-        $di->instanceManager()->setParameters(
             'ZendTest\Di\TestAsset\InheritanceClasses\B',
             array('test' => 'b')
         );
+        $di->instanceManager()->setParameters(
+            'ZendTest\Di\TestAsset\InheritanceClasses\A',
+            array('test' => 'a')
+        );
+
         $b = $di->get('ZendTest\Di\TestAsset\InheritanceClasses\B');
         $this->assertEquals('b', $b->test);
+
+        $c = $di->get('ZendTest\Di\TestAsset\InheritanceClasses\C');
+        $this->assertEquals('b', $c->test);
     }
     
     /**

--- a/tests/Zend/Di/TestAsset/InheritanceClasses/A.php
+++ b/tests/Zend/Di/TestAsset/InheritanceClasses/A.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ZendTest\Di\TestAsset\InheritanceClasses;
+
+class A
+{
+    public $test;
+ 
+    public function setTest($test)
+    {
+        $this->test = $test;
+        return $this;
+    }
+}

--- a/tests/Zend/Di/TestAsset/InheritanceClasses/A.php
+++ b/tests/Zend/Di/TestAsset/InheritanceClasses/A.php
@@ -5,10 +5,9 @@ namespace ZendTest\Di\TestAsset\InheritanceClasses;
 class A
 {
     public $test;
- 
+
     public function setTest($test)
     {
         $this->test = $test;
-        return $this;
     }
 }

--- a/tests/Zend/Di/TestAsset/InheritanceClasses/B.php
+++ b/tests/Zend/Di/TestAsset/InheritanceClasses/B.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ZendTest\Di\TestAsset\InheritanceClasses;
+
+class B extends A
+{
+}

--- a/tests/Zend/Di/TestAsset/InheritanceClasses/C.php
+++ b/tests/Zend/Di/TestAsset/InheritanceClasses/C.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ZendTest\Di\TestAsset\InheritanceClasses;
+
+class C extends B
+{
+}

--- a/tests/Zend/Di/TestAsset/SetterInjection/DuplicateInjection.php
+++ b/tests/Zend/Di/TestAsset/SetterInjection/DuplicateInjection.php
@@ -8,10 +8,10 @@ namespace ZendTest\Di\TestAsset\SetterInjection;
 class DuplicateInjection extends DuplicateInjectionParent
 {
     /**
-     * @param \ZendTest\Di\TestAsset\SetterInjection\A $a
+     * @param string $a
      * @return void
      */
-    public function setA(A $a) {
+    public function setA($a) {
         parent::setA($a);
     }
 }

--- a/tests/Zend/Di/TestAsset/SetterInjection/DuplicateInjection.php
+++ b/tests/Zend/Di/TestAsset/SetterInjection/DuplicateInjection.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ZendTest\Di\TestAsset\SetterInjection;
+
+/**
+ * Test mock used to verify that injections are not duplicated because of class hierarchies
+ */
+class DuplicateInjection extends DuplicateInjectionParent
+{
+    /**
+     * @param \ZendTest\Di\TestAsset\SetterInjection\A $a
+     * @return void
+     */
+    public function setA(A $a) {
+        parent::setA($a);
+    }
+}

--- a/tests/Zend/Di/TestAsset/SetterInjection/DuplicateInjectionParent.php
+++ b/tests/Zend/Di/TestAsset/SetterInjection/DuplicateInjectionParent.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ZendTest\Di\TestAsset\SetterInjection;
+
+/**
+ * Test mock used to verify that injections are not duplicated because of class hierarchies
+ */
+class DuplicateInjectionParent
+{
+    /**
+     * @var int
+     */
+    protected $injectionsCount = 0;
+
+    /**
+     * @param A $a
+     */
+    public function setA(A $a) {
+        $this->injectionsCount += 1;
+    }
+
+    /**
+     * @return int
+     */
+    public function getInjectionsCount()
+    {
+        return $this->injectionsCount;
+    }
+}

--- a/tests/Zend/Di/TestAsset/SetterInjection/DuplicateInjectionParent.php
+++ b/tests/Zend/Di/TestAsset/SetterInjection/DuplicateInjectionParent.php
@@ -8,15 +8,16 @@ namespace ZendTest\Di\TestAsset\SetterInjection;
 class DuplicateInjectionParent
 {
     /**
-     * @var int
+     * @var array
      */
-    protected $injectionsCount = 0;
+    public $injections = array();
 
     /**
-     * @param A $a
+     * @param string $a
+     * @return void
      */
-    public function setA(A $a) {
-        $this->injectionsCount += 1;
+    public function setA($a) {
+        $this->injections[] = $a;
     }
 
     /**
@@ -24,6 +25,6 @@ class DuplicateInjectionParent
      */
     public function getInjectionsCount()
     {
-        return $this->injectionsCount;
+        return count($this->injections);
     }
 }


### PR DESCRIPTION
This added failing tests demonstrate how injections are duplicated when a setter is available both in a retrieved instance and its superclass and how injections are computed in the wrong order.

This PR supersedes #1115. 

All tests currently pass.

Please read notes I've put on code below.
