### PR TITLE
[ZF2-258][ZF2-359] mail mime encoding

### DIFF
--- a/library/Zend/Mail/Header/AbstractAddressList.php
+++ b/library/Zend/Mail/Header/AbstractAddressList.php
@@ -146,7 +146,7 @@ abstract class AbstractAddressList implements HeaderInterface
                 }
 
                 if ('ASCII' !== $encoding) {
-                    $name = HeaderWrap::mimeEncodeValue($name, $encoding, false);
+                    $name = HeaderWrap::mimeEncodeValue($name, $encoding);
                 }
                 $emails[] = sprintf('%s <%s>', $name, $email);
             }

--- a/library/Zend/Mail/Header/HeaderWrap.php
+++ b/library/Zend/Mail/Header/HeaderWrap.php
@@ -22,6 +22,7 @@
 namespace Zend\Mail\Header;
 
 use Zend\Mail\Headers;
+use Zend\Mime\Mime;
 
 /**
  * Utility class used for creating wrapped or MIME-encoded versions of header
@@ -45,7 +46,7 @@ abstract class HeaderWrap
     public static function wrap($value, HeaderInterface $header)
     {
         if ($header instanceof UnstructuredInterface) {
-            return static::wrapUnstructuredHeader($value);
+            return static::wrapUnstructuredHeader($value, $header);
         } elseif ($header instanceof StructuredInterface) {
             return static::wrapStructuredHeader($value, $header);
         }
@@ -56,23 +57,28 @@ abstract class HeaderWrap
      * Wrap an unstructured header line
      *
      * Wrap at 78 characters or before, based on whitespace.
-     * 
-     * @param  string $value 
+     *
+     * @param string          $value
+     * @param HeaderInterface $header
      * @return string
      */
-    protected static function wrapUnstructuredHeader($value)
+    protected static function wrapUnstructuredHeader($value, HeaderInterface $header)
     {
-        return wordwrap($value, 78, Headers::FOLDING);
+        $encoding = $header->getEncoding();
+        if ($encoding == 'ASCII') {
+            return wordwrap($value, 78, Headers::FOLDING);
+        }
+        return static::mimeEncodeValue($value, $encoding, 78);
     }
 
     /**
      * Wrap a structured header line
      * 
-     * @param  string          $value 
-     * @param  HeaderInterface $header 
+     * @param  string              $value
+     * @param  StructuredInterface $header
      * @return string
      */
-    protected static function wrapStructuredHeader($value, HeaderInterface $header)
+    protected static function wrapStructuredHeader($value, StructuredInterface $header)
     {
         $delimiter = $header->getDelimiter();
 
@@ -97,29 +103,11 @@ abstract class HeaderWrap
      * 
      * @param  string $value 
      * @param  string $encoding 
-     * @param  bool $splitWords Whether or not to split the $value on whitespace 
-     *                          and encode each word separately.
-     * @return string
+     * @param  int    $lineLength maximum line-length, by default 998
+     * @return string Returns the mime encode value without the last line ending
      */
-    public static function mimeEncodeValue($value, $encoding, $splitWords = false)
+    public static function mimeEncodeValue($value, $encoding, $lineLength = 998)
     {
-        if ($splitWords) {
-            $words = array_map(function($word) use ($encoding) {
-                $header = iconv_mime_encode('Header', $word, array(
-                    'scheme'         => 'Q',
-                    'line-length'    => 78,
-                    'output-charset' => $encoding,
-                ));
-                return str_replace('Header: ', '', $header);
-            }, explode(' ', $value));
-            return implode(Headers::FOLDING, $words);
-        }
-
-        $header = iconv_mime_encode('Header', $value, array(
-            'scheme'         => 'Q',
-            'line-length'    => 998,
-            'output-charset' => $encoding,
-        ));
-        return str_replace('Header: ', '', $header);
+        return Mime::encodeQuotedPrintableHeader($value, $encoding, $lineLength, Headers::EOL);
     }
 }

