### PR TITLE
Hotfix/di code generator fixes rebased

### DIFF
--- a/library/Zend/Di/Definition/CompilerDefinition.php
+++ b/library/Zend/Di/Definition/CompilerDefinition.php
@@ -92,7 +92,7 @@ class CompilerDefinition implements DefinitionInterface
         if ($this->directoryScanner == null) {
             $this->directoryScanner = new DirectoryScanner();
         }
-        
+
         $this->directoryScanner->addFileScanner($fileScanner);
     }
 
@@ -103,8 +103,8 @@ class CompilerDefinition implements DefinitionInterface
      */
     public function compile()
     {
-        /* 
-         * @var $classScanner \Zend\Code\Scanner\DerivedClassScanner 
+        /*
+         * @var $classScanner \Zend\Code\Scanner\DerivedClassScanner
          */
         foreach ($this->directoryScanner->getClassNames() as $class) {
             $this->processClass($class);
@@ -246,9 +246,6 @@ class CompilerDefinition implements DefinitionInterface
                 }
             }
         }
-
-
-        //var_dump($this->classes);
     }
 
     protected function processParams(&$def, Reflection\ClassReflection $rClass, Reflection\MethodReflection $rMethod)

--- a/library/Zend/Di/Definition/RuntimeDefinition.php
+++ b/library/Zend/Di/Definition/RuntimeDefinition.php
@@ -52,7 +52,7 @@ class RuntimeDefinition implements DefinitionInterface
     {
         $this->introspectionStrategy = $introspectionStrategy;
     }
-    
+
     /**
      * @return IntrospectionStrategy
      */
@@ -82,7 +82,7 @@ class RuntimeDefinition implements DefinitionInterface
 
     /**
      * Retrieves registered classes names
-     * 
+     *
      * @return array
      */
     public function getClasses()
@@ -101,7 +101,7 @@ class RuntimeDefinition implements DefinitionInterface
         if ($this->explicitLookups === true) {
             return (array_key_exists($class, $this->classes));
         }
-        
+
         return class_exists($class) || interface_exists($class);
     }
 
@@ -324,9 +324,6 @@ class RuntimeDefinition implements DefinitionInterface
                 }
             }
         }
-
-
-        //var_dump($this->classes);
     }
 
     protected function processParams(&$def, Reflection\ClassReflection $rClass, Reflection\MethodReflection $rMethod)

