### PR TITLE
fixed typo 'Zend\FOrm\Exception' => 'Zend\Form\Exception'

### DIFF
--- a/library/Zend/Form/View/Helper/Captcha/Figlet.php
+++ b/library/Zend/Form/View/Helper/Captcha/Figlet.php
@@ -23,7 +23,7 @@ namespace Zend\Form\View\Helper\Captcha;
 
 use Zend\Captcha\Figlet as CaptchaAdapter;
 use Zend\Form\ElementInterface;
-use Zend\FOrm\Exception;
+use Zend\Form\Exception;
 
 /**
  * @category   Zend

--- a/library/Zend/Form/View/Helper/Captcha/Image.php
+++ b/library/Zend/Form/View/Helper/Captcha/Image.php
@@ -23,7 +23,7 @@ namespace Zend\Form\View\Helper\Captcha;
 
 use Zend\Captcha\Image as CaptchaAdapter;
 use Zend\Form\ElementInterface;
-use Zend\FOrm\Exception;
+use Zend\Form\Exception;
 
 /**
  * @category   Zend


### PR DESCRIPTION
noted by @hoochie-coochie on #1538
