### PR TITLE
Feature/mail refactor

### DIFF
--- a/library/Zend/Mail/Header/AbstractAddressList.php
+++ b/library/Zend/Mail/Header/AbstractAddressList.php
@@ -208,6 +208,6 @@ abstract class AbstractAddressList implements HeaderInterface
     {
         $name  = $this->getFieldName();
         $value = $this->getFieldValue();
-        return sprintf("%s: %s\r\n", $name, $value);
+        return sprintf('%s: %s', $name, $value);
     }
 }

--- a/library/Zend/Mail/Header/AbstractAddressList.php
+++ b/library/Zend/Mail/Header/AbstractAddressList.php
@@ -22,6 +22,7 @@
 namespace Zend\Mail\Header;
 
 use Zend\Mail\AddressList;
+use Zend\Mail\Headers;
 
 /**
  * Base class for headers composing address lists (to, from, cc, bcc, reply-to)
@@ -79,7 +80,7 @@ abstract class AbstractAddressList implements HeaderInterface
         $header = new static();
 
         // split value on ","
-        $fieldValue = str_replace("\r\n ", " ", $fieldValue);
+        $fieldValue = str_replace(Headers::FOLDING, ' ', $fieldValue);
         $values     = explode(',', $fieldValue);
         array_walk($values, 'trim');
 
@@ -150,7 +151,7 @@ abstract class AbstractAddressList implements HeaderInterface
                 $emails[] = sprintf('%s <%s>', $name, $email);
             }
         }
-        $string = implode(",\r\n ", $emails);
+        $string = implode(',' . Headers::FOLDING, $emails);
         return $string;
     }
 

--- a/library/Zend/Mail/Header/AbstractAddressList.php
+++ b/library/Zend/Mail/Header/AbstractAddressList.php
@@ -208,6 +208,6 @@ abstract class AbstractAddressList implements HeaderInterface
     {
         $name  = $this->getFieldName();
         $value = $this->getFieldValue();
-        return sprintf('%s: %s', $name, $value);
+        return (empty($value)) ? '' : sprintf('%s: %s', $name, $value);
     }
 }

--- a/library/Zend/Mail/Header/ContentType.php
+++ b/library/Zend/Mail/Header/ContentType.php
@@ -21,6 +21,8 @@
 
 namespace Zend\Mail\Header;
 
+use Zend\Mail\Headers;
+
 /**
  * @category   Zend
  * @package    Zend_Mail
@@ -64,7 +66,7 @@ class ContentType implements HeaderInterface
             throw new Exception\InvalidArgumentException('Invalid header line for Content-Type string');
         }
 
-        $value  = str_replace("\r\n ", " ", $value);
+        $value  = str_replace(Headers::FOLDING, " ", $value);
         $values = preg_split('#\s*;\s*#', $value);
         $type   = array_shift($values);
 
@@ -108,7 +110,7 @@ class ContentType implements HeaderInterface
         foreach ($this->parameters as $attribute => $value) {
             $values[] = sprintf('%s="%s"', $attribute, $value);
         }
-        $value = implode(";\r\n ", $values);
+        $value = implode(';' . Headers::FOLDING, $values);
         return $value;
     }
 

--- a/library/Zend/Mail/Header/ContentType.php
+++ b/library/Zend/Mail/Header/ContentType.php
@@ -141,7 +141,7 @@ class ContentType implements HeaderInterface
      */
     public function toString()
     {
-        return 'Content-Type: ' . $this->getFieldValue() . "\r\n";
+        return 'Content-Type: ' . $this->getFieldValue();
     }
 
     /**

--- a/library/Zend/Mail/Header/GenericHeader.php
+++ b/library/Zend/Mail/Header/GenericHeader.php
@@ -56,8 +56,11 @@ class GenericHeader implements HeaderInterface
     public static function fromString($headerLine)
     {
         $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR);
-        list($fieldName, $fieldValue) = explode(': ', $headerLine, 2);
-        $header = new static($fieldName, $fieldValue);
+        $parts = explode(': ', $headerLine, 2);
+        if (count($parts) != 2) {
+            throw new Exception\InvalidArgumentException('Header must match with the format "name: value"');
+        }
+        $header = new static($parts[0], $parts[1]);
         return $header;
     }
 
@@ -79,7 +82,7 @@ class GenericHeader implements HeaderInterface
     }
 
     /**
-     * Set header field name
+     * Set header name
      *
      * @param  string $fieldName
      * @throws Exception\InvalidArgumentException
@@ -96,7 +99,9 @@ class GenericHeader implements HeaderInterface
 
         // Validate what we have
         if (!preg_match('/^[a-z][a-z0-9-]*$/i', $fieldName)) {
-            throw new Exception\InvalidArgumentException('Header name must start with a letter, and consist of only letters, numbers, and dashes');
+            throw new Exception\InvalidArgumentException(
+                'Header name must start with a letter, and consist of only letters, numbers and dashes'
+            );
         }
 
         $this->fieldName = $fieldName;
@@ -104,7 +109,7 @@ class GenericHeader implements HeaderInterface
     }
 
     /**
-     * Retrieve header field name
+     * Retrieve header name
      *
      * @return string
      */
@@ -114,7 +119,7 @@ class GenericHeader implements HeaderInterface
     }
 
     /**
-     * Set header field value
+     * Set header value
      * 
      * @param  string $fieldValue
      * @return GenericHeader
@@ -132,7 +137,7 @@ class GenericHeader implements HeaderInterface
     }
 
     /**
-     * Retrieve header field value
+     * Retrieve header value
      * 
      * @return string
      */
