### PR TITLE
[Hotfix]  ViewHelper Doctype - svn sync & cleanup

### DIFF
--- a/documentation/manual/en/module_specs/Zend_View-Helpers-Doctype.xml
+++ b/documentation/manual/en/module_specs/Zend_View-Helpers-Doctype.xml
@@ -20,6 +20,7 @@
         <listitem><para><constant>XHTML1_STRICT</constant></para></listitem>
         <listitem><para><constant>XHTML1_TRANSITIONAL</constant></para></listitem>
         <listitem><para><constant>XHTML1_FRAMESET</constant></para></listitem>
+        <listitem><para><constant>XHTML1_RDFA</constant></para></listitem>
         <listitem><para><constant>XHTML_BASIC1</constant></para></listitem>
         <listitem><para><constant>HTML4_STRICT</constant></para></listitem>
         <listitem><para><constant>HTML4_LOOSE</constant></para></listitem>
@@ -36,8 +37,8 @@
         <link linkend="zend.view.helpers.initial.placeholder">Placeholder helper</link>.
     </para>
 
-    <example xml:id="zend.view.helpers.initial.doctype.basicusage"><title>Doctype Helper Basic Usage</title>
-        
+    <example xml:id="zend.view.helpers.initial.doctype.basicusage">
+        <title>Doctype Helper Basic Usage</title>
 
         <para>
             You may specify the doctype at any time. However, helpers that
@@ -60,8 +61,8 @@ $doctypeHelper->doctype('XHTML1_STRICT');
 ]]></programlisting>
     </example>
 
-    <example xml:id="zend.view.helpers.initial.doctype.retrieving"><title>Retrieving the Doctype</title>
-        
+    <example xml:id="zend.view.helpers.initial.doctype.retrieving">
+        <title>Retrieving the Doctype</title>
 
         <para>
             If you need to know the doctype, you can do so by calling
@@ -85,7 +86,7 @@ if ($view->doctype()->isXhtml()) {
 ]]></programlisting>
 
         <para>
