### PR TITLE
Http\Headers hotfix, bit of refactoring and new headers

### DIFF
--- a/library/Zend/Http/Header/AbstractDate.php
+++ b/library/Zend/Http/Header/AbstractDate.php
@@ -215,7 +215,7 @@ abstract class AbstractDate implements HeaderInterface
     }
 
     /**
-     * Output header line
+     * Return header line
      *
      * @return string
      */

--- a/library/Zend/Http/Header/AbstractDate.php
+++ b/library/Zend/Http/Header/AbstractDate.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Uri
+ */
+
+namespace Zend\Http\Header;
+
+use DateTime;
+use DateTimeZone;
+
+/**
+ * Abstract Date/Time Header
+ * Supports headers that have date/time as value
+ *
+ * @see Zend\Http\Header\Date
+ * @see Zend\Http\Header\Expires
+ * @see Zend\Http\Header\IfModifiedSince
+ * @see Zend\Http\Header\IfUnmodifiedSince
+ * @see Zend\Http\Header\LastModified
+ *
+ * Note for 'Location' header:
+ * While RFC 1945 requires an absolute URI, most of the browsers also support relative URI
+ * This class allows relative URIs, and let user retrieve URI instance if strict validation needed
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+abstract class AbstractDate implements HeaderInterface
+{
+    /**
+     * Date formats according to RFC 2616
+     * @link http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3
+     */
+    const DATE_RFC1123 = 0;
+    const DATE_RFC1036 = 1;
+    const DATE_ANSIC   = 2;
+
+    /**
+     * Date instance for this header
+     *
+     * @var DateTime
+     */
+    protected $date = null;
+
+    /**
+     * Date output format
+     *
+     * @var string
+     */
+    protected static $dateFormat = 'D, d M Y H:i:s \G\M\T';
+
+    /**
+     * Date formats defined by RFC 2616. RFC 1123 date is required
+     * RFC 1036 and ANSI C formats are provided for compatibility with old servers/clients
+     * @link http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3
+     *
+     * @var array
+     */
+    protected static $dateFormats = array(
+        self::DATE_RFC1123 => 'D, d M Y H:i:s \G\M\T',
+        self::DATE_RFC1036 => 'D, d M y H:i:s \G\M\T',
+        self::DATE_ANSIC   => 'D M j H:i:s Y',
+    );
+
+    /**
+     * Create date-based header from string
+     *
+     * @param string $headerLine
+     * @return AbstractDate
+     * @throws Exception\InvalidArgumentException
+     */
+    public static function fromString($headerLine)
+    {
+        $dateHeader = new static();
+
+        list($name, $date) = explode(': ', $headerLine, 2);
+
+        // check to ensure proper header type for this factory
+        if (strtolower($name) !== strtolower($dateHeader->getFieldName())) {
+            throw new Exception\InvalidArgumentException(
+                'Invalid header line for "' . $dateHeader->getFieldName() . '" header string'
+            );
+        }
+
+        $dateHeader->setDate($date);
+
+        return $dateHeader;
+    }
+
+    /**
+     * Set date output format
+     *
+     * @param int $format
+     * @throws Exception\InvalidArgumentException
+     */
+    public static function setDateFormat($format)
+    {
+        if (!isset(static::$dateFormats[$format])) {
+            throw new Exception\InvalidArgumentException(
+                "No constant defined for provided date format: {$format}"
+            );
+        }
+
+        static::$dateFormat = static::$dateFormats[$format];
+    }
+
+    /**
+     * Return current date output format
+     *
+     * @return string
+     */
+    public static function getDateFormat()
+    {
+        return static::$dateFormat;
+    }
+
+    /**
+     * Set the date for this header, this can be a string or an instance of \DateTime
+     *
+     * @param string|DateTime $date
+     * @return AbstractDate
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setDate($date)
+    {
+        if (is_string($date)) {
+            try {
+                $date = new DateTime($date, new DateTimeZone('GMT'));
+            } catch (\Exception $e) {
+                throw new Exception\InvalidArgumentException(
+                    sprintf('Invalid date passed as string (%s)', (string) $date),
+                    $e->getCode(),
+                    $e
+                );
+            }
+        } elseif (!($date instanceof DateTime)) {
+            throw new Exception\InvalidArgumentException('Date must be an instance of \DateTime or a string');
+        }
+
+        $date->setTimezone(new DateTimeZone('GMT'));
+        $this->date = $date;
+
+        return $this;
+    }
+
+    /**
+     * Return date for this header
+     *
+     * @return string
+     */
+    public function getDate()
+    {
+        return $this->date()->format(static::$dateFormat);
+    }
+
+    /**
+     * Return date for this header as an instance of \DateTime
+     *
+     * @return DateTime
+     */
+    public function date()
+    {
+        if ($this->date === null) {
+            $this->date = new DateTime(null, new DateTimeZone('GMT'));
+        }
+        return $this->date;
+    }
+
+    /**
+     * Compare provided date to date for this header
+     * Returns < 0 if date in header is less than $date; > 0 if it's greater, and 0 if they are equal.
+     * @see \strcmp()
+     *
+     * @param string|DateTime $date
+     * @return int
+     * @throws Exception\InvalidArgumentException
+     */
+    public function compareTo($date)
+    {
+        if (is_string($date)) {
+            try {
+                $date = new DateTime($date, new DateTimeZone('GMT'));
+            } catch (\Exception $e) {
+                throw new Exception\InvalidArgumentException(
+                    sprintf('Invalid Date passed as string (%s)', (string) $date),
+                    $e->getCode(),
+                    $e
+                );
+            }
+        } elseif (!($date instanceof DateTime)) {
+            throw new Exception\InvalidArgumentException('Date must be an instance of \DateTime or a string');
+        }
+
+        $dateTimestamp = $date->getTimestamp();
+        $thisTimestamp = $this->date()->getTimestamp();
+
+        return ($thisTimestamp === $dateTimestamp) ? 0 : (($thisTimestamp > $dateTimestamp) ? 1 : -1);
+    }
+
+    /**
+     * Get header value as formatted date
+     *
+     * @return string
+     */
+    public function getFieldValue()
+    {
+        return $this->getDate();
+    }
+
+    /**
+     * Output header line
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return $this->getFieldName() . ': ' . $this->getDate();
+    }
+
+    /**
+     * Allow casting to string
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toString();
+    }
+}

--- a/library/Zend/Http/Header/AbstractLocation.php
+++ b/library/Zend/Http/Header/AbstractLocation.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Uri
+ */
+
+namespace Zend\Http\Header;
+
+use Zend\Uri\Http as HttpUri;
+use Zend\Uri\Exception as UriException;
+
+/**
+ * Abstract Location Header
+ *
+ * Lays out foundation for:
+ * @see Zend\Http\Header\Location
+ * @see Zend\Http\Header\ContentLocation
+ * @see Zend\Http\Header\Referer
+ *
+ * Note for 'Location' header:
+ * While RFC 1945 requires an absolute URI, most of the browsers also support relative URI
+ * This class allows relative URIs, and let user retrieve URI instance if strict validation needed
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+abstract class AbstractLocation implements HeaderInterface
+{
+    /**
+     * @var HttpUri
+     */
+    protected $uri = null;
+
+    /**
+     * Create location-based header from string
+     *
+     * @param string $headerLine
+     * @return AbstractLocation
+     * @throws Exception\InvalidArgumentException
+     */
+    public static function fromString($headerLine)
+    {
+        $locationHeader = new static();
+
+        list($name, $uri) = explode(': ', $headerLine, 2);
+
+        // check to ensure proper header type for this factory
+        if (strtolower($name) !== strtolower($locationHeader->getFieldName())) {
+            throw new Exception\InvalidArgumentException(
+                'Invalid header line for "' . $locationHeader->getFieldName() . '" header string'
+            );
+        }
+
+        $locationHeader->setUri(trim($uri));
+
+        return $locationHeader;
+    }
+
+    /**
+     * Set the URI/URL for this request, this can be a string or an instance of Zend\Uri\Http
+     *
+     * @param string|HttpUri $uri
+     * @return AbstractLocation
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setUri($uri)
+    {
+        if (is_string($uri)) {
+            try {
+                $uri = new HttpUri($uri);
+            } catch (UriException\InvalidUriPartException $e) {
+                throw new Exception\InvalidArgumentException(
+                        sprintf('Invalid URI passed as string (%s)', (string) $uri),
+                        $e->getCode(),
+                        $e
+                );
+            }
+        } elseif (!($uri instanceof HttpUri)) {
+            throw new Exception\InvalidArgumentException('URI must be an instance of Zend\Uri\Http or a string');
+        }
+        $this->uri = $uri;
+
+        return $this;
+    }
+
+    /**
+     * Return the URI for this request object
+     *
+     * @return string
+     */
+    public function getUri()
+    {
+        if ($this->uri instanceof HttpUri) {
+            return $this->uri->toString();
+        }
+        return $this->uri;
+    }
+
+    /**
+     * Return the URI for this request object as an instance of Zend\Uri\Http
+     *
+     * @return HttpUri
+     */
+    public function uri()
+    {
+        if ($this->uri === null || is_string($this->uri)) {
+            $this->uri = new HttpUri($this->uri);
+        }
+        return $this->uri;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFieldValue()
+    {
+        return $this->getUri();
+    }
+
+    /**
+     * @return string
+     */
+    public function toString()
+    {
+        return $this->getFieldName() . ': ' . $this->getUri();
+    }
+
+    /**
+     * Allow casting to string
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toString();
+    }
+}

--- a/library/Zend/Http/Header/AbstractLocation.php
+++ b/library/Zend/Http/Header/AbstractLocation.php
@@ -15,8 +15,7 @@ use Zend\Uri\Exception as UriException;
 
 /**
  * Abstract Location Header
- *
- * Lays out foundation for:
+ * Supports headers that have URI as value
  * @see Zend\Http\Header\Location
  * @see Zend\Http\Header\ContentLocation
  * @see Zend\Http\Header\Referer
@@ -33,6 +32,8 @@ use Zend\Uri\Exception as UriException;
 abstract class AbstractLocation implements HeaderInterface
 {
     /**
+     * URI for this header
+     *
      * @var HttpUri
      */
     protected $uri = null;
@@ -48,7 +49,8 @@ abstract class AbstractLocation implements HeaderInterface
     {
         $locationHeader = new static();
 
-        list($name, $uri) = explode(': ', $headerLine, 2);
+        // ZF-5520 - IIS bug, no space after colon
+        list($name, $uri) = explode(':', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== strtolower($locationHeader->getFieldName())) {
@@ -63,7 +65,7 @@ abstract class AbstractLocation implements HeaderInterface
     }
 
     /**
-     * Set the URI/URL for this request, this can be a string or an instance of Zend\Uri\Http
+     * Set the URI/URL for this header, this can be a string or an instance of Zend\Uri\Http
      *
      * @param string|HttpUri $uri
      * @return AbstractLocation
@@ -90,7 +92,7 @@ abstract class AbstractLocation implements HeaderInterface
     }
 
     /**
-     * Return the URI for this request object
+     * Return the URI for this header
      *
      * @return string
      */
@@ -103,7 +105,7 @@ abstract class AbstractLocation implements HeaderInterface
     }
 
     /**
-     * Return the URI for this request object as an instance of Zend\Uri\Http
+     * Return the URI for this header as an instance of Zend\Uri\Http
      *
      * @return HttpUri
      */
@@ -116,6 +118,8 @@ abstract class AbstractLocation implements HeaderInterface
     }
 
     /**
+     * Get header value as URI string
+     *
      * @return string
      */
     public function getFieldValue()
@@ -124,6 +128,8 @@ abstract class AbstractLocation implements HeaderInterface
     }
 
     /**
+     * Output header line
+     *
      * @return string
      */
     public function toString()

