### PR TITLE
[Feed_Writer][BC Break] Remove code declared as @deprecated

### DIFF
--- a/library/Zend/Feed/Writer/AbstractFeed.php
+++ b/library/Zend/Feed/Writer/AbstractFeed.php
@@ -63,9 +63,9 @@ class AbstractFeed
      * Set a single author
      *
      * The following option keys are supported:
-     * 'name'  => The name
-     * 'email' => An optional email
-     * 'uri'   => An optional uri
+     * 'name'  => (string) The name
+     * 'email' => (string) An optional email
+     * 'uri'   => (string) An optional and valid URI
      *
      * @param array $author
      * @throws Exception\InvalidArgumentException If any value of $author not follow the format.

--- a/library/Zend/Feed/Writer/AbstractFeed.php
+++ b/library/Zend/Feed/Writer/AbstractFeed.php
@@ -62,54 +62,50 @@ class AbstractFeed
     /**
      * Set a single author
      *
-     * @param  int $index
-     * @return string|null
+     * The following option keys are supported:
+     * 'name'  => The name
+     * 'email' => An optional email
+     * 'uri'   => An optional uri
+     *
+     * @param array $author
+     * @throws Exception\InvalidArgumentException If any value of $author not follow the format.
+     * @return void
      */
-    public function addAuthor($name, $email = null, $uri = null)
+    public function addAuthor(array $author)
     {
-        $author = array();
-        if (is_array($name)) {
-            if (!array_key_exists('name', $name) || empty($name['name']) || !is_string($name['name'])) {
-                throw new Exception('Invalid parameter: author array must include a "name" key with a non-empty string value');
-            }
-            $author['name'] = $name['name'];
-            if (isset($name['email'])) {
-                if (empty($name['email']) || !is_string($name['email'])) {
-                    throw new Exception('Invalid parameter: "email" array value must be a non-empty string');
-                }
-                $author['email'] = $name['email'];
-            }
-            if (isset($name['uri'])) {
-                if (empty($name['uri']) || !is_string($name['uri']) || !Uri\UriFactory::factory($name['uri'])->isValid()) {
-                    throw new Exception('Invalid parameter: "uri" array value must be a non-empty string and valid URI/IRI');
-                }
-                $author['uri'] = $name['uri'];
-            }
-        } else {
-            if (empty($name['name']) || !is_string($name['name'])) {
-                throw new Exception('Invalid parameter: "name" must be a non-empty string value');
-            }
-            $author['name'] = $name;
-            if (isset($email)) {
-                if (empty($email) || !is_string($email)) {
-                    throw new Exception('Invalid parameter: "email" value must be a non-empty string');
-                }
-                $author['email'] = $email;
-            }
-            if (isset($uri)) {
-                if (empty($uri) || !is_string($uri) || !Uri\UriFactory::factory($uri)->isValid()) {
-                    throw new Exception('Invalid parameter: "uri" value must be a non-empty string and valid URI/IRI');
-                }
-                $author['uri'] = $uri;
+        // Check array values
+        if (!array_key_exists('name', $author)
+            || empty($author['name'])
+            || !is_string($author['name'])
+        ) {
+            throw new Exception\InvalidArgumentException(
+                'Invalid parameter: author array must include a "name" key with a non-empty string value');
+        }
+
+        if (isset($author['email'])) {
+            if (empty($author['email']) || !is_string($author['email'])) {
+                throw new Exception\InvalidArgumentException(
+                    'Invalid parameter: "email" array value must be a non-empty string');
             }
         }
+        if (isset($author['uri'])) {
+            if (empty($author['uri']) || !is_string($author['uri']) ||
+                !Uri\UriFactory::factory($author['uri'])->isValid()
+            ) {
+                throw new Exception\InvalidArgumentException(
+                    'Invalid parameter: "uri" array value must be a non-empty string and valid URI/IRI');
+            }
+        }
+
         $this->_data['authors'][] = $author;
     }
 
     /**
      * Set an array with feed authors
      *
-     * @return array
+     * @see addAuthor
+     * @param array $authors
+     * @return void
      */
     public function addAuthors(array $authors)
     {

--- a/library/Zend/Feed/Writer/Entry.php
+++ b/library/Zend/Feed/Writer/Entry.php
@@ -69,61 +69,50 @@ class Entry
     /**
      * Set a single author
      *
-     * @param  int $index
-     * @return string|null
+     * The following option keys are supported:
+     * 'name'  => The name
+     * 'email' => An optional email
+     * 'uri'   => An optional uri
+     *
+     * @param array $author
+     * @throws Exception\InvalidArgumentException If any value of $author not follow the format.
+     * @return void
      */
-    public function addAuthor($name, $email = null, $uri = null)
+    public function addAuthor(array $author)
     {
-        $author = array();
-        if (is_array($name)) {
-            if (!array_key_exists('name', $name)
-                || empty($name['name'])
-                || !is_string($name['name'])
-            ) {
-                throw new Exception('Invalid parameter: author array must include a "name" key with a non-empty string value');
-            }
-            $author['name'] = $name['name'];
-            if (isset($name['email'])) {
-                if (empty($name['email']) || !is_string($name['email'])) {
-                    throw new Exception('Invalid parameter: "email" array value must be a non-empty string');
-                }
-                $author['email'] = $name['email'];
-            }
-            if (isset($name['uri'])) {
-                if (empty($name['uri']) || !is_string($name['uri']) || !Uri\UriFactory::factory($name['uri'])->isValid()) {
-                    throw new Exception('Invalid parameter: "uri" array value must be a non-empty string and valid URI/IRI');
-                }
-                $author['uri'] = $name['uri'];
-            }
-        /**
-         * @deprecated
-         * Array notation (above) is preferred and will be the sole supported input from ZF 2.0
-         */
-        } else {
-            if (empty($name['name']) || !is_string($name['name'])) {
-                throw new Exception('Invalid parameter: "name" must be a non-empty string value');
-            }
-            $author['name'] = $name;
-            if (isset($email)) {
-                if (empty($email) || !is_string($email)) {
-                    throw new Exception('Invalid parameter: "email" value must be a non-empty string');
-                }
-                $author['email'] = $email;
-            }
-            if (isset($uri)) {
-                if (empty($uri) || !is_string($uri) || !Uri\UriFactory::factory($uri)->isValid()) {
-                    throw new Exception('Invalid parameter: "uri" array value must be a non-empty string and valid URI/IRI');
-                }
-                $author['uri'] = $uri;
+        // Check array values
+        if (!array_key_exists('name', $author)
+            || empty($author['name'])
+            || !is_string($author['name'])
+        ) {
+            throw new Exception\InvalidArgumentException(
+                'Invalid parameter: author array must include a "name" key with a non-empty string value');
+        }
+
+        if (isset($author['email'])) {
+            if (empty($author['email']) || !is_string($author['email'])) {
+                throw new Exception\InvalidArgumentException(
+                    'Invalid parameter: "email" array value must be a non-empty string');
             }
         }
+        if (isset($author['uri'])) {
+            if (empty($author['uri']) || !is_string($author['uri']) ||
+                !Uri\UriFactory::factory($author['uri'])->isValid()
+            ) {
+                throw new Exception\InvalidArgumentException(
+                    'Invalid parameter: "uri" array value must be a non-empty string and valid URI/IRI');
+            }
+        }
+
         $this->_data['authors'][] = $author;
     }
 
     /**
      * Set an array with feed authors
      *
-     * @return array
+     * @see addAuthor
+     * @param array $authors
+     * @return void
      */
     public function addAuthors(array $authors)
     {

--- a/library/Zend/Feed/Writer/Entry.php
+++ b/library/Zend/Feed/Writer/Entry.php
@@ -70,9 +70,9 @@ class Entry
      * Set a single author
      *
      * The following option keys are supported:
-     * 'name'  => The name
-     * 'email' => An optional email
-     * 'uri'   => An optional uri
+     * 'name'  => (string) The name
+     * 'email' => (string) An optional email
+     * 'uri'   => (string) An optional and valid URI
      *
      * @param array $author
      * @throws Exception\InvalidArgumentException If any value of $author not follow the format.

--- a/library/Zend/Feed/Writer/Exception/ExceptionInterface.php
+++ b/library/Zend/Feed/Writer/Exception/ExceptionInterface.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category  Zend
+ * @package   Zend_Feed
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Writer\Exception;
+
+/**
+ * Feed exceptions
+ *
+ * Interface to represent exceptions that occur during Feed operations.
+ *
+ * @todo This Exception is pending of exception's milestone
+ *
+ * @category  Zend
+ * @package   Zend_Feed
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+interface ExceptionInterface
+{
+}

--- a/library/Zend/Feed/Writer/Exception/InvalidArgumentException.php
+++ b/library/Zend/Feed/Writer/Exception/InvalidArgumentException.php
@@ -21,8 +21,6 @@
 
 namespace Zend\Feed\Writer\Exception;
 
-use Zend\Feed\Writer\Exception;
-
 /**
  * Feed exceptions
  *
@@ -36,5 +34,5 @@ use Zend\Feed\Writer\Exception;
  */
 class InvalidArgumentException 
     extends \InvalidArgumentException 
-    implements Exception
+    implements ExceptionInterface
 {}

--- a/library/Zend/Feed/Writer/Exception/InvalidMethodException.php
+++ b/library/Zend/Feed/Writer/Exception/InvalidMethodException.php
@@ -22,12 +22,6 @@
 namespace Zend\Feed\Writer\Exception;
 
 /**
- * @see Zend_Feed_Exception
- */
-require_once 'Zend/Feed/Exception.php';
-
-
-/**
  * Feed exceptions
  *
  * Class to represent exceptions that occur during Feed operations.
@@ -37,5 +31,5 @@ require_once 'Zend/Feed/Exception.php';
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class InvalidMethodException extends \Exception
+class InvalidMethodException extends \Exception implements ExceptionInterface
 {}

--- a/tests/Zend/Feed/Writer/EntryTest.php
+++ b/tests/Zend/Feed/Writer/EntryTest.php
@@ -20,18 +20,19 @@
  */
 
 namespace ZendTest\Feed\Writer;
+
 use Zend\Feed\Writer;
 use Zend\Date;
 
 /**
-* @category Zend
-* @package Zend_Exception
-* @subpackage UnitTests
-* @group Zend_Feed
-* @group Zend_Feed_Writer
-* @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
-* @license http://framework.zend.com/license/new-bsd New BSD License
-*/
+ * @category   Zend
+ * @package    Zend_Exception
+ * @subpackage UnitTests
+ * @group      Zend_Feed
+ * @group      Zend_Feed_Writer
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd New BSD License
+ */
 class EntryTest extends \PHPUnit_Framework_TestCase
 {
 
@@ -42,86 +43,38 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $this->_feedSamplePath = dirname(__FILE__) . '/_files';
     }
 
-    public function testAddsAuthorName()
-    {
-        $entry = new Writer\Entry;
-        $entry->addAuthor('Joe');
-        $this->assertEquals(array(array('name'=>'Joe')), $entry->getAuthors());
-    }
-
-    public function testAddsAuthorEmail()
-    {
-        $entry = new Writer\Entry;
-        $entry->addAuthor('Joe', 'joe@example.com');
-        $this->assertEquals(array(array('name'=>'Joe', 'email' => 'joe@example.com')), $entry->getAuthors());
-    }
-
-    public function testAddsAuthorUri()
-    {
-        $entry = new Writer\Entry;
-        $entry->addAuthor('Joe', null, 'http://www.example.com');
-        $this->assertEquals(array(array('name'=>'Joe', 'uri' => 'http://www.example.com')), $entry->getAuthors());
-    }
-
-    public function testAddAuthorThrowsExceptionOnInvalidName()
-    {
-        $entry = new Writer\Entry;
-        try {
-            $entry->addAuthor('');
-            $this->fail();
-        } catch (Writer\Exception $e) {
-        }
-    }
-
-    public function testAddAuthorThrowsExceptionOnInvalidEmail()
-    {
-        $entry = new Writer\Entry;
-        try {
-            $entry->addAuthor('Joe', '');
-            $this->fail();
-        } catch (Writer\Exception $e) {
-        }
-    }
-
-    public function testAddAuthorThrowsExceptionOnInvalidUri()
-    {
-        $this->markTestIncomplete('Pending Zend\URI fix for validation');
-        $entry = new Writer\Entry;
-        try {
-            $entry->addAuthor('Joe', null, 'notauri');
-            $this->fail();
-        } catch (Writer\Exception $e) {
-        }
-    }
-
     public function testAddsAuthorNameFromArray()
     {
         $entry = new Writer\Entry;
-        $entry->addAuthor(array('name'=>'Joe'));
-        $this->assertEquals(array(array('name'=>'Joe')), $entry->getAuthors());
+        $entry->addAuthor(array('name'=> 'Joe'));
+        $this->assertEquals(array(array('name'=> 'Joe')), $entry->getAuthors());
     }
 
     public function testAddsAuthorEmailFromArray()
     {
         $entry = new Writer\Entry;
-        $entry->addAuthor(array('name'=>'Joe','email'=>'joe@example.com'));
-        $this->assertEquals(array(array('name'=>'Joe', 'email' => 'joe@example.com')), $entry->getAuthors());
+        $entry->addAuthor(array('name' => 'Joe',
+                                'email'=> 'joe@example.com'));
+        $this->assertEquals(array(array('name'  => 'Joe',
+                                        'email' => 'joe@example.com')), $entry->getAuthors());
     }
 
     public function testAddsAuthorUriFromArray()
     {
         $entry = new Writer\Entry;
-        $entry->addAuthor(array('name'=>'Joe','uri'=>'http://www.example.com'));
-        $this->assertEquals(array(array('name'=>'Joe', 'uri' => 'http://www.example.com')), $entry->getAuthors());
+        $entry->addAuthor(array('name'=> 'Joe',
+                                'uri' => 'http://www.example.com'));
+        $this->assertEquals(array(array('name'=> 'Joe',
+                                        'uri' => 'http://www.example.com')), $entry->getAuthors());
     }
 
     public function testAddAuthorThrowsExceptionOnInvalidNameFromArray()
     {
         $entry = new Writer\Entry;
         try {
-            $entry->addAuthor(array('name'=>''));
+            $entry->addAuthor(array('name'=> ''));
             $this->fail();
-        } catch (Writer\Exception $e) {
+        } catch (Writer\Exception\InvalidArgumentException $e) {
         }
     }
 
@@ -129,9 +82,10 @@ class EntryTest extends \PHPUnit_Framework_TestCase
     {
         $entry = new Writer\Entry;
         try {
-            $entry->addAuthor(array('name'=>'Joe','email'=>''));
+            $entry->addAuthor(array('name' => 'Joe',
+                                    'email'=> ''));
             $this->fail();
-        } catch (Writer\Exception $e) {
+        } catch (Writer\Exception\InvalidArgumentException $e) {
         }
     }
 
@@ -140,9 +94,10 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete('Pending Zend\URI fix for validation');
         $entry = new Writer\Entry;
         try {
-            $entry->addAuthor(array('name'=>'Joe','uri'=>'notauri'));
+            $entry->addAuthor(array('name'=> 'Joe',
+                                    'uri' => 'notauri'));
             $this->fail();
-        } catch (Writer\Exception $e) {
+        } catch (Writer\Exception\InvalidArgumentException $e) {
         }
     }
 
@@ -150,9 +105,9 @@ class EntryTest extends \PHPUnit_Framework_TestCase
     {
         $entry = new Writer\Entry;
         try {
-            $entry->addAuthor(array('uri'=>'notauri'));
+            $entry->addAuthor(array('uri'=> 'notauri'));
             $this->fail();
-        } catch (Writer\Exception $e) {
+        } catch (Writer\Exception\InvalidArgumentException $e) {
         }
     }
 
@@ -160,32 +115,36 @@ class EntryTest extends \PHPUnit_Framework_TestCase
     {
         $entry = new Writer\Entry;
         $entry->addAuthors(array(
-            array('name'=>'Joe','uri'=>'http://www.example.com'),
-            array('name'=>'Jane','uri'=>'http://www.example.com')
-        ));
+                                array('name'=> 'Joe',
+                                      'uri' => 'http://www.example.com'),
+                                array('name'=> 'Jane',
+                                      'uri' => 'http://www.example.com')
+                           ));
         $expected = array(
-            array('name'=>'Joe','uri'=>'http://www.example.com'),
-            array('name'=>'Jane','uri'=>'http://www.example.com')
+            array('name'=> 'Joe',
+                  'uri' => 'http://www.example.com'),
+            array('name'=> 'Jane',
+                  'uri' => 'http://www.example.com')
         );
         $this->assertEquals($expected, $entry->getAuthors());
     }
-    
+
     public function testAddsEnclosure()
     {
         $entry = new Writer\Entry;
         $entry->setEnclosure(array(
-            'type' => 'audio/mpeg',
-            'uri' => 'http://example.com/audio.mp3',
-            'length' => '1337'
-        ));
+                                  'type'   => 'audio/mpeg',
+                                  'uri'    => 'http://example.com/audio.mp3',
+                                  'length' => '1337'
+                             ));
         $expected = array(
-            'type' => 'audio/mpeg',
-            'uri' => 'http://example.com/audio.mp3',
+            'type'   => 'audio/mpeg',
+            'uri'    => 'http://example.com/audio.mp3',
             'length' => '1337'
         );
         $this->assertEquals($expected, $entry->getEnclosure());
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -194,11 +153,11 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete('Pending Zend\URI fix for validation');
         $entry = new Writer\Entry;
         $entry->setEnclosure(array(
-            'type' => 'audio/mpeg',
-            'length' => '1337'
-        ));
+                                  'type'   => 'audio/mpeg',
+                                  'length' => '1337'
+                             ));
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -207,10 +166,10 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete('Pending Zend\URI fix for validation');
         $entry = new Writer\Entry;
         $entry->setEnclosure(array(
-            'type' => 'audio/mpeg',
-            'uri' => 'http://',
-            'length' => '1337'
-        ));
+                                  'type'   => 'audio/mpeg',
+                                  'uri'    => 'http://',
+                                  'length' => '1337'
+                             ));
     }
 
     public function testSetsCopyright()
