### PR TITLE
Change the StandardAutoloader so that Zend namespace is optionally auto-registered

### DIFF
--- a/documentation/manual/en/module_specs/Zend_Loader-StandardAutoloader.xml
+++ b/documentation/manual/en/module_specs/Zend_Loader-StandardAutoloader.xml
@@ -6,7 +6,7 @@
         
 
         <para>
-            <classname>Zend\Loader\StandardAutoloader</classname> is designed as a <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://groups.google.com/group/php-standards/web/psr-0-final-proposal">PSR-0</link>-compliant
+            <classname>Zend\Loader\StandardAutoloader</classname> is designed as a <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md">PSR-0</link>-compliant
             autoloader. It assumes a 1:1 mapping of the namespace+classname to the filesystem,
             wherein namespace separators and underscores are translated to directory separators. A
             simple statement that illustrates how resolution works is as follows:
@@ -104,8 +104,8 @@ $filename = str_replace(array('_', '\\'), DIRECTORY_SEPARATOR, $classname)
         </para>
 
         <para>
-            By default, the class will register the "Zend" namespace to the directory above where
-            its own classfile is located on the filesystem.
+            If the option key 'autoregister_zf' is set to true then the class will register the "Zend" 
+            namespace to the directory above where its own classfile is located on the filesystem.
         </para>
 
         <example xml:id="zend.loader.standard-autoloader.quick-start.example-manual-configuration"><title>Manual Configuration</title>
@@ -116,7 +116,7 @@ $filename = str_replace(array('_', '\\'), DIRECTORY_SEPARATOR, $classname)
 // You could also load the autoloader class from a path relative to the
 // current script, or via an absolute path.
 require_once 'Zend/Loader/StandardAutoloader.php';
-$loader = new Zend\Loader\StandardAutoloader();
+$loader = new Zend\Loader\StandardAutoloader(array('autoregister_zf' => true));
 
 // Register the "Phly" namespace:
 $loader->registerNamespace('Phly', APPLICATION_PATH . '/../library/Phly');
@@ -165,6 +165,7 @@ $loader->register();
             <programlisting xml:lang="php"><![CDATA[
 require_once 'Zend/Loader/StandardAutoloader.php';
 $loader = new Zend\Loader\StandardAutoloader(array(
+    'autoregister_zf' => true,
     'namespaces' => array(
         'Phly' => APPLICATION_PATH . '/../library/Phly',
     ),
@@ -188,7 +189,6 @@ $loader->register();
         </para>
 
         <variablelist><title>StandardAutoloader Options</title>
-            
 
             <varlistentry>
                 <term>namespaces</term>
@@ -228,6 +228,19 @@ $loader->register();
                     </para>
                 </listitem>
             </varlistentry>
+
+            <varlistentry>
+                <term>autoregister_zf</term>
+
+                <listitem>
+                    <para>
+                        An boolean value indicating that the class should register the "Zend" 
+                        namespace to the directory above where its own classfile is located 
+                        on the filesystem.
+                    </para>
+                </listitem>
+            </varlistentry>            
+
         </variablelist>
     </section>
 

--- a/library/Zend/Loader/StandardAutoloader.php
+++ b/library/Zend/Loader/StandardAutoloader.php
@@ -41,6 +41,7 @@ class StandardAutoloader implements SplAutoloader
     const LOAD_NS          = 'namespaces';
     const LOAD_PREFIX      = 'prefixes';
     const ACT_AS_FALLBACK  = 'fallback_autoloader';
+    const AUTOREGISTER_ZF  = 'autoregister_zf';
 
     /**
      * @var array Namespace/directory pairs to search; ZF library added by default
@@ -65,8 +66,6 @@ class StandardAutoloader implements SplAutoloader
      */
     public function __construct($options = null)
     {
-        $this->registerNamespace('Zend', dirname(__DIR__));
-
         if (null !== $options) {
             $this->setOptions($options);
         }
@@ -102,6 +101,11 @@ class StandardAutoloader implements SplAutoloader
 
         foreach ($options as $type => $pairs) {
             switch ($type) {
+                case self::AUTOREGISTER_ZF:
+                    if ($pairs) {
+                        $this->registerNamespace('Zend', dirname(__DIR__));
+                    }
+                    break;
                 case self::LOAD_NS:
                     if (is_array($pairs) || $pairs instanceof \Traversable) {
                         $this->registerNamespaces($pairs);

--- a/tests/Zend/Loader/StandardAutoloaderTest.php
+++ b/tests/Zend/Loader/StandardAutoloaderTest.php
@@ -22,8 +22,9 @@
 
 namespace ZendTest\Loader;
 
-use Zend\Loader\StandardAutoloader,
-    Zend\Loader\Exception\InvalidArgumentException;
+use Zend\Loader\StandardAutoloader;
+use Zend\Loader\Exception\InvalidArgumentException;
+use ReflectionClass;
 
 /**
  * @category   Zend
@@ -190,4 +191,21 @@ class StandardAutoloaderTest extends \PHPUnit_Framework_TestCase
         $loader->autoload('ZendTest\UnusualNamespace\Name_Space\Namespaced_Class');
         $this->assertTrue(class_exists('ZendTest\UnusualNamespace\Name_Space\Namespaced_Class', false));
     }
+
+    public function testZendFrameworkNamespaceIsNotLoadedByDefault()
+    {
+        $loader = new StandardAutoloader();
+        $expected = array();
+        $this->assertAttributeEquals($expected, 'namespaces', $loader);
+    }
+
+    public function testCanTellAutoloaderToRegisterZendNamespaceAtInstantiation()
+    {
+        $loader = new StandardAutoloader(array('autoregister_zf' => true));
+        $r      = new ReflectionClass($loader);
+        $file   = $r->getFileName();
+        $expected = array('Zend\\' => dirname(dirname($file)) . DIRECTORY_SEPARATOR);
+        $this->assertAttributeEquals($expected, 'namespaces', $loader);
+    }
+
 }


### PR DESCRIPTION
Change the StandardAutoloader so that it only automatically registers the Zend namespace if the option key autoregister_zf is set to true in the constructor. Also update the link to PSR-0 in the StandardAutoloader documention
