### PR TITLE
Check for empty tags in Zend\Service\AgileZen\Resources\Story

### DIFF
--- a/library/Zend/Service/AgileZen/Resources/Story.php
+++ b/library/Zend/Service/AgileZen/Resources/Story.php
@@ -161,7 +161,7 @@ class Story extends Entity
         if (isset($data['owner']) && !empty($data['owner'])) {
             $this->owner = new User($service, $data['owner']);
         }
-        if (isset($data['tags']) && is_array($data['tags'])) {
+        if (isset($data['tags']) && is_array($data['tags']) && !empty($data['tags'])) {
             $this->tags = new Container($service, $data['tags'], 'tag', $this->projectId);
         }
 


### PR DESCRIPTION
There was a missing check when the array of tags is empty.
