### PR TITLE
[Form] New Email element and HTML5 Email view helper

### DIFF
--- a/library/Zend/Form/Element/Email.php
+++ b/library/Zend/Form/Element/Email.php
@@ -23,6 +23,7 @@ namespace Zend\Form\Element;
 
 use Zend\Form\Element;
 use Zend\InputFilter\InputProviderInterface;
+use Zend\Validator\ValidatorInterface;
 use Zend\Validator\EmailAddress as EmailValidator;
 use Zend\Validator\Explode as ExplodeValidator;
 
@@ -55,7 +56,7 @@ class Email extends Element implements InputProviderInterface
      * @param  ValidatorInterface $validator
      * @return Email
      */
-    public function setValidator($validator)
+    public function setValidator(ValidatorInterface $validator)
     {
         $this->validator = $validator;
         return $this;

--- a/library/Zend/Form/Element/Email.php
+++ b/library/Zend/Form/Element/Email.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Element
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\Element;
+
+use Zend\Form\Element;
+use Zend\InputFilter\InputProviderInterface;
+use Zend\Validator\EmailAddress as EmailValidator;
+use Zend\Validator\Explode as ExplodeValidator;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Element
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Email extends Element implements InputProviderInterface
+{
+    /**
+     * Seed attributes
+     *
+     * @var array
+     */
+    protected $attributes = array(
+        'type' => 'email',
+    );
+
+    /**
+     * @var ValidatorInterface
+     */
+    protected $validator;
+
+    /**
+     * Set validator
+     *
+     * @param  ValidatorInterface $validator
+     * @return Email
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+        return $this;
+    }
+
+    /**
+     * Get validator
+     *
+     * @return ValidatorInterface
+     */
+    public function getValidator()
+    {
+        if (null === $this->validator) {
+            if (!empty($this->attributes['multiple'])) {
+                $this->setValidator(new ExplodeValidator(array(
+                    'validator' => new EmailValidator(),
+                )));
+            } else {
+                $this->setValidator(new EmailValidator());
+            }
+        }
+        return $this->validator;
+    }
+
+    /**
+     * Provide default input rules for this element
+     *
+     * Attaches an email validator.
+     *
+     * @return array
+     */
+    public function getInputSpecification()
+    {
+        return array(
+            'name' => $this->getName(),
+            'required' => true,
+            'filters' => array(
+                array('name' => 'Zend\Filter\StringTrim'),
+            ),
+            'validators' => array(
+                $this->getValidator(),
+            ),
+        );
+    }
+}

--- a/library/Zend/Form/View/Helper/FormEmail.php
+++ b/library/Zend/Form/View/Helper/FormEmail.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\View\Helper;
+
+use Zend\Form\ElementInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormEmail extends FormInput
+{
+    /**
+     * Attributes valid for the input tag type="email"
+     *
+     * @var array
+     */
+    protected $validTagAttributes = array(
+        'name'           => true,
+        'autocomplete'   => true,
+        'autofocus'      => true,
+        'disabled'       => true,
+        'form'           => true,
+        'list'           => true,
+        'maxlength'      => true,
+        'multiple'       => true,
+        'pattern'        => true,
+        'placeholder'    => true,
+        'readonly'       => true,
+        'required'       => true,
+        'size'           => true,
+        'type'           => true,
+        'value'          => true,
+    );
+
+    /**
+     * Determine input type to use
+     *
+     * @param  ElementInterface $element
+     * @return string
+     */
+    protected function getType(ElementInterface $element)
+    {
+        return 'email';
+    }
+}

--- a/library/Zend/Form/View/HelperLoader.php
+++ b/library/Zend/Form/View/HelperLoader.php
@@ -73,6 +73,8 @@ class HelperLoader extends PluginClassLoader
         'form_element'           => 'Zend\Form\View\Helper\FormElement',
         'formelementerrors'      => 'Zend\Form\View\Helper\FormElementErrors',
         'form_element_errors'    => 'Zend\Form\View\Helper\FormElementErrors',
+        'formemail'              => 'Zend\Form\View\Helper\FormEmail',
+        'form_email'             => 'Zend\Form\View\Helper\FormEmail',
         'formfile'               => 'Zend\Form\View\Helper\FormFile',
         'form_file'              => 'Zend\Form\View\Helper\FormFile',
         'formhidden'             => 'Zend\Form\View\Helper\FormHidden',

--- a/library/Zend/Validator/Explode.php
+++ b/library/Zend/Validator/Explode.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Validate
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Validator;
+
+/**
+ * @category   Zend
+ * @package    Zend_Validate
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Explode extends AbstractValidator
+{
+    const INVALID = 'explodeInvalid';
+
+    /**
+     * @var array
+     */
+    protected $_messageTemplates = array(
+        self::INVALID => "Invalid type given. String expected",
+    );
+
+    /**
+     * @var array
+     */
+    protected $_messageVariables = array();
+
+    /**
+     * @var string
+     */
+    protected $valueDelimiter = ',';
+
+    /**
+     * @var ValidatorInterface
+     */
+    protected $validator;
+
+    /**
+     * @var boolean
+     */
+    protected $breakOnFirstFailure = false;
+
+    /**
+     * Sets the delimiter string that the values will be split upon
+     *
+     * @param string $delimiter
+     * @return Explode
+     */
+    public function setValueDelimiter($delimiter)
+    {
+        $this->valueDelimiter = $delimiter;
+        return $this;
+    }
+
+    /**
+     * Returns the delimiter string that the values will be split upon
+     *
+     * @return string
+     */
+    public function getValueDelimiter()
+    {
+        return $this->valueDelimiter;
+    }
+
+    /**
+     * Sets the Validator for validating each value
+     *
+     * @param ValidatorInterface $validator
+     * @return Explode
+     */
+    public function setValidator(ValidatorInterface $validator)
+    {
+        $this->validator = $validator;
+        return $this;
+    }
+
+    /**
+     * Gets the Validator for validating each value
+     *
+     * @return ValidatorInterface
+     */
+    public function getValidator()
+    {
+        return $this->validator;
+    }
+
+    /**
+     * Set break on first failure setting
+     *
+     * @param boolean $break
+     * @return Explode
+     */
+    public function setBreakOnFirstFailure($break)
+    {
+        $this->breakOnFirstFailure = (bool) $break;
+        return $this;
+    }
+
+    /**
+     * Get break on first failure setting
+     *
+     * @return boolean
+     */
+    public function isBreakOnFirstFailure()
+    {
+        return $this->breakOnFirstFailure;
+    }
+
+    /**
+     * Defined by Zend_Validate_Interface
+     *
+     * Returns true if and only if $value is a valid list of email addresses
+     * (separated by comma) according to RFC2822
+     *
+     * @link   http://www.ietf.org/rfc/rfc2822.txt RFC2822
+     * @link   http://www.columbia.edu/kermit/ascii.html US-ASCII characters
+     * @param  string $value
+     * @return boolean
+     */
+    public function isValid($value)
+    {
+        if (!is_string($value)) {
+            $this->error(self::INVALID);
+            return false;
+        }
+
+        $this->setValue($value);
+
+        $values    = explode($this->valueDelimiter, $value);
+        $retval    = true;
+        $messages  = array();
+        $validator = $this->getValidator();
+
+        if (!$validator) {
+            throw new Exception\RuntimeException(sprintf(
+                '%s expects a validator to be set; none given',
+                __METHOD__
+            ));
+        }
+
+        foreach ($values as $value) {
+            if (!$validator->isValid($value)) {
+                $messages[] = $validator->getMessages();
+                $retval = false;
+
+                if ($this->isBreakOnFirstFailure()) {
+                    break;
+                }
+            }
+        }
+
+        $this->abstractOptions['messages'] = $messages;
+
+        return $retval;
+    }
+}

