### PR TITLE
For whatever reason Curl adapter was overwriting accept header regardles...

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -372,7 +372,9 @@ class Curl implements HttpAdapter, StreamInterface
         }
 
         // set additional headers
-        $headers['Accept'] = '';
+        if (!isset($headers['Accept'])) {
+            $headers['Accept'] = '';
+        }
         $curlHeaders = array();
         foreach ($headers as $key => $value) {
             $curlHeaders[] = $key . ': ' . $value;


### PR DESCRIPTION
...s if the user set it or not

Basically even if a user set the Accept header, the adapter was overwriting it.  This was not acceptable for our api use case.