--- a/library/Zend/Http/Header/Age.php
+++ b/library/Zend/Http/Header/Age.php
@@ -1,16 +1,40 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
 
 namespace Zend\Http\Header;
 
 /**
- * @throws Exception\InvalidArgumentException
- * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.6
+ * Age HTTP Header
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.6
  */
 class Age implements HeaderInterface
 {
-
+    /**
+     * Estimate of the amount of time in seconds since the response
+     *
+     * @var int
+     */
     protected $deltaSeconds = null;
 
+    /**
+     * Create Age header from string
+     *
+     * @param string $headerLine
+     * @return Age
+     * @throws Exception\InvalidArgumentException
+     */
     public static function fromString($headerLine)
     {
         $header = new static();
@@ -22,35 +46,61 @@ class Age implements HeaderInterface
             throw new Exception\InvalidArgumentException('Invalid header line for Age string: "' . $name . '"');
         }
 
-        $header->deltaSeconds = $value;
+        $header->deltaSeconds = (int) $value;
 
         return $header;
     }
 
+    /**
+     * Get header name
+     *
+     * @return string
+     */
     public function getFieldName()
     {
         return 'Age';
     }
 
+    /**
+     * Get header value (number of seconds)
+     *
+     * @return int
+     */
     public function getFieldValue()
     {
         return $this->getDeltaSeconds();
     }
 
-    public function setDeltaSeconds($deltaSeconds)
+    /**
+     * Set number of seconds
+     *
+     * @param int $delta
+     * @return RetryAfter
+     */
+    public function setDeltaSeconds($delta)
     {
-        $this->deltaSeconds = $deltaSeconds;
+        $this->deltaSeconds = (int) $delta;
         return $this;
     }
 
+    /**
+     * Get number of seconds
+     *
+     * @return int
+     */
     public function getDeltaSeconds()
     {
         return $this->deltaSeconds;
     }
 
+    /**
+     * Return header line
+     * In case of overflow RFC states to set value of 2147483648 (2^31)
+     *
+     * @return string
+     */
     public function toString()
     {
-        return 'Age: ' . $this->getFieldValue();
+        return 'Age: ' . (($this->deltaSeconds >= PHP_INT_MAX) ? '2147483648' : $this->deltaSeconds);
     }
-    
 }

--- a/library/Zend/Http/Header/Age.php
+++ b/library/Zend/Http/Header/Age.php
@@ -15,8 +15,7 @@ namespace Zend\Http\Header;
  *
  * @category   Zend
  * @package    Zend_Http
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage Headers
  * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.6
  */
 class Age implements HeaderInterface

--- a/library/Zend/Http/Header/Allow.php
+++ b/library/Zend/Http/Header/Allow.php
@@ -1,16 +1,54 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
 
 namespace Zend\Http\Header;
 
+use Zend\Http\Request;
+
 /**
- * @throws Exception\InvalidArgumentException
- * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.7
+ * Allow Header
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.7
  */
 class Allow implements HeaderInterface
 {
+    /**
+     * List of request methods
+     * true states that method is allowed, false - disallowed
+     * By default GET and POST are allowed
+     *
+     * @var array
+     */
+    protected $methods = array(
+        Request::METHOD_OPTIONS => false,
+        Request::METHOD_GET     => true,
+        Request::METHOD_HEAD    => false,
+        Request::METHOD_POST    => true,
+        Request::METHOD_PUT     => false,
+        Request::METHOD_DELETE  => false,
+        Request::METHOD_TRACE   => false,
+        Request::METHOD_CONNECT => false,
+        Request::METHOD_PATCH   => false,
+    );
 
-    protected $allowedMethods = array();
-
+    /**
+     * Create Allow header from header line
+     *
+     * @param string $headerLine
+     * @return Allow
+     * @throws Exception\InvalidArgumentException
+     */
     public static function fromString($headerLine)
     {
         $header = new static();
@@ -22,36 +60,126 @@ class Allow implements HeaderInterface
             throw new Exception\InvalidArgumentException('Invalid header line for Allow string: "' . $name . '"');
         }
 
+        // reset list of methods
+        $header->methods = array_fill_keys(array_keys($header->methods), false);
+
+        // allow methods from header line
         foreach (explode(',', $value) as $method) {
-            $header->allowedMethods[] = trim(strtoupper($method));
+            $method = trim(strtoupper($method));
+            $header->methods[$method] = true;
         }
 
         return $header;
     }
 
+    /**
+     * Get header name
+     *
+     * @return string
+     */
     public function getFieldName()
     {
         return 'Allow';
     }
 
+    /**
+     * Get comma-separated list of allowed methods
+     *
+     * @return string
+     */
     public function getFieldValue()
     {
-        return implode(', ', $this->allowedMethods);
+        return implode(', ', array_keys($this->methods, true, true));
     }
 
+    /**
+     * Get list of all defined methods
+     *
+     * @return array
+     */
+    public function getAllMethods()
+    {
+        return $this->methods;
+    }
+
+    /**
+     * Get list of allowed methods
+     *
+     * @return array
+     */
     public function getAllowedMethods()
     {
-        return $this->allowedMethods;
+        return array_keys($this->methods, true, true);
     }
 
-    public function setAllowedMethods(array $allowedMethods)
+    /**
+     * Allow methods or list of methods
+     *
+     * @param array|string $allowedMethods
+     * @return Allow
+     */
+    public function allowMethods($allowedMethods)
     {
-        $this->allowedMethods = $allowedMethods;
+        foreach ((array) $allowedMethods as $method) {
+            $method = trim(strtoupper($method));
+            $this->methods[$method] = true;
+        }
+
+        return $this;
     }
 
