### PR TITLE
Added Math\BigInteger::abs()

### DIFF
--- a/library/Zend/Math/BigInteger/Adapter/AdapterInterface.php
+++ b/library/Zend/Math/BigInteger/Adapter/AdapterInterface.php
@@ -86,6 +86,14 @@ interface AdapterInterface
     public function sqrt($operand);
 
     /**
+     * Get absolute value of a big integer
+     *
+     * @param  string $operand
+     * @return string
+     */
+    public function abs($operand);
+
+    /**
      * Get modulus of a big integer
      *
      * @param  string $leftOperand

--- a/library/Zend/Math/BigInteger/Adapter/Bcmath.php
+++ b/library/Zend/Math/BigInteger/Adapter/Bcmath.php
@@ -158,6 +158,20 @@ class Bcmath implements AdapterInterface
     }
 
     /**
+     * Get absolute value of a big integer
+     *
+     * @param  string $operand
+     * @return string
+     */
+    public function abs($operand)
+    {
+        if ('-' == $operand[0]) {
+            return substr($operand, 1);
+        }
+        return $operand;
+    }
+
+    /**
      * Get modulus of a big integer
      *
      * @param  string $leftOperand

--- a/library/Zend/Math/BigInteger/Adapter/Gmp.php
+++ b/library/Zend/Math/BigInteger/Adapter/Gmp.php
@@ -139,6 +139,18 @@ class Gmp implements AdapterInterface
     }
 
     /**
+     * Get absolute value of a big integer
+     *
+     * @param  string $operand
+     * @return string
+     */
+    public function abs($operand)
+    {
+        $result = gmp_abs($operand);
+        return gmp_strval($result);
+    }
+
+    /**
      * Get modulus of a big integer
      *
      * @param  string $leftOperand

--- a/tests/Zend/Math/BigInteger/Adapter/BcmathTest.php
+++ b/tests/Zend/Math/BigInteger/Adapter/BcmathTest.php
@@ -148,8 +148,8 @@ class BcmathTest extends \PHPUnit_Framework_TestCase
 
     public function testAbs()
     {
-        $this->assertSame('1152921504606847103.14159', $this->adapter->abs('1152921504606847103.14159'));
-        $this->assertSame('1152921504606847103.14159', $this->adapter->abs('-1152921504606847103.14159'));
+        $this->assertSame('1152921504606847103', $this->adapter->abs('1152921504606847103'));
+        $this->assertSame('1152921504606847103', $this->adapter->abs('-1152921504606847103'));
     }
 
     public function testIntegerToBinaryConversion()

--- a/tests/Zend/Math/BigInteger/Adapter/BcmathTest.php
+++ b/tests/Zend/Math/BigInteger/Adapter/BcmathTest.php
@@ -146,6 +146,12 @@ class BcmathTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('2', $this->adapter->sqrt('4'));
     }
 
+    public function testAbs()
+    {
+        $this->assertSame('1152921504606847103.14159', $this->adapter->abs('1152921504606847103.14159'));
+        $this->assertSame('1152921504606847103.14159', $this->adapter->abs('-1152921504606847103.14159'));
+    }
+
     public function testIntegerToBinaryConversion()
     {
         // zero

--- a/tests/Zend/Math/BigInteger/Adapter/GmpTest.php
+++ b/tests/Zend/Math/BigInteger/Adapter/GmpTest.php
@@ -153,8 +153,8 @@ class GmpTest extends \PHPUnit_Framework_TestCase
 
     public function testAbs()
     {
-        $this->assertSame('1152921504606847103.14159', $this->adapter->abs('1152921504606847103.14159'));
-        $this->assertSame('1152921504606847103.14159', $this->adapter->abs('-1152921504606847103.14159'));
+        $this->assertSame('1152921504606847103', $this->adapter->abs('1152921504606847103'));
+        $this->assertSame('1152921504606847103', $this->adapter->abs('-1152921504606847103'));
     }
 
     public function testIntegerToBinaryConversion()

--- a/tests/Zend/Math/BigInteger/Adapter/GmpTest.php
+++ b/tests/Zend/Math/BigInteger/Adapter/GmpTest.php
@@ -151,6 +151,11 @@ class GmpTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('2', $this->adapter->sqrt('4'));
     }
 
+    public function testAbs()
+    {
+        $this->assertSame('1152921504606847103.14159', $this->adapter->abs('1152921504606847103.14159'));
+        $this->assertSame('1152921504606847103.14159', $this->adapter->abs('-1152921504606847103.14159'));
+    }
 
     public function testIntegerToBinaryConversion()
     {


### PR DESCRIPTION
I don't have GMP installed, so someone needs to check to make sure that works (It _should_ work).

For BcMath I'm just stripping off the first hyphen, if it exists. Is that good enough?