-            You can also check if the doctype represents an <acronym>HTML5</acronym> document
+            You can also check if the doctype represents an <acronym>HTML5</acronym> document.
         </para>
 
         <programlisting language="php"><![CDATA[
@@ -112,22 +113,22 @@ $doctypeHelper->doctype('XHTML1_RDFA');
 
         <para>
         The RDFa doctype allows XHTML to validate when the 'property'
-        meta tag attribute is used per the Open Graph Protocol spec. Example
+        meta tag attribute is used per the Open Graph Protocol spec.  Example
         within a view script:
         </para>
 
         <programlisting language="html"><![CDATA[
 <?php echo $this->doctype('XHTML1_RDFA'); ?>
 <html xmlns="http://www.w3.org/1999/xhtml"
-xmlns:og="http://opengraphprotocol.org/schema/">
+      xmlns:og="http://opengraphprotocol.org/schema/">
 <head>
-<meta property="og:type" content="musician" />
+   <meta property="og:type" content="musician" />
 ]]></programlisting>
 
         <para>
             In the previous example, we set the property to og:type. The og references
             the Open Graph namespace we specified in the html tag.
-            The content identifies the page as being about a musician. See
+            The content identifies the page as being about a musician.  See
             the <ulink url="http://opengraphprotocol.org/">Open Graph Protocol documentation</ulink>
             for supported properties. The <link linkend="zend.view.helpers.initial.headmeta">HeadMeta helper</link>
             may be used to programmatically set these Open Graph Protocol meta tags.
@@ -140,10 +141,10 @@ xmlns:og="http://opengraphprotocol.org/schema/">
         <programlisting language="php"><![CDATA[
 <?php echo $this->doctype() ?>
 <html xmlns="http://www.w3.org/1999/xhtml"
-<?php if ($view->doctype()->isRdfa()): ?>
-xmlns:og="http://opengraphprotocol.org/schema/"
-xmlns:fb="http://www.facebook.com/2008/fbml"
-<?php endif; ?>
+      <?php if ($view->doctype()->isRdfa()): ?>
+      xmlns:og="http://opengraphprotocol.org/schema/"
+      xmlns:fb="http://www.facebook.com/2008/fbml"
+      <?php endif; ?>
 >
 ]]></programlisting>
 

--- a/documentation/manual/en/module_specs/Zend_View-Helpers-HeadMeta.xml
+++ b/documentation/manual/en/module_specs/Zend_View-Helpers-HeadMeta.xml
@@ -137,8 +137,8 @@
         <link linkend="zend.view.helpers.initial.placeholder">Placeholder helper</link>.
     </para>
 
-    <example xml:id="zend.view.helpers.initial.headmeta.basicusage"><title>HeadMeta Helper Basic Usage</title>
-        
+    <example xml:id="zend.view.helpers.initial.headmeta.basicusage">
+        <title>HeadMeta Helper Basic Usage</title>
 
         <para>
             You may specify a new meta tag at any time. Typically, you
@@ -210,4 +210,30 @@ $this->headMeta()->appendHttpEquiv('Refresh',
 <?php echo $this->headMeta() ?>
 ]]></programlisting>
     </example>
+
+    <example xml:id="zend.view.helpers.initial.headmeta.property">
+        <title>HeadMeta Usage with XHTML1_RDFA doctype</title>
+
+        <para>
+            Enabling the RDFa doctype with the <link linkend="zend.view.helpers.initial.doctype">Doctype helper</link>
+            enables the use of the 'property' attribute (in addition to the standard 'name' and 'http-equiv') with HeadMeta.
+            This is commonly used with the Facebook <ulink url="http://opengraphprotocol.org/">Open Graph Protocol</ulink>.
+        </para>
+
+        <para>
+            For instance, you may specify an open graph page title and type as follows:
+        </para>
+
+        <programlisting language="php"><![CDATA[
+$this->doctype(Zend_View_Helper_Doctype::XHTML_RDFA);
+$this->headMeta()->setProperty('og:title', 'my article title');
+$this->headMeta()->setProperty('og:type', 'article');
+echo $this->headMeta();
+
+// output is:
+//   <meta property="og:title" content="my article title" />
+//   <meta property="og:type" content="article" />
+]]></programlisting>
+    </example>
+
 </section>

--- a/library/Zend/View/Helper/Doctype.php
+++ b/library/Zend/View/Helper/Doctype.php
@@ -117,8 +117,8 @@ class Doctype extends AbstractHelper
                 case self::XHTML1_STRICT:
                 case self::XHTML1_TRANSITIONAL:
                 case self::XHTML1_FRAMESET:
-                case self::XHTML1_RDFA:
                 case self::XHTML_BASIC1:
+                case self::XHTML1_RDFA:
                 case self::XHTML5:
                 case self::HTML4_STRICT:
                 case self::HTML4_LOOSE:

--- a/tests/Zend/View/Helper/DoctypeTest.php
+++ b/tests/Zend/View/Helper/DoctypeTest.php
@@ -134,9 +134,9 @@ class DoctypeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($doctype->isXhtml());
     }
 
-	public function testIsHtml5()
+    public function testIsHtml5()
     {
-		foreach (array(Helper\Doctype::HTML5, Helper\Doctype::XHTML5) as $type) {
+        foreach (array(Helper\Doctype::HTML5, Helper\Doctype::XHTML5) as $type) {
             $doctype = $this->helper->__invoke($type);
             $this->assertEquals($type, $doctype->getDoctype());
             $this->assertTrue($doctype->isHtml5());
@@ -152,18 +152,48 @@ class DoctypeTest extends \PHPUnit_Framework_TestCase
         );
 
 
-		foreach ($types as $type) {
-			$doctype = $this->helper->__invoke($type);
+        foreach ($types as $type) {
+            $doctype = $this->helper->__invoke($type);
             $this->assertEquals($type, $doctype->getDoctype());
             $this->assertFalse($doctype->isHtml5());
-		}
-	}
+        }
+    }
 