+    /**
+     * Disallow methods or list of methods
+     *
+     * @param array|string $disallowedMethods
+     * @return Allow
+     */
+    public function disallowMethods($disallowedMethods)
+    {
+        foreach ((array) $disallowedMethods as $method) {
+            $method = trim(strtoupper($method));
+            $this->methods[$method] = false;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Convenience alias for @see disallowMethods()
+     *
+     * @param array|string $disallowedMethods
+     * @return Allow
+     */
+    public function denyMethods($disallowedMethods)
+    {
+        return $this->disallowMethods($disallowedMethods);
+    }
+
+    /**
+     * Check whether method is allowed
+     *
+     * @param string $method
+     * @return boolean
+     */
+    public function isAllowedMethod($method)
+    {
+        $method = trim(strtoupper($method));
+
+        // disallow unknown method
+        if (! isset($this->methods[$method])) {
+            $this->methods[$method] = false;
+        }
+
+        return $this->methods[$method];
+    }
+
+    /**
+     * Return header as string
+     *
+     * @return string
+     */
     public function toString()
     {
         return 'Allow: ' . $this->getFieldValue();
     }
-    
 }

--- a/library/Zend/Http/Header/Allow.php
+++ b/library/Zend/Http/Header/Allow.php
@@ -17,8 +17,7 @@ use Zend\Http\Request;
  *
  * @category   Zend
  * @package    Zend_Http
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage Headers
  * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.7
  */
 class Allow implements HeaderInterface

--- a/library/Zend/Http/Header/Connection.php
+++ b/library/Zend/Http/Header/Connection.php
@@ -14,8 +14,7 @@ namespace Zend\Http\Header;
  *
  * @category   Zend
  * @package    Zend_Http
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage Headers
  * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.10
  */
 class Connection implements HeaderInterface
@@ -23,8 +22,18 @@ class Connection implements HeaderInterface
     const CONNECTION_CLOSE      = 'close';
     const CONNECTION_KEEP_ALIVE = 'keep-alive';
 
+    /**
+     * Value of this header
+     *
+     * @var string
+     */
     protected $value = self::CONNECTION_KEEP_ALIVE;
 
+    /**
+     * @param $headerLine
+     * @return Connection
+     * @throws Exception\InvalidArgumentException
+     */
     public static function fromString($headerLine)
     {
         $header = new static();

--- a/library/Zend/Http/Header/Connection.php
+++ b/library/Zend/Http/Header/Connection.php
@@ -1,13 +1,29 @@
 <?php
-
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
 namespace Zend\Http\Header;
 
 /**
- * @throws Exception\InvalidArgumentException
- * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.10
+ * Connection Header
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.10
  */
 class Connection implements HeaderInterface
 {
+    const CONNECTION_CLOSE      = 'close';
+    const CONNECTION_KEEP_ALIVE = 'keep-alive';
+
+    protected $value = self::CONNECTION_KEEP_ALIVE;
 
     public static function fromString($headerLine)
     {
@@ -20,22 +36,77 @@ class Connection implements HeaderInterface
             throw new Exception\InvalidArgumentException('Invalid header line for Connection string: "' . $name . '"');
         }
 
-        // @todo implementation details
-        $header->value = $value;
+        $header->setValue(trim($value));
 
         return $header;
     }
 
+
+    /**
+     * Set Connection header to define persistent connection
+     *
+     * @param boolean $flag
+     * @return Connection
+     */
+    public function setPersistent($flag)
+    {
+        if ((bool)$flag === true) {
+            $this->value = self::CONNECTION_KEEP_ALIVE;
+        } else {
+            $this->value = self::CONNECTION_CLOSE;
+        }
+        return $this;
+    }
+
+    /**
+     * Get whether this connection is persistent
+     *
+     * @return bool
+     */
+    public function isPersistent()
+    {
+        return ($this->value === self::CONNECTION_KEEP_ALIVE);
+    }
+
+    /**
+     * Set arbitrary header value
+     * RFC allows any token as value, 'close' and 'keep-alive' are commonly used
+     *
+     * @param string $value
+     * @return Connection
+     */
+    public function setValue($value)
+    {
+        $this->value = strtolower($value);
+        return $this;
+    }
+
+
+    /**
+     * Connection header name
+     *
+     * @return string
+     */
     public function getFieldName()
     {
         return 'Connection';
     }
 
+    /**
+     * Connection header value
+     *
+     * @return string
+     */
     public function getFieldValue()
     {
         return $this->value;
     }
 
+    /**
+     * Return header line
+     *
+     * @return string
+     */
     public function toString()
     {
         return 'Connection: ' . $this->getFieldValue();

--- a/library/Zend/Http/Header/ContentLocation.php
+++ b/library/Zend/Http/Header/ContentLocation.php
@@ -15,11 +15,10 @@ namespace Zend\Http\Header;
  *
  * @category   Zend
  * @package    Zend_Http
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage Headers
  * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.14
  */
-class ContentLocation extends AbstractLocation implements HeaderInterface
+class ContentLocation extends AbstractLocation
 {
     /**
      * Return header name

--- a/library/Zend/Http/Header/ContentLocation.php
+++ b/library/Zend/Http/Header/ContentLocation.php
@@ -1,44 +1,33 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
 
 namespace Zend\Http\Header;
 
 /**
- * @throws Exception\InvalidArgumentException
- * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.14
+ * Content-Location Header
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.14
  */
-class ContentLocation implements HeaderInterface
+class ContentLocation extends AbstractLocation implements HeaderInterface
 {
-
-    public static function fromString($headerLine)
-    {
-        $header = new static();
-
-        list($name, $value) = explode(': ', $headerLine, 2);
-
-        // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'content-location') {
-            throw new Exception\InvalidArgumentException('Invalid header line for Content-Location string: "' . $name . '"');
-        }
-
-        // @todo implementation details
-        $header->value = $value;
-
-        return $header;
-    }
-
+    /**
+     * Return header name
+     *
+     * @return string
+     */
     public function getFieldName()
     {
         return 'Content-Location';
     }
-
-    public function getFieldValue()
-    {
-        return $this->value;
-    }
-
-    public function toString()
-    {
-        return 'Content-Location: ' . $this->getFieldValue();
-    }
-
 }

--- a/library/Zend/Http/Header/Date.php
+++ b/library/Zend/Http/Header/Date.php
@@ -15,11 +15,10 @@ namespace Zend\Http\Header;
  *
  * @category   Zend
  * @package    Zend_Http
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage Headers
  * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.18
  */
-class Date extends AbstractDate implements HeaderInterface
+class Date extends AbstractDate
 {
     /**
      * Get header name

--- a/library/Zend/Http/Header/Date.php
+++ b/library/Zend/Http/Header/Date.php
@@ -5,7 +5,7 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Uri
+ * @package   Zend_Http
  */
 
 namespace Zend\Http\Header;

--- a/library/Zend/Http/Header/Date.php
+++ b/library/Zend/Http/Header/Date.php
@@ -1,44 +1,33 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Uri
+ */
 
 namespace Zend\Http\Header;
 
 /**
- * @throws Exception\InvalidArgumentException
- * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.18
+ * Date Header
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.18
  */
-class Date implements HeaderInterface
+class Date extends AbstractDate implements HeaderInterface
 {
-
-    public static function fromString($headerLine)
-    {
-        $header = new static();
-
-        list($name, $value) = explode(': ', $headerLine, 2);
-
-        // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'date') {
-            throw new Exception\InvalidArgumentException('Invalid header line for Date string: "' . $name . '"');
-        }
-
-        // @todo implementation details
-        $header->value = $value;
-
-        return $header;
-    }
-
+    /**
+     * Get header name
+     *
+     * @return string
+     */
     public function getFieldName()
     {
         return 'Date';
     }
-
-    public function getFieldValue()
-    {
-        return $this->value;
-    }
-
-    public function toString()
-    {
-        return 'Date: ' . $this->getFieldValue();
-    }
-
 }

--- a/library/Zend/Http/Header/Expires.php
+++ b/library/Zend/Http/Header/Expires.php
@@ -5,7 +5,7 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Uri
+ * @package   Zend_Http
  */
 
 namespace Zend\Http\Header;

--- a/library/Zend/Http/Header/Expires.php
+++ b/library/Zend/Http/Header/Expires.php
@@ -15,11 +15,10 @@ namespace Zend\Http\Header;
  *
  * @category   Zend
  * @package    Zend_Http
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage Headers
  * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21
  */
-class Expires extends AbstractDate implements HeaderInterface
+class Expires extends AbstractDate
 {
     /**
      * Get header name

--- a/library/Zend/Http/Header/Expires.php
+++ b/library/Zend/Http/Header/Expires.php
@@ -1,44 +1,33 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Uri
+ */
 
 namespace Zend\Http\Header;
 
 /**
- * @throws Exception\InvalidArgumentException
- * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21
+ * Expires Header
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21
  */
-class Expires implements HeaderInterface
+class Expires extends AbstractDate implements HeaderInterface
 {
-
-    public static function fromString($headerLine)
-    {
-        $header = new static();
-
-        list($name, $value) = explode(': ', $headerLine, 2);
-
-        // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'expires') {
-            throw new Exception\InvalidArgumentException('Invalid header line for Expires string: "' . $name . '"');
-        }
-
-        // @todo implementation details
-        $header->value = $value;
-
-        return $header;
-    }
-
+    /**
+     * Get header name
+     *
+     * @return string
+     */
     public function getFieldName()
     {
         return 'Expires';
     }
-
-    public function getFieldValue()
-    {
-        return $this->value;
-    }
-
-    public function toString()
-    {
-        return 'Expires: ' . $this->getFieldValue();
-    }
-
 }

--- a/library/Zend/Http/Header/GenericHeader.php
+++ b/library/Zend/Http/Header/GenericHeader.php
@@ -50,6 +50,7 @@ class GenericHeader implements HeaderInterface
      * 
      * @param  string $fieldName
      * @return GenericHeader
+     * @throws Exception\InvalidArgumentException(
      */
     public function setFieldName($fieldName)
     {
@@ -62,7 +63,9 @@ class GenericHeader implements HeaderInterface
 
         // Validate what we have
         if (!preg_match('/^[a-z][a-z0-9-]*$/i', $fieldName)) {
-            throw new Exception\InvalidArgumentException('Header name must start with a letter, and consist of only letters, numbers, and dashes');
+            throw new Exception\InvalidArgumentException(
+                'Header name must start with a letter, and consist of only letters, numbers, and dashes'
+            );
         }
 
         $this->fieldName = $fieldName;
@@ -116,10 +119,7 @@ class GenericHeader implements HeaderInterface
      */
     public function toString()
     {
-        $name  = $this->getFieldName();
-        $value = $this->getFieldValue();
-
-        return $name. ': ' . $value . "\r\n";
+        return $this->getFieldName() . ': ' . $this->getFieldValue();
     }
 
 }

--- a/library/Zend/Http/Header/GenericHeader.php
+++ b/library/Zend/Http/Header/GenericHeader.php
@@ -1,7 +1,22 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
 
 namespace Zend\Http\Header;
 
+/**
+ * Content-Location Header
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @subpackage Headers
+  */
 class GenericHeader implements HeaderInterface
 {
     /**
@@ -121,5 +136,4 @@ class GenericHeader implements HeaderInterface
     {
         return $this->getFieldName() . ': ' . $this->getFieldValue();
     }
-
 }

--- a/library/Zend/Http/Header/IfModifiedSince.php
+++ b/library/Zend/Http/Header/IfModifiedSince.php
@@ -1,44 +1,33 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Uri
+ */
 
 namespace Zend\Http\Header;
 
 /**
- * @throws Exception\InvalidArgumentException
- * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25
+ * If-Modified-Since Header
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25
  */
-class IfModifiedSince implements HeaderInterface
+class IfModifiedSince extends AbstractDate implements HeaderInterface
 {
-
-    public static function fromString($headerLine)
-    {
-        $header = new static();
-
-        list($name, $value) = explode(': ', $headerLine, 2);
-
-        // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'if-modified-since') {
-            throw new Exception\InvalidArgumentException('Invalid header line for If-Modified-Since string: "' . $name . '"');
-        }
-
-        // @todo implementation details
-        $header->value = $value;
-
-        return $header;
-    }
-
+    /**
+     * Get header name
+     *
+     * @return string
+     */
     public function getFieldName()
     {
         return 'If-Modified-Since';
     }
-
-    public function getFieldValue()
-    {
-        return $this->value;
-    }
-
-    public function toString()
-    {
-        return 'If-Modified-Since: ' . $this->getFieldValue();
-    }
-
 }

--- a/library/Zend/Http/Header/IfModifiedSince.php
+++ b/library/Zend/Http/Header/IfModifiedSince.php
@@ -15,11 +15,10 @@ namespace Zend\Http\Header;
  *
  * @category   Zend
  * @package    Zend_Http
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage Headers
  * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25
  */
-class IfModifiedSince extends AbstractDate implements HeaderInterface
+class IfModifiedSince extends AbstractDate
 {
     /**
      * Get header name

--- a/library/Zend/Http/Header/IfModifiedSince.php
+++ b/library/Zend/Http/Header/IfModifiedSince.php
@@ -5,7 +5,7 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Uri
+ * @package   Zend_Http
  */
 
 namespace Zend\Http\Header;

--- a/library/Zend/Http/Header/IfUnmodifiedSince.php
+++ b/library/Zend/Http/Header/IfUnmodifiedSince.php
@@ -15,11 +15,10 @@ namespace Zend\Http\Header;
  *
  * @category   Zend
  * @package    Zend_Http
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage Headers
  * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.28
  */
-class IfUnmodifiedSince extends AbstractDate implements HeaderInterface
+class IfUnmodifiedSince extends AbstractDate
 {
     /**
      * Get header name

--- a/library/Zend/Http/Header/IfUnmodifiedSince.php
+++ b/library/Zend/Http/Header/IfUnmodifiedSince.php
@@ -5,7 +5,7 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Uri
+ * @package   Zend_Http
  */
 
 namespace Zend\Http\Header;

--- a/library/Zend/Http/Header/IfUnmodifiedSince.php
+++ b/library/Zend/Http/Header/IfUnmodifiedSince.php
@@ -1,44 +1,33 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Uri
+ */
 
 namespace Zend\Http\Header;
 
 /**
- * @throws Exception\InvalidArgumentException
- * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.28
+ * If-Unmodified-Since Header
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.28
  */
-class IfUnmodifiedSince implements HeaderInterface
+class IfUnmodifiedSince extends AbstractDate implements HeaderInterface
 {
-
-    public static function fromString($headerLine)
-    {
-        $header = new static();
-
-        list($name, $value) = explode(': ', $headerLine, 2);
-
-        // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'if-unmodified-since') {
-            throw new Exception\InvalidArgumentException('Invalid header line for If-Unmodified-Since string: "' . $name . '"');
-        }
-
-        // @todo implementation details
-        $header->value = $value;
-
-        return $header;
-    }
-
+    /**
+     * Get header name
+     *
+     * @return string
+     */
     public function getFieldName()
     {
         return 'If-Unmodified-Since';
     }
-
-    public function getFieldValue()
-    {
-        return $this->value;
-    }
-
-    public function toString()
-    {
-        return 'If-Unmodified-Since: ' . $this->getFieldValue();
-    }
-
 }

--- a/library/Zend/Http/Header/LastModified.php
+++ b/library/Zend/Http/Header/LastModified.php
@@ -15,11 +15,10 @@ namespace Zend\Http\Header;
  *
  * @category   Zend
  * @package    Zend_Http
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage Headers
  * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.29
  */
-class LastModified extends AbstractDate implements HeaderInterface
+class LastModified extends AbstractDate
 {
     /**
      * Get header name

--- a/library/Zend/Http/Header/LastModified.php
+++ b/library/Zend/Http/Header/LastModified.php
@@ -1,44 +1,33 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Uri
+ */
 
 namespace Zend\Http\Header;
 
 /**
- * @throws Exception\InvalidArgumentException
- * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.29
+ * Last-Modified Header
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.29
  */
-class LastModified implements HeaderInterface
+class LastModified extends AbstractDate implements HeaderInterface
 {
-
-    public static function fromString($headerLine)
-    {
-        $header = new static();
-
-        list($name, $value) = explode(': ', $headerLine, 2);
-
-        // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'last-modified') {
-            throw new Exception\InvalidArgumentException('Invalid header line for Last-Modified string: "' . $name . '"');
-        }
-
-        // @todo implementation details
-        $header->value = $value;
-
-        return $header;
-    }
-
+    /**
+     * Get header name
+     *
+     * @return string
+     */
     public function getFieldName()
     {
         return 'Last-Modified';
     }
-
-    public function getFieldValue()
-    {
-        return $this->value;
-    }
-
-    public function toString()
-    {
-        return 'Last-Modified: ' . $this->getFieldValue();
-    }
-
 }

--- a/library/Zend/Http/Header/LastModified.php
+++ b/library/Zend/Http/Header/LastModified.php
@@ -5,7 +5,7 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Uri
+ * @package   Zend_Http
  */
 
 namespace Zend\Http\Header;

--- a/library/Zend/Http/Header/Location.php
+++ b/library/Zend/Http/Header/Location.php
@@ -17,11 +17,10 @@ use Zend\Uri\Http as HttpUri;
  *
  * @category   Zend
  * @package    Zend_Http
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage Headers
  * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30
  */
-class Location extends AbstractLocation implements HeaderInterface
+class Location extends AbstractLocation
 {
     /**
      * Return header name

--- a/library/Zend/Http/Header/Location.php
+++ b/library/Zend/Http/Header/Location.php
@@ -1,50 +1,35 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
 
 namespace Zend\Http\Header;
 
-use Zend\Uri\Uri;
+use Zend\Uri\Http as HttpUri;
 
 /**
- * @throws Exception\InvalidArgumentException
- * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30
+ * Location Header
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30
  */
-class Location implements HeaderInterface
+class Location extends AbstractLocation implements HeaderInterface
 {
-
-    public static function fromString($headerLine)
-    {
-        $header = new static();
-
-        list($name, $value) = explode(':', $headerLine, 2);
-        $value = trim($value);
-
-        // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'location') {
-            throw new Exception\InvalidArgumentException('Invalid header line for Location string: "' . $name . '"');
-        }
-
-        if (!Uri::validateHost($value)) {
-            throw new Exception\InvalidArgumentException('Invalid URI value for Location: "' . $value . '"');
-        }
-        // @todo implementation details
-        $header->value = $value;
-
-        return $header;
-    }
-
+    /**
+     * Return header name
+     *
+     * @return string
+     */
     public function getFieldName()
     {
         return 'Location';
     }
-
-    public function getFieldValue()
-    {
-        return $this->value;
-    }
-
-    public function toString()
-    {
-        return 'Location: ' . $this->getFieldValue();
-    }
-    
 }

--- a/library/Zend/Http/Header/Referer.php
+++ b/library/Zend/Http/Header/Referer.php
@@ -17,24 +17,23 @@ use Zend\Uri\Http as HttpUri;
  *
  * @category   Zend
  * @package    Zend_Http
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage Headers
  * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.36
  */
-class Referer extends AbstractLocation implements HeaderInterface
+class Referer extends AbstractLocation
 {
     /**
      * Set the URI/URL for this header
      * according to RFC Referer URI should not have fragment
      *
-     * @param string|HttpUri $uri
+     * @param  string|HttpUri $uri
      * @return Referer
      */
     public function setUri($uri)
     {
         parent::setUri($uri);
-
         $this->uri->setFragment(null);
+
         return $this;
     }
 

--- a/library/Zend/Http/Header/Referer.php
+++ b/library/Zend/Http/Header/Referer.php
@@ -10,6 +10,8 @@
 
 namespace Zend\Http\Header;
 
+use Zend\Uri\Http as HttpUri;
+
 /**
  * Content-Location Header
  *
@@ -21,6 +23,21 @@ namespace Zend\Http\Header;
  */
 class Referer extends AbstractLocation implements HeaderInterface
 {
+    /**
+     * Set the URI/URL for this header
+     * according to RFC Referer URI should not have fragment
+     *
+     * @param string|HttpUri $uri
+     * @return Referer
+     */
+    public function setUri($uri)
+    {
+        parent::setUri($uri);
+
+        $this->uri->setFragment(null);
+        return $this;
+    }
+
     /**
      * Return header name
      *

--- a/library/Zend/Http/Header/Referer.php
+++ b/library/Zend/Http/Header/Referer.php
@@ -1,44 +1,33 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
 
 namespace Zend\Http\Header;
 
 /**
- * @throws Exception\InvalidArgumentException
- * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.36
+ * Content-Location Header
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.36
  */
-class Referer implements HeaderInterface
+class Referer extends AbstractLocation implements HeaderInterface
 {
-
-    public static function fromString($headerLine)
-    {
-        $header = new static();
-
-        list($name, $value) = explode(': ', $headerLine, 2);
-
-        // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'referer') {
-            throw new Exception\InvalidArgumentException('Invalid header line for Referer string: "' . $name . '"');
-        }
-
-        // @todo implementation details
-        $header->value = $value;
-
-        return $header;
-    }
-
+    /**
+     * Return header name
+     *
+     * @return string
+     */
     public function getFieldName()
     {
         return 'Referer';
     }
-
-    public function getFieldValue()
-    {
-        return $this->value;
-    }
-
-    public function toString()
-    {
-        return 'Referer: ' . $this->getFieldValue();
-    }
-
 }

--- a/library/Zend/Http/Header/RetryAfter.php
+++ b/library/Zend/Http/Header/RetryAfter.php
@@ -15,11 +15,10 @@ namespace Zend\Http\Header;
  *
  * @category   Zend
  * @package    Zend_Http
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage Headers
  * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37
  */
-class RetryAfter extends AbstractDate implements HeaderInterface
+class RetryAfter extends AbstractDate
 {
     /**
      * Value of header in delta-seconds
@@ -32,7 +31,7 @@ class RetryAfter extends AbstractDate implements HeaderInterface
     /**
      * Create Retry-After header from string
      *
-     * @param string $headerLine
+     * @param  string $headerLine
      * @return RetryAfter
      * @throws Exception\InvalidArgumentException
      */

--- a/library/Zend/Http/Header/RetryAfter.php
+++ b/library/Zend/Http/Header/RetryAfter.php
@@ -1,41 +1,110 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
 
 namespace Zend\Http\Header;
 
 /**
- * @throws Exception\InvalidArgumentException
- * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37
+ * Retry-After HTTP Header
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link       http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37
  */
-class RetryAfter implements HeaderInterface
+class RetryAfter extends AbstractDate implements HeaderInterface
 {
+    /**
+     * Value of header in delta-seconds
+     * By default set to 1 hour
+     *
+     * @var int
+     */
+    protected $deltaSeconds = 3600;
 
+    /**
+     * Create Retry-After header from string
+     *
+     * @param string $headerLine
+     * @return RetryAfter
+     * @throws Exception\InvalidArgumentException
+     */
     public static function fromString($headerLine)
     {
-        $header = new static();
+        $dateHeader = new static();
 
-        list($name, $value) = explode(': ', $headerLine, 2);
+        list($name, $date) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'retry-after') {
-            throw new Exception\InvalidArgumentException('Invalid header line for Retry-After string: "' . $name . '"');
+        if (strtolower($name) !== strtolower($dateHeader->getFieldName())) {
+            throw new Exception\InvalidArgumentException(
+                'Invalid header line for "' . $dateHeader->getFieldName() . '" header string'
+            );
         }
 
-        // @todo implementation details
-        $header->value = $value;
+        if (is_numeric($date)) {
+            $dateHeader->setDeltaSeconds($date);
+        } else {
+            $dateHeader->setDate($date);
+        }
 
-        return $header;
+        return $dateHeader;
     }
 
+    /**
+     * Set number of seconds
+     *
+     * @param int $delta
+     * @return RetryAfter
+     */
+    public function setDeltaSeconds($delta)
+    {
+        $this->deltaSeconds = (int) $delta;
+        return $this;
+    }
+
+    /**
+     * Get number of seconds
+     *
+     * @return int
+     */
+    public function getDeltaSeconds()
+    {
+        return $this->deltaSeconds;
+    }
+
+    /**
+     * Get header name
+     *
+     * @return string
+     */
     public function getFieldName()
     {
         return 'Retry-After';
     }
 
+    /**
+     * Returns date if it's set, or number of seconds
+     *
+     * @return int|string
+     */
     public function getFieldValue()
     {
-        return $this->value;
+        return ($this->date === null) ? $this->deltaSeconds : $this->getDate();
     }
 
+    /**
+     * Return header line
+     *
+     * @return string
+     */
     public function toString()
     {
         return 'Retry-After: ' . $this->getFieldValue();

--- a/library/Zend/Http/HeaderLoader.php
+++ b/library/Zend/Http/HeaderLoader.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
+
+namespace Zend\Http;
+
+use Zend\Loader\PluginClassLoader;
+
+/**
+ * Plugin Class Loader implementation for HTTP headers
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class HeaderLoader extends PluginClassLoader
+{
+    /**
+     * @var array Pre-aliased Header plugins
+     */
+    protected $plugins = array(
+        'accept'             => 'Zend\Http\Header\Accept',
+        'acceptcharset'      => 'Zend\Http\Header\AcceptCharset',
+        'acceptencoding'     => 'Zend\Http\Header\AcceptEncoding',
+        'acceptlanguage'     => 'Zend\Http\Header\AcceptLanguage',
+        'acceptranges'       => 'Zend\Http\Header\AcceptRanges',
+        'age'                => 'Zend\Http\Header\Age',
+        'allow'              => 'Zend\Http\Header\Allow',
+        'authenticationinfo' => 'Zend\Http\Header\AuthenticationInfo',
+        'authorization'      => 'Zend\Http\Header\Authorization',
+        'cachecontrol'       => 'Zend\Http\Header\CacheControl',
+        'connection'         => 'Zend\Http\Header\Connection',
+        'contentdisposition' => 'Zend\Http\Header\ContentDisposition',
+        'contentencoding'    => 'Zend\Http\Header\ContentEncoding',
+        'contentlanguage'    => 'Zend\Http\Header\ContentLanguage',
+        'contentlength'      => 'Zend\Http\Header\ContentLength',
+        'contentlocation'    => 'Zend\Http\Header\ContentLocation',
+        'contentmd5'         => 'Zend\Http\Header\ContentMD5',
+        'contentrange'       => 'Zend\Http\Header\ContentRange',
+        'contenttype'        => 'Zend\Http\Header\ContentType',
+        'cookie'             => 'Zend\Http\Header\Cookie',
+        'date'               => 'Zend\Http\Header\Date',
+        'etag'               => 'Zend\Http\Header\Etag',
+        'expect'             => 'Zend\Http\Header\Expect',
+        'expires'            => 'Zend\Http\Header\Expires',
+        'from'               => 'Zend\Http\Header\From',
+        'host'               => 'Zend\Http\Header\Host',
+        'ifmatch'            => 'Zend\Http\Header\IfMatch',
+        'ifmodifiedsince'    => 'Zend\Http\Header\IfModifiedSince',
+        'ifnonematch'        => 'Zend\Http\Header\IfNoneMatch',
+        'ifrange'            => 'Zend\Http\Header\IfRange',
+        'ifunmodifiedsince'  => 'Zend\Http\Header\IfUnmodifiedSince',
+        'keepalive'          => 'Zend\Http\Header\KeepAlive',
+        'lastmodified'       => 'Zend\Http\Header\LastModified',
+        'location'           => 'Zend\Http\Header\Location',
+        'maxforwards'        => 'Zend\Http\Header\MaxForwards',
+        'pragma'             => 'Zend\Http\Header\Pragma',
+        'proxyauthenticate'  => 'Zend\Http\Header\ProxyAuthenticate',
+        'proxyauthorization' => 'Zend\Http\Header\ProxyAuthorization',
+        'range'              => 'Zend\Http\Header\Range',
+        'referer'            => 'Zend\Http\Header\Referer',
+        'refresh'            => 'Zend\Http\Header\Refresh',
+        'retryafter'         => 'Zend\Http\Header\RetryAfter',
+        'server'             => 'Zend\Http\Header\Server',
+        'setcookie'          => 'Zend\Http\Header\SetCookie',
+        'te'                 => 'Zend\Http\Header\TE',
+        'trailer'            => 'Zend\Http\Header\Trailer',
+        'transferencoding'   => 'Zend\Http\Header\TransferEncoding',
+        'upgrade'            => 'Zend\Http\Header\Upgrade',
+        'useragent'          => 'Zend\Http\Header\UserAgent',
+        'vary'               => 'Zend\Http\Header\Vary',
+        'via'                => 'Zend\Http\Header\Via',
+        'warning'            => 'Zend\Http\Header\Warning',
+        'wwwauthenticate'    => 'Zend\Http\Header\WWWAuthenticate'
+    );
+}

--- a/library/Zend/Http/Headers.php
+++ b/library/Zend/Http/Headers.php
@@ -262,7 +262,7 @@ class Headers implements Iterator, Countable
             foreach (array_keys($this->headersKeys, $key) as $index) {
                 $headers[] = $this->headers[$index];
             }
-            return new \ArrayIterator($headers);
+            return new ArrayIterator($headers);
         } else {
             $index = array_search($key, $this->headersKeys);
             if ($index === false) {

--- a/library/Zend/Http/Headers.php
+++ b/library/Zend/Http/Headers.php
@@ -23,8 +23,6 @@ use ArrayIterator;
  *
  * @category   Zend
  * @package    Zend_Http
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
  */
 class Headers implements Iterator, Countable
@@ -68,7 +66,7 @@ class Headers implements Iterator, Countable
                 if ($current) {
                     // a header name was present, then store the current complete line
                     $headers->headersKeys[] = static::createKey($current['name']);
-                    $headers->headers[] = $current;
+                    $headers->headers[]     = $current;
                 }
                 $current = array(
                     'name' => $matches['name'],
@@ -90,7 +88,7 @@ class Headers implements Iterator, Countable
         }
         if ($current) {
             $headers->headersKeys[] = static::createKey($current['name']);
-            $headers->headers[] = $current;
+            $headers->headers[]     = $current;
         }
         return $headers;
     }
@@ -191,6 +189,7 @@ class Headers implements Iterator, Countable
 
         $this->headersKeys[] = $headerKey;
         $this->headers[]     = array('name' => $headerName, 'line' => $line);
+
         return $this;
     }
 
@@ -204,6 +203,7 @@ class Headers implements Iterator, Countable
     {
         $this->headersKeys[] = static::createKey($header->getFieldName());
         $this->headers[]     = $header;
+
         return $this;
     }
 
@@ -219,6 +219,7 @@ class Headers implements Iterator, Countable
         if ($index !== false) {
             unset($this->headersKeys[$index]);
             unset($this->headers[$index]);
+
             return true;
         }
         return false;

--- a/library/Zend/Http/Headers.php
+++ b/library/Zend/Http/Headers.php
@@ -1,16 +1,31 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
 
 namespace Zend\Http;
 
-use Zend\Loader\PluginClassLoader,
-    Zend\Loader\PluginClassLocator,
-    Iterator,
-    Countable;
+use Zend\Http\HeaderLoader;
+use Zend\Loader\PluginClassLocator;
+use Iterator;
+use Countable;
+use Traversable;
+use ArrayIterator;
 
 /**
  * Basic HTTP headers collection functionality
- *
  * Handles aggregation of headers
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @see        http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
  */
 class Headers implements Iterator, Countable
 {
@@ -38,6 +53,7 @@ class Headers implements Iterator, Countable
      *
      * @param  string $string
      * @return Headers
+     * @throws Exception\RuntimeException
      */
     public static function fromString($string)
     {
@@ -51,7 +67,7 @@ class Headers implements Iterator, Countable
             if (preg_match('/^(?P<name>[^()><@,;:\"\\/\[\]?=}{ \t]+):.*$/', $line, $matches)) {
                 if ($current) {
                     // a header name was present, then store the current complete line
-                    $headers->headersKeys[] = str_replace(array('-', '_'), '', strtolower($current['name']));
+                    $headers->headersKeys[] = static::createKey($current['name']);
                     $headers->headers[] = $current;
                 }
                 $current = array(
@@ -73,7 +89,7 @@ class Headers implements Iterator, Countable
             }
         }
         if ($current) {
-            $headers->headersKeys[] = str_replace(array('-', '_'), '', strtolower($current['name']));
+            $headers->headersKeys[] = static::createKey($current['name']);
             $headers->headers[] = $current;
         }
         return $headers;
@@ -99,61 +115,7 @@ class Headers implements Iterator, Countable
     public function getPluginClassLoader()
     {
         if ($this->pluginClassLoader === null) {
-            $this->pluginClassLoader = new \Zend\Loader\PluginClassLoader(array(
-                'accept'             => 'Zend\Http\Header\Accept',
-                'acceptcharset'      => 'Zend\Http\Header\AcceptCharset',
-                'acceptencoding'     => 'Zend\Http\Header\AcceptEncoding',
-                'acceptlanguage'     => 'Zend\Http\Header\AcceptLanguage',
-                'acceptranges'       => 'Zend\Http\Header\AcceptRanges',
-                'age'                => 'Zend\Http\Header\Age',
-                'allow'              => 'Zend\Http\Header\Allow',
-                'authenticationinfo' => 'Zend\Http\Header\AuthenticationInfo',
-                'authorization'      => 'Zend\Http\Header\Authorization',
-                'cachecontrol'       => 'Zend\Http\Header\CacheControl',
-                'connection'         => 'Zend\Http\Header\Connection',
-                'contentdisposition' => 'Zend\Http\Header\ContentDisposition',
-                'contentencoding'    => 'Zend\Http\Header\ContentEncoding',
-                'contentlanguage'    => 'Zend\Http\Header\ContentLanguage',
-                'contentlength'      => 'Zend\Http\Header\ContentLength',
-                'contentlocation'    => 'Zend\Http\Header\ContentLocation',
-                'contentmd5'         => 'Zend\Http\Header\ContentMD5',
-                'contentrange'       => 'Zend\Http\Header\ContentRange',
-                'contenttype'        => 'Zend\Http\Header\ContentType',
-                'cookie'             => 'Zend\Http\Header\Cookie',
-                'date'               => 'Zend\Http\Header\Date',
-                'etag'               => 'Zend\Http\Header\Etag',
-                'expect'             => 'Zend\Http\Header\Expect',
-                'expires'            => 'Zend\Http\Header\Expires',
-                'from'               => 'Zend\Http\Header\From',
-                'host'               => 'Zend\Http\Header\Host',
-                'ifmatch'            => 'Zend\Http\Header\IfMatch',
-                'ifmodifiedsince'    => 'Zend\Http\Header\IfModifiedSince',
-                'ifnonematch'        => 'Zend\Http\Header\IfNoneMatch',
-                'ifrange'            => 'Zend\Http\Header\IfRange',
-                'ifunmodifiedsince'  => 'Zend\Http\Header\IfUnmodifiedSince',
-                'keepalive'          => 'Zend\Http\Header\KeepAlive',
-                'lastmodified'       => 'Zend\Http\Header\LastModified',
-                'location'           => 'Zend\Http\Header\Location',
-                'maxforwards'        => 'Zend\Http\Header\MaxForwards',
-                'pragma'             => 'Zend\Http\Header\Pragma',
-                'proxyauthenticate'  => 'Zend\Http\Header\ProxyAuthenticate',
-                'proxyauthorization' => 'Zend\Http\Header\ProxyAuthorization',
-                'range'              => 'Zend\Http\Header\Range',
-                'referer'            => 'Zend\Http\Header\Referer',
-                'refresh'            => 'Zend\Http\Header\Refresh',
-                'retryafter'         => 'Zend\Http\Header\RetryAfter',
-                'server'             => 'Zend\Http\Header\Server',
-                'setcookie'          => 'Zend\Http\Header\SetCookie',
-                'te'                 => 'Zend\Http\Header\TE',
-                'trailer'            => 'Zend\Http\Header\Trailer',
-                'transferencoding'   => 'Zend\Http\Header\TransferEncoding',
-                'upgrade'            => 'Zend\Http\Header\Upgrade',
-                'useragent'          => 'Zend\Http\Header\UserAgent',
-                'vary'               => 'Zend\Http\Header\Vary',
-                'via'                => 'Zend\Http\Header\Via',
-                'warning'            => 'Zend\Http\Header\Warning',
-                'wwwauthenticate'    => 'Zend\Http\Header\WWWAuthenticate'
-            ));
+            $this->pluginClassLoader = new HeaderLoader();
         }
         return $this->pluginClassLoader;
     }
@@ -165,6 +127,7 @@ class Headers implements Iterator, Countable
      *
      * @param  array|Traversable $headers
      * @return Headers
+     * @throws Exception\InvalidArgumentException
      */
     public function addHeaders($headers)
     {
@@ -213,13 +176,13 @@ class Headers implements Iterator, Countable
             && $fieldValue === null) {
             // is a header
             $headerName = $matches['name'];
-            $headerKey = str_replace(array('-', '_', ' ', '.'), '', strtolower($matches['name']));
+            $headerKey  = static::createKey($matches['name']);
             $line = $headerFieldNameOrLine;
         } elseif ($fieldValue === null) {
             throw new Exception\InvalidArgumentException('A field name was provided without a field value');
         } else {
             $headerName = $headerFieldNameOrLine;
-            $headerKey = str_replace(array('-', '_', ' ', '.'), '', strtolower($headerFieldNameOrLine));
+            $headerKey  = static::createKey($headerFieldNameOrLine);
             if (is_array($fieldValue)) {
                 $fieldValue = implode(', ', $fieldValue);
             }
@@ -227,7 +190,7 @@ class Headers implements Iterator, Countable
         }
 
         $this->headersKeys[] = $headerKey;
-        $this->headers[] = array('name' => $headerName, 'line' => $line);
+        $this->headers[]     = array('name' => $headerName, 'line' => $line);
         return $this;
     }
 
@@ -239,10 +202,8 @@ class Headers implements Iterator, Countable
      */
     public function addHeader(Header\HeaderInterface $header)
     {
-        $key = str_replace(array('-', '_', ' ', '.'), '', strtolower($header->getFieldName()));
-
-        $this->headersKeys[] = $key;
-        $this->headers[] = $header;
+        $this->headersKeys[] = static::createKey($header->getFieldName());
+        $this->headers[]     = $header;
         return $this;
     }
 
@@ -280,11 +241,11 @@ class Headers implements Iterator, Countable
      * Get all headers of a certain name/type
      * 
      * @param  string $name
-     * @return false|Header\HeaderInterface|\ArrayIterator
+     * @return bool|Header\HeaderInterface|ArrayIterator
      */
     public function get($name)
     {
-        $key = str_replace(array('-', '_', ' ', '.'), '', strtolower($name));
+        $key = static::createKey($name);
         if (!in_array($key, $this->headersKeys)) {
             return false;
         }
@@ -323,8 +284,7 @@ class Headers implements Iterator, Countable
      */
     public function has($name)
     {
-        $name = str_replace(array('-', '_', ' ', '.'), '', strtolower($name));
-        return (in_array($name, $this->headersKeys));
+        return (in_array(static::createKey($name), $this->headersKeys));
     }
 
     /**
@@ -370,7 +330,7 @@ class Headers implements Iterator, Countable
     /**
      * Return the current value for this iterator, lazy loading it if need be
      *
-     * @return Header\HeaderInterface
+     * @return array|Header\HeaderInterface
      */
     public function current()
     {
@@ -477,7 +437,7 @@ class Headers implements Iterator, Countable
             $this->headers[$index] = $current = array_shift($headers);
             foreach ($headers as $header) {
                 $this->headersKeys[] = $key;
-                $this->headers[] = $header;
+                $this->headers[]     = $header;
             }
             return $current;
         } else {
@@ -487,4 +447,14 @@ class Headers implements Iterator, Countable
 
     }
 
+    /**
+     * Create array key from header name
+     *
+     * @param string $name
+     * @return string
+     */
+    protected static function createKey($name)
+    {
+        return str_replace(array('-', '_', ' ', '.'), '', strtolower($name));
+    }
 }

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -1,13 +1,29 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
 
 namespace Zend\Http\PhpEnvironment;
 
-use Zend\Http\Request as HttpRequest,
-    Zend\Uri\Http as HttpUri,
-    Zend\Http\Header\Cookie,
-    Zend\Stdlib\Parameters,
-    Zend\Stdlib\ParametersInterface;
+use Zend\Http\Request as HttpRequest;
+use Zend\Uri\Http as HttpUri;
+use Zend\Http\Header\Cookie;
+use Zend\Stdlib\Parameters;
+use Zend\Stdlib\ParametersInterface;
 
+/**
+ * HTTP Request for current PHP environment
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
 class Request extends HttpRequest
 {
     /**
@@ -33,10 +49,7 @@ class Request extends HttpRequest
 
     /**
      * Construct
-     *
      * Instantiates request.
-     *
-     * @return void
      */
     public function __construct()
     {
@@ -150,7 +163,7 @@ class Request extends HttpRequest
      * Provide an alternate Parameter Container implementation for server parameters in this object, (this is NOT the
      * primary API for value setting, for that see server())
      *
-     * @param \Zend\Stdlib\ParametersInterface $server
+     * @param ParametersInterface $server
      * @return Request
      */
     public function setServer(ParametersInterface $server)
@@ -211,20 +224,28 @@ class Request extends HttpRequest
         return $this;
     }
 
+    /**
+     * Grab headers from array or Traversable
+     *
+     * @param array|\Traversable $server
+     * @return array
+     */
     protected function serverToHeaders($server)
     {
         $headers = array();
 
         foreach ($server as $key => $value) {
-            if (strpos($key, 'HTTP_') === 0 && $value) {
-                $header = substr($key, 5);
-            } elseif (in_array($key, array('CONTENT_LENGTH', 'CONTENT_MD5', 'CONTENT_TYPE')) && $value) {
-                $header = $key;
+            if ($value && strpos($key, 'HTTP_') === 0) {
+                $name = strtr(substr($key, 5), '_', ' ');
+                $name = strtr(ucwords(strtolower($name)), ' ', '-');
+            } elseif ($value && strpos($key, 'CONTENT_') === 0) {
+                $name = substr($key, 8);
+                $name = 'Content-' . (($name == 'MD5') ? $name : ucfirst(strtolower($name)));
             } else {
                 continue;
             }
 
-            $headers[strtr($header, '_', '-')] = $value;
+            $headers[$name] = $value;
         }
 
         return $headers;

--- a/tests/Zend/Http/Header/AgeTest.php
+++ b/tests/Zend/Http/Header/AgeTest.php
@@ -38,7 +38,7 @@ class AgeTest extends \PHPUnit_Framework_TestCase
     public function testAgeCorrectsDeltaSecondsOverflow()
     {
         $ageHeader = new Age();
-        $ageHeader->setDeltaSeconds('2147483650');
+        $ageHeader->setDeltaSeconds(PHP_INT_MAX);
         $this->assertEquals('Age: 2147483648', $ageHeader->toString());
     }
 }

--- a/tests/Zend/Http/Header/AgeTest.php
+++ b/tests/Zend/Http/Header/AgeTest.php
@@ -30,11 +30,16 @@ class AgeTest extends \PHPUnit_Framework_TestCase
 
     public function testAgeToStringReturnsHeaderFormattedString()
     {
-        $ageHeader = Age::fromString('Age: 12');
+        $ageHeader = new Age();
+        $ageHeader->setDeltaSeconds('12');
         $this->assertEquals('Age: 12', $ageHeader->toString());
     }
 
-    /** Implmentation specific tests here */
-    
+    public function testAgeCorrectsDeltaSecondsOverflow()
+    {
+        $ageHeader = new Age();
+        $ageHeader->setDeltaSeconds('2147483650');
+        $this->assertEquals('Age: 2147483648', $ageHeader->toString());
+    }
 }
 

--- a/tests/Zend/Http/Header/AllowTest.php
+++ b/tests/Zend/Http/Header/AllowTest.php
@@ -9,10 +9,16 @@ class AllowTest extends \PHPUnit_Framework_TestCase
 
     public function testAllowFromStringCreatesValidAllowHeader()
     {
-        $allowHeader = Allow::fromString('Allow: GET, POST');
+        $allowHeader = Allow::fromString('Allow: GET, POST, PUT');
         $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $allowHeader);
         $this->assertInstanceOf('Zend\Http\Header\Allow', $allowHeader);
-        $this->assertEquals(array('GET', 'POST'), $allowHeader->getAllowedMethods());
+        $this->assertEquals(array('GET', 'POST', 'PUT'), $allowHeader->getAllowedMethods());
+    }
+
+    public function testAllowFromStringSupportsExtensionMethods()
+    {
+        $allowHeader = Allow::fromString('Allow: GET, POST, PROCREATE');
+        $this->assertTrue($allowHeader->isAllowedMethod('PROCREATE'));
     }
 
     public function testAllowGetFieldNameReturnsHeaderName()
@@ -21,21 +27,48 @@ class AllowTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Allow', $allowHeader->getFieldName());
     }
 
+    public function testAllowListAllDefinedMethods()
+    {
+        $methods = array(
+            'OPTIONS' => false,
+            'GET'     => true,
+            'HEAD'    => false,
+            'POST'    => true,
+            'PUT'     => false,
+            'DELETE'  => false,
+            'TRACE'   => false,
+            'CONNECT' => false,
+            'PATCH'   => false,
+        );
+        $allowHeader = new Allow();
+        $this->assertEquals($methods, $allowHeader->getAllMethods());
+    }
+
+    public function testAllowGetDefaultAllowedMethods()
+    {
+        $allowHeader = new Allow();
+        $this->assertEquals(array('GET', 'POST'), $allowHeader->getAllowedMethods());
+    }
+
     public function testAllowGetFieldValueReturnsProperValue()
     {
         $allowHeader = new Allow();
-        $allowHeader->setAllowedMethods(array('GET', 'POST'));
-        $this->assertEquals('GET, POST', $allowHeader->getFieldValue());
+        $allowHeader->allowMethods(array('GET', 'POST', 'TRACE'));
+        $this->assertEquals('GET, POST, TRACE', $allowHeader->getFieldValue());
     }
 
     public function testAllowToStringReturnsHeaderFormattedString()
     {
         $allowHeader = new Allow();
-        $allowHeader->setAllowedMethods(array('GET', 'POST'));
-
-        // @todo set some values, then test output
-        $this->assertEquals('Allow: GET, POST', $allowHeader->toString());
+        $allowHeader->allowMethods(array('GET', 'POST', 'TRACE'));
+        $this->assertEquals('Allow: GET, POST, TRACE', $allowHeader->toString());
     }
 
+    public function testAllowChecksAllowedMethod()
+    {
+        $allowHeader = new Allow();
+        $allowHeader->allowMethods(array('GET', 'POST', 'TRACE'));
+        $this->assertTrue($allowHeader->isAllowedMethod('TRACE'));
+    }
 }
 

--- a/tests/Zend/Http/Header/ConnectionTest.php
+++ b/tests/Zend/Http/Header/ConnectionTest.php
@@ -6,12 +6,13 @@ use Zend\Http\Header\Connection;
 
 class ConnectionTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testConnectionFromStringCreatesValidConnectionHeader()
     {
-        $connectionHeader = Connection::fromString('Connection: xxx');
+        $connectionHeader = Connection::fromString('Connection: close');
         $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $connectionHeader);
         $this->assertInstanceOf('Zend\Http\Header\Connection', $connectionHeader);
+        $this->assertEquals('close', $connectionHeader->getFieldValue());
+        $this->assertFalse($connectionHeader->isPersistent());
     }
 
     public function testConnectionGetFieldNameReturnsHeaderName()
@@ -22,10 +23,9 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
 
     public function testConnectionGetFieldValueReturnsProperValue()
     {
-        $this->markTestIncomplete('Connection needs to be completed');
-
         $connectionHeader = new Connection();
-        $this->assertEquals('xxx', $connectionHeader->getFieldValue());
+        $connectionHeader->setValue('Keep-Alive');
+        $this->assertEquals('keep-alive', $connectionHeader->getFieldValue());
     }
 
     public function testConnectionToStringReturnsHeaderFormattedString()
@@ -33,12 +33,19 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete('Connection needs to be completed');
 
         $connectionHeader = new Connection();
-
-        // @todo set some values, then test output
-        $this->assertEmpty('Connection: xxx', $connectionHeader->toString());
+        $connectionHeader->setValue('close');
+        $this->assertEmpty('Connection: close', $connectionHeader->toString());
     }
 
-    /** Implmentation specific tests here */
+    public function testConnectionSetPersistentReturnsProperValue()
+    {
+        $connectionHeader = new Connection();
+        $connectionHeader->setPersistent(true);
+        $this->assertEquals('keep-alive', $connectionHeader->getFieldValue());
+        $connectionHeader->setPersistent(false);
+        $this->assertEquals('close', $connectionHeader->getFieldValue());
+
+    }
     
 }
 

--- a/tests/Zend/Http/Header/ContentLocationTest.php
+++ b/tests/Zend/Http/Header/ContentLocationTest.php
@@ -3,42 +3,55 @@
 namespace ZendTest\Http\Header;
 
 use Zend\Http\Header\ContentLocation;
+use Zend\Uri\Http as HttpUri;
 
 class ContentLocationTest extends \PHPUnit_Framework_TestCase
 {
 
-    public function testContentLocationFromStringCreatesValidContentLocationHeader()
+    public function testContentLocationFromStringCreatesValidLocationHeader()
     {
-        $contentLocationHeader = ContentLocation::fromString('Content-Location: xxx');
+        $contentLocationHeader = ContentLocation::fromString('Content-Location: http://www.example.com/');
         $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $contentLocationHeader);
         $this->assertInstanceOf('Zend\Http\Header\ContentLocation', $contentLocationHeader);
     }
 
-    public function testContentLocationGetFieldNameReturnsHeaderName()
-    {
-        $contentLocationHeader = new ContentLocation();
-        $this->assertEquals('Content-Location', $contentLocationHeader->getFieldName());
-    }
-
     public function testContentLocationGetFieldValueReturnsProperValue()
     {
-        $this->markTestIncomplete('ContentLocation needs to be completed');
-
         $contentLocationHeader = new ContentLocation();
-        $this->assertEquals('xxx', $contentLocationHeader->getFieldValue());
+        $contentLocationHeader->setUri('http://www.example.com/');
+        $this->assertEquals('http://www.example.com/', $contentLocationHeader->getFieldValue());
+
+        $contentLocationHeader->setUri('/path');
+        $this->assertEquals('/path', $contentLocationHeader->getFieldValue());
     }
 
     public function testContentLocationToStringReturnsHeaderFormattedString()
     {
-        $this->markTestIncomplete('ContentLocation needs to be completed');
-
         $contentLocationHeader = new ContentLocation();
+        $contentLocationHeader->setUri('http://www.example.com/path?query');
 
-        // @todo set some values, then test output
-        $this->assertEmpty('Content-Location: xxx', $contentLocationHeader->toString());
+        $this->assertEquals('Content-Location: http://www.example.com/path?query', $contentLocationHeader->toString());
     }
 
-    /** Implmentation specific tests here */
-    
+    /** Implementation specific tests  */
+
+    public function testContentLocationCanSetAndAccessAbsoluteUri()
+    {
+        $contentLocationHeader = ContentLocation::fromString('Content-Location: http://www.example.com/path');
+        $uri = $contentLocationHeader->uri();
+        $this->assertInstanceOf('Zend\Uri\Http', $uri);
+        $this->assertTrue($uri->isAbsolute());
+        $this->assertEquals('http://www.example.com/path', $contentLocationHeader->getUri());
+    }
+
+    public function testContentLocationCanSetAndAccessRelativeUri()
+    {
+        $contentLocationHeader = ContentLocation::fromString('Content-Location: /path/to');
+        $uri = $contentLocationHeader->uri();
+        $this->assertInstanceOf('Zend\Uri\Http', $uri);
+        $this->assertFalse($uri->isAbsolute());
+        $this->assertEquals('/path/to', $contentLocationHeader->getUri());
+    }
+
 }
 

--- a/tests/Zend/Http/Header/DateTest.php
+++ b/tests/Zend/Http/Header/DateTest.php
@@ -3,13 +3,21 @@
 namespace ZendTest\Http\Header;
 
 use Zend\Http\Header\Date;
+use DateTime;
+use DateTimeZone;
 
 class DateTest extends \PHPUnit_Framework_TestCase
 {
+    public function tearDown()
+    {
+        // set to RFC default date format
+        Date::setDateFormat(Date::DATE_RFC1123);
+    }
+
 
     public function testDateFromStringCreatesValidDateHeader()
     {
-        $dateHeader = Date::fromString('Date: xxx');
+        $dateHeader = Date::fromString('Date: Sun, 06 Nov 1994 08:49:37 GMT');
         $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $dateHeader);
         $this->assertInstanceOf('Zend\Http\Header\Date', $dateHeader);
     }
@@ -22,23 +30,64 @@ class DateTest extends \PHPUnit_Framework_TestCase
 
     public function testDateGetFieldValueReturnsProperValue()
     {
-        $this->markTestIncomplete('Date needs to be completed');
-
         $dateHeader = new Date();
-        $this->assertEquals('xxx', $dateHeader->getFieldValue());
+        $dateHeader->setDate('Sun, 06 Nov 1994 08:49:37 GMT');
+        $this->assertEquals('Sun, 06 Nov 1994 08:49:37 GMT', $dateHeader->getFieldValue());
     }
 
     public function testDateToStringReturnsHeaderFormattedString()
     {
-        $this->markTestIncomplete('Date needs to be completed');
-
         $dateHeader = new Date();
-
-        // @todo set some values, then test output
-        $this->assertEmpty('Date: xxx', $dateHeader->toString());
+        $dateHeader->setDate('Sun, 06 Nov 1994 08:49:37 GMT');
+        $this->assertEquals('Date: Sun, 06 Nov 1994 08:49:37 GMT', $dateHeader->toString());
     }
 
-    /** Implmentation specific tests here */
-    
+    /** Implementation specific tests */
+
+    public function testDateReturnsDateTimeObject()
+    {
+        $dateHeader = new Date();
+        $this->assertInstanceOf('\DateTime', $dateHeader->date());
+    }
+
+    public function testDateFromStringCreatesValidDateTime()
+    {
+        $dateHeader = Date::fromString('Date: Sun, 06 Nov 1994 08:49:37 GMT');
+        $this->assertInstanceOf('\DateTime', $dateHeader->date());
+        $this->assertEquals('Sun, 06 Nov 1994 08:49:37 GMT', $dateHeader->date()->format('D, d M Y H:i:s \G\M\T'));
+    }
+
+    public function testDateReturnsProperlyFormattedDate()
+    {
+        $date = new DateTime('now', new DateTimeZone('GMT'));
+
+        $dateHeader = new Date();
+        $dateHeader->setDate($date);
+        $this->assertEquals($date->format('D, d M Y H:i:s \G\M\T'), $dateHeader->getDate());
+    }
+
+    public function testDateThrowsExceptionForInvalidDate()
+    {
+        $this->setExpectedException('Zend\Http\Header\Exception\InvalidArgumentException', 'Invalid date');
+        $dateHeader = new Date();
+        $dateHeader->setDate('~~~~');
+    }
+
+    public function testDateCanCompareDates()
+    {
+        $dateHeader = new Date();
+        $dateHeader->setDate('1 day ago');
+        $this->assertEquals(-1, $dateHeader->compareTo(new DateTime('now')));
+    }
+
+    public function testDateCanOutputDatesInOldFormats()
+    {
+        Date::setDateFormat(Date::DATE_ANSIC);
+
+        $dateHeader = new Date();
+        $dateHeader->setDate('Sun, 06 Nov 1994 08:49:37 GMT');
+
+        $this->assertEquals('Date: Sun Nov 6 08:49:37 1994', $dateHeader->toString());
+    }
 }
 

