### PR TITLE
[XmlRpc][Hotfix] sync zf1's fix

### DIFF
--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -256,7 +256,7 @@ class Client implements ServerClient
         }
 
         $this->_lastResponse = $response;
-        $this->_lastResponse->loadXml($httpResponse->getBody());
+        $this->_lastResponse->loadXml(trim($httpResponse->getBody()));
     }
 
     /**

--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -296,21 +296,30 @@ class Client implements ServerClient
                     $params = array($params);
                 }
                 foreach ($params as $key => $param) {
-
                     if ($param instanceof Value) {
                         continue;
                     }
 
-                    $type = Value::AUTO_DETECT_TYPE;
-                    foreach ($signatures as $signature) {
-                        if (!is_array($signature)) {
-                            continue;
+                    if (count($signatures) > 1) {
+                        $type = Value::getXmlRpcTypeByValue($param);
+                        foreach ($signatures as $signature) {
+                            if (!is_array($signature)) {
+                                continue;
+                            }
+                            if (isset($signature['parameters'][$key])) {
+                                if ($signature['parameters'][$key] == $type) {
+                                    break;
+                                }
+                            }
                         }
+                    } elseif (isset($signatures[0]['parameters'][$key])) {
+                        $type = $signatures[0]['parameters'][$key];
+                    } else {
+                        $type = null;
+                    }
 
-                        if (isset($signature['parameters'][$key])) {
-                            $type = $signature['parameters'][$key];
-                            $type = in_array($type, $validTypes) ? $type : Value::AUTO_DETECT_TYPE;
-                        }
+                    if (empty($type) || !in_array($type, $validTypes)) {
+                        $type = Value::AUTO_DETECT_TYPE;
                     }
 
                     $params[$key] = Value::getXmlRpcValue($param, $type);

--- a/library/Zend/XmlRpc/Value/DateTime.php
+++ b/library/Zend/XmlRpc/Value/DateTime.php
@@ -43,7 +43,7 @@ class DateTime extends Scalar
      *
      * @var string
      */
-    protected $_isoFormatString = 'YYYYMMddTHH:mm:ss';
+    protected $_isoFormatString = 'yyyyMMddTHH:mm:ss';
 
     /**
      * Set the value of a dateTime.iso8601 native type

--- a/library/Zend/XmlRpc/Value/DateTime.php
+++ b/library/Zend/XmlRpc/Value/DateTime.php
@@ -64,12 +64,13 @@ class DateTime extends Scalar
         } elseif (is_numeric($value)) { // The value is numeric, we make sure it is an integer
             $this->_value = date($this->_phpFormatString, (int)$value);
         } else {
-            $timestamp = strtotime($value);
-            if ($timestamp === false || $timestamp == -1) { // cannot convert the value to a timestamp
-                throw new Exception\ValueException('Cannot convert given value \''. $value .'\' to a timestamp');
+            try {
+                $dateTime = new \DateTime($value);
+            } catch (\Exception $e) {
+                throw new Exception\ValueException($e->getMessage(), $e->getCode(), $e);
             }
 
-            $this->_value = date($this->_phpFormatString, $timestamp); // Convert the timestamp to iso8601 format
+            $this->_value = $dateTime->format($this->_phpFormatString); // Convert the DateTime to iso8601 format
         }
     }
 

--- a/tests/Zend/XmlRpc/ClientTest.php
+++ b/tests/Zend/XmlRpc/ClientTest.php
@@ -655,6 +655,24 @@ class ClientTest extends \PHPUnit_Framework_TestCase
           );
     }
 
+    /**
+     * @group ZF-1897
+     */
+    public function testHandlesLeadingOrTrailingWhitespaceInChunkedResponseProperly()
+    {
+        $baseUri = "http://foo:80";
+        $this->httpAdapter = new Adapter\Test();
+        $this->httpClient = new Http\Client(null, array('adapter' => $this->httpAdapter));
+        
+        $respBody = file_get_contents(dirname(__FILE__) . "/_files/ZF1897-response-chunked.txt");
+        $this->httpAdapter->setResponse($respBody);
+
+        $this->xmlrpcClient = new Client($baseUri);
+        $this->xmlrpcClient->setHttpClient($this->httpClient);
+        
+        $this->assertEquals('FOO', $this->xmlrpcClient->call('foo'));
+    }
+
     // Helpers
     public function setServerResponseTo($nativeVars)
     {

--- a/tests/Zend/XmlRpc/ClientTest.php
+++ b/tests/Zend/XmlRpc/ClientTest.php
@@ -621,6 +621,40 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $signature = $introspector->getMethodSignature('add');
     }
 
