### PR TITLE
Revamp Bootstrap

### DIFF
--- a/documentation/manual/en/module_specs/zend.module-manager.module-manager.xml
+++ b/documentation/manual/en/module_specs/zend.module-manager.module-manager.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Reviewed: no -->
-<section 
+<section
     xmlns="http://docbook.org/ns/docbook" version="5.0"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xml:id="zend.module-manager.module-manager">
-    
+
         <title>The Module Manager</title>
-    
+
 
     <para>
         The module manager, <classname>Zend\ModuleManager\ModuleManager</classname>, is a very
@@ -16,23 +16,24 @@
     </para>
 
     <section xml:id="zend.module-manager.module-manager.module-manager-events">
-        
+
             <title>Module Manager Events</title>
-        
+
 
         <variablelist>
             <title>Events triggered by <classname>Zend\ModuleManager\ModuleManager</classname></title>
 
             <varlistentry>
-                <term>loadModules.pre</term>
+                <term>loadModules</term>
 
                 <listitem>
                     <para>
-                        Triggered prior to any modules being loaded. This event is useful for
-                        registering a module autoloader. ZF2 ships with a default module autoloader
-                        which is automatically attached to this event if you are using
-                        <classname>Zend\ModuleManager\Listener\DefaultListenerAggregate</classname>, both
-                        of which are covered in detail later.
+                        This event is primarily used internally to help encapsulate the work of
+                        loading modules in event listeners, and allow the loadModules.post event to
+                        be more user-friendly. Internal listeners will attach to this event with a
+                        negative priority instead of loadModules.post so that users can safely
+                        assume things like config merging have been done once loadModules.post is
+                        triggered, without having to worry about priorities at all.
                     </para>
                 </listitem>
             </varlistentry>
@@ -91,16 +92,16 @@
             </varlistentry>
         </variablelist>
     </section>
-    
+
     <section xml:id="zend.module-manager.module-manager.module-manager-listeners">
-        
+
             <title>Module Manager Listeners</title>
-        
+
 
         <para>
             By default, Zend Framework provides several useful module manager listeners.
         </para>
-        
+
         <variablelist>
             <title>Provided Module Manager Listeners</title>
 
@@ -123,7 +124,7 @@
 
                 <listitem>
                     <para>
-                        This listener checks each module to see if it has implemented 
+                        This listener checks each module to see if it has implemented
                         <classname>Zend\ModuleManager\Feature\AutoloaderProviderInterface</classname>
                         or simply defined the <methodname>getAutoloaderConfig()</methodname> method. If
                         so, it calls the <methodname>getAutoloaderConfig()</methodname> method on
@@ -145,7 +146,7 @@
                     </para>
                 </listitem>
             </varlistentry>
-            
+
             <varlistentry>
                 <term><classname>Zend\ModuleManager\Listener\InitTrigger</classname></term>
 
@@ -164,7 +165,7 @@
                     </para>
                 </listitem>
             </varlistentry>
-            
+
             <varlistentry>
                 <term><classname>Zend\ModuleManager\Listener\LocatorRegistrationListener</classname></term>
 
@@ -179,7 +180,7 @@
                     </para>
                 </listitem>
             </varlistentry>
-            
+
             <varlistentry>
                 <term><classname>Zend\ModuleManager\Listener\ModuleResolverListener</classname></term>
 
@@ -191,7 +192,7 @@
                     </para>
                 </listitem>
             </varlistentry>
-            
+
             <varlistentry>
                 <term><classname>Zend\ModuleManager\Listener\OnBootstrapListener</classname></term>
 
@@ -217,7 +218,7 @@
                     </para>
                 </listitem>
             </varlistentry>
-            
+
             <varlistentry>
                 <term><classname>Zend\ModuleManager\Listener\ServiceListener</classname></term>
 

--- a/library/Zend/ModuleManager/Listener/ConfigListener.php
+++ b/library/Zend/ModuleManager/Listener/ConfigListener.php
@@ -22,22 +22,27 @@ use Zend\EventManager\ListenerAggregateInterface;
 
 /**
  * Config listener
- * 
+ *
  * @category   Zend
  * @package    Zend_ModuleManager
  * @subpackage Listener
  */
