### PR TITLE
Always decode strings to ZF2 default charset (UTF-8)

### DIFF
--- a/library/Zend/Mail/Header/AbstractAddressList.php
+++ b/library/Zend/Mail/Header/AbstractAddressList.php
@@ -66,7 +66,7 @@ abstract class AbstractAddressList implements HeaderInterface
      */
     public static function fromString($headerLine)
     {
-        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR);
+        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
 
         // split into name/value
         list($fieldName, $fieldValue) = explode(': ', $headerLine, 2);
@@ -98,7 +98,7 @@ abstract class AbstractAddressList implements HeaderInterface
             if (empty($name)) {
                 $name = null;
             } else {
-                $name = iconv_mime_decode($name, ICONV_MIME_DECODE_CONTINUE_ON_ERROR);
+                $name = iconv_mime_decode($name, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
             }
 
             if (isset($matches['namedEmail'])) {

--- a/library/Zend/Mail/Header/ContentType.php
+++ b/library/Zend/Mail/Header/ContentType.php
@@ -58,7 +58,7 @@ class ContentType implements HeaderInterface
      */
     public static function fromString($headerLine)
     {
-        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR);
+        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
         list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory

--- a/library/Zend/Mail/Header/GenericHeader.php
+++ b/library/Zend/Mail/Header/GenericHeader.php
@@ -55,7 +55,7 @@ class GenericHeader implements HeaderInterface
      */
     public static function fromString($headerLine)
     {
-        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR);
+        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
         $parts = explode(': ', $headerLine, 2);
         if (count($parts) != 2) {
             throw new Exception\InvalidArgumentException('Header must match with the format "name: value"');

--- a/library/Zend/Mail/Header/GenericMultiHeader.php
+++ b/library/Zend/Mail/Header/GenericMultiHeader.php
@@ -40,7 +40,7 @@ class GenericMultiHeader extends GenericHeader implements MultipleHeadersInterfa
      */
     public static function fromString($headerLine)
     {
-        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR);
+        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
         $parts = explode(': ', $headerLine, 2);
         if (count($parts) != 2) {
             throw new Exception\InvalidArgumentException('Header must match with the format "name: value"');

--- a/library/Zend/Mail/Header/Sender.php
+++ b/library/Zend/Mail/Header/Sender.php
@@ -53,7 +53,7 @@ class Sender implements HeaderInterface
      */
     public static function fromString($headerLine)
     {
-        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR);
+        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
         list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
@@ -69,7 +69,7 @@ class Sender implements HeaderInterface
             if (empty($name)) {
                 $name = null;
             } else {
-                $name = iconv_mime_decode($name, ICONV_MIME_DECODE_CONTINUE_ON_ERROR);
+                $name = iconv_mime_decode($name, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
             }
             $header->setAddress($matches['email'], $name);
         }

--- a/library/Zend/Mail/Header/Subject.php
+++ b/library/Zend/Mail/Header/Subject.php
@@ -51,7 +51,7 @@ class Subject implements UnstructuredInterface
      */
     public static function fromString($headerLine)
     {
-        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR);
+        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
         list($name, $value) = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory

--- a/library/Zend/Mime/Decode.php
+++ b/library/Zend/Mime/Decode.php
@@ -138,7 +138,7 @@ class Decode
             @list($headers, $body) = @preg_split("%([\r\n]+)\\1%U", $message, 2);
         }
 
-        $headers = iconv_mime_decode_headers($headers, ICONV_MIME_DECODE_CONTINUE_ON_ERROR);
+        $headers = iconv_mime_decode_headers($headers, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
 
         if ($headers === false) {
             // an error occurs during the decoding
@@ -237,6 +237,6 @@ class Decode
      */
     public static function decodeQuotedPrintable($string)
     {
-        return iconv_mime_decode($string, ICONV_MIME_DECODE_CONTINUE_ON_ERROR);
+        return iconv_mime_decode($string, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
     }
 }

--- a/tests/Zend/Mail/Header/HeaderWrapTest.php
+++ b/tests/Zend/Mail/Header/HeaderWrapTest.php
@@ -61,7 +61,7 @@ class HeaderWrapTest extends \PHPUnit_Framework_TestCase
 
         $test = HeaderWrap::wrap($string, $header);
         $this->assertEquals($expected, $test);
-        $this->assertEquals($string, iconv_mime_decode($test));
+        $this->assertEquals($string, iconv_mime_decode($test, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8'));
     }
 
     /**

--- a/tests/Zend/Mail/Storage/MessageTest.php
+++ b/tests/Zend/Mail/Storage/MessageTest.php
@@ -74,8 +74,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     {
         $message = new Message(array('file' => $this->_file));
 
-        $this->assertEquals($message->from, iconv('UTF-8', iconv_get_encoding('internal_encoding'),
-                                                                   '"Peter Müller" <peter-mueller@example.com>'));
+        $this->assertEquals('"Peter Müller" <peter-mueller@example.com>', $message->from);
     }
 
     public function testGetHeaderAsArray()
@@ -213,9 +212,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testDecodeString()
     {
         $is = Mime\Decode::decodeQuotedPrintable('=?UTF-8?Q?"Peter M=C3=BCller"?= <peter-mueller@example.com>');
-        $should = iconv('UTF-8', iconv_get_encoding('internal_encoding'),
-                        '"Peter Müller" <peter-mueller@example.com>');
-        $this->assertEquals($is, $should);
+        $this->assertEquals('"Peter Müller" <peter-mueller@example.com>', $is);
     }
 
     public function testSplitHeader()


### PR DESCRIPTION
This commit set the output charset of iconv_mime_decode to ZF2 charset (UTF-8)

Prevent issues when the data is encoded again but this is encoded in system depend charset
