### PR TITLE
Fix/zf2 330

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -151,7 +151,7 @@ class BaseInputFilter implements InputFilterInterface
         $inputs = $this->validationGroup ?: array_keys($this->inputs);
         foreach ($inputs as $name) {
             $input = $this->inputs[$name];
-            if (!array_key_exists($name, $this->data) or ($this->data[$name] == "")) {
+            if (!array_key_exists($name, $this->data) || ($this->data[$name] == '')) {
                 // - test if input is required
                 if (!$input->isRequired()) {
                     $this->validInputs[$name] = $input;
@@ -163,7 +163,7 @@ class BaseInputFilter implements InputFilterInterface
                     continue;
                 }
                 // make sure we have a value (empty) for validation
-                $this->data[$name] = "";
+                $this->data[$name] = '';
             }
             
             $value = $this->data[$name];

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -150,9 +150,8 @@ class BaseInputFilter implements InputFilterInterface
         
         $inputs = $this->validationGroup ?: array_keys($this->inputs);
         foreach ($inputs as $name) {
-            $input = $this->inputs[$name];
-
-            if (!array_key_exists($name, $this->data) || (strlen($this->data[$name]) === 0)) {
+            $input = $this->inputs[$name]; 
+            if (!array_key_exists($name, $this->data) || (is_string($this->data[$name]) && strlen($this->data[$name]) === 0)) {
                 if($input instanceof InputInterface) {
                     // - test if input is required
                     if (!$input->isRequired()) {

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -152,15 +152,18 @@ class BaseInputFilter implements InputFilterInterface
         foreach ($inputs as $name) {
             $input = $this->inputs[$name];
             if (!array_key_exists($name, $this->data) || ($this->data[$name] == '')) {
-                // - test if input is required
-                if (!$input->isRequired()) {
-                    $this->validInputs[$name] = $input;
-                    continue;
-                }
-                // - test if input allows empty
-                if ($input->allowEmpty()) {
-                    $this->validInputs[$name] = $input;
-                    continue;
+		        if($input instanceof InputInterface)
+		        {
+                    // - test if input is required
+                    if (!$input->isRequired()) {
+                        $this->validInputs[$name] = $input;
+                        continue;
+                    }
+                    // - test if input allows empty
+                    if ($input->allowEmpty()) {
+                        $this->validInputs[$name] = $input;
+                        continue;
+                    }
                 }
                 // make sure we have a value (empty) for validation
                 $this->data[$name] = '';

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -151,9 +151,9 @@ class BaseInputFilter implements InputFilterInterface
         $inputs = $this->validationGroup ?: array_keys($this->inputs);
         foreach ($inputs as $name) {
             $input = $this->inputs[$name];
-            if (!array_key_exists($name, $this->data) || ($this->data[$name] == '')) {
-		        if($input instanceof InputInterface)
-		        {
+
+            if (!array_key_exists($name, $this->data) || (strlen($this->data[$name]) === 0)) {
+                if($input instanceof InputInterface) {
                     // - test if input is required
                     if (!$input->isRequired()) {
                         $this->validInputs[$name] = $input;

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -151,46 +151,21 @@ class BaseInputFilter implements InputFilterInterface
         $inputs = $this->validationGroup ?: array_keys($this->inputs);
         foreach ($inputs as $name) {
             $input = $this->inputs[$name];
-
-            if (!array_key_exists($name, $this->data)) {
-                // Not sure how to handle input filters in this case
-                if ($input instanceof InputFilterInterface) {
-                    if (!$input->isValid()) {
-                        $this->invalidInputs[$name] = $input;
-                        $valid = false;
-                        continue;
-                    }
-                    $this->validInputs[$name] = $input;
-                    continue;
-                }
-
-                // no matching value in data
+            if (!array_key_exists($name, $this->data) or ($this->data[$name] == "")) {
                 // - test if input is required
-                // - test if input allows empty
                 if (!$input->isRequired()) {
                     $this->validInputs[$name] = $input;
                     continue;
                 }
-
+                // - test if input allows empty
                 if ($input->allowEmpty()) {
                     $this->validInputs[$name] = $input;
                     continue;
                 }
-
-                // How do we mark the input as invalid in this case?
-                // (for purposes of a validation error message)
-
-                // Mark validation as having failed
-                $this->invalidInputs[$name] = $input;
-                $valid = false;
-                if ($input->breakOnFailure()) {
-                    // We failed validation, and this input is marked to
-                    // break on failure
-                    return false;
-                }
-                continue;
+                // make sure we have a value (empty) for validation
+                $this->data[$name] = "";
             }
-
+            
             $value = $this->data[$name];
             if ($input instanceof InputFilterInterface) {
                 if (!$input->isValid()) {

--- a/tests/Zend/InputFilter/BaseInputFilterTest.php
+++ b/tests/Zend/InputFilter/BaseInputFilterTest.php
@@ -78,9 +78,15 @@ class BaseInputFilterTest extends TestCase
         $bar = new Input();
         $bar->getFilterChain()->attachByName('stringtrim');
         $bar->getValidatorChain()->addValidator(new Validator\Digits());
+        
+        $baz = new Input();
+        $baz->setRequired(false);
+        $baz->getFilterChain()->attachByName('stringtrim');
+        $baz->getValidatorChain()->addValidator(new Validator\StringLength(1, 6)); 
 
         $filter->add($foo, 'foo')
                ->add($bar, 'bar')
+               ->add($baz, 'baz')
                ->add($this->getChildInputFilter(), 'nest');
 
         return $filter;
@@ -99,8 +105,14 @@ class BaseInputFilterTest extends TestCase
         $bar->getFilterChain()->attachByName('stringtrim');
         $bar->getValidatorChain()->addValidator(new Validator\Digits());
 
+        $baz = new Input();
+        $baz->setRequired(false);
+        $baz->getFilterChain()->attachByName('stringtrim');
+        $baz->getValidatorChain()->addValidator(new Validator\StringLength(1, 6));
+        
         $filter->add($foo, 'foo')
-               ->add($bar, 'bar');
+               ->add($bar, 'bar')
+               ->add($baz, 'baz');
         return $filter;
     }
 
@@ -110,9 +122,11 @@ class BaseInputFilterTest extends TestCase
         $validData = array(
             'foo' => ' bazbat ',
             'bar' => '12345',
+            'baz' => '',
             'nest' => array(
                 'foo' => ' bazbat ',
                 'bar' => '12345',
+                'baz' => '',
             ),
         );
         $filter->setData($validData);
@@ -121,9 +135,11 @@ class BaseInputFilterTest extends TestCase
         $invalidData = array(
             'foo' => ' baz bat ',
             'bar' => 'abc45',
+            'baz' => ' ',
             'nest' => array(
                 'foo' => ' baz bat ',
                 'bar' => '123ab',
+                'baz' => ' ',
             ),
         );
         $filter->setData($invalidData);
@@ -210,9 +226,11 @@ class BaseInputFilterTest extends TestCase
         $validData = array(
             'foo' => ' bazbat ',
             'bar' => '12345',
+            'baz' => '',
             'nest' => array(
                 'foo' => ' bazbat ',
                 'bar' => '12345',
+                'baz' => '',
             ),
         );
         $filter->setData($validData);
@@ -220,9 +238,11 @@ class BaseInputFilterTest extends TestCase
         $expected = array(
             'foo' => 'bazbat',
             'bar' => '12345',
+            'baz' => '',
             'nest' => array(
                 'foo' => 'bazbat',
                 'bar' => '12345',
+                'baz' => '',
             ),
         );
         $this->assertEquals($expected, $filter->getValues());
@@ -234,9 +254,11 @@ class BaseInputFilterTest extends TestCase
         $validData = array(
             'foo' => ' bazbat ',
             'bar' => '12345',
+            'baz' => '',
             'nest' => array(
                 'foo' => ' bazbat ',
                 'bar' => '12345',
+                'baz' => '',
             ),
         );
         $filter->setData($validData);
@@ -247,12 +269,16 @@ class BaseInputFilterTest extends TestCase
     public function testCanGetValidationMessages()
     {
         $filter = $this->getInputFilter();
+        $filter->get('baz')->setRequired(true);
+        $filter->get('nest')->get('baz')->setRequired(true);
         $invalidData = array(
             'foo' => ' bazbat boo ',
             'bar' => 'abc45',
+            'baz' => '',
             'nest' => array(
                 'foo' => ' baz bat boo ',
                 'bar' => '123yz',
+                'baz' => '',
             ),
         );
         $filter->setData($invalidData);
@@ -268,6 +294,9 @@ class BaseInputFilterTest extends TestCase
                 case 'bar':
                     $this->assertArrayHasKey(Validator\Digits::NOT_DIGITS, $currentMessages);
                     break;
+                case 'baz':
+                    $this->assertArrayHasKey(Validator\NotEmpty::IS_EMPTY, $currentMessages);
+                    break;
                 case 'nest':
                     foreach ($value as $k => $v) {
                         $this->assertArrayHasKey($k, $messages[$key]);
@@ -278,6 +307,9 @@ class BaseInputFilterTest extends TestCase
                                 break;
                             case 'bar':
                                 $this->assertArrayHasKey(Validator\Digits::NOT_DIGITS, $currentMessages);
+                                break;
+                            case 'baz':
+                                $this->assertArrayHasKey(Validator\NotEmpty::IS_EMPTY, $currentMessages);
                                 break;
                             default:
                                 $this->fail(sprintf('Invalid key "%s" encountered in messages array', $k));


### PR DESCRIPTION
When submitting empty form elements, the data array entry associated with that element and used in the input filter validation (BaseInputFilter::isValid) will be set, but with an empty value ("").
The way isValid() checks for these is wrong as it only checks if the array entry is set or not, making the check (!isset) always false, causing empty fields not be accepted even if they are not required.
Also the validation for empty elements will not produce an error message in the case that these are required.
The best way to handle these empty required fields is just to pass an empty string and let the validator handle it.
It will set a "The Value is required and cannot be empty" error message in these cases.
