### PR TITLE
Zend\Navigation replaced "get_class()" with "get_called_class()" because...

### DIFF
--- a/library/Zend/Navigation/Container.php
+++ b/library/Zend/Navigation/Container.php
@@ -367,7 +367,7 @@ abstract class Container implements RecursiveIterator, Countable
         throw new Exception\BadMethodCallException(
             sprintf(
                 'Bad method call: Unknown method %s::%s',
-                get_class($this),
+                get_called_class(),
                 $method
             )
         );

--- a/library/Zend/Navigation/Page/AbstractPage.php
+++ b/library/Zend/Navigation/Page/AbstractPage.php
@@ -1142,7 +1142,7 @@ abstract class AbstractPage extends Container
             'privilege' => $this->getPrivilege(),
             'active'    => $this->isActive(),
             'visible'   => $this->isVisible(),
-            'type'      => get_class($this),
+            'type'      => get_called_class(),
             'pages'     => parent::toArray(),
         ));
     }


### PR DESCRIPTION
... it's faster

[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=navigation)](http://travis-ci.org/prolic/zf2)
