### PR TITLE
Zend\Db\Metadata: Add allowed values in errata for ENUM and SET column types

### DIFF
--- a/library/Zend/Db/Adapter/Adapter.php
+++ b/library/Zend/Db/Adapter/Adapter.php
@@ -283,6 +283,8 @@ class Adapter
                 return new Platform\SqlServer();
             case 'Sqlite':
                 return new Platform\Sqlite();
+            case 'Postgresql':
+                return new Platform\Postgresql();
             default:
                 return new Platform\Sql92();
         }

--- a/library/Zend/Db/Adapter/Driver/Pdo/Pdo.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Pdo.php
@@ -158,13 +158,20 @@ class Pdo implements DriverInterface, DriverFeatureInterface
     {
         $name = $this->getConnection()->getDriverName();
         if ($nameFormat == self::NAME_FORMAT_CAMELCASE) {
-            return ucfirst($name);
+            switch ($name) {
+                case 'pgsql':
+                    return 'Postgresql';
+                default:
+                    return ucfirst($name);
+            }
         } else {
             switch ($name) {
                 case 'sqlite':
                     return 'SQLite';
                 case 'mysql':
                     return 'MySQL';
+                case 'pgsql':
+                    return 'PostgreSQL';
                 default:
                     return ucfirst($name);
             }

--- a/library/Zend/Db/Adapter/Platform/Postgresql.php
+++ b/library/Zend/Db/Adapter/Platform/Postgresql.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Db
+ */
+
+namespace Zend\Db\Adapter\Platform;
+
+/**
+ * @category   Zend
+ * @package    Zend_Db
+ * @subpackage Adapter
+ */
+class Postgresql implements PlatformInterface
+{
+    /**
+     * Get name
+     * 
+     * @return string 
+     */
+    public function getName()
+    {
+        return 'PostgreSQL';
+    }
+
+    /**
+     * Get quote indentifier symbol
+     * 
+     * @return string
+     */
+    public function getQuoteIdentifierSymbol()
+    {
+        return '"';
+    }
+
+    /**
+     * Quote identifier
+     * 
+     * @param  string $identifier
+     * @return string 
+     */
+    public function quoteIdentifier($identifier)
+    {
+        return '"' . str_replace('"', '\\' . '"', $identifier) . '"';
+    }
+
+    /**
+     * Get quote value symbol
+     * 
+     * @return string 
+     */
+    public function getQuoteValueSymbol()
+    {
+        return '\'';
+    }
+
+    /**
+     * Quote value
+     * 
+     * @param  string $value
+     * @return string 
+     */
+    public function quoteValue($value)
+    {
+        return '\'' . str_replace('\'', '\\' . '\'', $value) . '\'';
+    }
+
+    /**
+     * Get identifier separator
+     * 
+     * @return string 
+     */
+    public function getIdentifierSeparator()
+    {
+        return '.';
+    }
+
+    /**
+     * Quote identifier in fragment
+     * 
+     * @param  string $identifier
+     * @param  array $safeWords
+     * @return string 
+     */
+    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
+    {
+        $parts = preg_split('#([\.\s])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE);
+        foreach($parts as $i => $part) {
+            if ($safeWords && in_array($part, $safeWords)) {
+                continue;
+            }
+            switch ($part) {
+                case ' ':
+                case '.':
+                case '*':
+                case 'AS':
+                case 'As':
+                case 'aS':
+                case 'as':
+                    break;
+                default:
+                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
+            }
+        }
+        return implode('', $parts);
+    }
+
+}


### PR DESCRIPTION
Reads ENUM/SET permitted values from MySQL them from the database, parses them into an array and sets it in the column errata data.

PostgreSQL also supports ENUM (and maybe SET), I'd need to install it to test properly. I'll see if I can get it added.
