### PR TITLE
Feature/mvc sm docs

### DIFF
--- a/documentation/manual/en/manual.xml.in
+++ b/documentation/manual/en/manual.xml.in
@@ -1579,6 +1579,12 @@
                 </xi:fallback>
             </xi:include>
 
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="module_specs/Zend_Mvc-Services.xml" parse="xml">
+                <xi:fallback>
+                    <xi:include href="../en/module_specs/Zend_Mvc-Services.xml" parse="xml"/>
+                </xi:fallback>
+            </xi:include>
+
             <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="module_specs/Zend_Mvc-Routing.xml" parse="xml">
                 <xi:fallback>
                     <xi:include href="../en/module_specs/Zend_Mvc-Routing.xml" parse="xml"/>

--- a/documentation/manual/en/module_specs/Zend_Mvc-Controllers.xml
+++ b/documentation/manual/en/module_specs/Zend_Mvc-Controllers.xml
@@ -44,7 +44,7 @@ class Foo implements DispatchableInterface
       <title>InjectApplicationEvent</title>
 
       <para>
-        The <classname>Zend\Mvc\InjectApplicationEvent</classname> interface
+        The <classname>Zend\Mvc\InjectApplicationEventInterface</classname>
         hints to the <classname>Application</classname> instance that it should
         inject its <classname>MvcEvent</classname> into the controller itself.
         Why would this be useful?
@@ -75,7 +75,7 @@ if (!$id) {
 ]]></programlisting>
 
       <para>
-        The <classname>InjectApplicationEvent</classname> interface defines
+        The <classname>InjectApplicationEventInterface</classname> defines
         simply two methods:
       </para>
 
@@ -87,12 +87,12 @@ public function getEvent($event);
 ]]></programlisting>
     </section>
 
-    <section xml:id="zend.mvc.controllers.interfaces.locator-aware">
-      <title>LocatorAware</title>
+    <section xml:id="zend.mvc.controllers.interfaces.service-manager-aware">
+      <title>ServiceManagerAware</title>
 
       <para>
         In most cases, you should define your controllers such that
-        dependencies are injected by the Dependency Injection container,
+        dependencies are injected by the application's <classname>ServiceManager</classname>,
         via either constructor arguments or setter methods.
       </para>
 
@@ -105,17 +105,54 @@ public function getEvent($event);
       </para>
 
       <para>
-        The <classname>LocatorAware</classname> interface hints to the
-        <classname>Application</classname> that it should inject its Locator
-        instance (whether that's a DI container or a custom Service
-        Locator) into the controller. It defines simply two methods:
+        The <classname>ServiceManagerAwareInterface</classname> interface hints to 
+        the <classname>ServiceManager</classname> that it should inject itself
+        into the controller. It defines simply one method:
       </para>
 
       <programlisting language="php"><![CDATA[
-use Zend\Di\LocatorInterface;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\ServiceManagerAwareInterface;
 
-public function setLocator(LocatorInterface $locator);
-public function getLocator($locator);
+public function setServiceManager(ServiceManager $serviceManager);
+]]></programlisting>
+    </section>
+
+    <section xml:id="zend.mvc.controllers.interfaces.event-manager-aware">
+        <info><title>EventManagerAware</title></info>
+
+        <para>
+            Typically, it's nice to be able to tie into a controller's workflow
+            without needing to extend it or hardcode behavior into it. The
+            solution for this at the framework level is to use the
+            <classname>EventManager</classname>.
+        </para>
+
+        <para>
+            You can hint to the <classname>ServiceManager</classname> that you
+            want an <classname>EventManager</classname> injected by implementing
+            the interfaces <classname>EventManagerAwareInterface</classname> and
+            <classname>EventsCapableInterface</classname>; the former tells the
+            <classname>ServiceManager</classname> to inject an
+            <classname>EventManager</classname>, the latter to other objects
+            that this class has an accessible
+            <classname>EventManager</classname> instance.
+        </para>
+
+        <para>
+            Combined, you define two methods. The first, a setter, should also
+            set any <classname>EventManager</classname> identifiers you want to
+            listen on, and the second, a getter, should simply return the
+            composed <classname>EventManager</classname> instance
+        </para>
+
+        <programlisting language="php"><![CDATA[
+use Zend\EventManager\EventManagerAwareInterface;
+use Zend\EventManager\EventManagerInterface;
+use Zend\EventManager\EventsCapableInterface;
+
+public function setEventManager(EventManagerInterface $events);
+public function events();
 ]]></programlisting>
     </section>
 
@@ -298,42 +335,32 @@ class BarController extends ActionController
 
         <listitem>
           <para>
-            <classname>Zend\Mvc\InjectApplicationEvent</classname>
+            <classname>Zend\Mvc\InjectApplicationEventInterface</classname>
           </para>
         </listitem>
 
         <listitem>
           <para>
-            <classname>Zend\Mvc\LocatorAware</classname>
+            <classname>Zend\ServiceManager\ServiceManagerAwareInterface</classname>
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
+            <classname>Zend\EventManager\EventManagerAwareInterface</classname>
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
+            <classname>Zend\EventManager\EventsCapableInterface</classname>
           </para>
         </listitem>
       </itemizedlist>
 
       <para>
