### PR TITLE
Hotfix for a potential security problem in randBytes()

### DIFF
--- a/library/Zend/Math/Math.php
+++ b/library/Zend/Math/Math.php
@@ -29,7 +29,7 @@ namespace Zend\Math;
 class Math extends BigInteger
 {
     /**
-     * Generate random bytes using OpenSSL and/or MCRYPT_DEV_URANDOM and/or /dev/urandom
+     * Generate random bytes using OpenSSL or Mcrypt and mt_rand() as fallback
      *
      * @param  integer $length
      * @param  boolean $strong true if you need a strong random generator (cryptography)

--- a/tests/Zend/Math/MathTest.php
+++ b/tests/Zend/Math/MathTest.php
@@ -35,7 +35,7 @@ class MathTest extends \PHPUnit_Framework_TestCase
 {
     public function testRandBytes()
     {
-        for ($length=1; $length<64; $length++) {
+        for ($length=1; $length<4096; $length++) {
             $rand = Math::randBytes($length);
             $this->assertTrue(!empty($rand));
             $this->assertEquals(strlen($rand), $length);
@@ -44,7 +44,7 @@ class MathTest extends \PHPUnit_Framework_TestCase
        
     public function testRand()
     {
-        for ($i=0; $i<100; $i++) {
+        for ($i=0; $i<1000; $i++) {
             $min = mt_rand(1,10000);
             $max = $min + mt_rand(1,10000);
             $rand = Math::rand($min, $max);


### PR DESCRIPTION
I removed the usage of XOR to mix different sources and I removed the /dev/urandom. In the previous implementation with Mcrypt() XOR /dev/urandom we could have a potential problem if the output of the sources is the same (because also Mcrypt uses /dev/urandom).
