### PR TITLE
Allow compiler to skip classes when a ReflectionException occurs. 

### DIFF
--- a/tests/Zend/Di/Definition/CompilerDefinitionTest.php
+++ b/tests/Zend/Di/Definition/CompilerDefinitionTest.php
@@ -79,4 +79,24 @@ class CompilerDefinitionTest extends TestCase
         $this->assertContains('ZendTest\Di\TestAsset\CompilerClasses\C', $definition->getClassSupertypes('ZendTest\Di\TestAsset\CompilerClasses\E'));
         $this->assertContains('ZendTest\Di\TestAsset\CompilerClasses\D', $definition->getClassSupertypes('ZendTest\Di\TestAsset\CompilerClasses\E'));
     }
+
+    public function testCompilerReflectionException()
+    {
+        $this->setExpectedException('ReflectionException', 'Class ZendTest\Di\TestAsset\InvalidCompilerClasses\Foo does not exist');
+        $definition = new CompilerDefinition;
+        $definition->addDirectory(__DIR__ . '/../TestAsset/InvalidCompilerClasses');
+        $definition->compile();
+    }
+
+    public function testCompilerAllowReflectionException()
+    {
+        $definition = new CompilerDefinition;
+        $definition->setAllowReflectionExceptions();
+        $definition->addDirectory(__DIR__ . '/../TestAsset/InvalidCompilerClasses');
+        $definition->compile();
+        $parameters = $definition->getMethodParameters('ZendTest\Di\TestAsset\InvalidCompilerClasses\InvalidClass', '__construct');
+
+        // The exception gets caught before the parameter's class is set
+        $this->assertCount(1, current($parameters));
+    }
 }

--- a/tests/Zend/Di/TestAsset/InvalidCompilerClasses/InvalidClass.php
+++ b/tests/Zend/Di/TestAsset/InvalidCompilerClasses/InvalidClass.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ZendTest\Di\TestAsset\InvalidCompilerClasses;
+
+class InvalidClass
+{
+
+    public function __construct(Foo $foo)
+    {
+        $this->foo = $foo;
+    }
+}


### PR DESCRIPTION
The flag defaults to false so there is no change in behavior by default.

Should we add a disclaimer that the behavior of definitions compiled with this flag set is sort of unknown?
