### PR TITLE
[ZF-12186] Zend\Text\MultiByte::strPad - warning when input length > pad length

### DIFF
--- a/library/Zend/Text/MultiByte.php
+++ b/library/Zend/Text/MultiByte.php
@@ -121,7 +121,7 @@ class MultiByte
         $lengthOfPadding = $padLength - iconv_strlen($input, $charset);
         $padStringLength = iconv_strlen($padString, $charset);
 
-        if ($padStringLength === 0 || $lengthOfPadding === 0) {
+        if ($padStringLength === 0 || $lengthOfPadding <= 0) {
             $return = $input;
         } else {
             $repeatCount = floor($lengthOfPadding / $padStringLength);

--- a/tests/Zend/Text/MultiByteTest.php
+++ b/tests/Zend/Text/MultiByteTest.php
@@ -250,4 +250,31 @@ class MultiByteTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Text\Exception\InvalidArgumentException', "Cannot force cut when width is zero");
         Text\MultiByte::wordWrap('a', 0, "\n", true);
     }
+
+    /**
+     * @group ZF-12186
+     */
+    public function testPadInputLongerThanPadLength()
+    {
+        $text = Text\MultiByte::strPad('äääöö', 2, 'ö');
+        $this->assertEquals('äääöö', $text);
+    }
+
+    /**
+     * @group ZF-12186
+     */
+    public function testPadInputSameAsPadLength()
+    {
+        $text = Text\MultiByte::strPad('äääöö', 5, 'ö');
+        $this->assertEquals('äääöö', $text);
+    }
+
+    /**
+     * @group ZF-12186
+     */
+    public function testPadNegativePadLength()
+    {
+        $text = Text\MultiByte::strPad('äääöö', -2, 'ö');
+        $this->assertEquals('äääöö', $text);
+    }
 }


### PR DESCRIPTION
SVN sync r24762
