### PR TITLE
Set identifiers of the EventManager even if the EventManager is injected...

### DIFF
--- a/library/Zend/View/View.php
+++ b/library/Zend/View/View.php
@@ -102,6 +102,10 @@ class View implements EventManagerAware
      */
     public function setEventManager(EventCollection $events)
     {
+        $events->setIdentifiers(array(
+            __CLASS__,
+            get_called_class(),
+        ));
         $this->events = $events;
         return $this;
     }
@@ -116,10 +120,7 @@ class View implements EventManagerAware
     public function events()
     {
         if (!$this->events instanceof EventCollection) {
-            $this->setEventManager(new EventManager(array(
-                __CLASS__,
-                get_called_class(),
-            )));
+            $this->setEventManager(new EventManager());
         }
         return $this->events;
     }


### PR DESCRIPTION
Else the EventManager will not trigger events registered in the SharedEventManager as the eventmanager doesn't have any identifiers registered.
