### PR TITLE
ServiceManager::has() working correctly

### DIFF
--- a/library/Zend/ServiceManager/AbstractFactoryInterface.php
+++ b/library/Zend/ServiceManager/AbstractFactoryInterface.php
@@ -4,6 +4,6 @@ namespace Zend\ServiceManager;
 
 interface AbstractFactoryInterface
 {
-    public function canCreateServiceWithName($name, $requestedName);
-    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name /*, $requestedName */);
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName);
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName);
 }

--- a/library/Zend/ServiceManager/AbstractFactoryInterface.php
+++ b/library/Zend/ServiceManager/AbstractFactoryInterface.php
@@ -4,6 +4,6 @@ namespace Zend\ServiceManager;
 
 interface AbstractFactoryInterface
 {
-    public function canCreateServiceWithName($name /*, $requestedName */);
+    public function canCreateServiceWithName($name, $requestedName);
     public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name /*, $requestedName */);
 }

--- a/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
+++ b/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
@@ -41,12 +41,12 @@ class DiAbstractServiceFactory extends DiServiceFactory implements AbstractFacto
     /**
      * {@inheritDoc}
      */
-    public function canCreateServiceWithName($name)
+    public function canCreateServiceWithName($name, $requestedName)
     {
-        return $this->instanceManager->hasSharedInstance($name)
-            || $this->instanceManager->hasAlias($name)
-            || $this->instanceManager->hasConfiguration($name)
-            || $this->instanceManager->hasTypePreferences($name)
-            || $this->definitions->hasClass($name);
+        return $this->instanceManager->hasSharedInstance($requestedName)
+            || $this->instanceManager->hasAlias($requestedName)
+            || $this->instanceManager->hasConfiguration($requestedName)
+            || $this->instanceManager->hasTypePreferences($requestedName)
+            || $this->definitions->hasClass($requestedName);
     }
 }

--- a/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
+++ b/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
@@ -27,7 +27,7 @@ class DiAbstractServiceFactory extends DiServiceFactory implements AbstractFacto
     /**
      * {@inheritDoc}
      */
