### PR TITLE
Added support for identifiers in JOINs

### DIFF
--- a/library/Zend/Db/Adapter/Platform/Mysql.php
+++ b/library/Zend/Db/Adapter/Platform/Mysql.php
@@ -94,6 +94,10 @@ class Mysql implements PlatformInterface
             if ($safeWords && in_array($part, $safeWords)) {
                 continue;
             }
+            if(($part[0] == ':') && preg_match('/^:\w+$/', $part)) {
+                // this is an identifier
+                continue;
+            }
             switch ($part) {
                 case ' ':
                 case '.':

--- a/library/Zend/Db/Adapter/Platform/Postgresql.php
+++ b/library/Zend/Db/Adapter/Platform/Postgresql.php
@@ -93,6 +93,10 @@ class Postgresql implements PlatformInterface
             if ($safeWords && in_array($part, $safeWords)) {
                 continue;
             }
+            if(($part[0] == ':') && preg_match('/^:\w+$/', $part)) {
+                // this is an identifier
+                continue;
+            }
             switch ($part) {
                 case ' ':
                 case '.':

--- a/library/Zend/Db/Adapter/Platform/Sql92.php
+++ b/library/Zend/Db/Adapter/Platform/Sql92.php
@@ -93,6 +93,10 @@ class Sql92 implements PlatformInterface
             if ($safeWords && in_array($part, $safeWords)) {
                 continue;
             }
+            if(($part[0] == ':') && preg_match('/^:\w+$/', $part)) {
+                // this is an identifier
+                continue;
+            }
             switch ($part) {
                 case ' ':
                 case '.':

--- a/library/Zend/Db/Adapter/Platform/SqlServer.php
+++ b/library/Zend/Db/Adapter/Platform/SqlServer.php
@@ -94,6 +94,10 @@ class SqlServer implements PlatformInterface
             if ($safeWords && in_array($part, $safeWords)) {
                 continue;
             }
+            if(($part[0] == ':') && preg_match('/^:\w+$/', $part)) {
+                // this is an identifier
+                continue;
+            }
             switch ($part) {
                 case ' ':
                 case '.':

--- a/library/Zend/Db/Adapter/Platform/Sqlite.php
+++ b/library/Zend/Db/Adapter/Platform/Sqlite.php
@@ -94,6 +94,10 @@ class Sqlite implements PlatformInterface
             if ($safeWords && in_array($part, $safeWords)) {
                 continue;
             }
+            if(($part[0] == ':') && preg_match('/^:\w+$/', $part)) {
+                // this is an identifier
+                continue;
+            }
             switch ($part) {
                 case ' ':
                 case '.':

--- a/library/Zend/Db/Sql/Insert.php
+++ b/library/Zend/Db/Sql/Insert.php
@@ -21,7 +21,7 @@ use Zend\Db\Adapter\Adapter,
  * @package    Zend_Db
  * @subpackage Sql
  */
-class Insert implements SqlInterface, PreparableSqlInterface
+class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
 {
     /**#@+
      * Constants

--- a/tests/Zend/Db/Adapter/Platform/MysqlTest.php
+++ b/tests/Zend/Db/Adapter/Platform/MysqlTest.php
@@ -85,5 +85,6 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('`foo`.`bar`', $this->platform->quoteIdentifierInFragment('foo.bar'));
         $this->assertEquals('`foo` as `bar`', $this->platform->quoteIdentifierInFragment('foo as bar'));
+        $this->assertEquals('`id` = :id', $this->platform->quoteIdentifierInFragment('id = :id', array('=')));
     }
 }

--- a/tests/Zend/Db/Adapter/Platform/Sql92Test.php
+++ b/tests/Zend/Db/Adapter/Platform/Sql92Test.php
@@ -85,5 +85,6 @@ class Sql92Test extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('"foo"."bar"', $this->platform->quoteIdentifierInFragment('foo.bar'));
         $this->assertEquals('"foo" as "bar"', $this->platform->quoteIdentifierInFragment('foo as bar'));
+        $this->assertEquals('"id" = :id', $this->platform->quoteIdentifierInFragment('id = :id', array('=')));
     }
 }

--- a/tests/Zend/Db/Adapter/Platform/SqlServerTest.php
+++ b/tests/Zend/Db/Adapter/Platform/SqlServerTest.php
@@ -85,5 +85,6 @@ class SqlServerTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('[foo].[bar]', $this->platform->quoteIdentifierInFragment('foo.bar'));
         $this->assertEquals('[foo] as [bar]', $this->platform->quoteIdentifierInFragment('foo as bar'));
+        $this->assertEquals('[id] = :id', $this->platform->quoteIdentifierInFragment('id = :id', array('=')));
     }
 }

--- a/tests/Zend/Db/Adapter/Platform/SqliteTest.php
+++ b/tests/Zend/Db/Adapter/Platform/SqliteTest.php
@@ -85,5 +85,6 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('"foo"."bar"', $this->platform->quoteIdentifierInFragment('foo.bar'));
         $this->assertEquals('"foo" as "bar"', $this->platform->quoteIdentifierInFragment('foo as bar'));
+        $this->assertEquals('"id" = :id', $this->platform->quoteIdentifierInFragment('id = :id', array('=')));
     }
 }


### PR DESCRIPTION
We need identifiers in JOINs, e.g.:

```
    $select->columns(array('id'))
                ->from($this->table)
                ->join('user', 'image.user_id = user.id AND image.user_id = :userId', array(), Select::JOIN_LEFT)
                ->where($select->where->isNull('user.id'));
```

This patch allows to use identifiers like :userId in joins.
