### PR TITLE
Fixing cookie handling in request object

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -57,7 +57,9 @@ class Request extends HttpRequest
         $this->setPost(new Parameters($_POST));
         $this->setQuery(new Parameters($_GET));
         $this->setServer(new Parameters($_SERVER));
-        $this->setCookies(new Parameters($_COOKIE));
+        if ($_COOKIE) {
+            $this->setCookies(new Parameters($_COOKIE));
+        }
 
         if ($_FILES) {
             $this->setFile(new Parameters($_FILES));
@@ -236,6 +238,10 @@ class Request extends HttpRequest
 
         foreach ($server as $key => $value) {
             if ($value && strpos($key, 'HTTP_') === 0) {
+                if (strpos($key, 'HTTP_COOKIE') === 0) {
+                    // Cookies are handled using the $_COOKIE superglobal
+                    continue;
+                }
                 $name = strtr(substr($key, 5), '_', ' ');
                 $name = strtr(ucwords(strtolower($name)), ' ', '-');
             } elseif ($value && strpos($key, 'CONTENT_') === 0) {


### PR DESCRIPTION
Making sure $_COOKIE is set before creating an empty cookie header object.
Making sure HTTP_COOKIE in $_SERVER isn't being used to populate the header object.

Ensured that tests for Zend\Http\PhpEnvironment\Request and Zend\Mvc\Application are still passing.
