### PR TITLE
Added PlatformInterface::quoteIdentifierChain()

### DIFF
--- a/library/Zend/Db/Adapter/Platform/Mysql.php
+++ b/library/Zend/Db/Adapter/Platform/Mysql.php
@@ -50,6 +50,21 @@ class Mysql implements PlatformInterface
     }
 
     /**
+     * Quote identifier chain
+     *
+     * @param string|string[] $identifierChain
+     * @return string
+     */
+    public function quoteIdentifierChain($identifierChain)
+    {
+        $identifierChain = str_replace('`', '\\`', $identifierChain);
+        if (is_array($identifierChain)) {
+            $identifierChain = implode('`.`', $identifierChain);
+        }
+        return '`' . $identifierChain . '`';
+    }
+
+    /**
      * Get quote value symbol
      * 
      * @return string 

--- a/library/Zend/Db/Adapter/Platform/PlatformInterface.php
+++ b/library/Zend/Db/Adapter/Platform/PlatformInterface.php
@@ -20,6 +20,7 @@ interface PlatformInterface
     public function getName();
     public function getQuoteIdentifierSymbol();
     public function quoteIdentifier($identifier);
+    public function quoteIdentifierChain($identifierChain);
     public function getQuoteValueSymbol();
     public function quoteValue($value);
     public function getIdentifierSeparator();

--- a/library/Zend/Db/Adapter/Platform/Postgresql.php
+++ b/library/Zend/Db/Adapter/Platform/Postgresql.php
@@ -49,6 +49,21 @@ class Postgresql implements PlatformInterface
     }
 
     /**
+     * Quote identifier chain
+     *
+     * @param string|string[] $identifierChain
+     * @return string
+     */
+    public function quoteIdentifierChain($identifierChain)
+    {
+        $identifierChain = str_replace('"', '\\"', $identifierChain);
+        if (is_array($identifierChain)) {
+            $identifierChain = implode('"."', $identifierChain);
+        }
+        return '"' . $identifierChain . '"';
+    }
+
+    /**
      * Get quote value symbol
      * 
      * @return string 

--- a/library/Zend/Db/Adapter/Platform/Sql92.php
+++ b/library/Zend/Db/Adapter/Platform/Sql92.php
@@ -49,6 +49,21 @@ class Sql92 implements PlatformInterface
     }
 
     /**
+     * Quote identifier chain
+     *
+     * @param string|string[] $identifierChain
+     * @return string
+     */
+    public function quoteIdentifierChain($identifierChain)
+    {
+        $identifierChain = str_replace('"', '\\"', $identifierChain);
+        if (is_array($identifierChain)) {
+            $identifierChain = implode('"."', $identifierChain);
+        }
+        return '"' . $identifierChain . '"';
+    }
+
+    /**
      * Get quote value symbol
      * 
      * @return string 

--- a/library/Zend/Db/Adapter/Platform/SqlServer.php
+++ b/library/Zend/Db/Adapter/Platform/SqlServer.php
@@ -50,6 +50,20 @@ class SqlServer implements PlatformInterface
     }
 
     /**
+     * Quote identifier chain
+     *
+     * @param string|string[] $identifierChain
+     * @return string
+     */
+    public function quoteIdentifierChain($identifierChain)
+    {
+        if (is_array($identifierChain)) {
+            $identifierChain = implode('].[', $identifierChain);
+        }
+        return '[' . $identifierChain . ']';
+    }
+
+    /**
      * Get quote value symbol
      * 
      * @return string 

--- a/library/Zend/Db/Adapter/Platform/Sqlite.php
+++ b/library/Zend/Db/Adapter/Platform/Sqlite.php
@@ -50,6 +50,21 @@ class Sqlite implements PlatformInterface
     }
 
     /**
+     * Quote identifier chain
+     *
+     * @param string|string[] $identifierChain
+     * @return string
+     */
+    public function quoteIdentifierChain($identifierChain)
+    {
+        $identifierChain = str_replace('"', '\\"', $identifierChain);
+        if (is_array($identifierChain)) {
+            $identifierChain = implode('"."', $identifierChain);
+        }
+        return '"' . $identifierChain . '"';
+    }
+
+    /**
      * Get quote value symbol
      * 
      * @return string 

--- a/tests/Zend/Db/Adapter/Platform/MysqlTest.php
+++ b/tests/Zend/Db/Adapter/Platform/MysqlTest.php
@@ -55,6 +55,16 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Zend\Db\Adapter\Platform\Mysql::quoteIdentifierChain
+     */
+    public function testQuoteIdentifierChain()
+    {
+        $this->assertEquals('`identifier`', $this->platform->quoteIdentifierChain('identifier'));
+        $this->assertEquals('`identifier`', $this->platform->quoteIdentifierChain(array('identifier')));
+        $this->assertEquals('`schema`.`identifier`', $this->platform->quoteIdentifierChain(array('schema','identifier')));
+    }
+
+    /**
      * @covers Zend\Db\Adapter\Platform\Mysql::getQuoteValueSymbol
      */
     public function testGetQuoteValueSymbol()