--- a/tests/Zend/Http/Header/ExpiresTest.php
+++ b/tests/Zend/Http/Header/ExpiresTest.php
@@ -6,10 +6,9 @@ use Zend\Http\Header\Expires;
 
 class ExpiresTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testExpiresFromStringCreatesValidExpiresHeader()
     {
-        $expiresHeader = Expires::fromString('Expires: xxx');
+        $expiresHeader = Expires::fromString('Expires: Sun, 06 Nov 1994 08:49:37 GMT');
         $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $expiresHeader);
         $this->assertInstanceOf('Zend\Http\Header\Expires', $expiresHeader);
     }
@@ -22,23 +21,22 @@ class ExpiresTest extends \PHPUnit_Framework_TestCase
 
     public function testExpiresGetFieldValueReturnsProperValue()
     {
-        $this->markTestIncomplete('Expires needs to be completed');
-
         $expiresHeader = new Expires();
-        $this->assertEquals('xxx', $expiresHeader->getFieldValue());
+        $expiresHeader->setDate('Sun, 06 Nov 1994 08:49:37 GMT');
+        $this->assertEquals('Sun, 06 Nov 1994 08:49:37 GMT', $expiresHeader->getFieldValue());
     }
 
     public function testExpiresToStringReturnsHeaderFormattedString()
     {
-        $this->markTestIncomplete('Expires needs to be completed');
-
         $expiresHeader = new Expires();
-
-        // @todo set some values, then test output
-        $this->assertEmpty('Expires: xxx', $expiresHeader->toString());
+        $expiresHeader->setDate('Sun, 06 Nov 1994 08:49:37 GMT');
+        $this->assertEquals('Expires: Sun, 06 Nov 1994 08:49:37 GMT', $expiresHeader->toString());
     }
 
