### PR TITLE
Hotfix/ZF2-233

### DIFF
--- a/library/Zend/EventManager/EventManagerAwareInterface.php
+++ b/library/Zend/EventManager/EventManagerAwareInterface.php
@@ -30,7 +30,7 @@ namespace Zend\EventManager;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface EventManagerAwareInterface
+interface EventManagerAwareInterface extends EventsCapableInterface
 {
     /**
      * Inject an EventManager instance

--- a/library/Zend/ModuleManager/ModuleManagerInterface.php
+++ b/library/Zend/ModuleManager/ModuleManagerInterface.php
@@ -19,7 +19,7 @@ use Zend\EventManager\EventsCapableInterface;
  * @category Zend
  * @package  Zend_Module
  */
-interface ModuleManagerInterface extends EventManagerAwareInterface, EventsCapableInterface
+interface ModuleManagerInterface extends EventManagerAwareInterface
 {
     /**
      * Load the provided modules.

--- a/library/Zend/Mvc/Controller/ActionController.php
+++ b/library/Zend/Mvc/Controller/ActionController.php
@@ -25,7 +25,6 @@ use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\EventInterface as Event;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerAwareInterface;
-use Zend\EventManager\EventsCapableInterface;
 use Zend\Http\PhpEnvironment\Response as HttpResponse;
 use Zend\Loader\Broker;
 use Zend\Loader\Pluggable;
@@ -51,7 +50,6 @@ use Zend\View\Model\ViewModel;
 abstract class ActionController implements 
     Dispatchable, 
     EventManagerAwareInterface, 
-    EventsCapableInterface,
     InjectApplicationEventInterface, 
     ServiceLocatorAwareInterface, 
     Pluggable

--- a/library/Zend/Mvc/Controller/RestfulController.php
+++ b/library/Zend/Mvc/Controller/RestfulController.php
@@ -25,7 +25,6 @@ use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\EventInterface as Event;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerAwareInterface;
-use Zend\EventManager\EventsCapableInterface;
 use Zend\Http\Request as HttpRequest;
 use Zend\Http\PhpEnvironment\Response as HttpResponse;
 use Zend\Loader\Broker;
@@ -51,7 +50,6 @@ use Zend\Stdlib\ResponseInterface as Response;
 abstract class RestfulController implements 
     Dispatchable,
     EventManagerAwareInterface,
-    EventsCapableInterface,
     InjectApplicationEventInterface,
     ServiceLocatorAwareInterface,
     Pluggable

--- a/library/Zend/Mvc/Service/ServiceManagerConfiguration.php
+++ b/library/Zend/Mvc/Service/ServiceManagerConfiguration.php
@@ -169,7 +169,8 @@ class ServiceManagerConfiguration implements ConfigurationInterface
 
         $serviceManager->addInitializer(function ($instance) use ($serviceManager) {
             if ($instance instanceof EventManagerAwareInterface
-                && !$instance->events() instanceof EventManagerInterface) {
+                && !$instance->events() instanceof EventManagerInterface
+            ) {
                 $instance->setEventManager($serviceManager->get('EventManager'));
             }
         });

--- a/library/Zend/Mvc/Service/ServiceManagerConfiguration.php
+++ b/library/Zend/Mvc/Service/ServiceManagerConfiguration.php
@@ -24,6 +24,8 @@ namespace Zend\Mvc\Service;
 use Zend\ServiceManager\ConfigurationInterface;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\ServiceManagerAwareInterface;
+use Zend\EventManager\EventManagerInterface;
+use Zend\EventManager\EventManagerAwareInterface;
 
 /**
  * @category   Zend
@@ -166,7 +168,8 @@ class ServiceManagerConfiguration implements ConfigurationInterface
         }
 
         $serviceManager->addInitializer(function ($instance) use ($serviceManager) {
-            if ($instance instanceof EventManagerAwareInterface) {
+            if ($instance instanceof EventManagerAwareInterface
+                && !$instance->events() instanceof EventManagerInterface) {
                 $instance->setEventManager($serviceManager->get('EventManager'));
             }
         });

--- a/library/Zend/View/View.php
+++ b/library/Zend/View/View.php
@@ -23,7 +23,6 @@ namespace Zend\View;
 use Zend\EventManager\EventManagerInterface,
     Zend\EventManager\EventManager,
     Zend\EventManager\EventManagerAwareInterface,
-    Zend\EventManager\EventsCapableInterface,
     Zend\Mvc\MvcEvent,
     Zend\Stdlib\RequestInterface as Request,
     Zend\Stdlib\ResponseInterface as Response,
@@ -37,7 +36,7 @@ use Zend\EventManager\EventManagerInterface,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class View implements EventManagerAwareInterface, EventsCapableInterface
+class View implements EventManagerAwareInterface
 {
     /**
      * @var EventManagerInterface


### PR DESCRIPTION
Fixes ZF2-233 -- Objects that implement EventManagerAwareInterface, but already had an EventManager, would have their EventManager overridden by the initializer.
