### PR TITLE
[CodeGenerator] Clean references in Zend\Code

### DIFF
--- a/library/Zend/Code/Generator/AbstractGenerator.php
+++ b/library/Zend/Code/Generator/AbstractGenerator.php
@@ -13,20 +13,21 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
 namespace Zend\Code\Generator;
+
 use Zend\Code\Generator
     /* Zend\Config */
     ;
 
 /**
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */

--- a/library/Zend/Code/Generator/AbstractGenerator.php
+++ b/library/Zend/Code/Generator/AbstractGenerator.php
@@ -145,7 +145,7 @@ abstract class AbstractGenerator implements Generator
 //     * setConfig()
 //     *
 //     * @param \Zend\Config\Config $config
-//     * @return \Zend\CodeGenerator\AbstractCodeGenerator
+//     * @return self
 //     */
 //    public function setConfig(Config\Config $config)
 //    {
@@ -157,7 +157,7 @@ abstract class AbstractGenerator implements Generator
 //     * setOptions()
 //     *
 //     * @param array $options
-//     * @return \Zend\CodeGenerator\AbstractCodeGenerator
+//     * @return self
 //     */
 //    public function setOptions(Array $options)
 //    {

--- a/library/Zend/Code/Generator/AbstractMemberGenerator.php
+++ b/library/Zend/Code/Generator/AbstractMemberGenerator.php
@@ -13,13 +13,14 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
 namespace Zend\Code\Generator;
+
 use Zend\Code\Generator,
     Zend\Code\Generator\Exception;
 
@@ -28,7 +29,7 @@ use Zend\Code\Generator,
  * @uses       \Zend\Code\GeneratorDocblock
  * @uses       \Zend\Code\Generator\Exception
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -108,7 +109,9 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
         if (is_string($docblock)) {
             $docblock = new DocblockGenerator($docblock);
         } elseif (!$docblock instanceof DocblockGenerator) {
-            throw new Exception\InvalidArgumentException('setDocblock() is expecting either a string, array or an instance of Zend_CodeGenerator_Php_Docblock');
+            throw new Exception\InvalidArgumentException(
+                'setDocblock() is expecting either a string, array or an instance of Zend\Code\Generator\DocblockGenerator'
+            );
         }
 
         $this->docblock = $docblock;

--- a/library/Zend/Code/Generator/BodyGenerator.php
+++ b/library/Zend/Code/Generator/BodyGenerator.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -22,9 +22,8 @@
 namespace Zend\Code\Generator;
 
 /**
- * @uses       \Zend\CodeGenerator\AbstractCodeGenerator
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */

--- a/library/Zend/Code/Generator/ClassGenerator.php
+++ b/library/Zend/Code/Generator/ClassGenerator.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -31,7 +31,7 @@ use Zend\Code\Reflection\ClassReflection;
  * @uses       \Zend\Code\Generator\PhpMethod
  * @uses       \Zend\Code\Generator\PhpProperty
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -318,7 +318,9 @@ class ClassGenerator extends AbstractGenerator
         if (is_array($docblock)) {
             $docblock = new DocblockGenerator($docblock);
         } elseif (!$docblock instanceof DocblockGenerator) {
-            throw new Exception\InvalidArgumentException('setDocblock() is expecting either a string, array or an instance of Zend_CodeGenerator_Php_Docblock');
+            throw new Exception\InvalidArgumentException(
+                'setDocblock() is expecting either a string, array or an instance of Zend\Code\Generator\DocblockGenerator'
+            );
         }
         */
 

--- a/library/Zend/Code/Generator/Docblock/Tag.php
+++ b/library/Zend/Code/Generator/Docblock/Tag.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -25,10 +25,9 @@ use Zend\Code\Reflection\ReflectionDocblockTag,
     Zend\Code\Generator\AbstractGenerator;
 
 /**
- * @uses       \Zend\CodeGenerator\AbstractCodeGenerator
  * @uses       \Zend\Loader\PluginLoader
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */

--- a/library/Zend/Code/Generator/Docblock/Tag/LicenseTag.php
+++ b/library/Zend/Code/Generator/Docblock/Tag/LicenseTag.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,7 +24,7 @@ namespace Zend\Code\Generator\Docblock\Tag;
 /**
  * @uses       \Zend\Code\Generator\DocBlock\Tag
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */

--- a/library/Zend/Code/Generator/Docblock/Tag/ParamTag.php
+++ b/library/Zend/Code/Generator/Docblock/Tag/ParamTag.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,7 +24,7 @@ namespace Zend\Code\Generator\Docblock\Tag;
 /**
  * @uses       \Zend\Code\Generator\DocBlock\Tag
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */

