### PR TITLE
Hotfix: Three fixes having to do with the Forward plugin

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/Forward.php
+++ b/library/Zend/Mvc/Controller/Plugin/Forward.php
@@ -66,7 +66,7 @@ class Forward extends AbstractPlugin
      */
     public function dispatch($name, array $params = null)
     {
-        $event   = $this->getEvent();
+        $event   = clone($this->getEvent());
         $locator = $this->getLocator();
         $scoped  = false;
 
@@ -90,11 +90,8 @@ class Forward extends AbstractPlugin
         }
 
         // Allow passing parameters to seed the RouteMatch with
-        $cachedMatches = false;
         if ($params) {
-            $matches       = new RouteMatch($params);
-            $cachedMatches = $event->getRouteMatch();
-            $event->setRouteMatch($matches);
+            $event->setRouteMatch(new RouteMatch($params));
         }
 
         if ($this->numNestedForwards > $this->maxNestedForwards) {
@@ -105,10 +102,6 @@ class Forward extends AbstractPlugin
         $return = $controller->dispatch($event->getRequest(), $event->getResponse());
 
         $this->numNestedForwards--;
-
-        if ($cachedMatches) {
-            $event->setRouteMatch($cachedMatches);
-        }
 
         return $return;
     }

--- a/library/Zend/Mvc/Controller/Plugin/Forward.php
+++ b/library/Zend/Mvc/Controller/Plugin/Forward.php
@@ -80,10 +80,10 @@ class Forward extends AbstractPlugin
         if (!$controller instanceof Dispatchable) {
             throw new Exception\DomainException('Can only forward to DispatchableInterface classes; class of type ' . get_class($controller) . ' received');
         }
+        if ($controller instanceof InjectApplicationEventInterface) {
+            $controller->setEvent($event);
+        }
         if (!$scoped) {
-            if ($controller instanceof InjectApplicationEventInterface) {
-                $controller->setEvent($event);
-            }
             if ($controller instanceof ServiceLocatorAwareInterface) {
                 $controller->setServiceLocator($locator);
             }

--- a/library/Zend/Mvc/Service/ControllerLoaderFactory.php
+++ b/library/Zend/Mvc/Service/ControllerLoaderFactory.php
@@ -89,7 +89,7 @@ class ControllerLoaderFactory implements FactoryInterface
 
         $controllerLoader->addInitializer(function ($instance) use ($serviceLocator) {
             if ($instance instanceof Pluggable) {
-                $instance->setBroker($serviceLocator->get('ControllerPluginBroker'));
+                $instance->setBroker(clone $serviceLocator->get('ControllerPluginBroker'));
             }
         });
 


### PR DESCRIPTION
First, we need to set the event on the controller as the ControllerLoader doesn't do this for us.

Cloning the event in the Forward plugin protects the original event from changes that happen when we dispatch to the forward controller, namely the target of the original event being changed to the forward controller. Also, since we are cloning, there's no need to cache the routeMatch.

In the ControllerLoaderFactory, the reason for the clone is so that each controller gets it's own plugin broker. In the case where the Forward plugin is being used, a shared plugin broker would get it's internal controller variable overwritten by each Forward.
