### PR TITLE
Feature/di compiler runtime definition config

### DIFF
--- a/library/Zend/Di/Configuration.php
+++ b/library/Zend/Di/Configuration.php
@@ -65,6 +65,10 @@ class Configuration
                         }
                         $definitions = new DefinitionList($definitions);
                         $di->setDefinitionList($definitions);
+                    } elseif (isset($definitionData['use_annotations']) && $definitionData['use_annotations']) {
+                        $di->definitions()->getDefinitionByType('\Zend\Di\Definition\RuntimeDefinition')
+                            ->getIntrospectionStrategy()
+                            ->setUseAnnotations(true);
                     }
                     break;
                 case 'class':

--- a/library/Zend/Di/Configuration.php
+++ b/library/Zend/Di/Configuration.php
@@ -48,7 +48,11 @@ class Configuration
         foreach ($definition as $definitionType => $definitionData) {
             switch ($definitionType) {
                 case 'compiler':
-                    // @todo
+                    foreach ($definitionData as $filename) {
+                        if (is_readable($filename)) {
+                            $di->definitions()->addDefinition(new \Zend\Di\Definition\ArrayDefinition(include $filename), false);
+                        }
+                    }
                     break;
                 case 'runtime':
                     // @todo

--- a/library/Zend/Di/Configuration.php
+++ b/library/Zend/Di/Configuration.php
@@ -55,7 +55,17 @@ class Configuration
                     }
                     break;
                 case 'runtime':
-                    // @todo
+                    if (isset($definitionData['enabled']) && !$definitionData['enabled']) {
+                        // Remove runtime from definition list if not enabled
+                        $definitions = array();
+                        foreach ($di->definitions() as $definition) {
+                            if (!$definition instanceof \Zend\Di\Definition\RuntimeDefinition) {
+                                $definitions[] = $definition;
+                            }
+                        }
+                        $definitions = new DefinitionList($definitions);
+                        $di->setDefinitionList($definitions);
+                    }
                     break;
                 case 'class':
                     foreach ($definitionData as $className => $classData) {

--- a/tests/Zend/Di/ConfigurationTest.php
+++ b/tests/Zend/Di/ConfigurationTest.php
@@ -103,4 +103,20 @@ class ConfigurationTest extends TestCase
         $definition = $di->definitions()->getDefinitionByType('Zend\Di\Definition\RuntimeDefinition');
         $this->assertTrue($definition->getIntrospectionStrategy()->getUseAnnotations());
     }
+
+    public function testConfigurationCanConfigureCompiledDefinition()
+    {
+        $config = ConfigFactory::fromFile(__DIR__ . '/_files/sample.php', true);
+        $config = new Configuration($config->di);
+        $di = new Di();
+        $di->configure($config);
+        $definition = $di->definitions()->getDefinitionByType('Zend\Di\Definition\ArrayDefinition');
+        $this->assertInstanceOf('Zend\Di\Definition\ArrayDefinition', $definition);
+        $this->assertTrue($di->definitions()->hasClass('My\DbAdapter'));
+        $this->assertTrue($di->definitions()->hasClass('My\EntityA'));
+        $this->assertTrue($di->definitions()->hasClass('My\Mapper'));
+        $this->assertTrue($di->definitions()->hasClass('My\RepositoryA'));
+        $this->assertTrue($di->definitions()->hasClass('My\RepositoryB'));
+        $this->assertFalse($di->definitions()->hasClass('My\Foo'));
+    }
 }

--- a/tests/Zend/Di/ConfigurationTest.php
+++ b/tests/Zend/Di/ConfigurationTest.php
@@ -72,7 +72,25 @@ class ConfigurationTest extends TestCase
             );
         
     }
-    
 
