### PR TITLE
A new route to match optional subdomains.

### DIFF
--- a/library/Zend/Mvc/Router/Http/HostnameOptionalSubdomain.php
+++ b/library/Zend/Mvc/Router/Http/HostnameOptionalSubdomain.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Mvc_Router
+ * @subpackage Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Mvc\Router\Http;
+
+use Traversable,
+    Zend\Stdlib\ArrayUtils,
+    Zend\Stdlib\RequestInterface as Request,
+    Zend\Mvc\Router\Exception;
+
+/**
+ * HostnameOptionalSubdomain route.
+ *
+ * @package    Zend_Mvc_Router
+ * @subpackage Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @see        http://manuals.rubyonrails.com/read/chapter/65
+ */
+class HostnameOptionalSubdomain implements RouteInterface
+{
+    /**
+     * RouteInterface to match.
+     *
+     * @var array
+     */
+    protected $route;
+
+    /**
+     * Constraints for parameters.
+     *
+     * @var array
+     */
+    protected $constraints;
+
+    /**
+     * Default values.
+     *
+     * @var array
+     */
+    protected $defaults;
+
+    /**
+     * List of assembled parameters.
+     *
+     * @var array
+     */
+    protected $assembledParams = array();
+
+    /**
+     * Create a new hostname optional subdomain route.
+     *
+     * @param  string $route
+     * @param  array  $constraints
+     * @param  array  $defaults
+     */
+    public function __construct($route, array $constraints = array(), array $defaults = array())
+    {
+        $this->route       = explode('.', $route);
+        $this->constraints = $constraints;
+        $this->defaults    = $defaults;
+    }
+
+    /**
+     * factory(): defined by RouteInterface interface.
+     *
+     * @see    Route::factory()
+     * @param  array|\Traversable $options
+     * @throws \Zend\Mvc\Router\Exception\InvalidArgumentException
+     * @return Hostname
+     */
+    public static function factory($options = array())
+    {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        } elseif (!is_array($options)) {
+            throw new Exception\InvalidArgumentException(__METHOD__ . ' expects an array or Traversable set of options');
+        }
+
+        if (!isset($options['route'])) {
+            throw new Exception\InvalidArgumentException('Missing "route" in options array');
+        }
+
+        if (!isset($options['constraints'])) {
+            $options['constraints'] = array();
+        }
+
+        if (!isset($options['defaults'])) {
+            $options['defaults'] = array();
+        }
+
+        return new static($options['route'], $options['constraints'], $options['defaults']);
+    }
+
+    /**
+     * match(): defined by RouteInterface interface.
+     *
+     * @see    Route::match()
+     * @param  Request $request
+     * @return RouteMatch
+     */
+    public function match(Request $request)
+    {
+        if (!method_exists($request, 'uri')) {
+            return null;
+        }
+
+        $uri      = $request->uri();
+        $hostname = explode('.', $uri->getHost());
+        $params   = array();
+
+        $firstIndexToCompare = 0;
+        $countHostname = count($hostname);
+        $countRoute = count($this->route);
+        if ($countHostname > $countRoute) {
+            // Hostname cannot have more parts than route
+            return null;
+        } elseif ($countHostname < $countRoute) {
+            // Account for case where the hostname has less pieces than route
+            $firstIndexToCompare = $countRoute - $countHostname;
+        }
+
+        foreach ($this->route as $index => $routePart) {
+            // This accounts for the offset between hostname and route
+            $hostnameIndex = $index - $firstIndexToCompare;
+            if (preg_match('(^:(?P<name>.+)$)', $routePart, $matches)) {
+                if ($index < $firstIndexToCompare) {
+                    // Optional part is missing
+                    continue;
+                }
+                if (isset($this->constraints[$matches['name']]) && !preg_match('(^' . $this->constraints[$matches['name']] . '$)', $hostname[$hostnameIndex])) {
+                    return null;
+                }
+                $params[$matches['name']] = $hostname[$hostnameIndex];
+            } elseif (!isset($hostname[$hostnameIndex]) || $hostname[$hostnameIndex] !== $routePart) {
+                return null;
+            }
+        }
+
+        return new RouteMatch(array_merge($this->defaults, $params));
+    }
+
+    /**
+     * assemble(): Defined by RouteInterface interface.
+     *
+     * @see    Route::assemble()
+     * @param  array $params
+     * @param  array $options
+     * @return mixed
+     * @throws Exception\InvalidArgumentException
+     */
+    public function assemble(array $params = array(), array $options = array())
+    {
+        $mergedParams          = array_merge($this->defaults, $params);
+        $this->assembledParams = array();
+
+        if (isset($options['uri'])) {
+            $parts = array();
+
+            foreach ($this->route as $index => $routePart) {
+                if (preg_match('(^:(?P<name>.+)$)', $routePart, $matches)) {
+                    if (!isset($mergedParams[$matches['name']])) {
+                        continue;
+                    }
+                    $parts[] = $mergedParams[$matches['name']];
+                    $this->assembledParams[] = $matches['name'];
+                } else {
+                    $parts[] = $routePart;
+                }
+            }
+            $options['uri']->setHost(implode('.', $parts));
+        }
+
+        // A hostname does not contribute to the path, thus nothing is returned.
+        return '';
+    }
+
+    /**
+     * getAssembledParams(): defined by RouteInterface interface.
+     *
+     * @see    Route::getAssembledParams
+     * @return array
+     */
+    public function getAssembledParams()
+    {
+        return $this->assembledParams;
+    }
+}

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -62,15 +62,16 @@ class TreeRouteStack extends SimpleRouteStack
     protected function init()
     {
         $this->routeBroker->getClassLoader()->registerPlugins(array(
-            'hostname' => __NAMESPACE__ . '\Hostname',
-            'literal'  => __NAMESPACE__ . '\Literal',
-            'part'     => __NAMESPACE__ . '\Part',
-            'regex'    => __NAMESPACE__ . '\Regex',
-            'scheme'   => __NAMESPACE__ . '\Scheme',
-            'segment'  => __NAMESPACE__ . '\Segment',
-            'wildcard' => __NAMESPACE__ . '\Wildcard',
-            'query'    => __NAMESPACE__ . '\Query',
-            'method'   => __NAMESPACE__ . '\Method',
+            'hostname'                  => __NAMESPACE__ . '\Hostname',
+            'hostnameoptionalsubdomain' => __NAMESPACE__ . '\HostnameOptionalSubdomain',
+            'literal'                   => __NAMESPACE__ . '\Literal',
+            'part'                      => __NAMESPACE__ . '\Part',
+            'regex'                     => __NAMESPACE__ . '\Regex',
+            'scheme'                    => __NAMESPACE__ . '\Scheme',
+            'segment'                   => __NAMESPACE__ . '\Segment',
+            'wildcard'                  => __NAMESPACE__ . '\Wildcard',
+            'query'                     => __NAMESPACE__ . '\Query',
+            'method'                    => __NAMESPACE__ . '\Method',
         ));
     }
 

