### PR TITLE
Use 'host' instead 'hostname' in data source name

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -203,7 +203,7 @@ class Connection implements ConnectionInterface
                     $dsn .= $database;
                     break;
                 default:
-                    $dsn .= (isset($hostname)) ? 'hostname=' . $hostname : '';
+                    $dsn .= (isset($hostname)) ? 'host=' . $hostname : '';
                     $dsn .= (isset($hostname) && isset($database)) ? ';' : '';
                     $dsn .= (isset($database)) ? 'dbname=' . $database : '';
             }


### PR DESCRIPTION
Use 'host' instead 'hostname' in data source name in pdo connection object