@@ -164,9 +169,9 @@ class GenericHeader implements HeaderInterface
     }
 
     /**
-     * Cast to string as a well formed HTTP header line
+     * Cast to string
      *
-     * Returns in form of "NAME: VALUE\r\n"
+     * Returns in form of "NAME: VALUE"
      *
      * @return string
      */
@@ -175,6 +180,6 @@ class GenericHeader implements HeaderInterface
         $name  = $this->getFieldName();
         $value = $this->getFieldValue();
 
-        return $name. ': ' . $value . "\r\n";
+        return $name. ': ' . $value;
     }
 }

--- a/library/Zend/Mail/Header/HeaderLoader.php
+++ b/library/Zend/Mail/Header/HeaderLoader.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mail
+ */
+
+namespace Zend\Mail\Header;
+
+use Zend\Loader\PluginClassLoader;
+
+/**
+ * Plugin Class Loader implementation for HTTP headers
+ *
+ * @category   Zend
+ * @package    Zend_Mail
+ * @subpackage Header
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class HeaderLoader extends PluginClassLoader
+{
+    /**
+     * @var array Pre-aliased Header plugins
+     */
+    protected $plugins = array(
+        'bcc'          => 'Zend\Mail\Header\Bcc',
+        'cc'           => 'Zend\Mail\Header\Cc',
+        'contenttype'  => 'Zend\Mail\Header\ContentType',
+        'content_type' => 'Zend\Mail\Header\ContentType',
+        'content-type' => 'Zend\Mail\Header\ContentType',
+        'date'         => 'Zend\Mail\Header\Date',
+        'from'         => 'Zend\Mail\Header\From',
+        'mimeversion'  => 'Zend\Mail\Header\MimeVersion',
+        'mime_version' => 'Zend\Mail\Header\MimeVersion',
+        'mime-version' => 'Zend\Mail\Header\MimeVersion',
+        'received'     => 'Zend\Mail\Header\Received',
+        'replyto'      => 'Zend\Mail\Header\ReplyTo',
+        'reply_to'     => 'Zend\Mail\Header\ReplyTo',
+        'reply-to'     => 'Zend\Mail\Header\ReplyTo',
+        'sender'       => 'Zend\Mail\Header\Sender',
+        'subject'      => 'Zend\Mail\Header\Subject',
+        'to'           => 'Zend\Mail\Header\To',
+    );
+}

--- a/library/Zend/Mail/Header/HeaderWrap.php
+++ b/library/Zend/Mail/Header/HeaderWrap.php
@@ -21,6 +21,8 @@
 
 namespace Zend\Mail\Header;
 
+use Zend\Mail\Headers;
+
 /**
  * Utility class used for creating wrapped or MIME-encoded versions of header
  * values.
@@ -60,7 +62,7 @@ abstract class HeaderWrap
      */
     protected static function wrapUnstructuredHeader($value)
     {
-        return wordwrap($value, 78, "\r\n ");
+        return wordwrap($value, 78, Headers::FOLDING);
     }
 
     /**
@@ -84,7 +86,7 @@ abstract class HeaderWrap
                 $temp    = '';
             }
         }
-        return implode("\r\n ", $lines);
+        return implode(Headers::FOLDING, $lines);
     }
 
     /**
@@ -110,7 +112,7 @@ abstract class HeaderWrap
                 ));
                 return str_replace('Header: ', '', $header);
             }, explode(' ', $value));
-            return implode("\r\n ", $words);
+            return implode(Headers::FOLDING, $words);
         }
 
         $header = iconv_mime_encode('Header', $value, array(

--- a/library/Zend/Mail/Header/MultipleHeadersInterface.php
+++ b/library/Zend/Mail/Header/MultipleHeadersInterface.php
@@ -27,7 +27,7 @@ namespace Zend\Mail\Header;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface MultipleHeadersInterface extends HeaderInterface
+interface MultipleHeadersInterface
 {
     public function toStringMultipleHeaders(array $headers);
 }

--- a/library/Zend/Mail/Header/Received.php
+++ b/library/Zend/Mail/Header/Received.php
@@ -21,6 +21,8 @@
 
 namespace Zend\Mail\Header;
 
+use Zend\Mail\Headers;
+
 /**
  * @todo       Allow setting date from DateTime, Zend\Date, or string
  * @category   Zend
@@ -135,6 +137,6 @@ class Received implements HeaderInterface, MultipleHeadersInterface
             }
             $strings[] = $header->toString();
         }
-        return implode("\r\n", $strings);
+        return implode(Headers::EOL, $strings);
     }
 }

--- a/library/Zend/Mail/Header/Received.php
+++ b/library/Zend/Mail/Header/Received.php
@@ -29,7 +29,7 @@ namespace Zend\Mail\Header;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Received implements MultipleHeadersInterface
+class Received implements HeaderInterface, MultipleHeadersInterface
 {
     /**
      * @var string

--- a/library/Zend/Mail/Headers.php
+++ b/library/Zend/Mail/Headers.php
@@ -25,7 +25,6 @@ use ArrayIterator,
     Iterator,
     Countable,
     Traversable,
-    Zend\Loader\PluginClassLoader,
     Zend\Loader\PluginClassLocator;
 
 /**
@@ -48,7 +47,7 @@ class Headers implements Iterator, Countable
     const FOLDING = "\r\n ";
 
     /**
-     * @var PluginClassLoader
+     * @var \Zend\Loader\PluginClassLoader
      */
     protected $pluginClassLoader = null;
 
