### PR TITLE
Zend\BarCode replaced "get_class()" with "get_called_class()" because it...

### DIFF
--- a/library/Zend/Barcode/Object/AbstractObject.php
+++ b/library/Zend/Barcode/Object/AbstractObject.php
@@ -226,7 +226,7 @@ abstract class AbstractObject implements ObjectInterface
         if (is_array($options)) {
             $this->setOptions($options);
         }
-        $this->type = strtolower(substr(get_class($this), strlen($this->barcodeNamespace) + 1));
+        $this->type = strtolower(substr(get_called_class(), strlen($this->barcodeNamespace) + 1));
         if ($this->mandatoryChecksum) {
             $this->withChecksum = true;
             $this->withChecksumInText = true;

--- a/library/Zend/Barcode/Object/Ean13.php
+++ b/library/Zend/Barcode/Object/Ean13.php
@@ -172,7 +172,7 @@ class Ean13 extends AbstractObject
      */
     protected function drawText()
     {
-        if (get_class($this) == 'Zend\Barcode\Object\Ean13') {
+        if (get_called_class() == 'Zend\Barcode\Object\Ean13') {
             $this->drawEan13Text();
         } else {
             parent::drawText();

--- a/library/Zend/Barcode/Renderer/AbstractRenderer.php
+++ b/library/Zend/Barcode/Renderer/AbstractRenderer.php
@@ -110,7 +110,7 @@ abstract class AbstractRenderer implements RendererInterface
             $this->setOptions($options);
         }
         $this->type = strtolower(substr(
-            get_class($this),
+            get_called_class(),
             strlen($this->rendererNamespace) + 1
         ));
     }


### PR DESCRIPTION
...'s faster

[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=barcode)](http://travis-ci.org/prolic/zf2)
