### PR TITLE
Feature/view manager injections

### DIFF
--- a/library/Zend/Mvc/View/ViewManager.php
+++ b/library/Zend/Mvc/View/ViewManager.php
@@ -42,6 +42,21 @@ use Zend\View\View;
  * object (and its associated rendering strategies), and the various MVC
  * strategies and listeners.
  *
+ * Defines and manages the following services:
+ *
+ * - ViewHelperLoader (also aliased to Zend\View\HelperLoader)
+ * - ViewHelperBroker (also aliased to Zend\View\HelperBroker)
+ * - ViewTemplateMapResolver (also aliased to Zend\View\Resolver\TemplateMapResolver)
+ * - ViewTemplatePathStack (also aliased to Zend\View\Resolver\TemplatePathStack)
+ * - ViewResolver (also aliased to Zend\View\Resolver\AggregateResolver and ResolverInterface)
+ * - ViewRenderer (also aliased to Zend\View\Renderer\PhpRenderer and RendererInterface)
+ * - ViewPhpRendererStrategy (also aliased to Zend\View\Strategy\PhpRendererStrategy)
+ * - View (also aliased to Zend\View\View)
+ * - DefaultRenderingStrategy (also aliased to Zend\Mvc\View\DefaultRenderingStrategy)
+ * - ExceptionStrategy (also aliased to Zend\Mvc\View\ExceptionStrategy)
+ * - RouteNotFoundStrategy (also aliased to Zend\Mvc\View\RouteNotFoundStrategy and 404Strategy)
+ * - ViewModel
+ *
  * @category   Zend
  * @package    Zend_Mvc
  * @subpackage View
@@ -160,6 +175,10 @@ class ViewManager implements ListenerAggregateInterface
             $map = $this->config['view_manager']['helper_map'];
         }
         $this->helperLoader = new ViewHelperLoader($map);
+
+        $this->services->setService('ViewHelperLoader', $this->helperLoader);
+        $this->services->setAlias('Zend\View\HelperLoader', 'ViewHelperLoader');
+
         return $this->helperLoader;
     }
 
@@ -199,6 +218,9 @@ class ViewManager implements ListenerAggregateInterface
             $doctype->setDoctype($this->config['view_manager']['doctype']);
         }
 
+        $this->services->setService('ViewHelperBroker', $this->helperBroker);
+        $this->services->setAlias('Zend\View\HelperBroker', 'ViewHelperBroker');
+
         return $this->helperBroker;
     }
 
@@ -237,6 +259,11 @@ class ViewManager implements ListenerAggregateInterface
         $this->services->setService('ViewTemplatePathStack', $templatePathStack);
         $this->services->setService('ViewResolver', $this->resolver);
 
+        $this->services->setAlias('Zend\View\Resolver\TemplateMapResolver', 'ViewTemplateMapResolver');
+        $this->services->setAlias('Zend\View\Resolver\TemplatePathStack', 'ViewTemplatePathStack');
+        $this->services->setAlias('Zend\View\Resolver\AggregateResolver', 'ViewResolver');
+        $this->services->setAlias('Zend\View\Resolver\ResolverInterface', 'ViewResolver');
+
         return $this->resolver;
     }
 
@@ -260,6 +287,8 @@ class ViewManager implements ListenerAggregateInterface
         $modelHelper->setRoot($model);
 
         $this->services->setService('ViewRenderer', $this->renderer);
+        $this->services->setAlias('Zend\View\Renderer\PhpRenderer', 'ViewRenderer');
+        $this->services->setAlias('Zend\View\Renderer\RendererInterface', 'ViewRenderer');
 
         return $this->renderer;
     }
@@ -278,6 +307,10 @@ class ViewManager implements ListenerAggregateInterface
         $this->rendererStrategy = new PhpRendererStrategy(
             $this->getRenderer()
         );
+
+        $this->services->setService('ViewPhpRendererStrategy', $this->rendererStrategy);
+        $this->services->setAlias('Zend\View\Strategy\PhpRendererStrategy', 'ViewPhpRendererStrategy');
+
         return $this->rendererStrategy;
     }
 
@@ -297,6 +330,8 @@ class ViewManager implements ListenerAggregateInterface
         $this->view->events()->attach($this->getRendererStrategy());
 
         $this->services->setService('View', $this->view);
+        $this->services->setAlias('Zend\View\View', 'View');
+
         return $this->view;
     }
 
@@ -327,6 +362,10 @@ class ViewManager implements ListenerAggregateInterface
 
         $this->mvcRenderingStrategy = new DefaultRenderingStrategy($this->getView());
         $this->mvcRenderingStrategy->setLayoutTemplate($this->getLayoutTemplate());
+
+        $this->services->setService('DefaultRenderingStrategy', $this->mvcRenderingStrategy);
+        $this->services->setAlias('Zend\Mvc\View\DefaultRenderingStrategy', 'DefaultRenderingStrategy');
+
         return $this->mvcRenderingStrategy;
     }
 