@@ -134,25 +133,7 @@ class Headers implements Iterator, Countable
     public function getPluginClassLoader()
     {
         if ($this->pluginClassLoader === null) {
-            $this->pluginClassLoader = new PluginClassLoader(array(
-                'bcc'          => 'Zend\Mail\Header\Bcc',
-                'cc'           => 'Zend\Mail\Header\Cc',
-                'contenttype'  => 'Zend\Mail\Header\ContentType',
-                'content_type' => 'Zend\Mail\Header\ContentType',
-                'content-type' => 'Zend\Mail\Header\ContentType',
-                'date'         => 'Zend\Mail\Header\Date',
-                'from'         => 'Zend\Mail\Header\From',
-                'mimeversion'  => 'Zend\Mail\Header\MimeVersion',
-                'mime_version' => 'Zend\Mail\Header\MimeVersion',
-                'mime-version' => 'Zend\Mail\Header\MimeVersion',
-                'received'     => 'Zend\Mail\Header\Received',
-                'replyto'      => 'Zend\Mail\Header\ReplyTo',
-                'reply_to'     => 'Zend\Mail\Header\ReplyTo',
-                'reply-to'     => 'Zend\Mail\Header\ReplyTo',
-                'sender'       => 'Zend\Mail\Header\Sender',
-                'subject'      => 'Zend\Mail\Header\Subject',
-                'to'           => 'Zend\Mail\Header\To',
-            ));
+            $this->pluginClassLoader = new Header\HeaderLoader();
         }
         return $this->pluginClassLoader;
     }

--- a/library/Zend/Mail/Headers.php
+++ b/library/Zend/Mail/Headers.php
@@ -52,13 +52,13 @@ class Headers implements Iterator, Countable
     protected $headersKeys = array();
 
     /**
-     * @var array Array of header array information or HeaderInterface instances
+     * @var  Header\HeaderInterface[] instances
      */
     protected $headers = array();
 
     /**
      * Header encoding; defaults to ASCII
-     * 
+     *
      * @var string
      */
     protected $encoding = 'ASCII';
@@ -76,26 +76,21 @@ class Headers implements Iterator, Countable
      */
     public static function fromString($string)
     {
-        $headers = new static();
-        $current = array();
+        $headers     = new static();
+        $currentLine = '';
 
         // iterate the header lines, some might be continuations
         foreach (explode("\r\n", $string) as $line) {
-
             // check if a header name is present
             if (preg_match('/^(?P<name>[^()><@,;:\"\\/\[\]?=}{ \t]+):.*$/', $line, $matches)) {
-                if ($current) {
+                if ($currentLine) {
                     // a header name was present, then store the current complete line
-                    $headers->headersKeys[] = str_replace(array('-', '_'), '', strtolower($current['name']));
-                    $headers->headers[] = $current;
+                    $headers->addHeaderLine($currentLine);
                 }
-                $current = array(
-                    'name' => $matches['name'],
-                    'line' => trim($line)
-                );
+                $currentLine = trim($line);
             } elseif (preg_match('/^\s+.*$/', $line, $matches)) {
                 // continuation: append to current line
-                $current['line'] .= trim($line);
+                $currentLine .= trim($line);
             } elseif (preg_match('/^\s*$/', $line)) {
                 // empty line indicates end of headers
                 break;
@@ -107,9 +102,8 @@ class Headers implements Iterator, Countable
                 ));
             }
         }
-        if ($current) {
-            $headers->headersKeys[] = str_replace(array('-', '_'), '', strtolower($current['name']));
-            $headers->headers[] = $current;
+        if ($currentLine) {
+            $headers->addHeaderLine($currentLine);
         }
         return $headers;
     }
@@ -159,8 +153,8 @@ class Headers implements Iterator, Countable
 
     /**
      * Set the header encoding
-     * 
-     * @param  string $encoding 
+     *
+     * @param  string $encoding
      * @return Headers
      */
     public function setEncoding($encoding)
@@ -174,7 +168,7 @@ class Headers implements Iterator, Countable
 
     /**
      * Get the header encoding
-     * 
+     *
      * @return string
      */
     public function getEncoding()
@@ -240,24 +234,13 @@ class Headers implements Iterator, Countable
             ));
         }
 
-        $matches = null;
-        if (preg_match('/^(?P<name>[^()><@,;:\"\\/\[\]?=}{ \t]+):.*$/', $headerFieldNameOrLine, $matches)
-            && $fieldValue === null
-        ) {
-            // is a header
-            $headerName = $matches['name'];
-            $headerKey  = str_replace(array('-', '_', ' ', '.'), '', strtolower($matches['name']));
-            $line       = $headerFieldNameOrLine;
-        } elseif ($fieldValue === null) {
-            throw new Exception\InvalidArgumentException('A field name was provided without a field value');
+        if ($fieldValue === null) {
+            $header = Header\GenericHeader::fromString($headerFieldNameOrLine);
         } else {
-            $headerName = $headerFieldNameOrLine;
-            $headerKey  = str_replace(array('-', '_', ' ', '.'), '', strtolower($headerFieldNameOrLine));
-            $line       = $headerFieldNameOrLine . ': ' . $fieldValue;
+            $header = new Header\GenericHeader($headerFieldNameOrLine, $fieldValue);
         }
 
-        $this->headersKeys[] = $headerKey;
-        $this->headers[]     = array('name' => $headerName, 'line' => $line);
+        $this->addHeader($header);
         return $this;
     }
 
