### PR TITLE
PHP 5.3.8 support for is_subclass_of

### DIFF
--- a/library/Zend/Form/Factory.php
+++ b/library/Zend/Form/Factory.php
@@ -82,15 +82,15 @@ class Factory
         $spec = $this->validateSpecification($spec, __METHOD__);
         $type = isset($spec['type']) ? $spec['type'] : 'Zend\Form\Element';
 
-        if (is_subclass_of($type, 'Zend\Form\FormInterface', true)) {
+        if (is_subclass_of($type, 'Zend\Form\FormInterface')) {
             return $this->createForm($spec);
         }
         
-        if (is_subclass_of($type, 'Zend\Form\FieldsetInterface', true)) {
+        if (is_subclass_of($type, 'Zend\Form\FieldsetInterface')) {
             return $this->createFieldset($spec);
         }
 
-        if (!is_subclass_of($type, 'Zend\Form\ElementInterface', true)) {
+        if (!is_subclass_of($type, 'Zend\Form\ElementInterface')) {
             throw new Exception\DomainException(sprintf(
                 '%s expects the $spec["type"] to implement one of %s, %s, or %s; received %s',
                 __METHOD__,


### PR DESCRIPTION
is_subclass_of function's 3rd parameter $allow_string was added in PHP 5.3.9, causing them to always return NULL when called in PHP 5.3.8 or below.

Removed the 3rd parameters in Zend\Form\Factory.php for PHP 5.3.8 support.
PHP 5.3.9+ works the same way as the $allow_string's default value is true.
