### PR TITLE
ZF2-340: Changed InputFilter Factory to imply required or allow_empty

### DIFF
--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -158,9 +158,15 @@ class Factory
                     break;
                 case 'required':
                     $input->setRequired($value);
+                    if (!isset($inputSpecification['allow_empty'])) {
+                        $input->setAllowEmpty(!$value);
+                    }
                     break;
                 case 'allow_empty':
                     $input->setAllowEmpty($value);
+                    if (!isset($inputSpecification['required'])) {
+                        $input->setRequired(!$value);
+                    }
                     break;
                 case 'filters':
                     if (!is_array($value) && !$value instanceof Traversable) {

--- a/tests/Zend/InputFilter/FactoryTest.php
+++ b/tests/Zend/InputFilter/FactoryTest.php
@@ -203,7 +203,7 @@ class FactoryTest extends TestCase
         }
     }
 
-    public function testFactoryWillCreateInputWithSuggestedRequiredFlag()
+    public function testFactoryWillCreateInputWithSuggestedRequiredFlagAndImpliesAllowEmptyFlag()
     {
         $factory = new Factory();
         $input   = $factory->createInput(array(
@@ -212,9 +212,24 @@ class FactoryTest extends TestCase
         ));
         $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
         $this->assertFalse($input->isRequired());
+        $this->assertTrue($input->allowEmpty());
     }
 
-    public function testFactoryWillCreateInputWithSuggestedAllowEmptyFlag()
+    public function testFactoryWillCreateInputWithSuggestedRequiredFlagAndAlternativeAllowEmptyFlag()
+    {
+        $factory = new Factory();
+        $input   = $factory->createInput(array(
+            'name'     => 'foo',
+            'required' => false,
+            'allow_empty' => false,
+        ));
+        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
+        $this->assertFalse($input->isRequired());
+        $this->assertFalse($input->allowEmpty());
+       
+    }
+
+    public function testFactoryWillCreateInputWithSuggestedAllowEmptyFlagAndImpliesRequiredFlag()
     {
         $factory = new Factory();
         $input   = $factory->createInput(array(
@@ -223,6 +238,7 @@ class FactoryTest extends TestCase
         ));
         $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
         $this->assertTrue($input->allowEmpty());
+        $this->assertFalse($input->isRequired());
     }
 
     public function testFactoryWillCreateInputWithSuggestedName()


### PR DESCRIPTION
Changes:

On the factory, if required or allow_empty is set, it will automatically set the other flag.  If both are set, it will listen to their respective values.

Why:

Overall, this makes the InputFilter more intuitive for the end user; rather than having to specify both columns which generally doesn't make complete sense for the user.  Generally speaking if they want to allow empty, they do not want it required and visa-versa.  If the other behavior is required, they can explicitly set it from the factory.

Tests:

Altered existing tests to check for the behavior and added a new test.

Results:

phpunit Zend/InputFilter/FactoryTest.php
OK (14 tests, 48 assertions)

phpunit Zend/InputFilter/
OK (56 tests, 136 assertions)
