### PR TITLE
Feature/service manager module config

### DIFF
--- a/library/Zend/ModuleManager/Listener/ServiceListener.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListener.php
@@ -123,19 +123,22 @@ class ServiceListener implements ListenerAggregateInterface
         }
 
         $config = $module->getServiceConfiguration();
+
+        if ($config instanceof ServiceConfiguration) {
+            $this->mergeServiceConfiguration($config);
+            return;
+        }
+
         if ($config instanceof Traversable) {
             $config = ArrayUtils::iteratorToArray($config);
         }
-        if (is_array($config)) {
-            $this->serviceConfig = ArrayUtils::merge($this->serviceConfig, $config);
+
+        if (!is_array($config)) {
+            // If we don't have an array by this point, nothing left to do.
             return;
         }
 
-        if (!$config instanceof ServiceConfiguration) {
-            return;
-        }
-
-        $this->mergeServiceConfiguration($config);
+        $this->serviceConfig = ArrayUtils::merge($this->serviceConfig, $config);
     }
 
     /**

--- a/library/Zend/ModuleManager/Listener/ServiceListener.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListener.php
@@ -155,14 +155,12 @@ class ServiceListener implements ListenerAggregateInterface
     {
         $configListener = $e->getConfigListener();
         $config         = $configListener->getMergedConfig(false);
-        if (!isset($config['service_manager'])
-            || !is_array($config['service_manager'])
-            || empty($config['service_manager'])
+        if (isset($config['service_manager'])
+            && is_array($config['service_manager'])
+            && !empty($config['service_manager'])
         ) {
-            return;
+            $this->serviceConfig = ArrayUtils::merge($this->serviceConfig, $config['service_manager']);
         }
-
-        $this->serviceConfig = ArrayUtils::merge($this->serviceConfig, $config['service_manager']);
 
         $this->configureServiceManager();
     }

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -146,9 +146,10 @@ class ServiceManager implements ServiceLocatorInterface
         }
 
         if ($this->allowOverride === false && $this->has($name)) {
-            throw new Exception\InvalidServiceNameException(
-                'A service by this name or alias already exists and cannot be overridden, please use an alternate name.'
-            );
+            throw new Exception\InvalidServiceNameException(sprintf(
+                'A service by the name or alias "%s" already exists and cannot be overridden, please use an alternate name',
+                $name
+            ));
         }
 
         $this->factories[$name] = $factory;

--- a/tests/Zend/ModuleManager/Listener/ServiceListenerTest.php
+++ b/tests/Zend/ModuleManager/Listener/ServiceListenerTest.php
@@ -94,6 +94,7 @@ class ServiceListenerTest extends TestCase
 
     public function assertServiceManagerIsConfigured()
     {
+        $this->listener->configureServiceManager();
         foreach ($this->getServiceConfiguration() as $prop => $expected) {
             if ($prop == 'invokables') {
                 $prop = 'invokableClasses';

--- a/tests/Zend/ModuleManager/Listener/ServiceListenerTest.php
+++ b/tests/Zend/ModuleManager/Listener/ServiceListenerTest.php
@@ -24,6 +24,7 @@ namespace ZendTest\ModuleManager\Listener;
 use ArrayObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use stdClass;
+use Zend\ModuleManager\Listener\ConfigListener;
 use Zend\ModuleManager\Listener\ServiceListener;
 use Zend\ModuleManager\ModuleEvent;
 use Zend\ServiceManager\Configuration as ServiceConfiguration;
@@ -136,6 +137,16 @@ class ServiceListenerTest extends TestCase
         $module = new TestAsset\ServiceProviderModule($config);
         $this->event->setModule($module);
         $this->listener->onLoadModule($this->event);
+        $this->assertServiceManagerIsConfigured();
+    }
+
+    public function testMergedConfigurationContainingServiceManagerKeyWillConfigureServiceManagerPostLoadModules()
+    {
+        $config = array('service_manager' => $this->getServiceConfiguration());
+        $configListener = new ConfigListener();
+        $configListener->setMergedConfig($config);
+        $this->event->setConfigListener($configListener);
+        $this->listener->onLoadModulesPost($this->event);
         $this->assertServiceManagerIsConfigured();
     }
 }


### PR DESCRIPTION
Allows several possibilities for service manager configuration:
- Modules or application autoload configuration may specify a service_manager key, with configuration. This will be merged once configuration merging is done, and used to seed the ServiceManager
- Modules may still provide configuration via getServiceConfiguration(). However, it is merged internally with an array of configuration, and thus merged and injected at the end, with the configuration as above.
- This does _not_ answer the question of overriding default services -- however, those can be handled by providing an alternate ServiceManagerConfiguration class during bootstrapping.
