### PR TITLE
removed dependency on deprecated \Zend\Loader class from Zend Validator ...

### DIFF
--- a/library/Zend/Validator/Barcode.php
+++ b/library/Zend/Validator/Barcode.php
@@ -103,9 +103,6 @@ class Barcode extends AbstractValidator
         if (is_string($adapter)) {
             $adapter = ucfirst(strtolower($adapter));
             $adapter = 'Zend\Validator\Barcode\\' . $adapter;
-            if (\Zend\Loader::isReadable('Zend/Validator/Barcode/' . $adapter . '.php')) {
-                $adapter = 'Zend\Validator\Barcode\\' . $adapter;
-            }
 
             if (!class_exists($adapter)) {
                 throw new Exception\InvalidArgumentException('Barcode adapter matching "' . $adapter . '" not found');

--- a/library/Zend/Validator/File/Crc32.php
+++ b/library/Zend/Validator/File/Crc32.php
@@ -20,8 +20,6 @@
 
 namespace Zend\Validator\File;
 
-use Zend\Loader;
-
 /**
  * Validator for the crc32 hash of given files
  *
@@ -106,7 +104,7 @@ class Crc32 extends Hash
         }
 
         // Is file readable ?
-        if (!Loader::isReadable($value)) {
+        if (false === stream_resolve_include_path($value)) {
             return $this->_throw($file, self::NOT_FOUND);
         }
 

--- a/library/Zend/Validator/File/ExcludeExtension.php
+++ b/library/Zend/Validator/File/ExcludeExtension.php
@@ -20,8 +20,6 @@
 
 namespace Zend\Validator\File;
 
-use Zend\Loader;
-
 /**
  * Validator for the excluding file extensions
  *
@@ -61,7 +59,7 @@ class ExcludeExtension extends Extension
         }
 
         // Is file readable ?
-        if (!Loader::isReadable($value)) {
+        if (false === stream_resolve_include_path($value)) {
             return $this->_throw($file, self::NOT_FOUND);
         }
 

--- a/library/Zend/Validator/File/ExcludeMimeType.php
+++ b/library/Zend/Validator/File/ExcludeMimeType.php
@@ -20,8 +20,7 @@
 
 namespace Zend\Validator\File;
 
-use finfo,
-    Zend\Loader;
+use finfo;
 
 /**
  * Validator for the mime type of a file
@@ -56,7 +55,7 @@ class ExcludeMimeType extends MimeType
         }
 
         // Is file readable ?
-        if (!Loader::isReadable($value)) {
+        if (false === stream_resolve_include_path($value)) {
             return $this->createError($file, self::NOT_READABLE);
         }
 

--- a/library/Zend/Validator/File/Extension.php
+++ b/library/Zend/Validator/File/Extension.php
@@ -22,7 +22,6 @@ namespace Zend\Validator\File;
 
 use Traversable;
 use Zend\Stdlib\ArrayUtils;
-use Zend\Loader;
 
 /**
  * Validator for the file extension of a file
@@ -197,7 +196,7 @@ class Extension extends \Zend\Validator\AbstractValidator
         }
 
         // Is file readable ?
-        if (!Loader::isReadable($value)) {
+        if (false === stream_resolve_include_path($value)) {
             return $this->_throw($file, self::NOT_FOUND);
         }
 

--- a/library/Zend/Validator/File/FilesSize.php
+++ b/library/Zend/Validator/File/FilesSize.php
@@ -22,7 +22,6 @@ namespace Zend\Validator\File;
 
 use Traversable;
 use Zend\Stdlib\ArrayUtils;
-use Zend\Loader;
 
 /**
  * Validator for the size of all files which will be validated in sum
@@ -109,7 +108,7 @@ class FilesSize extends Size
         $size = $this->_getSize();
         foreach ($value as $files) {
             // Is file readable ?
-            if (!Loader::isReadable($files)) {
+            if (false === stream_resolve_include_path($files)) {
                 $this->_throw($file, self::NOT_READABLE);
                 continue;
             }

--- a/library/Zend/Validator/File/Hash.php
+++ b/library/Zend/Validator/File/Hash.php
@@ -20,8 +20,7 @@
 
 namespace Zend\Validator\File;
 
-use Zend\Loader,
-    Zend\Validator,
+use Zend\Validator,
     Zend\Validator\Exception;
 
 /**
@@ -151,7 +150,7 @@ class Hash extends Validator\AbstractValidator
         }
 
         // Is file readable ?
-        if (!Loader::isReadable($value)) {
+        if (false === stream_resolve_include_path($value)) {
             return $this->_throw($file, self::NOT_FOUND);
         }
 

--- a/library/Zend/Validator/File/ImageSize.php
+++ b/library/Zend/Validator/File/ImageSize.php
@@ -20,8 +20,7 @@
 
 namespace Zend\Validator\File;
 
-use Zend\Loader,
-    Zend\Validator,
+use Zend\Validator,
     Zend\Validator\Exception;
 
 /**
@@ -393,7 +392,7 @@ class ImageSize extends Validator\AbstractValidator
         }
 
         // Is file readable ?
-        if (!Loader::isReadable($value)) {
+        if (false === stream_resolve_include_path($value)) {
             return $this->_throw($file, self::NOT_READABLE);
         }
 

--- a/library/Zend/Validator/File/Md5.php
+++ b/library/Zend/Validator/File/Md5.php
@@ -20,8 +20,6 @@
 
 namespace Zend\Validator\File;
 
-use Zend\Loader;
-
 /**
  * Validator for the md5 hash of given files
  *
@@ -106,7 +104,7 @@ class Md5 extends Hash
         }
 
         // Is file readable ?
-        if (!Loader::isReadable($value)) {
+        if (false === stream_resolve_include_path($value)) {
             return $this->_throw($file, self::NOT_FOUND);
         }
 

--- a/library/Zend/Validator/File/MimeType.php
+++ b/library/Zend/Validator/File/MimeType.php
@@ -21,7 +21,6 @@
 namespace Zend\Validator\File;
 
 use Traversable,
-    Zend\Loader,
     Zend\Stdlib\ArrayUtils,
     Zend\Validator\AbstractValidator,
     Zend\Validator\Exception;
@@ -358,7 +357,7 @@ class MimeType extends AbstractValidator
         }
 
         // Is file readable ?
-        if (!Loader::isReadable($value)) {
+        if (false === stream_resolve_include_path($value)) {
             return $this->createError($file, self::NOT_READABLE);
         }
 

--- a/library/Zend/Validator/File/Sha1.php
+++ b/library/Zend/Validator/File/Sha1.php
@@ -20,8 +20,7 @@
 
 namespace Zend\Validator\File;
 
-use Zend\Loader,
-    Zend\Validator\Exception;
+use Zend\Validator\Exception;
 
 /**
  * Validator for the sha1 hash of given files
@@ -107,7 +106,7 @@ class Sha1 extends Hash
         }
 
         // Is file readable ?
-        if (!Loader::isReadable($value)) {
+        if (false === stream_resolve_include_path($value)) {
             return $this->_throw($file, self::NOT_FOUND);
         }
 

--- a/library/Zend/Validator/File/Size.php
+++ b/library/Zend/Validator/File/Size.php
@@ -20,8 +20,7 @@
 
 namespace Zend\Validator\File;
 
-use Zend\Loader,
-    Zend\Validator,
+use Zend\Validator,
     Zend\Validator\Exception;
 
 /**
@@ -253,7 +252,7 @@ class Size extends Validator\AbstractValidator
         }
 
         // Is file readable ?
-        if (!Loader::isReadable($value)) {
+        if (false === stream_resolve_include_path($value)) {
             return $this->_throw($file, self::NOT_FOUND);
         }
 

--- a/library/Zend/Validator/File/WordCount.php
+++ b/library/Zend/Validator/File/WordCount.php
@@ -20,8 +20,6 @@
 
 namespace Zend\Validator\File;
 
-use Zend\Loader;
-
 /**
  * Validator for counting all words in a file
  *
@@ -63,7 +61,7 @@ class WordCount extends Count
         }
 
         // Is file readable ?
-        if (!Loader::isReadable($value)) {
+        if (false === stream_resolve_include_path($value)) {
             return $this->_throw($file, self::NOT_FOUND);
         }
 


### PR DESCRIPTION
...package

Removed static calls to \Zend\Loader::isReadable() from Zend Validator package, replacing with direct calls to stream_resolve_include_path().

If there's a replacement strategy for checking the existence of a file within ZF2 I can use that instead and would re-work the PR - but there didn't seem to be one established.
