### PR TITLE
[Hotfix][View\Helper] zf1 fix's sync

### DIFF
--- a/library/Zend/View/Helper/Currency.php
+++ b/library/Zend/View/Helper/Currency.php
@@ -61,7 +61,7 @@ class Currency extends AbstractHelper
      * Output a formatted currency
      *
      * @param  integer|float                    $value    Currency value to output
-     * @param  string|\Zend\Locale\Locale|\Zend\Currency\Currency $currency OPTIONAL Currency to use for this call
+     * @param  string|\Zend\Locale\Locale|array $currency OPTIONAL Currency to use for this call
      * @return string Formatted currency
      */
     public function __invoke($value = null, $currency = null)

--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -40,7 +40,7 @@ class HeadLink extends Placeholder\Container\Standalone
      *
      * @var array
      */
-    protected $_itemKeys = array('charset', 'href', 'hreflang', 'media', 'rel', 'rev', 'type', 'title', 'extras');
+    protected $_itemKeys = array('charset', 'href', 'hreflang', 'id', 'media', 'rel', 'rev', 'type', 'title', 'extras');
 
     /**
      * @var string registry key

--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -369,7 +369,6 @@ class HeadScript extends Placeholder\Container\Standalone
             );
         }
 
-        $this->_isValid($value);
         return $this->getContainer()->offsetSet($index, $value);
     }
 

--- a/library/Zend/View/Helper/HeadTitle.php
+++ b/library/Zend/View/Helper/HeadTitle.php
@@ -64,7 +64,6 @@ class HeadTitle extends Placeholder\Container\Standalone
      *
      * @param  string $title
      * @param  string $setType
-     * @param  string $separator
      * @return \Zend\View\Helper\HeadTitle
      */
     public function __invoke($title = null, $setType = null)

--- a/library/Zend/View/Helper/HeadTitle.php
+++ b/library/Zend/View/Helper/HeadTitle.php
@@ -141,7 +141,7 @@ class HeadTitle extends Placeholder\Container\Standalone
         return $this;
     }
 
-    /*
+    /**
      * Retrieve translation object
      *
      * If none is currently registered, attempts to pull it from the registry

--- a/library/Zend/View/Helper/HeadTitle.php
+++ b/library/Zend/View/Helper/HeadTitle.php
@@ -68,11 +68,12 @@ class HeadTitle extends Placeholder\Container\Standalone
      */
     public function __invoke($title = null, $setType = null)
     {
-        if ($setType === null && $this->getDefaultAttachOrder() === null) {
-            $setType = Placeholder\Container\AbstractContainer::APPEND;
-        } elseif ($setType === null && $this->getDefaultAttachOrder() !== null) {
-            $setType = $this->getDefaultAttachOrder();
+        if (null === $setType) {
+            $setType = (null === $this->getDefaultAttachOrder())
+                     ? Placeholder\Container\AbstractContainer::APPEND
+                     : $this->getDefaultAttachOrder();
         }
+
         $title = (string) $title;
         if ($title !== '') {
             if ($setType == Placeholder\Container\AbstractContainer::SET) {

--- a/library/Zend/View/Helper/HeadTitle.php
+++ b/library/Zend/View/Helper/HeadTitle.php
@@ -107,6 +107,8 @@ class HeadTitle extends Placeholder\Container\Standalone
             );
         }
         $this->_defaultAttachOrder = $setType;
+
+        return $this;
     }
 
     /**

--- a/library/Zend/View/Helper/Placeholder/Registry.php
+++ b/library/Zend/View/Helper/Placeholder/Registry.php
@@ -80,7 +80,7 @@ class Registry
     {
         $key = (string) $key;
 
-        $this->_items[$key] = new $this->_containerClass(array());
+        $this->_items[$key] = new $this->_containerClass($value);
         return $this->_items[$key];
     }
 

--- a/library/Zend/View/Helper/ServerUrl.php
+++ b/library/Zend/View/Helper/ServerUrl.php
@@ -53,9 +53,13 @@ class ServerUrl extends AbstractHelper
      */
     public function __construct()
     {
-        if (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] === true)) {
-            $scheme = 'https';
-        } else {
+        switch (true) {
+            case (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] === true)):
+            case (isset($_SERVER['HTTP_SCHEME']) && ($_SERVER['HTTP_SCHEME'] == 'https')):
+            case (isset($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == 443)):
+                $scheme = 'https';
+                break;
+            default:
             $scheme = 'http';
         }
         $this->setScheme($scheme);

