### PR TITLE
[zen-52] Renamed abstract classes in Zend\Stdlib

### DIFF
--- a/library/Zend/Cache/Pattern/PatternOptions.php
+++ b/library/Zend/Cache/Pattern/PatternOptions.php
@@ -24,7 +24,7 @@ namespace Zend\Cache\Pattern;
 use Zend\Cache\Exception,
     Zend\Cache\StorageFactory,
     Zend\Cache\Storage\StorageInterface as Storage,
-    Zend\Stdlib\Options;
+    Zend\Stdlib\AbstractOptions;
 
 /**
  * @category   Zend
@@ -33,7 +33,7 @@ use Zend\Cache\Exception,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class PatternOptions extends Options
+class PatternOptions extends AbstractOptions
 {
     /**
      * Used by:

--- a/library/Zend/Cache/Storage/Adapter/AdapterOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/AdapterOptions.php
@@ -26,7 +26,7 @@ use ArrayObject,
     Zend\Cache\Storage\Event,
     Zend\Cache\Storage\StorageInterface,
     Zend\EventManager\EventsCapableInterface,
-    Zend\Stdlib\Options;
+    Zend\Stdlib\AbstractOptions;
 
 /**
  * Unless otherwise marked, all options in this class affect all adapters.
@@ -37,7 +37,7 @@ use ArrayObject,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class AdapterOptions extends Options
+class AdapterOptions extends AbstractOptions
 {
 
     /**

--- a/library/Zend/Cache/Storage/Plugin/PluginOptions.php
+++ b/library/Zend/Cache/Storage/Plugin/PluginOptions.php
@@ -24,7 +24,7 @@ namespace Zend\Cache\Storage\Plugin;
 use Zend\Cache\Exception,
     Zend\Serializer\Adapter\AdapterInterface as SerializerAdapter,
     Zend\Serializer\Serializer as SerializerFactory,
-    Zend\Stdlib\Options;
+    Zend\Stdlib\AbstractOptions;
 
 /**
  * @category   Zend
@@ -33,7 +33,7 @@ use Zend\Cache\Exception,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class PluginOptions extends Options
+class PluginOptions extends AbstractOptions
 {
     /**
      * Used by:

--- a/library/Zend/Crypt/PublicKey/RsaOptions.php
+++ b/library/Zend/Crypt/PublicKey/RsaOptions.php
@@ -10,7 +10,7 @@
 
 namespace Zend\Crypt\PublicKey;
 
-use Zend\Stdlib\Options;
+use Zend\Stdlib\AbstractOptions;
 use Zend\Crypt\PublicKey\Rsa\Exception;
 use Zend\Stdlib\ArrayUtils;
 use Traversable;
@@ -22,7 +22,7 @@ use Traversable;
  * @package    Zend_Crypt
  * @subpackage PublicKey
  */
