### PR TITLE
Hotfix random integer generator rand() in Zend\Math\Math

### DIFF
--- a/documentation/manual/en/module_specs/Zend_Crypt-Introduction.xml
+++ b/documentation/manual/en/module_specs/Zend_Crypt-Introduction.xml
@@ -67,4 +67,13 @@
         </itemizedlist>
     </para>
 
+    <note>
+        <title>PHP-CryptLib</title>
+
+        <para>
+            Most of the ideas behind the <classname>Zend\Crypt</classname> component have been inspired by the <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://github.com/ircmaxell/PHP-CryptLib">PHP-CryptLib project</link> of <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://blog.ircmaxell.com/">Anthony Ferrara</link>.
+            PHP-CryptLib is an all-inclusive pure PHP cryptographic library for all cryptographic needs. It is meant to be easy to install and use, yet extensible and powerful enough for even the most experienced developer.
+        </para>
+    </note>
+    
 </section>

--- a/library/Zend/Math/Math.php
+++ b/library/Zend/Math/Math.php
@@ -92,9 +92,15 @@ class Math extends BigInteger
                 'The supplied range is too great to generate'
             );
         }
-        $bytes = (int) max(log($range,2) / 8, 1);
-        $rnd   = hexdec(bin2hex(self::randBytes($bytes, $strong)));
-        return $min + $rnd % ($range+1);
+        $log    = log($range, 2);
+        $bytes  = (int) ($log / 8) + 1; 
+        $bits   = (int) $log + 1; 
+        $filter = (int) (1 << $bits) - 1;
+        do {
+            $rnd = hexdec(bin2hex(self::randBytes($bytes, $strong)));
+            $rnd = $rnd & $filter;
+        } while ($rnd > $range);
+        return $min + $rnd;
     }
 
     /**

--- a/tests/Zend/Math/MathTest.php
+++ b/tests/Zend/Math/MathTest.php
@@ -33,22 +33,65 @@ use Zend\Math\Math;
  */
 class MathTest extends \PHPUnit_Framework_TestCase
 {
+    public static function provideRandInt()
+    {
+        return array(
+            array(2, 1, 10000, 100, 0.9, 1.1, false),
+            array(2, 1, 10000, 100, 0.8, 1.2, true)
+        );
+    }        
+    
     public function testRandBytes()
     {
         for ($length=1; $length<4096; $length++) {
             $rand = Math::randBytes($length);
             $this->assertTrue(!empty($rand));
-            $this->assertEquals(strlen($rand), $length);
+            $this->assertEquals($length, strlen($rand));
         }
     }
        
-    public function testRand()
+    /**
+     * A Monte Carlo test that generates $cycles numbers from 0 to $tot
+     * and test if the numbers are above or below the line y=x with a 
+     * frequency range of [$min, $max]
+     * 
+     * Note: this code is inspired by the random number generator test
+     * included in the PHP-CryptLib project of Anthony Ferrara
+     * @see https://github.com/ircmaxell/PHP-CryptLib
+     * 
+     * @dataProvider provideRandInt
+     */
+    public function testRandInt($num, $valid, $cycles, $tot, $min, $max, $strong)
     {
-        for ($i=0; $i<10000; $i++) {
-            $min = mt_rand(0,10000);
-            $max = $min + mt_rand(0,10000);
-            $rand = Math::rand($min, $max);
-            $this->assertTrue(($rand >= $min) && ($rand <= $max));
+        try {
+            $test = Math::randBytes(1, $strong);
+        } catch (\Zend\Math\Exception\RuntimeException $e) {
+            $this->markTestSkipped($e->getMessage());
+        }
+        $i     = 0;
+        $count = 0;
+        do {
+            $up   = 0;
+            $down = 0;
+            for ($i=0; $i<$cycles; $i++) {
+                $x = Math::rand(0, $tot, $strong);
+                $y = Math::rand(0, $tot, $strong);
+                if ($x > $y) {
+                    $up++;
+                } elseif ($x < $y) {
+                    $down++;
+                } 
+            }
+            $this->assertGreaterThan(0, $up);
+            $this->assertGreaterThan(0, $down);
+            $ratio = $up / $down;
+            if ($ratio > $min && $ratio < $max) {
+                $count++;
+            }
+            $i++;
+        } while ($i < $num && $count < $valid); 
+        if ($count < $valid) {
+            $this->fail('The random number generator failed the Monte Carlo test');
         }
     }
     


### PR DESCRIPTION
Fixed the integer random generator. The previous implementation didn't provide a uniform distribution (because the usage of %). See: http://www.php.net/manual/en/function.openssl-random-pseudo-bytes.php#104322
I also added a new test case for the randomness using an idea present in the PHP-CryptLib project.
I added a note in the Zend\Crypt documentation for thanks the PHP-CryptLib project.