-    
+    public function testConfigurationCanConfigureRuntimeDefinitionEnabledByDefaultFromIni()
+    {
+        $ini = ConfigFactory::fromFile(__DIR__ . '/_files/sample.ini', true)->get('section-c');
+        $config = new Configuration($ini->di);
+        $di = new Di();
+        $di->configure($config);
+        $definition = $di->definitions()->getDefinitionByType('Zend\Di\Definition\RuntimeDefinition');
+        $this->assertInstanceOf('Zend\Di\Definition\RuntimeDefinition', $definition);
+    }
+
+    public function testConfigurationCanConfigureRuntimeDefinitionDisabledFromIni()
+    {
+        $ini = ConfigFactory::fromFile(__DIR__ . '/_files/sample.ini', true)->get('section-d');
+        $config = new Configuration($ini->di);
+        $di = new Di();
+        $di->configure($config);
+        $definition = $di->definitions()->getDefinitionByType('Zend\Di\Definition\RuntimeDefinition');
+        $this->assertFalse($definition);
+    }
+
 }

--- a/tests/Zend/Di/ConfigurationTest.php
+++ b/tests/Zend/Di/ConfigurationTest.php
@@ -73,7 +73,7 @@ class ConfigurationTest extends TestCase
         
     }
 
-    public function testConfigurationCanConfigureRuntimeDefinitionEnabledByDefaultFromIni()
+    public function testConfigurationCanConfigureRuntimeDefinitionDefaultFromIni()
     {
         $ini = ConfigFactory::fromFile(__DIR__ . '/_files/sample.ini', true)->get('section-c');
         $config = new Configuration($ini->di);
@@ -81,6 +81,7 @@ class ConfigurationTest extends TestCase
         $di->configure($config);
         $definition = $di->definitions()->getDefinitionByType('Zend\Di\Definition\RuntimeDefinition');
         $this->assertInstanceOf('Zend\Di\Definition\RuntimeDefinition', $definition);
+        $this->assertFalse($definition->getIntrospectionStrategy()->getUseAnnotations());
     }
 
     public function testConfigurationCanConfigureRuntimeDefinitionDisabledFromIni()
@@ -93,4 +94,13 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($definition);
     }
 
+    public function testConfigurationCanConfigureRuntimeDefinitionUseAnnotationFromIni()
+    {
+        $ini = ConfigFactory::fromFile(__DIR__ . '/_files/sample.ini', true)->get('section-e');
+        $config = new Configuration($ini->di);
+        $di = new Di();
+        $di->configure($config);
+        $definition = $di->definitions()->getDefinitionByType('Zend\Di\Definition\RuntimeDefinition');
+        $this->assertTrue($definition->getIntrospectionStrategy()->getUseAnnotations());
+    }
 }

--- a/tests/Zend/Di/_files/sample.ini
+++ b/tests/Zend/Di/_files/sample.ini
@@ -20,3 +20,11 @@ di.definitions.1.My\DbAdapter.methods.__construct.username = NULL
 di.definitions.1.My\DbAdapter.methods.__construct.password = NULL
 di.definitions.1.My\Mapper.methods.__construct.dbAdapter = My\DbAdapter
 di.definitions.1.My\Repository.methods.__construct.mapper = My\Mapper
+
+[section-c]
+
+di.definition.runtime.xxx = zzz
+
+[section-d]
+
+di.definition.runtime.enabled = 0

--- a/tests/Zend/Di/_files/sample.ini
+++ b/tests/Zend/Di/_files/sample.ini
@@ -28,3 +28,7 @@ di.definition.runtime.xxx = zzz
 [section-d]
 
 di.definition.runtime.enabled = 0
+
+[section-e]
+
+di.definition.runtime.use_annotations = 1

--- a/tests/Zend/Di/_files/sample.php
+++ b/tests/Zend/Di/_files/sample.php
@@ -1,0 +1,10 @@
+<?php
+return array(
+    'di' => array(
+        'definition' => array(
+            'compiler' => array(
+                __DIR__ . '/definition-array.php',
+            ),
+        ),
+    ),
+);


### PR DESCRIPTION
Before the ServiceManager, I could configure Di in my application after bootstrap. With the ServiceManager in place, Di is stored as an instance in SM as well as a DiAbstractServiceFactory, however I can only configure the instance stored in SM after bootstrap.

This patch, while not a complete implementation of all Runtime options, allows the configuration to happen before the DiAbstractServiceFactory is created.
