### PR TITLE
[i18n][TimeSync] Remove support for locale and Zend\Date

### DIFF
--- a/documentation/manual/en/module_specs/Zend_TimeSync-Working.xml
+++ b/documentation/manual/en/module_specs/Zend_TimeSync-Working.xml
@@ -27,7 +27,7 @@
         <programlisting language="php"><![CDATA[
 $server = new Zend_TimeSync('0.pool.ntp.org');
 
-print $server->getDate()->getIso();
+print $server->getDate()->format(DateTime::ISO8601);
 ]]></programlisting>
 
         <para>
@@ -37,13 +37,14 @@ print $server->getDate()->getIso();
             for a time server. Then when calling <methodname>getDate()</methodname> the actual set
             time server is requested and it will return its own time.
             <classname>Zend_TimeSync</classname> then calculates the difference to the actual time
-            of the server running the script and returns a <classname>Zend_Date</classname> object
+            of the server running the script and returns a <classname>DateTime</classname> object
             with the correct time.
         </para>
 
         <para>
-            For details about <classname>Zend_Date</classname> and its methods see the <link linkend="zend.date.introduction"><classname>Zend_Date</classname>
-                documentation</link>.
+            For details about <classname>DateTime</classname> and its methods see the
+            <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://php.net/class.datetime.php">
+                <classname>DateTime</classname>documentation</link>.
         </para>
     </section>
 
@@ -70,7 +71,7 @@ $server = new Zend_TimeSync(array('0.pool.ntp.org',
                                   '2.pool.ntp.org'));
 $server->addServer('3.pool.ntp.org');
 
-print $server->getDate()->getIso();
+print $server->getDate()->format(DateTime::ISO8601);
 ]]></programlisting>
 
         <para>
@@ -92,7 +93,7 @@ $server = new Zend_TimeSync(array('generic'  => '0.pool.ntp.org',
                                   'reserve'  => '2.pool.ntp.org'));
 $server->addServer('3.pool.ntp.org', 'additional');
 
-print $server->getDate()->getIso();
+print $server->getDate()->format(DateTime::ISO8601);
 ]]></programlisting>
 
         <para>
@@ -124,7 +125,7 @@ $server = new Zend_TimeSync(array('generic'  => 'ntp:\\0.pool.ntp.org',
                                   'reserve'  => 'ntp:\\2.pool.ntp.org'));
 $server->addServer('sntp:\\internal.myserver.com', 'additional');
 
-print $server->getDate()->getIso();
+print $server->getDate()->format(DateTime::ISO8601);
 ]]></programlisting>
 
         <para>
@@ -154,7 +155,7 @@ $server = new Zend_TimeSync(array('generic'  => 'ntp:\\0.pool.ntp.org:200',
                                   'fallback' => 'ntp:\\1.pool.ntp.org'));
 $server->addServer('sntp:\\internal.myserver.com:399', 'additional');
 
-print $server->getDate()->getIso();
+print $server->getDate()->format(DateTime::ISO8601);
 ]]></programlisting>
     </section>
 
@@ -190,7 +191,7 @@ $server = new Zend_TimeSync(array('generic'  => 'ntp:\\0.pool.ntp.org',
                                   'fallback' => 'ntp:\\1.pool.ntp.org'));
 $server->addServer('sntp:\\internal.myserver.com', 'additional');
 
-print $server->getDate()->getIso();
+print $server->getDate()->format(DateTime::ISO8601);
 print_r(Zend_TimeSync::getOptions();
 print "Timeout = " . Zend_TimeSync::getOptions('timeout');
 ]]></programlisting>
@@ -265,7 +266,7 @@ $server = new Zend_TimeSync($serverlist);
 
 try {
     $result = $server->getDate();
-    echo $result->getIso();
+    echo $result->format(DateTime::ISO8601);
 } catch (Zend_TimeSync_Exception $e) {
 
     $exceptions = $e->get();

--- a/documentation/manual/en/module_specs/Zend_TimeSync.xml
+++ b/documentation/manual/en/module_specs/Zend_TimeSync.xml
@@ -22,7 +22,7 @@
 
         <para>
             <classname>Zend_TimeSync</classname> is not able to change the server's time, but it
-            will return a <link linkend="zend.date.introduction">Zend_Date</link> instance from
+            will return a <classname>DateTime</classname> instance from
             which the difference from the server's time can be worked with.
         </para>
     </note>

--- a/library/Zend/TimeSync/Protocol.php
+++ b/library/Zend/TimeSync/Protocol.php
@@ -20,7 +20,7 @@
 
 namespace Zend\TimeSync;
 
-use Zend\TimeSync\Exception;
+use DateTime;
 
 /**
  * Abstract class definition for all timeserver protocols
@@ -137,15 +137,16 @@ abstract class Protocol
     /**
      * Query this timeserver without using the fallback mechanism
      *
-     * @param  string|\Zend\Locale\Locale $locale (Optional) Locale
-     * @return \Zend\Date\Date
+     * @return DateTime
      */
-    public function getDate($locale = null)
+    public function getDate()
     {
         $this->_write($this->_prepare());
-        $timestamp = $this->_extract($this->_read());
+        $this->_extract($this->_read());
 
-        $date = new \Zend\Date\Date($this, null, $locale);
-        return $date;
+        // Apply to the local time the offset obtained from the server
+        $info = $this->getInfo();
+        $time = (time() + round($info['offset']));
+        return date_timestamp_set(new DateTime(), $time);
     }
 }

--- a/library/Zend/TimeSync/TimeSync.php
+++ b/library/Zend/TimeSync/TimeSync.php
@@ -228,16 +228,15 @@ class TimeSync implements IteratorAggregate
      * facade and will try to return the date from the first server that
      * returns a valid result.
      *
-     * @param  Zend_Locale $locale OPTIONAL locale
-     * @return TimeSync
+     * @return \DateTime
      * @throws Exception\RuntimeException
      */
-    public function getDate($locale = null)
+    public function getDate()
     {
         foreach ($this->_timeservers as $alias => $server) {
             $this->_current = $server;
             try {
-                return $server->getDate($locale);
+                return $server->getDate();
             } catch (Exception\ExceptionInterface $e) {
                 if (!isset($masterException)) {
                     $masterException = new Exception\RuntimeException($e->getMessage(), $e->getCode());


### PR DESCRIPTION
- Protocol::getDate() now returns PHP native class DateTime.
- The support for pass the locale as attribute has been removed.
  Now the user must transform manually DateTime to the locale that he/she wants.
