### PR TITLE
Allow nested fieldsets

### DIFF
--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -70,11 +70,11 @@ class Fieldset extends Element implements FieldsetInterface
     /**
      * Add an element or fieldset
      *
-     * $flags could contain metadata such as the alias under which to register 
+     * $flags could contain metadata such as the alias under which to register
      * the element or fieldset, order in which to prioritize it, etc.
-     * 
+     *
      * @todo   Should we detect if the element/fieldset name conflicts?
-     * @param  ElementInterface $elementOrFieldset 
+     * @param  ElementInterface $elementOrFieldset
      * @param  array $flags
      * @return FieldsetInterface
      */
@@ -122,8 +122,8 @@ class Fieldset extends Element implements FieldsetInterface
 
     /**
      * Does the fieldset have an element/fieldset by the given name?
-     * 
-     * @param  string $elementOrFieldset 
+     *
+     * @param  string $elementOrFieldset
      * @return bool
      */
     public function has($elementOrFieldset)
@@ -133,9 +133,9 @@ class Fieldset extends Element implements FieldsetInterface
 
     /**
      * Retrieve a named element or fieldset
-     * 
+     *
      * @todo   Should this raise an exception if no entry is found?
-     * @param  string $elementOrFieldset 
+     * @param  string $elementOrFieldset
      * @return ElementInterface
      */
     public function get($elementOrFieldset)
@@ -148,8 +148,8 @@ class Fieldset extends Element implements FieldsetInterface
 
     /**
      * Remove a named element or fieldset
-     * 
-     * @param  string $elementOrFieldset 
+     *
+     * @param  string $elementOrFieldset
      * @return void
      */
     public function remove($elementOrFieldset)
@@ -166,7 +166,7 @@ class Fieldset extends Element implements FieldsetInterface
         if ($entry instanceof FieldsetInterface) {
             unset($this->fieldsets[$elementOrFieldset]);
             return;
-        } 
+        }
 
         unset($this->elements[$elementOrFieldset]);
         return;
@@ -176,7 +176,7 @@ class Fieldset extends Element implements FieldsetInterface
      * Retrieve all attached elements
      *
      * Storage is an implementation detail of the concrete class.
-     * 
+     *
      * @return array|Traversable
      */
     public function getElements()
@@ -186,9 +186,9 @@ class Fieldset extends Element implements FieldsetInterface
 
     /**
      * Retrieve all attached fieldsets
-     * 
+     *
      * Storage is an implementation detail of the concrete class.
-     * 
+     *
      * @return array|Traversable
      */
     public function getFieldsets()
@@ -226,11 +226,11 @@ class Fieldset extends Element implements FieldsetInterface
     /**
      * Get validation error messages, if any
      *
-     * Returns a hash of element names/messages for all elements failing 
-     * validation, or, if $elementName is provided, messages for that element 
+     * Returns a hash of element names/messages for all elements failing
+     * validation, or, if $elementName is provided, messages for that element
      * only.
-     * 
-     * @param  null|string $elementName 
+     *
+     * @param  null|string $elementName
      * @return array|Traversable
      */
     public function getMessages($elementName = null)
@@ -260,9 +260,29 @@ class Fieldset extends Element implements FieldsetInterface
     }
 
     /**
+     * Ensures state is ready for use. Here, we append the name of the fieldsets to every elements in order to avoid
+     * name clashes if the same fieldset is used multiple times
+     *
+     * @return void
+     */
+    public function prepare()
+    {
+        $name = $this->getName();
+
+        foreach($this->byName as $elementOrFieldset) {
+            $elementOrFieldset->setName($name . '[' . $elementOrFieldset->getName() . ']');
+
+            // Recursively prepare fieldsets
+            if ($elementOrFieldset instanceof FieldsetInterface) {
+                $elementOrFieldset->prepare();
+            }
+        }
+    }
+
+    /**
      * Recursively populate values of attached elements and fieldsets
-     * 
-     * @param  array|Traversable $data 
+     *
+     * @param  array|Traversable $data
      * @return void
      */
     public function populateValues($data)
@@ -292,7 +312,7 @@ class Fieldset extends Element implements FieldsetInterface
 
     /**
      * Countable: return count of attached elements/fieldsets
-     * 
+     *
      * @return int
      */
     public function count()
@@ -302,7 +322,7 @@ class Fieldset extends Element implements FieldsetInterface
 
     /**
      * IteratorAggregate: return internal iterator
-     * 
+     *
      * @return PriorityQueue
      */
     public function getIterator()

--- a/library/Zend/Form/FieldsetInterface.php
+++ b/library/Zend/Form/FieldsetInterface.php
@@ -29,19 +29,19 @@ use IteratorAggregate;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface FieldsetInterface extends 
+interface FieldsetInterface extends
     Countable,
