### PR TITLE
Fix Capital and geographical data of Thailand.

### DIFF
--- a/library/Zend/Date/Cities.php
+++ b/library/Zend/Date/Cities.php
@@ -68,7 +68,7 @@ class Cities
         'Baku'        => array('latitude' =>   40.3952778, 'longitude' =>   49.8822222),
         'Bamako'      => array('latitude' =>   12.65,      'longitude' =>   -8),
         'Bandar Seri Begawan' => array('latitude' => 4.8833333, 'longitude' => 114.9333333),
-        'Bankok'      => array('latitude' =>   13.5833333, 'longitude' =>  100.2166667),
+        'Bangkok'     => array('latitude' =>   13.757203, 'longitude' =>  100.502096),
         'Bangui'      => array('latitude' =>    4.3666667, 'longitude' =>   18.5833333),
         'Banjul'      => array('latitude' =>   13.4530556, 'longitude' =>  -16.5775),
         'Basel'       => array('latitude' =>   47.5666667, 'longitude' =>    7.6),


### PR DESCRIPTION
Reference:
Data from www.fallingrain.com/world are old data. For example new country as East Timor (Timor-Leste in Portuguese) http://en.wikipedia.org/wiki/East_Timor Internet TLD should be .tl (www.google.tl) but Internet TLD of East Timor in www.fallingrain.com/world is .tt that is Internet TLD of Trinidad and Tobago (www.google.tt) now.

For Capital of Thailand is "Bangkok" (http://en.wikipedia.org/wiki/Thailand).

If we use 13.5833333, 100.2166667 in google map. It's near Ban Ko, Mueang Samut Sakhon, Samut Sakhon 74000, Thailand.

For geographical data of Thailand, if it bases on the zero mile(kilometer). The zero kilometer marker of Thailand is about 13.757203, 100.502096 near Bowon Niwet, Phra Nakhon, Bangkok 10200, Thailand.

The zero kilometer marker of Thailand 's detail www.flickr.com/photos/ren-on/6611753203/sizes/l/in/photostream