-        Additionally, it composes
-        <classname>Zend\EventManager\EventCollection</classname>, exposing the
-        following methods:
-      </para>
-
-      <itemizedlist>
-        <listitem>
-          <para>
-            <classname>setEventManager(EventCollection $events)</classname>
-          </para>
-        </listitem>
-
-        <listitem>
-          <para>
-            <methodname>events()</methodname> (returns the attached
-            <classname>EventCollection</classname>, and an
-            <classname>EventManager</classname> by default.
-          </para>
-        </listitem>
-      </itemizedlist>
-
-      <para>
-        By default, it will create an <classname>EventManager</classname> that
-        listens on the following contexts:
+        The composed <classname>EventManager</classname> will be configured to
+        listen on the following contexts:
       </para>
 
       <itemizedlist>
@@ -451,42 +478,32 @@ class BarController extends ActionController
 
         <listitem>
           <para>
-            <classname>Zend\Mvc\InjectApplicationEvent</classname>
+            <classname>Zend\Mvc\InjectApplicationEventInterface</classname>
           </para>
         </listitem>
 
         <listitem>
           <para>
-            <classname>Zend\Mvc\LocatorAware</classname>
+            <classname>Zend\ServiceManager\ServiceManagerAwareInterface</classname>
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
+            <classname>Zend\EventManager\EventManagerAwareInterface</classname>
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
+            <classname>Zend\EventManager\EventsCapableInterface</classname>
           </para>
         </listitem>
       </itemizedlist>
 
       <para>
-        Additionally, it composes
-        <classname>Zend\EventManager\EventCollection</classname>, exposing the
-        following methods:
-      </para>
-
-      <itemizedlist>
-        <listitem>
-          <para>
-            <methodname>setEventManager(EventCollection $events)</methodname>
-          </para>
-        </listitem>
-
-        <listitem>
-          <para>
-            <methodname>events()</methodname> (returns the attached
-            <classname>EventCollection</classname>, and an
-            <classname>EventManager</classname> by default.
-          </para>
-        </listitem>
-      </itemizedlist>
-
-      <para>
-        By default, it will create an <classname>EventManager</classname> that
-        listens on the following contexts:
+        The composed <classname>EventManager</classname> will be configured to
+        listen on the following contexts:
       </para>
 
       <itemizedlist>
@@ -498,7 +515,7 @@ class BarController extends ActionController
 
         <listitem>
           <para>
-            <classname>Zend\Mvc\Controller\RestfulController</classname>
+            <classname>Zend\Mvc\Controller\ActionController</classname>
           </para>
         </listitem>
       </itemizedlist>

--- a/documentation/manual/en/module_specs/Zend_Mvc-Examples.xml
+++ b/documentation/manual/en/module_specs/Zend_Mvc-Examples.xml
@@ -31,7 +31,7 @@ $response = $this->response;
 
       <para>
         Additionally, if your controller implements
-        <classname>InjectApplicationEvent</classname> (as both
+        <classname>InjectApplicationEventInterface</classname> (as both
         <classname>ActionController</classname> and
         <classname>RestfulController</classname> do), you can access these
         objects from the attached <classname>MvcEvent</classname>:
@@ -60,7 +60,7 @@ $response = $event->getResponse();
 
       <para>
         Within your controller, if you implement
-        <classname>InjectApplicationEvent</classname> (as both
+        <classname>InjectApplicationEventInterface</classname> (as both
         <classname>ActionController</classname> and
         <classname>RestfulController</classname> do), you can access this
         object from the attached <classname>MvcEvent</classname>:
@@ -113,20 +113,20 @@ $matches = $event->getRouteMatch();
 
       <para>
         Each <classname>Module</classname> class can have an optional
-        <methodname>init()</methodname> method. Typically, you'll setup
-        event listeners for you module here. The <methodname>init()</methodname>
-        method is called for <emphasis>every</emphasis> module on
-        <emphasis>every</emphasis> page request and should
-        <emphasis>only</emphasis> be used for performing
+        <methodname>onBootstrap()</methodname> method. Typically, you'll do
+        module-specific configuration here, or setup event listeners for you
+        module here. The <methodname>onBootstrap()</methodname> method is called
+        for <emphasis>every</emphasis> module on <emphasis>every</emphasis> page
+        request and should <emphasis>only</emphasis> be used for performing
         <emphasis>lightweight</emphasis> tasks such as registering event
         listeners.
       </para>
 
       <para>
-        The base <classname>Bootstrap</classname> class shipped with the
+        The base <classname>Application</classname> class shipped with the
         framework has an <classname>EventManager</classname> associated with it,
-        and once the locator and router instances are initialized, it triggers a
-        "bootstrap" event, with "application" and "config" parameters.
+        and once the modules are initialized, it triggers a "bootstrap" event,
+        with a <methodname>getApplication()</methodname> method on the event.
       </para>
 
       <para>
@@ -137,23 +137,13 @@ $matches = $event->getRouteMatch();
       <programlisting language="php"><![CDATA[
 namespace SomeCustomModule;
 
-use Zend\EventManager\StaticEventManager,
-    Zend\Mvc\MvcEvent;
-
 class Module
 {
-    public function init()
+    public function onBootstrap($e)
     {
-        // Remember to keep the init() method as lightweight as possible
-        $events = StaticEventManager::getInstance();
-        $events->attach('bootstrap', MvcEvent::EVENT_BOOTSTRAP, array($this, 'registerListeners'));
-    }
-
-    public function registerListeners($e)
-    {
-        $application = $e->getParam('application');
-        $config      = $e->getParam('config');
-        $view        = $application->getLocator()->get('view');
+        $application = $e->getApplication();
+        $config      = $application->getConfiguration();
+        $view        = $application->getServiceManager()->get('View');
         $view->headTitle($config['view']['base_title']);
 
         $listeners   = new Listeners\ViewListener();
@@ -164,17 +154,15 @@ class Module
 ]]></programlisting>
 
       <para>
-        The above demonstrates several things. First, it shows registering a
-        callback on the bootstrap's "bootstrap" event (within the
-        <methodname>init()</methodname> method). Second, it demonstrates that
+        The above demonstrates several things. First, it demonstrates a listener
+        on the application's "bootstrap" event (the
+        <methodname>onBootstrap()</methodname> method). Second, it demonstrates that
         listener, and how it can be used to register listeners with the
-        application. It grabs the <classname>Application</classname> instance,
-        as well as the module manager instance. From the
-        <classname>Application</classname>, it is able to grab the attached
-        locator, and from the <classname>Managar</classname>, it grabs
-        configuration. These are then used to retrieve the view, configure some
-        helpers, and then register a listener aggregate with the application
-        event manager.
+        application. It grabs the <classname>Application</classname> instance;
+        from the <classname>Application</classname>, it is able to grab the attached
+        service manager and configuration. These are then used to retrieve the
+        view, configure some helpers, and then register a listener aggregate
+        with the application event manager.
       </para>
     </section>
   </section>

--- a/documentation/manual/en/module_specs/Zend_Mvc-Intro.xml
+++ b/documentation/manual/en/module_specs/Zend_Mvc-Intro.xml
@@ -19,15 +19,17 @@
   <itemizedlist>
     <listitem>
       <para>
-        <classname>Zend\Di</classname>, specifically its
-        <classname>LocatorInterface</classname> interface, but by default the dependency
-        injection container
+        <classname>Zend\ServiceManager</classname>. Zend Framework provides a
+        set of default service definitions to use in order to create and
+        configure your application instance and workflow.
       </para>
     </listitem>
 
     <listitem>
       <para>
-        <classname>Zend\EventManager</classname>
+        <classname>Zend\EventManager</classname>, which is used everywhere from
+        initial bootstrapping of the application to returning the response; the
+        MVC is event driven.
       </para>
     </listitem>
 
@@ -76,16 +78,35 @@
         event wiring, action dispatching, etc.
       </para>
     </listitem>
+
+    <listitem>
+      <para>
+        <classname>Zend\Mvc\Service</classname>, which provides a set of
+        <classname>ServiceManager</classname> factories and definitions for the
+        default application workflow.
+      </para>
+    </listitem>
+
+    <listitem>
+      <para>
+        <classname>Zend\Mvc\View</classname>, which provides the default
+        wiring for renderer selection, view script resolution, helper
+        registration, and more; additionally, it provides a number of
+        listeners that tie into the MVC workflow to provide features such as
+        automated template name resolution, automated view model creation
+        and injection, and more.
+      </para>
+    </listitem>
   </itemizedlist>
 
   <para>
     The gateway to the MVC is the
-    <classname>Zend\Mvc\Application</classname> object (referred to simply
-    as <classname>Application</classname> from this point forward). Its
-    primary responsibilities are to <emphasis>route</emphasis> the
-    request, and to retrieve and <emphasis>dispatch</emphasis> the
-    controller discovered. Once accomplished, it returns a response,
-    which can then be <emphasis>sent</emphasis>.
+    <classname>Zend\Mvc\Application</classname> object (referred to simply as
+    <classname>Application</classname> from this point forward). Its primary
+    responsibilities are to <emphasis>bootstrap</emphasis> resources,
+    <emphasis>route</emphasis> the request, and to retrieve and
+    <emphasis>dispatch</emphasis> the controller discovered. Once accomplished,
+    it returns a response, which can then be <emphasis>sent</emphasis>.
   </para>
 
   <section xml:id="zend.mvc.intro.basic-application-structure">
@@ -98,7 +119,11 @@
     <literallayout>
 application_root/
     config/
-        application.config.php
+        application.php
+        autoload/
+            global.php
+            local.php
+            // etc.
     data/
     module/
     vendor/
@@ -181,8 +206,9 @@ module_root/
         &lt;module_namespace&gt;/
             &lt;test code files&gt;
     view/
-        &lt;dir-named-after-a-controller/
-            &lt;.phtml files&gt;
+        &lt;dir-named-after-module-namespace&gt;/
+            &lt;dir-named-after-a-controller&gt;/
+                &lt;.phtml files&gt;
 </literallayout>
 
     <para>
@@ -217,7 +243,10 @@ class Module
       <emphasis>every</emphasis> page request and should
       <emphasis>only</emphasis> be used for performing
       <emphasis>lightweight</emphasis> tasks such as registering event
-      listeners.
+      listeners. Similarly, an <methodname>onBootstrap()</methodname> method
+      (which accepts an <classname>MvcEvent</classname> instance) may be
+      defined; it will be triggered for every page request, and should be used
+      for lightweight tasks only.
     </para>
 
     <para>
@@ -304,102 +333,184 @@ class Module
     <title>Bootstrapping an Application</title>
 
     <para>
-      An <classname>Application</classname> composes several objects, but the
-      ones of particular interest to the developer are the Router and the
-      Locator. These will always need to be configured and injected in
-      order for the <classname>Application</classname> to run. Thus,
-      bootstrapping consists of configuring and injecting the router, as
-      well as the locator.
+        The <classname>Application</classname> has six basic dependencies.
     </para>
 
-    <para>
-      Zend Framework ships a default bootstrap implementation in
-      <classname>Zend\Mvc\Bootstrap</classname>. This class accepts an
-      instance of <classname>Zend\Config\Config</classname> to its constructor;
-      once you have an instance, you then call its
-      <methodname>bootstrap()</methodname> method, passing it the
-      <classname>Application</classname> instance. It will then configure your
-      locator (using <classname>Zend\Di\Di</classname> by default) and your
-      router (using <classname>Zend\Mvc\Router\Http\TreeRouteStack</classname>
-      by default).
-    </para>
+    <itemizedlist>
+        <listitem>
+            <para>
+                <emphasis role="strong">configuration</emphasis>, usually an
+                array or object implementing <classname>ArrayAccess</classname>.
+            </para>
+        </listitem>
+
+        <listitem>
+            <para>
+                <emphasis role="strong">ServiceManager</emphasis> instance.
+            </para>
+        </listitem>
+
+        <listitem>
+            <para>
+                <emphasis role="strong">EventManager</emphasis> instance, which,
+                by default, is pulled from the
+                <classname>ServiceManager</classname>, by the service name
+                "EventManager".
+            </para>
+        </listitem>
+
+        <listitem>
+            <para>
+                <emphasis role="strong">ModuleManager</emphasis> instance, which,
+                by default, is pulled from the
+                <classname>ServiceManager</classname>, by the service name
+                "ModuleManager".
+            </para>
+        </listitem>
+
+        <listitem>
+            <para>
+                <emphasis role="strong">Request</emphasis> instance, which,
+                by default, is pulled from the
+                <classname>ServiceManager</classname>, by the service name
+                "Request".
+            </para>
+        </listitem>
+
+        <listitem>
+            <para>
+                <emphasis role="strong">Response</emphasis> instance, which,
+                by default, is pulled from the
+                <classname>ServiceManager</classname>, by the service name
+                "Response".
+            </para>
+        </listitem>
+    </itemizedlist>
 
     <para>
-      Once those two tasks are accomplished, it then triggers a "bootstrap"
-      event on its attached <classname>EventManager</classname> instance. This
-      allows your modules to attach listeners, and thus perform additional, 
-      module-specific, bootstrapping tasks (which might include registering
-      ACLs, setting up cache or log listeners, etc.).
-    </para>
-
-    <para>
-      Usage would then be as follows:
+        These may be satisfied at instantiation:
     </para>
 
     <programlisting language="php"><![CDATA[
-// Assuming $config is the merged config from all modules
-$bootstrap   = new Bootstrap($config);
-$application = new Application();
-$bootstrap->bootstrap($application);
+use Zend\EventManager\EventManager;
+use Zend\Http\PhpEnvironment;
+use Zend\ModuleManager\ModuleManager;
+use Zend\Mvc\Application;
+use Zend\ServiceManager\ServiceManager;
+
+$config = include 'config/application.php';
+
+$serviceManager = new ServiceManager();
+$serviceManager->setService('EventManager', new EventManager());
+$serviceManager->setService('ModuleManager', new ModuleManager());
+$serviceManager->setService('Request', new PhpEnvironment\Request());
+$serviceManager->setService('Response', new PhpEnvironment\Response());
+
+$application = new Application($config, $serviceManager);
 ]]></programlisting>
 
     <para>
-      At this point, your <classname>Application</classname> would be ready
-      to run:
+      Once you've done this, there are two additional actions you can take. The
+      first is to "bootstrap" the application. In the default implementation,
+      this does the following:
+    </para>
+
+    <itemizedlist>
+        <listitem>
+            <para>
+                Attaches the default route listener
+                (<classname>Zend\Mvc\RouteListener</classname>).
+            </para>
+        </listitem>
+
+        <listitem>
+            <para>
+                Attaches the default dispatch listener
+                (<classname>Zend\Mvc\DispatchListener</classname>).
+            </para>
+        </listitem>
+
+        <listitem>
+            <para>
+                Attaches the <classname>ViewManager</classname> listener
+                (<classname>Zend\Mvc\View\ViewManager</classname>).
+            </para>
+        </listitem>
+
+        <listitem>
+            <para>
+                Creates the <classname>MvcEvent</classname>, and injects it with
+                the application, request, and response; it also retrieves the
+                router (<classname>Zend\Mvc\Router\Http\TreeRouteStack</classname>)
+                at this time and attaches it to the event.
+            </para>
+        </listitem>
+
+        <listitem>
+            <para>
+                Triggers the "bootstrap" event.
+            </para>
+        </listitem>
+    </itemizedlist>
+
+    <para>
+      If you do not want these actions, or want to provide alternatives, you can
+      do so by extending the <classname>Application</classname> class and/or
+      simply coding what actions you want to occur.
+    </para>
+
+    <para>
+      The second action you can take with the configured
+      <classname>Application</classname> is to <methodname>run()</methodname>
+      it. Calling this method simply does the following: it triggers the
+      "route" event, followed by the "dispatch" event, and, depending on
+      execution, the "render" event; when done, it triggers the "finish"
+      event, and then returns the response instance. If an error occurs during
+      either the "route" or "dispatch" event, a "dispatch.error" event is
+      triggered as well.
+    </para>
+
+    <para>
+      This is a lot to remember in order to bootstrap the application; in fact,
+      we haven't covered all the services available by default yet. You can
+      greatly simplify things by using the default
+      <classname>ServiceManager</classname> configuration shipped with the MVC.
     </para>
 
     <programlisting language="php"><![CDATA[
+use Zend\Loader\AutoloaderFactory;
+use Zend\Mvc\Service\ServiceManagerConfiguration;
+use Zend\ServiceManager\ServiceManager;
+
+// setup autoloader
+AutoloaderFactory::factory();
+
+// get application stack configuration
+$configuration = include 'config/application.config.php';
+
+// setup service manager
+$serviceManager = new ServiceManager(new ServiceManagerConfiguration());
+$serviceManager->setService('ApplicationConfiguration', $configuration);
+
+// load modules -- which will provide services, configuration, and more
+$serviceManager->get('ModuleManager')->loadModules();
+
+// bootstrap and run application
+$application = $serviceManager->get('Application');
+$application->bootstrap();
 $response = $application->run();
 $response->send();
 ]]></programlisting>
 
     <para>
-      The <methodname>run()</methodname> method does basically four things:
-    </para>
-
-    <itemizedlist>
-      <listitem>
-        <para>
-          It martials the <classname>Request</classname> object, ensuring that it
-          is fully configured based on the current request environment (this
-          includes injecting headers, query and POST parameters, and more).
-        </para>
-      </listitem>
-
-      <listitem>
-        <para>
-          It triggers a "route" event. By default, the
-          <methodname>route()</methodname> method of the
-          <classname>Application</classname> is registered as a listener, but you
-          can provide your own listeners to either replace it or intercept
-          before or after it executes.
-        </para>
-      </listitem>
-
-      <listitem>
-        <para>
-          It triggers a "dispatch" event. By default, the
-          <methodname>dispatch()</methodname> method of the
-          <classname>Application</classname> is registered as a listener, but you
-          can provide your own listeners to either replace it or intercept
-          before or after it executes.
-        </para>
-      </listitem>
-
-      <listitem>
-        <para>
-          It martials a <classname>Response</classname> object capable of sending
-          itself from the return values of the "dispatch" event.
-        </para>
-      </listitem>
-    </itemizedlist>
-
-    <para>
-      You'll note that you have a great amount of control over the
-      workflow. Using the EventManager's priority system, you can
-      intercept the "route" and "dispatch" events
-      anywhere during execution, allowing you to craft your own
-      application workflows as needed.
+      You'll note that you have a great amount of control over the workflow.
+      Using the <classname>ServiceManager</classname>, you have fine-grained
+      control over what services are available, how they are instantiated, and
+      what dependencies are injected into them. Using the
+      <classname>EventManager</classname>'s priority system, you can intercept
+      any of the application events ("bootstrap", "route", "dispatch",
+      "dispatch.error", "render", and "finish") anywhere during execution,
+      allowing you to craft your own application workflows as needed.
     </para>
   </section>
 
@@ -414,12 +525,11 @@ $response->send();
     </para>
 
     <para>
-      The answer is via <classname>Zend\Module\Manager</classname>. This
+      The answer is via <classname>Zend\ModuleManager\ModuleManager</classname>. This
       component allows you to specify where modules exist, and it will
-      then locate each module and initialize it. If a module's
-      <classname>Module</classname> class has a
-      <methodname>getConfig()</methodname> method, it will retrieve its
-      configuration and merge it with the application configuration.
+      then locate each module and initialize it. Module classes can tie into
+      various listeners on the <classname>ModuleManager</classname> in order to
+      provide configuration, services, listeners, and more to the application.
       Sound complicated? It's not.
     </para>
 
@@ -427,21 +537,19 @@ $response->send();
       <title>Configuring the Module Manager</title>
 
       <para>
-          The first step is configuring the module manager. The easiest way to
-          do this is to utilize the provided
-          <classname>Zend\Module\Listener\DefaultListenerAggregate</classname>.
-          Then you simply inform the module manager which modules to load and
-          attach the listener aggregate.
+          The first step is configuring the module manager.  You simply inform
+          the module manager which modules to load, and potentially provide
+          configuration for the module listeners.
       </para>
 
       <para>
-        Remember the <filename>application.config.php</filename> from
-        earlier? We're going to provide some configuration.
+        Remember the <filename>application.php</filename> from earlier? We're
+        going to provide some configuration.
       </para>
 
       <programlisting language="php"><![CDATA[
 <?php
-// config/application.config.php
+// config/application.php
 return array(
     'modules' => array(
         /* ... */
@@ -459,33 +567,6 @@ return array(
         As we add modules to the system, we'll add items to the
         <varname>modules</varname> array.
       </para>
-
-      <para>
-        Now, within our <filename>public/index.php</filename>, we can setup
-        the <classname>DefaultListenerAggregate</classname>:
-      </para>
-
-      <programlisting language="php"><![CDATA[
-use Zend\Module\Listener;
-
-$moduleConfig     = include __DIR__ . '/../configs/application.config.php';
-$listenerOptions  = new Listener\ListenerOptions($moduleConfig['module_listener_options']);
-$defaultListeners = new Listener\DefaultListenerAggregate($listenerOptions);
-]]></programlisting>
-
-      <para>
-        Once we have that out of the way, we can instantiate our module
-        manager:
-      </para>
-
-      <programlisting language="php"><![CDATA[
-use Zend\Module\Manager as ModuleManager;
-
-$moduleManager = new ModuleManager(
-    $moduleConfig['modules']
-);
-$moduleManager->events()->attachAggregate($defaultListeners);
-]]></programlisting>
 
       <para>
         Each <classname>Module</classname> class that has configuration it wants
@@ -506,6 +587,13 @@ class Module
     }
 }
 ]]></programlisting>
+
+      <para>
+        There are a number of other methods you can define for tasks ranging
+        from providing autoloader configuration, to providing services to the
+        <classname>ServiceManager</classname>, to listening to the bootstrap
+        event. The ModuleManager documentation goes into more detail on these.
+      </para>
     </section>
   </section>
 
@@ -513,15 +601,12 @@ class Module
     <title>Conclusion</title>
 
     <para>
-      The ZF2 MVC layer is incredibly flexible, offering an opt-in, easy
-      to create modular infrastructure, as well as the ability to craft
-      your own application workflows via the EventManager system.
-      Bootstrapping, while largely left to the developer, is
-      straight-forward and provides a simple methodology for configuring
-      the application and informing it of the various routes and services
-      in play. The module manager is a lightweight and simple approach to
-      enforcing a modular architecture that encourages clean separation
-      of concerns and code re-use.
+      The ZF2 MVC layer is incredibly flexible, offering an opt-in, easy to
+      create modular infrastructure, as well as the ability to craft your own
+      application workflows via the <classname>ServiceManager</classname> and
+      <classname>EventManager</classname>.  The module manager is a lightweight
+      and simple approach to enforcing a modular architecture that encourages
+      clean separation of concerns and code re-use.
     </para>
   </section>
 </section>

--- a/documentation/manual/en/module_specs/Zend_Mvc-MvcEvent.xml
+++ b/documentation/manual/en/module_specs/Zend_Mvc-MvcEvent.xml
@@ -24,6 +24,12 @@
   <itemizedlist>
     <listitem>
       <para>
+        <classname>Application</classname> object
+      </para>
+    </listitem>
+
+    <listitem>
+      <para>
         <classname>Request</classname> object
       </para>
     </listitem>
@@ -51,6 +57,13 @@
         "Result", usually the result of dispatching a controller
       </para>
     </listitem>
+
+    <listitem>
+      <para>
+        <classname>ViewModel</classname> object, typically representing the
+        layout view model
+      </para>
+    </listitem>
   </itemizedlist>
 
   <para>
@@ -58,6 +71,18 @@
   </para>
 
   <itemizedlist>
+    <listitem>
+      <para>
+        <methodname>setApplication($application)</methodname>
+      </para>
+    </listitem>
+
+    <listitem>
+      <para>
+        <methodname>getApplication()</methodname>
+      </para>
+    </listitem>
+
     <listitem>
       <para>
         <methodname>setRequest($request)</methodname>
@@ -117,14 +142,27 @@
         <methodname>getResult()</methodname>
       </para>
     </listitem>
+
+    <listitem>
+      <para>
+        <methodname>setViewModel($viewModel)</methodname>
+      </para>
+    </listitem>
+
+    <listitem>
+      <para>
+        <methodname>getViewModel()</methodname>
+      </para>
+    </listitem>
   </itemizedlist>
 
   <para>
-    Within <methodname>Application::run()</methodname>, the event is injected
-    with the Request, Response, and Router immediately. Following the
-    <varname>route</varname> event, it will be injected also with the
-    <classname>RouteMatch</classname> object encapsulating the results of
-    routing.
+    The <classname>Application</classname>, <classname>Request</classname>,
+    <classname>Response</classname>, <classname>Router</classname>, and
+    <classname>ViewModel</classname> are all injected during the
+    <varname>bootstrap</varname> event. Following the <varname>route</varname>
+    event, it will be injected also with the <classname>RouteMatch</classname>
+    object encapsulating the results of routing.
   </para>
 
   <para>

--- a/documentation/manual/en/module_specs/Zend_Mvc-Plugins.xml
+++ b/documentation/manual/en/module_specs/Zend_Mvc-Plugins.xml
@@ -210,7 +210,7 @@ public function successAction()
 
     <para>
       For the <classname>Forward</classname> plugin to work, the controller
-      calling it must be <classname>LocatorAware</classname>; otherwise, the
+      calling it must be <classname>ServiceManagerAware</classname>; otherwise, the
       plugin will be unable to retrieve a configured and injected
       instance of the requested controller.
     </para>
@@ -223,10 +223,10 @@ public function successAction()
     <itemizedlist>
       <listitem>
         <para>
-          <varname>$name</varname>, the name of the controller to invoke.
-          This may be either the fully qualified class name, or an alias
-          defined and recognized by the Locator instance attached to the
-          invoking controller.
+          <varname>$name</varname>, the name of the controller to invoke.  This
+          may be either the fully qualified class name, or an alias defined and
+          recognized by the <classname>ServiceManager</classname> instance
+          attached to the invoking controller.
         </para>
       </listitem>
 

--- a/documentation/manual/en/module_specs/Zend_Mvc-QuickStart.xml
+++ b/documentation/manual/en/module_specs/Zend_Mvc-QuickStart.xml
@@ -84,17 +84,10 @@ prompt> git clone --recursive git://github.com/zendframework/ZendSkeletonApplica
     <para>
       By default, one module is provided with the
       <classname>ZendSkeletonApplication</classname>, named
-      "Application". It provides the following:
+      "Application". It provides simply a controller to handle the "home" page
+      of the application, the layout template, and templates for 404 and error
+      pages.
     </para>
-
-    <itemizedlist>
-      <listitem>
-        <para>
-          A view listener that will render views based on the selected
-          controller, and inject it into a site layout.
-        </para>
-      </listitem>
-    </itemizedlist>
 
     <para>
       Typically, you will not need to touch this other than to provide an
@@ -168,15 +161,9 @@ return array();
 
     <programlisting language="php"><![CDATA[
 return array(
-    'di' => array(
-        'instance' => array(
-            'alias' => array(
-            ),
-            'Zend\View\TemplatePathStack' => array('parameters' => array(
-                'paths'  => array(
-                    '<module-name>' => __DIR__ . '/../views',
-                ),
-            )),
+    'view_manager' => array(
+        'template_path_stack' => array(
+            '<module-name>' => __DIR__ . '/../view'
         ),
     ),
 );
@@ -195,8 +182,6 @@ return array(
 
     <programlisting language="php"><![CDATA[
 namespace <your module name here>;
-
-use Zend\Module\Consumer\AutoloaderProvider;
 
 class Module implements AutoloaderProvider
 {
@@ -312,14 +297,15 @@ class Module implements AutoloaderProvider
 <?php
 namespace <module name>\Controller;
 
-use Zend\Mvc\Controller\ActionController,
-    Zend\View\Model\ViewModel;
+use Zend\Mvc\Controller\ActionController;
+use Zend\View\Model\ViewModel;
 
 class HelloController extends ActionController
 {
     public function worldAction()
     {
-        $message = $this->getRequest()->query()->get('message', 'foo');
+        $request = $this->getRequest();
+        $message = $request->query()->get('message', 'foo');
         return new ViewModel(array('message' => $message));
     }
 }
@@ -377,9 +363,9 @@ class HelloController extends ActionController
     <title>Create a view script</title>
 
     <para>
-      Create the directory <filename>view/hello</filename>.  Inside that
-      directory, create a file named <filename>world.phtml</filename>. Inside
-      that, paste in the following:
+      Create the directory <filename>view/&lt;module-name&gt;hello</filename>.
+      Inside that directory, create a file named
+      <filename>world.phtml</filename>. Inside that, paste in the following:
     </para>
 
     <programlisting language="php"><![CDATA[
@@ -427,34 +413,46 @@ class HelloController extends ActionController
     </note>
 
     <para>
-      Open your <filename>configs/module.config.php</filename> file, and
-      modify it to add to the "routes" parameters so it reads as
+      Additionally, we need to tell the application we have a controller.
+    </para>
+
+    <note>
+        <para>
+            We inform the application about controllers we expect to have in the
+            application. This is to prevent somebody requesting any service the
+            <classname>ServiceManager</classname> knows about in an attempt to
+            break the application. The dispatcher uses a special, scoped
+            container that will only pull controllers that are specifically
+            registered with it, either as invokable classes or via factories.
+        </para>
+    </note>
+
+    <para>
+      Open your <filename>config/module.config.php</filename> file, and modify
+      it to add to the "routes" and "controller" parameters so it reads as
       follows:
     </para>
 
     <programlisting language="php"><![CDATA[
 return array(
-    'di' => array(
-        'instance' => array(
-            'Zend\Mvc\Router\RouteStack' => array(
-                'parameters' => array(
-                    'routes' => array(
-                        '<module name>-hello-world' => array(
-                            'type'    => 'Zend\Mvc\Router\Http\Literal',
-                                'options' => array(
-                                'route' => '/hello/world',
-                                'defaults' => array(
-                                    'controller' => '<module namespace>\Controller\HelloController',
-                                    'action'     => 'world',
-                                ),
-                            ),
-                        ),
-                    ),
+    'routes' => array(
+        '<module name>-hello-world' => array(
+            'type'    => 'Literal',
+                'options' => array(
+                'route' => '/hello/world',
+                'defaults' => array(
+                    'controller' => '<module namespace>-Hello',
+                    'action'     => 'world',
                 ),
             ),
         ),
-        // ... other di configuration ...
     ),
+    'controller' => array(
+        'classes' => array(
+            '<module namespace>-Hello' => '<module namespace>\Controller\HelloController',
+        ),
+    ),
+    // ... other configuration ...
 );
 ]]></programlisting>
   </section>
@@ -473,7 +471,7 @@ return array(
     </para>
 
     <para>
-      Remember the <filename>config/application.config.php</filename>
+      Remember the <filename>config/application.php</filename>
       file? Let's modify it to add our new module. Once done, it should
       read as follows:
     </para>

--- a/documentation/manual/en/module_specs/Zend_Mvc-Services.xml
+++ b/documentation/manual/en/module_specs/Zend_Mvc-Services.xml
@@ -1,0 +1,658 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Reviewed: no -->
+<section 
+    xmlns="http://docbook.org/ns/docbook" version="5.0"
+    xml:id="zend.mvc.services">
+  <title>Default Services</title>
+
+  <para>
+      The default and recommended way to write Zend Framework applications uses a set of services
+      defined in the <classname>Zend\Mvc\Service</classname> namespace. This chapter details what
+      each of those services are, the classes they represent, and the configuration options
+      available.
+  </para>
+
+  <section xml:id="zend.mvc.services.service-manager-configuration">
+      <info><title>ServiceManagerConfiguration</title></info>
+
+      <para>
+          This is the one service class referenced directly in the bootstrapping. It provides the
+          following:
+      </para>
+
+      <itemizedlist>
+          <listitem>
+              <para><emphasis role="strong">Invokable services</emphasis></para>
+
+              <itemizedlist>
+                  <listitem>
+                      <para>
+                          <classname>DispatchListener</classname>, mapping to
+                          <classname>Zend\Mvc\DispatchListener</classname>.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>Request</classname>, mapping to
+                          <classname>Zend\Http\PhpEnvironment\Request</classname>.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>Response</classname>, mapping to
+                          <classname>Zend\Http\PhpEnvironment\Response</classname>.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>RouteListener</classname>, mapping to
+                          <classname>Zend\Mvc\RouteListener</classname>.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>VeiwManager</classname>, mapping to
+                          <classname>Zend\Mvc\View\ViewManager</classname>.
+                      </para>
+                  </listitem>
+              </itemizedlist>
+          </listitem>
+
+          <listitem>
+              <para><emphasis role="strong">Factories</emphasis></para>
+
+              <itemizedlist>
+                  <listitem>
+                      <para>
+                          <classname>Application</classname>, mapping to
+                          <classname>Zend\Mvc\Service\ApplicationFactory</classname>.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>Configuration</classname>, mapping to
+                          <classname>Zend\Mvc\Service\ConfigurationFactory</classname>. Internally,
+                          this pulls the <classname>ModuleManager</classname> service, and calls its
+                          <methodname>loadModules()</methodname> method, and retrieves the merged
+                          configuration from the module event. As such, this service contains the
+                          entire, merged application configuration.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>ControllerLoader</classname>, mapping to
+                          <classname>Zend\Mvc\Service\ControllerLoaderFactory</classname>.
+                          Internally, this pulls the <classname>Configuration</classname> service,
+                          and, if it contains a <varname>controller</varname> key, inspects that for
+                          <varname>classes</varname> and
+                          <varname>factories</varname> subkeys. These are used to configure a scoped service manager
+                          container, from which controllers will be retrieved.
+                      </para>
+
+                      <para>
+                          Additionally, the scoped container is configured to use the
+                          <classname>Di</classname> service as both an initializer as well as an
+                          abstract service factory -- effectively allowing you to fall back to DI in
+                          order to retrieve your controllers.
+                      </para>
+
+                      <para>
+                          Finally, if the loaded controller is <classname>Pluggable</classname>, an
+                          initializer will inject it with the
+                          <classname>ControllerPluginBroker</classname> service.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>ControllerPluginBroker</classname>, mapping to
+                          <classname>Zend\Mvc\Service\ControllerPluginBrokerFactory</classname>.
+                          This instantiates the
+                          <classname>Zend\Mvc\Controller\PluginBroker</classname> instance, passing
+                          it the <classname>ControllerPluginLoader</classname> service as well as
+                          the service manager instance.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>ControllerPluginLoader</classname>, mapping to
+                          <classname>Zend\Mvc\Service\ControllerPluginLoaderFactory</classname>.
+                          This grabs the <classname>Configuration</classname> service, and looks for
+                          a <varname>controller</varname> key with a <varname>map</varname> subkey. If found, this value is passed to
+                          the constructor of <classname>Zend\Mvc\Controller\PluginLoader</classname>
+                          (otherwise, an empty array is passed).
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>DependencyInjector</classname>, mapping to
+                          <classname>Zend\Mvc\Service\DiFactory</classname>. This pulls the
+                          <classname>Configuration</classname> service, and looks for a "di" key; if
+                          found, that value is used to configure a new
+                          <classname>Zend\Di\Di</classname> instance. Additionally, the
+                          <classname>Di</classname> instance is used to seed a
+                          <classname>Zend\ServiceManager\Di\DiAbstractServiceFactory</classname>
+                          instance which is then attached to the service manager as an abstract
+                          factory -- effectively enabling DI as a fallback for providing services.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>EventManager</classname>, mapping to
+                          <classname>Zend\Mvc\Service\EventManagerFactory</classname>. This factory
+                          composes a static reference to a
+                          <classname>SharedEventManager</classname>, which is injected in a new
+                          <classname>EventManager</classname> instance. This service is not shared
+                          by default, allowing the ability to have an
+                          <classname>EventManager</classname> per service, with a shared
+                          <classname>SharedEventManager</classname> injected in each.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>ModuleManager</classname>, mapping to
+                          <classname>Zend\Mvc\Service\ModuleManagerFactory</classname>.
+                      </para>
+
+                      <para>
+                          This is perhaps the most complex factory in the MVC stack. It expects that
+                          an <classname>ApplicationConfiguration</classname> service has been injected, with keys for
+                          <varname>module_listener_options</varname> and <varname>modules</varname>; see the quick start for samples.
+                      </para>
+
+                      <para>
+                          It instantiates an instance of
+                          <classname>Zend\ModuleManager\Listener\DefaultListenerAggregate</classname>,
+                          using the "module_listener_options" retrieved. It also instantiates an
+                          instance of
+                          <classname>Zend\ModuleManager\Listener\ServiceListener</classname>,
+                          providing it the service manager.
+                      </para>
+
+                      <para>
+                          Next, it retrieves the <classname>EventManager</classname> service, and
+                          attaches the above listeners.
+                      </para>
+
+                      <para>
+                          It instantiates a <classname>Zend\ModuleManager\ModuleEvent</classname>
+                          instance, setting the "ServiceManager" parameter to the service manager
+                          object.
+                      </para>
+
+                      <para>
+                          Finally, it instantiates a
+                          <classname>Zend\ModuleManager\ModuleManager</classname> instance, and
+                          injects the <classname>EventManager</classname> and
+                          <classname>ModuleEvent</classname>.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>Router</classname>, mapping to
+                          <classname>Zend\Mvc\Service\RouterFactory</classname>. This grabs the
+                          <classname>Configuration</classname> service, and pulls from the <varname>router</varname>
+                          key, passing it to
+                          <methodname>Zend\Mvc\Router\Http\TreeRouteStack::factory</methodname> in
+                          order to get a configured router instance.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>ViewFeedRenderer</classname>, mapping to
+                          <classname>Zend\Mvc\Service\ViewFeedRendererFactory</classname>, which
+                          simply returns a <classname>Zend\View\Renderer\FeedRenderer</classname>
+                          instance.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>ViewFeedStrategy</classname>, mapping to
+                          <classname>Zend\Mvc\Service\ViewFeedStrategyFactory</classname>. This
+                          instantiates a <classname>Zend\View\Strategy\FeedStrategy</classname>
+                          instance with the <classname>VeiwFeedRenderer</classname> service.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>ViewJsonRenderer</classname>, mapping to
+                          <classname>Zend\Mvc\Service\ViewJsonRendererFactory</classname>, which
+                          simply returns a <classname>Zend\View\Renderer\JsonRenderer</classname>
+                          instance.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>ViewJsonStrategy</classname>, mapping to
+                          <classname>Zend\Mvc\Service\ViewJsonStrategyFactory</classname>. This
+                          instantiates a <classname>Zend\View\Strategy\JsonStrategy</classname>
+                          instance with the <classname>VeiwJsonRenderer</classname> service.
+                      </para>
+                  </listitem>
+              </itemizedlist>
+          </listitem>
+
+          <listitem>
+              <para><emphasis role="strong">Aliases</emphasis></para>
+
+              <itemizedlist>
+                  <listitem>
+                      <para>
+                          <classname>Config</classname>, mapping to the
+                          <classname>Configuration</classname> service.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>Di</classname>, mapping to the
+                          <classname>DependencyInjector</classname> service.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>Zend\EventManager\EventManagerInterface</classname>, mapping to the
+                          <classname>EventManager</classname> service. This is mainly to
+                          ensure that when falling through to DI, classes are still injected via the
+                          <classname>ServiceManager</classname>.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>Zend\Mvc\Controller\PluginBroker</classname>, mapping to the
+                          <classname>ControllerPluginBroker</classname> service. This is mainly to
+                          ensure that when falling through to DI, classes are still injected via the
+                          <classname>ServiceManager</classname>.
+                      </para>
+                  </listitem>
+
+                  <listitem>
+                      <para>
+                          <classname>Zend\Mvc\Controller\PluginLoader</classname>, mapping to the
+                          <classname>ControllerPluginLoader</classname> service. This is mainly to
+                          ensure that when falling through to DI, classes are still injected via the
+                          <classname>ServiceManager</classname>.
+                      </para>
+                  </listitem>
+
+              </itemizedlist>
+          </listitem>
+      </itemizedlist>
+
+      <para>
+          Additionally, two initializers are registered. Initializers are run on created instances,
+          and may be used to further configure them. The two initializers the
+          <classname>ServiceManagerConfiguration</classname> class creates and registers do the
+          following:
+      </para>
+
+      <itemizedlist>
+          <listitem>
+              <para>
+                  For objects that implement
+                  <classname>Zend\EventManager\EventManagerAwareInterface</classname>, the
+                  <classname>EventManager</classname> service will be retrieved and injected. This
+                  service is <emphasis role="strong">not</emphasis> shared, though each instance it
+                  creates is injected with a shared instance of
+                  <classname>SharedEventManager</classname>.
+              </para>
+          </listitem>
+
+          <listitem>
+              <para>
+                  For objects that implement
+                  <classname>Zend\ServiceManager\ServiceManagerAwareInterface</classname>, the
+                  <classname>ServiceManager</classname> will inject itself into the object.
+              </para>
+          </listitem>
+      </itemizedlist>
+
+      <para>
+          Finally, the <classname>ServiceManager</classname> registers itself as the
+          <classname>ServiceManager</classname> service, and aliases itself to the class names
+          <classname>Zend\ServiceManager\ServiceManagerInterface</classname> and
+          <classname>Zend\ServiceManager\ServiceManager</classname>.
+      </para>
+  </section>
+
+  <section xml:id="zend.mvc.services.view-manager">
+      <info><title>ViewManager</title></info>
+
+      <para>
+          The View layer within <classname>Zend\Mvc</classname> consists of a large number of
+          collaborators and event listeners. As such,
+          <classname>Zend\Mvc\View\ViewManager</classname> was created to handle creation of the
+          various objects, as well as wiring them together and establishing event listeners.
+      </para>
+
+      <para>
+          The <classname>ViewManager</classname> itself is an event listener on the
+          <varname>bootstrap</varname> event. It retrieves the <classname>ServiceManager</classname>
+          from the <classname>Application</classname> object, as well as its composed
+          <classname>EventManager</classname>. 
+      </para>
+
+      <para>
+          Configuration for all members of the <classname>ViewManager</classname> fall under the
+          <varname>view_manager</varname> configuration key, and expect values as noted below.
+          The following services are created and managed by the <classname>ViewManager</classname>:
+      </para>
+
+      <itemizedlist>
+            <listitem>
+                <para>
+                    <classname>ViewHelperLoader</classname>, representing and aliased to
+                    <classname>Zend\View\HelperLoader</classname>. If a
+                    <varname>helper_map</varname> subkey is provided, its value will be used as a
+                    map to seed the helper loader.
+                </para>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <classname>ViewHelperBroker</classname>, representing and aliased to
+                    <classname>Zend\View\HelperBroker</classname>. It is seeded with the
+                    <classname>ViewHelperLoader</classname> service, as well as the
+                    <classname>ServiceManager</classname> itself. 
+                </para>
+
+                <para>
+                    The <classname>Router</classname> service is retrieved, and injected into the
+                    <classname>Url</classname> helper. 
+                </para>
+
+                <para>
+                    If the <varname>base_path</varname> key is present, it is used to inject the
+                    <classname>BasePath</classname> view helper; otherwise, the
+                    <classname>Request</classname> service is retrieved, and the value of its
+                    <methodname>getBasePath()</methodname> method is used.
+                </para>
+
+                <para>
+                    If the <varname>doctype</varname> key is present, it will be used to set the
+                    value of the <classname>Doctype</classname> view helper.
+                </para>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <classname>ViewTemplateMapResolver</classname>, representing and aliased to
+                    <classname>Zend\View\Resolver\TemplateMapResolver</classname>. If a
+                    <varname>template_map</varname> key is present, it will be used to seed the
+                    template map.
+                </para>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <classname>ViewTemplatePathStack</classname>, representing and aliased to
+                    <classname>Zend\View\Resolver\TemplatePathStack</classname>. If a
+                    <varname>template_path_stack</varname> key is prsent, it will be used to seed
+                    the stack.
+                </para>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <classname>ViewResolver</classname>, representing and  aliased to
+                    <classname>Zend\View\Resolver\AggregateResolver</classname> and
+                    <classname>Zend\View\Resolver\ResolverInterface</classname>. It is seeded with
+                    the <classname>ViewTemplateMapResolver</classname> and
+                    <classname>ViewTemplatePathStack</classname> services as resolvers.
+                </para>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <classname>ViewRenderer</classname>, representing and aliased to
+                    <classname>Zend\View\Renderer\PhpRenderer</classname> and
+                    <classname>Zend\View\Renderer\RendererInterface</classname>. It is seeded with
+                    the <classname>ViewResolver</classname> and
+                    <classname>ViewHelperBroker</classname> services. Additionally, the
+                    <classname>ViewModel</classname> helper gets seeded with the
+                    <classname>ViewModel</classname> as its root (layout) model.
+                </para>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <classname>ViewPhpRendererStrategy</classname>, representing and aliased to
+                    <classname>Zend\View\Strategy\PhpRendererStrategy</classname>. It gets seeded
+                    with the <classname>ViewRenderer</classname> service.
+                </para>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <classname>View</classname>, representing and aliased to
+                    <classname>Zend\View\View</classname>. It gets seeded with the
+                    <classname>EventManager</classname> service, and attaches the
+                    <classname>ViewPhpRendererStrategy</classname> as an aggregate listener.
+                </para>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <classname>DefaultRenderingStrategy</classname>, representing and aliased to
+                    <classname>Zend\Mvc\View\DefaultRenderingStrategy</classname>. If the
+                    <varname>layout</varname> key is prsent, it is used to seed the strategy's
+                    layout template. It is seeded with the <classname>View</classname> service.
+                </para>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <classname>ExceptionStrategy</classname>, representing and aliased to
+                    <classname>Zend\Mvc\View\ExceptionStrategy</classname>. If the
+                    <varname>dislay_exceptions</varname> or <varname>exception_template</varname>
+                    keys are present, they are usd to configure the strategy.
+                </para>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <classname>RouteNotFoundStrategy</classname>, representing and aliased to
+                    <classname>Zend\Mvc\View\RouteNotFoundStrategy</classname> and
+                    <classname>404Stategy</classname>. If the
+                    <varname>display_not_found_reason</varname> or
+                    <varname>not_found_template</varname> keys are present, they are used to
+                    configure the strategy.
+                </para>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <classname>ViewModel</classname>. In this case, no service is registered; the
+                    <classname>ViewModel</classname> is simply retrieved from the
+                    <classname>MvcEvent</classname> and injected with the layout template name.
+                    template
+                </para>
+            </listitem>
+      </itemizedlist>
+
+      <para>
+          The <classname>ViewManager</classname> also creates several other listeners, but does not
+          expose them as services; these include
+          <classname>Zend\Mvc\View\CreateViewModelListener</classname>,
+          <classname>Zend\Mvc\View\InjectTemplateListener</classname>, and
+          <classname>Zend\Mvc\View\InjectViewModelListener</classname>. These, along with
+          <classname>RouteNotFoundStrategy</classname>,
+          <classname>ExceptionStrategy</classname>, and
+          <classname>DefaultRenderingStrategy</classname> are attached as listeners either to the
+          application
+          <classname>EventManager</classname> instance or the
+          <classname>SharedEventManager</classname> instance.
+      </para>
+
+      <para>
+          Finally, if you have a <varname>strategies</varname> key in your configuration, the
+          <classname>ViewManager</classname> will loop over these and attach them in order to the
+          <classname>View</classname> service as listeners, at a priority of 100 (allowing them to
+          execute before the <classname>DefaultRenderingStrategy</classname>).
+      </para>
+  </section>
+
+  <section xml:id="zend.mvc.services.app-config">
+      <info><title>Application Configuration Options</title></info>
+
+      <para>
+          The following options may be used to provide initial configuration for the
+          <classname>ServiceManager</classname>, <classname>ModuleManager</classname>, and
+          <classname>Application</classname> instances, allowing them to then find and aggregate the
+          configuration used for the <classname>Configuration</classname> service, which is intended
+          for configuring all other objects in the system.
+      </para>
+
+      <programlisting language="php"><![CDATA[
+<?php
+return array(
+    // This should be an array of module namespaces used in the application.
+    'modules' => array(
+    ),
+
+    // These are various options for the listeners attached to the ModuleManager
+    'module_listener_options' => array(
+        // This should be an array of paths in which modules reside.
+        // If a string key is provided, the listener will consider that a module
+        // namespace, the value of that key the specific path to that module's 
+        // Module class.
+        'module_paths' => array(
+        ),
+
+        // An array of paths from which to glob configuration files after 
+        // modules are loaded. These effectively overide configuration 
+        // provided by modules themselves. Paths may use GLOB_BRACE notation.
+        'config_glob_paths' => array(
+        ),
+
+        // Whether or not to enable a configuration cache.
+        // If enabled, the merged configuration will be cached and used in
+        // subsequent requests.
+        'config_cache_enabled' => $booleanValue,
+
+        // The key used to create the configuration cache file name.
+        'config_cache_key' => $stringKey,
+
+        // The path in which to cache merged configuration.
+        'cache_dir' => $stringPath,
+    ),
+
+    // Initial configuration with which to seed the ServiceManager.
+    // Should be compatible with Zend\ServiceManager\Configuration.
+    'service_manager' => array(
+    ),
+);
+]]></programlisting>
+  </section>
+
+  <section xml:id="zend.mvc.services.config">
+      <info><title>Default Configuration Options</title></info>
+
+      <para>
+          The following options are available when using the default services configured by the
+          <classname>ServiceManagerConfiguration</classname> and <classname>ViewManager</classname>.
+      </para>
+
+      <programlisting language="php"><![CDATA[
+<?php
+return array(
+    // The following are used to configure controller or controller plugin loading
+    'controller' => array(
+        // Map of controller "name" to class
+        // This should be used if you do not need to inject any dependencies
+        // in your controller
+        'classes' => array(
+        ),
+
+        // Map of controller "name" to factory for creating controller instance
+        // You may provide either the class name of a factory, or a PHP callback.
+        'factories' => array(
+        ),
+
+        // Map of controller plugin names to their classes
+        'map' => array(
+        ),
+    ),
+
+    // The following is used to configure a Zend\Di\Di instance.
+    // The array should be in a format that Zend\Di\Configuration can understand.
+    'di' => array(
+    ),
+
+    // Configuration for the Router service
+    // Can contain any router configuration, but typically will always define
+    // the routes for the application. See the router documentation for details
+    // on route configuration.
+    'router' => array(
+        'routes' => array(
+        ),
+    ),
+
+    // ViewManager configuration
+    'view_manager' => array(
+        // Defined helpers.
+        // Typically helper name/helper class pairs. Can contain values without keys
+        // that refer to either Traversable classes or Zend\Loader\PluginClassLoader
+        // instances as well.
+        'helper_map' => array(
+            'foo' => 'My\Helper\Foo',      // name/class pair
+            'Zend\Form\View\HelperLoader', // additional helper loader to seed
+        ),
+
+        // Base URL path to the application
+        'base_path' => $stringBasePath,
+
+        // Doctype with which to seed the Doctype helper
+        'doctype' => $doctypeHelperConstantString, // e.g. HTML5, XHTML1
+
+        // TemplateMapResolver configuration
+        // template/path pairs
+        'template_map' => array(
+        ),
+
+        // TemplatePathStack configuration
+        // module/view script path pairs
+        'template_path_stack' => array(
+        ),
+
+        // Layout template name
+        'layout' => $layoutTemplateName, // e.g., 'layout/layout'
+
+        // ExceptionStrategy configuration
+        'display_exceptions' => $bool, // display exceptions in template
+        'exception_template' => $stringTemplateName, // e.g. 'error'
+
+        // RouteNotFoundStrategy configuration
+        'display_not_found_reason' => $bool, // display 404 reason in template
+        'not_found_template' => $stringTemplateName, // e.g. '404'
+
+        // Additional strategies to attach
+        // These should be class names or service names of View strategy classes
+        // that act as ListenerAggregates. They will be attached at priority 100, 
+        // in the order registered.
+        'strategies' => array(
+            'ViewJsonStrategy', // register JSON renderer strategy
+            'ViewFeedStrategy', // register Feed renderer strategy
+        ),
+    ),
+);
+]]></programlisting>
+  </section>
+</section>


### PR DESCRIPTION
Updated MVC docs to discuss ServiceManager and remove references to DI. QuickStart is rewritten to follow new ZendSkeletonApplication. New "Services" section added to discuss all default services, as well as all available configuration options for those services.