-    IteratorAggregate, 
+    IteratorAggregate,
     ElementInterface
 {
     /**
      * Add an element or fieldset
      *
-     * $flags could contain metadata such as the alias under which to register 
+     * $flags could contain metadata such as the alias under which to register
      * the element or fieldset, order in which to prioritize it, etc.
-     * 
-     * @param  array|ElementInterface $elementOrFieldset Typically, only allow objects implementing ElementInterface; 
-     *                                                   however, keeping it flexible to allow a factory-based form 
+     *
+     * @param  array|ElementInterface $elementOrFieldset Typically, only allow objects implementing ElementInterface;
+     *                                                   however, keeping it flexible to allow a factory-based form
      *                                                   implementation as well
      * @param  array $flags
      * @return FieldsetInterface
@@ -50,24 +50,24 @@ interface FieldsetInterface extends
 
     /**
      * Does the fieldset have an element/fieldset by the given name?
-     * 
-     * @param  string $elementOrFieldset 
+     *
+     * @param  string $elementOrFieldset
      * @return bool
      */
     public function has($elementOrFieldset);
 
     /**
      * Retrieve a named element or fieldset
-     * 
-     * @param  string $elementOrFieldset 
+     *
+     * @param  string $elementOrFieldset
      * @return ElementInterface
      */
     public function get($elementOrFieldset);
 
     /**
      * Remove a named element or fieldset
-     * 
-     * @param  string $elementOrFieldset 
+     *
+     * @param  string $elementOrFieldset
      * @return void
      */
     public function remove($elementOrFieldset);
@@ -76,24 +76,31 @@ interface FieldsetInterface extends
      * Retrieve all attached elements
      *
      * Storage is an implementation detail of the concrete class.
-     * 
+     *
      * @return array|\Traversable
      */
     public function getElements();
 
     /**
      * Retrieve all attached fieldsets
-     * 
+     *
      * Storage is an implementation detail of the concrete class.
-     * 
+     *
      * @return array|\Traversable
      */
     public function getFieldsets();
 
     /**
+     * Ensures state is ready for use
+     *
+     * @return void
+     */
+    public function prepare();
+
+    /**
      * Recursively populate value attributes of elements
-     * 
-     * @param  array|\Traversable $data 
+     *
+     * @param  array|\Traversable $data
      * @return void
      */
     public function populateValues($data);

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -21,6 +21,7 @@
 namespace Zend\Form;
 
 use Traversable;
+use Zend\InputFilter\InputFilter;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputFilterProviderInterface;
 use Zend\InputFilter\InputProviderInterface;
@@ -186,12 +187,13 @@ class Form extends BaseForm implements FormFactoryAwareInterface
             $name = $fieldset->getName();
             if (!$fieldset instanceof InputFilterProviderInterface) {
                 if (!$inputFilter->has($name)) {
-                    // Not an input filter provider, and no matching input for this fieldset.
-                    // Nothing more to do for this one.
-                    continue;
+                    // Add a new empty input filter if it does not exist, so that elements of nested fieldsets can be
+                    // recursively added
+                    $inputFilter->add(new InputFilter(), $name);
                 }
 
                 $fieldsetFilter = $inputFilter->get($name);
+
                 if (!$fieldsetFilter instanceof InputFilterInterface) {
                     // Input attached for fieldset, not input filter; nothing more to do.
                     continue;

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -39,17 +39,17 @@ class Form extends BaseForm implements FormFactoryAwareInterface
     protected $factory;
 
     /**
-     * Whether or not to automatically scan for input filter defaults on 
+     * Whether or not to automatically scan for input filter defaults on
      * attached fieldsets and elements
-     * 
+     *
      * @var bool
      */
     protected $useInputFilterDefaults = true;
 
     /**
      * Compose a form factory to use when calling add() with a non-element/fieldset
-     * 
-     * @param  Factory $factory 
+     *
+     * @param  Factory $factory
      * @return Form
      */
     public function setFormFactory(Factory $factory)
@@ -62,7 +62,7 @@ class Form extends BaseForm implements FormFactoryAwareInterface
      * Retrieve composed form factory
      *
      * Lazy-loads one if none present.
-     * 
+     *
      * @return Factory
      */
     public function getFormFactory()
@@ -84,7 +84,7 @@ class Form extends BaseForm implements FormFactoryAwareInterface
         $this->useInputFilterDefaults = (bool) $useInputFilterDefaults;
         return $this;
     }
-    
+
     /**
      * Should we use input filter defaults from elements and fieldsets?
      *
@@ -101,16 +101,16 @@ class Form extends BaseForm implements FormFactoryAwareInterface
      * If $elementOrFieldset is an array or Traversable, passes the argument on
      * to the composed factory to create the object before attaching it.
      *
-     * $flags could contain metadata such as the alias under which to register 
+     * $flags could contain metadata such as the alias under which to register
      * the element or fieldset, order in which to prioritize it, etc.
-     * 
-     * @param  array|Traversable|ElementInterface $elementOrFieldset 
-     * @param  array $flags 
+     *
+     * @param  array|Traversable|ElementInterface $elementOrFieldset
+     * @param  array $flags
      * @return Form
      */
     public function add($elementOrFieldset, array $flags = array())
     {
-        if (is_array($elementOrFieldset) 
+        if (is_array($elementOrFieldset)
             || ($elementOrFieldset instanceof Traversable && !$elementOrFieldset instanceof ElementInterface)
         ) {
             $factory = $this->getFormFactory();
@@ -122,14 +122,18 @@ class Form extends BaseForm implements FormFactoryAwareInterface
     /**
      * Ensures state is ready for use
      *
-     * Currently, simply ensures that if using input filter defaults, all input 
+     * Currently, simply ensures that if using input filter defaults, all input
      * is marshalled.
-     * 
+     *
      * @return void
      */
     public function prepare()
     {
         $this->getInputFilter();
+
+        foreach ($this->fieldsets as $fieldset) {
+            $fieldset->prepare();
+        }
     }
 
     /**
@@ -137,7 +141,7 @@ class Form extends BaseForm implements FormFactoryAwareInterface
      *
      * Attaches defaults from attached elements, if no corresponding input
      * exists for the given element in the input filter.
-     * 
+     *
      * @return InputFilterInterface
      */
     public function getInputFilter()
@@ -151,9 +155,9 @@ class Form extends BaseForm implements FormFactoryAwareInterface
 
     /**
      * Attach defaults provided by the elements to the input filter
-     * 
-     * @param  InputFilterInterface $inputFilter 
-     * @param  FieldsetInterface $fieldset Fieldset to traverse when looking for default inputs 
+     *
+     * @param  InputFilterInterface $inputFilter
+     * @param  FieldsetInterface $fieldset Fieldset to traverse when looking for default inputs
      * @return void
      */
     public function attachInputFilterDefaults(InputFilterInterface $inputFilter, FieldsetInterface $fieldset)
@@ -193,7 +197,7 @@ class Form extends BaseForm implements FormFactoryAwareInterface
                     continue;
                 }
 
-                // Traverse the elements of the fieldset, and attach any 
+                // Traverse the elements of the fieldset, and attach any
                 // defaults to the fieldset's input filter
                 $this->attachInputFilterDefaults($fieldsetFilter, $fieldset);
                 continue;

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -212,6 +212,9 @@ class Form extends BaseForm implements FormFactoryAwareInterface
             $spec   = $fieldset->getInputFilterSpecification();
             $filter = $inputFactory->createInputFilter($spec);
             $inputFilter->add($filter, $name);
+
+            // Recursively attach sub filters
+            $this->attachInputFilterDefaults($filter, $fieldset);
         }
     }
 }

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -186,4 +186,62 @@ class FormTest extends TestCase
         $this->assertTrue($input->isRequired());
         $this->assertEquals('foo', $input->getName());
     }
