### PR TITLE
[zen-54] Add type hintings and optimize argument type check

### DIFF
--- a/library/Zend/Acl/Acl.php
+++ b/library/Zend/Acl/Acl.php
@@ -119,9 +119,7 @@ class Acl
     {
         if (is_string($role)) {
             $role = new Role\GenericRole($role);
-        }
-
-        if (!$role instanceof Role\RoleInterface) {
+        } elseif (!$role instanceof Role\RoleInterface) {
             throw new Exception\InvalidArgumentException('addRole() expects $role to be of type Zend\Acl\Role\RoleInterface');
         }
 
@@ -248,9 +246,7 @@ class Acl
     {
         if (is_string($resource)) {
             $resource = new Resource\GenericResource($resource);
-        }
-
-        if (!$resource instanceof Resource\ResourceInterface) {
+        } elseif (!$resource instanceof Resource\ResourceInterface) {
             throw new Exception\InvalidArgumentException('addResource() expects $resource to be of type Zend\Acl\Resource\ResourceInterface');
         }
 

--- a/library/Zend/Barcode/Renderer/AbstractRenderer.php
+++ b/library/Zend/Barcode/Renderer/AbstractRenderer.php
@@ -317,13 +317,8 @@ abstract class AbstractRenderer implements RendererInterface
      * @param  Object\ObjectInterface $barcode
      * @return AbstractRenderer
      */
-    public function setBarcode($barcode)
+    public function setBarcode(Object\ObjectInterface $barcode)
     {
-        if (!$barcode instanceof Object\ObjectInterface) {
-            throw new Exception\InvalidArgumentException(
-                'Invalid barcode object provided to setBarcode()'
-            );
-        }
         $this->barcode = $barcode;
         return $this;
     }

--- a/library/Zend/Barcode/Renderer/RendererInterface.php
+++ b/library/Zend/Barcode/Renderer/RendererInterface.php
@@ -21,6 +21,8 @@
 
 namespace Zend\Barcode\Renderer;
 
+use Zend\Barcode\Object\ObjectInterface;
+
 /**
  * Class for rendering the barcode
  *
@@ -146,14 +148,14 @@ interface RendererInterface
 
     /**
      * Set the barcode object
-     * @param  Object\ObjectInterface $barcode
+     * @param  ObjectInterface $barcode
      * @return Renderer
      */
-    public function setBarcode($barcode);
+    public function setBarcode(ObjectInterface $barcode);
 
     /**
      * Retrieve the barcode object
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function getBarcode();
 

--- a/library/Zend/Barcode/Renderer/Svg.php
+++ b/library/Zend/Barcode/Renderer/Svg.php
@@ -116,17 +116,11 @@ class Svg extends AbstractRenderer
     /**
      * Set an image resource to draw the barcode inside
      *
-     * @param DOMDocument $value
+     * @param  DOMDocument $svg
      * @return Svg
-     * @throw  Exception
      */
-    public function setResource($svg)
+    public function setResource(DOMDocument $svg)
     {
-        if (!$svg instanceof DOMDocument) {
-            throw new Exception\InvalidArgumentException(
-                'Invalid DOMDocument resource provided to setResource()'
-            );
-        }
         $this->resource = $svg;
         return $this;
     }

--- a/library/Zend/Cache/PatternFactory.php
+++ b/library/Zend/Cache/PatternFactory.php
@@ -54,8 +54,7 @@ class PatternFactory
         }
         if (is_array($options)) {
             $options = new Pattern\PatternOptions($options);
-        }
-        if (!$options instanceof Pattern\PatternOptions) {
+        } elseif (!$options instanceof Pattern\PatternOptions) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an array, Traversable object, or %s\Pattern\PatternOptions object; received "%s"',
                 __METHOD__,

--- a/library/Zend/Code/Generator/ClassGenerator.php
+++ b/library/Zend/Code/Generator/ClassGenerator.php
@@ -301,20 +301,6 @@ class ClassGenerator extends AbstractGenerator
      */
     public function setDocBlock(DocBlockGenerator $docBlock)
     {
-        /*
-        if (is_string($docBlock)) {
-            $docBlock = array('shortDescription' => $docBlock);
-        }
-
-        if (is_array($docBlock)) {
-            $docBlock = new DocBlockGenerator($docBlock);
-        } elseif (!$docBlock instanceof DocBlockGenerator) {
-            throw new Exception\InvalidArgumentException(
-                'setDocBlock() is expecting either a string, array or an instance of Zend\Code\Generator\DocBlockGenerator'
-            );
-        }
-        */
-
         $this->docBlock = $docBlock;
 
         return $this;

--- a/library/Zend/Code/Generator/FileGenerator.php
+++ b/library/Zend/Code/Generator/FileGenerator.php
@@ -393,15 +393,10 @@ class FileGenerator extends AbstractGenerator
     public function setClass($class)
     {
         if (is_array($class)) {
-            $class     = ClassGenerator::fromArray($class);
-            $className = $class->getName();
-        }
-
-        if (is_string($class)) {
+            $class = ClassGenerator::fromArray($class);
+        } elseif (is_string($class)) {
             $class = new ClassGenerator($class);
-        }
-
-        if (!$class instanceof ClassGenerator) {
+        } elseif (!$class instanceof ClassGenerator) {
             throw new Exception\InvalidArgumentException(
                 'setClass() is expecting either a string, array or an instance of Zend\Code\Generator\ClassGenerator'
             );

--- a/library/Zend/Db/Adapter/Adapter.php
+++ b/library/Zend/Db/Adapter/Adapter.php
@@ -74,9 +74,7 @@ class Adapter
     {
         if (is_array($driver)) {
             $driver = $this->createDriverFromParameters($driver);
-        }
-
-        if (!$driver instanceof Driver\DriverInterface) {
+        } elseif (!$driver instanceof Driver\DriverInterface) {
             throw new Exception\InvalidArgumentException(
                 'The supplied or instantiated driver object does not implement Zend\Db\Adapter\Driver\DriverInterface'
             );

--- a/library/Zend/Db/Adapter/Driver/Mysqli/Mysqli.php
+++ b/library/Zend/Db/Adapter/Driver/Mysqli/Mysqli.php
@@ -54,10 +54,6 @@ class Mysqli implements DriverInterface
             $connection = new Connection($connection);
         }
 
-        if (!$connection instanceof Connection) {
-            throw new Exception\InvalidArgumentException('$connection must be an array of parameters or a Pdo\Connection object');
-        }
-
         $this->registerConnection($connection);
         $this->registerStatementPrototype(($statementPrototype) ?: new Statement());
         $this->registerResultPrototype(($resultPrototype) ?: new Result());

--- a/library/Zend/Db/Adapter/Driver/Pdo/Pdo.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Pdo.php
@@ -58,10 +58,6 @@ class Pdo implements DriverInterface, DriverFeatureInterface
             $connection = new Connection($connection);
         }
 
-        if (!$connection instanceof Connection) {
-            throw new Exception\InvalidArgumentException('$connection must be an array of parameters or a Pdo\Connection object');
-        }
-
         $this->registerConnection($connection);
         $this->registerStatementPrototype(($statementPrototype) ?: new Statement());
         $this->registerResultPrototype(($resultPrototype) ?: new Result());

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Sqlsrv.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Sqlsrv.php
@@ -47,10 +47,6 @@ class Sqlsrv implements DriverInterface
             $connection = new Connection($connection);
         }
 
-        if (!$connection instanceof Connection) {
-            throw new Exception\InvalidArgumentException('$connection must be an array of parameters or a Pdo\Connection object');
-        }
-
         $this->registerConnection($connection);
         $this->registerStatementPrototype(($statementPrototype) ?: new Statement());
         $this->registerResultPrototype(($resultPrototype) ?: new Result());

--- a/library/Zend/Form/Element/Captcha.php
+++ b/library/Zend/Form/Element/Captcha.php
@@ -23,6 +23,7 @@ namespace Zend\Form\Element;
 
 use Zend\Captcha as ZendCaptcha;
 use Zend\Form\Element;
+use Zend\Form\Exception;
 use Zend\InputFilter\InputProviderInterface;
 
 /**
@@ -60,9 +61,7 @@ class Captcha extends Element implements InputProviderInterface
     {
         if (is_array($captcha) || $captcha instanceof Traversable) {
             $captcha = ZendCaptcha\Factory::factory($captcha);
-        }
-
-        if (!$captcha instanceof ZendCaptcha\AdapterInterface) {
+        } elseif (!$captcha instanceof ZendCaptcha\AdapterInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects either a Zend\Captcha\AdapterInterface or specification to pass to Zend\Captcha\Factory; received "%s"',
                 __METHOD__,

--- a/library/Zend/GData/App.php
+++ b/library/Zend/GData/App.php
@@ -238,8 +238,7 @@ class App
     {
         if ($client === null) {
             $client = new Http\Client();
-        }
-        if (!$client instanceof Http\Client) {
+        } elseif (!$client instanceof Http\Client) {
             throw new App\HttpException(
                 'Argument is not an instance of Zend\Http\Client.');
         }

--- a/library/Zend/GData/AuthSub.php
+++ b/library/Zend/GData/AuthSub.php
@@ -220,8 +220,7 @@ class AuthSub
     {
         if ($client == null) {
             $client = new HttpClient();
-        }
-        if (!$client instanceof Client) {
+        } elseif (!$client instanceof Client) {
             throw new App\HttpException('Client is not an instance of Zend_Http_Client.');
         }
         $useragent = 'Zend_Framework_Gdata/' . \Zend\Version::VERSION;

--- a/library/Zend/GData/ClientLogin.php
+++ b/library/Zend/GData/ClientLogin.php
@@ -84,9 +84,7 @@ class ClientLogin
 
         if ($client == null) {
             $client = new HttpClient();
-        }
-        
-        if (!$client instanceof \Zend\Http\Client) {
+        } elseif (!$client instanceof \Zend\Http\Client) {
             throw new App\HttpException(
                     'Client is not an instance of Zend\Http\Client.');
         }

--- a/library/Zend/GData/YouTube.php
+++ b/library/Zend/GData/YouTube.php
@@ -176,10 +176,9 @@ class YouTube extends Media
     {
         if ($client === null) {
             $client = new Http\Client();
-        }
-        if (!$client instanceof Http\Client) {
+        } elseif (!$client instanceof Http\Client) {
             throw new App\HttpException(
-                'Argument is not an instance of Zend_Http_Client.');
+                'Argument is not an instance of Zend\Http\Client.');
         }
 
         if ($clientId != null) {

--- a/library/Zend/Http/Client/Cookies.php
+++ b/library/Zend/Http/Client/Cookies.php
@@ -137,12 +137,8 @@ class Cookies //implements ParametersInterface
      * @param Response $response
      * @param Uri\Uri|string $ref_uri Requested URI
      */
-    public function addCookiesFromResponse($response, $ref_uri)
+    public function addCookiesFromResponse(Response $response, $ref_uri)
     {
-        if (!$response instanceof Response) {
-            throw new Exception\InvalidArgumentException('$response is expected to be a Response object');
-        }
-
         $cookie_hdrs = $response->headers()->get('Set-Cookie');
 
         if (is_array($cookie_hdrs)) {
@@ -182,8 +178,7 @@ class Cookies //implements ParametersInterface
     {
         if (is_string($uri)) {
             $uri = Uri\UriFactory::factory($uri, 'http');
-        }
-        if (!$uri instanceof Uri\Uri) {
+        } elseif (!$uri instanceof Uri\Uri) {
             throw new Exception\InvalidArgumentException("Invalid URI string or object passed");
         }
 
@@ -221,9 +216,7 @@ class Cookies //implements ParametersInterface
     {
         if (is_string($uri)) {
             $uri = Uri\UriFactory::factory($uri, 'http');
-        }
-
-        if (!$uri instanceof Uri\Uri) {
+        } elseif (!$uri instanceof Uri\Uri) {
             throw new Exception\InvalidArgumentException('Invalid URI specified');
         }
 

--- a/library/Zend/Http/Cookies.php
+++ b/library/Zend/Http/Cookies.php
@@ -140,12 +140,8 @@ class Cookies extends Headers
      * @param Response $response
      * @param Uri\Uri|string $ref_uri Requested URI
      */
-    public function addCookiesFromResponse($response, $ref_uri)
+    public function addCookiesFromResponse(Response $response, $ref_uri)
     {
-        if (!$response instanceof Response) {
-            throw new Exception\InvalidArgumentException('$response is expected to be a Response object');
-        }
-
         $cookie_hdrs = $response->headers()->get('Set-Cookie');
 
         if (is_array($cookie_hdrs)) {
@@ -185,8 +181,7 @@ class Cookies extends Headers
     {
         if (is_string($uri)) {
             $uri = Uri\UriFactory::factory($uri, 'http');
-        }
-        if (!$uri instanceof Uri\Uri) {
+        } elseif (!$uri instanceof Uri\Uri) {
             throw new Exception\InvalidArgumentException("Invalid URI string or object passed");
         }
 
@@ -224,9 +219,7 @@ class Cookies extends Headers
     {
         if (is_string($uri)) {
             $uri = Uri\UriFactory::factory($uri, 'http');
-        }
-
-        if (!$uri instanceof Uri\Uri) {
+        } elseif (!$uri instanceof Uri\Uri) {
             throw new Exception\InvalidArgumentException('Invalid URI specified');
         }
 

--- a/library/Zend/Log/Filter/Validator.php
+++ b/library/Zend/Log/Filter/Validator.php
@@ -44,15 +44,9 @@ class Validator implements FilterInterface
      * Filter out any log messages not matching the validator
      *
      * @param  ZendValidator $validator
-     * @throws Exception\InvalidArgumentException
      */
-    public function __construct($validator)
+    public function __construct(ZendValidator $validator)
     {
-        if (!$validator instanceof ZendValidator) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'Expected Zend\Validator object'
-            ));
-        }
         $this->validator = $validator;
     }
 

--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -239,11 +239,8 @@ class Logger implements LoggerInterface, Pluggable
      * @throws Exception\InvalidArgumentException
      * @return Logger
      */
-    public function setWriters($writers)
+    public function setWriters(SplPriorityQueue $writers)
     {
-        if (!$writers instanceof SplPriorityQueue) {
-            throw new Exception\InvalidArgumentException('Writers must be a SplPriorityQueue of Zend\Log\Writer');
-        }
         foreach ($writers->toArray() as $writer) {
             if (!$writer instanceof Writer\WriterInterface) {
                 throw new Exception\InvalidArgumentException('Writers must be a SplPriorityQueue of Zend\Log\Writer');

--- a/library/Zend/Log/Writer/AbstractWriter.php
+++ b/library/Zend/Log/Writer/AbstractWriter.php
@@ -59,9 +59,7 @@ abstract class AbstractWriter implements WriterInterface
     {
         if (is_int($filter)) {
             $filter = new Filter\Priority($filter);
-        }
-
-        if (!$filter instanceof Filter\FilterInterface) {
+        } elseif (!$filter instanceof Filter\FilterInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Filter must implement Zend\Log\Filter; received %s',
                 is_object($filter) ? get_class($filter) : gettype($filter)

--- a/library/Zend/Mail/AddressList.php
+++ b/library/Zend/Mail/AddressList.php
@@ -50,8 +50,7 @@ class AddressList implements Countable, Iterator
     {
         if (is_string($emailOrAddress)) {
             $emailOrAddress = $this->createAddress($emailOrAddress, $name);
-        }
-        if (!$emailOrAddress instanceof Address\AddressInterface) {
+        } elseif (!$emailOrAddress instanceof Address\AddressInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an email address or %s\Address object as its first argument; received "%s"',
                 __METHOD__,

--- a/library/Zend/Mail/Header/Sender.php
+++ b/library/Zend/Mail/Header/Sender.php
@@ -154,8 +154,7 @@ class Sender implements HeaderInterface
     {
         if (is_string($emailOrAddress)) {
             $emailOrAddress = new Mail\Address($emailOrAddress, $name);
-        }
-        if (!$emailOrAddress instanceof Mail\Address\AddressInterface) {
+        } elseif (!$emailOrAddress instanceof Mail\Address\AddressInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects a string or AddressInterface object; received "%s"',
                 __METHOD__,

--- a/library/Zend/ModuleManager/ModuleEvent.php
+++ b/library/Zend/ModuleManager/ModuleEvent.php
@@ -90,19 +90,11 @@ class ModuleEvent extends Event
     /**
      * Set module object to compose in this event
      *
-     * @param  Listener\ConfigMergerInterface $listener
+     * @param  Listener\ConfigMergerInterface $configListener
      * @return ModuleEvent
      */
-    public function setConfigListener($configListener)
+    public function setConfigListener(Listener\ConfigMergerInterface $configListener)
     {
-        if (!$configListener instanceof Listener\ConfigMergerInterface) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s::%s() expects an object implementing Zend\ModuleManager\Listener\ConfigMergerInterface as an argument; %s provided',
-                __CLASS__, 
-                __METHOD__, 
-                (is_object($configListener) ? get_class($configListener) : gettype($configListener))
-            ));
-        }
         $this->setParam('configListener', $configListener);
         return $this;
     }

--- a/library/Zend/Search/Lucene/Index.php
+++ b/library/Zend/Search/Lucene/Index.php
@@ -668,9 +668,7 @@ class Index implements SearchIndexInterface
     {
         if (is_string($query)) {
             $query = Search\QueryParser::parse($query);
-        }
-
-        if (!$query instanceof Search\Query\AbstractQuery) {
+        } elseif (!$query instanceof Search\Query\AbstractQuery) {
             throw new InvalidArgumentException('Query must be a string or Zend\Search\Lucene\Search\Query object');
         }
 

--- a/library/Zend/Search/Lucene/Index/SegmentInfo.php
+++ b/library/Zend/Search/Lucene/Index/SegmentInfo.php
@@ -927,7 +927,7 @@ class SegmentInfo implements TermsStreamInterface
      * @throws \Zend\Search\Lucene\Exception\InvalidArgumentException
      * @return array
      */
-    public function termDocs(Term $term, $shift = 0, $docsFilter = null)
+    public function termDocs(Term $term, $shift = 0, DocsFilter $docsFilter = null)
     {
         $termInfo = $this->getTermInfo($term);
 
@@ -944,12 +944,6 @@ class SegmentInfo implements TermsStreamInterface
         $result = array();
 
         if ($docsFilter !== null) {
-            if (!$docsFilter instanceof DocsFilter) {
-                throw new InvalidArgumentException(
-                	'Documents filter must be an instance of Zend\Search\Lucene\Index\DocsFilter or null.'
-                );
-            }
-
             if (isset($docsFilter->segmentFilters[$this->_name])) {
                 // Filter already has some data for the current segment
 
@@ -1049,7 +1043,7 @@ class SegmentInfo implements TermsStreamInterface
      * @param \Zend\Search\Lucene\Index\DocsFilter|null $docsFilter
      * @return \Zend\Search\Lucene\Index\TermInfo
      */
-    public function termFreqs(Term $term, $shift = 0, $docsFilter = null)
+    public function termFreqs(Term $term, $shift = 0, DocsFilter $docsFilter = null)
     {
         $termInfo = $this->getTermInfo($term);
 
@@ -1068,12 +1062,6 @@ class SegmentInfo implements TermsStreamInterface
         $result = array();
 
         if ($docsFilter !== null) {
-            if (!$docsFilter instanceof DocsFilter) {
-                throw new InvalidArgumentException(
-                	'Documents filter must be an instance of Zend\Search\Lucene\Index\DocsFilter or null.'
-                );
-            }
-
             if (isset($docsFilter->segmentFilters[$this->_name])) {
                 // Filter already has some data for the current segment
 
@@ -1175,7 +1163,7 @@ class SegmentInfo implements TermsStreamInterface
      * @param \Zend\Search\Lucene\Index\DocsFilter|null $docsFilter
      * @return \Zend\Search\Lucene\Index\TermInfo
      */
-    public function termPositions(Term $term, $shift = 0, $docsFilter = null)
+    public function termPositions(Term $term, $shift = 0, DocsFilter $docsFilter = null)
     {
         $termInfo = $this->getTermInfo($term);
 
@@ -1194,12 +1182,6 @@ class SegmentInfo implements TermsStreamInterface
 
 
         if ($docsFilter !== null) {
-            if (!$docsFilter instanceof DocsFilter) {
-                throw new InvalidArgumentException(
-                	'Documents filter must be an instance of Zend_Search_Lucene_Index_DocsFilter or null.'
-                );
-            }
-
             if (isset($docsFilter->segmentFilters[$this->_name])) {
                 // Filter already has some data for the current segment
 

--- a/library/Zend/Service/Amazon/Item.php
+++ b/library/Zend/Service/Amazon/Item.php
@@ -20,6 +20,8 @@
  */
 
 namespace Zend\Service\Amazon;
+
+use DOMElement;
 use Zend\Service\Amazon\Exception;
 
 /**
@@ -112,17 +114,12 @@ class Item
     /**
      * Parse the given <Item> element
      *
-     * @param  null|DOMElement $dom
-     * @return void
-     * @throws	\Zend\Service\Amazon\Exception
+     * @param DOMElement $dom
      * 
      * @group ZF-9547
      */
-    public function __construct($dom)
+    public function __construct(DOMElement $dom)
     {
-        if (!$dom instanceof \DOMElement) {
-            throw new Exception\InvalidArgumentException('Item passed to Amazon\Item must be instace of DOMElement');
-        }
         $xpath = new \DOMXPath($dom->ownerDocument);
         $xpath->registerNamespace('az', 'http://webservices.amazon.com/AWSECommerceService/2011-08-01');
         $this->ASIN = $xpath->query('./az:ASIN/text()', $dom)->item(0)->data;

--- a/library/Zend/Wildfire/Protocol/JsonStream.php
+++ b/library/Zend/Wildfire/Protocol/JsonStream.php
@@ -146,16 +146,12 @@ class JsonStream
     /**
      * Retrieves all formatted data ready to be sent by the channel.
      *
-     * @param \Zend\Wildfire\Channel $channel The instance of the channel that will be transmitting the data
+     * @param Wildfire\Channel\HttpHeaders $channel The instance of the channel that will be transmitting the data
      * @return mixed Returns the data to be sent by the channel.
      * @throws \Zend\Wildfire\Exception
      */
-    public function getPayload(Wildfire\Channel $channel)
+    public function getPayload(Wildfire\Channel\HttpHeaders $channel)
     {
-        if (!$channel instanceof Wildfire\Channel\HttpHeaders) {
-            throw new Exception\InvalidArgumentException('The '.get_class($channel).' channel is not supported by the '.get_called_class().' protocol.');
-        }
-
         if ($this->_plugins) {
             foreach ($this->_plugins as $plugin) {
                 $plugin->flushMessages(self::PROTOCOL_URI);

--- a/tests/Zend/Barcode/Renderer/SvgTest.php
+++ b/tests/Zend/Barcode/Renderer/SvgTest.php
@@ -81,13 +81,6 @@ class SvgTest extends TestCommon
         $this->renderer->setResource($svgResource, 10);
     }
 
-    public function testObjectSvgResource()
-    {
-        $this->setExpectedException('Zend\Barcode\Renderer\Exception\ExceptionInterface');
-        $svgResource = new \StdClass();
-        $this->renderer->setResource($svgResource);
-    }
-
     public function testDrawReturnResource()
     {
         Barcode\Barcode::setBarcodeFont(__DIR__ . '/../Object/_fonts/Vera.ttf');

--- a/tests/Zend/Barcode/Renderer/TestCommon.php
+++ b/tests/Zend/Barcode/Renderer/TestCommon.php
@@ -74,13 +74,6 @@ abstract class TestCommon extends \PHPUnit_Framework_TestCase
         $this->assertSame($barcode, $this->renderer->getBarcode());
     }
 
-    public function testSetInvalidBarcodeObject()
-    {
-        $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
-        $barcode = new \StdClass();
-        $this->renderer->setBarcode($barcode);
-    }
-
     public function testGoodModuleSize()
     {
         $this->renderer->setModuleSize(2.34);

--- a/tests/Zend/Log/Filter/ValidatorTest.php
+++ b/tests/Zend/Log/Filter/ValidatorTest.php
@@ -37,12 +37,6 @@ use Zend\Log\Logger,
  */
 class ValidatorTest extends \PHPUnit_Framework_TestCase
 {
-    public function testRecognizesInvalidValidator()
-    {
-        $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException', 'Expected Zend\Validator object');
-        new Validator('invalid');
-    }
-
     public function testValidatorFilter()
     {
         $filter = new Validator(new Alnum());

--- a/tests/Zend/ModuleManager/ModuleEventTest.php
+++ b/tests/Zend/ModuleManager/ModuleEventTest.php
@@ -93,10 +93,4 @@ class ModuleEventTest extends TestCase
         $test = $this->event->getConfigListener();
         $this->assertSame($configListener, $test);
     }
-
-    public function testPassingNonConfigMergerToSetConfigListenerRaisesException()
-    {
-        $this->setExpectedException('Zend\ModuleManager\Exception\InvalidArgumentException');
-        $this->event->setConfigListener(new StdClass);
-    }
 }


### PR DESCRIPTION
- Add type hinting where possible without broke interface contracts.
- Optimize argument type check:

From:

``` php
if (is_string($arg) {
    $arg = new Class();
}

if (!$arg instanceof Class) {
    throw Exception;
}
```

To: 

``` php
if (is_string($arg) {
    $arg = new Class();
} elseif (!$arg instanceof Class) {
    throw Exception;
}
```

[![Build Status](https://secure.travis-ci.org/Maks3w/zf2.png?branch=zen-54)](http://travis-ci.org/Maks3w/zf2)