-	public function testCanRegisterCustomHtml5Doctype() {
-		$doctype = $this->helper->__invoke('<!DOCTYPE html>');
+    public function testIsRdfa()
+    {
+        // ensure default registerd Doctype is false
+        $this->assertFalse($this->helper->isRdfa());
+
+        $this->assertTrue($this->helper->__invoke(Helper\Doctype::XHTML1_RDFA)->isRdfa());
+
+        // build-in doctypes
+        $doctypes = array(
+            Helper\Doctype::XHTML11,
+            Helper\Doctype::XHTML1_STRICT,
+            Helper\Doctype::XHTML1_TRANSITIONAL,
+            Helper\Doctype::XHTML1_FRAMESET,
+            Helper\Doctype::XHTML_BASIC1,
+            Helper\Doctype::XHTML5,
+            Helper\Doctype::HTML4_STRICT,
+            Helper\Doctype::HTML4_LOOSE,
+            Helper\Doctype::HTML4_FRAMESET,
+            Helper\Doctype::HTML5,
+        );
+
+        foreach ($doctypes as $type) {
+            $this->assertFalse($this->helper->__invoke($type)->isRdfa());
+        }
+
+        // custom doctype
+        $doctype = $this->helper->__invoke('<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 10.0 Strict//EN" "http://framework.zend.com/foo/DTD/html10-custom.dtd">');
+        $this->assertFalse($doctype->isRdfa());
+    }
+
+    public function testCanRegisterCustomHtml5Doctype() {
+        $doctype = $this->helper->__invoke('<!DOCTYPE html>');
         $this->assertEquals('CUSTOM', $doctype->getDoctype());
         $this->assertTrue($doctype->isHtml5());
-	}
+    }
 
     public function testCanRegisterCustomXhtmlDoctype()
     {
@@ -194,30 +224,6 @@ class DoctypeTest extends \PHPUnit_Framework_TestCase
         $string   = $doctype->__toString();
         $registry = \Zend\Registry::get('Zend_View_Helper_Doctype');
         $this->assertEquals($registry['doctypes'][Helper\Doctype::XHTML1_STRICT], $string);
-    }
-
-    public function testIsRdfaReturnsTrueForRdfaDoctype()
-    {
-        $this->assertFalse($this->helper->isRdfa());
-
-        $doctypes = array(
-            Helper\Doctype::XHTML11,
-            Helper\Doctype::XHTML1_STRICT,
-            Helper\Doctype::XHTML1_TRANSITIONAL,
-            Helper\Doctype::XHTML1_FRAMESET,
-            Helper\Doctype::XHTML_BASIC1,
-            Helper\Doctype::XHTML5,
-            Helper\Doctype::HTML4_STRICT,
-            Helper\Doctype::HTML4_LOOSE,
-            Helper\Doctype::HTML4_FRAMESET,
-            Helper\Doctype::HTML5,
-        );
-
-        foreach ($doctypes as $type) {
-            $this->assertFalse($this->helper->__invoke($type)->isRdfa());
-        }
-
-        $this->assertTrue($this->helper->__invoke(Helper\Doctype::XHTML1_RDFA)->isRdfa());
     }
 }
 


### PR DESCRIPTION
I had checked zf1's trunk, & some workirng.
r23525 vs ZF2-229 (#961), r23538(ZF-10796) , #1427 & r23610 (ZF-9743)

This PR includes
- "testIsRdfaReturnsTrueForRdfaDoctype"(ZF2-229) -> testIsRdfa (zf1)
  "custom doctype test-case" is missing.
  https://github.com/sasezaki/zf2/pull/new/hotfix/view_doctype#L3R187
- adding listitem node in Doctype xml.
- adding "HeadMeta Usage with XHTML1_RDFA doctype" node  in  documentation (from r23610)
- Tab to space
