### PR TITLE
Improve service manager / dispatch exception handling

### DIFF
--- a/library/Zend/Mvc/DispatchListener.php
+++ b/library/Zend/Mvc/DispatchListener.php
@@ -101,24 +101,7 @@ class DispatchListener implements ListenerAggregateInterface
         $exception = false;
         try {
             $controller = $controllerLoader->get($controllerName);
-            $wasLoaded  = true;
         } catch (ServiceNotFoundException $exception) {
-            $wasLoaded =false;
-        } catch (ServiceNotCreatedException $exception) {
-            $error = clone $e;
-            $error->setError($application::ERROR_EXCEPTION)
-                  ->setController($controllerName)
-                  ->setParam('exception', $exception);
-            $results = $events->trigger('dispatch.error', $error);
-            if (count($results)) {
-                $return  = $results->last();
-            } else {
-                $return = $error->getParams();
-            }
-            return $this->complete($return, $e);
-        }
-
-        if (!$wasLoaded) {
             $error = clone $e;
             $error->setError($application::ERROR_CONTROLLER_NOT_FOUND)
                   ->setController($controllerName)
@@ -131,6 +114,20 @@ class DispatchListener implements ListenerAggregateInterface
             } else {
                 $return = $error->getParams();
             }
+            
+            return $this->complete($return, $e);
+        } catch (\Exception $exception) {
+            $error = clone $e;
+            $error->setError($application::ERROR_EXCEPTION)
+                  ->setController($controllerName)
+                  ->setParam('exception', $exception);
+            $results = $events->trigger('dispatch.error', $error);
+            if (count($results)) {
+                $return = $results->last();
+            } else {
+                $return = $error->getParams();
+            }
+
             return $this->complete($return, $e);
         }
 
@@ -142,7 +139,7 @@ class DispatchListener implements ListenerAggregateInterface
 
             $results = $events->trigger('dispatch.error', $error);
             if (count($results)) {
-                $return  = $results->last();
+                $return = $results->last();
             } else {
                 $return = $error->getParams();
             }
@@ -157,7 +154,7 @@ class DispatchListener implements ListenerAggregateInterface
         }
 
         try {
-            $return   = $controller->dispatch($request, $response);
+            $return = $controller->dispatch($request, $response);
         } catch (\Exception $ex) {
             $error = clone $e;
             $error->setError($application::ERROR_EXCEPTION)
@@ -166,7 +163,7 @@ class DispatchListener implements ListenerAggregateInterface
                   ->setParam('exception', $ex);
             $results = $events->trigger('dispatch.error', $error);
             if (count($results)) {
-                $return  = $results->last();
+                $return = $results->last();
             } else {
                 $return = $error->getParams();
             }

--- a/library/Zend/Mvc/DispatchListener.php
+++ b/library/Zend/Mvc/DispatchListener.php
@@ -100,12 +100,10 @@ class DispatchListener implements ListenerAggregateInterface
 
         $exception = false;
         try {
-            try {
-                $controller = $controllerLoader->get($controllerName);
-                $wasLoaded  = true;
-            } catch (ServiceNotFoundException $exception) {
-                $wasLoaded =false;
-            }
+            $controller = $controllerLoader->get($controllerName);
+            $wasLoaded  = true;
+        } catch (ServiceNotFoundException $exception) {
+            $wasLoaded =false;
         } catch (ServiceNotCreatedException $exception) {
             $error = clone $e;
             $error->setError($application::ERROR_EXCEPTION)

--- a/library/Zend/ServiceManager/Di/DiServiceFactory.php
+++ b/library/Zend/ServiceManager/Di/DiServiceFactory.php
@@ -99,7 +99,7 @@ class DiServiceFactory extends Di implements FactoryInterface
             if ($this->useServiceLocator == self::USE_SL_AFTER_DI && $this->serviceLocator->has($name)) {
                 return $this->serviceLocator->get($name);
             } else {
-                throw new Exception\ServiceNotCreatedException(
+                throw new Exception\ServiceNotFoundException(
                     sprintf('Service %s was not found in this DI instance', $name),
                     null,
                     $e

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -277,12 +277,12 @@ class ServiceManager implements ServiceLocatorInterface
         if (!$instance && !is_array($instance)) {
             try {
                 $instance = $this->create(array($cName, $rName));
-            } catch (Exception\ServiceNotCreatedException $selfException) {
+            } catch (Exception\ServiceNotFoundException $selfException) {
                 foreach ($this->peeringServiceManagers as $peeringServiceManager) {
                     try {
                         $instance = $peeringServiceManager->get($name);
                         break;
-                    } catch (Exception\ServiceNotCreatedException $e) {
+                    } catch (Exception\ServiceNotFoundException $e) {
                         continue;
                     }
                 }
@@ -291,7 +291,7 @@ class ServiceManager implements ServiceLocatorInterface
 
         // Still no instance? raise an exception
         if (!$instance && !is_array($instance)) {
-            throw new Exception\ServiceNotCreatedException(sprintf(
+            throw new Exception\ServiceNotFoundException(sprintf(
                 '%s was unable to fetch or create an instance for %s',
                     __METHOD__,
                     $name
@@ -383,7 +383,7 @@ class ServiceManager implements ServiceLocatorInterface
         }
 
         if ($this->throwExceptionInCreate == true && $instance === false) {
-            throw new Exception\ServiceNotCreatedException(sprintf(
+            throw new Exception\ServiceNotFoundException(sprintf(
                 'No valid instance was found for %s%s',
                 $cName,
                 ($rName ? '(alias: ' . $rName . ')' : '')
@@ -541,6 +541,9 @@ class ServiceManager implements ServiceLocatorInterface
         try {
             $instance = call_user_func($callable, $this, $cName, $rName);
         } catch (\Exception $e) {
+            if ($e instanceof Exception\ServiceNotFoundException) {
+                throw $e;
+            }
             throw new Exception\ServiceNotCreatedException(
                 sprintf('Abstract factory raised an exception when creating "%s"; no instance returned', $rName),
                 $e->getCode(),

--- a/tests/Zend/Mvc/ApplicationTest.php
+++ b/tests/Zend/Mvc/ApplicationTest.php
@@ -421,7 +421,8 @@ class ApplicationTest extends TestCase
     {
         $this->serviceManager->get('ControllerLoader');
         $this->setupBadController(false);
-        $this->serviceManager->setFactory('bad', function() {
+        $controllerLoader = $this->serviceManager->get('ControllerLoader');
+        $controllerLoader->setFactory('bad', function() {
             return new stdClass;
         });
         $response = $this->application->getResponse();

--- a/tests/Zend/ServiceManager/ServiceManagerTest.php
+++ b/tests/Zend/ServiceManager/ServiceManagerTest.php
@@ -170,7 +170,7 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetThrowsExceptionOnUnknownService()
     {
-        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotCreatedException');
+        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotFoundException');
         $this->assertEquals('bar', $this->serviceManager->get('foo'));
     }
 


### PR DESCRIPTION
This PR fixes an issue where exceptions thrown while fetching a controller from the ServiceManager would be hidden by a 404 page with no exception information present.
