### PR TITLE
[Authentication] Change namespaces

### DIFF
--- a/tests/Zend/Authentication/Adapter/Http/AuthTest.php
+++ b/tests/Zend/Authentication/Adapter/Http/AuthTest.php
@@ -19,7 +19,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace ZendTest\Auth\Adapter\Http;
+namespace ZendTest\Authentication\Adapter\Http;
 
 use Zend\Authentication\Adapter\Http,
     Zend\Http\Headers,

--- a/tests/Zend/Authentication/Adapter/Http/FileResolverTest.php
+++ b/tests/Zend/Authentication/Adapter/Http/FileResolverTest.php
@@ -19,7 +19,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace ZendTest\Auth\Adapter\Http;
+namespace ZendTest\Authentication\Adapter\Http;
 
 use Zend\Authentication\Adapter\Http;
 

--- a/tests/Zend/Authentication/Adapter/Http/ObjectTest.php
+++ b/tests/Zend/Authentication/Adapter/Http/ObjectTest.php
@@ -19,7 +19,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace ZendTest\Auth\Adapter\Http;
+namespace ZendTest\Authentication\Adapter\Http;
 
 use Zend\Authentication\Adapter\Http,
     Zend\Authentication\Adapter,

--- a/tests/Zend/Authentication/Adapter/Http/ProxyTest.php
+++ b/tests/Zend/Authentication/Adapter/Http/ProxyTest.php
@@ -19,7 +19,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace ZendTest\Auth\Adapter\Http;
+namespace ZendTest\Authentication\Adapter\Http;
 
 use Zend\Authentication\Adapter\Http,
     Zend\Http\Headers,

--- a/tests/Zend/Authentication/Adapter/Ldap/OfflineTest.php
+++ b/tests/Zend/Authentication/Adapter/Ldap/OfflineTest.php
@@ -19,7 +19,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace ZendTest\Auth\Adapter\Ldap;
+namespace ZendTest\Authentication\Adapter\Ldap;
 
 use Zend\Authentication\Adapter,
     Zend\Ldap;

--- a/tests/Zend/Authentication/Adapter/Ldap/OnlineTest.php
+++ b/tests/Zend/Authentication/Adapter/Ldap/OnlineTest.php
@@ -19,7 +19,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace ZendTest\Auth\Adapter\Ldap;
+namespace ZendTest\Authentication\Adapter\Ldap;
 
 use Zend\Authentication,
     Zend\Authentication\Adapter,


### PR DESCRIPTION
Change some namespaces from ZendTest\Auth\ to ZenTest\Authentication\