-    /** Implmentation specific tests here */
+    /**
+     * Implementation specific tests are covered by DateTest
+     * @see ZendTest\Http\Header\DateTest
+     */
     
 }
 

--- a/tests/Zend/Http/Header/IfModifiedSinceTest.php
+++ b/tests/Zend/Http/Header/IfModifiedSinceTest.php
@@ -9,7 +9,7 @@ class IfModifiedSinceTest extends \PHPUnit_Framework_TestCase
 
     public function testIfModifiedSinceFromStringCreatesValidIfModifiedSinceHeader()
     {
-        $ifModifiedSinceHeader = IfModifiedSince::fromString('If-Modified-Since: xxx');
+        $ifModifiedSinceHeader = IfModifiedSince::fromString('If-Modified-Since: Sun, 06 Nov 1994 08:49:37 GMT');
         $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $ifModifiedSinceHeader);
         $this->assertInstanceOf('Zend\Http\Header\IfModifiedSince', $ifModifiedSinceHeader);
     }
@@ -22,23 +22,22 @@ class IfModifiedSinceTest extends \PHPUnit_Framework_TestCase
 
     public function testIfModifiedSinceGetFieldValueReturnsProperValue()
     {
-        $this->markTestIncomplete('IfModifiedSince needs to be completed');
-
         $ifModifiedSinceHeader = new IfModifiedSince();
-        $this->assertEquals('xxx', $ifModifiedSinceHeader->getFieldValue());
+        $ifModifiedSinceHeader->setDate('Sun, 06 Nov 1994 08:49:37 GMT');
+        $this->assertEquals('Sun, 06 Nov 1994 08:49:37 GMT', $ifModifiedSinceHeader->getFieldValue());
     }
 
     public function testIfModifiedSinceToStringReturnsHeaderFormattedString()
     {
-        $this->markTestIncomplete('IfModifiedSince needs to be completed');
-
         $ifModifiedSinceHeader = new IfModifiedSince();
-
-        // @todo set some values, then test output
-        $this->assertEmpty('If-Modified-Since: xxx', $ifModifiedSinceHeader->toString());
+        $ifModifiedSinceHeader->setDate('Sun, 06 Nov 1994 08:49:37 GMT');
+        $this->assertEquals('If-Modified-Since: Sun, 06 Nov 1994 08:49:37 GMT', $ifModifiedSinceHeader->toString());
     }
 
