### PR TITLE
Hotfix/abstract di factory circular dependency

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -779,13 +779,18 @@ class ServiceManager implements ServiceLocatorInterface
                     ($requestedName ? '(alias: ' . $requestedName . ')' : '')
                 ));
             }
-            $this->pendingAbstractFactoryRequests[get_class($abstractFactory)] = $requestedName;
-            $instance = $this->createServiceViaCallback(
-                array($abstractFactory, 'createServiceWithName'),
-                $canonicalName,
-                $requestedName
-            );
-            unset($this->pendingAbstractFactoryRequests[get_class($abstractFactory)]);
+            try {
+                $this->pendingAbstractFactoryRequests[get_class($abstractFactory)] = $requestedName;
+                $instance = $this->createServiceViaCallback(
+                    array($abstractFactory, 'createServiceWithName'),
+                    $canonicalName,
+                    $requestedName
+                );
+                unset($this->pendingAbstractFactoryRequests[get_class($abstractFactory)]);
+            } catch (\Exception $e) {
+                unset($this->pendingAbstractFactoryRequests[get_class($abstractFactory)]);
+                throw $e;
+            }
             if (is_object($instance)) {
                 break;
             }

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -789,7 +789,15 @@ class ServiceManager implements ServiceLocatorInterface
                 unset($this->pendingAbstractFactoryRequests[get_class($abstractFactory)]);
             } catch (\Exception $e) {
                 unset($this->pendingAbstractFactoryRequests[get_class($abstractFactory)]);
-                throw $e;
+                throw new Exception\ServiceNotCreatedException(
+                    sprintf(
+                        'An abstract factory could not create an instance of %s%s.',
+                        $canonicalName,
+                        ($requestedName ? '(alias: ' . $requestedName . ')' : '')
+                    ),
+                    $e->getCode(),
+                    $e
+                );
             }
             if (is_object($instance)) {
                 break;

--- a/tests/Zend/ServiceManager/Di/DiServiceFactoryTest.php
+++ b/tests/Zend/ServiceManager/Di/DiServiceFactoryTest.php
@@ -64,19 +64,4 @@ class DiServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $foo = $this->diServiceFactory->createService($this->mockServiceLocator);
         $this->assertEquals($this->fooInstance, $foo);
     }
-
-    /**
-     * @covers Zend\ServiceManager\Di\DiServiceFactory::get
-     */
-    public function testWillNotCreateCircularReferences()
-    {
-        $sm = new ServiceManager;
-        $di = new Di;
-        $di->instanceManager()->addAlias('foo', 'stdClass');
-        $diFactory = new DiServiceFactory($di, 'Di', array(), DiServiceFactory::USE_SL_BEFORE_DI);
-        $abstractFactory = new DiAbstractServiceFactory($diFactory, DiAbstractServiceFactory::USE_SL_BEFORE_DI);
-        $sm->addAbstractFactory($abstractFactory);
-        $foo = $sm->get('foo');
-        $this->assertInstanceOf('stdClass', $foo);
-    }
 }

--- a/tests/Zend/ServiceManager/Di/DiServiceFactoryTest.php
+++ b/tests/Zend/ServiceManager/Di/DiServiceFactoryTest.php
@@ -2,12 +2,18 @@
 
 namespace ZendTest\ServiceManager\Di;
 
-use Zend\ServiceManager\Di\DiServiceFactory,
-    Zend\ServiceManager\Di\DiInstanceManagerProxy;
+use Zend\Di\Di;
+use Zend\ServiceManager\Di\DiServiceFactory;
+use Zend\ServiceManager\Di\DiInstanceManagerProxy;
+use Zend\ServiceManager\Di\DiAbstractServiceFactory;
+use Zend\ServiceManager\ServiceManager;
 
 class DiServiceFactoryTest extends \PHPUnit_Framework_TestCase
 {
 
+    /**
+     * @var DiServiceFactory
+     */
     protected $diServiceFactory = null;
 
     /**@#+
@@ -57,5 +63,20 @@ class DiServiceFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $foo = $this->diServiceFactory->createService($this->mockServiceLocator);
         $this->assertEquals($this->fooInstance, $foo);
+    }
+
+    /**
+     * @covers Zend\ServiceManager\Di\DiServiceFactory::get
+     */
+    public function testWillNotCreateCircularReferences()
+    {
+        $sm = new ServiceManager;
+        $di = new Di;
+        $di->instanceManager()->addAlias('foo', 'stdClass');
+        $diFactory = new DiServiceFactory($di, 'Di', array(), DiServiceFactory::USE_SL_BEFORE_DI);
+        $abstractFactory = new DiAbstractServiceFactory($diFactory, DiAbstractServiceFactory::USE_SL_BEFORE_DI);
+        $sm->addAbstractFactory($abstractFactory);
+        $foo = $sm->get('foo');
+        $this->assertInstanceOf('stdClass', $foo);
     }
 }

--- a/tests/Zend/ServiceManager/ServiceManagerTest.php
+++ b/tests/Zend/ServiceManager/ServiceManagerTest.php
@@ -478,4 +478,17 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         // should throw an exception because 'foo' already exists in the service manager
         $this->serviceManager->setAlias('foo', 'bar');
     }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::createFromAbstractFactory
+     * @covers Zend\ServiceManager\ServiceManager::has
+     */
+    public function testWillNotCreateCircularReferences()
+    {
+        $abstractFactory = new TestAsset\CircularDependencyAbstractFactory();
+        $sm = new ServiceManager();
+        $sm->addAbstractFactory($abstractFactory);
+        $foo = $sm->get('foo');
+        $this->assertSame($abstractFactory->expectedInstance, $foo);
+    }
 }

--- a/tests/Zend/ServiceManager/TestAsset/CircularDependencyAbstractFactory.php
+++ b/tests/Zend/ServiceManager/TestAsset/CircularDependencyAbstractFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Zend\ServiceManager\AbstractFactoryInterface,
+Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Class used to try to simulate a cyclic dependency in ServiceManager.
+ */
+class CircularDependencyAbstractFactory implements AbstractFactoryInterface
+{
+    public $expectedInstance = 'a retrieved value';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        if ($serviceLocator->has($name)) {
+            return $serviceLocator->get($name);
+        }
+
+        return $this->expectedInstance;
+    }
+}


### PR DESCRIPTION
This solves the issue I reported in the Mailing List, "PR 1698 has caused circular dependency issue". The theory is, if a SM asks an AbstractFactory for a $requestedName, it should return false when it is asked if it has $requestedName.

Although this fixes the issue, I'm slightly uncomfortable with it as it seems like when PR 1698 fixed the SM has method, it exposed a bug in DiServiceFactory.

Thanks to @Ocramius for helping with the test.
