### PR TITLE
New Zend\Crypt + refactor Zend/Crypt/Math in Zend/Math

### DIFF
--- a/library/Zend/Crypt/BlockCipher.php
+++ b/library/Zend/Crypt/BlockCipher.php
@@ -12,7 +12,7 @@ namespace Zend\Crypt;
 use Zend\Crypt\Symmetric\SymmetricInterface;
 use Zend\Crypt\Hmac;
 use Zend\Crypt\Tool;
-use Zend\Crypt\Key\Derivation\PBKDF2;
+use Zend\Crypt\Key\Derivation\Pbkdf2;
 use Zend\Math\Math;
 
 /**
@@ -57,7 +57,7 @@ class BlockCipher
      */
     protected $key;
     /**
-     * Number of iterations for PBKDF2
+     * Number of iterations for Pbkdf2
      *
      * @var string
      */
@@ -151,7 +151,7 @@ class BlockCipher
     }
 
     /**
-     * Set the number of iterations for PBKDF2
+     * Set the number of iterations for Pbkdf2
      *
      * @param  integer $num
      * @return BlockCipher
@@ -163,7 +163,7 @@ class BlockCipher
     }
 
     /**
-     * Get the number of iterations for PBKDF2
+     * Get the number of iterations for Pbkdf2
      *
      * @return integer
      */

--- a/library/Zend/Crypt/Key/Derivation/Pbkdf2.php
+++ b/library/Zend/Crypt/Key/Derivation/Pbkdf2.php
@@ -19,7 +19,7 @@ use Zend\Crypt\Hmac;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class PBKDF2
+class Pbkdf2
 {
     /**
      * Generate the new key

--- a/library/Zend/Crypt/Symmetric/Mcrypt.php
+++ b/library/Zend/Crypt/Symmetric/Mcrypt.php
@@ -178,7 +178,7 @@ class Mcrypt implements SymmetricInterface
     /**
      * Set the symmetric cipher broker
      *
-     * @param  PaddingBroker $broker
+     * @param  string|PaddingBroker $broker
      * @return void
      */
     public static function setPaddingBroker($broker)

--- a/library/Zend/Crypt/Symmetric/Padding/Pkcs7.php
+++ b/library/Zend/Crypt/Symmetric/Padding/Pkcs7.php
@@ -17,7 +17,7 @@ namespace Zend\Crypt\Symmetric\Padding;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class PKCS7 implements PaddingInterface
+class Pkcs7 implements PaddingInterface
 {
 
     /**

--- a/library/Zend/Crypt/Symmetric/PaddingLoader.php
+++ b/library/Zend/Crypt/Symmetric/PaddingLoader.php
@@ -27,6 +27,6 @@ class PaddingLoader extends PluginClassLoader
      * @var array Pre-aliased adapters
      */
     protected $plugins = array(
-        'pkcs7' => 'Zend\Crypt\Symmetric\Padding\PKCS7'
+        'pkcs7' => 'Zend\Crypt\Symmetric\Padding\Pkcs7'
     );
 }

--- a/tests/Zend/Crypt/Key/Derivation/Pbkdf2Test.php
+++ b/tests/Zend/Crypt/Key/Derivation/Pbkdf2Test.php
@@ -21,7 +21,7 @@
 
 namespace ZendTest\Crypt\Key\Derivation;
 
-use Zend\Crypt\Key\Derivation\PBKDF2;
+use Zend\Crypt\Key\Derivation\Pbkdf2;
 
 /**
  * @category   Zend
@@ -30,7 +30,7 @@ use Zend\Crypt\Key\Derivation\PBKDF2;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class PBKDF2Test extends \PHPUnit_Framework_TestCase
+class Pbkdf2Test extends \PHPUnit_Framework_TestCase
 {
 
     /** @var string */
@@ -43,7 +43,7 @@ class PBKDF2Test extends \PHPUnit_Framework_TestCase
 
     public function testCalc()
     {
-        $password = PBKDF2::calc('sha256', 'test', $this->salt, 5000, 32);
+        $password = Pbkdf2::calc('sha256', 'test', $this->salt, 5000, 32);
         $this->assertEquals(32, strlen($password));
         $this->assertEquals(base64_encode($password), '323tCTB8Z/KVrJYWPvMoKqbL34gMziymMdvYTfELpKI=');
     }
@@ -51,8 +51,8 @@ class PBKDF2Test extends \PHPUnit_Framework_TestCase
     public function testCalcWithWrongHash()
     {
         $this->setExpectedException('Zend\Crypt\Key\Derivation\Exception\InvalidArgumentException',
-                                    'The hash algorihtm wrong is not supported by Zend\Crypt\Key\Derivation\PBKDF2');
-        $password = PBKDF2::calc('wrong', 'test', $this->salt, 5000, 32);
+                                    'The hash algorihtm wrong is not supported by Zend\Crypt\Key\Derivation\Pbkdf2');
+        $password = Pbkdf2::calc('wrong', 'test', $this->salt, 5000, 32);
     }
 
 }


### PR DESCRIPTION
New Zend\Crypt component:
- moved RSA and DiffieHellman in Zend\Crypt\PublicKey;
- added the namespace Zend\Crypt\Symmetric for symmetric ciphers (like AES, BLOWFISH, etc).
- added the namespace Zend\Crypt\Password for algorithm about password (like BCrypt);
- added the namespace Zend\Crypt\Key\Derivation for Key Derivation Function (like PBKDF2);
- new component Zend\Crypt\BlockCipher for encryption/decryption using block cipher then authenticate using HMAC;
- added the namespace Zend\Password for algorithm about password (like BCrypt);
- deleted the Zend\Crypt\Crypt;

New Zend\Math namespace:
- Moved the old Zend\Crypt\Math in Zend\Math;
- refactor the random number generator using more robust entropy sources (OpenSSL, Mcrypt, \dev\urandom);

I added the documentation in my last commit. I think this PR is ready to be merged.
