### PR TITLE
Handle return of config object from $this->config['helper_map'] in ViewManager

### DIFF
--- a/library/Zend/Mvc/View/ViewManager.php
+++ b/library/Zend/Mvc/View/ViewManager.php
@@ -178,6 +178,9 @@ class ViewManager implements ListenerAggregateInterface
         $map = array();
         if (isset($this->config['helper_map'])) {
             $map = $this->config['helper_map'];
+            if(!is_array($map)){
+                $map = $map->toArray();
+            }
         }
         if (!in_array('Zend\Form\View\HelperLoader', $map)) {
             array_unshift($map, 'Zend\Form\View\HelperLoader');


### PR DESCRIPTION
There was a warning when config object, rather than array was returned.