--- a/tests/Zend/View/Helper/HeadLinkTest.php
+++ b/tests/Zend/View/Helper/HeadLinkTest.php
@@ -417,5 +417,14 @@ class HeadLinkTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $test);
     }
+
+    /**
+     * @issue ZF-10345
+     */
+    public function testIdAttributeIsSupported()
+    {
+        $this->helper->appendStylesheet(array('href' => '/bar/baz', 'id' => 'foo'));
+        $this->assertContains('id="foo"', $this->helper->toString());
+    }
 }
 

--- a/tests/Zend/View/Helper/HeadTitleTest.php
+++ b/tests/Zend/View/Helper/HeadTitleTest.php
@@ -212,4 +212,14 @@ class HeadTitleTest extends \PHPUnit_Framework_TestCase
         $placeholder = $this->helper->__invoke('Bar');
         $this->assertContains('BarFoo', $placeholder->toString());
     }
+
+
+    /**
+     *  @group ZF-10284
+     */
+    public function testReturnTypeDefaultAttachOrder()
+    {
+        $this->assertTrue($this->helper->setDefaultAttachOrder('PREPEND') instanceof Helper\HeadTitle);
+        $this->assertEquals('PREPEND', $this->helper->getDefaultAttachOrder());
+    }
 }

--- a/tests/Zend/View/Helper/Placeholder/RegistryTest.php
+++ b/tests/Zend/View/Helper/Placeholder/RegistryTest.php
@@ -180,10 +180,29 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
         $registered = \Zend\Registry::get(Registry::REGISTRY_KEY);
         $this->assertSame($registry, $registered);
     }
+
+    /**
+     * @group ZF-10793
+     */
+    public function testSetValueCreateContainer()
+    {
+        $this->registry->setContainerClass('ZendTest\View\Helper\Placeholder\MockContainer');
+        $data = array(
+            'ZF-10793'
+        );
+        $container = $this->registry->createContainer('foo', $data);
+        $this->assertEquals(array('ZF-10793'), $container->data);
+    }
 }
 
 class MockContainer extends Container\AbstractContainer
 {
+    public $data = array();
+
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
 }
 
 class BogusContainer

--- a/tests/Zend/View/Helper/ServerUrlTest.php
+++ b/tests/Zend/View/Helper/ServerUrlTest.php
@@ -151,4 +151,26 @@ class ServerUrlTest extends \PHPUnit_Framework_TestCase
         $url = new Helper\ServerUrl();
         $this->assertEquals('http://example.com', $url->__invoke(new \stdClass()));
     }
+
+    /**
+     * @group ZF-9919
+     */
+    public function testServerUrlWithScheme()
+    {
+        $_SERVER['HTTP_SCHEME'] = 'https';
+        $_SERVER['HTTP_HOST'] = 'example.com';
+        $url = new Helper\ServerUrl();
+        $this->assertEquals('https://example.com', $url->__invoke());
+    }
+
+    /**
+     * @group ZF-9919
+     */
+    public function testServerUrlWithPort()
+    {
+        $_SERVER['SERVER_PORT'] = 443;
+        $_SERVER['HTTP_HOST'] = 'example.com';
+        $url = new Helper\ServerUrl();
+        $this->assertEquals('https://example.com', $url->__invoke());
+    }
 }


### PR DESCRIPTION
This PR includes zf1 fix's sync
- [ZF-10284] Zend_View - Added support fluent interface.
  [r22879](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=22879)
- ZF-10345: allow specifying id attribute in headLink helper
  [r23242](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=23242)
- ZF-9919: extended serverUrl helper to correctly identify scheme
  [r23370](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=23370)
- ZF-9324 Zend_View Fixed docblock
  [r23386](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=23386)
- [CS] Zend_View - Fixed ajust in docblock, missing '*'
  [r23387](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=23387)
- [ZF-10793] Zend_View - Fixed allow set value to class of container.
  [r23544](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=23544)
- ZF-10843 removing unnecessary call to _isValid in Zend_View_Helper_HeadScript
  [r23548](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=23548)
- ZF-11013 Zend_View_Helper: headTitle helper minor code readability improvement
  [r23722](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=23722)
- ZF-12174: Fixed incorrect docblock in Zend_View_Helper_Currency
  [r24768](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=24768)

Travis Status : [http://travis-ci.org/#!/sasezaki/zf2/builds/1456064](http://travis-ci.org/#!/sasezaki/zf2/builds/1456064)
