### PR TITLE
Added the CTR and NCFB mode to Mcrypt adapter

### DIFF
--- a/library/Zend/Crypt/Symmetric/Mcrypt.php
+++ b/library/Zend/Crypt/Symmetric/Mcrypt.php
@@ -92,8 +92,10 @@ class Mcrypt implements SymmetricInterface
     protected $supportedModes = array(
         'cbc'  => MCRYPT_MODE_CBC,
         'cfb'  => MCRYPT_MODE_CFB,
+        'ctr'  => 'ctr',
         'ofb'  => MCRYPT_MODE_OFB,
-        'nofb' => MCRYPT_MODE_NOFB
+        'nofb' => MCRYPT_MODE_NOFB,
+        'ncfb' => 'ncfb'
     );
 
     /**


### PR DESCRIPTION
Added the CTR (Counter) mode and the NCFB mode to the Mcrypt adapter. Supported by PHP 5.3.
