### PR TITLE
Create SharedEventManager service

### DIFF
--- a/library/Zend/Mvc/Service/EventManagerFactory.php
+++ b/library/Zend/Mvc/Service/EventManagerFactory.php
@@ -22,7 +22,6 @@
 namespace Zend\Mvc\Service;
 
 use Zend\EventManager\EventManager;
-use Zend\EventManager\SharedEventManager;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -46,13 +45,8 @@ class EventManagerFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        static $sharedEventManager = null;
-        if (!$sharedEventManager) {
-            $sharedEventManager = new SharedEventManager();
-        }
-
         $em = new EventManager();
-        $em->setSharedManager($sharedEventManager);
+        $em->setSharedManager($serviceLocator->get('SharedEventManager'));
         return $em;
     }
 }

--- a/library/Zend/Mvc/Service/ServiceManagerConfiguration.php
+++ b/library/Zend/Mvc/Service/ServiceManagerConfiguration.php
@@ -42,11 +42,12 @@ class ServiceManagerConfiguration implements ConfigurationInterface
      * @var array
      */
     protected $services = array(
-        'DispatchListener' => 'Zend\Mvc\DispatchListener',
-        'Request'          => 'Zend\Http\PhpEnvironment\Request',
-        'Response'         => 'Zend\Http\PhpEnvironment\Response',
-        'RouteListener'    => 'Zend\Mvc\RouteListener',
-        'ViewManager'      => 'Zend\Mvc\View\ViewManager',
+        'DispatchListener'   => 'Zend\Mvc\DispatchListener',
+        'Request'            => 'Zend\Http\PhpEnvironment\Request',
+        'Response'           => 'Zend\Http\PhpEnvironment\Response',
+        'RouteListener'      => 'Zend\Mvc\RouteListener',
+        'SharedEventManager' => 'Zend\EventManager\SharedEventManager',
+        'ViewManager'        => 'Zend\Mvc\View\ViewManager',
     );
 
     /**
@@ -100,7 +101,7 @@ class ServiceManagerConfiguration implements ConfigurationInterface
      * @var array
      */
     protected $shared = array(
-        'EventManager' => false
+        'EventManager' => false,
     );
 
     /**


### PR DESCRIPTION
- Creates a SharedEventManager service inthe MVC ServiceManagerConfiguration,
  as an invokable
- Alters the MVC EventManagerFactory to pull the SharedEventManager instance
  from the service manager

This has been suggested a few times, and is a BC change at this point.