--- a/library/Zend/Validator/ValidatorLoader.php
+++ b/library/Zend/Validator/ValidatorLoader.php
@@ -33,7 +33,7 @@ use Zend\Loader\PluginClassLoader;
 class ValidatorLoader extends PluginClassLoader
 {
     /**
-     * @var array Pre-aliased filter 
+     * @var array Pre-aliased filter
      */
     protected $plugins = array(
         'alnum'                        => 'Zend\Validator\Alnum',
@@ -154,6 +154,7 @@ class ValidatorLoader extends PluginClassLoader
         'digits'                       => 'Zend\Validator\Digits',
         'email_address'                => 'Zend\Validator\EmailAddress',
         'emailaddress'                 => 'Zend\Validator\EmailAddress',
+        'explode'                      => 'Zend\Validator\Explode',
         'file_count'                   => 'Zend\Validator\File\Count',
         'file\\count'                  => 'Zend\Validator\File\Count',
         'file_crc_32'                  => 'Zend\Validator\File\Crc32',

--- a/tests/Zend/Form/Element/EmailTest.php
+++ b/tests/Zend/Form/Element/EmailTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\Element;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Element\Email as EmailElement;
+use Zend\Form\Factory;
+use Zend\Validator\EmailAddress as EmailValidator;
+
+class EmailTest extends TestCase
+{
+    public function testLazyLoadsEmailValidatorByDefault()
+    {
+        $element   = new EmailElement();
+        $validator = $element->getValidator();
+        $this->assertInstanceOf('Zend\Validator\EmailAddress', $validator);
+    }
+
+    public function testLazyLoadsExplodeValidatorWhenMultipleAttributeSet()
+    {
+        $element   = new EmailElement();
+        $element->setAttribute('multiple', true);
+        $validator = $element->getValidator();
+        $this->assertInstanceOf('Zend\Validator\Explode', $validator);
+    }
+
+    public function testCanInjectEmailValidator()
+    {
+        $element   = new EmailElement();
+        $validator = new EmailValidator();
+        $element->setValidator($validator);
+        $this->assertSame($validator, $element->getValidator());
+    }
+}

--- a/tests/Zend/Form/Element/EmailTest.php
+++ b/tests/Zend/Form/Element/EmailTest.php
@@ -50,4 +50,17 @@ class EmailTest extends TestCase
         $element->setValidator($validator);
         $this->assertSame($validator, $element->getValidator());
     }
+
+    public function testProvidesInputSpecificationThatIncludesEmailValidator()
+    {
+        $element   = new EmailElement();
+        $validator = new EmailValidator();
+        $element->setValidator($validator);
+
+        $inputSpec = $element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $this->assertInternalType('array', $inputSpec['validators']);
+        $test = array_shift($inputSpec['validators']);
+        $this->assertSame($validator, $test);
+    }
 }

