### PR TITLE
Feature/mvc service view strategies

### DIFF
--- a/library/Zend/Mvc/Service/ServiceManagerConfiguration.php
+++ b/library/Zend/Mvc/Service/ServiceManagerConfiguration.php
@@ -40,11 +40,11 @@ class ServiceManagerConfiguration implements ConfigurationInterface
      * @var array
      */
     protected $services = array(
-        'Request'                      => 'Zend\Http\PhpEnvironment\Request',
-        'Response'                     => 'Zend\Http\PhpEnvironment\Response',
-        'RouteListener'                => 'Zend\Mvc\RouteListener',
-        'DispatchListener'             => 'Zend\Mvc\DispatchListener',
-        'ViewManager'                  => 'Zend\Mvc\View\ViewManager',
+        'DispatchListener' => 'Zend\Mvc\DispatchListener',
+        'Request'          => 'Zend\Http\PhpEnvironment\Request',
+        'Response'         => 'Zend\Http\PhpEnvironment\Response',
+        'RouteListener'    => 'Zend\Mvc\RouteListener',
+        'ViewManager'      => 'Zend\Mvc\View\ViewManager',
     );
 
     /**
@@ -53,15 +53,19 @@ class ServiceManagerConfiguration implements ConfigurationInterface
      * @var array
      */
     protected $factories = array(
-        'EventManager'                 => 'Zend\Mvc\Service\EventManagerFactory',
-        'ModuleManager'                => 'Zend\Mvc\Service\ModuleManagerFactory',
-        'Configuration'                => 'Zend\Mvc\Service\ConfigurationFactory',
-        'Router'                       => 'Zend\Mvc\Service\RouterFactory',
-        'ControllerPluginLoader'       => 'Zend\Mvc\Service\ControllerPluginLoaderFactory',
-        'ControllerPluginBroker'       => 'Zend\Mvc\Service\ControllerPluginBrokerFactory',
-        'Application'                  => 'Zend\Mvc\Service\ApplicationFactory',
-        'DependencyInjector'           => 'Zend\Mvc\Service\DiFactory',
-        'ControllerLoader'             => 'Zend\Mvc\Service\ControllerLoaderFactory',
+        'Application'            => 'Zend\Mvc\Service\ApplicationFactory',
+        'Configuration'          => 'Zend\Mvc\Service\ConfigurationFactory',
+        'ControllerLoader'       => 'Zend\Mvc\Service\ControllerLoaderFactory',
+        'ControllerPluginBroker' => 'Zend\Mvc\Service\ControllerPluginBrokerFactory',
+        'ControllerPluginLoader' => 'Zend\Mvc\Service\ControllerPluginLoaderFactory',
+        'DependencyInjector'     => 'Zend\Mvc\Service\DiFactory',
+        'EventManager'           => 'Zend\Mvc\Service\EventManagerFactory',
+        'ModuleManager'          => 'Zend\Mvc\Service\ModuleManagerFactory',
+        'Router'                 => 'Zend\Mvc\Service\RouterFactory',
+        'ViewFeedRenderer'       => 'Zend\Mvc\Service\ViewFeedRendererFactory',
+        'ViewFeedStrategy'       => 'Zend\Mvc\Service\ViewFeedStrategyFactory',
+        'ViewJsonRenderer'       => 'Zend\Mvc\Service\ViewJsonRendererFactory',
+        'ViewJsonStrategy'       => 'Zend\Mvc\Service\ViewJsonStrategyFactory',
     );
 
     /**

--- a/library/Zend/Mvc/Service/ViewFeedStrategyFactory.php
+++ b/library/Zend/Mvc/Service/ViewFeedStrategyFactory.php
@@ -49,10 +49,6 @@ class ViewFeedStrategyFactory implements FactoryInterface
     {
         $feedRenderer = $serviceLocator->get('ViewFeedRenderer');
         $feedStrategy = new FeedStrategy($feedRenderer);
-
-        $view = $serviceLocator->get('View');
-        $view->events()->attach($feedStrategy, 100);
-
         return $feedStrategy;
     }
 }

--- a/library/Zend/Mvc/Service/ViewJsonStrategyFactory.php
+++ b/library/Zend/Mvc/Service/ViewJsonStrategyFactory.php
@@ -49,10 +49,6 @@ class ViewJsonStrategyFactory implements FactoryInterface
     {
         $jsonRenderer = $serviceLocator->get('ViewJsonRenderer');
         $jsonStrategy = new JsonStrategy($jsonRenderer);
-
-        $view = $serviceLocator->get('View');
-        $view->events()->attach($jsonStrategy, 100);
-
         return $jsonStrategy;
     }
 }

--- a/library/Zend/Mvc/View/ViewManager.php
+++ b/library/Zend/Mvc/View/ViewManager.php
@@ -21,6 +21,7 @@
 
 namespace Zend\Mvc\View;
 
+use ArrayAccess;
 use Traversable;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\ListenerAggregateInterface;
@@ -136,7 +137,9 @@ class ViewManager implements ListenerAggregateInterface
         $events       = $application->events();
         $sharedEvents = $events->getSharedManager();
 
-        $this->config   = $config;
+        $this->config   = isset($config['view_manager']) && (is_array($config['view_manager']) || $config['view_manager'] instanceof ArrayAccess)
+                        ? $config['view_manager'] 
+                        : array();
         $this->services = $services;
         $this->event    = $event;
 
@@ -146,6 +149,8 @@ class ViewManager implements ListenerAggregateInterface
         $createViewModelListener = new CreateViewModelListener();
         $injectTemplateListener  = new InjectTemplateListener();
         $injectViewModelListener = new InjectViewModelListener();
+
+        $this->registerViewStrategies();
 
         $events->attach($routeNotFoundStrategy);
         $events->attach($exceptionStrategy);
@@ -171,8 +176,8 @@ class ViewManager implements ListenerAggregateInterface
         }
 
         $map = array();
-        if (isset($this->config['view_manager']) && isset($this->config['view_manager']['helper_map'])) {
-            $map = $this->config['view_manager']['helper_map'];
+        if (isset($this->config['helper_map'])) {
+            $map = $this->config['helper_map'];
         }
         $this->helperLoader = new ViewHelperLoader($map);
 
@@ -205,8 +210,8 @@ class ViewManager implements ListenerAggregateInterface
         $url->setRouter($router);
 
         // Configure basePath view helper with base path from configuration, if available
-        if (isset($this->config['view_manager']) && isset($this->config['view_manager']['base_path'])) {
-            $basePath = $this->config['view_manager']['base_path'];
+        if (isset($this->config['base_path'])) {
+            $basePath = $this->config['base_path'];
         } else {
             $basePath = $this->services->get('Request')->getBasePath();
         }
@@ -214,9 +219,9 @@ class ViewManager implements ListenerAggregateInterface
         $basePathHelper->setBasePath($basePath);
 
         // Configure doctype view helper with doctype from configuration, if available
-        if (isset($this->config['view_manager']) && isset($this->config['view_manager']['doctype'])) {
+        if (isset($this->config['doctype'])) {
             $doctype = $this->helperBroker->load('doctype');
-            $doctype->setDoctype($this->config['view_manager']['doctype']);
+            $doctype->setDoctype($this->config['doctype']);
         }
 
         $this->services->setService('ViewHelperBroker', $this->helperBroker);
@@ -237,14 +242,14 @@ class ViewManager implements ListenerAggregateInterface
         }
 
         $map = array();
-        if (isset($this->config['view_manager']) && isset($this->config['view_manager']['template_map'])) {
-            $map = $this->config['view_manager']['template_map'];
+        if (isset($this->config['template_map'])) {
+            $map = $this->config['template_map'];
         }
         $templateMapResolver = new ViewResolver\TemplateMapResolver($map);
 
         $stack = array();
-        if (isset($this->config['view_manager']) && isset($this->config['view_manager']['template_path_stack'])) {
-            $stack = $this->config['view_manager']['template_path_stack'];
+        if (isset($this->config['template_path_stack'])) {
+            $stack = $this->config['template_path_stack'];
             if ($stack instanceof Traversable) {
                 $stack = ArrayUtils::iteratorToArray($stack);
             }
@@ -344,8 +349,8 @@ class ViewManager implements ListenerAggregateInterface
     public function getLayoutTemplate()
     {
         $layout = 'layout/layout';
-        if (isset($this->config['view_manager']) && isset($this->config['view_manager']['layout'])) {
-            $layout = $this->config['view_manager']['layout'];
+        if (isset($this->config['layout'])) {
+            $layout = $this->config['layout'];
         }
         return $layout;
     }
@@ -386,11 +391,11 @@ class ViewManager implements ListenerAggregateInterface
         $displayExceptions = false;
         $exceptionTemplate = 'error';
 
-        if (isset($this->config['view_manager']) && isset($this->config['view_manager']['display_exceptions'])) {
-            $displayExceptions = $this->config['view_manager']['display_exceptions'];
+        if (isset($this->config['display_exceptions'])) {
+            $displayExceptions = $this->config['display_exceptions'];
         }
-        if (isset($this->config['view_manager']) && isset($this->config['view_manager']['exception_template'])) {
-            $exceptionTemplate = $this->config['view_manager']['exception_template'];
+        if (isset($this->config['exception_template'])) {
+            $exceptionTemplate = $this->config['exception_template'];
         }
 
         $this->exceptionStrategy->setDisplayExceptions($displayExceptions);
@@ -418,11 +423,11 @@ class ViewManager implements ListenerAggregateInterface
         $displayNotFoundReason = false;
         $notFoundTemplate      = '404';
 
-        if (isset($this->config['view_manager']) && isset($this->config['view_manager']['display_not_found_reason'])) {
-            $displayNotFoundReason = $this->config['view_manager']['display_not_found_reason'];
+        if (isset($this->config['display_not_found_reason'])) {
+            $displayNotFoundReason = $this->config['display_not_found_reason'];
         }
-        if (isset($this->config['view_manager']) && isset($this->config['view_manager']['not_found_template'])) {
-            $notFoundTemplate = $this->config['view_manager']['not_found_template'];
+        if (isset($this->config['not_found_template'])) {
+            $notFoundTemplate = $this->config['not_found_template'];
         }
 
         $this->routeNotFoundStrategy->setDisplayNotFoundReason($displayNotFoundReason);
@@ -450,5 +455,43 @@ class ViewManager implements ListenerAggregateInterface
         $model->setTemplate($this->getLayoutTemplate());
 
         return $this->viewModel;
+    }
+
+    /**
+     * Register additional view strategies
+     *
+     * If there is a "strategies" key of the view manager configuration, loop
+     * through it. Pull each as a service from the service manager, and, if it
+     * is a ListenerAggregate, attach it to the view, at priority 100. This 
+     * latter allows each to trigger before the default strategy, and for them
+     * to trigger in the order they are registered.
+     * 
+     * @return void
+     */
+    protected function registerViewStrategies()
+    {
+        if (!isset($this->config['strategies'])) {
+            return;
+        }
+        $strategies = $this->config['strategies'];
+        if (is_string($strategies)) {
+            $strategies = array($strategies);
+        }
+        if (!is_array($strategies) && !$strategies instanceof Traversable) {
+            return;
+        }
+
+        $view = $this->getView();
+
+        foreach ($strategies as $strategy) {
+            if (!is_string($strategy)) {
+                continue;
+            }
+
+            $listener = $this->services->get($strategy);
+            if ($listener instanceof ListenerAggregateInterface) {
+                $view->attach($listener, 100);
+            }
+        }
     }
 }

--- a/library/Zend/Mvc/View/ViewManager.php
+++ b/library/Zend/Mvc/View/ViewManager.php
@@ -490,7 +490,7 @@ class ViewManager implements ListenerAggregateInterface
 
             $listener = $this->services->get($strategy);
             if ($listener instanceof ListenerAggregateInterface) {
-                $view->attach($listener, 100);
+                $view->events()->attach($listener, 100);
             }
         }
     }


### PR DESCRIPTION
Created service manager factories for each of:
- JsonRenderer
- JsonStrategy
- FeedRenderer
- FeedStrategy

Configuration of the SM is simple, as the strategy factories each register the strategy with the View's events system:

```
'factories' => array(
    'ViewJsonRenderer' => 'Zend\Mvc\Service\ViewJsonRendererFactory',
    'ViewJsonStrategy' => 'Zend\Mvc\Service\ViewJsonStrategyFactory,
    'ViewFeedRenderer' => 'Zend\Mvc\Service\ViewFeedRendererFactory',
    'ViewFeedStrategy' => 'Zend\Mvc\Service\ViewFeedStrategyFactory,
),
```

This should serve as an easy blueprint for creating and enabling other renderers and strategies.
