### PR TITLE
Adds more verbosity to several autoloader errors

### DIFF
--- a/library/Zend/Loader/ClassMapAutoloader.php
+++ b/library/Zend/Loader/ClassMapAutoloader.php
@@ -100,7 +100,7 @@ class ClassMapAutoloader implements SplAutoloader
         if (!is_array($map)) {
             require_once __DIR__ . '/Exception/InvalidArgumentException.php';
             throw new Exception\InvalidArgumentException(sprintf(
-                'Map file provided (%s) does not return a map',
+                'Map file provided does not return a map. Map file: "%s"',
                 (isset($location) && is_string($location) ? $location : 'unexpected type: ' . gettype($map))
             ));
         }
@@ -181,7 +181,7 @@ class ClassMapAutoloader implements SplAutoloader
         if (!file_exists($location)) {
             require_once __DIR__ . '/Exception/InvalidArgumentException.php';
             throw new Exception\InvalidArgumentException(sprintf(
-                'Map file provided (%s) does not exist',
+                'Map file provided does not exist. Map file: "%s"',
                 (is_string($location) ? $location : 'unexpected type: ' . gettype($location))
             ));
         }

--- a/library/Zend/Loader/ClassMapAutoloader.php
+++ b/library/Zend/Loader/ClassMapAutoloader.php
@@ -99,7 +99,10 @@ class ClassMapAutoloader implements SplAutoloader
 
         if (!is_array($map)) {
             require_once __DIR__ . '/Exception/InvalidArgumentException.php';
-            throw new Exception\InvalidArgumentException('Map file provided does not return a map');
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Map file provided (%s) does not return a map',
+                (is_string($location) ? $location : gettype($map))
+            ));
         }
 
         $this->map = array_merge($this->map, $map);

--- a/library/Zend/Loader/ClassMapAutoloader.php
+++ b/library/Zend/Loader/ClassMapAutoloader.php
@@ -101,7 +101,7 @@ class ClassMapAutoloader implements SplAutoloader
             require_once __DIR__ . '/Exception/InvalidArgumentException.php';
             throw new Exception\InvalidArgumentException(sprintf(
                 'Map file provided (%s) does not return a map',
-                (is_string($location) ? $location : 'unexpected type: ' . gettype($map))
+                (isset($location) && is_string($location) ? $location : 'unexpected type: ' . gettype($map))
             ));
         }
 

--- a/library/Zend/Loader/ClassMapAutoloader.php
+++ b/library/Zend/Loader/ClassMapAutoloader.php
@@ -85,7 +85,7 @@ class ClassMapAutoloader implements SplAutoloader
      * An autoload map should be an associative array containing 
      * classname/file pairs.
      * 
-     * @param  string|array $location 
+     * @param  string|array $map 
      * @return ClassMapAutoloader
      */
     public function registerAutoloadMap($map)
@@ -101,7 +101,7 @@ class ClassMapAutoloader implements SplAutoloader
             require_once __DIR__ . '/Exception/InvalidArgumentException.php';
             throw new Exception\InvalidArgumentException(sprintf(
                 'Map file provided (%s) does not return a map',
-                (is_string($location) ? $location : gettype($map))
+                (is_string($location) ? $location : 'unexpected type: ' . gettype($map))
             ));
         }
 
@@ -180,7 +180,10 @@ class ClassMapAutoloader implements SplAutoloader
     {
         if (!file_exists($location)) {
             require_once __DIR__ . '/Exception/InvalidArgumentException.php';
-            throw new Exception\InvalidArgumentException('Map file provided does not exist');
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Map file provided (%s) does not exist',
+                (is_string($location) ? $location : 'unexpected type: ' . gettype($location))
+            ));
         }
 
         if (!$path = static::realPharPath($location)) {


### PR DESCRIPTION
In the case of multiple modules, each providing their own autoload map,
the errors now state which map file failed.
