### PR TITLE
removed EventManagerAwareInterface from ModuleManagerInterface

### DIFF
--- a/library/Zend/ModuleManager/ModuleManagerInterface.php
+++ b/library/Zend/ModuleManager/ModuleManagerInterface.php
@@ -10,7 +10,6 @@
 
 namespace Zend\ModuleManager;
 
-use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventsCapableInterface;
 
 /**
@@ -19,7 +18,7 @@ use Zend\EventManager\EventsCapableInterface;
  * @category Zend
  * @package  Zend_Module
  */
-interface ModuleManagerInterface extends EventManagerAwareInterface, EventsCapableInterface
+interface ModuleManagerInterface extends EventsCapableInterface
 {
     /**
      * Load the provided modules.


### PR DESCRIPTION
Hey, I don't know if this is the best way to fix this problem, but at least it shows the problem. ServiceManager was recognising EventManagerAwareInterface on a ModuleManager and so injecting an EventManager after ModuleManager had been build by the ModuleManagerFactory, therefore replacing the EventManager injected by ModuleManagerFactory and effectively deleting all module events (ie modules wouldn't load).

Removing EventManagerAwareInterface stops ServiceManager injecting a new EventManager over the top, so everything works again.

:)
