### PR TITLE
[ZF-4520] Reorder Zend\Http\Header\SetCookie constructor arguments to match PHP setcookie()

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -468,7 +468,7 @@ class Client implements Stdlib\DispatchableInterface
      * @param boolean $httponly
      * @return Client
      */
-    public function addCookie($cookie, $value = null, $version = null, $maxAge = null, $domain = null, $expire = null, $path = null, $secure = false, $httponly = true)
+    public function addCookie($cookie, $value = null, $expire = null, $path = null, $domain = null, $secure = false, $httponly = true, $maxAge = null, $version = null)
     {
         if (is_array($cookie) || $cookie instanceof ArrayIterator) {
             foreach ($cookie as $setCookie) {
@@ -481,7 +481,7 @@ class Client implements Stdlib\DispatchableInterface
         } elseif ($cookie instanceof Header\SetCookie) {
             $this->cookies[$this->getCookieId($cookie)] = $cookie;
         } elseif (is_string($cookie) && $value !== null) {
-            $setCookie = new Header\SetCookie($cookie, $value, $version, $maxAge, $domain, $expire, $path, $secure, $httponly);
+            $setCookie = new Header\SetCookie($cookie, $value, $expire, $path, $domain, $secure, $httponly, $maxAge, $version);
             $this->cookies[$this->getCookieId($setCookie)] = $setCookie;
         } else {
             throw new Exception\InvalidArgumentException('Invalid parameter type passed as Cookie');

--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -148,14 +148,16 @@ class SetCookie implements MultipleHeaderDescription
      *
      * @param string $name
      * @param string $value
-     * @param string $domain
      * @param int $expires
      * @param string $path
+     * @param string $domain
      * @param bool $secure
      * @param bool $httponly
+     * @param string $maxAge
+     * @param int $version
      * @return SetCookie
      */
-    public function __construct($name = null, $value = null, $version = null, $maxAge = null, $domain = null, $expires = null, $path = null, $secure = false, $httponly = false)
+    public function __construct($name = null, $value = null, $expires = null, $path = null, $domain = null, $secure = false, $httponly = false, $maxAge = null, $version = null)
     {
         $this->type = 'Cookie';
 

--- a/tests/Zend/Http/Header/SetCookieTest.php
+++ b/tests/Zend/Http/Header/SetCookieTest.php
@@ -12,18 +12,18 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
     public function testSetCookieConstructor()
     {
         $setCookieHeader = new SetCookie(
-            'myname', 'myvalue', 9, 99, 'docs.foo.com', 
-            'Wed, 13-Jan-2021 22:23:01 GMT', '/accounts', true, true
+            'myname', 'myvalue', 'Wed, 13-Jan-2021 22:23:01 GMT', 
+            '/accounts', 'docs.foo.com', true, true, 99, 9
         );
         $this->assertEquals('myname', $setCookieHeader->getName());
         $this->assertEquals('myvalue', $setCookieHeader->getValue());
-        $this->assertEquals(9, $setCookieHeader->getVersion());
-        $this->assertEquals(99, $setCookieHeader->getMaxAge());
-        $this->assertEquals('docs.foo.com', $setCookieHeader->getDomain());
         $this->assertEquals('Wed, 13-Jan-2021 22:23:01 GMT', $setCookieHeader->getExpires());
         $this->assertEquals('/accounts', $setCookieHeader->getPath());
+        $this->assertEquals('docs.foo.com', $setCookieHeader->getDomain());
         $this->assertTrue($setCookieHeader->isSecure());
         $this->assertTrue($setCookieHeader->isHttpOnly());
+        $this->assertEquals(99, $setCookieHeader->getMaxAge());
+        $this->assertEquals(9, $setCookieHeader->getVersion());
     }
 
     public function testSetCookieFromStringCreatesValidSetCookieHeader()
@@ -167,5 +167,156 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
         $setCookieHeader = SetCookie::fromString($cookie);
         $this->assertNotEquals('leo_auth_token', $setCookieHeader->getName());
     }
+
+    public function testGetFieldName()
+    {
+        $c = new SetCookie();
+        $this->assertEquals('Set-Cookie', $c->getFieldName());
+    }
+    
+    /**
+     * @dataProvider validCookieWithInfoProvider
+     */
+    public function testGetFieldValue($cStr, $info, $expected)
+    {
+        $cookie = SetCookie::fromString($cStr);
+        if (! $cookie instanceof SetCookie) {
+            $this->fail("Failed creating a cookie object from '$cStr'");
+        }        
+        $this->assertEquals($expected, $cookie->getFieldValue());
+        $this->assertEquals($cookie->getFieldName() . ': ' . $expected, $cookie->toString());
+    }
+    
+    /**
+     * @dataProvider validCookieWithInfoProvider
+     */
+    public function testToString($cStr, $info, $expected)
+    {
+        $cookie = SetCookie::fromString($cStr);
+        if (! $cookie instanceof SetCookie) {
+            $this->fail("Failed creating a cookie object from '$cStr'");
+        }        
+        $this->assertEquals($cookie->getFieldName() . ': ' . $expected, $cookie->toString());
+    }
+
+    /**
+     * Provide valid cookie strings with information about them
+     *
+     * @return array
+     */
+    public static function validCookieWithInfoProvider()
+    {
+        $now = time();
+        $yesterday = $now - (3600 * 24);
+
+        return array(
+            array(
+                'Set-Cookie: justacookie=foo; domain=example.com',
+                array(
+                    'name'    => 'justacookie',
+                    'value'   => 'foo',
+                    'domain'  => 'example.com',
+                    'path'    => '/',
+                    'expires' => null,
+                    'secure'  => false,
+                    'httponly'=> false
+                ),
+                'justacookie=foo; Domain=example.com'
+            ),
+            array(
+                'Set-Cookie: expires=tomorrow; secure; path=/Space Out/; expires=Tue, 21-Nov-2006 08:33:44 GMT; domain=.example.com',
+                array(
+                    'name'    => 'expires',
+                    'value'   => 'tomorrow',
+                    'domain'  => '.example.com',
+                    'path'    => '/Space Out/',
+                    'expires' => strtotime('Tue, 21-Nov-2006 08:33:44 GMT'),
+                    'secure'  => true,
+                    'httponly'=> false
+                ),
+                'expires=tomorrow; Expires=Tue, 21-Nov-2006 08:33:44 GMT; Domain=.example.com; Path=/Space Out/; Secure'
+            ),
+            array(
+                'Set-Cookie: domain=unittests; expires=' . gmdate('D, d-M-Y H:i:s', $now) . ' GMT; domain=example.com; path=/some%20value/',
+                array(
+                    'name'    => 'domain',
+                    'value'   => 'unittests',
+                    'domain'  => 'example.com',
+                    'path'    => '/some%20value/',
+                    'expires' => $now,
+                    'secure'  => false,
+                    'httponly'=> false
+                ),
+                'domain=unittests; Expires=' . gmdate('D, d-M-Y H:i:s', $now) . ' GMT; Domain=example.com; Path=/some%20value/'
+            ),
+            array(
+                'Set-Cookie: path=indexAction; path=/; domain=.foo.com; expires=' . gmdate('D, d-M-Y H:i:s', $yesterday) . ' GMT',
+                array(
+                    'name'    => 'path',
+                    'value'   => 'indexAction',
+                    'domain'  => '.foo.com',
+                    'path'    => '/',
+                    'expires' => $yesterday,
+                    'secure'  => false,
+                    'httponly'=> false
+                ),
+                'path=indexAction; Expires=' . gmdate('D, d-M-Y H:i:s', $yesterday) . ' GMT; Domain=.foo.com; Path=/'
+            ),
+
+            array(
+                'Set-Cookie: secure=sha1; secure; SECURE; domain=some.really.deep.domain.com',
+                array(
+                    'name'    => 'secure',
+                    'value'   => 'sha1',
+                    'domain'  => 'some.really.deep.domain.com',
+                    'path'    => '/',
+                    'expires' => null,
+                    'secure'  => true,
+                    'httponly'=> false
+                ),
+                'secure=sha1; Domain=some.really.deep.domain.com; Secure'
+            ),
+            array(
+                'Set-Cookie: justacookie=foo; domain=example.com; httpOnly',
+                array(
+                    'name'    => 'justacookie',
+                    'value'   => 'foo',
+                    'domain'  => 'example.com',
+                    'path'    => '/',
+                    'expires' => null,
+                    'secure'  => false,
+                    'httponly'=> true
+                ),
+                'justacookie=foo; Domain=example.com; HttpOnly'
+            ),
+            array(
+                'Set-Cookie: PHPSESSID=123456789+abcd%2Cef; secure; domain=.localdomain; path=/foo/baz; expires=Tue, 21-Nov-2006 08:33:44 GMT;',
+                array(
+                    'name'    => 'PHPSESSID',
+                    'value'   => '123456789+abcd%2Cef',
+                    'domain'  => '.localdomain',
+                    'path'    => '/foo/baz',
+                    'expires' => 'Tue, 21-Nov-2006 08:33:44 GMT',
+                    'secure'  => true,
+                    'httponly'=> false
+                ),
+                'PHPSESSID=123456789%2Babcd%252Cef; Expires=Tue, 21-Nov-2006 08:33:44 GMT; Domain=.localdomain; Path=/foo/baz; Secure'
+            ),
+            array(
+                'Set-Cookie: myname=myvalue; Domain=docs.foo.com; Path=/accounts; Expires=Wed, 13-Jan-2021 22:23:01 GMT; Secure; HttpOnly',
+                array(
+                    'name'    => 'myname',
+                    'value'   => 'myvalue',
+                    'domain'  => 'docs.foo.com',
+                    'path'    => '/accounts',
+                    'expires' => 'Wed, 13-Jan-2021 22:23:01 GMT',
+                    'secure'  => true,
+                    'httponly'=> true
+                ),
+                'myname=myvalue; Expires=Wed, 13-Jan-2021 22:23:01 GMT; Domain=docs.foo.com; Path=/accounts; Secure; HttpOnly'
+            ),
+        );
+    }
+
 }
 


### PR DESCRIPTION
Mirrors change made in [ZF 1.12.0 @ r24783](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2F&rev=24783&peg=24783)
