### PR TITLE
Zend\Db: Fixed issue with Sql Expressions containing % sign (used in vsprintf), is now escaped

### DIFF
--- a/library/Zend/Db/Sql/Expression.php
+++ b/library/Zend/Db/Sql/Expression.php
@@ -125,7 +125,8 @@ class Expression implements ExpressionInterface
                 ? $this->types[$i] : self::TYPE_VALUE;
         }
 
-        $expression = $this->expression;
+        // assign locally, escaping % signs
+        $expression = str_replace('%', '%%', $this->expression);
 
         if (count($parameters) > 0) {
             $count = 0;

--- a/tests/Zend/Db/Sql/ExpressionTest.php
+++ b/tests/Zend/Db/Sql/ExpressionTest.php
@@ -95,6 +95,18 @@ class ExpressionTest extends \PHPUnit_Framework_TestCase
             )),
             $expression->getExpressionData()
         );
-
     }
+
+    public function testGetExpressionDataWillEscapePercent()
+    {
+        $expression = new Expression('X LIKE "foo%"');
+        $this->assertEquals(array(array(
+                'X LIKE "foo%%"',
+                array(),
+                array()
+            )),
+            $expression->getExpressionData()
+        );
+    }
+
 }


### PR DESCRIPTION
Zend\Db: Fixed issue with Sql Expressions containing % sign (used in vsprintf), is now escaped
