### PR TITLE
Allow objects or class names to act as maps when passed as array elements

### DIFF
--- a/library/Zend/Loader/PluginClassLoader.php
+++ b/library/Zend/Loader/PluginClassLoader.php
@@ -140,6 +140,15 @@ class PluginClassLoader implements PluginClassLocator
         }
 
         foreach ($map as $name => $class) {
+            if ((is_int($name) || is_numeric($name)) 
+                && (is_object($class) || class_exists($class))
+                && is_subclass_of($class, 'Traversable')
+            ) {
+                $subMap = new $class();
+                $this->registerPlugins($subMap);
+                continue;
+            }
+
             $this->registerPlugin($name, $class);
         }
 

--- a/tests/Zend/Loader/PluginClassLoaderTest.php
+++ b/tests/Zend/Loader/PluginClassLoaderTest.php
@@ -259,4 +259,18 @@ class PluginClassLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->registerPlugin('loader', __CLASS__);
         $this->assertEquals(__CLASS__, $loader->getClassName('loader'));
     }
+
+    public function testRegisterPluginsCanAcceptArrayElementWithClassNameProvidingAMap()
+    {
+        $this->loader->registerPlugins(array('ZendTest\Loader\TestAsset\TestPluginMap'));
+        $pluginMap = new TestAsset\TestPluginMap;
+        $this->assertEquals($pluginMap->map, $this->loader->getRegisteredPlugins());
+    }
+
+    public function testRegisterPluginsCanAcceptArrayElementWithObjectProvidingAMap()
+    {
+        $pluginMap = new TestAsset\TestPluginMap;
+        $this->loader->registerPlugins(array($pluginMap));
+        $this->assertEquals($pluginMap->map, $this->loader->getRegisteredPlugins());
+    }
 }


### PR DESCRIPTION
- Allows:
  $loader->registerPlugins(array('SomeClassMap'));
  $loader->registerPlugins(array(new SomeClassMap));
- Basically makes it possible to seed the class map with classes
  providing maps
