### PR TITLE
[zen-24] Create ModuleRouteListener

### DIFF
--- a/library/Zend/Mvc/ModuleRouteListener.php
+++ b/library/Zend/Mvc/ModuleRouteListener.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Mvc;
+
+use Zend\EventManager\EventManagerInterface;
+use Zend\EventManager\ListenerAggregateInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class ModuleRouteListener implements ListenerAggregateInterface
+{
+    const MODULE_NAMESPACE    = '__NAMESPACE__';
+    const ORIGINAL_CONTROLLER = '__CONTROLLER__';
+
+    /**
+     * @var \Zend\Stdlib\CallbackHandler[]
+     */
+    protected $listeners = array();
+
+    /**
+     * Attach to an event manager
+     * 
+     * @param  EventManagerInterface $events 
+     * @return void
+     */
+    public function attach(EventManagerInterface $events, $priority = 1)
+    {
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'onRoute'), $priority);
+    }
+
+    /**
+     * Detach all our listeners from the event manager
+     * 
+     * @param  EventManagerInterface $events 
+     * @return void
+     */
+    public function detach(EventManagerInterface $events)
+    {
+        foreach ($this->listeners as $index => $listener) {
+            if ($events->detach($listener)) {
+                unset($this->listeners[$index]);
+            }
+        }
+    }
+
+    /**
+     * Listen to the "route" event and determine if the module namespace should
+     * be prepended to the controller name.
+     *
+     * If the route match contains a parameter key matching the MODULE_NAMESPACE 
+     * constant, that value will be prepended, with a namespace separator, to 
+     * the matched controller parameter.
+     * 
+     * @param  MvcEvent $e 
+     * @return null
+     */
+    public function onRoute($e)
+    {
+        $matches = $e->getRouteMatch();
+        if (!$matches instanceof Router\RouteMatch) {
+            // Can't do anything without a route match
+            return;
+        }
+
+        $module = $matches->getParam(self::MODULE_NAMESPACE, false);
+        if (!$module) {
+            // No module namespace found; nothing to do
+            return;
+        }
+
+        $controller = $matches->getParam('controller', false);
+        if (!$controller) {
+            // no controller matched, nothing to do
+            return;
+        }
+
+        // Keep the originally matched controller name around
+        $matches->setParam(self::ORIGINAL_CONTROLLER, $controller);
+
+        // Prepend the controllername with the module, and replace it in the 
+        // matches
+        $controller = $module . '\\' . $controller;
+        $matches->setParam('controller', $controller);
+    }
+}

--- a/library/Zend/Mvc/ModuleRouteListener.php
+++ b/library/Zend/Mvc/ModuleRouteListener.php
@@ -96,6 +96,11 @@ class ModuleRouteListener implements ListenerAggregateInterface
             return;
         }
 
+        // Ensure the module namespace has not already been applied
+        if (0 === strpos($controller, $module)) {
+            return;
+        }
+
         // Keep the originally matched controller name around
         $matches->setParam(self::ORIGINAL_CONTROLLER, $controller);
 

--- a/tests/Zend/Mvc/ModuleRouteListenerTest.php
+++ b/tests/Zend/Mvc/ModuleRouteListenerTest.php
@@ -88,4 +88,31 @@ class ModuleRouteListenerTest extends TestCase
         $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $matches);
         $this->assertEquals('Index', $matches->getParam('controller'));
     }
+
+    public function testMultipleRegistrationShouldNotResultInMultiplePrefixingOfControllerName()
+    {
+        $moduleListener = new ModuleRouteListener();
+        $this->events->attach($moduleListener);
+
+        $this->router->addRoute('foo', array(
+            'type' => 'Literal',
+            'options' => array(
+                'route'    => '/foo',
+                'defaults' => array(
+                    ModuleRouteListener::MODULE_NAMESPACE => 'Foo',
+                    'controller' => 'Index',
+                ),
+            ),
+        ));
+        $this->request->setUri('/foo');
+        $event = new MvcEvent();
+        $event->setRouter($this->router);
+        $event->setRequest($this->request);
+        $this->events->trigger('route', $event);
+
+        $matches = $event->getRouteMatch();
+        $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $matches);
+        $this->assertEquals('Foo\Index', $matches->getParam('controller'));
+        $this->assertEquals('Index', $matches->getParam(ModuleRouteListener::ORIGINAL_CONTROLLER));
+    }
 }

--- a/tests/Zend/Mvc/ModuleRouteListenerTest.php
+++ b/tests/Zend/Mvc/ModuleRouteListenerTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Mvc;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\EventManager\EventManager;
+use Zend\Http\PhpEnvironment\Request;
+use Zend\Mvc\MvcEvent;
+use Zend\Mvc\ModuleRouteListener;
+use Zend\Mvc\RouteListener;
+use Zend\Mvc\Router;
+
+class ModuleRouteListenerTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request             = new Request();
+        $this->events              = new EventManager();
+        $this->router              = new Router\Http\TreeRouteStack();
+        $this->routeListener       = new RouteListener();
+        $this->moduleRouteListener = new ModuleRouteListener();
+
+        $this->events->attach($this->routeListener);
+        $this->events->attach($this->moduleRouteListener, -1);
+    }
+
+    public function testRouteReturningModuleNamespaceInRouteMatchTriggersControllerRename()
+    {
+        $this->router->addRoute('foo', array(
+            'type' => 'Literal',
+            'options' => array(
+                'route'    => '/foo',
+                'defaults' => array(
+                    ModuleRouteListener::MODULE_NAMESPACE => 'Foo',
+                    'controller' => 'Index',
+                ),
+            ),
+        ));
+        $this->request->setUri('/foo');
+        $event = new MvcEvent();
+        $event->setRouter($this->router);
+        $event->setRequest($this->request);
+        $this->events->trigger('route', $event);
+
+        $matches = $event->getRouteMatch();
+        $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $matches);
+        $this->assertEquals('Foo\Index', $matches->getParam('controller'));
+        $this->assertEquals('Index', $matches->getParam(ModuleRouteListener::ORIGINAL_CONTROLLER));
+    }
+
+    public function testRouteNotReturningModuleNamespaceInRouteMatchLeavesControllerUntouched()
+    {
+        $this->router->addRoute('foo', array(
+            'type' => 'Literal',
+            'options' => array(
+                'route'    => '/foo',
+                'defaults' => array(
+                    'controller' => 'Index',
+                ),
+            ),
+        ));
+        $this->request->setUri('/foo');
+        $event = new MvcEvent();
+        $event->setRouter($this->router);
+        $event->setRequest($this->request);
+        $this->events->trigger('route', $event);
+
+        $matches = $event->getRouteMatch();
+        $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $matches);
+        $this->assertEquals('Index', $matches->getParam('controller'));
+    }
+}


### PR DESCRIPTION
- Listens on route event
- If the route match contains a parameter matching MODULE_NAMESPACE, it
  will prepend the matched controller parameter with that value

Ideally, I'd rather use specific route types. However, in a discussion with @DASPRiD, it turns out there a variety of obstacles to implementing in that way. The approach in this PR requires the key to be "**NAMESPACE**", and the listener would have to be explicitly registered by a module and/or application in order to be triggered.
