### PR TITLE
Rename Zend\Mail accessors to get*() style

### DIFF
--- a/library/Zend/Mail/Address.php
+++ b/library/Zend/Mail/Address.php
@@ -54,7 +54,7 @@ class Address implements Address\AddressInterface
 
     /**
      * Retrieve email
-     * 
+     *
      * @return string
      */
     public function getEmail()
@@ -64,7 +64,7 @@ class Address implements Address\AddressInterface
 
     /**
      * Retrieve name
-     * 
+     *
      * @return string
      */
     public function getName()
@@ -74,7 +74,7 @@ class Address implements Address\AddressInterface
 
     /**
      * String representation of address
-     * 
+     *
      * @return string
      */
     public function toString()

--- a/library/Zend/Mail/AddressList.php
+++ b/library/Zend/Mail/AddressList.php
@@ -33,7 +33,7 @@ class AddressList implements Countable, Iterator
 {
     /**
      * List of Address objects we're managing
-     * 
+     *
      * @var array
      */
     protected $addresses = array();
@@ -97,9 +97,9 @@ class AddressList implements Countable, Iterator
     }
 
     /**
-     * Merge another address list into this one 
-     * 
-     * @param  AddressList $addressList 
+     * Merge another address list into this one
+     *
+     * @param  AddressList $addressList
      * @return AddressList
      */
     public function merge(AddressList $addressList)
@@ -112,8 +112,8 @@ class AddressList implements Countable, Iterator
 
     /**
      * Does the email exist in this list?
-     * 
-     * @param  string $email 
+     *
+     * @param  string $email
      * @return bool
      */
     public function has($email)
@@ -124,8 +124,8 @@ class AddressList implements Countable, Iterator
 
     /**
      * Get an address by email
-     * 
-     * @param  string $email 
+     *
+     * @param  string $email
      * @return boolean|Address\AddressInterface
      */
     public function get($email)
@@ -140,7 +140,7 @@ class AddressList implements Countable, Iterator
 
     /**
      * Delete an address from the list
-     * 
+     *
      * @param  string $email
      * @return bool
      */
@@ -157,7 +157,7 @@ class AddressList implements Countable, Iterator
 
     /**
      * Return count of addresses
-     * 
+     *
      * @return int
      */
     public function count()
@@ -179,7 +179,7 @@ class AddressList implements Countable, Iterator
 
     /**
      * Return current item in iteration
-     * 
+     *
      * @return Address
      */
     public function current()
@@ -189,7 +189,7 @@ class AddressList implements Countable, Iterator
 
     /**
      * Return key of current item of iteration
-     * 
+     *
      * @return string
      */
     public function key()
@@ -211,7 +211,7 @@ class AddressList implements Countable, Iterator
 
     /**
      * Is the current item of iteration valid?
-     * 
+     *
      * @return bool
      */
     public function valid()
@@ -221,10 +221,10 @@ class AddressList implements Countable, Iterator
     }
 
     /**
-     * Create an address object 
-     * 
-     * @param  string $email 
-     * @param  string|null $name 
+     * Create an address object
+     *
+     * @param  string $email
+     * @param  string|null $name
      * @return Address
      */
     protected function createAddress($email, $name)

