### PR TITLE
Form view helpers' invoke method should be chainable for options

### DIFF
--- a/library/Zend/Form/View/Helper/FormElement.php
+++ b/library/Zend/Form/View/Helper/FormElement.php
@@ -101,11 +101,15 @@ class FormElement extends BaseAbstractHelper
      *
      * Proxies to {@link render()}.
      * 
-     * @param  ElementInterface $element 
+     * @param  ElementInterface|null $element 
      * @return string
      */
-    public function __invoke(ElementInterface $element)
+    public function __invoke(ElementInterface $element = null)
     {
+        if (!$element) {
+            return $this;
+        }
+
         return $this->render($element);
     }
 }

--- a/library/Zend/Form/View/Helper/FormInput.php
+++ b/library/Zend/Form/View/Helper/FormInput.php
@@ -135,11 +135,15 @@ class FormInput extends AbstractHelper
      *
      * Proxies to {@link render()}.
      * 
-     * @param  ElementInterface $element 
+     * @param  ElementInterface|null $element 
      * @return string
      */
-    public function __invoke(ElementInterface $element)
+    public function __invoke(ElementInterface $element = null)
     {
+        if (!$element) {
+            return $this;
+        }
+
         return $this->render($element);
     }
 

--- a/library/Zend/Form/View/Helper/FormMultiCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormMultiCheckbox.php
@@ -185,11 +185,15 @@ class FormMultiCheckbox extends FormInput
      *
      * Proxies to {@link render()}.
      * 
-     * @param  ElementInterface $element 
+     * @param  ElementInterface|null $element 
      * @return string
      */
-    public function __invoke(ElementInterface $element)
+    public function __invoke(ElementInterface $element = null)
     {
+        if (!$element) {
+            return $this;
+        }
+
         return $this->render($element);
     }
 

--- a/library/Zend/Form/View/Helper/FormSelect.php
+++ b/library/Zend/Form/View/Helper/FormSelect.php
@@ -219,11 +219,15 @@ class FormSelect extends AbstractHelper
      *
      * Proxies to {@link render()}.
      * 
-     * @param  ElementInterface $element 
+     * @param  ElementInterface|null $element 
      * @return string
      */
-    public function __invoke(ElementInterface $element)
+    public function __invoke(ElementInterface $element = null)
     {
+        if (!$element) {
+            return $this;
+        }
+
         return $this->render($element);
     }
 

--- a/library/Zend/Form/View/Helper/FormTextarea.php
+++ b/library/Zend/Form/View/Helper/FormTextarea.php
@@ -86,11 +86,15 @@ class FormTextarea extends AbstractHelper
      *
      * Proxies to {@link render()}.
      * 
-     * @param  ElementInterface $element 
+     * @param  ElementInterface|null $element 
      * @return string
      */
-    public function __invoke(ElementInterface $element)
+    public function __invoke(ElementInterface $element = null)
     {
+        if (!$element) {
+            return $this;
+        }
+
         return $this->render($element);
     }
 }

--- a/tests/Zend/Form/View/Helper/FormElementTest.php
+++ b/tests/Zend/Form/View/Helper/FormElementTest.php
@@ -167,4 +167,10 @@ class FormElementTest extends TestCase
         $this->assertContains('<textarea', $markup);
         $this->assertContains('>Initial content<', $markup);
     }
+
+    public function testInvokeWithNoElementChainsHelper()
+    {
+        $element = new Element('foo');
+        $this->assertSame($this->helper, $this->helper->__invoke());
+    }
 }

--- a/tests/Zend/Form/View/Helper/FormInputTest.php
+++ b/tests/Zend/Form/View/Helper/FormInputTest.php
@@ -431,4 +431,10 @@ class FormInputTest extends CommonTestCase
         $this->assertContains('<input', $markup);
         $this->assertContains('name="foo"', $markup);
     }
+
+    public function testInvokeWithNoElementChainsHelper()
+    {
+        $element = new Element('foo');
+        $this->assertSame($this->helper, $this->helper->__invoke());
+    }
 }

--- a/tests/Zend/Form/View/Helper/FormMultiCheckboxTest.php
+++ b/tests/Zend/Form/View/Helper/FormMultiCheckboxTest.php
@@ -126,4 +126,10 @@ class FormMultiCheckboxTest extends CommonTestCase
         $markup  = $this->helper->render($element);
         $this->assertContains('foo[]', $markup);
     }
+
+    public function testInvokeWithNoElementChainsHelper()
+    {
+        $element = $this->getElement();
+        $this->assertSame($this->helper, $this->helper->__invoke());
+    }
 }

--- a/tests/Zend/Form/View/Helper/FormSelectTest.php
+++ b/tests/Zend/Form/View/Helper/FormSelectTest.php
@@ -180,4 +180,10 @@ class FormSelectTest extends CommonTestCase
         $markup = $this->helper->render($element);
         $this->assertRegexp('#<select[^>]*?(name="foo\[\]")#', $markup);
     }
+
+    public function testInvokeWithNoElementChainsHelper()
+    {
+        $element = $this->getElement();
+        $this->assertSame($this->helper, $this->helper->__invoke());
+    }
 }

--- a/tests/Zend/Form/View/Helper/FormTextareaTest.php
+++ b/tests/Zend/Form/View/Helper/FormTextareaTest.php
@@ -300,4 +300,10 @@ class FormTextareaTest extends CommonTestCase
         $this->assertContains('<textarea', $markup);
         $this->assertContains('name="foo"', $markup);
     }
+
+    public function testInvokeWithNoElementChainsHelper()
+    {
+        $element = new Element('foo');
+        $this->assertSame($this->helper, $this->helper->__invoke());
+    }
 }


### PR DESCRIPTION
View Helper Elements:
- Select
- Input
- Textarea
- Multicheckbox
- Element

It does not seem to be possible to set options (separator, label position, etc.) on the above form view helpers directly from the view. It can be set at a higher level, but there are cases where you might want to set view-level options on a per-element basis when building out the view.

This simply makes it so that you can call the invoke() of the view helper to fluently get the helper object in which case option methods can be directly called, such as:

$this->formMulticheckbox()->setSeparator('</span><span>')->render($element);

This functionality is already present in the label view helpers, I'm simply extending it to all other helpers.

Tests:
- Invoke with no element chains helper (x5, one per form view helper test)