--- a/tests/Zend/Mvc/Router/Http/HostnameOptionalSubdomainTest.php
+++ b/tests/Zend/Mvc/Router/Http/HostnameOptionalSubdomainTest.php
@@ -1,0 +1,159 @@
+<?php
+namespace ZendTest\Mvc\Router\Http;
+
+use Zend\Mvc\Router\Http\HostnameOptionalSubdomain;
+
+use PHPUnit_Framework_TestCase as TestCase,
+    Zend\Http\Request as Request,
+    Zend\Stdlib\Request as BaseRequest,
+    Zend\Uri\Http as HttpUri,
+    Zend\Mvc\Router\Http\Hostname,
+    ZendTest\Mvc\Router\FactoryTester;
+
+class HostnameOptionalSubdomainTest extends TestCase
+{
+    public static function routeProvider()
+    {
+        return array(
+            'simple-match' => array(
+                new HostnameOptionalSubdomain('foo.example.com'),
+                'foo.example.com',
+                array(),
+                null
+            ),
+        	'simple-match-with-param' => array(
+                new HostnameOptionalSubdomain(':foo.example.com'),
+                'bar.example.com',
+                array('foo' => 'bar'),
+                null
+            ),
+            'no-match-on-different-hostname' => array(
+                new HostnameOptionalSubdomain('foo.example.com'),
+                'bar.example.com',
+                null,
+                null
+            ),
+            'no-match-with-different-number-of-non-optional-parts' => array(
+                new HostnameOptionalSubdomain('foo.example.com'),
+                'example.com',
+                null,
+                null
+            ),
+            'no-match-with-too-many-parts' => array(
+                new HostnameOptionalSubdomain(':foo.example.com'),
+                'bar.baz.example.com',
+                null,
+                null
+            ),
+            'match-overrides-default' => array(
+                new HostnameOptionalSubdomain(':foo.example.com', array(), array('foo' => 'baz')),
+                'bat.example.com',
+                array('foo' => 'bat'),
+                null
+            ),
+            'constraints-prevent-match' => array(
+                new HostnameOptionalSubdomain(':foo.example.com', array('foo' => '\d+')),
+                'bar.example.com',
+                null,
+                null
+            ),
+            'constraints-allow-match' => array(
+                new HostnameOptionalSubdomain(':foo.example.com', array('foo' => '\d+')),
+                '123.example.com',
+                array('foo' => '123'),
+                null
+            ),
+            'match-optional-subdomain-parts' => array(
+                new HostnameOptionalSubdomain(':bar.:foo.example.com'),
+                'bat.example.com',
+                array('foo' => 'bat', 'bar' => null),
+                null
+            ),
+            'match-optional-subdomain-parts-with-defaults' => array(
+                new HostnameOptionalSubdomain(':bar.:foo.example.com', array(), array('bar' => 'baz')),
+                'bat.example.com',
+                array('foo' => 'bat', 'bar' => 'baz'),
+                'baz.bat.example.com',
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider routeProvider
+     * @param        Hostname $route
+     * @param        string   $hostname
+     * @param        array    $params
+     */
+    public function testMatching(HostnameOptionalSubdomain $route, $hostname, array $params = null, $onlyUsedForAssembly = null)
+    {
+        $request = new Request();
+        $request->setUri('http://' . $hostname . '/');
+        $match = $route->match($request);
+
+        if ($params === null) {
+            $this->assertNull($match);
+        } else {
+            $this->assertInstanceOf('Zend\Mvc\Router\Http\RouteMatch', $match);
+
+            foreach ($params as $key => $value) {
+                $this->assertEquals($value, $match->getParam($key));
+            }
+        }
+    }
+
+    /**
+     * @dataProvider routeProvider
+     * @param        Hostname $route
+     * @param        string   $hostname
+     * @param        array    $params
+     */
+    public function testAssembling(HostnameOptionalSubdomain $route, $hostname, array $params = null, $assembledHostname = null)
+    {
+        if ($params === null) {
+            // Data which will not match are not tested for assembling.
+            return;
+        }
+
+        $uri  = new HttpUri();
+        $path = $route->assemble($params, array('uri' => $uri));
+
+        $this->assertEquals('', $path);
+        if (isset($assembledHostname)) {
+            $this->assertEquals($assembledHostname, $uri->getHost());
+        } else {
+            $this->assertEquals($hostname, $uri->getHost());
+        }
+    }
+
+    public function testNoMatchWithoutUriMethod()
+    {
+        $route   = new HostnameOptionalSubdomain('example.com');
+        $request = new BaseRequest();
+
+        $this->assertNull($route->match($request));
+    }
+
+    public function testGetAssembledParams()
+    {
+        $route = new HostnameOptionalSubdomain(':foo.example.com');
+        $uri   = new HttpUri();
+        $route->assemble(array('foo' => 'bar', 'baz' => 'bat'), array('uri' => $uri));
+
+        $this->assertEquals(array('foo'), $route->getAssembledParams());
+    }
+
+    public function testFactory()
+    {
+        $tester = new FactoryTester($this);
+        $tester->testFactory(
+            'Zend\Mvc\Router\Http\HostnameOptionalSubdomain',
+            array(
+                'route' => 'Missing "route" in options array'
+            ),
+            array(
+                'route' => 'example.com'
+            )
+        );
+    }
+}
+


### PR DESCRIPTION
For example, route :subdomain.zend.com would match both framework.zend.com and www.zend.com. 

Another important feature is URL assembly for various environments. We configure the route to be :env.www.zend.com. In our code, we assemble the URL for www.zend.com. But through local configuration, we could set an environment variable. Depending on the environment variable, the assembled URL would be dev.www.zend.com, stg.www.zend.com, or simply www.zend.com for production.

Please note: I chose to make a separate class for this use case, however, if you'd rather me integrate this feature into the Hostname route, I'm willing to do so.
