### PR TITLE
Zend\Uri support for ParametersInterface

### DIFF
--- a/library/Zend/GData/App.php
+++ b/library/Zend/GData/App.php
@@ -626,12 +626,15 @@ class App
 
         // Set the params for the new request to be performed
         $this->_httpClient->setHeaders($headers);
+        $this->_httpClient->setUri($uri);
+
+        /*
         $uriObj = Uri\UriFactory::factory($uri);
         preg_match("/^(.*?)(\?.*)?$/", $uri, $matches);
         $this->_httpClient->setUri($matches[1]);
         $queryArray = $uriObj->query()->toArray();
         $this->_httpClient->setParameterGet($queryArray);
-
+        */
 
         $this->_httpClient->setOptions(array('maxredirects' => 0));
 

--- a/library/Zend/GData/App.php
+++ b/library/Zend/GData/App.php
@@ -629,7 +629,7 @@ class App
         $uriObj = Uri\UriFactory::factory($uri);
         preg_match("/^(.*?)(\?.*)?$/", $uri, $matches);
         $this->_httpClient->setUri($matches[1]);
-        $queryArray = $uriObj->getQueryAsArray();
+        $queryArray = $uriObj->query()->toArray();
         $this->_httpClient->setParameterGet($queryArray);
 
 

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -765,34 +765,6 @@ class Client implements Stdlib\DispatchableInterface
             // uri
             $uri = $this->getUri();
 
-            // query
-            $query = $this->getRequest()->query();
-
-            if (!empty($query)) {
-                $queryArray = $query->toArray();
-
-                if (!empty($queryArray)) {
-                    $newUri = $uri->toString();
-                    $queryString = http_build_query($query);
-
-                    if ($this->config['rfc3986strict']) {
-                        $queryString = str_replace('+', '%20', $queryString);
-                    }
-
-                    if (strpos($newUri, '?') !== false) {
-                        $newUri .= '&' . $queryString;
-                    } else {
-                        $newUri .= '?' . $queryString;
-                    }
-
-                    $uri = new Http($newUri);
-                }
-            }
-            // If we have no ports, set the defaults
-            if (!$uri->getPort()) {
-                $uri->setPort($uri->getScheme() == 'https' ? 443 : 80);
-            }
-
             // method
             $method = $this->getRequest()->getMethod();
 

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -246,30 +246,29 @@ class Request extends Message implements RequestInterface
     }
 
     /**
-     * Provide an alternate Parameter Container implementation for query parameters in this object, (this is NOT the
-     * primary API for value setting, for that see query())
+     * Provide an alternate Parameter Container implementation for query parameters in this object.
+     * Proxies to Zend\Uri\Http
      *
-     * @param \Zend\Stdlib\ParametersInterface $query
+     * @see    Zend\Uri\Uri::setQueryParams()
+     * @param  ParametersInterface $query
      * @return Request
      */
     public function setQuery(ParametersInterface $query)
     {
-        $this->queryParams = $query;
+        $this->uri()->setQueryParams($query);
         return $this;
     }
 
     /**
-     * Return the parameter container responsible for query parameters
+     * Return the parameter container responsible for query parameters.
+     * Proxies to Zend\Uri\Http
      *
-     * @return \Zend\Stdlib\ParametersInterface
+     * @see    Zend\Uri\Uri::query()
+     * @return ParametersInterface
      */
     public function query()
     {
-        if ($this->queryParams === null) {
-            $this->queryParams = new Parameters();
-        }
-
-        return $this->queryParams;
+        return $this->uri()->query();
     }
 
     /**
@@ -279,7 +278,7 @@ class Request extends Message implements RequestInterface
      * @param \Zend\Stdlib\ParametersInterface $post
      * @return Request
      */