@@ -498,9 +457,11 @@ class EntryTest extends \PHPUnit_Framework_TestCase
     public function testSetsCommentFeedLink()
     {
         $entry = new Writer\Entry;
-        
-        $entry->setCommentFeedLink(array('uri'=>'http://www.example.com/id/comments', 'type'=>'rdf'));
-        $this->assertEquals(array(array('uri'=>'http://www.example.com/id/comments', 'type'=>'rdf')), $entry->getCommentFeedLinks());
+
+        $entry->setCommentFeedLink(array('uri' => 'http://www.example.com/id/comments',
+                                         'type'=> 'rdf'));
+        $this->assertEquals(array(array('uri' => 'http://www.example.com/id/comments',
+                                        'type'=> 'rdf')), $entry->getCommentFeedLinks());
     }
 
     public function testSetCommentFeedLinkThrowsExceptionOnEmptyString()
@@ -508,7 +469,8 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete('Pending Zend\URI fix for validation');
         $entry = new Writer\Entry;
         try {
-            $entry->setCommentFeedLink(array('uri'=>'', 'type'=>'rdf'));
+            $entry->setCommentFeedLink(array('uri' => '',
+                                             'type'=> 'rdf'));
             $this->fail();
         } catch (Writer\Exception $e) {
         }
@@ -518,17 +480,19 @@ class EntryTest extends \PHPUnit_Framework_TestCase
     {
         $entry = new Writer\Entry;
         try {
-            $entry->setCommentFeedLink(array('uri'=>'http://', 'type'=>'rdf'));
+            $entry->setCommentFeedLink(array('uri' => 'http://',
+                                             'type'=> 'rdf'));
             $this->fail();
         } catch (Writer\Exception $e) {
         }
     }
-    
+
     public function testSetCommentFeedLinkThrowsExceptionOnInvalidType()
     {
         $entry = new Writer\Entry;
         try {
-            $entry->setCommentFeedLink(array('uri'=>'http://www.example.com/id/comments', 'type'=>'foo'));
+            $entry->setCommentFeedLink(array('uri' => 'http://www.example.com/id/comments',
+                                             'type'=> 'foo'));
             $this->fail();
         } catch (Writer\Exception $e) {
         }

--- a/tests/Zend/Feed/Writer/FeedTest.php
+++ b/tests/Zend/Feed/Writer/FeedTest.php
@@ -20,19 +20,20 @@
  */
 
 namespace ZendTest\Feed\Writer;
+
 use Zend\Feed\Writer;
 use Zend\Feed\Writer\Feed;
 use Zend\Date;
 
 /**
-* @category Zend
-* @package Zend_Feed
-* @subpackage UnitTests
-* @group Zend_Feed
-* @group Zend_Feed_Writer
-* @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
-* @license http://framework.zend.com/license/new-bsd New BSD License
-*/
+ * @category   Zend
+ * @package    Zend_Feed
+ * @subpackage UnitTests
+ * @group      Zend_Feed
+ * @group      Zend_Feed_Writer
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd New BSD License
+ */
 class FeedTest extends \PHPUnit_Framework_TestCase
 {
 
@@ -43,86 +44,38 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $this->_feedSamplePath = dirname(__FILE__) . '/Writer/_files';
     }
 
-    public function testAddsAuthorName()
-    {
-        $writer = new Writer\Feed;
-        $writer->addAuthor('Joe');
-        $this->assertEquals(array('name'=>'Joe'), $writer->getAuthor());
-    }
-
-    public function testAddsAuthorEmail()
-    {
-        $writer = new Writer\Feed;
-        $writer->addAuthor('Joe', 'joe@example.com');
-        $this->assertEquals(array('name'=>'Joe', 'email' => 'joe@example.com'), $writer->getAuthor());
-    }
-
-    public function testAddsAuthorUri()
-    {
-        $writer = new Writer\Feed;
-        $writer->addAuthor('Joe', null, 'http://www.example.com');
-        $this->assertEquals(array('name'=>'Joe', 'uri' => 'http://www.example.com'), $writer->getAuthor());
-    }
-
-    public function testAddAuthorThrowsExceptionOnInvalidName()
-    {
-        $writer = new Writer\Feed;
-        try {
-            $writer->addAuthor('');
-            $this->fail();
-        } catch (Writer\Exception $e) {
-        }
-    }
-
-    public function testAddAuthorThrowsExceptionOnInvalidEmail()
-    {
-        $writer = new Writer\Feed;
-        try {
-            $writer->addAuthor('Joe', '');
-            $this->fail();
-        } catch (Writer\Exception $e) {
-        }
-    }
-
-    public function testAddAuthorThrowsExceptionOnInvalidUri()
-    {
-        $this->markTestIncomplete('Pending Zend\URI fix for validation');
-        $writer = new Writer\Feed;
-        try {
-            $writer->addAuthor('Joe', null, 'notauri');
-            $this->fail();
-        } catch (Writer\Exception $e) {
-        }
-    }
-
     public function testAddsAuthorNameFromArray()
     {
         $writer = new Writer\Feed;
-        $writer->addAuthor(array('name'=>'Joe'));
-        $this->assertEquals(array('name'=>'Joe'), $writer->getAuthor());
+        $writer->addAuthor(array('name'=> 'Joe'));
+        $this->assertEquals(array('name'=> 'Joe'), $writer->getAuthor());
     }
 
     public function testAddsAuthorEmailFromArray()
     {
         $writer = new Writer\Feed;
-        $writer->addAuthor(array('name'=>'Joe','email'=>'joe@example.com'));
-        $this->assertEquals(array('name'=>'Joe', 'email' => 'joe@example.com'), $writer->getAuthor());
+        $writer->addAuthor(array('name' => 'Joe',
+                                 'email'=> 'joe@example.com'));
+        $this->assertEquals(array('name'  => 'Joe',
+                                  'email' => 'joe@example.com'), $writer->getAuthor());
     }
 
     public function testAddsAuthorUriFromArray()
     {
         $writer = new Writer\Feed;
-        $writer->addAuthor(array('name'=>'Joe','uri'=>'http://www.example.com'));
-        $this->assertEquals(array('name'=>'Joe', 'uri' => 'http://www.example.com'), $writer->getAuthor());
+        $writer->addAuthor(array('name'=> 'Joe',
+                                 'uri' => 'http://www.example.com'));
+        $this->assertEquals(array('name'=> 'Joe',
+                                  'uri' => 'http://www.example.com'), $writer->getAuthor());
     }
 
     public function testAddAuthorThrowsExceptionOnInvalidNameFromArray()
     {
         $writer = new Writer\Feed;
         try {
-            $writer->addAuthor(array('name'=>''));
+            $writer->addAuthor(array('name'=> ''));
             $this->fail();
-        } catch (Writer\Exception $e) {
+        } catch (Writer\Exception\InvalidArgumentException $e) {
         }
     }
 
@@ -130,9 +83,10 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new Writer\Feed;
         try {
-            $writer->addAuthor(array('name'=>'Joe','email'=>''));
+            $writer->addAuthor(array('name' => 'Joe',
+                                     'email'=> ''));
             $this->fail();
-        } catch (Writer\Exception $e) {
+        } catch (Writer\Exception\InvalidArgumentException $e) {
         }
     }
 
