### PR TITLE
[Soap] Fix documentation

### DIFF
--- a/documentation/manual/en/module_specs/Zend_Soap_AutoDiscovery.xml
+++ b/documentation/manual/en/module_specs/Zend_Soap_AutoDiscovery.xml
@@ -92,8 +92,8 @@
 
         <para>
             Here is an example of common usage of the autodiscovery functionality. The
-            <methodname>handle()</methodname> function generates the WSDL file and posts it to the
-            browser.
+            <methodname>generate()</methodname> function generates the WSDL object and in conjunction
+            with <methodname>toXml()</methodname> function you can posts it to the browser.
         </para>
 
         <programlisting language="php"><![CDATA[


### PR DESCRIPTION
handle() function is not longer used and the example below has changed.
