### PR TITLE
[i18n][Ldap] Drop support for Zend\Date

### DIFF
--- a/library/Zend/Ldap/Converter/Converter.php
+++ b/library/Zend/Ldap/Converter/Converter.php
@@ -22,7 +22,6 @@ namespace Zend\Ldap\Converter;
 
 use DateTime;
 use DateTimeZone;
-use Zend\Date\Date;
 
 /**
  * Zend\Ldap\Converter is a collection of useful LDAP related conversion functions.
@@ -114,8 +113,6 @@ class Converter
                     } else if (is_object($value)) {
                         if ($value instanceof DateTime) {
                             return self::toLdapDatetime($value);
-                        } else if ($value instanceof Date) {
-                            return self::toLdapDatetime($value);
                         } else {
                             return self::toLdapSerialize($value);
                         }
@@ -137,11 +134,10 @@ class Converter
      * Converts a date-entity to an LDAP-compatible date-string
      *
      * The date-entity <var>$date</var> can be either a timestamp, a
-     * DateTime Object, a string that is parseable by strtotime() or a Zend\Date\Date
-     * Object.
+     * DateTime Object, a string that is parseable by strtotime().
      *
-     * @param integer|string|DateTime|Date $date  The date-entity
-     * @param boolean                      $asUtc Whether to return the LDAP-compatible date-string as UTC or as local value
+     * @param integer|string|DateTime $date  The date-entity
+     * @param boolean                 $asUtc Whether to return the LDAP-compatible date-string as UTC or as local value
      * @return string
      * @throws Exception\InvalidArgumentException
      */
@@ -153,8 +149,6 @@ class Converter
                 $date->setTimezone(new DateTimeZone(date_default_timezone_get()));
             } else if (is_string($date)) {
                 $date = new DateTime($date);
-            } else if ($date instanceof Date) {
-                $date = new DateTime($date->get(Date::ISO_8601));
             } else {
                 throw new Exception\InvalidArgumentException('Parameter $date is not of the expected type');
             }

--- a/tests/Zend/Ldap/Converter/ConverterTest.php
+++ b/tests/Zend/Ldap/Converter/ConverterTest.php
@@ -23,7 +23,6 @@ namespace ZendTest\Ldap\Converter;
 
 use DateTime;
 use DateTimeZone;
-use Zend\Date\Date;
 use Zend\Ldap\Converter\Converter;
 
 /**
@@ -84,11 +83,11 @@ class ConverterTest extends \PHPUnit_Framework_TestCase
                         'utc' => false), '20100512131445+0300'),
             array(array('date'=> '2010-05-12 13:14:45+0300',
                         'utc' => true), '20100512101445Z'),
-            array(array('date'=> new Date('2010-05-12T13:14:45+0300', Date::ISO_8601),
+            array(array('date'=> DateTime::createFromFormat(DateTime::ISO8601, '2010-05-12T13:14:45+0300'),
                         'utc' => true), '20100512101445Z'),
-            array(array('date'=> new Date('2010-05-12T13:14:45+0300', Date::ISO_8601),
+            array(array('date'=> DateTime::createFromFormat(DateTime::ISO8601, '2010-05-12T13:14:45+0300'),
                         'utc' => false), '20100512131445+0300'),
-            array(array('date'=> new Date('0', Date::TIMESTAMP),
+            array(array('date'=> date_timestamp_set(new DateTime(), 0),
                         'utc' => true), '19700101000000Z'),
         );
     }
@@ -153,7 +152,7 @@ class ConverterTest extends \PHPUnit_Framework_TestCase
                              'type' => 0)),
             array('FALSE', array('value'=> 0,
                                  'type' => 1)),
-            array('19700101000000Z', array('value'=> new Date('1970-01-01T00:00:00+0000', Date::ISO_8601),
+            array('19700101000000Z', array('value'=> DateTime::createFromFormat(DateTime::ISO8601, '1970-01-01T00:00:00+0000'),
                                            'type' => 0)),
 
         );
@@ -192,6 +191,11 @@ class ConverterTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider fromLdapDateTimeProvider
+     *
+     * @param DateTime $expected
+     * @param string   $convert
+     * @param boolean  $utc
+     * @return void
      */
     public function testFromLdapDateTime($expected, $convert, $utc)
     {


### PR DESCRIPTION
Zend\Date\Date has been replaced by PHP native DateTime