@@ -141,9 +95,10 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete('Pending Zend\URI fix for validation');
         $writer = new Writer\Feed;
         try {
-            $writer->addAuthor(array('name'=>'Joe','uri'=>'notauri'));
+            $writer->addAuthor(array('name'=> 'Joe',
+                                     'uri' => 'notauri'));
             $this->fail();
-        } catch (Writer\Exception $e) {
+        } catch (Writer\Exception\InvalidArgumentException $e) {
         }
     }
 
@@ -151,9 +106,9 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new Writer\Feed;
         try {
-            $writer->addAuthor(array('uri'=>'notauri'));
+            $writer->addAuthor(array('uri'=> 'notauri'));
             $this->fail();
-        } catch (Writer\Exception $e) {
+        } catch (Writer\Exception\InvalidArgumentException $e) {
         }
     }
 
@@ -161,10 +116,13 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new Writer\Feed;
         $writer->addAuthors(array(
-            array('name'=>'Joe','uri'=>'http://www.example.com'),
-            array('name'=>'Jane','uri'=>'http://www.example.com')
-        ));
-        $this->assertEquals(array('name'=>'Jane', 'uri' => 'http://www.example.com'), $writer->getAuthor(1));
+                                 array('name'=> 'Joe',
+                                       'uri' => 'http://www.example.com'),
+                                 array('name'=> 'Jane',
+                                       'uri' => 'http://www.example.com')
+                            ));
+        $this->assertEquals(array('name'=> 'Jane',
+                                  'uri' => 'http://www.example.com'), $writer->getAuthor(1));
     }
 
     public function testSetsCopyright()
@@ -235,7 +193,8 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer\Feed;
         $writer->setDateModified();
         $dateNow = new Date\Date;
-        $this->assertTrue($dateNow->isLater($writer->getDateModified()) || $dateNow->equals($writer->getDateModified()));
+        $this->assertTrue(
+            $dateNow->isLater($writer->getDateModified()) || $dateNow->equals($writer->getDateModified()));
     }
 
     public function testSetDateModifiedUsesGivenUnixTimestamp()
@@ -245,7 +204,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $myDate = new Date\Date('1234567890', Date\Date::TIMESTAMP);
         $this->assertTrue($myDate->equals($writer->getDateModified()));
     }
-    
+
     /**
      * @group ZF-12023
      */
@@ -267,7 +226,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $myDate = new Date\Date('123', Date\Date::TIMESTAMP);
         $this->assertTrue($myDate->equals($writer->getDateModified()));
     }
-    
+
     public function testSetDateModifiedUsesZendDateObject()
     {
         $writer = new Writer\Feed;
@@ -313,7 +272,8 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer\Feed;
         $writer->setLastBuildDate();
         $dateNow = new Date\Date;
-        $this->assertTrue($dateNow->isLater($writer->getLastBuildDate()) || $dateNow->equals($writer->getLastBuildDate()));
+        $this->assertTrue(
+            $dateNow->isLater($writer->getLastBuildDate()) || $dateNow->equals($writer->getLastBuildDate()));
     }
 
     public function testSetLastBuildDateUsesGivenUnixTimestamp()
@@ -334,7 +294,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $myDate = new Date\Date('123456789', Date\Date::TIMESTAMP);
         $this->assertTrue($myDate->equals($writer->getLastBuildDate()));
     }
-    
+
     /**
      * @group ZF-11610
      */
@@ -345,7 +305,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $myDate = new Date\Date('123', Date\Date::TIMESTAMP);
         $this->assertTrue($myDate->equals($writer->getLastBuildDate()));
     }
-    
+
     public function testSetLastBuildDateUsesZendDateObject()
     {
         $writer = new Writer\Feed;
@@ -412,19 +372,20 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $writer->setId('urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6');
         $this->assertEquals('urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6', $writer->getId());
     }
-    
+
     public function testSetsIdAcceptsSimpleTagUri()
     {
         $writer = new Writer\Feed;
         $writer->setId('tag:example.org,2010:/foo/bar/');
         $this->assertEquals('tag:example.org,2010:/foo/bar/', $writer->getId());
     }
-    
+
     public function testSetsIdAcceptsComplexTagUri()
     {
         $writer = new Writer\Feed;
         $writer->setId('tag:diveintomark.org,2004-05-27:/archives/2004/05/27/howto-atom-linkblog');
-        $this->assertEquals('tag:diveintomark.org,2004-05-27:/archives/2004/05/27/howto-atom-linkblog', $writer->getId());
+        $this->assertEquals('tag:diveintomark.org,2004-05-27:/archives/2004/05/27/howto-atom-linkblog',
+                            $writer->getId());
     }
 
     public function testSetIdThrowsExceptionOnInvalidParameter()
@@ -558,22 +519,26 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testSetsGeneratorName()
     {
         $writer = new Writer\Feed;
-        $writer->setGenerator(array('name'=>'ZFW'));
-        $this->assertEquals(array('name'=>'ZFW'), $writer->getGenerator());
+        $writer->setGenerator(array('name'=> 'ZFW'));
+        $this->assertEquals(array('name'=> 'ZFW'), $writer->getGenerator());
     }
 
     public function testSetsGeneratorVersion()
     {
         $writer = new Writer\Feed;
-        $writer->setGenerator(array('name'=>'ZFW', 'version' => '1.0'));
-        $this->assertEquals(array('name'=>'ZFW', 'version' => '1.0'), $writer->getGenerator());
+        $writer->setGenerator(array('name'    => 'ZFW',
+                                    'version' => '1.0'));
+        $this->assertEquals(array('name'    => 'ZFW',
+                                  'version' => '1.0'), $writer->getGenerator());
     }
 
     public function testSetsGeneratorUri()
     {
         $writer = new Writer\Feed;
-        $writer->setGenerator(array('name'=>'ZFW', 'uri'=>'http://www.example.com'));
-        $this->assertEquals(array('name'=>'ZFW', 'uri' => 'http://www.example.com'), $writer->getGenerator());
+        $writer->setGenerator(array('name'=> 'ZFW',
+                                    'uri' => 'http://www.example.com'));
+        $this->assertEquals(array('name'=> 'ZFW',
+                                  'uri' => 'http://www.example.com'), $writer->getGenerator());
     }
 
     public function testSetsGeneratorThrowsExceptionOnInvalidName()
@@ -590,7 +555,8 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new Writer\Feed;
         try {
-            $writer->setGenerator(array('name'=>'ZFW', 'version'=>''));
+            $writer->setGenerator(array('name'   => 'ZFW',
+                                        'version'=> ''));
             $this->fail('Should have failed since version is empty');
         } catch (Writer\Exception $e) {
         }
@@ -601,7 +567,8 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete('Pending Zend\URI fix for validation');
         $writer = new Writer\Feed;
         try {
-            $writer->setGenerator(array('name'=>'ZFW','uri'=>'notauri'));
+            $writer->setGenerator(array('name'=> 'ZFW',
+                                        'uri' => 'notauri'));
             $this->fail();
         } catch (Writer\Exception $e) {
         }
@@ -614,7 +581,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new Writer\Feed;
         $writer->setGenerator('ZFW');