+
+    public function testCanProperlyPrepareNestedFieldsets()
+    {
+        $this->form->add(array(
+            'name'       => 'foo',
+            'attributes' => array(
+                'type'         => 'text'
+            )
+        ));
+
+        $this->form->add(array(
+            'type' => 'ZendTest\Form\SimpleFieldset'
+        ));
+
+        $this->form->prepare();
+
+        $this->assertEquals('foo', $this->form->get('foo')->getName());
+
+        $simpleFieldset = $this->form->get('simple_fieldset');
+        $this->assertEquals('simple_fieldset[field]', $simpleFieldset->get('field')->getName());
+
+        $nestedFieldset = $simpleFieldset->get('nested_fieldset');
+        $this->assertEquals('simple_fieldset[nested_fieldset][anotherField]', $nestedFieldset->get('anotherField')
+                                                                                             ->getName());
+    }
+}
+
+class SimpleFieldset extends Fieldset
+{
+    public function __construct()
+    {
+        parent::__construct('simple_fieldset');
+
+        $field = new \Zend\Form\Element('field');
+        $field->setAttributes(array(
+            'type' => 'text',
+            'label' => 'Name'
+        ));
+        $this->add($field);
+
+        $nestedFieldset = new NestedFieldset();
+        $this->add($nestedFieldset);
+    }
+}
+
+class NestedFieldset extends Fieldset
+{
+    public function __construct()
+    {
+        parent::__construct('nested_fieldset');
+
+        $field = new \Zend\Form\Element('anotherField');
+        $field->setAttributes(array(
+            'type' => 'text',
+            'label' => 'Name'
+        ));
+        $this->add($field);
+    }
 }

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -209,39 +209,6 @@ class FormTest extends TestCase
 
         $nestedFieldset = $basicFieldset->get('nested_fieldset');
         $this->assertEquals('basic_fieldset[nested_fieldset][anotherField]', $nestedFieldset->get('anotherField')
-                                                                                             ->getName());
+                                                                                            ->getName());
     }
 }