--- a/library/Zend/Code/Generator/Docblock/Tag/ReturnTag.php
+++ b/library/Zend/Code/Generator/Docblock/Tag/ReturnTag.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,7 +24,7 @@ namespace Zend\Code\Generator\Docblock\Tag;
 /**
  * @uses       \Zend\Code\Generator\DocBlock\Tag
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */

--- a/library/Zend/Code/Generator/DocblockGenerator.php
+++ b/library/Zend/Code/Generator/DocblockGenerator.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -28,7 +28,7 @@ use Zend\Code\Reflection\DocBlockReflection;
  * @uses       \Zend\Code\Generator\DocBlock\Tag
  * @uses       \Zend\Code\Generator\Exception
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */

--- a/library/Zend/Code/Generator/Exception.php
+++ b/library/Zend/Code/Generator/Exception.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -22,9 +22,8 @@
 namespace Zend\Code\Generator;
 
 /**
- * @uses       \Zend\CodeGenerator\Exception
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */

--- a/library/Zend/Code/Generator/Exception.php
+++ b/library/Zend/Code/Generator/Exception.php
@@ -27,7 +27,7 @@ namespace Zend\Code\Generator;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Exception extends \Zend\CodeGenerator\Exception
+interface Exception extends \Zend\Code\Exception
 {
 
 }

--- a/library/Zend/Code/Generator/FileGenerator.php
+++ b/library/Zend/Code/Generator/FileGenerator.php
@@ -128,7 +128,7 @@ class FileGenerator extends AbstractGenerator
                     $bodyReturn[] = str_replace(
                         '?',
                         $class->getName(),
-                        '/* Zend_CodeGenerator_Php_File-ClassMarker: {?} */'
+                        '/* Zend_Code_Generator_Php_File-ClassMarker: {?} */'
                     );
 
                     $lineNum = $classEndLine;
@@ -162,7 +162,7 @@ class FileGenerator extends AbstractGenerator
                     $bodyReturn[] = str_replace(
                         '?',
                         $class->getName(),
-                        '/* Zend_CodeGenerator_Php_File-DocblockMarker */'
+                        '/* Zend_Code_Generator_FileGenerator-DocblockMarker */'
                     );
                     $lineNum = $docblock->getEndLine();
                 } else {
@@ -484,7 +484,7 @@ class FileGenerator extends AbstractGenerator
         }
 
         // if there are markers, put the body into the output
