### PR TITLE
Use MvcEvent::CONSTANTS instead of strings

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -23,7 +23,6 @@ namespace Zend\Mvc;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\ModuleManager\ModuleManagerInterface;
-use Zend\Mvc\MvcEvent;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Stdlib\RequestInterface;
 use Zend\Stdlib\ResponseInterface;
@@ -163,7 +162,7 @@ class Application implements
               ->setRouter($serviceManager->get('Router'));
 
         // Trigger bootstrap events
-        $events->trigger('bootstrap', $event);
+        $events->trigger(MvcEvent::EVENT_BOOTSTRAP, $event);
         return $this;
     }
 
@@ -269,12 +268,12 @@ class Application implements
         };
 
         // Trigger route event
-        $result = $events->trigger('route', $event, $shortCircuit);
+        $result = $events->trigger(MvcEvent::EVENT_ROUTE, $event, $shortCircuit);
         if ($result->stopped()) {
             $response = $result->last();
             if ($response instanceof ResponseInterface) {
                 $event->setTarget($this);
-                $events->trigger('finish', $event);
+                $events->trigger(MvcEvent::EVENT_FINISH, $event);
                 return $response;
             }
             if ($event->getError()) {
@@ -287,13 +286,13 @@ class Application implements
         }
 
         // Trigger dispatch event
-        $result = $events->trigger('dispatch', $event, $shortCircuit);
+        $result = $events->trigger(MvcEvent::EVENT_DISPATCH, $event, $shortCircuit);
 
         // Complete response
         $response = $result->last();
         if ($response instanceof ResponseInterface) {
             $event->setTarget($this);
-            $events->trigger('finish', $event);
+            $events->trigger(MvcEvent::EVENT_FINISH, $event);
             return $response;
         }
 
@@ -316,8 +315,8 @@ class Application implements
     {
         $events = $this->getEventManager();
         $event->setTarget($this);
-        $events->trigger('render', $event);
-        $events->trigger('finish', $event);
+        $events->trigger(MvcEvent::EVENT_RENDER, $event);
+        $events->trigger(MvcEvent::EVENT_FINISH, $event);
         return $event->getResponse();
     }
 }

