### PR TITLE
Fix passing options to Captcha factory

### DIFF
--- a/library/Zend/Captcha/Factory.php
+++ b/library/Zend/Captcha/Factory.php
@@ -81,7 +81,9 @@ abstract class Factory
                 $class
             ));
         }
-        $options = array();
+        
+        unset($options['class']);
+
         if (isset($options['options'])) {
             $options = $options['options'];
         }

--- a/tests/Zend/Captcha/FactoryTest.php
+++ b/tests/Zend/Captcha/FactoryTest.php
@@ -181,4 +181,15 @@ class FactoryTest extends TestCase
         ));
         $this->assertInstanceOf('Zend\Captcha\ReCaptcha', $captcha);
     }
+
+    public function testOptionsArePassedToCaptchaAdapter()
+    {
+        $captcha = Captcha\Factory::factory(array(
+            'class'   => 'ZendTest\Captcha\TestAsset\MockCaptcha',
+            'options' => array(
+                'foo' => 'bar',
+            ),
+        ));
+        $this->assertEquals(array('foo' => 'bar'), $captcha->options);
+    }
 }

--- a/tests/Zend/Captcha/TestAsset/MockCaptcha.php
+++ b/tests/Zend/Captcha/TestAsset/MockCaptcha.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Captcha
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Captcha\TestAsset;
+
+use Zend\Captcha\AdapterInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Captcha
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class MockCaptcha implements AdapterInterface
+{
+    public $name;
+    public $options = array();
+
+    public function __construct($options = null)
+    {
+        $this->options = $options;
+    }
+
+    public function generate()
+    {
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getHelperName()
+    {
+        return 'doctype';
+    }
+
+    public function isValid($value)
+    {
+        return true;
+    }
+
+    public function getMessages()
+    {
+        return array();
+    }
+}


### PR DESCRIPTION
- Factory was resetting options array, making it impossible to seed
  captcha adapters with options during instantiation.
