### PR TITLE
Added Form Display view helper

### DIFF
--- a/library/Zend/Form/BaseForm.php
+++ b/library/Zend/Form/BaseForm.php
@@ -412,7 +412,7 @@ class BaseForm extends Fieldset implements FormInterface
         }
         return $this->filter;
     }
-
+    
     /**
      * Extract values from the bound object and populate
      * the form elements

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -210,4 +210,17 @@ class Form extends BaseForm implements FormFactoryAwareInterface
             $inputFilter->add($filter, $name);
         }
     }
+    
+    /* (non-PHPdoc)
+     * Retrieve all elements in the form, include those in the fieldsets
+     * 
+     * @see \Zend\Form\Fieldset::getElements()
+     */
+    public function getElements() {
+    	$elements = parent::getElements();
+    	foreach ($this->getFieldsets() as $fieldSet) { /* @var $fieldSet Fieldset */
+    		$elements = array_merge($elements, $fieldSet->getElements());
+    	}
+    	return $elements;
+    }
 }

--- a/library/Zend/Form/View/Helper/FormDisplay.php
+++ b/library/Zend/Form/View/Helper/FormDisplay.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Zend\Form\View\Helper;
+
+use Zend\Form\Form as zendForm;
+
+class FormDisplay extends AbstractHelper {
+	/**
+	 * Retrieve a printable form string
+	 *
+	 * @param zendForm $form
+	 * @return string
+	 */
+	public function __invoke(zendForm $form, $renderer = null) {
+		if (is_null($renderer)) {
+			$renderer = $this->getView()->formtable();
+		}
+		
+		$result = '';
+		
+		// Render the opening tag
+		$result .= $this->getView()->form()->openTag($form);
+		
+		foreach ($form->getFieldsets() as $fieldSet) { /* @var $fieldSet Fieldset */
+			$result .= '<fieldset><legend>'.$fieldSet->getName().'</legend>';
+			
+			$result .= $renderer->openTag();
+			
+			foreach ($fieldSet->getElements() as $element) { /* @var $element Element */
+				$result .= $renderer->element($element);
+			}
+			
+			$result .= $renderer->closeTag();
+			
+			$result .= '</fieldset>';
+		}
+
+		$result .= $renderer->openTag();
+		
+		foreach ($form->getElements() as $element) { /* @var $element Element */
+			$result .= $renderer->element($element);
+		}
+		
+		$result .= $renderer->closeTag();
+		
+		$result .= $this->getView()->form()->closeTag($form);
+		
+		return $result;
+	}
+}	

--- a/library/Zend/Form/View/Helper/Renderer/RendererInterface.php
+++ b/library/Zend/Form/View/Helper/Renderer/RendererInterface.php
@@ -1,0 +1,23 @@
+<?php
+namespace Zend\Form\View\Helper\Renderer;
+
+use Zend\Form\Element;
+
+interface RendererInterface
+{
+	/**
+	 * @return string
+	 */
+	public function openTag();
+	
+	/**
+	 * @return string
+	 */
+	public function closeTag();
+	
+	/**
+	 * @param Element $element
+	 * @return string
+	 */
+	public function element(Element $element);
+}

--- a/library/Zend/Form/View/Helper/Renderer/Table.php
+++ b/library/Zend/Form/View/Helper/Renderer/Table.php
@@ -1,0 +1,47 @@
+<?php
+namespace Zend\Form\View\Helper\Renderer;
+
+use Zend\View\Helper\AbstractHelper,
+	Zend\Form\Element;
+
+class Table extends AbstractHelper {
+
+	/**
+	 * @return Table
+	 */
+	public function __invoke() {
+		return $this;
+	}
+	
+	/**
+	 * @return string
+	 */
+	public function openTag() {
+		return '<table class="zend-form-table">';
+	}
+	
+	/**
+	 * @return string
+	 */
+	public function closeTag() {
+		return '</table>';
+	}
+	
+	/**
+	 * @param Element $element
+	 * @return string
+	 */
+	public function element(Element $element) {
+		$label = is_null($element->getAttribute('label')) ? '' : $this->getView()->FormLabel($element);	
+		$value = $this->getView()->FormElement($element);
+		$errors = $this->getView()->FormElementErrors($element);
+		
+		return <<<ELEMENT
+<tr>
+	<td>{$label}</td>
+	<td>{$value}</td>
+	<td>{$errors}</td>
+</tr>
+ELEMENT;
+	}
+}

--- a/library/Zend/Form/View/Helper/Renderer/Table.php
+++ b/library/Zend/Form/View/Helper/Renderer/Table.php
@@ -4,7 +4,7 @@ namespace Zend\Form\View\Helper\Renderer;
 use Zend\View\Helper\AbstractHelper,
 	Zend\Form\Element;
 
-class Table extends AbstractHelper {
+class Table extends AbstractHelper implements RendererInterface {
 
 	/**
 	 * @return Table

--- a/library/Zend/Form/View/HelperLoader.php
+++ b/library/Zend/Form/View/HelperLoader.php
@@ -109,6 +109,7 @@ class HelperLoader extends PluginClassLoader
         'formtextarea'           => 'Zend\Form\View\Helper\FormTextarea',
         'form_textarea'          => 'Zend\Form\View\Helper\FormTextarea',
         'formdisplay'            => 'Zend\Form\View\Helper\FormDisplay',
+        'rendererInterface'    	 => 'Zend\Form\View\Helper\Renderer\RendererInterface',
         'formtable'            	 => 'Zend\Form\View\Helper\Renderer\Table',
     );
 }

--- a/library/Zend/Form/View/HelperLoader.php
+++ b/library/Zend/Form/View/HelperLoader.php
@@ -108,5 +108,7 @@ class HelperLoader extends PluginClassLoader
         'form_text'              => 'Zend\Form\View\Helper\FormText',
         'formtextarea'           => 'Zend\Form\View\Helper\FormTextarea',
         'form_textarea'          => 'Zend\Form\View\Helper\FormTextarea',
+        'formdisplay'            => 'Zend\Form\View\Helper\FormDisplay',
+        'formtable'            	 => 'Zend\Form\View\Helper\Renderer\Table',
     );
 }


### PR DESCRIPTION
This helper retrieve a formatted form just like the old echo $this->form

example:

```
echo $this->formdisplay($form);
```

Also extended the `Zend\Form\Form::getElements()` to retrieve all elements, include those in the fieldsets
