### PR TITLE
Zend\Stdlib\Hydator\HydratorInterface::hydrate() returns object

### DIFF
--- a/library/Zend/Stdlib/Hydrator/ArraySerializable.php
+++ b/library/Zend/Stdlib/Hydrator/ArraySerializable.php
@@ -67,10 +67,8 @@ class ArraySerializable implements HydratorInterface
     {
         if (is_callable(array($object, 'exchangeArray'))) {
             $object->exchangeArray($data);
-            return;
         } else if (is_callable(array($object, 'populate'))) {
             $object->populate($data);
-            return;
         } else {
             throw new Exception\BadMethodCallException(sprintf(
                 '%s expects the provided object to implement exchangeArray() or populate()',

--- a/library/Zend/Stdlib/Hydrator/ArraySerializable.php
+++ b/library/Zend/Stdlib/Hydrator/ArraySerializable.php
@@ -60,25 +60,23 @@ class ArraySerializable implements HydratorInterface
      * 
      * @param  array $data 
      * @param  object $object 
-     * @return void
+     * @return object
      * @throws Exception\BadMethodCallException for an $object not implementing exchangeArray() or populate()
      */
     public function hydrate(array $data, $object)
     {
-        if (!is_callable(array($object, 'exchangeArray'))
-            && !is_callable(array($object, 'populate'))
-        ) {
+        if (is_callable(array($object, 'exchangeArray'))) {
+            $object->exchangeArray($data);
+            return;
+        } else if (is_callable(array($object, 'populate'))) {
+            $object->populate($data);
+            return;
+        } else {
             throw new Exception\BadMethodCallException(sprintf(
                 '%s expects the provided object to implement exchangeArray() or populate()',
                 __METHOD__
             ));
         }
-
-        if (is_callable(array($object, 'exchangeArray'))) {
-            $object->exchangeArray($data);
-            return;
-        }
-
-        $object->populate($data);
+        return $object;
     }
 }

--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -98,7 +98,7 @@ class ClassMethods implements HydratorInterface
      * 
      * @param  array $data 
      * @param  object $object 
-     * @return void
+     * @return object
      * @throws Exception\BadMethodCallException for a non-object $object
      */
     public function hydrate(array $data, $object)
@@ -122,5 +122,6 @@ class ClassMethods implements HydratorInterface
             $method = 'set' . ucfirst($property);
             $object->$method($value);
         }
+        return $object;
     }
 }

--- a/library/Zend/Stdlib/Hydrator/HydratorInterface.php
+++ b/library/Zend/Stdlib/Hydrator/HydratorInterface.php
@@ -43,7 +43,7 @@ interface HydratorInterface
      * 
      * @param  array $data 
      * @param  object $object 
-     * @return void
+     * @return object
      */
     public function hydrate(array $data, $object);
 }

--- a/library/Zend/Stdlib/Hydrator/ObjectProperty.php
+++ b/library/Zend/Stdlib/Hydrator/ObjectProperty.php
@@ -60,7 +60,7 @@ class ObjectProperty implements HydratorInterface
      * 
      * @param  array $data 
      * @param  object $object 
-     * @return void
+     * @return object
      * @throws Exception\BadMethodCallException for a non-object $object
      */
     public function hydrate(array $data, $object)
@@ -74,5 +74,6 @@ class ObjectProperty implements HydratorInterface
         foreach ($data as $property => $value) {
             $object->$property = $value;
         }
+        return $object;
     }
 }

--- a/tests/Zend/Stdlib/HydratorTest.php
+++ b/tests/Zend/Stdlib/HydratorTest.php
@@ -60,7 +60,7 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($datas['fooBar'], '1');
         $this->assertTrue(isset($datas['fooBarBaz']));
         $this->assertFalse(isset($datas['foo_bar']));
-        $hydrator->hydrate(array('fooBar' => 'foo', 'fooBarBaz' => 'bar'), $this->classMethodsCamelCase);
+        $this->classMethodsCamelCase = $hydrator->hydrate(array('fooBar' => 'foo', 'fooBarBaz' => 'bar'), $this->classMethodsCamelCase);
         $this->assertEquals($this->classMethodsCamelCase->getFooBar(), 'foo');
         $this->assertEquals($this->classMethodsCamelCase->getFooBarBaz(), 'bar');
     }
@@ -73,7 +73,7 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($datas['fooBar'], '1');
         $this->assertFalse(isset($datas['fooBarBaz']));
         $this->assertFalse(isset($datas['foo_bar']));
-        $hydrator->hydrate(array('fooBar' => 'foo'), $this->classMethodsCamelCaseMissing);
+        $this->classMethodsCamelCaseMissing = $hydrator->hydrate(array('fooBar' => 'foo'), $this->classMethodsCamelCaseMissing);
         $this->assertEquals($this->classMethodsCamelCaseMissing->getFooBar(), 'foo');
         $this->assertEquals($this->classMethodsCamelCaseMissing->getFooBarBaz(), '2');
     }
@@ -86,7 +86,7 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($datas['foo_bar'], '1');
         $this->assertTrue(isset($datas['foo_bar_baz']));
         $this->assertFalse(isset($datas['fooBar']));
-        $hydrator->hydrate(array('foo_bar' => 'foo', 'foo_bar_baz' => 'bar'), $this->classMethodsUnderscore);
+        $this->classMethodsUnderscore = $hydrator->hydrate(array('foo_bar' => 'foo', 'foo_bar_baz' => 'bar'), $this->classMethodsUnderscore);
         $this->assertEquals($this->classMethodsUnderscore->getFooBar(), 'foo');
         $this->assertEquals($this->classMethodsUnderscore->getFooBarBaz(), 'bar');
     }


### PR DESCRIPTION
Currently for the implementations we provide, it's not needed, but in case you want a doctrine\hydrator (f.e. https://github.com/prolic/HumusDoctrineHydrator), the object must be returned by that method, because it could be, that a new object instance will be created by doctrine, because it get's loaded from database, so finally it's a needed change and the api is also cleaner, imo
