### PR TITLE
[Form] MultiCheckbox/Radio view helper - overrideable attributes per option

### DIFF
--- a/library/Zend/Form/View/Helper/FormMultiCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormMultiCheckbox.php
@@ -22,6 +22,7 @@
 namespace Zend\Form\View\Helper;
 
 use Traversable;
+use Zend\Loader\Pluggable;
 use Zend\Form\ElementInterface;
 use Zend\Form\Exception;
 
@@ -202,7 +203,7 @@ class FormMultiCheckbox extends FormInput
      */
     public function render(ElementInterface $element)
     {
-        $name   = static::getName($element);
+        $name = static::getName($element);
         if (empty($name)) {
             throw new Exception\DomainException(sprintf(
                 '%s requires that the element has an assigned name; none discovered',
@@ -221,54 +222,106 @@ class FormMultiCheckbox extends FormInput
             ));
         }
 
-        if (isset($attributes['labelAttributes'])) {
-            $labelAttributes = $attributes['labelAttributes'];
-            unset($attributes['labelAttributes']);
-        } else {
-            $labelAttributes = $this->labelAttributes;
-        }
-
         $options = $attributes['options'];
         unset($attributes['options']);
 
         $attributes['name'] = $name;
         $attributes['type'] = $this->getInputType();
 
-        $values = array();
+        $selectedOptions = array();
         if (isset($attributes['value'])) {
-            $values = (array) $attributes['value'];
+            $selectedOptions = (array) $attributes['value'];
             unset($attributes['value']);
+        }
+
+        $rendered = $this->renderOptions($options, $selectedOptions, $attributes);
+
+        // Render hidden element
+        $useHiddenElement = isset($attributes['useHiddenElement'])
+            ? (bool) $attributes['useHiddenElement']
+            : $this->useHiddenElement;
+
+        if ($useHiddenElement) {
+            $rendered = $this->renderHiddenElement($element, $attributes) . $rendered;
+        }
+
+        return $rendered;
+    }
+
+    protected function renderOptions(array $options, array $selectedOptions, array $attributes)
+    {
+        if (isset($attributes['labelAttributes'])) {
+            $globalLabelAttributes = $attributes['labelAttributes'];
+            unset($attributes['labelAttributes']);
+        } else {
+            $globalLabelAttributes = $this->labelAttributes;
         }
 
         $inputHelper    = $this->getInputHelper();
         $escapeHelper   = $this->getEscapeHelper();
         $labelHelper    = $this->getLabelHelper();
-        $labelOpen      = $labelHelper->openTag($labelAttributes);
         $labelClose     = $labelHelper->closeTag();
         $labelPosition  = $this->getLabelPosition();
         $closingBracket = $this->getInlineClosingBracket();
-        $template       = $labelOpen . '%s%s' . $labelClose;
+
         $combinedMarkup = array();
         $count          = 0;
 
-        foreach ($options as $label => $value) {
+        foreach ($options as $key => $optionSpec) {
             $count++;
             if ($count > 1 && array_key_exists('id', $attributes)) {
                 unset($attributes['id']);
             }
-            $attributes['value']   = $value;
-            $attributes['checked'] = '';
-            if (in_array($value, $values, true)) {
-                $attributes['checked'] = 'checked';
+
+            $value           = '';
+            $label           = $key;
+            $selected        = false;
+            $disabled        = false;
+            $inputAttributes = $attributes;
+            $labelAttributes = $globalLabelAttributes;
+
+            if (is_string($optionSpec) || is_numeric($optionSpec) || is_bool($optionSpec)) {
+                $optionSpec = array('value' => (string) $optionSpec);
             }
 
-            $label = $escapeHelper($label);
+            if (isset($optionSpec['value'])) {
+                $value = $optionSpec['value'];
+            }
+            if (isset($optionSpec['label'])) {
+                $label = $optionSpec['label'];
+            }
+            if (isset($optionSpec['selected'])) {
+                $selected = $optionSpec['selected'];
+            }
+            if (isset($optionSpec['disabled'])) {
+                $disabled = $optionSpec['disabled'];
+            }
+            if (isset($optionSpec['labelAttributes'])) {
+                $labelAttributes = (isset($labelAttributes))
+                    ? array_merge($labelAttributes, $optionSpec['labelAttributes'])
+                    : $optionSpec['labelAttributes'];
+            }
+            if (isset($optionSpec['attributes'])) {
+                $inputAttributes = array_merge($inputAttributes, $optionSpec['attributes']);
+            }
+
+            if (in_array($value, $selectedOptions, true)) {
+                $selected = true;
+            }
+
+            $inputAttributes['value']    = $value;
+            $inputAttributes['checked']  = $selected;
+            $inputAttributes['disabled'] = $disabled;
+
             $input = sprintf(
                 '<input %s%s',
-                $this->createAttributesString($attributes),
+                $this->createAttributesString($inputAttributes),
                 $closingBracket
             );
 
+            $label     = $escapeHelper($label);
+            $labelOpen = $labelHelper->openTag($labelAttributes);
+            $template  = $labelOpen . '%s%s' . $labelClose;
             switch ($labelPosition) {
                 case self::LABEL_PREPEND:
                     $markup = sprintf($template, $label, $input);
@@ -282,30 +335,34 @@ class FormMultiCheckbox extends FormInput
             $combinedMarkup[] = $markup;
         }
 
-        $rendered = implode($this->getSeparator(), $combinedMarkup);
+        return implode($this->getSeparator(), $combinedMarkup);
+    }
 
-        $useHiddenElement = isset($attributes['useHiddenElement'])
-            ? (bool) $attributes['useHiddenElement']
-            : $this->useHiddenElement;
+    /**
+     * Render a hidden element for empty/unchecked value
+     *
+     * @param  ElementInterface $element
+     * @param  array $attributes
+     * @return string
+     */
+    protected function renderHiddenElement(ElementInterface $element, array $attributes)
+    {
+        $closingBracket = $this->getInlineClosingBracket();
 
-        if ($useHiddenElement) {
-            $uncheckedValue = isset($attributes['uncheckedValue'])
+        $uncheckedValue = isset($attributes['uncheckedValue'])
                 ? $attributes['uncheckedValue']
                 : $this->uncheckedValue;
 
-            $hiddenAttributes = array(
-                'name'  => $element->getName(),
-                'value' => $uncheckedValue,
-            );
+        $hiddenAttributes = array(
+            'name'  => $element->getName(),
+            'value' => $uncheckedValue,
+        );
 
-            $rendered = sprintf(
-                '<input type="hidden" %s%s',
-                $this->createAttributesString($hiddenAttributes),
-                $closingBracket
-            ) . $rendered;
-        }
-
-        return $rendered;
+        return sprintf(
+            '<input type="hidden" %s%s',
+            $this->createAttributesString($hiddenAttributes),
+            $closingBracket
+        );
     }
 
     /**

--- a/tests/Zend/Form/View/Helper/FormMultiCheckboxTest.php
+++ b/tests/Zend/Form/View/Helper/FormMultiCheckboxTest.php
@@ -51,6 +51,24 @@ class FormMultiCheckboxTest extends CommonTestCase
         return $element;
     }
 
+    public function getElementWithOptionSpec()
+    {
+        $element = new Element('foo');
+        $options = array(
+            'This is the first label' => 'value1',
+            'This is the second label' => array(
+                'value'           => 'value2',
+                'label'           => 'This is the second label (overridden)',
+                'disabled'        => false,
+                'labelAttributes' => array('class' => 'label-class'),
+                'attributes'      => array('class' => 'input-class'),
+            ),
+            'This is the third label' => 'value3',
+        );
+        $element->setAttribute('options', $options);
+        return $element;
+    }
+
     public function testUsesOptionsAttributeToGenerateCheckBoxes()
     {
         $element = $this->getElement();
@@ -66,6 +84,36 @@ class FormMultiCheckboxTest extends CommonTestCase
             $this->assertContains(sprintf('>%s</label>', $label), $markup);
             $this->assertContains(sprintf('value="%s"', $value), $markup);
         }
+    }
+
+    public function testUsesOptionsAttributeWithOptionSpecToGenerateCheckBoxes()
+    {
+        $element = $this->getElementWithOptionSpec();
+        $options = $element->getAttribute('options');
+        $markup  = $this->helper->render($element);
+
+        $this->assertEquals(3, substr_count($markup, 'name="foo'));
+        $this->assertEquals(3, substr_count($markup, 'type="checkbox"'));
+        $this->assertEquals(3, substr_count($markup, '<input'));
+        $this->assertEquals(3, substr_count($markup, '<label'));
+
+        $this->assertContains(
+            sprintf('>%s</label>', 'This is the first label'), $markup
+        );
+        $this->assertContains(sprintf('value="%s"', 'value1'), $markup);
+
+        $this->assertContains(
+            sprintf('>%s</label>', 'This is the second label (overridden)'), $markup
+        );
+        $this->assertContains(sprintf('value="%s"', 'value2'), $markup);
+        $this->assertEquals(1, substr_count($markup, 'class="label-class"'));
+        $this->assertEquals(1, substr_count($markup, 'class="input-class"'));
+
+        $this->assertContains(
+            sprintf('>%s</label>', 'This is the third label'), $markup
+        );
+        $this->assertContains(sprintf('value="%s"', 'value3'), $markup);
+
     }
 
     public function testGenerateCheckBoxesAndHiddenElement()

--- a/tests/Zend/Form/View/Helper/FormRadioTest.php
+++ b/tests/Zend/Form/View/Helper/FormRadioTest.php
@@ -51,6 +51,24 @@ class FormRadioTest extends CommonTestCase
         return $element;
     }
 
+    public function getElementWithOptionSpec()
+    {
+        $element = new Element('foo');
+        $options = array(
+            'This is the first label' => 'value1',
+            'This is the second label' => array(
+                'value'           => 'value2',
+                'label'           => 'This is the second label (overridden)',
+                'disabled'        => false,
+                'labelAttributes' => array('class' => 'label-class'),
+                'attributes'      => array('class' => 'input-class'),
+            ),
+            'This is the third label' => 'value3',
+        );
+        $element->setAttribute('options', $options);
+        return $element;
+    }
+
     public function testUsesOptionsAttributeToGenerateRadioOptions()
     {
         $element = $this->getElement();
@@ -66,6 +84,36 @@ class FormRadioTest extends CommonTestCase
             $this->assertContains(sprintf('>%s</label>', $label), $markup);
             $this->assertContains(sprintf('value="%s"', $value), $markup);
         }
+    }
+
+    public function testUsesOptionsAttributeWithOptionSpecToGenerateRadioOptions()
+    {
+        $element = $this->getElementWithOptionSpec();
+        $options = $element->getAttribute('options');
+        $markup  = $this->helper->render($element);
+
+        $this->assertEquals(3, substr_count($markup, 'name="foo'));
+        $this->assertEquals(3, substr_count($markup, 'type="radio"'));
+        $this->assertEquals(3, substr_count($markup, '<input'));
+        $this->assertEquals(3, substr_count($markup, '<label'));
+
+        $this->assertContains(
+            sprintf('>%s</label>', 'This is the first label'), $markup
+        );
+        $this->assertContains(sprintf('value="%s"', 'value1'), $markup);
+
+        $this->assertContains(
+            sprintf('>%s</label>', 'This is the second label (overridden)'), $markup
+        );
+        $this->assertContains(sprintf('value="%s"', 'value2'), $markup);
+        $this->assertEquals(1, substr_count($markup, 'class="label-class"'));
+        $this->assertEquals(1, substr_count($markup, 'class="input-class"'));
+
+        $this->assertContains(
+            sprintf('>%s</label>', 'This is the third label'), $markup
+        );
+        $this->assertContains(sprintf('value="%s"', 'value3'), $markup);
+
     }
 
     public function testGenerateRadioOptionsAndHiddenElement()


### PR DESCRIPTION
@Freeaqingme had asked on IRC about having the ability to add an attribute to specific multi-checkbox/radio inputs (ie. Wanted to style one checkbox differently). Here's an attempt to solve that.

Borrowed ideas from FormSelect, with it's $optionSpec array which does something similar. I kept the $optionSpec keys the same (used "selected" instead of changing to "checked"), in case one might want to swap out view helpers.

``` php
// In a Form...
$multicbElement = new Element('multicb');
$multicbElement->setAttributes(array(
    'id' => 'my-multicb',
    'labelAttributes' => array(
        'class' => 'checkbox inline',
    ),
    'uncheckedValue' => 'uncheckedValue',
    'options' => array(
       'Option 1' => 'option1',
       'Option 2' => array(
            'value' => 'option2',
            'labelAttributes' => array(
                'class' => 'checkbox inline zf-green'
           ),
        ),
        'Option 3' => 'option3',
        'Option 4' => array(
            'value' => 'option4',
            'disabled' => true,
            'labelAttributes' => array(
                'class' => 'checkbox inline disabled'
            ),
            'attributes' => (
                'class' => 'disabled',
            ),
        ),
        'Option 5' => 'option5',
    ),
));
$this->add($multicbElement);
```