@@ -285,7 +268,8 @@ class Headers implements Iterator, Countable
      */
     public function removeHeader(Header\HeaderInterface $header)
     {
-        $index = array_search($header, $this->headers, true);
+        $key = $this->normalizeFieldName($header->getFieldName());
+        $index = array_search($key, $this->headersKeys, true);
         if ($index !== false) {
             unset($this->headersKeys[$index]);
             unset($this->headers[$index]);
@@ -298,7 +282,7 @@ class Headers implements Iterator, Countable
      * Clear all headers
      *
      * Removes all headers from queue
-     * 
+     *
      * @return Headers
      */
     public function clearHeaders()
@@ -309,53 +293,45 @@ class Headers implements Iterator, Countable
 
     /**
      * Get all headers of a certain name/type
-     * 
+     *
      * @param  string $name
-     * @return boolean|Header\HeaderInterface|ArrayIterator
+     * @return boolean|ArrayIterator|Header\HeaderInterface Returns false if there is no headers with $name in this
+     * contain, an ArrayIterator if the header is a MultipleHeadersInterface instance and finally returns
+     * HeaderInterface for the rest of cases.
      */
     public function get($name)
     {
         $key = $this->normalizeFieldName($name);
-        if (!in_array($key, $this->headersKeys)) {
-            return false;
+        $results = array();
+
+        foreach (array_keys($this->headersKeys, $key) as $index) {
+            $results[] = $this->headers[$index];
         }
 
-        $class = ($this->getPluginClassLoader()->load($key)) ?: 'Zend\Mail\Header\GenericHeader';
-
-        if (in_array('Zend\Mail\Header\MultipleHeadersInterface', class_implements($class, true))) {
-            $headers = array();
-            foreach (array_keys($this->headersKeys, $key) as $index) {
-                if (is_array($this->headers[$index])) {
-                    $this->lazyLoadHeader($index);
-                }
-            }
-            foreach (array_keys($this->headersKeys, $key) as $index) {
-                $headers[] = $this->headers[$index];
-            }
-            return new ArrayIterator($headers);
-        } else {
-            $index = array_search($key, $this->headersKeys);
-            if ($index === false) {
+        switch(count($results)) {
+            case 0:
                 return false;
-            }
-            if (is_array($this->headers[$index])) {
-                return $this->lazyLoadHeader($index);
-            } else {
-                return $this->headers[$index];
-            }
+            case 1:
+                if ($results[0] instanceof Header\MultipleHeadersInterface) {
+                    return new ArrayIterator($results);
+                } else {
+                    return $results[0];
+                }
+            default:
+                return new ArrayIterator($results);
         }
     }
 
     /**
      * Test for existence of a type of header
-     * 
+     *
      * @param  string $name
      * @return bool
      */
     public function has($name)
     {
         $name = $this->normalizeFieldName($name);
-        return (in_array($name, $this->headersKeys));
+        return in_array($name, $this->headersKeys);
     }
 
     /**
@@ -374,7 +350,7 @@ class Headers implements Iterator, Countable
      */
     public function key()
     {
-        return (key($this->headers));
+        return key($this->headers);
     }
 
     /**
@@ -404,7 +380,7 @@ class Headers implements Iterator, Countable
     public function current()
     {
         $current = current($this->headers);
-        if (is_array($current)) {
+        if ($current instanceof Header\GenericHeader) {
             $current = $this->lazyLoadHeader(key($this->headers));
         }
         return $current;
@@ -432,17 +408,12 @@ class Headers implements Iterator, Countable
     public function toString()
     {
         $headers = '';
-        foreach ($this->toArray() as $fieldName => $fieldValue) {
-            if (is_array($fieldValue)) {
-                // Handle multi-value headers
-                foreach ($fieldValue as $value) {
-                    $headers .= $fieldName . ': ' . $value . "\r\n";
-                }
-                continue;
+        foreach ($this->headers as $header) {
+            if ($str = $header->toString()) {
+                $headers .= $str . "\r\n";
             }
-            // Handle single-value headers
-            $headers .= $fieldName . ': ' . $fieldValue . "\r\n";
         }
+
         return $headers;
     }
 
@@ -463,14 +434,8 @@ class Headers implements Iterator, Countable
                     $headers[$name] = array();
                 }
                 $headers[$name][] = $header->getFieldValue();
-            } elseif ($header instanceof Header\HeaderInterface) {
-                $headers[$header->getFieldName()] = $header->getFieldValue();
             } else {
-                $matches = null;
-                preg_match('/^(?P<name>[^()><@,;:\"\\/\[\]?=}{ \t]+):\s*(?P<value>.*)$/', $header['line'], $matches);
-                if ($matches) {
-                    $headers[$matches['name']] = $matches['value'];
-                }
+                $headers[$header->getFieldName()] = $header->getFieldValue();
             }
         }
         return $headers;
@@ -502,7 +467,7 @@ class Headers implements Iterator, Countable
         $class = ($this->getPluginClassLoader()->load($key)) ?: 'Zend\Mail\Header\GenericHeader';
 
         $encoding = $this->getEncoding();
-        $headers  = $class::fromString($current['line']);
+        $headers  = $class::fromString($current->toString());
         if (is_array($headers)) {
             $current = array_shift($headers);
             $current->setEncoding($encoding);
@@ -523,8 +488,8 @@ class Headers implements Iterator, Countable
 
     /**
      * Normalize a field name
-     * 
-     * @param  string $fieldName 
+     *
+     * @param  string $fieldName
      * @return string
      */
     protected function normalizeFieldName($fieldName)

--- a/library/Zend/Mail/Headers.php
+++ b/library/Zend/Mail/Headers.php
@@ -41,6 +41,12 @@ use ArrayIterator,
  */
 class Headers implements Iterator, Countable
 {
+    /** @var string End of Line for fields */
+    const EOL = "\r\n";
+
+    /** @var string Start of Line when folding */
+    const FOLDING = "\r\n ";
+
     /**
      * @var PluginClassLoader
      */
@@ -80,7 +86,7 @@ class Headers implements Iterator, Countable
         $currentLine = '';
 
         // iterate the header lines, some might be continuations
-        foreach (explode("\r\n", $string) as $line) {
+        foreach (explode(self::EOL, $string) as $line) {
             // check if a header name is present
             if (preg_match('/^(?P<name>[^()><@,;:\"\\/\[\]?=}{ \t]+):.*$/', $line, $matches)) {
                 if ($currentLine) {
@@ -410,7 +416,7 @@ class Headers implements Iterator, Countable
         $headers = '';
         foreach ($this->headers as $header) {
             if ($str = $header->toString()) {
-                $headers .= $str . "\r\n";
+                $headers .= $str . self::EOL;
             }
         }
 

--- a/library/Zend/Mail/Headers.php
+++ b/library/Zend/Mail/Headers.php
@@ -250,12 +250,12 @@ class Headers implements Iterator, Countable
     /**
      * Remove a Header from the container
      *
-     * @param Header\HeaderInterface $header
+     * @param  string $fieldName
      * @return bool
      */
-    public function removeHeader(Header\HeaderInterface $header)
+    public function removeHeader($fieldName)
     {
-        $key = $this->normalizeFieldName($header->getFieldName());
+        $key = $this->normalizeFieldName($fieldName);
         $index = array_search($key, $this->headersKeys, true);
         if ($index !== false) {
             unset($this->headersKeys[$index]);

--- a/library/Zend/Mail/Message.php
+++ b/library/Zend/Mail/Message.php
@@ -475,11 +475,7 @@ class Message
      */
     protected function clearHeaderByName($headerName)
     {
-        $headers = $this->headers();
-        if ($headers->has($headerName)) {
-            $header = $headers->get($headerName);
-            $headers->removeHeader($header);
-        }
+        $this->headers()->removeHeader($headerName);
     }
 
     /**

--- a/library/Zend/Mail/Message.php
+++ b/library/Zend/Mail/Message.php
@@ -441,7 +441,7 @@ class Message
     public function getBodyText()
     {
         if ($this->body instanceof Mime\Message) {
-            return $this->body->generateMessage();
+            return $this->body->generateMessage(Headers::EOL);
         }
 
         return (string) $this->body;

--- a/library/Zend/Mail/Message.php
+++ b/library/Zend/Mail/Message.php
@@ -546,6 +546,8 @@ class Message
     public function toString()
     {
         $headers = $this->headers();
-        return $headers->toString() . "\r\n" . $this->getBodyText();
+        return $headers->toString()
+               . Headers::EOL
+               . $this->getBodyText();
     }
 }

--- a/library/Zend/Mail/Protocol/Smtp.php
+++ b/library/Zend/Mail/Protocol/Smtp.php
@@ -22,8 +22,6 @@
 
 namespace Zend\Mail\Protocol;
 
-use Zend\Mime\Mime;
-
 /**
  * SMTP implementation of Zend\Mail\Protocol\AbstractProtocol
  *
@@ -294,14 +292,14 @@ class Smtp extends AbstractProtocol
     public function data($data)
     {
         // Ensure recipients have been set
-        if ($this->_rcpt !== true) {
+        if ($this->_rcpt !== true) { // Per RFC 2821 3.3 (page 18)
             throw new Exception\RuntimeException('No recipient forward path has been supplied');
         }
 
         $this->_send('DATA');
         $this->_expect(354, 120); // Timeout set for 2 minutes as per RFC 2821 4.5.3.2
 
-        foreach (explode(Mime::LINEEND, $data) as $line) {
+        foreach (explode(self::EOL, $data) as $line) {
             if (strpos($line, '.') === 0) {
                 // Escape lines prefixed with a '.'
                 $line = '.' . $line;

--- a/library/Zend/Mail/Transport/Sendmail.php
+++ b/library/Zend/Mail/Transport/Sendmail.php
@@ -222,25 +222,16 @@ class Sendmail implements TransportInterface
      */
     protected function prepareHeaders(Mail\Message $message)
     {
-        $headers = $message->headers();
-
         // On Windows, simply return verbatim
         if ($this->isWindowsOs()) {
-            return $headers->toString();
+            return $message->headers()->toString();
         }
 
         // On *nix platforms, strip the "to" header
-        $headersToSend = new Headers();
-        foreach ($headers as $header) {
-            if ('To' == $header->getFieldName()) {
-                continue;
-            }
-            if ('Subject' == $header->getFieldName()) {
-                continue;
-            }
-            $headersToSend->addHeader($header);
-        }
-        return $headersToSend->toString();
+        $headers = clone $message->headers();
+        $headers->removeHeader('To');
+        $headers->removeHeader('Subject');
+        return $headers->toString();
     }
 
     /**

--- a/library/Zend/Mail/Transport/Smtp.php
+++ b/library/Zend/Mail/Transport/Smtp.php
@@ -235,6 +235,14 @@ class Smtp implements TransportInterface, Pluggable
         $headers    = $this->prepareHeaders($message);
         $body       = $this->prepareBody($message);
 
+        if ((count($recipients) == 0) && (!empty($headers) || !empty($body))) {
+            throw new Exception\RuntimeException(  // Per RFC 2821 3.3 (page 18)
+                sprintf(
+                    '%s transport expects at least one recipient if the message has at least one header or body',
+                    __CLASS__
+                ));
+        }
+
         // Set sender email address
         $connection->mail($from);
 
@@ -262,7 +270,7 @@ class Smtp implements TransportInterface, Pluggable
         }
 
         $from = $message->from();
-        if (!count($from)) {
+        if (!count($from)) { // Per RFC 2822 3.6
             throw new Exception\RuntimeException(sprintf(
                 '%s transport expects either a Sender or at least one From address in the Message; none provided',
                 __CLASS__

--- a/library/Zend/Mail/Transport/Smtp.php
+++ b/library/Zend/Mail/Transport/Smtp.php
@@ -243,7 +243,7 @@ class Smtp implements TransportInterface, Pluggable
         }
 
         // Issue DATA command to client
-        $connection->data($headers . "\r\n" . $body);
+        $connection->data($headers . Headers::EOL . $body);
     }
 
     /**

--- a/library/Zend/Mail/Transport/Smtp.php
+++ b/library/Zend/Mail/Transport/Smtp.php
@@ -22,15 +22,16 @@
 namespace Zend\Mail\Transport;
 
 use Zend\Loader\Pluggable,
-    Zend\Mail,
+    Zend\Mail\Address,
     Zend\Mail\Headers,
+    Zend\Mail\Message,
     Zend\Mail\Protocol,
     Zend\Mail\Protocol\Exception as ProtocolException;
 
 /**
  * SMTP connection object
  *
- * Loads an instance of \Zend\Mail\Protocol\Smtp and forwards smtp transactions
+ * Loads an instance of Zend\Mail\Protocol\Smtp and forwards smtp transactions
  *
  * @category   Zend
  * @package    Zend_Mail
@@ -213,9 +214,9 @@ class Smtp implements TransportInterface, Pluggable
      * The connection via the protocol adapter is made just-in-time to allow a
      * developer to add a custom adapter if required before mail is sent.
      *
-     * @param Mail\Message $message
+     * @param Message $message
      */
-    public function send(Mail\Message $message)
+    public function send(Message $message)
     {
         // If sending multiple messages per session use existing adapter
         $connection = $this->getConnection();
@@ -249,14 +250,14 @@ class Smtp implements TransportInterface, Pluggable
     /**
      * Retrieve email address for envelope FROM
      *
-     * @param  Mail\Message $message
+     * @param  Message $message
      * @throws Exception\RuntimeException
      * @return string
      */
-    protected function prepareFromAddress(Mail\Message $message)
+    protected function prepareFromAddress(Message $message)
     {
         $sender = $message->getSender();
-        if ($sender instanceof Mail\Address\AddressInterface) {
+        if ($sender instanceof Address\AddressInterface) {
             return $sender->getEmail();
         }
 
@@ -275,11 +276,11 @@ class Smtp implements TransportInterface, Pluggable
 
     /**
      * Prepare array of email address recipients
-     * 
-     * @param  Mail\Message $message
+     *
+     * @param  Message $message
      * @return array
      */
-    protected function prepareRecipients(Mail\Message $message)
+    protected function prepareRecipients(Message $message)
     {
         $recipients = array();
         foreach ($message->to() as $address) {
@@ -297,29 +298,24 @@ class Smtp implements TransportInterface, Pluggable
 
     /**
      * Prepare header string from message
-     * 
-     * @param  Mail\Message $message
+     *
+     * @param  Message $message
      * @return string
      */
-    protected function prepareHeaders(Mail\Message $message)
+    protected function prepareHeaders(Message $message)
     {
-        $headers = new Headers();
-        foreach ($message->headers() as $header) {
-            if ('Bcc' == $header->getFieldName()) {
-                continue;
-            }
-            $headers->addHeader($header);
-        }
+        $headers = clone $message->headers();
+        $headers->removeHeader('Bcc');
         return $headers->toString();
     }
 
     /**
      * Prepare body string from message
-     * 
-     * @param  Mail\Message $message
+     *
+     * @param  Message $message
      * @return string
      */
-    protected function prepareBody(Mail\Message $message)
+    protected function prepareBody(Message $message)
     {
         return $message->getBodyText();
     }
@@ -327,7 +323,7 @@ class Smtp implements TransportInterface, Pluggable
     /**
      * Lazy load the connection, and pass it helo
      * 
-     * @return Mail\Protocol\Smtp
+     * @return Protocol\Smtp
      */
     protected function lazyLoadConnection()
     {

--- a/tests/Zend/Mail/Header/AddressListHeaderTest.php
+++ b/tests/Zend/Mail/Header/AddressListHeaderTest.php
@@ -110,7 +110,7 @@ class AddressListHeaderTest extends \PHPUnit_Framework_TestCase
     public function testStringRepresentationIncludesHeaderAndFieldValue($header, $type)
     {
         $this->populateAddressList($header->getAddressList());
-        $expected = sprintf("%s: %s\r\n", $type, $this->getExpectedFieldValue());
+        $expected = sprintf('%s: %s', $type, $this->getExpectedFieldValue());
         $this->assertEquals($expected, $header->toString());
     }
 

--- a/tests/Zend/Mail/Header/ContentTypeTest.php
+++ b/tests/Zend/Mail/Header/ContentTypeTest.php
@@ -58,7 +58,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
     {
         $contentTypeHeader = new ContentType();
         $contentTypeHeader->setType('foo/bar');
-        $this->assertEquals("Content-Type: foo/bar\r\n", $contentTypeHeader->toString());
+        $this->assertEquals("Content-Type: foo/bar", $contentTypeHeader->toString());
     }
 
     public function testProvidingParametersIntroducesHeaderFolding()

--- a/tests/Zend/Mail/HeadersTest.php
+++ b/tests/Zend/Mail/HeadersTest.php
@@ -200,7 +200,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $headers->addHeaders(array('Foo' => 'bar', 'Baz' => 'baz'));
         $header = $headers->get('foo');
         $this->assertEquals(2, $headers->count());
-        $headers->removeHeader($header);
+        $headers->removeHeader($header->getFieldName());
         $this->assertEquals(1, $headers->count());
         $this->assertFalse($headers->get('foo'));
     }
@@ -315,5 +315,15 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $loader  = $headers->getPluginClassLoader();
         $test    = $loader->load($plugin);
         $this->assertEquals($class, $test);
+    }
+
+    public function testClone() {
+        $headers = new Mail\Headers();
+        $headers->addHeader(new Header\Bcc());
+        $headers2 = clone($headers);
+        $this->assertEquals($headers, $headers2);
+        $headers2->removeHeader('Bcc');
+        $this->assertTrue($headers->has('Bcc'));
+        $this->assertFalse($headers2->has('Bcc'));
     }
 }

--- a/tests/Zend/Mail/HeadersTest.php
+++ b/tests/Zend/Mail/HeadersTest.php
@@ -144,7 +144,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
 
     public function testHeadersAddHeaderLineThrowsExceptionOnMissingFieldValue()
     {
-        $this->setExpectedException('Zend\Mail\Exception\InvalidArgumentException', 'without a field');
+        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException', 'Header must match with the format "name: value"');
         $headers = new Mail\Headers();
         $headers->addHeaderLine('Foo');
     }

--- a/tests/Zend/Mail/MessageTest.php
+++ b/tests/Zend/Mail/MessageTest.php
@@ -25,6 +25,7 @@ use stdClass,
     Zend\Mail\Address,
     Zend\Mail\AddressList,
     Zend\Mail\Header,
+    Zend\Mail\Headers,
     Zend\Mail\Message,
     Zend\Mime\Message as MimeMessage,
     Zend\Mime\Mime,
@@ -596,7 +597,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->message->setBody($body);
 
         $text = $this->message->getBodyText();
-        $this->assertEquals($body->generateMessage(), $text);
+        $this->assertEquals($body->generateMessage(Headers::EOL), $text);
         $this->assertContains('--foo-bar', $text);
         $this->assertContains('--foo-bar--', $text);
         $this->assertContains('Content-Type: text/plain', $text);

--- a/tests/Zend/Mail/MessageTest.php
+++ b/tests/Zend/Mail/MessageTest.php
@@ -40,6 +40,9 @@ use stdClass,
  */
 class MessageTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var Message */
+    public $message;
+
     public function setUp()
     {
         $this->message = new Message();

--- a/tests/Zend/Mail/Protocol/SmtpTest.php
+++ b/tests/Zend/Mail/Protocol/SmtpTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Mail
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Mail\Protocol;
+
+use Zend\Mail\Headers,
+    Zend\Mail\Message,
+    Zend\Mail\Transport\Smtp,
+    Zend\Mail\Transport\SmtpOptions,
+    ZendTest\Mail\TestAsset\SmtpProtocolSpy;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mail
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Zend_Mail
+ */
+class SmtpTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Smtp */
+    public $transport;
+    /** @var SmtpProtocolSpy */
+    public $connection;
+
+    public function setUp()
+    {
+        $this->transport  = new Smtp();
+        $this->connection = new SmtpProtocolSpy();
+        $this->transport->setConnection($this->connection);
+    }
+
+    public function testSendMinimalMail() {
+        $headers = new Headers();
+        $headers->addHeaderLine('Date', 'Sun, 10 Jun 2012 20:07:24 +0200');
+        $message = new Message();
+        $message
+            ->setHeaders($headers)
+            ->setSender('ralph.schindler@zend.com', 'Ralph Schindler')
+            ->setBody('testSendMailWithoutMinimalHeaders')
+            ->addTo('zf-devteam@zend.com', 'ZF DevTeam')
+        ;
+        $expectedMessage = "RSET\r\n"
+                           . "MAIL FROM:<ralph.schindler@zend.com>\r\n"
+                           . "DATA\r\n"
+                           . "Date: Sun, 10 Jun 2012 20:07:24 +0200\r\n"
+                           . "Sender: Ralph Schindler <ralph.schindler@zend.com>\r\n"
+                           . "To: ZF DevTeam <zf-devteam@zend.com>\r\n"
+                           . "\r\n"
+                           . "testSendMailWithoutMinimalHeaders\r\n"
+                           . ".\r\n";
+
+        $this->transport->send($message);
+
+        $this->assertEquals($expectedMessage, $this->connection->getLog());
+    }
+}

--- a/tests/Zend/Mail/TestAsset/SmtpProtocolSpy.php
+++ b/tests/Zend/Mail/TestAsset/SmtpProtocolSpy.php
@@ -38,101 +38,59 @@ class SmtpProtocolSpy extends Smtp
     protected $helo;
     protected $mail;
     protected $rcpt = array();
-    protected $data;
+    protected $_sess = true;
 
-    /**
-     * "Connect" to server
-     * 
-     * @return void
-     */
     public function connect()
     {
         $this->connect = true;
+        return true;
     }
 
-    /**
-     * Set server name we're talking to
-     * 
-     * @param  string $serverName 
-     * @return void
-     */
     public function helo($serverName = '127.0.0.1')
     {
+        parent::helo($serverName);
         $this->helo = $serverName;
     }
 
-    /**
-     * quit implementation
-     *
-     * Resets helo value and calls rset
-     * 
-     * @return void
-     */
     public function quit()
     {
         $this->helo = null;
         $this->rset();
     }
 
-    /**
-     * Disconnect implementation
-     *
-     * Resets connect flag and calls rset
-     * 
-     * @return void
-     */
     public function disconnect()
     {
         $this->helo    = null;
         $this->connect = false;
         $this->rset();
     }
-    
-    /**
-     * "Reset" connection
-     *
-     * Resets state of mail, rcpt, and data properties
-     * 
-     * @return void
-     */
+
     public function rset()
     {
-        $this->mail = null;
+        parent::rset();
         $this->rcpt = array();
-        $this->data = null;
     }
 
-    /**
-     * Set envelope FROM
-     * 
-     * @param  string $from 
-     * @return void
-     */
     public function mail($from)
     {
+        parent::mail($from);
         $this->mail = $from;
     }
 
-    /**
-     * Add recipient
-     * 
-     * @param  string $to 
-     * @return void
-     */
     public function rcpt($to)
     {
+        $this->_rcpt = true;
         $this->rcpt[] = $to;
     }
 
-    /**
-     * Set data
-     * 
-     * @param  string $data 
-     * @return void
-     */
-    public function data($data)
+    protected function _send($request)
     {
-        $this->data = $data;
+        // Save request to internal log
+        $this->_addLog($request . self::EOL);
+    }
+
+    protected function _expect($code, $timeout = null) {
+        return '';
     }
 
     /**
@@ -173,15 +131,5 @@ class SmtpProtocolSpy extends Smtp
     public function getRecipients()
     {
         return $this->rcpt;
-    }
-
-    /**
-     * Get data value
-     * 
-     * @return null|string
-     */
-    public function getData()
-    {
-        return $this->data;
     }
 }

--- a/tests/Zend/Mail/Transport/SmtpTest.php
+++ b/tests/Zend/Mail/Transport/SmtpTest.php
@@ -68,13 +68,29 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         return $message;
     }
 
+    /**
+     *  Per RFC 2822 3.6
+     */
     public function testSendMailWithoutMinimalHeaders() {
         $this->setExpectedException(
             'Zend\Mail\Transport\Exception\RuntimeException',
             'transport expects either a Sender or at least one From address in the Message; none provided'
         );
         $message = new Message();
-        $message->setBody('testSendMailWithoutMinimalHeaders');
+        $this->transport->send($message);
+    }
+
+    /**
+     *  Per RFC 2821 3.3 (page 18)
+     *  - RCPT (recipient) must be called before DATA (headers or body)
+     */
+    public function testSendMailWithoutRecipient() {
+        $this->setExpectedException(
+            'Zend\Mail\Transport\Exception\RuntimeException',
+            'at least one recipient if the message has at least one header or body'
+        );
+        $message = new Message();
+        $message->setSender('ralph.schindler@zend.com', 'Ralph Schindler');
         $this->transport->send($message);
     }
 
@@ -86,14 +102,17 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
             ->setHeaders($headers)
             ->setSender('ralph.schindler@zend.com', 'Ralph Schindler')
             ->setBody('testSendMailWithoutMinimalHeaders')
+            ->addTo('zf-devteam@zend.com', 'ZF DevTeam')
         ;
         $expectedMessage = "Date: Sun, 10 Jun 2012 20:07:24 +0200\r\n"
-            . "Sender: Ralph Schindler <ralph.schindler@zend.com>\r\n"
-            . "\r\ntestSendMailWithoutMinimalHeaders";
+                           . "Sender: Ralph Schindler <ralph.schindler@zend.com>\r\n"
+                           . "To: ZF DevTeam <zf-devteam@zend.com>\r\n"
+                           . "\r\n"
+                           . "testSendMailWithoutMinimalHeaders";
 
         $this->transport->send($message);
 
-        $this->assertSame($expectedMessage, $this->connection->getData());
+        $this->assertContains($expectedMessage, $this->connection->getLog());
     }
 
     public function testReceivesMailArtifacts()
@@ -105,7 +124,7 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         $expectedRecipients = array('zf-devteam@zend.com', 'matthew@zend.com', 'zf-crteam@lists.zend.com');
         $this->assertEquals($expectedRecipients, $this->connection->getRecipients());
 
-        $data = $this->connection->getData();
+        $data = $this->connection->getLog();
         $this->assertContains('To: ZF DevTeam <zf-devteam@zend.com>', $data);
         $this->assertContains('Subject: Testing Zend\Mail\Transport\Sendmail', $data);
         $this->assertContains("Cc: matthew@zend.com\r\n", $data);


### PR DESCRIPTION
[Mail] Refactor headers
- Use more HeadersInterface instances in Headers implementation rather than manipulate strings
- Centralize the render of headers newlines (CRLF) in Headers implementation rather than each HeaderInterface::toString()
- Delegate headers rendering to the specific header class (toString)

[Mail] Changes in Generic headers and HeaderMultiInterface
- GenericMultiHeader now inherits from GenericHeader
- HeaderMultiInterface now is independent from HeaderInterface

[Mail] Avoid render To: and Cc: headers if doesn't have addresses

[Mail] Replace line endings for fields (\r\n) with a constant

[Mail] Various improvements.
- Fix a issue with headers being rendered as CRCRLF with SMTP Protocol (ZF2-185)
- Add test case to detect the above issue and trace the full command sended.
- Add check in SMTP Transport for require at least one recipient if at least one DATA (header or body) will send per RFC-2821

[![Build Status](https://secure.travis-ci.org/Maks3w/zf2.png?branch=mail-refactor)](http://travis-ci.org/Maks3w/zf2)
