### PR TITLE
[Form] New formButton view helper

### DIFF
--- a/library/Zend/Form/View/Helper/FormButton.php
+++ b/library/Zend/Form/View/Helper/FormButton.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\View\Helper;
+
+use Zend\Form\ElementInterface;
+use Zend\Form\Exception;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormButton extends FormInput
+{
+
+    /**
+     * Valid values for the button type
+     *
+     * @var array
+     */
+    protected $validTypes = array(
+        'button'         => true,
+        'reset'          => true,
+        'submit'         => true,
+    );
+
+    /**
+     * Generate an opening button tag
+     *
+     * @param  null|array|ElementInterface $attributesOrElement
+     * @return string
+     */
+    public function openTag($attributesOrElement = null)
+    {
+        if (null === $attributesOrElement) {
+            return '<button>';
+        }
+
+        if (is_array($attributesOrElement)) {
+            $attributes = $this->createAttributesString($attributesOrElement);
+            return sprintf('<button %s>', $attributes);
+        }
+
+        if (!$attributesOrElement instanceof ElementInterface) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects an array or Zend\Form\ElementInterface instance; received "%s"',
+                __METHOD__,
+                (is_object($attributesOrElement) ? get_class($attributesOrElement) : gettype($attributesOrElement))
+            ));
+        }
+
+        $element = $attributesOrElement;
+        $name    = $element->getName();
+        if (empty($name)) {
+            throw new Exception\DomainException(sprintf(
+                '%s requires that the element has an assigned name; none discovered',
+                __METHOD__
+            ));
+        }
+
+        $attributes         = $element->getAttributes();
+        $attributes['name'] = $name;
+        $attributes['type'] = $this->getType($element);
+
+        return sprintf(
+            '<button %s>',
+            $this->createAttributesString($attributes)
+        );
+    }
+
+    /**
+     * Return a closing button tag
+     *
+     * @return string
+     */
+    public function closeTag()
+    {
+        return '</button>';
+    }
+
+    /**
+     * Render a form <button> element from the provided $element
+     *
+     * @param  ElementInterface $element
+     * @param  null|string $buttonContent
+     * @return string
+     */
+    public function render(ElementInterface $element, $buttonContent = null)
+    {
+        $openTag = $this->openTag($element);
+        $content = false;
+        if (null === $buttonContent) {
+            $content = $element->getAttribute('content');
+            if (null === $content) {
+                throw new Exception\DomainException(sprintf(
+                    '%s expects either button content as the second argument, or that the element provided has a content attribute; neither found',
+                    __METHOD__
+                ));
+            }
+        }
+
+        if ($content && null === $buttonContent) {
+            $buttonContent = $content;
+        }
+
+        return $openTag . $buttonContent . $this->closeTag();
+    }
+
+    /**
+     * Invoke helper as functor
+     *
+     * Proxies to {@link render()}.
+     *
+     * @param  ElementInterface|null $element
+     * @param  null|string $buttonContent
+     * @return string
+     */
+    public function __invoke(ElementInterface $element = null, $buttonContent = null)
+    {
+        if (!$element) {
+            return $this;
+        }
+
+        return $this->render($element, $buttonContent);
+    }
+
+    /**
+     * Determine button type to use
+     *
+     * @param  ElementInterface $element
+     * @return string
+     */
+    protected function getType(ElementInterface $element)
+    {
+        $type = $element->getAttribute('type');
+        if (empty($type)) {
+            return 'submit';
+        }
+
+        $type = strtolower($type);
+        if (!isset($this->validTypes[$type])) {
+            return 'submit';
+        }
+
+        return $type;
+    }
+}