-    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $serviceName, $requestedName = null)
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $serviceName, $requestedName)
     {
         $this->serviceLocator = $serviceLocator;
         if ($requestedName) {
@@ -41,7 +41,7 @@ class DiAbstractServiceFactory extends DiServiceFactory implements AbstractFacto
     /**
      * {@inheritDoc}
      */
-    public function canCreateServiceWithName($name, $requestedName)
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
         return $this->instanceManager->hasSharedInstance($requestedName)
             || $this->instanceManager->hasAlias($requestedName)

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -366,11 +366,11 @@ class ServiceManager implements ServiceLocatorInterface
             if (!$instance) {
                 try {
                     $instance = $this->create(array($cName, $rName));
-                } catch (Exception\ServiceNotFoundException $e) {
+                } catch (Exception\ServiceNotFoundException $selfException) {
                     if ($usePeeringServiceManagers && !$retrieveFromPeeringManagerFirst) {
                         $instance = $this->retrieveFromPeeringManager($name);
                     }
-                } catch (Exception\ServiceNotCreatedException $e) {
+                } catch (Exception\ServiceNotCreatedException $selfException) {
                     if ($usePeeringServiceManagers && !$retrieveFromPeeringManagerFirst) {
                         $instance = $this->retrieveFromPeeringManager($name);
                     }
@@ -462,7 +462,7 @@ class ServiceManager implements ServiceLocatorInterface
             list($cName, $rName) = $nameOrAlias;
         } else {
             $cName = $this->canonicalizeName($nameOrAlias);
-            $rName = $cName;
+            $rName = $nameOrAlias;
         }
 
         $has = (
@@ -717,7 +717,7 @@ class ServiceManager implements ServiceLocatorInterface
             // support factories as strings
             if (is_string($abstractFactory) && class_exists($abstractFactory, true)) {
                 $this->abstractFactories[$index] = $abstractFactory = new $abstractFactory;
-            } else {
+            } else if (!$abstractFactory instanceof AbstractFactoryInterface) {
                 throw new Exception\ServiceNotCreatedException(sprintf(
                     'While attempting to create %s%s an abstract factory could not produce a valid instance.',
                     $canonicalName,

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -483,7 +483,7 @@ class ServiceManager implements ServiceLocatorInterface
                 $this->abstractFactory[$index] = $abstractFactory = new $abstractFactory();
             }
 
-            if ($abstractFactory->canCreateServiceWithName($cName, $rName)) {
+            if ($abstractFactory->canCreateServiceWithName($this, $cName, $rName)) {
                 return true;
             }
         }

--- a/tests/Zend/ServiceManager/Di/DiAbstractServiceFactoryTest.php
+++ b/tests/Zend/ServiceManager/Di/DiAbstractServiceFactoryTest.php
@@ -3,7 +3,8 @@
 namespace ZendTest\ServiceManager\Di;
 
 use Zend\ServiceManager\Di\DiAbstractServiceFactory,
-Zend\ServiceManager\Di\DiInstanceManagerProxy;
+    Zend\ServiceManager\ServiceManager,
+    Zend\ServiceManager\Di\DiInstanceManagerProxy;
 
 class DiAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -51,7 +52,7 @@ class DiAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateServiceWithName()
     {
-        $foo = $this->diAbstractServiceFactory->createServiceWithName($this->mockServiceLocator, 'foo');
+        $foo = $this->diAbstractServiceFactory->createServiceWithName($this->mockServiceLocator, 'foo', 'foo');
         $this->assertEquals($this->fooInstance, $foo);
     }
 
@@ -63,29 +64,31 @@ class DiAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $instance = new DiAbstractServiceFactory($this->getMock('Zend\Di\Di'));
         $im = $instance->instanceManager();
 
+        $locator = new ServiceManager();
+
         // will check shared instances
-        $this->assertFalse($instance->canCreateServiceWithName('a-shared-instance-alias', 'a-shared-instance-alias'));
+        $this->assertFalse($instance->canCreateServiceWithName($locator, 'a-shared-instance-alias', 'a-shared-instance-alias'));
         $im->addSharedInstance(new \stdClass(), 'a-shared-instance-alias');
-        $this->assertTrue($instance->canCreateServiceWithName('a-shared-instance-alias', 'a-shared-instance-alias'));
+        $this->assertTrue($instance->canCreateServiceWithName($locator, 'a-shared-instance-alias', 'a-shared-instance-alias'));
 
         // will check aliases
-        $this->assertFalse($instance->canCreateServiceWithName('an-alias', 'an-alias'));
+        $this->assertFalse($instance->canCreateServiceWithName($locator, 'an-alias', 'an-alias'));
         $im->addAlias('an-alias', 'stdClass');
-        $this->assertTrue($instance->canCreateServiceWithName('an-alias', 'an-alias'));
+        $this->assertTrue($instance->canCreateServiceWithName($locator, 'an-alias', 'an-alias'));
 
         // will check instance configurations
-        $this->assertFalse($instance->canCreateServiceWithName(__NAMESPACE__ . '\Non\Existing', __NAMESPACE__ . '\Non\Existing'));
+        $this->assertFalse($instance->canCreateServiceWithName($locator, __NAMESPACE__ . '\Non\Existing', __NAMESPACE__ . '\Non\Existing'));
         $im->setConfiguration(__NAMESPACE__ . '\Non\Existing', array('parameters' => array('a' => 'b')));
-        $this->assertTrue($instance->canCreateServiceWithName(__NAMESPACE__ . '\Non\Existing', __NAMESPACE__ . '\Non\Existing'));
+        $this->assertTrue($instance->canCreateServiceWithName($locator, __NAMESPACE__ . '\Non\Existing', __NAMESPACE__ . '\Non\Existing'));
 
         // will check preferences for abstract types
-        $this->assertFalse($instance->canCreateServiceWithName(__NAMESPACE__ . '\AbstractClass', __NAMESPACE__ . '\AbstractClass'));
+        $this->assertFalse($instance->canCreateServiceWithName($locator, __NAMESPACE__ . '\AbstractClass', __NAMESPACE__ . '\AbstractClass'));
         $im->setTypePreference(__NAMESPACE__ . '\AbstractClass', array(__NAMESPACE__ . '\Non\Existing'));
-        $this->assertTrue($instance->canCreateServiceWithName(__NAMESPACE__ . '\AbstractClass', __NAMESPACE__ . '\AbstractClass'));
+        $this->assertTrue($instance->canCreateServiceWithName($locator, __NAMESPACE__ . '\AbstractClass', __NAMESPACE__ . '\AbstractClass'));
 
         // will check definitions
         $def = $instance->definitions();
-        $this->assertFalse($instance->canCreateServiceWithName(__NAMESPACE__ . '\Other\Non\Existing', __NAMESPACE__ . '\Other\Non\Existing'));
+        $this->assertFalse($instance->canCreateServiceWithName($locator, __NAMESPACE__ . '\Other\Non\Existing', __NAMESPACE__ . '\Other\Non\Existing'));
         $classDefinition = $this->getMock('Zend\Di\Definition\DefinitionInterface');
         $classDefinition
             ->expects($this->any())
@@ -93,6 +96,6 @@ class DiAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo(__NAMESPACE__ . '\Other\Non\Existing'))
             ->will($this->returnValue(true));
         $def->addDefinition($classDefinition);
-        $this->assertTrue($instance->canCreateServiceWithName(__NAMESPACE__ . '\Other\Non\Existing', __NAMESPACE__ . '\Other\Non\Existing'));
+        $this->assertTrue($instance->canCreateServiceWithName($locator, __NAMESPACE__ . '\Other\Non\Existing', __NAMESPACE__ . '\Other\Non\Existing'));
     }
 }

--- a/tests/Zend/ServiceManager/Di/DiAbstractServiceFactoryTest.php
+++ b/tests/Zend/ServiceManager/Di/DiAbstractServiceFactoryTest.php
@@ -64,28 +64,28 @@ class DiAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $im = $instance->instanceManager();
 
         // will check shared instances
-        $this->assertFalse($instance->canCreateServiceWithName('a-shared-instance-alias'));
+        $this->assertFalse($instance->canCreateServiceWithName('a-shared-instance-alias', 'a-shared-instance-alias'));
         $im->addSharedInstance(new \stdClass(), 'a-shared-instance-alias');
-        $this->assertTrue($instance->canCreateServiceWithName('a-shared-instance-alias'));
+        $this->assertTrue($instance->canCreateServiceWithName('a-shared-instance-alias', 'a-shared-instance-alias'));
 
         // will check aliases
-        $this->assertFalse($instance->canCreateServiceWithName('an-alias'));
+        $this->assertFalse($instance->canCreateServiceWithName('an-alias', 'an-alias'));
         $im->addAlias('an-alias', 'stdClass');
-        $this->assertTrue($instance->canCreateServiceWithName('an-alias'));
+        $this->assertTrue($instance->canCreateServiceWithName('an-alias', 'an-alias'));
 
         // will check instance configurations
-        $this->assertFalse($instance->canCreateServiceWithName(__NAMESPACE__ . '\Non\Existing'));
+        $this->assertFalse($instance->canCreateServiceWithName(__NAMESPACE__ . '\Non\Existing', __NAMESPACE__ . '\Non\Existing'));
         $im->setConfiguration(__NAMESPACE__ . '\Non\Existing', array('parameters' => array('a' => 'b')));
-        $this->assertTrue($instance->canCreateServiceWithName(__NAMESPACE__ . '\Non\Existing'));
+        $this->assertTrue($instance->canCreateServiceWithName(__NAMESPACE__ . '\Non\Existing', __NAMESPACE__ . '\Non\Existing'));
 
         // will check preferences for abstract types
-        $this->assertFalse($instance->canCreateServiceWithName(__NAMESPACE__ . '\AbstractClass'));
+        $this->assertFalse($instance->canCreateServiceWithName(__NAMESPACE__ . '\AbstractClass', __NAMESPACE__ . '\AbstractClass'));
         $im->setTypePreference(__NAMESPACE__ . '\AbstractClass', array(__NAMESPACE__ . '\Non\Existing'));
-        $this->assertTrue($instance->canCreateServiceWithName(__NAMESPACE__ . '\AbstractClass'));
+        $this->assertTrue($instance->canCreateServiceWithName(__NAMESPACE__ . '\AbstractClass', __NAMESPACE__ . '\AbstractClass'));
 
         // will check definitions
         $def = $instance->definitions();
-        $this->assertFalse($instance->canCreateServiceWithName(__NAMESPACE__ . '\Other\Non\Existing'));
+        $this->assertFalse($instance->canCreateServiceWithName(__NAMESPACE__ . '\Other\Non\Existing', __NAMESPACE__ . '\Other\Non\Existing'));
         $classDefinition = $this->getMock('Zend\Di\Definition\DefinitionInterface');
         $classDefinition
             ->expects($this->any())
@@ -93,6 +93,6 @@ class DiAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo(__NAMESPACE__ . '\Other\Non\Existing'))
             ->will($this->returnValue(true));
         $def->addDefinition($classDefinition);
-        $this->assertTrue($instance->canCreateServiceWithName(__NAMESPACE__ . '\Other\Non\Existing'));
+        $this->assertTrue($instance->canCreateServiceWithName(__NAMESPACE__ . '\Other\Non\Existing', __NAMESPACE__ . '\Other\Non\Existing'));
     }
 }