-    /** Implmentation specific tests here */
+    /**
+     * Implementation specific tests are covered by DateTest
+     * @see ZendTest\Http\Header\DateTest
+     */
     
 }
 

--- a/tests/Zend/Http/Header/IfUnmodifiedSinceTest.php
+++ b/tests/Zend/Http/Header/IfUnmodifiedSinceTest.php
@@ -9,7 +9,7 @@ class IfUnmodifiedSinceTest extends \PHPUnit_Framework_TestCase
 
     public function testIfUnmodifiedSinceFromStringCreatesValidIfUnmodifiedSinceHeader()
     {
-        $ifUnmodifiedSinceHeader = IfUnmodifiedSince::fromString('If-Unmodified-Since: xxx');
+        $ifUnmodifiedSinceHeader = IfUnmodifiedSince::fromString('If-Unmodified-Since: Sun, 06 Nov 1994 08:49:37 GMT');
         $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $ifUnmodifiedSinceHeader);
         $this->assertInstanceOf('Zend\Http\Header\IfUnmodifiedSince', $ifUnmodifiedSinceHeader);
     }
@@ -22,23 +22,22 @@ class IfUnmodifiedSinceTest extends \PHPUnit_Framework_TestCase
 
     public function testIfUnmodifiedSinceGetFieldValueReturnsProperValue()
     {
-        $this->markTestIncomplete('IfUnmodifiedSince needs to be completed');
-
         $ifUnmodifiedSinceHeader = new IfUnmodifiedSince();
-        $this->assertEquals('xxx', $ifUnmodifiedSinceHeader->getFieldValue());
+        $ifUnmodifiedSinceHeader->setDate('Sun, 06 Nov 1994 08:49:37 GMT');
+        $this->assertEquals('Sun, 06 Nov 1994 08:49:37 GMT', $ifUnmodifiedSinceHeader->getFieldValue());
     }
 
     public function testIfUnmodifiedSinceToStringReturnsHeaderFormattedString()
     {
-        $this->markTestIncomplete('IfUnmodifiedSince needs to be completed');
-
         $ifUnmodifiedSinceHeader = new IfUnmodifiedSince();
-
-        // @todo set some values, then test output
-        $this->assertEmpty('If-Unmodified-Since: xxx', $ifUnmodifiedSinceHeader->toString());
+        $ifUnmodifiedSinceHeader->setDate('Sun, 06 Nov 1994 08:49:37 GMT');
+        $this->assertEquals('If-Unmodified-Since: Sun, 06 Nov 1994 08:49:37 GMT', $ifUnmodifiedSinceHeader->toString());
     }
 
