### PR TITLE
Zend\Queue replaced "get_class()" with "get_called_class()" because it's...

### DIFF
--- a/library/Zend/Queue/Adapter/Activemq.php
+++ b/library/Zend/Queue/Adapter/Activemq.php
@@ -123,7 +123,7 @@ class Activemq extends AbstractAdapter
      */
     public function create($name, $timeout=null)
     {
-        throw new Exception\UnsupportedMethodCallException('create() is not supported in ' . get_class($this));
+        throw new Exception\UnsupportedMethodCallException('create() is not supported in ' . get_called_class());
     }
 
     /**
@@ -135,7 +135,7 @@ class Activemq extends AbstractAdapter
      */
     public function delete($name)
     {
-        throw new Exception\UnsupportedMethodCallException('delete() is not supported in ' . get_class($this));
+        throw new Exception\UnsupportedMethodCallException('delete() is not supported in ' . get_called_class());
     }
 
     /**

--- a/library/Zend/Queue/Adapter/Memcacheq.php
+++ b/library/Zend/Queue/Adapter/Memcacheq.php
@@ -333,7 +333,7 @@ class Memcacheq extends AbstractAdapter
      */
     public function deleteMessage(Message $message)
     {
-        throw new Exception\UnsupportedMethodCallException('deleteMessage() is not supported in  ' . get_class($this));
+        throw new Exception\UnsupportedMethodCallException('deleteMessage() is not supported in  ' . get_called_class());
     }
 
     /********************************************************************

--- a/library/Zend/Queue/Adapter/Null.php
+++ b/library/Zend/Queue/Adapter/Null.php
@@ -47,7 +47,7 @@ class Null extends AbstractAdapter
      */
     public function isExists($name)
     {
-        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_class($this));
+        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_called_class());
     }
 
 
@@ -58,7 +58,7 @@ class Null extends AbstractAdapter
      */
     public function create($name, $timeout=null)
     {
-        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_class($this));
+        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_called_class());
     }
 
     /**
@@ -68,7 +68,7 @@ class Null extends AbstractAdapter
      */
     public function delete($name)
     {
-        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_class($this));
+        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_called_class());
     }
 
     /**
@@ -78,7 +78,7 @@ class Null extends AbstractAdapter
      */
     public function getQueues()
     {
-        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_class($this));
+        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_called_class());
     }
 
     /**
@@ -88,7 +88,7 @@ class Null extends AbstractAdapter
      */
     public function count(Queue $queue=null)
     {
-        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_class($this));
+        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_called_class());
     }
 
     /********************************************************************
@@ -102,7 +102,7 @@ class Null extends AbstractAdapter
      */
     public function send($message, Queue $queue=null)
     {
-        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_class($this));
+        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_called_class());
     }
 
     /**
@@ -112,7 +112,7 @@ class Null extends AbstractAdapter
      */
     public function receive($maxMessages=null, $timeout=null, Queue $queue=null)
     {
-        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_class($this));
+        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_called_class());
     }
 
     /**
@@ -122,7 +122,7 @@ class Null extends AbstractAdapter
      */
     public function deleteMessage(Message $message)
     {
-        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_class($this));
+        throw new Exception\UnsupportedMethodCallException(__FUNCTION__ . '() is not supported by ' . get_called_class());
     }
 
     /********************************************************************

--- a/library/Zend/Queue/Adapter/PlatformJobQueue.php
+++ b/library/Zend/Queue/Adapter/PlatformJobQueue.php
@@ -110,7 +110,7 @@ class PlatformJobQueue extends AbstractAdapter
      */
     public function create($name, $timeout=null)
     {
-        throw new Exception\UnsupportedMethodCallException('create() is not supported in ' . get_class($this));
+        throw new Exception\UnsupportedMethodCallException('create() is not supported in ' . get_called_class());
     }
 
     /**
@@ -122,7 +122,7 @@ class PlatformJobQueue extends AbstractAdapter
      */
     public function delete($name)
     {
-        throw new Exception\UnsupportedMethodCallException('delete() is not supported in ' . get_class($this));
+        throw new Exception\UnsupportedMethodCallException('delete() is not supported in ' . get_called_class());
     }
 
     /**

--- a/library/Zend/Queue/Queue.php
+++ b/library/Zend/Queue/Queue.php
@@ -532,7 +532,7 @@ class Queue implements Countable
     public function debugInfo()
     {
         $info = array();
-        $info['self']                     = get_class($this);
+        $info['self']                     = get_called_class();
         $info['adapter']                  = get_class($this->getAdapter());
         foreach ($this->getAdapter()->getCapabilities() as $feature => $supported) {
             $info['adapter-' . $feature]  = ($supported) ? 'yes' : 'no';


### PR DESCRIPTION
... faster

[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=queue)](http://travis-ci.org/prolic/zf2)
