### PR TITLE
Replace Url view helper by Router

### DIFF
--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -200,7 +200,18 @@ class Mvc extends AbstractPage
             $params['action'] = $param;
         }
 
-        $options = array('name' => $this->getRoute());
+        switch (true) {
+            case ($this->getRoute() !== null):
+                $name = $this->getRoute();
+                break;
+            case ($this->getRouteMatch() !== null):
+                $name = $this->getRouteMatch()->getMatchedRouteName();
+                break;
+            default:
+                throw new Exception\DomainException('No route name could be found');
+        }
+
+        $options = array('name' => $name);
         $url = $router->assemble($params, $options);
 
         // Add the fragment identifier if it is set

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -21,9 +21,9 @@
 
 namespace Zend\Navigation\Page;
 
-use Zend\Mvc\Router\RouteMatch,
-    Zend\Navigation\Exception,
-    Zend\View\Helper\Url as UrlHelper;
+use Zend\Mvc\Router\RouteMatch;
+use Zend\Mvc\Router\RouteStackInterface;
+use Zend\Navigation\Exception;
 
 /**
  * Represents a page that is defined using controller, action, route
@@ -86,21 +86,21 @@ class Mvc extends AbstractPage
     protected $routeMatch;
 
     /**
-     * View helper for assembling URLs
+     * Router for assembling URLs
      *
      * @see getHref()
-     * @var UrlHelper
+     * @var RouteStackInterface
      */
-    protected $urlHelper = null;
+    protected $router = null;
 
     /**
-     * Default urlHelper to be used if urlHelper is not given.
+     * Default router to be used if router is not given.
      *
      * @see getHref()
      *
-     * @var UrlHelper
+     * @var RouteStackInterface
      */
-    protected static $defaultUrlHelper = null;
+    protected static $defaultRouter= null;
 
     // Accessors:
 
@@ -165,12 +165,12 @@ class Mvc extends AbstractPage
     /**
      * Returns href for this page
      *
-     * This method uses {@link UrlHelper} to assemble
+     * This method uses {@link RouteStackInterface} to assemble
      * the href based on the page's properties.
      *
-     * @see UrlHelper
+     * @see RouteStackInterface
      * @return string  page href
-     * @throws Exception\DomainException if no UrlHelper is set
+     * @throws Exception\DomainException if no router is set
      */
     public function getHref()
     {
@@ -178,15 +178,15 @@ class Mvc extends AbstractPage
             return $this->hrefCache;
         }
 
-        $helper = $this->urlHelper;
-        if (null === $helper) {
-            $helper = self::$defaultUrlHelper;
+        $router = $this->router;
+        if (null === $router) {
+            $router = self::$defaultRouter;
         }
 
-        if (!$helper instanceof UrlHelper) {
+        if (!$router instanceof RouteStackInterface) {
             throw new Exception\DomainException(
                 __METHOD__
-                . ' cannot execute as no Zend\View\Helper\Url instance is composed'
+                . ' cannot execute as no Zend\Mvc\Router\RouteStackInterface instance is composed'
             );
         }
 
@@ -200,10 +200,8 @@ class Mvc extends AbstractPage
             $params['action'] = $param;
         }
 
-        $url = $helper(
-            $this->getRoute(),
-            $params
-        );
+        $options = array('name' => $this->getRoute());
+        $url = $router->assemble($params, $options);
 
         // Add the fragment identifier if it is set
         $fragment = $this->getFragment();
@@ -372,49 +370,49 @@ class Mvc extends AbstractPage
     }
 
     /**
-     * Get the url helper.
+     * Get the router.
      *
-     * @return null|\Zend\View\Helper\Url
+     * @return null|RouteStackInterface
      */
-    public function getUrlHelper()
+    public function getRouter()
     {
-        return $this->urlHelper;
+        return $this->router;
     }
 
     /**
-     * Sets action helper for assembling URLs
+     * Sets router for assembling URLs
      *
      * @see getHref()
      *
-     * @param  UrlHelper $helper URL helper plugin
+     * @param  RouteStackInterface $router Router
      * @return Mvc    fluent interface, returns self
      */
