### PR TITLE
Zend\Crypt binary output over subcomponents

### DIFF
--- a/library/Zend/Crypt/BlockCipher.php
+++ b/library/Zend/Crypt/BlockCipher.php
@@ -7,6 +7,7 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  * @package   Zend_Crypt
  */
+
 namespace Zend\Crypt;
 
 use Zend\Crypt\Symmetric\SymmetricInterface;
@@ -20,42 +21,46 @@ use Zend\Math\Math;
  *
  * @category   Zend
  * @package    Zend_Crypt
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class BlockCipher
 {
     const KEY_DERIV_HMAC = 'sha256';
+
     /**
      * Symmetric cipher
      *
      * @var SymmetricInterface
      */
     protected $cipher;
+
     /**
      * Symmetric cipher broker
      *
      * @var SymmetricBroker
      */
     protected static $symmetricBroker = null;
+
     /**
      * Hash algorithm fot HMAC
      *
      * @var string
      */
     protected $hash = 'sha256';
+
     /**
      * The output is binary?
      *
      * @var boolean
      */
     protected $binaryOutput = false;
+
     /**
      * User's key
      *
      * @var string
      */
     protected $key;
+
     /**
      * Number of iterations for Pbkdf2
      *
@@ -278,7 +283,7 @@ class BlockCipher
     {
         if (!Hash::isSupported($hash)) {
             throw new Exception\InvalidArgumentException(
-                "The specified hash algorithm $hash is not supported by Zend\Crypt\Hash"
+                "The specified hash algorithm '{$hash}' is not supported by Zend\Crypt\Hash"
             );
         }
         $this->hash = $hash;
@@ -328,7 +333,7 @@ class BlockCipher
         $keyHmac = substr($hash, $keySize);
         // encryption
         $ciphertext = $this->cipher->encrypt($data);
-        // HMAC 
+        // HMAC
         $hmac = Hmac::compute($keyHmac,
                               $this->hash,
                               $this->cipher->getAlgorithm() . $ciphertext);

--- a/library/Zend/Crypt/Hash.php
+++ b/library/Zend/Crypt/Hash.php
@@ -16,6 +16,9 @@ namespace Zend\Crypt;
  */
 class Hash
 {
+    const OUTPUT_STRING = 'string';
+    const OUTPUT_BINARY = 'binary';
+
     /**
      * List of hash algorithms supported
      *
@@ -26,11 +29,11 @@ class Hash
     /**
      * @param  string $hash
      * @param  string $data
-     * @param  bool   $binaryOutput
+     * @param  string $output
      * @throws Exception\InvalidArgumentException
      * @return string
      */
-    public static function compute($hash, $data, $binaryOutput = false)
+    public static function compute($hash, $data, $output = self::OUTPUT_STRING)
     {
         $hash = strtolower($hash);
         if (!self::isSupported($hash)) {
@@ -39,19 +42,20 @@ class Hash
             );
         }
 
-        return hash($hash, $data, (bool) $binaryOutput);
+        $output = ($output === self::OUTPUT_BINARY);
+        return hash($hash, $data, $output);
     }
 
     /**
      * Get the output size according to the hash algorithm and the output format
      *
      * @param  string $hash
-     * @param  bool   $binaryOutput
+     * @param  string $output
      * @return integer
      */
-    public static function getOutputSize($hash, $binaryOutput = false)
+    public static function getOutputSize($hash, $output = self::OUTPUT_STRING)
     {
-        return strlen(self::compute($hash, 'data', (bool) $binaryOutput));
+        return strlen(self::compute($hash, 'data', $output));
     }
 
     /**

--- a/library/Zend/Crypt/Hash.php
+++ b/library/Zend/Crypt/Hash.php
@@ -7,18 +7,15 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  * @package   Zend_Crypt
  */
+
 namespace Zend\Crypt;
 
 /**
  * @category   Zend
  * @package    Zend_Crypt
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Hash
 {
-    const STRING = 'string';
-    const BINARY = 'binary';
     /**
      * List of hash algorithms supported
      *
@@ -29,31 +26,32 @@ class Hash
     /**
      * @param  string $hash
      * @param  string $data
-     * @param  string $output
+     * @param  bool   $binaryOutput
      * @throws Exception\InvalidArgumentException
      * @return string
      */
-    public static function compute($hash, $data, $output = self::STRING)
+    public static function compute($hash, $data, $binaryOutput = false)
     {
         $hash = strtolower($hash);
         if (!self::isSupported($hash)) {
-            throw new Exception\InvalidArgumentException('Hash algorithm provided is not supported on this PHP installation');
+            throw new Exception\InvalidArgumentException(
+                'Hash algorithm provided is not supported on this PHP installation'
+            );
         }
 
-        $output = ($output === self::BINARY);
-        return hash($hash, $data, $output);
+        return hash($hash, $data, (bool) $binaryOutput);
     }
 
     /**
      * Get the output size according to the hash algorithm and the output format
      *
      * @param  string $hash
-     * @param  string $output
+     * @param  bool   $binaryOutput
      * @return integer
      */
-    public static function getOutputSize($hash, $output = self::STRING)
+    public static function getOutputSize($hash, $binaryOutput = false)
     {
-        return strlen(self::compute($hash, 'data', $output));
+        return strlen(self::compute($hash, 'data', (bool) $binaryOutput));
     }
 
     /**

--- a/library/Zend/Crypt/Hmac.php
+++ b/library/Zend/Crypt/Hmac.php
@@ -18,6 +18,9 @@ namespace Zend\Crypt;
  */
 class Hmac
 {
+    const OUTPUT_STRING = 'string';
+    const OUTPUT_BINARY = 'binary';
+
     /**
      * List of hash algorithms supported
      *
@@ -33,11 +36,11 @@ class Hmac
      * @param  string $key
      * @param  string $hash
      * @param  string $data
-     * @param  bool   $binaryOutput
+     * @param  string $output
      * @throws Exception\InvalidArgumentException
      * @return string
      */
-    public static function compute($key, $hash, $data, $binaryOutput = false)
+    public static function compute($key, $hash, $data, $output = self::OUTPUT_STRING)
     {
         if (!isset($key) || empty($key)) {
             throw new Exception\InvalidArgumentException('Provided key is null or empty');
@@ -50,19 +53,20 @@ class Hmac
             );
         }
 
-        return hash_hmac($hash, $data, $key, (bool) $binaryOutput);
+        $output = ($output === self::OUTPUT_BINARY);
+        return hash_hmac($hash, $data, $key, $output);
     }
 
     /**
      * Get the output size according to the hash algorithm and the output format
      *
      * @param  string $hash
-     * @param  bool $binaryOutput
+     * @param  string $output
      * @return integer
      */
-    public static function getOutputSize($hash, $binaryOutput = false)
+    public static function getOutputSize($hash, $output = self::OUTPUT_STRING)
     {
-        return strlen(self::compute('key', $hash, 'data', (bool) $binaryOutput));
+        return strlen(self::compute('key', $hash, 'data', $output));
     }
 
     /**

--- a/library/Zend/Crypt/Hmac.php
+++ b/library/Zend/Crypt/Hmac.php
@@ -7,6 +7,7 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  * @package   Zend_Crypt
  */
+
 namespace Zend\Crypt;
 
 /**
@@ -14,8 +15,6 @@ namespace Zend\Crypt;
  *
  * @category   Zend
  * @package    Zend_Crypt
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Hmac
 {
@@ -27,24 +26,18 @@ class Hmac
     protected static $supportedAlgorithms = array();
 
     /**
-     * Constants representing the output mode of the hash algorithm
-     */
-    const STRING = 'string';
-    const BINARY = 'binary';
-
-    /**
      * Performs a HMAC computation given relevant details such as Key, Hashing
      * algorithm, the data to compute MAC of, and an output format of String,
-     * Binary notation or BTWOC.
+     * or Binary.
      *
      * @param  string $key
      * @param  string $hash
      * @param  string $data
-     * @param  string $output
+     * @param  bool   $binaryOutput
      * @throws Exception\InvalidArgumentException
      * @return string
      */
-    public static function compute($key, $hash, $data, $output = self::STRING)
+    public static function compute($key, $hash, $data, $binaryOutput = false)
     {
         if (!isset($key) || empty($key)) {
             throw new Exception\InvalidArgumentException('Provided key is null or empty');
@@ -52,26 +45,24 @@ class Hmac
 
         $hash = strtolower($hash);
         if (!self::isSupported($hash)) {
-            throw new Exception\InvalidArgumentException('Hash algorithm provided is not supported on this PHP installation');
+            throw new Exception\InvalidArgumentException(
+                "Hash algorithm is not supported on this PHP installation; provided '{$hash}'"
+            );
         }
 
-        if ($output == self::BINARY) {
-            return hash_hmac($hash, $data, $key, 1);
-        } else {
-            return hash_hmac($hash, $data, $key);
-        }
+        return hash_hmac($hash, $data, $key, (bool) $binaryOutput);
     }
 
     /**
      * Get the output size according to the hash algorithm and the output format
      *
      * @param  string $hash
-     * @param  string $output
+     * @param  bool $binaryOutput
      * @return integer
      */
-    public static function getOutputSize($hash, $output = self::STRING)
+    public static function getOutputSize($hash, $binaryOutput = false)
     {
-        return strlen(self::compute('key', $hash, 'data', $output));
+        return strlen(self::compute('key', $hash, 'data', (bool) $binaryOutput));
     }
 
     /**

--- a/library/Zend/Crypt/Key/Derivation/Pbkdf2.php
+++ b/library/Zend/Crypt/Key/Derivation/Pbkdf2.php
@@ -36,13 +36,13 @@ class Pbkdf2
         if (!in_array($hash, Hmac::getSupportedAlgorithms())) {
             throw new Exception\InvalidArgumentException("The hash algorihtm $hash is not supported by " . __CLASS__);
         }
-        $num    = ceil($length / Hmac::getOutputSize($hash, true));
+        $num    = ceil($length / Hmac::getOutputSize($hash, Hmac::OUTPUT_BINARY));
         $result = '';
         for ($block = 1; $block <= $num; $block++) {
-            $hmac = Hmac::compute($password, $hash, $salt . pack('N', $block), true);
+            $hmac = Hmac::compute($password, $hash, $salt . pack('N', $block), Hmac::OUTPUT_BINARY);
             $mix  = $hmac; 
             for ($i = 1; $i < $iterations; $i++) {
-                $hmac = Hmac::compute($password, $hash, $hmac, true);
+                $hmac = Hmac::compute($password, $hash, $hmac, Hmac::OUTPUT_BINARY);
                 $mix ^= $hmac;    
             }
             $result .= $mix;

--- a/library/Zend/Crypt/Key/Derivation/Pbkdf2.php
+++ b/library/Zend/Crypt/Key/Derivation/Pbkdf2.php
@@ -7,6 +7,7 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  * @package   Zend_Crypt
  */
+
 namespace Zend\Crypt\Key\Derivation;
 
 use Zend\Crypt\Hmac;
@@ -16,8 +17,6 @@ use Zend\Crypt\Hmac;
  *
  * @category   Zend
  * @package    Zend_Crypt
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Pbkdf2
 {
@@ -37,13 +36,13 @@ class Pbkdf2
         if (!in_array($hash, Hmac::getSupportedAlgorithms())) {
             throw new Exception\InvalidArgumentException("The hash algorihtm $hash is not supported by " . __CLASS__);
         }
-        $num    = ceil($length / Hmac::getOutputSize($hash, Hmac::BINARY));
+        $num    = ceil($length / Hmac::getOutputSize($hash, true));
         $result = '';
         for ($block = 1; $block <= $num; $block++) {
-            $hmac = Hmac::compute($password, $hash, $salt . pack('N', $block), Hmac::BINARY);
+            $hmac = Hmac::compute($password, $hash, $salt . pack('N', $block), true);
             $mix  = $hmac; 
             for ($i = 1; $i < $iterations; $i++) {
-                $hmac = Hmac::compute($password, $hash, $hmac, Hmac::BINARY);
+                $hmac = Hmac::compute($password, $hash, $hmac, true);
                 $mix ^= $hmac;    
             }
             $result .= $mix;

--- a/library/Zend/Crypt/PublicKey/Rsa/AbstractKey.php
+++ b/library/Zend/Crypt/PublicKey/Rsa/AbstractKey.php
@@ -7,9 +7,8 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  * @package   Zend_Crypt
  */
-namespace Zend\Crypt\PublicKey\Rsa;
 
-use Countable;
+namespace Zend\Crypt\PublicKey\Rsa;
 
 /**
  * @category   Zend
@@ -17,21 +16,16 @@ use Countable;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class AbstractKey implements Countable
+abstract class AbstractKey
 {
     const DEFAULT_KEY_SIZE = 2048;
 
     /**
+     * PEM formatted key
+     *
      * @var string
      */
     protected $pemString = null;
-
-    /**
-     * Bits, key string and type of key
-     *
-     * @var array
-     */
-    protected $details = array();
 
     /**
      * Key Resource
@@ -39,6 +33,23 @@ abstract class AbstractKey implements Countable
      * @var resource
      */
     protected $opensslKeyResource = null;
+
+    /**
+     * Openssl details array
+     *
+     * @var array
+     */
+    protected $details = array();
+
+    /**
+     * Get key size in bits
+     *
+     * @return int
+     */
+    public function getSize()
+    {
+        return $this->details['bits'];
+    }
 
     /**
      * Retrieve openssl key resource
@@ -82,25 +93,5 @@ abstract class AbstractKey implements Countable
     public function __toString()
     {
         return $this->toString();
-    }
-
-    /**
-     * Count
-     *
-     * @return integer
-     */
-    public function count()
-    {
-        return $this->details['bits'];
-    }
-
-    /**
-     * Get type
-     *
-     * @return string
-     */
-    public function getType()
-    {
-        return $this->details['type'];
     }
 }

--- a/library/Zend/Crypt/PublicKey/Rsa/Exception/ExceptionInterface.php
+++ b/library/Zend/Crypt/PublicKey/Rsa/Exception/ExceptionInterface.php
@@ -7,6 +7,7 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  * @package   Zend_Crypt
  */
+
 namespace Zend\Crypt\PublicKey\Rsa\Exception;
 
 use Zend\Crypt\Exception\ExceptionInterface as Exception;
@@ -14,8 +15,7 @@ use Zend\Crypt\Exception\ExceptionInterface as Exception;
 /**
  * @category   Zend
  * @package    Zend_Crypt
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage PublicKey
  */
 interface ExceptionInterface extends Exception
 {}

--- a/library/Zend/Crypt/PublicKey/Rsa/Exception/InvalidArgumentException.php
+++ b/library/Zend/Crypt/PublicKey/Rsa/Exception/InvalidArgumentException.php
@@ -7,6 +7,7 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  * @package   Zend_Crypt
  */
+
 namespace Zend\Crypt\PublicKey\Rsa\Exception;
 
 use Zend\Crypt\Exception;
@@ -16,10 +17,9 @@ use Zend\Crypt\Exception;
  *
  * @category   Zend
  * @package    Zend_Crypt
- * @subpackage Exception
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage PublicKey
  */
-class InvalidArgumentException extends Exception\InvalidArgumentException implements 
-    ExceptionInterface
+class InvalidArgumentException
+    extends Exception\InvalidArgumentException
+    implements ExceptionInterface
 {}

--- a/library/Zend/Crypt/PublicKey/Rsa/Exception/RuntimeException.php
+++ b/library/Zend/Crypt/PublicKey/Rsa/Exception/RuntimeException.php
@@ -7,6 +7,7 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  * @package   Zend_Crypt
  */
+
 namespace Zend\Crypt\PublicKey\Rsa\Exception;
 
 use Zend\Crypt\Exception;
@@ -16,10 +17,9 @@ use Zend\Crypt\Exception;
  *
  * @category   Zend
  * @package    Zend_Crypt
- * @subpackage Rsa_Exception
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage PublicKey
  */
-class RuntimeException extends Exception\RuntimeException implements 
-    ExceptionInterface
+class RuntimeException
+    extends Exception\RuntimeException
+    implements ExceptionInterface
 {}

--- a/library/Zend/Crypt/PublicKey/Rsa/PrivateKey.php
+++ b/library/Zend/Crypt/PublicKey/Rsa/PrivateKey.php
@@ -7,13 +7,15 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  * @package   Zend_Crypt
  */
+
 namespace Zend\Crypt\PublicKey\Rsa;
 
 /**
+ * RSA private key
+ *
  * @category   Zend
  * @package    Zend_Crypt
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage PublicKey
  */
 class PrivateKey extends AbstractKey
 {
@@ -25,11 +27,30 @@ class PrivateKey extends AbstractKey
     protected $publicKey = null;
 
     /**
+     * Create private key instance from PEM formatted key file
+     *
+     * @param  string      $pemFile
+     * @param  string|null $passPhrase
+     * @return PrivateKey
+     * @throws Exception\InvalidArgumentException
+     */
+    public static function fromFile($pemFile, $passPhrase = null)
+    {
+        if (!is_readable($pemFile)) {
+            throw new Exception\InvalidArgumentException(
+                "PEM file '{$pemFile}' is not readable"
+            );
+        }
+
+        return new static(file_get_contents($pemFile), $passPhrase);
+    }
+
+    /**
      * Constructor
      *
-     * @param string $pemString
-     * @param string $passPhrase
-     * @throws  Exception\RuntimeException
+     * @param  string $pemString
+     * @param  string $passPhrase
+     * @throws Exception\RuntimeException
      */
     public function __construct($pemString, $passPhrase = null)
     {
@@ -62,12 +83,17 @@ class PrivateKey extends AbstractKey
     /**
      * Encrypt using this key
      *
-     * @param string $data
+     * @param  string $data
      * @return string
      * @throws Exception\RuntimeException
+     * @throws Exception\InvalidArgumentException
      */
     public function encrypt($data)
     {
+        if (empty($data)) {
+            throw new Exception\InvalidArgumentException('The data to encrypt cannot be empty');
+        }
+
         $encrypted = '';
         $result = openssl_private_encrypt($data, $encrypted, $this->getOpensslKeyResource());
         if (false === $result) {
@@ -79,16 +105,23 @@ class PrivateKey extends AbstractKey
         return $encrypted;
     }
 
-
     /**
      * Decrypt using this key
      *
-     * @param string $data
+     * @param  string $data
      * @return string
      * @throws Exception\RuntimeException
+     * @throws Exception\InvalidArgumentException
      */
     public function decrypt($data)
     {
+        if (!is_string($data)) {
+            throw new Exception\InvalidArgumentException('The data to decrypt must be a string');
+        }
+        if ('' === $data) {
+            throw new Exception\InvalidArgumentException('The data to decrypt cannot be empty');
+        }
+
         $decrypted = '';
         $result = openssl_private_decrypt($data, $decrypted, $this->getOpensslKeyResource());
         if (false === $result) {

--- a/library/Zend/Crypt/PublicKey/Rsa/PublicKey.php
+++ b/library/Zend/Crypt/PublicKey/Rsa/PublicKey.php
@@ -7,13 +7,15 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  * @package   Zend_Crypt
  */
+
 namespace Zend\Crypt\PublicKey\Rsa;
 
 /**
- * @category   Zend
- * @package    Zend_Crypt
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * RSA public key
+ *
+ * @category    Zend
+ * @package     Zend_Crypt
+ * @subpackage  PublicKey
  */
 class PublicKey extends AbstractKey
 {
@@ -25,22 +27,43 @@ class PublicKey extends AbstractKey
     protected $certificateString = null;
 
     /**
-     * @param string $string
+     * Create public key instance public key from PEM formatted key file
+     * or X.509 certificate file
+     *
+     * @param  string      $pemOrCertificateFile
+     * @return PublicKey
+     * @throws Exception\InvalidArgumentException
+     */
+    public static function fromFile($pemOrCertificateFile)
+    {
+        if (!is_readable($pemOrCertificateFile)) {
+            throw new Exception\InvalidArgumentException(
+                "File '{$pemOrCertificateFile}' is not readable"
+            );
+        }
+
+        return new static(file_get_contents($pemOrCertificateFile));
+    }
+
+    /**
+     * Construct public key with PEM formatted string or X.509 certificate
+     *
+     * @param  string $pemStringOrCertificate
      * @throws Exception\RuntimeException
      */
-    public function __construct($string)
+    public function __construct($pemStringOrCertificate)
     {
-        $result = openssl_pkey_get_public($string);
+        $result = openssl_pkey_get_public($pemStringOrCertificate);
         if (false === $result) {
             throw new Exception\RuntimeException(
                 'Unable to load public key; openssl ' . openssl_error_string()
             );
         }
 
-        if (strpos($string, self::CERT_START) !== false) {
-            $this->certificateString = $string;
+        if (strpos($pemStringOrCertificate, self::CERT_START) !== false) {
+            $this->certificateString = $pemStringOrCertificate;
         } else {
-            $this->pemString = $string;
+            $this->pemString = $pemStringOrCertificate;
         }
 
         $this->opensslKeyResource = $result;
@@ -50,12 +73,16 @@ class PublicKey extends AbstractKey
     /**
      * Encrypt using this key
      *
-     * @param string $data
+     * @param  string $data
      * @return string
      * @throws Exception\RuntimeException
      */
     public function encrypt($data)
     {
+        if (empty($data)) {
+            throw new Exception\InvalidArgumentException('The data to encrypt cannot be empty');
+        }
+
         $encrypted = '';
         $result = openssl_public_encrypt($data, $encrypted, $this->getOpensslKeyResource());
         if (false === $result) {
@@ -71,12 +98,19 @@ class PublicKey extends AbstractKey
     /**
      * Decrypt using this key
      *
-     * @param string $data
+     * @param  string $data
      * @return string
      * @throws Exception\RuntimeException
      */
     public function decrypt($data)
     {
+        if (!is_string($data)) {
+            throw new Exception\InvalidArgumentException('The data to decrypt must be a string');
+        }
+        if ('' === $data) {
+            throw new Exception\InvalidArgumentException('The data to decrypt cannot be empty');
+        }
+
         $decrypted = '';
         $result = openssl_public_decrypt($data, $decrypted, $this->getOpensslKeyResource());
         if (false === $result) {

--- a/library/Zend/Crypt/PublicKey/RsaOptions.php
+++ b/library/Zend/Crypt/PublicKey/RsaOptions.php
@@ -11,64 +11,60 @@
 namespace Zend\Crypt\PublicKey;
 
 use Zend\Stdlib\Options;
-use Zend\Crypt\PublicKey\Rsa\PrivateKey;
-use Zend\Crypt\PublicKey\Rsa\PublicKey;
 use Zend\Crypt\PublicKey\Rsa\Exception;
+use Zend\Stdlib\ArrayUtils;
+use Traversable;
 
 /**
+ * RSA instance options
+ *
  * @category   Zend
  * @package    Zend_Crypt
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @subpackage PublicKey
  */
 class RsaOptions extends Options
 {
     /**
-     * @var PrivateKey
+     * @var Rsa\PrivateKey
      */
     protected $privateKey = null;
 
     /**
-     * @var PublicKey
+     * @var Rsa\PublicKey
      */
     protected $publicKey = null;
 
     /**
      * @var string
      */
-    protected $pemString;
+    protected $hashAlgorithm = 'sha1';
+
+    /**
+     * Signature hash algorithm defined by openss constants
+     *
+     * @var int
+     */
+    protected $opensslSignatureAlgorithm = null;
 
     /**
      * @var string
      */
-    protected $pemPath;
+    protected $passPhrase = null;
 
     /**
-     * @var string
+     * Output is binary
+     *
+     * @var bool
      */
-    protected $certificateString;
+    protected $binaryOutput = true;
 
     /**
-     * @var string
-     */
-    protected $certificatePath;
-
-    /**
-     * @var string
-     */
-    protected $hashAlgorithm;
-
-    /**
-     * @var string
-     */
-    protected $passPhrase;
-
-
-    /**
-     * @param Rsa\PrivateKey $key
+     * Set private key
+     *
+     * @param  Rsa\PrivateKey $key
      * @return RsaOptions
      */
-    public function setPrivateKey(PrivateKey $key)
+    public function setPrivateKey(Rsa\PrivateKey $key)
     {
         $this->privateKey = $key;
         $this->publicKey  = $this->privateKey->getPublicKey();
@@ -76,6 +72,8 @@ class RsaOptions extends Options
     }
 
     /**
+     * Get private key
+     *
      * @return null|Rsa\PrivateKey
      */
     public function getPrivateKey()
@@ -84,16 +82,20 @@ class RsaOptions extends Options
     }
 
     /**
-     * @param Rsa\PublicKey $key
+     * Set public key
+     *
+     * @param  Rsa\PublicKey $key
      * @return RsaOptions
      */
-    public function setPublicKey(PublicKey $key)
+    public function setPublicKey(Rsa\PublicKey $key)
     {
         $this->publicKey = $key;
         return $this;
     }
 
     /**
+     * Get public key
+     *
      * @return null|Rsa\PublicKey
      */
     public function getPublicKey()
@@ -124,107 +126,24 @@ class RsaOptions extends Options
     }
 
     /**
-     * Set PEM string
-     *
-     * @param string $value
-     * @return RsaOptions
-     */
-    public function setPemString($value)
-    {
-        $this->pemString = $value;
-
-        try {
-            $this->privateKey = new Rsa\PrivateKey($this->pemString, $this->passPhrase);
-            $this->publicKey  = $this->privateKey->getPublicKey();
-        } catch (Rsa\Exception\RuntimeException $e) {
-            $this->privateKey = null;
-            $this->publicKey  = new Rsa\PublicKey($this->pemString);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Get PEM string
-     *
-     * @return string
-     */
-    public function getPemString()
-    {
-        return $this->pemString;
-    }
-
-    /**
-     * Set PEM path
-     *
-     * @param string $path
-     * @return RsaOptions
-     * @throws Rsa\Exception\InvalidArgumentException
-     */
-    public function setPemPath($path)
-    {
-        if (!is_readable($path)) {
-            throw new Exception\InvalidArgumentException(
-                "PEM file '{$path}' is not readable"
-            );
-        }
-
-        $this->pemPath = $path;
-        $this->setPemString(file_get_contents($path));
-
-        return $this;
-    }
-
-    /**
-     * Get PEM path
-     *
-     * @return string
-     */
-    public function getPemPath()
-    {
-        return $this->pemPath;
-    }
-
-    /**
      * Set hash algorithm
      *
-     * @param  $name
+     * @param  string $hash
      * @return RsaOptions
      * @throws Rsa\Exception\RuntimeException
      * @throws Rsa\Exception\InvalidArgumentException
      */
-    public function setHashAlgorithm($name)
+    public function setHashAlgorithm($hash)
     {
-        switch (strtolower($name)) {
-            case 'md2':
-                // check if md2 digest is enabled on openssl just for backwards compatibility
-                $digests = openssl_get_md_methods();
-                if (!in_array(strtoupper($name), $digests)) {
-                    throw new Exception\RuntimeException(
-                        'Openssl md2 digest is not enabled  (deprecated)'
-                    );
-                }
-                $this->hashAlgorithm = OPENSSL_ALGO_MD2;
-                break;
-            case 'md4':
-                $this->hashAlgorithm = OPENSSL_ALGO_MD4;
-                break;
-            case 'md5':
-                $this->hashAlgorithm = OPENSSL_ALGO_MD5;
-                break;
-            case 'sha1':
-                $this->hashAlgorithm = OPENSSL_ALGO_SHA1;
-                break;
-            case 'dss1':
-                $this->hashAlgorithm = OPENSSL_ALGO_DSS1;
-                break;
-            default:
-                throw new Exception\InvalidArgumentException(
-                    "Hash algorithm '{$name}' is not supported"
-                );
-                break;
+        $hashUpper = strtoupper($hash);
+        if (!defined('OPENSSL_ALGO_' . $hashUpper)) {
+            throw new Exception\InvalidArgumentException(
+                "Hash algorithm '{$hash}' is not supported"
+            );
         }
 
+        $this->hashAlgorithm = strtolower($hash);
+        $this->opensslSignatureAlgorithm = constant('OPENSSL_ALGO_' . $hashUpper);
         return $this;
     }
 
@@ -235,65 +154,75 @@ class RsaOptions extends Options
      */
     public function getHashAlgorithm()
     {
-        if (!isset($this->hashAlgorithm)) {
-            $this->hashAlgorithm = OPENSSL_ALGO_SHA1;
-        }
-
         return $this->hashAlgorithm;
     }
 
-    /**
-     * Set certificate string
-     *
-     * @param string $value
-     * @return RsaOptions
-     */
-    public function setCertificateString($value)
+    public function getOpensslSignatureAlgorithm()
     {
-        $this->certificateString = $value;
-        $this->publicKey         = new Rsa\PublicKey($this->certificateString);
-
-        return $this;
-    }
-
-    /**
-     * Get certificate string
-     *
-     * @return string
-     */
-    public function getCertificateString()
-    {
-        return $this->certificateString;
-    }
-
-    /**
-     * Set certificate path
-     *
-     * @param string $path
-     * @return RsaOptions
-     * @throws Rsa\Exception\InvalidArgumentException
-     */
-    public function setCertificatePath($path)
-    {
-        if (!is_readable($path)) {
-            throw new Exception\InvalidArgumentException(
-                "Certificate file '{$path}' is not readable"
-            );
+        if (!isset($this->opensslSignatureAlgorithm)) {
+            $this->opensslSignatureAlgorithm = constant('OPENSSL_ALGO_' . strtoupper($this->hashAlgorithm));
         }
+        return $this->opensslSignatureAlgorithm;
+    }
 
-        $this->certificatePath = $path;
-        $this->setCertificateString(file_get_contents($path));
-
+    /**
+     * Enable/disable the binary output
+     *
+     * @param  boolean $value
+     * @return RsaOptions
+     */
+    public function setBinaryOutput($value)
+    {
+        $this->binaryOutput = (boolean)$value;
         return $this;
     }
 
     /**
-     * Get certificate path
+     * Get the value of binary output
      *
-     * @return string
+     * @return boolean
      */
-    public function getCertificatePath()
+    public function getBinaryOutput()
     {
-        return $this->certificatePath;
+        return $this->binaryOutput;
     }
+
+    /**
+     * Generate new private/public key pair
+     *
+     * @param  array $opensslConfig
+     * @return RsaOptions
+     * @throws Rsa\Exception\RuntimeException
+     */
+    public function generateKeys(array $opensslConfig = array())
+     {
+         $opensslConfig = array_replace(array(
+              'private_key_type' => OPENSSL_KEYTYPE_RSA,
+              'private_key_bits' => Rsa\PrivateKey::DEFAULT_KEY_SIZE,
+              'digest_alg'       => $this->getHashAlgorithm()
+         ), $opensslConfig);
+
+         // generate
+         $resource = openssl_pkey_new($opensslConfig);
+         if (false === $resource) {
+             throw new Exception\RuntimeException(
+                 'Can not generate keys; openssl ' . openssl_error_string()
+             );
+         }
+
+         // export key
+         $passPhrase = $this->getPassPhrase();
+         $result     = openssl_pkey_export($resource, $private, $passPhrase);
+         if (false === $result) {
+             throw new Exception\RuntimeException(
+                 'Can not export key; openssl ' . openssl_error_string()
+             );
+         }
+
+         $details          = openssl_pkey_get_details($resource);
+         $this->privateKey = new Rsa\PrivateKey($private, $passPhrase);
+         $this->publicKey  = new Rsa\PublicKey($details['key']);
+
+         return $this;
+     }
 }

--- a/library/Zend/Crypt/Symmetric/Mcrypt.php
+++ b/library/Zend/Crypt/Symmetric/Mcrypt.php
@@ -22,48 +22,53 @@ use Zend\Stdlib\ArrayUtils;
  *
  * @category   Zend
  * @package    Zend_Crypt
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Mcrypt implements SymmetricInterface
 {
     const DEFAULT_PADDING = 'pkcs7';
+
     /**
      * Key
      *
      * @var string
      */
     protected $key;
+
     /**
      * IV
      *
      * @var string
      */
     protected $iv;
+
     /**
      * Encryption algorithm
      *
      * @var string
      */
     protected $algo = 'aes';
+
     /**
      * Encryption mode
      *
      * @var string
      */
     protected $mode = 'cbc';
+
     /**
      * Padding
      *
      * @var Padding\PaddingInterface
      */
     protected $padding;
+
     /**
      * Padding broker
      *
      * @var PaddingBroker
      */
     protected static $paddingBroker = null;
+
     /**
      * Supported cipher algorithms
      *
@@ -84,6 +89,7 @@ class Mcrypt implements SymmetricInterface
         'serpent'      => 'serpent',
         'twofish'      => 'twofish'
     );
+
     /**
      * Supported encryption modes
      *
@@ -191,17 +197,17 @@ class Mcrypt implements SymmetricInterface
         if (is_string($broker)) {
             if (!class_exists($broker)) {
                 throw new Exception\InvalidArgumentException(sprintf(
-                                                                 'Unable to locate padding broker of class "%s"',
-                                                                 $broker
-                                                             ));
+                    'Unable to locate padding broker of class "%s"',
+                    $broker
+                ));
             }
             $broker = new $broker();
         }
         if (!$broker instanceof PaddingBroker) {
             throw new Exception\InvalidArgumentException(sprintf(
-                                                             'Padding broker must extend PaddingBroker; received "%s"',
-                                                             (is_object($broker) ? get_class($broker) : gettype($broker))
-                                                         ));
+                'Padding broker must extend PaddingBroker; received "%s"',
+                (is_object($broker) ? get_class($broker) : gettype($broker))
+            ));
         }
         self::$paddingBroker = $broker;
     }

--- a/library/Zend/OAuth/Signature/Hmac.php
+++ b/library/Zend/OAuth/Signature/Hmac.php
@@ -43,7 +43,7 @@ class Hmac extends AbstractSignature
             $this->_key,
             $this->_hashAlgorithm,
             $this->_getBaseSignatureString($params, $method, $url),
-            true
+            HMACEncryption::OUTPUT_BINARY
         );
         return base64_encode($binaryHash);
     }

--- a/library/Zend/OAuth/Signature/Hmac.php
+++ b/library/Zend/OAuth/Signature/Hmac.php
@@ -43,7 +43,7 @@ class Hmac extends AbstractSignature
             $this->_key,
             $this->_hashAlgorithm,
             $this->_getBaseSignatureString($params, $method, $url),
-            HMACEncryption::BINARY
+            true
         );
         return base64_encode($binaryHash);
     }

--- a/library/Zend/OAuth/Signature/Rsa.php
+++ b/library/Zend/OAuth/Signature/Rsa.php
@@ -19,7 +19,9 @@
  */
 
 namespace Zend\OAuth\Signature;
-use Zend\Crypt\PublicKey\Rsa as RSAEncryption;
+
+use Zend\Crypt\PublicKey\Rsa as RsaEnc;
+use Zend\Crypt\PublicKey\RsaOptions as RsaEncOptions;
 
 /**
  * @category   Zend
@@ -39,14 +41,12 @@ class Rsa extends AbstractSignature
      */
     public function sign(array $params, $method = null, $url = null) 
     {
-        $rsa = new RSAEncryption;
-        $rsa->setHashAlgorithm($this->_hashAlgorithm);
-        $sign = $rsa->sign(
-            $this->_getBaseSignatureString($params, $method, $url),
-            $this->_key,
-            RSAEncryption::BASE64
-        );
-        return $sign;
+        $rsa = new RsaEnc(new RsaEncOptions(array(
+            'hash_algorithm' => $this->_hashAlgorithm,
+            'bnary_output'   => true
+        )));
+
+        return $rsa->sign($this->_getBaseSignatureString($params, $method, $url), $this->_key);
     }
 
     /**

--- a/library/Zend/Service/Amazon/Amazon.php
+++ b/library/Zend/Service/Amazon/Amazon.php
@@ -239,7 +239,7 @@ class Amazon
     {
         $signature = self::buildRawSignature($baseUri, $options);
         return base64_encode(
-            Hmac::compute($secretKey, 'sha256', $signature, true)
+            Hmac::compute($secretKey, 'sha256', $signature, Hmac::OUTPUT_BINARY)
         );
     }
 

--- a/library/Zend/Service/Amazon/Amazon.php
+++ b/library/Zend/Service/Amazon/Amazon.php
@@ -239,7 +239,7 @@ class Amazon
     {
         $signature = self::buildRawSignature($baseUri, $options);
         return base64_encode(
-            Hmac::compute($secretKey, 'sha256', $signature, Hmac::BINARY)
+            Hmac::compute($secretKey, 'sha256', $signature, true)
         );
     }
 

--- a/library/Zend/Service/Amazon/Authentication/S3.php
+++ b/library/Zend/Service/Amazon/Authentication/S3.php
@@ -96,7 +96,7 @@ class S3 extends Authentication
                     $sig_str .= '?torrent';
                 }
         
-        $signature = base64_encode(Hmac::compute($this->_secretKey, 'sha1', utf8_encode($sig_str), Hmac::BINARY));
+        $signature = base64_encode(Hmac::compute($this->_secretKey, 'sha1', utf8_encode($sig_str), true));
         $headers['Authorization'] = 'AWS ' . $this->_accessKey . ':' . $signature;
 
         return $sig_str;

--- a/library/Zend/Service/Amazon/Authentication/S3.php
+++ b/library/Zend/Service/Amazon/Authentication/S3.php
@@ -96,8 +96,8 @@ class S3 extends Authentication
                     $sig_str .= '?torrent';
                 }
         
-        $signature = base64_encode(Hmac::compute($this->_secretKey, 'sha1', utf8_encode($sig_str), true));
-        $headers['Authorization'] = 'AWS ' . $this->_accessKey . ':' . $signature;
+        $signature = Hmac::compute($this->_secretKey, 'sha1', utf8_encode($sig_str), Hmac::OUTPUT_BINARY);
+        $headers['Authorization'] = 'AWS ' . $this->_accessKey . ':' . base64_encode($signature);
 
         return $sig_str;
     }

--- a/library/Zend/Service/Amazon/Authentication/V1.php
+++ b/library/Zend/Service/Amazon/Authentication/V1.php
@@ -92,7 +92,7 @@ class V1 extends Authentication
             $data .= $key . $value;
         }
 
-        $hmac = Hmac::compute($this->_secretKey, 'SHA1', $data, Hmac::BINARY);
+        $hmac = Hmac::compute($this->_secretKey, 'SHA1', $data, true);
 
         $paramaters['Signature'] = base64_encode($hmac);
         

--- a/library/Zend/Service/Amazon/Authentication/V1.php
+++ b/library/Zend/Service/Amazon/Authentication/V1.php
@@ -92,7 +92,7 @@ class V1 extends Authentication
             $data .= $key . $value;
         }
 
-        $hmac = Hmac::compute($this->_secretKey, 'SHA1', $data, true);
+        $hmac = Hmac::compute($this->_secretKey, 'SHA1', $data, Hmac::OUTPUT_BINARY);
 
         $paramaters['Signature'] = base64_encode($hmac);
         

--- a/library/Zend/Service/Amazon/Authentication/V2.php
+++ b/library/Zend/Service/Amazon/Authentication/V2.php
@@ -122,7 +122,7 @@ class V2 extends Authentication
 
         $data .= implode('&', $arrData);
 
-        $hmac = Hmac::compute($this->_secretKey, 'SHA256', $data, true);
+        $hmac = Hmac::compute($this->_secretKey, 'SHA256', $data, Hmac::OUTPUT_BINARY);
 
         $paramaters['Signature'] = base64_encode($hmac);
 

--- a/library/Zend/Service/Amazon/Authentication/V2.php
+++ b/library/Zend/Service/Amazon/Authentication/V2.php
@@ -122,7 +122,7 @@ class V2 extends Authentication
 
         $data .= implode('&', $arrData);
 
-        $hmac = Hmac::compute($this->_secretKey, 'SHA256', $data, Hmac::BINARY);
+        $hmac = Hmac::compute($this->_secretKey, 'SHA256', $data, true);
 
         $paramaters['Signature'] = base64_encode($hmac);
 

--- a/library/Zend/Service/Amazon/Ec2/AbstractEc2.php
+++ b/library/Zend/Service/Amazon/Ec2/AbstractEc2.php
@@ -232,7 +232,7 @@ abstract class AbstractEc2 extends Amazon\AbstractAmazon
 
         $data .= implode('&', $arrData);
 
-        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA256', $data, true);
+        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA256', $data, Hmac::OUTPUT_BINARY);
 
         return base64_encode($hmac);
     }

--- a/library/Zend/Service/Amazon/Ec2/AbstractEc2.php
+++ b/library/Zend/Service/Amazon/Ec2/AbstractEc2.php
@@ -232,7 +232,7 @@ abstract class AbstractEc2 extends Amazon\AbstractAmazon
 
         $data .= implode('&', $arrData);
 
-        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA256', $data, Hmac::BINARY);
+        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA256', $data, true);
 
         return base64_encode($hmac);
     }

--- a/library/Zend/Service/Amazon/Ec2/WindowsInstance.php
+++ b/library/Zend/Service/Amazon/Ec2/WindowsInstance.php
@@ -176,7 +176,7 @@ class WindowsInstance extends AbstractEc2
      */
     protected function _signS3UploadPolicy($policy)
     {
-        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA1', $policy, Hmac::BINARY);
+        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA1', $policy, true);
         return $hmac;
     }
 }

--- a/library/Zend/Service/Amazon/Ec2/WindowsInstance.php
+++ b/library/Zend/Service/Amazon/Ec2/WindowsInstance.php
@@ -176,7 +176,6 @@ class WindowsInstance extends AbstractEc2
      */
     protected function _signS3UploadPolicy($policy)
     {
-        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA1', $policy, true);
-        return $hmac;
+        return Hmac::compute($this->_getSecretKey(), 'SHA1', $policy, Hmac::OUTPUT_BINARY);
     }
 }

--- a/library/Zend/Service/Amazon/S3/S3.php
+++ b/library/Zend/Service/Amazon/S3/S3.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Service\Amazon\S3;
 
-use Zend\Crypt;
+use Zend\Crypt\Hmac;
 use Zend\Http\Header;
 use Zend\Http\Response\Stream as StreamResponse;
 use Zend\Service\Amazon;
@@ -246,7 +246,7 @@ class S3 extends \Zend\Service\Amazon\AbstractAmazon
             
             //Prevents from the fatal error method call on a non-object
             foreach ($info as $key => $value)
-                if ($value instanceof Header\HeaderDescription) {
+                if ($value instanceof Header\HeaderInterface) {
                     $info[$key] = $value->getFieldValue();
                 }
                 
@@ -794,8 +794,8 @@ class S3 extends \Zend\Service\Amazon\AbstractAmazon
             $sig_str .= '?torrent';
         }
 
-        $signature = base64_encode(Crypt\Hmac::compute($this->_getSecretKey(), 'sha1', utf8_encode($sig_str), Crypt\Hmac::BINARY));
-        $headers['Authorization'] = 'AWS '.$this->_getAccessKey().':'.$signature;
+        $signature = base64_encode(Hmac::compute($this->_getSecretKey(), 'sha1', utf8_encode($sig_str), true));
+        $headers['Authorization'] = 'AWS ' . $this->_getAccessKey() . ':' . $signature;
         
         return $headers;
     }

--- a/library/Zend/Service/Amazon/SimpleDb/SimpleDb.php
+++ b/library/Zend/Service/Amazon/SimpleDb/SimpleDb.php
@@ -527,7 +527,7 @@ class SimpleDb extends \Zend\Service\Amazon\AbstractAmazon
 
         $data .= implode('&', $arrData);
 
-        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA256', $data, Hmac::BINARY);
+        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA256', $data, true);
 
         return base64_encode($hmac);
     }

--- a/library/Zend/Service/Amazon/SimpleDb/SimpleDb.php
+++ b/library/Zend/Service/Amazon/SimpleDb/SimpleDb.php
@@ -527,7 +527,7 @@ class SimpleDb extends \Zend\Service\Amazon\AbstractAmazon
 
         $data .= implode('&', $arrData);
 
-        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA256', $data, true);
+        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA256', $data, Hmac::OUTPUT_BINARY);
 
         return base64_encode($hmac);
     }

--- a/library/Zend/Service/Amazon/Sqs/Sqs.php
+++ b/library/Zend/Service/Amazon/Sqs/Sqs.php
@@ -424,7 +424,7 @@ class Sqs extends \Zend\Service\Amazon\AbstractAmazon
 
         $data .= implode('&', $arrData);
 
-        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA256', $data, Hmac::BINARY);
+        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA256', $data, true);
 
         return base64_encode($hmac);
     }

--- a/library/Zend/Service/Amazon/Sqs/Sqs.php
+++ b/library/Zend/Service/Amazon/Sqs/Sqs.php
@@ -424,7 +424,7 @@ class Sqs extends \Zend\Service\Amazon\AbstractAmazon
 
         $data .= implode('&', $arrData);
 
-        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA256', $data, true);
+        $hmac = Hmac::compute($this->_getSecretKey(), 'SHA256', $data, Hmac::OUTPUT_BINARY);
 
         return base64_encode($hmac);
     }

--- a/tests/Zend/Crypt/BlockCipherTest.php
+++ b/tests/Zend/Crypt/BlockCipherTest.php
@@ -42,11 +42,11 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         try {
-            $cipher            = new Mcrypt(array(
-                                                 'algorithm' => 'aes',
-                                                 'mode'      => 'cbc',
-                                                 'padding'   => 'pkcs7'
-                                            ));
+            $cipher = new Mcrypt(array(
+                'algorithm' => 'aes',
+                'mode'      => 'cbc',
+                'padding'   => 'pkcs7'
+            ));
             $this->blockCipher = new BlockCipher($cipher);
         } catch (Exception\RuntimeException $e) {
             $this->markTestSkipped('Mcrypt is not installed, I cannot execute the BlockCipherTest');

--- a/tests/Zend/Crypt/HashTest.php
+++ b/tests/Zend/Crypt/HashTest.php
@@ -84,7 +84,7 @@ class HashTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($output, $hash);
     }
 
-    // MD5 test suite talen from RFC 1321
+    // MD5 test suite taken from RFC 1321
 
     public static function provideTestMD5Data()
     {
@@ -118,7 +118,7 @@ class HashTest extends \PHPUnit_Framework_TestCase
 
     public function testBinaryOutput()
     {
-        $hash = Hash::compute('sha1', 'test', Hash::BINARY);
+        $hash = Hash::compute('sha1', 'test', true);
         $this->assertEquals('qUqP5cyxm6YcTAhz05Hph5gvu9M=', base64_encode($hash));
     }
 

--- a/tests/Zend/Crypt/HashTest.php
+++ b/tests/Zend/Crypt/HashTest.php
@@ -118,7 +118,7 @@ class HashTest extends \PHPUnit_Framework_TestCase
 
     public function testBinaryOutput()
     {
-        $hash = Hash::compute('sha1', 'test', true);
+        $hash = Hash::compute('sha1', 'test', Hash::OUTPUT_BINARY);
         $this->assertEquals('qUqP5cyxm6YcTAhz05Hph5gvu9M=', base64_encode($hash));
     }
 

--- a/tests/Zend/Crypt/HmacTest.php
+++ b/tests/Zend/Crypt/HmacTest.php
@@ -222,13 +222,13 @@ class HmacTest extends \PHPUnit_Framework_TestCase
     public function testWrongHashAlgorithm()
     {
         $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
-                                    'Hash algorithm provided is not supported on this PHP installation');
+                                    'Hash algorithm is not supported on this PHP installation');
         $hash = HMAC::compute('key', 'wrong', 'test');
     }
 
     public function testBinaryOutput()
     {
-        $data = HMAC::compute('key', 'sha256', 'test', HMAC::BINARY);
+        $data = HMAC::compute('key', 'sha256', 'test', true);
         $this->assertEquals('Aq+1YwSQLGVvy3N83QPeYgW7bUAdooEu/ZstNqCK8Vk=', base64_encode($data));
     }
 }

--- a/tests/Zend/Crypt/HmacTest.php
+++ b/tests/Zend/Crypt/HmacTest.php
@@ -228,7 +228,7 @@ class HmacTest extends \PHPUnit_Framework_TestCase
 
     public function testBinaryOutput()
     {
-        $data = HMAC::compute('key', 'sha256', 'test', true);
+        $data = HMAC::compute('key', 'sha256', 'test', HMAC::OUTPUT_BINARY);
         $this->assertEquals('Aq+1YwSQLGVvy3N83QPeYgW7bUAdooEu/ZstNqCK8Vk=', base64_encode($data));
     }
 }

--- a/tests/Zend/Crypt/PublicKey/RsaTest.php
+++ b/tests/Zend/Crypt/PublicKey/RsaTest.php
@@ -36,22 +36,32 @@ use Zend\Crypt\PublicKey\Rsa\Exception;
 class RsaTest extends \PHPUnit_Framework_TestCase
 {
     /** @var string */
-    protected $_testPemString = null;
+    protected $testPemString = null;
 
     /** @var string */
-    protected $_testPemPath = null;
+    protected $testPemFile = null;
 
     /** @var string */
-    public $openSslConf;
+    protected $testPemStringPublic;
 
     /** @var string */
-    public $_testPemStringPublic;
+    protected $testCertificateString;
 
     /** @var string */
-    public $_testCertificateString;
+    protected $testCertificateFile;
 
     /** @var string */
-    public $_testCertificatePath;
+    protected $openSslConf;
+
+    /** @var string */
+    protected $userOpenSslConf;
+
+
+    /** @var Rsa */
+    protected $rsa;
+    
+    /** @var Rsa */
+    protected $rsaBase64Out;
 
     public function setUp()
     {
@@ -67,7 +77,7 @@ class RsaTest extends \PHPUnit_Framework_TestCase
 
         try {
             $rsa = new Rsa();
-        } catch (Exception\RuntimeException $e) {
+        } catch (Rsa\Exception\RuntimeException $e) {
             if (strpos($e->getMessage(), 'requires openssl extension') !== false) {
                 $this->markTestSkipped($e->getMessage());
             } else {
@@ -75,7 +85,7 @@ class RsaTest extends \PHPUnit_Framework_TestCase
             }
         }
 
-        $this->_testPemString = <<<RSAKEY
+        $this->testPemString = <<<RSAKEY
 -----BEGIN RSA PRIVATE KEY-----
 MIIBOgIBAAJBANDiE2+Xi/WnO+s120NiiJhNyIButVu6zxqlVzz0wy2j4kQVUC4Z
 RZD80IY+4wIiX2YxKBZKGnd2TtPkcJ/ljkUCAwEAAQJAL151ZeMKHEU2c1qdRKS9
@@ -88,14 +98,14 @@ I2SvDkQ5CmrzkW5qPaE2oO7BSqAhRZxiYpZFb5CI
 
 RSAKEY;
 
-        $this->_testPemStringPublic   = <<<RSAKEY
+        $this->testPemStringPublic   = <<<RSAKEY
 -----BEGIN PUBLIC KEY-----
 MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANDiE2+Xi/WnO+s120NiiJhNyIButVu6
 zxqlVzz0wy2j4kQVUC4ZRZD80IY+4wIiX2YxKBZKGnd2TtPkcJ/ljkUCAwEAAQ==
 -----END PUBLIC KEY-----
 
 RSAKEY;
-        $this->_testCertificateString = <<<CERT
+        $this->testCertificateString = <<<CERT
 -----BEGIN CERTIFICATE-----
 MIIC6TCCApOgAwIBAgIBADANBgkqhkiG9w0BAQQFADCBhzELMAkGA1UEBhMCSUUx
 DzANBgNVBAgTBkR1YmxpbjEPMA0GA1UEBxMGRHVibGluMQ4wDAYDVQQKEwVHcm91
@@ -117,291 +127,307 @@ l9Nwj3KnPKFdqzJchujP2TLNwSYoQnxgyoMxdho=
 
 CERT;
 
-        $this->_testPemPath = realpath(__DIR__ . '/../_files/test.pem');
+        $this->testPemFile = realpath(__DIR__ . '/../_files/test.pem');
 
-        $this->_testCertificatePath = realpath(__DIR__ . '/../_files/test.cert');
+        $this->testCertificateFile = realpath(__DIR__ . '/../_files/test.cert');
+
+        $this->userOpenSslConf = realpath(__DIR__ . '/../_files/openssl.cnf');
+
+        $rsaOptions = new RsaOptions(array(
+            'private_key'   => new Rsa\PrivateKey($this->testPemString),
+        ));
+        $this->rsa = new Rsa($rsaOptions);
+
+        $rsaOptions = new RsaOptions(array(
+            'private_key'   => new Rsa\PrivateKey($this->testPemString),
+            'binary_output' => false
+        ));
+        $this->rsaBase64Out = new Rsa($rsaOptions);
     }
 
-
-    public function testConstructorSetsPemString()
+    public function testFacrotyCreatesInstance()
     {
-        $rsa = new Rsa(new RsaOptions(array('pem_string' => $this->_testPemString)));
-        $this->assertEquals($this->_testPemString, $rsa->getOptions()->getPemString());
+        $rsa = Rsa::factory(array(
+            'hash_algorithm' => 'sha1',
+            'binary_output'  => false,
+            'private_key'    => $this->testPemString
+        ));
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\Rsa', $rsa);
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\RsaOptions', $rsa->getOptions());
+    }    
+
+    public function testFacrotyCreatesKeys()
+    {
+        $rsa = Rsa::factory(array(
+            'private_key'    => $this->testPemString,
+            'public_key'     => $this->testCertificateString,
+        ));
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\Rsa\PrivateKey', $rsa->getOptions()->getPrivateKey());
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\Rsa\PublicKey', $rsa->getOptions()->getPublicKey());
     }
 
-    public function testConstructorSetsPemPath()
+    public function testFacrotyCreatesKeysFromFiles()
     {
-        $rsa = new Rsa(new RsaOptions(array('pem_path' => $this->_testPemPath)));
-        $this->assertEquals($this->_testPemPath, $rsa->getOptions()->getPemPath());
+        $rsa = Rsa::factory(array(
+            'private_key'    => $this->testPemFile,
+        ));
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\Rsa\PrivateKey', $rsa->getOptions()->getPrivateKey());
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\Rsa\PublicKey', $rsa->getOptions()->getPublicKey());
     }
 
-    public function testSetPemPathLoadsPemString()
+    public function testFacrotyCreatesJustPublicKey()
     {
-        $rsa = new Rsa(new RsaOptions(array('pem_path' => $this->_testPemPath)));
-        $this->assertEquals($this->_testPemString, $rsa->getOptions()->getPemString());
+        $rsa = Rsa::factory(array(
+            'public_key'     => $this->testCertificateString,
+        ));
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\Rsa\PublicKey', $rsa->getOptions()->getPublicKey());
+        $this->assertNull($rsa->getOptions()->getPrivateKey());
     }
 
-    public function testConstructorSetsCertificateString()
+    public function testConstructorCreatesInstanceWithDefaultOptions()
     {
-        $rsa = new Rsa(new RsaOptions(array('certificate_string' => $this->_testCertificateString)));
-        $this->assertEquals($this->_testCertificateString, $rsa->getOptions()->getCertificateString());
+        $rsa = new Rsa();
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\Rsa', $rsa);
+        $this->assertEquals('sha1', $rsa->getOptions()->getHashAlgorithm());
+        $this->assertEquals(OPENSSL_ALGO_SHA1, $rsa->getOptions()->getOpensslSignatureAlgorithm());
+        $this->assertTrue($rsa->getOptions()->getBinaryOutput());
     }
 
-    public function testConstructorSetsCertificatePath()
+    public function testPrivateKeyInstanceCreation()
     {
-        $rsa = new Rsa(new RsaOptions(array('certificate_path' => $this->_testCertificatePath)));
-        $this->assertEquals($this->_testCertificatePath, $rsa->getOptions()->getCertificatePath());
+        $privateKey = Rsa\PrivateKey::fromFile($this->testPemFile);
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\Rsa\PrivateKey', $privateKey);
+
+        $privateKey = new Rsa\PrivateKey($this->testPemString);
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\Rsa\PrivateKey', $privateKey);
     }
 
-    public function testSetCertificatePathLoadsCertificateString()
+    public function testPublicKeyInstanceCreation()
     {
-        $rsa = new Rsa(new RsaOptions(array('certificate_path' => $this->_testCertificatePath)));
-        $this->assertEquals($this->_testCertificateString, $rsa->getOptions()->getCertificateString());
-    }
+        $publicKey = new Rsa\PublicKey($this->testPemStringPublic);
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\Rsa\PublicKey', $publicKey);
 
-    public function testConstructorSetsHashOption()
-    {
-        $rsa = new Rsa(new RsaOptions(array('hash_algorithm' => 'md5')));
-        $this->assertEquals(OPENSSL_ALGO_MD5, $rsa->getOptions()->getHashAlgorithm());
-    }
+        $publicKey = Rsa\PublicKey::fromFile($this->testCertificateFile);
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\Rsa\PublicKey', $publicKey);
 
-    public function testSetPemStringParsesPemForPrivateKey()
-    {
-        $rsa = new Rsa(new RsaOptions(array('pem_string' => $this->_testPemString)));
-        $this->assertInstanceOf('Zend\\Crypt\\PublicKey\\RSA\\PrivateKey', $rsa->getOptions()->getPrivateKey());
-    }
-
-
-    public function testSetPemStringParsesPemForPublicKey()
-    {
-        $rsa = new Rsa(new RsaOptions(array('pem_string' => $this->_testPemString)));
-        $this->assertInstanceOf('Zend\\Crypt\\PublicKey\\RSA\\PublicKey', $rsa->getOptions()->getPublicKey());
-
-    }
-
-    public function testSetCertificateStringParsesCertificateForNullPrivateKey()
-    {
-        $rsa = new Rsa(new RsaOptions(array('certificate_string' => $this->_testCertificateString)));
-        $this->assertSame(null, $rsa->getOptions()->getPrivateKey());
-    }
-
-    public function testSetCertificateStringParsesCertificateForPublicKey()
-    {
-        $rsa = new Rsa(new RsaOptions(array('certificate_string' => $this->_testCertificateString)));
-        $this->assertInstanceOf('Zend\\Crypt\\PublicKey\\RSA\\PublicKey', $rsa->getOptions()->getPublicKey());
+        $publicKey = new Rsa\PublicKey($this->testCertificateString);
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\Rsa\PublicKey', $publicKey);
     }
 
     public function testSignGeneratesExpectedBinarySignature()
     {
-        $rsa       = new Rsa(new RsaOptions(array('pem_string' => $this->_testPemString)));
-        $signature = $rsa->sign('1234567890');
+        $signature = $this->rsa->sign('1234567890');
         $this->assertEquals(
             'sMHpp3u6DNecIm5RIkDD3xyKaH6qqP8roUWDs215iOGHehfK1ypqwoETKNP7NaksGS2C1Up813ixlGXkipPVbQ==',
-            base64_encode($signature));
+            base64_encode($signature)
+        );
     }
 
     public function testSignGeneratesExpectedBinarySignatureUsingExternalKey()
     {
-        $rsa        = new Rsa(new RsaOptions(array('certificate_string' => $this->_testCertificateString)));
-        $privateKey = new Rsa\PrivateKey($this->_testPemString);
+        $rsaOptions = new RsaOptions(array(
+            'public_key'    => new Rsa\PublicKey($this->testCertificateString),
+            'binary_output' => true, // output as binary
+        ));
+
+        $rsa        = new Rsa($rsaOptions);
+        $privateKey = new Rsa\PrivateKey($this->testPemString);
         $signature  = $rsa->sign('1234567890', $privateKey);
         $this->assertEquals(
             'sMHpp3u6DNecIm5RIkDD3xyKaH6qqP8roUWDs215iOGHehfK1ypqwoETKNP7NaksGS2C1Up813ixlGXkipPVbQ==',
-            base64_encode($signature));
+            base64_encode($signature)
+        );
     }
 
     public function testSignGeneratesExpectedBase64Signature()
     {
-
-        $rsa       = new Rsa(new RsaOptions(array('pem_string' => $this->_testPemString)));
-        $signature = $rsa->sign('1234567890', null, Rsa::FORMAT_BASE64);
+        $signature = $this->rsaBase64Out->sign('1234567890');
         $this->assertEquals(
             'sMHpp3u6DNecIm5RIkDD3xyKaH6qqP8roUWDs215iOGHehfK1ypqwoETKNP7NaksGS2C1Up813ixlGXkipPVbQ==',
-            $signature);
+            $signature
+        );
     }
 
     public function testVerifyVerifiesBinarySignatures()
     {
-        $rsa       = new Rsa(new RsaOptions(array('pem_string' => $this->_testPemString)));
-        $signature = $rsa->sign('1234567890');
-        $result    = $rsa->verify('1234567890', $signature);
+        $signature = $this->rsa->sign('1234567890');
+        $result    = $this->rsa->verify('1234567890', $signature);
 
-        $this->assertSame(true, $result);
+        $this->assertTrue($result);
     }
 
     public function testVerifyVerifiesBinarySignaturesUsingCertificate()
     {
-        $rsa        = new Rsa(new RsaOptions(array('certificate_string' => $this->_testCertificateString)));
-        $privateKey = new Rsa\PrivateKey($this->_testPemString);
+        $rsaOptions = new RsaOptions(array(
+            'public_key'   => new Rsa\PublicKey($this->testCertificateString),
+            'binary_output' => true,
+        ));
+
+        $rsa        = new Rsa($rsaOptions);
+        $privateKey = new Rsa\PrivateKey($this->testPemString);
         $signature  = $rsa->sign('1234567890', $privateKey);
         $result     = $rsa->verify('1234567890', $signature);
 
-        $this->assertSame(true, $result);
+        $this->assertTrue($result);
     }
 
     public function testVerifyVerifiesBase64Signatures()
     {
-        $rsa       = new Rsa(new RsaOptions(array('pem_string' => $this->_testPemString)));
-        $signature = $rsa->sign('1234567890', null, Rsa::FORMAT_BASE64);
-        $result    = $rsa->verify('1234567890', $signature, null, Rsa::FORMAT_BASE64);
+        $signature = $this->rsaBase64Out->sign('1234567890');
+        $result    = $this->rsaBase64Out->verify('1234567890', base64_decode($signature));
 
         $this->assertSame(true, $result);
     }
 
     public function testEncryptionWithPublicKey()
     {
-        $publicKey  = new Rsa\PublicKey($this->_testCertificateString);
-        $privateKey = new Rsa\PrivateKey($this->_testPemString);
-
-        $encrypted = $publicKey->encrypt('1234567890');
+        $publicKey  = new Rsa\PublicKey($this->testCertificateString);
+        $privateKey = new Rsa\PrivateKey($this->testPemString);
+        $encrypted  = $publicKey->encrypt('1234567890');
 
         $this->assertEquals('1234567890', $privateKey->decrypt($encrypted));
     }
 
     public function testEncryptionWithPrivateKey()
     {
-        $publicKey  = new Rsa\PublicKey($this->_testCertificateString);
-        $privateKey = new Rsa\PrivateKey($this->_testPemString);
-
-        $encrypted = $privateKey->encrypt('1234567890');
+        $publicKey  = new Rsa\PublicKey($this->testCertificateString);
+        $privateKey = new Rsa\PrivateKey($this->testPemString);
+        $encrypted  = $privateKey->encrypt('1234567890');
 
         $this->assertEquals('1234567890', $publicKey->decrypt($encrypted));
     }
 
     public function testEncryptionWithOwnKeys()
     {
-        $rsa       = new Rsa(new RsaOptions(array('pem_string' => $this->_testPemString)));
-        $encrypted = $rsa->encrypt('1234567890');
+        $encrypted = $this->rsa->encrypt('1234567890');
 
-        $this->assertEquals('1234567890', $rsa->decrypt($encrypted));
+        $this->assertEquals('1234567890', $this->rsa->decrypt($encrypted));
     }
 
     public function testEncryptionUsingPublicKeyEncryption()
     {
-        $rsa       = new Rsa(new RsaOptions(array('pem_string' => $this->_testPemString)));
-        $encrypted = $rsa->encrypt('1234567890', $rsa->getOptions()->getPublicKey());
+        $encrypted = $this->rsa->encrypt('1234567890', $this->rsa->getOptions()->getPublicKey());
 
         $this->assertEquals(
             '1234567890',
-            $rsa->decrypt($encrypted, $rsa->getOptions()->getPrivateKey())
+            $this->rsa->decrypt($encrypted, $this->rsa->getOptions()->getPrivateKey())
         );
     }
 
     public function testEncryptionUsingPublicKeyBase64Encryption()
     {
-        $rsa       = new Rsa(new RsaOptions(array('pem_string' => $this->_testPemString)));
-        $encrypted = $rsa->encrypt('1234567890', $rsa->getOptions()->getPublicKey(), Rsa::FORMAT_BASE64);
+        $encrypted = $this->rsaBase64Out->encrypt('1234567890', $this->rsaBase64Out->getOptions()->getPublicKey());
 
         $this->assertEquals(
             '1234567890',
-            $rsa->decrypt($encrypted, $rsa->getOptions()->getPrivateKey(), Rsa::FORMAT_BASE64)
+            $this->rsaBase64Out->decrypt(
+                base64_decode($encrypted),
+                $this->rsaBase64Out->getOptions()->getPrivateKey()
+            )
         );
     }
 
     public function testBase64EncryptionUsingCertificatePublicKeyEncryption()
     {
-        $rsa       = new Rsa(new RsaOptions(array('certificate_string' => $this->_testCertificateString)));
-        $rsa2      = new Rsa(new RsaOptions(array('pem_string' => $this->_testPemString)));
-        $encrypted = $rsa->encrypt('1234567890', $rsa->getOptions()->getPublicKey(), Rsa::FORMAT_BASE64);
+        $rsa1 = new Rsa(new RsaOptions(array(
+            'public_key'    => new Rsa\PublicKey($this->testCertificateString),
+            'binary_output' => false, // output as base 64
+        )));
+
+        $rsa2 = new Rsa(new RsaOptions(array(
+            'private_key'   => new Rsa\PrivateKey($this->testPemString),
+            'binary_output' => false, // output as base 64
+        )));
+
+        $encrypted = $rsa1->encrypt('1234567890', $rsa1->getOptions()->getPublicKey());
 
         $this->assertEquals(
             '1234567890',
-            $rsa->decrypt($encrypted, $rsa2->getOptions()->getPrivateKey(), Rsa::FORMAT_BASE64)
+            $rsa1->decrypt(base64_decode($encrypted), $rsa2->getOptions()->getPrivateKey())
         );
     }
 
     public function testEncryptionUsingPrivateKeyEncryption()
     {
-        $rsa       = new Rsa(new RsaOptions(array('pem_string' => $this->_testPemString)));
-        $encrypted = $rsa->encrypt('1234567890', $rsa->getOptions()->getPrivateKey());
+        $encrypted = $this->rsa->encrypt('1234567890', $this->rsa->getOptions()->getPrivateKey());
+        $decrypted = $this->rsa->decrypt($encrypted, $this->rsa->getOptions()->getPublicKey());
 
-        $this->assertEquals(
-            '1234567890',
-            $rsa->decrypt($encrypted, $rsa->getOptions()->getPublicKey())
-        );
+        $this->assertEquals('1234567890', $decrypted);
     }
 
     public function testEncryptionUsingPrivateKeyBase64Encryption()
     {
-        $rsa       = new Rsa(new RsaOptions(array('pem_string' => $this->_testPemString)));
-        $encrypted = $rsa->encrypt('1234567890', $rsa->getOptions()->getPrivateKey(), Rsa::FORMAT_BASE64);
-        $this->assertEquals(
-            '1234567890',
-            $rsa->decrypt($encrypted, $rsa->getOptions()->getPublicKey(), Rsa::FORMAT_BASE64)
+        $encrypted = $this->rsaBase64Out->encrypt('1234567890', $this->rsaBase64Out->getOptions()->getPrivateKey());
+        $decrypted = $this->rsaBase64Out->decrypt(
+            base64_decode($encrypted),
+            $this->rsaBase64Out->getOptions()->getPublicKey()
         );
+
+        $this->assertEquals('1234567890', $decrypted);
     }
 
-    public function testKeyGeneration()
+    public function testKeyGenerationWithDefaults()
     {
         if (!$this->openSslConf) {
             $this->markTestSkipped('No openssl.cnf found or defined; cannot generate keys');
         }
 
-        $rsa  = new Rsa();
-        $keys = $rsa->generateKeys(array(
-            'config'           => $this->openSslConf,
+        $rsa = new Rsa();
+        $rsa->getOptions()->generateKeys();
+
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\Rsa\PrivateKey', $rsa->getOptions()->getPrivateKey());
+        $this->assertInstanceOf('Zend\Crypt\PublicKey\Rsa\PublicKey', $rsa->getOptions()->getPublicKey());
+    }
+
+    public function testKeyGenerationWithUserOpensslConfig()
+    {
+        $rsaOptions  = new RsaOptions();
+        $rsaOptions->generateKeys(array(
+            'config'           => $this->userOpenSslConf,
             'private_key_bits' => 512,
         ));
 
-        $this->assertInstanceOf('Zend\\Crypt\\PublicKey\\Rsa\\PrivateKey', $keys->privateKey);
-        $this->assertInstanceOf('Zend\\Crypt\\PublicKey\\Rsa\\PublicKey', $keys->publicKey);
+        $this->assertInstanceOf('Zend\\Crypt\\PublicKey\\Rsa\\PrivateKey', $rsaOptions->getPrivateKey());
+        $this->assertInstanceOf('Zend\\Crypt\\PublicKey\\Rsa\\PublicKey', $rsaOptions->getPublicKey());
     }
 
     public function testKeyGenerationCreatesPassphrasedPrivateKey()
     {
-        if (!$this->openSslConf) {
-            $this->markTestSkipped('No openssl.cnf found or defined; cannot generate keys');
-        }
-
-        $rsa  = new Rsa();
-        $keys = $rsa->generateKeys(array(
-            'config'           => $this->openSslConf,
+        $rsaOptions  = new RsaOptions(array(
+            'pass_phrase' => '0987654321'
+        ));
+        $rsaOptions->generateKeys(array(
+            'config'           => $this->userOpenSslConf,
             'private_key_bits' => 512,
-            'pass_phrase'     => '0987654321'
         ));
 
         try {
-            $rsa = new Rsa(new RsaOptions(array(
+            $rsa = Rsa::factory(array(
                 'pass_phrase' => '1234567890',
-                'pem_string'  => $keys->privateKey->toString()
-            )));
-            $this->fail('Expected exception not thrown');
-        } catch (Exception\ExceptionInterface $e) {
+                'private_key' => $rsaOptions->getPrivateKey()->toString()
+            ));
+            $this->fail('Expected passphrase mismatch exception not thrown');
+        } catch (Exception\RuntimeException $e) {
         }
     }
 
-    public function testConstructorLoadsPassphrasedKeys()
+    public function testRsaLoadsPassphrasedKeys()
     {
-        if (!$this->openSslConf) {
-            $this->markTestSkipped('No openssl.cnf found or defined; cannot generate keys');
-        }
-
-        $rsa  = new Rsa();
-        $keys = $rsa->generateKeys(array(
-            'config'           => $this->openSslConf,
+        $rsaOptions  = new RsaOptions(array(
+            'pass_phrase' => '0987654321'
+        ));
+        $rsaOptions->generateKeys(array(
+            'config'           => $this->userOpenSslConf,
             'private_key_bits' => 512,
-            'pass_phrase'     => '0987654321'
         ));
 
         try {
-            $rsa = new Rsa(new RsaOptions(array(
+            $rsa = Rsa::factory(array(
                 'pass_phrase' => '0987654321',
-                'pem_string'  => $keys->privateKey->toString()
-            )));
-        } catch (Exception\ExceptionInterface $e) {
-            $this->fail('Passphrase loading failed of a private key');
+                'private_key' => $rsaOptions->getPrivateKey()->toString(),
+            ));
+        } catch (Exception\RuntimeException $e) {
+            $this->fail('Passphrase loading of a private key failed');
         }
     }
-
-
-    /**
-     * @group ZF-8846
-     */
-    /*
-    public function testLoadsPublicKeyFromPEMWithoutPrivateKeyAndThrowsNoException()
-    {
-        $rsa = new Rsa;
-        $rsa->setPemString($this->_testPemStringPublic);
-    }
-     */
 }

--- a/tests/Zend/Crypt/_files/openssl.cnf
+++ b/tests/Zend/Crypt/_files/openssl.cnf
@@ -1,0 +1,60 @@
+#
+# OpenSSL configuration file.
+#
+
+dir                                     = .
+
+[ ca ]
+default_ca                              = CA_default
+
+[ CA_default ]
+serial                                  = $dir/serial
+database                                = $dir/certindex.txt
+new_certs_dir                           = $dir/certs
+certificate                             = $dir/cacert.pem
+private_key                             = $dir/private/cakey.pem
+default_days                            = 365
+default_md                              = sha1
+preserve                                = no
+email_in_dn                             = no
+nameopt                                 = default_ca
+certopt                                 = default_ca
+policy                                  = policy_match
+
+[ policy_match ]
+countryName                             = match
+stateOrProvinceName                     = match
+organizationName                        = match
+organizationalUnitName                  = optional
+commonName                              = supplied
+emailAddress                            = optional
+
+[ req ]
+default_bits                            = 2048
+default_keyfile                         = key.pem
+default_md                              = sha1
+string_mask                             = nombstr
+distinguished_name                      = req_distinguished_name
+req_extensions                          = v3_req
+
+[ req_distinguished_name ]
+0.organizationName                      = Organization Name (company)
+organizationalUnitName                  = Organizational Unit Name (department, division)
+emailAddress                            = Email Address
+emailAddress_max                        = 40
+localityName                            = Locality Name (city, district)
+stateOrProvinceName                     = State or Province Name (full name)
+countryName                             = Country Name (2 letter code)
+countryName_min                         = 2
+countryName_max                         = 2
+commonName                              = Common Name (hostname, IP, or your name)
+commonName_max                          = 64
+
+[ v3_ca ]
+basicConstraints                        = CA:TRUE
+subjectKeyIdentifier                    = hash
+authorityKeyIdentifier                  = keyid:always,issuer:always
+
+[ v3_req ]
+basicConstraints                        = CA:FALSE
+subjectKeyIdentifier                    = hash


### PR DESCRIPTION
- Crypt\PublicKey\Rsa
  - new facroty method
  - setting PEM file/string is ambigous, because PEM could have private key, public key or both, so I removed those methods and providing private/public keys is easy with new facroty method
  - `generateKeys()` is moved to `RsaOptions`, so now one could generate and retrieve new keypair without main Rsa instance, and no need for dumb `ArrayObject` container
  - new `$binaryOputput` flag
- Crypt\Hash, Crypt\Hmac -- `$bnaryOutput` flag for static methods

[Buid status](http://travis-ci.org/#!/denixport/zf2/builds/1681838)
