### PR TITLE
Add SQL error code to exceptions thrown due to SQL errors in Zend\Db

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Mysqli/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Mysqli/Statement.php
@@ -206,7 +206,7 @@ class Statement implements StatementInterface
         }
             
         if ($this->resource->execute() === false) {
-            throw new \RuntimeException($this->resource->error);
+            throw new \RuntimeException($this->resource->error, $this->resource->errno);
         }
 
         $result = $this->driver->createResult($this->resource);


### PR DESCRIPTION
I'm not sure exceptions are done on the new Zend\Db but if so some of them are missing an error code. It is quite helpful to have the origin SQL error code with the exception.

This pull request shows one place where this is missing - it is very possible this needs more work.
