### PR TITLE
Rename Zend\Http accessors to get*() style

### DIFF
--- a/library/Zend/Authentication/Adapter/Http.php
+++ b/library/Zend/Authentication/Adapter/Http.php
@@ -348,7 +348,7 @@ class Http implements AdapterInterface
             $getHeader = 'Authorization';
         }
 
-        $headers = $this->_request->headers();
+        $headers = $this->_request->getHeaders();
         if (!$headers->has($getHeader)) {
             return $this->_challengeClient();
         }
@@ -412,7 +412,7 @@ class Http implements AdapterInterface
         $this->_response->setStatusCode($statusCode);
 
         // Send a challenge in each acceptable authentication scheme
-        $headers = $this->_response->headers();
+        $headers = $this->_response->getHeaders();
         if (in_array('basic', $this->_acceptSchemes)) {
             $headers->addHeaderLine($headerName, $this->_basicHeader());
         }
@@ -614,7 +614,7 @@ class Http implements AdapterInterface
         // would be surprising if the user just logged in.
         $timeout = ceil(time() / $this->_nonceTimeout) * $this->_nonceTimeout;
 
-        $nonce = hash('md5', $timeout . ':' . $this->_request->server()->get('HTTP_USER_AGENT') . ':' . __CLASS__);
+        $nonce = hash('md5', $timeout . ':' . $this->_request->getServer()->get('HTTP_USER_AGENT') . ':' . __CLASS__);
         return $nonce;
     }
 
@@ -688,7 +688,7 @@ class Http implements AdapterInterface
         // Section 3.2.2.5 in RFC 2617 says the authenticating server must
         // verify that the URI field in the Authorization header is for the
         // same resource requested in the Request Line.
-        $rUri = $this->_request->uri();
+        $rUri = $this->_request->getUri();
         $cUri = UriFactory::factory($temp[1]);
 
         // Make sure the path portion of both URIs is the same
