### PR TITLE
allowing IPv6 addresses in HTTP URIs (fix ZF2-366)

### DIFF
--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -39,7 +39,7 @@ class Http extends Uri
     /**
      * @see Uri::$validHostTypes
      */
-    protected $validHostTypes = self::HOST_DNSORIPV4;
+    protected $validHostTypes = self::HOST_DNSORIPV6;
 
     /**
      * User name as provided in authority of URI

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -39,6 +39,7 @@ class Uri
     const HOST_IPVANY    = 7;
     const HOST_DNSNAME   = 8;
     const HOST_DNSORIPV4 = 9;
+    const HOST_DNSORIPV6 = 10;
     const HOST_REGNAME   = 16;
     const HOST_ALL       = 31;
 


### PR DESCRIPTION
This fixes http://framework.zend.com/issues/browse/ZF2-366
