### PR TITLE
[Json] Fix unit tests for PHP 5.3 and PHP 5.4

### DIFF
--- a/library/Zend/Json/Server/Server.php
+++ b/library/Zend/Json/Server/Server.php
@@ -49,9 +49,11 @@ class Server extends AbstractServer
     protected $returnResponse = false;
 
     /**
+     * Inherited from Zend\Server\AbstractServer
+     *
      * @var bool Flag; allow overwriting existing methods when creating server definition
      */
-    protected $_overwriteExistingMethods = true;
+    protected $overwriteExistingMethods = true;
 
     /**
      * Request object

--- a/tests/Zend/Json/Server/ResponseTest.php
+++ b/tests/Zend/Json/Server/ResponseTest.php
@@ -99,7 +99,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     {
         $this->response->setVersion('2.0');
         $this->assertEquals('2.0', $this->response->getVersion());
-        foreach (array('a', 1, '1.0', array(), true) as $version) {
+        foreach (array('a', 1, '1.0', true) as $version) {
             $this->response->setVersion($version);
             $this->assertNull($this->response->getVersion());
         }


### PR DESCRIPTION
here were 2 errors:

``` bash
1) ZendTest\Json\Server\ResponseTest::testVersionShouldBeLimitedToV2
Array to string conversion

/home/vagrant/builds/Maks3w/zf2/library/Zend/Json/Server/Response.php:188
/home/vagrant/builds/Maks3w/zf2/tests/Zend/Json/Server/ResponseTest.php:103
/home/vagrant/.phpenv/versions/5.4.0/bin/phpunit:46

2) ZendTest\Json\ServerTest::testNamingCollisionsShouldResolveToLastRegisteredMethod
Zend\Server\Exception\RuntimeException: Duplicate method registered: setOptions

/home/vagrant/builds/Maks3w/zf2/library/Zend/Server/AbstractServer.php:140
/home/vagrant/builds/Maks3w/zf2/library/Zend/Json/Server/Server.php:147
/home/vagrant/builds/Maks3w/zf2/tests/Zend/Json/ServerTest.php:137
/home/vagrant/.phpenv/versions/5.4.0/bin/phpunit:46
```

The first was fixed adapting the test for not use array data types.

The second was fixed adapting the code to the new attribute name from the parent class
