### PR TITLE
[zen-52] Renamed abstract classes in Zend\TimeSync, fixed CS and phpdoc

### DIFF
--- a/documentation/manual/en/module_specs/Zend_TimeSync-Working.xml
+++ b/documentation/manual/en/module_specs/Zend_TimeSync-Working.xml
@@ -27,7 +27,7 @@
         <programlisting language="php"><![CDATA[
 $server = new Zend_TimeSync('0.pool.ntp.org');
 
-print $server->getDate()->getIso();
+print $server->getDate()->format(DateTime::ISO8601);
 ]]></programlisting>
 
         <para>
@@ -37,13 +37,14 @@ print $server->getDate()->getIso();
             for a time server. Then when calling <methodname>getDate()</methodname> the actual set
             time server is requested and it will return its own time.
             <classname>Zend_TimeSync</classname> then calculates the difference to the actual time
-            of the server running the script and returns a <classname>Zend_Date</classname> object
+            of the server running the script and returns a <classname>DateTime</classname> object
             with the correct time.
         </para>
 
         <para>
-            For details about <classname>Zend_Date</classname> and its methods see the <link linkend="zend.date.introduction"><classname>Zend_Date</classname>
-                documentation</link>.
+            For details about <classname>DateTime</classname> and its methods see the
+            <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://php.net/class.datetime.php">
+                <classname>DateTime</classname>documentation</link>.
         </para>
     </section>
 
@@ -70,7 +71,7 @@ $server = new Zend_TimeSync(array('0.pool.ntp.org',
                                   '2.pool.ntp.org'));
 $server->addServer('3.pool.ntp.org');
 
-print $server->getDate()->getIso();
+print $server->getDate()->format(DateTime::ISO8601);
 ]]></programlisting>
 
         <para>
@@ -92,7 +93,7 @@ $server = new Zend_TimeSync(array('generic'  => '0.pool.ntp.org',
                                   'reserve'  => '2.pool.ntp.org'));
 $server->addServer('3.pool.ntp.org', 'additional');
 
-print $server->getDate()->getIso();
+print $server->getDate()->format(DateTime::ISO8601);
 ]]></programlisting>
 
         <para>
@@ -124,7 +125,7 @@ $server = new Zend_TimeSync(array('generic'  => 'ntp:\\0.pool.ntp.org',
                                   'reserve'  => 'ntp:\\2.pool.ntp.org'));
 $server->addServer('sntp:\\internal.myserver.com', 'additional');
 
-print $server->getDate()->getIso();
+print $server->getDate()->format(DateTime::ISO8601);
 ]]></programlisting>
 
         <para>
@@ -154,7 +155,7 @@ $server = new Zend_TimeSync(array('generic'  => 'ntp:\\0.pool.ntp.org:200',
                                   'fallback' => 'ntp:\\1.pool.ntp.org'));
 $server->addServer('sntp:\\internal.myserver.com:399', 'additional');
 
-print $server->getDate()->getIso();
+print $server->getDate()->format(DateTime::ISO8601);
 ]]></programlisting>
     </section>
 
@@ -190,7 +191,7 @@ $server = new Zend_TimeSync(array('generic'  => 'ntp:\\0.pool.ntp.org',
                                   'fallback' => 'ntp:\\1.pool.ntp.org'));
 $server->addServer('sntp:\\internal.myserver.com', 'additional');
 
-print $server->getDate()->getIso();
+print $server->getDate()->format(DateTime::ISO8601);
 print_r(Zend_TimeSync::getOptions();
 print "Timeout = " . Zend_TimeSync::getOptions('timeout');
 ]]></programlisting>