@@ -744,7 +744,7 @@ class Http implements AdapterInterface
             if (!$ret || empty($temp[1])) {
 
                 // Big surprise: IE isn't RFC 2617-compliant.
-                $headers = $this->_request->headers();
+                $headers = $this->_request->getHeaders();
                 if (!$headers->has('User-Agent')) {
                     return false;
                 }

--- a/library/Zend/GData/App.php
+++ b/library/Zend/GData/App.php
@@ -241,7 +241,7 @@ class App
 
         $userAgent = $applicationId . ' Zend_Framework_Gdata/' .
             \Zend\Version::VERSION;
-        $client->getRequest()->headers()->addHeaderLine('User-Agent', $userAgent);
+        $client->getRequest()->getHeaders()->addHeaderLine('User-Agent', $userAgent);
         $client->setOptions(array(
             'strictredirects' => true
             )
@@ -750,7 +750,7 @@ class App
             return $feedContent;
         }
 
-        $header = $response->headers()->get('GData-Version');
+        $header = $response->getHeaders()->get('GData-Version');
         $majorProtocolVersion = null;
         $minorProtocolVersion = null;
         if ($header instanceof Http\Header\HeaderInterface) {
@@ -769,7 +769,7 @@ class App
         if ($this->getHttpClient() != null) {
             $feed->setHttpClient($this->getHttpClient());
         }
-        $etag = $response->headers()->get('ETag');
+        $etag = $response->getHeaders()->get('ETag');
         if ($etag instanceof Etag) {
             $feed->setEtag($etag);
         }
@@ -956,7 +956,7 @@ class App
         $returnEntry = new $className($response->getBody());
         $returnEntry->setHttpClient(self::getstaticHttpClient());
 
-        $etag = $response->headers()->get('ETag');
+        $etag = $response->getHeaders()->get('ETag');
         if ($etag instanceof Etag) {
             $returnEntry->setEtag($etag);
         }
@@ -995,7 +995,7 @@ class App
         $returnEntry = new $className($response->getBody());
         $returnEntry->setHttpClient(self::getstaticHttpClient());
 
-        $etag = $response->headers()->get('ETag');
+        $etag = $response->getHeaders()->get('ETag');
         if ($etag instanceof Etag) {
             $returnEntry->setEtag($etag);
         }

--- a/library/Zend/GData/YouTube.php
+++ b/library/Zend/GData/YouTube.php
@@ -178,11 +178,11 @@ class YouTube extends Media
         }
 
         if ($clientId != null) {
-            $client->getRequest()->headers()->addHeaderLine('X-GData-Client', $clientId);
+            $client->getRequest()->getHeaders()->addHeaderLine('X-GData-Client', $clientId);
         }
 
         if ($developerKey != null) {
-            $client->getRequest()->headers()->addHeaderLine('X-GData-Key', 'key='. $developerKey);
+            $client->getRequest()->getHeaders()->addHeaderLine('X-GData-Key', 'key='. $developerKey);
         }
 
         return parent::setHttpClient($client, $applicationId);

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -334,7 +334,7 @@ class Client implements Stdlib\DispatchableInterface
      */
     public function getUri()
     {
-        return $this->getRequest()->uri();
+        return $this->getRequest()->getUri();
     }
 
     /**
@@ -415,7 +415,7 @@ class Client implements Stdlib\DispatchableInterface
      */
     public function setParameterPost(array $post)
     {
-        $this->getRequest()->post()->fromArray($post);
+        $this->getRequest()->getPost()->fromArray($post);
         return $this;
     }
 
@@ -427,7 +427,7 @@ class Client implements Stdlib\DispatchableInterface
      */
     public function setParameterGet(array $query)
     {
-        $this->getRequest()->query()->fromArray($query);
+        $this->getRequest()->getQuery()->fromArray($query);
         return $this;
     }
 
@@ -545,7 +545,7 @@ class Client implements Stdlib\DispatchableInterface
      */
     public function hasHeader($name)
     {
-        $headers = $this->getRequest()->headers();
+        $headers = $this->getRequest()->getHeaders();
 
         if ($headers instanceof Headers) {
             return $headers->has($name);
@@ -562,7 +562,7 @@ class Client implements Stdlib\DispatchableInterface
      */
     public function getHeader($name)
     {
-        $headers = $this->getRequest()->headers();
+        $headers = $this->getRequest()->getHeaders();
 
         if ($headers instanceof Headers) {
             if ($headers->get($name)) {
@@ -766,7 +766,7 @@ class Client implements Stdlib\DispatchableInterface
             $uri = $this->getUri();
 
             // query
-            $query = $this->getRequest()->query();
+            $query = $this->getRequest()->getQuery();
 
             if (!empty($query)) {
                 $queryArray = $query->toArray();
@@ -855,17 +855,17 @@ class Client implements Stdlib\DispatchableInterface
             }
 
             // Get the cookies from response (if any)
-            $setCookie = $response->cookie();
+            $setCookie = $response->getCookie();
             if (!empty($setCookie)) {
                 $this->addCookie($setCookie);
             }
 
             // If we got redirected, look for the Location header
-            if ($response->isRedirect() && ($response->headers()->has('Location'))) {
+            if ($response->isRedirect() && ($response->getHeaders()->has('Location'))) {
 
                 // Avoid problems with buggy servers that add whitespace at the
                 // end of some headers
-                $location = trim($response->headers()->get('Location')->getFieldValue());
+                $location = trim($response->getHeaders()->get('Location')->getFieldValue());
 
                 // Check whether we send the exact same request again, or drop the parameters
                 // and send a GET request
@@ -946,7 +946,7 @@ class Client implements Stdlib\DispatchableInterface
             }
         }
 
-        $this->getRequest()->file()->set($filename, array(
+        $this->getRequest()->getFile()->set($filename, array(
             'formname' => $formname,
             'filename' => basename($filename),
             'ctype' => $ctype,
@@ -964,9 +964,9 @@ class Client implements Stdlib\DispatchableInterface
      */
     public function removeFileUpload($filename)
     {
-        $file = $this->getRequest()->file()->get($filename);
+        $file = $this->getRequest()->getFile()->get($filename);
         if (!empty($file)) {
-            $this->getRequest()->file()->set($filename, null);
+            $this->getRequest()->getFile()->set($filename, null);
             return true;
         }
         return false;
@@ -1026,7 +1026,7 @@ class Client implements Stdlib\DispatchableInterface
         }
 
         // Set the connection header
-        if (!$this->getRequest()->headers()->has('Connection')) {
+        if (!$this->getRequest()->getHeaders()->has('Connection')) {
             if (!$this->config['keepalive']) {
                 $headers['Connection'] = 'close';
             }
@@ -1044,7 +1044,7 @@ class Client implements Stdlib\DispatchableInterface
 
 
         // Set the user agent header
-        if (!$this->getRequest()->headers()->has('User-Agent') && isset($this->config['useragent'])) {
+        if (!$this->getRequest()->getHeaders()->has('User-Agent') && isset($this->config['useragent'])) {
             $headers['User-Agent'] = $this->config['useragent'];
         }
 
@@ -1078,7 +1078,7 @@ class Client implements Stdlib\DispatchableInterface
         }
 
         // Merge the headers of the request (if any)
-        $requestHeaders = $this->getRequest()->headers()->toArray();
+        $requestHeaders = $this->getRequest()->getHeaders()->toArray();
         foreach ($requestHeaders as $key => $value) {
             $headers[$key] = $value;
         }
@@ -1107,8 +1107,8 @@ class Client implements Stdlib\DispatchableInterface
         $body = '';
         $totalFiles = 0;
 
-        if (!$this->getRequest()->headers()->has('Content-Type')) {
-            $totalFiles = count($this->getRequest()->file()->toArray());
+        if (!$this->getRequest()->getHeaders()->has('Content-Type')) {
+            $totalFiles = count($this->getRequest()->getFile()->toArray());
             // If we have files to upload, force encType to multipart/form-data
             if ($totalFiles > 0) {
                 $this->setEncType(self::ENC_FORMDATA);
@@ -1118,26 +1118,26 @@ class Client implements Stdlib\DispatchableInterface
         }
 
         // If we have POST parameters or files, encode and add them to the body
-        if (count($this->getRequest()->post()->toArray()) > 0 || $totalFiles > 0) {
+        if (count($this->getRequest()->getPost()->toArray()) > 0 || $totalFiles > 0) {
             if (stripos($this->getEncType(), self::ENC_FORMDATA) === 0) {
                 $boundary = '---ZENDHTTPCLIENT-' . md5(microtime());
                 $this->setEncType(self::ENC_FORMDATA, $boundary);
 
                 // Get POST parameters and encode them
-                $params = self::flattenParametersArray($this->getRequest()->post()->toArray());
+                $params = self::flattenParametersArray($this->getRequest()->getPost()->toArray());
                 foreach ($params as $pp) {
                     $body .= $this->encodeFormData($boundary, $pp[0], $pp[1]);
                 }
 
                 // Encode files
-                foreach ($this->getRequest()->file()->toArray() as $key => $file) {
+                foreach ($this->getRequest()->getFile()->toArray() as $key => $file) {
                     $fhead = array('Content-Type' => $file['ctype']);
                     $body .= $this->encodeFormData($boundary, $file['formname'], $file['data'], $file['filename'], $fhead);
                 }
                 $body .= "--{$boundary}--\r\n";
             } elseif (stripos($this->getEncType(), self::ENC_URLENCODED) === 0) {
                 // Encode body as application/x-www-form-urlencoded
-                $body = http_build_query($this->getRequest()->post()->toArray());
+                $body = http_build_query($this->getRequest()->getPost()->toArray());
             } else {
                 throw new Client\Exception\RuntimeException("Cannot handle content type '{$this->encType}' automatically");
             }

--- a/library/Zend/Http/Client/Adapter/Proxy.php
+++ b/library/Zend/Http/Client/Adapter/Proxy.php
@@ -81,7 +81,7 @@ class Proxy extends Socket
         if (! $this->config['proxy_host']) {
             return parent::connect($host, $port, $secure);
         }
-        
+
         /* Url might require stream context even if proxy connection doesn't */
         if ($secure) {
             $this->config['sslusecontext'] = true;
@@ -172,7 +172,7 @@ class Proxy extends Socket
                 throw new AdapterException\RuntimeException('Error writing request to server');
             }
         }
-        
+
         return $request;
     }
 

--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -55,11 +55,11 @@ class Socket implements HttpAdapter, StreamInterface
 
     /**
      * Stream for storing output
-     * 
+     *
      * @var resource
      */
     protected $out_stream = null;
-    
+
     /**
      * Parameters array
      *
@@ -237,7 +237,7 @@ class Socket implements HttpAdapter, StreamInterface
         }
     }
 
-    
+
     /**
      * Send request to the remote server
      *
@@ -279,12 +279,12 @@ class Socket implements HttpAdapter, StreamInterface
             // Add the request body
             $request .= "\r\n" . $body;
         }
-        
+
         // Send the request
         if (! @fwrite($this->socket, $request)) {
             throw new AdapterException\RuntimeException('Error writing request to server');
         }
-        
+
         if (is_resource($body)) {
             if (stream_copy_to_stream($body, $this->socket) == 0) {
                 throw new AdapterException\RuntimeException('Error writing request to server');
@@ -312,18 +312,18 @@ class Socket implements HttpAdapter, StreamInterface
                 if (rtrim($line) === '') break;
             }
         }
-        
+
         $this->_checkSocketReadTimeout();
 
         $responseObj= Response::fromString($response);
-        
+
         $statusCode = $responseObj->getStatusCode();
 
         // Handle 100 and 101 responses internally by restarting the read again
         if ($statusCode == 100 || $statusCode == 101) return $this->read();
 
         // Check headers to see what kind of connection / transfer encoding we have
-        $headers = $responseObj->headers();
+        $headers = $responseObj->getHeaders();
 
         /**
          * Responses to HEAD requests and 204 or 304 responses are not expected
@@ -344,7 +344,7 @@ class Socket implements HttpAdapter, StreamInterface
         $transfer_encoding = $headers->get('transfer-encoding');
         $content_length = $headers->get('content-length');
         if ($transfer_encoding !== false) {
-            
+
             if (strtolower($transfer_encoding->getFieldValue()) == 'chunked') {
 
                 do {
@@ -374,7 +374,7 @@ class Socket implements HttpAdapter, StreamInterface
                         if ($this->out_stream) {
                             if (stream_copy_to_stream($this->socket, $this->out_stream, $read_to - $current_pos) == 0) {
                               $this->_checkSocketReadTimeout();
-                              break;   
+                              break;
                              }
                         } else {
                             $line = @fread($this->socket, $read_to - $current_pos);
@@ -398,7 +398,7 @@ class Socket implements HttpAdapter, StreamInterface
                 throw new AdapterException\RuntimeException('Cannot handle "' .
                     $transfer_encoding->getFieldValue() . '" transfer encoding');
             }
-            
+
             // We automatically decode chunked-messages when writing to a stream
             // this means we have to disallow the Zend_Http_Response to do it again
             if ($this->out_stream) {
@@ -413,7 +413,7 @@ class Socket implements HttpAdapter, StreamInterface
                 $content_length = $content_length[count($content_length) - 1];
             }
             $contentLength = $content_length->getFieldValue();
-            
+
             $current_pos = ftell($this->socket);
             $chunk = '';
 
@@ -424,7 +424,7 @@ class Socket implements HttpAdapter, StreamInterface
                  if ($this->out_stream) {
                      if (@stream_copy_to_stream($this->socket, $this->out_stream, $read_to - $current_pos) == 0) {
                           $this->_checkSocketReadTimeout();
-                          break;   
+                          break;
                      }
                  } else {
                     $chunk = @fread($this->socket, $read_to - $current_pos);
@@ -447,7 +447,7 @@ class Socket implements HttpAdapter, StreamInterface
                 if ($this->out_stream) {
                     if (@stream_copy_to_stream($this->socket, $this->out_stream) == 0) {
                           $this->_checkSocketReadTimeout();
-                          break;   
+                          break;
                      }
                 } else {
                     $buff = @fread($this->socket, 8192);
@@ -504,19 +504,19 @@ class Socket implements HttpAdapter, StreamInterface
             }
         }
     }
-    
+
     /**
      * Set output stream for the response
-     * 
+     *
      * @param resource $stream
      * @return \Zend\Http\Client\Adapter\Socket
      */
-    public function setOutputStream($stream) 
+    public function setOutputStream($stream)
     {
         $this->out_stream = $stream;
         return $this;
     }
-    
+
     /**
      * Destructor: make sure the socket is disconnected
      *

--- a/library/Zend/Http/Client/Adapter/StreamInterface.php
+++ b/library/Zend/Http/Client/Adapter/StreamInterface.php
@@ -36,11 +36,11 @@ interface StreamInterface
 {
     /**
      * Set output stream
-     * 
+     *
      * This function sets output stream where the result will be stored.
-     * 
+     *
      * @param resource $stream Stream to write the output to
-     * 
+     *
      */
     function setOutputStream($stream);
 }

--- a/library/Zend/Http/Client/Cookies.php
+++ b/library/Zend/Http/Client/Cookies.php
@@ -31,7 +31,7 @@ use Zend\Stdlib\ParametersInterface,
  * be used along with Zend_Http_Client in order to manage cookies across HTTP requests and
  * responses.
  *
- * The class contains an array of Zend\Http\Header\Cookie objects. Cookies can be added 
+ * The class contains an array of Zend\Http\Header\Cookie objects. Cookies can be added
  * automatically from a request or manually. Then, the Cookies class can find and return the
  * cookies needed for a specific HTTP request.
  *
@@ -49,7 +49,7 @@ use Zend\Stdlib\ParametersInterface,
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Cookies //implements ParametersInterface
+class Cookies
 {
     /**
      * Return cookie(s) as a Zend\Http\Header\Cookie object
@@ -96,7 +96,7 @@ class Cookies //implements ParametersInterface
     protected $_rawCookies = array();
 
     /**
-     * Construct 
+     * Construct
      *
      */
     public function __construct()
@@ -139,7 +139,7 @@ class Cookies //implements ParametersInterface
      */
     public function addCookiesFromResponse(Response $response, $ref_uri)
     {
-        $cookie_hdrs = $response->headers()->get('Set-Cookie');
+        $cookie_hdrs = $response->getHeaders()->get('Set-Cookie');
 
         if (is_array($cookie_hdrs)) {
             foreach ($cookie_hdrs as $cookie) {
@@ -375,7 +375,7 @@ class Cookies //implements ParametersInterface
     }
 
     /**
-     * Tells if the array of cookies is empty 
+     * Tells if the array of cookies is empty
      *
      * @return bool
      */

--- a/library/Zend/Http/ClientStatic.php
+++ b/library/Zend/Http/ClientStatic.php
@@ -67,11 +67,11 @@ class ClientStatic
         $request->setMethod(Request::METHOD_GET);
 
         if (!empty($query) && is_array($query)) {
-            $request->query()->fromArray($query);
+            $request->getQuery()->fromArray($query);
         }
 
         if (!empty($headers) && is_array($headers)) {
-            $request->headers()->addHeaders($headers);
+            $request->getHeaders()->addHeaders($headers);
         }
 
         if (!empty($body)) {
@@ -99,7 +99,7 @@ class ClientStatic
         $request->setMethod(Request::METHOD_POST);
 
         if (!empty($params) && is_array($params)) {
-            $request->post()->fromArray($params);
+            $request->getPost()->fromArray($params);
         } else {
             throw new Exception\InvalidArgumentException('The array of post parameters is empty');
         }
@@ -109,7 +109,7 @@ class ClientStatic
         }
 
         if (!empty($headers) && is_array($headers)) {
-            $request->headers()->addHeaders($headers);
+            $request->getHeaders()->addHeaders($headers);
         }
 
         if (!empty($body)) {

--- a/library/Zend/Http/ClientStatic.php
+++ b/library/Zend/Http/ClientStatic.php
@@ -32,7 +32,7 @@ use Zend\Http\Client;
  */
 class ClientStatic
 {
-    
+
     protected static $client;
 
     /**
@@ -47,7 +47,7 @@ class ClientStatic
         }
         return self::$client;
     }
-    
+
     /**
      * HTTP GET METHOD (static)
      *
@@ -61,23 +61,23 @@ class ClientStatic
         if (empty($url)) {
             return false;
         }
-        
+
         $request= new Request();
         $request->setUri($url);
         $request->setMethod(Request::METHOD_GET);
-        
+
         if (!empty($query) && is_array($query)) {
             $request->query()->fromArray($query);
         }
-        
+
         if (!empty($headers) && is_array($headers)) {
             $request->headers()->addHeaders($headers);
         }
-        
+
         if (!empty($body)) {
             $request->setBody($body);
         }
-        
+
         return self::getStaticClient()->send($request);
     }
     /**
@@ -93,29 +93,29 @@ class ClientStatic
         if (empty($url)) {
             return false;
         }
-        
+
         $request= new Request();
         $request->setUri($url);
         $request->setMethod(Request::METHOD_POST);
-        
+
         if (!empty($params) && is_array($params)) {
             $request->post()->fromArray($params);
         } else {
             throw new Exception\InvalidArgumentException('The array of post parameters is empty');
         }
-        
+
         if (!isset($headers['Content-Type'])) {
             $headers['Content-Type']= Client::ENC_URLENCODED;
         }
-        
+
         if (!empty($headers) && is_array($headers)) {
             $request->headers()->addHeaders($headers);
         }
-        
+
         if (!empty($body)) {
             $request->setContent($body);
         }
-        
+
         return self::getStaticClient()->send($request);
     }
 }

--- a/library/Zend/Http/Cookies.php
+++ b/library/Zend/Http/Cookies.php
@@ -11,7 +11,7 @@ use Zend\Uri,
  * be used along with Zend_Http_Client in order to manage cookies across HTTP requests and
  * responses.
  *
- * The class contains an array of Zend\Http\Header\Cookie objects. Cookies can be added 
+ * The class contains an array of Zend\Http\Header\Cookie objects. Cookies can be added
  * automatically from a request or manually. Then, the Cookies class can find and return the
  * cookies needed for a specific HTTP request.
  *
@@ -31,48 +31,6 @@ use Zend\Uri,
  */
 class Cookies extends Headers
 {
-
-
-
-
-//    /**
-//     * Return cookie(s) as a Zend\Http\Header\Cookie object
-//     *
-//     */
-//    const COOKIE_OBJECT = 0;
-//
-//    /**
-//     * Return cookie(s) as a string (suitable for sending in an HTTP request)
-//     *
-//     */
-//    const COOKIE_STRING_ARRAY = 1;
-//
-//    /**
-//     * Return all cookies as one long string (suitable for sending in an HTTP request)
-//     *
-//     */
-//    const COOKIE_STRING_CONCAT = 2;
-//
-//    /**
-//     * Array storing cookies
-//     *
-//     * Cookies are stored according to domain and path:
-//     * $cookies
-//     *  + www.mydomain.com
-//     *    + /
-//     *      - cookie1
-//     *      - cookie2
-//     *    + /somepath
-//     *      - othercookie
-//     *  + www.otherdomain.net
-//     *    + /
-//     *      - alsocookie
-//     *
-//     * @var array
-//     */
-
-
-
     /**
      * @var Headers
      */
@@ -91,13 +49,6 @@ class Cookies extends Headers
             . __NAMESPACE__ . '\Headers::fromtString() instead.'
         );
     }
-
-//    /**
-//     * The Zend\Http\Header\Cookie array
-//     *
-//     * @var array
-//     */
-//    protected $_rawCookies = array();
 
     public function __construct(Headers $headers, $context = self::CONTEXT_REQUEST)
     {
@@ -358,7 +309,7 @@ class Cookies extends Headers
     }
 
     /**
-     * Tells if the array of cookies is empty 
+     * Tells if the array of cookies is empty
      *
      * @return bool
      */

--- a/library/Zend/Http/Exception/RuntimeException.php
+++ b/library/Zend/Http/Exception/RuntimeException.php
@@ -3,7 +3,7 @@
 namespace Zend\Http\Exception;
 
 class RuntimeException
-    extends \RuntimeException 
+    extends \RuntimeException
     implements ExceptionInterface
 {
 }

--- a/library/Zend/Http/Headers.php
+++ b/library/Zend/Http/Headers.php
@@ -195,7 +195,7 @@ class Headers implements Iterator, Countable
 
     /**
      * Add a Header to this container, for raw values @see addHeaderLine() and addHeaders()
-     * 
+     *
      * @param  Header\HeaderInterface $header
      * @return Headers
      */
@@ -229,7 +229,7 @@ class Headers implements Iterator, Countable
      * Clear all headers
      *
      * Removes all headers from queue
-     * 
+     *
      * @return Headers
      */
     public function clearHeaders()
@@ -240,7 +240,7 @@ class Headers implements Iterator, Countable
 
     /**
      * Get all headers of a certain name/type
-     * 
+     *
      * @param  string $name
      * @return bool|Header\HeaderInterface|ArrayIterator
      */
@@ -279,7 +279,7 @@ class Headers implements Iterator, Countable
 
     /**
      * Test for existence of a type of header
-     * 
+     *
      * @param  string $name
      * @return bool
      */

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -28,21 +28,21 @@ class Request extends HttpRequest
 {
     /**
      * Base URL of the application.
-     * 
+     *
      * @var string
      */
     protected $baseUrl;
-    
+
     /**
      * Base Path of the application.
      *
      * @var string
      */
     protected $basePath;
-    
+
     /**
      * Actual request URI, independent of the platform.
-     * 
+     *
      * @var string
      */
     protected $requestUri;
@@ -109,7 +109,7 @@ class Request extends HttpRequest
         }
         return $this->requestUri;
     }
-    
+
     /**
      * Set the base URL.
      *
@@ -134,10 +134,10 @@ class Request extends HttpRequest
         }
         return $this->baseUrl;
     }
-    
+
     /**
      * Set the base path.
-     * 
+     *
      * @param  string $basePath
      * @return self
      */
@@ -157,7 +157,7 @@ class Request extends HttpRequest
         if ($this->basePath === null) {
             $this->setBasePath($this->detectBasePath());
         }
-        
+
         return $this->basePath;
     }
 
@@ -188,14 +188,14 @@ class Request extends HttpRequest
             $this->setMethod($this->serverParams['REQUEST_METHOD']);
         }
 
-        if (isset($this->serverParams['SERVER_PROTOCOL']) 
+        if (isset($this->serverParams['SERVER_PROTOCOL'])
             && strpos($this->serverParams['SERVER_PROTOCOL'], '1.0') !== false) {
             $this->setVersion('1.0');
         }
 
         $this->setUri($uri = new HttpUri());
 
-        if (isset($this->serverParams['HTTPS']) && $this->serverParams['HTTPS'] === 'on') { 
+        if (isset($this->serverParams['HTTPS']) && $this->serverParams['HTTPS'] === 'on') {
             $uri->setScheme('https');
         } else {
             $uri->setScheme('http');
@@ -262,7 +262,7 @@ class Request extends HttpRequest
      *
      * Looks at a variety of criteria in order to attempt to autodetect a base
      * URI, including rewrite URIs, proxy URIs, etc.
-     * 
+     *
      * @return string
      */
     protected function detectRequestUri()
@@ -274,21 +274,21 @@ class Request extends HttpRequest
         if ($httpXRewriteUrl !== null) {
             $requestUri = $httpXRewriteUrl;
         }
-        
+
         // Check for IIS 7.0 or later with ISAPI_Rewrite
         $httpXOriginalUrl = $this->server()->get('HTTP_X_ORIGINAL_URL');
         if ($httpXOriginalUrl !== null) {
             $requestUri = $httpXOriginalUrl;
         }
-       
+
         // IIS7 with URL Rewrite: make sure we get the unencoded url
         // (double slash problem).
         $iisUrlRewritten = $this->server()->get('IIS_WasUrlRewritten');
         $unencodedUrl    = $this->server()->get('UNENCODED_URL', '');
         if ('1' == $iisUrlRewritten && '' !== $unencodedUrl) {
             return $unencodedUrl;
-        } 
-        
+        }
+
         // HTTP proxy requests setup request URI with scheme and host
         // [and port] + the URL path, only use URL path.
         if (!$httpXRewriteUrl) {
@@ -296,13 +296,13 @@ class Request extends HttpRequest
         }
         if ($requestUri !== null) {
             $schemeAndHttpHost = $this->uri()->getScheme() . '://' . $this->uri()->getHost();
-            
+
             if (strpos($requestUri, $schemeAndHttpHost) === 0) {
                 $requestUri = substr($requestUri, strlen($schemeAndHttpHost));
             }
             return $requestUri;
-        } 
-        
+        }
+
         // IIS 5.0, PHP as CGI.
         $origPathInfo = $this->server()->get('ORIG_PATH_INFO');
         if ($origPathInfo !== null) {
@@ -323,7 +323,7 @@ class Request extends HttpRequest
      * (i.e., anything additional to the document root).
      *
      * The base URL includes the schema, host, and port, in addition to the path.
-     * 
+     *
      * @return string
      */
     protected function detectBaseUrl()
@@ -393,7 +393,7 @@ class Request extends HttpRequest
      * Autodetect the base path of the request
      *
      * Uses several criteria to determine the base path of the request.
-     * 
+     *
      * @return string
      */
     protected function detectBasePath()
@@ -404,8 +404,8 @@ class Request extends HttpRequest
         // Empty base url detected
         if ($baseUrl === '') {
             return '';
-        } 
-        
+        }
+
         // basename() matches the script filename; return the directory
         if (basename($baseUrl) === $filename) {
             return str_replace('\\', '/', dirname($baseUrl));

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -295,7 +295,7 @@ class Request extends HttpRequest
             $requestUri = $this->getServer()->get('REQUEST_URI');
         }
         if ($requestUri !== null) {
-            $schemeAndHttpHost = $this->getUri()->getScheme() . '://' . $this->uri()->getHost();
+            $schemeAndHttpHost = $this->getUri()->getScheme() . '://' . $this->getUri()->getHost();
 
             if (strpos($requestUri, $schemeAndHttpHost) === 0) {
                 $requestUri = substr($requestUri, strlen($schemeAndHttpHost));

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -81,7 +81,7 @@ class Request extends HttpRequest
      */
     public function setCookies($cookie)
     {
-        $this->headers()->addHeader(new Cookie((array) $cookie));
+        $this->getHeaders()->addHeader(new Cookie((array) $cookie));
         return $this;
     }
 
@@ -182,7 +182,7 @@ class Request extends HttpRequest
             }
         }
 
-        $this->headers()->addHeaders($this->serverToHeaders($this->serverParams));
+        $this->getHeaders()->addHeaders($this->serverToHeaders($this->serverParams));
 
         if (isset($this->serverParams['REQUEST_METHOD'])) {
             $this->setMethod($this->serverParams['REQUEST_METHOD']);
@@ -205,13 +205,13 @@ class Request extends HttpRequest
             $uri->setQuery($this->serverParams['QUERY_STRING']);
         }
 
-        if ($this->headers()->get('host')) {
+        if ($this->getHeaders()->get('host')) {
             //TODO handle IPv6 with port
-            if (preg_match('|^([^:]+):([^:]+)$|', $this->headers()->get('host')->getFieldValue(), $match)) {
+            if (preg_match('|^([^:]+):([^:]+)$|', $this->getHeaders()->get('host')->getFieldValue(), $match)) {
                 $uri->setHost($match[1]);
                 $uri->setPort($match[2]);
             } else {
-                $uri->setHost($this->headers()->get('host')->getFieldValue());
+                $uri->setHost($this->getHeaders()->get('host')->getFieldValue());
             }
         } elseif (isset($this->serverParams['SERVER_NAME'])) {
             $uri->setHost($this->serverParams['SERVER_NAME']);
@@ -270,21 +270,21 @@ class Request extends HttpRequest
         $requestUri = null;
 
         // Check this first so IIS will catch.
-        $httpXRewriteUrl = $this->server()->get('HTTP_X_REWRITE_URL');
+        $httpXRewriteUrl = $this->getServer()->get('HTTP_X_REWRITE_URL');
         if ($httpXRewriteUrl !== null) {
             $requestUri = $httpXRewriteUrl;
         }
 
         // Check for IIS 7.0 or later with ISAPI_Rewrite
-        $httpXOriginalUrl = $this->server()->get('HTTP_X_ORIGINAL_URL');
+        $httpXOriginalUrl = $this->getServer()->get('HTTP_X_ORIGINAL_URL');
         if ($httpXOriginalUrl !== null) {
             $requestUri = $httpXOriginalUrl;
         }
 
         // IIS7 with URL Rewrite: make sure we get the unencoded url
         // (double slash problem).
-        $iisUrlRewritten = $this->server()->get('IIS_WasUrlRewritten');
-        $unencodedUrl    = $this->server()->get('UNENCODED_URL', '');
+        $iisUrlRewritten = $this->getServer()->get('IIS_WasUrlRewritten');
+        $unencodedUrl    = $this->getServer()->get('UNENCODED_URL', '');
         if ('1' == $iisUrlRewritten && '' !== $unencodedUrl) {
             return $unencodedUrl;
         }
@@ -292,10 +292,10 @@ class Request extends HttpRequest
         // HTTP proxy requests setup request URI with scheme and host
         // [and port] + the URL path, only use URL path.
         if (!$httpXRewriteUrl) {
-            $requestUri = $this->server()->get('REQUEST_URI');
+            $requestUri = $this->getServer()->get('REQUEST_URI');
         }
         if ($requestUri !== null) {
-            $schemeAndHttpHost = $this->uri()->getScheme() . '://' . $this->uri()->getHost();
+            $schemeAndHttpHost = $this->getUri()->getScheme() . '://' . $this->uri()->getHost();
 
             if (strpos($requestUri, $schemeAndHttpHost) === 0) {
                 $requestUri = substr($requestUri, strlen($schemeAndHttpHost));
@@ -304,9 +304,9 @@ class Request extends HttpRequest
         }
 
         // IIS 5.0, PHP as CGI.
-        $origPathInfo = $this->server()->get('ORIG_PATH_INFO');
+        $origPathInfo = $this->getServer()->get('ORIG_PATH_INFO');
         if ($origPathInfo !== null) {
-            $queryString = $this->server()->get('QUERY_STRING', '');
+            $queryString = $this->getServer()->get('QUERY_STRING', '');
             if ($queryString !== '') {
                 $origPathInfo .= '?' . $queryString;
             }
@@ -329,10 +329,10 @@ class Request extends HttpRequest
     protected function detectBaseUrl()
     {
         $baseUrl        = '';
-        $filename       = $this->server()->get('SCRIPT_FILENAME', '');
-        $scriptName     = $this->server()->get('SCRIPT_NAME');
-        $phpSelf        = $this->server()->get('PHP_SELF');
-        $origScriptName = $this->server()->get('ORIG_SCRIPT_NAME');
+        $filename       = $this->getServer()->get('SCRIPT_FILENAME', '');
+        $scriptName     = $this->getServer()->get('SCRIPT_NAME');
+        $phpSelf        = $this->getServer()->get('PHP_SELF');
+        $origScriptName = $this->getServer()->get('ORIG_SCRIPT_NAME');
 
         if ($scriptName !== null && basename($scriptName) === $filename) {
             $baseUrl = $scriptName;
@@ -398,7 +398,7 @@ class Request extends HttpRequest
      */
     protected function detectBasePath()
     {
-        $filename = basename($this->server()->get('SCRIPT_FILENAME', ''));
+        $filename = basename($this->getServer()->get('SCRIPT_FILENAME', ''));
         $baseUrl  = $this->getBaseUrl();
 
         // Empty base url detected

--- a/library/Zend/Http/PhpEnvironment/Response.php
+++ b/library/Zend/Http/PhpEnvironment/Response.php
@@ -36,7 +36,7 @@ class Response extends HttpResponse
         $status  = $this->renderStatusLine();
         header($status);
 
-        foreach ($this->headers() as $header) {
+        foreach ($this->getHeaders() as $header) {
             if ($header instanceof MultipleHeaderInterface) {
                 header($header->toString(), false);
                 continue;

--- a/library/Zend/Http/PhpEnvironment/Response.php
+++ b/library/Zend/Http/PhpEnvironment/Response.php
@@ -16,17 +16,17 @@ class Response extends HttpResponse
     public function __construct()
     {
     }
-    
+
     public function headersSent()
     {
         return $this->headersSent;
     }
-    
+
     public function contentSent()
     {
         return $this->contentSent;
     }
-    
+
     public function sendHeaders()
     {
         if ($this->headersSent()) {
@@ -47,7 +47,7 @@ class Response extends HttpResponse
         $this->headersSent = true;
         return $this;
     }
-    
+
     public function sendContent()
     {
         if ($this->contentSent()) {
@@ -64,6 +64,6 @@ class Response extends HttpResponse
              ->sendContent();
         return $this;
     }
-    
+
 }
-    
+

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -194,11 +194,11 @@ class Request extends Message implements RequestInterface
     }
 
     /**
-     * Return the URI for this request object
+     * Return the URI for this request object as a string
      *
      * @return string
      */
-    public function getUri()
+    public function getUriString()
     {
         if ($this->uri instanceof HttpUri) {
             return $this->uri->toString();
@@ -207,11 +207,11 @@ class Request extends Message implements RequestInterface
     }
 
     /**
-     * Return the URI for this request object as an instance of Zend\Uri\Http
+     * Return the URI for this request object
      *
      * @return HttpUri
      */
-    public function uri()
+    public function getUri()
     {
         if ($this->uri === null || is_string($this->uri)) {
             $this->uri = new HttpUri($this->uri);
@@ -263,7 +263,7 @@ class Request extends Message implements RequestInterface
      *
      * @return \Zend\Stdlib\ParametersInterface
      */
-    public function query()
+    public function getQuery()
     {
         if ($this->queryParams === null) {
             $this->queryParams = new Parameters();
@@ -290,7 +290,7 @@ class Request extends Message implements RequestInterface
      *
      * @return \Zend\Stdlib\ParametersInterface
      */
-    public function post()
+    public function getPost()
     {
         if ($this->postParams === null) {
             $this->postParams = new Parameters();
@@ -305,9 +305,9 @@ class Request extends Message implements RequestInterface
      * @convenience $request->headers()->get('Cookie');
      * @return Header\Cookie
      */
-    public function cookie()
+    public function getCookie()
     {
-        return $this->headers()->get('Cookie');
+        return $this->getHeaders()->get('Cookie');
     }
 
     /**
@@ -328,7 +328,7 @@ class Request extends Message implements RequestInterface
      *
      * @return ParametersInterface
      */
-    public function file()
+    public function getFile()
     {
         if ($this->fileParams === null) {
             $this->fileParams = new Parameters();
@@ -356,7 +356,7 @@ class Request extends Message implements RequestInterface
      * @see http://www.faqs.org/rfcs/rfc3875.html
      * @return \Zend\Stdlib\ParametersInterface
      */
-    public function server()
+    public function getServer()
     {
         if ($this->serverParams === null) {
             $this->serverParams = new Parameters();
@@ -383,7 +383,7 @@ class Request extends Message implements RequestInterface
      *
      * @return \Zend\Stdlib\ParametersInterface
      */
-    public function env()
+    public function getEnv()
     {
         if ($this->envParams === null) {
             $this->envParams = new Parameters();
@@ -410,7 +410,7 @@ class Request extends Message implements RequestInterface
      *
      * @return \Zend\Http\Headers
      */
-    public function headers()
+    public function getHeaders()
     {
         if ($this->headers === null || is_string($this->headers)) {
             // this is only here for fromString lazy loading
@@ -509,7 +509,7 @@ class Request extends Message implements RequestInterface
      */
     public function isXmlHttpRequest()
     {
-        $header = $this->headers()->get('X_REQUESTED_WITH');
+        $header = $this->getHeaders()->get('X_REQUESTED_WITH');
         return false !== $header && $header->getFieldValue() == 'XMLHttpRequest';
     }
 
@@ -520,7 +520,7 @@ class Request extends Message implements RequestInterface
      */
     public function isFlashRequest()
     {
-        $header = $this->headers()->get('USER_AGENT');
+        $header = $this->getHeaders()->get('USER_AGENT');
         return false !== $header && stristr($header->getFieldValue(), ' flash');
 
     }

--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -257,7 +257,7 @@ class Response extends Message implements ResponseInterface
      *
      * @return Headers
      */
-    public function headers()
+    public function getHeaders()
     {
         if ($this->headers === null || is_string($this->headers)) {
             $this->headers = (is_string($this->headers)) ? Headers::fromString($this->headers) : new Headers();
@@ -268,9 +268,9 @@ class Response extends Message implements ResponseInterface
     /**
      * @return Header\SetCookie[]
      */
-    public function cookie()
+    public function getCookie()
     {
-        return $this->headers()->get('Set-Cookie');
+        return $this->getHeaders()->get('Set-Cookie');
     }
 
     /**
@@ -354,7 +354,7 @@ class Response extends Message implements ResponseInterface
     {
         $body = (string) $this->getContent();
 
-        $transferEncoding = $this->headers()->get('Transfer-Encoding');
+        $transferEncoding = $this->getHeaders()->get('Transfer-Encoding');
 
         if (!empty($transferEncoding)) {
             if (strtolower($transferEncoding->getFieldValue()) == 'chunked') {
@@ -362,7 +362,7 @@ class Response extends Message implements ResponseInterface
             }
         }
 
-        $contentEncoding = $this->headers()->get('Content-Encoding');
+        $contentEncoding = $this->getHeaders()->get('Content-Encoding');
 
         if (!empty($contentEncoding)) {
             $contentEncoding = $contentEncoding->getFieldValue();
@@ -470,7 +470,7 @@ class Response extends Message implements ResponseInterface
     public function toString()
     {
         $str  = $this->renderStatusLine() . "\r\n";
-        $str .= $this->headers()->toString();
+        $str .= $this->getHeaders()->toString();
         $str .= "\r\n";
         $str .= $this->getContent();
         return $str;

--- a/library/Zend/Http/Response/Stream.php
+++ b/library/Zend/Http/Response/Stream.php
@@ -195,7 +195,7 @@ class Stream extends Response
             $response->content = implode("\n", $responseArray);
         }
 
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         foreach($headers as $header) {
             if ($header instanceof \Zend\Http\Header\ContentLength) {
                 $response->contentLength = (int) $header->getFieldValue();

--- a/library/Zend/Http/Response/Stream.php
+++ b/library/Zend/Http/Response/Stream.php
@@ -37,21 +37,21 @@ use Zend\Http\Response,
  */
 class Stream extends Response
 {
-    
+
     /**
      * The Content-Length value, if set
      *
      * @var int
      */
     protected $contentLength = null;
-    
+
     /**
      * The portion of the body that has alredy been streamed
      *
      * @var int
      */
     protected $contentStreamed = 0;
-    
+
     /**
      * Response as stream
      *
@@ -139,7 +139,7 @@ class Stream extends Response
         return $this;
     }
 
-    
+
     /**
      * Create a new Zend\Http\Response\Stream object from a stream
      *
@@ -149,14 +149,14 @@ class Stream extends Response
      */
     public static function fromStream($responseString, $stream)
     {
-    
+
         if (!is_resource($stream)) {
             throw new Exception\InvalidArgumentException('A valid stream is required');
         }
 
         $headerComplete = false;
         $headersString  = '';
-        
+
         $responseArray = explode("\n",$responseString);
 
         while (count($responseArray)) {
@@ -167,34 +167,34 @@ class Stream extends Response
                 $headerComplete = true;
                 break;
             }
-            
+
         }
-        
+
         if (!$headerComplete) {
             while (false !== ($nextLine = fgets($stream))) {
-                
+
                 $headersString .= trim($nextLine)."\r\n";
                 if ($nextLine == "\r\n" || $nextLine == "\n") {
                     $headerComplete = true;
                     break;
                 }
             }
-        } 
+        }
 
         if (!$headerComplete) {
             throw new Exception\OutOfRangeException('End of header not found');
         }
-            
+
         $response = static::fromString($headersString);
-    
+
         if (is_resource($stream)) {
             $response->setStream($stream);
         }
-        
+
         if (count($responseArray)) {
             $response->content = implode("\n", $responseArray);
-        } 
-    
+        }
+
         $headers = $response->headers();
         foreach($headers as $header) {
             if ($header instanceof \Zend\Http\Header\ContentLength) {
@@ -210,8 +210,8 @@ class Stream extends Response
 
         return $response;
     }
-    
-    
+
+
     /**
      * Get the response body as string
      *
@@ -248,7 +248,7 @@ class Stream extends Response
         return $this->content;
     }
 
-    
+
     /**
      * Read stream content and return it as string
      *
@@ -267,15 +267,15 @@ class Stream extends Response
         if (!is_resource($this->stream) || $bytes == 0) {
             return '';
         }
-    
+
         $this->content         .= stream_get_contents($this->stream, $bytes);
         $this->contentStreamed += strlen($this->content);
-    
+
         if ($this->contentLength == $this->contentStreamed) {
             $this->stream = null;
         }
     }
-        
+
     /**
      * Destructor
      */

--- a/library/Zend/Json/Server/Client.php
+++ b/library/Zend/Json/Server/Client.php
@@ -138,7 +138,7 @@ class Client implements ServerClient
             $this->httpClient->setUri($this->serverAddress);
         }
 
-        $headers = $httpRequest->headers();
+        $headers = $httpRequest->getHeaders();
         $headers->addHeaders(array(
             'Content-Type' => 'application/json',
             'Accept'       => 'application/json',

--- a/library/Zend/Json/Server/Client.php
+++ b/library/Zend/Json/Server/Client.php
@@ -134,7 +134,7 @@ class Client implements ServerClient
         $this->lastRequest = $request;
 
         $httpRequest = $this->httpClient->getRequest();
-        if ($httpRequest->getUri() === null) {
+        if ($httpRequest->getUriString() === null) {
             $this->httpClient->setUri($this->serverAddress);
         }
 

--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -200,7 +200,7 @@ abstract class AbstractRestfulController implements
                         $return = $this->get($id);
                         break;
                     }
-                    if (null !== $id = $request->query()->get('id')) {
+                    if (null !== $id = $request->getQuery()->get('id')) {
                         $action = 'get';
                         $return = $this->get($id);
                         break;
@@ -210,11 +210,11 @@ abstract class AbstractRestfulController implements
                     break;
                 case 'post':
                     $action = 'create';
-                    $return = $this->create($request->post()->toArray());
+                    $return = $this->create($request->getPost()->toArray());
                     break;
                 case 'put':
                     if (null === $id = $routeMatch->getParam('id')) {
-                        if (!($id = $request->query()->get('id', false))) {
+                        if (!($id = $request->getQuery()->get('id', false))) {
                             throw new \DomainException('Missing identifier');
                         }
                     }
@@ -225,7 +225,7 @@ abstract class AbstractRestfulController implements
                     break;
                 case 'delete':
                     if (null === $id = $routeMatch->getParam('id')) {
-                        if (!($id = $request->query()->get('id', false))) {
+                        if (!($id = $request->getQuery()->get('id', false))) {
                             throw new \DomainException('Missing identifier');
                         }
                     }

--- a/library/Zend/Mvc/Controller/Plugin/Params.php
+++ b/library/Zend/Mvc/Controller/Plugin/Params.php
@@ -76,7 +76,7 @@ class Params extends AbstractPlugin
      */
     public function fromPost($param, $default = null)
     {
-        return $this->getController()->getRequest()->post()->get($param, $default);
+        return $this->getController()->getRequest()->getPost()->get($param, $default);
     }
 
     /**
@@ -88,6 +88,6 @@ class Params extends AbstractPlugin
      */
     public function fromQuery($param, $default = null)
     {
-        return $this->getController()->getRequest()->query()->get($param, $default);
+        return $this->getController()->getRequest()->getQuery()->get($param, $default);
     }
 }

--- a/library/Zend/Mvc/Controller/Plugin/Redirect.php
+++ b/library/Zend/Mvc/Controller/Plugin/Redirect.php
@@ -58,7 +58,7 @@ class Redirect extends AbstractPlugin
 
         $options['name'] = $route;
         $url = $router->assemble($params, $options);
-        $response->headers()->addHeaderLine('Location', $url);
+        $response->getHeaders()->addHeaderLine('Location', $url);
         $response->setStatusCode(302);
         return $response;
     }
@@ -72,7 +72,7 @@ class Redirect extends AbstractPlugin
     public function toUrl($url)
     {
         $response = $this->getResponse();
-        $response->headers()->addHeaderLine('Location', $url);
+        $response->getHeaders()->addHeaderLine('Location', $url);
         $response->setStatusCode(302);
         return $response;
     }

--- a/library/Zend/Mvc/Router/Http/Hostname.php
+++ b/library/Zend/Mvc/Router/Http/Hostname.php
@@ -119,11 +119,11 @@ class Hostname implements RouteInterface
      */
     public function match(Request $request)
     {
-        if (!method_exists($request, 'uri')) {
+        if (!method_exists($request, 'getUri')) {
             return null;
         }
 
-        $uri      = $request->uri();
+        $uri      = $request->getUri();
         $hostname = explode('.', $uri->getHost());
         $params   = array();
 

--- a/library/Zend/Mvc/Router/Http/Literal.php
+++ b/library/Zend/Mvc/Router/Http/Literal.php
@@ -100,11 +100,11 @@ class Literal implements RouteInterface
      */
     public function match(Request $request, $pathOffset = null)
     {
-        if (!method_exists($request, 'uri')) {
+        if (!method_exists($request, 'getUri')) {
             return null;
         }
 
-        $uri  = $request->uri();
+        $uri  = $request->getUri();
         $path = $uri->getPath();
 
         if ($pathOffset !== null) {

--- a/library/Zend/Mvc/Router/Http/Part.php
+++ b/library/Zend/Mvc/Router/Http/Part.php
@@ -141,7 +141,7 @@ class Part extends TreeRouteStack implements RouteInterface
 
         $match = $this->route->match($request, $pathOffset);
 
-        if ($match !== null && method_exists($request, 'uri')) {
+        if ($match !== null && method_exists($request, 'getUri')) {
             if ($this->childRoutes !== null) {
                 $this->addRoutes($this->childRoutes);
                 $this->childRoutes = null;
@@ -149,7 +149,7 @@ class Part extends TreeRouteStack implements RouteInterface
 
             $nextOffset = $pathOffset + $match->getLength();
 
-            $uri        = $request->uri();
+            $uri        = $request->getUri();
             $pathLength = strlen($uri->getPath());
 
             if ($this->mayTerminate && $nextOffset === $pathLength) {

--- a/library/Zend/Mvc/Router/Http/Query.php
+++ b/library/Zend/Mvc/Router/Http/Query.php
@@ -98,11 +98,11 @@ class Query implements RouteInterface
      */
     public function match(Request $request, $pathOffset = null)
     {
-        if (!method_exists($request, 'query')) {
+        if (!method_exists($request, 'getQuery')) {
             return null;
         }
 
-        $matches = $this->recursiveUrldecode($request->query()->toArray());
+        $matches = $this->recursiveUrldecode($request->getQuery()->toArray());
 
         return new RouteMatch(array_merge($this->defaults, $matches));
     }

--- a/library/Zend/Mvc/Router/Http/Regex.php
+++ b/library/Zend/Mvc/Router/Http/Regex.php
@@ -121,11 +121,11 @@ class Regex implements RouteInterface
      */
     public function match(Request $request, $pathOffset = null)
     {
-        if (!method_exists($request, 'uri')) {
+        if (!method_exists($request, 'getUri')) {
             return null;
         }
 
-        $uri  = $request->uri();
+        $uri  = $request->getUri();
         $path = $uri->getPath();
 
         if ($pathOffset !== null) {

--- a/library/Zend/Mvc/Router/Http/Scheme.php
+++ b/library/Zend/Mvc/Router/Http/Scheme.php
@@ -99,11 +99,11 @@ class Scheme implements RouteInterface
      */
     public function match(Request $request)
     {
-        if (!method_exists($request, 'uri')) {
+        if (!method_exists($request, 'getUri')) {
             return null;
         }
 
-        $uri    = $request->uri();
+        $uri    = $request->getUri();
         $scheme = $uri->getScheme();
 
         if ($scheme !== $this->scheme) {

--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -321,11 +321,11 @@ class Segment implements RouteInterface
      */
     public function match(Request $request, $pathOffset = null)
     {
-        if (!method_exists($request, 'uri')) {
+        if (!method_exists($request, 'getUri')) {
             return null;
         }
 
-        $uri  = $request->uri();
+        $uri  = $request->getUri();
         $path = $uri->getPath();
 
         if ($pathOffset !== null) {

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -145,7 +145,7 @@ class TreeRouteStack extends SimpleRouteStack
      */
     public function match(Request $request)
     {
-        if (!method_exists($request, 'uri')) {
+        if (!method_exists($request, 'getUri')) {
             return null;
         }
 
@@ -153,7 +153,7 @@ class TreeRouteStack extends SimpleRouteStack
             $this->setBaseUrl($request->getBaseUrl());
         }
 
-        $uri           = $request->uri();
+        $uri           = $request->getUri();
         $baseUrlLength = strlen($this->baseUrl) ?: null;
 
         if ($this->requestUri === null) {

--- a/library/Zend/Mvc/Router/Http/Wildcard.php
+++ b/library/Zend/Mvc/Router/Http/Wildcard.php
@@ -120,11 +120,11 @@ class Wildcard implements RouteInterface
      */
     public function match(Request $request, $pathOffset = null)
     {
-        if (!method_exists($request, 'uri')) {
+        if (!method_exists($request, 'getUri')) {
             return null;
         }
 
-        $uri  = $request->uri();
+        $uri  = $request->getUri();
         $path = $uri->getPath();
 
         if ($pathOffset !== null) {

--- a/library/Zend/OAuth/Client.php
+++ b/library/Zend/OAuth/Client.php
@@ -232,7 +232,7 @@ class Client extends HttpClient
         switch ($requestScheme) {
             case OAuth::REQUEST_SCHEME_HEADER:
                 $oauthHeaderValue = $this->getToken()->toHeader(
-                    $this->getRequest()->getUri(),
+                    $this->getRequest()->getUriString(),
                     $this->_config,
                     $this->_getSignableParameters()
                 );
@@ -247,7 +247,7 @@ class Client extends HttpClient
                     );
                 }
                 $query  = $this->getToken()->toQueryString(
-                    $this->getRequest()->getUri(),
+                    $this->getRequest()->getUriString(),
                     $this->_config,
                     $this->_getSignableParameters()
                 );
@@ -256,7 +256,7 @@ class Client extends HttpClient
                 break;
             case OAuth::REQUEST_SCHEME_QUERYSTRING:
                 $query  = $this->getToken()->toQueryString(
-                    $this->getRequest()->getUri(),
+                    $this->getRequest()->getUriString(),
                     $this->_config,
                     $this->_getSignableParameters()
                 );
@@ -277,12 +277,12 @@ class Client extends HttpClient
     protected function _getSignableParameters()
     {
         $params = array();
-        if ($this->getRequest()->query()->count() > 0) {
-            $params = array_merge($params, $this->getRequest()->query()->toArray());
+        if ($this->getRequest()->getQuery()->count() > 0) {
+            $params = array_merge($params, $this->getRequest()->getQuery()->toArray());
         }
 
-        if ($this->getRequest()->post()->count() > 0) {
-            $params = array_merge($params, $this->getRequest()->post()->toArray());
+        if ($this->getRequest()->getPost()->count() > 0) {
+            $params = array_merge($params, $this->getRequest()->getPost()->toArray());
         }
 
         return $params;

--- a/library/Zend/OAuth/Http/RequestToken.php
+++ b/library/Zend/OAuth/Http/RequestToken.php
@@ -106,7 +106,7 @@ class RequestToken extends HTTPClient
         $client->setUri($this->_consumer->getRequestTokenUrl());
 
         $request = $client->getRequest();
-        $request->headers()
+        $request->getHeaders()
                 ->addHeaderLine('Authorization', $headerValue);
         $rawdata = $this->_httpUtility->toEncodedQueryString($params, true);
         if (!empty($rawdata)) {
@@ -132,7 +132,7 @@ class RequestToken extends HTTPClient
         $request->setContent(
             $this->_httpUtility->toEncodedQueryString($params)
         );
-        $request->headers()
+        $request->getHeaders()
                 ->addHeaderLine('Content-Type', Http\Client::ENC_URLENCODED);
         return $client;
     }

--- a/library/Zend/OAuth/OAuth.php
+++ b/library/Zend/OAuth/OAuth.php
@@ -71,7 +71,7 @@ class OAuth
             self::$httpClient = new HTTPClient;
         } else {
             $request = self::$httpClient->getRequest();
-            $headers = $request->headers();
+            $headers = $request->getHeaders();
             if ($headers->has('Authorization')) {
                 $auth = $headers->get('Authorization');
                 $headers->removeHeader($auth);

--- a/library/Zend/OpenId/OpenId.php
+++ b/library/Zend/OpenId/OpenId.php
@@ -451,11 +451,12 @@ class OpenId
         }
 
         $response->setStatusCode(302);
-        $response->headers()->addHeaderLine('Location', $url);
+
+        $response->getHeaders()->addHeaderLine('Location', $url);
 
         if (!headers_sent()) {
             header($response->renderStatusLine());
-            foreach ($response->headers() as $header) {
+            foreach ($response->getHeaders() as $header) {
                 header($header->toString());
             }
         }

--- a/library/Zend/Rest/Client/RestClient.php
+++ b/library/Zend/Rest/Client/RestClient.php
@@ -65,8 +65,8 @@ class RestClient extends \Zend\Service\AbstractService
 
     /**
      * Set HTTP client instance to use with this service instance
-     * 
-     * @param  HttpClient $client 
+     *
+     * @param  HttpClient $client
      * @return RestClient
      */
     public function setHttpClient(HttpClient $client)
@@ -79,7 +79,7 @@ class RestClient extends \Zend\Service\AbstractService
      * Get the HTTP client instance registered with this service instance
      *
      * If none set, will check for a default instance.
-     * 
+     *
      * @return HttpClient
      */
     public function getHttpClient()
@@ -140,8 +140,8 @@ class RestClient extends \Zend\Service\AbstractService
         $this->uri->setPath($path);
 
         /**
-         * Get the HTTP client and configure it for the endpoint URI.  Do this 
-         * each time as the Zend\Http\Client instance may be shared with other 
+         * Get the HTTP client and configure it for the endpoint URI.  Do this
+         * each time as the Zend\Http\Client instance may be shared with other
          * Zend\Service\AbstractService subclasses.
          */
         $client = $this->getHttpClient();
@@ -186,7 +186,7 @@ class RestClient extends \Zend\Service\AbstractService
         if (is_string($data)) {
             $request->setContent($data);
         } elseif (is_array($data) || is_object($data)) {
-            $request->post()->fromArray((array) $data);
+            $request->getPost()->fromArray((array) $data);
         }
         return $client->send($request);
     }

--- a/library/Zend/Service/Rackspace/Rackspace.php
+++ b/library/Zend/Service/Rackspace/Rackspace.php
@@ -94,8 +94,8 @@ abstract class Rackspace
     protected $cdnUrl;
     /**
      * Server management URL
-     * 
-     * @var string 
+     *
+     * @var string
      */
     protected $managementUrl;
     /**
@@ -155,7 +155,7 @@ abstract class Rackspace
      *
      * @return string|boolean
      */
-    public function getStorageUrl() 
+    public function getStorageUrl()
     {
         if (empty($this->storageUrl)) {
             if (!$this->authenticate()) {
@@ -169,7 +169,7 @@ abstract class Rackspace
      *
      * @return string|boolean
      */
-    public function getCdnUrl() 
+    public function getCdnUrl()
     {
         if (empty($this->cdnUrl)) {
             if (!$this->authenticate()) {
@@ -180,9 +180,9 @@ abstract class Rackspace
     }
     /**
      * Get the management server URL
-     * 
+     *
      * @return string|boolean
-     */     
+     */
     public function getManagementUrl()
     {
         if (empty($this->managementUrl)) {
@@ -249,16 +249,16 @@ abstract class Rackspace
      *
      * @return string
      */
-    public function getErrorMsg() 
+    public function getErrorMsg()
     {
         return $this->errorMsg;
     }
     /**
      * Get the error code of the last HTTP call
-     * 
-     * @return string 
+     *
+     * @return string
      */
-    public function getErrorCode() 
+    public function getErrorCode()
     {
         return $this->errorCode;
     }
@@ -276,8 +276,8 @@ abstract class Rackspace
     }
     /**
      * Return true is the last call was successful
-     * 
-     * @return boolean 
+     *
+     * @return boolean
      */
     public function isSuccessful()
     {
@@ -299,12 +299,12 @@ abstract class Rackspace
         $client->resetParameters();
         if (empty($headers[self::AUTHUSER_HEADER])) {
             $headers[self::AUTHTOKEN]= $this->getToken();
-        } 
+        }
         $client->setMethod($method);
         if (empty($data['format'])) {
             $data['format']= self::API_FORMAT;
         }
-        $client->setParameterGet($data);    
+        $client->setParameterGet($data);
         if (!empty($body)) {
             $client->setRawBody($body);
             if (!isset($headers['Content-Type'])) {
@@ -330,14 +330,14 @@ abstract class Rackspace
         );
         $result = $this->httpCall($this->authUrl.'/'.self::VERSION,'GET', $headers);
         if ($result->getStatusCode()===204) {
-            $this->token = $result->headers()->get(self::AUTHTOKEN)->getFieldValue();
-            $this->storageUrl = $result->headers()->get(self::STORAGE_URL)->getFieldValue();
-            $this->cdnUrl = $result->headers()->get(self::CDNM_URL)->getFieldValue();
-            $this->managementUrl = $result->headers()->get(self::MANAGEMENT_URL)->getFieldValue();
+            $this->token = $result->getHeaders()->get(self::AUTHTOKEN)->getFieldValue();
+            $this->storageUrl = $result->getHeaders()->get(self::STORAGE_URL)->getFieldValue();
+            $this->cdnUrl = $result->getHeaders()->get(self::CDNM_URL)->getFieldValue();
+            $this->managementUrl = $result->getHeaders()->get(self::MANAGEMENT_URL)->getFieldValue();
             return true;
         }
         $this->errorMsg = $result->getBody();
         $this->errorCode = $result->getStatusCode();
         return false;
-    } 
+    }
 }

--- a/library/Zend/View/Helper/Json.php
+++ b/library/Zend/View/Helper/Json.php
@@ -41,8 +41,8 @@ class Json extends AbstractHelper
 
     /**
      * Set the response object
-     * 
-     * @param  Response $response 
+     *
+     * @param  Response $response
      * @return Json
      */
     public function setResponse(Response $response)
@@ -63,7 +63,7 @@ class Json extends AbstractHelper
         $data = JsonFormatter::encode($data, null, $jsonOptions);
 
         if ($this->response instanceof Response) {
-            $headers = $this->response->headers();
+            $headers = $this->response->getHeaders();
             $headers->addHeaderLine('Content-Type', 'application/json');
         }
 

--- a/library/Zend/View/Strategy/FeedStrategy.php
+++ b/library/Zend/View/Strategy/FeedStrategy.php
@@ -110,7 +110,7 @@ class FeedStrategy implements ListenerAggregateInterface
             return;
         }
 
-        $headers = $request->headers();
+        $headers = $request->getHeaders();
         if ($headers->has('accept')) {
             $accept  = $headers->get('accept');
             foreach ($accept->getPrioritized() as $mediaType) {
@@ -165,7 +165,7 @@ class FeedStrategy implements ListenerAggregateInterface
         // Populate response
         $response = $e->getResponse();
         $response->setContent($result);
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $headers->addHeaderLine('content-type', $feedType);
     }
 }

--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -109,7 +109,7 @@ class JsonStrategy implements ListenerAggregateInterface
             return;
         }
 
-        $headers = $request->headers();
+        $headers = $request->getHeaders();
         if ($headers->has('accept')) {
             $accept  = $headers->get('Accept');
             foreach ($accept->getPrioritized() as $mediaType) {
@@ -119,7 +119,7 @@ class JsonStrategy implements ListenerAggregateInterface
                 }
                 if (0 === strpos($mediaType, 'application/javascript')) {
                     // application/javascript Accept header found
-                    if (false != ($callback = $request->query()->get('callback'))) {
+                    if (false != ($callback = $request->getQuery()->get('callback'))) {
                         $this->renderer->setJsonpCallback($callback);
                     }
                     return $this->renderer;
@@ -154,7 +154,7 @@ class JsonStrategy implements ListenerAggregateInterface
         // Populate response
         $response = $e->getResponse();
         $response->setContent($result);
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         if ($this->renderer->hasJsonpCallback()) {
             $headers->addHeaderLine('content-type', 'application/javascript');
         } else {

--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -223,7 +223,7 @@ class Client implements ServerClient
 
         $http        = $this->getHttpClient();
         $httpRequest = $http->getRequest();
-        if ($httpRequest->getUri() === null) {
+        if ($httpRequest->getUriString() === null) {
             $http->setUri($this->_serverAddress);
         }
 

--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -227,7 +227,7 @@ class Client implements ServerClient
             $http->setUri($this->_serverAddress);
         }
 
-        $headers = $httpRequest->headers();
+        $headers = $httpRequest->getHeaders();
         $headers->addHeaders(array(
             'Content-Type: text/xml; charset=utf-8',
             'Accept: text/xml',

--- a/tests/Zend/Authentication/Adapter/Http/AuthTest.php
+++ b/tests/Zend/Authentication/Adapter/Http/AuthTest.php
@@ -341,7 +341,7 @@ class AuthTest extends \PHPUnit_Framework_TestCase
         $request->setUri('http://localhost/');
         $request->setMethod('GET');
         $request->setServer(new Parameters(array('HTTP_USER_AGENT' => 'PHPUnit')));
-        $headers = $request->headers();
+        $headers = $request->getHeaders();
         $headers->addHeaderLine('Authorization', $clientHeader);
 
         // Select an Authentication scheme
@@ -370,7 +370,7 @@ class AuthTest extends \PHPUnit_Framework_TestCase
         $return = array(
             'result'  => $result,
             'status'  => $response->getStatusCode(),
-            'headers' => $response->headers(),
+            'headers' => $response->getHeaders(),
         );
         return $return;
     }

--- a/tests/Zend/Authentication/Adapter/Http/ProxyTest.php
+++ b/tests/Zend/Authentication/Adapter/Http/ProxyTest.php
@@ -361,7 +361,7 @@ class ProxyTest extends \PHPUnit_Framework_TestCase
         $return = array(
             'result'  => $result,
             'status'  => $response->getStatusCode(),
-            'headers' => $response->headers(),
+            'headers' => $response->getHeaders(),
         );
         return $return;
     }

--- a/tests/Zend/Http/ClientTest.php
+++ b/tests/Zend/Http/ClientTest.php
@@ -14,7 +14,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client->setMethod('post');
         $this->assertEquals(Client::ENC_URLENCODED, $client->getEncType());
     }
-    
+
     public function testIfZeroValueCookiesCanBeSet()
     {
         try {
@@ -27,7 +27,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertTrue(true);
     }
-    
+
     /**
     * @expectedException Zend\Http\Exception\InvalidArgumentException
     */
@@ -35,7 +35,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new Client();
         $client->addCookie("test", null);
-    } 
+    }
 
     public function testIfCookieHeaderCanBeSet()
     {
@@ -43,7 +43,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $client = new Client();
         $client->addCookie($header);
-        
+
         $cookies = $client->getCookies();
         $this->assertEquals(1, count($cookies));
         $this->assertEquals($header, $cookies['foo']);
@@ -58,7 +58,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $client = new Client();
         $client->addCookie($headers);
-        
+
         $cookies = $client->getCookies();
         $this->assertEquals(2, count($cookies));
     }
@@ -69,10 +69,10 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             new SetCookie('foo'),
             new SetCookie('bar')
         ));
-        
+
         $client = new Client();
         $client->addCookie($headers);
-        
+
         $cookies = $client->getCookies();
         $this->assertEquals(2, count($cookies));
     }

--- a/tests/Zend/Http/PhpEnvironment/RequestTest.php
+++ b/tests/Zend/Http/PhpEnvironment/RequestTest.php
@@ -256,7 +256,7 @@ class RequestTest extends TestCase
         $_SERVER = $server;
         $request = new Request();
 
-        $header = $request->headers()->get($name);
+        $header = $request->getHeaders()->get($name);
         $this->assertNotEquals($header, false);
         $this->assertEquals($name,  $header->getFieldName($value));
         $this->assertEquals($value, $header->getFieldValue($value));
@@ -330,7 +330,7 @@ class RequestTest extends TestCase
         $_SERVER = $server;
         $request = new Request();
 
-        $host = $request->uri()->getHost();
+        $host = $request->getUri()->getHost();
         $this->assertEquals($expectedHost, $host);
 
         $requestUri = $request->getRequestUri();

--- a/tests/Zend/Http/RequestTest.php
+++ b/tests/Zend/Http/RequestTest.php
@@ -21,11 +21,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testRequestUsesParametersContainerByDefault()
     {
         $request = new Request();
-        $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->query());
-        $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->post());
-        $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->file());
-        $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->server());
-        $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->env());
+        $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->getQuery());
+        $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->getPost());
+        $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->getFile());
+        $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->getServer());
+        $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->getEnv());
     }
 
     public function testRequestAllowsSettingOfParameterContainer()
@@ -38,11 +38,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request->setServer($p);
         $request->setEnv($p);
 
-        $this->assertSame($p, $request->query());
-        $this->assertSame($p, $request->post());
-        $this->assertSame($p, $request->file());
-        $this->assertSame($p, $request->server());
-        $this->assertSame($p, $request->env());
+        $this->assertSame($p, $request->getQuery());
+        $this->assertSame($p, $request->getPost());
+        $this->assertSame($p, $request->getFile());
+        $this->assertSame($p, $request->getServer());
+        $this->assertSame($p, $request->getEnv());
     }
 
     public function testRequestPersistsRawBody()
@@ -55,7 +55,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testRequestUsesHeadersContainerByDefault()
     {
         $request = new Request();
-        $this->assertInstanceOf('Zend\Http\Headers', $request->headers());
+        $this->assertInstanceOf('Zend\Http\Headers', $request->getHeaders());
     }
 
     public function testRequestCanSetHeaders()
@@ -65,7 +65,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $ret = $request->setHeaders($headers);
         $this->assertInstanceOf('Zend\Http\Request', $ret);
-        $this->assertSame($headers, $request->headers());
+        $this->assertSame($headers, $request->getHeaders());
     }
 
     public function testRequestCanSetAndRetrieveValidMethod()
@@ -90,9 +90,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $request->setUri($uri);
         $this->assertEquals($uri, $request->getUri());
-        $this->assertInstanceOf('Zend\Uri\Uri', $request->uri());
-        $this->assertEquals($uri, $request->uri()->toString());
-        $this->assertEquals($uri, $request->getUri());
+        $this->assertInstanceOf('Zend\Uri\Uri', $request->getUri());
+        $this->assertEquals($uri, $request->getUri()->toString());
+        $this->assertEquals($uri, $request->getUriString());
     }
 
     public function uriDataProvider()
@@ -156,11 +156,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($request->isXmlHttpRequest());
 
         $request = new Request();
-        $request->headers()->addHeaderLine('X_REQUESTED_WITH', 'FooBazBar');
+        $request->getHeaders()->addHeaderLine('X_REQUESTED_WITH', 'FooBazBar');
         $this->assertFalse($request->isXmlHttpRequest());
 
         $request = new Request();
-        $request->headers()->addHeaderLine('X_REQUESTED_WITH', 'XMLHttpRequest');
+        $request->getHeaders()->addHeaderLine('X_REQUESTED_WITH', 'XMLHttpRequest');
         $this->assertTrue($request->isXmlHttpRequest());
     }
 
@@ -170,11 +170,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($request->isFlashRequest());
 
         $request = new Request();
-        $request->headers()->addHeaderLine('USER_AGENT', 'FooBazBar');
+        $request->getHeaders()->addHeaderLine('USER_AGENT', 'FooBazBar');
         $this->assertFalse($request->isFlashRequest());
 
         $request = new Request();
-        $request->headers()->addHeaderLine('USER_AGENT', 'Shockwave Flash');
+        $request->getHeaders()->addHeaderLine('USER_AGENT', 'Shockwave Flash');
         $this->assertTrue($request->isFlashRequest());
     }
 

--- a/tests/Zend/Http/Response/ResponseStreamTest.php
+++ b/tests/Zend/Http/Response/ResponseStreamTest.php
@@ -13,7 +13,7 @@ class ResponseStreamTest extends \PHPUnit_Framework_TestCase
 		$stream = fopen('php://temp','rb+');
 		fwrite($stream, 'Bar Foo');
 		rewind($stream);
-		
+
         $response = Stream::fromStream($string, $stream);
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals("Foo Bar\r\nBar Foo", $response->getBody());
@@ -30,13 +30,13 @@ class ResponseStreamTest extends \PHPUnit_Framework_TestCase
                 break;
             }
         }
-        
-        
+
+
         $headers .= fread($stream, 100); //Should accept also part of body as text
-        
+
         $res = Stream::fromStream($headers, $stream);
 
-        $this->assertEquals('gzip', $res->headers()->get('Content-encoding')->getFieldValue());
+        $this->assertEquals('gzip', $res->getHeaders()->get('Content-encoding')->getFieldValue());
         $this->assertEquals('0b13cb193de9450aa70a6403e2c9902f', md5($res->getBody()));
         $this->assertEquals('f24dd075ba2ebfb3bf21270e3fdc5303', md5($res->getContent()));
     }
@@ -61,15 +61,15 @@ class ResponseStreamTest extends \PHPUnit_Framework_TestCase
 
     public function testMultilineHeader()
     {
-        $values   = $this->readResponse('response_multiline_header');        
+        $values   = $this->readResponse('response_multiline_header');
         $response = Stream::fromStream($values['data'],$values['stream']);
-        
+
         // Make sure we got the corrent no. of headers
-        $this->assertEquals(6, count($response->headers()), 'Header count is expected to be 6');
+        $this->assertEquals(6, count($response->getHeaders()), 'Header count is expected to be 6');
 
         // Check header integrity
-        $this->assertEquals('timeout=15,max=100', $response->headers()->get('keep-alive')->getFieldValue());
-        $this->assertEquals('text/html;charset=iso-8859-1', $response->headers()->get('content-type')->getFieldValue());
+        $this->assertEquals('timeout=15,max=100', $response->getHeaders()->get('keep-alive')->getFieldValue());
+        $this->assertEquals('text/html;charset=iso-8859-1', $response->getHeaders()->get('content-type')->getFieldValue());
     }
 
 
@@ -81,9 +81,9 @@ class ResponseStreamTest extends \PHPUnit_Framework_TestCase
      */
     protected function readResponse($response)
     {
-        
+
         $stream = fopen(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . $response, 'rb');
-        
+
         $data = '';
         while(false!== ($newLine = fgets($stream))) {
             $data .= $newLine;
@@ -91,14 +91,14 @@ class ResponseStreamTest extends \PHPUnit_Framework_TestCase
                 break;
             }
         }
-        
-        
+
+
         $data .= fread($stream, 100); //Should accept also part of body as text
-        
+
         $return = array();
         $return['stream'] = $stream;
         $return['data']   = $data;
-        
-        return $return; 
+
+        return $return;
     }
 }

--- a/tests/Zend/Http/ResponseTest.php
+++ b/tests/Zend/Http/ResponseTest.php
@@ -29,7 +29,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     public function testResponseUsesHeadersContainerByDefault()
     {
         $response = new Response();
-        $this->assertInstanceOf('Zend\Http\Headers', $response->headers());
+        $this->assertInstanceOf('Zend\Http\Headers', $response->getHeaders());
     }
 
     public function testRequestCanSetHeaders()
@@ -39,7 +39,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $ret = $response->setHeaders($headers);
         $this->assertInstanceOf('Zend\Http\Response', $ret);
-        $this->assertSame($headers, $response->headers());
+        $this->assertSame($headers, $response->getHeaders());
     }
 
     public function testResponseCanSetStatusCode()
@@ -71,7 +71,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $res = Response::fromString($response_text);
 
-        $this->assertEquals('gzip', $res->headers()->get('Content-encoding')->getFieldValue());
+        $this->assertEquals('gzip', $res->getHeaders()->get('Content-encoding')->getFieldValue());
         $this->assertEquals('0b13cb193de9450aa70a6403e2c9902f', md5($res->getBody()));
         $this->assertEquals('f24dd075ba2ebfb3bf21270e3fdc5303', md5($res->getContent()));
     }
@@ -82,7 +82,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $res = Response::fromString($response_text);
 
-        $this->assertEquals('deflate', $res->headers()->get('Content-encoding')->getFieldValue());
+        $this->assertEquals('deflate', $res->getHeaders()->get('Content-encoding')->getFieldValue());
         $this->assertEquals('0b13cb193de9450aa70a6403e2c9902f', md5($res->getBody()));
         $this->assertEquals('ad62c21c3aa77b6a6f39600f6dd553b8', md5($res->getContent()));
     }
@@ -103,7 +103,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $res = Response::fromString($response_text);
 
-        $this->assertEquals('deflate', $res->headers()->get('Content-encoding')->getFieldValue());
+        $this->assertEquals('deflate', $res->getHeaders()->get('Content-encoding')->getFieldValue());
         $this->assertEquals('d82c87e3d5888db0193a3fb12396e616', md5($res->getBody()));
         $this->assertEquals('c830dd74bb502443cf12514c185ff174', md5($res->getContent()));
     }
@@ -114,7 +114,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $res = Response::fromString($response_text);
 
-        $this->assertEquals('chunked', $res->headers()->get('Transfer-encoding')->getFieldValue());
+        $this->assertEquals('chunked', $res->getHeaders()->get('Transfer-encoding')->getFieldValue());
         $this->assertEquals('0b13cb193de9450aa70a6403e2c9902f', md5($res->getBody()));
         $this->assertEquals('c0cc9d44790fa2a58078059bab1902a9', md5($res->getContent()));
     }
@@ -125,7 +125,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $res = Response::fromString($response_text);
 
-        $this->assertEquals('chunked', strtolower($res->headers()->get('Transfer-encoding')->getFieldValue()));
+        $this->assertEquals('chunked', strtolower($res->getHeaders()->get('Transfer-encoding')->getFieldValue()));
         $this->assertEquals('0b13cb193de9450aa70a6403e2c9902f', md5($res->getBody()));
         $this->assertEquals('c0cc9d44790fa2a58078059bab1902a9', md5($res->getContent()));
     }
@@ -138,7 +138,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response_text_crlf = $this->readResponse('response_crlf');
         $res_crlf = Response::fromString($response_text_crlf);
 
-        $this->assertEquals($res_lf->headers()->toString(), $res_crlf->headers()->toString(), 'Responses headers do not match');
+        $this->assertEquals($res_lf->getHeaders()->toString(), $res_crlf->getHeaders()->toString(), 'Responses headers do not match');
 
         $this->markTestIncomplete('Something is fishy with the response bodies in the test responses');
         $this->assertEquals($res_lf->getBody(), $res_crlf->getBody(), 'Response bodies do not match');
@@ -186,8 +186,8 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response    = Response::fromString($this->readResponse('response_302'));
         $responseIis = Response::fromString($this->readResponse('response_302_iis'));
 
-        $this->assertEquals($headerValue, $response->headers()->get($headerName)->getFieldValue());
-        $this->assertEquals($headerValue, $responseIis->headers()->get($headerName)->getFieldValue());
+        $this->assertEquals($headerValue, $response->getHeaders()->get($headerName)->getFieldValue());
+        $this->assertEquals($headerValue, $responseIis->getHeaders()->get($headerName)->getFieldValue());
     }
 
     public function test300isRedirect()
@@ -264,7 +264,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     public function testGetHeaders()
     {
         $response = Response::fromString($this->readResponse('response_deflate'));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
 
         $this->assertEquals(8, count($headers), 'Header count is not as expected');
         $this->assertEquals('Apache', $headers->get('Server')->getFieldValue(), 'Server header is not as expected');
@@ -289,11 +289,11 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response = Response::fromString($this->readResponse('response_multiline_header'));
 
         // Make sure we got the corrent no. of headers
-        $this->assertEquals(6, count($response->headers()), 'Header count is expected to be 6');
+        $this->assertEquals(6, count($response->getHeaders()), 'Header count is expected to be 6');
 
         // Check header integrity
-        $this->assertEquals('timeout=15,max=100', $response->headers()->get('keep-alive')->getFieldValue());
-        $this->assertEquals('text/html;charset=iso-8859-1', $response->headers()->get('content-type')->getFieldValue());
+        $this->assertEquals('timeout=15,max=100', $response->getHeaders()->get('keep-alive')->getFieldValue());
+        $this->assertEquals('text/html;charset=iso-8859-1', $response->getHeaders()->get('content-type')->getFieldValue());
     }
 
     /**

--- a/tests/Zend/Json/Server/ClientTest.php
+++ b/tests/Zend/Json/Server/ClientTest.php
@@ -207,7 +207,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->jsonClient->setHttpClient($this->httpClient);
 
         $this->setServerResponseTo(null);
-        $this->assertNull($this->jsonClient->getHttpClient()->getRequest()->getUri());
+        $this->assertNull($this->jsonClient->getHttpClient()->getRequest()->getUriString());
         $this->jsonClient->call('foo');
         $uri = $this->jsonClient->getHttpClient()->getUri();
 

--- a/tests/Zend/Mvc/Controller/Plugin/ParamsTest.php
+++ b/tests/Zend/Mvc/Controller/Plugin/ParamsTest.php
@@ -79,7 +79,7 @@ class ParamsTest extends TestCase
     protected function setQuery()
     {
         $this->request->setMethod(Request::METHOD_GET);
-        $this->request->query()->set('value', 'query:1234');
+        $this->request->getQuery()->set('value', 'query:1234');
 
         $this->controller->dispatch($this->request);
     }
@@ -87,7 +87,7 @@ class ParamsTest extends TestCase
     protected function setPost()
     {
         $this->request->setMethod(Request::METHOD_POST);
-        $this->request->post()->set('value', 'post:1234');
+        $this->request->getPost()->set('value', 'post:1234');
 
         $this->controller->dispatch($this->request);
     }

--- a/tests/Zend/Mvc/Controller/Plugin/RedirectTest.php
+++ b/tests/Zend/Mvc/Controller/Plugin/RedirectTest.php
@@ -38,7 +38,7 @@ class RedirectTest extends TestCase
     {
         $response = $this->plugin->toRoute('home');
         $this->assertTrue($response->isRedirect());
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $location = $headers->get('Location');
         $this->assertEquals('/', $location->getFieldValue());
     }
@@ -47,7 +47,7 @@ class RedirectTest extends TestCase
     {
         $response = $this->plugin->toUrl('/foo');
         $this->assertTrue($response->isRedirect());
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $location = $headers->get('Location');
         $this->assertEquals('/foo', $location->getFieldValue());
     }

--- a/tests/Zend/Mvc/Controller/RestfulControllerTest.php
+++ b/tests/Zend/Mvc/Controller/RestfulControllerTest.php
@@ -57,7 +57,7 @@ class RestfulControllerTest extends TestCase
     {
         $entity = array('id' => 1, 'name' => __FUNCTION__);
         $this->request->setMethod('POST');
-        $post = $this->request->post();
+        $post = $this->request->getPost();
         $post->fromArray($entity);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertArrayHasKey('entity', $result);

--- a/tests/Zend/OAuth/OAuthTest.php
+++ b/tests/Zend/OAuth/OAuthTest.php
@@ -103,58 +103,58 @@ class OAuthTest extends \PHPUnit_Framework_TestCase
         $mock = $this->getMock('Zend\\OAuth\\Http\\Utility', array('generateTimestamp', 'generateNonce'));
         $mock->expects($this->once())->method('generateTimestamp')->will($this->returnValue('123456789'));
         $mock->expects($this->once())->method('generateNonce')->will($this->returnValue('67648c83ba9a7de429bd1b773fb96091'));
-        
+
         $token   = new OAuth\Token\Access(null, $mock);
         $token->setToken('123')
               ->setTokenSecret('456');
-        
+
         $client = new OAuth\Client(array(
             'token' => $token
         ), 'http://www.example.com');
-        $client->getRequest()->query()->set('foo', 'bar');
+        $client->getRequest()->getQuery()->set('foo', 'bar');
         $client->prepareOAuth();
-        
+
         $header = 'OAuth realm="",oauth_consumer_key="",oauth_nonce="67648c83ba9a7de429bd1b773fb96091",oauth_signature_method="HMAC-SHA1",oauth_timestamp="123456789",oauth_version="1.0",oauth_token="123",oauth_signature="fzWiYe4gZ2wkEMp9bEzWnlD88KE%3D"';
         $this->assertEquals($header, $client->getHeader('Authorization'));
     }
-    
+
     public function testOauthClientUsingPostRequestParametersForSignature()
     {
         $mock = $this->getMock('Zend\\OAuth\\Http\\Utility', array('generateTimestamp', 'generateNonce'));
         $mock->expects($this->once())->method('generateTimestamp')->will($this->returnValue('123456789'));
         $mock->expects($this->once())->method('generateNonce')->will($this->returnValue('67648c83ba9a7de429bd1b773fb96091'));
-        
+
         $token   = new OAuth\Token\Access(null, $mock);
         $token->setToken('123')
               ->setTokenSecret('456');
-        
+
         $client = new OAuth\Client(array(
             'token' => $token
         ), 'http://www.example.com');
-        $client->getRequest()->post()->set('foo', 'bar');
+        $client->getRequest()->getPost()->set('foo', 'bar');
         $client->prepareOAuth();
-        
+
         $header = 'OAuth realm="",oauth_consumer_key="",oauth_nonce="67648c83ba9a7de429bd1b773fb96091",oauth_signature_method="HMAC-SHA1",oauth_timestamp="123456789",oauth_version="1.0",oauth_token="123",oauth_signature="fzWiYe4gZ2wkEMp9bEzWnlD88KE%3D"';
         $this->assertEquals($header, $client->getHeader('Authorization'));
     }
-    
+
     public function testOauthClientUsingPostAndGetRequestParametersForSignature()
     {
         $mock = $this->getMock('Zend\\OAuth\\Http\\Utility', array('generateTimestamp', 'generateNonce'));
         $mock->expects($this->once())->method('generateTimestamp')->will($this->returnValue('123456789'));
         $mock->expects($this->once())->method('generateNonce')->will($this->returnValue('67648c83ba9a7de429bd1b773fb96091'));
-        
+
         $token   = new OAuth\Token\Access(null, $mock);
         $token->setToken('123')
               ->setTokenSecret('456');
-        
+
         $client = new OAuth\Client(array(
             'token' => $token
         ), 'http://www.example.com');
-        $client->getRequest()->post()->set('foo', 'bar');
-        $client->getRequest()->query()->set('baz', 'bat');
+        $client->getRequest()->getPost()->set('foo', 'bar');
+        $client->getRequest()->getQuery()->set('baz', 'bat');
         $client->prepareOAuth();
-        
+
         $header = 'OAuth realm="",oauth_consumer_key="",oauth_nonce="67648c83ba9a7de429bd1b773fb96091",oauth_signature_method="HMAC-SHA1",oauth_timestamp="123456789",oauth_version="1.0",oauth_token="123",oauth_signature="qj3FYtStzP083hT9QkqCdxsMauw%3D"';
         $this->assertEquals($header, $client->getHeader('Authorization'));
     }

--- a/tests/Zend/OpenId/ConsumerTest.php
+++ b/tests/Zend/OpenId/ConsumerTest.php
@@ -68,7 +68,7 @@ class ConsumerTest extends TestCase
         $response = new ResponseHelper(true);
         $consumer = new Consumer($storage);
         $this->assertTrue( $consumer->login(self::ID, null, null, null, $response) );
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
 
         $this->assertTrue(1 <= count($headers));
         $this->assertTrue($headers->has('Location'));
@@ -99,7 +99,7 @@ class ConsumerTest extends TestCase
         $response = new ResponseHelper(true);
         $consumer = new Consumer($storage);
         $this->assertTrue( $consumer->login(self::ID, "http://www.zf-test.com/return.php", "http://www.zf-test.com/trust.php", null, $response) );
-        $headers  = $response->headers();
+        $headers  = $response->getHeaders();
         $location = $headers->get('Location');
         $url      = $location->getFieldValue();
         $url      = parse_url($url);
@@ -127,7 +127,7 @@ class ConsumerTest extends TestCase
         $response = new ResponseHelper(true);
         $consumer = new Consumer($storage);
         $this->assertTrue( $consumer->login(self::ID, "http://www.zf-test.com/return.php", "http://www.zf-test.com/trust.php", null, $response) );
-        $headers  = $response->headers();
+        $headers  = $response->getHeaders();
         $location = $headers->get('Location');
         $url      = $location->getFieldValue();
         $url      = parse_url($url);
@@ -154,7 +154,7 @@ class ConsumerTest extends TestCase
         $response = new ResponseHelper(true);
         $consumer = new Consumer($storage);
         $this->assertTrue( $consumer->login(self::ID, "http://www.zf-test.com/return.php", "http://www.zf-test.com/trust.php", $ext, $response) );
-        $headers  = $response->headers();
+        $headers  = $response->getHeaders();
         $location = $headers->get('Location');
         $url      = $location->getFieldValue();
         $url      = parse_url($url);
@@ -183,7 +183,7 @@ class ConsumerTest extends TestCase
         $response = new ResponseHelper(true);
         $consumer = new Consumer($storage, true);
         $this->assertTrue( $consumer->login(self::ID, "http://www.zf-test.com/return.php", "http://www.zf-test.com/trust.php", null, $response) );
-        $headers  = $response->headers();
+        $headers  = $response->getHeaders();
         $location = $headers->get('Location');
         $url      = $location->getFieldValue();
         $url      = parse_url($url);
@@ -225,7 +225,7 @@ class ConsumerTest extends TestCase
         $response = new ResponseHelper(true);
         $consumer = new Consumer($storage);
         $this->assertTrue( $consumer->check(self::ID, null, null, null, $response) );
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
 
         $this->assertTrue(1 <= count($headers));
         $this->assertTrue($headers->has('Location'));

--- a/tests/Zend/OpenId/OpenIdTest.php
+++ b/tests/Zend/OpenId/OpenIdTest.php
@@ -407,7 +407,7 @@ class OpenIdTest extends \PHPUnit_Framework_TestCase
         OpenId::redirect("http://www.test.com/", null, $response, 'GET');
         $this->assertSame( 302, $response->getStatusCode() );
 
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue(1 <= count($headers));
         $this->assertTrue($headers->has('Location'));
         $location = $headers->get('Location');
@@ -416,27 +416,27 @@ class OpenIdTest extends \PHPUnit_Framework_TestCase
 
         $response = new ResponseHelper(true);
         OpenId::redirect("http://www.test.com/test.php?a=b", null, $response, 'GET');
-        $location = $response->headers()->get('Location');
+        $location = $response->getHeaders()->get('Location');
         $this->assertSame( 'http://www.test.com/test.php?a=b', $location->getFieldValue() );
 
         $response = new ResponseHelper(true);
         OpenId::redirect("http://www.test.com/test.php", array('a'=>'b'), $response, 'GET');
-        $location = $response->headers()->get('Location');
+        $location = $response->getHeaders()->get('Location');
         $this->assertSame( 'http://www.test.com/test.php?a=b', $location->getFieldValue() );
 
         $response = new ResponseHelper(true);
         OpenId::redirect("http://www.test.com/test.php", array('a'=>'b', 'c'=>'d'), $response, 'GET');
-        $location = $response->headers()->get('Location');
+        $location = $response->getHeaders()->get('Location');
         $this->assertSame( 'http://www.test.com/test.php?a=b&c=d', $location->getFieldValue() );
 
         $response = new ResponseHelper(true);
         OpenId::redirect("http://www.test.com/test.php?a=b", array('c'=>'d'), $response, 'GET');
-        $location = $response->headers()->get('Location');
+        $location = $response->getHeaders()->get('Location');
         $this->assertSame( 'http://www.test.com/test.php?a=b&c=d', $location->getFieldValue() );
 
         $response = new ResponseHelper(true);
         OpenId::redirect("http://www.test.com/test.php", array('a'=>'x y'), $response, 'GET');
-        $location = $response->headers()->get('Location');
+        $location = $response->getHeaders()->get('Location');
         $this->assertSame( 'http://www.test.com/test.php?a=x+y', $location->getFieldValue() );
 
         $response = new ResponseHelper(false);

--- a/tests/Zend/OpenId/ProviderTest.php
+++ b/tests/Zend/OpenId/ProviderTest.php
@@ -748,7 +748,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
                 'openid_assoc_handle' => self::HANDLE,
                 'openid_return_to' => 'http://www.test.com/test.php'
             ), null, $response) );
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -776,7 +776,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
                 'openid_assoc_handle' => self::HANDLE,
                 'openid_return_to' => 'http://www.test.com/test.php'
             ), null, $response) );
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -808,7 +808,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
                 'openid_identity' => 'http://identity/',
                 'openid_unknown' => 'http://www.test.com/test.php',
             ), null, $response);
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -839,7 +839,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue( $provider->respondToConsumer(array(
                 'openid_return_to' => 'http://www.test.com/test.php',
             ), $sreg, $response) );
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -878,7 +878,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $this->assertSame( 'http://www.test.com/test.php?openid.mode=cancel', $headers->get('Location')->getFieldValue() );
 
@@ -888,7 +888,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_mode'=>'checkid_immediate',
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -919,7 +919,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -953,7 +953,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_ns_sreg'=>Extension\Sreg::NAMESPACE_1_1,
             'openid_sreg_required'=>'nickname'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -987,7 +987,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1020,7 +1020,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1054,7 +1054,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_ns_sreg'=>Extension\Sreg::NAMESPACE_1_1,
             'openid_sreg_required'=>'nickname'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1088,7 +1088,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $this->assertSame( 'http://www.test.com/test.php?openid.mode=cancel', $headers->get('Location')->getFieldValue() );
 
@@ -1101,7 +1101,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $this->assertSame( 'http://www.test.com/test.php?openid.mode=cancel', $headers->get('Location')->getFieldValue() );
 
@@ -1114,7 +1114,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1141,7 +1141,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_trust_root'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertEquals(0, count($headers));
         $this->assertSame( '', $response->getBody() );
 
@@ -1157,7 +1157,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1189,7 +1189,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1226,7 +1226,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_sreg_optional'=>'email',
             ),
             $sreg, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1262,7 +1262,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_sreg_required'=>'nickname,email',
             ),
             $sreg, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1317,7 +1317,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $this->assertSame( 'http://www.test.com/test.php?openid.mode=cancel', $headers->get('Location')->getFieldValue() );
 
@@ -1327,7 +1327,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_mode'=>'checkid_setup',
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1349,7 +1349,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1372,7 +1372,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1395,7 +1395,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $this->assertSame( 'http://www.test.com/test.php?openid.mode=cancel', $headers->get('Location')->getFieldValue() );
 
@@ -1407,7 +1407,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1434,7 +1434,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_trust_root'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertEquals(0, count($headers));
         $this->assertSame( '', $response->getBody() );
 
@@ -1450,7 +1450,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1482,7 +1482,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_identity'=>self::USER,
             'openid_return_to'=>'http://www.test.com/test.php'),
             null, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1519,7 +1519,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_sreg_optional'=>'email',
             ),
             $sreg, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1555,7 +1555,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             'openid_sreg_required'=>'nickname,email',
             ),
             $sreg, $response));
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );
@@ -1610,7 +1610,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
                 'openid_assoc_handle' => self::HANDLE,
                 'openid_return_to' => 'http://www.test.com/test.php'
             ), null, $response) );
-        $headers = $response->headers();
+        $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Location'));
         $url = parse_url($headers->get('Location')->getFieldValue());
         $this->assertSame( 'www.test.com', $url['host'] );

--- a/tests/Zend/View/Helper/JsonTest.php
+++ b/tests/Zend/View/Helper/JsonTest.php
@@ -55,7 +55,7 @@ class JsonTest extends TestCase
 
     public function verifyJsonHeader()
     {
-        $headers = $this->response->headers();
+        $headers = $this->response->getHeaders();
         $this->assertTrue($headers->has('Content-Type'));
         $header = $headers->get('Content-Type');
         $this->assertEquals('application/json', $header->getFieldValue());

--- a/tests/Zend/View/Strategy/FeedStrategyTest.php
+++ b/tests/Zend/View/Strategy/FeedStrategyTest.php
@@ -60,7 +60,7 @@ class FeedStrategyTest extends TestCase
     public function testRssAcceptHeaderSelectsFeedStrategy()
     {
         $request = new HttpRequest();
-        $request->headers()->addHeaderLine('Accept', 'application/rss+xml');
+        $request->getHeaders()->addHeaderLine('Accept', 'application/rss+xml');
         $this->event->setRequest($request);
         $result = $this->strategy->selectRenderer($this->event);
         $this->assertSame($this->renderer, $result);
@@ -69,7 +69,7 @@ class FeedStrategyTest extends TestCase
     public function testAtomAcceptHeaderSelectsFeedStrategy()
     {
         $request = new HttpRequest();
-        $request->headers()->addHeaderLine('Accept', 'application/atom+xml');
+        $request->getHeaders()->addHeaderLine('Accept', 'application/atom+xml');
         $this->event->setRequest($request);
         $result = $this->strategy->selectRenderer($this->event);
         $this->assertSame($this->renderer, $result);
@@ -85,7 +85,7 @@ class FeedStrategyTest extends TestCase
     protected function assertResponseNotInjected()
     {
         $content = $this->response->getContent();
-        $headers = $this->response->headers();
+        $headers = $this->response->getHeaders();
         $this->assertTrue(empty($content));
         $this->assertFalse($headers->has('content-type'));
     }
@@ -125,7 +125,7 @@ class FeedStrategyTest extends TestCase
 
         $this->strategy->injectResponse($this->event);
         $content = $this->response->getContent();
-        $headers = $this->response->headers();
+        $headers = $this->response->getHeaders();
         $this->assertEquals($expected, $content);
         $this->assertTrue($headers->has('content-type'));
         $this->assertEquals('application/atom+xml', $headers->get('content-type')->getFieldValue());
@@ -182,7 +182,7 @@ class FeedStrategyTest extends TestCase
 
         $this->strategy->injectResponse($this->event);
         $content = $this->response->getContent();
-        $headers = $this->response->headers();
+        $headers = $this->response->getHeaders();
         $this->assertEquals($expected->export('atom'), $content);
         $this->assertTrue($headers->has('content-type'));
         $this->assertEquals('application/atom+xml', $headers->get('content-type')->getFieldValue());
@@ -198,7 +198,7 @@ class FeedStrategyTest extends TestCase
 
         $this->strategy->injectResponse($this->event);
         $content = $this->response->getContent();
-        $headers = $this->response->headers();
+        $headers = $this->response->getHeaders();
         $this->assertEquals($expected->export('rss'), $content);
         $this->assertTrue($headers->has('content-type'));
         $this->assertEquals('application/rss+xml', $headers->get('content-type')->getFieldValue());

--- a/tests/Zend/View/Strategy/JsonStrategyTest.php
+++ b/tests/Zend/View/Strategy/JsonStrategyTest.php
@@ -60,7 +60,7 @@ class JsonStrategyTest extends TestCase
     public function testJsonAcceptHeaderSelectsJsonStrategy()
     {
         $request = new HttpRequest();
-        $request->headers()->addHeaderLine('Accept', 'application/json');
+        $request->getHeaders()->addHeaderLine('Accept', 'application/json');
         $this->event->setRequest($request);
         $result = $this->strategy->selectRenderer($this->event);
         $this->assertSame($this->renderer, $result);
@@ -69,7 +69,7 @@ class JsonStrategyTest extends TestCase
     public function testJavascriptAcceptHeaderSelectsJsonStrategy()
     {
         $request = new HttpRequest();
-        $request->headers()->addHeaderLine('Accept', 'application/javascript');
+        $request->getHeaders()->addHeaderLine('Accept', 'application/javascript');
         $this->event->setRequest($request);
         $result = $this->strategy->selectRenderer($this->event);
         $this->assertSame($this->renderer, $result);
@@ -79,7 +79,7 @@ class JsonStrategyTest extends TestCase
     public function testJavascriptAcceptHeaderSelectsJsonStrategyAndSetsJsonpCallback()
     {
         $request = new HttpRequest();
-        $request->headers()->addHeaderLine('Accept', 'application/javascript');
+        $request->getHeaders()->addHeaderLine('Accept', 'application/javascript');
         $request->setQuery(new Parameters(array('callback' => 'foo')));
         $this->event->setRequest($request);
         $result = $this->strategy->selectRenderer($this->event);
@@ -97,7 +97,7 @@ class JsonStrategyTest extends TestCase
     protected function assertResponseNotInjected()
     {
         $content = $this->response->getContent();
-        $headers = $this->response->headers();
+        $headers = $this->response->getHeaders();
         $this->assertTrue(empty($content));
         $this->assertFalse($headers->has('content-type'));
     }
@@ -136,7 +136,7 @@ class JsonStrategyTest extends TestCase
 
         $this->strategy->injectResponse($this->event);
         $content = $this->response->getContent();
-        $headers = $this->response->headers();
+        $headers = $this->response->getHeaders();
         $this->assertEquals($expected, $content);
         $this->assertTrue($headers->has('content-type'));
         $this->assertEquals('application/json', $headers->get('content-type')->getFieldValue());
@@ -152,7 +152,7 @@ class JsonStrategyTest extends TestCase
 
         $this->strategy->injectResponse($this->event);
         $content = $this->response->getContent();
-        $headers = $this->response->headers();
+        $headers = $this->response->getHeaders();
         $this->assertEquals($expected, $content);
         $this->assertTrue($headers->has('content-type'));
         $this->assertEquals('application/javascript', $headers->get('content-type')->getFieldValue());

--- a/tests/Zend/View/Strategy/PhpRendererStrategyTest.php
+++ b/tests/Zend/View/Strategy/PhpRendererStrategyTest.php
@@ -60,7 +60,7 @@ class PhpRendererStrategyTest extends TestCase
     protected function assertResponseNotInjected()
     {
         $content = $this->response->getContent();
-        $headers = $this->response->headers();
+        $headers = $this->response->getHeaders();
         $this->assertTrue(empty($content));
         $this->assertFalse($headers->has('content-type'));
     }
@@ -79,7 +79,7 @@ class PhpRendererStrategyTest extends TestCase
         $this->strategy->injectResponse($this->event);
         $this->assertResponseNotInjected();
     }
-    
+
     public function testResponseContentSetToContentPlaceholderWhenResultAndArticlePlaceholderAreEmpty()
     {
         $this->renderer->placeholder('content')->set('Content');
@@ -152,7 +152,7 @@ class PhpRendererStrategyTest extends TestCase
             $this->assertTrue($found, 'Listener not found');
         }
     }
-    
+
     public function testCanAttachListenersAtSpecifiedPriority()
     {
         $events = new EventManager();

--- a/tests/Zend/XmlRpc/ClientTest.php
+++ b/tests/Zend/XmlRpc/ClientTest.php
@@ -577,7 +577,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->xmlrpcClient->setHttpClient($this->httpClient);
 
         $this->setServerResponseTo(array());
-        $this->assertNull($this->xmlrpcClient->getHttpClient()->getRequest()->getUri());
+        $this->assertNull($this->xmlrpcClient->getHttpClient()->getRequest()->getUriString());
         $this->xmlrpcClient->call('foo');
         $uri = $this->xmlrpcClient->getHttpClient()->getUri();
 


### PR DESCRIPTION
All Zend\Http\Request and Zend\Http\Response methods like `query()` and `post()` change with this PR to `getQuery()` and `getPost()`. All tests from Zend\Http and all other components are adjusted to reflect these changes.

Because of many failures in components the Travis tests say also in this case the build did not pass. However, if you read all failures from [this build](http://travis-ci.org/#!/juriansluiman/zf2/builds/1744086) you see nothing is Zend\Http related.
