### PR TITLE
Utilize getter/setter in Subscription model for now() to prevent test failure

### DIFF
--- a/library/Zend/Feed/PubSubHubbub/Model/Subscription.php
+++ b/library/Zend/Feed/PubSubHubbub/Model/Subscription.php
@@ -32,6 +32,12 @@ use Zend\Date;
  */
 class Subscription extends AbstractModel implements SubscriptionPersistenceInterface
 {
+    /**
+     * Common Date\Date object to assist with unit testing
+     * 
+     * @var Date\Date
+     */
+    protected $now;
     
     /**
      * Save subscription to RDMBS
@@ -50,7 +56,7 @@ class Subscription extends AbstractModel implements SubscriptionPersistenceInter
         $result = $this->_db->select(array('id' => $data['id']));
         if ($result && (0 < count($result))) {
             $data['created_time'] = $result->current()->created_time;
-            $now = new Date\Date;
+            $now = $this->getNow();
             if (array_key_exists('lease_seconds', $data) 
                 && $data['lease_seconds']
             ) {
@@ -126,4 +132,28 @@ class Subscription extends AbstractModel implements SubscriptionPersistenceInter
         return false;
     }
 
+    /**
+     * Get a new Date\Date or the one injected for testing
+     * 
+     * @return Date\Date
+     */
+    public function getNow()
+    {
+        if (null === $this->now) {
+            return new Date\Date;
+        }
+        return $this->now;
+    }
+
+    /**
+     * Set a Date\Date instance for assisting with unit testing
+     * 
+     * @param Date\Date $now
+     * @return Subscription
+     */
+    public function setNow(Date\Date $now)
+    {
+        $this->now = $now;
+        return $this;
+    }
 }

--- a/tests/Zend/Feed/PubSubHubbub/Model/SubscriptionTest.php
+++ b/tests/Zend/Feed/PubSubHubbub/Model/SubscriptionTest.php
@@ -21,8 +21,9 @@
 namespace ZendTest\Feed\PubSubHubbub\Model;
 
 use Zend\Feed\PubSubHubbub\Model\Subscription;
-use \Zend\Db\Adapter\Adapter as DbAdapter;
-use \Zend\Db\TableGateway\TableGateway;
+use Zend\Db\Adapter\Adapter as DbAdapter;
+use Zend\Db\TableGateway\TableGateway;
+use Zend\Date;
 
 /**
  * @category   Zend
@@ -71,6 +72,14 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase
         $reflection = new \ReflectionClass('Zend\Feed\PubSubHubbub\Model\Subscription');
         $this->assertTrue($reflection->implementsInterface('Zend\Feed\PubSubHubbub\Model\SubscriptionPersistenceInterface'));
         unset($reflection);
+    }
+
+    public function testCurrentTimeSetterAndGetter()
+    {
+        $now = new Date\Date;
+        $subscription = new Subscription(new TableGateway('subscription', $this->initDb()));
+        $subscription->setNow($now);
+        $this->assertSame($subscription->getNow(), $now);
     }
 
     protected function initDb()

--- a/tests/Zend/Feed/PubSubHubbub/Subscriber/CallbackTest.php
+++ b/tests/Zend/Feed/PubSubHubbub/Subscriber/CallbackTest.php
@@ -54,6 +54,10 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $this->_tableGateway->expects($this->any())->method('getAdapter')
             ->will($this->returnValue($this->_adapter));
         $storage = new Model\Subscription($this->_tableGateway);
+
+        $this->now = new Date\Date;
+        $storage->setNow(clone $this->now);
+
         $this->_callback->setStorage($storage);
 
         $this->_get = array(
@@ -268,7 +272,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo(array('id' => 'verifytokenkey')))
             ->will($this->returnValue($this->_rowset));
 
-        $t = new Date\Date;
+        $t = clone $this->now;
         $rowdata = array(
             'id' => 'verifytokenkey',
             'verify_token' => hash('sha256', 'cba'),
@@ -305,7 +309,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo(array('id' => 'verifytokenkey')))
             ->will($this->returnValue($this->_rowset));
 
-        $t = new Date\Date;
+        $t = clone $this->now;
         $rowdata = array(
             'id' => 'verifytokenkey',
             'verify_token' => hash('sha256', 'cba'),
@@ -348,7 +352,6 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo(array('id' => 'verifytokenkey')))
             ->will($this->returnValue($this->_rowset));
 
-        $t = new Date\Date;
         $rowdata = array(
             'id' => 'verifytokenkey',
             'verify_token' => hash('sha256', 'cba'),


### PR DESCRIPTION
The way the tests were set up, depending on when exactly during a particular
second that the test was ran, it could produce a failure, as two separate
Zend\Date\Date instances were being instantiated at different times. _Most_ of
the time they were both instantiated during the same second, but not always.
