### PR TITLE
[zen-52] Renamed abstract classes in Zend\XmlRpc

### DIFF
--- a/library/Zend/XmlRpc/AbstractValue.php
+++ b/library/Zend/XmlRpc/AbstractValue.php
@@ -39,7 +39,7 @@ use Zend\Math\BigInteger;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class Value
+abstract class AbstractValue
 {
     /**
      * The native XML-RPC representation of this object's value
@@ -188,7 +188,7 @@ abstract class Value
      *
      * @param  mixed $value
      * @param  Zend\XmlRpc\Value::constant $type
-     * @return Value
+     * @return AbstractValue
      */
     public static function getXmlRpcValue($value, $type = self::AUTO_DETECT_TYPE)
     {
@@ -252,7 +252,7 @@ abstract class Value
     public static function getXmlRpcTypeByValue($value)
     {
         if (is_object($value)) {
-            if ($value instanceof Value) {
+            if ($value instanceof AbstractValue) {
                 return $value->getType();
             } elseif (($value instanceof Date\Date) || ($value instanceof DateTime)) {
                 return self::XMLRPC_TYPE_DATETIME;
@@ -285,14 +285,14 @@ abstract class Value
      *
      * @param mixed $value The PHP variable for convertion
      *
-     * @return Value
+     * @return AbstractValue
      * @static
      */
     protected static function _phpVarToNativeXmlRpc($value)
     {
         // @see http://framework.zend.com/issues/browse/ZF-8623
         if (is_object($value)) {
-            if ($value instanceof Value) {
+            if ($value instanceof AbstractValue) {
                 return $value;
             }
             if ($value instanceof BigInteger) {
@@ -341,7 +341,7 @@ abstract class Value
      * @param string|SimpleXMLElement $xml A SimpleXMLElement object represent the XML string
      * It can be also a valid XML string for convertion
      *
-     * @return Zend\XmlRpc\Value\Value
+     * @return Zend\XmlRpc\Value\AbstractValue
      * @static
      */
     protected static function _xmlStringToNativeXmlRpc($xml)

--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -23,7 +23,7 @@ namespace Zend\XmlRpc;
 
 use Zend\Http,
     Zend\Server\Client as ServerClient,
-    Zend\XmlRpc\Value;
+    Zend\XmlRpc\AbstractValue;
 
 /**
  * An XML-RPC client implementation
@@ -280,28 +280,28 @@ class Client implements ServerClient
             }
             if ($success) {
                 $validTypes = array(
-                    Value::XMLRPC_TYPE_ARRAY,
-                    Value::XMLRPC_TYPE_BASE64,
-                    Value::XMLRPC_TYPE_BOOLEAN,
-                    Value::XMLRPC_TYPE_DATETIME,
-                    Value::XMLRPC_TYPE_DOUBLE,
-                    Value::XMLRPC_TYPE_I4,
-                    Value::XMLRPC_TYPE_INTEGER,
-                    Value::XMLRPC_TYPE_NIL,
-                    Value::XMLRPC_TYPE_STRING,
-                    Value::XMLRPC_TYPE_STRUCT,
+                    AbstractValue::XMLRPC_TYPE_ARRAY,
+                    AbstractValue::XMLRPC_TYPE_BASE64,
+                    AbstractValue::XMLRPC_TYPE_BOOLEAN,
+                    AbstractValue::XMLRPC_TYPE_DATETIME,
+                    AbstractValue::XMLRPC_TYPE_DOUBLE,
+                    AbstractValue::XMLRPC_TYPE_I4,
+                    AbstractValue::XMLRPC_TYPE_INTEGER,
+                    AbstractValue::XMLRPC_TYPE_NIL,
+                    AbstractValue::XMLRPC_TYPE_STRING,
+                    AbstractValue::XMLRPC_TYPE_STRUCT,
                 );
 
                 if (!is_array($params)) {
                     $params = array($params);
                 }
                 foreach ($params as $key => $param) {
-                    if ($param instanceof Value) {
+                    if ($param instanceof AbstractValue) {
                         continue;
                     }
 
                     if (count($signatures) > 1) {
-                        $type = Value::getXmlRpcTypeByValue($param);
+                        $type = AbstractValue::getXmlRpcTypeByValue($param);
                         foreach ($signatures as $signature) {
                             if (!is_array($signature)) {
                                 continue;
@@ -319,10 +319,10 @@ class Client implements ServerClient
                     }
 
                     if (empty($type) || !in_array($type, $validTypes)) {
-                        $type = Value::AUTO_DETECT_TYPE;
+                        $type = AbstractValue::AUTO_DETECT_TYPE;
                     }
 
-                    $params[$key] = Value::getXmlRpcValue($param, $type);
+                    $params[$key] = AbstractValue::getXmlRpcValue($param, $type);
                 }
             }
         }

--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -21,9 +21,9 @@
 
 namespace Zend\XmlRpc;
 
-use Zend\Http,
-    Zend\Server\Client as ServerClient,
-    Zend\XmlRpc\AbstractValue;
+use Zend\Http;
+use Zend\Server\Client as ServerClient;
+use Zend\XmlRpc\AbstractValue;
 
 /**
  * An XML-RPC client implementation

--- a/library/Zend/XmlRpc/Client/Exception/ExceptionInterface.php
+++ b/library/Zend/XmlRpc/Client/Exception/ExceptionInterface.php
@@ -33,4 +33,5 @@ use Zend\XmlRpc\Exception\ExceptionInterface as Exception;
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 interface ExceptionInterface extends Exception
-{}
+{
+}

--- a/library/Zend/XmlRpc/Client/Exception/FaultException.php
+++ b/library/Zend/XmlRpc/Client/Exception/FaultException.php
@@ -32,7 +32,6 @@ use Zend\XmlRpc\Exception;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class FaultException
-    extends Exception\BadMethodCallException
-    implements ExceptionInterface
-{}
+class FaultException extends Exception\BadMethodCallException implements ExceptionInterface
+{
+}

--- a/library/Zend/XmlRpc/Client/Exception/HttpException.php
+++ b/library/Zend/XmlRpc/Client/Exception/HttpException.php
@@ -31,6 +31,6 @@ namespace Zend\XmlRpc\Client\Exception;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class HttpException
-    extends RuntimeException
-{}
+class HttpException extends RuntimeException
+{
+}

--- a/library/Zend/XmlRpc/Client/Exception/IntrospectException.php
+++ b/library/Zend/XmlRpc/Client/Exception/IntrospectException.php
@@ -30,6 +30,6 @@ namespace Zend\XmlRpc\Client\Exception;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class IntrospectException
-    extends InvalidArgumentException
-{}
+class IntrospectException extends InvalidArgumentException
+{
+}

--- a/library/Zend/XmlRpc/Client/Exception/InvalidArgumentException.php
+++ b/library/Zend/XmlRpc/Client/Exception/InvalidArgumentException.php
@@ -4,7 +4,6 @@ namespace Zend\XmlRpc\Client\Exception;
 
 use Zend\XmlRpc\Exception;
 
-class InvalidArgumentException
-    extends Exception\InvalidArgumentException
-    implements ExceptionInterface
-{}
+class InvalidArgumentException extends Exception\InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/library/Zend/XmlRpc/Client/Exception/RuntimeException.php
+++ b/library/Zend/XmlRpc/Client/Exception/RuntimeException.php
@@ -4,7 +4,6 @@ namespace Zend\XmlRpc\Client\Exception;
 
 use Zend\XmlRpc\Exception;
 
-class RuntimeException
-    extends Exception\RuntimeException
-    implements ExceptionInterface
-{}
+class RuntimeException extends Exception\RuntimeException implements ExceptionInterface
+{
+}

--- a/library/Zend/XmlRpc/Exception/BadMethodCallException.php
+++ b/library/Zend/XmlRpc/Exception/BadMethodCallException.php
@@ -2,7 +2,6 @@
 
 namespace Zend\XmlRpc\Exception;
 
-class BadMethodCallException
-    extends \BadMethodCallException
-    implements ExceptionInterface
-{}
+class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
+{
+}

--- a/library/Zend/XmlRpc/Exception/ExceptionInterface.php
+++ b/library/Zend/XmlRpc/Exception/ExceptionInterface.php
@@ -27,4 +27,5 @@ namespace Zend\XmlRpc\Exception;
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 interface ExceptionInterface
-{}
+{
+}

--- a/library/Zend/XmlRpc/Exception/InvalidArgumentException.php
+++ b/library/Zend/XmlRpc/Exception/InvalidArgumentException.php
@@ -2,7 +2,6 @@
 
 namespace Zend\XmlRpc\Exception;
 
-class InvalidArgumentException
-    extends \InvalidArgumentException
-    implements ExceptionInterface
-{}
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/library/Zend/XmlRpc/Exception/RuntimeException.php
+++ b/library/Zend/XmlRpc/Exception/RuntimeException.php
@@ -2,7 +2,6 @@
 
 namespace Zend\XmlRpc\Exception;
 
-class RuntimeException
-    extends \RuntimeException
-    implements ExceptionInterface
-{}
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/library/Zend/XmlRpc/Exception/ValueException.php
+++ b/library/Zend/XmlRpc/Exception/ValueException.php
@@ -28,7 +28,6 @@ namespace Zend\XmlRpc\Exception;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class ValueException
-    extends \LogicException
-    implements ExceptionInterface
-{}
+class ValueException extends \LogicException implements ExceptionInterface
+{
+}

--- a/library/Zend/XmlRpc/Fault.php
+++ b/library/Zend/XmlRpc/Fault.php
@@ -164,7 +164,7 @@ class Fault
     public function setEncoding($encoding)
     {
         $this->_encoding = $encoding;
-        Value::setEncoding($encoding);
+        AbstractValue::setEncoding($encoding);
         return $this;
     }
 
@@ -212,7 +212,7 @@ class Fault
         }
 
         $structXml = $xml->fault->value->asXML();
-        $struct    = Value::getXmlRpcValue($structXml, Value::XML_STRING);
+        $struct    = AbstractValue::getXmlRpcValue($structXml, AbstractValue::XML_STRING);
         $struct    = $struct->getValue();
 
         if (isset($struct['faultCode'])) {
@@ -274,9 +274,9 @@ class Fault
             'faultCode'   => $this->getCode(),
             'faultString' => $this->getMessage()
         );
-        $value = Value::getXmlRpcValue($faultStruct);
+        $value = AbstractValue::getXmlRpcValue($faultStruct);
 
-        $generator = Value::getGenerator();
+        $generator = AbstractValue::getGenerator();
         $generator->openElement('methodResponse')
                   ->openElement('fault');
         $value->generateXml();

--- a/library/Zend/XmlRpc/Request.php
+++ b/library/Zend/XmlRpc/Request.php
@@ -107,7 +107,7 @@ class Request
     public function setEncoding($encoding)
     {
         $this->_encoding = $encoding;
-        Value::setEncoding($encoding);
+        AbstractValue::setEncoding($encoding);
         return $this;
     }
 
@@ -164,10 +164,10 @@ class Request
         $this->_params[] = $value;
         if (null === $type) {
             // Detect type if not provided explicitly
-            if ($value instanceof Value) {
+            if ($value instanceof AbstractValue) {
                 $type = $value->getType();
             } else {
-                $xmlRpcValue = Value::getXmlRpcValue($value);
+                $xmlRpcValue = AbstractValue::getXmlRpcValue($value);
                 $type        = $xmlRpcValue->getType();
             }
         }
@@ -216,7 +216,7 @@ class Request
                 $params[] = $arg['value'];
 
                 if (!isset($arg['type'])) {
-                    $xmlRpcValue = Value::getXmlRpcValue($arg['value']);
+                    $xmlRpcValue = AbstractValue::getXmlRpcValue($arg['value']);
                     $arg['type'] = $xmlRpcValue->getType();
                 }
                 $types[] = $arg['type'];
@@ -230,10 +230,10 @@ class Request
                 $this->_types  = array();
                 $xmlRpcParams  = array();
                 foreach ($argv[0] as $arg) {
-                    if ($arg instanceof Value) {
+                    if ($arg instanceof AbstractValue) {
                         $type = $arg->getType();
                     } else {
-                        $xmlRpcValue = Value::getXmlRpcValue($arg);
+                        $xmlRpcValue = AbstractValue::getXmlRpcValue($arg);
                         $type        = $xmlRpcValue->getType();
                     }
                     $xmlRpcParams[] = array('value' => $arg, 'type' => $type);
@@ -248,10 +248,10 @@ class Request
         $this->_types  = array();
         $xmlRpcParams  = array();
         foreach ($argv as $arg) {
-            if ($arg instanceof Value) {
+            if ($arg instanceof AbstractValue) {
                 $type = $arg->getType();
             } else {
-                $xmlRpcValue = Value::getXmlRpcValue($arg);
+                $xmlRpcValue = AbstractValue::getXmlRpcValue($arg);
                 $type        = $xmlRpcValue->getType();
             }
             $xmlRpcParams[] = array('value' => $arg, 'type' => $type);
@@ -329,7 +329,7 @@ class Request
                 }
 
                 try {
-                    $param   = Value::getXmlRpcValue($param->value, Value::XML_STRING);
+                    $param   = AbstractValue::getXmlRpcValue($param->value, AbstractValue::XML_STRING);
                     $types[] = $param->getType();
                     $argv[]  = $param->getValue();
                 } catch (\Exception $e) {
@@ -380,10 +380,10 @@ class Request
         if (is_array($this->_xmlRpcParams)) {
             foreach ($this->_xmlRpcParams as $param) {
                 $value = $param['value'];
-                $type  = $param['type'] ?: Value::AUTO_DETECT_TYPE;
+                $type  = $param['type'] ?: AbstractValue::AUTO_DETECT_TYPE;
 
-                if (!$value instanceof Value) {
-                    $value = Value::getXmlRpcValue($value, $type);
+                if (!$value instanceof AbstractValue) {
+                    $value = AbstractValue::getXmlRpcValue($value, $type);
                 }
                 $params[] = $value;
             }
@@ -402,7 +402,7 @@ class Request
         $args   = $this->_getXmlRpcParams();
         $method = $this->getMethod();
 
-        $generator = Value::getGenerator();
+        $generator = AbstractValue::getGenerator();
         $generator->openElement('methodCall')
                   ->openElement('methodName', $method)
                   ->closeElement('methodName');

--- a/library/Zend/XmlRpc/Request/Http.php
+++ b/library/Zend/XmlRpc/Request/Http.php
@@ -20,8 +20,8 @@
 
 namespace Zend\XmlRpc\Request;
 
-use Zend\XmlRpc\Request as XmlRpcRequest,
-    Zend\XmlRpc\Fault;
+use Zend\XmlRpc\Request as XmlRpcRequest;
+use Zend\XmlRpc\Fault;
 
 /**
  * XmlRpc Request object -- Request via HTTP

--- a/library/Zend/XmlRpc/Request/Stdin.php
+++ b/library/Zend/XmlRpc/Request/Stdin.php
@@ -20,8 +20,8 @@
 
 namespace Zend\XmlRpc\Request;
 
-use Zend\XmlRpc\Request as XmlRpcRequest,
-    Zend\XmlRpc\Server\Exception as ServerException;
+use Zend\XmlRpc\Request as XmlRpcRequest;
+use Zend\XmlRpc\Server\Exception as ServerException;
 
 /**
  * XmlRpc Request object -- Request via STDIN

--- a/library/Zend/XmlRpc/Response.php
+++ b/library/Zend/XmlRpc/Response.php
@@ -80,7 +80,7 @@ class Response
     public function setEncoding($encoding)
     {
         $this->_encoding = $encoding;
-        Value::setEncoding($encoding);
+        AbstractValue::setEncoding($encoding);
         return $this;
     }
 
@@ -126,7 +126,7 @@ class Response
      */
     protected function _getXmlRpcReturn()
     {
-        return Value::getXmlRpcValue($this->_return);
+        return AbstractValue::getXmlRpcValue($this->_return);
     }
 
     /**
@@ -203,7 +203,7 @@ class Response
                 throw new Exception\ValueException('Missing XML-RPC value in XML');
             }
             $valueXml = $xml->params->param->value->asXML();
-            $value = Value::getXmlRpcValue($valueXml, Value::XML_STRING);
+            $value = AbstractValue::getXmlRpcValue($valueXml, AbstractValue::XML_STRING);
         } catch (Exception\ValueException $e) {
             $this->_fault = new Fault(653);
             $this->_fault->setEncoding($this->getEncoding());
@@ -222,7 +222,7 @@ class Response
     public function saveXml()
     {
         $value = $this->_getXmlRpcReturn();
-        $generator = Value::getGenerator();
+        $generator = AbstractValue::getGenerator();
         $generator->openElement('methodResponse')
                   ->openElement('params')
                   ->openElement('param');

--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -379,7 +379,7 @@ class Server extends AbstractServer
     public function setEncoding($encoding)
     {
         $this->encoding = $encoding;
-        Value::setEncoding($encoding);
+        AbstractValue::setEncoding($encoding);
         return $this;
     }
 
@@ -571,7 +571,7 @@ class Server extends AbstractServer
         $paramsLen  = count($params);
         if ($sigLength < $paramsLen) {
             for ($i = $sigLength; $i < $paramsLen; ++$i) {
-                $xmlRpcValue = Value::getXmlRpcValue($params[$i]);
+                $xmlRpcValue = AbstractValue::getXmlRpcValue($params[$i]);
                 $sigCalled[] = $xmlRpcValue->getType();
             }
         }

--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -21,10 +21,10 @@
 
 namespace Zend\XmlRpc;
 
-use ReflectionClass,
-    Zend\Server\AbstractServer,
-    Zend\Server\Definition,
-    Zend\Server\Reflection;
+use ReflectionClass;
+use Zend\Server\AbstractServer;
+use Zend\Server\Definition;
+use Zend\Server\Reflection;
 
 /**
  * An XML-RPC server implementation

--- a/library/Zend/XmlRpc/Server/Exception/BadMethodCallException.php
+++ b/library/Zend/XmlRpc/Server/Exception/BadMethodCallException.php
@@ -4,7 +4,6 @@ namespace Zend\XmlRpc\Server\Exception;
 
 use Zend\XmlRpc\Exception;
 
-class BadMethodCallException
-    extends Exception\BadMethodCallException
-    implements ExceptionInterface
-{}
+class BadMethodCallException extends Exception\BadMethodCallException implements ExceptionInterface
+{
+}

--- a/library/Zend/XmlRpc/Server/Exception/ExceptionInterface.php
+++ b/library/Zend/XmlRpc/Server/Exception/ExceptionInterface.php
@@ -33,4 +33,5 @@ use Zend\XmlRpc\Exception\ExceptionInterface as Exception;
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 interface ExceptionInterface extends Exception
-{}
+{
+}

--- a/library/Zend/XmlRpc/Server/Exception/InvalidArgumentException.php
+++ b/library/Zend/XmlRpc/Server/Exception/InvalidArgumentException.php
@@ -4,7 +4,6 @@ namespace Zend\XmlRpc\Server\Exception;
 
 use Zend\XmlRpc\Exception;
 
-class InvalidArgumentException
-    extends Exception\InvalidArgumentException
-    implements ExceptionInterface
-{}
+class InvalidArgumentException extends Exception\InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/library/Zend/XmlRpc/Server/Exception/RuntimeException.php
+++ b/library/Zend/XmlRpc/Server/Exception/RuntimeException.php
@@ -4,7 +4,6 @@ namespace Zend\XmlRpc\Server\Exception;
 
 use Zend\XmlRpc\Exception;
 
-class RuntimeException
-    extends Exception\RuntimeException
-    implements ExceptionInterface
-{}
+class RuntimeException extends Exception\RuntimeException implements ExceptionInterface
+{
+}

--- a/library/Zend/XmlRpc/Value/AbstractCollection.php
+++ b/library/Zend/XmlRpc/Value/AbstractCollection.php
@@ -21,7 +21,7 @@
 
 namespace Zend\XmlRpc\Value;
 
-use Zend\XmlRpc\Value as XmlRpcValue;
+use Zend\XmlRpc\AbstractValue;
 
 /**
  * @category   Zend
@@ -30,7 +30,7 @@ use Zend\XmlRpc\Value as XmlRpcValue;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class Collection extends XmlRpcValue
+abstract class AbstractCollection extends AbstractValue
 {
 
     /**

--- a/library/Zend/XmlRpc/Value/AbstractScalar.php
+++ b/library/Zend/XmlRpc/Value/AbstractScalar.php
@@ -21,7 +21,7 @@
 
 namespace Zend\XmlRpc\Value;
 
-use Zend\XmlRpc\Value as XmlRpcValue;
+use Zend\XmlRpc\AbstractValue;
 
 /**
  * @category   Zend
@@ -30,7 +30,7 @@ use Zend\XmlRpc\Value as XmlRpcValue;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class Scalar extends XmlRpcValue
+abstract class AbstractScalar extends AbstractValue
 {
     /**
      * Generate the XML code that represent a scalar native MXL-RPC value

--- a/library/Zend/XmlRpc/Value/ArrayValue.php
+++ b/library/Zend/XmlRpc/Value/ArrayValue.php
@@ -28,7 +28,7 @@ namespace Zend\XmlRpc\Value;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class ArrayValue extends Collection
+class ArrayValue extends AbstractCollection
 {
     /**
      * Set the value of an array native type

--- a/library/Zend/XmlRpc/Value/Base64.php
+++ b/library/Zend/XmlRpc/Value/Base64.php
@@ -28,7 +28,7 @@ namespace Zend\XmlRpc\Value;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Base64 extends Scalar
+class Base64 extends AbstractScalar
 {
 
     /**

--- a/library/Zend/XmlRpc/Value/Boolean.php
+++ b/library/Zend/XmlRpc/Value/Boolean.php
@@ -28,7 +28,7 @@ namespace Zend\XmlRpc\Value;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Boolean extends Scalar
+class Boolean extends AbstractScalar
 {
 
     /**

--- a/library/Zend/XmlRpc/Value/DateTime.php
+++ b/library/Zend/XmlRpc/Value/DateTime.php
@@ -29,7 +29,7 @@ use Zend\XmlRpc\Exception;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class DateTime extends Scalar
+class DateTime extends AbstractScalar
 {
     /**
      * PHP compatible format string for XML/RPC datetime values

--- a/library/Zend/XmlRpc/Value/Double.php
+++ b/library/Zend/XmlRpc/Value/Double.php
@@ -28,7 +28,7 @@ namespace Zend\XmlRpc\Value;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Double extends Scalar
+class Double extends AbstractScalar
 {
 
     /**

--- a/library/Zend/XmlRpc/Value/Integer.php
+++ b/library/Zend/XmlRpc/Value/Integer.php
@@ -29,7 +29,7 @@ use Zend\XmlRpc\Exception;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Integer extends Scalar
+class Integer extends AbstractScalar
 {
 
     /**

--- a/library/Zend/XmlRpc/Value/Nil.php
+++ b/library/Zend/XmlRpc/Value/Nil.php
@@ -28,7 +28,7 @@ namespace Zend\XmlRpc\Value;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Nil extends Scalar
+class Nil extends AbstractScalar
 {
 
     /**

--- a/library/Zend/XmlRpc/Value/String.php
+++ b/library/Zend/XmlRpc/Value/String.php
@@ -27,7 +27,7 @@ namespace Zend\XmlRpc\Value;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class String extends Scalar
+class String extends AbstractScalar
 {
 
     /**

--- a/library/Zend/XmlRpc/Value/Struct.php
+++ b/library/Zend/XmlRpc/Value/Struct.php
@@ -28,7 +28,7 @@ namespace Zend\XmlRpc\Value;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Struct extends Collection
+class Struct extends AbstractCollection
 {
     /**
      * Set the value of an struct native type

--- a/tests/Zend/XmlRpc/BigIntegerValueTest.php
+++ b/tests/Zend/XmlRpc/BigIntegerValueTest.php
@@ -20,7 +20,7 @@
  */
 
 namespace ZendTest\XmlRpc;
-use Zend\XmlRpc\Value;
+use Zend\XmlRpc\AbstractValue;
 use Zend\XmlRpc\Value\BigInteger;
 use Zend\XmlRpc\Exception;
 use Zend\XmlRpc\Generator\GeneratorInterface as Generator;
@@ -68,7 +68,7 @@ class BigIntegerValueTest extends \PHPUnit_Framework_TestCase
     {
         $bigIntegerValue = (string)(PHP_INT_MAX + 42);
         $bigInteger = new BigInteger($bigIntegerValue);
-        $this->assertSame(Value::XMLRPC_TYPE_I8, $bigInteger->getType());
+        $this->assertSame(AbstractValue::XMLRPC_TYPE_I8, $bigInteger->getType());
     }
 
     /**
@@ -91,19 +91,19 @@ class BigIntegerValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarschalBigIntegerFromXmlRpc(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
 
         $bigIntegerValue = (string)(PHP_INT_MAX + 42);
         $bigInteger = new BigInteger($bigIntegerValue);
         $bigIntegerXml = '<value><i8>' . $bigIntegerValue . '</i8></value>';
 
-        $value = Value::getXmlRpcValue(
+        $value = AbstractValue::getXmlRpcValue(
             $bigIntegerXml,
-            Value::XML_STRING
+            AbstractValue::XML_STRING
         );
 
         $this->assertSame($bigIntegerValue, $value->getValue());
-        $this->assertEquals(Value::XMLRPC_TYPE_I8, $value->getType());
+        $this->assertEquals(AbstractValue::XMLRPC_TYPE_I8, $value->getType());
         $this->assertEquals($this->wrapXml($bigIntegerXml), $value->saveXml());
     }
 
@@ -113,19 +113,19 @@ class BigIntegerValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarschalBigIntegerFromApacheXmlRpc(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
 
         $bigIntegerValue = (string)(PHP_INT_MAX + 42);
         $bigInteger = new BigInteger($bigIntegerValue);
         $bigIntegerXml = '<value><ex:i8 xmlns:ex="http://ws.apache.org/xmlrpc/namespaces/extensions">' . $bigIntegerValue . '</ex:i8></value>';
 
-        $value = Value::getXmlRpcValue(
+        $value = AbstractValue::getXmlRpcValue(
             $bigIntegerXml,
-            Value::XML_STRING
+            AbstractValue::XML_STRING
         );
 
         $this->assertSame($bigIntegerValue, $value->getValue());
-        $this->assertEquals(Value::XMLRPC_TYPE_I8, $value->getType());
+        $this->assertEquals(AbstractValue::XMLRPC_TYPE_I8, $value->getType());
         $this->assertEquals($this->wrapXml($bigIntegerXml), $value->saveXml());
     }
 
@@ -136,12 +136,12 @@ class BigIntegerValueTest extends \PHPUnit_Framework_TestCase
     {
         $bigIntegerValue = (string)(PHP_INT_MAX + 42);
 
-        $value = Value::getXmlRpcValue(
+        $value = AbstractValue::getXmlRpcValue(
             $bigIntegerValue,
-            Value::XMLRPC_TYPE_I8
+            AbstractValue::XMLRPC_TYPE_I8
         );
 
-        $this->assertEquals(Value::XMLRPC_TYPE_I8, $value->getType());
+        $this->assertEquals(AbstractValue::XMLRPC_TYPE_I8, $value->getType());
         $this->assertSame($bigIntegerValue, $value->getValue());
     }
 

--- a/tests/Zend/XmlRpc/ClientTest.php
+++ b/tests/Zend/XmlRpc/ClientTest.php
@@ -26,6 +26,7 @@ use Zend\Http\Client\Adapter,
     Zend\Http\Request as HttpRequest,
     Zend\Http\Response as HttpResponse,
     Zend\XmlRpc\Client,
+    Zend\XmlRpc\AbstractValue,
     Zend\XmlRpc\Value,
     Zend\XmlRpc;
 
@@ -278,7 +279,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $expects = 'date.method response';
         $this->setServerResponseTo($expects);
-        $this->assertSame($expects, $this->xmlrpcClient->call('date.method', array(Value::getXmlRpcValue(time(), Value::XMLRPC_TYPE_DATETIME), 'foo')));
+        $this->assertSame($expects, $this->xmlrpcClient->call('date.method', array(AbstractValue::getXmlRpcValue(time(), AbstractValue::XMLRPC_TYPE_DATETIME), 'foo')));
     }
 
     public function testAllowsSkippingSystemCallForArrayStructLookup()

--- a/tests/Zend/XmlRpc/ClientTest.php
+++ b/tests/Zend/XmlRpc/ClientTest.php
@@ -21,14 +21,14 @@
 
 namespace ZendTest\XmlRpc;
 
-use Zend\Http\Client\Adapter,
-    Zend\Http,
-    Zend\Http\Request as HttpRequest,
-    Zend\Http\Response as HttpResponse,
-    Zend\XmlRpc\Client,
-    Zend\XmlRpc\AbstractValue,
-    Zend\XmlRpc\Value,
-    Zend\XmlRpc;
+use Zend\Http\Client\Adapter;
+use Zend\Http;
+use Zend\Http\Request as HttpRequest;
+use Zend\Http\Response as HttpResponse;
+use Zend\XmlRpc\Client;
+use Zend\XmlRpc\AbstractValue;
+use Zend\XmlRpc\Value;
+use Zend\XmlRpc;
 
 /**
  * Test case for Zend\XmlRpc\Client

--- a/tests/Zend/XmlRpc/FaultTest.php
+++ b/tests/Zend/XmlRpc/FaultTest.php
@@ -21,7 +21,7 @@
 
 namespace ZendTest\XmlRpc;
 
-use Zend\XmlRpc\Value,
+use Zend\XmlRpc\AbstractValue,
     Zend\XmlRpc;
 
 /**
@@ -46,7 +46,7 @@ class FaultTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        Value::setGenerator(null);
+        AbstractValue::setGenerator(null);
         $this->_fault = new XmlRpc\Fault();
     }
 
@@ -258,10 +258,10 @@ class FaultTest extends \PHPUnit_Framework_TestCase
     public function testSetGetEncoding()
     {
         $this->assertEquals('UTF-8', $this->_fault->getEncoding());
-        $this->assertEquals('UTF-8', Value::getGenerator()->getEncoding());
+        $this->assertEquals('UTF-8', AbstractValue::getGenerator()->getEncoding());
         $this->_fault->setEncoding('ISO-8859-1');
         $this->assertEquals('ISO-8859-1', $this->_fault->getEncoding());
-        $this->assertEquals('ISO-8859-1', Value::getGenerator()->getEncoding());
+        $this->assertEquals('ISO-8859-1', AbstractValue::getGenerator()->getEncoding());
     }
 
     public function testUnknownErrorIsUsedIfUnknownErrorCodeEndEmptyMessageIsPassed()

--- a/tests/Zend/XmlRpc/FaultTest.php
+++ b/tests/Zend/XmlRpc/FaultTest.php
@@ -21,8 +21,8 @@
 
 namespace ZendTest\XmlRpc;
 
-use Zend\XmlRpc\AbstractValue,
-    Zend\XmlRpc;
+use Zend\XmlRpc\AbstractValue;
+use Zend\XmlRpc;
 
 /**
  * Test case for Zend_XmlRpc_Fault

--- a/tests/Zend/XmlRpc/Request/HttpTest.php
+++ b/tests/Zend/XmlRpc/Request/HttpTest.php
@@ -21,8 +21,8 @@
 
 namespace ZendTest\XmlRpc\Request;
 
-use Zend\XmlRpc\Request,
-    ZendTest\AllTests\StreamWrapper\PHPInput;
+use Zend\XmlRpc\Request;
+use ZendTest\AllTests\StreamWrapper\PHPInput;
 
 /**
  * Test case for Zend\XmlRpc\Request\Http

--- a/tests/Zend/XmlRpc/RequestTest.php
+++ b/tests/Zend/XmlRpc/RequestTest.php
@@ -21,9 +21,9 @@
 
 namespace ZendTest\XmlRpc;
 
-use Zend\XmlRpc\Request,
-    Zend\XmlRpc\Value,
-    Zend\XmlRpc\AbstractValue;
+use Zend\XmlRpc\Request;
+use Zend\XmlRpc\AbstractValue;
+use Zend\XmlRpc\Value;
 
 /**
  * Test case for Zend_XmlRpc_Request

--- a/tests/Zend/XmlRpc/RequestTest.php
+++ b/tests/Zend/XmlRpc/RequestTest.php
@@ -22,7 +22,8 @@
 namespace ZendTest\XmlRpc;
 
 use Zend\XmlRpc\Request,
-    Zend\XmlRpc\Value;
+    Zend\XmlRpc\Value,
+    Zend\XmlRpc\AbstractValue;
 
 /**
  * Test case for Zend_XmlRpc_Request
@@ -119,7 +120,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testAddDateParamGeneratesCorrectXml()
     {
         $time = time();
-        $this->_request->addParam($time, Value::XMLRPC_TYPE_DATETIME);
+        $this->_request->addParam($time, AbstractValue::XMLRPC_TYPE_DATETIME);
         $this->_request->setMethod('foo.bar');
         $xml = $this->_request->saveXml();
         $sxl = new \SimpleXMLElement($xml);
@@ -328,10 +329,10 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testSetGetEncoding()
     {
         $this->assertEquals('UTF-8', $this->_request->getEncoding());
-        $this->assertEquals('UTF-8', Value::getGenerator()->getEncoding());
+        $this->assertEquals('UTF-8', AbstractValue::getGenerator()->getEncoding());
         $this->assertSame($this->_request, $this->_request->setEncoding('ISO-8859-1'));
         $this->assertEquals('ISO-8859-1', $this->_request->getEncoding());
-        $this->assertEquals('ISO-8859-1', Value::getGenerator()->getEncoding());
+        $this->assertEquals('ISO-8859-1', AbstractValue::getGenerator()->getEncoding());
     }
 
     /**

--- a/tests/Zend/XmlRpc/ResponseTest.php
+++ b/tests/Zend/XmlRpc/ResponseTest.php
@@ -21,8 +21,8 @@
 
 namespace ZendTest\XmlRpc;
 
-use Zend\XmlRpc\Response,
-    Zend\XmlRpc\AbstractValue;
+use Zend\XmlRpc\Response;
+use Zend\XmlRpc\AbstractValue;
 
 /**
  * Test case for Zend_XmlRpc_Response

--- a/tests/Zend/XmlRpc/ResponseTest.php
+++ b/tests/Zend/XmlRpc/ResponseTest.php
@@ -22,7 +22,7 @@
 namespace ZendTest\XmlRpc;
 
 use Zend\XmlRpc\Response,
-    Zend\XmlRpc\Value;
+    Zend\XmlRpc\AbstractValue;
 
 /**
  * Test case for Zend_XmlRpc_Response
@@ -218,10 +218,10 @@ EOD;
     public function testSetGetEncoding()
     {
         $this->assertEquals('UTF-8', $this->_response->getEncoding());
-        $this->assertEquals('UTF-8', Value::getGenerator()->getEncoding());
+        $this->assertEquals('UTF-8', AbstractValue::getGenerator()->getEncoding());
         $this->assertSame($this->_response, $this->_response->setEncoding('ISO-8859-1'));
         $this->assertEquals('ISO-8859-1', $this->_response->getEncoding());
-        $this->assertEquals('ISO-8859-1', Value::getGenerator()->getEncoding());
+        $this->assertEquals('ISO-8859-1', AbstractValue::getGenerator()->getEncoding());
     }
 
     public function testLoadXmlCreatesFaultWithMissingNodes()

--- a/tests/Zend/XmlRpc/ServerTest.php
+++ b/tests/Zend/XmlRpc/ServerTest.php
@@ -23,7 +23,7 @@ namespace ZendTest\XmlRpc;
 use Zend\XmlRpc\Server,
     Zend\XmlRpc\Request,
     Zend\XmlRpc\Response,
-    Zend\XmlRpc\Value,
+    Zend\XmlRpc\AbstractValue,
     Zend\XmlRpc\Fault,
     Zend\XmlRpc;
 
@@ -426,10 +426,10 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function testGetSetEncoding()
     {
         $this->assertEquals('UTF-8', $this->_server->getEncoding());
-        $this->assertEquals('UTF-8', Value::getGenerator()->getEncoding());
+        $this->assertEquals('UTF-8', AbstractValue::getGenerator()->getEncoding());
         $this->assertSame($this->_server, $this->_server->setEncoding('ISO-8859-1'));
         $this->assertEquals('ISO-8859-1', $this->_server->getEncoding());
-        $this->assertEquals('ISO-8859-1', Value::getGenerator()->getEncoding());
+        $this->assertEquals('ISO-8859-1', AbstractValue::getGenerator()->getEncoding());
     }
 
     /**

--- a/tests/Zend/XmlRpc/ServerTest.php
+++ b/tests/Zend/XmlRpc/ServerTest.php
@@ -20,12 +20,14 @@
  */
 
 namespace ZendTest\XmlRpc;
-use Zend\XmlRpc\Server,
-    Zend\XmlRpc\Request,
-    Zend\XmlRpc\Response,
-    Zend\XmlRpc\AbstractValue,
-    Zend\XmlRpc\Fault,
-    Zend\XmlRpc;
+
+use Zend\XmlRpc\Server;
+use Zend\XmlRpc\Request;
+use Zend\XmlRpc\Response;
+use Zend\XmlRpc\AbstractValue;
+use Zend\XmlRpc\Value;
+use Zend\XmlRpc\Fault;
+use Zend\XmlRpc;
 
 /**
  * Test case for Zend_XmlRpc_Server

--- a/tests/Zend/XmlRpc/ValueTest.php
+++ b/tests/Zend/XmlRpc/ValueTest.php
@@ -813,7 +813,7 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function testFactoryThrowsWhenInvalidTypeSpecified()
     {
-        $this->setExpectedException('Zend\XmlRpc\Exception\ValueException', 'Given type is not a Zend\XmlRpc\Value constant');
+        $this->setExpectedException('Zend\XmlRpc\Exception\ValueException', 'Given type is not a Zend\XmlRpc\AbstractValue constant');
         AbstractValue::getXmlRpcValue('', 'bad type here');
     }
 

--- a/tests/Zend/XmlRpc/ValueTest.php
+++ b/tests/Zend/XmlRpc/ValueTest.php
@@ -22,6 +22,7 @@
 namespace ZendTest\XmlRpc;
 use stdClass;
 use DateTime;
+use Zend\XmlRpc\AbstractValue;
 use Zend\XmlRpc\Value;
 use Zend\XmlRpc\Generator\GeneratorInterface as Generator;
 use Zend\Math\BigInteger;
@@ -46,7 +47,7 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testFactoryAutodetectsBoolean()
     {
         foreach (array(true, false) as $native) {
-            $val = Value::getXmlRpcValue($native);
+            $val = AbstractValue::getXmlRpcValue($native);
             $this->assertXmlRpcType('boolean', $val);
         }
     }
@@ -54,8 +55,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalBooleanFromNative()
     {
         $native = true;
-        $val = Value::getXmlRpcValue($native,
-                                    Value::XMLRPC_TYPE_BOOLEAN);
+        $val = AbstractValue::getXmlRpcValue($native,
+                                    AbstractValue::XMLRPC_TYPE_BOOLEAN);
 
         $this->assertXmlRpcType('boolean', $val);
         $this->assertSame($native, $val->getValue());
@@ -66,10 +67,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalBooleanFromXmlRpc(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $xml = '<value><boolean>1</boolean></value>';
-        $val = Value::getXmlRpcValue($xml,
-                                    Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml,
+                                    AbstractValue::XML_STRING);
 
         $this->assertXmlRpcType('boolean', $val);
         $this->assertEquals('boolean', $val->getType());
@@ -81,18 +82,18 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function testFactoryAutodetectsInteger()
     {
-        $val = Value::getXmlRpcValue(1);
+        $val = AbstractValue::getXmlRpcValue(1);
         $this->assertXmlRpcType('integer', $val);
     }
 
     public function testMarshalIntegerFromNative()
     {
         $native = 1;
-        $types = array(Value::XMLRPC_TYPE_I4,
-                       Value::XMLRPC_TYPE_INTEGER);
+        $types = array(AbstractValue::XMLRPC_TYPE_I4,
+                       AbstractValue::XMLRPC_TYPE_INTEGER);
 
         foreach ($types as $type) {
-            $val = Value::getXmlRpcValue($native, $type);
+            $val = AbstractValue::getXmlRpcValue($native, $type);
             $this->assertXmlRpcType('integer', $val);
             $this->assertSame($native, $val->getValue());
         }
@@ -103,15 +104,15 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalIntegerFromXmlRpc(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
 
         $native = 1;
         $xmls = array("<value><int>$native</int></value>",
                       "<value><i4>$native</i4></value>");
 
         foreach ($xmls as $xml) {
-            $val = Value::getXmlRpcValue($xml,
-                                        Value::XML_STRING);
+            $val = AbstractValue::getXmlRpcValue($xml,
+                                        AbstractValue::XML_STRING);
             $this->assertXmlRpcType('integer', $val);
             $this->assertEquals('int', $val->getType());
             $this->assertSame($native, $val->getValue());
@@ -125,7 +126,7 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalI4FromOverlongNativeThrowsException()
     {
         $this->setExpectedException('Zend\XmlRpc\Exception\ValueException', 'Overlong integer given');
-        $x = Value::getXmlRpcValue(PHP_INT_MAX + 5000, Value::XMLRPC_TYPE_I4);
+        $x = AbstractValue::getXmlRpcValue(PHP_INT_MAX + 5000, AbstractValue::XMLRPC_TYPE_I4);
         var_dump($x);
     }
 
@@ -135,22 +136,22 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalIntegerFromOverlongNativeThrowsException()
     {
         $this->setExpectedException('Zend\XmlRpc\Exception\ValueException', 'Overlong integer given');
-        Value::getXmlRpcValue(PHP_INT_MAX + 5000, Value::XMLRPC_TYPE_INTEGER);
+        AbstractValue::getXmlRpcValue(PHP_INT_MAX + 5000, AbstractValue::XMLRPC_TYPE_INTEGER);
     }
 
     // Double
 
     public function testFactoryAutodetectsFloat()
     {
-        $val = Value::getXmlRpcValue((float)1);
+        $val = AbstractValue::getXmlRpcValue((float)1);
         $this->assertXmlRpcType('double', $val);
     }
 
     public function testMarshalDoubleFromNative()
     {
         $native = 1.1;
-        $val = Value::getXmlRpcValue($native,
-                                    Value::XMLRPC_TYPE_DOUBLE);
+        $val = AbstractValue::getXmlRpcValue($native,
+                                    AbstractValue::XMLRPC_TYPE_DOUBLE);
 
         $this->assertXmlRpcType('double', $val);
         $this->assertSame($native, $val->getValue());
@@ -161,11 +162,11 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalDoubleFromXmlRpc(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $native = 1.1;
         $xml = "<value><double>$native</double></value>";
-        $val = Value::getXmlRpcValue($xml,
-                                    Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml,
+                                    AbstractValue::XML_STRING);
 
         $this->assertXmlRpcType('double', $val);
         $this->assertEquals('double', $val->getType());
@@ -179,13 +180,13 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshallingDoubleWithHigherPrecisionFromNative(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         if (ini_get('precision') < 7) {
             $this->markTestSkipped('precision is too low');
         }
 
         $native = 0.1234567;
-        $value = Value::getXmlRpcValue($native, Value::XMLRPC_TYPE_DOUBLE);
+        $value = AbstractValue::getXmlRpcValue($native, AbstractValue::XMLRPC_TYPE_DOUBLE);
         $this->assertXmlRpcType('double', $value);
         $this->assertSame($native, $value->getValue());
         $this->assertSame('<value><double>0.1234567</double></value>', trim($value->saveXml()));
@@ -197,12 +198,12 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshallingDoubleWithHigherPrecisionFromNativeWithTrailingZeros(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         if (ini_get('precision') < 7) {
             $this->markTestSkipped('precision is too low');
         }
         $native = 0.1;
-        $value = Value::getXmlRpcValue($native, Value::XMLRPC_TYPE_DOUBLE);
+        $value = AbstractValue::getXmlRpcValue($native, AbstractValue::XMLRPC_TYPE_DOUBLE);
         $this->assertXmlRpcType('double', $value);
         $this->assertSame($native, $value->getValue());
         $this->assertSame('<value><double>0.1</double></value>', trim($value->saveXml()));
@@ -212,7 +213,7 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function testFactoryAutodetectsString()
     {
-        $val = Value::getXmlRpcValue('');
+        $val = AbstractValue::getXmlRpcValue('');
         $this->assertXmlRpcType('string', $val);
     }
 
@@ -220,8 +221,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalStringFromNative()
     {
         $native = 'foo';
-        $val = Value::getXmlRpcValue($native,
-                                    Value::XMLRPC_TYPE_STRING);
+        $val = AbstractValue::getXmlRpcValue($native,
+                                    AbstractValue::XMLRPC_TYPE_STRING);
 
         $this->assertXmlRpcType('string', $val);
         $this->assertSame($native, $val->getValue());
@@ -232,11 +233,11 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalStringFromXmlRpc(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $native = 'foo<>';
         $xml = "<value><string>foo&lt;&gt;</string></value>";
-        $val = Value::getXmlRpcValue($xml,
-                                    Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml,
+                                    AbstractValue::XML_STRING);
 
         $this->assertXmlRpcType('string', $val);
         $this->assertEquals('string', $val->getType());
@@ -249,11 +250,11 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalStringFromDefault(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $native = 'foo<br/>bar';
         $xml = "<string>foo&lt;br/&gt;bar</string>";
-        $val = Value::getXmlRpcValue($xml,
-                                    Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml,
+                                    AbstractValue::XML_STRING);
 
         $this->assertXmlRpcType('string', $val);
         $this->assertEquals('string', $val->getType());
@@ -265,17 +266,17 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function testFactoryAutodetectsNil()
     {
-        $val = Value::getXmlRpcValue(NULL);
+        $val = AbstractValue::getXmlRpcValue(NULL);
         $this->assertXmlRpcType('nil', $val);
     }
 
     public function testMarshalNilFromNative()
     {
         $native = NULL;
-        $types = array(Value::XMLRPC_TYPE_NIL,
-                       Value::XMLRPC_TYPE_APACHENIL);
+        $types = array(AbstractValue::XMLRPC_TYPE_NIL,
+                       AbstractValue::XMLRPC_TYPE_APACHENIL);
         foreach ($types as $type) {
-            $value = Value::getXmlRpcValue($native, $type);
+            $value = AbstractValue::getXmlRpcValue($native, $type);
 
             $this->assertXmlRpcType('nil', $value);
             $this->assertSame($native, $value->getValue());
@@ -287,13 +288,13 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalNilFromXmlRpc(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $xmls = array('<value><nil/></value>',
                      '<value><ex:nil xmlns:ex="http://ws.apache.org/xmlrpc/namespaces/extensions"/></value>');
 
         foreach ($xmls as $xml) {
-            $val = Value::getXmlRpcValue($xml,
-                                        Value::XML_STRING);
+            $val = AbstractValue::getXmlRpcValue($xml,
+                                        AbstractValue::XML_STRING);
             $this->assertXmlRpcType('nil', $val);
             $this->assertEquals('nil', $val->getType());
             $this->assertSame(NULL, $val->getValue());
@@ -305,15 +306,15 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function testFactoryAutodetectsArray()
     {
-        $val = Value::getXmlRpcValue(array(0, 'foo'));
+        $val = AbstractValue::getXmlRpcValue(array(0, 'foo'));
         $this->assertXmlRpcType('array', $val);
     }
 
     public function testMarshalArrayFromNative()
     {
         $native = array(0,1);
-        $val = Value::getXmlRpcValue($native,
-                                    Value::XMLRPC_TYPE_ARRAY);
+        $val = AbstractValue::getXmlRpcValue($native,
+                                    AbstractValue::XMLRPC_TYPE_ARRAY);
 
         $this->assertXmlRpcType('array', $val);
         $this->assertSame($native, $val->getValue());
@@ -324,13 +325,13 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalArrayFromXmlRpc(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $native = array(0,1);
         $xml = '<value><array><data><value><int>0</int></value>'
              . '<value><int>1</int></value></data></array></value>';
 
-        $val = Value::getXmlRpcValue($xml,
-                                    Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml,
+                                    AbstractValue::XML_STRING);
 
         $this->assertXmlRpcType('array', $val);
         $this->assertEquals('array', $val->getType());
@@ -343,18 +344,18 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testEmptyXmlRpcArrayResultsInEmptyArray(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $native = array();
         $xml    = '<value><array><data/></array></value>';
 
-        $val = Value::getXmlRpcValue($xml,
-                                    Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml,
+                                    AbstractValue::XML_STRING);
 
         $this->assertXmlRpcType('array', $val);
         $this->assertEquals('array', $val->getType());
         $this->assertSame($native, $val->getValue());
 
-        $value = Value::getXmlRpcValue($xml, Value::XML_STRING);
+        $value = AbstractValue::getXmlRpcValue($xml, AbstractValue::XML_STRING);
         $this->assertXmlRpcType('array', $value);
         $this->assertEquals('array', $value->getType());
         $this->assertSame($native, $value->getValue());
@@ -365,14 +366,14 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testArrayMustContainDataElement(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $native = array();
         $xml    = '<value><array/></value>';
 
         $this->setExpectedException('Zend\XmlRpc\Exception\ValueException',
             'Invalid XML for XML-RPC native array type: ARRAY tag must contain DATA tag'
             );
-        $val = Value::getXmlRpcValue($xml, Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml, AbstractValue::XML_STRING);
     }
 
     /**
@@ -386,14 +387,14 @@ class ValueTest extends \PHPUnit_Framework_TestCase
             $this->markTestIncomplete('Code to test is not compatible with PHP 5.4');
         }
 
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $expected = array(array('id' => '1', 'name' => 'vertebra, caudal', 'description' => null));
         $xml = '<value>'
              . '<array><data><value><struct><member><name>id</name><value><string>1</string></value></member>'
              . '<member><name>name</name><value><string>vertebra, caudal</string></value></member>'
              . '<member><name>description</name><value><nil/></value></member></struct></value></data></array>'
              . '</value>';
-        $val = Value::getXmlRpcValue($xml, Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml, AbstractValue::XML_STRING);
         $this->assertSame($expected, $val->getValue());
     }
 
@@ -401,21 +402,21 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function testFactoryAutodetectsStruct()
     {
-        $val = Value::getXmlRpcValue(array('foo' => 0));
+        $val = AbstractValue::getXmlRpcValue(array('foo' => 0));
         $this->assertXmlRpcType('struct', $val);
     }
 
     public function testFactoryAutodetectsStructFromObject()
     {
-        $val = Value::getXmlRpcValue((object)array('foo' => 0));
+        $val = AbstractValue::getXmlRpcValue((object)array('foo' => 0));
         $this->assertXmlRpcType('struct', $val);
     }
 
     public function testMarshalStructFromNative()
     {
         $native = array('foo' => 0);
-        $val = Value::getXmlRpcValue($native,
-                                    Value::XMLRPC_TYPE_STRUCT);
+        $val = AbstractValue::getXmlRpcValue($native,
+                                    AbstractValue::XMLRPC_TYPE_STRUCT);
 
         $this->assertXmlRpcType('struct', $val);
         $this->assertSame($native, $val->getValue());
@@ -426,14 +427,14 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalStructFromXmlRpc(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $native = array('foo' => 0, 'bar' => 'foo<>bar');
         $xml = '<value><struct><member><name>foo</name><value><int>0</int>'
              . '</value></member><member><name>bar</name><value><string>'
              . 'foo&lt;&gt;bar</string></value></member></struct></value>';
 
-        $val = Value::getXmlRpcValue($xml,
-                                    Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml,
+                                    AbstractValue::XML_STRING);
 
         $this->assertXmlRpcType('struct', $val);
         $this->assertEquals('struct', $val->getType());
@@ -446,20 +447,20 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshallingNestedStructFromXmlRpc(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $native = array('foo' => array('bar' => '<br/>'));
         $xml = '<value><struct><member><name>foo</name><value><struct><member>'
              . '<name>bar</name><value><string>&lt;br/&gt;</string></value>'
              . '</member></struct></value></member></struct></value>';
 
-        $val = Value::getXmlRpcValue($xml, Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml, AbstractValue::XML_STRING);
 
         $this->assertXmlRpcType('struct', $val);
         $this->assertEquals('struct', $val->getType());
         $this->assertSame($native, $val->getValue());
         $this->assertSame($this->wrapXml($xml), $val->saveXml());
 
-        $val = Value::getXmlRpcValue($native);
+        $val = AbstractValue::getXmlRpcValue($native);
         $this->assertSame(trim($xml), trim($val->saveXml()));
     }
 
@@ -468,7 +469,7 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshallingStructWithMemberWithoutValue(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $native = array('foo' => 0, 'bar' => 1);
         $xml = '<value><struct>'
              . '<member><name>foo</name><value><int>0</int></value></member>'
@@ -476,8 +477,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
              . '<member><name>bar</name><value><int>1</int></value></member>'
              . '</struct></value>';
 
-        $val = Value::getXmlRpcValue($xml,
-                                    Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml,
+                                    AbstractValue::XML_STRING);
 
         $this->assertXmlRpcType('struct', $val);
         $this->assertEquals('struct', $val->getType());
@@ -490,7 +491,7 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshallingStructWithMemberWithoutName(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $native = array('foo' => 0, 'bar' => 1);
         $xml = '<value><struct>'
              . '<member><name>foo</name><value><int>0</int></value></member>'
@@ -498,8 +499,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
              . '<member><name>bar</name><value><int>1</int></value></member>'
              . '</struct></value>';
 
-        $val = Value::getXmlRpcValue($xml,
-                                    Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml,
+                                    AbstractValue::XML_STRING);
 
         $this->assertXmlRpcType('struct', $val);
         $this->assertEquals('struct', $val->getType());
@@ -513,11 +514,11 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalStructFromXmlRpcWithEntities(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $native = array('&nbsp;' => 0);
         $xml = '<value><struct><member><name>&amp;nbsp;</name><value><int>0</int>'
              . '</value></member></struct></value>';
-        $val = Value::getXmlRpcValue($xml, Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml, AbstractValue::XML_STRING);
         $this->assertXmlRpcType('struct', $val);
         $this->assertSame($native, $val->getValue());
         $this->assertSame($this->wrapXml($xml), $val->saveXml());
@@ -529,13 +530,13 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshallingStructsWithEmptyValueFromXmlRpcShouldRetainKeys(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $native = array('foo' => '');
         $xml = '<value><struct><member><name>foo</name>'
              . '<value><string/></value></member></struct></value>';
 
-        $val = Value::getXmlRpcValue($xml,
-                                    Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml,
+                                    AbstractValue::XML_STRING);
 
         $this->assertXmlRpcType('struct', $val);
         $this->assertEquals('struct', $val->getType());
@@ -548,20 +549,20 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshallingStructWithMultibyteValueFromXmlRpcRetainsMultibyteValue(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $native = array('foo' => 'ß');
         $xmlDecl = '<?xml version="1.0" encoding="UTF-8"?>';
         $xml = '<value><struct><member><name>foo</name><value><string>ß</string></value></member></struct></value>';
 
-        $val = Value::getXmlRpcValue($xmlDecl . $xml,
-                                    Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xmlDecl . $xml,
+                                    AbstractValue::XML_STRING);
 
         $this->assertXmlRpcType('struct', $val);
         $this->assertEquals('struct', $val->getType());
         $this->assertSame($native, $val->getValue());
         $this->assertEquals($this->wrapXml($xml), $val->saveXml());
 
-        $val = Value::getXmlRpcValue($native, Value::XMLRPC_TYPE_STRUCT);
+        $val = AbstractValue::getXmlRpcValue($native, AbstractValue::XMLRPC_TYPE_STRUCT);
         $this->assertSame($native, $val->getValue());
         $this->assertSame(trim($xml), trim($val->saveXml()));
     }
@@ -571,8 +572,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalDateTimeFromNativeString()
     {
         $native = '1997-07-16T19:20+01:00';
-        $val = Value::getXmlRpcValue($native,
-                                    Value::XMLRPC_TYPE_DATETIME);
+        $val = AbstractValue::getXmlRpcValue($native,
+                                    AbstractValue::XMLRPC_TYPE_DATETIME);
 
         $this->assertXmlRpcType('dateTime', $val);
 
@@ -583,8 +584,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalDateTimeFromNativeStringProducesIsoOutput()
     {
         $native = '1997-07-16T19:20+01:00';
-        $val = Value::getXmlRpcValue($native,
-                                    Value::XMLRPC_TYPE_DATETIME);
+        $val = AbstractValue::getXmlRpcValue($native,
+                                    AbstractValue::XMLRPC_TYPE_DATETIME);
 
         $this->assertXmlRpcType('dateTime', $val);
 
@@ -597,14 +598,14 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Zend\XmlRpc\Exception\ValueException', 
                                     "The timezone could not be found in the database");
-        Value::getXmlRpcValue('foobarbaz', Value::XMLRPC_TYPE_DATETIME);
+        AbstractValue::getXmlRpcValue('foobarbaz', AbstractValue::XMLRPC_TYPE_DATETIME);
     }
 
     public function testMarshalDateTimeFromNativeInteger()
     {
         $native = strtotime('1997-07-16T19:20+01:00');
-        $val = Value::getXmlRpcValue($native,
-                                    Value::XMLRPC_TYPE_DATETIME);
+        $val = AbstractValue::getXmlRpcValue($native,
+                                    AbstractValue::XMLRPC_TYPE_DATETIME);
 
         $this->assertXmlRpcType('dateTime', $val);
         $this->assertSame($native, strtotime($val->getValue()));
@@ -626,12 +627,12 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalDateTimeFromXmlRpc(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $iso8601 = '1997-07-16T19:20+01:00';
         $xml = "<value><dateTime.iso8601>$iso8601</dateTime.iso8601></value>";
 
-        $val = Value::getXmlRpcValue($xml,
-                                    Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml,
+                                    AbstractValue::XML_STRING);
 
         $this->assertXmlRpcType('dateTime', $val);
         $this->assertEquals('dateTime.iso8601', $val->getType());
@@ -646,13 +647,13 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalDateTimeFromFromZendDate(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $date = new Date\Date(array('year' => 2039, 'month' => 4, 'day' => 18,
                                     'hour' => 13, 'minute' => 14, 'second' => 15));
         $dateString = '20390418T13:14:15';
         $xml = "<value><dateTime.iso8601>$dateString</dateTime.iso8601></value>";
 
-        $val = Value::getXmlRpcValue($date, Value::XMLRPC_TYPE_DATETIME);
+        $val = AbstractValue::getXmlRpcValue($date, AbstractValue::XMLRPC_TYPE_DATETIME);
         $this->assertXmlRpcType('dateTime', $val);
         $this->assertEquals('dateTime.iso8601', $val->getType());
         $this->assertSame($dateString, $val->getValue());
@@ -666,13 +667,13 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalDateTimeFromZendDateAndAutodetectingType(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $date = new Date\Date(array('year' => 2039, 'month' => 4, 'day' => 18,
                                     'hour' => 13, 'minute' => 14, 'second' => 15));
         $dateString = '20390418T13:14:15';
         $xml = "<value><dateTime.iso8601>$dateString</dateTime.iso8601></value>";
 
-        $val = Value::getXmlRpcValue($date, Value::AUTO_DETECT_TYPE);
+        $val = AbstractValue::getXmlRpcValue($date, AbstractValue::AUTO_DETECT_TYPE);
         $this->assertXmlRpcType('dateTime', $val);
         $this->assertEquals('dateTime.iso8601', $val->getType());
         $this->assertSame($dateString, $val->getValue());
@@ -685,13 +686,13 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalDateTimeFromFromDateTime(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $dateString = '20390418T13:14:15';
         $date = new \DateTime($dateString);
         $dateString = '20390418T13:14:15';
         $xml = "<value><dateTime.iso8601>$dateString</dateTime.iso8601></value>";
 
-        $val = Value::getXmlRpcValue($date, Value::XMLRPC_TYPE_DATETIME);
+        $val = AbstractValue::getXmlRpcValue($date, AbstractValue::XMLRPC_TYPE_DATETIME);
         $this->assertXmlRpcType('dateTime', $val);
         $this->assertEquals('dateTime.iso8601', $val->getType());
         $this->assertSame($dateString, $val->getValue());
@@ -705,12 +706,12 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalDateTimeFromDateTimeAndAutodetectingType(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $dateString = '20390418T13:14:15';
         $date = new \DateTime($dateString);
         $xml = "<value><dateTime.iso8601>$dateString</dateTime.iso8601></value>";
 
-        $val = Value::getXmlRpcValue($date, Value::AUTO_DETECT_TYPE);
+        $val = AbstractValue::getXmlRpcValue($date, AbstractValue::AUTO_DETECT_TYPE);
         $this->assertXmlRpcType('dateTime', $val);
         $this->assertEquals('dateTime.iso8601', $val->getType());
         $this->assertSame($dateString, $val->getValue());
@@ -742,8 +743,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalBase64FromString()
     {
         $native = 'foo';
-        $val = Value::getXmlRpcValue($native,
-                                    Value::XMLRPC_TYPE_BASE64);
+        $val = AbstractValue::getXmlRpcValue($native,
+                                    AbstractValue::XMLRPC_TYPE_BASE64);
 
         $this->assertXmlRpcType('base64', $val);
         $this->assertSame($native, $val->getValue());
@@ -754,12 +755,12 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalBase64FromXmlRpc(Generator $generator)
     {
-        Value::setGenerator($generator);
+        AbstractValue::setGenerator($generator);
         $native = 'foo';
         $xml = '<value><base64>' .base64_encode($native). '</base64></value>';
 
-        $val = Value::getXmlRpcValue($xml,
-                                    Value::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue($xml,
+                                    AbstractValue::XML_STRING);
 
         $this->assertXmlRpcType('base64', $val);
         $this->assertEquals('base64', $val->getType());
@@ -770,8 +771,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testXmlRpcValueBase64GeneratedXmlContainsBase64EncodedText()
     {
         $native = 'foo';
-        $val = Value::getXmlRpcValue($native,
-                                    Value::XMLRPC_TYPE_BASE64);
+        $val = AbstractValue::getXmlRpcValue($native,
+                                    AbstractValue::XMLRPC_TYPE_BASE64);
 
         $this->assertXmlRpcType('base64', $val);
         $xml = $val->saveXml();
@@ -787,8 +788,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         $o = new SerializableTestClass();
         $o->setProperty('foobar');
         $serialized = serialize($o);
-        $val = Value::getXmlRpcValue($serialized,
-                                    Value::XMLRPC_TYPE_BASE64);
+        $val = AbstractValue::getXmlRpcValue($serialized,
+                                    AbstractValue::XMLRPC_TYPE_BASE64);
 
         $this->assertXmlRpcType('base64', $val);
         $o2 = unserialize($val->getValue());
@@ -797,15 +798,15 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function testChangingExceptionResetsGeneratorObject()
     {
-        $generator = Value::getGenerator();
-        Value::setEncoding('UTF-8');
-        $this->assertNotSame($generator, Value::getGenerator());
-        $this->assertEquals($generator, Value::getGenerator());
+        $generator = AbstractValue::getGenerator();
+        AbstractValue::setEncoding('UTF-8');
+        $this->assertNotSame($generator, AbstractValue::getGenerator());
+        $this->assertEquals($generator, AbstractValue::getGenerator());
 
-        $generator = Value::getGenerator();
-        Value::setEncoding('ISO-8859-1');
-        $this->assertNotSame($generator, Value::getGenerator());
-        $this->assertNotEquals($generator, Value::getGenerator());
+        $generator = AbstractValue::getGenerator();
+        AbstractValue::setEncoding('ISO-8859-1');
+        $this->assertNotSame($generator, AbstractValue::getGenerator());
+        $this->assertNotEquals($generator, AbstractValue::getGenerator());
     }
 
     // Exceptions
@@ -813,91 +814,91 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testFactoryThrowsWhenInvalidTypeSpecified()
     {
         $this->setExpectedException('Zend\XmlRpc\Exception\ValueException', 'Given type is not a Zend\XmlRpc\Value constant');
-        Value::getXmlRpcValue('', 'bad type here');
+        AbstractValue::getXmlRpcValue('', 'bad type here');
     }
 
     public function testPassingXmlRpcObjectReturnsTheSameObject()
     {
         $xmlRpcValue = new Value\String('foo');
-        $this->assertSame($xmlRpcValue, Value::getXmlRpcValue($xmlRpcValue));
+        $this->assertSame($xmlRpcValue, AbstractValue::getXmlRpcValue($xmlRpcValue));
     }
 
 
     public function testGetXmlRpcTypeByValue()
     {
         $this->assertSame(
-            Value::XMLRPC_TYPE_NIL,
-            Value::getXmlRpcTypeByValue(new Value\Nil)
+            AbstractValue::XMLRPC_TYPE_NIL,
+            AbstractValue::getXmlRpcTypeByValue(new Value\Nil)
         );
 
         $this->assertEquals(
-            Value::XMLRPC_TYPE_DATETIME,
-            Value::getXmlRpcTypeByValue(new DateTime)
+            AbstractValue::XMLRPC_TYPE_DATETIME,
+            AbstractValue::getXmlRpcTypeByValue(new DateTime)
         );
 
         $this->assertEquals(
-            Value::XMLRPC_TYPE_DATETIME,
-            Value::getXmlRpcTypeByValue(new \Zend\Date\Date)
+            AbstractValue::XMLRPC_TYPE_DATETIME,
+            AbstractValue::getXmlRpcTypeByValue(new \Zend\Date\Date)
         );
 
         $this->assertEquals(
-            Value::XMLRPC_TYPE_STRUCT,
-            Value::getXmlRpcTypeByValue(array('foo' => 'bar'))
+            AbstractValue::XMLRPC_TYPE_STRUCT,
+            AbstractValue::getXmlRpcTypeByValue(array('foo' => 'bar'))
         );
 
         $object = new stdClass;
         $object->foo = 'bar';
 
         $this->assertEquals(
-            Value::XMLRPC_TYPE_STRUCT,
-            Value::getXmlRpcTypeByValue($object)
+            AbstractValue::XMLRPC_TYPE_STRUCT,
+            AbstractValue::getXmlRpcTypeByValue($object)
         );
 
         $this->assertEquals(
-            Value::XMLRPC_TYPE_ARRAY,
-            Value::getXmlRpcTypeByValue(new stdClass)
+            AbstractValue::XMLRPC_TYPE_ARRAY,
+            AbstractValue::getXmlRpcTypeByValue(new stdClass)
         );
 
         $this->assertEquals(
-            Value::XMLRPC_TYPE_ARRAY,
-            Value::getXmlRpcTypeByValue(array(1, 3, 3, 7))
+            AbstractValue::XMLRPC_TYPE_ARRAY,
+            AbstractValue::getXmlRpcTypeByValue(array(1, 3, 3, 7))
         );
 
         $this->assertEquals(
-            Value::XMLRPC_TYPE_INTEGER,
-            Value::getXmlRpcTypeByValue(42)
+            AbstractValue::XMLRPC_TYPE_INTEGER,
+            AbstractValue::getXmlRpcTypeByValue(42)
         );
 
         $this->assertEquals(
-            Value::XMLRPC_TYPE_DOUBLE,
-            Value::getXmlRpcTypeByValue(13.37)
+            AbstractValue::XMLRPC_TYPE_DOUBLE,
+            AbstractValue::getXmlRpcTypeByValue(13.37)
         );
 
         $this->assertEquals(
-            Value::XMLRPC_TYPE_BOOLEAN,
-            Value::getXmlRpcTypeByValue(true)
+            AbstractValue::XMLRPC_TYPE_BOOLEAN,
+            AbstractValue::getXmlRpcTypeByValue(true)
         );
 
         $this->assertEquals(
-            Value::XMLRPC_TYPE_BOOLEAN,
-            Value::getXmlRpcTypeByValue(false)
+            AbstractValue::XMLRPC_TYPE_BOOLEAN,
+            AbstractValue::getXmlRpcTypeByValue(false)
         );
 
         $this->assertEquals(
-            Value::XMLRPC_TYPE_NIL,
-            Value::getXmlRpcTypeByValue(null)
+            AbstractValue::XMLRPC_TYPE_NIL,
+            AbstractValue::getXmlRpcTypeByValue(null)
         );
 
         $this->assertEquals(
-            Value::XMLRPC_TYPE_STRING,
-            Value::getXmlRpcTypeByValue('Zend Framework')
+            AbstractValue::XMLRPC_TYPE_STRING,
+            AbstractValue::getXmlRpcTypeByValue('Zend Framework')
         );
     }
 
     public function testGetXmlRpcTypeByValueThrowsExceptionOnInvalidValue()
     {
         $this->setExpectedException('Zend\XmlRpc\Exception\InvalidArgumentException');
-        Value::getXmlRpcTypeByValue(fopen(__FILE__, 'r'));
+        AbstractValue::getXmlRpcTypeByValue(fopen(__FILE__, 'r'));
     }
 
     // Custom Assertions and Helper Methods


### PR DESCRIPTION
Fix use statements in Zend\XmlRpc

[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=xmlrpc)](http://travis-ci.org/prolic/zf2)