-    /** Implmentation specific tests here */
+    /**
+     * Implementation specific tests are covered by DateTest
+     * @see ZendTest\Http\Header\DateTest
+     */
     
 }
 

--- a/tests/Zend/Http/Header/LastModifiedTest.php
+++ b/tests/Zend/Http/Header/LastModifiedTest.php
@@ -7,9 +7,9 @@ use Zend\Http\Header\LastModified;
 class LastModifiedTest extends \PHPUnit_Framework_TestCase
 {
 
-    public function testLastModifiedFromStringCreatesValidLastModifiedHeader()
+    public function testExpiresFromStringCreatesValidLastModifiedHeader()
     {
-        $lastModifiedHeader = LastModified::fromString('Last-Modified: xxx');
+        $lastModifiedHeader = LastModified::fromString('Last-Modified: Sun, 06 Nov 1994 08:49:37 GMT');
         $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $lastModifiedHeader);
         $this->assertInstanceOf('Zend\Http\Header\LastModified', $lastModifiedHeader);
     }
@@ -22,23 +22,22 @@ class LastModifiedTest extends \PHPUnit_Framework_TestCase
 
     public function testLastModifiedGetFieldValueReturnsProperValue()
     {
-        $this->markTestIncomplete('LastModified needs to be completed');
-
         $lastModifiedHeader = new LastModified();
-        $this->assertEquals('xxx', $lastModifiedHeader->getFieldValue());
+        $lastModifiedHeader->setDate('Sun, 06 Nov 1994 08:49:37 GMT');
+        $this->assertEquals('Sun, 06 Nov 1994 08:49:37 GMT', $lastModifiedHeader->getFieldValue());
     }
 
     public function testLastModifiedToStringReturnsHeaderFormattedString()
     {
-        $this->markTestIncomplete('LastModified needs to be completed');
-
         $lastModifiedHeader = new LastModified();
-
-        // @todo set some values, then test output
-        $this->assertEmpty('Last-Modified: xxx', $lastModifiedHeader->toString());
+        $lastModifiedHeader->setDate('Sun, 06 Nov 1994 08:49:37 GMT');
+        $this->assertEquals('Last-Modified: Sun, 06 Nov 1994 08:49:37 GMT', $lastModifiedHeader->toString());
     }
 
