### PR TITLE
[Ldap] Remove Stdlib dependency

### DIFF
--- a/library/Zend/Ldap/Ldap.php
+++ b/library/Zend/Ldap/Ldap.php
@@ -21,7 +21,6 @@
 namespace Zend\Ldap;
 
 use Traversable;
-use Zend\Stdlib\ArrayUtils;
 
 /**
  * @category   Zend
@@ -216,7 +215,7 @@ class Ldap
      *  accountFilterFormat
      *  allowEmptyPassword
      *  useStartTls
-     *  optRefferals
+     *  optReferrals
      *  tryUsernameSplit
      *  networkTimeout
      *
@@ -227,7 +226,7 @@ class Ldap
     public function setOptions($options)
     {
         if ($options instanceof Traversable) {
-            $options = ArrayUtils::iteratorToArray($options);
+            $options = iterator_to_array($options);
         }
 
         $permittedOptions = array(


### PR DESCRIPTION
The use of ArrayUtils for parse Zend\Ldap\Ldap options is unnecessary since Zend\Ldap only use flat options.

[![Build Status](https://secure.travis-ci.org/Maks3w/zf2.png?branch=ldap_drop-stdlib-depency)](http://travis-ci.org/Maks3w/zf2)