--- a/library/Zend/Mail/Message.php
+++ b/library/Zend/Mail/Message.php
@@ -33,7 +33,7 @@ class Message
 {
     /**
      * Content of the message
-     * 
+     *
      * @var string|object
      */
     protected $body;
@@ -47,7 +47,7 @@ class Message
      * Message encoding
      *
      * Used to determine whether or not to encode headers; defaults to ASCII.
-     * 
+     *
      * @var string
      */
     protected $encoding = 'ASCII';
@@ -56,12 +56,12 @@ class Message
      * Is the message valid?
      *
      * If we don't any From addresses, we're invalid, according to RFC2822.
-     * 
+     *
      * @return bool
      */
     public function isValid()
     {
-        $from = $this->from();
+        $from = $this->getFrom();
         if (!$from instanceof AddressList) {
             return false;
         }
@@ -70,20 +70,20 @@ class Message
 
     /**
      * Set the message encoding
-     * 
-     * @param  string $encoding 
+     *
+     * @param  string $encoding
      * @return Message
      */
     public function setEncoding($encoding)
     {
         $this->encoding = $encoding;
-        $this->headers()->setEncoding($encoding);
+        $this->getHeaders()->setEncoding($encoding);
         return $this;
     }
 
     /**
      * Get the message encoding
-     * 
+     *
      * @return string
      */
     public function getEncoding()
@@ -93,8 +93,8 @@ class Message
 
     /**
      * Compose headers
-     * 
-     * @param  Headers $headers 
+     *
+     * @param  Headers $headers
      * @return Message
      */
     public function setHeaders(Headers $headers)
@@ -108,10 +108,10 @@ class Message
      * Access headers collection
      *
      * Lazy-loads if not already attached.
-     * 
+     *
      * @return Headers
      */
-    public function headers()
+    public function getHeaders()
     {
         if (null === $this->headers) {
             $this->setHeaders(new Headers());
@@ -122,9 +122,9 @@ class Message
 
     /**
      * Set (overwrite) From addresses
-     * 
-     * @param  string|Address\AddressInterface|array|AddressList|Traversable $emailOrAddressList 
-     * @param  string|null $name 
+     *
+     * @param  string|Address\AddressInterface|array|AddressList|Traversable $emailOrAddressList
+     * @param  string|null $name
      * @return Message
      */
     public function setFrom($emailOrAddressList, $name = null)
@@ -135,33 +135,33 @@ class Message
 
     /**
      * Add a "From" address
-     * 
-     * @param  string|Address|array|AddressList|Traversable $emailOrAddressOrList 
-     * @param  string|null $name 
+     *
+     * @param  string|Address|array|AddressList|Traversable $emailOrAddressOrList
+     * @param  string|null $name
      * @return Message
      */
     public function addFrom($emailOrAddressOrList, $name = null)
     {
-        $addressList = $this->from();
+        $addressList = $this->getFrom();
         $this->updateAddressList($addressList, $emailOrAddressOrList, $name, __METHOD__);
         return $this;
     }
 
     /**
      * Retrieve list of From senders
-     * 
+     *
      * @return AddressList
      */
-    public function from()
+    public function getFrom()
     {
         return $this->getAddressListFromHeader('from', __NAMESPACE__ . '\Header\From');
     }
 
     /**
      * Overwrite the address list in the To recipients
-     * 
-     * @param  string|Address\AddressInterface|array|AddressList|Traversable $emailOrAddressList 
-     * @param  null|string $name 
+     *
+     * @param  string|Address\AddressInterface|array|AddressList|Traversable $emailOrAddressList
+     * @param  null|string $name
      * @return Message
      */
     public function setTo($emailOrAddressList, $name = null)
@@ -174,33 +174,33 @@ class Message
      * Add one or more addresses to the To recipients
      *
      * Appends to the list.
-     * 
-     * @param  string|Address\AddressInterface|array|AddressList|Traversable $emailOrAddressOrList 
-     * @param  null|string $name 
+     *
+     * @param  string|Address\AddressInterface|array|AddressList|Traversable $emailOrAddressOrList
+     * @param  null|string $name
      * @return Message
      */
     public function addTo($emailOrAddressOrList, $name = null)
     {
-        $addressList = $this->to();
+        $addressList = $this->getTo();
         $this->updateAddressList($addressList, $emailOrAddressOrList, $name, __METHOD__);
         return $this;
     }
 
     /**
      * Access the address list of the To header
-     * 
+     *
      * @return AddressList
      */
-    public function to()
+    public function getTo()
     {
         return $this->getAddressListFromHeader('to', __NAMESPACE__ . '\Header\To');
     }
 
     /**
      * Set (overwrite) CC addresses
-     * 
-     * @param  string|Address\AddressInterface|array|AddressList|Traversable $emailOrAddressList 
-     * @param  string|null $name 
+     *
+     * @param  string|Address\AddressInterface|array|AddressList|Traversable $emailOrAddressList
+     * @param  string|null $name
      * @return Message
      */
     public function setCc($emailOrAddressList, $name = null)
@@ -211,33 +211,33 @@ class Message
 
     /**
      * Add a "Cc" address
-     * 
-     * @param  string|Address|array|AddressList|Traversable $emailOrAddressOrList 
-     * @param  string|null $name 
+     *
+     * @param  string|Address|array|AddressList|Traversable $emailOrAddressOrList
+     * @param  string|null $name
      * @return Message
      */
     public function addCc($emailOrAddressOrList, $name = null)
     {
-        $addressList = $this->cc();
+        $addressList = $this->getCc();
         $this->updateAddressList($addressList, $emailOrAddressOrList, $name, __METHOD__);
         return $this;
     }
 
     /**
      * Retrieve list of CC recipients
-     * 
+     *
      * @return AddressList
      */
-    public function cc()
+    public function getCc()
     {
         return $this->getAddressListFromHeader('cc', __NAMESPACE__ . '\Header\Cc');
     }
 
     /**
      * Set (overwrite) BCC addresses
-     * 
-     * @param  string|Address\AddressInterface|array|AddressList|Traversable $emailOrAddressList 
-     * @param  string|null $name 
+     *
+     * @param  string|Address\AddressInterface|array|AddressList|Traversable $emailOrAddressList
+     * @param  string|null $name
      * @return Message
      */
     public function setBcc($emailOrAddressList, $name = null)
@@ -248,33 +248,33 @@ class Message
 
     /**
      * Add a "Bcc" address
-     * 
-     * @param  string|Address|array|AddressList|Traversable $emailOrAddressOrList 
-     * @param  string|null $name 
+     *
+     * @param  string|Address|array|AddressList|Traversable $emailOrAddressOrList
+     * @param  string|null $name
      * @return Message
      */
     public function addBcc($emailOrAddressOrList, $name = null)
     {
-        $addressList = $this->bcc();
+        $addressList = $this->getBcc();
         $this->updateAddressList($addressList, $emailOrAddressOrList, $name, __METHOD__);
         return $this;
     }
 
     /**
      * Retrieve list of BCC recipients
-     * 
+     *
      * @return AddressList
      */
-    public function bcc()
+    public function getBcc()
     {
         return $this->getAddressListFromHeader('bcc', __NAMESPACE__ . '\Header\Bcc');
     }
 
     /**
      * Overwrite the address list in the Reply-To recipients
-     * 
-     * @param  string|Address\AddressInterface|array|AddressList|Traversable $emailOrAddressList 
-     * @param  null|string $name 
+     *
+     * @param  string|Address\AddressInterface|array|AddressList|Traversable $emailOrAddressList
+     * @param  null|string $name
      * @return Message
      */
     public function setReplyTo($emailOrAddressList, $name = null)
@@ -287,62 +287,62 @@ class Message
      * Add one or more addresses to the Reply-To recipients
      *
      * Appends to the list.
-     * 
-     * @param  string|Address\AddressInterface|array|AddressList|Traversable $emailOrAddressOrList 
-     * @param  null|string $name 
+     *
+     * @param  string|Address\AddressInterface|array|AddressList|Traversable $emailOrAddressOrList
+     * @param  null|string $name
      * @return Message
      */
     public function addReplyTo($emailOrAddressOrList, $name = null)
     {
-        $addressList = $this->replyTo();
+        $addressList = $this->getReplyTo();
         $this->updateAddressList($addressList, $emailOrAddressOrList, $name, __METHOD__);
         return $this;
     }
 
     /**
      * Access the address list of the Reply-To header
-     * 
+     *
      * @return AddressList
      */
-    public function replyTo()
+    public function getReplyTo()
     {
         return $this->getAddressListFromHeader('reply-to', __NAMESPACE__ . '\Header\ReplyTo');
     }
 
     /**
-     * setSender 
-     * 
-     * @param mixed $emailOrAddress 
-     * @param mixed $name 
+     * setSender
+     *
+     * @param mixed $emailOrAddress
+     * @param mixed $name
      * @return Message
      */
     public function setSender($emailOrAddress, $name = null)
     {
-        $header = $this->getHeader('sender', __NAMESPACE__ . '\Header\Sender');
+        $header = $this->getHeaderByName('sender', __NAMESPACE__ . '\Header\Sender');
         $header->setAddress($emailOrAddress, $name);
         return $this;
     }
 
     /**
      * Retrieve the sender address, if any
-     * 
+     *
      * @return null|Address\AddressInterface
      */
     public function getSender()
     {
-        $header = $this->getHeader('sender', __NAMESPACE__ . '\Header\Sender');
+        $header = $this->getHeaderByName('sender', __NAMESPACE__ . '\Header\Sender');
         return $header->getAddress();
     }
 
     /**
      * Set the message subject header value
-     * 
-     * @param  string $subject 
+     *
+     * @param  string $subject
      * @return Message
      */
     public function setSubject($subject)
     {
-        $headers = $this->headers();
+        $headers = $this->getHeaders();
         if (!$headers->has('subject')) {
             $header = new Header\Subject();
             $headers->addHeader($header);
@@ -355,12 +355,12 @@ class Message
 
     /**
      * Get the message subject header value
-     * 
+     *
      * @return null|string
      */
     public function getSubject()
     {
-        $headers = $this->headers();
+        $headers = $this->getHeaders();
         if (!$headers->has('subject')) {
             return null;
         }
@@ -402,13 +402,13 @@ class Message
         }
 
         // Get headers, and set Mime-Version header
-        $headers = $this->headers();
-        $this->getHeader('mime-version', __NAMESPACE__ . '\Header\MimeVersion');
+        $headers = $this->getHeaders();
+        $this->getHeaderByName('mime-version', __NAMESPACE__ . '\Header\MimeVersion');
 
         // Multipart content headers
         if ($this->body->isMultiPart()) {
             $mime   = $this->body->getMime();
-            $header = $this->getHeader('content-type', __NAMESPACE__ . '\Header\ContentType');
+            $header = $this->getHeaderByName('content-type', __NAMESPACE__ . '\Header\ContentType');
             $header->setType('multipart/mixed');
             $header->addParameter('boundary', $mime->boundary());
             return $this;
@@ -425,7 +425,7 @@ class Message
 
     /**
      * Return the currently set message body
-     * 
+     *
      * @return object
      */
     public function getBody()
@@ -435,7 +435,7 @@ class Message
 
     /**
      * Get the string-serialized message body text
-     * 
+     *
      * @return string
      */
     public function getBodyText()
@@ -451,14 +451,14 @@ class Message
      * Retrieve a header by name
      *
      * If not found, instantiates one based on $headerClass.
-     * 
-     * @param  string $headerName 
-     * @param  string $headerClass 
+     *
+     * @param  string $headerName
+     * @param  string $headerClass
      * @return \Zend\Mail\Header\HeaderInterface
      */
-    protected function getHeader($headerName, $headerClass)
+    protected function getHeaderByName($headerName, $headerClass)
     {
-        $headers = $this->headers();
+        $headers = $this->getHeaders();
         if ($headers->has($headerName)) {
             $header = $headers->get($headerName);
         } else {
@@ -470,12 +470,12 @@ class Message
 
     /**
      * Clear a header by name
-     * 
-     * @param  string $headerName 
+     *
+     * @param  string $headerName
      */
     protected function clearHeaderByName($headerName)
     {
-        $this->headers()->removeHeader($headerName);
+        $this->getHeaders()->removeHeader($headerName);
     }
 
     /**
@@ -491,7 +491,7 @@ class Message
      */
     protected function getAddressListFromHeader($headerName, $headerClass)
     {
-        $header = $this->getHeader($headerName, $headerClass);
+        $header = $this->getHeaderByName($headerName, $headerClass);
         if (!$header instanceof Header\AbstractAddressList) {
             throw new Exception\DomainException(sprintf(
                 'Cannot grab address list from header of type "%s"; not an AbstractAddressList implementation',
@@ -536,12 +536,12 @@ class Message
 
     /**
      * Serialize to string
-     * 
+     *
      * @return string
      */
     public function toString()
     {
-        $headers = $this->headers();
+        $headers = $this->getHeaders();
         return $headers->toString()
                . Headers::EOL
                . $this->getBodyText();

--- a/library/Zend/Mail/Protocol/Smtp.php
+++ b/library/Zend/Mail/Protocol/Smtp.php
@@ -103,10 +103,10 @@ class Smtp extends AbstractProtocol
      * Constructor.
      *
      * The first argument may be an array of all options. If so, it must include
-     * the 'host' and 'port' keys in order to ensure that all required values 
+     * the 'host' and 'port' keys in order to ensure that all required values
      * are present.
      *
-     * @param  string|array $host 
+     * @param  string|array $host
      * @param  null|integer $port
      * @param  null|array   $config
      * @throws Exception\InvalidArgumentException

--- a/library/Zend/Mail/Storage/Part.php
+++ b/library/Zend/Mail/Storage/Part.php
@@ -178,7 +178,7 @@ class Part implements RecursiveIterator, Part\PartInterface
      *
      * @return int size
      */
-    public function getSize() 
+    public function getSize()
     {
         return strlen($this->getContent());
     }

--- a/library/Zend/Mail/Transport/File.php
+++ b/library/Zend/Mail/Transport/File.php
@@ -43,7 +43,7 @@ class File implements TransportInterface
 
     /**
      * Last file written to
-     * 
+     *
      * @var string
      */
     protected $lastFile;
@@ -97,7 +97,7 @@ class File implements TransportInterface
 
     /**
      * Get the name of the last file written to
-     * 
+     *
      * @return string
      */
     public function getLastFile()

--- a/library/Zend/Mail/Transport/FileOptions.php
+++ b/library/Zend/Mail/Transport/FileOptions.php
@@ -67,7 +67,7 @@ class FileOptions extends AbstractOptions
      * Get path
      *
      * If none is set, uses value from sys_get_temp_dir()
-     * 
+     *
      * @return string
      */
     public function getPath()
@@ -100,7 +100,7 @@ class FileOptions extends AbstractOptions
 
     /**
      * Get callback used to generate a file name
-     * 
+     *
      * @return callback
      */
     public function getCallback()

--- a/library/Zend/Mail/Transport/Sendmail.php
+++ b/library/Zend/Mail/Transport/Sendmail.php
@@ -48,7 +48,7 @@ class Sendmail implements TransportInterface
 
     /**
      * Callback to use when sending mail; typically, {@link mailHandler()}
-     * 
+     *
      * @var callable
      */
     protected $callable;
@@ -135,7 +135,7 @@ class Sendmail implements TransportInterface
 
     /**
      * Send a message
-     * 
+     *
      * @param  \Zend\Mail\Message $message
      */
     public function send(Mail\Message $message)
@@ -158,7 +158,7 @@ class Sendmail implements TransportInterface
      */
     protected function prepareRecipients(Mail\Message $message)
     {
-        $headers = $message->headers();
+        $headers = $message->getHeaders();
 
         if (!$headers->has('to')) {
             throw new Exception\RuntimeException('Invalid email; contains no "To" header');
@@ -186,7 +186,7 @@ class Sendmail implements TransportInterface
 
     /**
      * Prepare the subject line string
-     * 
+     *
      * @param  \Zend\Mail\Message $message
      * @return string
      */
@@ -197,7 +197,7 @@ class Sendmail implements TransportInterface
 
     /**
      * Prepare the body string
-     * 
+     *
      * @param  \Zend\Mail\Message $message
      * @return string
      */
@@ -216,7 +216,7 @@ class Sendmail implements TransportInterface
 
     /**
      * Prepare the textual representation of headers
-     * 
+     *
      * @param  \Zend\Mail\Message $message
      * @return string
      */
@@ -224,11 +224,11 @@ class Sendmail implements TransportInterface
     {
         // On Windows, simply return verbatim
         if ($this->isWindowsOs()) {
-            return $message->headers()->toString();
+            return $message->getHeaders()->toString();
         }
 
         // On *nix platforms, strip the "to" header
-        $headers = clone $message->headers();
+        $headers = clone $message->getHeaders();
         $headers->removeHeader('To');
         $headers->removeHeader('Subject');
         return $headers->toString();
@@ -237,9 +237,9 @@ class Sendmail implements TransportInterface
     /**
      * Prepare additional_parameters argument
      *
-     * Basically, overrides the MAIL FROM envelope with either the Sender or 
+     * Basically, overrides the MAIL FROM envelope with either the Sender or
      * From address.
-     * 
+     *
      * @param  \Zend\Mail\Message $message
      * @return string
      */
@@ -257,7 +257,7 @@ class Sendmail implements TransportInterface
             return $parameters;
         }
 
-        $from = $message->from();
+        $from = $message->getFrom();
         if (count($from)) {
             $from->rewind();
             $sender      = $from->current();
@@ -315,7 +315,7 @@ class Sendmail implements TransportInterface
 
     /**
      * Is this a windows OS?
-     * 
+     *
      * @return bool
      */
     protected function isWindowsOs()

--- a/library/Zend/Mail/Transport/Smtp.php
+++ b/library/Zend/Mail/Transport/Smtp.php
@@ -49,7 +49,7 @@ class Smtp implements TransportInterface
      * @var Protocol\Smtp
      */
     protected $connection;
-    
+
     /**
      * @var boolean
      */
@@ -87,7 +87,7 @@ class Smtp implements TransportInterface
 
     /**
      * Get options
-     * 
+     *
      * @return SmtpOptions
      */
     public function getOptions()
@@ -107,7 +107,7 @@ class Smtp implements TransportInterface
         $this->plugins = $plugins;
         return $this;
     }
-    
+
     /**
      * Get plugin manager for loading SMTP protocol connection
      *
@@ -123,11 +123,11 @@ class Smtp implements TransportInterface
 
     /**
      * Set the automatic disconnection when destruct
-     * 
+     *
      * @param  boolean $flag
      * @return Smtp
      */
-    public function setAutoDisconnect($flag) 
+    public function setAutoDisconnect($flag)
     {
         $this->autoDisconnect = (bool) $flag;
         return $this;
@@ -135,7 +135,7 @@ class Smtp implements TransportInterface
 
     /**
      * Get the automatic disconnection value
-     * 
+     *
      * @return boolean
      */
     public function getAutoDisconnect()
@@ -145,9 +145,9 @@ class Smtp implements TransportInterface
 
     /**
      * Return an SMTP connection
-     * 
-     * @param  string $name 
-     * @param  array|null $options 
+     *
+     * @param  string $name
+     * @param  array|null $options
      * @return Protocol\Smtp
      */
     public function plugin($name, array $options = null)
@@ -168,7 +168,7 @@ class Smtp implements TransportInterface
             }
             if ($this->autoDisconnect) {
                 $this->connection->disconnect();
-            }    
+            }
         }
     }
 
@@ -195,7 +195,7 @@ class Smtp implements TransportInterface
 
     /**
      * Disconnect the connection protocol instance
-     * 
+     *
      * @return void
      */
     public function disconnect()
@@ -266,7 +266,7 @@ class Smtp implements TransportInterface
             return $sender->getEmail();
         }
 
-        $from = $message->from();
+        $from = $message->getFrom();
         if (!count($from)) { // Per RFC 2822 3.6
             throw new Exception\RuntimeException(sprintf(
                 '%s transport expects either a Sender or at least one From address in the Message; none provided',
@@ -288,13 +288,13 @@ class Smtp implements TransportInterface
     protected function prepareRecipients(Message $message)
     {
         $recipients = array();
-        foreach ($message->to() as $address) {
+        foreach ($message->getTo() as $address) {
             $recipients[] = $address->getEmail();
         }
-        foreach ($message->cc() as $address) {
+        foreach ($message->getCc() as $address) {
             $recipients[] = $address->getEmail();
         }
-        foreach ($message->bcc() as $address) {
+        foreach ($message->getBcc() as $address) {
             $recipients[] = $address->getEmail();
         }
         $recipients = array_unique($recipients);
@@ -309,7 +309,7 @@ class Smtp implements TransportInterface
      */
     protected function prepareHeaders(Message $message)
     {
-        $headers = clone $message->headers();
+        $headers = clone $message->getHeaders();
         $headers->removeHeader('Bcc');
         return $headers->toString();
     }
@@ -327,7 +327,7 @@ class Smtp implements TransportInterface
 
     /**
      * Lazy load the connection, and pass it helo
-     * 
+     *
      * @return Protocol\Smtp
      */
     protected function lazyLoadConnection()

--- a/library/Zend/Mail/Transport/SmtpOptions.php
+++ b/library/Zend/Mail/Transport/SmtpOptions.php
@@ -45,7 +45,7 @@ class SmtpOptions extends AbstractOptions
 
     /**
      * Connection configuration (passed to the underlying Protocol class)
-     * 
+     *
      * @var array
      */
     protected $connectionConfig = array();
@@ -93,13 +93,13 @@ class SmtpOptions extends AbstractOptions
     /**
      * Get connection class
      *
-     * This should be either the class Zend\Mail\Protocol\Smtp or a class 
+     * This should be either the class Zend\Mail\Protocol\Smtp or a class
      * extending it -- typically a class in the Zend\Mail\Protocol\Smtp\Auth
      * namespace.
      *
      * @return string
      */
-    public function getConnectionClass() 
+    public function getConnectionClass()
     {
         return $this->connectionClass;
     }
@@ -111,7 +111,7 @@ class SmtpOptions extends AbstractOptions
      * @throws \Zend\Mail\Exception\InvalidArgumentException
      * @return SmtpOptions
      */
-    public function setConnectionClass($connectionClass) 
+    public function setConnectionClass($connectionClass)
     {
         if (!is_string($connectionClass) && $connectionClass !== null) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -125,7 +125,7 @@ class SmtpOptions extends AbstractOptions
 
     /**
      * Get connection configuration array
-     * 
+     *
      * @return array
      */
     public function getConnectionConfig()
@@ -135,8 +135,8 @@ class SmtpOptions extends AbstractOptions
 
     /**
      * Set connection configuration array
-     * 
-     * @param  array $connectionConfig 
+     *
+     * @param  array $connectionConfig
      * @return SmtpOptions
      */
     public function setConnectionConfig(array $connectionConfig)
@@ -147,7 +147,7 @@ class SmtpOptions extends AbstractOptions
 
     /**
      * Get the host name
-     * 
+     *
      * @return string
      */
     public function getHost()
@@ -157,9 +157,9 @@ class SmtpOptions extends AbstractOptions
 
     /**
      * Set the SMTP host
-     * 
+     *
      * @todo   hostname/IP validation
-     * @param  string $host 
+     * @param  string $host
      * @return SmtpOptions
      */
     public function setHost($host)

--- a/tests/Zend/Mail/MessageTest.php
+++ b/tests/Zend/Mail/MessageTest.php
@@ -56,7 +56,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
     public function testSetsOrigDateHeaderByDefault()
     {
-        $headers = $this->message->headers();
+        $headers = $this->message->getHeaders();
         $this->assertInstanceOf('Zend\Mail\Headers', $headers);
         $this->assertTrue($headers->has('date'));
         $header  = $headers->get('date');
@@ -75,22 +75,22 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
     public function testHeadersMethodReturnsHeadersObject()
     {
-        $headers = $this->message->headers();
+        $headers = $this->message->getHeaders();
         $this->assertInstanceOf('Zend\Mail\Headers', $headers);
     }
 
     public function testToMethodReturnsAddressListObject()
     {
         $this->message->addTo('zf-devteam@zend.com');
-        $to = $this->message->to();
+        $to = $this->message->getTo();
         $this->assertInstanceOf('Zend\Mail\AddressList', $to);
     }
 
     public function testToAddressListLivesInHeaders()
     {
         $this->message->addTo('zf-devteam@zend.com');
-        $to      = $this->message->to();
-        $headers = $this->message->headers();
+        $to      = $this->message->getTo();
+        $headers = $this->message->getHeaders();
         $this->assertInstanceOf('Zend\Mail\Headers', $headers);
         $this->assertTrue($headers->has('to'));
         $header  = $headers->get('to');
@@ -100,15 +100,15 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testFromMethodReturnsAddressListObject()
     {
         $this->message->addFrom('zf-devteam@zend.com');
-        $from = $this->message->from();
+        $from = $this->message->getFrom();
         $this->assertInstanceOf('Zend\Mail\AddressList', $from);
     }
 
     public function testFromAddressListLivesInHeaders()
     {
         $this->message->addFrom('zf-devteam@zend.com');
-        $from    = $this->message->from();
-        $headers = $this->message->headers();
+        $from    = $this->message->getFrom();
+        $headers = $this->message->getHeaders();
         $this->assertInstanceOf('Zend\Mail\Headers', $headers);
         $this->assertTrue($headers->has('from'));
         $header  = $headers->get('from');
@@ -118,15 +118,15 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testCcMethodReturnsAddressListObject()
     {
         $this->message->addCc('zf-devteam@zend.com');
-        $cc = $this->message->cc();
+        $cc = $this->message->getCc();
         $this->assertInstanceOf('Zend\Mail\AddressList', $cc);
     }
 
     public function testCcAddressListLivesInHeaders()
     {
         $this->message->addCc('zf-devteam@zend.com');
-        $cc      = $this->message->cc();
-        $headers = $this->message->headers();
+        $cc      = $this->message->getCc();
+        $headers = $this->message->getHeaders();
         $this->assertInstanceOf('Zend\Mail\Headers', $headers);
         $this->assertTrue($headers->has('cc'));
         $header  = $headers->get('cc');
@@ -136,15 +136,15 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testBccMethodReturnsAddressListObject()
     {
         $this->message->addBcc('zf-devteam@zend.com');
-        $bcc = $this->message->bcc();
+        $bcc = $this->message->getBcc();
         $this->assertInstanceOf('Zend\Mail\AddressList', $bcc);
     }
 
     public function testBccAddressListLivesInHeaders()
     {
         $this->message->addBcc('zf-devteam@zend.com');
-        $bcc     = $this->message->bcc();
-        $headers = $this->message->headers();
+        $bcc     = $this->message->getBcc();
+        $headers = $this->message->getHeaders();
         $this->assertInstanceOf('Zend\Mail\Headers', $headers);
         $this->assertTrue($headers->has('bcc'));
         $header  = $headers->get('bcc');
@@ -154,15 +154,15 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testReplyToMethodReturnsAddressListObject()
     {
         $this->message->addReplyTo('zf-devteam@zend.com');
-        $replyTo = $this->message->replyTo();
+        $replyTo = $this->message->getReplyTo();
         $this->assertInstanceOf('Zend\Mail\AddressList', $replyTo);
     }
 
     public function testReplyToAddressListLivesInHeaders()
     {
         $this->message->addReplyTo('zf-devteam@zend.com');
-        $replyTo = $this->message->replyTo();
-        $headers = $this->message->headers();
+        $replyTo = $this->message->getReplyTo();
+        $headers = $this->message->getHeaders();
         $this->assertInstanceOf('Zend\Mail\Headers', $headers);
         $this->assertTrue($headers->has('reply-to'));
         $header  = $headers->get('reply-to');
@@ -200,7 +200,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testSenderAccessorsProxyToSenderHeader()
     {
         $header = new Header\Sender();
-        $this->message->headers()->addHeader($header);
+        $this->message->getHeaders()->addHeader($header);
         $address = new Address('zf-devteam@zend.com', 'ZF DevTeam');
         $this->message->setSender($address);
         $this->assertSame($address, $header->getAddress());
@@ -209,7 +209,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testCanAddFromAddressUsingName()
     {
         $this->message->addFrom('zf-devteam@zend.com', 'ZF DevTeam');
-        $addresses = $this->message->from();
+        $addresses = $this->message->getFrom();
         $this->assertEquals(1, count($addresses));
         $address = $addresses->current();
         $this->assertEquals('zf-devteam@zend.com', $address->getEmail());
@@ -221,7 +221,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $address = new Address('zf-devteam@zend.com', 'ZF DevTeam');
         $this->message->addFrom($address);
 
-        $addresses = $this->message->from();
+        $addresses = $this->message->getFrom();
         $this->assertEquals(1, count($addresses));
         $test = $addresses->current();
         $this->assertSame($address, $test);
@@ -236,7 +236,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         );
         $this->message->addFrom($addresses);
 
-        $from = $this->message->from();
+        $from = $this->message->getFrom();
         $this->assertEquals(3, count($from));
 
         $this->assertTrue($from->has('zf-devteam@zend.com'));
@@ -251,7 +251,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->message->addFrom('fw-announce@lists.zend.com');
         $this->message->addFrom($list);
-        $from = $this->message->from();
+        $from = $this->message->getFrom();
         $this->assertEquals(2, count($from));
         $this->assertTrue($from->has('fw-announce@lists.zend.com'));
         $this->assertTrue($from->has('zf-devteam@zend.com'));
@@ -264,7 +264,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->message->addFrom('fw-announce@lists.zend.com');
         $this->message->setFrom($list);
-        $from = $this->message->from();
+        $from = $this->message->getFrom();
         $this->assertEquals(1, count($from));
         $this->assertFalse($from->has('fw-announce@lists.zend.com'));
         $this->assertTrue($from->has('zf-devteam@zend.com'));
@@ -273,7 +273,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testCanAddCcAddressUsingName()
     {
         $this->message->addCc('zf-devteam@zend.com', 'ZF DevTeam');
-        $addresses = $this->message->cc();
+        $addresses = $this->message->getCc();
         $this->assertEquals(1, count($addresses));
         $address = $addresses->current();
         $this->assertEquals('zf-devteam@zend.com', $address->getEmail());
@@ -285,7 +285,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $address = new Address('zf-devteam@zend.com', 'ZF DevTeam');
         $this->message->addCc($address);
 
-        $addresses = $this->message->cc();
+        $addresses = $this->message->getCc();
         $this->assertEquals(1, count($addresses));
         $test = $addresses->current();
         $this->assertSame($address, $test);
@@ -300,7 +300,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         );
         $this->message->addCc($addresses);
 
-        $cc = $this->message->cc();
+        $cc = $this->message->getCc();
         $this->assertEquals(3, count($cc));
 
         $this->assertTrue($cc->has('zf-devteam@zend.com'));
@@ -315,7 +315,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->message->addCc('fw-announce@lists.zend.com');
         $this->message->addCc($list);
-        $cc = $this->message->cc();
+        $cc = $this->message->getCc();
         $this->assertEquals(2, count($cc));
         $this->assertTrue($cc->has('fw-announce@lists.zend.com'));
         $this->assertTrue($cc->has('zf-devteam@zend.com'));
@@ -328,7 +328,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->message->addCc('fw-announce@lists.zend.com');
         $this->message->setCc($list);
-        $cc = $this->message->cc();
+        $cc = $this->message->getCc();
         $this->assertEquals(1, count($cc));
         $this->assertFalse($cc->has('fw-announce@lists.zend.com'));
         $this->assertTrue($cc->has('zf-devteam@zend.com'));
@@ -337,7 +337,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testCanAddBccAddressUsingName()
     {
         $this->message->addBcc('zf-devteam@zend.com', 'ZF DevTeam');
-        $addresses = $this->message->bcc();
+        $addresses = $this->message->getBcc();
         $this->assertEquals(1, count($addresses));
         $address = $addresses->current();
         $this->assertEquals('zf-devteam@zend.com', $address->getEmail());
@@ -349,7 +349,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $address = new Address('zf-devteam@zend.com', 'ZF DevTeam');
         $this->message->addBcc($address);
 
-        $addresses = $this->message->bcc();
+        $addresses = $this->message->getBcc();
         $this->assertEquals(1, count($addresses));
         $test = $addresses->current();
         $this->assertSame($address, $test);
@@ -364,7 +364,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         );
         $this->message->addBcc($addresses);
 
-        $bcc = $this->message->bcc();
+        $bcc = $this->message->getBcc();
         $this->assertEquals(3, count($bcc));
 
         $this->assertTrue($bcc->has('zf-devteam@zend.com'));
@@ -379,7 +379,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->message->addBcc('fw-announce@lists.zend.com');
         $this->message->addBcc($list);
-        $bcc = $this->message->bcc();
+        $bcc = $this->message->getBcc();
         $this->assertEquals(2, count($bcc));
         $this->assertTrue($bcc->has('fw-announce@lists.zend.com'));
         $this->assertTrue($bcc->has('zf-devteam@zend.com'));
@@ -392,7 +392,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->message->addBcc('fw-announce@lists.zend.com');
         $this->message->setBcc($list);
-        $bcc = $this->message->bcc();
+        $bcc = $this->message->getBcc();
         $this->assertEquals(1, count($bcc));
         $this->assertFalse($bcc->has('fw-announce@lists.zend.com'));
         $this->assertTrue($bcc->has('zf-devteam@zend.com'));
@@ -401,7 +401,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testCanAddReplyToAddressUsingName()
     {
         $this->message->addReplyTo('zf-devteam@zend.com', 'ZF DevTeam');
-        $addresses = $this->message->replyTo();
+        $addresses = $this->message->getReplyTo();
         $this->assertEquals(1, count($addresses));
         $address = $addresses->current();
         $this->assertEquals('zf-devteam@zend.com', $address->getEmail());
@@ -413,7 +413,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $address = new Address('zf-devteam@zend.com', 'ZF DevTeam');
         $this->message->addReplyTo($address);
 
-        $addresses = $this->message->replyTo();
+        $addresses = $this->message->getReplyTo();
         $this->assertEquals(1, count($addresses));
         $test = $addresses->current();
         $this->assertSame($address, $test);
@@ -428,7 +428,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         );
         $this->message->addReplyTo($addresses);
 
-        $replyTo = $this->message->replyTo();
+        $replyTo = $this->message->getReplyTo();
         $this->assertEquals(3, count($replyTo));
 
         $this->assertTrue($replyTo->has('zf-devteam@zend.com'));
@@ -443,7 +443,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->message->addReplyTo('fw-announce@lists.zend.com');
         $this->message->addReplyTo($list);
-        $replyTo = $this->message->replyTo();
+        $replyTo = $this->message->getReplyTo();
         $this->assertEquals(2, count($replyTo));
         $this->assertTrue($replyTo->has('fw-announce@lists.zend.com'));
         $this->assertTrue($replyTo->has('zf-devteam@zend.com'));
@@ -456,7 +456,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->message->addReplyTo('fw-announce@lists.zend.com');
         $this->message->setReplyTo($list);
-        $replyTo = $this->message->replyTo();
+        $replyTo = $this->message->getReplyTo();
         $this->assertEquals(1, count($replyTo));
         $this->assertFalse($replyTo->has('fw-announce@lists.zend.com'));
         $this->assertTrue($replyTo->has('zf-devteam@zend.com'));
@@ -477,7 +477,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testSettingSubjectProxiesToHeader()
     {
         $this->message->setSubject('test subject');
-        $headers = $this->message->headers();
+        $headers = $this->message->getHeaders();
         $this->assertInstanceOf('Zend\Mail\Headers', $headers);
         $this->assertTrue($headers->has('subject'));
         $header = $headers->get('subject');
@@ -545,7 +545,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $body->addPart($part);
 
         $this->message->setBody($body);
-        $headers = $this->message->headers();
+        $headers = $this->message->getHeaders();
         $this->assertInstanceOf('Zend\Mail\Headers', $headers);
 
         $this->assertTrue($headers->has('mime-version'));
@@ -570,7 +570,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $body->addPart($html);
 
         $this->message->setBody($body);
-        $headers = $this->message->headers();
+        $headers = $this->message->getHeaders();
         $this->assertInstanceOf('Zend\Mail\Headers', $headers);
 
         $this->assertTrue($headers->has('mime-version'));
@@ -624,7 +624,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->message->setSubject('This is a subject');
         $this->message->setEncoding('UTF-8');
 
-        $test = $this->message->headers()->toString();
+        $test = $this->message->getHeaders()->toString();
 
         $expected = '=?UTF-8?Q?ZF=20DevTeam?=';
         $this->assertContains($expected, $test);

--- a/tests/Zend/Mail/Transport/FileTest.php
+++ b/tests/Zend/Mail/Transport/FileTest.php
@@ -43,7 +43,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
         } else {
             $this->cleanup($this->tempDir);
         }
-        
+
         $fileOptions = new FileOptions(array(
             'path' => $this->tempDir,
         ));
@@ -76,7 +76,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
                 ->setSender('ralph.schindler@zend.com', 'Ralph Schindler')
                 ->setSubject('Testing Zend\Mail\Transport\Sendmail')
                 ->setBody('This is only a test.');
-        $message->headers()->addHeaders(array(
+        $message->getHeaders()->addHeaders(array(
             'X-Foo-Bar' => 'Matthew',
         ));
         return $message;

--- a/tests/Zend/Mail/Transport/SendmailTest.php
+++ b/tests/Zend/Mail/Transport/SendmailTest.php
@@ -77,7 +77,7 @@ class SendmailTest extends \PHPUnit_Framework_TestCase
                 ->setSender('ralph.schindler@zend.com', 'Ralph Schindler')
                 ->setSubject('Testing Zend\Mail\Transport\Sendmail')
                 ->setBody('This is only a test.');
-        $message->headers()->addHeaders(array(
+        $message->getHeaders()->addHeaders(array(
             'X-Foo-Bar' => 'Matthew',
         ));
         return $message;

--- a/tests/Zend/Mail/Transport/SmtpTest.php
+++ b/tests/Zend/Mail/Transport/SmtpTest.php
@@ -62,7 +62,7 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
                 ->setSender('ralph.schindler@zend.com', 'Ralph Schindler')
                 ->setSubject('Testing Zend\Mail\Transport\Sendmail')
                 ->setBody('This is only a test.');
-        $message->headers()->addHeaders(array(
+        $message->getHeaders()->addHeaders(array(
             'X-Foo-Bar' => 'Matthew',
         ));
         return $message;
@@ -151,25 +151,25 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('matthew', $connection->getUsername());
         $this->assertEquals('password', $connection->getPassword());
     }
-    
+
     public function testSetAutoDisconnect()
     {
         $this->transport->setAutoDisconnect(false);
         $this->assertFalse($this->transport->getAutoDisconnect());
     }
-    
+
     public function testGetDefaultAutoDisconnectValue()
     {
         $this->assertTrue($this->transport->getAutoDisconnect());
     }
-    
+
     public function testAutoDisconnectTrue()
     {
         $this->connection->connect();
         unset($this->transport);
         $this->assertFalse($this->connection->isConnected());
     }
-    
+
     public function testAutoDisconnectFalse()
     {
         $this->connection->connect();
@@ -177,7 +177,7 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         unset($this->transport);
         $this->assertTrue($this->connection->isConnected());
     }
-    
+
     public function testDisconnect()
     {
         $this->connection->connect();


### PR DESCRIPTION
All accessors on the Zend\Mail\Message object like to(), from() and cc()
are transformed into a getTo(), getFrom(), getCc() style accessor.

All tests for Zend\Mail pass right now. I am waiting for Travis to give me the test results for other components. Link to [current build](http://travis-ci.org/#!/juriansluiman/zf2/jobs/1745361).

[![Build Status](https://secure.travis-ci.org/juriansluiman/zf2.png?branch=feature/mail-accessors)](http://travis-ci.org/juriansluiman/zf2)
