### PR TITLE
Zend\Filter replaced "get_class()" with "get_called_class()" because it'...

### DIFF
--- a/library/Zend/Filter/PregReplace.php
+++ b/library/Zend/Filter/PregReplace.php
@@ -163,7 +163,7 @@ class PregReplace extends AbstractFilter
     public function filter($value)
     {
         if ($this->_matchPattern == null) {
-            throw new Exception\RuntimeException(get_class($this) . ' does not have a valid MatchPattern set.');
+            throw new Exception\RuntimeException(get_called_class() . ' does not have a valid MatchPattern set.');
         }
 
         return preg_replace($this->_matchPattern, $this->_replacement, $value);


### PR DESCRIPTION
...s faster, fixed some phpdoc

[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=filter)](http://travis-ci.org/prolic/zf2)
