### PR TITLE
[Code\Generator] ClassGenerator renaming setProperty & setMethod 

### DIFF
--- a/library/Zend/Code/Generator/AbstractMemberGenerator.php
+++ b/library/Zend/Code/Generator/AbstractMemberGenerator.php
@@ -70,7 +70,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
     /**
      * Set flags
      *
-     * @param $flags
+     * @param int|array $flags
      * @return AbstractMemberGenerator
      */
     public function setFlags($flags)
@@ -91,7 +91,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
     /**
      * Add flag
      *
-     * @param $flag
+     * @param int $flag
      * @return AbstractMemberGenerator
      */
     public function addFlag($flag)
@@ -103,7 +103,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
     /**
      * Remove flag
      *
-     * @param $flag
+     * @param int $flag
      * @return AbstractMemberGenerator
      */
     public function removeFlag($flag)

--- a/library/Zend/Di/ServiceLocator/Generator.php
+++ b/library/Zend/Di/ServiceLocator/Generator.php
@@ -241,9 +241,9 @@ class Generator
         $container = new CodeGen\PhpClass();
         $container->setName($this->containerClass)
                   ->setExtendedClass('ServiceLocator')
-                  ->setMethod($get)
-                  ->setMethods($getters)
-                  ->setMethods($aliasMethods);
+                  ->addMethodFromGenerator($get)
+                  ->addMethods($getters)
+                  ->addMethods($aliasMethods);
 
         // Create PHP file code generation object
         $classFile = new CodeGen\PhpFile();

--- a/tests/Zend/Code/Generator/ClassGeneratorTest.php
+++ b/tests/Zend/Code/Generator/ClassGeneratorTest.php
@@ -83,7 +83,7 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testPropertyAccessors()
     {
         $classGenerator = new ClassGenerator();
-        $classGenerator->setProperties(array(
+        $classGenerator->addProperties(array(
             'propOne',
             new PropertyGenerator('propTwo')
             ));
@@ -119,7 +119,7 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException(
             'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'setProperty() expects either a string or an instance of Zend\Code\Generator\PropertyGenerator'
+            'addProperty() expects string for name'
             );
         $classGenerator->addProperty(true);
     }
@@ -127,7 +127,7 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testMethodAccessors()
     {
         $classGenerator = new ClassGenerator();
-        $classGenerator->setMethods(array(
+        $classGenerator->addMethods(array(
             'methodOne',
             new MethodGenerator('methodTwo')
             ));
@@ -151,7 +151,7 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException(
             'Zend\Code\Generator\Exception\ExceptionInterface',
-            'setMethod() expects either a string method name or an instance of Zend\Code\Generator\MethodGenerator'
+            'addMethod() expects string for name'
             );
 
         $classGenerator->addMethod(true);
@@ -165,11 +165,11 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
         $methodB->setName("foo");
 
         $classGenerator = new ClassGenerator();
-        $classGenerator->setMethod($methodA);
+        $classGenerator->addMethodFromGenerator($methodA);
 
         $this->setExpectedException('Zend\Code\Generator\Exception\InvalidArgumentException', 'A method by name foo already exists in this class.');
 
-        $classGenerator->setMethod($methodB);
+        $classGenerator->addMethodFromGenerator($methodB);
     }
 
     /**
@@ -177,11 +177,8 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testHasMethod()
     {
-        $method = new MethodGenerator();
-        $method->setName('methodOne');
-
         $classGenerator = new ClassGenerator();
-        $classGenerator->setMethod($method);
+        $classGenerator->addMethod('methodOne');
 
         $this->assertTrue($classGenerator->hasMethod('methodOne'));
     }
@@ -191,11 +188,8 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testHasProperty()
     {
-        $property = new PropertyGenerator();
-        $property->setName('propertyOne');
-
         $classGenerator = new ClassGenerator();
-        $classGenerator->setProperty($property);
+        $classGenerator->addProperty('propertyOne');
 
         $this->assertTrue($classGenerator->hasProperty('propertyOne'));
     }


### PR DESCRIPTION
Related this commit,
https://github.com/zendframework/zf2/commit/5fab54b7a64515ba8fb5bf4cc63174e544555018

Currently, there is setPropeties, setPropery(for Generator), addProperty(for sclar).
also setMethos, setMethod(for Generator), addMethod(for sclar).
But these are just allow adding new key, not setter.
So, these method name is updated in this PR.

[![Build Status](https://secure.travis-ci.org/sasezaki/zf2.png?branch=code_generator_renaming)](http://travis-ci.org/sasezaki/zf2)
