### PR TITLE
Zend\Serializer replaced "get_class()" with "get_called_class()" because...

### DIFF
--- a/library/Zend/Serializer/Adapter/PythonPickle.php
+++ b/library/Zend/Serializer/Adapter/PythonPickle.php
@@ -263,7 +263,7 @@ class PythonPickle extends AbstractAdapter
             $this->_writeObject($value);
         } else {
             throw new RuntimeException(
-                'PHP-Type "'.gettype($value).'" isn\'t serializable with '.get_class($this)
+                'PHP-Type "'.gettype($value).'" isn\'t serializable with '.get_called_class()
             );
         }
     }


### PR DESCRIPTION
... it's faster

[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=serializer)](http://travis-ci.org/prolic/zf2)