--- a/library/Zend/Form/View/Helper/FormButton.php
+++ b/library/Zend/Form/View/Helper/FormButton.php
@@ -100,7 +100,8 @@ class FormButton extends FormInput
     }
 
     /**
-     * Render a form <button> element from the provided $element
+     * Render a form <button> element from the provided $element,
+     * using content from $buttonContent or the element's "label" attribute
      *
      * @param  ElementInterface $element
      * @param  null|string $buttonContent
@@ -111,10 +112,10 @@ class FormButton extends FormInput
         $openTag = $this->openTag($element);
         $content = false;
         if (null === $buttonContent) {
-            $content = $element->getAttribute('content');
+            $content = $element->getAttribute('label');
             if (null === $content) {
                 throw new Exception\DomainException(sprintf(
-                    '%s expects either button content as the second argument, or that the element provided has a content attribute; neither found',
+                    '%s expects either button content as the second argument, or that the element provided has a label attribute; neither found',
                     __METHOD__
                 ));
             }

--- a/tests/Zend/Form/View/Helper/FormButtonTest.php
+++ b/tests/Zend/Form/View/Helper/FormButtonTest.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\View\Helper;
+
+use Zend\Form\Element;
+use Zend\Form\Fieldset;
+use Zend\Form\Form;
+use Zend\Form\View\Helper\FormButton as FormButtonHelper;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormButtonTest extends CommonTestCase
+{
+    public function setUp()
+    {
+        $this->helper = new FormButtonHelper();
+        parent::setUp();
+    }
+
+    public function testCanEmitStartTagOnly()
+    {
+        $markup = $this->helper->openTag();
+        $this->assertEquals('<button>', $markup);
+    }
+
+    public function testPassingArrayToOpenTagRendersAttributes()
+    {
+        $attributes = array(
+            'name'  => 'my-button',
+            'class' => 'email-button',
+            'type'  => 'button',
+        );
+        $markup = $this->helper->openTag($attributes);
+
+        foreach ($attributes as $key => $value) {
+            $this->assertContains(sprintf('%s="%s"', $key, $value), $markup);
+        }
+    }
+
+    public function testCanEmitCloseTagOnly()
+    {
+        $markup = $this->helper->closeTag();
+        $this->assertEquals('</button>', $markup);
+    }
+
+    public function testPassingElementToOpenTagWillUseNameAttribute()
+    {
+        $element = new Element('foo');
+        $markup = $this->helper->openTag($element);
+        $this->assertContains('name="foo"', $markup);
+    }
+
+    public function testRaisesExceptionWhenNameIsNotPresentInElementWhenPassedToOpenTag()
+    {
+        $element = new Element();
+        $this->setExpectedException('Zend\Form\Exception\DomainException', 'name');
+        $this->helper->openTag($element);
+    }
+
+    public function testGeneratesSubmitTypeWhenProvidedAnElementWithNoTypeAttribute()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->openTag($element);
+        $this->assertContains('<button ', $markup);
+        $this->assertContains('type="submit"', $markup);
+    }
+
+    public function testGeneratesButtonTagWithElementsTypeAttribute()
+    {
+        $element = new Element('foo');
+        $element->setAttribute('type', 'button');
+        $markup  = $this->helper->openTag($element);
+        $this->assertContains('<button ', $markup);
+        $this->assertContains('type="button"', $markup);
+    }
+
+    public function inputTypes()
+    {
+        return array(
+            array('submit', 'assertContains'),
+            array('button', 'assertContains'),
+            array('reset', 'assertContains'),
+            array('lunar', 'assertNotContains'),
+            array('name', 'assertNotContains'),
+            array('username', 'assertNotContains'),
+            array('text', 'assertNotContains'),
+            array('checkbox', 'assertNotContains'),
+        );
+    }
+
+    /**
+     * @dataProvider inputTypes
+     */
+    public function testOpenTagOnlyAllowsValidButtonTypes($type, $assertion)
+    {
+        $element = new Element('foo');
+        $element->setAttribute('type', $type);
+        $markup   = $this->helper->openTag($element);
+        $expected = sprintf('type="%s"', $type);
+        $this->$assertion($expected, $markup);
+    }
+
+    public function testRaisesExceptionWhenContentAttributeIsNotPresentInElement()
+    {
+        $element = new Element('foo');
+        $this->setExpectedException('Zend\Form\Exception\DomainException', 'content');
+        $markup = $this->helper->render($element);
+    }
+
+    public function testPassingElementToRenderGeneratesButtonMarkup()
+    {
+        $element = new Element('foo');
+        $element->setAttribute('content', '{button_content}');
+        $markup = $this->helper->render($element);
+        $this->assertContains('>{button_content}<', $markup);
+        $this->assertContains('name="foo"', $markup);
+        $this->assertContains('<button', $markup);
+        $this->assertContains('</button>', $markup);
+    }
+
+    public function testPassingElementAndContentToRenderUsesContent()
+    {
+        $element = new Element('foo');
+        $markup = $this->helper->render($element, '{button_content}');
+        $this->assertContains('>{button_content}<', $markup);
+        $this->assertContains('name="foo"', $markup);
+        $this->assertContains('<button', $markup);
+        $this->assertContains('</button>', $markup);
+    }
+
+    public function testCallingFromViewHelperCanHandleOpenTagAndCloseTag()
+    {
+        $helper = $this->helper;
+        $markup = $helper()->openTag();
+        $this->assertEquals('<button>', $markup);
+        $markup = $helper()->closeTag();
+        $this->assertEquals('</button>', $markup);
+    }
+
+    public function testInvokeProxiesToRender()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->__invoke($element, '{button_content}');
+        $this->assertContains('<button', $markup);
+        $this->assertContains('name="foo"', $markup);
+        $this->assertContains('>{button_content}<', $markup);
+    }
+
+    public function testInvokeWithNoElementChainsHelper()
+    {
+        $element = new Element('foo');
+        $this->assertSame($this->helper, $this->helper->__invoke());
+    }
+}

--- a/tests/Zend/Form/View/Helper/FormButtonTest.php
+++ b/tests/Zend/Form/View/Helper/FormButtonTest.php
@@ -124,17 +124,17 @@ class FormButtonTest extends CommonTestCase
         $this->$assertion($expected, $markup);
     }
 
-    public function testRaisesExceptionWhenContentAttributeIsNotPresentInElement()
+    public function testRaisesExceptionWhenLabelAttributeIsNotPresentInElement()
     {
         $element = new Element('foo');
-        $this->setExpectedException('Zend\Form\Exception\DomainException', 'content');
+        $this->setExpectedException('Zend\Form\Exception\DomainException', 'label');
         $markup = $this->helper->render($element);
     }
 
     public function testPassingElementToRenderGeneratesButtonMarkup()
     {
         $element = new Element('foo');
-        $element->setAttribute('content', '{button_content}');
+        $element->setAttribute('label', '{button_content}');
         $markup = $this->helper->render($element);
         $this->assertContains('>{button_content}<', $markup);
         $this->assertContains('name="foo"', $markup);


### PR DESCRIPTION
My first contribution to ZF2. Thought I'd start with something relatively easy...
- Borrowed patterns from formLabel and formInput.
- Extends from FormInput, though not much is re-used ($validTagAttributes only). 
- On render()/__invoke(), it looks for an element attribute named "content" or for a $buttonContent parameter as a convenience. For complex content, the user will can use the openTag()/closeTag() explicitly.

Looking forward to feedback.
Cheers,
Chris Martin
