### PR TITLE
[Composer] Add zendframework/zendframework1 as conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
     "config": {
         "bin-dir": "bin"
     },
+    "conflict": {
+        "zendframework/zendframework1": "*"
+    },
     "replace": {
         "zendframework/zend-acl": "self.version",
         "zendframework/zend-amf": "self.version",


### PR DESCRIPTION
zendframework/zendframework1 is incompatible with zendframework/zendframework because both register the same vendor name preffix (Zend)
