### PR TITLE
Fixed Operator. Exception will never be thrown

### DIFF
--- a/library/Zend/Soap/AutoDiscover.php
+++ b/library/Zend/Soap/AutoDiscover.php
@@ -253,7 +253,7 @@ class AutoDiscover
      */
     public function setWsdlClass($wsdlClass)
     {
-        if (!is_string($wsdlClass) && !is_subclass_of($wsdlClass, 'Zend\Soap\Wsdl')) {
+        if (!is_string($wsdlClass) || !is_subclass_of($wsdlClass, 'Zend\Soap\Wsdl')) {
             throw new Exception\InvalidArgumentException(
                 'No \Zend\Soap\Wsdl subclass given to Zend\Soap\AutoDiscover::setWsdlClass as string.'
             );


### PR DESCRIPTION
$wsdlClass cannot be not a string AND not a subclass of Zend\Soap\Wsdl
