### PR TITLE
Zend\Crypt\Tool -> Utils + more general safe string comparison

### DIFF
--- a/library/Zend/Crypt/BlockCipher.php
+++ b/library/Zend/Crypt/BlockCipher.php
@@ -11,7 +11,7 @@ namespace Zend\Crypt;
 
 use Zend\Crypt\Symmetric\SymmetricInterface;
 use Zend\Crypt\Hmac;
-use Zend\Crypt\Tool;
+use Zend\Crypt\Utils;
 use Zend\Crypt\Key\Derivation\Pbkdf2;
 use Zend\Math\Math;
 
@@ -241,7 +241,7 @@ class BlockCipher
     /**
      * Get the cipher algorithm
      *
-     * @return string|false
+     * @return string|boolean
      */
     public function getCipherAlgorithm()
     {
@@ -338,6 +338,7 @@ class BlockCipher
      *
      * @param  string $data
      * @return string|boolean
+     * @throws Exception\InvalidArgumentException
      */
     public function decrypt($data)
     {
@@ -371,7 +372,7 @@ class BlockCipher
         $hmacNew = Hmac::compute($keyHmac,
                                  $this->hash,
                                  $this->cipher->getAlgorithm() . $ciphertext);
-        if (!Tool::compareString($hmacNew, $hmac)) {
+        if (!Utils::compareStrings($hmacNew, $hmac)) {
             return false;
         }
         return $this->cipher->decrypt($ciphertext);

--- a/library/Zend/Crypt/BlockCipher.php
+++ b/library/Zend/Crypt/BlockCipher.php
@@ -105,6 +105,7 @@ class BlockCipher
      * Set the symmetric cipher broker
      *
      * @param  string|SymmetricBroker $broker
+     * @throws Exception\InvalidArgumentException
      */
     public static function setSymmetricBroker($broker)
     {
@@ -199,6 +200,7 @@ class BlockCipher
      *
      * @param  string $key
      * @return BlockCipher
+     * @throws Exception\InvalidArgumentException
      */
     public function setKey($key)
     {
@@ -224,6 +226,7 @@ class BlockCipher
      *
      * @param  string $algo
      * @return BlockCipher
+     * @throws Exception\InvalidArgumentException
      */
     public function setCipherAlgorithm($algo)
     {
@@ -269,6 +272,7 @@ class BlockCipher
      *
      * @param  string $hash
      * @return BlockCipher
+     * @throws Exception\InvalidArgumentException
      */
     public function setHashAlgorithm($hash)
     {
@@ -296,6 +300,7 @@ class BlockCipher
      *
      * @param  string $data
      * @return string
+     * @throws Exception\InvalidArgumentException
      */
     public function encrypt($data)
     {

--- a/library/Zend/Crypt/Utils.php
+++ b/library/Zend/Crypt/Utils.php
@@ -17,31 +17,34 @@ namespace Zend\Crypt;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-
-class Tool
+class Utils
 {
     /**
      * Compare two strings to avoid timing attacks
      *
-     * @param  string $stringA
-     * @param  string $stringB
+     * C function memcmp() internally used by PHP, exits as soon as a difference
+     * is found in the two buffers. That makes possible of leaking
+     * timing information useful to an attacker attempting to iteratively guess
+     * the unknown string (e.g. password).
+     *
+     * @param  string $expected
+     * @param  string $actual
      * @return boolean
      */
-    public static function compareString($stringA, $stringB)
+    public static function compareStrings($expected, $actual)
     {
-        $stringA = (string)$stringA;
-        $stringB = (string)$stringB;
-        if (strlen($stringA) === 0) {
-            return false;
-        }
-        if (strlen($stringA) !== strlen($stringB)) {
-            return false;
-        }
+        $expected     = (string) $expected;
+        $actual       = (string) $actual;
+        $lenExpected  = strlen($expected);
+        $lenActual    = strlen($actual);
+        $len          = min($lenExpected, $lenActual);
+
         $result = 0;
-        $len    = strlen($stringA);
         for ($i = 0; $i < $len; $i++) {
-            $result |= ord($stringA{$i}) ^ ord($stringB{$i});
+            $result |= ord($expected[$i]) ^ ord($actual[$i]);
         }
-        return $result === 0;
+        $result |= $lenExpected ^ $lenActual;
+
+        return ($result === 0);
     }
 }

--- a/tests/Zend/Crypt/UtilsTest.php
+++ b/tests/Zend/Crypt/UtilsTest.php
@@ -21,7 +21,7 @@
 
 namespace ZendTest\Crypt;
 
-use Zend\Crypt\Tool;
+use Zend\Crypt\Utils;
 
 /**
  * Outside the Internal Function tests, tests do not distinguish between hash and mhash
@@ -36,11 +36,11 @@ use Zend\Crypt\Tool;
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Crypt
  */
-class ToolTest extends \PHPUnit_Framework_TestCase
+class UtilsTest extends \PHPUnit_Framework_TestCase
 {
-    public function testCompare()
+    public function testCompareStringsBasic()
     {
-        $this->assertTrue(Tool::compareString('test', 'test'));
-        $this->assertFalse(Tool::compareString('test', 'Test'));
+        $this->assertTrue(Utils::compareStrings('test', 'test'));
+        $this->assertFalse(Utils::compareStrings('test', 'Test'));
     }
 }


### PR DESCRIPTION
There are two changes proposed in this PR:
-- class Tool renamed into Utils, as Utils is more common around the framework
-- Tool::compareString() reworked to not exit early if compared strings are not of equal length. 
   This allows to keep time even if length of compared strings doesn't match
