### PR TITLE
Add form row helper

### DIFF
--- a/library/Zend/Form/View/Helper/FormLabel.php
+++ b/library/Zend/Form/View/Helper/FormLabel.php
@@ -48,8 +48,8 @@ class FormLabel extends AbstractHelper
 
     /**
      * Generate an opening label tag
-     * 
-     * @param  null|array|ElementInterface $attributesOrElement 
+     *
+     * @param  null|array|ElementInterface $attributesOrElement
      * @return string
      */
     public function openTag($attributesOrElement = null)
@@ -86,7 +86,7 @@ class FormLabel extends AbstractHelper
 
     /**
      * Return a closing label tag
-     * 
+     *
      * @return string
      */
     public function closeTag()
@@ -99,10 +99,10 @@ class FormLabel extends AbstractHelper
      *
      * Always generates a "for" statement, as we cannot assume the form input
      * will be provided in the $labelContent.
-     * 
-     * @param  ElementInterface $element 
-     * @param  null|string $labelContent 
-     * @param  string $position 
+     *
+     * @param  ElementInterface $element
+     * @param  null|string $labelContent
+     * @param  string $position
      * @return string
      */
     public function __invoke(ElementInterface $element = null, $labelContent = null, $position = null)

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -24,7 +24,7 @@ namespace Zend\Form\View\Helper;
 use Zend\Form\ElementInterface;
 use Zend\Form\Exception;
 use Zend\Loader\Pluggable;
-use Zend\View\Helper\AbstractHelper as BaseAbstractHelper;
+use Zend\Form\View\Helper\AbstractHelper;
 
 /**
  * @category   Zend
@@ -33,7 +33,7 @@ use Zend\View\Helper\AbstractHelper as BaseAbstractHelper;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class FormRow extends BaseAbstractHelper
+class FormRow extends AbstractHelper
 {
     const LABEL_APPEND  = 'append';
     const LABEL_PREPEND = 'prepend';
@@ -47,6 +47,21 @@ class FormRow extends BaseAbstractHelper
      * @var array
      */
     protected $rowLabelAttributes;
+
+    /**
+     * @var FormLabel
+     */
+    protected $labelHelper;
+
+    /**
+     * @var FormElement
+     */
+    protected $elementHelper;
+
+    /**
+     * @var FormElementErrors
+     */
+    protected $elementErrorsHelper;
 
 
     /**
@@ -64,14 +79,16 @@ class FormRow extends BaseAbstractHelper
             return '';
         }
 
-        $labelHelper         = $renderer->plugin('form_label');
-        $elementHelper       = $renderer->plugin('form_element');
-        $elementErrorsHelper = $renderer->plugin('form_element_errors');
+        $escapeHelper        = $this->getEscapeHelper();
+        $labelHelper         = $this->getLabelHelper();
+        $elementHelper       = $this->getElementHelper();
+        $elementErrorsHelper = $this->getElementErrorsHelper();
         $label               = $element->getAttribute('label');
         $elementString       = $elementHelper->render($element);
         $elementErrors       = $elementErrorsHelper->render($element);
 
         if (!empty($label)) {
+            $label = $escapeHelper($label);
             $rowLabelAttributes = $element->getAttribute('rowLabelAttributes');
 
             if (empty($rowLabelAttributes)) {
@@ -182,5 +199,71 @@ class FormRow extends BaseAbstractHelper
     public function getRowLabelAttributes()
     {
         return $this->rowLabelAttributes;
+    }
+
+    /**
+     * Retrieve the FormLabel helper
+     *
+     * @return FormLabel
+     */
+    protected function getLabelHelper()
+    {
+        if ($this->labelHelper) {
+            return $this->labelHelper;
+        }
+
+        if ($this->view instanceof Pluggable) {
+            $this->labelHelper = $this->view->plugin('form_label');
+        }
+
+        if (!$this->labelHelper instanceof FormLabel) {
+            $this->labelHelper = new FormLabel();
+        }
+
+        return $this->labelHelper;
+    }
+
+    /**
+     * Retrieve the FormElement helper
+     *
+     * @return FormElement
+     */
+    protected function getElementHelper()
+    {
+        if ($this->elementHelper) {
+            return $this->elementHelper;
+        }
+
+        if ($this->view instanceof Pluggable) {
+            $this->elementHelper = $this->view->plugin('form_element');
+        }
+
+        if (!$this->elementHelper instanceof FormElement) {
+            $this->elementHelper = new FormElement();
+        }
+
+        return $this->elementHelper;
+    }
+
+    /**
+     * Retrieve the FormElementErrors helper
+     *
+     * @return FormElementErrors
+     */
+    protected function getElementErrorsHelper()
+    {
+        if ($this->elementErrorsHelper) {
+            return $this->elementErrorsHelper;
+        }
+
+        if ($this->view instanceof Pluggable) {
+            $this->elementErrorsHelper = $this->view->plugin('form_element_errors');
+        }
+
+        if (!$this->elementErrorsHelper instanceof FormElementErrors) {
+            $this->elementErrorsHelper = new FormElementErrors();
+        }
+
+        return $this->elementErrorsHelper;
     }
 }

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -80,7 +80,7 @@ class FormRow extends BaseAbstractHelper
                     break;
             }
         } else {
-            $markup = $element . $elementErrors;
+            $markup = $elementString . $elementErrors;
         }
 
         return $markup;

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -112,13 +112,18 @@ class FormRow extends BaseAbstractHelper
      *
      * Proxies to {@link render()}.
      *
