### PR TITLE
[zen-18] DateFormat helper should work with 5.3.3

### DIFF
--- a/library/Zend/I18n/View/Helper/DateFormat.php
+++ b/library/Zend/I18n/View/Helper/DateFormat.php
@@ -68,11 +68,18 @@ class DateFormat extends AbstractHelper
      */
     public function __invoke($date, $formatterName)
     {
-        if (!isset($this->formatters[$formatterName]) {
+        if (!isset($this->formatters[$formatterName])) {
             throw new Exception\RuntimeException(sprintf(
                 'No formatter with name %s found',
                 $formatterName
-            )));
+            ));
+        }
+
+        // DateTime support for IntlDateFormatter::format() was only added in 5.3.4
+        if ($date instanceof DateTime
+            && version_compare(PHP_VERSION, '5.3.4', '<')
+        ) {
+            $date = $date->getTimestamp();
         }
 
         return $this->formatters[$formatterName]


### PR DESCRIPTION
- Added a check if $date is a DateTime object, and PHP < 5.3.4; if so, casts
  $date to a timestamp before passing it to format()