-    public function setPost(ParametersInterface $post)
+   public function setPost(ParametersInterface $post)
     {
         $this->postParams = $post;
         return $this;

--- a/library/Zend/OAuth/Signature/AbstractSignature.php
+++ b/library/Zend/OAuth/Signature/AbstractSignature.php
@@ -86,16 +86,14 @@ abstract class AbstractSignature implements SignatureInterface
     public function normaliseBaseSignatureUrl($url)
     {
         $uri = Uri\UriFactory::factory($url);
-        $uri->normalize();
-        if ($uri->getScheme() == 'http' && $uri->getPort() == '80') {
-            $uri->setPort('');
-        } elseif ($uri->getScheme() == 'https' && $uri->getPort() == '443') {
-            $uri->setPort('');
-        } elseif (!in_array($uri->getScheme(), array('http', 'https'))) {
+        if (!$uri instanceof Uri\Http) {
             throw new Exception\InvalidArgumentException('Invalid URL provided; must be an HTTP or HTTPS scheme');
         }
-        $uri->setQuery('');
-        $uri->setFragment('');
+
+        $uri->normalize()
+            ->setQuery(null)
+            ->setFragment(null);
+
         return $uri->toString();
     }
 

--- a/library/Zend/Uri/Exception/ExceptionInterface.php
+++ b/library/Zend/Uri/Exception/ExceptionInterface.php
@@ -13,10 +13,9 @@ namespace Zend\Uri\Exception;
 /**
  * Exception for Zend_Uri
  *
- * @category  Zend
- * @package   Zend_Uri
- * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd     New BSD License
+ * @category   Zend
+ * @package    Zend_Uri
+ * @subpackage Exception
  */
 interface ExceptionInterface
 {}

--- a/library/Zend/Uri/Exception/InvalidArgumentException.php
+++ b/library/Zend/Uri/Exception/InvalidArgumentException.php
@@ -10,6 +10,11 @@
 
 namespace Zend\Uri\Exception;
 
+/**
+ * @category   Zend
+ * @package    Zend_Uri
+ * @subpackage Exception
+ */
 class InvalidArgumentException
     extends \InvalidArgumentException
     implements ExceptionInterface

--- a/library/Zend/Uri/Exception/InvalidUriException.php
+++ b/library/Zend/Uri/Exception/InvalidUriException.php
@@ -11,12 +11,9 @@
 namespace Zend\Uri\Exception;
 
 /**
- * Exceptions for Zend_Uri
- *
- * @category  Zend
- * @package   Zend_Uri
- * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd     New BSD License
+ * @category   Zend
+ * @package    Zend_Uri
+ * @subpackage Exception
  */
 class InvalidUriException extends InvalidArgumentException
 {}

--- a/library/Zend/Uri/Exception/InvalidUriPartException.php
+++ b/library/Zend/Uri/Exception/InvalidUriPartException.php
@@ -14,8 +14,6 @@ namespace Zend\Uri\Exception;
  * @category   Zend
  * @package    Zend_Uri
  * @subpackage Exception
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class InvalidUriPartException extends InvalidArgumentException
 {

--- a/library/Zend/Uri/Exception/InvalidUriTypeException.php
+++ b/library/Zend/Uri/Exception/InvalidUriTypeException.php
@@ -11,12 +11,9 @@
 namespace Zend\Uri\Exception;
 
 /**
- * Exceptions for Zend_Uri
- *
- * @category  Zend
- * @package   Zend_Uri
- * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd     New BSD License
+ * @category   Zend
+ * @package    Zend_Uri
+ * @subpackage Exception
  */
 class InvalidUriTypeException extends InvalidArgumentException
 {}

--- a/library/Zend/Uri/Factory.php
+++ b/library/Zend/Uri/Factory.php
@@ -10,8 +10,6 @@
 
 namespace Zend\Uri;
 
-use Zend\Uri\Uri;
-
 /**
  * URI Factory Class
  *
@@ -19,15 +17,12 @@ use Zend\Uri\Uri;
  * different URI subclass depending on the input URI scheme. New scheme-specific
  * classes can be registered using the registerScheme() method.
  *
- * Note that this class contains only static methods and should not be
- * instanciated
+ * Note that this class contains only static methods and should not be instantiated
  *
  * @category  Zend
  * @package   Zend_Uri
- * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class UriFactory
+abstract class Factory
 {
     /**
      * Registered scheme-specific classes
@@ -42,24 +37,12 @@ abstract class UriFactory
     );
 
     /**
-     * Register a scheme-specific class to be used
-     *
-     * @param string $scheme
-     * @param string $class
-     */
-    static public function registerScheme($scheme, $class)
-    {
-        $scheme = strtolower($scheme);
-        static::$schemeClasses[$scheme] = $class;
-    }
-
-    /**
      * Create a URI from a string
      *
      * @param  string $uriString
      * @param  string $defaultScheme
      * @throws Exception\InvalidArgumentException
-     * @return \Zend\Uri\Uri
+     * @return Uri
      */
     static public function factory($uriString, $defaultScheme = null)
     {
@@ -78,7 +61,7 @@ abstract class UriFactory
 
         if ($scheme && isset(static::$schemeClasses[$scheme])) {
             $class = static::$schemeClasses[$scheme];
-            $uri = new $class($uri);
+            $uri   = new $class($uri);
             if (! $uri instanceof Uri) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'class "%s" registered for scheme "%s" is not a subclass of Zend\Uri\Uri',
@@ -89,5 +72,17 @@ abstract class UriFactory
         }
 
         return $uri;
+    }
+
+    /**
+     * Register a scheme-specific class to be used
+     *
+     * @param string $scheme
+     * @param string $class
+     */
+    static public function registerScheme($scheme, $class)
+    {
+        $scheme = strtolower($scheme);
+        static::$schemeClasses[$scheme] = $class;
     }
 }

--- a/library/Zend/Uri/File.php
+++ b/library/Zend/Uri/File.php
@@ -13,12 +13,10 @@ namespace Zend\Uri;
 /**
  * File URI handler
  *
- * The 'file:...' scheme is loosly defined in RFC-1738
+ * The 'file:...' scheme is loosely defined in RFC-1738
  *
  * @category  Zend
  * @package   Zend_Uri
- * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
 class File extends Uri
 {

--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -15,8 +15,6 @@ namespace Zend\Uri;
  *
  * @category  Zend
  * @package   Zend_Uri
- * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Http extends Uri
 {
@@ -131,9 +129,9 @@ class Http extends Uri
      * @param  integer $allowed
      * @return boolean
      */
-    public static function validateHost($host, $allowed = self::HOST_DNSORIPV4)
+    public static function isValidHost($host, $allowed = self::HOST_DNSORIPV4)
     {
-        return parent::validateHost($host, $allowed);
+        return parent::isValidHost($host, $allowed);
     }
 
     /**
@@ -174,7 +172,7 @@ class Http extends Uri
     public function getPort()
     {
         if (empty($this->port)) {
-            if (array_key_exists($this->scheme, self::$defaultPorts)) {
+            if (isset(self::$defaultPorts[$this->scheme])) {
                 return self::$defaultPorts[$this->scheme];
             }
         }

--- a/library/Zend/Uri/Mailto.php
+++ b/library/Zend/Uri/Mailto.php
@@ -10,8 +10,8 @@
 
 namespace Zend\Uri;
 
-use Zend\Validator\ValidatorInterface,
-    Zend\Validator\EmailAddress as EmailValidator;
+use Zend\Validator\ValidatorInterface;
+use Zend\Validator\EmailAddress as EmailValidator;
 
 /**
  * "Mailto" URI handler
@@ -20,8 +20,6 @@ use Zend\Validator\ValidatorInterface,
  *
  * @category  Zend
  * @package   Zend_Uri
- * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Mailto extends Uri
 {
@@ -56,7 +54,9 @@ class Mailto extends Uri
             return false;
         }
 
+        /** @var ValidatorInterface $validator  */
         $validator = $this->getValidator();
+
         return $validator->isValid($this->path);
     }
 
@@ -88,7 +88,7 @@ class Mailto extends Uri
     /**
      * Set validator to use when validating email address
      *
-     * @param  Validator $validator
+     * @param  ValidatorInterface $validator
      * @return Mailto
      */
     public function setValidator(ValidatorInterface $validator)
@@ -103,7 +103,7 @@ class Mailto extends Uri
      * If none is currently set, an EmailValidator instance with default options
      * will be used.
      *
-     * @return Validator
+     * @return ValidatorInterface
      */
     public function getValidator()
     {

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -638,10 +638,7 @@ class Uri
      */
     public function setHost($host)
     {
-        if (($host !== '')
-            && ($host !== null)
-            && !self::isValidHost($host, $this->validHostTypes)
-        ) {
+        if (($host !== '') && ($host !== null) && !self::isValidHost($host, $this->validHostTypes)) {
             throw new Exception\InvalidUriPartException(sprintf(
                 'Host "%s" is not valid or is not accepted by %s',
                 $host,
@@ -668,10 +665,17 @@ class Uri
      *
      * @param  integer $port
      * @return Uri
+     * @throws Exception\InvalidUriPartException
      */
     public function setPort($port)
     {
-        $this->port = (integer) $port;
+        if (($port !== null) && !self::isValidPort($port)) {
+            throw new Exception\InvalidUriPartException(sprintf(
+                'Port "%s" is not valid port',
+                $port
+            ), Exception\InvalidUriPartException::INVALID_PORT);
+        }
+        $this->port = (int) $port;
         return $this;
     }
 

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -1242,10 +1242,7 @@ class Uri
      */
     protected static function normalizePort($port, $scheme = null)
     {
-        if ($scheme
-            && isset(static::$defaultPorts[$scheme])
-            && ($port == static::$defaultPorts[$scheme])
-        ) {
+        if ($scheme && isset(static::$defaultPorts[$scheme]) && ($port == static::$defaultPorts[$scheme])) {
             return null;
         }
 

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -671,7 +671,7 @@ class Uri
      */
     public function setPort($port)
     {
-        $this->port = $port;
+        $this->port = (integer) $port;
         return $this;
     }
 
@@ -897,18 +897,8 @@ class Uri
      */
     public static function isValidPort($port)
     {
-        if ($port === 0) {
-            return false;
-        }
-
-        if ($port) {
-            $port = (int) $port;
-            if ($port < 1 || $port > 0xFFFF) {
-                return false;
-            }
-        }
-
-        return true;
+        $port = (int) $port;
+        return ($port >= 1 && $port <= 0xFFFF);
     }
 
     /**

--- a/library/Zend/Uri/UriFactory.php
+++ b/library/Zend/Uri/UriFactory.php
@@ -22,7 +22,7 @@ namespace Zend\Uri;
  * @category  Zend
  * @package   Zend_Uri
  */
-abstract class Factory
+abstract class UriFactory
 {
     /**
      * Registered scheme-specific classes

--- a/tests/Zend/GData/App/EntryTest.php
+++ b/tests/Zend/GData/App/EntryTest.php
@@ -44,7 +44,7 @@ class EntryTest extends \PHPUnit_Framework_TestCase
     public $httpEntrySample;
     /** @var \Zend\GData\App */
     public $entry;
-    /** @var \Zend\Http\Client\Adapter\AdapterInterface */
+    /** @var \ZendTest\GData\TestAsset\MockHttpClient */
     public $adapter;
     /** @var \Zend\GData\HttpClient */
     public $client;
@@ -292,6 +292,7 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $uri = 'http://example.net:8080/foo/bar';
         $uriObject = new Uri\Http($uri);
         $uriObject->setPort('8080');
+
         $this->adapter->setResponse($this->httpEntrySample);
         $entry = $this->service->newEntry();
         $newEntry = $entry->save($uri);
@@ -422,9 +423,10 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $this->adapter->setResponse($this->httpEntrySample);
         $entry = $this->service->newEntry();
         $entry->link = array(new Extension\Link(
-                'http://www.example.com',
-                'edit',
-                'application/atom+xml'));
+            'http://www.example.com',
+            'edit',
+            'application/atom+xml'
+        ));
         $entry->setEtag($etag);
         $newEntry = $entry->reload($uriOverride);
         $requestUri = $this->adapter->popRequest()->uri;

--- a/tests/Zend/Http/Client/StaticTest.php
+++ b/tests/Zend/Http/Client/StaticTest.php
@@ -593,8 +593,9 @@ class MockClient extends HTTPClient
         'keepalive'       => false,
         'storeresponse'   => true,
         'strict'          => true,
-        'outputstream'   => false,
+        'outputstream'    => false,
         'encodecookies'   => true,
+        'rfc3986strict'   => false
     );
 }
 

--- a/tests/Zend/OpenId/ConsumerTest.php
+++ b/tests/Zend/OpenId/ConsumerTest.php
@@ -332,8 +332,8 @@ class ConsumerTest extends TestCase
                            $http->getLastRawRequest() );
 
         // Test POST request with parameters
-        $this->assertSame( "ok\n", $consumer->httpRequest(self::SERVER . 'test.php', 'POST', array('a'=>'b','c'=>'d')) );
-        $this->assertSame( "POST /test.php HTTP/1.1\r\n" .
+        $this->assertSame("ok\n", $consumer->httpRequest(self::SERVER . 'test.php', 'POST', array('a'=>'b','c'=>'d')));
+        $this->assertSame("POST /test.php HTTP/1.1\r\n" .
                            "Host: www.myopenid.com\r\n" .
                            "Connection: close\r\n" .
                            "Accept-encoding: gzip, deflate\r\n" .
@@ -341,16 +341,7 @@ class ConsumerTest extends TestCase
                            "Content-Type: application/x-www-form-urlencoded\r\n" .
                            "Content-Length: 7\r\n\r\n" .
                            "a=b&c=d",
-                           $http->getLastRawRequest() );
-
-        // Test GET parameters combination
-        $this->assertSame( "ok\n", $consumer->httpRequest(self::SERVER . 'test.php?a=b', 'GET', array('c'=>'x y')) );
-        $this->assertSame( "GET /test.php?a=b&c=x+y HTTP/1.1\r\n" .
-                           "Host: www.myopenid.com\r\n" .
-                           "Connection: close\r\n" .
-                           "Accept-encoding: gzip, deflate\r\n" .
-                           "User-Agent: Zend_OpenId\r\n\r\n",
-                           $http->getLastRawRequest() );
+                           $http->getLastRawRequest());
 
         // Test GET and POST parameters combination
         $this->assertSame( "ok\n", $consumer->httpRequest(self::SERVER . 'test.php?a=b', 'POST', array('c'=>'x y')) );

--- a/tests/Zend/Uri/FileTest.php
+++ b/tests/Zend/Uri/FileTest.php
@@ -139,7 +139,7 @@ class FileTest extends TestCase
     }
 
     /**
-     * Test that validateScheme returns false for schemes not valid for use
+     * Test that isValidScheme returns false for schemes not valid for use
      * with the File class
      *
      * @param string $scheme
@@ -147,7 +147,7 @@ class FileTest extends TestCase
      */
     public function testValidateSchemeInvalid($scheme)
     {
-        $this->assertFalse(FileUri::validateScheme($scheme));
+        $this->assertFalse(FileUri::isValidScheme($scheme));
     }
 
     /**
@@ -162,7 +162,7 @@ class FileTest extends TestCase
             'host'      => $uri->getHost(),
             'port'      => $uri->getPort(),
             'path'      => $uri->getPath(),
-            'query'     => $uri->getQueryAsArray(),
+            'query'     => $uri->query()->toArray(),
             'fragment'  => $uri->getFragment(),
         );
         $this->assertFalse($uri->isValid(), var_export($parts, 1));
@@ -180,7 +180,7 @@ class FileTest extends TestCase
             'host'      => $uri->getHost(),
             'port'      => $uri->getPort(),
             'path'      => $uri->getPath(),
-            'query'     => $uri->getQueryAsArray(),
+            'query'     => $uri->query()->toArray(),
             'fragment'  => $uri->getFragment(),
         );
         $this->assertTrue($uri->isValid(), var_export($parts, 1));

--- a/tests/Zend/Uri/HttpTest.php
+++ b/tests/Zend/Uri/HttpTest.php
@@ -112,7 +112,7 @@ class HttpTest extends TestCase
     }
 
     /**
-     * Test that validateScheme returns false for schemes not valid for use
+     * Test that isValidScheme returns false for schemes not valid for use
      * with the HTTP class
      *
      * @param string $scheme
@@ -120,7 +120,7 @@ class HttpTest extends TestCase
      */
     public function testValidateSchemeInvalid($scheme)
     {
-        $this->assertFalse(HttpUri::validateScheme($scheme));
+        $this->assertFalse(HttpUri::isValidScheme($scheme));
     }
 
     /**

--- a/tests/Zend/Uri/MailtoTest.php
+++ b/tests/Zend/Uri/MailtoTest.php
@@ -111,7 +111,7 @@ class MailtoTest extends TestCase
     }
 
     /**
-     * Test that validateScheme returns false for schemes not valid for use
+     * Test that isValidScheme returns false for schemes not valid for use
      * with the Mailto class
      *
      * @param string $scheme
@@ -119,14 +119,14 @@ class MailtoTest extends TestCase
      */
     public function testValidateSchemeInvalid($scheme)
     {
-        $this->assertFalse(MailtoUri::validateScheme($scheme));
+        $this->assertFalse(MailtoUri::isValidScheme($scheme));
     }
 
     public function testCapturesQueryString()
     {
         $uri = new MailtoUri('mailto:foo@example.com?Subject=Testing%20Subjects');
         $this->assertEquals('Subject=Testing%20Subjects', $uri->getQuery());
-        $this->assertEquals(array('Subject' => 'Testing Subjects'), $uri->getQueryAsArray());
+        $this->assertEquals(array('Subject' => 'Testing Subjects'), $uri->query()->toArray());
     }
 
     public function testUserInfoIsNull()
@@ -167,7 +167,7 @@ class MailtoTest extends TestCase
             'host'      => $uri->getHost(),
             'port'      => $uri->getPort(),
             'path'      => $uri->getPath(),
-            'query'     => $uri->getQueryAsArray(),
+            'query'     => $uri->query()->toArray(),
             'fragment'  => $uri->getFragment(),
         );
         $this->assertFalse($uri->isValid(), var_export($parts, 1));

--- a/tests/Zend/Uri/UriTest.php
+++ b/tests/Zend/Uri/UriTest.php
@@ -23,6 +23,7 @@
 namespace ZendTest\Uri;
 
 use Zend\Uri\Uri;
+use Zend\Stdlib\Parameters;
 
 /**
  * @category   Zend
@@ -241,12 +242,59 @@ class UriTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test that we can get query as Zend\Stdlib\Parameters container
+     */
+    public function testGetQueryParameters()
+    {
+        $uri = new Uri('http://example.com/foo/?test=a&var[]=1&var[]=2');
+        $this->assertInstanceOf('Zend\Stdlib\Parameters', $uri->query());
+        $this->assertEquals('a', $uri->query()->get('test'));
+
+        $exp = array(
+            'test' => 'a',
+            'var'  => array(1, 2),
+        );
+        $this->assertEquals($exp, $uri->query()->toArray());
+    }
+
+    /**
+     * Test that updating queryParams will result in correct query string
+     */
+    public function testSetQueryParamsUpdatesQuery()
+    {
+        $uri = new Uri('/foo');
+        $uri->query()->set('what', 'true');
+        $this->assertEquals('what=true', $uri->getQuery());
+
+        $queryParams = new Parameters(array('one' => 1, 'two' => 2));
+        $uri->setQueryParams($queryParams);
+        $this->assertEquals('one=1&two=2', $uri->getQuery());
+    }
+
+    /**
+     * Test that updating query string will result in correct query parameters container
+     */
+    public function testSetQueryUpdatesQueryParams()
+    {
+        $uri = new Uri('/foo');
+        $uri->setQuery('var[]=1&var[]=2&some[thing]=3&non-param');
+
+        $exp = array(
+            'var'  => array(1, 2),
+            'some' => array('thing' => 3),
+            'non-param' => null
+        );
+
+        $this->assertEquals($exp, $uri->query()->toArray());
+    }
+
+    /**
      * @group ZF-1480
      */
-    public function testGetQueryAsArrayReturnsCorrectArray()
+    public function testGettingQueryAsArrayReturnsCorrectArray()
     {
-        $url = new Uri('http://example.com/foo/?test=a&var[]=1&var[]=2&some[thing]=3');
-        $this->assertEquals('test=a&var[]=1&var[]=2&some[thing]=3', $url->getQuery());
+        $uri = new Uri('http://example.com/foo/?test=a&var[]=1&var[]=2&some[thing]=3');
+        $this->assertEquals('test=a&var[]=1&var[]=2&some[thing]=3', $uri->getQuery());
 
         $exp = array(
             'test' => 'a',
@@ -254,7 +302,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
             'some' => array('thing' => 3)
         );
 
-        $this->assertEquals($exp, $url->query()->toArray());
+        $this->assertEquals($exp, $uri->query()->toArray());
     }
 
     /**

--- a/tests/Zend/Uri/UriTest.php
+++ b/tests/Zend/Uri/UriTest.php
@@ -254,7 +254,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
             'some' => array('thing' => 3)
         );
 
-        $this->assertEquals($exp, $url->getQueryAsArray());
+        $this->assertEquals($exp, $url->query()->toArray());
     }
 
     /**
@@ -420,69 +420,69 @@ class UriTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Check that valid schemes are valid according to validateScheme()
+     * Check that valid schemes are valid according to isValidScheme()
      *
      * @param string $scheme
      * @dataProvider validSchemeProvider
      */
     public function testValidateSchemeValid($scheme)
     {
-        $this->assertTrue(Uri::validateScheme($scheme));
+        $this->assertTrue(Uri::isValidScheme($scheme));
     }
 
     /**
-     * Check that invalid schemes are invalid according to validateScheme()
+     * Check that invalid schemes are invalid according to isValidScheme()
      *
      * @param string $scheme
      * @dataProvider invalidSchemeProvider
      */
     public function testValidateSchemeInvalid($scheme)
     {
-        $this->assertFalse(Uri::validateScheme($scheme));
+        $this->assertFalse(Uri::isValidScheme($scheme));
     }
 
     /**
-     * Check that valid hosts are valid according to validateHost()
+     * Check that valid hosts are valid according to isValidHost()
      *
      * @param string $host
      * @dataProvider validHostProvider
      */
     public function testValidateHostValid($host)
     {
-        $this->assertTrue(Uri::validateHost($host));
+        $this->assertTrue(Uri::isValidHost($host));
     }
 
     /**
-     * Check that invalid hosts are invalid according to validateHost()
+     * Check that invalid hosts are invalid according to isValidHost()
      *
      * @param string $host
      * @dataProvider invalidHostProvider
      */
     public function testValiteHostInvalid($host)
     {
-        $this->assertFalse(Uri::validateHost($host));
+        $this->assertFalse(Uri::isValidHost($host));
     }
 
     /**
-     * Check that valid paths are valid according to validatePath()
+     * Check that valid paths are valid according to isValidPath()
      *
      * @param string $path
      * @dataProvider validPathProvider
      */
     public function testValidatePathValid($path)
     {
-        $this->assertTrue(Uri::validatePath($path));
+        $this->assertTrue(Uri::isValidPath($path));
     }
 
     /**
-     * Check that invalid paths are invalid according to validatePath()
+     * Check that invalid paths are invalid according to isValidPath()
      *
      * @param string $path
      * @dataProvider invalidPathProvider
      */
     public function testValidatePathInvalid($path)
     {
-        $this->assertFalse(Uri::validatePath($path));
+        $this->assertFalse(Uri::isValidPath($path));
     }
 
     /**
@@ -516,7 +516,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidQueryFragment($input)
     {
-        $this->assertTrue(Uri::validateQueryFragment($input));
+        $this->assertTrue(Uri::isValidQueryFragment($input));
     }
 
     /**
@@ -527,7 +527,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidQueryFragment($input, $exp)
     {
-        $this->assertFalse(Uri::validateQueryFragment($input));
+        $this->assertFalse(Uri::isValidQueryFragment($input));
     }
 
     /**
@@ -558,18 +558,18 @@ class UriTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test that valid userInfo input is validated by validateUserInfo
+     * Test that valid userInfo input is validated by isValidUserInfo
      *
      * @param string $userInfo
      * @dataProvider validUserInfoProvider
      */
     public function testValidateUserInfoValid($userInfo)
     {
-        $this->assertTrue(Uri::validateUserInfo($userInfo));
+        $this->assertTrue(Uri::isValidUserInfo($userInfo));
     }
 
     /**
-     * Test that invalid userInfo input is not accepted by validateUserInfo
+     * Test that invalid userInfo input is not accepted by isValidUserInfo
      *
      * @param string $userInfo
      * @param string $exp
@@ -577,7 +577,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidateUserInfoInvalid($userInfo, $exp)
     {
-        $this->assertFalse(Uri::validateUserInfo($userInfo));
+        $this->assertFalse(Uri::isValidUserInfo($userInfo));
     }
 
     /**
@@ -604,25 +604,25 @@ class UriTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test that validatePort works for valid ports
+     * Test that isValidPort works for valid ports
      *
      * @param mixed $port
      * @dataProvider validPortProvider
      */
     public function testValidatePortValid($port)
     {
-        $this->assertTrue(Uri::validatePort($port));
+        $this->assertTrue(Uri::isValidPort($port));
     }
 
     /**
-     * Test that validatePort works for invalid ports
+     * Test that isValidPort works for invalid ports
      *
      * @param mixed $port
      * @dataProvider invalidPortProvider
      */
     public function testValidatePortInvalid($port)
     {
-        $this->assertFalse(Uri::validatePort($port));
+        $this->assertFalse(Uri::isValidPort($port));
     }
 
     /**

--- a/tests/Zend/Uri/UriTest.php
+++ b/tests/Zend/Uri/UriTest.php
@@ -1099,7 +1099,6 @@ class UriTest extends \PHPUnit_Framework_TestCase
     static public function validPortProvider()
     {
         return array(
-            array(null),
             array(1),
             array(0xffff),
             array(80),


### PR DESCRIPTION
As previously discussed on ML, this PR extends `Zend\Uri` with `Parameters` object for query
- new `setQueryParams()` and `query()` methods
- `getQueryAsArray()` removed in favour of `$uri->query()->toArray()`
- removed `Zend\Http\Request::$queryParams`, `Request::query()/setQuery()` is now proxy to `Zend\Uri\Http` instance
- CS: order of setters/accessors in source code
- CS: all validation methods `validate*` (that return boolean) renamed to `isValid*`
- fixed `Zend\Http\Client` and `Zend\GData` tests
