### PR TITLE
Zend\Db\Sql\Select - 

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -564,7 +564,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 }
                 $columnSql .= $columnParts['sql'];
             } else {
-                $columnSql .= $platform->quoteIdentifier($column);
+                $columnSql .= $platform->quoteIdentifierInFragment($column);
             }
             $groups[] = $columnSql;
         }
@@ -599,9 +599,9 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 }
             }
             if (strtoupper($v) == self::ORDER_DESENDING) {
-                $orders[] = array($platform->quoteIdentifier($k), self::ORDER_DESENDING);
+                $orders[] = array($platform->quoteIdentifierInFragment($k), self::ORDER_DESENDING);
             } else {
-                $orders[] = array($platform->quoteIdentifier($k), self::ORDER_ASCENDING);
+                $orders[] = array($platform->quoteIdentifierInFragment($k), self::ORDER_ASCENDING);
             }
         }
         return array($orders);

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -530,7 +530,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $joinSpecArgArray[$j] = array();
             $joinSpecArgArray[$j][] = strtoupper($join['type']); // type
             $joinSpecArgArray[$j][] = $nameArg; // table
-            $joinSpecArgArray[$j][] = $platform->quoteIdentifierInFragment($join['on'], array('=', 'AND', 'OR', '(', ')')); // on
+            $joinSpecArgArray[$j][] = $platform->quoteIdentifierInFragment($join['on'], array('=', 'AND', 'OR', '(', ')', 'BETWEEN')); // on
         }
 
         return array($joinSpecArgArray);


### PR DESCRIPTION
I encountered the problem that the group and order methods don't let me have table names and values. 

Currently ->group('table.column') produces : 
GROUP BY `table.column` which I think should be `table`.`column`. 

I also added BETWEEN as on of the "don't quote words" in processJoin. 

Hopefully my changes are correct and I didn't do something wrong. 

P.S. First contribution :)
