### PR TITLE
Zend\Db: Fixed issue with iterating Mysqli Result objects when using with libmysql and unbuffered statements.

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Mysqli/Result.php
+++ b/library/Zend/Db/Adapter/Driver/Mysqli/Result.php
@@ -192,6 +192,7 @@ class Result implements \Iterator, ResultInterface
         }
 
         if (($r = $this->resource->fetch()) === null) {
+            $this->resource->close();
             return false;
         } elseif ($r === false) {
             throw new Exception\RuntimeException($this->resource->error);


### PR DESCRIPTION
Simple one liner for Zend\Db: Fixed issue with iterating Mysqli Result objects when using with libmysql and unbuffered statements.
