### PR TITLE
Simplify preparation of elements

### DIFF
--- a/library/Zend/Form/Element/Csrf.php
+++ b/library/Zend/Form/Element/Csrf.php
@@ -153,7 +153,7 @@ class Csrf extends Element implements InputProviderInterface, ElementPrepareAwar
     /**
      * Prepare the form element
      */
-    public function prepare(Form $form)
+    public function prepareElement(Form $form)
     {
         $this->getValidator()->getHash(true);
     }

--- a/library/Zend/Form/ElementPrepareAwareInterface.php
+++ b/library/Zend/Form/ElementPrepareAwareInterface.php
@@ -28,9 +28,11 @@ namespace Zend\Form;
  */
 interface ElementPrepareAwareInterface
 {
-
     /**
      * Prepare the form element
+     *
+     * @param Form $form
+     * @return mixed
      */
-    public function prepare(Form $form);
+    public function prepareElement(Form $form);
 }

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -263,9 +263,10 @@ class Fieldset extends Element implements FieldsetInterface
      * Ensures state is ready for use. Here, we append the name of the fieldsets to every elements in order to avoid
      * name clashes if the same fieldset is used multiple times
      *
-     * @return void
+     * @param Form $form
+     * @return mixed|void
      */
-    public function prepare()
+    public function prepareElement(Form $form)
     {
         $name = $this->getName();
 
@@ -273,8 +274,8 @@ class Fieldset extends Element implements FieldsetInterface
             $elementOrFieldset->setName($name . '[' . $elementOrFieldset->getName() . ']');
 
             // Recursively prepare fieldsets
-            if ($elementOrFieldset instanceof FieldsetInterface) {
-                $elementOrFieldset->prepare();
+            if ($elementOrFieldset instanceof ElementPrepareAwareInterface) {
+                $elementOrFieldset->prepareElement($form);
             }
         }
     }

--- a/library/Zend/Form/FieldsetInterface.php
+++ b/library/Zend/Form/FieldsetInterface.php
@@ -32,7 +32,8 @@ use IteratorAggregate;
 interface FieldsetInterface extends
     Countable,
     IteratorAggregate,
-    ElementInterface
+    ElementInterface,
+    ElementPrepareAwareInterface
 {
     /**
      * Add an element or fieldset
@@ -89,13 +90,6 @@ interface FieldsetInterface extends
      * @return array|\Traversable
      */
     public function getFieldsets();
-
-    /**
-     * Ensures state is ready for use
-     *
-     * @return void
-     */
-    public function prepare();
 
     /**
      * Recursively populate value attributes of elements

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -135,48 +135,7 @@ class Form extends BaseForm implements FormFactoryAwareInterface
 
         foreach ($this->getIterator() as $elementOrFieldset) {
             if ($elementOrFieldset instanceof ElementPrepareAwareInterface) {
-                $this->prepareElement($elementOrFieldset);
-                continue;
-            }
-            if ($elementOrFieldset instanceof FieldsetInterface) {
-                $this->prepareFieldset($elementOrFieldset);
-                continue;
-            }
-        }
-    }
-
-    /**
-     * Prepare a form element
-     *
-     * @param  ElementPrepareAwareInterface $element
-     * @return void
-     */
-    protected function prepareElement(ElementPrepareAwareInterface $element)
-    {
-        $element->prepare($this);
-    }
-
-    /**
-     * Recursively prepare a fieldset
-     * 
-     * @param  FieldsetInterface $fieldset 
-     * @return void
-     */
-    protected function prepareFieldset(FieldsetInterface $fieldset)
-    {
-        if (method_exists($fieldset, 'prepare')) {
-            $fieldset->prepare();
-            return;
-        }
-
-        foreach ($fieldset->getIterator() as $elementOrFieldset) {
-            if ($elementOrFieldset instanceof ElementPrepareAwareInterface) {
-                $this->prepareElement($elementOrFieldset);
-                continue;
-            }
-            if ($elementOrFieldset instanceof FieldsetInterface) {
-                $this->prepareFieldset($elementOrFieldset);
-                continue;
+                $elementOrFieldset->prepareElement($this);
             }
         }
     }


### PR DESCRIPTION
Refactored it a bit. I'm not sure if prepareElement should accept a Form instance. If not we could remove it and have a single prepare function.

But well, it can have uses I didn't spot yet.