-        if (preg_match('#/\* Zend_CodeGenerator_Php_File-(.*?)Marker:#', $body)) {
+        if (preg_match('#/\* Zend_Code_Generator_FileGenerator-(.*?)Marker:#', $body)) {
             $output .= $body;
             $body    = '';
         }
@@ -493,7 +493,7 @@ class FileGenerator extends AbstractGenerator
         if (null !== ($docblock = $this->getDocblock())) {
             $docblock->setIndentation('');
 
-            if (preg_match('#/* Zend_CodeGenerator_Php_File-DocblockMarker */#', $output)) {
+            if (preg_match('#/* Zend_Code_Generator_FileGenerator-DocblockMarker */#', $output)) {
                 $output = preg_replace('#/* Zend_CodeGenerator_Php_File-DocblockMarker */#', $docblock->generate(), $output, 1);
             } else {
                 $output .= $docblock->generate() . self::LINE_FEED;
@@ -537,7 +537,8 @@ class FileGenerator extends AbstractGenerator
         $classes = $this->getClasses();
         if (!empty($classes)) {
             foreach ($classes as $class) {
-                $regex = str_replace('?', $class->getName(), '/* Zend_CodeGenerator_Php_File-ClassMarker: {?} */');
+                $regex = str_replace('?', $class->getName(),
+                                     '/* Zend_Code_Generator_FileGenerator-ClassMarker: {?} */');
                 $regex = preg_quote($regex, '#');
                 if (preg_match('#'.$regex.'#', $output)) {
                     $output = preg_replace('#'.$regex.'#', $class->generate(), $output, 1);

--- a/library/Zend/Code/Generator/FileGenerator.php
+++ b/library/Zend/Code/Generator/FileGenerator.php
@@ -13,13 +13,14 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
 namespace Zend\Code\Generator;
+
 use Zend\Code\Reflection\FileReflection;
 
 /**
@@ -27,7 +28,7 @@ use Zend\Code\Reflection\FileReflection;
  * @uses       \Zend\Code\Generator\PhpClass
  * @uses       \Zend\Code\Generator\Exception
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -215,7 +216,9 @@ class FileGenerator extends AbstractGenerator
         if (is_array($docblock)) {
             $docblock = new DocblockGenerator($docblock);
         } elseif (!$docblock instanceof DocblockGenerator) {
-            throw new Exception\InvalidArgumentException('setDocblock() is expecting either a string, array or an instance of Zend_CodeGenerator_Php_Docblock');
+            throw new Exception\InvalidArgumentException(
+                'setDocblock() is expecting either a string, array or an instance of Zend\Code\Generator\DocblockGenerator'
+            );
         }
 
         $this->docblock = $docblock;
@@ -376,7 +379,9 @@ class FileGenerator extends AbstractGenerator
         } elseif ($class instanceof ClassGenerator) {
             $className = $class->getName();
         } else {
-            throw new Exception\InvalidArgumentException('Expecting either an array or an instance of Zend_CodeGenerator_Php_Class');
+            throw new Exception\InvalidArgumentException(
+                'setClass() is expecting either a string, array or an instance of Zend\Code\Generator\ClassGenerator'
+            );
         }*/
 
         // @todo check for dup here

--- a/library/Zend/Code/Generator/MethodGenerator.php
+++ b/library/Zend/Code/Generator/MethodGenerator.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -29,7 +29,7 @@ use Zend\Code\Reflection\MethodReflection;
  * @uses       \Zend\Code\Generator\PhpMember\AbstractMember
  * @uses       \Zend\Code\Generator\PhpParameter
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -139,7 +139,9 @@ class MethodGenerator extends AbstractMemberGenerator
         if (is_string($parameter)) {
             $parameter = new ParameterGenerator($parameter);
         } elseif (!$parameter instanceof ParameterGenerator) {
-            throw new Exception\InvalidArgumentException('setParameter() expects either an array of method options or an instance of Zend_CodeGenerator_Php_Parameter');
+            throw new Exception\InvalidArgumentException(
+                'setParameter() is expecting either a string, array or an instance of Zend\Code\Generator\ParameterGenerator'
+            );
         }
         $parameterName = $parameter->getName();
 

--- a/library/Zend/Code/Generator/ParameterGenerator.php
+++ b/library/Zend/Code/Generator/ParameterGenerator.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -26,9 +26,8 @@ use Zend\Code\Reflection\ParameterReflection;
 /**
  *
  * @uses       \Zend\Code\Generator\AbstractPhp
- * @uses       Zend_CodeGenerator_Php_ParameterDefaultValue
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */

--- a/library/Zend/Code/Generator/PropertyGenerator.php
+++ b/library/Zend/Code/Generator/PropertyGenerator.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -28,7 +28,7 @@ use Zend\Code\Reflection\PropertyReflection;
  * @uses       \Zend\Code\Generator\PhpMember\AbstractMember
  * @uses       \Zend\Code\Generator\PhpPropertyValue
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */

--- a/library/Zend/Code/Generator/PropertyValueGenerator.php
+++ b/library/Zend/Code/Generator/PropertyValueGenerator.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -25,7 +25,7 @@ namespace Zend\Code\Generator;
  * @uses       \Zend\Code\Generator\AbstractPhp
  * @uses       \Zend\Code\Generator\Exception
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */

--- a/library/Zend/Code/Generator/ValueGenerator.php
+++ b/library/Zend/Code/Generator/ValueGenerator.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/library/Zend/CodeGenerator/Exception.php
+++ b/library/Zend/CodeGenerator/Exception.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage PHP
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License

--- a/tests/Zend/Code/Generator/ClassGeneratorTest.php
+++ b/tests/Zend/Code/Generator/ClassGeneratorTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -28,13 +28,13 @@ use Zend\Code\Generator\ClassGenerator,
 
 /**
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  *
- * @group Zend_CodeGenerator
- * @group Zend_CodeGenerator_Php
+ * @group Zend_Code_Generator
+ * @group Zend_Code_Generator_Php
  */
 class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Zend/Code/Generator/DocblockGeneratorTest.php
+++ b/tests/Zend/Code/Generator/DocblockGeneratorTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,18 +24,14 @@ namespace ZendTest\Code\Generator;
 use Zend\Code\Generator\DocblockGenerator;
 
 /**
- * @see Zend_CodeGenerator_Php_Class
- */
-
-/**
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  *
- * @group Zend_CodeGenerator
- * @group Zend_CodeGenerator_Php
+ * @group Zend_Code_Generator
+ * @group Zend_Code_Generator_Php
  */
 class DocblockGeneratorTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Zend/Code/Generator/FileGeneratorTest.php
+++ b/tests/Zend/Code/Generator/FileGeneratorTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -25,14 +25,14 @@ use Zend\Code\Generator\FileGenerator,
 
 /**
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  *
- * @group Zend_CodeGenerator
- * @group Zend_CodeGenerator_Php
- * @group Zend_CodeGenerator_Php_File
+ * @group Zend_Code_Generator
+ * @group Zend_Code_Generator_Php
+ * @group Zend_Code_Generator_Php_File
  */
 class FileGeneratorTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Zend/Code/Generator/MethodGeneratorTest.php
+++ b/tests/Zend/Code/Generator/MethodGeneratorTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -27,13 +27,13 @@ use Zend\Code\Generator\MethodGenerator,
 
 /**
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  *
- * @group Zend_CodeGenerator
- * @group Zend_CodeGenerator_Php
+ * @group Zend_Code_Generator
+ * @group Zend_Code_Generator_Php
  */
 class PhpMethodTest extends \PHPUnit_Framework_TestCase
 {
@@ -52,7 +52,8 @@ class PhpMethodTest extends \PHPUnit_Framework_TestCase
         $methodGenerator->setParameters(array('one'));
         $params = $methodGenerator->getParameters();
         $param = array_shift($params);
-        $this->assertTrue($param instanceof \Zend\Code\Generator\ParameterGenerator, 'Failed because $param was not instance of Zend_CodeGenerator_Php_Property');
+        $this->assertTrue($param instanceof \Zend\Code\Generator\ParameterGenerator,
+                          'Failed because $param was not instance of Zend\Code\Generator\ParameterGenerator');
     }
 
     public function testMethodBodyGetterAndSetter()

--- a/tests/Zend/Code/Generator/ParameterGeneratorTest.php
+++ b/tests/Zend/Code/Generator/ParameterGeneratorTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -26,13 +26,13 @@ use Zend\Code\Generator\ParameterGenerator,
 
 /**
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  *
- * @group Zend_CodeGenerator
- * @group Zend_CodeGenerator_Php
+ * @group Zend_Code_Generator
+ * @group Zend_Code_Generator_Php
  */
 class ParameterGeneratorTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Zend/Code/Generator/PhpDocblockDocblockTagGeneratorTest.php
+++ b/tests/Zend/Code/Generator/PhpDocblockDocblockTagGeneratorTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -22,24 +22,20 @@
 namespace ZendTest\Code\Generator;
 
 /**
- * @see Zend_CodeGenerator_Php_Class
- */
-
-/**
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  *
- * @group Zend_CodeGenerator
- * @group Zend_CodeGenerator_Php
+ * @group Zend_Code_Generator
+ * @group Zend_Code_Generator_Php
  */
 class DocblockTagGeneratorTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
-     * @var Zend_CodeGenerator_Php_Docblock_Tag
+     * @var \Zend\Code\Generator\Docblock\Tag
      */
     protected $_tag = null;
 

--- a/tests/Zend/Code/Generator/PropertyGeneratorTest.php
+++ b/tests/Zend/Code/Generator/PropertyGeneratorTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -25,13 +25,13 @@ use Zend\Code\Generator\PropertyGenerator,
 
 /**
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  *
- * @group Zend_CodeGenerator
- * @group Zend_CodeGenerator_Php
+ * @group Zend_Code_Generator
+ * @group Zend_Code_Generator_Php
  */
 class PropertyGeneratorTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Zend/Code/Generator/PropertyValueGeneratorTest.php
+++ b/tests/Zend/Code/Generator/PropertyValueGeneratorTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,13 +24,13 @@ use Zend\Code\Generator\PropertyValueGenerator;
 
 /**
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  *
- * @group Zend_CodeGenerator
- * @group Zend_CodeGenerator_Php
+ * @group Zend_Code_Generator
+ * @group Zend_Code_Generator_Php
  */
 class PropertyValueGeneratorTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Zend/Code/Generator/ValueGeneratorTest.php
+++ b/tests/Zend/Code/Generator/ValueGeneratorTest.php
@@ -13,7 +13,7 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
@@ -24,13 +24,13 @@ use Zend\Code\Generator\ValueGenerator;
 
 /**
  * @category   Zend
- * @package    Zend_CodeGenerator
+ * @package    Zend_Code_Generator
  * @subpackage UnitTests
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  *
- * @group Zend_CodeGenerator
- * @group Zend_CodeGenerator_Php
+ * @group Zend_Code_Generator
+ * @group Zend_Code_Generator_Php
  */
 class ValueGeneratorTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
References to CodeGenerator has been cleaned from Zend\Code

Files with references to CodeGenerator not covered by this PR:
- Zend\Di\ServiceLocator\Generator
- ZendTest\Di\ServiceLocator\GeneratorTest
