### PR TITLE
Zend\View\Helper replaced "get_class()" with "get_called_class()" becaus...

### DIFF
--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -769,7 +769,7 @@ abstract class AbstractHelper extends View\Helper\HtmlElement implements HelperI
      */
     protected function _normalizeId($value)
     {
-        $prefix = get_class($this);
+        $prefix = get_called_class();
         $prefix = strtolower(trim(substr($prefix, strrpos($prefix, '\\')), '\\'));
 
         return $prefix . '-' . $value;


### PR DESCRIPTION
...e it's faster

[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=view)](http://travis-ci.org/prolic/zf2)
