### PR TITLE
Zend\GData replaced "get_class()" with "get_called_class()" because it's...

### DIFF
--- a/library/Zend/GData/App/Base.php
+++ b/library/Zend/GData/App/Base.php
@@ -510,7 +510,7 @@ abstract class Base
      */
     public function __isset($name)
     {
-        $rc = new \ReflectionClass(get_class($this));
+        $rc = new \ReflectionClass(get_called_class());
         $privName = '_' . $name;
         if (!($rc->hasProperty($privName))) {
             throw new InvalidArgumentException(

--- a/library/Zend/GData/App/BaseMediaSource.php
+++ b/library/Zend/GData/App/BaseMediaSource.php
@@ -147,7 +147,7 @@ abstract class BaseMediaSource implements MediaSource
      */
     public function __isset($name)
     {
-        $rc = new \ReflectionClass(get_class($this));
+        $rc = new \ReflectionClass(get_called_class());
         $privName = '_' . $name;
         if (!($rc->hasProperty($privName))) {
             throw new InvalidArgumentException(

--- a/library/Zend/GData/App/Entry.php
+++ b/library/Zend/GData/App/Entry.php
@@ -215,7 +215,7 @@ class Entry extends FeedEntryParent
 
         // Set classname to current class, if not otherwise set
         if ($className === null) {
-            $className = get_class($this);
+            $className = get_called_class();
         }
 
         // Append ETag, if present (Gdata v2 and above, only) and doesn't

--- a/library/Zend/GData/App/Feed.php
+++ b/library/Zend/GData/App/Feed.php
@@ -277,7 +277,7 @@ class Feed extends FeedSourceParent
         $nextLinkHref = $nextLink->getHref();
         $service = new App($this->getHttpClient());
 
-        return $service->getFeed($nextLinkHref, get_class($this));
+        return $service->getFeed($nextLinkHref, get_called_class());
     }
 
    /**
@@ -297,7 +297,7 @@ class Feed extends FeedSourceParent
         $previousLinkHref = $previousLink->getHref();
         $service = new App($this->getHttpClient());
 
-        return $service->getFeed($previousLinkHref, get_class($this));
+        return $service->getFeed($previousLinkHref, get_called_class());
     }
 
     /**


### PR DESCRIPTION
... faster

[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=gdata)](http://travis-ci.org/prolic/zf2)