--- a/library/Zend/Mail/Header/MultipleHeadersInterface.php
+++ b/library/Zend/Mail/Header/MultipleHeadersInterface.php
@@ -27,7 +27,7 @@ namespace Zend\Mail\Header;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface MultipleHeadersInterface
+interface MultipleHeadersInterface extends HeaderInterface
 {
     public function toStringMultipleHeaders(array $headers);
 }

--- a/library/Zend/Mail/Header/Sender.php
+++ b/library/Zend/Mail/Header/Sender.php
@@ -103,7 +103,7 @@ class Sender implements HeaderInterface
         if (!empty($name)) {
             $encoding = $this->getEncoding();
             if ('ASCII' !== $encoding) {
-                $name  = HeaderWrap::mimeEncodeValue($name, $encoding, false);
+                $name  = HeaderWrap::mimeEncodeValue($name, $encoding);
             }
             $email = sprintf('%s %s', $name, $email);
         }

--- a/library/Zend/Mail/Header/StructuredInterface.php
+++ b/library/Zend/Mail/Header/StructuredInterface.php
@@ -28,7 +28,7 @@ namespace Zend\Mail\Header;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface StructuredInterface
+interface StructuredInterface extends HeaderInterface
 {
     /**
      * Return the delimiter at which a header line should be wrapped

--- a/library/Zend/Mail/Header/Subject.php
+++ b/library/Zend/Mail/Header/Subject.php
@@ -82,11 +82,7 @@ class Subject implements UnstructuredInterface
      */
     public function getFieldValue()
     {
-        $encoding = $this->getEncoding();
-        if ($encoding == 'ASCII') {
-            return HeaderWrap::wrap($this->subject, $this);
-        }
-        return HeaderWrap::mimeEncodeValue($this->subject, $encoding, true);
+        return HeaderWrap::wrap($this->subject, $this);
     }
 
     /**

--- a/library/Zend/Mail/Header/Subject.php
+++ b/library/Zend/Mail/Header/Subject.php
@@ -28,7 +28,7 @@ namespace Zend\Mail\Header;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Subject implements HeaderInterface, UnstructuredInterface
+class Subject implements UnstructuredInterface
 {
     /**
      * @var string

--- a/library/Zend/Mail/Header/UnstructuredInterface.php
+++ b/library/Zend/Mail/Header/UnstructuredInterface.php
@@ -30,6 +30,6 @@ namespace Zend\Mail\Header;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface UnstructuredInterface
+interface UnstructuredInterface extends HeaderInterface
 {
 }

--- a/tests/Zend/Mail/Header/HeaderWrapTest.php
+++ b/tests/Zend/Mail/Header/HeaderWrapTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Mail
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Mail\Header;
+
+use Zend\Mail\Header\HeaderWrap;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mail
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Zend_Mail
+ */
+class HeaderWrapTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWrapUnstructuredHeaderAscii()
+    {
+        $string = str_repeat('foobarblahblahblah baz bat', 4);
+        $header = $this->getMock('Zend\Mail\Header\UnstructuredInterface');
+        $header->expects($this->any())
+            ->method('getEncoding')
+            ->will($this->returnValue('ASCII'));
+        $expected = wordwrap($string, 78, "\r\n ");
+
+        $test = HeaderWrap::wrap($string, $header);
+        $this->assertEquals($expected, $test);
+    }
+
+    /**
+     * @group ZF2-258
+     */
+    public function testWrapUnstructuredHeaderMime()
+    {
+        $string = str_repeat('foobarblahblahblah baz bat', 3);
+        $header = $this->getMock('Zend\Mail\Header\UnstructuredInterface');
+        $header->expects($this->any())
+            ->method('getEncoding')
+            ->will($this->returnValue('UTF-8'));
+        $expected = "=?UTF-8?Q?foobarblahblahblah=20baz=20batfoobarblahblahblah=20baz=20?=\r\n"
+                    . " =?UTF-8?Q?batfoobarblahblahblah=20baz=20bat?=";
+
+        $test = HeaderWrap::wrap($string, $header);
+        $this->assertEquals($expected, $test);
+        $this->assertEquals($string, iconv_mime_decode($test));
+    }
+
+    /**
+     * @group ZF2-359
+     */
+    public function testMimeEncoding()
+    {
+        $string   = 'Umlauts: ä';
+        $expected = '=?UTF-8?Q?Umlauts:=20=C3=A4?=';
+
+        $test = HeaderWrap::mimeEncodeValue($string, 'UTF-8', 78);
+        $this->assertEquals($expected, $test);
+        $this->assertEquals($string, iconv_mime_decode($test, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8'));
+    }
+}

--- a/tests/Zend/Mail/MessageTest.php
+++ b/tests/Zend/Mail/MessageTest.php
@@ -617,10 +617,6 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
     public function testSettingNonAsciiEncodingForcesMimeEncodingOfSomeHeaders()
     {
-        if (!function_exists('iconv_mime_encode')) {
-            $this->markTestSkipped('Encoding relies on iconv extension');
-        }
-
         $this->message->addTo('zf-devteam@zend.com', 'ZF DevTeam');
         $this->message->addFrom('matthew@zend.com', "Matthew Weier O'Phinney");
         $this->message->addCc('zf-contributors@lists.zend.com', 'ZF Contributors List');
@@ -630,38 +626,23 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $test = $this->message->headers()->toString();
 
-        $expected = $this->encodeString('ZF DevTeam', 'UTF-8');
+        $expected = '=?UTF-8?Q?ZF=20DevTeam?=';
         $this->assertContains($expected, $test);
         $this->assertContains('<zf-devteam@zend.com>', $test);
 
-        $expected = $this->encodeString("Matthew Weier O'Phinney", 'UTF-8');
+        $expected = "=?UTF-8?Q?Matthew=20Weier=20O'Phinney?=";
         $this->assertContains($expected, $test, $test);
         $this->assertContains('<matthew@zend.com>', $test);
 
-        $expected = $this->encodeString("ZF Contributors List", 'UTF-8');
+        $expected = '=?UTF-8?Q?ZF=20Contributors=20List?=';
         $this->assertContains($expected, $test);
         $this->assertContains('<zf-contributors@lists.zend.com>', $test);
 
-        $expected = $this->encodeString("ZF CR Team", 'UTF-8');
+        $expected = '=?UTF-8?Q?ZF=20CR=20Team?=';
         $this->assertContains($expected, $test);
         $this->assertContains('<zf-crteam@lists.zend.com>', $test);
 
-        $self     = $this;
-        $words    = array_map(function($word) use ($self) {
-            return $self->encodeString($word, 'UTF-8');
-        }, explode(' ', 'This is a subject'));
-        $expected = 'Subject: ' . implode("\r\n ", $words);
-        $this->assertContains($expected, $test, $test);
-    }
-
-    public function encodeString($string, $charset)
-    {
-        $encoded = iconv_mime_encode('Header', $string, array(
-            'scheme'         => 'Q',
-            'output-charset' => $charset,
-            'line-length'    => 998,
-        ));
-        $encoded = str_replace('Header: ', '', $encoded);
-        return $encoded;
+        $expected = 'Subject: =?UTF-8?Q?This=20is=20a=20subject?=';
+        $this->assertContains($expected, $test);
     }
 }


### PR DESCRIPTION
[Mail] Make several header interfaces inherit from the main header interface
- Make StructuredInterface, UnstructuredInterface and MultipleHeadersInterface inherit from the main HeaderInterface
  
  Undo part of 4a54739

[Mail] Replace wrap mime algorithm with the algorithm provided by Zend\Mime\Mime
- Replace the splitWords argument with  the lineLength

Fix ZF2-258 & ZF2-359
