### PR TITLE
Add module namespace to view template injection

### DIFF
--- a/library/Zend/Mvc/View/InjectTemplateListener.php
+++ b/library/Zend/Mvc/View/InjectTemplateListener.php
@@ -92,7 +92,13 @@ class InjectTemplateListener implements ListenerAggregateInterface
         }
 
         $routeMatch = $e->getRouteMatch();
-        $controller = $routeMatch->getParam('controller', 'index');
+        $controller = $e->getTarget();
+        if (is_object($controller)) {
+            $controller = get_class($controller);
+        }
+        if (!$controller) {
+            $controller = $routeMatch->getParam('controller', '');
+        }
 
         $module     = $this->deriveModuleNamespace($controller);
         $controller = $this->deriveControllerClass($controller);

--- a/library/Zend/Mvc/View/InjectTemplateListener.php
+++ b/library/Zend/Mvc/View/InjectTemplateListener.php
@@ -93,8 +93,15 @@ class InjectTemplateListener implements ListenerAggregateInterface
 
         $routeMatch = $e->getRouteMatch();
         $controller = $routeMatch->getParam('controller', 'index');
+
+        $module     = $this->deriveModuleNamespace($controller);
         $controller = $this->deriveControllerClass($controller);
-        $template   = $this->inflectName($controller);
+
+        $template   = $this->inflectName($module);
+        if (!empty($template)) {
+            $template .= '/';
+        }
+        $template  .= $this->inflectName($controller);
 
         $action     = $routeMatch->getParam('action');
         if (null !== $action) {
@@ -116,6 +123,21 @@ class InjectTemplateListener implements ListenerAggregateInterface
         }
         $name = $this->inflector->filter($name);
         return strtolower($name);
+    }
+
+    /**
+     * Determine the top-level namespace of the controller
+     * 
+     * @param  string $controller 
+     * @return string
+     */
+    protected function deriveModuleNamespace($controller)
+    {
+        if (!strstr($controller, '\\')) {
+            return '';
+        }
+        $module = substr($controller, 0, strpos($controller, '\\'));
+        return $module;
     }
 
     /**

--- a/tests/Zend/Mvc/View/InjectTemplateListenerTest.php
+++ b/tests/Zend/Mvc/View/InjectTemplateListenerTest.php
@@ -55,10 +55,10 @@ class InjectTemplateListenerTest extends TestCase
 
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('somewhat/useful', $model->getTemplate());
+        $this->assertEquals('foo/somewhat/useful', $model->getTemplate());
     }
 
-    public function testUsesControllerOnlyIfNoActionInRouteMatch()
+    public function testUsesModuleAndControllerOnlyIfNoActionInRouteMatch()
     {
         $this->routeMatch->setParam('controller', 'Foo\Controller\SomewhatController');
 
@@ -67,7 +67,7 @@ class InjectTemplateListenerTest extends TestCase
 
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('somewhat', $model->getTemplate());
+        $this->assertEquals('foo/somewhat', $model->getTemplate());
     }
 
     public function testNormalizesLiteralControllerNameIfNoNamespaceSeparatorPresent()


### PR DESCRIPTION
- If the controller is namespaced, uses the top-level namespace (usually
  the module namespace) as an initial segment of the view script
  injected into the view model.
  
  Thus, for controller "Foo\Controller\SomewhatController", on the
  action "barAction", the automatically injected view template name
  would be "foo/somewhat/bar".
