### PR TITLE
[ZF2-113] Fixes issue with filters with undefined constructors

### DIFF
--- a/library/Zend/Filter/FilterChain.php
+++ b/library/Zend/Filter/FilterChain.php
@@ -177,6 +177,8 @@ class FilterChain extends AbstractFilter
     {
         if (!is_array($options)) {
             $options = (array) $options;
+        } elseif (empty($options)) {
+            $options = null;
         } else {
             if (range(0, count($options) - 1) != array_keys($options)) {
                 $options = array($options);

--- a/tests/Zend/Filter/FilterChainTest.php
+++ b/tests/Zend/Filter/FilterChainTest.php
@@ -111,6 +111,17 @@ class FilterChainTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($valueExpected, $chain->filter($value));
     }
 
+    public function testCanRetrieveFilterWithUndefinedConstructor()
+    {
+        $chain = new FilterChain(array(
+            'filters' => array(
+                array('name' => 'int'),
+            ),
+        ));
+        $filtered = $chain->filter('127.1');
+        $this->assertEquals(127, $filtered);
+    }
+
     protected function getChainConfig()
     {
         return array(


### PR DESCRIPTION
- Test for empty array in attachByName(), and set $options to null if
  detected
