### PR TITLE
ZF-7586: Zend\Json\Decoder emits fatal error when decoding JSON string with empty key

### DIFF
--- a/library/Zend/Json/Decoder.php
+++ b/library/Zend/Json/Decoder.php
@@ -223,6 +223,9 @@ class Decoder
                 // Create new StdClass and populate with $members
                 $result = new \stdClass();
                 foreach ($members as $key => $value) {
+                    if ($key === '') {
+                        $key = '_empty_';
+                    }
                     $result->$key = $value;
                 }
                 break;

--- a/tests/Zend/Json/JsonTest.php
+++ b/tests/Zend/Json/JsonTest.php
@@ -847,6 +847,19 @@ EOB;
         $this->assertEquals($expected, $json);
     }
 
+    /**
+     * @group ZF-7586
+     */
+    public function testWillDecodeStructureWithEmptyKeyToObjectProperly()
+    {
+        Json\Json::$useBuiltinEncoderDecoder = true;
+
+        $json = '{"":"test"}';
+        $object = Json\Json::decode($json, Json\Json::TYPE_OBJECT);
+        $this->assertTrue(isset($object->_empty_));
+        $this->assertEquals('test', $object->_empty_);
+    }
+
 }
 
 /**


### PR DESCRIPTION
Fixes [ZF-7586](http://framework.zend.com/issues/browse/ZF-7586).  SVN sync r24799