--- a/tests/Zend/Form/Element/EmailTest.php
+++ b/tests/Zend/Form/Element/EmailTest.php
@@ -43,18 +43,18 @@ class EmailTest extends TestCase
         $this->assertInstanceOf('Zend\Validator\Explode', $validator);
     }
 
-    public function testCanInjectEmailValidator()
+    public function testCanInjectCustomValidator()
     {
         $element   = new EmailElement();
-        $validator = new EmailValidator();
+        $validator = $this->getMock('Zend\Validator\ValidatorInterface');
         $element->setValidator($validator);
         $this->assertSame($validator, $element->getValidator());
     }
 
-    public function testProvidesInputSpecificationThatIncludesEmailValidator()
+    public function testProvidesInputSpecificationThatIncludesCustomValidator()
     {
         $element   = new EmailElement();
-        $validator = new EmailValidator();
+        $validator = $this->getMock('Zend\Validator\ValidatorInterface');
         $element->setValidator($validator);
 
         $inputSpec = $element->getInputSpecification();

--- a/tests/Zend/Form/View/Helper/FormEmailTest.php
+++ b/tests/Zend/Form/View/Helper/FormEmailTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\View\Helper;
+
+use Zend\Form\Element;
+use Zend\Form\View\Helper\FormEmail as FormEmailHelper;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormEmailTest extends CommonTestCase
+{
+    public function setUp()
+    {
+        $this->helper = new FormEmailHelper();
+        parent::setUp();
+    }
+
+    public function testRaisesExceptionWhenNameIsNotPresentInElement()
+    {
+        $element = new Element();
+        $this->setExpectedException('Zend\Form\Exception\DomainException', 'name');
+        $this->helper->render($element);
+    }
+
+    public function testGeneratesEmailInputTagWithElement()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->render($element);
+        $this->assertContains('<input ', $markup);
+        $this->assertContains('type="email"', $markup);
+    }
+
+    public function testGeneratesEmailInputTagRegardlessOfElementType()
+    {
+        $element = new Element('foo');
+        $element->setAttribute('type', 'radio');
+        $markup  = $this->helper->render($element);
+        $this->assertContains('<input ', $markup);
+        $this->assertContains('type="email"', $markup);
+    }
+
+    public function validAttributes()
+    {
+        return array(
+            array('name', 'assertContains'),
+            array('accept', 'assertNotContains'),
+            array('alt', 'assertNotContains'),
+            array('autocomplete', 'assertContains'),
+            array('autofocus', 'assertContains'),
+            array('checked', 'assertNotContains'),
+            array('dirname', 'assertNotContains'),
+            array('disabled', 'assertContains'),
+            array('form', 'assertContains'),
+            array('formaction', 'assertNotContains'),
+            array('formenctype', 'assertNotContains'),
+            array('formmethod', 'assertNotContains'),
+            array('formnovalidate', 'assertNotContains'),
+            array('formtarget', 'assertNotContains'),
+            array('height', 'assertNotContains'),
+            array('list', 'assertContains'),
+            array('max', 'assertNotContains'),
+            array('maxlength', 'assertContains'),
+            array('min', 'assertNotContains'),
+            array('multiple', 'assertContains'),
+            array('pattern', 'assertContains'),
+            array('placeholder', 'assertContains'),
+            array('readonly', 'assertContains'),
+            array('required', 'assertContains'),
+            array('size', 'assertContains'),
+            array('src', 'assertNotContains'),
+            array('step', 'assertNotContains'),
+            array('value', 'assertContains'),
+            array('width', 'assertNotContains'),
+        );
+    }
+
+    public function getCompleteElement()
+    {
+        $element = new Element('foo');
+        $element->setAttributes(array(
+            'accept'             => 'value',
+            'alt'                => 'value',
+            'autocomplete'       => 'on',
+            'autofocus'          => 'autofocus',
+            'checked'            => 'checked',
+            'dirname'            => 'value',
+            'disabled'           => 'disabled',
+            'form'               => 'value',
+            'formaction'         => 'value',
+            'formenctype'        => 'value',
+            'formmethod'         => 'value',
+            'formnovalidate'     => 'value',
+            'formtarget'         => 'value',
+            'height'             => 'value',
+            'id'                 => 'value',
+            'list'               => 'value',
+            'max'                => 'value',
+            'maxlength'          => 'value',
+            'min'                => 'value',
+            'multiple'           => 'multiple',
+            'name'               => 'value',
+            'pattern'            => 'value',
+            'placeholder'        => 'value',
+            'readonly'           => 'readonly',
+            'required'           => 'required',
+            'size'               => 'value',
+            'src'                => 'value',
+            'step'               => 'value',
+            'value'              => 'value',
+            'width'              => 'value',
+        ));
+        return $element;
+    }
+
+    /**
+     * @dataProvider validAttributes
+     */
+    public function testAllValidFormMarkupAttributesPresentInElementAreRendered($attribute, $assertion)
+    {
+        $element = $this->getCompleteElement();
+        $markup  = $this->helper->render($element);
+        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        $this->$assertion($expect, $markup);
+    }
+
+    public function testInvokeProxiesToRender()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->__invoke($element);
+        $this->assertContains('<input', $markup);
+        $this->assertContains('name="foo"', $markup);
+        $this->assertContains('type="email"', $markup);
+    }
+
+    public function testInvokeWithNoElementChainsHelper()
+    {
+        $this->assertSame($this->helper, $this->helper->__invoke());
+    }
+}