-class ConfigListener extends AbstractListener implements 
-    ConfigMergerInterface, 
+class ConfigListener extends AbstractListener implements
+    ConfigMergerInterface,
     ListenerAggregateInterface
 {
-	const STATIC_PATH = 'static_path';
-	const GLOB_PATH = 'glob_path';
+    const STATIC_PATH = 'static_path';
+    const GLOB_PATH   = 'glob_path';
 
     /**
      * @var array
      */
     protected $listeners = array();
+
+    /**
+     * @var array
+     */
+    protected $configs = array();
 
     /**
      * @var array
@@ -95,9 +100,15 @@ class ConfigListener extends AbstractListener implements
      */
     public function attach(EventManagerInterface $events)
     {
-        $this->listeners[] = $events->attach('loadModule', array($this, 'loadModule'), 1000);
         $this->listeners[] = $events->attach('loadModules.pre', array($this, 'loadModulesPre'), 9000);
+
+        if ($this->skipConfig) {
+            return $this;
+        }
+
+        $this->listeners[] = $events->attach('loadModule', array($this, 'loadModule'), 1000);
         $this->listeners[] = $events->attach('loadModules.post', array($this, 'loadModulesPost'), 9000);
+
         return $this;
     }
 
@@ -110,6 +121,7 @@ class ConfigListener extends AbstractListener implements
     public function loadModulesPre(ModuleEvent $e)
     {
         $e->setConfigListener($this);
+
         return $this;
     }
 
@@ -121,32 +133,46 @@ class ConfigListener extends AbstractListener implements
      */
     public function loadModule(ModuleEvent $e)
     {
-        if (true === $this->skipConfig) {
-            return;
-        }
         $module = $e->getParam('module');
-        if (is_callable(array($module, 'getConfig'))) {
-            $this->mergeModuleConfig($module);
+
+        if (!$module instanceof ConfigProviderInterface
+            && !is_callable(array($module, 'getConfig'))
+        ) {
+            return $this;
         }
+
+        $config = $module->getConfig();
+        $this->addConfig($e->getModuleName(), $config);
+
         return $this;
     }
 
     /**
      * Merge all config files matched by the given glob()s
      *
-     * This should really only be called by the module manager.
+     * This is only attached if config is not cached.
      *
      * @param  ModuleEvent $e
      * @return ConfigListener
      */
     public function loadModulesPost(ModuleEvent $e)
     {
-        if (true === $this->skipConfig) {
-            return $this;
-        }
+        // Load the config files
         foreach ($this->paths as $path) {
-            $this->mergePath($path);
+            $this->addConfigByPath($path['path'], $path['type']);
         }
+
+        // Merge all of the collected configs
+        $this->mergedConfig = array();
+        foreach ($this->configs as $key => $config) {
+            $this->mergedConfig = ArrayUtils::merge($this->mergedConfig, $config);
+        }
+
+        // If enabled, update the config cache
+        if ($this->getOptions()->getConfigCacheEnabled()) {
+            $this->updateCache();
+        }
+
         return $this;
     }
 
@@ -198,27 +224,9 @@ class ConfigListener extends AbstractListener implements
     }
 
     /**
-     * Add a path of config files to merge after loading modules
-     *
-     * @param  string $path
-     * @return ConfigListener
-     */
-    protected function addConfigPath($path, $type)
-    {
-        if (!is_string($path)) {
-            throw new Exception\InvalidArgumentException(
-                sprintf('Parameter to %s::%s() must be a string; %s given.',
-                __CLASS__, __METHOD__, gettype($path))
-            );
-        }
-        $this->paths[] = array('type' => $type, 'path' => $path);
-        return $this;
-    }
-
-    /**
      * Add an array of glob paths of config files to merge after loading modules
      *
-     * @param  mixed $globPaths
+     * @param  array|Traversable $globPaths
      * @return ConfigListener
      */
     public function addConfigGlobPaths($globPaths)
@@ -242,12 +250,12 @@ class ConfigListener extends AbstractListener implements
     /**
      * Add an array of static paths of config files to merge after loading modules
      *
-     * @param  mixed $staticPaths
+     * @param  array|Traversable $staticPaths
      * @return ConfigListener
      */
     public function addConfigStaticPaths($staticPaths)
     {
-    	$this->addConfigPaths($staticPaths, self::STATIC_PATH);
+        $this->addConfigPaths($staticPaths, self::STATIC_PATH);
         return $this;
     }
 
@@ -259,7 +267,7 @@ class ConfigListener extends AbstractListener implements
      */
     public function addConfigStaticPath($staticPath)
     {
-    	$this->addConfigPath($staticPath, self::STATIC_PATH);
+        $this->addConfigPath($staticPath, self::STATIC_PATH);
         return $this;
     }
 
@@ -271,7 +279,7 @@ class ConfigListener extends AbstractListener implements
      */
     protected function addConfigPaths($paths, $type)
     {
-    	if ($paths instanceof Traversable) {
+        if ($paths instanceof Traversable) {
             $paths = ArrayUtils::iteratorToArray($paths);
         }
 
@@ -290,74 +298,32 @@ class ConfigListener extends AbstractListener implements
     }
 
     /**
-     * Merge all config files matching a glob
+     * Add a path of config files to load and merge after loading modules
      *
-     * @param  mixed $path
+     * @param  string $path
+     * @param  string $type
      * @return ConfigListener
      */
-    protected function mergePath($path)
+    protected function addConfigPath($path, $type)
     {
-        switch ($path['type']) {
-            case self::STATIC_PATH:
-                $config = ConfigFactory::fromFile($path['path']);
-                break;
-
-            case self::GLOB_PATH:
-                $config = ConfigFactory::fromFiles(Glob::glob($path['path'], Glob::GLOB_BRACE));
-                break;
-        }
-        $this->mergeTraversableConfig($config);
-        if ($this->getOptions()->getConfigCacheEnabled()) {
-            $this->updateCache();
-        }
-        return $this;
-    }
-
-    /**
-     * mergeModuleConfig
-     *
-     * @param  mixed $module
-     * @return ConfigListener
-     */
-    protected function mergeModuleConfig($module)
-    {
-        if (false !== $this->skipConfig
-            || (!$module instanceof ConfigProviderInterface
-                && !is_callable(array($module, 'getConfig')))
-        ) {
-            return $this;
-        }
-
-        $config = $module->getConfig();
-        try {
-            $this->mergeTraversableConfig($config);
-        } catch (Exception\InvalidArgumentException $e) {
-            // Throw a more descriptive exception
+        if (!is_string($path)) {
             throw new Exception\InvalidArgumentException(
-                sprintf('getConfig() method of %s must be an array, '
-                . 'implement the \Traversable interface, or be an '
-                . 'instance of Zend\Config\Config. %s given.',
-                get_class($module), gettype($config))
+                sprintf('Parameter to %s::%s() must be a string; %s given.',
+                __CLASS__, __METHOD__, gettype($path))
             );
         }
-
-        if ($this->getOptions()->getConfigCacheEnabled()) {
-            $this->updateCache();
-        }
-
+        $this->paths[] = array('type' => $type, 'path' => $path);
         return $this;
     }
 
-    /**
-     * @param  $config
-     * @throws Exception\InvalidArgumentException
-     * @return void
-     */
-    protected function mergeTraversableConfig($config)
+
+
+    protected function addConfig($key, $config)
     {
         if ($config instanceof Traversable) {
             $config = ArrayUtils::iteratorToArray($config);
         }
+
         if (!is_array($config)) {
             throw new Exception\InvalidArgumentException(
                 sprintf('Config being merged must be an array, '
@@ -365,7 +331,37 @@ class ConfigListener extends AbstractListener implements
                 . 'instance of Zend\Config\Config. %s given.', gettype($config))
             );
         }
-        $this->setMergedConfig(ArrayUtils::merge($this->mergedConfig, $config));
+
+        $this->configs[$key] = $config;
+
+        return $this;
+    }
+
+    /**
+     * Given a path (glob or static), fetch the config and add it to the array
+     * of configs to merge.
+     *
+     * @param string $path
+     * @param string $type
+     * @return ConfigListener
+     */
+    protected function addConfigByPath($path, $type)
+    {
+        switch ($type) {
+            case self::STATIC_PATH:
+                $this->addConfig($path, ConfigFactory::fromFile($path));
+                break;
+
+            case self::GLOB_PATH:
+                // We want to keep track of where each value came from so we don't
+                // use ConfigFactory::fromFiles() since it does merging internally.
+                foreach(Glob::glob($path, Glob::GLOB_BRACE) as $file) {
+                    $this->addConfig($file, ConfigFactory::fromFile($file));
+                }
+                break;
+        }
+
+        return $this;
     }
 
     /**

--- a/library/Zend/ModuleManager/Listener/ConfigListener.php
+++ b/library/Zend/ModuleManager/Listener/ConfigListener.php
@@ -100,14 +100,15 @@ class ConfigListener extends AbstractListener implements
      */
     public function attach(EventManagerInterface $events)
     {
-        $this->listeners[] = $events->attach('loadModules.pre', array($this, 'loadModulesPre'), 9000);
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULES, array($this, 'onloadModulesPre'), 1000);
 
         if ($this->skipConfig) {
+            // We already have the config from cache, no need to collect or merge.
             return $this;
         }
 
-        $this->listeners[] = $events->attach('loadModule', array($this, 'loadModule'), 1000);
-        $this->listeners[] = $events->attach('loadModules.post', array($this, 'loadModulesPost'), 9000);
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, array($this, 'onLoadModule'));
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULES, array($this, 'onLoadModulesPost'), -1000);
 
         return $this;
     }
@@ -118,7 +119,7 @@ class ConfigListener extends AbstractListener implements
      * @param  ModuleEvent $e
      * @return ConfigListener
      */
