### PR TITLE
[Crypt] Check for cases where "0" is treated as an empty string.

### DIFF
--- a/library/Zend/Crypt/BlockCipher.php
+++ b/library/Zend/Crypt/BlockCipher.php
@@ -347,7 +347,10 @@ class BlockCipher
      */
     public function decrypt($data)
     {
-        if (empty($data)) {
+        if (!is_string($data)) {
+            throw new Exception\InvalidArgumentException('The data to decrypt must be a string');
+        }
+        if ('' === $data) {
             throw new Exception\InvalidArgumentException('The data to decrypt cannot be empty');
         }
         if (empty($this->key)) {


### PR DESCRIPTION
This fix a random failure in the tests when the data to decrypt is a string with the zero character inside `"0"`

PHP treat that strings as empty (http://es.php.net/manual/en/function.empty.php)

[![Build Status](https://secure.travis-ci.org/Maks3w/zf2.png?branch=crypt-random-fail)](http://travis-ci.org/Maks3w/zf2)
