### PR TITLE
[Form] Date/Time elements, view helpers and DateStep Validator

### DIFF
--- a/library/Zend/Form/Element/Date.php
+++ b/library/Zend/Form/Element/Date.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Element
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\Element;
+
+use Zend\Date\Date as ZendDate;
+use Zend\Form\Element;
+use Zend\InputFilter\InputProviderInterface;
+use Zend\Validator\Date as DateValidator;
+use Zend\Validator\GreaterThan as GreaterThanValidator;
+use Zend\Validator\LessThan as LessThanValidator;
+use Zend\Validator\DateStep as DateStepValidator;
+use Zend\Validator\ValidatorInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Element
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Date extends DateTime
+{
+    /**
+     * Seed attributes
+     *
+     * @var array
+     */
+    protected $attributes = array(
+        'type' => 'date',
+    );
+
+    /**
+     * Retrieves a DateStep Validator configured for a Date Input type
+     *
+     * @return DateStepValidator
+     */
+    protected function getStepValidator()
+    {
+        $stepValue = (isset($this->attributes['step']))
+                     ? $this->attributes['step'] : 1; // Days
+
+        $baseValue = (isset($this->attributes['min']))
+                     ? $this->attributes['min'] : '1970-01-01T00:00:00Z';
+
+        return new DateStepValidator(array(
+            'format'       => ZendDate::ISO_8601,
+            'baseValue'    => $baseValue,
+            'stepValue'    => $stepValue,
+            'stepDatePart' => ZendDate::DAY,
+        ));
+    }
+
+}

--- a/library/Zend/Form/Element/Date.php
+++ b/library/Zend/Form/Element/Date.php
@@ -23,6 +23,7 @@ namespace Zend\Form\Element;
 
 use Zend\Form\Element;
 use Zend\InputFilter\InputProviderInterface;
+use Zend\Validator\Date as DateValidator;
 use Zend\Validator\DateStep as DateStepValidator;
 use Zend\Validator\ValidatorInterface;
 
@@ -43,6 +44,16 @@ class Date extends DateTime
     protected $attributes = array(
         'type' => 'date',
     );
+
+    /**
+     * Retrieves a Date Validator configured for a DateTime Input type
+     *
+     * @return ValidatorInterface
+     */
+    protected function getDateValidator()
+    {
+        return new DateValidator(array('format' => 'Y-m-d'));
+    }
 
     /**
      * Retrieves a DateStep Validator configured for a Date Input type

--- a/library/Zend/Form/Element/Date.php
+++ b/library/Zend/Form/Element/Date.php
@@ -21,12 +21,8 @@
 
 namespace Zend\Form\Element;
 
-use Zend\Date\Date as ZendDate;
 use Zend\Form\Element;
 use Zend\InputFilter\InputProviderInterface;
-use Zend\Validator\Date as DateValidator;
-use Zend\Validator\GreaterThan as GreaterThanValidator;
-use Zend\Validator\LessThan as LessThanValidator;
 use Zend\Validator\DateStep as DateStepValidator;
 use Zend\Validator\ValidatorInterface;
 
@@ -51,7 +47,7 @@ class Date extends DateTime
     /**
      * Retrieves a DateStep Validator configured for a Date Input type
      *
-     * @return DateStepValidator
+     * @return ValidatorInterface
      */
     protected function getStepValidator()
     {
@@ -62,11 +58,9 @@ class Date extends DateTime
                      ? $this->attributes['min'] : '1970-01-01T00:00:00Z';
 
         return new DateStepValidator(array(
-            'format'       => ZendDate::ISO_8601,
+            'format'       => \DateTime::ISO8601,
             'baseValue'    => $baseValue,
-            'stepValue'    => $stepValue,
-            'stepDatePart' => ZendDate::DAY,
+            'stepInterval' => new \DateInterval("P{$stepValue}D"),
         ));
     }
-
 }

--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Form\Element;
 
-use DateTime as DateTime;
+use DateTime;
 use Zend\Form\Element;
 use Zend\InputFilter\InputProviderInterface;
 use Zend\Validator\Date as DateValidator;

--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Form\Element;
 
-use Zend\Date\Date as ZendDate;
+use DateTime as DateTime;
 use Zend\Form\Element;
 use Zend\InputFilter\InputProviderInterface;
 use Zend\Validator\Date as DateValidator;
@@ -106,7 +106,7 @@ class DateTime extends Element implements InputProviderInterface
      */
     protected function getDateValidator()
     {
-        return new DateValidator(array('format' => ZendDate::ISO_8601));
+        return new DateValidator(array('format' => DateTime::ISO8601));
     }
 
     /**

--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Element
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\Element;
+
+use Zend\Date\Date as ZendDate;
+use Zend\Form\Element;
+use Zend\InputFilter\InputProviderInterface;
+use Zend\Validator\Date as DateValidator;
+use Zend\Validator\GreaterThan as GreaterThanValidator;
+use Zend\Validator\LessThan as LessThanValidator;
+use Zend\Validator\DateStep as DateStepValidator;
+use Zend\Validator\ValidatorInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Element
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class DateTime extends Element implements InputProviderInterface
+{
+    /**
+     * Seed attributes
+     *
+     * @var array
+     */
+    protected $attributes = array(
+        'type' => 'datetime',
+    );
+
+    /**
+     * @var array
+     */
+    protected $validators;
+
+    /**
+     * Set validator
+     *
+     * @param  array $validator
+     * @return DateTime
+     */
+    public function setValidators($validators)
+    {
+        $this->validators = $validators;
+        return $this;
+    }
+
+    /**
+     * Get validators
+     *
+     * @return array
+     */
+    public function getValidators()
+    {
+        if (null === $this->validator) {
+            $validators = array();
+
+            $validators[] = new DateValidator(array(
+                'format' => ZendDate::ISO_8601
+            ));
+            if (isset($this->attributes['min'])) {
+                $validators[] = new GreaterThanValidator(array(
+                    'min'       => $this->attributes['min'],
+                    'inclusive' => true,
+                ));
+            }
+            if (isset($this->attributes['max'])) {
+                $validators[] = new LessThanValidator(array(
+                    'max'       => $this->attributes['max'],
+                    'inclusive' => true,
+                ));
+            }
+            if (isset($this->attributes['step']) && 'any' !== $this->attributes['step']) {
+                $validators[] = $this->getStepValidator();
+            }
+
+            $this->setValidators($validators);
+        }
+        return $this->validator;
+    }
+
+    /**
+     * Retrieves a DateStep Validator configured for a DateTime Input type
+     *
+     * @return DateStepValidator
+     */
+    protected function getStepValidator()
+    {
+        $stepValue = (isset($this->attributes['step']))
+                     ? $this->attributes['step'] : 1; // Minutes
+
+        $baseValue = (isset($this->attributes['min']))
+                     ? $this->attributes['min'] : '1970-01-01T00:00:00';
+
+        return new DateStepValidator(array(
+            'format'       => ZendDate::ISO_8601,
+            'baseValue'    => $baseValue,
+            'stepValue'    => $stepValue,
+            'stepDatePart' => ZendDate::MINUTE,
+        ));
+    }
+
+    /**
+     * Provide default input rules for this element
+     *
+     * Attaches default validators for the datetime input.
+     *
+     * @return array
+     */
+    public function getInputSpecification()
+    {
+        return array(
+            'name' => $this->getName(),
+            'required' => true,
+            'filters' => array(
+                array('name' => 'Zend\Filter\StringTrim'),
+            ),
+            'validators' => $this->getValidators(),
+        );
+    }
+}

