### PR TITLE
Implement lazy-loading for Headers

### DIFF
--- a/library/Zend/Mail/Headers.php
+++ b/library/Zend/Mail/Headers.php
@@ -296,7 +296,11 @@ class Headers implements Iterator, Countable
         $results = array();
 
         foreach (array_keys($this->headersKeys, $key) as $index) {
-            $results[] = $this->headers[$index];
+            if ($this->headers[$index] instanceof Header\GenericHeader) {
+                $results[] = $this->lazyLoadHeader($index);
+            } else {
+                $results[] = $this->headers[$index];
+            }
         }
 
         switch(count($results)) {

--- a/tests/Zend/Mail/HeadersTest.php
+++ b/tests/Zend/Mail/HeadersTest.php
@@ -114,7 +114,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($headers->has('foobar'));
         $this->assertTrue($headers->has('foo'));
         $this->assertTrue($headers->has('Foo'));
-        $this->assertSame($f, $headers->get('foo'));
+        $this->assertEquals('bar', $headers->get('foo')->getFieldValue());
     }
 
     public function testHeadersAggregatesHeaderObjects()
@@ -123,7 +123,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $headers = new Mail\Headers();
         $headers->addHeader($fakeHeader);
         $this->assertEquals(1, $headers->count());
-        $this->assertSame($fakeHeader, $headers->get('Fake'));
+        $this->assertEquals('bar', $headers->get('Fake')->getFieldValue());
     }
 
     public function testHeadersAggregatesHeaderThroughAddHeader()


### PR DESCRIPTION
See DocBlock of `addHeaderLine()` which suggests that get() should support lazy-loading

[![Build Status](https://secure.travis-ci.org/davidwindell/zf2.png?branch=feature-mailheaders-lazyload)](http://travis-ci.org/davidwindell/zf2)
