### PR TITLE
Zend\Code replaced "get_class()" with "get_called_class()" because it's ...

### DIFF
--- a/library/Zend/Code/Reflection/DocBlockReflection.php
+++ b/library/Zend/Code/Reflection/DocBlockReflection.php
@@ -121,7 +121,7 @@ class DocBlockReflection implements ReflectionInterface
             $this->docComment = $commentOrReflector;
         } else {
             throw new Exception\InvalidArgumentException(
-                get_class($this) . ' must have a (string) DocComment or a Reflector in the constructor'
+                get_called_class() . ' must have a (string) DocComment or a Reflector in the constructor'
             );
         }
 


### PR DESCRIPTION
...faster, fixed some phpdoc

[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=code)](http://travis-ci.org/prolic/zf2)