-    public function setUrlHelper(UrlHelper $helper)
+    public function setRouter(RouteStackInterface $router)
     {
-        $this->urlHelper = $helper;
+        $this->router = $router;
         return $this;
     }
 
     /**
-     * Sets the default view helper for assembling URLs.
+     * Sets the default router for assembling URLs.
      *
      * @see getHref()
-     * @param  null|UrlHelper $helper  URL helper
+     * @param  RouteStackInterface $router Router
      * @return void
      */
-    public static function setDefaultUrlHelper($helper)
+    public static function setDefaultRouter($router)
     {
-        self::$defaultUrlHelper = $helper;
+        self::$defaultRouter = $router;
     }
 
     /**
-     * Gets the default view helper for assembling URLs.
+     * Gets the default router for assembling URLs.
      *
-     * @return UrlHelper
+     * @return RouteStackInterface
      */
-    public static function getDefaultUrlHelper()
+    public static function getDefaultRouter()
     {
-        return self::$defaultUrlHelper;
+        return self::$defaultRouter;
     }
 
     // Public methods:

--- a/library/Zend/Navigation/Service/AbstractNavigationFactory.php
+++ b/library/Zend/Navigation/Service/AbstractNavigationFactory.php
@@ -26,9 +26,9 @@ use Zend\Navigation\Exception;
 use Zend\Navigation\Navigation;
 use Zend\Navigation\Page\Mvc as MvcPage;
 use Zend\Mvc\Router\RouteMatch;
+use Zend\Mvc\Router\RouteStackInterface as Router;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\View\Helper\Url as UrlHelper;
 
 /**
  * Abstract navigation factory
@@ -82,11 +82,11 @@ abstract class AbstractNavigationFactory implements FactoryInterface
             }
 
             $application = $serviceLocator->get('Application');
-            $urlHelper   = $serviceLocator->get('ViewHelperManager')->get('url');
             $routeMatch  = $application->getMvcEvent()->getRouteMatch();
+            $router      = $application->getMvcEvent()->getRouter();
             $pages       = $this->getPagesFromConfig($configuration['navigation'][$this->getName()]);
 
-            $this->pages = $this->injectComponents($pages, $routeMatch, $urlHelper);
+            $this->pages = $this->injectComponents($pages, $routeMatch, $router);
         }
         return $this->pages;
     }
@@ -125,6 +125,7 @@ abstract class AbstractNavigationFactory implements FactoryInterface
      * @return mixed
      */
     protected function injectComponents(array $pages, RouteMatch $routeMatch = null, UrlHelper $urlHelper = null)
