### PR TITLE
PluginBroker checks if new instances are service locator aware

### DIFF
--- a/library/Zend/Loader/PluginBroker.php
+++ b/library/Zend/Loader/PluginBroker.php
@@ -62,7 +62,7 @@ class PluginBroker implements Broker, ServiceLocatorAwareInterface
     protected $validator;
 
     /**
-     * @var Zend\Di\LocatorInterface
+     * @var \Zend\ServiceManager\ServiceManager
      */
     protected $locator;
 
@@ -252,8 +252,26 @@ class PluginBroker implements Broker, ServiceLocatorAwareInterface
         if ($this->getRegisterPluginsOnLoad()) {
             $this->register($pluginName, $instance);
         }
-        
+
+        if ($instance instanceof ServiceLocatorAwareInterface) {
+            $this->injectServiceLocator($instance);
+        }
+
         return $instance;
+    }
+
+    /**
+     * Injects this broker's ServiceLocator instance into the passed
+     * ServiceLocatorAwareInterface
+     *
+     * @param ServiceLocatorAwareInterface $instance
+     */
+    public function injectServiceLocator(ServiceLocatorAwareInterface $instance)
+    {
+        $locator = $this->getServiceLocator();
+        if ($locator) {
+            $instance->setServiceLocator($this->locator);
+        }
     }
 
     /**

--- a/library/Zend/Loader/PluginBroker.php
+++ b/library/Zend/Loader/PluginBroker.php
@@ -270,7 +270,7 @@ class PluginBroker implements Broker, ServiceLocatorAwareInterface
     {
         $locator = $this->getServiceLocator();
         if ($locator) {
-            $instance->setServiceLocator($this->locator);
+            $instance->setServiceLocator($locator);
         }
     }
 

--- a/tests/Zend/Loader/PluginBrokerTest.php
+++ b/tests/Zend/Loader/PluginBrokerTest.php
@@ -290,4 +290,16 @@ class PluginBrokerTest extends \PHPUnit_Framework_TestCase
         $test = $this->broker->load('foo');
         $this->assertSame($plugin, $test);
     }
+
+    public function testBrokerInjectsLocatorToLocatorAwareInstance()
+    {
+        $locator = new TestAsset\ServiceLocator();
+        $this->broker->setServiceLocator($locator);
+
+        $loader = $this->broker->getClassLoader();
+        $loader->registerPlugin('sample', 'ZendTest\Loader\TestAsset\SampleLocatorAwarePlugin');
+
+        $test = $this->broker->load('sample');
+        $this->assertSame($locator, $test->getServiceLocator());
+    }
 }

--- a/tests/Zend/Loader/TestAsset/SampleLocatorAwarePlugin.php
+++ b/tests/Zend/Loader/TestAsset/SampleLocatorAwarePlugin.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Loader
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
+ */
+
+namespace ZendTest\Loader\TestAsset;
+
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * @category   Zend
+ * @package    Loader
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Loader
+ */
+class SampleLocatorAwarePlugin implements ServiceLocatorAwareInterface
+{
+    protected $locator;
+
+    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->locator = $serviceLocator;
+    }
+
+    public function getServiceLocator()
+    {
+        return $this->locator;
+    }
+}


### PR DESCRIPTION
This enables the PluginBroker to check if an instantiated class is service locator aware, and if so, it injects its locator instance (in a separate overridable method).

This should allow plugins to become a little more independent and find services/resources/configs as they need on their own.
