### PR TITLE
Navigation: consider route params when checking if page is active.

### DIFF
--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -125,8 +125,25 @@ class Mvc extends AbstractPage
                 if (null !== $this->getRoute()
                     && $this->routeMatch->getMatchedRouteName() === $this->getRoute()
                 ) {
-                    $this->active = true;
-                    return true;
+
+                    if(empty($this->params)) {
+                        $this->active = true;
+                        return true;
+                    }
+
+                    $paramsMatch = false;
+                    foreach($this->params as $param => $value) {
+                        if($reqParams[$param] == $value){
+                            $paramsMatch = true;
+                        } else {
+                            $paramsMatch = false;
+                        }
+                    }
+
+                    if($paramsMatch) {
+                        $this->active = true;
+                        return true;
+                    }
                 }
             }
 


### PR DESCRIPTION
Currently to determine if page is active we only check for route name  to  match. That does not allow to have multiple menu items point to the same route but with different parameters. All of those items will be active, wich is not correct.

When calculating if a page is active and route params are defined for the page, they must be considered to determine if a page is active.
