### PR TITLE
Fix lazy creation of external SMTP

### DIFF
--- a/library/Zend/Mail/Transport/Smtp.php
+++ b/library/Zend/Mail/Transport/Smtp.php
@@ -333,11 +333,11 @@ class Smtp implements TransportInterface
     protected function lazyLoadConnection()
     {
         // Check if authentication is required and determine required class
-        $options    = $this->getOptions();
-        $host       = $options->getHost();
-        $port       = $options->getPort();
-        $config     = $options->getConnectionConfig();
-        $connection = $this->plugin($options->getConnectionClass(), array($host, $port, $config));
+        $options        = $this->getOptions();
+        $config         = $options->getConnectionConfig();
+        $config['host'] = $options->getHost();
+        $config['port'] = $options->getPort();
+        $connection = $this->plugin($options->getConnectionClass(), $config);
         $this->connection = $connection;
         $this->connection->connect();
         $this->connection->helo($options->getName());


### PR DESCRIPTION
Hi, the `Zend\Mail\Transport\Smtp::lazyLoadConnection` method is currently passing this wrong variable to `Zend\Mail\Protocol\Smtp::__construct($host = '127.0.0.1', $port = null, array $config = null)`:

``` php
<?php
$host = array(
    0 => 'myhost',
    1 => 'myport',
    2 => array(),
);
$port = null;
$config = null;
```

while the `__construct` internal logic expects:

``` php
<?php
$host = $config = array(
    'host' => 'myhost',
    'port' => 'myport',
);
$port = null;
$config = null;
```

The bug is visible only with an external SMTP host or different SMTP port set.
Every test related to `Zend\Mail` uses only internal or default values, so the bug never pops up.

Furthermore, `lazyLoadConnection` is the only one method completly untested: I didn't write a test too because this involves an integration test with an external smtp server, or a white-box test to check internal state, and both solutions are not so pretty; if you didn't create tests for this method before, I suppose you prefer not to use this type of testing, as I can see in the commit that generated current code: https://github.com/zendframework/zf2/commit/90a4633e54bb837fcc7b68c5d14d5a726fae2052

[![Build Status](https://secure.travis-ci.org/Slamdunk/zf2.png?branch=external-smtp-creation)](http://travis-ci.org/Slamdunk/zf2)
