### PR TITLE
Update InitProviderInterface to latest changes

### DIFF
--- a/library/Zend/ModuleManager/Feature/InitProviderInterface.php
+++ b/library/Zend/ModuleManager/Feature/InitProviderInterface.php
@@ -21,6 +21,8 @@
 
 namespace Zend\ModuleManager\Feature;
 
+use Zend\ModuleManager\ModuleManagerInterface;
+
 /**
  * @category   Zend
  * @package    Zend_ModuleManager
@@ -33,8 +35,8 @@ interface InitProviderInterface
     /**
      * Initialize workflow
      *
-     * @param  \Zend\ModuleManager\Manager $manager 
+     * @param  \Zend\ModuleManager\ModuleManagerInterface $manager 
      * @return void
      */
-    public function init($manager = null);
+    public function init(ModuleManagerInterface $manager);
 }


### PR DESCRIPTION
- Module is now called ModuleManager
- Type hint to ModuleManagerInterface for init()
- Remove $manager assignment to null when no manager is given

I did not provide additional unit tests, as this is quite a trivial change. However, all tests on Zend\ModuleManager still pass after merge :)
