### PR TITLE
#ZF2-319 Fix multi search and access document

### DIFF
--- a/library/Zend/Search/Lucene/Index.php
+++ b/library/Zend/Search/Lucene/Index.php
@@ -685,13 +685,15 @@ class Index implements SearchIndexInterface
         $query->execute($this);
 
         $topScore = 0;
-
+        $hitId = 0;
+        
         $resultSetLimit = Lucene::getResultSetLimit();
         foreach ($query->matchedDocs() as $id => $num) {
             $docScore = $query->score($id, $this);
             if( $docScore != 0 ) {
                 $hit = new Search\QueryHit($this);
-                $hit->id = $id;
+                $hit->id = ++$hitId;
+                $hit->document_id = $id;
                 $hit->score = $docScore;
 
                 $hits[]   = $hit;

--- a/library/Zend/Search/Lucene/Index.php
+++ b/library/Zend/Search/Lucene/Index.php
@@ -685,15 +685,13 @@ class Index implements SearchIndexInterface
         $query->execute($this);
 
         $topScore = 0;
-        $hitId = 0;
         
         $resultSetLimit = Lucene::getResultSetLimit();
         foreach ($query->matchedDocs() as $id => $num) {
             $docScore = $query->score($id, $this);
             if( $docScore != 0 ) {
                 $hit = new Search\QueryHit($this);
-                $hit->id = ++$hitId;
-                $hit->document_id = $id;
+                $hit->document_id = $hit->id = $id;
                 $hit->score = $docScore;
 
                 $hits[]   = $hit;

--- a/library/Zend/Search/Lucene/MultiSearcher.php
+++ b/library/Zend/Search/Lucene/MultiSearcher.php
@@ -379,7 +379,7 @@ class MultiSearcher implements SearchIndexInterface
                 }
             }
 
-            $indexShift += count($hits);
+            $indexShift += $index->count();
             $hitsList[] = $hits;
         }
 

--- a/library/Zend/Search/Lucene/MultiSearcher.php
+++ b/library/Zend/Search/Lucene/MultiSearcher.php
@@ -379,7 +379,7 @@ class MultiSearcher implements SearchIndexInterface
                 }
             }
 
-            $indexShift += $index->count();
+            $indexShift += count($hits);
             $hitsList[] = $hits;
         }
 

--- a/library/Zend/Search/Lucene/Search/QueryHit.php
+++ b/library/Zend/Search/Lucene/Search/QueryHit.php
@@ -45,10 +45,16 @@ class QueryHit
     protected $_document = null;
 
     /**
-     * Number of the document in the index
+     * Unique hit id
      * @var integer
      */
     public $id;
+    
+    /**
+     * Number of the document in the index
+     * @var integer
+     */
+    public $document_id;
 
     /**
      * Score of the hit
@@ -102,7 +108,7 @@ class QueryHit
     public function getDocument()
     {
         if (!$this->_document instanceof Document) {
-            $this->_document = $this->_index->getDocument($this->id);
+            $this->_document = $this->_index->getDocument($this->document_id);
         }
 
         return $this->_document;

--- a/tests/Zend/Search/Lucene/MultiIndexTest.php
+++ b/tests/Zend/Search/Lucene/MultiIndexTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Search_Lucene
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Search\Lucene;
+
+use Zend\Search\Lucene;
+
+/**
+ * @category   Zend
+ * @package    Zend_Search_Lucene
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Zend_Search_Lucene
+ */
+class MultiIndexTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers Zend\Search\Lucene\MultiSearcher::find
+     * @covers Zend\Search\Lucene\Search\QueryHit::getDocument
+     */
+    public function testFind()
+    {
+        $index = new Lucene\MultiSearcher(array(
+                Lucene\Lucene::open(__DIR__ . '/_indexSample/_files'),
+                Lucene\Lucene::open(__DIR__ . '/_indexSample/_files'),
+        ));
+
+        $hits = $index->find('submitting');
+        $this->assertEquals(count($hits), 2*3);
+        foreach($hits as $hit) {
+            $document = $hit->getDocument();
+            $this->assertTrue($document instanceof Lucene\Document);
+        }
+    }
+}


### PR DESCRIPTION
Hit id must be changed because it's the document id.
To fix that, i add a "document_id" and the id will be the uniq id.