--- a/tests/Zend/Validator/ExplodeTest.php
+++ b/tests/Zend/Validator/ExplodeTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Validator
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Validator;
+use Zend\Validator,
+    ReflectionClass;
+
+/**
+ * Test helper
+ */
+
+/**
+ * @see Zend_Validator_Explode
+ */
+
+
+/**
+ * @category   Zend
+ * @package    Zend_Validator
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Zend_Validator
+ */
+class ExplodeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRaisesExceptionWhenValidatorIsMissing()
+    {
+        $validator = new Validator\Explode();
+        $this->setExpectedException('Zend\Validator\Exception\RuntimeException', 'validator');
+        $validator->isValid('foo,bar');
+    }
+
+    public function getExpectedData()
+    {
+        return array(
+            //    value              delim break  N  valid  messages    assertion
+            array('foo,bar,dev,null', ',', false, 4, true,  array(),    'assertTrue'),
+            array('foo,bar,dev,null', ',', true,  1, false, array('X'), 'assertFalse'),
+            array('foo,bar,dev,null', ',', false, 4, false, array('X', 'X', 'X', 'X'), 'assertFalse'),
+            array('foo,bar,dev,null', ';', false, 1, true,  array(), 'assertTrue'),
+            array('foo;bar,dev;null', ',', false, 2, true,  array(), 'assertTrue'),
+            array('foo;bar,dev;null', ',', false, 2, false, array('X', 'X'), 'assertFalse'),
+            array('foo;bar;dev;null', ';', false, 4, true,  array(), 'assertTrue'),
+            array('foo',              ',', false, 1, true,  array(), 'assertTrue'),
+            array('foo',              ',', false, 1, false, array('X'), 'assertFalse'),
+            array('foo',              ',', true,  1, false, array('X'), 'assertFalse'),
+            array(array(),            ',', false, 0, true,  array(Validator\Explode::INVALID => 'Invalid'), 'assertFalse'),
+        );
+    }
+
+    /**
+     * @dataProvider getExpectedData
+     */
+    public function testExpectedBehavior($value, $delimiter, $breakOnFirst, $numIsValidCalls, $isValidReturn, $messages, $assertion)
+    {
+        $mockValidator = $this->getMock('Zend\Validator\ValidatorInterface');
+        $mockValidator->expects($this->exactly($numIsValidCalls))->method('isValid')->will($this->returnValue($isValidReturn));
+        $mockValidator->expects($this->any())->method('getMessages')->will($this->returnValue('X'));
+
+        $validator = new Validator\Explode(array(
+            'validator'           => $mockValidator,
+            'valueDelimiter'      => $delimiter,
+            'breakOnFirstFailure' => $breakOnFirst,
+        ));
+        $validator->setMessage('Invalid', Validator\Explode::INVALID);
+
+        $this->$assertion($validator->isValid($value));
+        $this->assertEquals($messages, $validator->getMessages());
+    }
+
+    public function testGetMessagesReturnsDefaultValue()
+    {
+        $validator = new Validator\Explode();
+        $this->assertEquals(array(), $validator->getMessages());
+    }
+
+    public function testEqualsMessageTemplates()
+    {
+        $validator = new Validator\Explode(array());
+        $reflection = new ReflectionClass($validator);
+
+        if(!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+
+    public function testEqualsMessageVariables()
+    {
+        $validator = new Validator\Explode(array());
+        $reflection = new ReflectionClass($validator);
+
+        if(!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
+    }
+}

--- a/tests/Zend/Validator/ExplodeTest.php
+++ b/tests/Zend/Validator/ExplodeTest.php
@@ -52,25 +52,25 @@ class ExplodeTest extends \PHPUnit_Framework_TestCase
     public function getExpectedData()
     {
         return array(
-            //    value              delim break  N  valid  messages    assertion
-            array('foo,bar,dev,null', ',', false, 4, true,  array(),    'assertTrue'),
-            array('foo,bar,dev,null', ',', true,  1, false, array('X'), 'assertFalse'),
-            array('foo,bar,dev,null', ',', false, 4, false, array('X', 'X', 'X', 'X'), 'assertFalse'),
-            array('foo,bar,dev,null', ';', false, 1, true,  array(), 'assertTrue'),
-            array('foo;bar,dev;null', ',', false, 2, true,  array(), 'assertTrue'),
-            array('foo;bar,dev;null', ',', false, 2, false, array('X', 'X'), 'assertFalse'),
-            array('foo;bar;dev;null', ';', false, 4, true,  array(), 'assertTrue'),
-            array('foo',              ',', false, 1, true,  array(), 'assertTrue'),
-            array('foo',              ',', false, 1, false, array('X'), 'assertFalse'),
-            array('foo',              ',', true,  1, false, array('X'), 'assertFalse'),
-            array(array(),            ',', false, 0, true,  array(Validator\Explode::INVALID => 'Invalid'), 'assertFalse'),
+            //    value              delim break  N  valid  messages                   expects
+            array('foo,bar,dev,null', ',', false, 4, true,  array(),                   true),
+            array('foo,bar,dev,null', ',', true,  1, false, array('X'),                false),
+            array('foo,bar,dev,null', ',', false, 4, false, array('X', 'X', 'X', 'X'), false),
+            array('foo,bar,dev,null', ';', false, 1, true,  array(),                   true),
+            array('foo;bar,dev;null', ',', false, 2, true,  array(),                   true),
+            array('foo;bar,dev;null', ',', false, 2, false, array('X', 'X'),           false),
+            array('foo;bar;dev;null', ';', false, 4, true,  array(),                   true),
+            array('foo',              ',', false, 1, true,  array(),                   true),
+            array('foo',              ',', false, 1, false, array('X'),                false),
+            array('foo',              ',', true,  1, false, array('X'),                false),
+            array(array(),            ',', false, 0, true,  array(Validator\Explode::INVALID => 'Invalid'), false),
         );
     }
 
     /**
      * @dataProvider getExpectedData
      */
-    public function testExpectedBehavior($value, $delimiter, $breakOnFirst, $numIsValidCalls, $isValidReturn, $messages, $assertion)
+    public function testExpectedBehavior($value, $delimiter, $breakOnFirst, $numIsValidCalls, $isValidReturn, $messages, $expects)
     {
         $mockValidator = $this->getMock('Zend\Validator\ValidatorInterface');
         $mockValidator->expects($this->exactly($numIsValidCalls))->method('isValid')->will($this->returnValue($isValidReturn));
@@ -83,7 +83,7 @@ class ExplodeTest extends \PHPUnit_Framework_TestCase
         ));
         $validator->setMessage('Invalid', Validator\Explode::INVALID);
 
-        $this->$assertion($validator->isValid($value));
+        $this->assertEquals($expects,  $validator->isValid($value));
         $this->assertEquals($messages, $validator->getMessages());
     }
 


### PR DESCRIPTION
Notes:
- Created a new "Explode" validator, to handle multiple email addresses (when "multiple" attribute is on). It's generic and works somewhat like a ValidatorChain. Although, I'm not sure I like the name "Explode".
- The Email element will check for the "multiple" attribute and either use a EmailAddress validator (if off), or a Explode Validator with an EmailAddress validator attached (if on).
