### PR TITLE
Fix for ZF2-279

### DIFF
--- a/library/Zend/Mvc/Controller/RestfulController.php
+++ b/library/Zend/Mvc/Controller/RestfulController.php
@@ -201,12 +201,12 @@ abstract class RestfulController implements
             switch (strtolower($request->getMethod())) {
                 case 'get':
                     if (null !== $id = $routeMatch->getParam('id')) {
-	                    $action = 'get';
+                        $action = 'get';
                         $return = $this->get($id);
                         break;
                     }
                     if (null !== $id = $request->query()->get('id')) {
-	                    $action = 'get';
+                        $action = 'get';
                         $return = $this->get($id);
                         break;
                     }
@@ -214,7 +214,7 @@ abstract class RestfulController implements
                     $return = $this->getList();
                     break;
                 case 'post':
-	                $action = 'create';
+                    $action = 'create';
                     $return = $this->create($request->post()->toArray());
                     break;
                 case 'put':
@@ -241,7 +241,7 @@ abstract class RestfulController implements
                     throw new \DomainException('Invalid HTTP method!');
             }
 
-	        $routeMatch->setParam('action', $action);
+            $routeMatch->setParam('action', $action);
         }
 
         // Emit post-dispatch signal, passing:

--- a/library/Zend/Mvc/Controller/RestfulController.php
+++ b/library/Zend/Mvc/Controller/RestfulController.php
@@ -201,16 +201,20 @@ abstract class RestfulController implements
             switch (strtolower($request->getMethod())) {
                 case 'get':
                     if (null !== $id = $routeMatch->getParam('id')) {
+	                    $action = 'get';
                         $return = $this->get($id);
                         break;
                     }
                     if (null !== $id = $request->query()->get('id')) {
+	                    $action = 'get';
                         $return = $this->get($id);
                         break;
                     }
+                    $action = 'getList';
                     $return = $this->getList();
                     break;
                 case 'post':
+	                $action = 'create';
                     $return = $this->create($request->post()->toArray());
                     break;
                 case 'put':
@@ -221,6 +225,7 @@ abstract class RestfulController implements
                     }
                     $content = $request->getContent();
                     parse_str($content, $parsedParams);
+                    $action = 'update';
                     $return = $this->update($id, $parsedParams);
                     break;
                 case 'delete':
@@ -229,11 +234,14 @@ abstract class RestfulController implements
                             throw new \DomainException('Missing identifier');
                         }
                     }
+                    $action = 'delete';
                     $return = $this->delete($id);
                     break;
                 default:
                     throw new \DomainException('Invalid HTTP method!');
             }
+
+	        $routeMatch->setParam('action', $action);
         }
 
         // Emit post-dispatch signal, passing:

--- a/tests/Zend/Mvc/Controller/RestfulControllerTest.php
+++ b/tests/Zend/Mvc/Controller/RestfulControllerTest.php
@@ -39,6 +39,7 @@ class RestfulControllerTest extends TestCase
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertArrayHasKey('entities', $result);
         $this->assertEquals($entities, $result['entities']);
+        $this->assertEquals('getList', $this->routeMatch->getParam('action'));
     }
 
     public function testDispatchInvokesGetMethodWhenNoActionPresentAndIdentifierPresentOnGet()
@@ -49,6 +50,7 @@ class RestfulControllerTest extends TestCase
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertArrayHasKey('entity', $result);
         $this->assertEquals($entity, $result['entity']);
+        $this->assertEquals('get', $this->routeMatch->getParam('action'));
     }
 
     public function testDispatchInvokesCreateMethodWhenNoActionPresentAndPostInvoked()
@@ -60,6 +62,7 @@ class RestfulControllerTest extends TestCase
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertArrayHasKey('entity', $result);
         $this->assertEquals($entity, $result['entity']);
+        $this->assertEquals('create', $this->routeMatch->getParam('action'));
     }
 
     public function testDispatchInvokesUpdateMethodWhenNoActionPresentAndPutInvokedWithIdentifier()
@@ -76,6 +79,7 @@ class RestfulControllerTest extends TestCase
         $this->assertEquals(1, $test['id']);
         $this->assertArrayHasKey('name', $test);
         $this->assertEquals(__FUNCTION__, $test['name']);
+        $this->assertEquals('update', $this->routeMatch->getParam('action'));
     }
 
     public function testDispatchInvokesDeleteMethodWhenNoActionPresentAndDeleteInvokedWithIdentifier()
@@ -87,6 +91,7 @@ class RestfulControllerTest extends TestCase
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertEquals(array(), $result);
         $this->assertEquals(array(), $this->controller->entity);
+        $this->assertEquals('delete', $this->routeMatch->getParam('action'));
     }
 
     public function testDispatchCallsActionMethodBasedOnNormalizingAction()


### PR DESCRIPTION
If there is no 'action' in the routematch, set the action param to the method
detected from the HTTP method.