-     * @param  ElementInterface|null $element
-     * @return string
+     * @param null|ElementInterface $element
+     * @param null|string $labelPosition
+     * @return string|FormRow
      */
-    public function __invoke(ElementInterface $element = null)
+    public function __invoke(ElementInterface $element = null, $labelPosition = null)
     {
         if (!$element) {
             return $this;
+        }
+
+        if ($labelPosition !== null) {
+            $this->setLabelPosition($labelPosition);
         }
 
         return $this->render($element);

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -43,6 +43,11 @@ class FormRow extends BaseAbstractHelper
      */
     protected $labelPosition = self::LABEL_PREPEND;
 
+    /**
+     * @var array
+     */
+    protected $rowLabelAttributes;
+
 
     /**
      * Utility form helper that renders a label (if it exists), an element and errors
@@ -59,17 +64,23 @@ class FormRow extends BaseAbstractHelper
             return '';
         }
 
-        $labelHelper = $renderer->plugin('form_label');
-        $elementHelper = $renderer->plugin('form_element');
+        $labelHelper         = $renderer->plugin('form_label');
+        $elementHelper       = $renderer->plugin('form_element');
         $elementErrorsHelper = $renderer->plugin('form_element_errors');
-
-        $labelOpen      = $labelHelper->openTag();
-        $labelClose     = $labelHelper->closeTag();
-        $label = $element->getAttribute('label');
-        $elementString = $elementHelper->render($element);
-        $elementErrors = $elementErrorsHelper->render($element);
+        $label               = $element->getAttribute('label');
+        $elementString       = $elementHelper->render($element);
+        $elementErrors       = $elementErrorsHelper->render($element);
 
         if (!empty($label)) {
+            $rowLabelAttributes  = $element->getAttribute('rowLabelAttributes');
+
+            if (empty($rowLabelAttributes)) {
+                $rowLabelAttributes = $this->rowLabelAttributes;
+            }
+
+            $labelOpen  = $labelHelper->openTag($rowLabelAttributes);
+            $labelClose = $labelHelper->closeTag();
+
             switch ($this->labelPosition) {
                 case self::LABEL_PREPEND:
                     $markup = $labelOpen . $label . $elementString . $labelClose . $elementErrors;
@@ -134,5 +145,27 @@ class FormRow extends BaseAbstractHelper
     public function getLabelPosition()
     {
         return $this->labelPosition;
+    }
+
+    /**
+     * Set the attributes for the row label
+     *
+     * @param array $rowLabelAttributes
+     * @return FormRow
+     */
+    public function setRowLabelAttributes($rowLabelAttributes)
+    {
+        $this->rowLabelAttributes = $rowLabelAttributes;
+        return $this;
+    }
+
+    /**
+     * Get the attributes for the row label
+     *
+     * @return array
+     */
+    public function getRowLabelAttributes()
+    {
+        return $this->rowLabelAttributes;
     }
 }

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -72,7 +72,7 @@ class FormRow extends BaseAbstractHelper
         $elementErrors       = $elementErrorsHelper->render($element);
 
         if (!empty($label)) {
-            $rowLabelAttributes  = $element->getAttribute('rowLabelAttributes');
+            $rowLabelAttributes = $element->getAttribute('rowLabelAttributes');
 
             if (empty($rowLabelAttributes)) {
                 $rowLabelAttributes = $this->rowLabelAttributes;
@@ -80,9 +80,12 @@ class FormRow extends BaseAbstractHelper
 
             // Multicheckbox elements have to be handled differently as the HTML standard does not allow nested
             // labels. The semantic way is to group them inside a fieldset
-            if ($element->getAttribute('type') === 'multi_checkbox' ||
-                $element->getAttribute('type') === 'radio') {
-                $markup = sprintf('<fieldset><legend>%s</legend>%s</fieldset>', $label, $elementString);
+            $type = $element->getAttribute('type');
+            if ($type === 'multi_checkbox' || $type === 'multicheckbox' || $type === 'radio') {
+                $markup = sprintf(
+                    '<fieldset><legend>%s</legend>%s</fieldset>',
+                    $label,
+                    $elementString);
             } else {
                 $labelOpen  = $labelHelper->openTag($rowLabelAttributes);
                 $labelClose = $labelHelper->closeTag();

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -78,17 +78,24 @@ class FormRow extends BaseAbstractHelper
                 $rowLabelAttributes = $this->rowLabelAttributes;
             }
 
-            $labelOpen  = $labelHelper->openTag($rowLabelAttributes);
-            $labelClose = $labelHelper->closeTag();
+            // Multicheckbox elements have to be handled differently as the HTML standard does not allow nested
+            // labels. The semantic way is to group them inside a fieldset
+            if ($element->getAttribute('type') === 'multi_checkbox' ||
+                $element->getAttribute('type') === 'radio') {
+                $markup = sprintf('<fieldset><legend>%s</legend>%s</fieldset>', $label, $elementString);
+            } else {
+                $labelOpen  = $labelHelper->openTag($rowLabelAttributes);
+                $labelClose = $labelHelper->closeTag();
 
-            switch ($this->labelPosition) {
-                case self::LABEL_PREPEND:
-                    $markup = $labelOpen . $label . $elementString . $labelClose . $elementErrors;
-                    break;
-                case self::LABEL_APPEND:
-                default:
-                    $markup = $labelOpen . $elementString . $label . $labelClose . $elementErrors;
-                    break;
+                switch ($this->labelPosition) {
+                    case self::LABEL_PREPEND:
+                        $markup = $labelOpen . $label . $elementString . $labelClose . $elementErrors;
+                        break;
+                    case self::LABEL_APPEND:
+                    default:
+                        $markup = $labelOpen . $elementString . $label . $labelClose . $elementErrors;
+                        break;
+                }
             }
         } else {
             $markup = $elementString . $elementErrors;

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\View\Helper;
+
+use Zend\Form\ElementInterface;
+use Zend\Form\Exception;
+use Zend\Loader\Pluggable;
+use Zend\View\Helper\AbstractHelper as BaseAbstractHelper;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage View
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormRow extends BaseAbstractHelper
+{
+    const LABEL_APPEND  = 'append';
+    const LABEL_PREPEND = 'prepend';
+
+    /**
+     * @var string
+     */
+    protected $labelPosition = self::LABEL_PREPEND;
+
+
+    /**
+     * Utility form helper that renders a label (if it exists), an element and errors
+     *
+     * @param ElementInterface $element
+     * @return string
+     * @throws \Zend\Form\Exception\DomainException
+     */
+    public function render(ElementInterface $element)
+    {
+        $renderer = $this->getView();
+        if (!$renderer instanceof Pluggable) {
+            // Bail early if renderer is not pluggable
+            return '';
+        }
+
+        $labelHelper = $renderer->plugin('form_label');
+        $elementHelper = $renderer->plugin('form_element');
+        $elementErrorsHelper = $renderer->plugin('form_element_errors');
+
+        $labelOpen      = $labelHelper->openTag();
+        $labelClose     = $labelHelper->closeTag();
+        $label = $element->getAttribute('label');
+        $elementString = $elementHelper->render($element);
+        $elementErrors = $elementErrorsHelper->render($element);
+
+        if (!empty($label)) {
+            switch ($this->labelPosition) {
+                case self::LABEL_PREPEND:
+                    $markup = $labelOpen . $label . $elementString . $labelClose . $elementErrors;
+                    break;
+                case self::LABEL_APPEND:
+                default:
+                    $markup = $labelOpen . $elementString . $label . $labelClose . $elementErrors;
+                    break;
+            }
+        } else {
+            $markup = $element . $elementErrors;
+        }
+
+        return $markup;
+    }
+
+    /**
+     * Invoke helper as functor
+     *
+     * Proxies to {@link render()}.
+     *
+     * @param  ElementInterface|null $element
+     * @return string
+     */
+    public function __invoke(ElementInterface $element = null)
+    {
+        if (!$element) {
+            return $this;
+        }
+
+        return $this->render($element);
+    }
+
+    /**
+     * Set the label position
+     *
+     * @param $labelPosition
+     * @return FormRow
+     * @throws \Zend\Form\Exception\InvalidArgumentException
+     */
+    public function setLabelPosition($labelPosition)
+    {
+        $labelPosition = strtolower($labelPosition);
+        if (!in_array($labelPosition, array(self::LABEL_APPEND, self::LABEL_PREPEND))) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects either %s::LABEL_APPEND or %s::LABEL_PREPEND; received "%s"',
+                __METHOD__,
+                __CLASS__,
+                __CLASS__,
+                (string) $labelPosition
+            ));
+        }
+        $this->labelPosition = $labelPosition;
+        return $this;
+    }
+
+    /**
+     * Get the label position
+     *
+     * @return string
+     */
+    public function getLabelPosition()
+    {
+        return $this->labelPosition;
+    }
+}

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -206,7 +206,7 @@ class FormRow extends AbstractHelper
             return $this->labelHelper;
         }
 