-        $this->assertEquals(array('name'=>'ZFW'), $writer->getGenerator());
+        $this->assertEquals(array('name'=> 'ZFW'), $writer->getGenerator());
     }
 
     /**
@@ -624,7 +591,8 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new Writer\Feed;
         $writer->setGenerator('ZFW', '1.0');
-        $this->assertEquals(array('name'=>'ZFW', 'version' => '1.0'), $writer->getGenerator());
+        $this->assertEquals(array('name'    => 'ZFW',
+                                  'version' => '1.0'), $writer->getGenerator());
     }
 
     /**
@@ -634,7 +602,8 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new Writer\Feed;
         $writer->setGenerator('ZFW', null, 'http://www.example.com');
-        $this->assertEquals(array('name'=>'ZFW', 'uri' => 'http://www.example.com'), $writer->getGenerator());
+        $this->assertEquals(array('name'=> 'ZFW',
+                                  'uri' => 'http://www.example.com'), $writer->getGenerator());
     }
 
     /**
@@ -687,7 +656,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new Writer\Feed;
         $writer->setFeedLink('http://www.example.com/rss', 'RSS');
-        $this->assertEquals(array('rss'=>'http://www.example.com/rss'), $writer->getFeedLinks());
+        $this->assertEquals(array('rss'=> 'http://www.example.com/rss'), $writer->getFeedLinks());
     }
 
     public function testSetsFeedLinkThrowsExceptionOnInvalidType()
@@ -715,7 +684,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer\Feed;
         $this->assertTrue(is_null($writer->getFeedLinks()));
     }
-    
+
     public function testSetsBaseUrl()
     {
         $writer = new Writer\Feed;
@@ -738,14 +707,14 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer\Feed;
         $this->assertTrue(is_null($writer->getBaseUrl()));
     }
-    
+
     public function testAddsHubUrl()
     {
         $writer = new Writer\Feed;
         $writer->addHub('http://www.example.com/hub');
         $this->assertEquals(array('http://www.example.com/hub'), $writer->getHubs());
     }
-    
+
     public function testAddsManyHubUrls()
     {
         $writer = new Writer\Feed;
@@ -772,39 +741,41 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testCreatesNewEntryDataContainer()
     {
         $writer = new Writer\Feed;
-        $entry = $writer->createEntry();
+        $entry  = $writer->createEntry();
         $this->assertTrue($entry instanceof Writer\Entry);
     }
-    
+
     public function testAddsCategory()
     {
         $writer = new Writer\Feed;
-        $writer->addCategory(array('term'=>'cat_dog'));
-        $this->assertEquals(array(array('term'=>'cat_dog')), $writer->getCategories());
+        $writer->addCategory(array('term'=> 'cat_dog'));
+        $this->assertEquals(array(array('term'=> 'cat_dog')), $writer->getCategories());
     }
-    
+
     public function testAddsManyCategories()
     {
         $writer = new Writer\Feed;
-        $writer->addCategories(array(array('term'=>'cat_dog'),array('term'=>'cat_mouse')));
-        $this->assertEquals(array(array('term'=>'cat_dog'),array('term'=>'cat_mouse')), $writer->getCategories());
+        $writer->addCategories(array(array('term'=> 'cat_dog'), array('term'=> 'cat_mouse')));
+        $this->assertEquals(array(array('term'=> 'cat_dog'), array('term'=> 'cat_mouse')), $writer->getCategories());
     }
 
     public function testAddingCategoryWithoutTermThrowsException()
     {
         $writer = new Writer\Feed;
         try {
-            $writer->addCategory(array('label' => 'Cats & Dogs', 'scheme' => 'http://www.example.com/schema1'));
+            $writer->addCategory(array('label'  => 'Cats & Dogs',
+                                       'scheme' => 'http://www.example.com/schema1'));
             $this->fail();
         } catch (Writer\Exception $e) {
         }
     }
-    
+
     public function testAddingCategoryWithInvalidUriAsSchemeThrowsException()
     {
         $writer = new Writer\Feed;
         try {
-            $writer->addCategory(array('term' => 'cat_dog', 'scheme' => 'http://'));
+            $writer->addCategory(array('term'   => 'cat_dog',
+                                       'scheme' => 'http://'));
             $this->fail();
         } catch (Writer\Exception $e) {
         }
@@ -816,11 +787,11 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new Writer\Feed;
         $writer->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif'
-        ));
+                               'uri' => 'http://www.example.com/logo.gif'
+                          ));
         $this->assertEquals(array(
-            'uri' => 'http://www.example.com/logo.gif'
-        ), $writer->getImage());
+                                 'uri' => 'http://www.example.com/logo.gif'
+                            ), $writer->getImage());
     }
 
     /**
@@ -830,8 +801,8 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new Writer\Feed;
         $writer->setImage(array(
-            'uri' => ''
-        ));
+                               'uri' => ''
+                          ));
     }
 
     /**
@@ -850,73 +821,73 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new Writer\Feed;
         $writer->setImage(array(
-            'uri' => 'http://'
-        ));
+                               'uri' => 'http://'
+                          ));
     }
 
     public function testSetsImageLink()
     {
         $writer = new Writer\Feed;
         $writer->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com'
-        ));
+                               'uri'  => 'http://www.example.com/logo.gif',
+                               'link' => 'http://www.example.com'
+                          ));
         $this->assertEquals(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com'
-        ), $writer->getImage());
+                                 'uri'  => 'http://www.example.com/logo.gif',
+                                 'link' => 'http://www.example.com'
+                            ), $writer->getImage());
     }
 
     public function testSetsImageTitle()
     {
         $writer = new Writer\Feed;
         $writer->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'title' => 'Image title'
-        ));
+                               'uri'   => 'http://www.example.com/logo.gif',
+                               'title' => 'Image title'
+                          ));
         $this->assertEquals(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'title' => 'Image title'
-        ), $writer->getImage());
+                                 'uri'   => 'http://www.example.com/logo.gif',
+                                 'title' => 'Image title'
+                            ), $writer->getImage());
     }
 
     public function testSetsImageHeight()
     {
         $writer = new Writer\Feed;
         $writer->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'height' => '88'
-        ));
+                               'uri'    => 'http://www.example.com/logo.gif',
+                               'height' => '88'
+                          ));
         $this->assertEquals(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'height' => '88'
-        ), $writer->getImage());
+                                 'uri'    => 'http://www.example.com/logo.gif',
+                                 'height' => '88'
+                            ), $writer->getImage());
     }
 
     public function testSetsImageWidth()
     {
         $writer = new Writer\Feed;
         $writer->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'width' => '88'
-        ));
+                               'uri'   => 'http://www.example.com/logo.gif',
+                               'width' => '88'
+                          ));
         $this->assertEquals(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'width' => '88'
-        ), $writer->getImage());
+                                 'uri'   => 'http://www.example.com/logo.gif',
+                                 'width' => '88'
+                            ), $writer->getImage());
     }
-    
+
     public function testSetsImageDescription()
     {
         $writer = new Writer\Feed;
         $writer->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'description' => 'Image description'
-        ));
+                               'uri'         => 'http://www.example.com/logo.gif',
+                               'description' => 'Image description'
+                          ));
         $this->assertEquals(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'description' => 'Image description'
-        ), $writer->getImage());
+                                 'uri'         => 'http://www.example.com/logo.gif',
+                                 'description' => 'Image description'
+                            ), $writer->getImage());
     }
 
     public function testGetCategoriesReturnsNullIfNotSet()
@@ -928,7 +899,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testAddsAndOrdersEntriesByDateIfRequested()
     {
         $writer = new Writer\Feed;
-        $entry = $writer->createEntry();
+        $entry  = $writer->createEntry();
         $entry->setDateCreated(1234567890);
         $entry2 = $writer->createEntry();
         $entry2->setDateCreated(1230000000);

--- a/tests/Zend/Feed/Writer/Renderer/Entry/AtomTest.php
+++ b/tests/Zend/Feed/Writer/Renderer/Entry/AtomTest.php
@@ -26,14 +26,14 @@ use Zend\Feed\Reader;
 use Zend\Date;
 
 /**
-* @category Zend
-* @package Zend_Feed
-* @subpackage UnitTests
-* @group Zend_Feed
-* @group Zend_Feed_Writer
-* @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
-* @license http://framework.zend.com/license/new-bsd New BSD License
-*/
+ * @category   Zend
+ * @package    Zend_Feed
+ * @subpackage UnitTests
+ * @group      Zend_Feed
+ * @group      Zend_Feed_Writer
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd New BSD License
+ */
 class AtomTest extends \PHPUnit_Framework_TestCase
 {
 
@@ -43,22 +43,26 @@ class AtomTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->_validWriter = new Writer\Feed;
-        
+
         $this->_validWriter->setType('atom');
-        
+
         $this->_validWriter->setTitle('This is a test feed.');
         $this->_validWriter->setDescription('This is a test description.');
         $this->_validWriter->setDateModified(1234567890);
         $this->_validWriter->setLink('http://www.example.com');
         $this->_validWriter->setFeedLink('http://www.example.com/atom', 'atom');
-        $this->_validWriter->addAuthor('Joe', 'joe@example.com', 'http://www.example.com/joe');
+        $this->_validWriter->addAuthor(array('name' => 'Joe',
+                                             'email'=> 'joe@example.com',
+                                             'uri'  => 'http://www.example.com/joe'));
         $this->_validEntry = $this->_validWriter->createEntry();
         $this->_validEntry->setTitle('This is a test entry.');
         $this->_validEntry->setDescription('This is a test entry description.');
         $this->_validEntry->setDateModified(1234567890);
         $this->_validEntry->setDateCreated(1234567000);
         $this->_validEntry->setLink('http://www.example.com/1');
-        $this->_validEntry->addAuthor('Jane', 'jane@example.com', 'http://www.example.com/jane');
+        $this->_validEntry->addAuthor(array('name' => 'Jane',
+                                            'email'=> 'jane@example.com',
+                                            'uri'  => 'http://www.example.com/jane'));
         $this->_validEntry->setContent('<p class="xhtml:">This is test content for <em>xhtml:</em></p>');
         $this->_validWriter->addEntry($this->_validEntry);
     }
@@ -66,7 +70,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $this->_validWriter = null;
-        $this->_validEntry = null;
+        $this->_validEntry  = null;
     }
 
     public function testRenderMethodRunsMinimalWriterContainerProperlyBeforeICheckAtomCompliance()
@@ -83,27 +87,27 @@ class AtomTest extends \PHPUnit_Framework_TestCase
     {
         $this->_validWriter->setEncoding('iso-8859-1');
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('iso-8859-1', $entry->getEncoding());
     }
 
     public function testEntryEncodingDefaultIsUsedIfEncodingNotSetByHand()
     {
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('UTF-8', $entry->getEncoding());
     }
 
     public function testEntryTitleHasBeenSet()
     {
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('This is a test entry.', $entry->getTitle());
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -117,8 +121,8 @@ class AtomTest extends \PHPUnit_Framework_TestCase
     public function testEntrySummaryDescriptionHasBeenSet()
     {
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('This is a test entry description.', $entry->getDescription());
     }
 
@@ -128,11 +132,11 @@ class AtomTest extends \PHPUnit_Framework_TestCase
     public function testEntryContentHasBeenSet_Xhtml()
     {
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('<p class="xhtml:">This is test content for <em>xhtml:</em></p>', $entry->getContent());
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -147,11 +151,11 @@ class AtomTest extends \PHPUnit_Framework_TestCase
     public function testEntryUpdatedDateHasBeenSet()
     {
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals(1234567890, $entry->getDateModified()->get(Date\Date::TIMESTAMP));
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -165,42 +169,42 @@ class AtomTest extends \PHPUnit_Framework_TestCase
     public function testEntryPublishedDateHasBeenSet()
     {
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals(1234567000, $entry->getDateCreated()->get(Date\Date::TIMESTAMP));
     }
 
     public function testEntryIncludesLinkToHtmlVersionOfFeed()
     {
-        $renderer= new Renderer\Feed\Atom($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $renderer = new Renderer\Feed\Atom($this->_validWriter);
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('http://www.example.com/1', $entry->getLink());
     }
 
     public function testEntryHoldsAnyAuthorAdded()
     {
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
-        $author = $entry->getAuthor();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
+        $author   = $entry->getAuthor();
         $this->assertEquals(array(
-            'name'=>'Jane',
-            'email'=>'jane@example.com',
-            'uri'=>'http://www.example.com/jane'), $entry->getAuthor());
+                                 'name' => 'Jane',
+                                 'email'=> 'jane@example.com',
+                                 'uri'  => 'http://www.example.com/jane'), $entry->getAuthor());
     }
-    
+
     public function testEntryHoldsAnyEnclosureAdded()
     {
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
         $this->_validEntry->setEnclosure(array(
-            'type' => 'audio/mpeg',
-            'length' => '1337',
-            'uri' => 'http://example.com/audio.mp3'
-        ));
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
+                                              'type'   => 'audio/mpeg',
+                                              'length' => '1337',
+                                              'uri'    => 'http://example.com/audio.mp3'
+                                         ));
+        $feed  = Reader\Reader::importString($renderer->render()->saveXml());
         $entry = $feed->current();
-        $enc = $entry->getEnclosure();
+        $enc   = $entry->getEnclosure();
         $this->assertEquals('audio/mpeg', $enc->type);
         $this->assertEquals('1337', $enc->length);
         $this->assertEquals('http://example.com/audio.mp3', $enc->url);
@@ -210,37 +214,38 @@ class AtomTest extends \PHPUnit_Framework_TestCase
     {
         $this->_validEntry->setId('urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6');
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6', $entry->getId());
     }
-    
+
     public function testEntryIdHasBeenSetUsingSimpleTagUri()
     {
         $this->_validEntry->setId('tag:example.org,2010:/foo/bar/');
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('tag:example.org,2010:/foo/bar/', $entry->getId());
     }
-    
+
     public function testEntryIdHasBeenSetUsingComplexTagUri()
     {
         $this->_validEntry->setId('tag:diveintomark.org,2004-05-27:/archives/2004/05/27/howto-atom-linkblog');
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
-        $this->assertEquals('tag:diveintomark.org,2004-05-27:/archives/2004/05/27/howto-atom-linkblog', $entry->getId());
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
+        $this->assertEquals('tag:diveintomark.org,2004-05-27:/archives/2004/05/27/howto-atom-linkblog',
+                            $entry->getId());
     }
 
     public function testFeedIdDefaultIsUsedIfNotSetByHand()
     {
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals($entry->getLink(), $entry->getId());
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -251,7 +256,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $this->_validEntry->remove('link');
         $atomFeed->render();
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -264,54 +269,62 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $this->_validEntry->setId('not-a-uri');
         $atomFeed->render();
     }
-    
+
     public function testCommentLinkRendered()
     {
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
         $this->_validEntry->setCommentLink('http://www.example.com/id/1');
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
+        $feed  = Reader\Reader::importString($renderer->render()->saveXml());
         $entry = $feed->current();
         $this->assertEquals('http://www.example.com/id/1', $entry->getCommentLink());
     }
-    
+
     public function testCommentCountRendered()
     {
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
         $this->_validEntry->setCommentCount(22);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
+        $feed  = Reader\Reader::importString($renderer->render()->saveXml());
         $entry = $feed->current();
         $this->assertEquals(22, $entry->getCommentCount());
     }
-    
+
     public function testCategoriesCanBeSet()
     {
         $this->_validEntry->addCategories(array(
-            array('term'=>'cat_dog', 'label' => 'Cats & Dogs', 'scheme' => 'http://example.com/schema1'),
-            array('term'=>'cat_dog2')
-        ));
+                                               array('term'   => 'cat_dog',
+                                                     'label'  => 'Cats & Dogs',
+                                                     'scheme' => 'http://example.com/schema1'),
+                                               array('term'=> 'cat_dog2')
+                                          ));
         $atomFeed = new Renderer\Feed\Atom($this->_validWriter);
         $atomFeed->render();
