### PR TITLE
Zend/Http/Client setParameterGet/Post replaces the entire storage GData/App.php

### DIFF
--- a/library/Zend/GData/App.php
+++ b/library/Zend/GData/App.php
@@ -632,9 +632,7 @@ class App
         preg_match("/^(.*?)(\?.*)?$/", $uri, $matches);
         $this->_httpClient->setUri($matches[1]);
         $queryArray = $uriObj->getQueryAsArray();
-        foreach ($queryArray as $name => $value) {
-          $this->_httpClient->setParameterGet(array($name, $value));
-        }
+        $this->_httpClient->setParameterGet($queryArray);
 
 
         $this->_httpClient->setOptions(array('maxredirects' => 0));


### PR DESCRIPTION
I noticed that the Client->setParameterGet replaces the stored value with the provided argument

as a result of this looping in the GData/App.php

``` php
$queryArray = $uriObj->getQueryAsArray();
foreach ($queryArray as $name => $value) {
    $this->_httpClient->setParameterGet(array($name, $value));
}
```

causes the "GET" to be equal to the last element
(not to mention that the 

array($name,$value) should be array($name=>$value) but that's a different bug
