### PR TITLE
[Mail] Use Headers container rather than array in Zend\Mail\Storage\Part

### DIFF
--- a/library/Zend/Mail/Headers.php
+++ b/library/Zend/Mail/Headers.php
@@ -222,12 +222,15 @@ class Headers implements Iterator, Countable
         }
 
         if ($fieldValue === null) {
-            $header = Header\GenericHeader::fromString($headerFieldNameOrLine);
+            $this->addHeader(Header\GenericHeader::fromString($headerFieldNameOrLine));
+        } elseif (is_array($fieldValue)) {
+            foreach($fieldValue as $i) {
+                $this->addHeader(new Header\GenericMultiHeader($headerFieldNameOrLine, $i));
+            }
         } else {
-            $header = new Header\GenericHeader($headerFieldNameOrLine, $fieldValue);
+            $this->addHeader(new Header\GenericHeader($headerFieldNameOrLine, $fieldValue));
         }
 
-        $this->addHeader($header);
         return $this;
     }
 

--- a/library/Zend/Mail/Headers.php
+++ b/library/Zend/Mail/Headers.php
@@ -76,16 +76,17 @@ class Headers implements Iterator, Countable
      * will be lazy loaded)
      *
      * @param  string $string
+     * @param  string $EOL EOL string; defaults to {@link EOL}
      * @throws Exception\RuntimeException
      * @return Headers
      */
