### PR TITLE
[ZF2-366][Uri] Add IPv6 to the list of valid types by default

### DIFF
--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -39,7 +39,7 @@ class Http extends Uri
     /**
      * @see Uri::$validHostTypes
      */
-    protected $validHostTypes = self::HOST_DNSORIPV6;
+    protected $validHostTypes = self::HOST_DNS_OR_IPV4_OR_IPV6;
 
     /**
      * User name as provided in authority of URI
@@ -56,7 +56,7 @@ class Http extends Uri
     /**
      * Check if the URI is a valid HTTP URI
      *
-     * This applys additional HTTP specific validation rules beyond the ones
+     * This applies additional HTTP specific validation rules beyond the ones
      * required by the generic URI syntax
      *
      * @return boolean
@@ -124,14 +124,14 @@ class Http extends Uri
     /**
      * Validate the host part of an HTTP URI
      *
-     * This overrides the common URI validation method with a DNS or IPv4 only
+     * This overrides the common URI validation method with a DNS or IP only
      * default. Users may still enforce allowing other host types.
      *
      * @param  string  $host
      * @param  integer $allowed
      * @return boolean
      */
-    public static function validateHost($host, $allowed = self::HOST_DNSORIPV4)
+    public static function validateHost($host, $allowed = self::HOST_DNS_OR_IPV4_OR_IPV6)
     {
         return parent::validateHost($host, $allowed);
     }

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -31,17 +31,23 @@ class Uri
     const CHAR_RESERVED   = ':\/\?#\[\]@!\$&\'\(\)\*\+,;=';
 
     /**
-     * Host part types
+     * Host part types represented as binary masks
+     * The binary mask consists of 5 bits in the following order:
+     * <RegName> | <DNS> | <IPvFuture> | <IPv6> | <IPv4>
+     * Place 1 or 0 in the different positions for enable or disable the part.
+     * Finally use a hexadecimal representation.
      */
-    const HOST_IPV4      = 1;
-    const HOST_IPV6      = 2;
-    const HOST_IPVF      = 4;
-    const HOST_IPVANY    = 7;
-    const HOST_DNSNAME   = 8;
-    const HOST_DNSORIPV4 = 9;
-    const HOST_DNSORIPV6 = 10;
-    const HOST_REGNAME   = 16;
-    const HOST_ALL       = 31;
+    const HOST_IPV4                 = 0x01; //00001
+    const HOST_IPV6                 = 0x02; //00010
+    const HOST_IPVFUTURE            = 0x04; //00100
+    const HOST_IPVANY               = 0x07; //00111
+    const HOST_DNS                  = 0x08; //01000
+    const HOST_DNS_OR_IPV4          = 0x09; //01001
+    const HOST_DNS_OR_IPV6          = 0x0A; //01010
+    const HOST_DNS_OR_IPV4_OR_IPV6  = 0x0B; //01011
+    const HOST_DNS_OR_IPVANY        = 0x0F; //01111
+    const HOST_REGNAME              = 0x10; //10000
+    const HOST_ALL                  = 0x1F; //11111
 
     /**
      * URI scheme
@@ -835,7 +841,7 @@ class Uri
             }
         }
 
-        if ($allowed & self::HOST_DNSNAME) {
+        if ($allowed & self::HOST_DNS) {
             if (static::isValidDnsHostname($host)) {
                 return true;
             }
@@ -1105,7 +1111,7 @@ class Uri
             'allowipv6' => (bool) ($allowed & self::HOST_IPV6),
         );
 
-        if ($allowed & (self::HOST_IPV6 | self::HOST_IPVF)) {
+        if ($allowed & (self::HOST_IPV6 | self::HOST_IPVFUTURE)) {
             if (preg_match('/^\[(.+)\]$/', $host, $match)) {
                 $host = $match[1];
                 $validatorParams['allowipv4'] = false;
@@ -1119,7 +1125,7 @@ class Uri
             }
         }
 
-        if ($allowed & self::HOST_IPVF) {
+        if ($allowed & self::HOST_IPVFUTURE) {
             $regex = '/^v\.[[:xdigit:]]+[' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . ':]+$/';
             return (bool) preg_match($regex, $host);
         }

--- a/tests/Zend/Uri/HttpTest.php
+++ b/tests/Zend/Uri/HttpTest.php
@@ -45,7 +45,7 @@ class HttpTest extends TestCase
      *
      * @return array
      */
-    static public function validSchemeProvider()
+    public function validSchemeProvider()
     {
         return array(
             array('http'),
@@ -55,12 +55,39 @@ class HttpTest extends TestCase
         );
     }
 
+    public function validHostProvider()
+    {
+        return array(
+            array('',                                   false),
+            array('http',                               true),
+            array('http:',                              false),
+            array('http:/',                             false),
+            array('http://',                            false),
+            array('http:///',                           false),
+            array('http://www.example.org/',            false),
+            array('www.example.org:80',                 false),
+            array('www.example.org',                    true),
+            array('http://foo',                         false),
+            array('foo',                                true),
+            array('ftp://user:pass@example.org/',       false),
+            array('www.fi/',                            false),
+            array('http://1.1.1.1/',                    false),
+            array('1.1.1.1',                            true),
+            array('1.256.1.1',                          true), // Hostnames can be only numbers
+            array('http://[::1]/',                      false),
+            array('[::1]',                              true),
+            array('http://[2620:0:1cfe:face:b00c::3]/', false),
+            array('[2620:0:1cfe:face:b00c::3]:80',      false),
+            array('[2620:0:1cfe:face:b00c::3]',         true),
+        );
+    }
+
     /**
      * Invalid HTTP schemes
      *
      * @return array
      */
-    static public function invalidSchemeProvider()
+    public function invalidSchemeProvider()
     {
         return array(
             array('file'),
@@ -70,7 +97,7 @@ class HttpTest extends TestCase
         );
     }
 
-    static public function portNormalizationTestsProvider()
+    public function portNormalizationTestsProvider()
     {
         return array(
             array('http://www.example.com:80/foo/bar', 'http://www.example.com/foo/bar'),
@@ -121,6 +148,19 @@ class HttpTest extends TestCase
     public function testValidateSchemeInvalid($scheme)
     {
         $this->assertFalse(HttpUri::validateScheme($scheme));
+    }
+
+    /**
+     * Test the validity of the hosts
+     *
+     * @param string  $host
+     * @param boolean $expected
+     * @return void
+     * @dataProvider validHostProvider
+     */
+    public function testValidateHost($host, $expected)
+    {
+        $this->assertEquals($expected, HttpUri::validateHost($host), "Wrong Host validation $host");
     }
 
     /**


### PR DESCRIPTION
Replaces the changes made in #1524 (4367cfa0748b4591c5f6a73d1abde6f0be1d21a4)

[![Build Status](https://secure.travis-ci.org/Maks3w/zf2.png?branch=uri-validation)](http://travis-ci.org/Maks3w/zf2)