--- a/tests/Zend/ServiceManager/ServiceManagerTest.php
+++ b/tests/Zend/ServiceManager/ServiceManagerTest.php
@@ -439,10 +439,13 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDiAbstractServiceFactory()
     {
-        $di = new Di();
-        $di->instanceManager()->setParameters('ZendTest\ServiceManager\TestAsset\Bar', array('foo' => array('a')));
-        $this->serviceManager->addAbstractFactory(new DiAbstractServiceFactory($di));
+        $di = $this->getMock('Zend\Di\Di');
+        $factory = new DiAbstractServiceFactory($di);
+        $factory->instanceManager()->setConfiguration('ZendTest\ServiceManager\TestAsset\Bar', array('parameters' => array('foo' => array('a'))));
+        $this->serviceManager->addAbstractFactory($factory);
+
         $this->assertTrue($this->serviceManager->has('ZendTest\ServiceManager\TestAsset\Bar', true));
+
         $bar = $this->serviceManager->get('ZendTest\ServiceManager\TestAsset\Bar', true);
         $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Bar', $bar);
     }

--- a/tests/Zend/ServiceManager/ServiceManagerTest.php
+++ b/tests/Zend/ServiceManager/ServiceManagerTest.php
@@ -268,15 +268,6 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Foo', $this->serviceManager->get('foo'));
     }
 
