### PR TITLE
[zen-52] Renamed abstract classes in Zend\Tag

### DIFF
--- a/library/Zend/Tag/Cloud.php
+++ b/library/Zend/Tag/Cloud.php
@@ -214,8 +214,8 @@ class Cloud
             $decorator = $this->getDecoratorPluginManager()->get($decorator, $options);
         }
 
-        if (!($decorator instanceof Cloud\Decorator\Cloud)) {
-            throw new Exception\InvalidArgumentException('DecoratorInterface is no instance of Cloud\Decorator\Cloud');
+        if (!($decorator instanceof Cloud\Decorator\AbstractCloud)) {
+            throw new Exception\InvalidArgumentException('DecoratorInterface is no instance of Cloud\Decorator\AbstractCloud');
         }
 
         $this->_cloudDecorator = $decorator;
@@ -261,7 +261,7 @@ class Cloud
             $decorator = $this->getDecoratorPluginManager()->get($decorator, $options);
         }
 
-        if (!($decorator instanceof Cloud\Decorator\Tag)) {
+        if (!($decorator instanceof Cloud\Decorator\AbstractTag)) {
             throw new Exception\InvalidArgumentException('DecoratorInterface is no instance of Cloud\Decorator\Tag');
         }
 

--- a/library/Zend/Tag/Cloud/Decorator/AbstractCloud.php
+++ b/library/Zend/Tag/Cloud/Decorator/AbstractCloud.php
@@ -26,14 +26,14 @@ use Zend\Stdlib\ArrayUtils;
 use Zend\Tag\Cloud\Decorator\DecoratorInterface as Decorator;
 
 /**
- * Abstract class for tag decorators
+ * Abstract class for cloud decorators
  *
  * @category  Zend
  * @package   Zend_Tag
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class Tag implements Decorator
+abstract class AbstractCloud implements Decorator
 {
     /**
      * Option keys to skip when calling setOptions()
@@ -64,7 +64,7 @@ abstract class Tag implements Decorator
      * Set options from array
      *
      * @param  array $options Configuration for the decorator
-     * @return \Zend\Tag\Cloud
+     * @return AbstractCloud
      */
     public function setOptions(array $options)
     {

--- a/library/Zend/Tag/Cloud/Decorator/AbstractTag.php
+++ b/library/Zend/Tag/Cloud/Decorator/AbstractTag.php
@@ -26,14 +26,14 @@ use Zend\Stdlib\ArrayUtils;
 use Zend\Tag\Cloud\Decorator\DecoratorInterface as Decorator;
 
 /**
- * Abstract class for cloud decorators
+ * Abstract class for tag decorators
  *
  * @category  Zend
  * @package   Zend_Tag
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class Cloud implements Decorator
+abstract class AbstractTag implements Decorator
 {
     /**
      * Option keys to skip when calling setOptions()
@@ -64,7 +64,7 @@ abstract class Cloud implements Decorator
      * Set options from array
      *
      * @param  array $options Configuration for the decorator
-     * @return \Zend\Tag\Cloud
+     * @return AbstractTag
      */
     public function setOptions(array $options)
     {

--- a/library/Zend/Tag/Cloud/Decorator/HtmlCloud.php
+++ b/library/Zend/Tag/Cloud/Decorator/HtmlCloud.php
@@ -29,7 +29,7 @@ namespace Zend\Tag\Cloud\Decorator;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
-class HtmlCloud extends Cloud
+class HtmlCloud extends AbstractCloud
 {
     /**
      * @var string Encoding to use

--- a/library/Zend/Tag/Cloud/Decorator/HtmlTag.php
+++ b/library/Zend/Tag/Cloud/Decorator/HtmlTag.php
@@ -21,8 +21,8 @@
 
 namespace Zend\Tag\Cloud\Decorator;
 
-use Zend\Tag\Cloud\Decorator\Exception\InvalidArgumentException,
-    Zend\Tag\ItemList;
+use Zend\Tag\Cloud\Decorator\Exception\InvalidArgumentException;
+use Zend\Tag\ItemList;
 
 /**
  * Simple HTML decorator for tags
@@ -32,7 +32,7 @@ use Zend\Tag\Cloud\Decorator\Exception\InvalidArgumentException,
  * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
-class HtmlTag extends Tag
+class HtmlTag extends AbstractTag
 {
     /**
      * List of tags which get assigned to the inner element instead of

--- a/library/Zend/Tag/ItemList.php
+++ b/library/Zend/Tag/ItemList.php
@@ -23,11 +23,11 @@ namespace Zend\Tag;
 
 use Zend\Amf\Parser\Exception;
 
-use Zend\Tag\Exception\InvalidArgumentException,
-	Zend\Tag\Exception\OutOfBoundsException,
-    Countable,
-    SeekableIterator,
-    ArrayAccess;
+use Zend\Tag\Exception\InvalidArgumentException;
+use Zend\Tag\Exception\OutOfBoundsException;
+use Countable;
+use SeekableIterator;
+use ArrayAccess;
 
 /**
  * @category   Zend

--- a/tests/Zend/Tag/ItemListTest.php
+++ b/tests/Zend/Tag/ItemListTest.php
@@ -21,9 +21,9 @@
 
 namespace ZendTest\Tag;
 
-use Zend\Tag,
-	Zend\Tag\Exception\InvalidArgumentException,
-	Zend\Tag\Exception\OutOfBoundsException;
+use Zend\Tag;
+use Zend\Tag\Exception\InvalidArgumentException;
+use Zend\Tag\Exception\OutOfBoundsException;
 
 /**
  * @category   Zend

--- a/tests/Zend/Tag/ItemTest.php
+++ b/tests/Zend/Tag/ItemTest.php
@@ -21,8 +21,8 @@
 
 namespace ZendTest\Tag;
 
-use Zend\Tag,
-	Zend\Tag\Exception\InvalidArgumentException;
+use Zend\Tag;
+use Zend\Tag\Exception\InvalidArgumentException;
 
 /**
  * @category   Zend


### PR DESCRIPTION
Renamed abstract classes
Fixed use statements

[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=tag)](http://travis-ci.org/prolic/zf2)