-        if ($this->view instanceof Pluggable) {
+        if (method_exists($this->view, 'plugin')) {
             $this->labelHelper = $this->view->plugin('form_label');
         }
 
@@ -228,7 +228,7 @@ class FormRow extends AbstractHelper
             return $this->elementHelper;
         }
 
-        if ($this->view instanceof Pluggable) {
+        if (method_exists($this->view, 'plugin')) {
             $this->elementHelper = $this->view->plugin('form_element');
         }
 
@@ -250,7 +250,7 @@ class FormRow extends AbstractHelper
             return $this->elementErrorsHelper;
         }
 
-        if ($this->view instanceof Pluggable) {
+        if (method_exists($this->view, 'plugin')) {
             $this->elementErrorsHelper = $this->view->plugin('form_element_errors');
         }
 

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -73,12 +73,6 @@ class FormRow extends AbstractHelper
      */
     public function render(ElementInterface $element)
     {
-        $renderer = $this->getView();
-        if (!$renderer instanceof Pluggable) {
-            // Bail early if renderer is not pluggable
-            return '';
-        }
-
         $escapeHelper        = $this->getEscapeHelper();
         $labelHelper         = $this->getLabelHelper();
         $elementHelper       = $this->getElementHelper();

--- a/library/Zend/Form/View/HelperConfiguration.php
+++ b/library/Zend/Form/View/HelperConfiguration.php
@@ -64,6 +64,9 @@ class HelperConfiguration implements ConfigurationInterface
         'formpassword'           => 'Zend\Form\View\Helper\FormPassword',
         'formradio'              => 'Zend\Form\View\Helper\FormRadio',
         'formreset'              => 'Zend\Form\View\Helper\FormReset',
+        'form_reset'             => 'Zend\Form\View\Helper\FormReset',
+        'formrow'                => 'Zend\Form\View\Helper\FormRow',
+        'form_row'               => 'Zend\Form\View\Helper\FormRow',
         'formsearch'             => 'Zend\Form\View\Helper\FormSearch',
         'formselect'             => 'Zend\Form\View\Helper\FormSelect',
         'formsubmit'             => 'Zend\Form\View\Helper\FormSubmit',
@@ -80,7 +83,7 @@ class HelperConfiguration implements ConfigurationInterface
      * service manager, also adds an initializer to inject ServiceManagerAware
      * classes with the service manager.
      *
-     * @param  ServiceManager $serviceManager 
+     * @param  ServiceManager $serviceManager
      * @return void
      */
     public function configureServiceManager(ServiceManager $serviceManager)

--- a/tests/Zend/Form/View/Helper/FormElementTest.php
+++ b/tests/Zend/Form/View/Helper/FormElementTest.php
@@ -44,7 +44,7 @@ class FormElementTest extends TestCase
     public function setUp()
     {
         $this->helper = new FormElementHelper();
-        
+
         Doctype::unsetDoctypeRegistry();
 
         $this->renderer = new PhpRenderer;

--- a/tests/Zend/Form/View/Helper/FormRowTest.php
+++ b/tests/Zend/Form/View/Helper/FormRowTest.php
@@ -23,8 +23,8 @@ namespace ZendTest\Form\View\Helper;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element;
+use Zend\Form\View\HelperConfiguration;
 use Zend\Form\View\Helper\FormRow as FormRowHelper;
-use Zend\Form\View\HelperLoader;
 use Zend\View\Renderer\PhpRenderer;
 
 /**
@@ -44,9 +44,10 @@ class FormRowTest extends TestCase
         $this->helper = new FormRowHelper();
 
         $this->renderer = new PhpRenderer;
-        $broker = $this->renderer->getBroker();
-        $loader = $broker->getClassLoader();
-        $loader->registerPlugins(new HelperLoader());
+        $helpers = $this->renderer->getHelperPluginManager();
+        $config  = new HelperConfiguration();
+        $config->configureServiceManager($helpers);
+
         $this->helper->setView($this->renderer);
     }
 

--- a/tests/Zend/Form/View/Helper/FormRowTest.php
+++ b/tests/Zend/Form/View/Helper/FormRowTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\View\Helper;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Element;
+use Zend\Form\View\Helper\FormRow as FormRowHelper;
+use Zend\Form\View\HelperLoader;
+use Zend\View\Renderer\PhpRenderer;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FormRowTest extends TestCase
+{
+    protected $helper;
+    protected $renderer;
+
+    public function setUp()
+    {
+        $this->helper = new FormRowHelper();
+
+        $this->renderer = new PhpRenderer;
+        $broker = $this->renderer->getBroker();
+        $loader = $broker->getClassLoader();
+        $loader->registerPlugins(new HelperLoader());
+        $this->helper->setView($this->renderer);
+    }
+
+    public function testCanGenerateLabel()
+    {
+        $element = new Element('foo');
+        $element->setAttribute('label', 'The value for foo:');
+        $markup = $this->helper->render($element);
+        $this->assertContains('>The value for foo:<', $markup);
+        $this->assertContains('<label', $markup);
+        $this->assertContains('</label>', $markup);
+    }
+
+    public function testCanCreateLabelValueBeforeInput()
+    {
+        $element = new Element('foo');
+        $element->setAttribute('label', 'The value for foo:');
+        $this->helper->setLabelPosition('prepend');
+        $markup = $this->helper->render($element);
+        $this->assertContains('<label>The value for foo:<', $markup);
+    }
+
+    public function testCanCreateLabelValueAfterInput()
+    {
+        $element = new Element('foo');
+        $element->setAttribute('label', 'The value for foo:');
+        $this->helper->setLabelPosition('append');
+        $markup = $this->helper->render($element);
+        $this->assertContains('<label><input', $markup);
+    }
+
+    public function testInvokeWithNoElementChainsHelper()
+    {
+        $this->assertSame($this->helper, $this->helper->__invoke());
+    }
+}

--- a/tests/Zend/Form/View/Helper/FormRowTest.php
+++ b/tests/Zend/Form/View/Helper/FormRowTest.php
@@ -67,6 +67,7 @@ class FormRowTest extends TestCase
         $this->helper->setLabelPosition('prepend');
         $markup = $this->helper->render($element);
         $this->assertContains('<label>The value for foo:<', $markup);
+        $this->assertContains('</label>', $markup);
     }
 
     public function testCanCreateLabelValueAfterInput()
@@ -76,6 +77,7 @@ class FormRowTest extends TestCase
         $this->helper->setLabelPosition('append');
         $markup = $this->helper->render($element);
         $this->assertContains('<label><input', $markup);
+        $this->assertContains('</label>', $markup);
     }
 
     public function testCanCreateMarkupWithoutLabel()

--- a/tests/Zend/Form/View/Helper/FormRowTest.php
+++ b/tests/Zend/Form/View/Helper/FormRowTest.php
@@ -80,12 +80,35 @@ class FormRowTest extends TestCase
         $this->assertContains('</label>', $markup);
     }
 
+    function testCanRenderRowLabelAttributes()
+    {
+        $element = new Element('foo');
+        $element->setAttribute('label', 'The value for foo:');
+        $element->setAttribute('rowLabelAttributes', array('class' => 'bar'));
+        $this->helper->setLabelPosition('append');
+        $markup = $this->helper->render($element);
+        $this->assertContains("<label class=\"bar\">", $markup);
+    }
+
     public function testCanCreateMarkupWithoutLabel()
     {
         $element = new Element('foo');
         $element->setAttribute('type', 'text');
         $markup = $this->helper->render($element);
         $this->assertEquals('<input name="foo" type="text">', $markup);
+    }
+
+    public function testCanRenderErrors()
+    {
+        $element  = new Element('foo');
+        $element->setMessages(array(
+            'First error message',
+            'Second error message',
+            'Third error message',
+        ));
+
+        $markup = $this->helper->render($element);
+        $this->assertRegexp('#<ul>\s*<li>First error message</li>\s*<li>Second error message</li>\s*<li>Third error message</li>\s*</ul>#s', $markup);
     }
 
     public function testInvokeWithNoElementChainsHelper()

--- a/tests/Zend/Form/View/Helper/FormRowTest.php
+++ b/tests/Zend/Form/View/Helper/FormRowTest.php
@@ -98,6 +98,24 @@ class FormRowTest extends TestCase
         $this->assertEquals('<input name="foo" type="text">', $markup);
     }
 
+    public function testCanHandleMultiCheckboxesCorrectly()
+    {
+        $options = array(
+            'This is the first label' => 'value1',
+            'This is the second label' => 'value2',
+            'This is the third label' => 'value3',
+        );
+
+        $element = new Element('foo');
+        $element->setAttribute('type', 'multi_checkbox');
+        $element->setAttribute('label', 'This is a multi-checkbox');
+        $element->setAttribute('options', $options);
+        $markup = $this->helper->render($element);
+        $this->assertContains("<fieldset>", $markup);
+        $this->assertContains("<legend>", $markup);
+        $this->assertContains("<label>", $markup);
+    }
+
     public function testCanRenderErrors()
     {
         $element  = new Element('foo');

--- a/tests/Zend/Form/View/Helper/FormRowTest.php
+++ b/tests/Zend/Form/View/Helper/FormRowTest.php
@@ -78,6 +78,14 @@ class FormRowTest extends TestCase
         $this->assertContains('<label><input', $markup);
     }
 
+    public function testCanCreateMarkupWithoutLabel()
+    {
+        $element = new Element('foo');
+        $element->setAttribute('type', 'text');
+        $markup = $this->helper->render($element);
+        $this->assertEquals('<input name="foo" type="text">', $markup);
+    }
+
     public function testInvokeWithNoElementChainsHelper()
     {
         $this->assertSame($this->helper, $this->helper->__invoke());


### PR DESCRIPTION
This is a utility form view helper that renders a very common use case : label (if specified), element and element errors. This is more flexible than a magic view helper that would render the all form, as it allows to add specific markup around every elements.

Basically, it allows to replace this :

<?php
$email = $form->get('email');
echo $formLabel->openTag() . $email->getAttribute('label');
echo $this->formInput($email);
echo $this->formElementErrors($email);
echo $formLabel->closeTag();
?>

By this shorter one, making views much more easier to read :

<?= $this->formRow($form->get('email')); ?>

EDIT : here are some more notes about this PR : if no label is set for a specific element, only the input will be drawn, so you don't "absolutely" need to set one for every elements to use this helper.

For multicheckboxes and radio, I prefered to group them inside field sets (which appears to be the more semantic way to do it) instead of generating "id" for elements to allow nested labels (which is prohibited by HTML, anyway).