--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -300,7 +300,8 @@ class Di implements DependencyInjectionInterface
                                         $methodParams = $definitions->getMethodParameters($type, $typeInjectionMethod);
                                         if ($methodParams) {
                                             foreach ($methodParams as $methodParam) {
-                                                if (get_class($objectToInject) == $methodParam[1] || $this->isSubclassOf(get_class($objectToInject), $methodParam[1])) {
+                                                $objectToInjectClass = $objectToInject instanceof ServiceLocator\GeneratorInstance ? $objectToInject->getClass() : get_class($objectToInject);
+                                                if ($objectToInjectClass == $methodParam[1] || $this->isSubclassOf($objectToInjectClass, $methodParam[1])) {
                                                     if ($this->resolveAndCallInjectionMethodForInstance($instance, $typeInjectionMethod, array($methodParam[0] => $objectToInject), $instanceAlias, true, $type)) {
                                                         $calledMethods[$typeInjectionMethod] = true;
                                                     }
@@ -315,7 +316,7 @@ class Di implements DependencyInjectionInterface
                     }
                     if ($methodsToCall) {
                         foreach ($methodsToCall as $methodInfo) {
-                            $this->resolveAndCallInjectionMethodForInstance($instance, $methodInfo['method'], $methodInfo['args'], $instanceAlias, true, get_class($instance));
+                            $this->resolveAndCallInjectionMethodForInstance($instance, $methodInfo['method'], $methodInfo['args'], $instanceAlias, true, $instanceClass);
                         }
                     }
                 }

--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -300,6 +300,7 @@ class Di implements DependencyInjectionInterface
                                         $methodParams = $definitions->getMethodParameters($type, $typeInjectionMethod);
                                         if ($methodParams) {
                                             foreach ($methodParams as $methodParam) {
+                                                // @todo override in ServiceLocator sub-namespace
                                                 $objectToInjectClass = $objectToInject instanceof ServiceLocator\GeneratorInstance ? $objectToInject->getClass() : get_class($objectToInject);
                                                 if ($objectToInjectClass == $methodParam[1] || $this->isSubclassOf($objectToInjectClass, $methodParam[1])) {
                                                     if ($this->resolveAndCallInjectionMethodForInstance($instance, $typeInjectionMethod, array($methodParam[0] => $objectToInject), $instanceAlias, true, $type)) {

--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -662,6 +662,9 @@ class Di implements DependencyInjectionInterface
      * Utility method used to retrieve the class of a particular instance. This is here to allow extending classes to
      * override how class names are resolved
      *
+     * @internal this method is used by the ServiceLocator\DependencyInjectorProxy class to interact with instances
+     *           and is a hack to be used internally until a major refactor does not split the `resolveMethodParameters`. Do not
+     *           rely on its functionality.
      * @param Object $instance
      * @return string
      */

--- a/library/Zend/Di/ServiceLocator/DependencyInjectorProxy.php
+++ b/library/Zend/Di/ServiceLocator/DependencyInjectorProxy.php
@@ -122,7 +122,7 @@ class DependencyInjectorProxy extends Di
     protected function resolveAndCallInjectionMethodForInstance($instance, $method, $params, $alias, $methodIsRequired, $methodClass = null)
     {
         if (!$instance instanceof GeneratorInstance) {
-            parent::resolveAndCallInjectionMethodForInstance($instance, $method, $params, $alias, $methodIsRequired, $methodClass);
+            return parent::resolveAndCallInjectionMethodForInstance($instance, $method, $params, $alias, $methodIsRequired, $methodClass);
         }
 
         /* @var $instance GeneratorInstance */
@@ -135,5 +135,13 @@ class DependencyInjectorProxy extends Di
                 'params' => $callParameters,
             ));
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getClass($instance)
+    {
+        return $instance instanceof GeneratorInstance ? $instance->getClass() : get_class($instance);
     }
 }

--- a/library/Zend/Di/ServiceLocator/DependencyInjectorProxy.php
+++ b/library/Zend/Di/ServiceLocator/DependencyInjectorProxy.php
@@ -23,10 +23,6 @@ class DependencyInjectorProxy extends Di
     }
 
     /**
-     * Methods with functionality overrides
-     */
-
-    /**
      * Override, as we want it to use the functionality defined in the proxy
      *
      * @param  string $name
@@ -35,19 +31,21 @@ class DependencyInjectorProxy extends Di
      */
     public function get($name, array $params = array())
     {
-        $im = $this->instanceManager();
+        return parent::get($name, $params);
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function newInstance($name, array $params = array(), $isShared = true)
+    {
+        $instance = parent::newInstance($name, $params, $isShared);
 
-        if ($params) {
-            $fastHash = $im->hasSharedInstanceWithParameters($name, $params, true);
-            if ($fastHash) {
-                return $im->getSharedInstanceWithParameters(null, array(), $fastHash);
-            }
-        } else {
-            if ($im->hasSharedInstance($name, $params)) {
-                return $im->getSharedInstance($name, $params);
-            }
+        if ($instance instanceof GeneratorInstance) {
+            /* @var $instance GeneratorInstance */
+            $instance->setShared($isShared);
         }
-        return $this->newInstance($name, $params);
+
+        return $instance;
     }
 
     /**
@@ -63,14 +61,15 @@ class DependencyInjectorProxy extends Di
     public function createInstanceViaConstructor($class, $params, $alias = null)
     {
         $callParameters = array();
+
         if ($this->di->definitions->hasMethod($class, '__construct')
             && (count($this->di->definitions->getMethodParameters($class, '__construct')) > 0)
         ) {
-            $callParameters = $this->resolveMethodParameters(
-                $class, '__construct', $params, true, $alias, true
-            );
+            $callParameters = $this->resolveMethodParameters($class, '__construct', $params, $alias, true, true);
+            $callParameters = $callParameters ?: array();
         }
-        return new GeneratorInstance($class, '__construct', $callParameters);
+
+        return new GeneratorInstance($class, $alias, '__construct', $callParameters);
     }
 
     /**
@@ -81,11 +80,13 @@ class DependencyInjectorProxy extends Di
      * @return GeneratorInstance
      * @throws Exception\InvalidCallbackException
      */
-    public function createInstanceViaCallback($callback, $params, $alias = null)
+    public function createInstanceViaCallback($callback, $params, $alias)
     {
         if (!is_callable($callback)) {
             throw new Exception\InvalidCallbackException('An invalid constructor callback was provided');
         }
+
+        // @todo add support for string callbacks?
 
         if (!is_array($callback) || is_object($callback[0])) {
             throw new Exception\InvalidCallbackException('For purposes of service locator generation, constructor callbacks must refer to static methods only');
@@ -96,89 +97,43 @@ class DependencyInjectorProxy extends Di
 
         $callParameters = array();
         if ($this->di->definitions->hasMethod($class, $method)) {
-            $callParameters = $this->resolveMethodParameters($class, $method, $params, true, $alias, true);
+            $callParameters = $this->resolveMethodParameters($class, $method, $params, $alias, true, true);
         }
 
-        return new GeneratorInstance(null, $callback, $callParameters);
+        $callParameters = $callParameters ?: array();
+
+        return new GeneratorInstance(null, $alias, $callback, $callParameters);
     }
 
     /**
-     * Retrieve metadata for injectible methods
-     *
-     * @param  string $class
-     * @param  string $method
-     * @param  array $params
-     * @param  string $alias
-     * @return array
+     * {@inheritDoc}
      */
     public function handleInjectionMethodForObject($class, $method, $params, $alias, $isRequired)
     {
-        $callParameters = $this->resolveMethodParameters($class, $method, $params, false, $alias, $isRequired);
         return array(
             'method' => $method,
-            'params' => $callParameters,
+            'params' =>  $this->resolveMethodParameters($class, $method, $params, $alias, $isRequired),
         );
     }
 
     /**
-     * Override new instance creation
-     *
-     * @param  string $name
-     * @param  array $params
-     * @param  bool $isShared
-     * @return GeneratorInstance
-     * @throws Exception\ClassNotFoundException
-     * @throws Exception\RuntimeException
+     * {@inheritDoc}
      */
-    public function newInstance($name, array $params = array(), $isShared = true)
+    protected function resolveAndCallInjectionMethodForInstance($instance, $method, $params, $alias, $methodIsRequired, $methodClass = null)
     {
-        $definition      = $this->definitions();
-        $instanceManager = $this->instanceManager();
-
-        if ($instanceManager->hasAlias($name)) {
-            $class = $instanceManager->getClassFromAlias($name);
-            $alias = $name;
-        } else {
-            $class = $name;
-            $alias = null;
+        if (!$instance instanceof GeneratorInstance) {
+            parent::resolveAndCallInjectionMethodForInstance($instance, $method, $params, $alias, $methodIsRequired, $methodClass);
         }
 
-        if (!$definition->hasClass($class)) {
-            $aliasMsg = ($alias) ? '(specified by alias ' . $alias . ') ' : '';
-            throw new Exception\ClassNotFoundException(
-                'Class ' . $aliasMsg . $class . ' could not be located in provided definitions.'
-            );
+        /* @var $instance GeneratorInstance */
+        $methodClass = $instance->getClass();
+        $callParameters = $this->resolveMethodParameters($methodClass, $method, $params, $alias, $methodIsRequired);
+
+        if ($callParameters !== false) {
+            $instance->addMethod(array(
+                'method' => $method,
+                'params' => $callParameters,
+            ));
         }
-
-        $instantiator     = $definition->getInstantiator($class);
-        $injectionMethods = $definition->getMethods($class);
-
-        if ($instantiator === '__construct') {
-            $object = $this->createInstanceViaConstructor($class, $params, $alias);
-            if (in_array('__construct', $injectionMethods)) {
-                unset($injectionMethods[array_search('__construct', $injectionMethods)]);
-            }
-        } elseif (is_callable($instantiator)) {
-            $object = $this->createInstanceViaCallback($instantiator, $params, $alias);
-            $object->setName($class);
-        } else {
-            throw new Exception\RuntimeException('Invalid instantiator');
-        }
-
-        if ($injectionMethods) {
-            foreach ($injectionMethods as $injectionMethod) {
-                $methodMetadata[] = $this->handleInjectionMethodForObject($class, $injectionMethod, $params, $alias);
-            }
-        }
-
-        if ($isShared) {
-            if ($params) {
-                $instanceManager->addSharedInstanceWithParameters($object, $name, $params);
-            } else {
-                $instanceManager->addSharedInstance($object, $name);
-            }
-        }
-
-        return $object;
     }
 }

--- a/library/Zend/Di/ServiceLocator/DependencyInjectorProxy.php
+++ b/library/Zend/Di/ServiceLocator/DependencyInjectorProxy.php
@@ -5,6 +5,9 @@ namespace Zend\Di\ServiceLocator;
 use Zend\Di\Di;
 use Zend\Di\Exception;
 
+/**
+ * Proxy used to analyze how instances are created by a given Di.
+ */
 class DependencyInjectorProxy extends Di
 {
     /**
@@ -81,8 +84,9 @@ class DependencyInjectorProxy extends Di
     /**
      * Override instance creation via callback
      *
-     * @param  callback $callback
-     * @param  null|array $params
+     * @param  callback    $callback
+     * @param  null|array  $params
+     * @param  null|string $alias
      * @return GeneratorInstance
      * @throws Exception\InvalidCallbackException
      */
@@ -139,12 +143,15 @@ class DependencyInjectorProxy extends Di
         $methodClass = $instance->getClass();
         $callParameters = $this->resolveMethodParameters($methodClass, $method, $params, $alias, $methodIsRequired);
 
-        if ($callParameters !== false) {
+        if ($callParameters === false) {
             $instance->addMethod(array(
                 'method' => $method,
                 'params' => $callParameters,
             ));
+            return true;
         }
+
+        return false;
     }
 
     /**
@@ -152,6 +159,11 @@ class DependencyInjectorProxy extends Di
      */
     protected function getClass($instance)
     {
-        return $instance instanceof GeneratorInstance ? $instance->getClass() : get_class($instance);
+        if ($instance instanceof GeneratorInstance) {
+            /* @var $instance GeneratorInstance */
+            return $instance->getClass();
+        }
+
+        return parent::getClass($instance);
     }
 }

--- a/library/Zend/Di/ServiceLocator/Generator.php
+++ b/library/Zend/Di/ServiceLocator/Generator.php
@@ -2,8 +2,11 @@
 
 namespace Zend\Di\ServiceLocator;
 
-use Zend\Code\Generator as CodeGen;
 use Zend\Di\Di;
+use Zend\Code\Generator\FileGenerator;
+use Zend\Code\Generator\ClassGenerator;
+use Zend\Code\Generator\MethodGenerator;
+use Zend\Code\Generator\ParameterGenerator;
 use Zend\Di\Exception;
 
 /**
@@ -22,7 +25,7 @@ class Generator
      * Constructor
      *
      * Requires a DependencyInjection manager on which to operate.
-     * 
+     *
      * @param Di $injector
      */
     public function __construct(Di $injector)
@@ -32,8 +35,8 @@ class Generator
 
     /**
      * Set the class name for the generated service locator container
-     * 
-     * @param  string $name 
+     *
+     * @param  string $name
      * @return Generator
      */
     public function setContainerClass($name)
@@ -44,8 +47,8 @@ class Generator
 
     /**
      * Set the namespace to use for the generated class file
-     * 
-     * @param  string $namespace 
+     *
+     * @param  string $namespace
      * @return Generator
      */
     public function setNamespace($namespace)
@@ -57,11 +60,11 @@ class Generator
     /**
      * Construct, configure, and return a PHP classfile code generation object
      *
-     * Creates a Zend\CodeGenerator\Php\PhpFile object that has 
+     * Creates a Zend\CodeGenerator\Php\PhpFile object that has
      * created the specified class and service locator methods.
-     * 
-     * @param  null|string $filename 
-     * @return CodeGen\FileGenerator
+     *
+     * @param  null|string $filename
+     * @return FileGenerator
      * @throws Exception\RuntimeException
      */
     public function getCodeGenerator($filename = null)
@@ -74,11 +77,13 @@ class Generator
         $getters        = array();
         $definitions    = $injector->definitions();
 
-        foreach ($definitions->getClasses() as $name) {
+        $fetched = array_unique(array_merge($definitions->getClasses(), $im->getAliases()));
+
+        foreach ($fetched as $name) {
             $getter = $this->normalizeAlias($name);
             $meta   = $injector->get($name);
             $params = $meta->getParams();
-            
+
             // Build parameter list for instantiation
             foreach ($params as $key => $param) {
                 if (null === $param || is_scalar($param) || is_array($param)) {
@@ -88,6 +93,7 @@ class Generator
                     }
                     $params[$key] = $string;
                 } elseif ($param instanceof GeneratorInstance) {
+                    /* @var $param GeneratorInstance */
                     $params[$key] = sprintf('$this->%s()', $this->normalizeAlias($param->getName()));
                 } else {
                     $message = sprintf('Unable to use object arguments when building containers. Encountered with "%s", parameter of type "%s"', $name, get_class($param));
@@ -188,9 +194,9 @@ class Generator
             // End getter body
             $getterBody .= "return \$object;\n";
 
-            $getterDef = new CodeGen\MethodGenerator();
-            $getterDef->setName($getter)
-                      ->setBody($getterBody);
+            $getterDef = new MethodGenerator();
+            $getterDef->setName($getter);
+            $getterDef->setBody($getterBody);
             $getters[] = $getterDef;
 
             // Get cases for case statements
@@ -215,14 +221,14 @@ class Generator
         $switch .= "}\n\n";
 
         // Build get() method
-        $nameParam   = new CodeGen\ParameterGenerator();
+        $nameParam   = new ParameterGenerator();
         $nameParam->setName('name');
-        $paramsParam = new CodeGen\ParameterGenerator();
+        $paramsParam = new ParameterGenerator();
         $paramsParam->setName('params')
                     ->setType('array')
                     ->setDefaultValue(array());
 
-        $get = new CodeGen\MethodGenerator();
+        $get = new MethodGenerator();
         $get->setName('get');
         $get->setParameters(array(
             $nameParam,
@@ -239,7 +245,7 @@ class Generator
         }
 
         // Create class code generation object
-        $container = new CodeGen\ClassGenerator();
+        $container = new ClassGenerator();
         $container->setName($this->containerClass)
                   ->setExtendedClass('ServiceLocator')
                   ->addMethodFromGenerator($get)
@@ -247,7 +253,7 @@ class Generator
                   ->addMethods($aliasMethods);
 
         // Create PHP file code generation object
-        $classFile = new CodeGen\FileGenerator();
+        $classFile = new FileGenerator();
         $classFile->setUse('Zend\Di\ServiceLocator')
                   ->setClass($container);
 
@@ -265,11 +271,11 @@ class Generator
     /**
      * Reduces aliases
      *
-     * Takes alias list and reduces it to a 2-dimensional array of 
-     * class names pointing to an array of aliases that resolve to 
+     * Takes alias list and reduces it to a 2-dimensional array of
+     * class names pointing to an array of aliases that resolve to
      * it.
-     * 
-     * @param  array $aliasList 
+     *
+     * @param  array $aliasList
      * @return array
      */
     protected function reduceAliases(array $aliasList)
@@ -292,24 +298,24 @@ class Generator
 
     /**
      * Create a PhpMethod code generation object named after a given alias
-     * 
-     * @param  string $alias 
-     * @param  class $class Class to which alias refers
-     * @return CodeGen\MethodGenerator
+     *
+     * @param  string $alias
+     * @param  string $class Class to which alias refers
+     * @return MethodGenerator
      */
     protected function getCodeGenMethodFromAlias($alias, $class)
     {
         $alias = $this->normalizeAlias($alias);
-        $method = new CodeGen\MethodGenerator();
-        $method->setName($alias)
-               ->setBody(sprintf('return $this->get(\'%s\');', $class));
+        $method = new MethodGenerator();
+        $method->setName($alias);
+        $method->setBody(sprintf('return $this->get(\'%s\');', $class));
         return $method;
     }
 
     /**
      * Normalize an alias to a getter method name
-     * 
-     * @param  string $alias 
+     *
+     * @param  string $alias
      * @return string
      */
     protected function normalizeAlias($alias)

--- a/library/Zend/Di/ServiceLocator/Generator.php
+++ b/library/Zend/Di/ServiceLocator/Generator.php
@@ -112,7 +112,6 @@ class Generator
             }
 
             // Create instantiation code
-            $creation    = '';
             $constructor = $meta->getConstructor();
             if ('__construct' != $constructor) {
                 // Constructor callback

--- a/library/Zend/Di/ServiceLocator/GeneratorInstance.php
+++ b/library/Zend/Di/ServiceLocator/GeneratorInstance.php
@@ -5,7 +5,7 @@ namespace Zend\Di\ServiceLocator;
 class GeneratorInstance
 {
     /**
-     * @var string
+     * @var string|null
      */
     protected $class;
 
@@ -49,7 +49,9 @@ class GeneratorInstance
     }
 
     /**
-     * @return string instance or class name
+     * Retrieves the best available name for this instance (instance alias first then class name)
+     *
+     * @return string|null
      */
     public function getName()
     {
@@ -57,7 +59,9 @@ class GeneratorInstance
     }
 
     /**
-     * @return string
+     * Class of the instance. Null if class is unclear (such as when the instance is produced by a callback)
+     *
+     * @return string|null
      */
     public function getClass()
     {
@@ -65,6 +69,8 @@ class GeneratorInstance
     }
 
     /**
+     * Alias for the instance (if any)
+     *
      * @return string|null
      */
     public function getAlias()
@@ -102,7 +108,7 @@ class GeneratorInstance
     /**
      * Get instantiator
      *
-     * @return mixed constructor method or callable for the instance
+     * @return mixed constructor method name or callable responsible for generating instance
      */
     public function getConstructor()
     {
@@ -110,7 +116,8 @@ class GeneratorInstance
     }
 
     /**
-     * Get params
+     * Parameters passed to the instantiator as an ordered list of parameters. Each parameter that refers to another
+     * instance fetched recursively is a GeneratorInstance itself
      *
      * @return array
      */
@@ -144,7 +151,9 @@ class GeneratorInstance
     }
 
     /**
-     * Retrieves an ordered list of methods called on the instance
+     * Retrieves a list of methods that are called on the instance in their call order. Each returned element has form
+     * array('method' => 'methodName', 'params' => array( ... ordered list of call parameters ... ), where every call
+     * parameter that is a recursively fetched instance is a GeneratorInstance itself
      *
      * @return array
      */
@@ -162,6 +171,8 @@ class GeneratorInstance
     }
 
     /**
+     * Retrieves whether the instance is shared or not
+     *
      * @return bool
      */
     public function isShared()

--- a/library/Zend/Di/ServiceLocator/GeneratorInstance.php
+++ b/library/Zend/Di/ServiceLocator/GeneratorInstance.php
@@ -7,7 +7,12 @@ class GeneratorInstance
     /**
      * @var string
      */
-    protected $name;
+    protected $class;
+
+    /**
+     * @var string|null
+     */
+    protected $alias;
 
     /**
      * @var mixed
@@ -25,48 +30,79 @@ class GeneratorInstance
     protected $methods = array();
 
     /**
-     * Constructor
-     *
-     * @param string $name
-     * @param mixed $constructor
-     * @param array $params
+     * @var bool
      */
-    public function __construct($name, $constructor, array $params)
+    protected $shared = true;
+
+    /**
+     * @param string|null $class
+     * @param string|null $alias
+     * @param mixed       $constructor
+     * @param array       $params
+     */
+    public function __construct($class, $alias, $constructor, array $params)
     {
-        $this->name        = $name;
+        $this->class       = $class;
+        $this->alias       = $alias;
         $this->constructor = $constructor;
         $this->params      = $params;
     }
 
     /**
-     * Get name
-     *
-     * @return string
+     * @return string instance or class name
      */
     public function getName()
     {
-        return $this->name;
+        return $this->alias ? $this->alias : $this->class;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClass()
+    {
+        return $this->class;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAlias()
+    {
+        return $this->alias;
     }
 
     /**
      * Set class name
      *
-     * In the case of an instance created via a callback, we need to set the 
+     * In the case of an instance created via a callback, we need to set the
      * class name after creating the generator instance.
-     * 
-     * @param  string $name 
+     *
+     * @param  string $class
      * @return GeneratorInstance
      */
-    public function setName($name)
+    public function setClass($class)
     {
-        $this->name = $name;
+        $this->class = $class;
         return $this;
     }
 
     /**
-     * Get constructor
+     * Set instance alias
      *
-     * @return mixed
+     * @param  string $alias
+     * @return GeneratorInstance
+     */
+    public function setAlias($alias)
+    {
+        $this->alias = $alias;
+        return $this;
+    }
+
+    /**
+     * Get instantiator
+     *
+     * @return mixed constructor method or callable for the instance
      */
     public function getConstructor()
     {
@@ -96,12 +132,40 @@ class GeneratorInstance
     }
 
     /**
-     * Get methods
+     * Add a method called on the instance
+     *
+     * @param $method
+     * @return GeneratorInstance
+     */
+    public function addMethod($method)
+    {
+        $this->methods[] = $method;
+        return $this;
+    }
+
+    /**
+     * Retrieves an ordered list of methods called on the instance
      *
      * @return array
      */
     public function getMethods()
     {
         return $this->methods;
+    }
+
+    /**
+     * @param bool $shared
+     */
+    public function setShared($shared)
+    {
+        $this->shared = (bool) $shared;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isShared()
+    {
+        return $this->shared;
     }
 }

--- a/library/Zend/Di/ServiceLocator/GeneratorInstance.php
+++ b/library/Zend/Di/ServiceLocator/GeneratorInstance.php
@@ -2,6 +2,9 @@
 
 namespace Zend\Di\ServiceLocator;
 
+/**
+ * Container for methods and parameters used by by Di to create a particular instance
+ */
 class GeneratorInstance
 {
     /**

--- a/tests/Zend/Di/ServiceLocator/GeneratorTest.php
+++ b/tests/Zend/Di/ServiceLocator/GeneratorTest.php
@@ -19,7 +19,6 @@ class GeneratorTest extends TestCase
 
     public function setUp()
     {
-        $this->markTestIncomplete('Generator must be refactored to current di.');
         $this->tmpFile = false;
         $this->di = new Di;
     }
@@ -164,11 +163,11 @@ class GeneratorTest extends TestCase
         }
         $expected = array(
             'composed',
-            'ZendTest\Di\TestAsset\ComposedClass', 
+            'ZendTest\Di\TestAsset\ComposedClass',
             'inspect',
-            'ZendTest\Di\TestAsset\InspectedClass', 
+            'ZendTest\Di\TestAsset\InspectedClass',
             'struct',
-            'ZendTest\Di\TestAsset\Struct', 
+            'ZendTest\Di\TestAsset\Struct',
         );
         $this->assertEquals(count($expected), count($services), var_export($services, 1));
         foreach ($expected as $service) {
@@ -206,7 +205,7 @@ class GeneratorTest extends TestCase
         $expected = array(
             'get',
             'getZendTestDiTestAssetComposedClass',
-            'getComposed', 
+            'getComposed',
             'getZendTestDiTestAssetInspectedClass',
             'getInspect',
             'getZendTestDiTestAssetStruct',
@@ -224,7 +223,7 @@ class GeneratorTest extends TestCase
         $builder = new ContainerGenerator($this->di);
         $builder->setContainerClass('Application');
         $codegen = $builder->getCodeGenerator();
-        $this->assertInstanceOf('Zend\CodeGenerator\Php\PhpFile', $codegen);
+        $this->assertInstanceOf('Zend\Code\Generator\FileGenerator', $codegen);
     }
 
     public function testCanSpecifyNamespaceForGeneratedPhpClassfile()


### PR DESCRIPTION
This PR makes `Zend\Di` code generator tests run again master. Anyway, I've moved that functionality to an own code generator for now.
There was also a minor fix in `Zend\Di\Di` which is probably too specific to the generator ( see https://github.com/zendframework/zf2/pull/1517/files#r998246 )