-/*
-class SimpleFieldset extends Fieldset
-{
-    public function __construct()
-    {
-        parent::__construct('simple_fieldset');
-
-        $field = new \Zend\Form\Element('field');
-        $field->setAttributes(array(
-            'type' => 'text',
-            'label' => 'Name'
-        ));
-        $this->add($field);
-
-        $nestedFieldset = new NestedFieldset();
-        $this->add($nestedFieldset);
-    }
-}
-
-class NestedFieldset extends Fieldset
-{
-    public function __construct()
-    {
-        parent::__construct('nested_fieldset');
-
-        $field = new \Zend\Form\Element('anotherField');
-        $field->setAttributes(array(
-            'type' => 'text',
-            'label' => 'Name'
-        ));
-        $this->add($field);
-    }
-}*/

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -197,22 +197,22 @@ class FormTest extends TestCase
         ));
 
         $this->form->add(array(
-            'type' => 'ZendTest\Form\SimpleFieldset'
+            'type' => 'ZendTest\Form\TestAsset\BasicFieldset'
         ));
 
         $this->form->prepare();
 
         $this->assertEquals('foo', $this->form->get('foo')->getName());
 
-        $simpleFieldset = $this->form->get('simple_fieldset');
-        $this->assertEquals('simple_fieldset[field]', $simpleFieldset->get('field')->getName());
+        $basicFieldset = $this->form->get('basic_fieldset');
+        $this->assertEquals('basic_fieldset[field]', $basicFieldset->get('field')->getName());
 
-        $nestedFieldset = $simpleFieldset->get('nested_fieldset');
-        $this->assertEquals('simple_fieldset[nested_fieldset][anotherField]', $nestedFieldset->get('anotherField')
+        $nestedFieldset = $basicFieldset->get('nested_fieldset');
+        $this->assertEquals('basic_fieldset[nested_fieldset][anotherField]', $nestedFieldset->get('anotherField')
                                                                                              ->getName());
     }
 }
-
+/*
 class SimpleFieldset extends Fieldset
 {
     public function __construct()
@@ -244,4 +244,4 @@ class NestedFieldset extends Fieldset
         ));
         $this->add($field);
     }
-}
+}*/

--- a/tests/Zend/Form/TestAsset/BasicFieldset.php
+++ b/tests/Zend/Form/TestAsset/BasicFieldset.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Form\Element;
+use Zend\Form\Fieldset;
+
+class BasicFieldset extends Fieldset
+{
+    public function __construct()
+    {
+        parent::__construct('basic_fieldset');
+
+        $field = new Element('field');
+        $field->setAttributes(array(
+            'type' => 'text',
+            'label' => 'Name'
+        ));
+        $this->add($field);
+
+        $nestedFieldset = new NestedFieldset();
+        $this->add($nestedFieldset);
+    }
+}
+
+class NestedFieldset extends Fieldset
+{
+    public function __construct()
+    {
+        parent::__construct('nested_fieldset');
+
+        $field = new Element('anotherField');
+        $field->setAttributes(array(
+            'type' => 'text',
+            'label' => 'Name'
+        ));
+        $this->add($field);
+    }
+}
+

--- a/tests/Zend/Form/TestAsset/NestedFieldset.php
+++ b/tests/Zend/Form/TestAsset/NestedFieldset.php
@@ -24,20 +24,17 @@ namespace ZendTest\Form\TestAsset;
 use Zend\Form\Element;
 use Zend\Form\Fieldset;
 
-class BasicFieldset extends Fieldset
+class NestedFieldset extends Fieldset
 {
     public function __construct()
     {
-        parent::__construct('basic_fieldset');
+        parent::__construct('nested_fieldset');
 
-        $field = new Element('field');
+        $field = new Element('anotherField');
         $field->setAttributes(array(
             'type' => 'text',
             'label' => 'Name'
         ));
         $this->add($field);
-
-        $nestedFieldset = new NestedFieldset();
-        $this->add($nestedFieldset);
     }
 }


### PR DESCRIPTION
This PR allow to have nested fieldsets, as well as correctly handle names using array notation so that users can had several times the same fieldset using a different name (it was not possible before as elements all had the same name).

I needed this feature for my upcoming Collection element, and this was an expected feature in Zend\Form documentation in any way, so here it is :).