--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -72,12 +72,10 @@ class DateTime extends Element implements InputProviderInterface
      */
     public function getValidators()
     {
-        if (null === $this->validator) {
+        if (null === $this->validators) {
             $validators = array();
 
-            $validators[] = new DateValidator(array(
-                'format' => ZendDate::ISO_8601
-            ));
+            $validators[] = $this->getDateValidator();
             if (isset($this->attributes['min'])) {
                 $validators[] = new GreaterThanValidator(array(
                     'min'       => $this->attributes['min'],
@@ -90,19 +88,31 @@ class DateTime extends Element implements InputProviderInterface
                     'inclusive' => true,
                 ));
             }
-            if (isset($this->attributes['step']) && 'any' !== $this->attributes['step']) {
+            if (!isset($this->attributes['step'])
+                || 'any' !== $this->attributes['step']
+            ) {
                 $validators[] = $this->getStepValidator();
             }
 
             $this->setValidators($validators);
         }
-        return $this->validator;
+        return $this->validators;
+    }
+
+    /**
+     * Retrieves a Date Validator configured for a DateTime Input type
+     *
+     * @return ValidatorInterface
+     */
+    protected function getDateValidator()
+    {
+        return new DateValidator(array('format' => ZendDate::ISO_8601));
     }
 
     /**
      * Retrieves a DateStep Validator configured for a DateTime Input type
      *
-     * @return DateStepValidator
+     * @return ValidatorInterface
      */
     protected function getStepValidator()
     {
@@ -110,13 +120,12 @@ class DateTime extends Element implements InputProviderInterface
                      ? $this->attributes['step'] : 1; // Minutes
 
         $baseValue = (isset($this->attributes['min']))
-                     ? $this->attributes['min'] : '1970-01-01T00:00:00';
+                     ? $this->attributes['min'] : '1970-01-01T00:00:00Z';
 
         return new DateStepValidator(array(
-            'format'       => ZendDate::ISO_8601,
+            'format'       => \DateTime::ISO8601,
             'baseValue'    => $baseValue,
-            'stepValue'    => $stepValue,
-            'stepDatePart' => ZendDate::MINUTE,
+            'stepInterval' => new \DateInterval("PT{$stepValue}M"),
         ));
     }
 

--- a/library/Zend/Form/Element/DateTimeLocal.php
+++ b/library/Zend/Form/Element/DateTimeLocal.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Element
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\Element;
+
+use Zend\Date\Date as ZendDate;
+use Zend\Form\Element;
+use Zend\InputFilter\InputProviderInterface;
+use Zend\Validator\Date as DateValidator;
+use Zend\Validator\GreaterThan as GreaterThanValidator;
+use Zend\Validator\LessThan as LessThanValidator;
+use Zend\Validator\DateStep as DateStepValidator;
+use Zend\Validator\ValidatorInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Element
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class DateTimeLocal extends DateTime
+{
+    /**
+     * Seed attributes
+     *
+     * @var array
+     */
+    protected $attributes = array(
+        'type' => 'datetime-local',
+    );
+
+    /**
+     * Retrieves a DateStepValidator configured for a Date Input type
+     *
+     * @return DateStepValidator
+     */
+    protected function getStepValidator()
+    {
+        $stepValue = (isset($this->attributes['step']))
+                     ? $this->attributes['step'] : 1; // Minutes
+
+        $baseValue = (isset($this->attributes['min']))
+                     ? $this->attributes['min'] : '1970-01-01T00:00:00';
+
+        return new DateStepValidator(array(
+            'format'       => ZendDate::ISO_8601,
+            'baseValue'    => $baseValue,
+            'stepValue'    => $stepValue,
+            'stepDatePart' => ZendDate::MINUTE,
+        ));
+    }
+
+}

--- a/library/Zend/Form/Element/DateTimeLocal.php
+++ b/library/Zend/Form/Element/DateTimeLocal.php
@@ -21,12 +21,8 @@
 
 namespace Zend\Form\Element;
 
-use Zend\Date\Date as ZendDate;
 use Zend\Form\Element;
 use Zend\InputFilter\InputProviderInterface;
-use Zend\Validator\Date as DateValidator;
-use Zend\Validator\GreaterThan as GreaterThanValidator;
-use Zend\Validator\LessThan as LessThanValidator;
 use Zend\Validator\DateStep as DateStepValidator;
 use Zend\Validator\ValidatorInterface;
 
@@ -51,7 +47,7 @@ class DateTimeLocal extends DateTime
     /**
      * Retrieves a DateStepValidator configured for a Date Input type
      *
-     * @return DateStepValidator
+     * @return ValidatorInterface
      */
     protected function getStepValidator()
     {
@@ -62,11 +58,9 @@ class DateTimeLocal extends DateTime
                      ? $this->attributes['min'] : '1970-01-01T00:00:00';
 
         return new DateStepValidator(array(
-            'format'       => ZendDate::ISO_8601,
+            'format'       => \DateTime::ISO8601,
             'baseValue'    => $baseValue,
-            'stepValue'    => $stepValue,
-            'stepDatePart' => ZendDate::MINUTE,
+            'stepInterval' => new \DateInterval("PT{$stepValue}M"),
         ));
     }
-
 }

--- a/library/Zend/Form/Element/Month.php
+++ b/library/Zend/Form/Element/Month.php
@@ -23,6 +23,7 @@ namespace Zend\Form\Element;
 
 use Zend\Form\Element;
 use Zend\InputFilter\InputProviderInterface;
+use Zend\Validator\Regex as RegexValidator;
 use Zend\Validator\DateStep as DateStepValidator;
 use Zend\Validator\ValidatorInterface;
 
@@ -33,7 +34,7 @@ use Zend\Validator\ValidatorInterface;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Time extends DateTime
+class Month extends DateTime
 {
     /**
      * Seed attributes
@@ -41,26 +42,36 @@ class Time extends DateTime
      * @var array
      */
     protected $attributes = array(
-        'type' => 'time',
+        'type' => 'month',
     );
 
     /**
-     * Retrieves a DateStepValidator configured for a Date Input type
+     * Retrieves a Date Validator configured for a Month Input type
+     *
+     * @return ValidatorInterface
+     */
+    protected function getDateValidator()
+    {
+        return new RegexValidator('/^#[0-9]{4}\-(0?[1-9]|1[012])$/');
+    }
+
+    /**
+     * Retrieves a DateStep Validator configured for a Month Input type
      *
      * @return ValidatorInterface
      */
     protected function getStepValidator()
     {
         $stepValue = (isset($this->attributes['step']))
-                     ? $this->attributes['step'] : 1; // Minutes
+                     ? $this->attributes['step'] : 1; // Months
 
         $baseValue = (isset($this->attributes['min']))
-                     ? $this->attributes['min'] : '00:00:00';
+                     ? $this->attributes['min'] : '1970-01-01T00:00:00Z';
 
         return new DateStepValidator(array(
-            'format'       => 'H:i:s',
+            'format'       => "Y-m",
             'baseValue'    => $baseValue,
-            'stepInterval' => new \DateInterval("PT{$stepValue}M"),
+            'stepInterval' => new \DateInterval("P{$stepValue}M"),
         ));
     }
 }

--- a/library/Zend/Form/Element/Time.php
+++ b/library/Zend/Form/Element/Time.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Element
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\Element;
+
+use Zend\Date\Date as ZendDate;
+use Zend\Form\Element;
+use Zend\InputFilter\InputProviderInterface;
+use Zend\Validator\Date as DateValidator;
+use Zend\Validator\GreaterThan as GreaterThanValidator;
+use Zend\Validator\LessThan as LessThanValidator;
+use Zend\Validator\DateStep as DateStepValidator;
+use Zend\Validator\ValidatorInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Element
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Time extends DateTime
+{
+    /**
+     * Seed attributes
+     *
+     * @var array
+     */
+    protected $attributes = array(
+        'type' => 'time',
+    );
+
+    /**
+     * Retrieves a DateStepValidator configured for a Date Input type
+     *
+     * @return DateStepValidator
+     */
+    protected function getStepValidator()
+    {
+        $stepValue = (isset($this->attributes['step']))
+                     ? $this->attributes['step'] : 1; // Minutes
+
+        $baseValue = (isset($this->attributes['min']))
+                     ? $this->attributes['min'] : '00:00:00';
+
+        return new DateStepValidator(array(
+            'format'       => ZendDate::ISO_8601,
+            'baseValue'    => $baseValue,
+            'stepValue'    => $stepValue,
+            'stepDatePart' => ZendDate::MINUTE,
+        ));
+    }
+
+}

--- a/library/Zend/Form/Element/Time.php
+++ b/library/Zend/Form/Element/Time.php
@@ -23,6 +23,7 @@ namespace Zend\Form\Element;
 
 use Zend\Form\Element;
 use Zend\InputFilter\InputProviderInterface;
+use Zend\Validator\Date as DateValidator;
 use Zend\Validator\DateStep as DateStepValidator;
 use Zend\Validator\ValidatorInterface;
 
@@ -43,6 +44,16 @@ class Time extends DateTime
     protected $attributes = array(
         'type' => 'time',
     );
+
+    /**
+     * Retrieves a Date Validator configured for a DateTime Input type
+     *
+     * @return ValidatorInterface
+     */
+    protected function getDateValidator()
+    {
+        return new DateValidator(array('format' => 'H:i:s'));
+    }
 
     /**
      * Retrieves a DateStepValidator configured for a Date Input type

--- a/library/Zend/Form/Element/Week.php
+++ b/library/Zend/Form/Element/Week.php
@@ -23,6 +23,7 @@ namespace Zend\Form\Element;
 
 use Zend\Form\Element;
 use Zend\InputFilter\InputProviderInterface;
+use Zend\Validator\Regex as RegexValidator;
 use Zend\Validator\DateStep as DateStepValidator;
 use Zend\Validator\ValidatorInterface;
 
@@ -33,7 +34,7 @@ use Zend\Validator\ValidatorInterface;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Time extends DateTime
+class Week extends DateTime
 {
     /**
      * Seed attributes
@@ -41,26 +42,36 @@ class Time extends DateTime
      * @var array
      */
     protected $attributes = array(
-        'type' => 'time',
+        'type' => 'week',
     );
 
     /**
-     * Retrieves a DateStepValidator configured for a Date Input type
+     * Retrieves a Date Validator configured for a Week Input type
+     *
+     * @return ValidatorInterface
+     */
+    protected function getDateValidator()
+    {
+        return new RegexValidator('/^#[0-9]{4}\-W[0-9]{2}$/');
+    }
+
+    /**
+     * Retrieves a DateStep Validator configured for a Week Input type
      *
      * @return ValidatorInterface
      */
     protected function getStepValidator()
     {
         $stepValue = (isset($this->attributes['step']))
-                     ? $this->attributes['step'] : 1; // Minutes
+                     ? $this->attributes['step'] : 1; // Weeks
 
         $baseValue = (isset($this->attributes['min']))
-                     ? $this->attributes['min'] : '00:00:00';
+                     ? $this->attributes['min'] : '1970-W01';
 
         return new DateStepValidator(array(
-            'format'       => 'H:i:s',
+            'format'       => 'Y-\WW',
             'baseValue'    => $baseValue,
-            'stepInterval' => new \DateInterval("PT{$stepValue}M"),
+            'stepInterval' => new \DateInterval("P{$stepValue}W"),
         ));
     }
 }

