### PR TITLE
Fix initialization of docblock tag description

### DIFF
--- a/library/Zend/Code/Generator/DocBlock/Tag.php
+++ b/library/Zend/Code/Generator/DocBlock/Tag.php
@@ -67,7 +67,7 @@ class Tag extends AbstractGenerator
             $this->setName($options['name']);
         }
         if (key_exists('description', $options)) {
-            $this->setName($options['description']);
+            $this->setDescription($options['description']);
         }
     }
 

--- a/tests/Zend/Code/Generator/DocBlockTagGeneratorTest.php
+++ b/tests/Zend/Code/Generator/DocBlockTagGeneratorTest.php
@@ -48,6 +48,18 @@ class DocBlockTagGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->tag = null;
     }
 
+    public function testCanPassNameToConstructor()
+    {
+        $tag = new Tag(array('name' => 'Foo'));
+        $this->assertEquals('Foo', $tag->getName());
+    }
+
+    public function testCanPassDescriptionToConstructor()
+    {
+        $tag = new Tag(array('description' => 'Foo'));
+        $this->assertEquals('Foo', $tag->getDescription());
+    }
+
     public function testNameGetterAndSetterPersistValue()
     {
         $this->tag->setName('Foo');


### PR DESCRIPTION
Bad method was called to initiliaze docblock tag description (setName() -> setDescription())
