### PR TITLE
Pass the original MvcEvent to dispatch.error listeners

### DIFF
--- a/library/Zend/Mvc/DispatchListener.php
+++ b/library/Zend/Mvc/DispatchListener.php
@@ -102,46 +102,40 @@ class DispatchListener implements ListenerAggregateInterface
         try {
             $controller = $controllerLoader->get($controllerName);
         } catch (ServiceNotFoundException $exception) {
-            $error = clone $e;
-            $error->setError($application::ERROR_CONTROLLER_NOT_FOUND)
+            $e->setError($application::ERROR_CONTROLLER_NOT_FOUND)
                   ->setController($controllerName)
                   ->setControllerClass('invalid controller class or alias: '.$controllerName)
                   ->setParam('exception', $exception);
 
-            $results = $events->trigger('dispatch.error', $error);
-            if (count($results)) {
-                $return = $results->last();
-            } else {
-                $return = $error->getParams();
+            $results = $events->trigger('dispatch.error', $e);
+            $return = $results->last();
+            if (! $return) {
+                $return = $e->getResult();
             }
             
             return $this->complete($return, $e);
         } catch (\Exception $exception) {
-            $error = clone $e;
-            $error->setError($application::ERROR_EXCEPTION)
+            $e->setError($application::ERROR_EXCEPTION)
                   ->setController($controllerName)
                   ->setParam('exception', $exception);
-            $results = $events->trigger('dispatch.error', $error);
-            if (count($results)) {
-                $return = $results->last();
-            } else {
-                $return = $error->getParams();
+            $results = $events->trigger('dispatch.error', $e);
+            $return = $results->last();
+            if (! $return) {
+                $return = $e->getResult();
             }
 
             return $this->complete($return, $e);
         }
 
         if (!$controller instanceof DispatchableInterface) {
-            $error = clone $e;
-            $error->setError($application::ERROR_CONTROLLER_INVALID)
+            $e->setError($application::ERROR_CONTROLLER_INVALID)
                 ->setController($controllerName)
                 ->setControllerClass(get_class($controller));
 
-            $results = $events->trigger('dispatch.error', $error);
-            if (count($results)) {
-                $return = $results->last();
-            } else {
-                $return = $error->getParams();
+            $results = $events->trigger('dispatch.error', $e);
+            $return = $results->last();
+            if (! $return) {
+                $return = $e->getResult();
             }
             return $this->complete($return, $e);
         }
@@ -156,16 +150,14 @@ class DispatchListener implements ListenerAggregateInterface
         try {
             $return = $controller->dispatch($request, $response);
         } catch (\Exception $ex) {
-            $error = clone $e;
-            $error->setError($application::ERROR_EXCEPTION)
+            $e->setError($application::ERROR_EXCEPTION)
                   ->setController($controllerName)
                   ->setControllerClass(get_class($controller))
                   ->setParam('exception', $ex);
-            $results = $events->trigger('dispatch.error', $error);
-            if (count($results)) {
-                $return = $results->last();
-            } else {
-                $return = $error->getParams();
+            $results = $events->trigger('dispatch.error', $e);
+            $return = $results->last();
+            if (! $return) {
+                $return = $e->getResult();
             }
         }
 

--- a/tests/Zend/Mvc/ApplicationTest.php
+++ b/tests/Zend/Mvc/ApplicationTest.php
@@ -560,4 +560,19 @@ class ApplicationTest extends TestCase
         $this->application->run();
         $this->assertContains('Zend\Mvc\Application', $response->getContent());
     }
+
+    public function testOnDispatchErrorEventPassedToTriggersShouldBeTheOriginalOne()
+    {
+        $this->setupPathController(false);
+        $controllerLoader = $this->serviceManager->get('ControllerLoader');
+        $controllerLoader->setInvokableClass('path', 'InvalidClassName');
+        $model = $this->getMock('Zend\View\Model\ViewModel');
+        $this->application->events()->attach('dispatch.error', function($e) use ($model) {
+            $e->setResult($model);
+        });
+
+        $this->application->run();
+        $event = $this->application->getMvcEvent();
+        $this->assertInstanceOf('Zend\View\Model\ViewModel', $event->getResult());
+    }
 }


### PR DESCRIPTION
Hi, the purpose of this PR is to let `dispatch.error` listeners to manipulate the original MvcEvent like `dispatch` listeners do.

I'll show an example: assume you want to render a custom `ViewModel` on `dispatch.error`, you'll probably do something like:

``` php
<?php
$app->events()->attach('dispatch.error', function(MvcEvent $e) {
    $model = new ViewModel();
    $e->setResult($model);
});
```

But currently this is not feasable.

Hey, wait, this is exactly what `Zend\Mvc\View\ExceptionStrategy` do, and it seems it works. Well, yes it works but it's a bug.

``` php
<?php
// Zend\Mvc\DispatchListener:159 clone the original event
// and pass it to Zend\Mvc\View\ExceptionStrategy
$error = clone $e;
$results = $events->trigger('dispatch.error', $error);

// Zend\Mvc\View\ExceptionStrategy:162 sets the new result
$model = new ViewModel();
$error->setResult($model);

// Now, at last Zend\Mvc\View\InjectViewModelListener:90 is triggered
// in the dispatch.error listeners list
$model = $error->getViewModel();

if ($result->terminate()) {
    $error->setViewModel($result);
    return;
}

$model->addChild($result);

// But in the past 6 lines note that

$error !== $e;
$model === $error->getViewModel();
$model === $e->getViewModel();

// Because clone clones the main object but not child, so the
// reference to the layout ViewModel is the same

// So, if I do not set my new ViewModel as Terminal, everything
// goes ok because 

$model->addChild($result);

// it's applied by reference to the original ViewModel of the original MvcEvent
// but if I want to set my ViewModel as Terminal

if ($result->terminate()) {
    $error->setViewModel($result);
    return;
}

// this sets the new ViewModel only in the cloned MvcEvent, and not in the original one.
// So, when all triggers are complete, in Zend\Mvc\DispatchListener:164

$results = $events->trigger('dispatch.error', $error);
    if (count($results)) {
        $return = $results->last();
    } else {
        $return = $error->getParams();
    }

return $this->complete($return, $e);

// $error has in memory the new result and the new ViewModel, but
// $e hasn't !
```

I've made a test to prove it, but it does not explain clearly all the logic behind this bug, so I preferred to document it on this PR.
