### PR TITLE
Made the messages in Zend\Validator more discreet.

### DIFF
--- a/library/Zend/Validator/Alnum.php
+++ b/library/Zend/Validator/Alnum.php
@@ -48,8 +48,8 @@ class Alnum extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID      => "Invalid type given. String, integer or float expected",
-        self::NOT_ALNUM    => "'%value%' contains characters which are non alphabetic and no digits",
-        self::STRING_EMPTY => "'%value%' is an empty string",
+        self::NOT_ALNUM    => "The input contains characters which are non alphabetic and no digits",
+        self::STRING_EMPTY => "The input is an empty string",
     );
 
     /**

--- a/library/Zend/Validator/Alpha.php
+++ b/library/Zend/Validator/Alpha.php
@@ -55,8 +55,8 @@ class Alpha extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID      => "Invalid type given. String expected",
-        self::NOT_ALPHA    => "'%value%' contains non alphabetic characters",
-        self::STRING_EMPTY => "'%value%' is an empty string"
+        self::NOT_ALPHA    => "The input contains non alphabetic characters",
+        self::STRING_EMPTY => "The input is an empty string"
     );
 
     /**

--- a/library/Zend/Validator/Barcode.php
+++ b/library/Zend/Validator/Barcode.php
@@ -36,9 +36,9 @@ class Barcode extends AbstractValidator
     const INVALID_LENGTH = 'barcodeInvalidLength';
 
     protected $messageTemplates = array(
-        self::FAILED         => "'%value%' failed checksum validation",
-        self::INVALID_CHARS  => "'%value%' contains invalid characters",
-        self::INVALID_LENGTH => "'%value%' should have a length of %length% characters",
+        self::FAILED         => "The input failed checksum validation",
+        self::INVALID_CHARS  => "The input contains invalid characters",
+        self::INVALID_LENGTH => "The input should have a length of %length% characters",
         self::INVALID        => "Invalid type given. String expected",
     );
 

--- a/library/Zend/Validator/Between.php
+++ b/library/Zend/Validator/Between.php
@@ -40,8 +40,8 @@ class Between extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_BETWEEN        => "'%value%' is not between '%min%' and '%max%', inclusively",
-        self::NOT_BETWEEN_STRICT => "'%value%' is not strictly between '%min%' and '%max%'"
+        self::NOT_BETWEEN        => "The input is not between '%min%' and '%max%', inclusively",
+        self::NOT_BETWEEN_STRICT => "The input is not strictly between '%min%' and '%max%'"
     );
 
     /**

--- a/library/Zend/Validator/Callback.php
+++ b/library/Zend/Validator/Callback.php
@@ -44,7 +44,7 @@ class Callback extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID_VALUE    => "'%value%' is not valid",
+        self::INVALID_VALUE    => "The input is not valid",
         self::INVALID_CALLBACK => "An exception has been raised within the callback",
     );
 

--- a/library/Zend/Validator/CreditCard.php
+++ b/library/Zend/Validator/CreditCard.php
@@ -69,7 +69,7 @@ class CreditCard extends AbstractValidator
         self::LENGTH         => "The input contains an invalid amount of digits",
         self::PREFIX         => "The input is not from an allowed institute",
         self::SERVICE        => "The input seems to be an invalid creditcard number",
-        self::SERVICEFAILURE => "An exception has been raised while validating '%value%'",
+        self::SERVICEFAILURE => "An exception has been raised while validating the input.",
     );
 
     /**

--- a/library/Zend/Validator/CreditCard.php
+++ b/library/Zend/Validator/CreditCard.php
@@ -63,12 +63,12 @@ class CreditCard extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::CHECKSUM       => "'%value%' seems to contain an invalid checksum",
-        self::CONTENT        => "'%value%' must contain only digits",
+        self::CHECKSUM       => "The input seems to contain an invalid checksum",
+        self::CONTENT        => "The input must contain only digits",
         self::INVALID        => "Invalid type given. String expected",
-        self::LENGTH         => "'%value%' contains an invalid amount of digits",
-        self::PREFIX         => "'%value%' is not from an allowed institute",
-        self::SERVICE        => "'%value%' seems to be an invalid creditcard number",
+        self::LENGTH         => "The input contains an invalid amount of digits",
+        self::PREFIX         => "The input is not from an allowed institute",
+        self::SERVICE        => "The input seems to be an invalid creditcard number",
         self::SERVICEFAILURE => "An exception has been raised while validating '%value%'",
     );
 

--- a/library/Zend/Validator/Date.php
+++ b/library/Zend/Validator/Date.php
@@ -42,8 +42,8 @@ class Date extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID        => "Invalid type given. String, integer, array or DateTime expected",
-        self::INVALID_DATE   => "'%value%' does not appear to be a valid date",
-        self::FALSEFORMAT    => "'%value%' does not fit the date format '%format%'",
+        self::INVALID_DATE   => "The input does not appear to be a valid date",
+        self::FALSEFORMAT    => "The input does not fit the date format '%format%'",
     );
 
     /**

--- a/library/Zend/Validator/DateStep.php
+++ b/library/Zend/Validator/DateStep.php
@@ -45,8 +45,8 @@ class DateStep extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID      => "Invalid type given. String, integer, array or DateTime expected",
-        self::INVALID_DATE => "'%value%' does not appear to be a valid date",
-        self::NOT_STEP     => "'%value%' is not a valid step."
+        self::INVALID_DATE => "The input does not appear to be a valid date",
+        self::NOT_STEP     => "The input is not a valid step."
     );
 
     /**

--- a/library/Zend/Validator/Db/AbstractDb.php
+++ b/library/Zend/Validator/Db/AbstractDb.php
@@ -48,8 +48,8 @@ abstract class AbstractDb extends AbstractValidator
      * @var array Message templates
      */
     protected $messageTemplates = array(
-        self::ERROR_NO_RECORD_FOUND => "No record matching '%value%' was found",
-        self::ERROR_RECORD_FOUND    => "A record matching '%value%' was found",
+        self::ERROR_NO_RECORD_FOUND => "No record matching the input was found",
+        self::ERROR_RECORD_FOUND    => "A record matching the input was found",
     );
 
     /**

--- a/library/Zend/Validator/Digits.php
+++ b/library/Zend/Validator/Digits.php
@@ -47,8 +47,8 @@ class Digits extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_DIGITS   => "'%value%' must contain only digits",
-        self::STRING_EMPTY => "'%value%' is an empty string",
+        self::NOT_DIGITS   => "The input must contain only digits",
+        self::STRING_EMPTY => "The input is an empty string",
         self::INVALID      => "Invalid type given. String, integer or float expected",
     );
 

--- a/library/Zend/Validator/EmailAddress.php
+++ b/library/Zend/Validator/EmailAddress.php
@@ -43,14 +43,14 @@ class EmailAddress extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID            => "Invalid type given. String expected",
-        self::INVALID_FORMAT     => "'%value%' is not a valid email address. Use the basic format local-part@hostname",
-        self::INVALID_HOSTNAME   => "'%hostname%' is not a valid hostname for email address '%value%'",
-        self::INVALID_MX_RECORD  => "'%hostname%' does not appear to have a valid MX record for the email address '%value%'",
-        self::INVALID_SEGMENT    => "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network",
+        self::INVALID_FORMAT     => "The input is not a valid email address. Use the basic format local-part@hostname",
+        self::INVALID_HOSTNAME   => "'%hostname%' is not a valid hostname for the email address",
+        self::INVALID_MX_RECORD  => "'%hostname%' does not appear to have a valid MX record for the email address",
+        self::INVALID_SEGMENT    => "'%hostname%' is not in a routable network segment. The email address should not be resolved from public network",
         self::DOT_ATOM           => "'%localPart%' can not be matched against dot-atom format",
         self::QUOTED_STRING      => "'%localPart%' can not be matched against quoted-string format",
-        self::INVALID_LOCAL_PART => "'%localPart%' is not a valid local part for email address '%value%'",
-        self::LENGTH_EXCEEDED    => "'%value%' exceeds the allowed length",
+        self::INVALID_LOCAL_PART => "'%localPart%' is not a valid local part for the email address",
+        self::LENGTH_EXCEEDED    => "The input exceeds the allowed length",
     );
 
     /**

--- a/library/Zend/Validator/Float.php
+++ b/library/Zend/Validator/Float.php
@@ -40,7 +40,7 @@ class Float extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID   => "Invalid type given. String, integer or float expected",
-        self::NOT_FLOAT => "'%value%' does not appear to be a float",
+        self::NOT_FLOAT => "The input does not appear to be a float",
     );
 
     /**

--- a/library/Zend/Validator/GreaterThan.php
+++ b/library/Zend/Validator/GreaterThan.php
@@ -40,8 +40,8 @@ class GreaterThan extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_GREATER => "'%value%' is not greater than '%min%'",
-        self::NOT_GREATER_INCLUSIVE => "'%value' is not greater or equal than '%min%'"
+        self::NOT_GREATER => "The input is not greater than '%min%'",
+        self::NOT_GREATER_INCLUSIVE => "The input is not greater or equal than '%min%'"
     );
 
     /**

--- a/library/Zend/Validator/Hex.php
+++ b/library/Zend/Validator/Hex.php
@@ -38,7 +38,7 @@ class Hex extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID => "Invalid type given. String expected",
-        self::NOT_HEX => "'%value%' has not only hexadecimal digit characters",
+        self::NOT_HEX => "The input contains non-hexadecimal characters",
     );
 
     /**

--- a/library/Zend/Validator/Hostname.php
+++ b/library/Zend/Validator/Hostname.php
@@ -53,17 +53,17 @@ class Hostname extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::CANNOT_DECODE_PUNYCODE  => "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded",
+        self::CANNOT_DECODE_PUNYCODE  => "The input appears to be a DNS hostname but the given punycode notation cannot be decoded",
         self::INVALID                 => "Invalid type given. String expected",
-        self::INVALID_DASH            => "'%value%' appears to be a DNS hostname but contains a dash in an invalid position",
-        self::INVALID_HOSTNAME        => "'%value%' does not match the expected structure for a DNS hostname",
-        self::INVALID_HOSTNAME_SCHEMA => "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'",
-        self::INVALID_LOCAL_NAME      => "'%value%' does not appear to be a valid local network name",
-        self::INVALID_URI             => "'%value%' does not appear to be a valid URI hostname",
-        self::IP_ADDRESS_NOT_ALLOWED  => "'%value%' appears to be an IP address, but IP addresses are not allowed",
-        self::LOCAL_NAME_NOT_ALLOWED  => "'%value%' appears to be a local network name but local network names are not allowed",
-        self::UNDECIPHERABLE_TLD      => "'%value%' appears to be a DNS hostname but cannot extract TLD part",
-        self::UNKNOWN_TLD             => "'%value%' appears to be a DNS hostname but cannot match TLD against known list",
+        self::INVALID_DASH            => "The input appears to be a DNS hostname but contains a dash in an invalid position",
+        self::INVALID_HOSTNAME        => "The input does not match the expected structure for a DNS hostname",
+        self::INVALID_HOSTNAME_SCHEMA => "The input appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'",
+        self::INVALID_LOCAL_NAME      => "The input does not appear to be a valid local network name",
+        self::INVALID_URI             => "The input does not appear to be a valid URI hostname",
+        self::IP_ADDRESS_NOT_ALLOWED  => "The input appears to be an IP address, but IP addresses are not allowed",
+        self::LOCAL_NAME_NOT_ALLOWED  => "The input appears to be a local network name but local network names are not allowed",
+        self::UNDECIPHERABLE_TLD      => "The input appears to be a DNS hostname but cannot extract TLD part",
+        self::UNKNOWN_TLD             => "The input appears to be a DNS hostname but cannot match TLD against known list",
     );
 
     /**

--- a/library/Zend/Validator/Iban.php
+++ b/library/Zend/Validator/Iban.php
@@ -44,9 +44,9 @@ class Iban extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOTSUPPORTED => "Unknown country within the IBAN '%value%'",
-        self::FALSEFORMAT  => "'%value%' has a false IBAN format",
-        self::CHECKFAILED  => "'%value%' has failed the IBAN check",
+        self::NOTSUPPORTED => "Unknown country within the IBAN",
+        self::FALSEFORMAT  => "The input has a false IBAN format",
+        self::CHECKFAILED  => "The input has failed the IBAN check",
     );
 
     /**

--- a/library/Zend/Validator/InArray.php
+++ b/library/Zend/Validator/InArray.php
@@ -37,7 +37,7 @@ class InArray extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_IN_ARRAY => "'%value%' was not found in the haystack",
+        self::NOT_IN_ARRAY => "The input was not found in the haystack",
     );
 
     /**

--- a/library/Zend/Validator/Int.php
+++ b/library/Zend/Validator/Int.php
@@ -41,7 +41,7 @@ class Int extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID => "Invalid type given. String or integer expected",
-        self::NOT_INT => "'%value%' does not appear to be an integer",
+        self::NOT_INT => "The input does not appear to be an integer",
     );
 
     protected $locale;

--- a/library/Zend/Validator/Ip.php
+++ b/library/Zend/Validator/Ip.php
@@ -39,7 +39,7 @@ class Ip extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID        => 'Invalid type given. String expected',
-        self::NOT_IP_ADDRESS => "'%value%' does not appear to be a valid IP address",
+        self::NOT_IP_ADDRESS => "The input does not appear to be a valid IP address",
     );
 
     /**

--- a/library/Zend/Validator/Isbn.php
+++ b/library/Zend/Validator/Isbn.php
@@ -41,7 +41,7 @@ class Isbn extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID => "Invalid type given. String or integer expected",
-        self::NO_ISBN => "'%value%' is not a valid ISBN number",
+        self::NO_ISBN => "The input is not a valid ISBN number",
     );
 
     protected $options = array(

--- a/library/Zend/Validator/LessThan.php
+++ b/library/Zend/Validator/LessThan.php
@@ -40,8 +40,8 @@ class LessThan extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_LESS           => "'%value%' is not less than '%max%'",
-        self::NOT_LESS_INCLUSIVE => "'%value%' is not less or equal than '%max%'"
+        self::NOT_LESS           => "The input is not less than '%max%'",
+        self::NOT_LESS_INCLUSIVE => "The input is not less or equal than '%max%'"
     );
 
     /**

--- a/library/Zend/Validator/PostCode.php
+++ b/library/Zend/Validator/PostCode.php
@@ -41,9 +41,9 @@ class PostCode extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID        => "Invalid type given. String or integer expected",
-        self::NO_MATCH       => "'%value%' does not appear to be a postal code",
-        self::SERVICE        => "'%value%' does not appear to be a postal code",
-        self::SERVICEFAILURE => "An exception has been raised while validating '%value%'",
+        self::NO_MATCH       => "The input does not appear to be a postal code",
+        self::SERVICE        => "The input does not appear to be a postal code",
+        self::SERVICEFAILURE => "An exception has been raised while validating the input.",
     );
 
     /**

--- a/library/Zend/Validator/Regex.php
+++ b/library/Zend/Validator/Regex.php
@@ -40,7 +40,7 @@ class Regex extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID   => "Invalid type given. String, integer or float expected",
-        self::NOT_MATCH => "'%value%' does not match against pattern '%pattern%'",
+        self::NOT_MATCH => "The input does not match against pattern '%pattern%'",
         self::ERROROUS  => "There was an internal error while using the pattern '%pattern%'",
     );
 

--- a/library/Zend/Validator/Sitemap/Changefreq.php
+++ b/library/Zend/Validator/Sitemap/Changefreq.php
@@ -49,7 +49,7 @@ class Changefreq extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_VALID => "'%value%' is not a valid sitemap changefreq",
+        self::NOT_VALID => "The input is not a valid sitemap changefreq",
         self::INVALID   => "Invalid type given. String expected",
     );
 

--- a/library/Zend/Validator/Sitemap/Lastmod.php
+++ b/library/Zend/Validator/Sitemap/Lastmod.php
@@ -55,7 +55,7 @@ class Lastmod extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_VALID => "'%value%' is not a valid sitemap lastmod",
+        self::NOT_VALID => "The input is not a valid sitemap lastmod",
         self::INVALID   => "Invalid type given. String expected",
     );
 

--- a/library/Zend/Validator/Sitemap/Loc.php
+++ b/library/Zend/Validator/Sitemap/Loc.php
@@ -51,7 +51,7 @@ class Loc extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_VALID => "'%value%' is not a valid sitemap location",
+        self::NOT_VALID => "The input is not a valid sitemap location",
         self::INVALID   => "Invalid type given. String expected",
     );
 

--- a/library/Zend/Validator/Sitemap/Priority.php
+++ b/library/Zend/Validator/Sitemap/Priority.php
@@ -49,7 +49,7 @@ class Priority extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_VALID => "'%value%' is not a valid sitemap priority",
+        self::NOT_VALID => "The input is not a valid sitemap priority",
         self::INVALID   => "Invalid type given. Numeric string, integer or float expected",
     );
 

--- a/library/Zend/Validator/Step.php
+++ b/library/Zend/Validator/Step.php
@@ -38,7 +38,7 @@ class Step extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID => "Invalid value given. Scalar expected.",
-        self::NOT_STEP => "'%value%' is not a valid step."
+        self::NOT_STEP => "The input is not a valid step."
     );
 
     /**

--- a/library/Zend/Validator/StringLength.php
+++ b/library/Zend/Validator/StringLength.php
@@ -37,8 +37,8 @@ class StringLength extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID   => "Invalid type given. String expected",
-        self::TOO_SHORT => "'%value%' is less than %min% characters long",
-        self::TOO_LONG  => "'%value%' is more than %max% characters long",
+        self::TOO_SHORT => "The input is less than %min% characters long",
+        self::TOO_LONG  => "The input is more than %max% characters long",
     );
 
     /**

--- a/library/Zend/Validator/Uri.php
+++ b/library/Zend/Validator/Uri.php
@@ -40,7 +40,7 @@ class Uri extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID => "Invalid type given. String expected",
-        self::NOT_URI => "'%value%' does not appear to be a valid Uri",
+        self::NOT_URI => "The input does not appear to be a valid Uri",
     );
 
     /**

--- a/tests/Zend/Validator/AlnumTest.php
+++ b/tests/Zend/Validator/AlnumTest.php
@@ -119,7 +119,7 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->isValid(''));
         $messages = $this->validator->getMessages();
         $arrayExpected = array(
-            Alnum::STRING_EMPTY => '\'\' is an empty string'
+            Alnum::STRING_EMPTY => 'The input is an empty string'
             );
         $this->assertThat($messages, $this->identicalTo($arrayExpected));
     }
@@ -132,7 +132,7 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->isValid('#'));
         $messages = $this->validator->getMessages();
         $arrayExpected = array(
-            Alnum::NOT_ALNUM => '\'#\' contains characters which are non alphabetic and no digits'
+            Alnum::NOT_ALNUM => 'The input contains characters which are non alphabetic and no digits'
             );
         $this->assertThat($messages, $this->identicalTo($arrayExpected));
     }

--- a/tests/Zend/Validator/DigitsTest.php
+++ b/tests/Zend/Validator/DigitsTest.php
@@ -84,7 +84,7 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->isValid(''));
         $messages = $this->validator->getMessages();
         $arrayExpected = array(
-            Digits::STRING_EMPTY => '\'\' is an empty string'
+            Digits::STRING_EMPTY => 'The input is an empty string'
             );
         $this->assertThat($messages, $this->identicalTo($arrayExpected));
     }
@@ -97,7 +97,7 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->isValid('#'));
         $messages = $this->validator->getMessages();
         $arrayExpected = array(
-            Digits::NOT_DIGITS => '\'#\' must contain only digits'
+            Digits::NOT_DIGITS => 'The input must contain only digits'
             );
         $this->assertThat($messages, $this->identicalTo($arrayExpected));
     }

--- a/tests/Zend/Validator/MessageTest.php
+++ b/tests/Zend/Validator/MessageTest.php
@@ -54,7 +54,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $inputInvalid = 'abcdefghij';
         $this->assertFalse($this->validator->isValid($inputInvalid));
         $messages = $this->validator->getMessages();
-        $this->assertEquals("'$inputInvalid' is more than 8 characters long", current($messages));
+        $this->assertEquals("The input is more than 8 characters long", current($messages));
 
         $this->validator->setMessage(
             'Your value is too long',


### PR DESCRIPTION
The Zend\Validator messages often put the inputted value in the messages. I don't think that that is necessary in most cases and often it actually stands of the way of some things.

For example, if you have a password field, you don't want your password to be exposed to anyone standing behind you if your password doesn't conform to the StringLenght validator. In most use cases, the value in the message doesn't add much value either, because it usually will be displayed next to the given value.

Of course, the '%value%' replacement will still be done if anyone does actually wants this in the message. Also, I have left it in the File validators, because in there it means the File name, which actually is usefull in most cases.