-    public function loadModulesPre(ModuleEvent $e)
+    public function onloadModulesPre(ModuleEvent $e)
     {
         $e->setConfigListener($this);
 
@@ -131,7 +132,7 @@ class ConfigListener extends AbstractListener implements
      * @param  ModuleEvent $e
      * @return ConfigListener
      */
-    public function loadModule(ModuleEvent $e)
+    public function onLoadModule(ModuleEvent $e)
     {
         $module = $e->getParam('module');
 
@@ -155,7 +156,7 @@ class ConfigListener extends AbstractListener implements
      * @param  ModuleEvent $e
      * @return ConfigListener
      */
-    public function loadModulesPost(ModuleEvent $e)
+    public function onLoadModulesPost(ModuleEvent $e)
     {
         // Load the config files
         foreach ($this->paths as $path) {

--- a/library/Zend/ModuleManager/Listener/ConfigListener.php
+++ b/library/Zend/ModuleManager/Listener/ConfigListener.php
@@ -163,7 +163,7 @@ class ConfigListener extends AbstractListener implements
         }
 
         // Merge all of the collected configs
-        $this->mergedConfig = array();
+        $this->mergedConfig = $this->getOptions()->getExtraConfig() ?: array();
         foreach ($this->configs as $key => $config) {
             $this->mergedConfig = ArrayUtils::merge($this->mergedConfig, $config);
         }

--- a/library/Zend/ModuleManager/Listener/DefaultListenerAggregate.php
+++ b/library/Zend/ModuleManager/Listener/DefaultListenerAggregate.php
@@ -13,16 +13,17 @@ namespace Zend\ModuleManager\Listener;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\ListenerAggregateInterface;
 use Zend\Loader\ModuleAutoloader;
+use Zend\ModuleManager\ModuleEvent;
 use Zend\Stdlib\CallbackHandler;
 
 /**
  * Default listener aggregate
- * 
+ *
  * @category   Zend
  * @package    Zend_ModuleManager
  * @subpackage Listener
  */
-class DefaultListenerAggregate extends AbstractListener implements 
+class DefaultListenerAggregate extends AbstractListener implements
     ListenerAggregateInterface
 {
     /**
@@ -48,11 +49,13 @@ class DefaultListenerAggregate extends AbstractListener implements
         $locatorRegistrationListener = new LocatorRegistrationListener($options);
         $moduleAutoloader            = new ModuleAutoloader($options->getModulePaths());
 
-        $this->listeners[] = $events->attach('loadModules.pre', array($moduleAutoloader, 'register'), 1000);
-        $this->listeners[] = $events->attach('loadModule.resolve', new ModuleResolverListener, 1000);
-        $this->listeners[] = $events->attach('loadModule', new AutoloaderListener($options), 2000);
-        $this->listeners[] = $events->attach('loadModule', new InitTrigger($options), 1000);
-        $this->listeners[] = $events->attach('loadModule', new OnBootstrapListener($options), 1000);
+        // High priority, we assume module autoloading (for FooNamespace\Module classes) should be available before anything else
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULES, array($moduleAutoloader, 'register'), 9000);
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE_RESOLVE, new ModuleResolverListener);
+        // High priority, because most other loadModule listeners will assume the module's classes are available via autoloading
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, new AutoloaderListener($options), 9000);
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, new InitTrigger($options));
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, new OnBootstrapListener($options));
         $this->listeners[] = $events->attach($locatorRegistrationListener);
         $this->listeners[] = $events->attach($configListener);
         return $this;

--- a/library/Zend/ModuleManager/Listener/ListenerOptions.php
+++ b/library/Zend/ModuleManager/Listener/ListenerOptions.php
@@ -15,7 +15,7 @@ use Zend\Stdlib\AbstractOptions;
 
 /**
  * Listener options
- * 
+ *
  * @category   Zend
  * @package    Zend_ModuleManager
  * @subpackage Listener
@@ -31,11 +31,16 @@ class ListenerOptions extends AbstractOptions
      * @var array
      */
     protected $configGlobPaths = array();
-    
+
     /**
      * @var array
      */
     protected $configStaticPaths = array();
+
+    /**
+     * @var array
+     */
+    protected $extraConfig = array();
 
     /**
      * @var bool
@@ -83,18 +88,18 @@ class ListenerOptions extends AbstractOptions
     }
 
     /**
-     * Get the glob patterns to load additional config files 
-     * 
+     * Get the glob patterns to load additional config files
+     *
      * @return array
      */
     public function getConfigGlobPaths()
     {
         return $this->configGlobPaths;
     }
-    
+
     /**
-     * Get the static paths to load additional config files 
-     * 
+     * Get the static paths to load additional config files
+     *
      * @return array
      */
     public function getConfigStaticPaths()
@@ -104,8 +109,8 @@ class ListenerOptions extends AbstractOptions
 
     /**
      * Set the glob patterns to use for loading additional config files
-     * 
-     * @param array $configGlobPaths
+     *
+     * @param array|Traversable $configGlobPaths
      * @return ListenerOptions
      */
     public function setConfigGlobPaths($configGlobPaths)
@@ -119,12 +124,13 @@ class ListenerOptions extends AbstractOptions
             );
         }
         $this->configGlobPaths = $configGlobPaths;
+        return $this;
     }
-    
+
     /**
      * Set the static paths to use for loading additional config files
-     * 
-     * @param array $configStaticPaths
+     *
+     * @param array|Traversable $configStaticPaths
      * @return ListenerOptions
      */
     public function setConfigStaticPaths($configStaticPaths)
@@ -138,6 +144,38 @@ class ListenerOptions extends AbstractOptions
             );
         }
         $this->configStaticPaths = $configStaticPaths;
+        return $this;
+    }
+
+    /**
+     * Get any extra config to merge in.
+     *
+     * @return array|Traversable
+     */
+    public function getExtraConfig()
+    {
+        return $this->extraConfig;
+    }
+
+    /**
+     * Add some extra config array to the main config. This is mainly useful
+     * for unit testing purposes.
+     *
+     * @param array|Traversable $extraConfig
+     * @return ListenerOptions
+     */
+    public function setExtraConfig($extraConfig)
+    {
+        if (!is_array($extraConfig) && !$extraConfig instanceof Traversable) {
+            throw new Exception\InvalidArgumentException(
+                sprintf('Argument passed to %s::%s() must be an array, '
+                . 'implement the \Traversable interface, or be an '
+                . 'instance of Zend\Config\Config. %s given.',
+                __CLASS__, __METHOD__, gettype($extraConfig))
+            );
+        }
+        $this->extraConfig = $extraConfig;
+        return $this;
     }
 
     /**

--- a/library/Zend/ModuleManager/Listener/LocatorRegistrationListener.php
+++ b/library/Zend/ModuleManager/Listener/LocatorRegistrationListener.php
@@ -18,12 +18,12 @@ use Zend\ModuleManager\ModuleEvent;
 
 /**
  * Locator registration listener
- * 
+ *
  * @category   Zend
  * @package    Zend_ModuleManager
  * @subpackage Listener
  */
-class LocatorRegistrationListener extends AbstractListener implements 
+class LocatorRegistrationListener extends AbstractListener implements
     ListenerAggregateInterface
 {
     /**
@@ -37,15 +37,15 @@ class LocatorRegistrationListener extends AbstractListener implements
     protected $listeners = array();
 
     /**
-     * loadModule 
+     * loadModule
      *
-     * Check each loaded module to see if it implements LocatorRegistered. If it 
+     * Check each loaded module to see if it implements LocatorRegistered. If it
      * does, we add it to an internal array for later.
-     * 
-     * @param  ModuleEvent $e 
+     *
+     * @param  ModuleEvent $e
      * @return void
      */
-    public function loadModule(ModuleEvent $e)
+    public function onLoadModule(ModuleEvent $e)
     {
         if (!$e->getModule() instanceof LocatorRegisteredInterface) {
             return;
@@ -54,14 +54,14 @@ class LocatorRegistrationListener extends AbstractListener implements
     }
 
     /**
-     * loadModulesPost 
+     * loadModulesPost
      *
-     * Once all the modules are loaded, loop 
-     * 
-     * @param  Event $e 
+     * Once all the modules are loaded, loop
+     *
+     * @param  Event $e
      * @return void
      */
-    public function loadModulesPost(Event $e)
+    public function onLoadModulesPost(Event $e)
     {
         $moduleManager = $e->getTarget();
         $events        = $moduleManager->getEventManager()->getSharedManager();
@@ -85,14 +85,14 @@ class LocatorRegistrationListener extends AbstractListener implements
     }
 
     /**
-     * Bootstrap listener 
+     * Bootstrap listener
      *
-     * This is ran during the MVC bootstrap event because it requires access to 
+     * This is ran during the MVC bootstrap event because it requires access to
      * the DI container.
      *
-     * @TODO: Check the application / locator / etc a bit better to make sure 
+     * @TODO: Check the application / locator / etc a bit better to make sure
      * the env looks how we're expecting it to?
-     * @param Event $e 
+     * @param Event $e
      * @return void
      */
     public function onBootstrap(Event $e)
@@ -116,8 +116,8 @@ class LocatorRegistrationListener extends AbstractListener implements
      */
     public function attach(EventManagerInterface $events)
     {
-        $this->listeners[] = $events->attach('loadModule', array($this, 'loadModule'), 1000);
-        $this->listeners[] = $events->attach('loadModules.post', array($this, 'loadModulesPost'), 9000);
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, array($this, 'onLoadModule'));
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULES, array($this, 'onLoadModulesPost'), -1000);
         return $this;
     }
 

--- a/library/Zend/ModuleManager/Listener/OnBootstrapListener.php
+++ b/library/Zend/ModuleManager/Listener/OnBootstrapListener.php
@@ -15,7 +15,7 @@ use Zend\ModuleManager\ModuleEvent;
 
 /**
  * Autoloader listener
- * 
+ *
  * @category   Zend
  * @package    Zend_ModuleManager
  * @subpackage Listener

--- a/library/Zend/ModuleManager/Listener/ServiceListener.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListener.php
@@ -59,14 +59,20 @@ class ServiceListener implements ListenerAggregateInterface
     /**
      * @var array
      */
+    protected $defaultServiceConfiguration;
+
+    /**
+     * @var array
+     */
     protected $serviceManagers = array();
 
     /**
      * @param ServiceManager $serviceManager
      */
