### PR TITLE
Added type to parameter in setOptions

### DIFF
--- a/library/Zend/Module/Listener/AbstractListener.php
+++ b/library/Zend/Module/Listener/AbstractListener.php
@@ -51,10 +51,10 @@ abstract class AbstractListener
     /**
      * Set options.
      *
-     * @param  $options the value to be set
+     * @param ListenerOptions $options the value to be set
      * @return AbstractListener
      */
-    public function setOptions($options)
+    public function setOptions(ListenerOptions $options)
     {
         $this->options = $options;
         return $this;


### PR DESCRIPTION
Do not allow stuff like:
$defaultListeners = new Zend\Module\Listener\DefaultListenerAggregate();
$defaultListeners->setOptions('randomstuff');

This triggered an php-error in the config-listener previously. 
