### PR TITLE
Zend\Service\WindowsAzure replaced "get_class()" with "get_called_class(...

### DIFF
--- a/library/Zend/Service/WindowsAzure/Storage/TableEntity.php
+++ b/library/Zend/Service/WindowsAzure/Storage/TableEntity.php
@@ -153,7 +153,7 @@ class TableEntity
     public function getAzureValues()
     {
         // Get accessors
-        $accessors = self::getAzureAccessors(get_class($this));
+        $accessors = self::getAzureAccessors(get_called_class());
 
         // Loop accessors and retrieve values
         $returnValue = array();
@@ -192,7 +192,7 @@ class TableEntity
     public function setAzureValues($values = array(), $throwOnError = false)
     {
         // Get accessors
-        $accessors = self::getAzureAccessors(get_class($this));
+        $accessors = self::getAzureAccessors(get_called_class());
 
         // Loop accessors and set values
         $returnValue = array();


### PR DESCRIPTION
...)" because it's faster

[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=azure)](http://travis-ci.org/prolic/zf2)
