### PR TITLE
Enabled in \Zend\Code\Scanner\TokenArrayScanner::getDocComment() and worked on Unit tests. 

### DIFF
--- a/library/Zend/Code/Reflection/DocBlock/Tag/GenericTag.php
+++ b/library/Zend/Code/Reflection/DocBlock/Tag/GenericTag.php
@@ -104,6 +104,7 @@ class GenericTag implements TagInterface
 
     protected function parse($docBlockLine)
     {
+        $this->content = trim($docBlockLine);
         $this->values = explode($this->contentSplitCharacter, $docBlockLine);
     }
 

--- a/library/Zend/Code/Reflection/DocBlock/Tag/ParamTag.php
+++ b/library/Zend/Code/Reflection/DocBlock/Tag/ParamTag.php
@@ -68,7 +68,7 @@ class ParamTag implements TagInterface
         }
 
         if (isset($matches[3])) {
-            $this->description = preg_replace('#\s+#', ' ', $matches[3]);
+            $this->description = trim(preg_replace('#\s+#', ' ', $matches[3]));
         }
     }
 

--- a/library/Zend/Code/Reflection/DocBlock/TagManager.php
+++ b/library/Zend/Code/Reflection/DocBlock/TagManager.php
@@ -32,7 +32,7 @@ class TagManager
 
     public function addTagPrototype(Tag\TagInterface $tag)
     {
-        $tagName = strtolower(str_replace(array('-', '_'), '', $tag->getName()));
+        $tagName = str_replace(array('-', '_'), '', $tag->getName());
 
         if (in_array($tagName, $this->tagNames)) {
             throw new Exception\InvalidArgumentException('A tag with this name already exists in this manager');
@@ -49,12 +49,12 @@ class TagManager
     public function hasTag($tagName)
     {
         // otherwise, only if its name exists as a key
-        return in_array(strtolower(str_replace(array('-', '_'), '', $tagName)), $this->tagNames);
+        return in_array(str_replace(array('-', '_'), '', $tagName), $this->tagNames);
     }
 
     public function createTag($tagName, $content = null)
     {
-        $tagName = strtolower(str_replace(array('-', '_'), '', $tagName));
+        $tagName = str_replace(array('-', '_'), '', $tagName);
 
         if (!$this->hasTag($tagName) && !isset($this->genericTag)) {
             throw new Exception\RuntimeException('This tag name is not supported by this tag manager');

--- a/library/Zend/Code/Scanner/TokenArrayScanner.php
+++ b/library/Zend/Code/Scanner/TokenArrayScanner.php
@@ -55,7 +55,22 @@ class TokenArrayScanner implements ScannerInterface
 
     public function getDocComment()
     {
-        return null;
+        #FIXME: Assignment of $this->docComment should probably be done in scan() and then $this->getDocComment() just retrieves it.
+        foreach ($this->tokens as $token) {
+            $type    = $token[0];
+            $value   = $token[1];
+            $lineNum = $token[2];
+            if(($type == T_OPEN_TAG) || ($type == T_WHITESPACE)) {
+                continue;
+            } elseif ($type == T_DOC_COMMENT) {
+                $this->docComment = $value;
+                $this->startLine  = $lineNum + substr_count($value, "\n") + 1;
+                return $this->docComment;
+            } else {
+                // Only whitespace is allowed before file docblocks
+                return;
+            }
+        }
     }
 
     public function getNamespaces()
@@ -313,6 +328,7 @@ class TokenArrayScanner implements ScannerInterface
 
             case T_DOC_COMMENT:
 
+                #FIXME: $this->docComment should be assigned for valid docblock during the scan instead of $this->getDocComment()
                 $MACRO_DOC_COMMENT_START();
                 goto SCANNER_CONTINUE;
 

--- a/tests/Zend/Code/Reflection/FileReflectionTest.php
+++ b/tests/Zend/Code/Reflection/FileReflectionTest.php
@@ -109,12 +109,12 @@ class FileReflectionTest extends \PHPUnit_Framework_TestCase
 
     public function testFileGetDocBlockReturnsFileDocBlock()
     {
-        $this->markTestIncomplete('File docblocks not implemented yet');
-
-        $fileToReflect = __DIR__ . '/TestAsset/TestSampleClass.php';
+        $fileToReflect = __DIR__ . '/TestAsset/TestSampleClass7.php';
         include_once $fileToReflect;
         $reflectionFile = new FileReflection($fileToReflect);
+        
         $this->assertTrue($reflectionFile->getDocBlock() instanceof \Zend\Code\Reflection\DocBlockReflection);
+        $this->assertEquals('Jeremiah Small <jsmall@soliantconsulting.com>', $reflectionFile->getDocBlock()->getTag('author')->getContent());
     }
 
     public function testFileGetFunctionsReturnsFunctions()

--- a/tests/Zend/Code/Reflection/ReflectionDocBlockTagTest.php
+++ b/tests/Zend/Code/Reflection/ReflectionDocBlockTagTest.php
@@ -37,7 +37,7 @@ class ReflectionDocBlockTagTest extends \PHPUnit_Framework_TestCase
 {
     public function testTagDescriptionIsReturned()
     {
-        $this->markTestIncomplete('DocBlock Tag not completed yet');
+//         $this->markTestIncomplete('DocBlock Tag not completed yet');
 
         $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
 
@@ -47,7 +47,7 @@ class ReflectionDocBlockTagTest extends \PHPUnit_Framework_TestCase
 
     public function testTagShouldAllowJustTagNameInDocBlockTagLine()
     {
-        $this->markTestIncomplete('DocBlock Tag not completed yet');
+//         $this->markTestIncomplete('DocBlock Tag not completed yet');
 
         $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass6');
 
@@ -57,17 +57,17 @@ class ReflectionDocBlockTagTest extends \PHPUnit_Framework_TestCase
 
     public function testTagShouldAllowMultipleWhitespacesBeforeDescription()
     {
-        $this->markTestIncomplete('DocBlock Tag not completed yet');
+//         $this->markTestIncomplete('DocBlock Tag not completed yet');
         $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass6');
 
         $tag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('descriptionTag');
-        $this->assertEquals('          A tag with just a description', $tag->getDescription(), 'Final Match Failed');
-        $this->assertEquals('A tag with just a description', $tag->getDescription('trimWhitespace'), 'Final Match Failed');
+        $this->assertNotEquals('          A tag with just a description', $tag->getContent(), 'Final Match Failed');
+        $this->assertEquals('A tag with just a description', $tag->getContent(), 'Final Match Failed');
     }
 
     public function testToString()
     {
-        $this->markTestIncomplete('DocBlock Tag not completed yet');
+//         $this->markTestIncomplete('DocBlock Tag not completed yet');
 
         $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass6');
 
@@ -98,17 +98,17 @@ class ReflectionDocBlockTagTest extends \PHPUnit_Framework_TestCase
 
     public function testAllowsMultipleSpacesInDocBlockTagLine()
     {
-        $this->markTestIncomplete('DocBlock Tag not completed yet');
+//         $this->markTestIncomplete('DocBlock Tag not completed yet');
 
         $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass6');
 
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('param');
 
-        $trimOpt = Reflection\ReflectionDocBlockTag::TRIM_WHITESPACE;
+//         $trimOpt = Reflection\ReflectionDocBlockTag::TRIM_WHITESPACE;
         
-        $this->assertEquals($paramTag->getType($trimOpt), 'int', 'Second Match Failed');
-        $this->assertEquals($paramTag->getVariable($trimOpt), '$var', 'Third Match Failed');
-        $this->assertEquals($paramTag->getDescription($trimOpt),'Description of $var', 'Final Match Failed');
+        $this->assertEquals($paramTag->getType(), 'int', 'Second Match Failed');
+        $this->assertEquals($paramTag->getVariableName(), '$var', 'Third Match Failed');
+        $this->assertEquals($paramTag->getDescription(),'Description of $var', 'Final Match Failed');
     }
 
 
@@ -117,16 +117,16 @@ class ReflectionDocBlockTagTest extends \PHPUnit_Framework_TestCase
      */
     public function testNamespaceInParam()
     {
-        $this->markTestIncomplete('DocBlock Tag not completed yet');
+//         $this->markTestIncomplete('DocBlock Tag not completed yet');
 
         $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass7');
         $paramTag        = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('param');
 
-        $trimOpt = Reflection\ReflectionDocBlockTag::TRIM_WHITESPACE;
-
-        $this->assertEquals('Zend\Foo\Bar', $paramTag->getType($trimOpt));
-        $this->assertEquals('$var', $paramTag->getVariable($trimOpt));
-        $this->assertEquals('desc', $paramTag->getDescription($trimOpt));
+//        $trimOpt = Reflection\ReflectionDocBlockTag::TRIM_WHITESPACE;
+        
+        $this->assertEquals('Zend\Foo\Bar', $paramTag->getType());
+        $this->assertEquals('$var', $paramTag->getVariableName());
+        $this->assertEquals('desc', $paramTag->getDescription());
     }
 
     public function testType()

--- a/tests/Zend/Code/Reflection/TestAsset/TestSampleClass7.php
+++ b/tests/Zend/Code/Reflection/TestAsset/TestSampleClass7.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * @author Jeremiah Small <jsmall@soliantconsulting.com>
+ */
 
 namespace ZendTest\Code\Reflection\TestAsset;
 
+/**
+ * This is a sample class docblock
+ *
+ * @myTag blah
+ */
 class TestSampleClass7
 {
     /**


### PR DESCRIPTION
I needed to use getDocComment() so I built it. It should probably be turned into a plain getter, and the docComment property should be populated by the scan() method, but I couldn't get that working right.

I also enabled the unit test for getDocComment(), and while I was at it, I enabled several other ones that were disabled but didn't need to be. Fixing those tests required a couple other additional minor tweaks to \Zend\Code\Reflection\DocBlock package, because while GenericTag::getContent() and ParamTag::getDescription() worked, the names were forced to lower case when they were set in TagManager. The unit tests would fail when the case differed. E.g. a tag as @myTag would not be returned when doing getTag('myTag'). Only getTag('mytag') would work previously.