-    public static function fromString($string)
+    public static function fromString($string, $EOL = self::EOL)
     {
         $headers     = new static();
         $currentLine = '';
 
         // iterate the header lines, some might be continuations
-        foreach (explode(self::EOL, $string) as $line) {
+        foreach (explode($EOL, $string) as $line) {
             // check if a header name is present
             if (preg_match('/^(?P<name>[^()><@,;:\"\\/\[\]?=}{ \t]+):.*$/', $line, $matches)) {
                 if ($currentLine) {

--- a/library/Zend/Mail/Storage/Part.php
+++ b/library/Zend/Mail/Storage/Part.php
@@ -117,18 +117,18 @@ class Part implements RecursiveIterator, Part\PartInterface
             $this->_headers->addHeaders($headers);
         } elseif (isset($params['headers'])) {
             if (is_array($params['headers'])) {
-                $headers = $params['headers'];
+                $this->_headers = new Headers();
+                $this->_headers->addHeaders($params['headers']);
             } else {
-                $body    = null; // "Declare" variable since it's passed by reference
-                $headers = null; // "Declare" variable since it's passed by reference
                 if (empty($params['noToplines'])) {
+                    $this->_headers = new Headers();
                     Mime\Decode::splitMessage($params['headers'], $headers, $this->_topLines);
+                    $this->_headers->addHeaders($headers);
                 } else {
-                    Mime\Decode::splitMessage($params['headers'], $headers, $body);
+                    $this->_headers = Headers::fromString($params['headers']);
                 }
             }
-            $this->_headers = new Headers();
-            $this->_headers->addHeaders($headers);
+
             if (isset($params['content'])) {
                 $this->_content = $params['content'];
             }
@@ -284,13 +284,11 @@ class Part implements RecursiveIterator, Part\PartInterface
     public function getHeaders()
     {
         if (null === $this->_headers) {
-            $this->_headers = new Headers();
             if ($this->_mail) {
-                $body    = null; // "Declare" variable since it's passed by reference
-                $headers = null; // "Declare" variable since it's passed by reference
                 $part = $this->_mail->getRawHeader($this->_messageNum);
-                Mime\Decode::splitMessage($part, $headers, $body);
-                $this->_headers->addHeaders($headers);
+                $this->_headers = Headers::fromString($part);
+            } else {
+                $this->_headers = new Headers();
             }
         }
 

--- a/library/Zend/Mail/Storage/Part.php
+++ b/library/Zend/Mail/Storage/Part.php
@@ -22,6 +22,8 @@
 namespace Zend\Mail\Storage;
 
 use RecursiveIterator;
+use Zend\Mail\Header\HeaderInterface;
+use Zend\Mail\Headers;
 use Zend\Mime;
 
 /**
@@ -34,8 +36,8 @@ use Zend\Mime;
 class Part implements RecursiveIterator, Part\PartInterface
 {
     /**
-     * headers of part as array
-     * @var null|array
+     * Headers of the part
+     * @var Headers|null
      */
     protected $_headers;
 
@@ -110,18 +112,23 @@ class Part implements RecursiveIterator, Part\PartInterface
         }
 
         if (isset($params['raw'])) {
-            Mime\Decode::splitMessage($params['raw'], $this->_headers, $this->_content);
-        } else if (isset($params['headers'])) {
+            Mime\Decode::splitMessage($params['raw'], $headers, $this->_content);
+            $this->_headers = new Headers();
+            $this->_headers->addHeaders($headers);
+        } elseif (isset($params['headers'])) {
             if (is_array($params['headers'])) {
-                $this->_headers = $params['headers'];
+                $headers = $params['headers'];
             } else {
-                $body = null; // "Declare" variable since it's passed by reference
-                if (!empty($params['noToplines'])) {
-                    Mime\Decode::splitMessage($params['headers'], $this->_headers, $body);
+                $body    = null; // "Declare" variable since it's passed by reference
+                $headers = null; // "Declare" variable since it's passed by reference
+                if (empty($params['noToplines'])) {
+                    Mime\Decode::splitMessage($params['headers'], $headers, $this->_topLines);
                 } else {
-                    Mime\Decode::splitMessage($params['headers'], $this->_headers, $this->_topLines);
+                    Mime\Decode::splitMessage($params['headers'], $headers, $body);
                 }
             }
+            $this->_headers = new Headers();
+            $this->_headers->addHeaders($headers);
             if (isset($params['content'])) {
                 $this->_content = $params['content'];
             }
@@ -159,9 +166,9 @@ class Part implements RecursiveIterator, Part\PartInterface
 
         if ($this->_mail) {
             return $this->_mail->getRawContent($this->_messageNum);
-        } else {
-            throw new Exception\RuntimeException('no content');
         }
+
+        throw new Exception\RuntimeException('no content');
     }
 
     /**
@@ -267,24 +274,23 @@ class Part implements RecursiveIterator, Part\PartInterface
         return $this->_countParts;
     }
 
-
     /**
-     * Get all headers
+     * Access headers collection
      *
-     * The returned headers are as saved internally. All names are lowercased. The value is a string or an array
-     * if a header with the same name occurs more than once.
+     * Lazy-loads if not already attached.
      *
-     * @return array headers as array(name => value)
+     * @return Headers
      */
     public function getHeaders()
     {
-        if ($this->_headers === null) {
-            if (!$this->_mail) {
-                $this->_headers = array();
-            } else {
+        if (null === $this->_headers) {
+            $this->_headers = new Headers();
+            if ($this->_mail) {
+                $body    = null; // "Declare" variable since it's passed by reference
+                $headers = null; // "Declare" variable since it's passed by reference
                 $part = $this->_mail->getRawHeader($this->_messageNum);
-                $body = null; // "Declare" variable since it's passed by reference
-                Mime\Decode::splitMessage($part, $this->_headers, $body);
+                Mime\Decode::splitMessage($part, $headers, $body);
+                $this->_headers->addHeaders($headers);
             }
         }
 
@@ -300,55 +306,48 @@ class Part implements RecursiveIterator, Part\PartInterface
      * @param  string $name   name of header, matches case-insensitive, but camel-case is replaced with dashes
      * @param  string $format change type of return value to 'string' or 'array'
      * @throws Exception\InvalidArgumentException
-     * @return string|array value of header in wanted or internal format
+     * @return string|array|HeaderInterface|\ArrayIterator value of header in wanted or internal format
      */
     public function getHeader($name, $format = null)
     {
-        if ($this->_headers === null) {
-            $this->getHeaders();
-        }
-
-        $lowerName = strtolower($name);
-
-        if ($this->headerExists($name) == false) {
+        $header = $this->getHeaders()->get($name);
+        if ($header === false) {
             $lowerName = strtolower(preg_replace('%([a-z])([A-Z])%', '\1-\2', $name));
-            if ($this->headerExists($lowerName) == false) {
-                throw new Exception\InvalidArgumentException("no Header with Name $name or $lowerName found");
+            $header = $this->getHeaders()->get($lowerName);
+            if ($header === false) {
+                throw new Exception\InvalidArgumentException(
+                    "Header with Name $name or $lowerName not found"
+                );
             }
         }
-        $name = $lowerName;
-
-        $header = $this->_headers[$name];
 
         switch ($format) {
             case 'string':
-                if (is_array($header)) {
-                    $header = implode(Mime\Mime::LINEEND, $header);
+                if ($header instanceof HeaderInterface) {
+                    $return = $header->getFieldValue();
+                } else {
+                    $return = '';
+                    foreach($header as $h) {
+                        $return .= $h->getFieldValue() . Mime\Mime::LINEEND;
+                    }
+                    $return = trim($return, Mime\Mime::LINEEND);
                 }
                 break;
             case 'array':
-                $header = (array)$header;
+                if ($header instanceof HeaderInterface) {
+                    $return = array($header->getFieldValue());
+                } else {
+                    $return = array();
+                    foreach($header as $h) {
+                        $return[] = $h->getFieldValue();
+                    }
+                }
+                break;
             default:
-                // do nothing
+                $return = $header;
         }
 
-        return $header;
-    }
-
-    /**
-     * Check whether the Mail part has a specific header.
-     *
-     * @param  string $name
-     * @return boolean
-     */
-    public function headerExists($name)
-    {
-        $name = strtolower($name);
-        if (isset($this->_headers[$name])) {
-            return true;
-        } else {
-            return false;
-        }
+        return $return;
     }
 
     /**
@@ -400,7 +399,7 @@ class Part implements RecursiveIterator, Part\PartInterface
      */
     public function __isset($name)
     {
-        return $this->headerExists($name);
+        return $this->getHeaders()->has($name);
     }
 
     /**

--- a/library/Zend/Mail/Storage/Part/File.php
+++ b/library/Zend/Mail/Storage/Part/File.php
@@ -21,8 +21,9 @@
 
 namespace Zend\Mail\Storage\Part;
 
-use Zend\Mail\Storage\Part,
-    Zend\Mime;
+use Zend\Mail\Headers;
+use Zend\Mail\Storage\Part;
+use Zend\Mime;
 
 /**
  * @category   Zend
@@ -72,9 +73,7 @@ class File extends Part
             $header .= $line;
         }
 
-        $body = null; // "Declare" variable since it's passed by reference
-        Mime\Decode::splitMessage($header, $headers, $body);
-        $this->getHeaders()->addHeaders($headers);
+        $this->_headers = Headers::fromString($header);
 
         $this->_contentPos[0] = ftell($this->_fh);
         if ($endPos !== null) {

--- a/library/Zend/Mail/Storage/Part/File.php
+++ b/library/Zend/Mail/Storage/Part/File.php
@@ -73,7 +73,8 @@ class File extends Part
         }
 
         $body = null; // "Declare" variable since it's passed by reference
-        Mime\Decode::splitMessage($header, $this->_headers, $body);
+        Mime\Decode::splitMessage($header, $headers, $body);
+        $this->getHeaders()->addHeaders($headers);
 
         $this->_contentPos[0] = ftell($this->_fh);
         if ($endPos !== null) {

--- a/library/Zend/Mail/Storage/Part/PartInterface.php
+++ b/library/Zend/Mail/Storage/Part/PartInterface.php
@@ -80,7 +80,7 @@ interface PartInterface extends RecursiveIterator
      * The returned headers are as saved internally. All names are lowercased. The value is a string or an array
      * if a header with the same name occurs more than once.
      *
-     * @return array headers as array(name => value)
+     * @return \Zend\Mail\Headers
      */
     public function getHeaders();
 
@@ -92,7 +92,7 @@ interface PartInterface extends RecursiveIterator
      *
      * @param  string $name   name of header, matches case-insensitive, but camel-case is replaced with dashes
      * @param  string $format change type of return value to 'string' or 'array'
-     * @return string|array value of header in wanted or internal format
+     * @return string|array|\Zend\Mail\Header\HeaderInterface|\ArrayIterator value of header in wanted or internal format
      * @throws Exception\ExceptionInterface
      */
     public function getHeader($name, $format = null);

--- a/tests/Zend/Mail/Storage/MessageTest.php
+++ b/tests/Zend/Mail/Storage/MessageTest.php
@@ -141,9 +141,11 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $raw = "sUBject: test\nSubJect: test2\n" . $raw;
         $message = new Message(array('raw' => $raw));
 
-        $this->assertEquals($message->getHeader('subject', 'string'),
-                           'test' . Mime\Mime::LINEEND . 'test2' . Mime\Mime::LINEEND .  'multipart');
-        $this->assertEquals($message->getHeader('subject'),  array('test', 'test2', 'multipart'));
+        $this->assertEquals('test' . Mime\Mime::LINEEND . 'test2' . Mime\Mime::LINEEND . 'multipart',
+                            $message->getHeader('subject', 'string'));
+
+        $this->assertEquals(array('test', 'test2', 'multipart'),
+                            $message->getHeader('subject', 'array'));
     }
 
     public function testContentTypeDecode()
@@ -279,18 +281,13 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testEmptyHeader()
     {
         $message = new Message(array());
-        $this->assertEquals(array(), $message->getHeaders());
+        $this->assertEquals(array(), $message->getHeaders()->toArray());
 
         $message = new Message(array());
         $subject = null;
-        try {
-            $subject = $message->subject;
-        } catch (Exception\InvalidArgumentException $e) {
-            // ok
-        }
-        if ($subject) {
-            $this->fail('no exception raised while getting header from empty message');
-        }
+
+        $this->setExpectedException('Zend\\Mail\\Exception\\InvalidArgumentException');
+        $message->subject;
     }
 
     public function testEmptyBody()
@@ -317,11 +314,11 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     {
         $message = new Message(array('headers' => array('subject' => 'foo')));
 
-        $this->assertTrue( $message->headerExists('subject'));
+        $this->assertTrue( $message->getHeaders()->has('subject'));
         $this->assertTrue( isset($message->subject) );
-        $this->assertTrue( $message->headerExists('SuBject'));
+        $this->assertTrue( $message->getHeaders()->has('SuBject'));
         $this->assertTrue( isset($message->suBjeCt) );
-        $this->assertFalse($message->headerExists('From'));
+        $this->assertFalse($message->getHeaders()->has('From'));
     }
 
     public function testWrongMultipart()


### PR DESCRIPTION
[![Build Status](https://secure.travis-ci.org/Maks3w/zf2.png?branch=mail-add-headers-containter-to-parts)](http://travis-ci.org/Maks3w/zf2)

This PR changes the API of Zend\Mail\Storage\Parts for return Headers and HeaderInterface objects instead of arrays
