### PR TITLE
Fix wrong exception messages caused by interface renaming

### DIFF
--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -103,7 +103,7 @@ class TreeRouteStack extends SimpleRouteStack
         if ($specs instanceof Traversable) {
             $specs = ArrayUtils::iteratorToArray($specs);
         } elseif (!is_array($specs)) {
-            throw new Exception\InvalidArgumentException('RouteInterface definition must be an array or Traversable object');
+            throw new Exception\InvalidArgumentException('Route definition must be an array or Traversable object');
         }
 
         $route = parent::routeFromArray($specs);
@@ -195,7 +195,7 @@ class TreeRouteStack extends SimpleRouteStack
         $route = $this->routes->get($names[0]);
 
         if (!$route) {
-            throw new Exception\RuntimeException(sprintf('RouteInterface with name "%s" not found', $names[0]));
+            throw new Exception\RuntimeException(sprintf('Route with name "%s" not found', $names[0]));
         }
 
         if (isset($names[1])) {

--- a/library/Zend/Mvc/Router/SimpleRouteStack.php
+++ b/library/Zend/Mvc/Router/SimpleRouteStack.php
@@ -237,7 +237,7 @@ class SimpleRouteStack implements RouteStackInterface
         if ($specs instanceof Traversable) {
             $specs = ArrayUtils::iteratorToArray($specs);
         } elseif (!is_array($specs)) {
-            throw new Exception\InvalidArgumentException('RouteInterface definition must be an array or Traversable object');
+            throw new Exception\InvalidArgumentException('Route definition must be an array or Traversable object');
         }
 
         if (!isset($specs['type'])) {
@@ -298,7 +298,7 @@ class SimpleRouteStack implements RouteStackInterface
         $route = $this->routes->get($options['name']);
 
         if (!$route) {
-            throw new Exception\RuntimeException(sprintf('RouteInterface with name "%s" not found', $options['name']));
+            throw new Exception\RuntimeException(sprintf('Route with name "%s" not found', $options['name']));
         }
 
         unset($options['name']);

--- a/tests/Zend/Mvc/Router/Http/TreeRouteStackTest.php
+++ b/tests/Zend/Mvc/Router/Http/TreeRouteStackTest.php
@@ -15,7 +15,7 @@ class TreeRouteStackTest extends TestCase
 {
     public function testAddRouteRequiresHttpSpecificRoute()
     {
-        $this->setExpectedException('Zend\Mvc\Router\Exception\InvalidArgumentException', 'RouteInterface definition must be an array or Traversable object');
+        $this->setExpectedException('Zend\Mvc\Router\Exception\InvalidArgumentException', 'Route definition must be an array or Traversable object');
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', new \ZendTest\Mvc\Router\TestAsset\DummyRoute());
     }
@@ -156,7 +156,7 @@ class TreeRouteStackTest extends TestCase
 
     public function testAssembleNonExistentRoute()
     {
-        $this->setExpectedException('Zend\Mvc\Router\Exception\RuntimeException', 'RouteInterface with name "foo" not found');
+        $this->setExpectedException('Zend\Mvc\Router\Exception\RuntimeException', 'Route with name "foo" not found');
         $stack = new TreeRouteStack();
         $stack->assemble(array(), array('name' => 'foo'));
     }

--- a/tests/Zend/Mvc/Router/SimpleRouteStackTest.php
+++ b/tests/Zend/Mvc/Router/SimpleRouteStackTest.php
@@ -96,7 +96,7 @@ class SimpleRouteStackTest extends TestCase
     
     public function testAddRouteWithInvalidArgument()
     {
-        $this->setExpectedException('Zend\Mvc\Router\Exception\InvalidArgumentException', 'RouteInterface definition must be an array or Traversable object');
+        $this->setExpectedException('Zend\Mvc\Router\Exception\InvalidArgumentException', 'Route definition must be an array or Traversable object');
         $stack = new SimpleRouteStack();
         $stack->addRoute('foo', 'bar');
     }
@@ -186,7 +186,7 @@ class SimpleRouteStackTest extends TestCase
     
     public function testAssembleNonExistentRoute()
     {
-        $this->setExpectedException('Zend\Mvc\Router\Exception\RuntimeException', 'RouteInterface with name "foo" not found');
+        $this->setExpectedException('Zend\Mvc\Router\Exception\RuntimeException', 'Route with name "foo" not found');
         $stack = new SimpleRouteStack();
         $stack->assemble(array(), array('name' => 'foo'));
     }


### PR DESCRIPTION
Probably happened due to mass search/replace by the guy who renamed the interfaces. Other components should be checked as well.
