### PR TITLE
FormLabel Helper Cannot Optionally Invoke

### DIFF
--- a/library/Zend/Form/View/Helper/FormLabel.php
+++ b/library/Zend/Form/View/Helper/FormLabel.php
@@ -105,8 +105,11 @@ class FormLabel extends AbstractHelper
      * @param  string $position 
      * @return string
      */
-    public function __invoke(ElementInterface $element, $labelContent = null, $position = null)
+    public function __invoke(ElementInterface $element = null, $labelContent = null, $position = null)
     {
+        if (!$element) {
+            return $this;
+        }
         $openTag = $this->openTag($element);
         $label   = false;
         if (null === $labelContent || null !== $position) {

--- a/tests/Zend/Form/View/Helper/FormLabelTest.php
+++ b/tests/Zend/Form/View/Helper/FormLabelTest.php
@@ -148,7 +148,6 @@ class FormLabelTest extends CommonTestCase
 
     public function testCallingFromViewHelperCanHandleOpenTagAndCloseTag()
     {
-        $element = new Element('foo');
         $helper = $this->helper;
         $markup = $helper()->openTag();
         $this->assertEquals('<label>', $markup);

--- a/tests/Zend/Form/View/Helper/FormLabelTest.php
+++ b/tests/Zend/Form/View/Helper/FormLabelTest.php
@@ -145,4 +145,14 @@ class FormLabelTest extends CommonTestCase
         $this->setExpectedException('Zend\Form\Exception\DomainException', 'label');
         $markup = $this->helper->__invoke($element, '<input type="text" id="foo" />', FormLabelHelper::APPEND);
     }
+
+    public function testCallingFromViewHelperCanHandleOpenTagAndCloseTag()
+    {
+        $element = new Element('foo');
+        $helper = $this->helper;
+        $markup = $helper()->openTag();
+        $this->assertEquals('<label>', $markup);
+        $markup = $helper()->closeTag();
+        $this->assertEquals('</label>', $markup);
+    }
 }


### PR DESCRIPTION
In the Form docs it states you should be able to do:

echo $this->formLabel()->openTag($name);

However, this does not currently work since __invoke is called and requires an element.  This fixes that and adds in a unit test to test the actual method in how it would be called as a view helper.
