### PR TITLE
[Travis] Add PHP v5.3.3 to the build matrix 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3.3
   - 5.3
   - 5.4
 


### PR DESCRIPTION
Travis v5.3.3 is now supported by Travis-Ci
