### PR TITLE
[WIP] - Reuse doctrine common annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
 
 before_install:
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
+ - curl -s http://getcomposer.org/installer
+ - php && php composer.phar install
 
 script:
  - php ./tests/run-tests.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ php:
 
 before_install:
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
- - curl -s http://getcomposer.org/installer
- - php && php composer.phar install
+ - curl -s http://getcomposer.org/installer | php
+ - php composer.phar install
 
 script:
  - php ./tests/run-tests.php

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "doctrine/common": ">=2.1"
     },
     "autoload": {
         "psr-0": {

--- a/library/Zend/Code/Annotation/AnnotationManager.php
+++ b/library/Zend/Code/Annotation/AnnotationManager.php
@@ -23,7 +23,6 @@ namespace Zend\Code\Annotation;
 
 use Zend\Code\Exception\InvalidArgumentException;
 use Zend\Code\Exception\RuntimeException;
-use SplObjectStorage;
 
 /**
  * @category   Zend

--- a/library/Zend/Code/Reflection/ClassReflection.php
+++ b/library/Zend/Code/Reflection/ClassReflection.php
@@ -25,6 +25,8 @@ use Zend\Code\Reflection\FileReflection;
 use Zend\Code\Scanner\FileScanner;
 use Zend\Code\Annotation;
 use Zend\Code\Scanner\AnnotationScanner;
+use Zend\Code\Annotation\AnnotationCollection;
+use Doctrine\Common\Annotations\AnnotationReader;
 
 /**
  * @category   Zend
@@ -83,8 +85,8 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
             return $this->annotations;
         }
 
-        $this->annotations = new \Zend\Code\Annotation\AnnotationCollection();
-        $reader            = new \Doctrine\Common\Annotations\AnnotationReader();
+        $this->annotations = new AnnotationCollection();
+        $reader            = new AnnotationReader();
         $annotations       = $reader->getClassAnnotations($this);
 
         foreach ($annotations as $annotation) {

--- a/library/Zend/Code/Reflection/ClassReflection.php
+++ b/library/Zend/Code/Reflection/ClassReflection.php
@@ -79,14 +79,18 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
      */
     public function getAnnotations(Annotation\AnnotationManager $annotationManager)
     {
-        if (($docComment = $this->getDocComment()) == '') {
-            return false;
+        if (null !== $this->annotations) {
+            return $this->annotations;
         }
 
-        if (!$this->annotations) {
-            $fileScanner       = new FileScanner($this->getFileName());
-            $nameInformation   = $fileScanner->getClassNameInformation($this->getName());
-            $this->annotations = new AnnotationScanner($annotationManager, $docComment, $nameInformation);
+        $this->annotations = new \Zend\Code\Annotation\AnnotationCollection();
+        $reader            = new \Doctrine\Common\Annotations\AnnotationReader();
+        $annotations       = $reader->getClassAnnotations($this);
+
+        foreach ($annotations as $annotation) {
+            if ($annotationManager->hasAnnotation(get_class($annotation))) {
+                $this->annotations[] = $annotation;
+            }
         }
 
         return $this->annotations;

--- a/library/Zend/Code/Reflection/DocBlockReflection.php
+++ b/library/Zend/Code/Reflection/DocBlockReflection.php
@@ -22,7 +22,6 @@ namespace Zend\Code\Reflection;
 
 use Reflector;
 use Zend\Code\Scanner\DocBlockScanner;
-use Zend\Code\Annotation\AnnotationManager;
 
 /**
  * @category   Zend

--- a/library/Zend/Code/Reflection/MethodReflection.php
+++ b/library/Zend/Code/Reflection/MethodReflection.php
@@ -25,7 +25,6 @@ use Zend\Code\Annotation\AnnotationCollection;
 use Zend\Code\Annotation\AnnotationManager;
 use Zend\Code\Scanner\CachingFileScanner;
 use Zend\Code\Scanner\AnnotationScanner;
-use Zend\Code\Annotation\AnnotationCollection;
 use Doctrine\Common\Annotations\AnnotationReader;
 
 /**
@@ -45,7 +44,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
     /**
      * Retrieve method DocBlock reflection
      *
-     * @return DocBlockReflection|false
+     * @return DocBlockReflection|bool false if no DocBlock is available
      */
     public function getDocBlock()
     {

--- a/library/Zend/Code/Reflection/MethodReflection.php
+++ b/library/Zend/Code/Reflection/MethodReflection.php
@@ -25,6 +25,8 @@ use Zend\Code\Annotation\AnnotationCollection;
 use Zend\Code\Annotation\AnnotationManager;
 use Zend\Code\Scanner\CachingFileScanner;
 use Zend\Code\Scanner\AnnotationScanner;
+use Zend\Code\Annotation\AnnotationCollection;
+use Doctrine\Common\Annotations\AnnotationReader;
 
 /**
  * @category   Zend
@@ -65,8 +67,8 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
             return $this->annotations;
         }
 
-        $this->annotations = new \Zend\Code\Annotation\AnnotationCollection();
-        $reader            = new \Doctrine\Common\Annotations\AnnotationReader();
+        $this->annotations = new AnnotationCollection();
+        $reader            = new AnnotationReader();
         $annotations       = $reader->getMethodAnnotations($this);
 
         foreach ($annotations as $annotation) {

--- a/library/Zend/Code/Reflection/MethodReflection.php
+++ b/library/Zend/Code/Reflection/MethodReflection.php
@@ -61,15 +61,18 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
      */
     public function getAnnotations(AnnotationManager $annotationManager)
     {
-        if (($docComment = $this->getDocComment()) == '') {
-            return false;
+        if (null !== $this->annotations) {
+            return $this->annotations;
         }
 
-        if (!$this->annotations) {
-            $cachingFileScanner = new CachingFileScanner($this->getFileName());
-            $nameInformation    = $cachingFileScanner->getClassNameInformation($this->getDeclaringClass()->getName());
+        $this->annotations = new \Zend\Code\Annotation\AnnotationCollection();
+        $reader            = new \Doctrine\Common\Annotations\AnnotationReader();
+        $annotations       = $reader->getMethodAnnotations($this);
 
-            $this->annotations = new AnnotationScanner($annotationManager, $docComment, $nameInformation);
+        foreach ($annotations as $annotation) {
+            if ($annotationManager->hasAnnotation(get_class($annotation))) {
+                $this->annotations[] = $annotation;
+            }
         }
 
         return $this->annotations;

--- a/library/Zend/Code/Reflection/PropertyReflection.php
+++ b/library/Zend/Code/Reflection/PropertyReflection.php
@@ -24,6 +24,8 @@ use ReflectionProperty as PhpReflectionProperty;
 use Zend\Code\Annotation\AnnotationManager;
 use Zend\Code\Scanner\AnnotationScanner;
 use Zend\Code\Scanner\CachingFileScanner;
+use Zend\Code\Annotation\AnnotationCollection;
+use Doctrine\Common\Annotations\AnnotationReader;
 
 /**
  * @todo       implement line numbers
@@ -81,8 +83,8 @@ class PropertyReflection extends PhpReflectionProperty implements ReflectionInte
             return $this->annotations;
         }
 
-        $this->annotations = new \Zend\Code\Annotation\AnnotationCollection();
-        $reader            = new \Doctrine\Common\Annotations\AnnotationReader();
+        $this->annotations = new AnnotationCollection();
+        $reader            = new AnnotationReader();
         $annotations       = $reader->getPropertyAnnotations($this);
 
         foreach ($annotations as $annotation) {

--- a/library/Zend/Code/Reflection/PropertyReflection.php
+++ b/library/Zend/Code/Reflection/PropertyReflection.php
@@ -81,14 +81,15 @@ class PropertyReflection extends PhpReflectionProperty implements ReflectionInte
             return $this->annotations;
         }
 
-        if (($docComment = $this->getDocComment()) == '') {
-            return false;
-        }
+        $this->annotations = new \Zend\Code\Annotation\AnnotationCollection();
+        $reader            = new \Doctrine\Common\Annotations\AnnotationReader();
+        $annotations       = $reader->getPropertyAnnotations($this);
 
-        $class              = $this->getDeclaringClass();
-        $cachingFileScanner = new CachingFileScanner($class->getFileName());
-        $nameInformation    = $cachingFileScanner->getClassNameInformation($class->getName());
-        $this->annotations  = new AnnotationScanner($annotationManager, $docComment, $nameInformation);
+        foreach ($annotations as $annotation) {
+            if ($annotationManager->hasAnnotation(get_class($annotation))) {
+                $this->annotations[] = $annotation;
+            }
+        }
 
         return $this->annotations;
     }

--- a/library/Zend/Di/Definition/Annotation/Inject.php
+++ b/library/Zend/Di/Definition/Annotation/Inject.php
@@ -4,13 +4,10 @@ namespace Zend\Di\Definition\Annotation;
 
 use Zend\Code\Annotation\AnnotationInterface;
 
+/** @Annotation */
 class Inject implements AnnotationInterface
 {
-
-    protected $content = null;
-
     public function initialize($content)
     {
-        $this->content = $content;
     }
 }

--- a/library/Zend/Di/Definition/Annotation/Instantiator.php
+++ b/library/Zend/Di/Definition/Annotation/Instantiator.php
@@ -4,13 +4,10 @@ namespace Zend\Di\Definition\Annotation;
 
 use Zend\Code\Annotation\AnnotationInterface;
 
+/** @Annotation */
 class Instantiator implements AnnotationInterface
 {
-
-    protected $content = null;
-
     public function initialize($content)
     {
-        $this->content = $content;
     }
 }

--- a/library/Zend/Form/Annotation/AbstractAnnotation.php
+++ b/library/Zend/Form/Annotation/AbstractAnnotation.php
@@ -29,8 +29,8 @@ use Zend\Json\Json;
 /**
  * Base annotation for use with form annotation builder.
  *
- * Provides a stub for initialize(), allowing for "presence only" annotations 
- * (i.e., annotations that define behavior simply by being present). 
+ * Provides a stub for initialize(), allowing for "presence only" annotations
+ * (i.e., annotations that define behavior simply by being present).
  * Additionally, provides a method for parsing the contents of an annotation
  * if provided as a JSON entity.
  *
@@ -39,13 +39,16 @@ use Zend\Json\Json;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
 abstract class AbstractAnnotation implements AnnotationInterface
 {
+
     /**
      * Basic annotation; presence only is required
-     * 
-     * @param  mixed $content 
+     *
+     * @param  mixed $content
      * @return void
      */
     public function initialize($content)
@@ -54,8 +57,8 @@ abstract class AbstractAnnotation implements AnnotationInterface
 
     /**
      * Parse and return JSON content
-     * 
-     * @param  string $content 
+     *
+     * @param  string $content
      * @return mixed
      * @throws JsonException
      */

--- a/library/Zend/Form/Annotation/AllowEmpty.php
+++ b/library/Zend/Form/Annotation/AllowEmpty.php
@@ -24,7 +24,7 @@ namespace Zend\Form\Annotation;
 /**
  * AllowEmpty annotation
  *
- * Presence of this annotation is a hint that the associated 
+ * Presence of this annotation is a hint that the associated
  * \Zend\InputFilter\Input should enable the allow_empty flag.
  *
  * @category   Zend
@@ -32,7 +32,9 @@ namespace Zend\Form\Annotation;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
-class AllowEmpty extends AbstractAnnotation
+class AllowEmpty
 {
 }

--- a/library/Zend/Form/Annotation/AnnotationBuilder.php
+++ b/library/Zend/Form/Annotation/AnnotationBuilder.php
@@ -34,7 +34,7 @@ use Zend\Form\Factory;
 use Zend\Stdlib\ArrayUtils;
 
 /**
- * Parses a class' properties for annotations in order to create a form and 
+ * Parses a class' properties for annotations in order to create a form and
  * input filter definition.
  *
  * @category   Zend
@@ -46,17 +46,17 @@ use Zend\Stdlib\ArrayUtils;
 class AnnotationBuilder implements EventManagerAwareInterface
 {
     /**
-     * @var AnnotationManager 
+     * @var AnnotationManager
      */
     protected $annotationManager;
 
-    /** 
-     * @var EventManagerInterface 
+    /**
+     * @var EventManagerInterface
      */
     protected $events;
 
-    /** 
-     * @var Factory 
+    /**
+     * @var Factory
      */
     protected $formFactory;
 
@@ -82,8 +82,8 @@ class AnnotationBuilder implements EventManagerAwareInterface
 
     /**
      * Set form factory to use when building form from annotations
-     * 
-     * @param  Factory $formFactory 
+     *
+     * @param  Factory $formFactory
      * @return AnnotationBuilder
      */
     public function setFormFactory(Factory $formFactory)
@@ -94,24 +94,24 @@ class AnnotationBuilder implements EventManagerAwareInterface
 
     /**
      * Set annotation manager to use when building form from annotations
-     * 
-     * @param  AnnotationManager $annotationManager 
+     *
+     * @param  AnnotationManager $annotationManager
      * @return AnnotationBuilder
      */
     public function setAnnotationManager(AnnotationManager $annotationManager)
     {
         foreach ($this->defaultAnnotations as $annotationName) {
-            $class = __NAMESPACE__ . '\\' . $annotationName;
-            $annotationManager->registerAnnotation(new $class);
+            $annotationManager->registerAnnotationClassName(__NAMESPACE__ . '\\' . $annotationName);
         }
+
         $this->annotationManager = $annotationManager;
         return $this;
     }
 
     /**
      * Set event manager instance
-     * 
-     * @param  EventManagerInterface $events 
+     *
+     * @param  EventManagerInterface $events
      * @return AnnotationBuilder
      */
     public function setEventManager(EventManagerInterface $events)
@@ -130,7 +130,7 @@ class AnnotationBuilder implements EventManagerAwareInterface
      * Retrieve form factory
      *
      * Lazy-loads the default form factory if none is currently set.
-     * 
+     *
      * @return Factory
      */
     public function getFormFactory()
@@ -147,7 +147,7 @@ class AnnotationBuilder implements EventManagerAwareInterface
      * Retrieve annotation manager
      *
      * If none is currently set, creates one with default annotations.
-     * 
+     *
      * @return AnnotationManager
      */
     public function getAnnotationManager()
@@ -162,7 +162,7 @@ class AnnotationBuilder implements EventManagerAwareInterface
 
     /**
      * Get event manager
-     * 
+     *
      * @return EventManagerInterface
      */
     public function events()
@@ -176,10 +176,10 @@ class AnnotationBuilder implements EventManagerAwareInterface
     /**
      * Creates and returns a form specification for use with a factory
      *
-     * Parses the object provided, and processes annotations for the class and 
-     * all properties. Information from annotations is then used to create 
+     * Parses the object provided, and processes annotations for the class and
+     * all properties. Information from annotations is then used to create
      * specifications for a form, its elements, and its input filter.
-     * 
+     *
      * @param  string|object $entity Either an instance or a valid class name for an entity
      * @return ArrayObject
      */
@@ -226,7 +226,7 @@ class AnnotationBuilder implements EventManagerAwareInterface
     /**
      * Create a form from an object.
      *
-     * @param  string|object $entity 
+     * @param  string|object $entity
      * @return \Zend\Form\Form
      */
     public function createForm($entity)
@@ -238,11 +238,11 @@ class AnnotationBuilder implements EventManagerAwareInterface
 
     /**
      * Configure the form specification from annotations
-     * 
-     * @param  AnnotationCollection $annotations 
-     * @param  ClassReflection $reflection 
-     * @param  ArrayObject $formSpec 
-     * @param  ArrayObject $filterSpec 
+     *
+     * @param  AnnotationCollection $annotations
+     * @param  ClassReflection $reflection
+     * @param  ArrayObject $formSpec
+     * @param  ArrayObject $filterSpec
      * @return void
      * @triggers discoverName
      * @triggers configureForm
@@ -258,9 +258,9 @@ class AnnotationBuilder implements EventManagerAwareInterface
         $events = $this->events();
         foreach ($annotations as $annotation) {
             $events->trigger(__FUNCTION__, $this, array(
-                'annotation' => $annotation, 
+                'annotation' => $annotation,
                 'name'        => $name,
-                'formSpec'   => $formSpec, 
+                'formSpec'   => $formSpec,
                 'filterSpec' => $filterSpec,
             ));
         }
@@ -268,11 +268,11 @@ class AnnotationBuilder implements EventManagerAwareInterface
 
     /**
      * Configure an element from annotations
-     * 
-     * @param  AnnotationCollection $annotations 
-     * @param  \Zend\Code\Reflection\PropertyReflection $reflection 
-     * @param  ArrayObject $formSpec 
-     * @param  ArrayObject $filterSpec 
+     *
+     * @param  AnnotationCollection $annotations
+     * @param  \Zend\Code\Reflection\PropertyReflection $reflection
+     * @param  ArrayObject $formSpec
+     * @param  ArrayObject $filterSpec
      * @return void
      * @triggers checkForExclude
      * @triggers discoverName
@@ -303,7 +303,7 @@ class AnnotationBuilder implements EventManagerAwareInterface
             'name'        => $name,
             'elementSpec' => $elementSpec,
             'inputSpec'   => $inputSpec,
-            'formSpec'    => $formSpec, 
+            'formSpec'    => $formSpec,
             'filterSpec'  => $filterSpec,
         ));
         foreach ($annotations as $annotation) {
@@ -334,9 +334,9 @@ class AnnotationBuilder implements EventManagerAwareInterface
 
     /**
      * Discover the name of the given form or element
-     * 
-     * @param  AnnotationCollection $annotations 
-     * @param  \Reflector $reflection 
+     *
+     * @param  AnnotationCollection $annotations
+     * @param  \Reflector $reflection
      * @return string
      */
     protected function discoverName($annotations, $reflection)
@@ -352,8 +352,8 @@ class AnnotationBuilder implements EventManagerAwareInterface
 
     /**
      * Determine if an element is marked to exclude from the definitions
-     * 
-     * @param  AnnotationCollection $annotations 
+     *
+     * @param  AnnotationCollection $annotations
      * @return true|false
      */
     protected function checkForExclude($annotations)
@@ -369,10 +369,10 @@ class AnnotationBuilder implements EventManagerAwareInterface
     /**
      * Determine if the type represents a fieldset
      *
-     * For PHP versions >= 5.3.7, uses is_subclass_of; otherwise, uses 
+     * For PHP versions >= 5.3.7, uses is_subclass_of; otherwise, uses
      * reflection to determine the interfaces implemented.
-     * 
-     * @param  string $type 
+     *
+     * @param  string $type
      * @return bool
      */
     protected function isFieldset($type)

--- a/library/Zend/Form/Annotation/Attributes.php
+++ b/library/Zend/Form/Annotation/Attributes.php
@@ -27,7 +27,7 @@ use Zend\Form\Exception;
  * Attributes annotation
  *
  * Expects a JSON-encoded object/associative array as the content. The value is
- * used to set any attributes on the related form object (element, fieldset, or 
+ * used to set any attributes on the related form object (element, fieldset, or
  * form).
  *
  * @category   Zend
@@ -35,8 +35,10 @@ use Zend\Form\Exception;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
-class Attributes extends AbstractAnnotation
+class Attributes
 {
     /**
      * @var array
@@ -44,27 +46,24 @@ class Attributes extends AbstractAnnotation
     protected $attributes;
 
     /**
-     * Receive and process the contents of an annotation
-     * 
-     * @param  string $content 
-     * @return void
+     * @param array $data
      */
-    public function initialize($content)
+    public function __construct(array $data)
     {
-        $attributes = $this->parseJsonContent($content, __METHOD__);
-        if (!is_array($attributes)) {
+        if (!isset($data['value']) && !is_array($data['value'])) {
             throw new Exception\DomainException(sprintf(
-                '%s expects the annotation to define a JSON object or array; received "%s"',
-                __METHOD__,
-                gettype($attributes)
+                'Annotation %s expects the annotation to define an array as value, %s given',
+                __CLASS__,
+                gettype($data['value'])
             ));
         }
-        $this->attributes = $attributes;
+
+        $this->attributes = $data['value'];
     }
 
     /**
      * Retrieve the attributes
-     * 
+     *
      * @return null|array
      */
     public function getAttributes()

--- a/library/Zend/Form/Annotation/ComposedObject.php
+++ b/library/Zend/Form/Annotation/ComposedObject.php
@@ -26,9 +26,9 @@ use Zend\Form\Exception;
 /**
  * ComposedObject annotation
  *
- * Use this annotation to specify another object with annotations to parse 
- * which you can then add to the form as a fieldset. The value should be a bare 
- * string or a JSON-encoded string indicating the fully qualified class name of 
+ * Use this annotation to specify another object with annotations to parse
+ * which you can then add to the form as a fieldset. The value should be a bare
+ * string or a JSON-encoded string indicating the fully qualified class name of
  * the composed object to use.
  *
  * @category   Zend
@@ -36,8 +36,10 @@ use Zend\Form\Exception;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
-class ComposedObject extends AbstractAnnotation
+class ComposedObject
 {
     /**
      * @var string
@@ -45,30 +47,24 @@ class ComposedObject extends AbstractAnnotation
     protected $composedObject;
 
     /**
-     * Receive and process the contents of an annotation
-     * 
-     * @param  string $content 
-     * @return void
+     * @param array $data
      */
-    public function initialize($content)
+    public function __construct(array $data)
     {
-        $input = $content;
-        if ('"' === substr($content, 0, 1)) {
-            $input = $this->parseJsonContent($content, __METHOD__);
-        }
-        if (!is_string($input)) {
+        if (!isset($data['value']) && !is_string($data['value'])) {
             throw new Exception\DomainException(sprintf(
-                '%s expects the annotation to define a string or a JSON string; received "%s"',
+                '%s expects the annotation to define a string; received "%s"',
                 __METHOD__,
-                gettype($input)
+                gettype($data['value'])
             ));
         }
-        $this->composedObject = $input;
+
+        $this->composedObject = $data['value'];
     }
 
     /**
      * Retrieve the composed object classname
-     * 
+     *
      * @return null|string
      */
     public function getComposedObject()

--- a/library/Zend/Form/Annotation/ErrorMessage.php
+++ b/library/Zend/Form/Annotation/ErrorMessage.php
@@ -26,7 +26,7 @@ use Zend\Form\Exception;
 /**
  * ErrorMessage annotation
  *
- * Allows providing an error message to seed the Input specification for a 
+ * Allows providing an error message to seed the Input specification for a
  * given element. The content may either be a bare string or a JSON-encoded
  * string.
  *
@@ -35,8 +35,10 @@ use Zend\Form\Exception;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
-class ErrorMessage extends AbstractAnnotation
+class ErrorMessage
 {
     /**
      * @var string
@@ -44,30 +46,24 @@ class ErrorMessage extends AbstractAnnotation
     protected $message;
 
     /**
-     * Receive and process the contents of an annotation
-     * 
-     * @param  string $content 
-     * @return void
+     * @param array $data
      */
-    public function initialize($content)
+    public function __construct(array $data)
     {
-        $message = $content;
-        if ('"' === substr($content, 0, 1)) {
-            $message = $this->parseJsonContent($content, __METHOD__);
-        }
-        if (!is_string($message)) {
+        if (!isset($data['value']) || !(is_string($data['value']) || is_array($data['value']))) {
             throw new Exception\DomainException(sprintf(
-                '%s expects the annotation to define a string or a JSON string; received "%s"',
+                '%s expects the annotation to define a string or array; received "%s"',
                 __METHOD__,
-                gettype($content)
+                gettype($data['value'])
             ));
         }
-        $this->message = $message;
+
+        $this->message = $data['value'];
     }
 
     /**
      * Retrieve the message
-     * 
+     *
      * @return null|string
      */
     public function getMessage()

--- a/library/Zend/Form/Annotation/Exclude.php
+++ b/library/Zend/Form/Annotation/Exclude.php
@@ -32,7 +32,9 @@ namespace Zend\Form\Annotation;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
-class Exclude extends AbstractAnnotation
+class Exclude
 {
 }

--- a/library/Zend/Form/Annotation/Filter.php
+++ b/library/Zend/Form/Annotation/Filter.php
@@ -26,7 +26,7 @@ use Zend\Form\Exception;
 /**
  * Filter annotation
  *
- * Expects a JSON-encoded object/associative array defining the filter. 
+ * Expects a JSON-encoded object/associative array defining the filter.
  * Typically, this includes the "name" with an associated string value
  * indicating the filter name or class, and optionally an "options" key
  * with an object/associative array value of options to pass to the
@@ -40,8 +40,10 @@ use Zend\Form\Exception;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
-class Filter extends AbstractAnnotation
+class Filter
 {
     /**
      * @var array
@@ -49,27 +51,24 @@ class Filter extends AbstractAnnotation
     protected $filter;
 
     /**
-     * Receive and process the contents of an annotation
-     * 
-     * @param  string $content 
-     * @return void
+     * @param array $data
      */
-    public function initialize($content)
+    public function __construct(array $data)
     {
-        $filter = $this->parseJsonContent($content, __METHOD__);
-        if (!is_array($filter)) {
+        if (!isset($data['value']) && is_array($data['value'])) {
             throw new Exception\DomainException(sprintf(
-                '%s expects the annotation to define a JSON object or array; received "%s"',
+                '%s expects the annotation to define an array; received "%s"',
                 __METHOD__,
-                gettype($filter)
+                gettype($data['value'])
             ));
         }
-        $this->filter = $filter;
+
+        $this->filter = $data['value'];
     }
 
     /**
      * Retrieve the filter specification
-     * 
+     *
      * @return null|array
      */
     public function getFilter()

--- a/library/Zend/Form/Annotation/Flags.php
+++ b/library/Zend/Form/Annotation/Flags.php
@@ -26,8 +26,8 @@ use Zend\Form\Exception;
 /**
  * Flags annotation
  *
- * Allows passing flags to the form factory. These flags are used to indicate 
- * metadata, and typically the priority (order) in which an element will be 
+ * Allows passing flags to the form factory. These flags are used to indicate
+ * metadata, and typically the priority (order) in which an element will be
  * included.
  *
  * The value should be a JSON-encoded object/associative array.
@@ -37,8 +37,10 @@ use Zend\Form\Exception;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
-class Flags extends AbstractAnnotation
+class Flags
 {
     /**
      * @var array
@@ -46,27 +48,24 @@ class Flags extends AbstractAnnotation
     protected $flags;
 
     /**
-     * Receive and process the contents of an annotation
-     * 
-     * @param  string $content 
-     * @return void
+     * @param array $data
      */
-    public function initialize($content)
+    public function __construct(array $data)
     {
-        $flags = $this->parseJsonContent($content, __METHOD__);
-        if (!is_array($flags)) {
+        if (!isset($data['value']) && is_array($data['value'])) {
             throw new Exception\DomainException(sprintf(
-                '%s expects the annotation to define a JSON object or array; received "%s"',
+                '%s expects the annotation to define an array; received "%s"',
                 __METHOD__,
-                gettype($flags)
+                gettype($data['value'])
             ));
         }
-        $this->flags = $flags;
+
+        $this->flags = $data['value'];
     }
 
     /**
      * Retrieve the flags
-     * 
+     *
      * @return null|array
      */
     public function getFlags()

--- a/library/Zend/Form/Annotation/Hydrator.php
+++ b/library/Zend/Form/Annotation/Hydrator.php
@@ -27,7 +27,7 @@ use Zend\Form\Exception;
  * Hydrator annotation
  *
  * Use this annotation to specify a specific hydrator class to use with the form.
- * The value should be a bare string or a JSON-encoded string indicating the 
+ * The value should be a bare string or a JSON-encoded string indicating the
  * fully qualified class name of the hydrator to use.
  *
  * @category   Zend
@@ -35,8 +35,10 @@ use Zend\Form\Exception;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
-class Hydrator extends AbstractAnnotation
+class Hydrator
 {
     /**
      * @var string
@@ -44,34 +46,24 @@ class Hydrator extends AbstractAnnotation
     protected $hydrator;
 
     /**
-     * Receive and process the contents of an annotation
-     * 
-     * @param  string $content 
-     * @return void
+     * @param array $data
      */
-    public function initialize($content)
+    public function __construct(array $data)
     {
-        $hydrator = $content;
-
-        if ('"' === substr($hydrator, 0, 1)) {
-            // Look for unescaped NS, and escape them so the parser knows what to do
-            $hydrator = preg_replace('#(\\\\)(?!\\\\)#', '$1$1', $hydrator);
-            $hydrator = $this->parseJsonContent($hydrator, __METHOD__);
-        }
-
-        if (!is_string($hydrator)) {
+        if (!isset($data['value']) && !is_string($data['value'])) {
             throw new Exception\DomainException(sprintf(
-                '%s expects the annotation to define a string or a JSON string; received "%s"',
+                '%s expects the annotation to define a string; received "%s"',
                 __METHOD__,
-                gettype($hydrator)
+                gettype($data['value'])
             ));
         }
-        $this->hydrator = $hydrator;
+
+        $this->hydrator = $data['value'];
     }
 
     /**
      * Retrieve the hydrator class
-     * 
+     *
      * @return null|string
      */
     public function getHydrator()

--- a/library/Zend/Form/Annotation/Input.php
+++ b/library/Zend/Form/Annotation/Input.php
@@ -27,7 +27,7 @@ use Zend\Form\Exception;
  * Input annotation
  *
  * Use this annotation to specify a specific input class to use with an element.
- * The value should be a bare string or a JSON-encoded string indicating the 
+ * The value should be a bare string or a JSON-encoded string indicating the
  * fully qualified class name of the input to use.
  *
  * @category   Zend
@@ -35,8 +35,10 @@ use Zend\Form\Exception;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
-class Input extends AbstractAnnotation
+class Input
 {
     /**
      * @var string
@@ -44,30 +46,24 @@ class Input extends AbstractAnnotation
     protected $input;
 
     /**
-     * Receive and process the contents of an annotation
-     * 
-     * @param  string $content 
-     * @return void
+     * @param array $data
      */
-    public function initialize($content)
+    public function __construct(array $data)
     {
-        $input = $content;
-        if ('"' === substr($content, 0, 1)) {
-            $input = $this->parseJsonContent($content, __METHOD__);
-        }
-        if (!is_string($input)) {
+        if (!isset($data['value']) && !is_string($data['value'])) {
             throw new Exception\DomainException(sprintf(
-                '%s expects the annotation to define a string or a JSON string; received "%s"',
+                '%s expects the annotation to define a string; received "%s"',
                 __METHOD__,
-                gettype($input)
+                gettype($data['value'])
             ));
         }
-        $this->input = $input;
+
+        $this->input = $data['value'];
     }
 
     /**
      * Retrieve the input class
-     * 
+     *
      * @return null|string
      */
     public function getInput()

--- a/library/Zend/Form/Annotation/InputFilter.php
+++ b/library/Zend/Form/Annotation/InputFilter.php
@@ -26,8 +26,8 @@ use Zend\Form\Exception;
 /**
  * InputFilter annotation
  *
- * Use this annotation to specify a specific input filter class to use with the 
- * form. The value should be a bare string or a JSON-encoded string indicating 
+ * Use this annotation to specify a specific input filter class to use with the
+ * form. The value should be a bare string or a JSON-encoded string indicating
  * the fully qualified class name of the input filter to use.
  *
  * @category   Zend
@@ -35,8 +35,10 @@ use Zend\Form\Exception;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
-class InputFilter extends AbstractAnnotation
+class InputFilter
 {
     /**
      * @var string
@@ -44,34 +46,24 @@ class InputFilter extends AbstractAnnotation
     protected $inputFilter;
 
     /**
-     * Receive and process the contents of an annotation
-     * 
-     * @param  string $content 
-     * @return void
+     * @param array $data
      */
-    public function initialize($content)
+    public function __construct(array $data)
     {
-        $inputFilter = $content;
-
-        if ('"' === substr($inputFilter, 0, 1)) {
-            // Look for unescaped NS, and escape them so the parser knows what to do
-            $inputFilter = preg_replace('#(\\\\)(?!\\\\)#', '$1$1', $inputFilter);
-            $inputFilter = $this->parseJsonContent($inputFilter, __METHOD__);
-        }
-
-        if (!is_string($inputFilter)) {
+        if (!isset($data['value']) && !is_string($data['value'])) {
             throw new Exception\DomainException(sprintf(
-                '%s expects the annotation to define a string or a JSON string; received "%s"',
+                '%s expects the annotation to define a string; received "%s"',
                 __METHOD__,
-                gettype($inputFilter)
+                gettype($data['value'])
             ));
         }
-        $this->inputFilter = $inputFilter;
+
+        $this->inputFilter = $data['value'];
     }
 
     /**
      * Retrieve the input filter class
-     * 
+     *
      * @return null|string
      */
     public function getInputFilter()

--- a/library/Zend/Form/Annotation/Name.php
+++ b/library/Zend/Form/Annotation/Name.php
@@ -35,8 +35,10 @@ use Zend\Form\Exception;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
-class Name extends AbstractAnnotation
+class Name
 {
     /**
      * @var string
@@ -44,30 +46,24 @@ class Name extends AbstractAnnotation
     protected $name;
 
     /**
-     * Receive and process the contents of an annotation
-     * 
-     * @param  string $content 
-     * @return void
+     * @param array $data
      */
-    public function initialize($content)
+    public function __construct(array $data)
     {
-        $name = $content;
-        if ('"' === substr($content, 0, 1)) {
-            $name = $this->parseJsonContent($content, __METHOD__);
-        }
-        if (!is_string($name)) {
+        if (!isset($data['value']) && !is_string($data['value'])) {
             throw new Exception\DomainException(sprintf(
-                '%s expects the annotation to define a string or a JSON string; received "%s"',
+                '%s expects the annotation to define a string; received "%s"',
                 __METHOD__,
-                gettype($name)
+                gettype($data['value'])
             ));
         }
-        $this->name = $name;
+
+        $this->name = $data['value'];
     }
 
     /**
      * Retrieve the name
-     * 
+     *
      * @return null|string
      */
     public function getName()

--- a/library/Zend/Form/Annotation/Required.php
+++ b/library/Zend/Form/Annotation/Required.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Form\Annotation;
 
-use Zend\Filter\Boolean as BooleanFilter;
+use Zend\Form\Exception;
 
 /**
  * Required annotation
@@ -37,43 +37,40 @@ use Zend\Filter\Boolean as BooleanFilter;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
-class Required extends AbstractAnnotation
+class Required
 {
     /**
      * @var bool
      */
-    protected $required = true;
+    protected $value = true;
 
     /**
-     * Receive and process the contents of an annotation
-     * 
-     * @param  string $content 
-     * @return void
+     * @param array $data
      */
-    public function initialize($content)
+    public function __construct(array $data)
     {
-        $required = $content;
-        if ('"' === substr($content, 0, 1)) {
-            $required = $this->parseJsonContent($content, __METHOD__);
+        if (!isset($data['value']) && !is_bool($data['value'])) {
+            throw new Exception\DomainException(sprintf(
+                '%s expects the annotation to define a boolean; received "%s"',
+                __METHOD__,
+                gettype($data['value'])
+            ));
         }
 
-        if (!is_bool($required)) {
-            $filter   = new BooleanFilter();
-            $required = $filter->filter($required);
-        }
-
-        $this->required = $required;
+        $this->value = $data['value'];
     }
 
     /**
      * Get value of required flag
-     * 
+     *
      * @return bool
      */
     public function getRequired()
     {
-        return $this->required;
+        return $this->value;
     }
 }
 

--- a/library/Zend/Form/Annotation/Type.php
+++ b/library/Zend/Form/Annotation/Type.php
@@ -26,7 +26,7 @@ use Zend\Form\Exception;
 /**
  * Type annotation
  *
- * Use this annotation to specify the specific \Zend\Form class to use when 
+ * Use this annotation to specify the specific \Zend\Form class to use when
  * building the form, fieldset, or element. The value should be a bare string
  * or JSON-encoded string, and represent a fully qualified classname.
  *
@@ -35,8 +35,10 @@ use Zend\Form\Exception;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
-class Type extends AbstractAnnotation
+class Type
 {
     /**
      * @var string
@@ -44,30 +46,24 @@ class Type extends AbstractAnnotation
     protected $type;
 
     /**
-     * Receive and process the contents of an annotation
-     * 
-     * @param  string $content 
-     * @return void
+     * @param array $data
      */
-    public function initialize($content)
+    public function __construct(array $data)
     {
-        $type = $content;
-        if ('"' === substr($content, 0, 1)) {
-            $type = $this->parseJsonContent($content, __METHOD__);
-        }
-        if (!is_string($type)) {
+        if (!isset($data['value']) && !is_string($data['value'])) {
             throw new Exception\DomainException(sprintf(
-                '%s expects the annotation to define a string or a JSON string; received "%s"',
+                '%s expects the annotation to define a string; received "%s"',
                 __METHOD__,
-                gettype($type)
+                gettype($data['value'])
             ));
         }
-        $this->type = $type;
+
+        $this->type = $data['value'];
     }
 
     /**
      * Retrieve the class type
-     * 
+     *
      * @return null|string
      */
     public function getType()

--- a/library/Zend/Form/Annotation/Validator.php
+++ b/library/Zend/Form/Annotation/Validator.php
@@ -26,7 +26,7 @@ use Zend\Form\Exception;
 /**
  * Validator annotation
  *
- * Expects a JSON-encoded object/associative array defining the validator. 
+ * Expects a JSON-encoded object/associative array defining the validator.
  * Typically, this includes the "name" with an associated string value
  * indicating the validator name or class, and optionally an "options" key
  * with an object/associative array value of options to pass to the
@@ -40,8 +40,10 @@ use Zend\Form\Exception;
  * @subpackage Annotation
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
+ * @Annotation
  */
-class Validator extends AbstractAnnotation
+class Validator
 {
     /**
      * @var array
@@ -49,27 +51,24 @@ class Validator extends AbstractAnnotation
     protected $validator;
 
     /**
-     * Receive and process the contents of an annotation
-     * 
-     * @param  string $content 
-     * @return void
+     * @param array $data
      */
-    public function initialize($content)
+    public function __construct(array $data)
     {
-        $validator = $this->parseJsonContent($content, __METHOD__);
-        if (!is_array($validator)) {
+        if (!(isset($data['value']) && is_array($data['value']))) {
             throw new Exception\DomainException(sprintf(
-                '%s expects the annotation to define a JSON object or array; received "%s"',
+                '%s expects the annotation to define an array; received "%s"',
                 __METHOD__,
-                gettype($validator)
+                gettype($data['value'])
             ));
         }
-        $this->validator = $validator;
+
+        $this->validator = $data['value'];
     }
 
     /**
      * Retrieve the validator specification
-     * 
+     *
      * @return null|array
      */
     public function getValidator()

--- a/tests/Zend/Code/Annotation/AnnotationManagerTest.php
+++ b/tests/Zend/Code/Annotation/AnnotationManagerTest.php
@@ -26,6 +26,11 @@ use Zend\Code\Annotation;
 
 class AnnotationManagerTest extends TestCase
 {
+    /**
+     * @var \Zend\Code\Annotation\AnnotationManager
+     */
+    protected $manager;
+
     public function setUp()
     {
         $this->manager = new Annotation\AnnotationManager();
@@ -78,5 +83,13 @@ class AnnotationManagerTest extends TestCase
         $this->assertInstanceOf(__NAMESPACE__ . '\TestAsset\Bar', $test);
         $this->assertNotSame($bar, $test);
         $this->assertEquals('test content', $test->content);
+    }
+
+    public function testAllowsRegisteringClassNames()
+    {
+        $this->manager->registerAnnotationClassName(__NAMESPACE__ . '\TestAsset\Bar');
+        $this->assertTrue($this->manager->hasAnnotation(__NAMESPACE__ . '\TestAsset\Bar'));
+        $this->setExpectedException('Zend\Code\Exception\RuntimeException');
+        $this->manager->createAnnotation(__NAMESPACE__ . '\TestAsset\Bar');
     }
 }

--- a/tests/Zend/Code/Annotation/TestAsset/Bar.php
+++ b/tests/Zend/Code/Annotation/TestAsset/Bar.php
@@ -23,6 +23,7 @@ namespace ZendTest\Code\Annotation\TestAsset;
 
 use Zend\Code\Annotation\AnnotationInterface;
 
+/** @Annotation */
 class Bar implements AnnotationInterface
 {
     public $content;

--- a/tests/Zend/Code/Annotation/TestAsset/Foo.php
+++ b/tests/Zend/Code/Annotation/TestAsset/Foo.php
@@ -23,6 +23,7 @@ namespace ZendTest\Code\Annotation\TestAsset;
 
 use Zend\Code\Annotation\AnnotationInterface;
 
+/** @Annotation */
 class Foo implements AnnotationInterface
 {
     public $content;

--- a/tests/Zend/Code/Reflection/ClassReflectionTest.php
+++ b/tests/Zend/Code/Reflection/ClassReflectionTest.php
@@ -97,7 +97,7 @@ class ClassReflectionTest extends \PHPUnit_Framework_TestCase
     protected \$_prop1 = null;
 
     /**
-     * @Sample({"foo":"bar"})
+     * @Sample(content="{""foo"":""bar""}")
      */
     protected \$_prop2 = null;
 

--- a/tests/Zend/Code/Reflection/PropertyReflectionTest.php
+++ b/tests/Zend/Code/Reflection/PropertyReflectionTest.php
@@ -43,9 +43,8 @@ class PropertyReflectionTest extends \PHPUnit_Framework_TestCase
 
     public function testAnnotationScanningIsPossible()
     {
-        $manager = new AnnotationManager(array(
-            new TestAsset\SampleAnnotation(array('content' => '')),
-        ));
+        $manager = new AnnotationManager();
+        $manager->registerAnnotationClassName('ZendTest\Code\Reflection\TestAsset\SampleAnnotation');
         $property = new \Zend\Code\Reflection\PropertyReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass2', '_prop2');
         $annotations = $property->getAnnotations($manager);
         $this->assertInstanceOf('Zend\Code\Annotation\AnnotationCollection', $annotations);

--- a/tests/Zend/Code/Reflection/PropertyReflectionTest.php
+++ b/tests/Zend/Code/Reflection/PropertyReflectionTest.php
@@ -44,14 +44,14 @@ class PropertyReflectionTest extends \PHPUnit_Framework_TestCase
     public function testAnnotationScanningIsPossible()
     {
         $manager = new AnnotationManager(array(
-            new TestAsset\SampleAnnotation(),
+            new TestAsset\SampleAnnotation(array('content' => '')),
         ));
         $property = new \Zend\Code\Reflection\PropertyReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass2', '_prop2');
         $annotations = $property->getAnnotations($manager);
         $this->assertInstanceOf('Zend\Code\Annotation\AnnotationCollection', $annotations);
         $this->assertTrue($annotations->hasAnnotation('ZendTest\Code\Reflection\TestAsset\SampleAnnotation'));
         $found = false;
-        foreach ($annotations as $key => $annotation) {
+        foreach ($annotations as $annotation) {
             if (!$annotation instanceof TestAsset\SampleAnnotation) {
                 continue;
             }

--- a/tests/Zend/Code/Reflection/TestAsset/SampleAnnotation.php
+++ b/tests/Zend/Code/Reflection/TestAsset/SampleAnnotation.php
@@ -4,12 +4,18 @@ namespace ZendTest\Code\Reflection\TestAsset;
 
 use Zend\Code\Annotation\AnnotationInterface;
 
+/** @Annotation */
 class SampleAnnotation implements AnnotationInterface
 {
     public $content;
 
+    public function __construct($data)
+    {
+        $this->content = __CLASS__ . ': ' . $data['content'];
+    }
+
     public function initialize($content)
     {
-        $this->content = __CLASS__ . ': ' . $content;
+        // @todo remove
     }
 }

--- a/tests/Zend/Code/Reflection/TestAsset/TestSampleClass2.php
+++ b/tests/Zend/Code/Reflection/TestAsset/TestSampleClass2.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace ZendTest\Code\Reflection\TestAsset;
 
@@ -9,7 +9,7 @@ class TestSampleClass2 implements \IteratorAggregate
     protected $_prop1 = null;
 
     /**
-     * @Sample({"foo":"bar"})
+     * @Sample(content="{""foo"":""bar""}")
      */
     protected $_prop2 = null;
 

--- a/tests/Zend/Code/Scanner/TestAsset/Annotation/Bar.php
+++ b/tests/Zend/Code/Scanner/TestAsset/Annotation/Bar.php
@@ -4,6 +4,7 @@ namespace ZendTest\Code\Scanner\TestAsset\Annotation;
 
 use Zend\Code\Annotation\AnnotationInterface;
 
+/** @Annotation */
 class Bar implements AnnotationInterface
 {
     protected $content = null;

--- a/tests/Zend/Code/Scanner/TestAsset/Annotation/Foo.php
+++ b/tests/Zend/Code/Scanner/TestAsset/Annotation/Foo.php
@@ -4,6 +4,7 @@ namespace ZendTest\Code\Scanner\TestAsset\Annotation;
 
 use Zend\Code\Annotation\AnnotationInterface;
 
+/** @Annotation */
 class Foo implements AnnotationInterface
 {
     protected $content = null;

--- a/tests/Zend/Form/TestAsset/Annotation/ComplexEntity.php
+++ b/tests/Zend/Form/TestAsset/Annotation/ComplexEntity.php
@@ -6,12 +6,12 @@ use Zend\Form\Annotation;
 /**
  * @Annotation\Name("user")
  * @Annotation\Attributes({"legend":"Register"})
- * @Annotation\Hydrator(Zend\Stdlib\Hydrator\ObjectProperty)
+ * @Annotation\Hydrator("Zend\Stdlib\Hydrator\ObjectProperty")
  */
 class ComplexEntity
 {
     /**
-     * @Annotation\ErrorMessage('Invalid or missing username')
+     * @Annotation\ErrorMessage("Invalid or missing username")
      * @Annotation\Filter({"name":"StringTrim"})
      * @Annotation\Validator({"name":"NotEmpty"})
      * @Annotation\Validator({"name":"StringLength","options":{"min":3,"max":25}})
@@ -38,7 +38,7 @@ class ComplexEntity
      * @Annotation\AllowEmpty()
      * @Annotation\Required(false)
      * @Annotation\Attributes({"type":"text","label":"Provide a URL for your avatar (optional):"})
-     * @Annotation\Validator({"name":"ZendTest\\Form\\TestAsset\\Annotation\\UrlValidator"})
+     * @Annotation\Validator({"name":"ZendTest\Form\TestAsset\Annotation\UrlValidator"})
      */
     public $avatar;
 

--- a/tests/Zend/Form/TestAsset/Annotation/Entity.php
+++ b/tests/Zend/Form/TestAsset/Annotation/Entity.php
@@ -6,7 +6,7 @@ use Zend\Form\Annotation;
 class Entity
 {
     /**
-      * @Annotation\ErrorMessage('Invalid or missing username')
+      * @Annotation\ErrorMessage("Invalid or missing username")
       * @Annotation\Required(true)
       * @Annotation\Filter({"name":"StringTrim"})
       * @Annotation\Validator({"name":"NotEmpty"})

--- a/tests/Zend/Form/TestAsset/Annotation/EntityComposingAnEntity.php
+++ b/tests/Zend/Form/TestAsset/Annotation/EntityComposingAnEntity.php
@@ -10,7 +10,7 @@ class EntityComposingAnEntity
 {
     /**
      * @Annotation\Name("composed")
-     * @Annotation\ComposedObject(ZendTest\Form\TestAsset\Annotation\Entity)
+     * @Annotation\ComposedObject("ZendTest\Form\TestAsset\Annotation\Entity")
      */
     public $child;
 }

--- a/tests/Zend/Form/TestAsset/Annotation/ExtendedEntity.php
+++ b/tests/Zend/Form/TestAsset/Annotation/ExtendedEntity.php
@@ -4,7 +4,7 @@ namespace ZendTest\Form\TestAsset\Annotation;
 use Zend\Form\Annotation;
 
 /**
- * @Annotation\Name(extended)
+ * @Annotation\Name("extended")
  */
 class ExtendedEntity extends Entity
 {

--- a/tests/Zend/Form/TestAsset/Annotation/TypedEntity.php
+++ b/tests/Zend/Form/TestAsset/Annotation/TypedEntity.php
@@ -4,13 +4,13 @@ namespace ZendTest\Form\TestAsset\Annotation;
 use Zend\Form\Annotation;
 
 /**
- * @Annotation\Type(ZendTest\Form\TestAsset\Annotation\Form)
+ * @Annotation\Type("ZendTest\Form\TestAsset\Annotation\Form")
  */
 class TypedEntity
 {
     /**
-     * @Annotation\Type(ZendTest\Form\TestAsset\Annotation\Element)
-     * @Annotation\Name(typed_element)
+     * @Annotation\Type("ZendTest\Form\TestAsset\Annotation\Element")
+     * @Annotation\Name("typed_element")
      */
     public $typedElement;
 }

--- a/tests/_autoload.php
+++ b/tests/_autoload.php
@@ -1,56 +1,15 @@
 <?php
-/**
- * Setup autoloading
- */
-function ZendTest_Autoloader($class) 
-{
-    $class = ltrim($class, '\\');
-
-    if (!preg_match('#^(Zend(Test)?|PHPUnit)(\\\\|_)#', $class)) {
-        return false;
-    }
-
-    // $segments = explode('\\', $class); // preg_split('#\\\\|_#', $class);//
-    $segments = preg_split('#[\\\\_]#', $class); // preg_split('#\\\\|_#', $class);//
-    $ns       = array_shift($segments);
-
-    switch ($ns) {
-        case 'Zend':
-            $file = dirname(__DIR__) . '/library/Zend/';
-            break;
-        case 'ZendTest':
-            // temporary fix for ZendTest namespace until we can migrate files 
-            // into ZendTest dir
-            $file = __DIR__ . '/Zend/';
-            break;
-        default:
-            $file = false;
-            break;
-    }
-
-    if ($file) {
-        $file .= implode('/', $segments) . '.php';
-        if (file_exists($file)) {
-            return include_once $file;
-        }
-    }
-
-    $segments = explode('_', $class);
-    $ns       = array_shift($segments);
-
-    switch ($ns) {
-        case 'Zend':
-            $file = dirname(__DIR__) . '/library/Zend/';
-            break;
-        default:
-            return false;
-    }
-    $file .= implode('/', $segments) . '.php';
-    if (file_exists($file)) {
-        return include_once $file;
-    }
-
-    return false;
+if (!include_once __DIR__ . '/../vendor/autoload.php') {
+    throw new UnexpectedValueException('Coul not find composer, did you run `php composer.phar install`?');
 }
-spl_autoload_register('ZendTest_Autoloader', true, true);
 
+require_once __DIR__ . '/../library/Zend/Loader/StandardAutoloader.php';
+
+$loader = new Zend\Loader\StandardAutoloader(array(
+    Zend\Loader\StandardAutoloader::LOAD_NS => array(
+        'Zend'      => __DIR__ . '/../library',
+        'ZendTest'  => __DIR__ . '/Zend',
+    ),
+));
+
+$loader->register();


### PR DESCRIPTION
This PR introduces a dependency to doctrine/common and makes tests depend on composer for autoloading. I also removed some parts of `tests/_autoload.php` since `Zend\Loader\StandardAutoloader` can handle it.

If you don't know about annotations, please read http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/annotations.html .

Basically, the idea is that the annotation parser in ZF2 can still exists, but [doctrine/common](https://github.com/doctrine/common) (which is not to be confused with ORM) already has a quite well affirmed syntax that could be re-used and covers all use cases I can think of right now. We should suggest end-users to use this "standard" instead of suggesting a new one that will collide hard with what currently Symfony 2 and Flow3 use.

@ezimuel has already suggested a nice approach at doctrine/common#156 to help in the process of making doctrine annotations compatible with other formats that could be used (since its parser doesn't really like ZF2's annotations right now).

I hope everybody will agree that we don't really need a new format for annotations since the one in doctrine/common has been working for everyone since a couple of years.

About tests requiring composer run, @Maks3w suggested to use a constant. Will eventually do that later.

[![Build Status](https://secure.travis-ci.org/Ocramius/zf2.png?branch=feature/reuse-doctrine-common-annotations)](http://travis-ci.org/Ocramius/zf2)