+    protected function injectComponents(array $pages, RouteMatch $routeMatch = null, Router $router = null)
     {
         foreach($pages as &$page) {
             $hasMvc = isset($page['action']) || isset($page['controller']) || isset($page['route']);
@@ -132,13 +133,13 @@ abstract class AbstractNavigationFactory implements FactoryInterface
                 if (!isset($page['routeMatch']) && $routeMatch) {
                     $page['routeMatch'] = $routeMatch;
                 }
-                if (!isset($page['urlHelper']) && $urlHelper) {
-                    $page['urlHelper'] = $urlHelper;
+                if (!isset($page['router'])) {
+                    $page['router'] = $router;
                 }
             }
 
             if (isset($page['pages'])) {
-                $page['pages'] = $this->injectComponents($page['pages'], $routeMatch, $urlHelper);
+                $page['pages'] = $this->injectComponents($page['pages'], $routeMatch, $router);
             }
         }
         return $pages;

--- a/library/Zend/Navigation/Service/AbstractNavigationFactory.php
+++ b/library/Zend/Navigation/Service/AbstractNavigationFactory.php
@@ -124,7 +124,6 @@ abstract class AbstractNavigationFactory implements FactoryInterface
      * @param UrlHelper $urlHelper
      * @return mixed
      */
-    protected function injectComponents(array $pages, RouteMatch $routeMatch = null, UrlHelper $urlHelper = null)
     protected function injectComponents(array $pages, RouteMatch $routeMatch = null, Router $router = null)
     {
         foreach($pages as &$page) {

--- a/tests/Zend/Navigation/NavigationTest.php
+++ b/tests/Zend/Navigation/NavigationTest.php
@@ -40,13 +40,13 @@ class NavigationTest extends \PHPUnit_Framework_TestCase
      * @var     Zend_Navigation
      */
     private $_navigation;
-    
+
     protected function setUp()
     {
         parent::setUp();
         $this->_navigation = new \Zend\Navigation\Navigation();
     }
-    
+
     protected function tearDown()
     {
         $this->_navigation = null;
@@ -55,7 +55,7 @@ class NavigationTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Testing that navigation order is done correctly
-     * 
+     *
      * @group   ZF-8337
      * @group   ZF-8313
      */
@@ -78,5 +78,5 @@ class NavigationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('page1', $pages[1]['uri']);
         $this->assertEquals('page2', $pages[2]['uri']);
     }
-    
+
 }

--- a/tests/Zend/Navigation/Page/MvcTest.php
+++ b/tests/Zend/Navigation/Page/MvcTest.php
@@ -63,7 +63,7 @@ class MvcTest extends TestCase
     {
     }
 
-    public function testHrefGeneratedByUrlHelperRequiresNoRoute()
+    public function testHrefGeneratedByRouterRequiresNoRoute()
     {
         $page = new Page\Mvc(array(
             'label'      => 'foo',
@@ -465,7 +465,8 @@ class MvcTest extends TestCase
             'label'            => 'foo',
             'action'           => 'index',
             'controller'       => 'index',
-            'defaultRouter' => $this->router
+            'route'            => 'default',
+            'defaultRouter'    => $this->router
         ));
 
         // If the default router is not used an exception will be thrown.

--- a/tests/Zend/Navigation/Page/MvcTest.php
+++ b/tests/Zend/Navigation/Page/MvcTest.php
@@ -181,7 +181,6 @@ class MvcTest extends TestCase
 
     public function testIsActiveReturnsTrueOnIdenticalControllerAction()
     {
-        $this->markTestSkipped();
         $page = new Page\Mvc(array(
             'action'     => 'index',
             'controller' => 'index'
@@ -192,8 +191,6 @@ class MvcTest extends TestCase
             'action'     => 'index',
         ));
 
-        $this->urlHelper->setRouteMatch($routeMatch);
-
         $page->setRouteMatch($routeMatch);
 
         $this->assertTrue($page->isActive());
@@ -201,7 +198,6 @@ class MvcTest extends TestCase
 
     public function testIsActiveReturnsFalseOnDifferentControllerAction()
     {
-        $this->markTestSkipped();
         $page = new Page\Mvc(array(
             'action'     => 'bar',
             'controller' => 'index'
@@ -212,8 +208,6 @@ class MvcTest extends TestCase
             'action'     => 'index',
         ));
 
-        $this->urlHelper->setRouteMatch($routeMatch);
-
         $page->setRouteMatch($routeMatch);
 
         $this->assertFalse($page->isActive());
@@ -221,7 +215,6 @@ class MvcTest extends TestCase
 
     public function testIsActiveReturnsTrueOnIdenticalIncludingPageParams()
     {
-        $this->markTestSkipped();
         $page = new Page\Mvc(array(
             'label'      => 'foo',
             'action'     => 'view',
@@ -237,8 +230,6 @@ class MvcTest extends TestCase
             'id'         => '1337'
         ));
 
-        $this->urlHelper->setRouteMatch($routeMatch);
-
         $page->setRouteMatch($routeMatch);
 
         $this->assertTrue($page->isActive());
@@ -246,7 +237,6 @@ class MvcTest extends TestCase
 
     public function testIsActiveReturnsTrueWhenRequestHasMoreParams()
     {
-        $this->markTestSkipped();
         $page = new Page\Mvc(array(
             'label'      => 'foo',
             'action'     => 'view',
@@ -259,8 +249,6 @@ class MvcTest extends TestCase
             'id'         => '1337',
         ));
 
-        $this->urlHelper->setRouteMatch($routeMatch);
-
         $page->setRouteMatch($routeMatch);
 
         $this->assertTrue($page->isActive());
@@ -268,7 +256,6 @@ class MvcTest extends TestCase
 
     public function testIsActiveReturnsFalseWhenRequestHasLessParams()
     {
-        $this->markTestSkipped();
         $page = new Page\Mvc(array(
             'label'      => 'foo',
             'action'     => 'view',
@@ -283,8 +270,6 @@ class MvcTest extends TestCase
             'action'     => 'view',
             'id'         => null
         ));
-
-        $this->urlHelper->setRouteMatch($routeMatch);
 
         $page->setRouteMatch($routeMatch);
 
@@ -421,13 +406,14 @@ class MvcTest extends TestCase
 
     public function testSpecifyingAnotherUrlHelperToGenerateHrefs()
     {
-        $this->markTestSkipped();
-        $newHelper = new TestAsset\UrlHelper();
+        $newRouter = new TestAsset\Router();
 
-        $page = new Page\Mvc();
-        $page->setUrlHelper($newHelper);
+        $page = new Page\Mvc(array(
+            'route' => 'default'
+        ));
+        $page->setRouter($newRouter);
 
-        $expected = TestAsset\UrlHelper::RETURN_URL;
+        $expected = TestAsset\Router::RETURN_URL;
         $actual   = $page->getHref();
 
         $this->assertEquals($expected, $actual);

--- a/tests/Zend/Navigation/Page/MvcTest.php
+++ b/tests/Zend/Navigation/Page/MvcTest.php
@@ -21,15 +21,14 @@
 
 namespace ZendTest\Navigation\Page;
 
-use PHPUnit_Framework_TestCase as TestCase,
-    Zend\View\Helper\Url as UrlHelper,
-    Zend\Mvc\Router\RouteMatch,
-    Zend\Mvc\Router\Http\Regex as RegexRoute,
-    Zend\Mvc\Router\Http\Literal as LiteralRoute,
-    Zend\Mvc\Router\Http\TreeRouteStack,
-    Zend\Navigation\Page,
-    Zend\Navigation,
-    ZendTest\Navigation\TestAsset;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mvc\Router\RouteMatch;
+use Zend\Mvc\Router\Http\Regex as RegexRoute;
+use Zend\Mvc\Router\Http\Literal as LiteralRoute;
+use Zend\Mvc\Router\Http\TreeRouteStack;
+use Zend\Navigation\Page;
+use Zend\Navigation;
+use ZendTest\Navigation\TestAsset;
 
 /**
  * Tests the class Zend_Navigation_Page_Mvc
@@ -43,10 +42,6 @@ use PHPUnit_Framework_TestCase as TestCase,
  */
 class MvcTest extends TestCase
 {
-    protected $_front;
-    protected $_oldRequest;
-    protected $_oldRouter;
-
     protected function setUp()
     {
         $this->route  = new RegexRoute(
@@ -62,10 +57,6 @@ class MvcTest extends TestCase
 
         $this->routeMatch = new RouteMatch(array());
         $this->routeMatch->setMatchedRouteName('default');
-
-        $this->urlHelper = new UrlHelper();
-        $this->urlHelper->setRouter($this->router);
-        $this->urlHelper->setRouteMatch($this->routeMatch);
     }
 
     protected function tearDown()
@@ -80,7 +71,7 @@ class MvcTest extends TestCase
             'controller' => 'index'
         ));
         $page->setRouteMatch($this->routeMatch);
-        $page->setUrlHelper($this->urlHelper);
+        $page->setRouter($this->router);
         $page->setAction('view');
         $page->setController('news');
 
@@ -117,11 +108,7 @@ class MvcTest extends TestCase
             'page'       => 1,
         ));
 
-        $urlHelper = new UrlHelper();
-        $urlHelper->setRouter($router);
-        $urlHelper->setRouteMatch($routeMatch);
-
-        $page->setUrlHelper($urlHelper);
+        $page->setRouter($router);
         $page->setRouteMatch($routeMatch);
 
         $this->assertEquals('/lolcat/myaction/1337', $page->getHref());
@@ -142,11 +129,7 @@ class MvcTest extends TestCase
         $routeMatch = new RouteMatch(array());
         $routeMatch->setMatchedRouteName('lolfish');
 
-        $urlHelper = new UrlHelper;
-        $urlHelper->setRouter($router);
-        $urlHelper->setRouteMatch($routeMatch);
-
-        $page->setUrlHelper($urlHelper);
+        $page->setRouter($router);
         $page->setRouteMatch($routeMatch);
 
         $this->assertEquals(true, $page->isActive());
@@ -157,8 +140,6 @@ class MvcTest extends TestCase
         $page = new Page\Mvc();
 
         $routeMatch = new RouteMatch(array());
-        $this->urlHelper->setRouteMatch($routeMatch);
-
         $page->setRouteMatch($routeMatch);
 
         $this->assertFalse($page->isActive());
@@ -193,13 +174,14 @@ class MvcTest extends TestCase
         $this->routeMatch->setMatchedRouteName('myroute');
 
         $page->setRouteMatch($this->routeMatch);
-        $page->setUrlHelper($this->urlHelper);
+        $page->setRouter($this->router);
 
         $this->assertEquals('/lolcat/myaction/1337#qux', $page->getHref());
     }
 
     public function testIsActiveReturnsTrueOnIdenticalControllerAction()
     {
+        $this->markTestSkipped();
         $page = new Page\Mvc(array(
             'action'     => 'index',
             'controller' => 'index'
@@ -219,6 +201,7 @@ class MvcTest extends TestCase
 
     public function testIsActiveReturnsFalseOnDifferentControllerAction()
     {
+        $this->markTestSkipped();
         $page = new Page\Mvc(array(
             'action'     => 'bar',
             'controller' => 'index'
@@ -238,6 +221,7 @@ class MvcTest extends TestCase
 
     public function testIsActiveReturnsTrueOnIdenticalIncludingPageParams()
     {
+        $this->markTestSkipped();
         $page = new Page\Mvc(array(
             'label'      => 'foo',
             'action'     => 'view',
@@ -262,6 +246,7 @@ class MvcTest extends TestCase
 
     public function testIsActiveReturnsTrueWhenRequestHasMoreParams()
     {
+        $this->markTestSkipped();
         $page = new Page\Mvc(array(
             'label'      => 'foo',
             'action'     => 'view',
@@ -283,6 +268,7 @@ class MvcTest extends TestCase
 
     public function testIsActiveReturnsFalseWhenRequestHasLessParams()
     {
+        $this->markTestSkipped();
         $page = new Page\Mvc(array(
             'label'      => 'foo',
             'action'     => 'view',
@@ -435,6 +421,7 @@ class MvcTest extends TestCase
 
     public function testSpecifyingAnotherUrlHelperToGenerateHrefs()
     {
+        $this->markTestSkipped();
         $newHelper = new TestAsset\UrlHelper();
 
         $page = new Page\Mvc();
@@ -446,44 +433,44 @@ class MvcTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testDefaultUrlHelperCanBeSetWithConstructor()
+    public function testDefaultRouterCanBeSetWithConstructor()
     {
         $page = new Page\Mvc(array(
-            'label'            => 'foo',
-            'action'           => 'index',
-            'controller'       => 'index',
-            'defaultUrlHelper' => $this->urlHelper
+            'label'         => 'foo',
+            'action'        => 'index',
+            'controller'    => 'index',
+            'defaultRouter' => $this->router
         ));
 
-        $this->assertEquals($this->urlHelper, $page->getDefaultUrlHelper());
-        $page->setDefaultUrlHelper(null);
+        $this->assertEquals($this->router, $page->getDefaultRouter());
+        $page->setDefaultRouter(null);
     }
 
-    public function testDefaultUrlHelperCanBeSetWithGetter()
+    public function testDefaultRouterCanBeSetWithGetter()
     {
         $page = new Page\Mvc(array(
             'label'            => 'foo',
             'action'           => 'index',
             'controller'       => 'index',
         ));
-        $page->setDefaultUrlHelper($this->urlHelper);
+        $page->setDefaultRouter($this->router);
 
-        $this->assertEquals($this->urlHelper, $page->getDefaultUrlHelper());
-        $page->setDefaultUrlHelper(null);
+        $this->assertEquals($this->router, $page->getDefaultRouter());
+        $page->setDefaultRouter(null);
     }
 
-    public function testNoExceptionForGetHrefIfDefaultUrlHelperIsSet()
+    public function testNoExceptionForGetHrefIfDefaultRouterIsSet()
     {
         $page = new Page\Mvc(array(
             'label'            => 'foo',
             'action'           => 'index',
             'controller'       => 'index',
-            'defaultUrlHelper' => $this->urlHelper
+            'defaultRouter' => $this->router
         ));
 
-        // If the default url helper is not used an exception will be thrown.
+        // If the default router is not used an exception will be thrown.
         // This method intentionally has no assertion.
         $page->getHref();
-        $page->setDefaultUrlHelper(null);
+        $page->setDefaultRouter(null);
     }
 }

--- a/tests/Zend/Navigation/ServiceFactoryTest.php
+++ b/tests/Zend/Navigation/ServiceFactoryTest.php
@@ -133,7 +133,7 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $recursive = function($that, $pages) use (&$recursive) {
             foreach($pages as $page) {
                 if ($page instanceof MvcPage) {
-                    $that->assertInstanceOf('Zend\View\Helper\Url', $page->getUrlHelper());
+                    $that->assertInstanceOf('Zend\Mvc\Router\RouteStackInterface', $page->getRouter());
                     $that->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $page->getRouteMatch());
                 }
 

--- a/tests/Zend/Navigation/TestAsset/Router.php
+++ b/tests/Zend/Navigation/TestAsset/Router.php
@@ -28,11 +28,11 @@ namespace ZendTest\Navigation\TestAsset;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class UrlHelper extends \Zend\View\Helper\Url
+class Router extends \Zend\Mvc\Router\Http\TreeRouteStack
 {
     const RETURN_URL = 'spotify:track:2nd6CTjR9zjHGT0QtpfLHe';
 
-    public function __invoke($name = null, array $params = array(), array $options = array(), $reuseMatchedParams = false)
+    public function assemble(array $params = array(), array $options = array())
     {
         return self::RETURN_URL;
     }


### PR DESCRIPTION
The `Url` view helper is depending on the `Router` to assemble urls. The use of the url view helper in `Zend\Navigation` adds an unnecessary dependency for `Zend\View`, where the mvc navigation page already depends on `Zend\Mvc\Router\Route\RouteInterface`. Replacing the url view helper by a router does not change any behavior in url assembling, and simplifies usage of navigation.

Using the url helper is also problematic for this use case: to inject automatically the `RouteMatch` into the helper, you set up a factory to inject the router and routematch ([example](https://github.com/juriansluiman/SlmCmfUtils/blob/master/Module.php#L33)). To get this working, you want to make sure the first usage of the view helper happens after routing, but navigation parsing can happen anywhere in the process (bootstrap or during an early route listener).

This will create complexity, as you have to have a factory for the url view helper to inject the router and a listener after the route event to inject the routematch. Using the router directly in the navigation solves this completely.

**P.S.** everything is updated, PR should be safe to merge. Travis puts a build status "unknown" here below, but click to see that the builds are passing.

**P.P.S** the previous PR #1565 went terribly wrong when I tried to rebase my commits. I cherry-picked the commits from #1565 and put those in a new branch, created from a fresh master. It should be OK to merge now, tests pass (link to Zend\Navigation test: http://travis-ci.org/#!/juriansluiman/zf2/jobs/1736399/L682)

[![Build Status](https://secure.travis-ci.org/juriansluiman/zf2.png?branch=feature/navigation-mvc-router2)](http://travis-ci.org/juriansluiman/zf2)
