### PR TITLE
Hotfix: Tree route with hostname and query parts (2nd attempt)

### DIFF
--- a/library/Zend/Mvc/Router/Http/Query.php
+++ b/library/Zend/Mvc/Router/Http/Query.php
@@ -136,17 +136,19 @@ class Query implements RouteInterface
      */
     public function assemble(array $params = array(), array $options = array())
     {
-        $mergedParams = array_merge($this->defaults, $params);
+        $mergedParams          = array_merge($this->defaults, $params);
+        $this->assembledParams = array();
 
-        if (count($mergedParams)) {
+        if (isset($options['uri']) && count($mergedParams)) {
             foreach ($mergedParams as $key => $value) {
                 $this->assembledParams[] = $key;
             }
 
-            return '?' . str_replace('+', '%20', http_build_query($mergedParams));
+            $options['uri']->setQuery($mergedParams);
         }
 
-        return null;
+        // A query does not contribute to the path, thus nothing is returned.
+        return '';
     }
 
     /**

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -236,6 +236,8 @@ class TreeRouteStack extends SimpleRouteStack
                 }
 
                 return $uri->setPath($path)->toString();
+            } elseif (!$uri->isAbsolute() && $uri->isValidRelative()) {
+                return $uri->setPath($path)->toString();
             }
         }
 

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -235,7 +235,7 @@ class TreeRouteStack extends SimpleRouteStack
                     $uri->setScheme($this->requestUri->getScheme());
                 }
 
-                return $uri->parse($path)->toString();
+                return $uri->setPath($path)->toString();
             }
         }
 

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -184,6 +184,33 @@ class Uri
     }
 
     /**
+     * Check if the URI is a valid relative URI
+     *
+     * @return boolean
+     */
+    public function isValidRelative()
+    {
+        if ($this->scheme || $this->host || $this->userInfo || $this->port) {
+            return false;
+        }
+
+        if ($this->path) {
+            // Check path-only (no host) URI
+            if (substr($this->path, 0, 2) == '//') {
+                return false;
+            }
+            return true;
+        }
+
+        if (! ($this->query || $this->fragment)) {
+            // No host, path, query or fragment - this is not a valid URI
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Check if the URI is an absolute or relative URI
      *
      * @return boolean
@@ -274,9 +301,11 @@ class Uri
     public function toString()
     {
         if (!$this->isValid()) {
-            throw new Exception\InvalidUriException(
-                'URI is not valid and cannot be converted into a string'
-            );
+            if ($this->isAbsolute() || !$this->isValidRelative()) {
+                throw new Exception\InvalidUriException(
+                    'URI is not valid and cannot be converted into a string'
+                );
+            }
         }
 
         $uri = '';

--- a/tests/Zend/Mvc/Router/Http/QueryTest.php
+++ b/tests/Zend/Mvc/Router/Http/QueryTest.php
@@ -5,7 +5,8 @@ use PHPUnit_Framework_TestCase as TestCase,
     Zend\Http\Request as Request,
     Zend\Stdlib\Request as BaseRequest,
     Zend\Mvc\Router\Http\Query,
-    ZendTest\Mvc\Router\FactoryTester;
+    ZendTest\Mvc\Router\FactoryTester,
+    Zend\Uri\Http;
 
 class QueryTest extends TestCase
 {
@@ -14,7 +15,7 @@ class QueryTest extends TestCase
         return array(
             'simple-match' => array(
                 new Query(),
-                '?foo=bar&baz=bat',
+                'foo=bar&baz=bat',
                 null,
                 array('foo' => 'bar', 'baz' => 'bat')
             ),
@@ -26,13 +27,13 @@ class QueryTest extends TestCase
             ),
             'url-encoded-parameters-are-decoded' => array(
                 new Query(),
-                '?foo=foo%20bar',
+                'foo=foo%20bar',
                 null,
                 array('foo' => 'foo bar')
             ),
             'nested-params' => array(
                 new Query(),
-                '?foo%5Bbar%5D=baz&foo%5Bbat%5D=foo%20bar',
+                'foo%5Bbar%5D=baz&foo%5Bbat%5D=foo%20bar',
                 null,
                 array('foo' => array('bar' => 'baz', 'bat' => 'foo bar'))
             ),
@@ -49,11 +50,11 @@ class QueryTest extends TestCase
     public function testMatching(Query $route, $path, $offset, array $params = null)
     {
         $request = new Request();
-        $request->setUri('http://example.com' . $path);
+        $request->setUri('http://example.com?' . $path);
         $match = $route->match($request, $offset);
         $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $match);
     }
-    
+
     /**
      * @dataProvider routeProvider
      * @param        Query $route
@@ -68,16 +69,17 @@ class QueryTest extends TestCase
             // Data which will not match are not tested for assembling.
             return;
         }
-                
-        $result = $route->assemble($params);
-        
+
+        $uri = new Http();
+        $result = $route->assemble($params, array('uri' => $uri));
+
         if ($offset !== null) {
-            $this->assertEquals($offset, strpos($path, $result, $offset));
+            $this->assertEquals($offset, strpos($path, $uri->getQuery(), $offset));
         } else {
-            $this->assertEquals($path, $result);
+            $this->assertEquals($path, $uri->getQuery());
         }
     }
-    
+
     public function testNoMatchWithoutUriMethod()
     {
         $route   = new Query();
@@ -85,16 +87,17 @@ class QueryTest extends TestCase
         $match   = $route->match($request);
         $this->assertNull($match);
     }
-    
+
     public function testGetAssembledParams()
     {
         $route = new Query();
-        $route->assemble(array('foo' => 'bar'));
-        
-        
+        $uri = new Http();
+        $route->assemble(array('foo' => 'bar'), array('uri' => $uri));
+
+
         $this->assertEquals(array('foo'), $route->getAssembledParams());
     }
-    
+
     public function testFactory()
     {
         $tester = new FactoryTester($this);

--- a/tests/Zend/Mvc/Router/Http/TreeRouteStackTest.php
+++ b/tests/Zend/Mvc/Router/Http/TreeRouteStackTest.php
@@ -179,6 +179,30 @@ class TreeRouteStackTest extends TestCase
         $this->assertEquals('http://example.com/?bar=baz', $stack->assemble(array('bar' => 'baz'), array('name' => 'foo/index/query')));
     }
 
+    public function testAssembleWithQueryRoute()
+    {
+        $uri   = new HttpUri();
+        $uri->setScheme('http');
+        $stack = new TreeRouteStack();
+        $stack->setRequestUri($uri);
+        $stack->addRoute(
+        	'index',
+            array(
+                'type' => 'Literal',
+                'options' => array(
+                    'route' => '/',
+                ),
+                'child_routes' => array(
+                    'query' => array(
+                        'type' => 'Query',
+                    ),
+                ),
+            )
+        );
+
+        $this->assertEquals('/?bar=baz', $stack->assemble(array('bar' => 'baz'), array('name' => 'index/query')));
+    }
+
     public function testAssembleWithoutNameOption()
     {
         $this->setExpectedException('Zend\Mvc\Router\Exception\InvalidArgumentException', 'Missing "name" option');

--- a/tests/Zend/Mvc/Router/Http/TreeRouteStackTest.php
+++ b/tests/Zend/Mvc/Router/Http/TreeRouteStackTest.php
@@ -113,7 +113,7 @@ class TreeRouteStackTest extends TestCase
         $stack = new TreeRouteStack();
 
         $stack->addRoute('foo', new TestAsset\DummyRoute());
-        $this->assertEquals('http://example.com:8080/', $stack->assemble(array(), array('name' => 'foo', 'uri' => $uri, 'force_canonical' => true)));
+        $this->assertEquals('http://example.com:8080', $stack->assemble(array(), array('name' => 'foo', 'uri' => $uri, 'force_canonical' => true)));
     }
 
     public function testAssembleCanonicalUriWithHostnameRoute()

--- a/tests/Zend/Uri/UriTest.php
+++ b/tests/Zend/Uri/UriTest.php
@@ -385,8 +385,20 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($uri->isValid());
     }
 
+	/**
+     * Test that valid relative URIs pass validation
+     *
+     * @param string $uriString
+     * @dataProvider validRelativeUriStringProvider
+     */
+    public function testValidRelativeUriIsValid($uriString)
+    {
+        $uri = new Uri($uriString);
+        $this->assertTrue($uri->isValidRelative());
+    }
+
     /**
-     * Test that invalid URIs pass validation
+     * Test that invalid URIs fail validation
      *
      * @param \Zend\Uri\Uri $uri
      * @dataProvider invalidUriObjectProvider
@@ -394,6 +406,17 @@ class UriTest extends \PHPUnit_Framework_TestCase
     public function testInvalidUriIsInvalid(Uri $uri)
     {
         $this->assertFalse($uri->isValid());
+    }
+
+	/**
+     * Test that invalid relative URIs fail validation
+     *
+     * @param \Zend\Uri\Uri $uri
+     * @dataProvider invalidRelativeUriObjectProvider
+     */
+    public function testInvalidRelativeUriIsInvalid(Uri $uri)
+    {
+        $this->assertFalse($uri->isValidRelative());
     }
 
     /**
@@ -819,6 +842,21 @@ class UriTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+	/**
+     * Data provider for valid relative URIs, not necessarily complete
+     *
+     * @return array
+     */
+    static public function validRelativeUriStringProvider()
+    {
+        return array(
+            array('foo/bar?query'),
+            array('../relative/path'),
+            array('?queryOnly'),
+            array('#fragmentOnly'),
+        );
+    }
+
     /**
      * Valid schemes
      *
@@ -918,6 +956,46 @@ class UriTest extends \PHPUnit_Framework_TestCase
             array($obj2),
             array($obj3),
             array($obj4)
+        );
+    }
+
+	/**
+     * Data provider for invalid relative URI objects
+     *
+     * @return array
+     */
+    static public function invalidRelativeUriObjectProvider()
+    {
+        // Empty URI is not valid
+        $obj1 = new Uri;
+
+        // Path cannot begin with '//'
+        $obj2 = new Uri;
+        $obj2->setPath('//path');
+
+        // A object with port
+        $obj3 = new Uri;
+        $obj3->setPort(123);
+
+        // A object with userInfo
+        $obj4 = new Uri;
+        $obj4->setUserInfo('shahar:password');
+
+        // A object with scheme
+        $obj5 = new Uri;
+        $obj5->setScheme('https');
+
+        // A object with host
+        $obj6 = new Uri;
+        $obj6->setHost('example.com');
+
+        return array(
+            array($obj1),
+            array($obj2),
+            array($obj3),
+            array($obj4),
+            array($obj5),
+            array($obj6)
         );
     }
 


### PR DESCRIPTION
After talking with DASPRiD, this pull request probably shouldn't have been merged: https://github.com/zendframework/zf2/pull/1242

This PR undoes some of those changes and corrects the real problem in the Query route.

In order for the TreeRouteStack to assemble relative URIs with query parts, I needed to add relative URI validation to Zend\Uri\Uri