-        $feed = Reader\Reader::importString($atomFeed->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($atomFeed->saveXml());
+        $entry    = $feed->current();
         $expected = array(
-            array('term'=>'cat_dog', 'label' => 'Cats & Dogs', 'scheme' => 'http://example.com/schema1'),
-            array('term'=>'cat_dog2', 'label' => 'cat_dog2', 'scheme' => null)
+            array('term'   => 'cat_dog',
+                  'label'  => 'Cats & Dogs',
+                  'scheme' => 'http://example.com/schema1'),
+            array('term'   => 'cat_dog2',
+                  'label'  => 'cat_dog2',
+                  'scheme' => null)
         );
-        $this->assertEquals($expected, (array) $entry->getCategories());
+        $this->assertEquals($expected, (array)$entry->getCategories());
     }
-    
+
     public function testCommentFeedLinksRendered()
     {
         $renderer = new Renderer\Feed\Atom($this->_validWriter);
         $this->_validEntry->setCommentFeedLinks(array(
-            array('uri'=>'http://www.example.com/atom/id/1','type'=>'atom'),
-            array('uri'=>'http://www.example.com/rss/id/1','type'=>'rss'),
-        ));
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
+                                                     array('uri' => 'http://www.example.com/atom/id/1',
+                                                           'type'=> 'atom'),
+                                                     array('uri' => 'http://www.example.com/rss/id/1',
+                                                           'type'=> 'rss'),
+                                                ));
+        $feed  = Reader\Reader::importString($renderer->render()->saveXml());
         $entry = $feed->current();
         // Skipped over due to ZFR bug (detects Atom in error when RSS requested)
         //$this->assertEquals('http://www.example.com/rss/id/1', $entry->getCommentFeedLink('rss'));
         $this->assertEquals('http://www.example.com/atom/id/1', $entry->getCommentFeedLink('atom'));
     }
-    
+
 }

--- a/tests/Zend/Feed/Writer/Renderer/Entry/RssTest.php
+++ b/tests/Zend/Feed/Writer/Renderer/Entry/RssTest.php
@@ -26,14 +26,14 @@ use Zend\Feed\Reader;
 use Zend\Date;
 
 /**
-* @category Zend
-* @package Zend_Feed
-* @subpackage UnitTests
-* @group Zend_Feed
-* @group Zend_Feed_Writer
-* @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
-* @license http://framework.zend.com/license/new-bsd New BSD License
-*/
+ * @category   Zend
+ * @package    Zend_Feed
+ * @subpackage UnitTests
+ * @group      Zend_Feed
+ * @group      Zend_Feed_Writer
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd New BSD License
+ */
 class RssTest extends \PHPUnit_Framework_TestCase
 {
 
@@ -43,9 +43,9 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->_validWriter = new Writer\Feed;
-        
+
         $this->_validWriter->setType('rss');
-        
+
         $this->_validWriter->setTitle('This is a test feed.');
         $this->_validWriter->setDescription('This is a test description.');
         $this->_validWriter->setLink('http://www.example.com');
@@ -59,7 +59,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $this->_validWriter = null;
-        $this->_validEntry = null;
+        $this->_validEntry  = null;
     }
 
     public function testRenderMethodRunsMinimalWriterContainerProperlyBeforeICheckAtomCompliance()
@@ -76,27 +76,27 @@ class RssTest extends \PHPUnit_Framework_TestCase
     {
         $this->_validWriter->setEncoding('iso-8859-1');
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('iso-8859-1', $entry->getEncoding());
     }
 
     public function testEntryEncodingDefaultIsUsedIfEncodingNotSetByHand()
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('UTF-8', $entry->getEncoding());
     }
 
     public function testEntryTitleHasBeenSet()
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('This is a test entry.', $entry->getTitle());
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -107,12 +107,12 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $this->_validEntry->remove('description');
         $atomFeed->render();
     }
-    
+
     public function testEntryTitleCharDataEncoding()
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
         $this->_validEntry->setTitle('<>&\'"áéíóú');
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
+        $feed  = Reader\Reader::importString($renderer->render()->saveXml());
         $entry = $feed->current();
         $this->assertEquals('<>&\'"áéíóú', $entry->getTitle());
     }
@@ -120,11 +120,11 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function testEntrySummaryDescriptionHasBeenSet()
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('This is a test entry description.', $entry->getDescription());
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -135,30 +135,30 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $this->_validEntry->remove('title');
         $atomFeed->render();
     }
-    
+
     public function testEntryDescriptionCharDataEncoding()
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
         $this->_validEntry->setDescription('<>&\'"áéíóú');
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
+        $feed  = Reader\Reader::importString($renderer->render()->saveXml());
         $entry = $feed->current();
         $this->assertEquals('<>&\'"áéíóú', $entry->getDescription());
     }
-    
+
     public function testEntryContentHasBeenSet()
     {
         $this->_validEntry->setContent('This is test entry content.');
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('This is test entry content.', $entry->getContent());
     }
-    
+
     public function testEntryContentCharDataEncoding()
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
         $this->_validEntry->setContent('<>&\'"áéíóú');
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
+        $feed  = Reader\Reader::importString($renderer->render()->saveXml());
         $entry = $feed->current();
         $this->assertEquals('<>&\'"áéíóú', $entry->getContent());
     }
@@ -167,8 +167,8 @@ class RssTest extends \PHPUnit_Framework_TestCase
     {
         $this->_validEntry->setDateModified(1234567890);
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals(1234567890, $entry->getDateModified()->get(Date\Date::TIMESTAMP));
     }
 
@@ -176,50 +176,54 @@ class RssTest extends \PHPUnit_Framework_TestCase
     {
         $this->_validEntry->setDateCreated(1234567000);
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals(1234567000, $entry->getDateCreated()->get(Date\Date::TIMESTAMP));
     }
 
     public function testEntryIncludesLinkToHtmlVersionOfFeed()
     {
-        $renderer= new Renderer\Feed\Rss($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $renderer = new Renderer\Feed\Rss($this->_validWriter);
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('http://www.example.com/1', $entry->getLink());
     }
 
     public function testEntryHoldsAnyAuthorAdded()
     {
-        $this->_validEntry->addAuthor('Jane', 'jane@example.com', 'http://www.example.com/jane');
+        $this->_validEntry->addAuthor(array('name' => 'Jane',
+                                            'email'=> 'jane@example.com',
+                                            'uri'  => 'http://www.example.com/jane'));
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
-        $author = $entry->getAuthor();
-        $this->assertEquals(array('name'=>'Jane'), $entry->getAuthor());
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
+        $author   = $entry->getAuthor();
+        $this->assertEquals(array('name'=> 'Jane'), $entry->getAuthor());
     }
-    
+
     public function testEntryAuthorCharDataEncoding()
     {
-        $this->_validEntry->addAuthor('<>&\'"áéíóú', 'jane@example.com', 'http://www.example.com/jane');
+        $this->_validEntry->addAuthor(array('name' => '<>&\'"áéíóú',
+                                            'email'=> 'jane@example.com',
+                                            'uri'  => 'http://www.example.com/jane'));
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
-        $author = $entry->getAuthor();
-        $this->assertEquals(array('name'=>'<>&\'"áéíóú'), $entry->getAuthor());
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
+        $author   = $entry->getAuthor();
+        $this->assertEquals(array('name'=> '<>&\'"áéíóú'), $entry->getAuthor());
     }
-    
+
     public function testEntryHoldsAnyEnclosureAdded()
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
         $this->_validEntry->setEnclosure(array(
-            'type' => 'audio/mpeg',
-            'length' => '1337',
-            'uri' => 'http://example.com/audio.mp3'
-        ));
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
+                                              'type'   => 'audio/mpeg',
+                                              'length' => '1337',
+                                              'uri'    => 'http://example.com/audio.mp3'
+                                         ));
+        $feed  = Reader\Reader::importString($renderer->render()->saveXml());
         $entry = $feed->current();
-        $enc = $entry->getEnclosure();
+        $enc   = $entry->getEnclosure();
         $this->assertEquals('audio/mpeg', $enc->type);
         $this->assertEquals('1337', $enc->length);
         $this->assertEquals('http://example.com/audio.mp3', $enc->url);
@@ -232,9 +236,9 @@ class RssTest extends \PHPUnit_Framework_TestCase
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
         $this->_validEntry->setEnclosure(array(
-            'uri' => 'http://example.com/audio.mp3',
-            'length' => '1337'
-        ));
+                                              'uri'    => 'http://example.com/audio.mp3',
+                                              'length' => '1337'
+                                         ));
         $renderer->render();
     }
 
