### PR TITLE
Replace Zend\Config\Config uses in favor of Traversable

### DIFF
--- a/library/Zend/Amf/AbstractAuthentication.php
+++ b/library/Zend/Amf/AbstractAuthentication.php
@@ -28,7 +28,7 @@ namespace Zend\Amf;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class AbstractAuthentication implements \Zend\Authentication\Adapter
+abstract class AbstractAuthentication implements \Zend\Authentication\Adapter\AdapterInterface
 {
     protected $_username;
     protected $_password;

--- a/library/Zend/Barcode/Object/ObjectInterface.php
+++ b/library/Zend/Barcode/Object/ObjectInterface.php
@@ -34,7 +34,7 @@ interface ObjectInterface
 {
     /**
      * Constructor
-     * @param array|Traversable $options
+     * @param array|\Traversable $options
      * @return void
      */
     public function __construct($options = null);

--- a/library/Zend/Barcode/Renderer/Image.php
+++ b/library/Zend/Barcode/Renderer/Image.php
@@ -79,8 +79,7 @@ class Image extends AbstractRenderer
 
     /**
      * Constructor
-     * @param array|\Zend\Config\Config $options
-     * @return void
+     * @param array|\Traversable $options
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Barcode/Renderer/RendererInterface.php
+++ b/library/Zend/Barcode/Renderer/RendererInterface.php
@@ -34,7 +34,7 @@ interface RendererInterface
 {
     /**
      * Constructor
-     * @param array|Traversable $options
+     * @param array|\Traversable $options
      * @return void
      */
     public function __construct($options = null);

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -72,7 +72,7 @@ class Filesystem extends AbstractAdapter
     /**
      * Set options.
      *
-     * @param  array|Traversable|FilesystemOptions $options
+     * @param  array|\Traversable|FilesystemOptions $options
      * @return Filesystem
      * @see    getOptions()
      */

--- a/library/Zend/Cache/Storage/Adapter/Memory.php
+++ b/library/Zend/Cache/Storage/Adapter/Memory.php
@@ -58,7 +58,7 @@ class Memory extends AbstractAdapter
     /**
      * Set options.
      *
-     * @param  array|Traversable|MemoryOptions $options
+     * @param  array|\Traversable|MemoryOptions $options
      * @return Memory
      * @see    getOptions()
      */

--- a/library/Zend/Cache/Storage/Adapter/WinCache.php
+++ b/library/Zend/Cache/Storage/Adapter/WinCache.php
@@ -75,7 +75,7 @@ class WinCache extends AbstractAdapter
     /**
      * Set options.
      *
-     * @param  array|Traversable|WinCacheOptions $options
+     * @param  array|\Traversable|WinCacheOptions $options
      * @return WinCache
      * @see    getOptions()
      */

--- a/library/Zend/Cache/Storage/Adapter/ZendServerDisk.php
+++ b/library/Zend/Cache/Storage/Adapter/ZendServerDisk.php
@@ -38,7 +38,7 @@ class ZendServerDisk extends AbstractZendServer
     /**
      * Constructor
      *
-     * @param  null|array|Traversable|AdapterOptions $options
+     * @param  null|array|\Traversable|AdapterOptions $options
      * @throws Exception\ExceptionInterface
      * @return void
      */

--- a/library/Zend/Cache/Storage/Adapter/ZendServerShm.php
+++ b/library/Zend/Cache/Storage/Adapter/ZendServerShm.php
@@ -37,7 +37,7 @@ class ZendServerShm extends AbstractZendServer
     /**
      * Constructor
      *
-     * @param  null|array|Traversable|AdapterOptions $options
+     * @param  null|array|\Traversable|AdapterOptions $options
      * @throws Exception\ExceptionInterface
      * @return void
      */

--- a/library/Zend/Cache/Storage/Event.php
+++ b/library/Zend/Cache/Storage/Event.php
@@ -63,7 +63,7 @@ class Event extends BaseEvent
     /**
      * Alias of setTarget
      *
-     * @param  Adapter $adapter
+     * @param  Adapter\AdapterInterface $adapter
      * @return Event
      * @see    \Zend\EventManager\Event::setTarget()
      */

--- a/library/Zend/Captcha/AbstractAdapter.php
+++ b/library/Zend/Captcha/AbstractAdapter.php
@@ -22,7 +22,7 @@
 namespace Zend\Captcha;
 
 use Traversable;
-use Zend\Config\Config;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\AbstractValidator;
 
 /**
@@ -87,16 +87,16 @@ abstract class AbstractAdapter extends AbstractValidator implements AdapterInter
     /**
      * Constructor
      *
-     * @param  array|Zend\Config\Config $options
-     * @return void
+     * @param array|Traversable $options
      */
     public function __construct($options = null)
     {
         // Set options
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
         if (is_array($options)) {
             $this->setOptions($options);
-        } else if ($options instanceof Config) {
-            $this->setConfig($options);
         }
     }
 
@@ -152,17 +152,6 @@ abstract class AbstractAdapter extends AbstractValidator implements AdapterInter
     public function getOptions()
     {
         return $this->_options;
-    }
-
-    /**
-     * Set object state from config object
-     *
-     * @param  Zend\Config\Config $config
-     * @return Zend\Captcha\AbstractAdapter
-     */
-    public function setConfig(Config $config)
-    {
-        return $this->setOptions($config->toArray());
     }
 
     /**

--- a/library/Zend/Captcha/Figlet.php
+++ b/library/Zend/Captcha/Figlet.php
@@ -46,8 +46,7 @@ class Figlet extends Word
     /**
      * Constructor
      *
-     * @param  null|string|array|\Zend\Config\Config $options
-     * @return void
+     * @param array|\Traversable $options
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Captcha/Image.php
+++ b/library/Zend/Captcha/Image.php
@@ -135,7 +135,7 @@ class Image extends Word
     /**
      * Constructor
      *
-     * @param  array|Zend\Config\Config $options
+     * @param  array|\Traversable $options
      * @return void
      */
     public function __construct($options = null)

--- a/library/Zend/Captcha/ReCaptcha.php
+++ b/library/Zend/Captcha/ReCaptcha.php
@@ -135,8 +135,7 @@ class ReCaptcha extends AbstractAdapter
     /**
      * Constructor
      *
-     * @param  array|Config $options
-     * @return void
+     * @param  array|\Traversable $options
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Cloud/AbstractFactory.php
+++ b/library/Zend/Cloud/AbstractFactory.php
@@ -20,6 +20,9 @@
 
 namespace Zend\Cloud;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * Abstract factory for Zend\Cloud resources
  *
@@ -44,13 +47,13 @@ class AbstractFactory
      * Get an individual adapter instance
      *
      * @param  string $adapterOption
-     * @param  array|\Zend\Config\Config $options
+     * @param  array|Traversable $options
      * @return null|DocumentService\Adapter\AdapterInterface|QueueService\Adapter\AdapterInterface|StorageService\Adapter\AdapterInterface|Infrastructure\Adapter\AdapterInterface
      */
     protected static function _getAdapter($adapterOption, $options)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (!isset($options[$adapterOption])) {

--- a/library/Zend/Cloud/DocumentService/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cloud/DocumentService/Adapter/AbstractAdapter.php
@@ -17,9 +17,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService\Adapter;
 
 use Zend\Cloud\DocumentService\Document,

--- a/library/Zend/Cloud/DocumentService/Adapter/AdapterInterface.php
+++ b/library/Zend/Cloud/DocumentService/Adapter/AdapterInterface.php
@@ -17,9 +17,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService\Adapter;
 
 /**

--- a/library/Zend/Cloud/DocumentService/Adapter/Exception/InvalidArgumentException.php
+++ b/library/Zend/Cloud/DocumentService/Adapter/Exception/InvalidArgumentException.php
@@ -18,9 +18,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService\Adapter\Exception;
 
 class InvalidArgumentException

--- a/library/Zend/Cloud/DocumentService/Adapter/Exception/OperationNotAvailableException.php
+++ b/library/Zend/Cloud/DocumentService/Adapter/Exception/OperationNotAvailableException.php
@@ -18,9 +18,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService\Adapter\Exception;
 
 /**

--- a/library/Zend/Cloud/DocumentService/Adapter/SimpleDb.php
+++ b/library/Zend/Cloud/DocumentService/Adapter/SimpleDb.php
@@ -17,11 +17,10 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Cloud\DocumentService\Adapter\SimpleDb\Query,
     Zend\Service\Amazon\Exception as AmazonException,
     Zend\Service\Amazon\SimpleDb\SimpleDb as SimpleDbService,
@@ -68,13 +67,12 @@ class SimpleDb extends AbstractAdapter
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $options
-     * @return void
+     * @param array|Traversable $options
      */
     public function __construct($options = array())
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (!is_array($options)) {

--- a/library/Zend/Cloud/DocumentService/Adapter/SimpleDb/Query.php
+++ b/library/Zend/Cloud/DocumentService/Adapter/SimpleDb/Query.php
@@ -17,9 +17,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService\Adapter\SimpleDb;
 
 use Zend\Cloud\DocumentService\Query as QueryInterface,

--- a/library/Zend/Cloud/DocumentService/Adapter/WindowsAzure.php
+++ b/library/Zend/Cloud/DocumentService/Adapter/WindowsAzure.php
@@ -17,16 +17,14 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Cloud\DocumentService\Document,
     Zend\Service\WindowsAzure\Storage,
     Zend\Service\WindowsAzure\Storage\Table,
-    Zend\Service\WindowsAzure\Storage\DynamicTableEntity,
-    Zend\Config\Config;
+    Zend\Service\WindowsAzure\Storage\DynamicTableEntity;
 
 
 /**
@@ -82,13 +80,12 @@ class WindowsAzure extends AbstractAdapter
     /**
      * Constructor
      *
-     * @param array $options
-     * @return void
+     * @param array|Traversable $options
      */
     public function __construct($options = array())
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (empty($options)) {

--- a/library/Zend/Cloud/DocumentService/Adapter/WindowsAzure/Query.php
+++ b/library/Zend/Cloud/DocumentService/Adapter/WindowsAzure/Query.php
@@ -17,9 +17,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService\Adapter\WindowsAzure;
 
 use Zend\Cloud\DocumentService\QueryAdapter\QueryAdapterInterface,

--- a/library/Zend/Cloud/DocumentService/Document.php
+++ b/library/Zend/Cloud/DocumentService/Document.php
@@ -17,9 +17,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService;
 
 /**

--- a/library/Zend/Cloud/DocumentService/DocumentSet.php
+++ b/library/Zend/Cloud/DocumentService/DocumentSet.php
@@ -17,9 +17,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService;
 
 /**
@@ -64,7 +61,7 @@ class DocumentSet implements \Countable, \IteratorAggregate
     /**
      * IteratorAggregate: retrieve iterator
      *
-     * @return Traversable
+     * @return \Traversable
      */
     public function getIterator()
     {

--- a/library/Zend/Cloud/DocumentService/Exception/InvalidArgumentException.php
+++ b/library/Zend/Cloud/DocumentService/Exception/InvalidArgumentException.php
@@ -18,9 +18,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService\Exception;
 
 class InvalidArgumentException

--- a/library/Zend/Cloud/DocumentService/Exception/OperationNotAvailableException.php
+++ b/library/Zend/Cloud/DocumentService/Exception/OperationNotAvailableException.php
@@ -18,9 +18,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService\Exception;
 
 /**

--- a/library/Zend/Cloud/DocumentService/Factory.php
+++ b/library/Zend/Cloud/DocumentService/Factory.php
@@ -19,9 +19,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService;
 
 use Zend\Cloud\AbstractFactory;

--- a/library/Zend/Cloud/DocumentService/Query.php
+++ b/library/Zend/Cloud/DocumentService/Query.php
@@ -17,9 +17,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService;
 
 

--- a/library/Zend/Cloud/DocumentService/QueryAdapter/QueryAdapterInterface.php
+++ b/library/Zend/Cloud/DocumentService/QueryAdapter/QueryAdapterInterface.php
@@ -17,9 +17,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\DocumentService\QueryAdapter;
 
 /**

--- a/library/Zend/Cloud/Exception/InvalidArgumentException.php
+++ b/library/Zend/Cloud/Exception/InvalidArgumentException.php
@@ -18,9 +18,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\Exception;
 
 /**

--- a/library/Zend/Cloud/Exception/OperationNotAvailableException.php
+++ b/library/Zend/Cloud/Exception/OperationNotAvailableException.php
@@ -18,9 +18,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\Exception;
 
 /**

--- a/library/Zend/Cloud/Infrastructure/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cloud/Infrastructure/Adapter/AbstractAdapter.php
@@ -17,9 +17,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\Infrastructure\Adapter;
 
 use Zend\Cloud\Infrastructure\Instance;

--- a/library/Zend/Cloud/Infrastructure/Adapter/AdapterInterface.php
+++ b/library/Zend/Cloud/Infrastructure/Adapter/AdapterInterface.php
@@ -7,9 +7,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\Infrastructure\Adapter;
 
 /**

--- a/library/Zend/Cloud/Infrastructure/Adapter/Ec2.php
+++ b/library/Zend/Cloud/Infrastructure/Adapter/Ec2.php
@@ -9,6 +9,8 @@
 
 namespace Zend\Cloud\Infrastructure\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Service\Amazon\Ec2\Instance as Ec2Instance,
     Zend\Service\Amazon\Ec2\Image as Ec2Image,
     Zend\Service\Amazon\Ec2\AvailabilityZones as Ec2Zone,
@@ -117,17 +119,12 @@ class Ec2 extends AbstractAdapter
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $options
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($options = array())
     {
-        if (is_object($options)) {
-            if (method_exists($options, 'toArray')) {
-                $options= $options->toArray();
-            } elseif ($options instanceof \Traversable) {
-                $options = iterator_to_array($options);
-            }
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
         
         if (empty($options) || !is_array($options)) {

--- a/library/Zend/Cloud/Infrastructure/Adapter/Rackspace.php
+++ b/library/Zend/Cloud/Infrastructure/Adapter/Rackspace.php
@@ -9,6 +9,8 @@
 
 namespace Zend\Cloud\Infrastructure\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Service\Rackspace\Servers as RackspaceServers,
     Zend\Cloud\Infrastructure\Instance,
     Zend\Cloud\Infrastructure\InstanceList,
@@ -91,19 +93,15 @@ class Rackspace extends AbstractAdapter
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $options
+     * @param  array|Traversable $options
      * @return void
      */
     public function __construct($options = array())
     {
-        if (is_object($options)) {
-            if (method_exists($options, 'toArray')) {
-                $options= $options->toArray();
-            } elseif ($options instanceof \Traversable) {
-                $options = iterator_to_array($options);
-            }
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
-        
+
         if (empty($options) || !is_array($options)) {
             throw new Exception\InvalidArgumentException('Invalid options provided');
         }

--- a/library/Zend/Cloud/Infrastructure/Factory.php
+++ b/library/Zend/Cloud/Infrastructure/Factory.php
@@ -7,9 +7,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\Infrastructure;
 
 use Zend\Cloud\AbstractFactory,

--- a/library/Zend/Cloud/Infrastructure/Image.php
+++ b/library/Zend/Cloud/Infrastructure/Image.php
@@ -7,9 +7,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\Infrastructure;
 
 /**

--- a/library/Zend/Cloud/Infrastructure/Instance.php
+++ b/library/Zend/Cloud/Infrastructure/Instance.php
@@ -7,9 +7,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\Infrastructure;
 
 /**

--- a/library/Zend/Cloud/QueueService/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cloud/QueueService/Adapter/AbstractAdapter.php
@@ -17,9 +17,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\QueueService\Adapter;
 
 use Zend\Cloud\QueueService\Adapter,

--- a/library/Zend/Cloud/QueueService/Adapter/Sqs.php
+++ b/library/Zend/Cloud/QueueService/Adapter/Sqs.php
@@ -17,14 +17,13 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\QueueService\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Service\Amazon\Sqs\Sqs as AmazonSqs,
-    \Zend\Cloud\QueueService\Message,
-    \Zend\Cloud\QueueService\Exception;
+    Zend\Cloud\QueueService\Message,
+    Zend\Cloud\QueueService\Exception;
 
 /**
  * SQS adapter for simple queue service.
@@ -57,14 +56,13 @@ class Sqs extends AbstractAdapter
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $options
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($options = array())
     {
 
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (!is_array($options)) {

--- a/library/Zend/Cloud/QueueService/Adapter/WindowsAzure.php
+++ b/library/Zend/Cloud/QueueService/Adapter/WindowsAzure.php
@@ -17,15 +17,13 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\QueueService\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Cloud\QueueService\Exception,
     Zend\Cloud\QueueService\Message,
-    Zend\Service\WindowsAzure\Storage\Queue,
-    Zend\Config\Config;
+    Zend\Service\WindowsAzure\Storage\Queue;
 
 /**
  * WindowsAzure adapter for simple queue service.
@@ -60,20 +58,23 @@ class WindowsAzure extends AbstractAdapter
     /**
      * Storage client
      *
-     * @var \Zend\Servic\WindowsAzure\Storage\Queue
+     * @var \Zend\Service\WindowsAzure\Storage\Queue
      */
     protected $_storageClient = null;
 
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $options
+     * @param  array|Traversable $options
      * @return void
      */
     public function __construct($options = array())
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (is_array($options)) {
+            $this->setOptions($options);
         }
 
         if (!is_array($options)) {

--- a/library/Zend/Cloud/QueueService/Adapter/WindowsAzure.php
+++ b/library/Zend/Cloud/QueueService/Adapter/WindowsAzure.php
@@ -73,9 +73,6 @@ class WindowsAzure extends AbstractAdapter
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         }
-        if (is_array($options)) {
-            $this->setOptions($options);
-        }
 
         if (!is_array($options)) {
             throw new Exception\InvalidArgumentException('Invalid options provided');

--- a/library/Zend/Cloud/QueueService/Adapter/ZendQueue.php
+++ b/library/Zend/Cloud/QueueService/Adapter/ZendQueue.php
@@ -17,14 +17,12 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\QueueService\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Cloud\QueueService\Exception,
-    Zend\Queue\Queue,
-    Zend\Config\Config;
+    Zend\Queue\Queue;
 
 /**
  * WindowsAzure adapter for simple queue service.
@@ -57,13 +55,12 @@ class ZendQueue extends AbstractAdapter
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $options
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct ($options = array())
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (!is_array($options)) {

--- a/library/Zend/Cloud/QueueService/Exception/InvalidArgumentException.php
+++ b/library/Zend/Cloud/QueueService/Exception/InvalidArgumentException.php
@@ -18,9 +18,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\QueueService\Exception;
 
 class InvalidArgumentException

--- a/library/Zend/Cloud/QueueService/Exception/OperationNotAvailableException.php
+++ b/library/Zend/Cloud/QueueService/Exception/OperationNotAvailableException.php
@@ -18,9 +18,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\QueueService\Exception;
 
 /**

--- a/library/Zend/Cloud/QueueService/Factory.php
+++ b/library/Zend/Cloud/QueueService/Factory.php
@@ -19,9 +19,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\QueueService;
 
 use Zend\Cloud\AbstractFactory;

--- a/library/Zend/Cloud/QueueService/Message.php
+++ b/library/Zend/Cloud/QueueService/Message.php
@@ -17,9 +17,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\QueueService;
 
 /**

--- a/library/Zend/Cloud/QueueService/MessageSet.php
+++ b/library/Zend/Cloud/QueueService/MessageSet.php
@@ -17,9 +17,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\QueueService;
 
 /**
@@ -64,7 +61,7 @@ class MessageSet implements \Countable, \IteratorAggregate
     /**
      * IteratorAggregate: return iterable object
      *
-     * @return Traversable
+     * @return \Traversable
      */
     public function getIterator()
     {

--- a/library/Zend/Cloud/StorageService/Adapter/AdapterInterface.php
+++ b/library/Zend/Cloud/StorageService/Adapter/AdapterInterface.php
@@ -17,9 +17,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\StorageService\Adapter;
 
 /**

--- a/library/Zend/Cloud/StorageService/Adapter/FileSystem.php
+++ b/library/Zend/Cloud/StorageService/Adapter/FileSystem.php
@@ -17,11 +17,10 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\StorageService\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Cloud\StorageService\Adapter,
     Zend\Cloud\StorageService\Exception;
 
@@ -51,13 +50,12 @@ class FileSystem implements AdapterInterface
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $options
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($options = array())
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (!is_array($options)) {

--- a/library/Zend/Cloud/StorageService/Adapter/Nirvanix.php
+++ b/library/Zend/Cloud/StorageService/Adapter/Nirvanix.php
@@ -17,11 +17,10 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\StorageService\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Cloud\StorageService\Adapter,
     Zend\Cloud\StorageService\Exception,
     Zend\Service\Nirvanix\Nirvanix as NirvanixService,
@@ -56,13 +55,12 @@ class Nirvanix implements AdapterInterface
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $options
-     * @return void
+     * @param  array|Traversable $options
      */
     function __construct($options = array())
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (!is_array($options)) {

--- a/library/Zend/Cloud/StorageService/Adapter/Rackspace.php
+++ b/library/Zend/Cloud/StorageService/Adapter/Rackspace.php
@@ -17,9 +17,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\StorageService\Adapter;
 
 use Traversable,

--- a/library/Zend/Cloud/StorageService/Adapter/S3.php
+++ b/library/Zend/Cloud/StorageService/Adapter/S3.php
@@ -17,11 +17,10 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\StorageService\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Cloud\StorageService\Adapter,
     Zend\Cloud\StorageService\Exception,
     Zend\Service\Amazon\S3\S3 as AmazonS3;
@@ -62,13 +61,12 @@ class S3 implements AdapterInterface
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $options
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($options = array())
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (!is_array($options)) {

--- a/library/Zend/Cloud/StorageService/Adapter/WindowsAzure.php
+++ b/library/Zend/Cloud/StorageService/Adapter/WindowsAzure.php
@@ -17,11 +17,10 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\StorageService\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Cloud\StorageService\Adapter,
     Zend\Cloud\StorageService\Exception,
     Zend\Service\WindowsAzure\Storage\Blob;
@@ -77,12 +76,15 @@ class WindowsAzure implements AdapterInterface
     /**
      * Creates a new \Zend\Cloud\Storage\WindowsAzure instance
      *
-     * @param array|\Zend\Config\Config  $options   Options for the \Zend\Cloud\Storage\WindowsAzure instance
+     * @param  array|Traversable $options Options for the \Zend\Cloud\Storage\WindowsAzure instance
      */
     public function __construct($options = array())
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (is_array($options)) {
+            $this->setOptions($options);
         }
 
         if (!is_array($options)) {

--- a/library/Zend/Cloud/StorageService/Adapter/WindowsAzure.php
+++ b/library/Zend/Cloud/StorageService/Adapter/WindowsAzure.php
@@ -83,9 +83,6 @@ class WindowsAzure implements AdapterInterface
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         }
-        if (is_array($options)) {
-            $this->setOptions($options);
-        }
 
         if (!is_array($options)) {
             throw new Exception\InvalidArgumentException('Invalid options provided');

--- a/library/Zend/Cloud/StorageService/Exception/InvalidArgumentException.php
+++ b/library/Zend/Cloud/StorageService/Exception/InvalidArgumentException.php
@@ -19,9 +19,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\StorageService\Exception;
 
 class InvalidArgumentException

--- a/library/Zend/Cloud/StorageService/Exception/OperationNotAvailableException.php
+++ b/library/Zend/Cloud/StorageService/Exception/OperationNotAvailableException.php
@@ -19,9 +19,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-/**
- * namespace
- */
 namespace Zend\Cloud\StorageService\Exception;
 
 /**

--- a/library/Zend/Config/Reader/Ini.php
+++ b/library/Zend/Config/Reader/Ini.php
@@ -52,7 +52,7 @@ class Ini implements Reader
     /**
      * Set nest separator.
      *
-     * @param  stirng $separator
+     * @param  string $separator
      * @return self
      */
     public function setNestSeparator($separator)

--- a/library/Zend/Di/Configuration.php
+++ b/library/Zend/Di/Configuration.php
@@ -3,6 +3,7 @@
 namespace Zend\Di;
 
 use Traversable;
+use Zend\Stdlib\ArrayUtils;
 
 class Configuration
 {
@@ -12,21 +13,25 @@ class Configuration
      * @var Zend\Di\DependencyInjector
      */
     protected $di = null;
-    
-    public function __construct($data)
+
+    /**
+     * @param  array|Traversable $options
+     */
+    public function __construct($options)
     {
-        if ($data instanceof Traversable) {
-            if (method_exists($data, 'toArray')) {
-                $data = $data->toArray();
-            } else {
-                $data = iterator_to_array($data, true);
-            }
-        } elseif (!is_array($data)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (is_array($options)) {
+            $this->setOptions($options);
+        }
+
+        if (!is_array($options)) {
             throw new Exception\InvalidArgumentException(
-                'Configuration data must be of type Zend\Config\Config or an array'
+                'Configuration data must be of type Traversable or an array'
             );
         }
-        $this->data = $data;
+        $this->data = $options;
     }
     
     public function configure(Di $di)

--- a/library/Zend/Di/Configuration.php
+++ b/library/Zend/Di/Configuration.php
@@ -22,9 +22,6 @@ class Configuration
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         }
-        if (is_array($options)) {
-            $this->setOptions($options);
-        }
 
         if (!is_array($options)) {
             throw new Exception\InvalidArgumentException(

--- a/library/Zend/Dojo/BuildLayer.php
+++ b/library/Zend/Dojo/BuildLayer.php
@@ -101,17 +101,15 @@ class BuildLayer
      */
     public function __construct($options = null)
     {
-        if ($options instanceof Traversable) {
-            $options = ArrayUtils::iteratorToArray($options);
-        }
-        if (is_array($options)) {
+        if (null !== $options) {
+            if ($options instanceof Traversable) {
+                $options = ArrayUtils::iteratorToArray($options);
+            }
+            if (!is_array($options)) {
+                throw new Exception\InvalidArgumentException('Invalid options provided to constructor');
+            }
             $this->setOptions($options);
         }
-
-        if (!is_array($options)) {
-            throw new Exception\InvalidArgumentException('Invalid options provided to constructor');
-        }
-        $this->setOptions($options);
     }
 
     /**

--- a/library/Zend/Dojo/BuildLayer.php
+++ b/library/Zend/Dojo/BuildLayer.php
@@ -20,8 +20,9 @@
 
 namespace Zend\Dojo;
 
-use Zend\Config\Config,
-    Zend\Json\Json,
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Json\Json,
     Zend\View\Renderer\RendererInterface as Renderer;
 
 /**
@@ -95,20 +96,22 @@ class BuildLayer
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $options
-     * @return void
-     * @throws \Zend\Dojo\Exception for invalid option argument
+     * @param  array|Traversable $options
+     * @throws \Zend\Dojo\Exception\InvalidArgumentException for invalid option argument
      */
     public function __construct($options = null)
     {
-        if (null !== $options) {
-            if ($options instanceof Config) {
-                $options = $options->toArray();
-            } elseif (!is_array($options)) {
-                throw new Exception\InvalidArgumentException('Invalid options provided to constructor');
-            }
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (is_array($options)) {
             $this->setOptions($options);
         }
+
+        if (!is_array($options)) {
+            throw new Exception\InvalidArgumentException('Invalid options provided to constructor');
+        }
+        $this->setOptions($options);
     }
 
     /**

--- a/library/Zend/Dojo/Data.php
+++ b/library/Zend/Dojo/Data.php
@@ -79,7 +79,7 @@ class Data implements \ArrayAccess,\IteratorAggregate,\Countable
     /**
      * Set the items to collect
      *
-     * @param array|Traversable $items
+     * @param array|\Traversable $items
      * @return \Zend\Dojo\Data
      */
     public function setItems($items)

--- a/library/Zend/Dojo/Form/DisplayGroup.php
+++ b/library/Zend/Dojo/Form/DisplayGroup.php
@@ -21,6 +21,8 @@
 
 namespace Zend\Dojo\Form;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Loader\PrefixPathMapper as PluginLoader,
     Zend\View\Renderer\RendererInterface as View;
 
@@ -39,8 +41,7 @@ class DisplayGroup extends \Zend\Form\DisplayGroup
      *
      * @param  string $name
      * @param  \Zend\Loader\PrefixPathMapper $loader
-     * @param  array|\Zend\Config\Config|null $options
-     * @return void
+     * @param  array|\Traversable $options
      */
     public function __construct($name, PluginLoader $loader, $options = null)
     {

--- a/library/Zend/Dojo/Form/Element/Button.php
+++ b/library/Zend/Dojo/Form/Element/Button.php
@@ -41,9 +41,8 @@ class Button extends Dijit
     /**
      * Constructor
      *
-     * @param  string|array|\Zend\Config\Config $spec Element name or configuration
-     * @param  string|array|\Zend\Config\Config $options Element value or configuration
-     * @return void
+     * @param  array|string|\Traversable $spec Element name or configuration
+     * @param  array|string|\Traversable $options Element value or configuration
      */
     public function __construct($spec, $options = null)
     {

--- a/library/Zend/Dojo/Form/Element/Dijit.php
+++ b/library/Zend/Dojo/Form/Element/Dijit.php
@@ -50,9 +50,8 @@ abstract class Dijit extends \Zend\Form\Element
      * Constructor
      *
      * @todo Should we set dojo view helper paths here?
-     * @param  mixed $spec
-     * @param  mixed $options
-     * @return void
+     * @param  array|string|\Traversable $spec
+     * @param  array|string|\Traversable $options
      */
     public function __construct($spec, $options = null)
     {

--- a/library/Zend/Dojo/Form/Form.php
+++ b/library/Zend/Dojo/Form/Form.php
@@ -36,8 +36,7 @@ class Form extends \Zend\Form\Form
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config|null $options
-     * @return void
+     * @param  array|\Traversable $options
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Dojo/Form/SubForm.php
+++ b/library/Zend/Dojo/Form/SubForm.php
@@ -40,8 +40,7 @@ class SubForm extends \Zend\Form\SubForm
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config|null $options
-     * @return void
+     * @param  array|\Traversable $options
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Dojo/View/Helper/Dojo/Container.php
+++ b/library/Zend/Dojo/View/Helper/Dojo/Container.php
@@ -21,9 +21,10 @@
 
 namespace Zend\Dojo\View\Helper\Dojo;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Dojo\View\Exception,
     Zend\Dojo\View\Helper\Dojo as DojoHelper,
-    Zend\Config\Config,
     Zend\View\Renderer\RendererInterface as View,
     Zend\Json\Json;
 
@@ -214,13 +215,12 @@ class Container
     /**
      * Add options for the Dojo Container to use
      *
-     * @param array|\Zend\Config\Config Array or \Zend\Config\Config object with options to use
-     * @return \Zend\Dojo\View\Helper\Dojo\Container
+     * @param  array|Traversable $options Options to use
      */
     public function setOptions($options)
     {
-        if($options instanceof Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         foreach($options as $key => $value) {

--- a/library/Zend/Feed/PubSubHubbub/AbstractCallback.php
+++ b/library/Zend/Feed/PubSubHubbub/AbstractCallback.php
@@ -21,6 +21,9 @@
 
 namespace Zend\Feed\PubSubHubbub;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * @category   Zend
  * @package    Zend_Feed_Pubsubhubbub
@@ -56,35 +59,40 @@ abstract class AbstractCallback implements Callback
     protected $_subscriberCount = 1;
 
     /**
-     * Constructor; accepts an array or Zend\Config instance to preset
+     * Constructor; accepts an array or Traversable object to preset
      * options for the Subscriber without calling all supported setter
      * methods in turn.
      *
-     * @param array|\Zend\Config\Config $options Options array or \Zend\Config\Config instance
+     * @param  array|Traversable $options Options array or Traversable object
      */
-    public function __construct($config = null)
+    public function __construct($options = null)
     {
-        if ($config !== null) {
-            $this->setConfig($config);
+        if ($options !== null) {
+            $this->setOptions($options);
         }
     }
 
     /**
      * Process any injected configuration options
      *
-     * @param  array|\Zend\Config\Config $options Options array or \Zend\Config\Config instance
+     * @param  array|Traversable $options Options array or Traversable object
      * @return \Zend\Feed\PubSubHubbub\AbstractCallback
      */
-    public function setConfig($config)
+    public function setOptions($options)
     {
-        if ($config instanceof \Zend\Config\Config) {
-            $config = $config->toArray();
-        } elseif (!is_array($config)) {
-            throw new Exception('Array or Zend_Config object'
-            . 'expected, got ' . gettype($config));
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
-        if (array_key_exists('storage', $config)) {
-            $this->setStorage($config['storage']);
+        if (is_array($options)) {
+            $this->setOptions($options);
+        }
+
+        if (!is_array($options)) {
+            throw new Exception('Array or Traversable object'
+            . 'expected, got ' . gettype($options));
+        }
+        if (array_key_exists('storage', $options)) {
+            $this->setStorage($options['storage']);
         }
         return $this;
     }

--- a/library/Zend/Feed/PubSubHubbub/Publisher.php
+++ b/library/Zend/Feed/PubSubHubbub/Publisher.php
@@ -20,6 +20,8 @@
 
 namespace Zend\Feed\PubSubHubbub;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Uri;
 
 /**
@@ -67,38 +69,42 @@ class Publisher
      * options for the Publisher without calling all supported setter
      * methods in turn.
      *
-     * @param  array|\Zend\Config\Config $options Options array or \Zend\Config\Config instance
-     * @return void
+     * @param  array|Traversable $options
      */
-    public function __construct($config = null)
+    public function __construct($options = null)
     {
-        if ($config !== null) {
-            $this->setConfig($config);
+        if ($options !== null) {
+            $this->setOptions($options);
         }
     }
 
     /**
      * Process any injected configuration options
      *
-     * @param  array|\Zend\Config\Config $options Options array or \Zend\Config\Config instance
+     * @param  array|Traversable $options Options array or Traversable object
      * @return \Zend\Feed\PubSubHubbub\Publisher
      */
-    public function setConfig($config)
+    public function setOptions($options)
     {
-        if ($config instanceof \Zend\Config\Config) {
-            $config = $config->toArray();
-        } elseif (!is_array($config)) {
-            throw new Exception('Array or Zend_Config object'
-                . 'expected, got ' . gettype($config));
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
-        if (array_key_exists('hubUrls', $config)) {
-            $this->addHubUrls($config['hubUrls']);
+        if (is_array($options)) {
+            $this->setOptions($options);
         }
-        if (array_key_exists('updatedTopicUrls', $config)) {
-            $this->addUpdatedTopicUrls($config['updatedTopicUrls']);
+
+        if (!is_array($options)) {
+            throw new Exception('Array or Traversable object'
+                                . 'expected, got ' . gettype($options));
         }
-        if (array_key_exists('parameters', $config)) {
-            $this->setParameters($config['parameters']);
+        if (array_key_exists('hubUrls', $options)) {
+            $this->addHubUrls($options['hubUrls']);
+        }
+        if (array_key_exists('updatedTopicUrls', $options)) {
+            $this->addUpdatedTopicUrls($options['updatedTopicUrls']);
+        }
+        if (array_key_exists('parameters', $options)) {
+            $this->setParameters($options['parameters']);
         }
         return $this;
     }
@@ -382,7 +388,7 @@ class Publisher
     {
         $client = PubSubHubbub::getHttpClient();
         $client->setMethod(\Zend\Http\Request::METHOD_POST);
-        $client->setConfig(array(
+        $client->setOptions(array(
             'useragent' => 'Zend_Feed_Pubsubhubbub_Publisher/' . \Zend\Version::VERSION,
         ));
         $params   = array();

--- a/library/Zend/Feed/PubSubHubbub/Publisher.php
+++ b/library/Zend/Feed/PubSubHubbub/Publisher.php
@@ -89,9 +89,6 @@ class Publisher
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         }
-        if (is_array($options)) {
-            $this->setOptions($options);
-        }
 
         if (!is_array($options)) {
             throw new Exception('Array or Traversable object'

--- a/library/Zend/Feed/PubSubHubbub/Subscriber.php
+++ b/library/Zend/Feed/PubSubHubbub/Subscriber.php
@@ -20,6 +20,8 @@
 
 namespace Zend\Feed\PubSubHubbub;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Date,
     Zend\Uri;
 
@@ -134,61 +136,65 @@ class Subscriber
     protected $_usePathParameter = false;
 
     /**
-     * Constructor; accepts an array or Zend\Config instance to preset
+     * Constructor; accepts an array or Traversable instance to preset
      * options for the Subscriber without calling all supported setter
      * methods in turn.
      *
-     * @param  array|\Zend\Config\Config $options Options array or \Zend\Config\Config instance
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($config = null)
     {
         if ($config !== null) {
-            $this->setConfig($config);
+            $this->setOptions($config);
         }
     }
 
     /**
      * Process any injected configuration options
      *
-     * @param  array|\Zend\Config\Config $options Options array or \Zend\Config\Config instance
+     * @param  array|Traversable $options
      * @return \Zend\Feed\PubSubHubbub\Subscriber\Subscriber
      */
-    public function setConfig($config)
+    public function setOptions($options)
     {
-        if ($config instanceof \Zend\Config\Config) {
-            $config = $config->toArray();
-        } elseif (!is_array($config)) {
-            throw new Exception('Array or Zend\Config object'
-                . ' expected, got ' . gettype($config));
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
-        if (array_key_exists('hubUrls', $config)) {
-            $this->addHubUrls($config['hubUrls']);
+        if (is_array($options)) {
+            $this->setOptions($options);
         }
-        if (array_key_exists('callbackUrl', $config)) {
-            $this->setCallbackUrl($config['callbackUrl']);
+
+        if (!is_array($options)) {
+            throw new Exception('Array or Traversable object'
+                                . 'expected, got ' . gettype($options));
         }
-        if (array_key_exists('topicUrl', $config)) {
-            $this->setTopicUrl($config['topicUrl']);
+        if (array_key_exists('hubUrls', $options)) {
+            $this->addHubUrls($options['hubUrls']);
         }
-        if (array_key_exists('storage', $config)) {
-            $this->setStorage($config['storage']);
+        if (array_key_exists('callbackUrl', $options)) {
+            $this->setCallbackUrl($options['callbackUrl']);
         }
-        if (array_key_exists('leaseSeconds', $config)) {
-            $this->setLeaseSeconds($config['leaseSeconds']);
+        if (array_key_exists('topicUrl', $options)) {
+            $this->setTopicUrl($options['topicUrl']);
         }
-        if (array_key_exists('parameters', $config)) {
-            $this->setParameters($config['parameters']);
+        if (array_key_exists('storage', $options)) {
+            $this->setStorage($options['storage']);
         }
-        if (array_key_exists('authentications', $config)) {
-            $this->addAuthentications($config['authentications']);
+        if (array_key_exists('leaseSeconds', $options)) {
+            $this->setLeaseSeconds($options['leaseSeconds']);
         }
-        if (array_key_exists('usePathParameter', $config)) {
-            $this->usePathParameter($config['usePathParameter']);
+        if (array_key_exists('parameters', $options)) {
+            $this->setParameters($options['parameters']);
         }
-        if (array_key_exists('preferredVerificationMode', $config)) {
+        if (array_key_exists('authentications', $options)) {
+            $this->addAuthentications($options['authentications']);
+        }
+        if (array_key_exists('usePathParameter', $options)) {
+            $this->usePathParameter($options['usePathParameter']);
+        }
+        if (array_key_exists('preferredVerificationMode', $options)) {
             $this->setPreferredVerificationMode(
-                $config['preferredVerificationMode']
+                $options['preferredVerificationMode']
             );
         }
         return $this;
@@ -653,7 +659,7 @@ class Subscriber
     {
         $client = PubSubHubbub::getHttpClient();
         $client->setMethod(\Zend\Http\Client::POST);
-        $client->setConfig(array('useragent' => 'Zend_Feed_Pubsubhubbub_Subscriber/'
+        $client->setOptions(array('useragent' => 'Zend_Feed_Pubsubhubbub_Subscriber/'
             . \Zend\Version::VERSION));
         return $client;
     }

--- a/library/Zend/Feed/PubSubHubbub/Subscriber.php
+++ b/library/Zend/Feed/PubSubHubbub/Subscriber.php
@@ -160,9 +160,6 @@ class Subscriber
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         }
-        if (is_array($options)) {
-            $this->setOptions($options);
-        }
 
         if (!is_array($options)) {
             throw new Exception('Array or Traversable object'

--- a/library/Zend/Feed/Writer/FeedFactory.php
+++ b/library/Zend/Feed/Writer/FeedFactory.php
@@ -19,7 +19,10 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
+
 namespace Zend\Feed\Writer;
+
+use Traversable;
 
 /**
  * @category   Zend
@@ -31,15 +34,15 @@ namespace Zend\Feed\Writer;
 abstract class FeedFactory
 {
     /**
-     * Create and return a Feed basd on data provided.
+     * Create and return a Feed based on data provided.
      * 
-     * @param  array|Traversable $data 
+     * @param  array|\Traversable $data
      * @return Feed
      */
     public static function factory($data)
     {
         if (!is_array($data) && !$data instanceof Traversable) {
-            throw Exception\InvalidArgumentException(sprintf(
+            throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an array or Traversable argument; received "%s"',
                 __METHOD__,
                 (is_object($data) ? get_class($data) : gettype($data))

--- a/library/Zend/Filter/Alnum.php
+++ b/library/Zend/Filter/Alnum.php
@@ -20,8 +20,9 @@
 
 namespace Zend\Filter;
 
-use Zend\Config\Config,
-    Zend\Locale\Locale as ZendLocale,
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Locale\Locale as ZendLocale,
     Zend\Registry;
 
 /**
@@ -56,14 +57,14 @@ class Alnum extends AbstractFilter
     /**
      * Sets default option values for this instance
      *
-     * @param  boolean $allowWhiteSpace
-     * @return void
+     * @param  boolean|Traversable|array $allowWhiteSpace
      */
     public function __construct($options = false)
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
-        } elseif (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/Boolean.php
+++ b/library/Zend/Filter/Boolean.php
@@ -19,6 +19,9 @@
  */
 
 namespace Zend\Filter;
+
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Locale\Locale;
 
 /**
@@ -79,13 +82,14 @@ class Boolean extends AbstractFilter
     /**
      * Constructor
      *
-     * @param string|array|\Zend\Config\Config $options OPTIONAL
+     * @param string|array|Traversable $options OPTIONAL
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
-        } elseif (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/Compress.php
+++ b/library/Zend/Filter/Compress.php
@@ -20,6 +20,9 @@
 
 namespace Zend\Filter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * Compresses a given string
  *
@@ -43,12 +46,12 @@ class Compress extends AbstractFilter
     /**
      * Class constructor
      *
-     * @param string|array $options (Optional) Options to set
+     * @param string|array|Traversable $options (Optional) Options to set
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
         if (is_string($options)) {
             $this->setAdapter($options);

--- a/library/Zend/Filter/Compress/Gz.php
+++ b/library/Zend/Filter/Compress/Gz.php
@@ -102,7 +102,7 @@ class Gz extends AbstractCompressionAlgorithm
      *
      * @param  string $mode Supported are 'compress', 'deflate' and 'file'
      * @return Gz
-     * @throws Exceptin\InvalidArgumentException for invalid $mode value
+     * @throws Exception\InvalidArgumentException for invalid $mode value
      */
     public function setMode($mode)
     {

--- a/library/Zend/Filter/Encrypt.php
+++ b/library/Zend/Filter/Encrypt.php
@@ -20,7 +20,8 @@
 
 namespace Zend\Filter;
 
-use Zend\Config;
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Loader;
 
 /**
@@ -41,12 +42,12 @@ class Encrypt extends AbstractFilter
     /**
      * Class constructor
      *
-     * @param string|array $options (Optional) Options to set, if null mcrypt is used
+     * @param string|array|Traversable $options (Optional) Options to set, if null mcrypt is used
      */
     public function __construct($options = null)
     {
-        if ($options instanceof Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         $this->setAdapter($options);
@@ -97,7 +98,9 @@ class Encrypt extends AbstractFilter
 
         $this->_adapter = new $adapter($options);
         if (!$this->_adapter instanceof Encrypt\EncryptionAlgorithmInterface) {
-            throw new Exception\InvalidArgumentException("Encoding adapter '" . $adapter . "' does not implement Zend\\Filter\\Encrypt\\EncryptionAlgorithmInterface");
+            throw new Exception\InvalidArgumentException(
+                "Encoding adapter '" . $adapter
+                . "' does not implement Zend\\Filter\\Encrypt\\EncryptionAlgorithmInterface");
         }
 
         return $this;

--- a/library/Zend/Filter/Encrypt/Mcrypt.php
+++ b/library/Zend/Filter/Encrypt/Mcrypt.php
@@ -19,6 +19,9 @@
  */
 
 namespace Zend\Filter\Encrypt;
+
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Filter\Exception,
     Zend\Filter\Compress,
     Zend\Filter\Decompress;
@@ -63,7 +66,7 @@ class Mcrypt implements EncryptionAlgorithmInterface
     /**
      * Class constructor
      *
-     * @param string|array|\Zend\Config\Config $options Cryption Options
+     * @param string|array|\Traversable $options Encryption Options
      */
     public function __construct($options)
     {
@@ -71,8 +74,8 @@ class Mcrypt implements EncryptionAlgorithmInterface
             throw new Exception\ExtensionNotLoadedException('This filter needs the mcrypt extension');
         }
 
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         } elseif (is_string($options)) {
             $options = array('key' => $options);
         } elseif (!is_array($options)) {

--- a/library/Zend/Filter/Encrypt/Openssl.php
+++ b/library/Zend/Filter/Encrypt/Openssl.php
@@ -20,6 +20,8 @@
 
 namespace Zend\Filter\Encrypt;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Filter\Exception,
     Zend\Filter\Compress,
     Zend\Filter\Decompress;
@@ -79,7 +81,7 @@ class Openssl implements EncryptionAlgorithmInterface
      *   'compression' => compress value with this compression adapter
      *   'package'     => pack envelope keys into encrypted string, simplifies decryption
      *
-     * @param string|array $options Options for this adapter
+     * @param string|array|Traversable $options Options for this adapter
      */
     public function __construct($options = array())
     {
@@ -87,8 +89,8 @@ class Openssl implements EncryptionAlgorithmInterface
             throw new Exception\ExtensionNotLoadedException('This filter needs the openssl extension');
         }
 
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (!is_array($options)) {

--- a/library/Zend/Filter/File/Rename.php
+++ b/library/Zend/Filter/File/Rename.php
@@ -19,6 +19,9 @@
  */
 
 namespace Zend\Filter\File;
+
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Filter,
     Zend\Filter\Exception;
 
@@ -41,18 +44,17 @@ class Rename extends Filter\AbstractFilter
      * Options argument may be either a string, a Zend_Config object, or an array.
      * If an array or Zend_Config object, it accepts the following keys:
      * 'source'    => Source filename or directory which will be renamed
-     * 'target'    => Target filename or directory, the new name of the sourcefile
+     * 'target'    => Target filename or directory, the new name of the source file
      * 'overwrite' => Shall existing files be overwritten ?
      *
-     * @param  string|array $options Target file or directory to be renamed
+     * @param  string|array|Traversable $options Target file or directory to be renamed
      * @param  string $target Source filename or directory (deprecated)
      * @param  bool $overwrite Should existing files be overwritten (deprecated)
-     * @return void
      */
     public function __construct($options)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         } elseif (is_string($options)) {
             $options = array('target' => $options);
         } elseif (!is_array($options)) {

--- a/library/Zend/Filter/HtmlEntities.php
+++ b/library/Zend/Filter/HtmlEntities.php
@@ -20,7 +20,8 @@
 
 namespace Zend\Filter;
 
-use Zend\Config\Config;
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 
 /**
  * @category   Zend
@@ -47,22 +48,21 @@ class HtmlEntities extends AbstractFilter
     /**
      * Corresponds to the forth htmlentities() argument
      *
-     * @var Config
+     * @var boolean
      */
     protected $_doubleQuote;
 
     /**
      * Sets filter options
      *
-     * @param  integer|array $quoteStyle
-     * @param  string  $charSet
-     * @return void
+     * @param array|Traversable $options
      */
     public function __construct($options = array())
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
-        } elseif (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             $options = func_get_args();
             $temp['quotestyle'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Filter/Inflector.php
+++ b/library/Zend/Filter/Inflector.php
@@ -20,8 +20,9 @@
 
 namespace Zend\Filter;
 
-use Zend\Config,
-    Zend\Loader\Broker;
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Loader\Broker;
 
 /**
  * Filter chain for string inflection
@@ -61,13 +62,14 @@ class Inflector extends AbstractFilter
     /**
      * Constructor
      *
-     * @param string|array $options Options to set
+     * @param string|array|Traversable $options Options to set
      */
     public function __construct($options = null)
     {
-        if ($options instanceof Config\Config) {
-            $options = $options->toArray();
-        } else if (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             $options = func_get_args();
             $temp    = array();
 
@@ -120,27 +122,15 @@ class Inflector extends AbstractFilter
     }
 
     /**
-     * Use Zend_Config object to set object state
-     *
-     * @deprecated Use setOptions() instead
-     * @param  \Zend\Config\Config $config
-     * @return Inflector
-     */
-    public function setConfig(Config\Config $config)
-    {
-        return $this->setOptions($config);
-    }
-
-    /**
      * Set options
      *
-     * @param  array $options
+     * @param  array|Traversable $options
      * @return Inflector
      */
     public function setOptions($options)
     {
-        if ($options instanceof Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         // Set broker

--- a/library/Zend/Filter/LocalizedToNormalized.php
+++ b/library/Zend/Filter/LocalizedToNormalized.php
@@ -19,6 +19,9 @@
  */
 
 namespace Zend\Filter;
+
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Locale\Format;
 
 /**
@@ -44,12 +47,12 @@ class LocalizedToNormalized extends AbstractFilter
     /**
      * Class constructor
      *
-     * @param string|\Zend\Locale\Locale $locale (Optional) Locale to set
+     * @param array|Traversable $options (Optional) Locale to set
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (null !== $options) {

--- a/library/Zend/Filter/NormalizedToLocalized.php
+++ b/library/Zend/Filter/NormalizedToLocalized.php
@@ -19,6 +19,9 @@
  */
 
 namespace Zend\Filter;
+
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Locale\Format,
     Zend\Date\Date;
 
@@ -44,12 +47,12 @@ class NormalizedToLocalized extends AbstractFilter
     /**
      * Class constructor
      *
-     * @param string|\Zend\Locale\Locale $locale (Optional) Locale to set
+     * @param array|Traversable $options (Optional) Locale to set
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (null !== $options) {

--- a/library/Zend/Filter/Null.php
+++ b/library/Zend/Filter/Null.php
@@ -20,6 +20,9 @@
 
 namespace Zend\Filter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * @category   Zend
  * @package    Zend_Filter
@@ -56,13 +59,14 @@ class Null extends AbstractFilter
     /**
      * Constructor
      *
-     * @param string|array|\Zend\Config\Config $options OPTIONAL
+     * @param string|array|Traversable $options OPTIONAL
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
-        } elseif (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/RealPath.php
+++ b/library/Zend/Filter/RealPath.php
@@ -20,6 +20,9 @@
 
 namespace Zend\Filter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * @category   Zend
  * @package    Zend_Filter
@@ -36,7 +39,7 @@ class RealPath extends AbstractFilter
     /**
      * Class constructor
      *
-     * @param boolean|\Zend\Config\Config $options Options to set
+     * @param boolean|\Traversable $options Options to set
      */
     public function __construct($options = true)
     {
@@ -58,22 +61,22 @@ class RealPath extends AbstractFilter
      * TRUE when the path must exist
      * FALSE when not existing paths can be given
      *
-     * @param boolean|\Zend\Config\Config $exists Path must exist
+     * @param boolean|array|Traversable $options Path must exist
      * @return RealPath
      */
-    public function setExists($exists)
+    public function setExists($options)
     {
-        if ($exists instanceof \Zend\Config\Config) {
-            $exists = $exists->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
-        if (is_array($exists)) {
-            if (isset($exists['exists'])) {
-                $exists = (boolean) $exists['exists'];
+        if (is_array($options)) {
+            if (isset($options['exists'])) {
+                $options = (boolean) $options['exists'];
             }
         }
 
-        $this->_exists = (boolean) $exists;
+        $this->_exists = (boolean) $options;
         return $this;
     }
 

--- a/library/Zend/Filter/StringToLower.php
+++ b/library/Zend/Filter/StringToLower.php
@@ -20,6 +20,9 @@
 
 namespace Zend\Filter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * @category   Zend
  * @package    Zend_Filter
@@ -38,13 +41,14 @@ class StringToLower extends AbstractFilter
     /**
      * Constructor
      *
-     * @param string|array|\Zend\Config\Config $options OPTIONAL
+     * @param string|array|Traversable $options OPTIONAL
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
-        } else if (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/StringToUpper.php
+++ b/library/Zend/Filter/StringToUpper.php
@@ -20,6 +20,9 @@
 
 namespace Zend\Filter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * @category   Zend
  * @package    Zend_Filter
@@ -38,14 +41,14 @@ class StringToUpper extends AbstractFilter
     /**
      * Constructor
      *
-     * @param string|array $options OPTIONAL
-     * @return void
+     * @param string|array|Traversable $options OPTIONAL
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
-        } else if (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/StringTrim.php
+++ b/library/Zend/Filter/StringTrim.php
@@ -20,6 +20,9 @@
 
 namespace Zend\Filter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * @category   Zend
  * @package    Zend_Filter
@@ -41,14 +44,14 @@ class StringTrim extends AbstractFilter
     /**
      * Sets filter options
      *
-     * @param  string|array|\Zend\Config\Config $options
-     * @return void
+     * @param  string|array|Traversable $options
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
-        } elseif (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             $options          = func_get_args();
             $temp['charlist'] = array_shift($options);
             $options          = $temp;

--- a/library/Zend/Filter/StripTags.php
+++ b/library/Zend/Filter/StripTags.php
@@ -20,7 +20,8 @@
 
 namespace Zend\Filter;
 
-use Zend\Config\Config;
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 
 /**
  * @category   Zend
@@ -61,14 +62,15 @@ class StripTags extends AbstractFilter
      *     'allowAttribs'  => Attributes which are allowed
      *     'allowComments' => Are comments allowed ?
      *
-     * @param  string|array|Config $options
+     * @param  string|array|Traversable $options
      * @return void
      */
     public function __construct($options = null)
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
-        } else if ((!is_array($options)) || (is_array($options) && !array_key_exists('allowTags', $options) &&
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if ((!is_array($options)) || (is_array($options) && !array_key_exists('allowTags', $options) &&
             !array_key_exists('allowAttribs', $options) && !array_key_exists('allowComments', $options))) {
             $options = func_get_args();
             $temp['allowTags'] = array_shift($options);

--- a/library/Zend/Form/DisplayGroup.php
+++ b/library/Zend/Form/DisplayGroup.php
@@ -120,8 +120,7 @@ class DisplayGroup implements \Iterator,\Countable
      *
      * @param  string $name
      * @param  PrefixPathMapper $loader
-     * @param  array|Config $options
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($name, PrefixPathMapper $loader, $options = null)
     {

--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -240,8 +240,8 @@ class Element implements ValidatorInterface
      * - array: options with which to configure element
      * - Zend_Config: Zend_Config with options for configuring element
      *
-     * @param  string|array|Config $spec
-     * @param  array|Traversable $options
+     * @param  array|string|Traversable $spec
+     * @param  array|string|Traversable $options
      * @return void
      * @throws ElementException if no element name after initialization
      */

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -246,8 +246,7 @@ class Form implements Iterator, Countable, ValidatorInterface
      *
      * Registers form view helper as decorator
      *
-     * @param mixed $options
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($options = null)
     {

--- a/library/Zend/GData/App.php
+++ b/library/Zend/GData/App.php
@@ -246,7 +246,7 @@ class App
         $userAgent = $applicationId . ' Zend_Framework_Gdata/' .
             \Zend\Version::VERSION;
         $client->getRequest()->headers()->addHeaderLine('User-Agent', $userAgent);
-        $client->setConfig(array(
+        $client->setOptions(array(
             'strictredirects' => true
             )
         );
@@ -280,7 +280,7 @@ class App
             $client = new Http\Client();
             $userAgent = 'Zend_Framework_Gdata/' . \Zend\Version::VERSION;
             $client->setHeaders('User-Agent', $userAgent);
-            $client->setConfig(array(
+            $client->setOptions(array(
                 'strictredirects' => true
                 )
             );
@@ -637,7 +637,7 @@ class App
         }
 
 
-        $this->_httpClient->setConfig(array('maxredirects' => 0));
+        $this->_httpClient->setOptions(array('maxredirects' => 0));
 
         // Set the proper adapter if we are handling a streaming upload
         $usingMimeStream = false;
@@ -1099,7 +1099,7 @@ class App
      */
     public function enableRequestDebugLogging($logfile)
     {
-        $this->_httpClient->setConfig(array(
+        $this->_httpClient->setOptions(array(
             'adapter' => 'Zend\GData\App\LoggingHttpClientAdapterSocket',
             'logfile' => $logfile
             ));

--- a/library/Zend/GData/AuthSub.php
+++ b/library/Zend/GData/AuthSub.php
@@ -225,7 +225,7 @@ class AuthSub
             throw new App\HttpException('Client is not an instance of Zend_Http_Client.');
         }
         $useragent = 'Zend_Framework_Gdata/' . \Zend\Version::VERSION;
-        $client->setConfig(array(
+        $client->setOptions(array(
                 'strictredirects' => true,
                 'useragent' => $useragent
             )

--- a/library/Zend/GData/ClientLogin.php
+++ b/library/Zend/GData/ClientLogin.php
@@ -95,7 +95,7 @@ class ClientLogin
         $client->setUri($loginUri);
         $client->setMethod('POST');
         $useragent = $source . ' Zend_Framework_Gdata/' . \Zend\Version::VERSION;
-        $client->setConfig(array(
+        $client->setOptions(array(
                 'maxredirects'    => 0,
                 'strictredirects' => true,
                 'useragent' => $useragent
@@ -147,7 +147,7 @@ class ClientLogin
         if ($response->getStatusCode() == 200) {
             $client->setClientLoginToken($goog_resp['Auth']);
             $useragent = $source . ' Zend_Framework_Gdata/' . \Zend\Version::VERSION;
-            $client->setConfig(array(
+            $client->setOptions(array(
                     'strictredirects' => true,
                     'useragent' => $useragent
                 )

--- a/library/Zend/Http/Client/Adapter.php
+++ b/library/Zend/Http/Client/Adapter.php
@@ -38,9 +38,9 @@ interface Adapter
     /**
      * Set the configuration array for the adapter
      *
-     * @param array $config
+     * @param array $options
      */
-    public function setConfig($config = array());
+    public function setOptions($options = array());
 
     /**
      * Connect to the remote server

--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -21,6 +21,9 @@
  */
 
 namespace Zend\Http\Client\Adapter;
+
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Http\Client\Adapter as HttpAdapter,
     Zend\Http\Client\Adapter\Exception as AdapterException,
     Zend\Http\Client,
@@ -83,9 +86,8 @@ class Curl implements HttpAdapter, Stream
     /**
      * Adapter constructor
      *
-     * Config is set using setConfig()
+     * Config is set using setOptions()
      *
-     * @return void
      * @throws \Zend\Http\Client\Adapter\Exception
      */
     public function __construct()
@@ -116,31 +118,32 @@ class Curl implements HttpAdapter, Stream
      * Set the configuration array for the adapter
      *
      * @throws \Zend\Http\Client\Adapter\Exception
-     * @param  \Zend\Config\Config | array $config
+     * @param  array|Traversable $options
      * @return \Zend\Http\Client\Adapter\Curl
      */
-    public function setConfig($config = array())
+    public function setOptions($options = array())
     {
-        if ($config instanceof \Zend\Config\Config) {
-            $config = $config->toArray();
-        } elseif (!is_array($config)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             throw new AdapterException\InvalidArgumentException(
-                'Array or Zend\Config\Config object expected, got ' . gettype($config)
+                'Array or Traversable object expected, got ' . gettype($options)
             );
         }
 
         /** Config Key Normalization */
-        foreach ($config as $k => $v) {
-            unset($config[$k]); // unset original value
-            $config[str_replace(array('-', '_', ' ', '.'), '', strtolower($k))] = $v; // replace w/ normalized
+        foreach ($options as $k => $v) {
+            unset($options[$k]); // unset original value
+            $options[str_replace(array('-', '_', ' ', '.'), '', strtolower($k))] = $v; // replace w/ normalized
         }
 
-        if (isset($config['proxyuser']) && isset($config['proxypass'])) {
-            $this->setCurlOption(CURLOPT_PROXYUSERPWD, $config['proxyuser'].":".$config['proxypass']);
-            unset($config['proxyuser'], $config['proxypass']);
+        if (isset($options['proxyuser']) && isset($options['proxypass'])) {
+            $this->setCurlOption(CURLOPT_PROXYUSERPWD, $options['proxyuser'].":".$options['proxypass']);
+            unset($options['proxyuser'], $options['proxypass']);
         }
 
-        foreach ($config as $k => $v) {
+        foreach ($options as $k => $v) {
             $option = strtolower($k);
             switch($option) {
                 case 'proxyhost':

--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -20,6 +20,9 @@
  */
 
 namespace Zend\Http\Client\Adapter;
+
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Http\Client\Adapter as HttpAdapter,
     Zend\Http\Client\Adapter\Exception as AdapterException,
     Zend\Http\Response;
@@ -85,7 +88,7 @@ class Socket implements HttpAdapter, Stream
     protected $_context = null;
 
     /**
-     * Adapter constructor, currently empty. Config is set using setConfig()
+     * Adapter constructor, currently empty. Config is set using setOptions()
      *
      */
     public function __construct()
@@ -95,20 +98,20 @@ class Socket implements HttpAdapter, Stream
     /**
      * Set the configuration array for the adapter
      *
-     * @param \Zend\Config\Config | array $config
+     * @param  array|Traversable $options
      */
-    public function setConfig($config = array())
+    public function setOptions($options = array())
     {
-        if ($config instanceof \Zend\Config\Config) {
-            $config = $config->toArray();
-
-        } elseif (! is_array($config)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             throw new AdapterException\InvalidArgumentException(
-                'Array or Zend_Config object expected, got ' . gettype($config)
+                'Array or Zend_Config object expected, got ' . gettype($options)
             );
         }
 
-        foreach ($config as $k => $v) {
+        foreach ($options as $k => $v) {
             $this->config[strtolower($k)] = $v;
         }
     }

--- a/library/Zend/Http/Client/Adapter/Test.php
+++ b/library/Zend/Http/Client/Adapter/Test.php
@@ -20,6 +20,9 @@
  */
 
 namespace Zend\Http\Client\Adapter;
+
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Http\Client\Adapter as HttpAdapter,
     Zend\Http\Client\Adapter\Exception as AdapterException,
     Zend\Http\Response;
@@ -70,8 +73,7 @@ class Test implements HttpAdapter
     protected $_nextRequestWillFail = false;
 
     /**
-     * Adapter constructor, currently empty. Config is set using setConfig()
-     *
+     * Adapter constructor, currently empty. Config is set using setOptions()
      */
     public function __construct()
     { }
@@ -92,20 +94,21 @@ class Test implements HttpAdapter
     /**
      * Set the configuration array for the adapter
      *
-     * @param \Zend\Config\Config | array $config
+     * @param  array|Traversable $options
      */
-    public function setConfig($config = array())
+    public function setOptions($options = array())
     {
-        if ($config instanceof \Zend\Config\Config) {
-            $config = $config->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
 
-        } elseif (! is_array($config)) {
+        if (! is_array($options)) {
             throw new AdapterException\InvalidArgumentException(
-                'Array or Zend\Config\Config object expected, got ' . gettype($config)
+                'Array or Traversable object expected, got ' . gettype($options)
             );
         }
 
-        foreach ($config as $k => $v) {
+        foreach ($options as $k => $v) {
             $this->config[strtolower($k)] = $v;
         }
     }

--- a/library/Zend/InfoCard/Cipher/PKI/RSA.php
+++ b/library/Zend/InfoCard/Cipher/PKI/RSA.php
@@ -44,5 +44,5 @@ interface RSA
      * @param integer $padding The padding to use during decryption (of not provided object value will be used)
      * @return string The decrypted data
      */
-    public function decrypt($encryptedData, $privateKey, $password = null, $padding = Adapter\AbstractAdapterAdapter\AbstractAdapter::NO_PADDING);
+    public function decrypt($encryptedData, $privateKey, $password = null, $padding = Adapter\AbstractAdapter::NO_PADDING);
 }

--- a/library/Zend/Loader/ClassMapAutoloader.php
+++ b/library/Zend/Loader/ClassMapAutoloader.php
@@ -53,8 +53,7 @@ class ClassMapAutoloader implements SplAutoloader
      *
      * Create a new instance, and optionally configure the autoloader.
      * 
-     * @param  null|array|Traversable $options 
-     * @return void
+     * @param  null|array|\Traversable $options
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Loader/PluginBroker.php
+++ b/library/Zend/Loader/PluginBroker.php
@@ -81,7 +81,7 @@ class PluginBroker implements Broker, LocatorAware
     /**
      * Configure plugin broker
      * 
-     * @param  array|Traversable $options 
+     * @param  array|\Traversable $options
      * @return PluginBroker
      */
     public function setOptions($options)

--- a/library/Zend/Loader/PluginSpecBroker.php
+++ b/library/Zend/Loader/PluginSpecBroker.php
@@ -44,7 +44,7 @@ class PluginSpecBroker extends PluginBroker implements LazyLoadingBroker
      * method, and then scanned for a "specs" key; if found, it is used to
      * configure plugin specifications.
      * 
-     * @param  array|Traversable $options 
+     * @param  array|\Traversable $options
      * @return PluginSpecBroker
      */
     public function setOptions($options)

--- a/library/Zend/Loader/PrefixPathLoader.php
+++ b/library/Zend/Loader/PrefixPathLoader.php
@@ -130,7 +130,7 @@ class PrefixPathLoader implements ShortNameLocator, PrefixPathMapper
      *
      * Proxies to {@link addPrefixPaths()}.
      * 
-     * @param  array|Traversable $options 
+     * @param  array|\Traversable $options
      * @return PrefixPathLoader
      */
     public function setOptions($options)

--- a/library/Zend/Loader/SplAutoloader.php
+++ b/library/Zend/Loader/SplAutoloader.php
@@ -37,8 +37,7 @@ interface SplAutoloader
      *
      * Allow configuration of the autoloader via the constructor.
      * 
-     * @param  null|array|Traversable $options 
-     * @return void
+     * @param  null|array|\Traversable $options
      */
     public function __construct($options = null);
 

--- a/library/Zend/Loader/StandardAutoloader.php
+++ b/library/Zend/Loader/StandardAutoloader.php
@@ -90,7 +90,7 @@ class StandardAutoloader implements SplAutoloader
      * )
      * </code>
      *
-     * @param  array|Traversable $options
+     * @param  array|\Traversable $options
      * @return StandardAutoloader
      */
     public function setOptions($options)

--- a/library/Zend/Log/Formatter/Simple.php
+++ b/library/Zend/Log/Formatter/Simple.php
@@ -22,8 +22,7 @@
 namespace Zend\Log\Formatter;
 
 use Zend\Log\Formatter,
-    Zend\Log\Exception,
-    Zend\Config\Config;
+    Zend\Log\Exception;
 
 /**
  * @category   Zend

--- a/library/Zend/Log/Formatter/Xml.php
+++ b/library/Zend/Log/Formatter/Xml.php
@@ -21,10 +21,11 @@
 
 namespace Zend\Log\Formatter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use DOMDocument,
     DOMElement,
-    Zend\Log\Formatter,
-    Zend\Config\Config;
+    Zend\Log\Formatter;
 
 /**
  * @category   Zend
@@ -54,14 +55,15 @@ class Xml implements Formatter
      * Class constructor
      * (the default encoding is UTF-8)
      *
-     * @param array|Config $options
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($options = array())
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
-        } elseif (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+
+        if (!is_array($options)) {
             $args = func_get_args();
 
             $options = array(

--- a/library/Zend/Log/Loggable.php
+++ b/library/Zend/Log/Loggable.php
@@ -33,56 +33,56 @@ interface Loggable
 {
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|\Traversable $extra
      * @return Loggabble
      */
     public function emerg($message, $extra = array());
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|\Traversable $extra
      * @return Loggabble
      */
     public function alert($message, $extra = array());
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|\Traversable $extra
      * @return Loggabble
      */
     public function crit($message, $extra = array());
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|\Traversable $extra
      * @return Loggabble
      */
     public function err($message, $extra = array());
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|\Traversable $extra
      * @return Loggabble
      */
     public function warn($message, $extra = array());
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|\Traversable $extra
      * @return Loggabble
      */
     public function notice($message, $extra = array());
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|\Traversable $extra
      * @return Loggabble
      */
     public function info($message, $extra = array());
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|\Traversable $extra
      * @return Loggabble
      */
     public function debug($message, $extra = array());

--- a/library/Zend/Markup/Parser.php
+++ b/library/Zend/Markup/Parser.php
@@ -34,9 +34,7 @@ interface Parser
     /**
      * Constructor
      *
-     * @param \Zend\Config\Config|array $options
-     *
-     * @return array
+     * @param array|\Traversable $options
      */
     public function __construct($options = array());
 

--- a/library/Zend/Markup/Parser/Bbcode.php
+++ b/library/Zend/Markup/Parser/Bbcode.php
@@ -20,10 +20,12 @@
  */
 
 namespace Zend\Markup\Parser;
+
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Markup\Parser,
     Zend\Markup\Token,
-    Zend\Markup\TokenList,
-    Zend\Config\Config;
+    Zend\Markup\TokenList;
 
 /**
  * @category   Zend
@@ -127,14 +129,14 @@ class Bbcode implements Parser
     /**
      * Constructor
      *
-     * @param \Zend\Config\Config|array $config
+     * @param  array|Traversable $options
      *
      * @return array
      */
     public function __construct($options = array())
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (isset($options['groups'])) {

--- a/library/Zend/Markup/Renderer/AbstractRenderer.php
+++ b/library/Zend/Markup/Renderer/AbstractRenderer.php
@@ -20,11 +20,13 @@
  */
 
 namespace Zend\Markup\Renderer;
+
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Markup\Token,
     Zend\Markup\TokenList,
     Zend\Markup\Parser,
-    Zend\Markup\Renderer\Markup,
-    Zend\Config\Config;
+    Zend\Markup\Renderer\Markup;
 
 /**
  * Defines the basic rendering functionality
@@ -77,16 +79,12 @@ abstract class AbstractRenderer
     /**
      * Constructor
      *
-     * @param array|\Zend\Config\Config $options
-     *
-     * @todo make constructor compliant with new configuration standards
-     *
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($options = array())
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (isset($options['encoding'])) {

--- a/library/Zend/Markup/Renderer/Html.php
+++ b/library/Zend/Markup/Renderer/Html.php
@@ -21,6 +21,8 @@
 
 namespace Zend\Markup\Renderer;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Markup\Renderer\Markup\Html\Root as RootMarkup;
 
 /**
@@ -38,16 +40,12 @@ class Html extends AbstractRenderer
     /**
      * Constructor
      *
-     * @param array|\Zend\Config\Config $options
-     *
-     * @todo make constructor compliant with new configuration standards
-     *
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($options = array())
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (isset($options['markups'])) {

--- a/library/Zend/Mvc/Bootstrap.php
+++ b/library/Zend/Mvc/Bootstrap.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Zend\Mvc;
 
+use Traversable;
 use Zend\Di\Configuration as DiConfiguration,
     Zend\Di\Di,
-    Zend\Config\Config,
     Zend\EventManager\EventManagerInterface as Events,
     Zend\EventManager\EventManager,
     Zend\EventManager\EventManagerAwareInterface,
@@ -13,7 +14,7 @@ use Zend\Di\Configuration as DiConfiguration,
 class Bootstrap implements BootstrapInterface, EventManagerAwareInterface, EventsCapableInterface
 {
     /**
-     * @var Config
+     * @var Traversable
      */
     protected $config;
 
@@ -25,9 +26,9 @@ class Bootstrap implements BootstrapInterface, EventManagerAwareInterface, Event
     /**
      * Constructor
      *
-     * @param Config $config
+     * @param Traversable $config
      */
-    public function __construct(Config $config)
+    public function __construct(Traversable $config)
     {
         $this->config = $config;
     }

--- a/library/Zend/Navigation/Page/AbstractPage.php
+++ b/library/Zend/Navigation/Page/AbstractPage.php
@@ -886,8 +886,7 @@ abstract class AbstractPage extends Container
 
         $method = 'set' . self::normalizePropertyName($property);
 
-        if ($method != 'setOptions' && $method != 'setConfig'
-            && method_exists($this, $method)
+        if ($method != 'setOptions' && method_exists($this, $method)
         ) {
             $this->$method($value);
         } else {

--- a/library/Zend/OAuth/Client.php
+++ b/library/Zend/OAuth/Client.php
@@ -20,6 +20,8 @@
 
 namespace Zend\OAuth;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Http\Client as HttpClient;
 use Zend\Http\Request as HttpRequest;
 
@@ -43,7 +45,7 @@ class Client extends HttpClient
      * of abstraction is unnecessary and doesn't let me escape the accessors
      * and mutators anyway!
      *
-     * @var Zend\OAuth\Config
+     * @var Config\StandardConfig
      */
     protected $_config = null;
 
@@ -59,20 +61,19 @@ class Client extends HttpClient
      * Constructor; creates a new HTTP Client instance which itself is
      * just a typical Zend_HTTP_Client subclass with some OAuth icing to
      * assist in automating OAuth parameter generation, addition and
-     * cryptographioc signing of requests.
+     * cryptographic signing of requests.
      *
-     * @param  array $oauthOptions
+     * @param  array|Traversable $oauthOptions
      * @param  string $uri
-     * @param  array|\Zend\Config\Config $config
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($oauthOptions, $uri = null, $config = null)
     {
         parent::__construct($uri, $config);
         $this->_config = new Config\StandardConfig;
         if ($oauthOptions !== null) {
-            if ($oauthOptions instanceof \Zend\Config\Config) {
-                $oauthOptions = $oauthOptions->toArray();
+            if ($oauthOptions instanceof Traversable) {
+                $oauthOptions = ArrayUtils::iteratorToArray($oauthOptions);
             }
             $this->_config->setOptions($oauthOptions);
         }

--- a/library/Zend/OAuth/Config/StandardConfig.php
+++ b/library/Zend/OAuth/Config/StandardConfig.php
@@ -20,6 +20,8 @@
 
 namespace Zend\OAuth\Config;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\OAuth\Config as OAuthConfig,
     Zend\OAuth,
     Zend\Uri;
@@ -144,27 +146,26 @@ class StandardConfig implements OAuthConfig
     protected $_token = null;
 
     /**
-     * Constructor; create a new object with an optional array|Zend_Config
+     * Constructor; create a new object with an optional array|Traversable
      * instance containing initialising options.
      *
-     * @param  array|\Zend\Config\Config $options
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($options = null)
     {
-        if ($options !== null) {
-            if ($options instanceof \Zend\Config\Config) {
-                $options = $options->toArray();
-            }
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (is_array($options)) {
             $this->setOptions($options);
         }
     }
 
     /**
-     * Parse option array or Zend_Config instance and setup options using their
+     * Parse option array and setup options using their
      * relevant mutators.
      *
-     * @param  array|\Zend\Config\Config $options
+     * @param  array $options
      * @return \Zend\OAuth\Config
      */
     public function setOptions(array $options)

--- a/library/Zend/OAuth/Consumer.php
+++ b/library/Zend/OAuth/Consumer.php
@@ -20,6 +20,9 @@
 
 namespace Zend\OAuth;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * @category   Zend
  * @package    Zend_OAuth
@@ -45,7 +48,7 @@ class Consumer extends OAuth
     protected $_accessToken = null;
 
     /**
-     * @var \Zend\OAuth\Config\Config
+     * @var \Zend\OAuth\Config
      */
     protected $_config = null;
 
@@ -53,15 +56,14 @@ class Consumer extends OAuth
      * Constructor; create a new object with an optional array|Zend_Config
      * instance containing initialising options.
      *
-     * @param  array|\Zend\Config\Config $options
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($options = null)
     {
         $this->_config = new Config\StandardConfig;
         if ($options !== null) {
-            if ($options instanceof \Zend\Config\Config) {
-                $options = $options->toArray();
+            if ($options instanceof Traversable) {
+                $options = ArrayUtils::iteratorToArray($options);
             }
             $this->_config->setOptions($options);
         }

--- a/library/Zend/OAuth/Token/Access.php
+++ b/library/Zend/OAuth/Token/Access.php
@@ -83,7 +83,7 @@ class Access extends AbstractToken
      * 
      * @param  array $oauthOptions 
      * @param  null|string $uri 
-     * @param  null|array|Zend\Config\Config $config 
+     * @param  null|array|\Traversable $config
      * @param  bool $excludeCustomParamsFromHeader 
      * @return Zend\OAuth\Client
      */

--- a/library/Zend/Paginator/Paginator.php
+++ b/library/Zend/Paginator/Paginator.php
@@ -251,7 +251,7 @@ class Paginator implements Countable, IteratorAggregate
      * @param array|\Traversable $config
      * @throws Exception\InvalidArgumentException
      */
-    public static function setConfig($config)
+    public static function setOptions($config)
     {
         if ($config instanceof Traversable) {
             $config = ArrayUtils::iteratorToArray($config);

--- a/library/Zend/Pdf/Font.php
+++ b/library/Zend/Pdf/Font.php
@@ -20,6 +20,7 @@
  */
 
 namespace Zend\Pdf;
+
 use Zend\Pdf\Exception;
 
 /**
@@ -474,7 +475,7 @@ abstract class Font
          *   file paths in a configuration file for frequently used custom
          *   fonts. This would allow a user to use custom fonts without having
          *   to hard-code file paths all over the place. Table this idea until
-         *   {@link \Zend\Config} is ready.
+         *   {@link \Traversable} is ready.
          */
 
         /* Not an existing font and no mapping in the config file. Check to see

--- a/library/Zend/ProgressBar/Adapter/AbstractAdapter.php
+++ b/library/Zend/ProgressBar/Adapter/AbstractAdapter.php
@@ -20,7 +20,8 @@
 
 namespace Zend\ProgressBar\Adapter;
 
-use Zend\Config\Config;
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 
 /**
  * Abstract class for Zend_ProgressBar_Adapters
@@ -48,28 +49,16 @@ abstract class AbstractAdapter
      * $options may be either be an array or a Zend_Config object which
      * specifies adapter related options.
      *
-     * @param null|array|\Zend\Config\Config $options
+     * @param  array|Traversable $options
      */
     public function __construct($options = null)
     {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
         if (is_array($options)) {
             $this->setOptions($options);
-        } elseif ($options instanceof Config) {
-            $this->setConfig($options);
         }
-    }
-
-    /**
-     * Set options via a Zend_Config instance
-     *
-     * @param  \Zend\Config\Config $config
-     * @return \Zend\ProgressBar\Adapter\Adapter
-     */
-    public function setConfig(Config $config)
-    {
-        $this->setOptions($config->toArray());
-
-        return $this;
     }
 
     /**

--- a/library/Zend/ProgressBar/Adapter/Console.php
+++ b/library/Zend/ProgressBar/Adapter/Console.php
@@ -17,6 +17,7 @@
  */
 
 namespace Zend\ProgressBar\Adapter;
+
 use Zend\ProgressBar\Adapter\Exception;
 
 /**
@@ -147,7 +148,7 @@ class Console extends AbstractAdapter
     /**
      * Defined by Zend_ProgressBar_Adapter
      *
-     * @param null|array|\Zend\Config\Config $options
+     * @param  array|\Traversable $options
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Queue/Adapter.php
+++ b/library/Zend/Queue/Adapter.php
@@ -35,7 +35,7 @@ interface Adapter
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $options
+     * @param  array|\Traversable $options
      * @param  \Zend\Queue\Queue $queue
      * @return void
      */

--- a/library/Zend/Queue/Adapter/AbstractAdapter.php
+++ b/library/Zend/Queue/Adapter/AbstractAdapter.php
@@ -21,10 +21,11 @@
 
 namespace Zend\Queue\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Queue\Adapter,
     Zend\Queue\Queue,
-    Zend\Queue\Exception,
-    Zend\Config\Config;
+    Zend\Queue\Exception;
 
 /**
  * Class for connecting to queues performing common operations.
@@ -43,7 +44,7 @@ abstract class AbstractAdapter implements Adapter
     const CREATE_TIMEOUT_DEFAULT = 30;
 
     /**
-     * Default timeout for recieve() function
+     * Default timeout for receive() function
      */
     const RECEIVE_TIMEOUT_DEFAULT = 30;
 
@@ -86,15 +87,15 @@ abstract class AbstractAdapter implements Adapter
      * host           => (string) What host to connect to, defaults to localhost
      * port           => (string) The port of the database
      *
-     * @param  array|\Zend\Config\Config $config An array having configuration data
+     * @param  array|Traversable $options An array having configuration data
      * @param  \Zend\Queue\Queue The \Zend\Queue\Queue object that created this class
      * @return void
      * @throws \Zend\Queue\Exception
      */
     public function __construct($options, Queue $queue = null)
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         /*

--- a/library/Zend/Queue/Adapter/Activemq.php
+++ b/library/Zend/Queue/Adapter/Activemq.php
@@ -20,6 +20,7 @@
  */
 
 namespace Zend\Queue\Adapter;
+
 use Zend\Queue\Queue,
     Zend\Queue\Message,
     Zend\Queue\Stomp\Client,
@@ -53,9 +54,8 @@ class Activemq extends AbstractAdapter
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $config An array having configuration data
+     * @param  array|\Traversable $options An array having configuration data
      * @param  \Zend\Queue\Queue The \Zend\Queue\Queue object that created this class
-     * @return void
      */
     public function __construct($options, Queue $queue = null)
     {

--- a/library/Zend/Queue/Adapter/Db.php
+++ b/library/Zend/Queue/Adapter/Db.php
@@ -57,9 +57,8 @@ class Db extends AbstractAdapter
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $options
+     * @param  array|\Traversable $options
      * @param  \Zend\Queue\Queue|null $queue
-     * @return void
      */
     public function __construct($options, Queue $queue = null)
     {

--- a/library/Zend/Queue/Adapter/Memcacheq.php
+++ b/library/Zend/Queue/Adapter/Memcacheq.php
@@ -68,7 +68,7 @@ class Memcacheq extends AbstractAdapter
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $options
+     * @param  array|\Traversable $options
      * @param  null|\Zend\Queue\Queue $queue
      * @return void
      */

--- a/library/Zend/Queue/Adapter/PlatformJobQueue.php
+++ b/library/Zend/Queue/Adapter/PlatformJobQueue.php
@@ -45,7 +45,7 @@ class PlatformJobQueue extends AbstractAdapter
     /**
      * Constructor
      *
-     * @param  array|\Zend\Config\Config $options
+     * @param  array|\Traversable $options
      * @param  \Zend\Queue\Queue|null $queue
      * @return void
      */

--- a/library/Zend/Queue/Queue.php
+++ b/library/Zend/Queue/Queue.php
@@ -19,8 +19,10 @@
  */
 
 namespace Zend\Queue;
-use Countable,
-    Zend\Config\Config;
+
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+use Countable;
 
 /**
  * Class for connecting to queues performing common operations.
@@ -88,9 +90,8 @@ class Queue implements Countable
      * - or -
      * $queue = new \Zend\Queue\Queue(null, $config); // \Zend\Queue\Queue->createQueue();
      *
-     * @param  string|\Zend\Queue\AdapterAbstract|array|\Zend\Config\Config|null String or adapter instance, or options array or \Zend\Config\Config instance
-     * @param  \Zend\Config\Config|array $options \Zend\Config\Config or a configuration array
-     * @return void
+     * @param  string|Queue\AdapterAbstract|array|\Traversable|null $spec
+     * @param  \Traversable|array $options
      */
     public function __construct($spec, $options = array())
     {
@@ -99,23 +100,24 @@ class Queue implements Countable
             $adapter = $spec;
         } elseif (is_string($spec)) {
             $adapter = $spec;
-        } elseif ($spec instanceof Config) {
-            $options = $spec->toArray();
+        } elseif ($spec instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($spec);
         } elseif (is_array($spec)) {
             $options = $spec;
         }
 
         // last minute error checking
         if ((null === $adapter)
-            && (!is_array($options) && (!$options instanceof Config))
+            && (!is_array($options) && (!$options instanceof Traversable))
         ) {
             throw new Exception\InvalidArgumentException('No valid params passed to constructor');
         }
 
         // Now continue as we would if we were a normal constructor
-        if ($options instanceof Config) {
-            $options = $options->toArray();
-        } elseif (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             $options = array();
         }
 

--- a/library/Zend/Search/Lucene/Analysis/TokenFilter/LowerCaseUtf8.php
+++ b/library/Zend/Search/Lucene/Analysis/TokenFilter/LowerCaseUtf8.php
@@ -23,7 +23,7 @@ namespace Zend\Search\Lucene\Analysis\TokenFilter;
 
 use Zend\Search\Lucene\Analysis\Token,
     Zend\Search\Lucene,
-    Zend\Search\Lucene\Exception\ExtensionNotLoadedExtension;
+    Zend\Search\Lucene\Exception\ExtensionNotLoadedException;
 
 /**
  * Lower case Token filter.

--- a/library/Zend/Search/Lucene/Document/Xlsx.php
+++ b/library/Zend/Search/Lucene/Document/Xlsx.php
@@ -23,7 +23,7 @@ namespace Zend\Search\Lucene\Document;
 
 use Zend\Search\Lucene,
 	Zend\Search\Lucene\Exception\RuntimeException,
-	Zend\Search\Lucene\Exception\ExtensionNotLoadedExtension;
+	Zend\Search\Lucene\Exception\ExtensionNotLoadedException;
 
 /**
  * Xlsx document.

--- a/library/Zend/Search/Lucene/Exception/ExtensionNotLoadedException.php
+++ b/library/Zend/Search/Lucene/Exception/ExtensionNotLoadedException.php
@@ -1,8 +1,6 @@
 <?php
 namespace Zend\Search\Lucene\Exception;
 
-use Zend\Search\Lucene\Exception\ExceptionInterface;
-
 class ExtensionNotLoadedException
     extends \RuntimeException
     implements ExceptionInterface

--- a/library/Zend/Serializer/Adapter/AbstractAdapter.php
+++ b/library/Zend/Serializer/Adapter/AbstractAdapter.php
@@ -21,9 +21,10 @@
 
 namespace Zend\Serializer\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Serializer\Adapter\AdapterInterface as SerializationAdapter,
-    Zend\Serializer\Exception\InvalidArgumentException,
-    Zend\Config\Config;
+    Zend\Serializer\Exception\InvalidArgumentException;
 
 /**
  * @category   Zend
@@ -44,28 +45,28 @@ abstract class AbstractAdapter implements SerializationAdapter
     /**
      * Constructor
      *
-     * @param array|Config $opts Serializer options
+     * @param  array|Traversable $options Serializer options
      */
-    public function __construct($opts = array()) 
+    public function __construct($options = array())
     {
-        $this->setOptions($opts);
+        $this->setOptions($options);
     }
 
     /**
      * Set serializer options
      *
-     * @param  array|Config $opts Serializer options
+     * @param  array|Traversable $options Serializer options
      * @return AbstractAdapter
      */
-    public function setOptions($opts) 
+    public function setOptions($options)
     {
-        if ($opts instanceof Config) {
-            $opts = $opts->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         } else {
-            $opts = (array) $opts;
+            $options = (array) $options;
         }
 
-        foreach ($opts as $k => $v) {
+        foreach ($options as $k => $v) {
             $this->setOption($k, $v);
         }
         return $this;

--- a/library/Zend/Serializer/Adapter/AdapterInterface.php
+++ b/library/Zend/Serializer/Adapter/AdapterInterface.php
@@ -33,18 +33,17 @@ interface AdapterInterface
     /**
      * Constructor
      *
-     * @param  array|Zend\Config\Config $opts Serializer options
-     * @return void
+     * @param  array|\Traversable $options Serializer options
      */
-    public function __construct($opts = array());
+    public function __construct($options = array());
 
     /**
      * Set serializer options
      *
-     * @param  array|Zend\Config\Config $opts Serializer options
+     * @param  array|\Traversable $options Serializer options
      * @return AdapterInterface
      */
-    public function setOptions($opts);
+    public function setOptions($options);
 
     /**
      * Set a serializer option

--- a/library/Zend/Serializer/Adapter/IgBinary.php
+++ b/library/Zend/Serializer/Adapter/IgBinary.php
@@ -41,17 +41,17 @@ class IgBinary extends AbstractAdapter
     /**
      * Constructor
      * 
-     * @param  array|\Zend\Config\Config $opts 
+     * @param  array|\Traversable $options
      * @return void
      * @throws ExtensionNotLoadedException If igbinary extension is not present
      */
-    public function __construct($opts = array()) 
+    public function __construct($options = array())
     {
         if (!extension_loaded('igbinary')) {
             throw new ExtensionNotLoadedException('PHP extension "igbinary" is required for this adapter');
         }
 
-        parent::__construct($opts);
+        parent::__construct($options);
 
         if (self::$_serializedNull === null) {
             self::$_serializedNull = igbinary_serialize(null);

--- a/library/Zend/Serializer/Adapter/PhpSerialize.php
+++ b/library/Zend/Serializer/Adapter/PhpSerialize.php
@@ -21,8 +21,7 @@
 
 namespace Zend\Serializer\Adapter;
 
-use Zend\Serializer\Exception\RuntimeException,
-    Zend\Config\Config;
+use Zend\Serializer\Exception\RuntimeException;
 
 /**
  * @category   Zend
@@ -41,12 +40,12 @@ class PhpSerialize extends AbstractAdapter
     /**
      * Constructor
      * 
-     * @param  array|Config $opts
+     * @param  array|\Traversable $options
      * @return void
      */
-    public function __construct($opts = array()) 
+    public function __construct($options = array())
     {
-        parent::__construct($opts);
+        parent::__construct($options);
 
         // needed to check if a returned false is based on a serialize false
         // or based on failure (igbinary can overwrite [un]serialize functions)

--- a/library/Zend/Serializer/Adapter/PythonPickle.php
+++ b/library/Zend/Serializer/Adapter/PythonPickle.php
@@ -145,9 +145,9 @@ class PythonPickle extends AbstractAdapter
      *
      * @link Zend_Serializer_Adapter_AdapterAbstract::__construct()
      */
-    public function __construct($opts=array())
+    public function __construct($options=array())
     {
-        parent::__construct($opts);
+        parent::__construct($options);
 
         // init
         if (self::$_isLittleEndian === null) {

--- a/library/Zend/Serializer/Adapter/Wddx.php
+++ b/library/Zend/Serializer/Adapter/Wddx.php
@@ -45,17 +45,17 @@ class Wddx extends AbstractAdapter
     /**
      * Constructor
      * 
-     * @param  array $opts 
+     * @param  array $options
      * @return void
      * @throws ExtensionNotLoadedException if wddx extension not found
      */
-    public function __construct($opts = array())
+    public function __construct($options = array())
     {
         if (!extension_loaded('wddx')) {
             throw new ExtensionNotLoadedException('PHP extension "wddx" is required for this adapter');
         }
 
-        parent::__construct($opts);
+        parent::__construct($options);
     }
 
     /**

--- a/library/Zend/Serializer/Serializer.php
+++ b/library/Zend/Serializer/Serializer.php
@@ -21,8 +21,7 @@
 namespace Zend\Serializer;
 
 use Zend\Loader\Broker,
-    Zend\Serializer\Adapter\AdapterInterface as Adapter,
-    Zend\Config\Config;
+    Zend\Serializer\Adapter\AdapterInterface as Adapter;
 
 /**
  * @category   Zend
@@ -50,7 +49,7 @@ class Serializer
      * Create a serializer adapter instance.
      *
      * @param string|Adapter $adapterName Name of the adapter class
-     * @param array |Config $opts Serializer options
+     * @param array |\Traversable $opts Serializer options
      * @return Adapter
      */
     public static function factory($adapterName, $opts = array()) 
@@ -112,7 +111,7 @@ class Serializer
      * Change the default adapter.
      *
      * @param string|Adapter $adapter
-     * @param array|Config $options
+     * @param array|\Traversable $options
      */
     public static function setDefaultAdapter($adapter, $options = array()) 
     {

--- a/library/Zend/Service/Akismet/Akismet.php
+++ b/library/Zend/Service/Akismet/Akismet.php
@@ -220,7 +220,7 @@ class Akismet extends \Zend\Service\AbstractService
         $uri    = 'http://' . $host . ':' . $this->getPort() . $path;
         $client = $this->getHttpClient();
         $client->setUri($uri);
-        $client->setConfig(array(
+        $client->setOptions(array(
             'useragent'    => $this->getUserAgent(),
         ));
 

--- a/library/Zend/Service/Amazon/Ec2/AbstractEc2.php
+++ b/library/Zend/Service/Amazon/Ec2/AbstractEc2.php
@@ -144,7 +144,7 @@ abstract class AbstractEc2 extends Amazon\AbstractAmazon
             $request = $this->getHttpClient();
             $request->resetParameters();
 
-            $request->setConfig(array(
+            $request->setOptions(array(
                 'timeout' => $this->_httpTimeout
             ));
 

--- a/library/Zend/Service/Amazon/Ec2/Keypair.php
+++ b/library/Zend/Service/Amazon/Ec2/Keypair.php
@@ -70,7 +70,7 @@ class Keypair extends AbstractEc2
      * key pairs, information about those key pairs is returned. Otherwise,
      * information for all registered key pairs is returned.
      *
-     * @param string|rarray $keyName    Key pair IDs to describe.
+     * @param string|array $keyName    Key pair IDs to describe.
      * @return array
      */
     public function describe($keyName = null)

--- a/library/Zend/Service/Amazon/SimpleDb/SimpleDb.php
+++ b/library/Zend/Service/Amazon/SimpleDb/SimpleDb.php
@@ -155,7 +155,7 @@ class SimpleDb extends \Zend\Service\Amazon\AbstractAmazon
      *
      * @param  string $domainName
      * @param  string $itemName
-     * @param  array|Traverable $attributes
+     * @param  array|\Traverable $attributes
      * @param  array $replace
      * @return void
      */
@@ -432,7 +432,7 @@ class SimpleDb extends \Zend\Service\Amazon\AbstractAmazon
             $request = self::getHttpClient();
             $request->resetParameters();
 
-            $request->setConfig(array(
+            $request->setOptions(array(
                 'timeout' => $this->_httpTimeout
             ));
 

--- a/library/Zend/Service/Delicious/Delicious.php
+++ b/library/Zend/Service/Delicious/Delicious.php
@@ -95,7 +95,7 @@ class Delicious
     public function __construct($uname = null, $pass = null)
     {
         $this->_rest = new RestClient\RestClient();
-        $this->_rest->getHttpClient()->setConfig(array('ssltransport' => 'ssl'));
+        $this->_rest->getHttpClient()->setOptions(array('ssltransport' => 'ssl'));
         $this->setAuth($uname, $pass);
     }
 

--- a/library/Zend/Service/DeveloperGarden/ConferenceCall/ConferenceDetail.php
+++ b/library/Zend/Service/DeveloperGarden/ConferenceCall/ConferenceDetail.php
@@ -89,7 +89,7 @@ class Zend_Service_DeveloperGarden_ConferenceCall_ConferenceDetail
     /**
      * set the description of this conference
      *
-     * @param $description the $description to set
+     * @param $description the description to set
      * @return Zend_Service_DeveloperGarden_ConferenceCall_ConferenceDetail
      */
     public function setDescription($description)

--- a/library/Zend/Service/LiveDocx/AbstractLiveDocx.php
+++ b/library/Zend/Service/LiveDocx/AbstractLiveDocx.php
@@ -21,8 +21,9 @@
 
 namespace Zend\Service\LiveDocx;
 
-use Zend\Config\Config,
-    Zend\Soap\Client as SoapClient;
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Soap\Client as SoapClient;
 
 /**
  * @category   Zend
@@ -74,18 +75,17 @@ abstract class AbstractLiveDocx
     /**
      * Constructor.
      *
-     * Optionally, pass an array of options (or \Zend\Config\Config object).
+     * Optionally, pass an array of options or Traversable object.
      *
-     * @param  array|Config $options
-     * @return void
+     * @param  array|Traversable $options
      * @since  LiveDocx 1.0
      */
     public function __construct($options = null)
     {
         $this->setIsLoggedIn(false);
 
-        if ($options instanceof Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (is_array($options)) {
@@ -106,8 +106,8 @@ abstract class AbstractLiveDocx
 
     /**
      * Set options. Valid options are username, password and soapClient.
-     * 
-     * @param  $options
+     *
+     * @param  array $options
      * @throws Exception\InvalidArgumentException
      * @return AbstractLiveDocx
      * @since  LiveDocx 1.2

--- a/library/Zend/Service/LiveDocx/MailMerge.php
+++ b/library/Zend/Service/LiveDocx/MailMerge.php
@@ -62,7 +62,7 @@ class MailMerge extends AbstractLiveDocx
      * This component implements the LiveDocx.MailMerge SOAP Service
      * by Text Control GmbH).
      *
-     * Optionally, pass an array of options (or \Zend\Config\Config object).
+     * Optionally, pass an array of options or Traversable object).
      *
      * If an option with the key 'soapClient' is provided, that value will be
      * used to set the internal SOAP client used to connect to the LiveDocx
@@ -115,7 +115,7 @@ class MailMerge extends AbstractLiveDocx
      * );
      * {/code}
      *
-     * @param  array|\Zend\Config\Config $options
+     * @param  array|\Traversable $options
      * @return void
      * @since  LiveDocx 1.0
      */

--- a/library/Zend/Service/ReCaptcha/MailHide.php
+++ b/library/Zend/Service/ReCaptcha/MailHide.php
@@ -21,6 +21,9 @@
 
 namespace Zend\Service\ReCaptcha;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * Zend_Service_ReCaptcha_MailHide
  *
@@ -87,7 +90,7 @@ class MailHide extends ReCaptcha
      * @param string $publicKey
      * @param string $privateKey
      * @param string $email
-     * @param array|\Zend\Config\Config $options
+     * @param array|Traversable $options
      */
     public function __construct($publicKey = null, $privateKey = null, $email = null, $options = null)
     {
@@ -95,8 +98,8 @@ class MailHide extends ReCaptcha
         $this->_requireMcrypt();
 
         /* If options is a Zend_Config object we want to convert it to an array so we can merge it with the default options */
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         /* Merge if needed */

--- a/library/Zend/Service/ReCaptcha/ReCaptcha.php
+++ b/library/Zend/Service/ReCaptcha/ReCaptcha.php
@@ -21,8 +21,9 @@
 
 namespace Zend\Service\ReCaptcha;
 
-use Zend\Config\Config,
-    Zend\Http\Request,
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Http\Request,
     Zend\Service\AbstractService;
 
 /**
@@ -115,10 +116,9 @@ class ReCaptcha extends AbstractService
      *
      * @param string $publicKey
      * @param string $privateKey
-     * @param array $params
-     * @param array $options
+     * @param array|Traversable $params
+     * @param array|Traversable $options
      * @param string $ip
-     * @param array|\Zend\Config\Config $params
      */
     public function __construct($publicKey = null, $privateKey = null,
                                 $params = null, $options = null, $ip = null)
@@ -207,14 +207,14 @@ class ReCaptcha extends AbstractService
     /**
      * Set parameters
      *
-     * @param array|\Zend\Config\Config $params
+     * @param  array|Traversable $params
      * @return \Zend\Service\ReCaptcha\ReCaptcha
      * @throws \Zend\Service\ReCaptcha\Exception
      */
     public function setParams($params)
     {
-        if ($params instanceof Config) {
-            $params = $params->toArray();
+        if ($params instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($params);
         }
 
         if (is_array($params)) {
@@ -223,7 +223,7 @@ class ReCaptcha extends AbstractService
             }
         } else {
             throw new Exception(
-                'Expected array or Zend\\Config\\Config object'
+                'Expected array or Traversable object'
             );
         }
 
@@ -268,14 +268,14 @@ class ReCaptcha extends AbstractService
     /**
      * Set options
      *
-     * @param array|\Zend\Config\Config $options
+     * @param  array|Traversable $options
      * @return \Zend\Service\ReCaptcha\ReCaptcha
      * @throws \Zend\Service\ReCaptcha\Exception
      */
     public function setOptions($options)
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (is_array($options)) {
@@ -284,7 +284,7 @@ class ReCaptcha extends AbstractService
             }
         } else {
             throw new Exception(
-                'Expected array or Zend\\Config\\Config object'
+                'Expected array or Traversable object'
             );
         }
 

--- a/library/Zend/Service/SlideShare/SlideShare.php
+++ b/library/Zend/Service/SlideShare/SlideShare.php
@@ -141,7 +141,7 @@ class SlideShare
 
         if (!($this->httpclient instanceof Http\Client)) {
             $client = new Http\Client();
-            $client->setConfig(array('maxredirects' => 2,
+            $client->setOptions(array('maxredirects' => 2,
                                      'timeout'      => 5));
 
             $this->setHttpClient($client);

--- a/library/Zend/Service/Twitter/Twitter.php
+++ b/library/Zend/Service/Twitter/Twitter.php
@@ -21,11 +21,12 @@
 
 namespace Zend\Service\Twitter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Http,
     Zend\OAuth,
     Zend\Rest,
     Zend\Uri,
-    Zend\Config,
     Zend\Rest\Client;
 
 /**
@@ -118,16 +119,15 @@ class Twitter extends Client\RestClient
     /**
      * Constructor
      *
-     * @param  array $options Optional options array
-     * @return void
+     * @param  array|Traversable $options
      */
-    public function __construct($options = null, Oauth\Consumer $consumer = null)
+    public function __construct($options = null, OAuth\Consumer $consumer = null)
     {
         $this->setUri('http://api.twitter.com');
         if (!is_array($options)) $options = array();
         $options['siteUrl'] = self::OAUTH_BASE_URI;
-        if ($options instanceof Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
         $this->options = $options;
         if (isset($options['username'])) {
@@ -960,7 +960,7 @@ class Twitter extends Client\RestClient
     {
         // Get the URI object and configure it
         if (!$this->uri instanceof Uri\Uri) {
-            throw new Client\Exception(
+            throw new Exception\UnexpectedValueException(
                 'URI object must be set before performing call'
             );
         }

--- a/library/Zend/Service/WindowsAzure/Storage.php
+++ b/library/Zend/Service/WindowsAzure/Storage.php
@@ -234,14 +234,14 @@ class Zend_Service_WindowsAzure_Storage
 	    	if(!isset($credentials[1])) {
 	    	    $credentials[1] = '';
 	    	}
-	    	$this->_httpClientChannel->setConfig(array(
+	    	$this->_httpClientChannel->setOptions(array(
 				'proxy_host' => $this->_proxyUrl,
 	    		'proxy_port' => $this->_proxyPort,
 	    		'proxy_user' => $credentials[0],
 	    		'proxy_pass' => $credentials[1],
 	    	));
 	    } else {
-			$this->_httpClientChannel->setConfig(array(
+			$this->_httpClientChannel->setOptions(array(
 				'proxy_host' => '',
 	    		'proxy_port' => 8080,
 	    		'proxy_user' => '',

--- a/library/Zend/Session/AbstractManager.php
+++ b/library/Zend/Session/AbstractManager.php
@@ -78,7 +78,7 @@ abstract class AbstractManager implements Manager
      */
     public function __construct(Configuration $config = null, Storage $storage = null, SaveHandler $saveHandler = null)
     {
-        $this->setConfig($config);
+        $this->setOptions($config);
         $this->setStorage($storage);
         if ($saveHandler) {
             $this->setSaveHandler($saveHandler);
@@ -91,7 +91,7 @@ abstract class AbstractManager implements Manager
      * @param  null|Configuration $config 
      * @return void
      */
-    public function setConfig(Configuration $config = null)
+    public function setOptions(Configuration $config = null)
     {
         if (null === $config) {
             $config = new $this->configDefaultClass();

--- a/library/Zend/Soap/Client.php
+++ b/library/Zend/Soap/Client.php
@@ -21,6 +21,8 @@
 
 namespace Zend\Soap;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Server\Client as ServerClient;
 
 /**
@@ -130,9 +132,9 @@ class Client implements ServerClient
     /**
      * Constructor
      *
-     * @param string $wsdl
-     * @param array $options
-     * @throws \Zend\Soap\Client\Exception
+     * @param  string $wsdl
+     * @param  array|Traversable $options
+     * @throws Exception\ExtensionNotLoadedException
      */
     public function __construct($wsdl = null, $options = null)
     {
@@ -177,14 +179,14 @@ class Client implements ServerClient
      *
      * Allows setting options as an associative array of option => value pairs.
      *
-     * @param  array|\Zend\Config\Config $options
+     * @param  array|Traversable $options
      * @return \Zend\Soap\Client\Client
-     * @throws \Zend\Soap\Client\Exception
+     * @throws Exception\InvalidArgumentException
      */
     public function setOptions($options)
     {
-        if($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         foreach ($options as $key => $value) {

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -21,8 +21,9 @@
 
 namespace Zend\Soap;
 
-use Zend\Config\Config,
-    DOMDocument,
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+use DOMDocument,
     DOMNode,
     SimpleXMLElement,
     stdClass;
@@ -179,13 +180,13 @@ class Server implements \Zend\Server\Server
      *
      * Allows setting options as an associative array of option => value pairs.
      *
-     * @param  array|\Zend\Config\Config $options
+     * @param  array|Traversable $options
      * @return \Zend\Soap\Server
      */
     public function setOptions($options)
     {
-        if($options instanceof Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         foreach ($options as $key => $value) {

--- a/library/Zend/Tag/Cloud.php
+++ b/library/Zend/Tag/Cloud.php
@@ -21,8 +21,9 @@
 
 namespace Zend\Tag;
 
-use Zend\Config,
-    Zend\Tag\Exception\InvalidArgumentException,
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Tag\Exception\InvalidArgumentException,
     Zend\Loader\Broker;
 
 /**
@@ -74,30 +75,16 @@ class Cloud
     /**
      * Create a new tag cloud with options
      *
-     * @param mixed $options
+     * @param  array|Traversable $options
      */
     public function __construct($options = null)
     {
-        if ($options instanceof Config\Config) {
-            $this->setConfig($options);
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
-
         if (is_array($options)) {
             $this->setOptions($options);
         }
-    }
-
-    /**
-     * Set options from Zend_Config
-     *
-     * @param  \Zend\Config\Config $config
-     * @return \Zend\Tag\Cloud
-     */
-    public function setConfig(Config\Config $config)
-    {
-        $this->setOptions($config->toArray());
-
-        return $this;
     }
 
     /**

--- a/library/Zend/Tag/Cloud/Decorator/Cloud.php
+++ b/library/Zend/Tag/Cloud/Decorator/Cloud.php
@@ -21,6 +21,8 @@
 
 namespace Zend\Tag\Cloud\Decorator;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Tag\Cloud\Decorator\DecoratorInterface as Decorator;
 
 /**
@@ -46,14 +48,13 @@ abstract class Cloud implements Decorator
     /**
      * Create a new cloud decorator with options
      *
-     * @param mixed $options
+     * @param  array|Traversable $options
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
-
         if (is_array($options)) {
             $this->setOptions($options);
         }

--- a/library/Zend/Tag/Cloud/Decorator/Tag.php
+++ b/library/Zend/Tag/Cloud/Decorator/Tag.php
@@ -21,6 +21,8 @@
 
 namespace Zend\Tag\Cloud\Decorator;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Tag\Cloud\Decorator\DecoratorInterface as Decorator;
 
 /**
@@ -46,14 +48,13 @@ abstract class Tag implements Decorator
     /**
      * Create a new cloud decorator with options
      *
-     * @param mixed $options
+     * @param  array|Traversable $options
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
-
         if (is_array($options)) {
             $this->setOptions($options);
         }

--- a/library/Zend/Tag/Item.php
+++ b/library/Zend/Tag/Item.php
@@ -21,6 +21,9 @@
 
 namespace Zend\Tag;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * @category   Zend
  * @package    Zend_Tag
@@ -63,7 +66,7 @@ class Item implements TaggableInterface
     /**
      * Create a new tag according to the options
      *
-     * @param  array|\Zend\Config\Config $options
+     * @param  array|Traversable $options
      * @throws \Zend\Tag\Exception\InvalidArgumentException When invalid options are provided
      * @throws \Zend\Tag\Exception\InvalidArgumentException When title was not set
      * @throws \Zend\Tag\Exception\InvalidArgumentException When weight was not set
@@ -71,8 +74,8 @@ class Item implements TaggableInterface
      */
     public function __construct($options)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (!is_array($options)) {

--- a/library/Zend/Text/Figlet/Figlet.php
+++ b/library/Zend/Text/Figlet/Figlet.php
@@ -20,7 +20,8 @@
 
 namespace Zend\Text\Figlet;
 
-use Zend\Config;
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 
 /**
  * Zend\Text\Figlet is a PHP implementation of FIGlet
@@ -274,15 +275,16 @@ class Figlet
      * the $options variable, which can either be an array or an instance of
      * Zend_Config.
      *
-     * @param array|\Zend\Config\Config $options Options for the output
+     * @param array|Traversable $options Options for the output
      */
     public function __construct($options = null)
     {
         // Set options
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
         if (is_array($options)) {
             $this->setOptions($options);
-        } else if ($options instanceof Config\Config) {
-            $this->setConfig($options);
         }
 
         // If no font was defined, load default font
@@ -310,17 +312,6 @@ class Figlet
             }
         }
         return $this;
-    }
-
-    /**
-     * Set options from config object
-     *
-     * @param  Config\Config $config Configuration for Figlet
-     * @return Figlet
-     */
-    public function setConfig(Config\Config $config)
-    {
-        return $this->setOptions($config->toArray());
     }
 
     /**

--- a/library/Zend/Text/Table/Table.php
+++ b/library/Zend/Text/Table/Table.php
@@ -20,8 +20,9 @@
 
 namespace Zend\Text\Table;
 
-use Zend\Config,
-    Zend\Loader\PrefixPathLoader,
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Loader\PrefixPathLoader,
     Zend\Text\Table\Decorator\DecoratorInterface as Decorator;
 
 /**
@@ -35,7 +36,7 @@ use Zend\Config,
 class Table
 {
     /**
-     * Auto seperator settings
+     * Auto separator settings
      */
     const AUTO_SEPARATE_NONE   = 0x0;
     const AUTO_SEPARATE_HEADER = 0x1;
@@ -119,17 +120,18 @@ class Table
     /**
      * Create a basic table object
      *
-     * @param  array             $columnsWidths List of all column widths
-     * @param  Config\Config|array $options       Configuration options
+     * @param  array             $columns Widths List of all column widths
+     * @param  array|Traversable $options Configuration options
      * @throws Exception\UnexpectedValueException When no columns widths were set
      */
     public function __construct($options = null)
     {
         // Set options
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
         if (is_array($options)) {
             $this->setOptions($options);
-        } else if ($options instanceof Config\Config) {
-            $this->setConfig($options);
         }
 
         // If no decorator was given, use default unicode decorator
@@ -162,17 +164,6 @@ class Table
         }
 
         return $this;
-    }
-
-    /**
-     * Set options from config object
-     *
-     * @param  Config\Config $config Configuration for Table
-     * @return Table
-     */
-    public function setConfig(Config\Config $config)
-    {
-        return $this->setOptions($config->toArray());
     }
 
     /**

--- a/library/Zend/Translator/Adapter/AbstractAdapter.php
+++ b/library/Zend/Translator/Adapter/AbstractAdapter.php
@@ -21,11 +21,12 @@
 
 namespace Zend\Translator\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use RecursiveDirectoryIterator,
     RecursiveIteratorIterator,
     RecursiveRegexIterator,
     Zend\Cache\Storage\Adapter\AdapterInterface as CacheAdapter,
-    Zend\Config\Config,
     Zend\Log,
     Zend\Locale,
     Zend\Translator,
@@ -125,14 +126,13 @@ abstract class AbstractAdapter
     /**
      * Generates the adapter
      *
-     * @param  array|Zend_Config $options Translation options for this adapter
+     * @param  array|Traversable $options Translation options for this adapter
      * @throws \Zend\Translator\Exception\InvalidArgumentException
-     * @return void
      */
     public function __construct($options = array())
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         } else if (func_num_args() > 1) {
             $args               = func_get_args();
             $options            = array();
@@ -215,14 +215,14 @@ abstract class AbstractAdapter
      * If the key 'clear' is true, then translations for the specified
      * language will be replaced and added otherwise
      *
-     * @param  array|Zend_Config $options Options and translations to be added
+     * @param  array|Traversable $options Options and translations to be added
      * @throws \Zend\Translator\Exception\InvalidArgumentException
      * @return \Zend\Translator\Adapter\AbstractAdapter Provides fluent interface
      */
     public function addTranslation($options = array())
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         } else if (func_num_args() > 1) {
             $args = func_get_args();
             $options            = array();
@@ -650,14 +650,14 @@ abstract class AbstractAdapter
      * language is replaced and added otherwise
      *
      * @see    Zend_Locale
-     * @param  array|\Zend\Config $content Translation data to add
+     * @param  array|Traversable $options Translation data to add
      * @throws \Zend\Translator\Exception\InvalidArgumentException
      * @return \Zend\Translator\Adapter\AbstractAdapter Provides fluent interface
      */
     private function _addTranslationData($options = array())
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         } else if (func_num_args() > 1) {
             $args = func_get_args();
             $options['content'] = array_shift($args);
@@ -692,7 +692,7 @@ abstract class AbstractAdapter
         try {
             $options['locale'] = Locale\Locale::findLocale($options['locale']);
         } catch (Locale\Exception $e) {
-            throw new Exception\InvalidArgumentException("The given Language '{$locale}' does not exist", 0, $e);
+            throw new Exception\InvalidArgumentException("The given Language '{$options['locale']}' does not exist", 0, $e);
         }
 
         if ($options['clear'] || !isset($this->_translate[$options['locale']])) {

--- a/library/Zend/Translator/Adapter/Csv.php
+++ b/library/Zend/Translator/Adapter/Csv.php
@@ -20,6 +20,8 @@
 
 namespace Zend\Translator\Adapter;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Translator\Adapter\AbstractAdapter,
     Zend\Translator\Exception\InvalidArgumentException;
 
@@ -34,7 +36,7 @@ class Csv extends AbstractAdapter
     /**
      * Generates the adapter
      *
-     * @param  array|Zend_Config $options Translation content
+     * @param  array|Traversable $options Translation content
      */
     public function __construct($options = array())
     {
@@ -42,8 +44,8 @@ class Csv extends AbstractAdapter
         $this->_options['length']    = 0;
         $this->_options['enclosure'] = '"';
 
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         } else if (func_num_args() > 1) {
             $args               = func_get_args();
             $options            = array();

--- a/library/Zend/Validator/AbstractValidator.php
+++ b/library/Zend/Validator/AbstractValidator.php
@@ -68,9 +68,9 @@ abstract class AbstractValidator implements ValidatorInterface
      *  - nothing f.e. Validator()
      *  - one or multiple scalar values f.e. Validator($first, $second, $third)
      *  - an array f.e. Validator(array($first => 'first', $second => 'second', $third => 'third'))
-     *  - an instance of Zend_Config f.e. Validator($config_instance)
+     *  - an instance of Traversable f.e. Validator($config_instance)
      *
-     * @param mixed $options
+     * @param array|Traversable $options
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Validator/Alnum.php
+++ b/library/Zend/Validator/Alnum.php
@@ -62,8 +62,7 @@ class Alnum extends AbstractValidator
     /**
      * Sets default option values for this instance
      *
-     * @param  boolean|\Zend\Config\Config $allowWhiteSpace
-     * @return void
+     * @param array|\Traversable $options
      */
     public function __construct($options = array())
     {

--- a/library/Zend/Validator/Alpha.php
+++ b/library/Zend/Validator/Alpha.php
@@ -62,7 +62,7 @@ class Alpha extends AbstractValidator
     /**
      * Sets default option values for this instance
      *
-     * @param  boolean|\Zend\Config\Config $allowWhiteSpace
+     * @param  boolean|\Traversable $allowWhiteSpace
      * @return void
      */
     public function __construct($allowWhiteSpace = false)

--- a/library/Zend/Validator/Barcode.php
+++ b/library/Zend/Validator/Barcode.php
@@ -20,6 +20,8 @@
 
 namespace Zend\Validator;
 
+use Traversable;
+
 /**
  * @category   Zend
  * @package    Zend_Validate
@@ -63,7 +65,7 @@ class Barcode extends AbstractValidator
      */
     public function __construct($options = null)
     {
-        if (!is_array($options) && !($options instanceof \Zend\Config\Config)) {
+        if (!is_array($options) && !($options instanceof Traversable)) {
             $options = array('adapter' => $options);
         }
 

--- a/library/Zend/Validator/Between.php
+++ b/library/Zend/Validator/Between.php
@@ -20,6 +20,9 @@
 
 namespace Zend\Validator;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * @category   Zend
  * @package    Zend_Validate
@@ -69,14 +72,14 @@ class Between extends AbstractValidator
      *   'max' => scalar, maximum border
      *   'inclusive' => boolean, inclusive border values
      *
-     * @param  array|\Zend\Config\Config $options
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
-        } else if (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             $options = func_get_args();
             $temp['min'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Validator/EmailAddress.php
+++ b/library/Zend/Validator/EmailAddress.php
@@ -98,7 +98,7 @@ class EmailAddress extends AbstractValidator
      * 'useMxCheck'        => If MX check should be enabled, boolean
      * 'useDeepMxCheck'    => If a deep MX check should be done, boolean
      *
-     * @param array|\Zend\Config\Config $options OPTIONAL
+     * @param array|\Traversable $options OPTIONAL
      * @return void
      */
     public function __construct($options = array())

--- a/library/Zend/Validator/File/Count.php
+++ b/library/Zend/Validator/File/Count.php
@@ -90,7 +90,7 @@ class Count extends Validator\AbstractValidator
      * 'min': Minimum filecount
      * 'max': Maximum filecount
      *
-     * @param  integer|array|\Zend\Config\Config $options Options for the adapter
+     * @param  integer|array|\Traversable $options Options for the adapter
      * @return void
      */
     public function __construct($options = null)

--- a/library/Zend/Validator/File/Exists.php
+++ b/library/Zend/Validator/File/Exists.php
@@ -63,7 +63,7 @@ class Exists extends Validator\AbstractValidator
     /**
      * Sets validator options
      *
-     * @param  string|array|\Zend\Config\Config $options
+     * @param  string|array|\Traversable $options
      * @return void
      */
     public function __construct($options = null)

--- a/library/Zend/Validator/File/Extension.php
+++ b/library/Zend/Validator/File/Extension.php
@@ -20,6 +20,8 @@
 
 namespace Zend\Validator\File;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Loader;
 
 /**
@@ -66,13 +68,12 @@ class Extension extends \Zend\Validator\AbstractValidator
     /**
      * Sets validator options
      *
-     * @param  string|array|\Zend\Config\Config $options
-     * @return void
+     * @param  string|array|\Traversable $options
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         $case = null;

--- a/library/Zend/Validator/File/FilesSize.php
+++ b/library/Zend/Validator/File/FilesSize.php
@@ -20,6 +20,8 @@
 
 namespace Zend\Validator\File;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Loader;
 
 /**
@@ -61,16 +63,15 @@ class FilesSize extends Size
      * Min limits the used diskspace for all files, when used with max=null it is the maximum filesize
      * It also accepts an array with the keys 'min' and 'max'
      *
-     * @param  integer|array|\Zend\Config\Config $options Options for this validator
-     * @return void
+     * @param  integer|array|Traversable $options Options for this validator
      */
     public function __construct($options = null)
     {
         $this->_files = array();
         $this->_setSize(0);
 
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         } elseif (is_scalar($options)) {
             $options = array('max' => $options);
         } elseif (!is_array($options)) {

--- a/library/Zend/Validator/File/ImageSize.php
+++ b/library/Zend/Validator/File/ImageSize.php
@@ -103,8 +103,7 @@ class ImageSize extends Validator\AbstractValidator
      * - maxheight
      * - maxwidth
      *
-     * @param  \Zend\Config\Config|array $options
-     * @return void
+     * @param  array|\Traversable $options
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Validator/File/IsCompressed.php
+++ b/library/Zend/Validator/File/IsCompressed.php
@@ -52,8 +52,7 @@ class IsCompressed extends MimeType
     /**
      * Sets validator options
      *
-     * @param  string|array|\Zend\Config\Config $compression
-     * @return void
+     * @param  string|array|Traversable $compression
      */
     public function __construct($options = array())
     {

--- a/library/Zend/Validator/File/Size.php
+++ b/library/Zend/Validator/File/Size.php
@@ -86,7 +86,7 @@ class Size extends Validator\AbstractValidator
      * 'max': Maximum filesize
      * 'useByteString': Use bytestring or real size for messages
      *
-     * @param  integer|array $options Options for the adapter
+     * @param  integer|array|\Traversable $options Options for the adapter
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Validator/File/Upload.php
+++ b/library/Zend/Validator/File/Upload.php
@@ -71,8 +71,7 @@ class Upload extends \Zend\Validator\AbstractValidator
      * If no files are given the $_FILES array will be used automatically.
      * NOTE: This validator will only work with HTTP POST uploads!
      *
-     * @param  array|Zend_Config $options Array of files in syntax of \Zend\File\Transfer\Transfer
-     * @return void
+     * @param  array|\Traversable $options Array of files in syntax of \Zend\File\Transfer\Transfer
      */
     public function __construct($options = array())
     {

--- a/library/Zend/Validator/GreaterThan.php
+++ b/library/Zend/Validator/GreaterThan.php
@@ -20,7 +20,8 @@
 
 namespace Zend\Validator;
 
-use Zend\Config\Config;
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 
 /**
  * @category   Zend
@@ -70,14 +71,14 @@ class GreaterThan extends AbstractValidator
     /**
      * Sets validator options
      *
-     * @param  mixed|array|Config $options
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($options = null)
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
-        } else if (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             $options = func_get_args();
             $temp['min'] = array_shift($options);
 

--- a/library/Zend/Validator/Iban.php
+++ b/library/Zend/Validator/Iban.php
@@ -107,34 +107,33 @@ class Iban extends AbstractValidator
     /**
      * Sets validator options
      *
-     * @param  null|string|Locale|array|Traversable $locale OPTIONAL
+     * @param  null|string|Locale|array|Traversable $options OPTIONAL
      * @return void
      */
-    public function __construct($locale = null)
+    public function __construct($options = null)
     {
-        $options = array();
-        if ($locale instanceof Traversable) {
-            $locale = ArrayUtils::iteratorToArray($locale);
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
-        if (is_array($locale)) {
-            $options = $locale;
-            if (array_key_exists('locale', $locale)) {
-                $locale  = $locale['locale'];
+        if (is_array($options)) {
+            $options = $options;
+            if (array_key_exists('locale', $options)) {
+                $options  = $options['locale'];
                 unset($options['locale']);
             } else {
-                $locale = null;
+                $options = null;
             }
         }
 
-        if (empty($locale) && ($locale !== false)) {
+        if (empty($options) && ($options !== false)) {
             if (Registry::isRegistered('Zend_Locale')) {
-                $locale = Registry::get('Zend_Locale');
+                $options = Registry::get('Zend_Locale');
             }
         }
 
-        if ($locale !== null) {
-            $this->setLocale($locale);
+        if ($options !== null) {
+            $this->setLocale($options);
         }
         
         parent::__construct($options);

--- a/library/Zend/Validator/InArray.php
+++ b/library/Zend/Validator/InArray.php
@@ -20,6 +20,9 @@
 
 namespace Zend\Validator;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * @category   Zend
  * @package    Zend_Validate
@@ -61,14 +64,14 @@ class InArray extends AbstractValidator
     /**
      * Sets validator options
      *
-     * @param  array|\Zend\Config\Config $haystack
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
-        } else if (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             throw new Exception\InvalidArgumentException('Array expected as parameter');
         } else {
             $count = func_num_args();

--- a/library/Zend/Validator/Int.php
+++ b/library/Zend/Validator/Int.php
@@ -19,7 +19,9 @@
  */
 
 namespace Zend\Validator;
-use Zend;
+
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 
 /**
  * @category   Zend
@@ -45,30 +47,30 @@ class Int extends AbstractValidator
     /**
      * Constructor for the integer validator
      *
-     * @param string|Zend_Config|\Zend\Locale\Locale $locale
+     * @param  array|Traversable|\Zend\Locale\Locale|string $options
      */
-    public function __construct($locale = null)
+    public function __construct($options = null)
     {
-        if ($locale instanceof \Zend\Config\Config) {
-            $locale = $locale->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
-        if (is_array($locale)) {
-            if (array_key_exists('locale', $locale)) {
-                $locale = $locale['locale'];
+        if (is_array($options)) {
+            if (array_key_exists('locale', $options)) {
+                $options = $options['locale'];
             } else {
-                $locale = null;
+                $options = null;
             }
         }
 
-        if (empty($locale)) {
+        if (empty($options)) {
             if (\Zend\Registry::isRegistered('Zend_Locale')) {
-                $locale = \Zend\Registry::get('Zend_Locale');
+                $options = \Zend\Registry::get('Zend_Locale');
             }
         }
 
-        if ($locale !== null) {
-            $this->setLocale($locale);
+        if ($options !== null) {
+            $this->setLocale($options);
         }
         
         parent::__construct();

--- a/library/Zend/Validator/Ip.php
+++ b/library/Zend/Validator/Ip.php
@@ -21,6 +21,7 @@
 namespace Zend\Validator;
 
 use Traversable;
+use Zend\Stdlib\ArrayUtils;
 
 /**
  * @category   Zend
@@ -54,14 +55,14 @@ class Ip extends AbstractValidator
     /**
      * Sets validator options
      *
-     * @param array $options OPTIONAL Options to set, see the manual for all available options
-     * @return void
+     * @param  array|Traversable $options OPTIONAL Options to set, see the manual for all available options
      */
     public function __construct($options = array())
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
-        } else if (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             $options = func_get_args();
             $temp['allowipv6'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Validator/LessThan.php
+++ b/library/Zend/Validator/LessThan.php
@@ -20,7 +20,8 @@
 
 namespace Zend\Validator;
 
-use Zend\Config\Config;
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 
 /**
  * @category   Zend
@@ -72,14 +73,14 @@ class LessThan extends AbstractValidator
     /**
      * Sets validator options
      *
-     * @param  mixed|array|Config $options
-     * @return void
+     * @param  array|Traversable $options
      */
     public function __construct($options = null)
     {
-        if ($options instanceof Config) {
-            $options = $options->toArray();
-        } else if (!is_array($options)) {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        if (!is_array($options)) {
             $options = func_get_args();
             $temp['max'] = array_shift($options);
 

--- a/library/Zend/Validator/NotEmpty.php
+++ b/library/Zend/Validator/NotEmpty.php
@@ -20,6 +20,9 @@
 
 namespace Zend\Validator;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * @category   Zend
  * @package    Zend_Validate
@@ -81,12 +84,12 @@ class NotEmpty extends AbstractValidator
     /**
      * Constructor
      *
-     * @param string|array|\Zend\Config\Config $options OPTIONAL
+     * @param  array|Traversable $options OPTIONAL
      */
     public function __construct($options = null)
     {
-        if ($options instanceof \Zend\Config\Config) {
-            $options = $options->toArray();
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
         }
 
         if (!is_array($options)) {

--- a/library/Zend/Validator/PostCode.php
+++ b/library/Zend/Validator/PostCode.php
@@ -65,7 +65,7 @@ class PostCode extends AbstractValidator
      * Accepts either a string locale, a Zend_Locale object, or an array or
      * Zend_Config object containing the keys "locale" and/or "format".
      *
-     * @param string|Zend_Locale|array|\Zend\Config\Config $options
+     * @param string|Zend_Locale|array|\Traversable $options
      * @throws \Zend\Validator\Exception On empty format
      */
     public function __construct($options = null)

--- a/library/Zend/Validator/StringLength.php
+++ b/library/Zend/Validator/StringLength.php
@@ -58,8 +58,7 @@ class StringLength extends AbstractValidator
     /**
      * Sets validator options
      *
-     * @param  integer|array|\Zend\Config\Config $options
-     * @return void
+     * @param  integer|array|\Traversable $options
      */
     public function __construct($options = array())
     {

--- a/library/Zend/View/Helper/Navigation/Links.php
+++ b/library/Zend/View/Helper/Navigation/Links.php
@@ -21,6 +21,8 @@
 
 namespace Zend\View\Helper\Navigation;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
 use RecursiveIteratorIterator,
     Zend\Navigation,
     Zend\Navigation\Page\AbstractPage,
@@ -643,28 +645,27 @@ class Links extends AbstractHelper
      */
     protected function convertToPages($mixed, $recursive = true)
     {
-        if (is_object($mixed)) {
-            if ($mixed instanceof AbstractPage) {
-                // value is a page instance; return directly
-                return $mixed;
-            } elseif ($mixed instanceof Navigation\Container) {
-                // value is a container; return pages in it
-                $pages = array();
-                foreach ($mixed as $page) {
-                    $pages[] = $page;
-                }
-                return $pages;
-            } elseif ($mixed instanceof \Zend\Config\Config) {
-                // convert config object to array and extract
-                return $this->convertToPages($mixed->toArray(), $recursive);
+        if ($mixed instanceof AbstractPage) {
+            // value is a page instance; return directly
+            return $mixed;
+        } elseif ($mixed instanceof Navigation\Container) {
+            // value is a container; return pages in it
+            $pages = array();
+            foreach ($mixed as $page) {
+                $pages[] = $page;
             }
+            return $pages;
+        } elseif ($mixed instanceof Traversable) {
+            $mixed = ArrayUtils::iteratorToArray($mixed);
         } elseif (is_string($mixed)) {
             // value is a string; make an URI page
             return AbstractPage::factory(array(
                 'type' => 'uri',
                 'uri'  => $mixed
             ));
-        } elseif (is_array($mixed) && !empty($mixed)) {
+        }
+
+        if (is_array($mixed) && !empty($mixed)) {
             if ($recursive && is_numeric(key($mixed))) {
                 // first key is numeric; assume several pages
                 $pages = array();

--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -84,7 +84,7 @@ class Client implements ServerClient
      *
      * @param  string $server      Full address of the XML-RPC service
      *                             (e.g. http://time.xmlrpc.com/RPC2)
-     * @param  Zend\Http\Client $httpClient HTTP Client to use for requests
+     * @param  \Zend\Http\Client $httpClient HTTP Client to use for requests
      * @return void
      */
     public function __construct($server, Http\Client $httpClient = null)

--- a/tests/Zend/Feed/PubSubHubbub/PublisherTest.php
+++ b/tests/Zend/Feed/PubSubHubbub/PublisherTest.php
@@ -64,7 +64,7 @@ class PublisherTest extends \PHPUnit_Framework_TestCase
 
     public function testAddsHubServerUrlsFromArrayUsingSetConfig()
     {
-        $this->_publisher->setConfig(array('hubUrls' => array(
+        $this->_publisher->setOptions(array('hubUrls' => array(
             'http://www.example.com/hub', 'http://www.example.com/hub2'
         )));
         $this->assertEquals(array(
@@ -138,7 +138,7 @@ class PublisherTest extends \PHPUnit_Framework_TestCase
 
     public function testAddsUpdatedTopicUrlsFromArrayUsingSetConfig()
     {
-        $this->_publisher->setConfig(array('updatedTopicUrls' => array(
+        $this->_publisher->setOptions(array('updatedTopicUrls' => array(
             'http://www.example.com/topic', 'http://www.example.com/topic2'
         )));
         $this->assertEquals(array(
@@ -222,7 +222,7 @@ class PublisherTest extends \PHPUnit_Framework_TestCase
 
     public function testAddsParametersFromArrayUsingSetConfig()
     {
-        $this->_publisher->setConfig(array('parameters' => array(
+        $this->_publisher->setOptions(array('parameters' => array(
             'foo' => 'bar', 'boo' => 'baz'
         )));
         $this->assertEquals(array(

--- a/tests/Zend/Filter/InflectorTest.php
+++ b/tests/Zend/Filter/InflectorTest.php
@@ -365,7 +365,7 @@ class InflectorTest extends \PHPUnit_Framework_TestCase
     {
         $config = $this->getConfig();
         $inflector = new InflectorFilter();
-        $inflector->setConfig($config);
+        $inflector->setOptions($config);
         $this->_testOptions($inflector);
     }
 

--- a/tests/Zend/Http/Client/CommonHttpTests.php
+++ b/tests/Zend/Http/Client/CommonHttpTests.php
@@ -496,7 +496,7 @@ abstract class CommonHttpTests extends \PHPUnit_Framework_TestCase
         $this->client->setParameterPost(array('Camelot' => 'A silly place'));
 
         // Set strict redirections
-        $this->client->setConfig(array('strictredirects' => true));
+        $this->client->setOptions(array('strictredirects' => true));
 
         // Request
         $this->client->setMethod('POST');
@@ -523,7 +523,7 @@ abstract class CommonHttpTests extends \PHPUnit_Framework_TestCase
 
         // Set lower max redirections
         // Try with strict redirections first
-        $this->client->setConfig(array('strictredirects' => true, 'maxredirects' => 2));
+        $this->client->setOptions(array('strictredirects' => true, 'maxredirects' => 2));
 
         $this->client->setMethod('POST');
         $res = $this->client->send();
@@ -532,7 +532,7 @@ abstract class CommonHttpTests extends \PHPUnit_Framework_TestCase
 
         // Then try with normal redirections
         $this->client->setParameterGet(array('redirection' => '0'));
-        $this->client->setConfig(array('strictredirects' => false));
+        $this->client->setOptions(array('strictredirects' => false));
         $this->client->setMethod('POST');
         $res = $this->client->send();
         $this->assertTrue($res->isRedirect(),
@@ -547,7 +547,7 @@ abstract class CommonHttpTests extends \PHPUnit_Framework_TestCase
     {
         $this->client->setUri($this->baseuri . 'testRelativeRedirections.php');
         $this->client->setParameterGet(array('redirect' => 'abpath'));
-        $this->client->setConfig(array('maxredirects' => 1));
+        $this->client->setOptions(array('maxredirects' => 1));
 
         // Get the host and port part of our baseuri
         $port = ($this->client->getUri()->getPort() == 80) ? '' : ':' .$this->client->getUri()->getPort();
@@ -567,7 +567,7 @@ abstract class CommonHttpTests extends \PHPUnit_Framework_TestCase
     {
         $this->client->setUri($this->baseuri . 'testRelativeRedirections.php');
         $this->client->setParameterGet(array('redirect' => 'relpath'));
-        $this->client->setConfig(array('maxredirects' => 1));
+        $this->client->setOptions(array('maxredirects' => 1));
 
         // Set the new expected URI
         $uri = clone $this->client->getUri();

--- a/tests/Zend/Http/Client/CurlTest.php
+++ b/tests/Zend/Http/Client/CurlTest.php
@@ -79,7 +79,7 @@ class CurlTest extends CommonHttpTests
             'someoption' => 'hasvalue'
         );
 
-        $this->_adapter->setConfig($config);
+        $this->_adapter->setOptions($config);
 
         $hasConfig = $this->_adapter->getConfig();
         foreach($config as $k => $v) {
@@ -102,7 +102,7 @@ class CurlTest extends CommonHttpTests
             )
         ));
 
-        $this->_adapter->setConfig($config);
+        $this->_adapter->setOptions($config);
 
         $hasConfig = $this->_adapter->getConfig();
         $this->assertEquals($config->timeout, $hasConfig['timeout']);
@@ -120,7 +120,7 @@ class CurlTest extends CommonHttpTests
             'Zend\Http\Client\Adapter\Exception\InvalidArgumentException',
             'Array or Zend\Config\Config object expected');
 
-        $this->_adapter->setConfig($config);
+        $this->_adapter->setOptions($config);
     }
 
     /**
@@ -178,7 +178,7 @@ class CurlTest extends CommonHttpTests
 
         $adapter = new Adapter\Curl();
         $this->client->setAdapter($adapter);
-        $adapter->setConfig(array(
+        $adapter->setOptions(array(
             'curloptions' => array(
                 CURLOPT_FOLLOWLOCATION => true,
                 CURLOPT_TIMEOUT => 1,
@@ -229,7 +229,7 @@ class CurlTest extends CommonHttpTests
 
         $adapter = new Adapter\Curl();
         $this->client->setAdapter($adapter);
-        $adapter->setConfig(array(
+        $adapter->setOptions(array(
             'curloptions' => array(CURLOPT_INFILE => $putFileHandle, CURLOPT_INFILESIZE => $putFileSize)
         ));
         $this->client->setMethod('PUT');
@@ -250,7 +250,7 @@ class CurlTest extends CommonHttpTests
         $this->setExpectedException('Zend\Http\Client\Adapter\Exception');
 
         $adapter = new Adapter\Curl();
-        $adapter->setConfig("foo");
+        $adapter->setOptions("foo");
     }
 
     public function testSetCurlOptions()
@@ -269,7 +269,7 @@ class CurlTest extends CommonHttpTests
     public function testWorkWithProxyConfiguration()
     {
         $adapter = new Adapter\Curl();
-        $adapter->setConfig(array(
+        $adapter->setOptions(array(
             'proxy_host' => 'localhost',
             'proxy_port' => 80,
             'proxy_user' => 'foo',
@@ -295,7 +295,7 @@ class CurlTest extends CommonHttpTests
     public function testGetCurlHandle()
     {
         $adapter = new Adapter\Curl();
-        $adapter->setConfig(array('timeout' => 2, 'maxredirects' => 1));
+        $adapter->setOptions(array('timeout' => 2, 'maxredirects' => 1));
         $adapter->connect("http://framework.zend.com");
 
         $this->assertTrue(is_resource($adapter->getHandle()));

--- a/tests/Zend/Http/Client/ProxyAdapterTest.php
+++ b/tests/Zend/Http/Client/ProxyAdapterTest.php
@@ -97,7 +97,7 @@ class ProxyAdapterTest extends SocketTest
      */
     public function testFallbackToSocket()
     {
-        $this->_adapter->setConfig(array(
+        $this->_adapter->setOptions(array(
             'proxy_host' => null,
         ));
 

--- a/tests/Zend/Http/Client/SocketTest.php
+++ b/tests/Zend/Http/Client/SocketTest.php
@@ -69,7 +69,7 @@ class SocketTest extends CommonHttpTests
             'someoption' => 'hasvalue'
         );
 
-        $this->_adapter->setConfig($config);
+        $this->_adapter->setOptions($config);
 
         $hasConfig = $this->_adapter->getConfig();
         foreach($config as $k => $v) {
@@ -92,7 +92,7 @@ class SocketTest extends CommonHttpTests
             )
         ));
 
-        $this->_adapter->setConfig($config);
+        $this->_adapter->setOptions($config);
 
         $hasConfig = $this->_adapter->getConfig();
         $this->assertEquals($config->timeout, $hasConfig['timeout']);
@@ -110,7 +110,7 @@ class SocketTest extends CommonHttpTests
             'Zend\Http\Client\Adapter\Exception\InvalidArgumentException',
             'Array or Zend_Config object expected');
 
-        $this->_adapter->setConfig($config);
+        $this->_adapter->setOptions($config);
     }
 
     /**
@@ -198,7 +198,7 @@ class SocketTest extends CommonHttpTests
     public function testExceptionOnReadTimeout()
     {
         // Set 1 second timeout
-        $this->client->setConfig(array('timeout' => 1));
+        $this->client->setOptions(array('timeout' => 1));
 
         $start = microtime(true);
 

--- a/tests/Zend/Http/Client/StaticTest.php
+++ b/tests/Zend/Http/Client/StaticTest.php
@@ -226,7 +226,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
             'someoption' => 'hasvalue'
         );
 
-        $this->_client->setConfig($config);
+        $this->_client->setOptions($config);
 
         $hasConfig = $this->_client->config;
 
@@ -250,7 +250,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
             )
         ));
 
-        $this->_client->setConfig($config);
+        $this->_client->setOptions($config);
 
         $hasConfig = $this->_client->config;
         $this->assertEquals($config->timeout, $hasConfig['timeout']);
@@ -265,10 +265,10 @@ class StaticTest extends \PHPUnit_Framework_TestCase
     public function testConfigSetInvalid($config)
     {
         $this->setExpectedException(
-            'Zend\Http\Exception\InvalidArgumentException',
+            'Zend\Http\Client\Exception\InvalidArgumentException',
             'Config parameter is not valid');
 
-        $this->_client->setConfig($config);
+        $this->_client->setOptions($config);
     }
 
     /**
@@ -283,13 +283,13 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         $adapter = new MockAdapter();
 
         // test that config passes when we set the adapter
-        $this->_client->setConfig(array('param' => 'value1'));
+        $this->_client->setOptions(array('param' => 'value1'));
         $this->_client->setAdapter($adapter);
         $adapterCfg = $adapter->config;
         $this->assertEquals('value1', $adapterCfg['param']);
 
         // test that adapter config value changes when we set client config
-        $this->_client->setConfig(array('param' => 'value2'));
+        $this->_client->setOptions(array('param' => 'value2'));
         $adapterCfg = $adapter->config;
         $this->assertEquals('value2', $adapterCfg['param']);
     }
@@ -326,7 +326,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         // Now, test we get a proper response after the request
         $this->_client->setUri('http://example.com/foo/bar');
         $this->_client->setAdapter('Zend\Http\Client\Adapter\Test');
-        $this->_client->setConfig(array('storeresponse' => false));
+        $this->_client->setOptions(array('storeresponse' => false));
 
         $response = $this->_client->send();
 
@@ -366,7 +366,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         $this->_client->setUri('http://255.255.255.255');
 
         // Reduce timeout to 3 seconds to avoid waiting
-        $this->_client->setConfig(array('timeout' => 3));
+        $this->_client->setOptions(array('timeout' => 3));
 
         // This call should cause an exception
         $this->_client->send();
@@ -519,7 +519,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
      */
     public function testRawCookiesInRequestHeaders()
     {
-        $this->_client->setConfig(array('encodecookies' => false));
+        $this->_client->setOptions(array('encodecookies' => false));
         $this->_client->addCookie('foo', 'bar=baz');
         $this->_client->send();
         $cookieValue = 'Cookie: foo=bar=baz';

--- a/tests/Zend/Http/Client/TestAdapterTest.php
+++ b/tests/Zend/Http/Client/TestAdapterTest.php
@@ -67,14 +67,14 @@ class TestAdapterTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(
             'Zend\Http\Client\Adapter\Exception\InvalidArgumentException',
-            'Array or Zend\Config\Config object expected');
+            'Array or Traversable object expected');
 
-        $this->adapter->setConfig('foo');
+        $this->adapter->setOptions('foo');
     }
 
     public function testSetConfigReturnsQuietly()
     {
-        $this->adapter->setConfig(array('foo' => 'bar'));
+        $this->adapter->setOptions(array('foo' => 'bar'));
     }
 
     public function testConnectReturnsQuietly()

--- a/tests/Zend/Paginator/PaginatorTest.php
+++ b/tests/Zend/Paginator/PaginatorTest.php
@@ -138,7 +138,7 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
         Paginator\Paginator::setDefaultScrollingStyle();
         Helper\PaginationControl::setDefaultViewPartial(null);
 
-        Paginator\Paginator::setConfig($this->_config->default);
+        Paginator\Paginator::setOptions($this->_config->default);
 
         Paginator\Paginator::setScrollingStyleBroker(new Paginator\ScrollingStyleBroker());
 
@@ -219,7 +219,7 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadsFromConfig()
     {
-        Paginator\Paginator::setConfig($this->_config->testing);
+        Paginator\Paginator::setOptions($this->_config->testing);
         $this->assertEquals('Scrolling', Paginator\Paginator::getDefaultScrollingStyle());
 
         $broker = Paginator\Paginator::getScrollingStyleBroker();
@@ -310,7 +310,7 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
 
     public function testGetsAndSetsItemCountPerPage()
     {
-        Paginator\Paginator::setConfig(new Config\Config(array()));
+        Paginator\Paginator::setOptions(new Config\Config(array()));
         $this->_paginator = new Paginator\Paginator(new Adapter\ArrayAdapter(range(1, 101)));
         $this->assertEquals(10, $this->_paginator->getItemCountPerPage());
         $this->_paginator->setItemCountPerPage(15);
@@ -325,7 +325,7 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetsAndSetsItemCounterPerPageOfNegativeOne()
     {
-        Paginator\Paginator::setConfig(new Config\Config(array()));
+        Paginator\Paginator::setOptions(new Config\Config(array()));
         $this->_paginator = new Paginator\Paginator(new Paginator\Adapter\ArrayAdapter(range(1, 101)));
         $this->_paginator->setItemCountPerPage(-1);
         $this->assertEquals(101, $this->_paginator->getItemCountPerPage());
@@ -337,7 +337,7 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetsAndSetsItemCounterPerPageOfZero()
     {
-        Paginator\Paginator::setConfig(new Config\Config(array()));
+        Paginator\Paginator::setOptions(new Config\Config(array()));
         $this->_paginator = new Paginator\Paginator(new Paginator\Adapter\ArrayAdapter(range(1, 101)));
         $this->_paginator->setItemCountPerPage(0);
         $this->assertEquals(101, $this->_paginator->getItemCountPerPage());
@@ -349,7 +349,7 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetsAndSetsItemCounterPerPageOfNull()
     {
-        Paginator\Paginator::setConfig(new Config\Config(array()));
+        Paginator\Paginator::setOptions(new Config\Config(array()));
         $this->_paginator = new Paginator\Paginator(new Paginator\Adapter\ArrayAdapter(range(1, 101)));
         $this->_paginator->setItemCountPerPage();
         $this->assertEquals(101, $this->_paginator->getItemCountPerPage());
@@ -716,7 +716,7 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetSetDefaultItemCountPerPage()
     {
-        Paginator\Paginator::setConfig(new Config\Config(array()));
+        Paginator\Paginator::setOptions(new Config\Config(array()));
 
         $paginator = Paginator\Paginator::factory(range(1, 10));
         $this->assertEquals(10, $paginator->getItemCountPerPage());

--- a/tests/Zend/Service/Audioscrobbler/AudioscrobblerTestCase.php
+++ b/tests/Zend/Service/Audioscrobbler/AudioscrobblerTestCase.php
@@ -54,7 +54,7 @@ class AudioscrobblerTestCase extends \PHPUnit_Framework_TestCase
     {
         $this->_httpTestAdapter = new Http\Client\Adapter\Test();
         $this->_httpClient = new Http\Client();
-        $this->_httpClient->setConfig(array('adapter' => $this->_httpTestAdapter));
+        $this->_httpClient->setOptions(array('adapter' => $this->_httpTestAdapter));
         $this->_asService = new Audioscrobbler\Audioscrobbler();
         $this->_asService->setHttpClient($this->_httpClient);
     }

--- a/tests/Zend/Service/Delicious/PrivateDataTest.php
+++ b/tests/Zend/Service/Delicious/PrivateDataTest.php
@@ -63,7 +63,7 @@ class PrivateDataTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('\Zend\Service\Delicious online tests are not enabled');
         }
         $httpClient = new Http\Client();
-        $httpClient->setConfig(array(
+        $httpClient->setOptions(array(
                 'useragent' => 'Zend\Service\Delicious - Unit tests/0.1',
                 'keepalive' => true
         ));

--- a/tests/Zend/Service/Delicious/PublicDataTest.php
+++ b/tests/Zend/Service/Delicious/PublicDataTest.php
@@ -54,7 +54,7 @@ class PublicDataTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('\Zend\Service\Delicious online tests are not enabled');
         }
         $httpClient = new Http\Client();
-        $httpClient->setConfig(array(
+        $httpClient->setOptions(array(
                 'useragent' => '\Zend\Service\Delicious - Unit tests/0.1',
                 'keepalive' => true
         ));


### PR DESCRIPTION
Zend\Forms and Zend\Module are not covered by this PR.

[![Build Status](https://secure.travis-ci.org/Maks3w/zf2.png?branch=config-dependencies)](http://travis-ci.org/Maks3w/zf2)

Also setConfig methods has been renamed to setOptions.