--- a/library/Zend/Form/View/Helper/FormDate.php
+++ b/library/Zend/Form/View/Helper/FormDate.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\View\Helper;
+
+use Zend\Form\ElementInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormDate extends FormDateTime
+{
+    /**
+     * Determine input type to use
+     *
+     * @param  ElementInterface $element
+     * @return string
+     */
+    protected function getType(ElementInterface $element)
+    {
+        return 'date';
+    }
+}

--- a/library/Zend/Form/View/Helper/FormDateTime.php
+++ b/library/Zend/Form/View/Helper/FormDateTime.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\View\Helper;
+
+use Zend\Form\ElementInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormDateTime extends FormInput
+{
+    /**
+     * Attributes valid for the input tag type="datetime"
+     *
+     * @var array
+     */
+    protected $validTagAttributes = array(
+        'name'           => true,
+        'autocomplete'   => true,
+        'autofocus'      => true,
+        'disabled'       => true,
+        'form'           => true,
+        'list'           => true,
+        'max'            => true,
+        'min'            => true,
+        'readonly'       => true,
+        'required'       => true,
+        'step'           => true,
+        'type'           => true,
+        'value'          => true,
+    );
+
+    /**
+     * Determine input type to use
+     *
+     * @param  ElementInterface $element
+     * @return string
+     */
+    protected function getType(ElementInterface $element)
+    {
+        return 'datetime';
+    }
+}

--- a/library/Zend/Form/View/Helper/FormDateTimeLocal.php
+++ b/library/Zend/Form/View/Helper/FormDateTimeLocal.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\View\Helper;
+
+use Zend\Form\ElementInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormDateTimeLocal extends FormDateTime
+{
+    /**
+     * Determine input type to use
+     *
+     * @param  ElementInterface $element
+     * @return string
+     */
+    protected function getType(ElementInterface $element)
+    {
+        return 'datetime-local';
+    }
+}

--- a/library/Zend/Form/View/Helper/FormMonth.php
+++ b/library/Zend/Form/View/Helper/FormMonth.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\View\Helper;
+
+use Zend\Form\ElementInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormMonth extends FormDateTime
+{
+    /**
+     * Determine input type to use
+     *
+     * @param  ElementInterface $element
+     * @return string
+     */
+    protected function getType(ElementInterface $element)
+    {
+        return 'month';
+    }
+}

--- a/library/Zend/Form/View/Helper/FormTime.php
+++ b/library/Zend/Form/View/Helper/FormTime.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\View\Helper;
+
+use Zend\Form\ElementInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormTime extends FormDateTime
+{
+    /**
+     * Determine input type to use
+     *
+     * @param  ElementInterface $element
+     * @return string
+     */
+    protected function getType(ElementInterface $element)
+    {
+        return 'time';
+    }
+}

--- a/library/Zend/Form/View/Helper/FormWeek.php
+++ b/library/Zend/Form/View/Helper/FormWeek.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\View\Helper;
+
+use Zend\Form\ElementInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormWeek extends FormDateTime
+{
+    /**
+     * Determine input type to use
+     *
+     * @param  ElementInterface $element
+     * @return string
+     */
+    protected function getType(ElementInterface $element)
+    {
+        return 'week';
+    }
+}

--- a/library/Zend/Form/View/HelperLoader.php
+++ b/library/Zend/Form/View/HelperLoader.php
@@ -71,6 +71,9 @@ class HelperLoader extends PluginClassLoader
         'form_checkbox'          => 'Zend\Form\View\Helper\FormCheckbox',
         'formcolor'              => 'Zend\Form\View\Helper\FormColor',
         'form_color'             => 'Zend\Form\View\Helper\FormColor',
+        'formdate'               => 'Zend\Form\View\Helper\FormDate',
+        'formdatetime'           => 'Zend\Form\View\Helper\FormDateTime',
+        'formdatetimelocal'      => 'Zend\Form\View\Helper\FormDateTimeLocal',
         'formelement'            => 'Zend\Form\View\Helper\FormElement',
         'form_element'           => 'Zend\Form\View\Helper\FormElement',
         'formelementerrors'      => 'Zend\Form\View\Helper\FormElementErrors',
@@ -87,6 +90,7 @@ class HelperLoader extends PluginClassLoader
         'form_input'             => 'Zend\Form\View\Helper\FormInput',
         'formlabel'              => 'Zend\Form\View\Helper\FormLabel',
         'form_label'             => 'Zend\Form\View\Helper\FormLabel',
+        'formmonth'              => 'Zend\Form\View\Helper\FormMonth',
         'formmulticheckbox'      => 'Zend\Form\View\Helper\FormMultiCheckbox',
         'form_multicheckbox'     => 'Zend\Form\View\Helper\FormMultiCheckbox',
         'form_multi_checkbox'    => 'Zend\Form\View\Helper\FormMultiCheckbox',
@@ -108,5 +112,7 @@ class HelperLoader extends PluginClassLoader
         'form_text'              => 'Zend\Form\View\Helper\FormText',
         'formtextarea'           => 'Zend\Form\View\Helper\FormTextarea',
         'form_textarea'          => 'Zend\Form\View\Helper\FormTextarea',
+        'formtime'               => 'Zend\Form\View\Helper\FormTime',
+        'formweek'               => 'Zend\Form\View\Helper\FormWeek',
     );
 }