-    /** Implmentation specific tests here */
+    /**
+     * Implementation specific tests are covered by DateTest
+     * @see ZendTest\Http\Header\DateTest
+     */
     
 }
 

--- a/tests/Zend/Http/Header/LocationTest.php
+++ b/tests/Zend/Http/Header/LocationTest.php
@@ -3,42 +3,55 @@
 namespace ZendTest\Http\Header;
 
 use Zend\Http\Header\Location;
+use Zend\Uri\Http as HttpUri;
 
 class LocationTest extends \PHPUnit_Framework_TestCase
 {
 
     public function testLocationFromStringCreatesValidLocationHeader()
     {
-        $locationHeader = Location::fromString('Location: xxx');
+        $locationHeader = Location::fromString('Location: http://www.example.com/');
         $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $locationHeader);
         $this->assertInstanceOf('Zend\Http\Header\Location', $locationHeader);
     }
 
-    public function testLocationGetFieldNameReturnsHeaderName()
-    {
-        $locationHeader = new Location();
-        $this->assertEquals('Location', $locationHeader->getFieldName());
-    }
-
     public function testLocationGetFieldValueReturnsProperValue()
     {
-        $this->markTestIncomplete('Location needs to be completed');
-
         $locationHeader = new Location();
-        $this->assertEquals('xxx', $locationHeader->getFieldValue());
+        $locationHeader->setUri('http://www.example.com/');
+        $this->assertEquals('http://www.example.com/', $locationHeader->getFieldValue());
+
+        $locationHeader->setUri('/path');
+        $this->assertEquals('/path', $locationHeader->getFieldValue());
     }
 
     public function testLocationToStringReturnsHeaderFormattedString()
     {
-        $this->markTestIncomplete('Location needs to be completed');
-
         $locationHeader = new Location();
+        $locationHeader->setUri('http://www.example.com/path?query');
 
-        // @todo set some values, then test output
-        $this->assertEmpty('Location: xxx', $locationHeader->toString());
+        $this->assertEquals('Location: http://www.example.com/path?query', $locationHeader->toString());
     }
 
-    /** Implmentation specific tests here */
-    
+    /** Implementation specific tests  */
+
+    public function testLocationCanSetAndAccessAbsoluteUri()
+    {
+        $locationHeader = Location::fromString('Location: http://www.example.com/path');
+        $uri = $locationHeader->uri();
+        $this->assertInstanceOf('Zend\Uri\Http', $uri);
+        $this->assertTrue($uri->isAbsolute());
+        $this->assertEquals('http://www.example.com/path', $locationHeader->getUri());
+    }
+
+    public function testLocationCanSetAndAccessRelativeUri()
+    {
+        $locationHeader = Location::fromString('Location: /path/to');
+        $uri = $locationHeader->uri();
+        $this->assertInstanceOf('Zend\Uri\Http', $uri);
+        $this->assertFalse($uri->isAbsolute());
+        $this->assertEquals('/path/to', $locationHeader->getUri());
+    }
+
 }
 

--- a/tests/Zend/Http/Header/RefererTest.php
+++ b/tests/Zend/Http/Header/RefererTest.php
@@ -3,42 +3,61 @@
 namespace ZendTest\Http\Header;
 
 use Zend\Http\Header\Referer;
+use Zend\Uri\Http as HttpUri;
 
 class RefererTest extends \PHPUnit_Framework_TestCase
 {
 
-    public function testRefererFromStringCreatesValidRefererHeader()
+    public function testRefererFromStringCreatesValidLocationHeader()
     {
-        $refererHeader = Referer::fromString('Referer: xxx');
+        $refererHeader = Referer::fromString('Referer: http://www.example.com/');
         $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $refererHeader);
         $this->assertInstanceOf('Zend\Http\Header\Referer', $refererHeader);
     }
 
-    public function testRefererGetFieldNameReturnsHeaderName()
-    {
-        $refererHeader = new Referer();
-        $this->assertEquals('Referer', $refererHeader->getFieldName());
-    }
-
     public function testRefererGetFieldValueReturnsProperValue()
     {
-        $this->markTestIncomplete('Referer needs to be completed');
-
         $refererHeader = new Referer();
-        $this->assertEquals('xxx', $refererHeader->getFieldValue());
+        $refererHeader->setUri('http://www.example.com/');
+        $this->assertEquals('http://www.example.com/', $refererHeader->getFieldValue());
+
+        $refererHeader->setUri('/path');
+        $this->assertEquals('/path', $refererHeader->getFieldValue());
     }
 
     public function testRefererToStringReturnsHeaderFormattedString()
     {
-        $this->markTestIncomplete('Referer needs to be completed');
-
         $refererHeader = new Referer();
+        $refererHeader->setUri('http://www.example.com/path?query');
 
-        // @todo set some values, then test output
-        $this->assertEmpty('Referer: xxx', $refererHeader->toString());
+        $this->assertEquals('Referer: http://www.example.com/path?query', $refererHeader->toString());
     }
 
-    /** Implmentation specific tests here */
-    
+    /** Implementation specific tests  */
+
+    public function testRefererCanSetAndAccessAbsoluteUri()
+    {
+        $refererHeader = Referer::fromString('Referer: http://www.example.com/path');
+        $uri = $refererHeader->uri();
+        $this->assertInstanceOf('Zend\Uri\Http', $uri);
+        $this->assertTrue($uri->isAbsolute());
+        $this->assertEquals('http://www.example.com/path', $refererHeader->getUri());
+    }
+
+    public function testRefererCanSetAndAccessRelativeUri()
+    {
+        $refererHeader = Referer::fromString('Referer: /path/to');
+        $uri = $refererHeader->uri();
+        $this->assertInstanceOf('Zend\Uri\Http', $uri);
+        $this->assertFalse($uri->isAbsolute());
+        $this->assertEquals('/path/to', $refererHeader->getUri());
+    }
+
+    public function testRefererDoesNotHaveUriFragment()
+    {
+        $refererHeader = new Referer();
+        $refererHeader->setUri('http://www.example.com/path?query#fragment');
+        $this->assertEquals('Referer: http://www.example.com/path?query', $refererHeader->toString());
+    }
 }
 

--- a/tests/Zend/Http/Header/RetryAfterTest.php
+++ b/tests/Zend/Http/Header/RetryAfterTest.php
@@ -9,9 +9,16 @@ class RetryAfterTest extends \PHPUnit_Framework_TestCase
 
     public function testRetryAfterFromStringCreatesValidRetryAfterHeader()
     {
-        $retryAfterHeader = RetryAfter::fromString('Retry-After: xxx');
+        $retryAfterHeader = RetryAfter::fromString('Retry-After: 10');
         $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $retryAfterHeader);
         $this->assertInstanceOf('Zend\Http\Header\RetryAfter', $retryAfterHeader);
+        $this->assertEquals('10', $retryAfterHeader->getDeltaSeconds());
+    }
+
+    public function testRetryAfterFromStringCreatesValidRetryAfterHeaderFromDate()
+    {
+        $retryAfterHeader = RetryAfter::fromString('Retry-After: Sun, 06 Nov 1994 08:49:37 GMT');
+        $this->assertEquals('Sun, 06 Nov 1994 08:49:37 GMT', $retryAfterHeader->getDate());
     }
 
     public function testRetryAfterGetFieldNameReturnsHeaderName()
@@ -22,23 +29,23 @@ class RetryAfterTest extends \PHPUnit_Framework_TestCase
 
     public function testRetryAfterGetFieldValueReturnsProperValue()
     {
-        $this->markTestIncomplete('RetryAfter needs to be completed');
-
         $retryAfterHeader = new RetryAfter();
-        $this->assertEquals('xxx', $retryAfterHeader->getFieldValue());
+        $retryAfterHeader->setDeltaSeconds(3600);
+        $this->assertEquals('3600', $retryAfterHeader->getFieldValue());
+        $retryAfterHeader->setDate('Sun, 06 Nov 1994 08:49:37 GMT');
+        $this->assertEquals('Sun, 06 Nov 1994 08:49:37 GMT', $retryAfterHeader->getFieldValue());
     }
 
     public function testRetryAfterToStringReturnsHeaderFormattedString()
     {
-        $this->markTestIncomplete('RetryAfter needs to be completed');
-
         $retryAfterHeader = new RetryAfter();
 
-        // @todo set some values, then test output
-        $this->assertEmpty('Retry-After: xxx', $retryAfterHeader->toString());
-    }
+        $retryAfterHeader->setDeltaSeconds(3600);
+        $this->assertEquals('Retry-After: 3600', $retryAfterHeader->toString());
 
-    /** Implmentation specific tests here */
-    
+        $retryAfterHeader->setDate('Sun, 06 Nov 1994 08:49:37 GMT');
+        $this->assertEquals('Retry-After: Sun, 06 Nov 1994 08:49:37 GMT', $retryAfterHeader->toString());
+
+    }
 }
 

--- a/tests/Zend/Http/HeadersTest.php
+++ b/tests/Zend/Http/HeadersTest.php
@@ -14,6 +14,12 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Countable', $headers);
     }
 
+    public function testHeadersCanGetPluginClassLoader()
+    {
+        $headers = new Headers();
+        $this->assertInstanceOf('Zend\Http\HeaderLoader', $headers->getPluginClassLoader());
+    }
+
     public function testHeadersFromStringFactoryCreatesSingleObject()
     {
         $headers = Headers::fromString("Fake: foo-bar");
@@ -192,6 +198,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $headers = new Headers();
         $headers->addHeaders(array('Foo' => 'bar', 'Baz' => 'baz'));
         $iterations = 0;
+        /** @var \Zend\Http\Header\HeaderInterface $header */
         foreach ($headers as $index => $header) {
             $iterations++;
             $this->assertInstanceOf('Zend\Http\Header\GenericHeader', $header);

--- a/tests/Zend/Http/PhpEnvironment/RequestTest.php
+++ b/tests/Zend/Http/PhpEnvironment/RequestTest.php
@@ -263,6 +263,19 @@ class RequestTest extends TestCase
     }
 
     /**
+     * @dataProvider serverHeaderProvider
+     * @param array  $server
+     * @param string $name
+     */
+    public function testRequestStringHasCorrectHeaderName(array $server, $name)
+    {
+        $_SERVER = $server;
+        $request = new Request();
+
+        $this->assertContains($name, $request->toString());
+    }
+
+    /**
      * Data provider for testing server hostname.
      */
     public static function serverHostnameProvider()


### PR DESCRIPTION
this PR includes:
- fix Http\PhpEnvironment\Request to set correct names for headers extracted from `$_SERVER`
- move PluginLoader for headers into separate HeaderLoader class
- location-based headers (Location, Content-Location, Referer)
- date-based headers (Date, Last-Modified, Expires etc.)
- Allow, Age and Retry-After headers

[![Build Status](https://secure.travis-ci.org/denixport/zf2.png?branch=feature/http-headers)](http://travis-ci.org/denixport/zf2)