@@ -245,12 +249,12 @@ class RssTest extends \PHPUnit_Framework_TestCase
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
         $this->_validEntry->setEnclosure(array(
-            'type' => 'audio/mpeg',
-            'uri' => 'http://example.com/audio.mp3'
-        ));
+                                              'type' => 'audio/mpeg',
+                                              'uri'  => 'http://example.com/audio.mp3'
+                                         ));
         $renderer->render();
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -258,13 +262,13 @@ class RssTest extends \PHPUnit_Framework_TestCase
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
         $this->_validEntry->setEnclosure(array(
-            'type' => 'audio/mpeg',
-            'uri' => 'http://example.com/audio.mp3',
-            'length' => 'abc'
-        ));
+                                              'type'   => 'audio/mpeg',
+                                              'uri'    => 'http://example.com/audio.mp3',
+                                              'length' => 'abc'
+                                         ));
         $renderer->render();
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -272,10 +276,10 @@ class RssTest extends \PHPUnit_Framework_TestCase
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
         $this->_validEntry->setEnclosure(array(
-            'type' => 'audio/mpeg',
-            'uri' => 'http://example.com/audio.mp3',
-            'length' => -23
-        ));
+                                              'type'   => 'audio/mpeg',
+                                              'uri'    => 'http://example.com/audio.mp3',
+                                              'length' => -23
+                                         ));
         $renderer->render();
     }
 
@@ -283,11 +287,11 @@ class RssTest extends \PHPUnit_Framework_TestCase
     {
         $this->_validEntry->setId('urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6');
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals('urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6', $entry->getId());
     }
-    
+
     public function testEntryIdHasBeenSetWithPermaLinkAsFalseWhenNotUri()
     {
         $this->markTestIncomplete('Untest due to ZFR potential bug');
@@ -296,76 +300,90 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function testEntryIdDefaultIsUsedIfNotSetByHand()
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $this->assertEquals($entry->getLink(), $entry->getId());
     }
-    
+
     public function testCommentLinkRendered()
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
         $this->_validEntry->setCommentLink('http://www.example.com/id/1');
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
+        $feed  = Reader\Reader::importString($renderer->render()->saveXml());
         $entry = $feed->current();
         $this->assertEquals('http://www.example.com/id/1', $entry->getCommentLink());
     }
-    
+
     public function testCommentCountRendered()
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
         $this->_validEntry->setCommentCount(22);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
+        $feed  = Reader\Reader::importString($renderer->render()->saveXml());
         $entry = $feed->current();
         $this->assertEquals(22, $entry->getCommentCount());
     }
-    
+
     public function testCommentFeedLinksRendered()
     {
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
         $this->_validEntry->setCommentFeedLinks(array(
-            array('uri'=>'http://www.example.com/atom/id/1','type'=>'atom'),
-            array('uri'=>'http://www.example.com/rss/id/1','type'=>'rss'),
-        ));
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
+                                                     array('uri' => 'http://www.example.com/atom/id/1',
+                                                           'type'=> 'atom'),
+                                                     array('uri' => 'http://www.example.com/rss/id/1',
+                                                           'type'=> 'rss'),
+                                                ));
+        $feed  = Reader\Reader::importString($renderer->render()->saveXml());
         $entry = $feed->current();
         // Skipped assertion is because RSS has no facility to show Atom feeds without an extension
         $this->assertEquals('http://www.example.com/rss/id/1', $entry->getCommentFeedLink('rss'));
         //$this->assertEquals('http://www.example.com/atom/id/1', $entry->getCommentFeedLink('atom'));
     }
-    
+
     public function testCategoriesCanBeSet()
     {
         $this->_validEntry->addCategories(array(
-            array('term'=>'cat_dog', 'label' => 'Cats & Dogs', 'scheme' => 'http://example.com/schema1'),
-            array('term'=>'cat_dog2')
-        ));
+                                               array('term'   => 'cat_dog',
+                                                     'label'  => 'Cats & Dogs',
+                                                     'scheme' => 'http://example.com/schema1'),
+                                               array('term'=> 'cat_dog2')
+                                          ));
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $expected = array(
-            array('term'=>'cat_dog', 'label' => 'cat_dog', 'scheme' => 'http://example.com/schema1'),
-            array('term'=>'cat_dog2', 'label' => 'cat_dog2', 'scheme' => null)
+            array('term'   => 'cat_dog',
+                  'label'  => 'cat_dog',
+                  'scheme' => 'http://example.com/schema1'),
+            array('term'   => 'cat_dog2',
+                  'label'  => 'cat_dog2',
+                  'scheme' => null)
         );
-        $this->assertEquals($expected, (array) $entry->getCategories());
+        $this->assertEquals($expected, (array)$entry->getCategories());
     }
-    
+
     /**
      * @group ZFWCHARDATA01
      */
     public function testCategoriesCharDataEncoding()
     {
         $this->_validEntry->addCategories(array(
-            array('term'=>'<>&\'"áéíóú', 'label' => 'Cats & Dogs', 'scheme' => 'http://example.com/schema1'),
-            array('term'=>'cat_dog2')
-        ));
+                                               array('term'   => '<>&\'"áéíóú',
+                                                     'label'  => 'Cats & Dogs',
+                                                     'scheme' => 'http://example.com/schema1'),
+                                               array('term'=> 'cat_dog2')
+                                          ));
         $renderer = new Renderer\Feed\Rss($this->_validWriter);
-        $feed = Reader\Reader::importString($renderer->render()->saveXml());
-        $entry = $feed->current();
+        $feed     = Reader\Reader::importString($renderer->render()->saveXml());
+        $entry    = $feed->current();
         $expected = array(
-            array('term'=>'<>&\'"áéíóú', 'label' => '<>&\'"áéíóú', 'scheme' => 'http://example.com/schema1'),
-            array('term'=>'cat_dog2', 'label' => 'cat_dog2', 'scheme' => null)
+            array('term'   => '<>&\'"áéíóú',
+                  'label'  => '<>&\'"áéíóú',
+                  'scheme' => 'http://example.com/schema1'),
+            array('term'   => 'cat_dog2',
+                  'label'  => 'cat_dog2',
+                  'scheme' => null)
         );
-        $this->assertEquals($expected, (array) $entry->getCategories());
+        $this->assertEquals($expected, (array)$entry->getCategories());
     }
 
 }

--- a/tests/Zend/Feed/Writer/Renderer/Feed/AtomTest.php
+++ b/tests/Zend/Feed/Writer/Renderer/Feed/AtomTest.php
@@ -26,14 +26,14 @@ use Zend\Feed\Reader;
 use Zend\Date;
 
 /**
-* @category Zend
-* @package Zend_Feed
-* @subpackage UnitTests
-* @group Zend_Feed
-* @group Zend_Feed_Writer
-* @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
-* @license http://framework.zend.com/license/new-bsd New BSD License
-*/
+ * @category   Zend
+ * @package    Zend_Feed
+ * @subpackage UnitTests
+ * @group      Zend_Feed
+ * @group      Zend_Feed_Writer
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd New BSD License
+ */
 class AtomTest extends \PHPUnit_Framework_TestCase
 {
 
@@ -47,8 +47,10 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $this->_validWriter->setDateModified(1234567890);
         $this->_validWriter->setLink('http://www.example.com');
         $this->_validWriter->setFeedLink('http://www.example.com/atom', 'atom');
-        $this->_validWriter->addAuthor('Joe', 'joe@example.com', 'http://www.example.com/joe');
-        
+        $this->_validWriter->addAuthor(array('name' => 'Joe',
+                                             'email'=> 'joe@example.com',
+                                             'uri'  => 'http://www.example.com/joe'));
+
         $this->_validWriter->setType('atom');
     }
 
@@ -60,7 +62,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
     public function testSetsWriterInConstructor()
     {
         $writer = new Writer\Feed;
-        $feed = new Renderer\Feed\Atom($writer);
+        $feed   = new Renderer\Feed\Atom($writer);
         $this->assertTrue($feed->getDataContainer() instanceof Writer\Feed);
     }
 
@@ -98,7 +100,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($atomFeed->saveXml());
         $this->assertEquals('This is a test feed.', $feed->getTitle());
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -108,7 +110,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $this->_validWriter->remove('title');
         $atomFeed->render();
     }
-    
+
     /**
      * @group ZFWCHARDATA01
      */
@@ -128,14 +130,14 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($atomFeed->saveXml());
         $this->assertEquals('This is a test description.', $feed->getDescription());
     }
-    
+
     public function testFeedSubtitleThrowsNoExceptionIfMissing()
     {
         $atomFeed = new Renderer\Feed\Atom($this->_validWriter);
         $this->_validWriter->remove('description');
         $atomFeed->render();
     }
-    
+
     /**
      * @group ZFWCHARDATA01
      */
@@ -155,7 +157,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($atomFeed->saveXml());
         $this->assertEquals(1234567890, $feed->getDateModified()->get(Date\Date::TIMESTAMP));
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -174,7 +176,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($atomFeed->saveXml());
         $this->assertEquals('FooFeedBuilder', $feed->getGenerator());
     }
-    
+
     public function testFeedGeneratorIfMissingThrowsNoException()
     {
         $atomFeed = new Renderer\Feed\Atom($this->_validWriter);
@@ -189,7 +191,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($atomFeed->saveXml());
         $this->assertEquals('Zend_Feed_Writer', $feed->getGenerator());
     }
-    
+
     /**
      * @group ZFWCHARDATA01
      */
@@ -210,7 +212,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($atomFeed->saveXml());
         $this->assertEquals('fr', $feed->getLanguage());
     }
-    
+
     public function testFeedLanguageIfMissingThrowsNoException()
     {
         $atomFeed = new Renderer\Feed\Atom($this->_validWriter);
@@ -233,7 +235,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($atomFeed->saveXml());
         $this->assertEquals('http://www.example.com', $feed->getLink());
     }
-    
+
     public function testFeedLinkToHtmlVersionOfFeedIfMissingThrowsNoExceptionIfIdSet()
     {
         $atomFeed = new Renderer\Feed\Atom($this->_validWriter);
@@ -241,7 +243,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $this->_validWriter->remove('link');
         $atomFeed->render();
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -259,7 +261,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($atomFeed->saveXml());
         $this->assertEquals('http://www.example.com/atom', $feed->getFeedLink());
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -274,14 +276,14 @@ class AtomTest extends \PHPUnit_Framework_TestCase
     {
         $atomFeed = new Renderer\Feed\Atom($this->_validWriter);
         $atomFeed->render();
-        $feed = Reader\Reader::importString($atomFeed->saveXml());
+        $feed   = Reader\Reader::importString($atomFeed->saveXml());
         $author = $feed->getAuthor();
         $this->assertEquals(array(
-            'email'=>'joe@example.com',
-            'name'=>'Joe',
-            'uri'=>'http://www.example.com/joe'), $feed->getAuthor());
+                                 'email'=> 'joe@example.com',
+                                 'name' => 'Joe',
+                                 'uri'  => 'http://www.example.com/joe'), $feed->getAuthor());
     }
-    
+
     /**
      * @group ZFWCHARDATA01
      */
@@ -290,28 +292,28 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $atomFeed = new Renderer\Feed\Atom($this->_validWriter);
         $this->_validWriter->remove('authors');
         $this->_validWriter->addAuthor(array(
-            'email'=>'<>&\'"áéíóú',
-            'name'=>'<>&\'"áéíóú',
-            'uri'=>'http://www.example.com/joe'));
+                                            'email'=> '<>&\'"áéíóú',
+                                            'name' => '<>&\'"áéíóú',
+                                            'uri'  => 'http://www.example.com/joe'));
         $atomFeed->render();