@@ -355,6 +394,10 @@ class ViewManager implements ListenerAggregateInterface
 
         $this->exceptionStrategy->setDisplayExceptions($displayExceptions);
         $this->exceptionStrategy->setExceptionTemplate($exceptionTemplate);
+
+        $this->services->setService('ExceptionStrategy', $this->exceptionStrategy);
+        $this->services->setAlias('Zend\Mvc\View\ExceptionStrategy', 'ExceptionStrategy');
+
         return $this->exceptionStrategy;
     }
 
@@ -383,6 +426,11 @@ class ViewManager implements ListenerAggregateInterface
 
         $this->routeNotFoundStrategy->setDisplayNotFoundReason($displayNotFoundReason);
         $this->routeNotFoundStrategy->setNotFoundTemplate($notFoundTemplate);
+
+        $this->services->setService('RouteNotFoundStrategy', $this->routeNotFoundStrategy);
+        $this->services->setAlias('Zend\Mvc\View\RouteNotFoundStrategy', 'RouteNotFoundStrategy');
+        $this->services->setAlias('404Strategy', 'RouteNotFoundStrategy');
+
         return $this->routeNotFoundStrategy;
     }
 
@@ -399,6 +447,9 @@ class ViewManager implements ListenerAggregateInterface
 
         $this->viewModel = $model = $this->event->getViewModel();
         $model->setTemplate($this->getLayoutTemplate());
+
+        $this->services->setService('ViewModel', $this->viewModel);
+
         return $this->viewModel;
     }
 }

--- a/library/Zend/Mvc/View/ViewManager.php
+++ b/library/Zend/Mvc/View/ViewManager.php
@@ -149,7 +149,7 @@ class ViewManager implements ListenerAggregateInterface
      * 
      * @return ViewHelperLoader
      */
-    protected function getHelperLoader()
+    public function getHelperLoader()
     {
         if ($this->helperLoader) {
             return $this->helperLoader;
@@ -168,7 +168,7 @@ class ViewManager implements ListenerAggregateInterface
      * 
      * @return ViewHelperBroker
      */
-    protected function getHelperBroker()
+    public function getHelperBroker()
     {
         if ($this->helperBroker) {
             return $this->helperBroker;
@@ -207,7 +207,7 @@ class ViewManager implements ListenerAggregateInterface
      * 
      * @return ViewAggregateResolver
      */
-    protected function getResolver()
+    public function getResolver()
     {
         if ($this->resolver) {
             return $this->resolver;
@@ -245,7 +245,7 @@ class ViewManager implements ListenerAggregateInterface
      * 
      * @return ViewPhpRenderer
      */
-    protected function getRenderer()
+    public function getRenderer()
     {
         if ($this->renderer) {
             return $this->renderer;
@@ -269,7 +269,7 @@ class ViewManager implements ListenerAggregateInterface
      * 
      * @return PhpRendererStrategy
      */
-    protected function getRendererStrategy()
+    public function getRendererStrategy()
     {
         if ($this->rendererStrategy) {
             return $this->rendererStrategy;
@@ -286,7 +286,7 @@ class ViewManager implements ListenerAggregateInterface
      * 
      * @return View
      */
-    protected function getView()
+    public function getView()
     {
         if ($this->view) {
             return $this->view;
@@ -305,7 +305,7 @@ class ViewManager implements ListenerAggregateInterface
      * 
      * @return string
      */
-    protected function getLayoutTemplate()
+    public function getLayoutTemplate()
     {
         $layout = 'layout/layout';
         if (isset($this->config['view_manager']) && isset($this->config['view_manager']['layout'])) {
@@ -319,7 +319,7 @@ class ViewManager implements ListenerAggregateInterface
      * 
      * @return DefaultRenderingStrategy
      */
-    protected function getMvcRenderingStrategy()
+    public function getMvcRenderingStrategy()
     {
         if ($this->mvcRenderingStrategy) {
             return $this->mvcRenderingStrategy;
@@ -335,7 +335,7 @@ class ViewManager implements ListenerAggregateInterface
      * 
      * @return ExceptionStrategy
      */
-    protected function getExceptionStrategy()
+    public function getExceptionStrategy()
     {
         if ($this->exceptionStrategy) {
             return $this->exceptionStrategy;
@@ -363,7 +363,7 @@ class ViewManager implements ListenerAggregateInterface
      * 
      * @return RouteNotFoundStrategy
      */
-    protected function getRouteNotFoundStrategy()
+    public function getRouteNotFoundStrategy()
     {
         if ($this->routeNotFoundStrategy) {
             return $this->routeNotFoundStrategy;
@@ -391,7 +391,7 @@ class ViewManager implements ListenerAggregateInterface
      * 
      * @return \Zend\Mvc\View\Model\ModelInterface
      */
-    protected function getViewModel()
+    public function getViewModel()
     {
         if ($this->viewModel) {
             return $this->viewModel;


### PR DESCRIPTION
This request does two things:
- All getters are now exposed publicly. This allows retrieving the ViewManager from the service manager, and then accessing all the various classes it composes and handles.
- All view services that are created and configured (except the listeners that have no configuration) are injected as services in the service manager, and provided aliases for their FQCN (which should allow retrieval from DI)