+
+    /**
+     * @group ZF-8580
+     */
+    public function testCallSelectsCorrectSignatureIfMoreThanOneIsAvailable()
+    {
+        $this->mockIntrospector();
+
+        $this->mockedIntrospector
+             ->expects($this->exactly(2))
+             ->method('getMethodSignature')
+             ->with('get')
+             ->will($this->returnValue(array(
+                 array('parameters' => array('int')),
+                 array('parameters' => array('array'))
+             )));
+
+          $expectedResult = 'array';
+          $this->setServerResponseTo($expectedResult);
+
+          $this->assertSame(
+              $expectedResult,
+              $this->xmlrpcClient->call('get', array(array(1)))
+          );
+
+          $expectedResult = 'integer';
+          $this->setServerResponseTo($expectedResult);
+
+          $this->assertSame(
+              $expectedResult,
+              $this->xmlrpcClient->call('get', array(1))
+          );
+    }
+
     // Helpers
     public function setServerResponseTo($nativeVars)
     {

--- a/tests/Zend/XmlRpc/ValueTest.php
+++ b/tests/Zend/XmlRpc/ValueTest.php
@@ -20,13 +20,14 @@
  */
 
 namespace ZendTest\XmlRpc;
+use stdClass;
 use Zend\XmlRpc\Value;
 use Zend\XmlRpc\Generator\GeneratorInterface as Generator;
 use Zend\Math\BigInteger;
 use Zend\Date;
 
 /**
- * Test case for Zend_XmlRpc_Value
+ * Test case for Value
  *
  * @category   Zend
  * @package    Zend_XmlRpc
@@ -785,6 +786,84 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     {
         $xmlRpcValue = new Value\String('foo');
         $this->assertSame($xmlRpcValue, Value::getXmlRpcValue($xmlRpcValue));
+    }
+
+
+    public function testGetXmlRpcTypeByValue()
+    {
+        $this->assertSame(
+            Value::XMLRPC_TYPE_NIL,
+            Value::getXmlRpcTypeByValue(new Value\Nil)
+        );
+
+        $this->assertEquals(
+            Value::XMLRPC_TYPE_DATETIME,
+            Value::getXmlRpcTypeByValue(new \DateTime)
+        );
+
+        $this->assertEquals(
+            Value::XMLRPC_TYPE_DATETIME,
+            Value::getXmlRpcTypeByValue(new \Zend\Date\Date)
+        );
+
+        $this->assertEquals(
+            Value::XMLRPC_TYPE_STRUCT,
+            Value::getXmlRpcTypeByValue(array('foo' => 'bar'))
+        );
+
+        $object = new stdClass;
+        $object->foo = 'bar';
+
+        $this->assertEquals(
+            Value::XMLRPC_TYPE_STRUCT,
+            Value::getXmlRpcTypeByValue($object)
+        );
+
+        $this->assertEquals(
+            Value::XMLRPC_TYPE_ARRAY,
+            Value::getXmlRpcTypeByValue(new stdClass)
+        );
+
+        $this->assertEquals(
+            Value::XMLRPC_TYPE_ARRAY,
+            Value::getXmlRpcTypeByValue(array(1, 3, 3, 7))
+        );
+
+        $this->assertEquals(
+            Value::XMLRPC_TYPE_INTEGER,
+            Value::getXmlRpcTypeByValue(42)
+        );
+
+        $this->assertEquals(
+            Value::XMLRPC_TYPE_DOUBLE,
+            Value::getXmlRpcTypeByValue(13.37)
+        );
+
+        $this->assertEquals(
+            Value::XMLRPC_TYPE_BOOLEAN,
+            Value::getXmlRpcTypeByValue(true)
+        );
+
+        $this->assertEquals(
+            Value::XMLRPC_TYPE_BOOLEAN,
+            Value::getXmlRpcTypeByValue(false)
+        );
+
+        $this->assertEquals(
+            Value::XMLRPC_TYPE_NIL,
+            Value::getXmlRpcTypeByValue(null)
+        );
+
+        $this->assertEquals(
+            Value::XMLRPC_TYPE_STRING,
+            Value::getXmlRpcTypeByValue('Zend Framework')
+        );
+    }
+
+    public function testGetXmlRpcTypeByValueThrowsExceptionOnInvalidValue()
+    {
+        $this->setExpectedException('Zend\XmlRpc\Exception\InvalidArgumentException');
+        Value::getXmlRpcTypeByValue(fopen(__FILE__, 'r'));
     }
 
     // Custom Assertions and Helper Methods

--- a/tests/Zend/XmlRpc/ValueTest.php
+++ b/tests/Zend/XmlRpc/ValueTest.php
@@ -21,6 +21,7 @@
 
 namespace ZendTest\XmlRpc;
 use stdClass;
+use DateTime;
 use Zend\XmlRpc\Value;
 use Zend\XmlRpc\Generator\GeneratorInterface as Generator;
 use Zend\Math\BigInteger;
@@ -703,6 +704,26 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(trim($xml), trim($val->saveXml()));
     }
 
+    /**
+     * @group ZF-10776
+     */
+    public function testGetValueDatetime()
+    {
+        $expectedValue = '20100101T00:00:00';
+        $zfDate         = new Date\Date('2010-01-01 00:00:00', 'yyyy-MM-dd HH:mm:ss');
+        $phpDatetime     = new DateTime('20100101T00:00:00');
+        $phpDateNative   = '20100101T00:00:00';
+
+        $xmlRpcValueDateTime = new Value\DateTime($zfDate);
+        $this->assertEquals($expectedValue, $xmlRpcValueDateTime->getValue());
+
+        $xmlRpcValueDateTime = new Value\DateTime($phpDatetime);
+        $this->assertEquals($expectedValue, $xmlRpcValueDateTime->getValue());
+
+        $xmlRpcValueDateTime = new Value\DateTime($phpDateNative);
+        $this->assertEquals($expectedValue, $xmlRpcValueDateTime->getValue());
+    }
+
     // Base64
 
     public function testMarshalBase64FromString()
@@ -798,7 +819,7 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             Value::XMLRPC_TYPE_DATETIME,
-            Value::getXmlRpcTypeByValue(new \DateTime)
+            Value::getXmlRpcTypeByValue(new DateTime)
         );
 
         $this->assertEquals(

--- a/tests/Zend/XmlRpc/_files/ZF1897-response-chunked.txt
+++ b/tests/Zend/XmlRpc/_files/ZF1897-response-chunked.txt
@@ -1,0 +1,22 @@
+HTTP/1.1 200 OK
+Date: Thu, 06 Sep 2007 14:58:44 GMT
+Server: Apache/2.0.54 (Debian GNU/Linux) DAV/2 SVN/1.1.4 mod_python/3.1.3 Python/2.3.5 mod_ssl/2.0.54 OpenSSL/0.9.7e PHP/5.1.6
+X-Powered-By: PHP/5.1.6
+Connection: close
+Transfer-Encoding: chunked
+Content-Type: text/html; charset=iso-8859-1
+
+92 
+
+ 
+<?xml version="1.0"?>
+<methodResponse>
+  <params>
+    <param>
+      <value>FOO</value>
+    </param>
+  </params>
+</methodResponse>
+ 
+0 
+ 


### PR DESCRIPTION
```
ZF-11588: handle string dates and dates beyond unix epoch
reference svn r24291

ZF-1897 XmlRpc Resolved issue with leading/trailing whitespace in chunked HTTP response
sync svn r24150

ZF-10776 - Fixed datetime the format past to object Zend_Date was wrong.
sync svn r23550

ZF-8580 SystemLookup in Zend_Xmlrpc_Client selects wrong signature
sync svn r23385
```

[r23385](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=23385),
[r23550](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=23550),
[r24150](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=24150),
[r24291](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=24291)

Build Status http://travis-ci.org/#!/sasezaki/zf2/builds/1477327
