### PR TITLE
remove unused $_logger  member in Zend\Queue\Queue

### DIFF
--- a/library/Zend/Queue/Queue.php
+++ b/library/Zend/Queue/Queue.php
@@ -76,11 +76,6 @@ class Queue implements Countable
     protected $_messageSetClass = '\Zend\Queue\Message\MessageIterator';
 
     /**
-     * @var \Zend\Log\Logger
-     */
-    protected $_logger = null;
-
-    /**
      * Constructor
      *
      * Can be called as


### PR DESCRIPTION
This is also appeared on zf1 :-/
http://framework.zend.com/issues/browse/ZF-12240
