### PR TITLE
Zend\Pdf replaced "get_class()" with "get_called_class()" because it's f...

### DIFF
--- a/library/Zend/Pdf/BinaryParser/DataSource/AbstractDataSource.php
+++ b/library/Zend/Pdf/BinaryParser/DataSource/AbstractDataSource.php
@@ -116,7 +116,7 @@ abstract class AbstractDataSource
      */
     public function __toString()
     {
-        return get_class($this);
+        return get_called_class();
     }
 
 


### PR DESCRIPTION
...aster

[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=pdf)](http://travis-ci.org/prolic/zf2)