--- a/tests/Zend/Db/Adapter/Platform/Sql92Test.php
+++ b/tests/Zend/Db/Adapter/Platform/Sql92Test.php
@@ -55,6 +55,16 @@ class Sql92Test extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Zend\Db\Adapter\Platform\Sql92::quoteIdentifierChain
+     */
+    public function testQuoteIdentifierChain()
+    {
+        $this->assertEquals('"identifier"', $this->platform->quoteIdentifierChain('identifier'));
+        $this->assertEquals('"identifier"', $this->platform->quoteIdentifierChain(array('identifier')));
+        $this->assertEquals('"schema"."identifier"', $this->platform->quoteIdentifierChain(array('schema','identifier')));
+    }
+
+    /**
      * @covers Zend\Db\Adapter\Platform\Sql92::getQuoteValueSymbol
      */
     public function testGetQuoteValueSymbol()

--- a/tests/Zend/Db/Adapter/Platform/SqlServerTest.php
+++ b/tests/Zend/Db/Adapter/Platform/SqlServerTest.php
@@ -55,6 +55,16 @@ class SqlServerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Zend\Db\Adapter\Platform\SqlServer::quoteIdentifierChain
+     */
+    public function testQuoteIdentifierChain()
+    {
+        $this->assertEquals('[identifier]', $this->platform->quoteIdentifierChain('identifier'));
+        $this->assertEquals('[identifier]', $this->platform->quoteIdentifierChain(array('identifier')));
+        $this->assertEquals('[schema].[identifier]', $this->platform->quoteIdentifierChain(array('schema','identifier')));
+    }
+
+    /**
      * @covers Zend\Db\Adapter\Platform\SqlServer::getQuoteValueSymbol
      */
     public function testGetQuoteValueSymbol()

--- a/tests/Zend/Db/Adapter/Platform/SqliteTest.php
+++ b/tests/Zend/Db/Adapter/Platform/SqliteTest.php
@@ -55,6 +55,16 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Zend\Db\Adapter\Platform\Sqlite::quoteIdentifierChain
+     */
+    public function testQuoteIdentifierChain()
+    {
+        $this->assertEquals('"identifier"', $this->platform->quoteIdentifierChain('identifier'));
+        $this->assertEquals('"identifier"', $this->platform->quoteIdentifierChain(array('identifier')));
+        $this->assertEquals('"schema"."identifier"', $this->platform->quoteIdentifierChain(array('schema','identifier')));
+    }
+
+    /**
      * @covers Zend\Db\Adapter\Platform\Sqlite::getQuoteValueSymbol
      */
     public function testGetQuoteValueSymbol()


### PR DESCRIPTION
Equivalent to:

``` php
<?php
$quotedIdentifierChain = array();
foreach ((array)$identifierChain as $identifier) {
    $quotedIdentifierChain[] = $platform->quoteIdentifier($identifier);
}
$quotedIdentifierChain = implode($platform->getIdentifierSeparator(), $quotedIdentifierChain);

```
