### PR TITLE
Remove uses of Loader:loadClass()

### DIFF
--- a/library/Zend/Filter/Encrypt.php
+++ b/library/Zend/Filter/Encrypt.php
@@ -20,6 +20,9 @@
 
 namespace Zend\Filter;
 
+use Zend\Config;
+use Zend\Loader;
+
 /**
  * Encrypts a given string
  *
@@ -42,7 +45,7 @@ class Encrypt extends AbstractFilter
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
+        if ($options instanceof Config\Config) {
             $options = $options->toArray();
         }
 
@@ -80,12 +83,16 @@ class Encrypt extends AbstractFilter
             $options = array();
         }
 
-        if (\Zend\Loader::isReadable('Zend/Filter/Encrypt/' . ucfirst($adapter). '.php')) {
+        if (Loader::isReadable('Zend/Filter/Encrypt/' . ucfirst($adapter). '.php')) {
             $adapter = 'Zend\\Filter\\Encrypt\\' . ucfirst($adapter);
         }
 
         if (!class_exists($adapter)) {
-            \Zend\Loader::loadClass($adapter);
+            throw new Exception\DomainException(
+                sprintf('%s expects a valid registry class name; received "%s", which did not resolve',
+                        __METHOD__,
+                        $adapter
+                ));
         }
 
         $this->_adapter = new $adapter($options);

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -1836,8 +1836,13 @@ class Form implements Iterator, Countable, ValidatorInterface
         }
 
         if (!class_exists($class)) {
-            Loader::loadClass($class);
+            throw new Exception\UnexpectedValueException(
+                sprintf('%s expects a valid registry class name; received "%s", which did not resolve',
+                        __METHOD__,
+                        $class
+                ));
         }
+
         $this->_displayGroups[$name] = new $class(
             $name,
             $this->getPluginLoader(self::DECORATOR),

--- a/library/Zend/Registry.php
+++ b/library/Zend/Registry.php
@@ -108,9 +108,6 @@ class Registry extends ArrayObject
             throw new RuntimeException("Argument is not a class name");
         }
 
-        /**
-         * @see Zend\\Loader
-         */
         if (!class_exists($registryClassName)) {
             throw new DomainException(sprintf(
                 '%s expects a valid registry class name; received "%s", which did not resolve',

--- a/library/Zend/View/Helper/Placeholder/Registry.php
+++ b/library/Zend/View/Helper/Placeholder/Registry.php
@@ -21,6 +21,7 @@
 
 namespace Zend\View\Helper\Placeholder;
 
+use Zend\Registry as RegistryZend;
 use Zend\View\Exception;
 
 /**
@@ -58,11 +59,11 @@ class Registry
      */
     public static function getRegistry()
     {
-        if (\Zend\Registry::isRegistered(self::REGISTRY_KEY)) {
-            $registry = \Zend\Registry::get(self::REGISTRY_KEY);
+        if (RegistryZend::isRegistered(self::REGISTRY_KEY)) {
+            $registry = RegistryZend::get(self::REGISTRY_KEY);
         } else {
             $registry = new self();
-            \Zend\Registry::set(self::REGISTRY_KEY, $registry);
+            RegistryZend::set(self::REGISTRY_KEY, $registry);
         }
 
         return $registry;
@@ -73,7 +74,7 @@ class Registry
      *
      * @param  string $key
      * @param  array $value
-     * @return \Zend\View\Helper\Placeholder\Container\AbstractContainer
+     * @return Container\AbstractContainer
      */
     public function createContainer($key, array $value = array())
     {
@@ -87,7 +88,7 @@ class Registry
      * Retrieve a placeholder container
      *
      * @param  string $key
-     * @return \Zend\View\Helper\Placeholder\Container\AbstractContainer
+     * @return Container\AbstractContainer
      */
     public function getContainer($key)
     {
@@ -118,10 +119,10 @@ class Registry
      * Set the container for an item in the registry
      *
      * @param  string $key
-     * @param  Zend\View\Placeholder\Container\AbstractContainer $container
-     * @return Zend\View\Placeholder\Registry
+     * @param  Container\AbstractContainer $container
+     * @return Registry
      */
-    public function setContainer($key, \Zend\View\Helper\Placeholder\Container\AbstractContainer $container)
+    public function setContainer($key, Container\AbstractContainer $container)
     {
         $key = (string) $key;
         $this->_items[$key] = $container;
@@ -149,15 +150,19 @@ class Registry
      * Set the container class to use
      *
      * @param  string $name
-     * @return \Zend\View\Helper\Placeholder\Registry
      * @throws Exception\InvalidArgumentException
+     * @throws Exception\DomainException
+     * @return Registry
      */
     public function setContainerClass($name)
     {
         if (!class_exists($name)) {
-            \Zend\Loader::loadClass($name);
+            throw new Exception\DomainException(
+                sprintf('%s expects a valid registry class name; received "%s", which did not resolve',
+                        __METHOD__,
+                        $name
+                ));
         }
-
 
         if (!in_array('Zend\View\Helper\Placeholder\Container\AbstractContainer', class_parents($name))) {
             throw new Exception\InvalidArgumentException('Invalid Container class specified');


### PR DESCRIPTION
Not necessary with PHP 5.3 and Autoload.

[![Build Status](https://secure.travis-ci.org/Maks3w/zf2.png?branch=remove-loadclass)](http://travis-ci.org/Maks3w/zf2)