-    public function __construct(ServiceManager $serviceManager)
+    public function __construct(ServiceManager $serviceManager, $configuration = null)
     {
         $this->defaultServiceManager = $serviceManager;
+        $this->defaultServiceConfiguration = $configuration;
     }
 
     /**
@@ -180,6 +186,10 @@ class ServiceListener implements ListenerAggregateInterface
     {
         $configListener = $e->getConfigListener();
         $config         = $configListener->getMergedConfig(false);
+
+        if ($this->defaultServiceConfiguration) {
+            $config = ArrayUtils::merge(array('service_manager' => $this->defaultServiceConfiguration), $config);
+        }
 
         foreach ($this->serviceManagers as $key => $sm) {
 

--- a/library/Zend/ModuleManager/Listener/ServiceListener.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListener.php
@@ -71,13 +71,13 @@ class ServiceListener implements ListenerAggregateInterface
 
     /**
      * @param string $key
-     * @param ServiceManager $serviceManager
+     * @param ServiceManager|string $serviceManager
      * @return ServiceListener
      */
     public function addServiceManager($serviceManager, $key, $moduleInterface, $method)
     {
         if (is_string($serviceManager)) {
-            $smKey = md5($serviceManager);
+            $smKey = $serviceManager;
         } elseif ($serviceManager instanceof ServiceManager) {
             $smKey = spl_object_hash($serviceManager);
         } else {

--- a/library/Zend/ModuleManager/Listener/ServiceListener.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListener.php
@@ -237,9 +237,8 @@ class ServiceListener implements ListenerAggregateInterface
 
         if (!$config instanceof ServiceConfiguration) {
             throw new Exception\RuntimeException(sprintf(
-                'Invalid service manager configuration class provided; received "%s", expected class implementing %s',
-                $class,
-                'Zend\ServiceManager\ConfigurationInterface'
+                'Invalid service manager configuration class provided; received "%s", expected an instance of Zend\ServiceManager\Configuration',
+                $class
             ));
         }
 

--- a/library/Zend/ModuleManager/Listener/ServiceListener.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListener.php
@@ -108,8 +108,8 @@ class ServiceListener implements ListenerAggregateInterface
      */
     public function attach(EventManagerInterface $events)
     {
-        $this->listeners[] = $events->attach('loadModule', array($this, 'onLoadModule'), 1500);
-        $this->listeners[] = $events->attach('loadModules.finish', array($this, 'onLoadModulesFinish'), 8500);
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, array($this, 'onLoadModule'));
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULES_POST, array($this, 'onLoadModulesPost'));
         return $this;
     }
 
@@ -182,7 +182,7 @@ class ServiceListener implements ListenerAggregateInterface
      * @param  ModuleEvent $e
      * @return void
      */
-    public function onLoadModulesFinish(ModuleEvent $e)
+    public function onLoadModulesPost(ModuleEvent $e)
     {
         $configListener = $e->getConfigListener();
         $config         = $configListener->getMergedConfig(false);

--- a/library/Zend/ModuleManager/ModuleEvent.php
+++ b/library/Zend/ModuleManager/ModuleEvent.php
@@ -22,6 +22,14 @@ use Zend\EventManager\Event;
 class ModuleEvent extends Event
 {
     /**
+     * Module events triggered by eventmanager
+     */
+    CONST EVENT_LOAD_MODULES        = 'loadModules';
+    CONST EVENT_LOAD_MODULE_RESOLVE = 'loadModule.resolve';
+    CONST EVENT_LOAD_MODULE         = 'loadModule';
+    CONST EVENT_LOAD_MODULES_POST   = 'loadModules.post';
+
+    /**
      * Get the name of a given module
      *
      * @return string

--- a/library/Zend/ModuleManager/ModuleManager.php
+++ b/library/Zend/ModuleManager/ModuleManager.php
@@ -88,6 +88,9 @@ class ModuleManager implements ModuleManagerInterface
         $this->getEventManager()->trigger(__FUNCTION__ . '.post', $this, $this->getEvent());
 
         $this->modulesAreLoaded = true;
+
+        $this->getEventManager()->trigger(__FUNCTION__ . '.finish', $this, $this->getEvent());
+
         return $this;
     }
 

--- a/library/Zend/ModuleManager/ModuleManager.php
+++ b/library/Zend/ModuleManager/ModuleManager.php
@@ -16,7 +16,7 @@ use Zend\EventManager\EventManager;
 
 /**
  * Module manager
- * 
+ *
  * @category Zend
  * @package  Zend_ModuleManager
  */
@@ -66,6 +66,19 @@ class ModuleManager implements ModuleManagerInterface
         }
     }
 
+    public function onLoadModules()
+    {
+        if (true === $this->modulesAreLoaded) {
+            return $this;
+        }
+
+        foreach ($this->getModules() as $moduleName) {
+            $this->loadModule($moduleName);
+        }
+
+        $this->modulesAreLoaded = true;
+    }
+
     /**
      * Load the provided modules.
      *
@@ -79,17 +92,15 @@ class ModuleManager implements ModuleManagerInterface
             return $this;
         }
 
-        $this->getEventManager()->trigger(__FUNCTION__ . '.pre', $this, $this->getEvent());
+        $this->getEventManager()->trigger(ModuleEvent::EVENT_LOAD_MODULES, $this, $this->getEvent());
 
-        foreach ($this->getModules() as $moduleName) {
-            $this->loadModule($moduleName);
-        }
-
-        $this->getEventManager()->trigger(__FUNCTION__ . '.post', $this, $this->getEvent());
-
-        $this->modulesAreLoaded = true;
-
-        $this->getEventManager()->trigger(__FUNCTION__ . '.finish', $this, $this->getEvent());
+        /**
+         * Having a dedicated .post event abstracts the complexity of priorities from the user.
+         * Users can attach to the .post event and be sure that important
+         * things like config merging are complete without having to worry if
+         * they set a low enough priority.
+         */
+        $this->getEventManager()->trigger(ModuleEvent::EVENT_LOAD_MODULES_POST, $this, $this->getEvent());
 
         return $this;
     }
@@ -111,7 +122,7 @@ class ModuleManager implements ModuleManagerInterface
         $event = $this->getEvent();
         $event->setModuleName($moduleName);
 
-        $result = $this->getEventManager()->trigger(__FUNCTION__ . '.resolve', $this, $event, function ($r) {
+        $result = $this->getEventManager()->trigger(ModuleEvent::EVENT_LOAD_MODULE_RESOLVE, $this, $event, function ($r) {
             return (is_object($r));
         });
 
@@ -125,7 +136,7 @@ class ModuleManager implements ModuleManagerInterface
         }
         $event->setModule($module);
 
-        $this->getEventManager()->trigger(__FUNCTION__, $this, $event);
+        $this->getEventManager()->trigger(ModuleEvent::EVENT_LOAD_MODULE, $this, $event);
         $this->loadedModules[$moduleName] = $module;
         return $module;
     }
@@ -145,9 +156,9 @@ class ModuleManager implements ModuleManagerInterface
     }
 
     /**
-     * Get an instance of a module class by the module name 
-     * 
-     * @param  string $moduleName 
+     * Get an instance of a module class by the module name
+     *
+     * @param  string $moduleName
      * @return mixed
      */
     public function getModule($moduleName)
@@ -226,6 +237,7 @@ class ModuleManager implements ModuleManagerInterface
             'module_manager',
         ));
         $this->events = $events;
+        $this->attachDefaultListeners();
         return $this;
     }
 
@@ -242,5 +254,16 @@ class ModuleManager implements ModuleManagerInterface
             $this->setEventManager(new EventManager());
         }
         return $this->events;
+    }
+
+    /**
+     * Register the default event listeners
+     *
+     * @return ModuleManager
+     */
+    protected function attachDefaultListeners()
+    {
+        $events = $this->getEventManager();
+        $events->attach(ModuleEvent::EVENT_LOAD_MODULES, array($this, 'onLoadModules'));
     }
 }

