### PR TITLE
Zend\Wildfire replaced "get_class()" with "get_called_class()" because it's faster

### DIFF
--- a/library/Zend/Wildfire/Channel/HttpHeaders.php
+++ b/library/Zend/Wildfire/Channel/HttpHeaders.php
@@ -201,7 +201,7 @@ class HttpHeaders
     protected function _registerControllerPlugin()
     {
         $controller = Controller\Front::getInstance();
-        if (!$controller->hasPlugin(get_class($this))) {
+        if (!$controller->hasPlugin(get_called_class())) {
             $controller->registerPlugin($this, self::$_controllerPluginStackIndex);
         }
     }

--- a/library/Zend/Wildfire/Protocol/JsonStream.php
+++ b/library/Zend/Wildfire/Protocol/JsonStream.php
@@ -153,7 +153,7 @@ class JsonStream
     public function getPayload(Wildfire\Channel $channel)
     {
         if (!$channel instanceof Wildfire\Channel\HttpHeaders) {
-            throw new Exception\InvalidArgumentException('The '.get_class($channel).' channel is not supported by the '.get_class($this).' protocol.');
+            throw new Exception\InvalidArgumentException('The '.get_class($channel).' channel is not supported by the '.get_called_class().' protocol.');
         }
 
         if ($this->_plugins) {


### PR DESCRIPTION
[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=wildfire)](http://travis-ci.org/prolic/zf2)
