### PR TITLE
Fixed the bcrypt using $2y$ syntax for PHP 5.3.7+

### DIFF
--- a/documentation/manual/en/module_specs/Zend_Crypt_Password.xml
+++ b/documentation/manual/en/module_specs/Zend_Crypt_Password.xml
@@ -56,5 +56,16 @@ if ($bcrypt->verify($password, $bcrypt)) {
         If you want to change the cost parameter of the bcrypt algorithm you can use the <methodname>setCost()</methodname> method.
     </para>
 
+    <note>
+        <title>Bcrypt with non-ASCII passwords (8-bit characters)</title>
+
+        <para>
+            The bcrypt implementation used by PHP &lt; 5.3.7 can contains a security flaw if the password uses 8-bit characters (<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://php.net/security/crypt_blowfish.php">here the security report</link>). 
+            The impact of this bug was that most (but not all) passwords containing non-ASCII characters with the 8th bit set were hashed incorrectly, resulting in password hashes
+            incompatible with those of OpenBSD's original implementation of bcrypt.
+             This security flaw has been fixed starting from PHP 5.3.7 and the prefix used in the output has changed in '$2y$' in order to put evidence on the correctness of the hash value.
+            If you are using PHP &lt; 5.3.7  with 8-bit passwords the <classname>Zend\Crypt\Password\Bcrypt</classname> throws an exception suggesting to upgrade to PHP 5.3.7+ or use only 7-bit passwords.
+        </para>
+    </note>
 </section>
 

--- a/library/Zend/Crypt/Password/Bcrypt.php
+++ b/library/Zend/Crypt/Password/Bcrypt.php
@@ -82,7 +82,15 @@ class Bcrypt implements PasswordInterface
             $salt = $this->salt;
         }
         $salt64 = substr(str_replace('+', '.', base64_encode($salt)), 0, 22);
-        $hash   = crypt($password, '$2a$' . $this->cost . '$' . $salt64);
+        $code   = '$2a$';
+        /**
+         * @see http://php.net/security/crypt_blowfish.php
+         * @see http://en.wikipedia.org/wiki/Crypt_%28Unix%29#Blowfish-based_scheme
+         */
+        if (version_compare(PHP_VERSION, '5.3.7') >= 0) {
+            $code = '$2y$';
+        }
+        $hash   = crypt($password, $code . $this->cost . '$' . $salt64);
         if (strlen($hash) <= 13) {
             throw new Exception\RuntimeException('Error during the bcrypt generation');
         }

--- a/tests/Zend/Crypt/Password/BcryptTest.php
+++ b/tests/Zend/Crypt/Password/BcryptTest.php
@@ -54,7 +54,11 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
         }
         $this->salt           = '1234567890123456';
         $this->password       = 'test';
-        $this->bcryptPassword = '$2a$14$MTIzNDU2Nzg5MDEyMzQ1NeWUUefVlefsTbFhsbqKFv/vPSZBrSFVm';
+        if (version_compare(PHP_VERSION, '5.3.7') >= 0) {
+            $this->bcryptPassword = '$2y$14$MTIzNDU2Nzg5MDEyMzQ1NeWUUefVlefsTbFhsbqKFv/vPSZBrSFVm';
+        } else {
+            $this->bcryptPassword = '$2a$14$MTIzNDU2Nzg5MDEyMzQ1NeWUUefVlefsTbFhsbqKFv/vPSZBrSFVm';
+        }    
     }
 
     public function testConstructByOptions()


### PR DESCRIPTION
Starting from PHP 5.3.7 the bcrypt implementation in crypt() should use the $2y$ syntax instead of $2a$. There was a security issue with password contains 8-bit characters for some specific environments.
More information here:
http://php.net/security/crypt_blowfish.php
http://en.wikipedia.org/wiki/Crypt_%28Unix%29#Blowfish-based_scheme