-        $feed = Reader\Reader::importString($atomFeed->saveXml());
+        $feed   = Reader\Reader::importString($atomFeed->saveXml());
         $author = $feed->getAuthor();
         $this->assertEquals(array(
-            'email'=>'<>&\'"áéíóú',
-            'name'=>'<>&\'"áéíóú',
-            'uri'=>'http://www.example.com/joe'), $feed->getAuthor());
+                                 'email'=> '<>&\'"áéíóú',
+                                 'name' => '<>&\'"áéíóú',
+                                 'uri'  => 'http://www.example.com/joe'), $feed->getAuthor());
     }
-    
+
     public function testFeedAuthorIfNotSetThrowsExceptionIfAnyEntriesAlsoAreMissingAuthors()
     {
         $this->markTestIncomplete('Not yet implemented...');
     }
-    
+
     public function testFeedAuthorIfNotSetThrowsNoExceptionIfAllEntriesIncludeAtLeastOneAuthor()
     {
         $this->markTestIncomplete('Not yet implemented...');
     }
-    
+
     public function testFeedIdHasBeenSet()
     {
         $this->_validWriter->setId('urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6');
@@ -328,7 +330,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($atomFeed->saveXml());
         $this->assertEquals($feed->getLink(), $feed->getId());
     }
-    
+
     public function testBaseUrlCanBeSet()
     {
         $this->_validWriter->setBaseUrl('http://www.example.com/base');
@@ -337,7 +339,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($atomFeed->saveXml());
         $this->assertEquals('http://www.example.com/base', $feed->getBaseUrl());
     }
-    
+
     public function testCopyrightCanBeSet()
     {
         $this->_validWriter->setCopyright('Copyright © 2009 Paddy');
@@ -346,7 +348,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($atomFeed->saveXml());
         $this->assertEquals('Copyright © 2009 Paddy', $feed->getCopyright());
     }
-    
+
     public function testCopyrightCharDataEncoding()
     {
         $this->_validWriter->setCopyright('<>&\'"áéíóú');
@@ -355,39 +357,51 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($atomFeed->saveXml());
         $this->assertEquals('<>&\'"áéíóú', $feed->getCopyright());
     }
-    
+
     public function testCategoriesCanBeSet()
     {
         $this->_validWriter->addCategories(array(
-            array('term'=>'cat_dog', 'label' => 'Cats & Dogs', 'scheme' => 'http://example.com/schema1'),
-            array('term'=>'cat_dog2')
-        ));
+                                                array('term'   => 'cat_dog',
+                                                      'label'  => 'Cats & Dogs',
+                                                      'scheme' => 'http://example.com/schema1'),
+                                                array('term'=> 'cat_dog2')
+                                           ));
         $atomFeed = new Renderer\Feed\Atom($this->_validWriter);
         $atomFeed->render();
-        $feed = Reader\Reader::importString($atomFeed->saveXml());
+        $feed     = Reader\Reader::importString($atomFeed->saveXml());
         $expected = array(
-            array('term'=>'cat_dog', 'label' => 'Cats & Dogs', 'scheme' => 'http://example.com/schema1'),
-            array('term'=>'cat_dog2', 'label' => 'cat_dog2', 'scheme' => null)
+            array('term'   => 'cat_dog',
+                  'label'  => 'Cats & Dogs',
+                  'scheme' => 'http://example.com/schema1'),
+            array('term'   => 'cat_dog2',
+                  'label'  => 'cat_dog2',
+                  'scheme' => null)
         );
-        $this->assertEquals($expected, (array) $feed->getCategories());
+        $this->assertEquals($expected, (array)$feed->getCategories());
     }
-    
+
     public function testCategoriesCharDataEncoding()
     {
         $this->_validWriter->addCategories(array(
-            array('term'=>'cat_dog', 'label' => '<>&\'"áéíóú', 'scheme' => 'http://example.com/schema1'),
-            array('term'=>'cat_dog2')
-        ));
+                                                array('term'   => 'cat_dog',
+                                                      'label'  => '<>&\'"áéíóú',
+                                                      'scheme' => 'http://example.com/schema1'),
+                                                array('term'=> 'cat_dog2')
+                                           ));
         $atomFeed = new Renderer\Feed\Atom($this->_validWriter);
         $atomFeed->render();
-        $feed = Reader\Reader::importString($atomFeed->saveXml());
+        $feed     = Reader\Reader::importString($atomFeed->saveXml());
         $expected = array(
-            array('term'=>'cat_dog', 'label' => '<>&\'"áéíóú', 'scheme' => 'http://example.com/schema1'),
-            array('term'=>'cat_dog2', 'label' => 'cat_dog2', 'scheme' => null)
+            array('term'   => 'cat_dog',
+                  'label'  => '<>&\'"áéíóú',
+                  'scheme' => 'http://example.com/schema1'),
+            array('term'   => 'cat_dog2',
+                  'label'  => 'cat_dog2',
+                  'scheme' => null)
         );
-        $this->assertEquals($expected, (array) $feed->getCategories());
+        $this->assertEquals($expected, (array)$feed->getCategories());
     }
-    
+
     public function testHubsCanBeSet()
     {
         $this->_validWriter->addHubs(
@@ -395,21 +409,21 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         );
         $atomFeed = new Renderer\Feed\Atom($this->_validWriter);
         $atomFeed->render();
-        $feed = Reader\Reader::importString($atomFeed->saveXml());
+        $feed     = Reader\Reader::importString($atomFeed->saveXml());
         $expected = array(
             'http://www.example.com/hub', 'http://www.example.com/hub2'
         );
-        $this->assertEquals($expected, (array) $feed->getHubs());
+        $this->assertEquals($expected, (array)$feed->getHubs());
     }
 
     public function testImageCanBeSet()
     {
         $this->_validWriter->setImage(
-            array('uri'=>'http://www.example.com/logo.gif')
+            array('uri'=> 'http://www.example.com/logo.gif')
         );
         $atomFeed = new Renderer\Feed\Atom($this->_validWriter);
         $atomFeed->render();
-        $feed = Reader\Reader::importString($atomFeed->saveXml());
+        $feed     = Reader\Reader::importString($atomFeed->saveXml());
         $expected = array(
             'uri' => 'http://www.example.com/logo.gif'
         );

--- a/tests/Zend/Feed/Writer/Renderer/Feed/RssTest.php
+++ b/tests/Zend/Feed/Writer/Renderer/Feed/RssTest.php
@@ -20,20 +20,21 @@
  */
 
 namespace ZendTest\Feed\Writer\Renderer\Feed;
+
 use Zend\Feed\Writer;
 use Zend\Feed\Writer\Renderer;
 use Zend\Feed\Reader;
 use Zend\Date;
 
 /**
-* @category Zend
-* @package Zend_Feed
-* @subpackage UnitTests
-* @group Zend_Feed
-* @group Zend_Feed_Writer
-* @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
-* @license http://framework.zend.com/license/new-bsd New BSD License
-*/
+ * @category   Zend
+ * @package    Zend_Feed
+ * @subpackage UnitTests
+ * @group      Zend_Feed
+ * @group      Zend_Feed_Writer
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd New BSD License
+ */
 class RssTest extends \PHPUnit_Framework_TestCase
 {
 
@@ -45,7 +46,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $this->_validWriter->setTitle('This is a test feed.');
         $this->_validWriter->setDescription('This is a test description.');
         $this->_validWriter->setLink('http://www.example.com');
-        
+
         $this->_validWriter->setType('rss');
     }
 
@@ -57,7 +58,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function testSetsWriterInConstructor()
     {
         $writer = new Writer\Feed;
-        $feed = new Renderer\Feed\Rss($writer);
+        $feed   = new Renderer\Feed\Rss($writer);
         $this->assertTrue($feed->getDataContainer() instanceof Writer\Feed);
     }
 
@@ -95,7 +96,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($rssFeed->saveXml());
         $this->assertEquals('This is a test feed.', $feed->getTitle());
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -125,7 +126,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($rssFeed->saveXml());
         $this->assertEquals('This is a test description.', $feed->getDescription());
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -135,7 +136,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $this->_validWriter->remove('description');
         $rssFeed->render();
     }
-    
+
     /**
      * @group ZFWCHARDATA01
      */
@@ -156,7 +157,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($rssFeed->saveXml());
         $this->assertEquals(1234567890, $feed->getDateModified()->get(Date\Date::TIMESTAMP));
     }
-    
+
     public function testFeedUpdatedDateIfMissingThrowsNoException()
     {
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
@@ -181,7 +182,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($rssFeed->saveXml());
         $this->assertEquals('FooFeedBuilder 1.00 (http://www.example.com)', $feed->getGenerator());
     }
-    
+
     public function testFeedGeneratorIfMissingThrowsNoException()
     {
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
@@ -194,7 +195,8 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
         $feed = Reader\Reader::importString($rssFeed->saveXml());
-        $this->assertEquals('Zend_Feed_Writer ' . \Zend\Version::VERSION . ' (http://framework.zend.com)', $feed->getGenerator());
+        $this->assertEquals(
+            'Zend_Feed_Writer ' . \Zend\Version::VERSION . ' (http://framework.zend.com)', $feed->getGenerator());
     }
 
     public function testFeedLanguageHasBeenSet()
@@ -205,7 +207,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($rssFeed->saveXml());
         $this->assertEquals('fr', $feed->getLanguage());
     }
-    
+
     public function testFeedLanguageIfMissingThrowsNoException()
     {
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
@@ -228,7 +230,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($rssFeed->saveXml());
         $this->assertEquals('http://www.example.com', $feed->getLink());
     }
-    
+
     /**
      * @expectedException Zend\Feed\Writer\Exception
      */
@@ -247,14 +249,14 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($rssFeed->saveXml());
         $this->assertEquals('http://www.example.com/rss', $feed->getFeedLink());
     }
-    
+
     public function testFeedLinkToXmlRssWhereTheFeedWillBeAvailableIfMissingThrowsNoException()
     {
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $this->_validWriter->remove('feedLinks');
         $rssFeed->render();
     }
-    
+
     public function testBaseUrlCanBeSet()
     {
         $this->_validWriter->setBaseUrl('http://www.example.com/base');
@@ -263,33 +265,37 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($rssFeed->saveXml());
         $this->assertEquals('http://www.example.com/base', $feed->getBaseUrl());
     }
-    
+
     /**
      * @group ZFW003
      */
     public function testFeedHoldsAnyAuthorAdded()
     {
-        $this->_validWriter->addAuthor('Joe', 'joe@example.com', 'http://www.example.com/joe');
+        $this->_validWriter->addAuthor(array('name' => 'Joe',
+                                             'email'=> 'joe@example.com',
+                                             'uri'  => 'http://www.example.com/joe'));
         $atomFeed = new Renderer\Feed\Rss($this->_validWriter);
         $atomFeed->render();
-        $feed = Reader\Reader::importString($atomFeed->saveXml());
+        $feed   = Reader\Reader::importString($atomFeed->saveXml());
         $author = $feed->getAuthor();
-        $this->assertEquals(array('name'=>'Joe'), $feed->getAuthor());
+        $this->assertEquals(array('name'=> 'Joe'), $feed->getAuthor());
     }
-    
+
     /**
      * @group ZFWCHARDATA01
      */
     public function testFeedAuthorCharDataEncoding()
