### PR TITLE
fix zf2-300

### DIFF
--- a/library/Zend/Config/Reader/Xml.php
+++ b/library/Zend/Config/Reader/Xml.php
@@ -168,7 +168,7 @@ class Xml implements Reader
                 }
 
                 if (isset($children[$name])) {
-                    if (!is_array($children[$name]) || !$children[$name]) {
+                    if (!is_array($children[$name]) || !array_key_exists(0, $children[$name])) {
                         $children[$name] = array($children[$name]);
                     }
 

--- a/tests/Zend/Config/Reader/TestAssets/Xml/array.xml
+++ b/tests/Zend/Config/Reader/TestAssets/Xml/array.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<config>
+    <one>
+        <two>2a</two>
+        <two>2b</two>
+    </one>
+    <three>
+        <four>
+            <five>5</five>
+        </four>
+        <four>4</four>
+        <four>
+            <five>5</five>
+        </four>
+    </three>
+    <six>
+        <seven>
+            <eight>1</eight>
+            <nine>1</nine>
+        </seven>
+        <seven>
+            <eight>2</eight>
+            <nine>2</nine>
+        </seven>
+        <seven>
+            <eight>3</eight>
+            <nine>3</nine>
+        </seven>
+    </six>
+</config>
+

--- a/tests/Zend/Config/Reader/XmlTest.php
+++ b/tests/Zend/Config/Reader/XmlTest.php
@@ -86,4 +86,26 @@ ECS;
         $this->setExpectedException('Zend\Config\Exception\RuntimeException');
         $arrayXml = $this->reader->fromString($xml);
     }
+
+    public function testZF300_MultipleKeysOfTheSameName()
+    {
+        $config = $this->reader->fromFile($this->getTestAssetPath('array'));
+
+        $this->assertEquals('2a', $config['one']['two'][0]);
+        $this->assertEquals('2b', $config['one']['two'][1]);
+        $this->assertEquals('4', $config['three']['four'][1]);
+        $this->assertEquals('5', $config['three']['four'][0]['five']);
+    }
+
+    public function testZF300_ArraysWithMultipleChildren()
+    {
+        $config = $this->reader->fromFile($this->getTestAssetPath('array'));
+
+        $this->assertEquals('1', $config['six']['seven'][0]['eight']);
+        $this->assertEquals('2', $config['six']['seven'][1]['eight']);
+        $this->assertEquals('3', $config['six']['seven'][2]['eight']);
+        $this->assertEquals('1', $config['six']['seven'][0]['nine']);
+        $this->assertEquals('2', $config['six']['seven'][1]['nine']);
+        $this->assertEquals('3', $config['six']['seven'][2]['nine']);
+    }
 }


### PR DESCRIPTION
Allow Zend\Config\Reader\Xml to support multiple values of the same name as an array