--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -248,7 +248,8 @@ class Application implements
      */
     public static function init($configuration = array())
     {
-        $serviceManager = new ServiceManager(new Service\ServiceManagerConfiguration);
+        $smConfig = isset($configuration['service_manager']) ? $configuration['service_manager'] : array();
+        $serviceManager = new ServiceManager(new Service\ServiceManagerConfiguration($smConfig));
         $serviceManager->setService('ApplicationConfiguration', $configuration);
         $serviceManager->get('ModuleManager')->loadModules();
         return $serviceManager->get('Application')->bootstrap();

--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -238,10 +238,18 @@ class Application implements
     /**
      * Static method for quick and easy initialization of the Application.
      *
-     * This has some service names hard-coded that you should be aware of:
-     * - ApplicationConfiguration
+     * If you use this init() method, you cannot specify a service with the
+     * name of 'ApplicationConfiguration' in your service manager config. That
+     * name is reserved to hold the array from application.config.php
+     *
+     * The following services can only be overridden from application.config.php:
+     *
      * - ModuleManager
+     * - SharedEventManager
      * - EventManager & Zend\EventManager\EventManagerInterface
+     *
+     * All other services are configured after module loading, thus can be
+     * overridden by modules.
      *
      * @param array $configuration
      * @return Application

--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -51,7 +51,7 @@ use Zend\Stdlib\ResponseInterface;
  * $response->send();
  * </code>
  *
- * bootstrap() opts in to the default route, dispatch, and view listeners, 
+ * bootstrap() opts in to the default route, dispatch, and view listeners,
  * sets up the MvcEvent, and triggers the bootstrap event. This can be omitted
  * if you wish to setup your own listeners and/or workflow; alternately, you
  * can simply extend the class to override such behavior.
@@ -111,7 +111,7 @@ class Application implements
      * Constructor
      *
      * @param mixed $configuration
-     * @param ServiceManager $serviceManager 
+     * @param ServiceManager $serviceManager
      */
     public function __construct($configuration, ServiceManager $serviceManager)
     {
@@ -127,7 +127,7 @@ class Application implements
 
     /**
      * Retrieve the application configuration
-     * 
+     *
      * @return array|object
      */
     public function getConfiguration()
@@ -138,10 +138,10 @@ class Application implements
     /**
      * Bootstrap the application
      *
-     * Defines and binds the MvcEvent, and passes it the request, response, and 
-     * router. Attaches the ViewManager as a listener. Triggers the bootstrap 
+     * Defines and binds the MvcEvent, and passes it the request, response, and
+     * router. Attaches the ViewManager as a listener. Triggers the bootstrap
      * event.
-     * 
+     *
      * @return Application
      */
     public function bootstrap()
@@ -168,7 +168,7 @@ class Application implements
 
     /**
      * Retrieve the service manager
-     * 
+     *
      * @return ServiceManager
      */
     public function getServiceManager()
@@ -233,6 +233,25 @@ class Application implements
     public function getEventManager()
     {
         return $this->events;
+    }
+
+    /**
+     * Static method for quick and easy initialization of the Application.
+     *
+     * This has some service names hard-coded that you should be aware of:
+     * - ApplicationConfiguration
+     * - ModuleManager
+     * - EventManager & Zend\EventManager\EventManagerInterface
+     *
+     * @param array $configuration
+     * @return Application
+     */
+    public static function init($configuration = array())
+    {
+        $serviceManager = new ServiceManager(new Service\ServiceManagerConfiguration);
+        $serviceManager->setService('ApplicationConfiguration', $configuration);
+        $serviceManager->get('ModuleManager')->loadModules();
+        return $serviceManager->get('Application')->bootstrap();
     }
 
     /**

--- a/library/Zend/Mvc/Service/ControllerLoaderFactory.php
+++ b/library/Zend/Mvc/Service/ControllerLoaderFactory.php
@@ -60,17 +60,16 @@ class ControllerLoaderFactory implements FactoryInterface
 
         $controllerLoader = $serviceLocator->createScopedServiceManager();
 
-        // @TODO: Add support for DI. We cannot pull the Configuration service here, as it causes a circular dependency.
-        //$configuration    = $serviceLocator->get('Configuration');
-        //if (isset($configuration['di']) && $serviceLocator->has('Di')) {
-        //    $di = $serviceLocator->get('Di');
-        //    $controllerLoader->addAbstractFactory(
-        //        new DiAbstractServiceFactory($di, DiAbstractServiceFactory::USE_SL_BEFORE_DI)
-        //    );
-        //    $controllerLoader->addInitializer(
-        //        new DiServiceInitializer($di, $serviceLocator)
-        //    );
-        //}
+        $configuration    = $serviceLocator->get('Configuration');
+        if (isset($configuration['di']) && $serviceLocator->has('Di')) {
+            $di = $serviceLocator->get('Di');
+            $controllerLoader->addAbstractFactory(
+                new DiAbstractServiceFactory($di, DiAbstractServiceFactory::USE_SL_BEFORE_DI)
+            );
+            $controllerLoader->addInitializer(
+                new DiServiceInitializer($di, $serviceLocator)
+            );
+        }
 
         $controllerLoader->addInitializer(function ($instance) use ($serviceLocator) {
             if ($instance instanceof ServiceLocatorAwareInterface) {

--- a/library/Zend/Mvc/Service/ModuleManagerFactory.php
+++ b/library/Zend/Mvc/Service/ModuleManagerFactory.php
@@ -39,6 +39,42 @@ use Zend\ServiceManager\ServiceLocatorInterface;
 class ModuleManagerFactory implements FactoryInterface
 {
     /**
+     * Default mvc-related service configuration -- can be overridden by modules.
+     *
+     * @var array
+     */
+    protected $defaultServiceConfiguration = array(
+        'invokables' => array(
+            'DispatchListener' => 'Zend\Mvc\DispatchListener',
+            'Request'          => 'Zend\Http\PhpEnvironment\Request',
+            'Response'         => 'Zend\Http\PhpEnvironment\Response',
+            'RouteListener'    => 'Zend\Mvc\RouteListener',
+            'ViewManager'      => 'Zend\Mvc\View\ViewManager',
+        ),
+        'factories' => array(
+            'Application'             => 'Zend\Mvc\Service\ApplicationFactory',
+            'Configuration'           => 'Zend\Mvc\Service\ConfigurationFactory',
+            'ControllerLoader'        => 'Zend\Mvc\Service\ControllerLoaderFactory',
+            'ControllerPluginManager' => 'Zend\Mvc\Service\ControllerPluginManagerFactory',
+            'DependencyInjector'      => 'Zend\Mvc\Service\DiFactory',
+            'Router'                  => 'Zend\Mvc\Service\RouterFactory',
+            'ViewHelperManager'       => 'Zend\Mvc\Service\ViewHelperManagerFactory',
+            'ViewFeedRenderer'        => 'Zend\Mvc\Service\ViewFeedRendererFactory',
+            'ViewFeedStrategy'        => 'Zend\Mvc\Service\ViewFeedStrategyFactory',
+            'ViewJsonRenderer'        => 'Zend\Mvc\Service\ViewJsonRendererFactory',
+            'ViewJsonStrategy'        => 'Zend\Mvc\Service\ViewJsonStrategyFactory',
+        ),
+        'aliases' => array(
+            'Config'                            => 'Configuration',
+            'ControllerPluginBroker'            => 'ControllerPluginManager',
+            'Di'                                => 'DependencyInjector',
+            'Zend\Di\LocatorInterface'          => 'DependencyInjector',
+            'Zend\Mvc\Controller\PluginBroker'  => 'ControllerPluginBroker',
+            'Zend\Mvc\Controller\PluginManager' => 'ControllerPluginManager',
+        ),
+    );
+
+    /**
      * Creates and returns the module manager
      *
      * Instantiates the default module listeners, providing them configuration
@@ -57,7 +93,7 @@ class ModuleManagerFactory implements FactoryInterface
         $configuration    = $serviceLocator->get('ApplicationConfiguration');
         $listenerOptions  = new ListenerOptions($configuration['module_listener_options']);
         $defaultListeners = new DefaultListenerAggregate($listenerOptions);
-        $serviceListener = new ServiceListener($serviceLocator);
+        $serviceListener  = new ServiceListener($serviceLocator, $this->defaultServiceConfiguration);
 
         $serviceListener->addServiceManager($serviceLocator, 'service_manager', 'Zend\ModuleManager\Feature\ServiceProviderInterface', 'getServiceConfiguration');
         $serviceListener->addServiceManager('ControllerLoader', 'controllers', 'Zend\ModuleManager\Feature\ControllerProviderInterface', 'getControllerConfiguration');

--- a/library/Zend/Mvc/Service/ModuleManagerFactory.php
+++ b/library/Zend/Mvc/Service/ModuleManagerFactory.php
@@ -57,12 +57,12 @@ class ModuleManagerFactory implements FactoryInterface
         $configuration    = $serviceLocator->get('ApplicationConfiguration');
         $listenerOptions  = new ListenerOptions($configuration['module_listener_options']);
         $defaultListeners = new DefaultListenerAggregate($listenerOptions);
-        $serviceListener = new ServiceListener();
+        $serviceListener = new ServiceListener($serviceLocator);
 
         $serviceListener->addServiceManager($serviceLocator, 'service_manager', 'Zend\ModuleManager\Feature\ServiceProviderInterface', 'getServiceConfiguration');
-        $serviceListener->addServiceManager($serviceLocator->get('ControllerLoader'), 'controllers', 'Zend\ModuleManager\Feature\ControllerProviderInterface', 'getControllerConfiguration');
-        $serviceListener->addServiceManager($serviceLocator->get('ControllerPluginManager'), 'controller_plugins', 'Zend\ModuleManager\Feature\ControllerPluginProviderInterface', 'getControllerPluginConfiguration');
-        $serviceListener->addServiceManager($serviceLocator->get('ViewHelperManager'), 'view_helpers', 'Zend\ModuleManager\Feature\ViewHelperProviderInterface', 'getViewHelperConfiguration');
+        $serviceListener->addServiceManager('ControllerLoader', 'controllers', 'Zend\ModuleManager\Feature\ControllerProviderInterface', 'getControllerConfiguration');
+        $serviceListener->addServiceManager('ControllerPluginManager', 'controller_plugins', 'Zend\ModuleManager\Feature\ControllerPluginProviderInterface', 'getControllerPluginConfiguration');
+        $serviceListener->addServiceManager('ViewHelperManager', 'view_helpers', 'Zend\ModuleManager\Feature\ViewHelperProviderInterface', 'getViewHelperConfiguration');
 
         $events        = $serviceLocator->get('EventManager');
         $events->attach($defaultListeners);

--- a/library/Zend/Mvc/Service/ServiceManagerConfiguration.php
+++ b/library/Zend/Mvc/Service/ServiceManagerConfiguration.php
@@ -42,12 +42,7 @@ class ServiceManagerConfiguration implements ConfigurationInterface
      * @var array
      */
     protected $services = array(
-        'DispatchListener'   => 'Zend\Mvc\DispatchListener',
-        'Request'            => 'Zend\Http\PhpEnvironment\Request',
-        'Response'           => 'Zend\Http\PhpEnvironment\Response',
-        'RouteListener'      => 'Zend\Mvc\RouteListener',
         'SharedEventManager' => 'Zend\EventManager\SharedEventManager',
-        'ViewManager'        => 'Zend\Mvc\View\ViewManager',
     );
 
     /**
@@ -56,19 +51,8 @@ class ServiceManagerConfiguration implements ConfigurationInterface
      * @var array
      */
     protected $factories = array(
-        'Application'             => 'Zend\Mvc\Service\ApplicationFactory',
-        'Configuration'           => 'Zend\Mvc\Service\ConfigurationFactory',
-        'ControllerLoader'        => 'Zend\Mvc\Service\ControllerLoaderFactory',
-        'ControllerPluginManager' => 'Zend\Mvc\Service\ControllerPluginManagerFactory',
-        'DependencyInjector'      => 'Zend\Mvc\Service\DiFactory',
-        'EventManager'            => 'Zend\Mvc\Service\EventManagerFactory',
-        'ModuleManager'           => 'Zend\Mvc\Service\ModuleManagerFactory',
-        'Router'                  => 'Zend\Mvc\Service\RouterFactory',
-        'ViewHelperManager'       => 'Zend\Mvc\Service\ViewHelperManagerFactory',
-        'ViewFeedRenderer'        => 'Zend\Mvc\Service\ViewFeedRendererFactory',
-        'ViewFeedStrategy'        => 'Zend\Mvc\Service\ViewFeedStrategyFactory',
-        'ViewJsonRenderer'        => 'Zend\Mvc\Service\ViewJsonRendererFactory',
-        'ViewJsonStrategy'        => 'Zend\Mvc\Service\ViewJsonStrategyFactory',
+        'EventManager'  => 'Zend\Mvc\Service\EventManagerFactory',
+        'ModuleManager' => 'Zend\Mvc\Service\ModuleManagerFactory',
     );
 
     /**
@@ -84,13 +68,7 @@ class ServiceManagerConfiguration implements ConfigurationInterface
      * @var array
      */
     protected $aliases = array(
-        'Config'                                  => 'Configuration',
-        'ControllerPluginBroker'                  => 'ControllerPluginManager',
-        'Di'                                      => 'DependencyInjector',
-        'Zend\Di\LocatorInterface'                => 'DependencyInjector',
         'Zend\EventManager\EventManagerInterface' => 'EventManager',
-        'Zend\Mvc\Controller\PluginBroker'        => 'ControllerPluginBroker',
-        'Zend\Mvc\Controller\PluginManager'       => 'ControllerPluginManager',
     );
 
     /**

--- a/library/Zend/Mvc/Service/ServiceManagerConfiguration.php
+++ b/library/Zend/Mvc/Service/ServiceManagerConfiguration.php
@@ -41,7 +41,7 @@ class ServiceManagerConfiguration implements ConfigurationInterface
      *
      * @var array
      */
-    protected $services = array(
+    protected $invokables = array(
         'SharedEventManager' => 'Zend\EventManager\SharedEventManager',
     );
 
@@ -92,8 +92,8 @@ class ServiceManagerConfiguration implements ConfigurationInterface
      */
     public function __construct(array $configuration = array())
     {
-        if (isset($configuration['services'])) {
-            $this->services = array_merge($this->services, $configuration['services']);
+        if (isset($configuration['invokables'])) {
+            $this->invokables = array_merge($this->invokables, $configuration['invokables']);
         }
 
         if (isset($configuration['factories'])) {
@@ -127,8 +127,8 @@ class ServiceManagerConfiguration implements ConfigurationInterface
      */
     public function configureServiceManager(ServiceManager $serviceManager)
     {
-        foreach ($this->services as $name => $service) {
-            $serviceManager->setInvokableClass($name, $service);
+        foreach ($this->invokables as $name => $class) {
+            $serviceManager->setInvokableClass($name, $class);
         }
 
         foreach ($this->factories as $name => $factoryClass) {

--- a/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
+++ b/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
@@ -107,7 +107,12 @@ class ViewHelperManagerFactory implements FactoryInterface
             return $basePathHelper;
         });
 
-        // Configure doctype view helper with doctype from configuration, if available
+        /**
+         * Configure doctype view helper with doctype from configuration, if available.
+         *
+         * Other view helpers depend on this to decide which spec to generate their tags
+         * based on. This is why it must be set early instead of later in the layout phtml.
+         */
         $plugins->setFactory('doctype', function($sm) use($serviceLocator) {
             $config = $serviceLocator->get('Configuration');
             $config = $config['view_manager'];

--- a/tests/Zend/ModuleManager/Listener/ConfigListenerTest.php
+++ b/tests/Zend/ModuleManager/Listener/ConfigListenerTest.php
@@ -386,12 +386,12 @@ class ConfigListenerTest extends TestCase
         $configListener = new ConfigListener;
 
         $moduleManager = $this->moduleManager;
-        $this->assertEquals(1, count($moduleManager->getEventManager()->getEvents()));
+        $this->assertEquals(2, count($moduleManager->getEventManager()->getEvents()));
 
         $configListener->attach($moduleManager->getEventManager());
-        $this->assertEquals(4, count($moduleManager->getEventManager()->getEvents()));
+        $this->assertEquals(3, count($moduleManager->getEventManager()->getEvents()));
 
         $configListener->detach($moduleManager->getEventManager());
-        $this->assertEquals(1, count($moduleManager->getEventManager()->getEvents()));
+        $this->assertEquals(2, count($moduleManager->getEventManager()->getEvents()));
     }
 }

--- a/tests/Zend/ModuleManager/Listener/ConfigListenerTest.php
+++ b/tests/Zend/ModuleManager/Listener/ConfigListenerTest.php
@@ -61,7 +61,7 @@ class ConfigListenerTest extends TestCase
     public function tearDown()
     {
         $file = glob($this->tmpdir . DIRECTORY_SEPARATOR . '*');
-        @unlink($file[0]); // change this if there's ever > 1 file 
+        @unlink($file[0]); // change this if there's ever > 1 file
         @rmdir($this->tmpdir);
         // Restore original autoloaders
         AutoloaderFactory::unregisterAutoloaders();
@@ -85,7 +85,7 @@ class ConfigListenerTest extends TestCase
         $configListener = new ConfigListener;
 
         $moduleManager = $this->moduleManager;
-        $moduleManager->getEventManager()->attach('loadModule', $configListener);
+        $configListener->attach($moduleManager->getEventManager());
         $moduleManager->setModules(array('SomeModule', 'ListenerTestModule'));
         $moduleManager->loadModules();
 
@@ -107,18 +107,18 @@ class ConfigListenerTest extends TestCase
 
         $moduleManager = $this->moduleManager;
         $moduleManager->setModules(array('SomeModule', 'ListenerTestModule'));
-        $moduleManager->getEventManager()->attach('loadModule', $configListener);
+        $configListener->attach($moduleManager->getEventManager());
         $moduleManager->loadModules(); // This should cache the config
 
         $modules = $moduleManager->getLoadedModules();
         $this->assertTrue($modules['ListenerTestModule']->getConfigCalled);
 
-        // Now we check to make sure it uses the config and doesn't hit 
+        // Now we check to make sure it uses the config and doesn't hit
         // the module objects getConfig() method(s)
         $moduleManager = new ModuleManager(array('SomeModule', 'ListenerTestModule'));
         $moduleManager->getEventManager()->attach('loadModule.resolve', new ModuleResolverListener, 1000);
         $configListener = new ConfigListener($options);
-        $moduleManager->getEventManager()->attach('loadModule', $configListener);
+        $configListener->attach($moduleManager->getEventManager());
         $moduleManager->loadModules();
         $modules = $moduleManager->getLoadedModules();
         $this->assertFalse($modules['ListenerTestModule']->getConfigCalled);
@@ -132,24 +132,24 @@ class ConfigListenerTest extends TestCase
 
         $moduleManager = $this->moduleManager;
         $moduleManager->setModules(array('BadConfigModule', 'SomeModule'));
-        $moduleManager->getEventManager()->attach('loadModule', $configListener);
+        $configListener->attach($moduleManager->getEventManager());
         $moduleManager->loadModules();
     }
-    
+
     public function testBadGlobPathTrowsInvalidArgumentException()
     {
         $this->setExpectedException('InvalidArgumentException');
         $configListener = new ConfigListener;
         $configListener->addConfigGlobPath(array('asd'));
     }
-    
+
     public function testBadGlobPathArrayTrowsInvalidArgumentException()
     {
         $this->setExpectedException('InvalidArgumentException');
         $configListener = new ConfigListener;
         $configListener->addConfigGlobPaths('asd');
     }
-    
+
     public function testBadStaticPathArrayTrowsInvalidArgumentException()
     {
         $this->setExpectedException('InvalidArgumentException');
@@ -165,7 +165,7 @@ class ConfigListenerTest extends TestCase
         $moduleManager = $this->moduleManager;
         $moduleManager->setModules(array('SomeModule'));
 
-        $moduleManager->getEventManager()->attachAggregate($configListener);
+        $configListener->attach($moduleManager->getEventManager());
 
         $moduleManager->loadModules();
         $configObjectCheck = $configListener->getMergedConfig();
@@ -182,7 +182,7 @@ class ConfigListenerTest extends TestCase
         $this->assertSame('loaded', $config['php']);
         $this->assertSame('loaded', $config['xml']);
     }
-    
+
     public function testCanMergeConfigFromStaticPath()
     {
         $configListener = new ConfigListener;
@@ -210,7 +210,7 @@ class ConfigListenerTest extends TestCase
         $this->assertSame('loaded', $config['php']);
         $this->assertSame('loaded', $config['xml']);
     }
-    
+
     public function testCanMergeConfigFromStaticPaths()
     {
         $configListener = new ConfigListener;
@@ -276,7 +276,7 @@ class ConfigListenerTest extends TestCase
         $this->assertNotNull($configObjectFromGlob->xml);
         $this->assertSame($configObjectFromGlob->xml, $configObjectFromCache->xml);
     }
-    
+
     public function testCanCacheMergedConfigFromStatic()
     {
         $options = new ListenerOptions(array(
@@ -338,7 +338,7 @@ class ConfigListenerTest extends TestCase
         $this->assertSame('loaded', $configObject->php);
         $this->assertSame('loaded', $configObject->xml);
     }
-    
+
     public function testCanMergeConfigFromArrayOfStatic()
     {
         $configListener = new ConfigListener;

--- a/tests/Zend/ModuleManager/Listener/DefaultListenerAggregateTest.php
+++ b/tests/Zend/ModuleManager/Listener/DefaultListenerAggregateTest.php
@@ -46,7 +46,7 @@ class DefaultListenerAggregateTest extends TestCase
         $this->includePath = get_include_path();
 
         $this->defaultListeners = new DefaultListenerAggregate(
-            new ListenerOptions(array( 
+            new ListenerOptions(array(
                 'module_paths'         => array(
                     realpath(__DIR__ . '/TestAsset'),
                 ),
@@ -80,9 +80,12 @@ class DefaultListenerAggregateTest extends TestCase
 
         $events = $moduleManager->getEventManager()->getEvents();
         $expectedEvents = array(
-            'loadModules.pre' => array(
+            'loadModules' => array(
                 'Zend\Loader\ModuleAutoloader',
-                'Zend\ModuleManager\Listener\ConfigListener',
+                'config-pre' => 'Zend\ModuleManager\Listener\ConfigListener',
+                'config-post' => 'Zend\ModuleManager\Listener\ConfigListener',
+                'Zend\ModuleManager\Listener\LocatorRegistrationListener',
+                'Zend\ModuleManager\ModuleManager',
             ),
             'loadModule.resolve' => array(
                 'Zend\ModuleManager\Listener\ModuleResolverListener',
@@ -91,10 +94,6 @@ class DefaultListenerAggregateTest extends TestCase
                 'Zend\ModuleManager\Listener\AutoloaderListener',
                 'Zend\ModuleManager\Listener\InitTrigger',
                 'Zend\ModuleManager\Listener\OnBootstrapListener',
-                'Zend\ModuleManager\Listener\ConfigListener',
-                'Zend\ModuleManager\Listener\LocatorRegistrationListener',
-            ),
-            'loadModules.post' => array(
                 'Zend\ModuleManager\Listener\ConfigListener',
                 'Zend\ModuleManager\Listener\LocatorRegistrationListener',
             ),
@@ -119,10 +118,12 @@ class DefaultListenerAggregateTest extends TestCase
         $listenerAggregate = new DefaultListenerAggregate;
         $moduleManager     = new ModuleManager(array('ListenerTestModule'));
 
+        $this->assertEquals(1, count($moduleManager->getEventManager()->getEvents()));
+
         $listenerAggregate->attach($moduleManager->getEventManager());
-        $this->assertEquals(4, count($moduleManager->getEventManager()->getEvents()));
+        $this->assertEquals(3, count($moduleManager->getEventManager()->getEvents()));
 
         $listenerAggregate->detach($moduleManager->getEventManager());
-        $this->assertEquals(0, count($moduleManager->getEventManager()->getEvents()));
+        $this->assertEquals(1, count($moduleManager->getEventManager()->getEvents()));
     }
 }

--- a/tests/Zend/ModuleManager/Listener/ServiceListenerTest.php
+++ b/tests/Zend/ModuleManager/Listener/ServiceListenerTest.php
@@ -46,7 +46,7 @@ class ServiceListenerTest extends TestCase
     public function setUp()
     {
         $this->services = new ServiceManager();
-        $this->listener = new ServiceListener();
+        $this->listener = new ServiceListener($this->services);
         $this->listener->addServiceManager($this->services, 'service_manager', 'Zend\ModuleManager\Feature\ServiceProviderInterface', 'getServiceConfiguration');
         $this->event    = new ModuleEvent();
         $this->configListener = new ConfigListener();
@@ -97,7 +97,7 @@ class ServiceListenerTest extends TestCase
 
     public function assertServiceManagerIsConfigured()
     {
-        $this->listener->onLoadModulesPost($this->event);
+        $this->listener->onLoadModulesFinish($this->event);
         foreach ($this->getServiceConfiguration() as $prop => $expected) {
             if ($prop == 'invokables') {
                 $prop = 'invokableClasses';

--- a/tests/Zend/ModuleManager/Listener/ServiceListenerTest.php
+++ b/tests/Zend/ModuleManager/Listener/ServiceListenerTest.php
@@ -97,7 +97,7 @@ class ServiceListenerTest extends TestCase
 
     public function assertServiceManagerIsConfigured()
     {
-        $this->listener->onLoadModulesFinish($this->event);
+        $this->listener->onLoadModulesPost($this->event);
         foreach ($this->getServiceConfiguration() as $prop => $expected) {
             if ($prop == 'invokables') {
                 $prop = 'invokableClasses';

--- a/tests/Zend/Mvc/ApplicationTest.php
+++ b/tests/Zend/Mvc/ApplicationTest.php
@@ -72,7 +72,7 @@ class ApplicationTest extends TestCase
         };
         $sm = $this->serviceManager = new ServiceManager(
             new ServiceManagerConfiguration(array(
-                'services' => array(
+                'invokables' => array(
                     'DispatchListener' => 'Zend\Mvc\DispatchListener',
                     'Request'          => 'Zend\Http\PhpEnvironment\Request',
                     'Response'         => 'Zend\Http\PhpEnvironment\Response',

--- a/tests/Zend/Mvc/ApplicationTest.php
+++ b/tests/Zend/Mvc/ApplicationTest.php
@@ -72,11 +72,22 @@ class ApplicationTest extends TestCase
         };
         $sm = $this->serviceManager = new ServiceManager(
             new ServiceManagerConfiguration(array(
-                'services'  => array(
-                    'ViewManager' => 'ZendTest\Mvc\TestAsset\MockViewManager'
+                'services' => array(
+                    'DispatchListener' => 'Zend\Mvc\DispatchListener',
+                    'Request'          => 'Zend\Http\PhpEnvironment\Request',
+                    'Response'         => 'Zend\Http\PhpEnvironment\Response',
+                    'RouteListener'    => 'Zend\Mvc\RouteListener',
+                    'ViewManager'      => 'ZendTest\Mvc\TestAsset\MockViewManager'
                 ),
                 'factories' => array(
-                    'Configuration' => $config,
+                    'ControllerLoader'        => 'Zend\Mvc\Service\ControllerLoaderFactory',
+                    'ControllerPluginManager' => 'Zend\Mvc\Service\ControllerPluginManagerFactory',
+                    'Application'             => 'Zend\Mvc\Service\ApplicationFactory',
+                    'Router'                  => 'Zend\Mvc\Service\RouterFactory',
+                    'Configuration'           => $config,
+                ),
+                'aliases' => array(
+                    'ControllerPluginBroker' => 'ControllerPluginManager',
                 ),
             ))
         );

--- a/tests/Zend/Navigation/ServiceFactoryTest.php
+++ b/tests/Zend/Navigation/ServiceFactoryTest.php
@@ -58,41 +58,43 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
                 'config_cache_enabled' => false,
                 'cache_dir'            => 'data/cache',
                 'module_paths'         => array(),
-            ),
-            'service_manager' => array(
-                'factories' => array(
-                    'Configuration' => function() {
-                        return array(
-                            'navigation' => array(
-                                'file'    => __DIR__ . '/_files/navigation.xml',
-                                'default' => array(
-                                    array(
-                                        'label' => 'Page 1',
-                                        'uri'   => 'page1.html'
-                                    ),
-                                    array(
-                                        'label' => 'MVC Page',
-                                        'route' => 'foo',
-                                        'pages' => array(
+                'extra_config'         => array(
+                    'service_manager' => array(
+                        'factories' => array(
+                            'Configuration' => function() {
+                                return array(
+                                    'navigation' => array(
+                                        'file'    => __DIR__ . '/_files/navigation.xml',
+                                        'default' => array(
                                             array(
-                                                'label' => 'Sub MVC Page',
-                                                'route' => 'foo'
+                                                'label' => 'Page 1',
+                                                'uri'   => 'page1.html'
+                                            ),
+                                            array(
+                                                'label' => 'MVC Page',
+                                                'route' => 'foo',
+                                                'pages' => array(
+                                                    array(
+                                                        'label' => 'Sub MVC Page',
+                                                        'route' => 'foo'
+                                                    )
+                                                )
+                                            ),
+                                            array(
+                                                'label' => 'Page 3',
+                                                'uri'   => 'page3.html'
                                             )
                                         )
-                                    ),
-                                    array(
-                                        'label' => 'Page 3',
-                                        'uri'   => 'page3.html'
                                     )
-                                )
-                            )
-                        );
-                    }
+                                );
+                            }
+                        )
+                    ),
                 )
             ),
         );
 
-        $sm = $this->serviceManager = new ServiceManager(new ServiceManagerConfiguration($config['service_manager']));
+        $sm = $this->serviceManager = new ServiceManager(new ServiceManagerConfiguration);
         $sm->setService('ApplicationConfiguration', $config);
         $sm->get('ModuleManager')->loadModules();
         $sm->get('Application')->bootstrap();

--- a/tests/Zend/View/Helper/Navigation/AbstractTest.php
+++ b/tests/Zend/View/Helper/Navigation/AbstractTest.php
@@ -123,21 +123,23 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
                 'config_cache_enabled' => false,
                 'cache_dir'            => 'data/cache',
                 'module_paths'         => array(),
-            ),
-            'service_manager' => array(
-                'factories' => array(
-                    'Configuration' => function() use ($config) {
-                        return array(
-                            'navigation' => array(
-                                'default' => $config->get('nav_test1')
-                            )
-                        );
-                    }
-                )
+                'extra_config'         => array(
+                    'service_manager' => array(
+                        'factories' => array(
+                            'Configuration' => function() use ($config) {
+                                return array(
+                                    'navigation' => array(
+                                        'default' => $config->get('nav_test1'),
+                                    ),
+                                );
+                            }
+                        ),
+                    ),
+                ),
             ),
         );
 
-        $sm = $this->serviceManager = new ServiceManager(new ServiceManagerConfiguration($smConfig['service_manager']));
+        $sm = $this->serviceManager = new ServiceManager(new ServiceManagerConfiguration);
         $sm->setService('ApplicationConfiguration', $smConfig);
         $sm->get('ModuleManager')->loadModules();
         $sm->get('Application')->bootstrap();


### PR DESCRIPTION
## Goals / features of this PR:
- Allow for a massively simplified index.php (one liner once autoloading is set up). [done]
- Allow modules to override the default services, which previously could only be overridden from application.config.php [done]
- Keep track of where all config values came from so we can tell which modules or config files overrode each other. [done]
- Fix EventManagerAwareInterface so that it does not force injection of a new event manager if one already exists. [done in [#1500](https://github.com/zendframework/zf2/pull/1500)]
- Allow modules to be able to provide initializers to the ServiceManager. [done in [#1695](https://github.com/zendframework/zf2/pull/1695)]
## index.php after this PR:

``` php
<?php
/**
 * This makes our life easier when dealing with paths. Everything is relative
 * to the application root now.
 */
chdir(dirname(__DIR__));

// Setup autoloading
include 'init_autoloader.php';

// Run the application!
Zend\Mvc\Application::init(include 'config/application.config.php')->run()->send();
```

Please merge [ZendSkeletonApplication PR #82](https://github.com/zendframework/ZendSkeletonApplication/pull/82) after this.