-class RsaOptions extends Options
+class RsaOptions extends AbstractOptions
 {
     /**
      * @var Rsa\PrivateKey

--- a/library/Zend/Mail/Transport/FileOptions.php
+++ b/library/Zend/Mail/Transport/FileOptions.php
@@ -22,7 +22,7 @@
 namespace Zend\Mail\Transport;
 
 use Zend\Mail\Exception,
-    Zend\Stdlib\Options;
+    Zend\Stdlib\AbstractOptions;
 
 /**
  * @category   Zend
@@ -31,7 +31,7 @@ use Zend\Mail\Exception,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class FileOptions extends Options
+class FileOptions extends AbstractOptions
 {
     /**
      * @var string Local client hostname

--- a/library/Zend/Mail/Transport/SmtpOptions.php
+++ b/library/Zend/Mail/Transport/SmtpOptions.php
@@ -22,7 +22,7 @@
 namespace Zend\Mail\Transport;
 
 use Zend\Mail\Exception,
-    Zend\Stdlib\Options;
+    Zend\Stdlib\AbstractOptions;
 
 /**
  * @category   Zend
@@ -31,7 +31,7 @@ use Zend\Mail\Exception,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class SmtpOptions extends Options
+class SmtpOptions extends AbstractOptions
 {
     /**
      * @var string Local client hostname

--- a/library/Zend/ModuleManager/Listener/ListenerOptions.php
+++ b/library/Zend/ModuleManager/Listener/ListenerOptions.php
@@ -11,7 +11,7 @@
 namespace Zend\ModuleManager\Listener;
 
 use Traversable;
-use Zend\Stdlib\Options;
+use Zend\Stdlib\AbstractOptions;
 
 /**
  * Listener options
@@ -20,7 +20,7 @@ use Zend\Stdlib\Options;
  * @package    Zend_ModuleManager
  * @subpackage Listener
  */
-class ListenerOptions extends Options
+class ListenerOptions extends AbstractOptions
 {
     /**
      * @var array

--- a/library/Zend/Service/Twitter/SearchOptions.php
+++ b/library/Zend/Service/Twitter/SearchOptions.php
@@ -21,7 +21,7 @@
 
 namespace Zend\Service\Twitter;
 
-use Zend\Stdlib\Options;
+use Zend\Stdlib\AbstractOptions;
 
 /**
  * @category   Zend
@@ -30,7 +30,7 @@ use Zend\Stdlib\Options;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class SearchOptions extends Options
+class SearchOptions extends AbstractOptions
 {
     /**
      * Search query. Should be URL encoded. Queries will be limited by complexity.

--- a/library/Zend/Session/SaveHandler/DbTableGatewayOptions.php
+++ b/library/Zend/Session/SaveHandler/DbTableGatewayOptions.php
@@ -21,7 +21,7 @@
 namespace Zend\Session\SaveHandler;
 
 use Zend\Session\Exception;
-use Zend\Stdlib\Options;
+use Zend\Stdlib\AbstractOptions;
 
 /**
  * DbTableGateway Save Handler Options
@@ -32,7 +32,7 @@ use Zend\Stdlib\Options;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class DbTableGatewayOptions extends Options
+class DbTableGatewayOptions extends AbstractOptions
 {
     /**
      * Data Column

--- a/library/Zend/Stdlib/AbstractOptions.php
+++ b/library/Zend/Stdlib/AbstractOptions.php
@@ -28,11 +28,11 @@ use Traversable;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class Options implements ParameterObjectInterface
+abstract class AbstractOptions implements ParameterObjectInterface
 {
     /**
      * @param  array|Traversable|null $options
-     * @return Options
+     * @return AbstractOptions
      * @throws Exception\InvalidArgumentException
      */
     public function __construct($options = null)

--- a/library/Zend/Stdlib/DispatchableInterface.php
+++ b/library/Zend/Stdlib/DispatchableInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Zend\Stdlib;
 
-use Zend\Stdlib\ResponseInterface as Response,
-    Zend\Stdlib\RequestInterface as Request;
+use Zend\Stdlib\ResponseInterface as Response;
+use Zend\Stdlib\RequestInterface as Request;
 
 interface DispatchableInterface
 {

--- a/tests/Zend/Stdlib/OptionsTest.php
+++ b/tests/Zend/Stdlib/OptionsTest.php
@@ -2,10 +2,10 @@
 
 namespace ZendTest\Stdlib;
 
-use ArrayObject,
-    ZendTest\Stdlib\TestAsset\TestOptions,
-    ZendTest\Stdlib\TestAsset\TestTraversable,
-    Zend\Stdlib\Exception\InvalidArgumentException;
+use ArrayObject;
+use ZendTest\Stdlib\TestAsset\TestOptions;
+use ZendTest\Stdlib\TestAsset\TestTraversable;
+use Zend\Stdlib\Exception\InvalidArgumentException;
 
 class OptionsTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Zend/Stdlib/PriorityQueueTest.php
+++ b/tests/Zend/Stdlib/PriorityQueueTest.php
@@ -21,8 +21,8 @@
 
 namespace ZendTest\Stdlib;
 
-use Zend\Stdlib\PriorityQueue,
-    SplPriorityQueue;
+use Zend\Stdlib\PriorityQueue;
+use SplPriorityQueue;
 
 /**
  * @category   Zend

--- a/tests/Zend/Stdlib/TestAsset/TestOptions.php
+++ b/tests/Zend/Stdlib/TestAsset/TestOptions.php
@@ -2,12 +2,12 @@
 
 namespace ZendTest\Stdlib\TestAsset;
 
-use Zend\Stdlib\Options;
+use Zend\Stdlib\AbstractOptions;
 
 /**
  * Dummy TestOptions used to test Stdlib\Options
  */
-class TestOptions extends Options
+class TestOptions extends AbstractOptions
 {
     protected $testField;
     


### PR DESCRIPTION
Renamed abstract classes
Fixed use statements

[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=stdlib)](http://travis-ci.org/prolic/zf2)