@@ -265,7 +266,7 @@ $server = new Zend_TimeSync($serverlist);
 
 try {
     $result = $server->getDate();
-    echo $result->getIso();
+    echo $result->format(DateTime::ISO8601);
 } catch (Zend_TimeSync_Exception $e) {
 
     $exceptions = $e->get();

--- a/documentation/manual/en/module_specs/Zend_TimeSync.xml
+++ b/documentation/manual/en/module_specs/Zend_TimeSync.xml
@@ -22,7 +22,7 @@
 
         <para>
             <classname>Zend_TimeSync</classname> is not able to change the server's time, but it
-            will return a <link linkend="zend.date.introduction">Zend_Date</link> instance from
+            will return a <classname>DateTime</classname> instance from
             which the difference from the server's time can be worked with.
         </para>
     </note>

--- a/library/Zend/Date/Date.php
+++ b/library/Zend/Date/Date.php
@@ -136,7 +136,7 @@ class Date extends DateObject
      */
     public function __construct($date = null, $part = null, $locale = null)
     {
-        if (is_object($date) and !($date instanceof TimeSync\Protocol) and
+        if (is_object($date) and !($date instanceof TimeSync\AbstractProtocol) and
             !($date instanceof Date)) {
             if ($locale instanceof Locale) {
                 $locale = $date;
@@ -147,7 +147,7 @@ class Date extends DateObject
             }
         }
 
-        if (($date !== null) and !is_array($date) and !($date instanceof TimeSync\Protocol) and
+        if (($date !== null) and !is_array($date) and !($date instanceof TimeSync\AbstractProtocol) and
             !($date instanceof Date) and !defined($date) and Locale::isLocale($date, true)) {
             $locale = $date;
             $date   = null;
@@ -172,7 +172,7 @@ class Date extends DateObject
             }
         }
 
-        if ($date instanceof TimeSync\Protocol) {
+        if ($date instanceof TimeSync\AbstractProtocol) {
             $date = $date->getInfo();
             $date = $this->_getTime($date['offset']);
             $part = null;
@@ -277,7 +277,7 @@ class Date extends DateObject
                         if ($value === null) {
                             parent::$_defaultOffset = 0;
                         } else {
-                            if (!$value instanceof TimeSync\Protocol) {
+                            if (!$value instanceof TimeSync\AbstractProtocol) {
                                 throw new Exception\InvalidArgumentException("Instance of Zend_TimeSync expected for option timesync");
                             }
 

--- a/library/Zend/TimeSync/AbstractProtocol.php
+++ b/library/Zend/TimeSync/AbstractProtocol.php
@@ -30,7 +30,7 @@ use DateTime;
  * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class Protocol
+abstract class AbstractProtocol
 {
     /**
      * Holds the current socket connection
@@ -94,7 +94,7 @@ abstract class Protocol
      * Connect to the specified timeserver.
      *
      * @return void
-     * @throws Exception\ExceptionInterface When the connection failed
+     * @throws Exception\RuntimeException When the connection failed
      */
     protected function _connect()
     {

--- a/library/Zend/TimeSync/Exception/ExceptionInterface.php
+++ b/library/Zend/TimeSync/Exception/ExceptionInterface.php
@@ -29,4 +29,5 @@ namespace Zend\TimeSync\Exception;
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
 interface ExceptionInterface
-{}
+{
+}

--- a/library/Zend/TimeSync/Exception/InvalidArgumentException.php
+++ b/library/Zend/TimeSync/Exception/InvalidArgumentException.php
@@ -29,7 +29,6 @@ namespace Zend\TimeSync\Exception;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class InvalidArgumentException
-    extends \InvalidArgumentException
-    implements ExceptionInterface
-{}
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/library/Zend/TimeSync/Exception/OutOfBoundsException.php
+++ b/library/Zend/TimeSync/Exception/OutOfBoundsException.php
@@ -29,7 +29,6 @@ namespace Zend\TimeSync\Exception;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class OutOfBoundsException
-    extends \OutOfBoundsException
-    implements ExceptionInterface
-{}
+class OutOfBoundsException extends \OutOfBoundsException implements ExceptionInterface
+{
+}

--- a/library/Zend/TimeSync/Exception/RuntimeException.php
+++ b/library/Zend/TimeSync/Exception/RuntimeException.php
@@ -29,7 +29,6 @@ namespace Zend\TimeSync\Exception;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class RuntimeException
-    extends \RuntimeException
-    implements ExceptionInterface
-{}
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/library/Zend/TimeSync/Ntp.php
+++ b/library/Zend/TimeSync/Ntp.php
@@ -30,7 +30,7 @@ use Zend\TimeSync\Exception;
  * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Ntp extends Protocol
+class Ntp extends AbstractProtocol
 {
     /**
      * NTP port number (123) assigned by the Internet Assigned Numbers Authority

--- a/library/Zend/TimeSync/Protocol.php
+++ b/library/Zend/TimeSync/Protocol.php
@@ -20,7 +20,7 @@
 
 namespace Zend\TimeSync;
 
-use Zend\TimeSync\Exception;
+use DateTime;
 
 /**
  * Abstract class definition for all timeserver protocols
@@ -137,15 +137,16 @@ abstract class Protocol
     /**
      * Query this timeserver without using the fallback mechanism
      *
-     * @param  string|\Zend\Locale\Locale $locale (Optional) Locale
-     * @return \Zend\Date\Date
+     * @return DateTime
      */
-    public function getDate($locale = null)
+    public function getDate()
     {
         $this->_write($this->_prepare());
-        $timestamp = $this->_extract($this->_read());
+        $this->_extract($this->_read());
 
-        $date = new \Zend\Date\Date($this, null, $locale);
-        return $date;
+        // Apply to the local time the offset obtained from the server
+        $info = $this->getInfo();
+        $time = (time() + round($info['offset']));
+        return date_timestamp_set(new DateTime(), $time);
     }
 }

--- a/library/Zend/TimeSync/Sntp.php
+++ b/library/Zend/TimeSync/Sntp.php
@@ -28,7 +28,7 @@ namespace Zend\TimeSync;
  * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Sntp extends Protocol
+class Sntp extends AbstractProtocol
 {
     /**
      * Port number for this timeserver

--- a/library/Zend/TimeSync/TimeSync.php
+++ b/library/Zend/TimeSync/TimeSync.php
@@ -228,16 +228,15 @@ class TimeSync implements IteratorAggregate
      * facade and will try to return the date from the first server that
      * returns a valid result.
      *
-     * @param  Zend_Locale $locale OPTIONAL locale
-     * @return TimeSync
+     * @return \DateTime
      * @throws Exception\RuntimeException
      */
-    public function getDate($locale = null)
+    public function getDate()
     {
         foreach ($this->_timeservers as $alias => $server) {
             $this->_current = $server;
             try {
-                return $server->getDate($locale);
+                return $server->getDate();
             } catch (Exception\ExceptionInterface $e) {
                 if (!isset($masterException)) {
                     $masterException = new Exception\RuntimeException($e->getMessage(), $e->getCode());

--- a/library/Zend/TimeSync/TimeSync.php
+++ b/library/Zend/TimeSync/TimeSync.php
@@ -20,9 +20,10 @@
 
 namespace Zend\TimeSync;
 
-use Zend\TimeSync\Exception,
-    ArrayObject,
-    IteratorAggregate;
+use ArrayObject;
+use DateTime;
+use IteratorAggregate;
+use Zend\TimeSync\Exception;
 
 /**
  * @category   Zend
@@ -77,7 +78,6 @@ class TimeSync implements IteratorAggregate
      *
      * @param  string|array $target - OPTIONAL single timeserver, or an array of timeservers.
      * @param  string       $alias  - OPTIONAL an alias for this timeserver
-     * @return  object
      */
     public function __construct($target = null, $alias = null)
     {
@@ -228,7 +228,7 @@ class TimeSync implements IteratorAggregate
      * facade and will try to return the date from the first server that
      * returns a valid result.
      *
-     * @return \DateTime
+     * @return DateTime
      * @throws Exception\RuntimeException
      */
     public function getDate()
@@ -254,6 +254,7 @@ class TimeSync implements IteratorAggregate
      *
      * @param  string|array $target   - Single timeserver, or an array of timeservers.
      * @param  string       $alias    - An alias for this timeserver
+     * @throws Exception\RuntimeException
      */
     protected function _addServer($target, $alias)
     {

--- a/tests/Zend/TimeSync/TimeSyncTest.php
+++ b/tests/Zend/TimeSync/TimeSyncTest.php
@@ -67,7 +67,7 @@ class TimeSyncTest extends \PHPUnit_Framework_TestCase
         $server = new TimeSync\TimeSync($this->timeservers);
         $result = $server->getServer('server_f');
 
-        $this->assertInstanceOf('Zend\TimeSync\Protocol', $result);
+        $this->assertInstanceOf('Zend\TimeSync\AbstractProtocol', $result);
     }
 
     /**
@@ -295,7 +295,7 @@ class TimeSyncTest extends \PHPUnit_Framework_TestCase
         $servers = new TimeSync\TimeSync($this->timeservers);
 
         foreach ($servers as $key => $server) {
-            $this->assertInstanceOf('Zend\TimeSync\Protocol', $server);
+            $this->assertInstanceOf('Zend\TimeSync\AbstractProtocol', $server);
         }
     }
 


### PR DESCRIPTION
see also: https://github.com/zendframework/zf2/pull/1614

[![Build Status](https://secure.travis-ci.org/prolic/zf2.png?branch=timesync)](http://travis-ci.org/prolic/zf2)