--- a/library/Zend/Validator/DateStep.php
+++ b/library/Zend/Validator/DateStep.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Validate
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Validator;
+
+use Traversable;
+use Zend\Date as ZendDate;
+use Zend\Locale\Format;
+use Zend\Locale\Locale;
+use Zend\Registry;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Validator\Exception;
+
+/**
+ * @category   Zend
+ * @package    Zend_Validate
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class DateStep extends AbstractValidator
+{
+    const INVALID      = 'dateStepInvalid';
+    const INVALID_DATE = 'dateStepInvalidDate';
+    const NOT_STEP     = 'dateStepNotStep';
+
+    /**
+     * @var array
+     */
+    protected $_messageTemplates = array(
+        self::INVALID      => "Invalid type given. String, integer, array or Zend_Date expected",
+        self::INVALID_DATE => "'%value%' does not appear to be a valid date",
+        self::NOT_STEP     => "'%value%' is not a valid step."
+    );
+
+    /**
+     * Optional base date value
+     *
+     * @var string|integer|array|\Zend\Date\Date
+     */
+    protected $baseValue = 0;
+
+    /**
+     * Optional date step value (defaults to 1)
+     *
+     * @var string|integer|array|\Zend\Date\Date
+     */
+    protected $stepValue = 1;
+
+    /**
+     * Optional date step value (defaults to \Zend\Date\Date::DAY)
+     *
+     * @var string
+     */
+    protected $stepDatePart = ZendDate\Date::DAY;
+
+    /**
+     * Optional format to be used when the baseValue
+     * and validation value are strings to be converted
+     * to \Zend\Date\Date objects.
+     *
+     * @var string|null
+     */
+    protected $format;
+
+    /**
+     * Optional locale to be used when the baseValue
+     * and validation value are strings to be converted
+     * to \Zend\Date\Date objects.
+     *
+     * @var string|\Zend\Locale\Locale|null
+     */
+    protected $locale;
+
+    /**
+     * Set default options for this instance
+     *
+     * @param array $options
+     */
+    public function __construct($options = array())
+    {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        } elseif (!is_array($options)) {
+            $options = func_get_args();
+            $temp['baseValue'] = array_shift($options);
+            if (!empty($options)) {
+                $temp['step'] = array_shift($options);
+            }
+
+            $options = $temp;
+        }
+
+        if (isset($options['baseValue'])) {
+            $this->setBaseValue($options['baseValue']);
+        }
+        if (isset($options['stepValue'])) {
+            $this->setStepValue($options['stepValue']);
+        }
+        if (isset($options['stepDatePart'])) {
+            $this->setStepDatePart($options['stepDatePart']);
+        }
+        if (array_key_exists('format', $options)) {
+            $this->setFormat($options['format']);
+        }
+        if (!isset($options['locale'])) {
+            if (Registry::isRegistered('Zend_Locale')) {
+                $options['locale'] = Registry::get('Zend_Locale');
+            }
+        }
+        if (isset($options['locale'])) {
+            $this->setLocale($options['locale']);
+        }
+
+        parent::__construct($options);
+    }
+
+    /**
+     * Sets the base value from which the step should be computed
+     *
+     * @param  string|integer|array|\Zend\Date\Date $baseValue
+     * @return DateStep
+     */
+    public function setBaseValue($baseValue)
+    {
+        $this->baseValue = $baseValue;
+        return $this;
+    }
+
+    /**
+     * Returns the base value from which the step should be computed
+     *
+     * @return string|integer|array|\Zend\Date\Date
+     */
+    public function getBaseValue()
+    {
+        return $this->baseValue;
+    }
+
+    /**
+     * Sets the step value
+     *
+     * @param  string|integer|array|\Zend\Date\Date $step
+     * @return DateStep
+     */
+    public function setStepValue($stepValue)
+    {
+        $this->stepValue = $stepValue;
+        return $this;
+    }
+
+    /**
+     * Returns the step value
+     *
+     * @return string|integer|array|\Zend\Date\Date
+     */
+    public function getStepValue()
+    {
+        return $this->stepValue;
+    }
+
+    /**
+     * Sets the step date part
+     *
+     * @param  string $stepDatePart
+     * @return DateStep
+     */
+    public function setStepDatePart($stepDatePart)
+    {
+        $this->stepDatePart = $stepDatePart;
+        return $this;
+    }
+
+    /**
+     * Returns the step date part
+     *
+     * @return string
+     */
+    public function getStepDatePart()
+    {
+        return $this->stepValue;
+    }
+
+    /**
+     * Returns the format option
+     *
+     * @return string|null
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
+
+    /**
+     * Sets the format option
+     *
+     * @param  string $format
+     * @return DateStep
+     */
+    public function setFormat($format = null)
+    {
+        $this->format = $format;
+        return $this;
+    }
+
+    /**
+     * Returns the locale option
+     *
+     * @return string|Locale|null
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * Sets the locale option
+     *
+     * @param  string|Locale $locale
+     * @return DateStep
+     */
+    public function setLocale($locale = null)
+    {
+        $this->locale = Locale::findLocale($locale);
+        return $this;
+    }
+
+    /**
+     * Returns true if $value is a scalar and a valid step value
+     *
+     * @param mixed $value
+     * @return bool
+     * @throws Exception\InvalidArgumentException|\Zend\Date\Exception
+     */
+    public function isValid($value)
+    {
+        if (!is_string($value)
+            && !is_int($value)
+            && !is_float($value)
+            && !is_array($value)
+            && !($value instanceof ZendDate\Date)
+        ) {
+            $this->error(self::INVALID);
+            return false;
+        }
+
+        $this->setValue($value);
+
+        $format       = $this->getFormat();
+        $locale       = $this->getLocale();
+        $baseValue    = $this->getBaseValue();
+        $stepValue    = $this->getStepValue();
+        $stepDatePart = $this->getStepDatePart();
+
+        // Confirm that baseValue and value are dates
+        if (!ZendDate\Date::isDate($baseValue, $format, $locale)) {
+            throw new Exception\InvalidArgumentException('Invalid baseValue given');
+        }
+
+        if (!ZendDate\Date::isDate($value, $format, $locale)) {
+            $this->error(self::INVALID_DATE);
+            return false;
+        }
+
+        // Convert baseValue and value to Date objects
+        $baseDate  = new ZendDate\Date($baseValue, $format, $locale);
+        $valueDate = new ZendDate\Date($value, $format, $locale);
+
+        if ($valueDate->equals($baseDate)) {
+            return true;
+        }
+
+        // Keep adding steps to the base date until a match is found
+        // or until the value is exceeded
+        while ($baseDate->isEarlier($valueDate)) {
+            $baseDate->add($stepValue, $stepDatePart, $locale);
+            if ($baseDate->equals($valueDate)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/library/Zend/Validator/ValidatorLoader.php
+++ b/library/Zend/Validator/ValidatorLoader.php
@@ -143,6 +143,7 @@ class ValidatorLoader extends PluginClassLoader
         'creditcard'                   => 'Zend\Validator\CreditCard',
         'csrf'                         => 'Zend\Validator\Csrf',
         'date'                         => 'Zend\Validator\Date',
+        'datestep'                     => 'Zend\Validator\DateStep',
         'db_\\no_record_exists'        => 'Zend\Validator\Db\NoRecordExists',
         'db_\\norecordexists'          => 'Zend\Validator\Db\NoRecordExists',
         'db\\no_record_exists'         => 'Zend\Validator\Db\NoRecordExists',

--- a/tests/Zend/Form/Element/DateTest.php
+++ b/tests/Zend/Form/Element/DateTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\Element;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Element\DateTime as DateElement;
+use Zend\Form\Factory;
+
+class DateTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->element = new DateElement('foo');
+        parent::setUp();
+    }
+
+    public function getAttributesAndValidatorsDataProvider()
+    {
+        return array(
+            array(
+                array('min' => true, 'max' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\LessThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('max' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\LessThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('min' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('min' => true, 'max' => true, 'step' => 'any'),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\LessThan',
+                ),
+            ),
+            array(
+                array(),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider getAttributesAndValidatorsDataProvider
+     */
+    public function testLazyLoadsValidatorsByDefault($attributes, $validatorClasses)
+    {
+        $this->element->setAttributes($attributes);
+        $validators = $this->element->getValidators();
+        foreach ($validators as $i => $validator) {
+            $this->assertInstanceOf($validatorClasses[$i], $validator);
+        }
+    }
+
+    public function testCanInjectValidator()
+    {
+        $validator  = $this->getMock('Zend\Validator\ValidatorInterface');
+        $this->element->setValidators(array($validator));
+        $validators = $this->element->getValidators();
+        $this->assertSame($validator, array_shift($validators));
+    }
+
+    public function testProvidesInputSpecificationThatIncludesValidator()
+    {
+        $validator = $this->getMock('Zend\Validator\ValidatorInterface');
+        $this->element->setValidators(array($validator));
+
+        $inputSpec = $this->element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $this->assertInternalType('array', $inputSpec['validators']);
+        $test = array_shift($inputSpec['validators']);
+        $this->assertSame($validator, $test);
+    }
+}

--- a/tests/Zend/Form/Element/DateTimeLocalTest.php
+++ b/tests/Zend/Form/Element/DateTimeLocalTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\Element;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Element\DateTimeLocal as DateTimeLocalElement;
+use Zend\Form\Factory;
+
+class DateTimeLocalTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->element = new DateTimeLocalElement('foo');
+        parent::setUp();
+    }
+
+    public function getAttributesAndValidatorsDataProvider()
+    {
+        return array(
+            array(
+                array('min' => true, 'max' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\LessThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('max' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\LessThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('min' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('min' => true, 'max' => true, 'step' => 'any'),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\LessThan',
+                ),
+            ),
+            array(
+                array(),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider getAttributesAndValidatorsDataProvider
+     */
+    public function testLazyLoadsValidatorsByDefault($attributes, $validatorClasses)
+    {
+        $this->element->setAttributes($attributes);
+        $validators = $this->element->getValidators();
+        foreach ($validators as $i => $validator) {
+            $this->assertInstanceOf($validatorClasses[$i], $validator);
+        }
+    }
+
+    public function testCanInjectValidator()
+    {
+        $validator  = $this->getMock('Zend\Validator\ValidatorInterface');
+        $this->element->setValidators(array($validator));
+        $validators = $this->element->getValidators();
+        $this->assertSame($validator, array_shift($validators));
+    }
+
+    public function testProvidesInputSpecificationThatIncludesValidator()
+    {
+        $validator = $this->getMock('Zend\Validator\ValidatorInterface');
+        $this->element->setValidators(array($validator));
+
+        $inputSpec = $this->element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $this->assertInternalType('array', $inputSpec['validators']);
+        $test = array_shift($inputSpec['validators']);
+        $this->assertSame($validator, $test);
+    }
+}

--- a/tests/Zend/Form/Element/DateTimeTest.php
+++ b/tests/Zend/Form/Element/DateTimeTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\Element;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Element\DateTime as DateTimeElement;
+use Zend\Form\Factory;
+
+class DateTimeTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->element = new DateTimeElement('foo');
+        parent::setUp();
+    }
+
+    public function getAttributesAndValidatorsDataProvider()
+    {
+        return array(
+            array(
+                array('min' => true, 'max' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\LessThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('max' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\LessThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('min' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('min' => true, 'max' => true, 'step' => 'any'),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\LessThan',
+                ),
+            ),
+            array(
+                array(),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider getAttributesAndValidatorsDataProvider
+     */
+    public function testLazyLoadsValidatorsByDefault($attributes, $validatorClasses)
+    {
+        $this->element->setAttributes($attributes);
+        $validators = $this->element->getValidators();
+        foreach ($validators as $i => $validator) {
+            $this->assertInstanceOf($validatorClasses[$i], $validator);
+        }
+    }
+
+    public function testCanInjectValidator()
+    {
+        $validator  = $this->getMock('Zend\Validator\ValidatorInterface');
+        $this->element->setValidators(array($validator));
+        $validators = $this->element->getValidators();
+        $this->assertSame($validator, array_shift($validators));
+    }
+
+    public function testProvidesInputSpecificationThatIncludesValidator()
+    {
+        $validator = $this->getMock('Zend\Validator\ValidatorInterface');
+        $this->element->setValidators(array($validator));
+
+        $inputSpec = $this->element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $this->assertInternalType('array', $inputSpec['validators']);
+        $test = array_shift($inputSpec['validators']);
+        $this->assertSame($validator, $test);
+    }
+}

--- a/tests/Zend/Form/Element/MonthTest.php
+++ b/tests/Zend/Form/Element/MonthTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\Element;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Element\Month as MonthElement;
+use Zend\Form\Factory;
+
+class MonthTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->element = new MonthElement('foo');
+        parent::setUp();
+    }
+
+    public function getAttributesAndValidatorsDataProvider()
+    {
+        return array(
+            array(
+                array('min' => true, 'max' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Regex',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\LessThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('max' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Regex',
+                    'Zend\Validator\LessThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('min' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Regex',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('min' => true, 'max' => true, 'step' => 'any'),
+                array(
+                    'Zend\Validator\Regex',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\LessThan',
+                ),
+            ),
+            array(
+                array(),
+                array(
+                    'Zend\Validator\Regex',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider getAttributesAndValidatorsDataProvider
+     */
+    public function testLazyLoadsValidatorsByDefault($attributes, $validatorClasses)
+    {
+        $this->element->setAttributes($attributes);
+        $validators = $this->element->getValidators();
+        foreach ($validators as $i => $validator) {
+            $this->assertInstanceOf($validatorClasses[$i], $validator);
+        }
+    }
+
+    public function testCanInjectValidator()
+    {
+        $validator  = $this->getMock('Zend\Validator\ValidatorInterface');
+        $this->element->setValidators(array($validator));
+        $validators = $this->element->getValidators();
+        $this->assertSame($validator, array_shift($validators));
+    }
+
+    public function testProvidesInputSpecificationThatIncludesValidator()
+    {
+        $validator = $this->getMock('Zend\Validator\ValidatorInterface');
+        $this->element->setValidators(array($validator));
+
+        $inputSpec = $this->element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $this->assertInternalType('array', $inputSpec['validators']);
+        $test = array_shift($inputSpec['validators']);
+        $this->assertSame($validator, $test);
+    }
+}

--- a/tests/Zend/Form/Element/TimeTest.php
+++ b/tests/Zend/Form/Element/TimeTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\Element;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Element\Time as TimeElement;
+use Zend\Form\Factory;
+
+class TimeTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->element = new TimeElement('foo');
+        parent::setUp();
+    }
+
+    public function getAttributesAndValidatorsDataProvider()
+    {
+        return array(
+            array(
+                array('min' => true, 'max' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\LessThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('max' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\LessThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('min' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('min' => true, 'max' => true, 'step' => 'any'),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\LessThan',
+                ),
+            ),
+            array(
+                array(),
+                array(
+                    'Zend\Validator\Date',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider getAttributesAndValidatorsDataProvider
+     */
+    public function testLazyLoadsValidatorsByDefault($attributes, $validatorClasses)
+    {
+        $this->element->setAttributes($attributes);
+        $validators = $this->element->getValidators();
+        foreach ($validators as $i => $validator) {
+            $this->assertInstanceOf($validatorClasses[$i], $validator);
+        }
+    }
+
+    public function testCanInjectValidator()
+    {
+        $validator  = $this->getMock('Zend\Validator\ValidatorInterface');
+        $this->element->setValidators(array($validator));
+        $validators = $this->element->getValidators();
+        $this->assertSame($validator, array_shift($validators));
+    }
+
+    public function testProvidesInputSpecificationThatIncludesValidator()
+    {
+        $validator = $this->getMock('Zend\Validator\ValidatorInterface');
+        $this->element->setValidators(array($validator));
+
+        $inputSpec = $this->element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $this->assertInternalType('array', $inputSpec['validators']);
+        $test = array_shift($inputSpec['validators']);
+        $this->assertSame($validator, $test);
+    }
+}

--- a/tests/Zend/Form/Element/WeekTest.php
+++ b/tests/Zend/Form/Element/WeekTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\Element;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Element\Week as WeekElement;
+use Zend\Form\Factory;
+
+class WeekTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->element = new WeekElement('foo');
+        parent::setUp();
+    }
+
+    public function getAttributesAndValidatorsDataProvider()
+    {
+        return array(
+            array(
+                array('min' => true, 'max' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Regex',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\LessThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('max' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Regex',
+                    'Zend\Validator\LessThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('min' => true, 'step' => true),
+                array(
+                    'Zend\Validator\Regex',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+            array(
+                array('min' => true, 'max' => true, 'step' => 'any'),
+                array(
+                    'Zend\Validator\Regex',
+                    'Zend\Validator\GreaterThan',
+                    'Zend\Validator\LessThan',
+                ),
+            ),
+            array(
+                array(),
+                array(
+                    'Zend\Validator\Regex',
+                    'Zend\Validator\DateStep'
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider getAttributesAndValidatorsDataProvider
+     */
+    public function testLazyLoadsValidatorsByDefault($attributes, $validatorClasses)
+    {
+        $this->element->setAttributes($attributes);
+        $validators = $this->element->getValidators();
+        foreach ($validators as $i => $validator) {
+            $this->assertInstanceOf($validatorClasses[$i], $validator);
+        }
+    }
+
+    public function testCanInjectValidator()
+    {
+        $validator  = $this->getMock('Zend\Validator\ValidatorInterface');
+        $this->element->setValidators(array($validator));
+        $validators = $this->element->getValidators();
+        $this->assertSame($validator, array_shift($validators));
+    }
+
+    public function testProvidesInputSpecificationThatIncludesValidator()
+    {
+        $validator = $this->getMock('Zend\Validator\ValidatorInterface');
+        $this->element->setValidators(array($validator));
+
+        $inputSpec = $this->element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $this->assertInternalType('array', $inputSpec['validators']);
+        $test = array_shift($inputSpec['validators']);
+        $this->assertSame($validator, $test);
+    }
+}

--- a/tests/Zend/Form/View/Helper/FormDateTest.php
+++ b/tests/Zend/Form/View/Helper/FormDateTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\View\Helper;
+
+use Zend\Form\Element;
+use Zend\Form\View\Helper\FormDate as FormDateHelper;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormDateTest extends CommonTestCase
+{
+    public function setUp()
+    {
+        $this->helper = new FormDateHelper();
+        parent::setUp();
+    }
+
+    public function testRaisesExceptionWhenNameIsNotPresentInElement()
+    {
+        $element = new Element();
+        $this->setExpectedException('Zend\Form\Exception\DomainException', 'name');
+        $this->helper->render($element);
+    }
+
+    public function testGeneratesInputTagWithElement()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->render($element);
+        $this->assertContains('<input ', $markup);
+        $this->assertContains('type="date"', $markup);
+    }
+
+    public function testGeneratesInputTagRegardlessOfElementType()
+    {
+        $element = new Element('foo');
+        $element->setAttribute('type', 'email');
+        $markup  = $this->helper->render($element);
+        $this->assertContains('<input ', $markup);
+        $this->assertContains('type="date"', $markup);
+    }
+
+    public function validAttributes()
+    {
+        return array(
+            array('name',           'assertContains'),
+            array('accept',         'assertNotContains'),
+            array('alt',            'assertNotContains'),
+            array('autocomplete',   'assertContains'),
+            array('autofocus',      'assertContains'),
+            array('checked',        'assertNotContains'),
+            array('dirname',        'assertNotContains'),
+            array('disabled',       'assertContains'),
+            array('form',           'assertContains'),
+            array('formaction',     'assertNotContains'),
+            array('formenctype',    'assertNotContains'),
+            array('formmethod',     'assertNotContains'),
+            array('formnovalidate', 'assertNotContains'),
+            array('formtarget',     'assertNotContains'),
+            array('height',         'assertNotContains'),
+            array('list',           'assertContains'),
+            array('max',            'assertContains'),
+            array('maxlength',      'assertNotContains'),
+            array('min',            'assertContains'),
+            array('multiple',       'assertNotContains'),
+            array('pattern',        'assertNotContains'),
+            array('placeholder',    'assertNotContains'),
+            array('readonly',       'assertContains'),
+            array('required',       'assertContains'),
+            array('size',           'assertNotContains'),
+            array('src',            'assertNotContains'),
+            array('step',           'assertContains'),
+            array('value',          'assertContains'),
+            array('width',          'assertNotContains'),
+        );
+    }
+
+    public function getCompleteElement()
+    {
+        $element = new Element('foo');
+        $element->setAttributes(array(
+            'accept'             => 'value',
+            'alt'                => 'value',
+            'autocomplete'       => 'on',
+            'autofocus'          => 'autofocus',
+            'checked'            => 'checked',
+            'dirname'            => 'value',
+            'disabled'           => 'disabled',
+            'form'               => 'value',
+            'formaction'         => 'value',
+            'formenctype'        => 'value',
+            'formmethod'         => 'value',
+            'formnovalidate'     => 'value',
+            'formtarget'         => 'value',
+            'height'             => 'value',
+            'id'                 => 'value',
+            'list'               => 'value',
+            'max'                => 'value',
+            'maxlength'          => 'value',
+            'min'                => 'value',
+            'multiple'           => 'multiple',
+            'name'               => 'value',
+            'pattern'            => 'value',
+            'placeholder'        => 'value',
+            'readonly'           => 'readonly',
+            'required'           => 'required',
+            'size'               => 'value',
+            'src'                => 'value',
+            'step'               => 'value',
+            'value'              => 'value',
+            'width'              => 'value',
+        ));
+        return $element;
+    }
+
+    /**
+     * @dataProvider validAttributes
+     */
+    public function testAllValidFormMarkupAttributesPresentInElementAreRendered($attribute, $assertion)
+    {
+        $element = $this->getCompleteElement();
+        $markup  = $this->helper->render($element);
+        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        $this->$assertion($expect, $markup);
+    }
+
+    public function testInvokeProxiesToRender()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->__invoke($element);
+        $this->assertContains('<input', $markup);
+        $this->assertContains('name="foo"', $markup);
+        $this->assertContains('type="date"', $markup);
+    }
+
+    public function testInvokeWithNoElementChainsHelper()
+    {
+        $this->assertSame($this->helper, $this->helper->__invoke());
+    }
+}

--- a/tests/Zend/Form/View/Helper/FormDateTimeLocalTest.php
+++ b/tests/Zend/Form/View/Helper/FormDateTimeLocalTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\View\Helper;
+
+use Zend\Form\Element;
+use Zend\Form\View\Helper\FormDateTimeLocal as FormDateTimeLocalHelper;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormDateTimeLocalTest extends CommonTestCase
+{
+    public function setUp()
+    {
+        $this->helper = new FormDateTimeLocalHelper();
+        parent::setUp();
+    }
+
+    public function testRaisesExceptionWhenNameIsNotPresentInElement()
+    {
+        $element = new Element();
+        $this->setExpectedException('Zend\Form\Exception\DomainException', 'name');
+        $this->helper->render($element);
+    }
+
+    public function testGeneratesInputTagWithElement()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->render($element);
+        $this->assertContains('<input ', $markup);
+        $this->assertContains('type="datetime-local"', $markup);
+    }
+
+    public function testGeneratesInputTagRegardlessOfElementType()
+    {
+        $element = new Element('foo');
+        $element->setAttribute('type', 'email');
+        $markup  = $this->helper->render($element);
+        $this->assertContains('<input ', $markup);
+        $this->assertContains('type="datetime-local"', $markup);
+    }
+
+    public function validAttributes()
+    {
+        return array(
+            array('name',           'assertContains'),
+            array('accept',         'assertNotContains'),
+            array('alt',            'assertNotContains'),
+            array('autocomplete',   'assertContains'),
+            array('autofocus',      'assertContains'),
+            array('checked',        'assertNotContains'),
+            array('dirname',        'assertNotContains'),
+            array('disabled',       'assertContains'),
+            array('form',           'assertContains'),
+            array('formaction',     'assertNotContains'),
+            array('formenctype',    'assertNotContains'),
+            array('formmethod',     'assertNotContains'),
+            array('formnovalidate', 'assertNotContains'),
+            array('formtarget',     'assertNotContains'),
+            array('height',         'assertNotContains'),
+            array('list',           'assertContains'),
+            array('max',            'assertContains'),
+            array('maxlength',      'assertNotContains'),
+            array('min',            'assertContains'),
+            array('multiple',       'assertNotContains'),
+            array('pattern',        'assertNotContains'),
+            array('placeholder',    'assertNotContains'),
+            array('readonly',       'assertContains'),
+            array('required',       'assertContains'),
+            array('size',           'assertNotContains'),
+            array('src',            'assertNotContains'),
+            array('step',           'assertContains'),
+            array('value',          'assertContains'),
+            array('width',          'assertNotContains'),
+        );
+    }
+
+    public function getCompleteElement()
+    {
+        $element = new Element('foo');
+        $element->setAttributes(array(
+            'accept'             => 'value',
+            'alt'                => 'value',
+            'autocomplete'       => 'on',
+            'autofocus'          => 'autofocus',
+            'checked'            => 'checked',
+            'dirname'            => 'value',
+            'disabled'           => 'disabled',
+            'form'               => 'value',
+            'formaction'         => 'value',
+            'formenctype'        => 'value',
+            'formmethod'         => 'value',
+            'formnovalidate'     => 'value',
+            'formtarget'         => 'value',
+            'height'             => 'value',
+            'id'                 => 'value',
+            'list'               => 'value',
+            'max'                => 'value',
+            'maxlength'          => 'value',
+            'min'                => 'value',
+            'multiple'           => 'multiple',
+            'name'               => 'value',
+            'pattern'            => 'value',
+            'placeholder'        => 'value',
+            'readonly'           => 'readonly',
+            'required'           => 'required',
+            'size'               => 'value',
+            'src'                => 'value',
+            'step'               => 'value',
+            'value'              => 'value',
+            'width'              => 'value',
+        ));
+        return $element;
+    }
+
+    /**
+     * @dataProvider validAttributes
+     */
+    public function testAllValidFormMarkupAttributesPresentInElementAreRendered($attribute, $assertion)
+    {
+        $element = $this->getCompleteElement();
+        $markup  = $this->helper->render($element);
+        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        $this->$assertion($expect, $markup);
+    }
+
+    public function testInvokeProxiesToRender()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->__invoke($element);
+        $this->assertContains('<input', $markup);
+        $this->assertContains('name="foo"', $markup);
+        $this->assertContains('type="datetime-local"', $markup);
+    }
+
+    public function testInvokeWithNoElementChainsHelper()
+    {
+        $this->assertSame($this->helper, $this->helper->__invoke());
+    }
+}

--- a/tests/Zend/Form/View/Helper/FormDateTimeTest.php
+++ b/tests/Zend/Form/View/Helper/FormDateTimeTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\View\Helper;
+
+use Zend\Form\Element;
+use Zend\Form\View\Helper\FormDateTime as FormDateTimeHelper;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormDateTimeTest extends CommonTestCase
+{
+    public function setUp()
+    {
+        $this->helper = new FormDateTimeHelper();
+        parent::setUp();
+    }
+
+    public function testRaisesExceptionWhenNameIsNotPresentInElement()
+    {
+        $element = new Element();
+        $this->setExpectedException('Zend\Form\Exception\DomainException', 'name');
+        $this->helper->render($element);
+    }
+
+    public function testGeneratesInputTagWithElement()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->render($element);
+        $this->assertContains('<input ', $markup);
+        $this->assertContains('type="datetime"', $markup);
+    }
+
+    public function testGeneratesInputTagRegardlessOfElementType()
+    {
+        $element = new Element('foo');
+        $element->setAttribute('type', 'email');
+        $markup  = $this->helper->render($element);
+        $this->assertContains('<input ', $markup);
+        $this->assertContains('type="datetime"', $markup);
+    }
+
+    public function validAttributes()
+    {
+        return array(
+            array('name',           'assertContains'),
+            array('accept',         'assertNotContains'),
+            array('alt',            'assertNotContains'),
+            array('autocomplete',   'assertContains'),
+            array('autofocus',      'assertContains'),
+            array('checked',        'assertNotContains'),
+            array('dirname',        'assertNotContains'),
+            array('disabled',       'assertContains'),
+            array('form',           'assertContains'),
+            array('formaction',     'assertNotContains'),
+            array('formenctype',    'assertNotContains'),
+            array('formmethod',     'assertNotContains'),
+            array('formnovalidate', 'assertNotContains'),
+            array('formtarget',     'assertNotContains'),
+            array('height',         'assertNotContains'),
+            array('list',           'assertContains'),
+            array('max',            'assertContains'),
+            array('maxlength',      'assertNotContains'),
+            array('min',            'assertContains'),
+            array('multiple',       'assertNotContains'),
+            array('pattern',        'assertNotContains'),
+            array('placeholder',    'assertNotContains'),
+            array('readonly',       'assertContains'),
+            array('required',       'assertContains'),
+            array('size',           'assertNotContains'),
+            array('src',            'assertNotContains'),
+            array('step',           'assertContains'),
+            array('value',          'assertContains'),
+            array('width',          'assertNotContains'),
+        );
+    }
+
+    public function getCompleteElement()
+    {
+        $element = new Element('foo');
+        $element->setAttributes(array(
+            'accept'             => 'value',
+            'alt'                => 'value',
+            'autocomplete'       => 'on',
+            'autofocus'          => 'autofocus',
+            'checked'            => 'checked',
+            'dirname'            => 'value',
+            'disabled'           => 'disabled',
+            'form'               => 'value',
+            'formaction'         => 'value',
+            'formenctype'        => 'value',
+            'formmethod'         => 'value',
+            'formnovalidate'     => 'value',
+            'formtarget'         => 'value',
+            'height'             => 'value',
+            'id'                 => 'value',
+            'list'               => 'value',
+            'max'                => 'value',
+            'maxlength'          => 'value',
+            'min'                => 'value',
+            'multiple'           => 'multiple',
+            'name'               => 'value',
+            'pattern'            => 'value',
+            'placeholder'        => 'value',
+            'readonly'           => 'readonly',
+            'required'           => 'required',
+            'size'               => 'value',
+            'src'                => 'value',
+            'step'               => 'value',
+            'value'              => 'value',
+            'width'              => 'value',
+        ));
+        return $element;
+    }
+
+    /**
+     * @dataProvider validAttributes
+     */
+    public function testAllValidFormMarkupAttributesPresentInElementAreRendered($attribute, $assertion)
+    {
+        $element = $this->getCompleteElement();
+        $markup  = $this->helper->render($element);
+        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        $this->$assertion($expect, $markup);
+    }
+
+    public function testInvokeProxiesToRender()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->__invoke($element);
+        $this->assertContains('<input', $markup);
+        $this->assertContains('name="foo"', $markup);
+        $this->assertContains('type="datetime"', $markup);
+    }
+
+    public function testInvokeWithNoElementChainsHelper()
+    {
+        $this->assertSame($this->helper, $this->helper->__invoke());
+    }
+}

--- a/tests/Zend/Form/View/Helper/FormMonthTest.php
+++ b/tests/Zend/Form/View/Helper/FormMonthTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\View\Helper;
+
+use Zend\Form\Element;
+use Zend\Form\View\Helper\FormMonth as FormMonthHelper;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormMonthTest extends CommonTestCase
+{
+    public function setUp()
+    {
+        $this->helper = new FormMonthHelper();
+        parent::setUp();
+    }
+
+    public function testRaisesExceptionWhenNameIsNotPresentInElement()
+    {
+        $element = new Element();
+        $this->setExpectedException('Zend\Form\Exception\DomainException', 'name');
+        $this->helper->render($element);
+    }
+
+    public function testGeneratesInputTagWithElement()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->render($element);
+        $this->assertContains('<input ', $markup);
+        $this->assertContains('type="month"', $markup);
+    }
+
+    public function testGeneratesInputTagRegardlessOfElementType()
+    {
+        $element = new Element('foo');
+        $element->setAttribute('type', 'email');
+        $markup  = $this->helper->render($element);
+        $this->assertContains('<input ', $markup);
+        $this->assertContains('type="month"', $markup);
+    }
+
+    public function validAttributes()
+    {
+        return array(
+            array('name',           'assertContains'),
+            array('accept',         'assertNotContains'),
+            array('alt',            'assertNotContains'),
+            array('autocomplete',   'assertContains'),
+            array('autofocus',      'assertContains'),
+            array('checked',        'assertNotContains'),
+            array('dirname',        'assertNotContains'),
+            array('disabled',       'assertContains'),
+            array('form',           'assertContains'),
+            array('formaction',     'assertNotContains'),
+            array('formenctype',    'assertNotContains'),
+            array('formmethod',     'assertNotContains'),
+            array('formnovalidate', 'assertNotContains'),
+            array('formtarget',     'assertNotContains'),
+            array('height',         'assertNotContains'),
+            array('list',           'assertContains'),
+            array('max',            'assertContains'),
+            array('maxlength',      'assertNotContains'),
+            array('min',            'assertContains'),
+            array('multiple',       'assertNotContains'),
+            array('pattern',        'assertNotContains'),
+            array('placeholder',    'assertNotContains'),
+            array('readonly',       'assertContains'),
+            array('required',       'assertContains'),
+            array('size',           'assertNotContains'),
+            array('src',            'assertNotContains'),
+            array('step',           'assertContains'),
+            array('value',          'assertContains'),
+            array('width',          'assertNotContains'),
+        );
+    }
+
+    public function getCompleteElement()
+    {
+        $element = new Element('foo');
+        $element->setAttributes(array(
+            'accept'             => 'value',
+            'alt'                => 'value',
+            'autocomplete'       => 'on',
+            'autofocus'          => 'autofocus',
+            'checked'            => 'checked',
+            'dirname'            => 'value',
+            'disabled'           => 'disabled',
+            'form'               => 'value',
+            'formaction'         => 'value',
+            'formenctype'        => 'value',
+            'formmethod'         => 'value',
+            'formnovalidate'     => 'value',
+            'formtarget'         => 'value',
+            'height'             => 'value',
+            'id'                 => 'value',
+            'list'               => 'value',
+            'max'                => 'value',
+            'maxlength'          => 'value',
+            'min'                => 'value',
+            'multiple'           => 'multiple',
+            'name'               => 'value',
+            'pattern'            => 'value',
+            'placeholder'        => 'value',
+            'readonly'           => 'readonly',
+            'required'           => 'required',
+            'size'               => 'value',
+            'src'                => 'value',
+            'step'               => 'value',
+            'value'              => 'value',
+            'width'              => 'value',
+        ));
+        return $element;
+    }
+
+    /**
+     * @dataProvider validAttributes
+     */
+    public function testAllValidFormMarkupAttributesPresentInElementAreRendered($attribute, $assertion)
+    {
+        $element = $this->getCompleteElement();
+        $markup  = $this->helper->render($element);
+        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        $this->$assertion($expect, $markup);
+    }
+
+    public function testInvokeProxiesToRender()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->__invoke($element);
+        $this->assertContains('<input', $markup);
+        $this->assertContains('name="foo"', $markup);
+        $this->assertContains('type="month"', $markup);
+    }
+
+    public function testInvokeWithNoElementChainsHelper()
+    {
+        $this->assertSame($this->helper, $this->helper->__invoke());
+    }
+}

--- a/tests/Zend/Form/View/Helper/FormTimeTest.php
+++ b/tests/Zend/Form/View/Helper/FormTimeTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\View\Helper;
+
+use Zend\Form\Element;
+use Zend\Form\View\Helper\FormTime as FormTimeHelper;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormTimeTest extends CommonTestCase
+{
+    public function setUp()
+    {
+        $this->helper = new FormTimeHelper();
+        parent::setUp();
+    }
+
+    public function testRaisesExceptionWhenNameIsNotPresentInElement()
+    {
+        $element = new Element();
+        $this->setExpectedException('Zend\Form\Exception\DomainException', 'name');
+        $this->helper->render($element);
+    }
+
+    public function testGeneratesInputTagWithElement()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->render($element);
+        $this->assertContains('<input ', $markup);
+        $this->assertContains('type="time"', $markup);
+    }
+
+    public function testGeneratesInputTagRegardlessOfElementType()
+    {
+        $element = new Element('foo');
+        $element->setAttribute('type', 'email');
+        $markup  = $this->helper->render($element);
+        $this->assertContains('<input ', $markup);
+        $this->assertContains('type="time"', $markup);
+    }
+
+    public function validAttributes()
+    {
+        return array(
+            array('name',           'assertContains'),
+            array('accept',         'assertNotContains'),
+            array('alt',            'assertNotContains'),
+            array('autocomplete',   'assertContains'),
+            array('autofocus',      'assertContains'),
+            array('checked',        'assertNotContains'),
+            array('dirname',        'assertNotContains'),
+            array('disabled',       'assertContains'),
+            array('form',           'assertContains'),
+            array('formaction',     'assertNotContains'),
+            array('formenctype',    'assertNotContains'),
+            array('formmethod',     'assertNotContains'),
+            array('formnovalidate', 'assertNotContains'),
+            array('formtarget',     'assertNotContains'),
+            array('height',         'assertNotContains'),
+            array('list',           'assertContains'),
+            array('max',            'assertContains'),
+            array('maxlength',      'assertNotContains'),
+            array('min',            'assertContains'),
+            array('multiple',       'assertNotContains'),
+            array('pattern',        'assertNotContains'),
+            array('placeholder',    'assertNotContains'),
+            array('readonly',       'assertContains'),
+            array('required',       'assertContains'),
+            array('size',           'assertNotContains'),
+            array('src',            'assertNotContains'),
+            array('step',           'assertContains'),
+            array('value',          'assertContains'),
+            array('width',          'assertNotContains'),
+        );
+    }
+
+    public function getCompleteElement()
+    {
+        $element = new Element('foo');
+        $element->setAttributes(array(
+            'accept'             => 'value',
+            'alt'                => 'value',
+            'autocomplete'       => 'on',
+            'autofocus'          => 'autofocus',
+            'checked'            => 'checked',
+            'dirname'            => 'value',
+            'disabled'           => 'disabled',
+            'form'               => 'value',
+            'formaction'         => 'value',
+            'formenctype'        => 'value',
+            'formmethod'         => 'value',
+            'formnovalidate'     => 'value',
+            'formtarget'         => 'value',
+            'height'             => 'value',
+            'id'                 => 'value',
+            'list'               => 'value',
+            'max'                => 'value',
+            'maxlength'          => 'value',
+            'min'                => 'value',
+            'multiple'           => 'multiple',
+            'name'               => 'value',
+            'pattern'            => 'value',
+            'placeholder'        => 'value',
+            'readonly'           => 'readonly',
+            'required'           => 'required',
+            'size'               => 'value',
+            'src'                => 'value',
+            'step'               => 'value',
+            'value'              => 'value',
+            'width'              => 'value',
+        ));
+        return $element;
+    }
+
+    /**
+     * @dataProvider validAttributes
+     */
+    public function testAllValidFormMarkupAttributesPresentInElementAreRendered($attribute, $assertion)
+    {
+        $element = $this->getCompleteElement();
+        $markup  = $this->helper->render($element);
+        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        $this->$assertion($expect, $markup);
+    }
+
+    public function testInvokeProxiesToRender()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->__invoke($element);
+        $this->assertContains('<input', $markup);
+        $this->assertContains('name="foo"', $markup);
+        $this->assertContains('type="time"', $markup);
+    }
+
+    public function testInvokeWithNoElementChainsHelper()
+    {
+        $this->assertSame($this->helper, $this->helper->__invoke());
+    }
+}

--- a/tests/Zend/Form/View/Helper/FormWeekTest.php
+++ b/tests/Zend/Form/View/Helper/FormWeekTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\View\Helper;
+
+use Zend\Form\Element;
+use Zend\Form\View\Helper\FormWeek as FormWeekHelper;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormWeekTest extends CommonTestCase
+{
+    public function setUp()
+    {
+        $this->helper = new FormWeekHelper();
+        parent::setUp();
+    }
+
+    public function testRaisesExceptionWhenNameIsNotPresentInElement()
+    {
+        $element = new Element();
+        $this->setExpectedException('Zend\Form\Exception\DomainException', 'name');
+        $this->helper->render($element);
+    }
+
+    public function testGeneratesInputTagWithElement()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->render($element);
+        $this->assertContains('<input ', $markup);
+        $this->assertContains('type="week"', $markup);
+    }
+
+    public function testGeneratesInputTagRegardlessOfElementType()
+    {
+        $element = new Element('foo');
+        $element->setAttribute('type', 'email');
+        $markup  = $this->helper->render($element);
+        $this->assertContains('<input ', $markup);
+        $this->assertContains('type="week"', $markup);
+    }
+
+    public function validAttributes()
+    {
+        return array(
+            array('name',           'assertContains'),
+            array('accept',         'assertNotContains'),
+            array('alt',            'assertNotContains'),
+            array('autocomplete',   'assertContains'),
+            array('autofocus',      'assertContains'),
+            array('checked',        'assertNotContains'),
+            array('dirname',        'assertNotContains'),
+            array('disabled',       'assertContains'),
+            array('form',           'assertContains'),
+            array('formaction',     'assertNotContains'),
+            array('formenctype',    'assertNotContains'),
+            array('formmethod',     'assertNotContains'),
+            array('formnovalidate', 'assertNotContains'),
+            array('formtarget',     'assertNotContains'),
+            array('height',         'assertNotContains'),
+            array('list',           'assertContains'),
+            array('max',            'assertContains'),
+            array('maxlength',      'assertNotContains'),
+            array('min',            'assertContains'),
+            array('multiple',       'assertNotContains'),
+            array('pattern',        'assertNotContains'),
+            array('placeholder',    'assertNotContains'),
+            array('readonly',       'assertContains'),
+            array('required',       'assertContains'),
+            array('size',           'assertNotContains'),
+            array('src',            'assertNotContains'),
+            array('step',           'assertContains'),
+            array('value',          'assertContains'),
+            array('width',          'assertNotContains'),
+        );
+    }
+
+    public function getCompleteElement()
+    {
+        $element = new Element('foo');
+        $element->setAttributes(array(
+            'accept'             => 'value',
+            'alt'                => 'value',
+            'autocomplete'       => 'on',
+            'autofocus'          => 'autofocus',
+            'checked'            => 'checked',
+            'dirname'            => 'value',
+            'disabled'           => 'disabled',
+            'form'               => 'value',
+            'formaction'         => 'value',
+            'formenctype'        => 'value',
+            'formmethod'         => 'value',
+            'formnovalidate'     => 'value',
+            'formtarget'         => 'value',
+            'height'             => 'value',
+            'id'                 => 'value',
+            'list'               => 'value',
+            'max'                => 'value',
+            'maxlength'          => 'value',
+            'min'                => 'value',
+            'multiple'           => 'multiple',
+            'name'               => 'value',
+            'pattern'            => 'value',
+            'placeholder'        => 'value',
+            'readonly'           => 'readonly',
+            'required'           => 'required',
+            'size'               => 'value',
+            'src'                => 'value',
+            'step'               => 'value',
+            'value'              => 'value',
+            'width'              => 'value',
+        ));
+        return $element;
+    }
+
+    /**
+     * @dataProvider validAttributes
+     */
+    public function testAllValidFormMarkupAttributesPresentInElementAreRendered($attribute, $assertion)
+    {
+        $element = $this->getCompleteElement();
+        $markup  = $this->helper->render($element);
+        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        $this->$assertion($expect, $markup);
+    }
+
+    public function testInvokeProxiesToRender()
+    {
+        $element = new Element('foo');
+        $markup  = $this->helper->__invoke($element);
+        $this->assertContains('<input', $markup);
+        $this->assertContains('name="foo"', $markup);
+        $this->assertContains('type="week"', $markup);
+    }
+
+    public function testInvokeWithNoElementChainsHelper()
+    {
+        $this->assertSame($this->helper, $this->helper->__invoke());
+    }
+}

--- a/tests/Zend/Validator/DateStepTest.php
+++ b/tests/Zend/Validator/DateStepTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Validator
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Validator;
+
+use Zend\Validator;
+use DateTime;
+use DateTimeZone;
+use DateInterval;
+use ReflectionClass;
+
+/**
+ * Test helper
+ */
+
+/**
+ * @see \Zend\Validator\DateStep
+ */
+
+
+/**
+ * @category   Zend
+ * @package    Zend_Validator
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Zend_Validator
+ */
+class DateStepTest extends \PHPUnit_Framework_TestCase
+{
+    public function stepTestsDataProvider()
+    {
+        return array(
+            //    interval format            baseValue               value                  isValid
+            array('PT1S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z', true ),
+            array('PT1S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-03T00:00:00Z', true ),
+            array('PT1S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:02Z', true ),
+            array('PT2S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:01Z', false),
+            array('PT2S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:16Z', true ),
+            array('PT2S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-03T00:00:00Z', true ),
+            // minutes
+            array('PT1M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true ),
+            array('PT1M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:30Z', false),
+            array('PT1M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:02:00Z', true ),
+            array('PT2M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:01:00Z', false),
+            array('PT2M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:16:00Z', true ),
+            array('PT2M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true ),
+            array('PT1M', 'H:i:s',           '00:00:00',             '12:34:00',             true ),
+            array('PT2M', 'H:i:s',           '00:00:00',             '12:34:00',             true ),
+            array('PT2M', 'H:i:s',           '00:00:00',             '12:35:00',             false),
+            // hours
+            array('PT1H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true ),
+            array('PT1H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:30Z', false),
+            array('PT1H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T02:00:00Z', true ),
+            array('PT2H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T01:00:00Z', false),
+            array('PT2H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T16:00:00Z', true ),
+            array('PT2H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true ),
+            // days
+            array('P1D',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true ),
+            array('P1D',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false),
+            array('P2D',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-02T00:00:00Z', false),
+            array('P2D',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-15T00:00:00Z', true ),
+            array('P2D',  DateTime::ISO8601, '1971-01-01T00:00:00Z', '1973-01-01T00:00:00Z', false),
+            array('P2D',  DateTime::ISO8601, '2000-01-01T00:00:00Z', '2001-01-01T00:00:00Z', true ), // leap year
+            // weeks
+            array('P1W',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-29T00:00:00Z', true ),
+            array('P1W',  'Y-\WW',           '1970-W01',             '1973-W16',             true ),
+            array('P2W',  'Y-\WW',           '1970-W01',             '1973-W16',             true ),
+            array('P2W',  'Y-\WW',           '1970-W01',             '1973-W17',             false),
+            // months
+            array('P1M',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true ),
+            array('P1M',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false),
+            array('P2M',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-02-01T00:00:00Z', false),
+            array('P2M',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1971-05-01T00:00:00Z', true ),
+            array('P1M',  'Y-m',             '1970-01',              '1970-10',              true ),
+            array('P2M',  'Y-m',             '1970-01',              '1970-11',              true ),
+            array('P2M',  'Y-m',             '1970-01',              '1970-10',              false),
+            // years
+            array('P1Y',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true ),
+            array('P1Y',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false),
+            array('P2Y',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1971-01-01T00:00:00Z', false),
+            array('P2Y',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1976-01-01T00:00:00Z', true ),
+            // complex
+            array('P2M2DT12H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-03T12:00:00Z', true ),
+            array('P2M2DT12M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-03T12:00:00Z', false),
+        );
+    }
+
+    /**
+     * @dataProvider stepTestsDataProvider
+     */
+    public function testDateStepValidation($interval, $format, $baseValue, $value, $isValid)
+    {
+        $validator = new Validator\DateStep(array(
+            'format'       => $format,
+            'baseValue'    => $baseValue,
+            'stepInterval' => new DateInterval($interval),
+        ));
+
+        $this->assertEquals($isValid, $validator->isValid($value));
+    }
+
+    public function testGetMessagesReturnsDefaultValue()
+    {
+        $validator = new Validator\DateStep();
+        $this->assertEquals(array(), $validator->getMessages());
+    }
+
+    public function testEqualsMessageTemplates()
+    {
+        $validator  = new Validator\DateStep(array());
+        $reflection = new ReflectionClass($validator);
+
+        if (!$reflection->hasProperty('_messageTemplates')) {
+            return;
+        }
+
+        $property = $reflection->getProperty('_messageTemplates');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageTemplates')
+        );
+    }
+
+    public function testEqualsMessageVariables()
+    {
+        $validator  = new Validator\DateStep(array());
+        $reflection = new ReflectionClass($validator);
+
+        if (!$reflection->hasProperty('_messageVariables')) {
+            return;
+        }
+
+        $property = $reflection->getProperty('_messageVariables');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            $property->getValue($validator),
+            $validator->getOption('messageVariables')
+        );
+    }
+}


### PR DESCRIPTION
A good place to start a review of this PR is with: Zend/Form/Element/DateTime.php
The other elements are extremely similar and extend from DateTime. They reconfigure the validator settings for their specific use-case.

The other juicy bit is Zend/Validate/DateStep.php.
I had heard mention that we were moving away from Zend_Date and to PHP5's DateTime objects, so I chose DateTime as the utility for validation. This file could use a thorough review by someone who has an idea of what the roadmap is for Zend_Date/Zend_Locale changes.

HTML5 Spec for the Date/Time elements:
http://www.whatwg.org/specs/web-apps/current-work/multipage/states-of-the-type-attribute.html#date-and-time-state-(type=datetime)