-    /**
-     * @covers Zend\ServiceManager\ServiceManager::create
-     */
-    public function testCreateWithCallableAbstractFactory()
-    {
-        $this->serviceManager->addAbstractFactory(function () { return new TestAsset\Foo; });
-        $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Foo', $this->serviceManager->get('foo'));
-    }
-
     public function testCreateWithInitializerObject()
     {
         $this->serviceManager->addInitializer(new TestAsset\FooInitializer(array('foo' => 'bar')));
@@ -443,6 +434,16 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $di->instanceManager()->setParameters('ZendTest\ServiceManager\TestAsset\Bar', array('foo' => array('a')));
         $sm->addAbstractFactory(new DiAbstractServiceFactory($di));
         $bar = $serviceManager->get('ZendTest\ServiceManager\TestAsset\Bar');
+        $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Bar', $bar);
+    }
+
+    public function testDiAbstractServiceFactory()
+    {
+        $di = new Di();
+        $di->instanceManager()->setParameters('ZendTest\ServiceManager\TestAsset\Bar', array('foo' => array('a')));
+        $this->serviceManager->addAbstractFactory(new DiAbstractServiceFactory($di));
+        $this->assertTrue($this->serviceManager->has('ZendTest\ServiceManager\TestAsset\Bar', true));
+        $bar = $this->serviceManager->get('ZendTest\ServiceManager\TestAsset\Bar', true);
         $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Bar', $bar);
     }
 }

--- a/tests/Zend/ServiceManager/TestAsset/FooAbstractFactory.php
+++ b/tests/Zend/ServiceManager/TestAsset/FooAbstractFactory.php
@@ -7,10 +7,10 @@ use Zend\ServiceManager\AbstractFactoryInterface,
 
 class FooAbstractFactory implements AbstractFactoryInterface
 {
-    public function canCreateServiceWithName($name, $requestedName)
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
     }
-    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name)
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
         return new Foo;
     }

--- a/tests/Zend/ServiceManager/TestAsset/FooAbstractFactory.php
+++ b/tests/Zend/ServiceManager/TestAsset/FooAbstractFactory.php
@@ -7,7 +7,7 @@ use Zend\ServiceManager\AbstractFactoryInterface,
 
 class FooAbstractFactory implements AbstractFactoryInterface
 {
-    public function canCreateServiceWithName($name)
+    public function canCreateServiceWithName($name, $requestedName)
     {
     }
     public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name)


### PR DESCRIPTION
This PR changes three things:
- ServiceManager::has() can now be relied upon. This is done by allowing only instances of AbstractFactoryInterface to be abstract factories (and not closures). 
- Changed the AbstractFactoryInterface to also have the $requestedName parameter on the canCreateServiceWithName() method, because this was used in the ServiceManager itself. And also changed this in all the implementations.
- Created the canCreateServiceWithName() method on the DiAbstractServiceFactory. This so the ServiceManager::has() method can be relied upon.

The implementation of the DiAbstractServiceFactory::canCreateServiceWithName() method will only check if definitions or an instance exist in the Di. @Ocramius considered this to be the best thing to make the has() method for the Service Manager reliable.

I also did some refactorings, to rely on the has() method in some cases instead of trying to use the get() method and catching exceptions that might occur.

[![Build Status](https://secure.travis-ci.org/kokx/zf2.png?branch=servicemanager-has)](http://travis-ci.org/kokx/zf2)