-    {   
-        $this->_validWriter->addAuthor('<>&\'"áéíóú', 'joe@example.com', 'http://www.example.com/joe');
+    {
+        $this->_validWriter->addAuthor(array('name' => '<>&\'"áéíóú',
+                                            'email'=> 'joe@example.com',
+                                            'uri'  => 'http://www.example.com/joe'));
         $atomFeed = new Renderer\Feed\Rss($this->_validWriter);
         $atomFeed->render();
-        $feed = Reader\Reader::importString($atomFeed->saveXml());
+        $feed   = Reader\Reader::importString($atomFeed->saveXml());
         $author = $feed->getAuthor();
-        $this->assertEquals(array('name'=>'<>&\'"áéíóú'), $feed->getAuthor());
+        $this->assertEquals(array('name'=> '<>&\'"áéíóú'), $feed->getAuthor());
     }
-    
+
     public function testCopyrightCanBeSet()
     {
         $this->_validWriter->setCopyright('Copyright © 2009 Paddy');
@@ -298,7 +304,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($rssFeed->saveXml());
         $this->assertEquals('Copyright © 2009 Paddy', $feed->getCopyright());
     }
-    
+
     /**
      * @group ZFWCHARDATA01
      */
@@ -310,42 +316,54 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($rssFeed->saveXml());
         $this->assertEquals('<>&\'"áéíóú', $feed->getCopyright());
     }
-    
+
     public function testCategoriesCanBeSet()
     {
         $this->_validWriter->addCategories(array(
-            array('term'=>'cat_dog', 'label' => 'Cats & Dogs', 'scheme' => 'http://example.com/schema1'),
-            array('term'=>'cat_dog2')
-        ));
+                                                array('term'   => 'cat_dog',
+                                                      'label'  => 'Cats & Dogs',
+                                                      'scheme' => 'http://example.com/schema1'),
+                                                array('term'=> 'cat_dog2')
+                                           ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
-        $feed = Reader\Reader::importString($rssFeed->saveXml());
+        $feed     = Reader\Reader::importString($rssFeed->saveXml());
         $expected = array(
-            array('term'=>'cat_dog', 'label' => 'cat_dog', 'scheme' => 'http://example.com/schema1'),
-            array('term'=>'cat_dog2', 'label' => 'cat_dog2', 'scheme' => null)
+            array('term'   => 'cat_dog',
+                  'label'  => 'cat_dog',
+                  'scheme' => 'http://example.com/schema1'),
+            array('term'   => 'cat_dog2',
+                  'label'  => 'cat_dog2',
+                  'scheme' => null)
         );
-        $this->assertEquals($expected, (array) $feed->getCategories());
+        $this->assertEquals($expected, (array)$feed->getCategories());
     }
-    
+
     /**
      * @group ZFWCHARDATA01
      */
     public function testCategoriesCharDataEncoding()
     {
         $this->_validWriter->addCategories(array(
-            array('term'=>'<>&\'"áéíóú', 'label' => 'Cats & Dogs', 'scheme' => 'http://example.com/schema1'),
-            array('term'=>'cat_dog2')
-        ));
+                                                array('term'   => '<>&\'"áéíóú',
+                                                      'label'  => 'Cats & Dogs',
+                                                      'scheme' => 'http://example.com/schema1'),
+                                                array('term'=> 'cat_dog2')
+                                           ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
-        $feed = Reader\Reader::importString($rssFeed->saveXml());
+        $feed     = Reader\Reader::importString($rssFeed->saveXml());
         $expected = array(
-            array('term'=>'<>&\'"áéíóú', 'label' => '<>&\'"áéíóú', 'scheme' => 'http://example.com/schema1'),
-            array('term'=>'cat_dog2', 'label' => 'cat_dog2', 'scheme' => null)
+            array('term'   => '<>&\'"áéíóú',
+                  'label'  => '<>&\'"áéíóú',
+                  'scheme' => 'http://example.com/schema1'),
+            array('term'   => 'cat_dog2',
+                  'label'  => 'cat_dog2',
+                  'scheme' => null)
         );
-        $this->assertEquals($expected, (array) $feed->getCategories());
+        $this->assertEquals($expected, (array)$feed->getCategories());
     }
-    
+
     public function testHubsCanBeSet()
     {
         $this->_validWriter->addHubs(
@@ -353,53 +371,53 @@ class RssTest extends \PHPUnit_Framework_TestCase
         );
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
-        $feed = Reader\Reader::importString($rssFeed->saveXml());
+        $feed     = Reader\Reader::importString($rssFeed->saveXml());
         $expected = array(
             'http://www.example.com/hub', 'http://www.example.com/hub2'
         );
-        $this->assertEquals($expected, (array) $feed->getHubs());
+        $this->assertEquals($expected, (array)$feed->getHubs());
     }
 
     public function testImageCanBeSet()
     {
         $this->_validWriter->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com',
-            'title' => 'Image ALT',
-            'height' => '400',
-            'width' => '144',
-            'description' => 'Image TITLE'
-        ));
+                                           'uri'         => 'http://www.example.com/logo.gif',
+                                           'link'        => 'http://www.example.com',
+                                           'title'       => 'Image ALT',
+                                           'height'      => '400',
+                                           'width'       => '144',
+                                           'description' => 'Image TITLE'
+                                      ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
-        $feed = Reader\Reader::importString($rssFeed->saveXml());
+        $feed     = Reader\Reader::importString($rssFeed->saveXml());
         $expected = array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com',
-            'title' => 'Image ALT',
-            'height' => '400',
-            'width' => '144',
-            'description' => 'Image TITLE'  
+            'uri'         => 'http://www.example.com/logo.gif',
+            'link'        => 'http://www.example.com',
+            'title'       => 'Image ALT',
+            'height'      => '400',
+            'width'       => '144',
+            'description' => 'Image TITLE'
         );
-        $this->assertEquals($expected, $feed->getImage()); 
+        $this->assertEquals($expected, $feed->getImage());
     }
 
     public function testImageCanBeSetWithOnlyRequiredElements()
     {
         $this->_validWriter->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com',
-            'title' => 'Image ALT'
-        ));
+                                           'uri'   => 'http://www.example.com/logo.gif',
+                                           'link'  => 'http://www.example.com',
+                                           'title' => 'Image ALT'
+                                      ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
-        $feed = Reader\Reader::importString($rssFeed->saveXml());
+        $feed     = Reader\Reader::importString($rssFeed->saveXml());
         $expected = array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com',
-            'title' => 'Image ALT' 
+            'uri'   => 'http://www.example.com/logo.gif',
+            'link'  => 'http://www.example.com',
+            'title' => 'Image ALT'
         );
-        $this->assertEquals($expected, $feed->getImage()); 
+        $this->assertEquals($expected, $feed->getImage());
     }
 
     /**
@@ -408,9 +426,9 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function testImageThrowsExceptionOnMissingLink()
     {
         $this->_validWriter->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'title' => 'Image ALT'
-        ));
+                                           'uri'   => 'http://www.example.com/logo.gif',
+                                           'title' => 'Image ALT'
+                                      ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
     }
@@ -421,9 +439,9 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function testImageThrowsExceptionOnMissingTitle()
     {
         $this->_validWriter->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com'
-        ));
+                                           'uri'  => 'http://www.example.com/logo.gif',
+                                           'link' => 'http://www.example.com'
+                                      ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
     }
@@ -434,9 +452,9 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function testImageThrowsExceptionOnMissingUri()
     {
         $this->_validWriter->setImage(array(
-            'link' => 'http://www.example.com',
-            'title' => 'Image ALT'
-        ));
+                                           'link'  => 'http://www.example.com',
+                                           'title' => 'Image ALT'
+                                      ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
     }
@@ -447,11 +465,11 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function testImageThrowsExceptionIfOptionalDescriptionInvalid()
     {
         $this->_validWriter->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com',
-            'title' => 'Image ALT',
-            'description' => 2
-        ));
+                                           'uri'         => 'http://www.example.com/logo.gif',
+                                           'link'        => 'http://www.example.com',
+                                           'title'       => 'Image ALT',
+                                           'description' => 2
+                                      ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
     }
@@ -462,11 +480,11 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function testImageThrowsExceptionIfOptionalDescriptionEmpty()
     {
         $this->_validWriter->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com',
-            'title' => 'Image ALT',
-            'description' => ''
-        ));
+                                           'uri'         => 'http://www.example.com/logo.gif',
+                                           'link'        => 'http://www.example.com',
+                                           'title'       => 'Image ALT',
+                                           'description' => ''
+                                      ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
     }
@@ -477,12 +495,12 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function testImageThrowsExceptionIfOptionalHeightNotAnInteger()
     {
         $this->_validWriter->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com',
-            'title' => 'Image ALT',
-            'height' => 'a',
-            'width' => 144
-        ));
+                                           'uri'    => 'http://www.example.com/logo.gif',
+                                           'link'   => 'http://www.example.com',
+                                           'title'  => 'Image ALT',
+                                           'height' => 'a',
+                                           'width'  => 144
+                                      ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
     }
@@ -493,12 +511,12 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function testImageThrowsExceptionIfOptionalHeightEmpty()
     {
         $this->_validWriter->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com',
-            'title' => 'Image ALT',
-            'height' => '',
-            'width' => 144
-        ));
+                                           'uri'    => 'http://www.example.com/logo.gif',
+                                           'link'   => 'http://www.example.com',
+                                           'title'  => 'Image ALT',
+                                           'height' => '',
+                                           'width'  => 144
+                                      ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
     }
@@ -509,12 +527,12 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function testImageThrowsExceptionIfOptionalHeightGreaterThan400()
     {
         $this->_validWriter->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com',
-            'title' => 'Image ALT',
-            'height' => '401',
-            'width' => 144
-        ));
+                                           'uri'    => 'http://www.example.com/logo.gif',
+                                           'link'   => 'http://www.example.com',
+                                           'title'  => 'Image ALT',
+                                           'height' => '401',
+                                           'width'  => 144
+                                      ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
     }
@@ -525,12 +543,12 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function testImageThrowsExceptionIfOptionalWidthNotAnInteger()
     {
         $this->_validWriter->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com',
-            'title' => 'Image ALT',
-            'height' => '400',
-            'width' => 'a'
-        ));
+                                           'uri'    => 'http://www.example.com/logo.gif',
+                                           'link'   => 'http://www.example.com',
+                                           'title'  => 'Image ALT',
+                                           'height' => '400',
+                                           'width'  => 'a'
+                                      ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
     }
@@ -541,12 +559,12 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function testImageThrowsExceptionIfOptionalWidthEmpty()
     {
         $this->_validWriter->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com',
-            'title' => 'Image ALT',
-            'height' => '400',
-            'width' => ''
-        ));
+                                           'uri'    => 'http://www.example.com/logo.gif',
+                                           'link'   => 'http://www.example.com',
+                                           'title'  => 'Image ALT',
+                                           'height' => '400',
+                                           'width'  => ''
+                                      ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
     }
@@ -557,15 +575,15 @@ class RssTest extends \PHPUnit_Framework_TestCase
     public function testImageThrowsExceptionIfOptionalWidthGreaterThan144()
     {
         $this->_validWriter->setImage(array(
-            'uri' => 'http://www.example.com/logo.gif',
-            'link' => 'http://www.example.com',
-            'title' => 'Image ALT',
-            'height' => '400',
-            'width' => '145'
-        ));
+                                           'uri'    => 'http://www.example.com/logo.gif',
+                                           'link'   => 'http://www.example.com',
+                                           'title'  => 'Image ALT',
+                                           'height' => '400',
+                                           'width'  => '145'
+                                      ));
         $rssFeed = new Renderer\Feed\Rss($this->_validWriter);
         $rssFeed->render();
     }
-    
+
 
 }


### PR DESCRIPTION
Removed the code that allow add an author with single parameters in favor to add an author using an array of parameters.

Method affected addAuthor()

This change fix the issue with PHP 5.4
