### PR TITLE
[Db\Adapter] Changed getDefault{Catalog,Schema} to getCurrent{Catalog,Schema}

### DIFF
--- a/library/Zend/Db/Adapter/Adapter.php
+++ b/library/Zend/Db/Adapter/Adapter.php
@@ -135,11 +135,6 @@ class Adapter
         return $this->platform;
     }
 
-    public function getCurrentCatalog()
-    {
-        return $this->driver->getConnection()->getCurrentCatalog();
-    }
-
     public function getCurrentSchema()
     {
         return $this->driver->getConnection()->getCurrentSchema();

--- a/library/Zend/Db/Adapter/Adapter.php
+++ b/library/Zend/Db/Adapter/Adapter.php
@@ -135,9 +135,14 @@ class Adapter
         return $this->platform;
     }
 
-    public function getDefaultSchema()
+    public function getCurrentCatalog()
     {
-        return $this->driver->getConnection()->getDefaultSchema();
+        return $this->driver->getConnection()->getCurrentCatalog();
+    }
+
+    public function getCurrentSchema()
+    {
+        return $this->driver->getConnection()->getCurrentSchema();
     }
 
     /**

--- a/library/Zend/Db/Adapter/Driver/ConnectionInterface.php
+++ b/library/Zend/Db/Adapter/Driver/ConnectionInterface.php
@@ -17,8 +17,8 @@ namespace Zend\Db\Adapter\Driver;
  */
 interface ConnectionInterface
 {
-    public function getDefaultCatalog();
-    public function getDefaultSchema();
+    public function getCurrentCatalog();
+    public function getCurrentSchema();
     public function getResource();
     public function connect();
     public function isConnected();

--- a/library/Zend/Db/Adapter/Driver/ConnectionInterface.php
+++ b/library/Zend/Db/Adapter/Driver/ConnectionInterface.php
@@ -17,7 +17,7 @@ namespace Zend\Db\Adapter\Driver;
  */
 interface ConnectionInterface
 {
-    public function getCurrentCatalog();
+    public function getDefaultCatalog();
     public function getCurrentSchema();
     public function getResource();
     public function connect();

--- a/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
@@ -95,11 +95,11 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Get current catalog
+     * Get default catalog
      * 
-     * @return string 
+     * @return null 
      */
-    public function getCurrentCatalog()
+    public function getDefaultCatalog()
     {
         return null;
     }

--- a/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
@@ -95,21 +95,21 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Get default catalog
+     * Get current catalog
      * 
-     * @return null 
+     * @return string 
      */
-    public function getDefaultCatalog()
+    public function getCurrentCatalog()
     {
         return null;
     }
 
     /**
-     * Get default schema
+     * Get current schema
      * 
      * @return string 
      */
-    public function getDefaultSchema()
+    public function getCurrentSchema()
     {
         if (!$this->isConnected()) {
             $this->connect();

--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -108,11 +108,9 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Get current catalog
-     * 
-     * @return string 
+     * @return null
      */
-    public function getCurrentCatalog()
+    public function getDefaultCatalog()
     {
         return null;
     }

--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -108,17 +108,21 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * @return null
+     * Get current catalog
+     * 
+     * @return string 
      */
-    public function getDefaultCatalog()
+    public function getCurrentCatalog()
     {
         return null;
     }
 
     /**
-     * @return mixed
+     * Get current schema
+     * 
+     * @return string 
      */
-    public function getDefaultSchema()
+    public function getCurrentSchema()
     {
         if (!$this->isConnected()) {
             $this->connect();

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Connection.php
@@ -92,21 +92,21 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Get default catalog
-     *
-     * @return null
+     * Get current catalog
+     * 
+     * @return string 
      */
-    public function getDefaultCatalog()
+    public function getCurrentCatalog()
     {
         return null;
     }
 
     /**
-     * Get dafault schema
+     * Get current schema
      *
      * @return string
      */
-    public function getDefaultSchema()
+    public function getCurrentSchema()
     {
         if (!$this->isConnected()) {
             $this->connect();

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Connection.php
@@ -92,11 +92,11 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Get current catalog
-     * 
-     * @return string 
+     * Get default catalog
+     *
+     * @return null
      */
-    public function getCurrentCatalog()
+    public function getDefaultCatalog()
     {
         return null;
     }

--- a/library/Zend/Db/Metadata/Source/InformationSchemaMetadata.php
+++ b/library/Zend/Db/Metadata/Source/InformationSchemaMetadata.php
@@ -48,7 +48,7 @@ class InformationSchemaMetadata implements MetadataInterface
     public function __construct(Adapter $adapter)
     {
         $this->adapter = $adapter;
-        $this->defaultSchema = ($adapter->getDefaultSchema()) ?: '__DEFAULT_SCHEMA__';
+        $this->defaultSchema = ($adapter->getCurrentSchema()) ?: '__DEFAULT_SCHEMA__';
     }
 
     /**

--- a/tests/Zend/Db/Adapter/AdapterTest.php
+++ b/tests/Zend/Db/Adapter/AdapterTest.php
@@ -143,13 +143,23 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @testdox unit test: Test getDefaultSchema() returns default schema from connection object
-     * @covers Zend\Db\Adapter\Adapter::getDefaultSchema
+     * @testdox unit test: Test getCurrentCatalog() returns current catalog from connection object
+     * @covers Zend\Db\Adapter\Adapter::getCurrentCatalog
      */
-    public function testGetDefaultSchema()
+    public function testGetCurrentCatalog()
     {
-        $this->mockConnection->expects($this->any())->method('getDefaultSchema')->will($this->returnValue('FooSchema'));
-        $this->assertEquals('FooSchema', $this->adapter->getDefaultSchema());
+        $this->mockConnection->expects($this->any())->method('getCurrentCatalog')->will($this->returnValue('FooCatalog'));
+        $this->assertEquals('FooCatalog', $this->adapter->getCurrentCatalog());
+    }
+
+    /**
+     * @testdox unit test: Test getCurrentSchema() returns current schema from connection object
+     * @covers Zend\Db\Adapter\Adapter::getCurrentSchema
+     */
+    public function testGetCurrentSchema()
+    {
+        $this->mockConnection->expects($this->any())->method('getCurrentSchema')->will($this->returnValue('FooSchema'));
+        $this->assertEquals('FooSchema', $this->adapter->getCurrentSchema());
     }
 
     /**

--- a/tests/Zend/Db/Adapter/AdapterTest.php
+++ b/tests/Zend/Db/Adapter/AdapterTest.php
@@ -143,16 +143,6 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @testdox unit test: Test getCurrentCatalog() returns current catalog from connection object
-     * @covers Zend\Db\Adapter\Adapter::getCurrentCatalog
-     */
-    public function testGetCurrentCatalog()
-    {
-        $this->mockConnection->expects($this->any())->method('getCurrentCatalog')->will($this->returnValue('FooCatalog'));
-        $this->assertEquals('FooCatalog', $this->adapter->getCurrentCatalog());
-    }
-
-    /**
      * @testdox unit test: Test getCurrentSchema() returns current schema from connection object
      * @covers Zend\Db\Adapter\Adapter::getCurrentSchema
      */


### PR DESCRIPTION
The SQL standard calls them CURRENT_CATALOG and CURRENT_SCHEMA, and it makes more sense to me this way.

I also added a test for the getCurrentCatalog
