### PR TITLE
Fixing FilterChain for plugins via ServiceManager.

### DIFF
--- a/library/Zend/Filter/FilterChain.php
+++ b/library/Zend/Filter/FilterChain.php
@@ -188,10 +188,6 @@ class FilterChain extends AbstractFilter implements Countable
             $options = (array) $options;
         } elseif (empty($options)) {
             $options = null;
-        } else {
-            if (range(0, count($options) - 1) != array_keys($options)) {
-                $options = array($options);
-            }
         }
         $filter = $this->getPluginManager()->get($name, $options);
         return $this->attach($filter, $priority);

--- a/library/Zend/Filter/Word/AbstractSeparator.php
+++ b/library/Zend/Filter/Word/AbstractSeparator.php
@@ -41,6 +41,13 @@ abstract class AbstractSeparator extends PregReplaceFilter
      */
     public function __construct($separator = ' ')
     {
+        if (is_array($separator)) {
+            $temp = ' ';
+            if (isset($separator['separator']) && is_string($separator['separator'])) {
+                $temp = $separator['separator'];
+            }
+            $separator = $temp;
+        }
         $this->setSeparator($separator);
     }
 
@@ -52,7 +59,7 @@ abstract class AbstractSeparator extends PregReplaceFilter
      */
     public function setSeparator($separator)
     {
-        if ($separator == null) {
+        if (!is_string($separator)) {
             throw new \Zend\Filter\Exception\InvalidArgumentException('"' . $separator . '" is not a valid separator.');
         }
         $this->_separator = $separator;

--- a/tests/Zend/Filter/FilterChainTest.php
+++ b/tests/Zend/Filter/FilterChainTest.php
@@ -91,8 +91,8 @@ class FilterChainTest extends \PHPUnit_Framework_TestCase
         $config = $this->getChainConfig();
         $chain  = new FilterChain();
         $chain->setOptions($config);
-        $value = '<a name="foo"> abc </a>';
-        $valueExpected = 'ABC';
+        $value = '<a name="foo"> abc </a><img id="bar" />';
+        $valueExpected = 'ABC <IMG ID="BAR" />';
         $this->assertEquals($valueExpected, $chain->filter($value));
     }
 
@@ -136,7 +136,7 @@ class FilterChainTest extends \PHPUnit_Framework_TestCase
                 }),
             ),
             'filters' => array(
-                array('name' => 'strip_tags', 'options' => array('encoding' => 'utf-8'), 'priority' => 10100),
+                array('name' => 'strip_tags', 'options' => array('allowTags' => 'img', 'allowAttribs' => 'id'), 'priority' => 10100),
             ),
         );
     }


### PR DESCRIPTION
Also, the word filters need to accept arrays or else they can't be attached with attachByName.
