### PR TITLE
FormElementErrors Helper: Attributes defaults and allow on invoke

### DIFF
--- a/library/Zend/Form/View/Helper/FormElementErrors.php
+++ b/library/Zend/Form/View/Helper/FormElementErrors.php
@@ -41,6 +41,11 @@ class FormElementErrors extends AbstractHelper
     protected $messageSeparatorString = '</li><li>';
     /**@-*/
 
+    /**@+
+     * @var array Default attributes for the open format tag
+     */
+    protected $attributes;
+
     /**
      * Set the string used to close message representation
      *
@@ -108,9 +113,31 @@ class FormElementErrors extends AbstractHelper
     }
 
     /**
+     * Set the attributes that will go on the message open format
+     *
+     * @param array key value pairs of attributes
+     * @return FormElementErrors
+     */
+    public function setAttributes(array $attributes)
+    {
+        $this->attributes = $attributes;
+    }
+
+    /**
+     * Get the attributes that will go on the message open format
+     *
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
      * Render validation errors for the provided $element
      * 
      * @param  ElementInterface $element 
+     * @param  array $attributes
      * @return string
      */
     public function render(ElementInterface $element, array $attributes = array())
@@ -128,6 +155,7 @@ class FormElementErrors extends AbstractHelper
         }
 
         // Prepare attributes for opening tag
+        $attributes = array_merge($this->attributes, $attributes);
         $attributes = $this->createAttributesString($attributes);
         if (!empty($attributes)) {
             $attributes = ' ' . $attributes;
@@ -151,13 +179,17 @@ class FormElementErrors extends AbstractHelper
     /**
      * Invoke helper as functor
      *
-     * Proxies to {@link render()}.
+     * Proxies to {@link render()} if an element is passed.
      * 
      * @param  ElementInterface $element 
-     * @return string
+     * @param  array $attributes
+     * @return string|FormElementErrors
      */
-    public function __invoke(ElementInterface $element)
+    public function __invoke(ElementInterface $element = null, array $attributes = array())
     {
-        return $this->render($element);
+        if ($element) {
+            return $this->render($element, $attributes);
+        }
+        return $this;
     }
 }

--- a/library/Zend/Form/View/Helper/FormElementErrors.php
+++ b/library/Zend/Form/View/Helper/FormElementErrors.php
@@ -121,6 +121,7 @@ class FormElementErrors extends AbstractHelper
     public function setAttributes(array $attributes)
     {
         $this->attributes = $attributes;
+        return $this;
     }
 
     /**

--- a/library/Zend/Form/View/Helper/FormElementErrors.php
+++ b/library/Zend/Form/View/Helper/FormElementErrors.php
@@ -41,7 +41,7 @@ class FormElementErrors extends AbstractHelper
     protected $messageSeparatorString = '</li><li>';
     /**@-*/
 
-    /**@+
+    /**
      * @var array Default attributes for the open format tag
      */
     protected $attributes = array();

--- a/library/Zend/Form/View/Helper/FormElementErrors.php
+++ b/library/Zend/Form/View/Helper/FormElementErrors.php
@@ -44,7 +44,7 @@ class FormElementErrors extends AbstractHelper
     /**@+
      * @var array Default attributes for the open format tag
      */
-    protected $attributes;
+    protected $attributes = array();
 
     /**
      * Set the string used to close message representation

--- a/tests/Zend/Form/View/Helper/FormElementErrorsTest.php
+++ b/tests/Zend/Form/View/Helper/FormElementErrorsTest.php
@@ -75,6 +75,17 @@ class FormElementErrorsTest extends CommonTestCase
         $this->assertContains('ul class="error"', $markup);
     }
 
+    public function testCanSpecifyAttributesForOpeningTagUsingInvoke()
+    {
+        $helper = $this->helper;
+        $messages = $this->getMessageList();
+        $element  = new Element('foo');
+        $element->setMessages($messages);
+
+        $markup = $helper($element, array('class' => 'error'));
+        $this->assertContains('ul class="error"', $markup);
+    }
+
     public function testCanSpecifyAlternateMarkupStringsViaSetters()
     {
         $messages = $this->getMessageList();
@@ -83,10 +94,22 @@ class FormElementErrorsTest extends CommonTestCase
 
         $this->helper->setMessageOpenFormat('<div%s><span>')
                      ->setMessageCloseString('</span></div>')
-                     ->setMessageSeparatorString('</span><span>');
+                     ->setMessageSeparatorString('</span><span>')
+                     ->setAttributes(array('class' => 'error'));
+
+        $markup = $this->helper->render($element);
+        $this->assertRegexp('#<div class="error">\s*<span>First error message</span>\s*<span>Second error message</span>\s*<span>Third error message</span>\s*</div>#s', $markup);
+    }
+
+    public function testSpecifiedAttributesOverrideDefaults()
+    {
+        $messages = $this->getMessageList();
+        $element  = new Element('foo');
+        $element->setMessages($messages);
+        $element->setAttributes(array('class' => 'foo'));
 
         $markup = $this->helper->render($element, array('class' => 'error'));
-        $this->assertRegexp('#<div class="error">\s*<span>First error message</span>\s*<span>Second error message</span>\s*<span>Third error message</span>\s*</div>#s', $markup);
+        $this->assertContains('ul class="error"', $markup);
     }
 
     public function testRendersNestedMessageSetsAsAFlatList()
@@ -106,4 +129,12 @@ class FormElementErrorsTest extends CommonTestCase
         $markup = $this->helper->render($element, array('class' => 'error'));
         $this->assertRegexp('#<ul class="error">\s*<li>First validator message</li>\s*<li>Second validator first message</li>\s*<li>Second validator second message</li>\s*</ul>#s', $markup);
     }
+
+    public function testCallingTheHelperToRenderInvokeCanReturnObject()
+    {
+        $helper = $this->helper;
+        $this->assertEquals($helper(), $helper);
+    }
+
+
 }


### PR DESCRIPTION
Why:
There are times when you might want to use a helper as an object:
$this->formElementErrors()
       ->setAttributes(array('class' => 'error'))
       ->setMessageOpenFormat('<div%s><span>')
       ->setMessageCloseString('</span></div>')
       ->setMessageSeparatorString('</span><span>')
       ->render($elment);

Othertimes, you may want to set default attributes, message open format, close string and separator string via DI.  

Lastly, there are times when you want to overwrite the default attributes quickly, so:
$this->formElementErrors($element, array('class' => 'youbrokeit');

Changes:
Added new protected attribute $attributes
Added methods for getters and setters
Changed __invoke to add optional $attributes parameter (consistent with the render method)
Changed __invoke to have an element be optional in the event you wanted to return the helper object to chain

Tests:
- Added test to check attributes via invoke
- Added test to check default attributes can be overwritten
- Added test to check invoke can return an object
- Modified test to check attributes via setters

Results:
phpunit Zend/Form/View/Helper/FormElementErrorsTest.php
OK (14 tests, 14 assertions)

phpunit Zend/Form/View/Helper/
OK (430 tests, 566 assertions)