--- a/library/Zend/Mvc/DispatchListener.php
+++ b/library/Zend/Mvc/DispatchListener.php
@@ -66,7 +66,7 @@ class DispatchListener implements ListenerAggregateInterface
      */
     public function attach(EventManagerInterface $events)
     {
-        $this->listeners[] = $events->attach('dispatch', array($this, 'onDispatch'));
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'onDispatch'));
     }
 
     /**
@@ -107,7 +107,7 @@ class DispatchListener implements ListenerAggregateInterface
                   ->setControllerClass('invalid controller class or alias: '.$controllerName)
                   ->setParam('exception', $exception);
 
-            $results = $events->trigger('dispatch.error', $e);
+            $results = $events->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $e);
             $return = $results->last();
             if (! $return) {
                 $return = $e->getResult();
@@ -118,7 +118,7 @@ class DispatchListener implements ListenerAggregateInterface
             $e->setError($application::ERROR_EXCEPTION)
                   ->setController($controllerName)
                   ->setParam('exception', $exception);
-            $results = $events->trigger('dispatch.error', $e);
+            $results = $events->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $e);
             $return = $results->last();
             if (! $return) {
                 $return = $e->getResult();
@@ -132,7 +132,7 @@ class DispatchListener implements ListenerAggregateInterface
                 ->setController($controllerName)
                 ->setControllerClass(get_class($controller));
 
-            $results = $events->trigger('dispatch.error', $e);
+            $results = $events->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $e);
             $return = $results->last();
             if (! $return) {
                 $return = $e->getResult();
@@ -154,7 +154,7 @@ class DispatchListener implements ListenerAggregateInterface
                   ->setController($controllerName)
                   ->setControllerClass(get_class($controller))
                   ->setParam('exception', $ex);
-            $results = $events->trigger('dispatch.error', $e);
+            $results = $events->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $e);
             $return = $results->last();
             if (! $return) {
                 $return = $e->getResult();

--- a/library/Zend/Mvc/RouteListener.php
+++ b/library/Zend/Mvc/RouteListener.php
@@ -44,7 +44,7 @@ class RouteListener implements ListenerAggregateInterface
      */
     public function attach(EventManagerInterface $events)
     {
-        $this->listeners[] = $events->attach('route', array($this, 'onRoute'));
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'onRoute'));
     }
 
     /**
@@ -83,7 +83,7 @@ class RouteListener implements ListenerAggregateInterface
         if (!$routeMatch instanceof Router\RouteMatch) {
             $e->setError($target::ERROR_ROUTER_NO_MATCH);
 
-            $results = $target->getEventManager()->trigger('dispatch.error', $e);
+            $results = $target->getEventManager()->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $e);
             if (count($results)) {
                 $return  = $results->last();
             } else {

--- a/library/Zend/Mvc/View/ViewManager.php
+++ b/library/Zend/Mvc/View/ViewManager.php
@@ -117,7 +117,7 @@ class ViewManager implements ListenerAggregateInterface
      */
     public function attach(EventManagerInterface $events)
     {
-        $this->listeners[] = $events->attach('bootstrap', array($this, 'onBootstrap'), 10000);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_BOOTSTRAP, array($this, 'onBootstrap'), 10000);
     }
 
     /**

--- a/tests/Zend/Mvc/Controller/ActionControllerTest.php
+++ b/tests/Zend/Mvc/Controller/ActionControllerTest.php
@@ -72,7 +72,7 @@ class ActionControllerTest extends TestCase
     {
         $response = new Response();
         $response->setContent('short circuited!');
-        $this->controller->getEventManager()->attach('dispatch', function($e) use ($response) {
+        $this->controller->getEventManager()->attach(MvcEvent::EVENT_DISPATCH, function($e) use ($response) {
             return $response;
         }, 100);
         $result = $this->controller->dispatch($this->request, $this->response);
@@ -83,7 +83,7 @@ class ActionControllerTest extends TestCase
     {
         $response = new Response();
         $response->setContent('short circuited!');
-        $this->controller->getEventManager()->attach('dispatch', function($e) use ($response) {
+        $this->controller->getEventManager()->attach(MvcEvent::EVENT_DISPATCH, function($e) use ($response) {
             return $response;
         }, -10);
         $result = $this->controller->dispatch($this->request, $this->response);
@@ -95,7 +95,7 @@ class ActionControllerTest extends TestCase
         $response = new Response();
         $response->setContent('short circuited!');
         $events = new SharedEventManager();
-        $events->attach('Zend\Stdlib\DispatchableInterface', 'dispatch', function($e) use ($response) {
+        $events->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, function($e) use ($response) {
             return $response;
         }, 10);
         $this->controller->getEventManager()->setSharedManager($events);
@@ -108,7 +108,7 @@ class ActionControllerTest extends TestCase
         $response = new Response();
         $response->setContent('short circuited!');
         $events = new SharedEventManager();
-        $events->attach('Zend\Mvc\Controller\AbstractActionController', 'dispatch', function($e) use ($response) {
+        $events->attach('Zend\Mvc\Controller\AbstractActionController', MvcEvent::EVENT_DISPATCH, function($e) use ($response) {
             return $response;
         }, 10);
         $this->controller->getEventManager()->setSharedManager($events);
@@ -121,7 +121,7 @@ class ActionControllerTest extends TestCase
         $response = new Response();
         $response->setContent('short circuited!');
         $events = new SharedEventManager();
-        $events->attach(get_class($this->controller), 'dispatch', function($e) use ($response) {
+        $events->attach(get_class($this->controller), MvcEvent::EVENT_DISPATCH, function($e) use ($response) {
             return $response;
         }, 10);
         $this->controller->getEventManager()->setSharedManager($events);

--- a/tests/Zend/Mvc/Controller/RestfulControllerTest.php
+++ b/tests/Zend/Mvc/Controller/RestfulControllerTest.php
@@ -116,7 +116,7 @@ class RestfulControllerTest extends TestCase
     {
         $response = new Response();
         $response->setContent('short circuited!');
-        $this->controller->getEventManager()->attach('dispatch', function($e) use ($response) {
+        $this->controller->getEventManager()->attach(MvcEvent::EVENT_DISPATCH, function($e) use ($response) {
             return $response;
         }, 10);
         $result = $this->controller->dispatch($this->request, $this->response);
@@ -127,7 +127,7 @@ class RestfulControllerTest extends TestCase
     {
         $response = new Response();
         $response->setContent('short circuited!');
-        $this->controller->getEventManager()->attach('dispatch', function($e) use ($response) {
+        $this->controller->getEventManager()->attach(MvcEvent::EVENT_DISPATCH, function($e) use ($response) {
             return $response;
         }, -10);
         $result = $this->controller->dispatch($this->request, $this->response);
@@ -139,7 +139,7 @@ class RestfulControllerTest extends TestCase
         $response = new Response();
         $response->setContent('short circuited!');
         $events = new SharedEventManager();
-        $events->attach('Zend\Stdlib\DispatchableInterface', 'dispatch', function($e) use ($response) {
+        $events->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, function($e) use ($response) {
             return $response;
         }, 10);
         $this->controller->getEventManager()->setSharedManager($events);
@@ -152,7 +152,7 @@ class RestfulControllerTest extends TestCase
         $response = new Response();
         $response->setContent('short circuited!');
         $events = new SharedEventManager();
-        $events->attach('Zend\Mvc\Controller\AbstractRestfulController', 'dispatch', function($e) use ($response) {
+        $events->attach('Zend\Mvc\Controller\AbstractRestfulController', MvcEvent::EVENT_DISPATCH, function($e) use ($response) {
             return $response;
         }, 10);
         $this->controller->getEventManager()->setSharedManager($events);
@@ -165,7 +165,7 @@ class RestfulControllerTest extends TestCase
         $response = new Response();
         $response->setContent('short circuited!');
         $events = new SharedEventManager();
-        $events->attach(get_class($this->controller), 'dispatch', function($e) use ($response) {
+        $events->attach(get_class($this->controller), MvcEvent::EVENT_DISPATCH, function($e) use ($response) {
             return $response;
         }, 10);
         $this->controller->getEventManager()->setSharedManager($events);

--- a/tests/Zend/Mvc/TestAsset/MockViewManager.php
+++ b/tests/Zend/Mvc/TestAsset/MockViewManager.php
@@ -23,6 +23,7 @@ namespace ZendTest\Mvc\TestAsset;
 
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\ListenerAggregateInterface;
+use Zend\Mvc\MvcEvent;
 
 class MockViewManager implements ListenerAggregateInterface
 {
@@ -30,7 +31,7 @@ class MockViewManager implements ListenerAggregateInterface
 
     public function attach(EventManagerInterface $events)
     {
-        $this->listeners[] = $events->attach('bootstrap', array($this, 'onBootstrap'), 10000);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_BOOTSTRAP, array($this, 'onBootstrap'), 10000);
     }
 
     public function detach(EventManagerInterface $events)

--- a/tests/Zend/Mvc/View/CreateViewModelListenerTest.php
+++ b/tests/Zend/Mvc/View/CreateViewModelListenerTest.php
@@ -90,7 +90,7 @@ class CreateViewModelListenerTest extends TestCase
     {
         $events = new EventManager();
         $events->attachAggregate($this->listener);
-        $listeners = $events->getListeners('dispatch');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
 
         $expectedArrayCallback = array($this->listener, 'createViewModelFromArray');
         $expectedNullCallback  = array($this->listener, 'createViewModelFromNull');
@@ -118,10 +118,10 @@ class CreateViewModelListenerTest extends TestCase
     {
         $events = new EventManager();
         $events->attachAggregate($this->listener);
-        $listeners = $events->getListeners('dispatch');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(2, count($listeners));
         $events->detachAggregate($this->listener);
-        $listeners = $events->getListeners('dispatch');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(0, count($listeners));
     }
 

--- a/tests/Zend/Mvc/View/DefaultRendereringStrategyTest.php
+++ b/tests/Zend/Mvc/View/DefaultRendereringStrategyTest.php
@@ -75,7 +75,7 @@ class DefaultRenderingStrategyTest extends TestCase
     {
         $events = new EventManager();
         $events->attachAggregate($this->strategy);
-        $listeners = $events->getListeners('render');
+        $listeners = $events->getListeners(MvcEvent::EVENT_RENDER);
 
         $expectedCallback = array($this->strategy, 'render');
         $expectedPriority = -10000;
@@ -96,10 +96,10 @@ class DefaultRenderingStrategyTest extends TestCase
     {
         $events = new EventManager();
         $events->attachAggregate($this->strategy);
-        $this->assertEquals(1, count($events->getListeners('render')));
+        $this->assertEquals(1, count($events->getListeners(MvcEvent::EVENT_RENDER)));
 
         $events->detachAggregate($this->strategy);
-        $this->assertEquals(0, count($events->getListeners('render')));
+        $this->assertEquals(0, count($events->getListeners(MvcEvent::EVENT_RENDER)));
     }
 
     public function testWillRenderAlternateStrategyWhenSelected()

--- a/tests/Zend/Mvc/View/ExceptionStrategyTest.php
+++ b/tests/Zend/Mvc/View/ExceptionStrategyTest.php
@@ -156,7 +156,7 @@ class ExceptionStrategyTest extends TestCase
     {
         $events = new EventManager();
         $events->attachAggregate($this->strategy);
-        $listeners = $events->getListeners('dispatch.error');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
 
         $expectedCallback = array($this->strategy, 'prepareExceptionViewModel');
         $expectedPriority = 1;
@@ -177,10 +177,10 @@ class ExceptionStrategyTest extends TestCase
     {
         $events = new EventManager();
         $events->attachAggregate($this->strategy);
-        $listeners = $events->getListeners('dispatch.error');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
         $this->assertEquals(1, count($listeners));
         $events->detachAggregate($this->strategy);
-        $listeners = $events->getListeners('dispatch.error');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
         $this->assertEquals(0, count($listeners));
     }
 }

--- a/tests/Zend/Mvc/View/InjectTemplateListenerTest.php
+++ b/tests/Zend/Mvc/View/InjectTemplateListenerTest.php
@@ -119,7 +119,7 @@ class InjectTemplateListenerTest extends TestCase
     {
         $events = new EventManager();
         $events->attachAggregate($this->listener);
-        $listeners = $events->getListeners('dispatch');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
 
         $expectedCallback = array($this->listener, 'injectTemplate');
         $expectedPriority = -90;
@@ -140,10 +140,10 @@ class InjectTemplateListenerTest extends TestCase
     {
         $events = new EventManager();
         $events->attachAggregate($this->listener);
-        $listeners = $events->getListeners('dispatch');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(1, count($listeners));
         $events->detachAggregate($this->listener);
-        $listeners = $events->getListeners('dispatch');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(0, count($listeners));
     }
 }

--- a/tests/Zend/Mvc/View/InjectViewModelListenerTest.php
+++ b/tests/Zend/Mvc/View/InjectViewModelListenerTest.php
@@ -83,7 +83,7 @@ class InjectViewModelListenerTest extends TestCase
     {
         $events = new EventManager();
         $events->attachAggregate($this->listener);
-        $listeners = $events->getListeners('dispatch');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
 
         $expectedCallback = array($this->listener, 'injectViewModel');
         $expectedPriority = -100;
@@ -99,7 +99,7 @@ class InjectViewModelListenerTest extends TestCase
         }
         $this->assertTrue($found, 'Listener not found');
 
-        $listeners = $events->getListeners('dispatch.error');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
         $found     = false;
         foreach ($listeners as $listener) {
             $callback = $listener->getCallback();
@@ -117,14 +117,14 @@ class InjectViewModelListenerTest extends TestCase
     {
         $events = new EventManager();
         $events->attachAggregate($this->listener);
-        $listeners = $events->getListeners('dispatch');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(1, count($listeners));
-        $listeners = $events->getListeners('dispatch.error');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
         $this->assertEquals(1, count($listeners));
         $events->detachAggregate($this->listener);
-        $listeners = $events->getListeners('dispatch');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(0, count($listeners));
-        $listeners = $events->getListeners('dispatch.error');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
         $this->assertEquals(0, count($listeners));
     }
 }

--- a/tests/Zend/Mvc/View/RouteNotFoundStrategyTest.php
+++ b/tests/Zend/Mvc/View/RouteNotFoundStrategyTest.php
@@ -265,7 +265,7 @@ class RouteNotFoundStrategyTest extends TestCase
         $events = new EventManager();
         $events->attachAggregate($this->strategy);
 
-        foreach (array('dispatch' => -90, 'dispatch.error' => 1) as $event => $expectedPriority) {
+        foreach (array(MvcEvent::EVENT_DISPATCH => -90, MvcEvent::EVENT_DISPATCH_ERROR => 1) as $event => $expectedPriority) {
             $listeners        = $events->getListeners($event);
             $expectedCallback = array($this->strategy, 'prepareNotFoundViewModel');
             $found            = false;
@@ -281,7 +281,7 @@ class RouteNotFoundStrategyTest extends TestCase
             $this->assertTrue($found, 'Listener not found');
         }
 
-        $listeners        = $events->getListeners('dispatch.error');
+        $listeners        = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
         $expectedCallback = array($this->strategy, 'detectNotFoundError');
         $expectedPriority = 1;
         $found            = false;
@@ -301,14 +301,14 @@ class RouteNotFoundStrategyTest extends TestCase
     {
         $events = new EventManager();
         $events->attachAggregate($this->strategy);
-        $listeners = $events->getListeners('dispatch');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(1, count($listeners));
-        $listeners = $events->getListeners('dispatch.error');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
         $this->assertEquals(2, count($listeners));
         $events->detachAggregate($this->strategy);
-        $listeners = $events->getListeners('dispatch');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(0, count($listeners));
-        $listeners = $events->getListeners('dispatch.error');
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
         $this->assertEquals(0, count($listeners));
     }
 }


### PR DESCRIPTION
Using class defined constants instead of strings enforces code and consistency.
