### PR TITLE
Use headers container in zend mime

### DIFF
--- a/library/Zend/Mail/Header/AbstractAddressList.php
+++ b/library/Zend/Mail/Header/AbstractAddressList.php
@@ -53,23 +53,15 @@ abstract class AbstractAddressList implements HeaderInterface
     protected $encoding = 'ASCII';
 
     /**
-     * @var string lowercased field name
+     * @var string lower case field name
      */
     protected static $type;
 
-    /**
-     * Parse string to create header object
-     *
-     * @param  string $headerLine
-     * @throws Exception\InvalidArgumentException
-     * @return AbstractAddressList
-     */
     public static function fromString($headerLine)
     {
-        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-
+        $decodedLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
         // split into name/value
-        list($fieldName, $fieldValue) = explode(': ', $headerLine, 2);
+        list($fieldName, $fieldValue) = explode(': ', $decodedLine, 2);
 
         if (strtolower($fieldName) !== static::$type) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -78,7 +70,9 @@ abstract class AbstractAddressList implements HeaderInterface
             ));
         }
         $header = new static();
-
+        if ($decodedLine != $headerLine) {
+            $header->setEncoding('UTF-8');
+        }
         // split value on ","
         $fieldValue = str_replace(Headers::FOLDING, ' ', $fieldValue);
         $values     = explode(',', $fieldValue);
@@ -97,8 +91,6 @@ abstract class AbstractAddressList implements HeaderInterface
             }
             if (empty($name)) {
                 $name = null;
-            } else {
-                $name = iconv_mime_decode($name, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
             }
 
             if (isset($matches['namedEmail'])) {
@@ -112,26 +104,15 @@ abstract class AbstractAddressList implements HeaderInterface
             // populate address list
             $addressList->add($email, $name);
         }
-
         return $header;
     }
 
-    /**
-     * Get field name of this header
-     *
-     * @return string
-     */
     public function getFieldName()
     {
         return $this->fieldName;
     }
 
-    /**
-     * Get field value of this header
-     *
-     * @return string
-     */
-    public function getFieldValue()
+    public function getFieldValue($format = HeaderInterface::FORMAT_RAW)
     {
         $emails   = array();
         $encoding = $this->getEncoding();
@@ -145,33 +126,24 @@ abstract class AbstractAddressList implements HeaderInterface
                     $name = sprintf('"%s"', $name);
                 }
 
-                if ('ASCII' !== $encoding) {
+                if ($format == HeaderInterface::FORMAT_ENCODED
+                    && 'ASCII' !== $encoding
+                ) {
                     $name = HeaderWrap::mimeEncodeValue($name, $encoding);
                 }
                 $emails[] = sprintf('%s <%s>', $name, $email);
             }
         }
-        $string = implode(',' . Headers::FOLDING, $emails);
-        return $string;
+
+        return implode(',' . Headers::FOLDING, $emails);
     }
 
-    /**
-     * Set header encoding
-     *
-     * @param  string $encoding
-     * @return AbstractAddressList
-     */
     public function setEncoding($encoding)
     {
         $this->encoding = $encoding;
         return $this;
     }
 
-    /**
-     * Get header encoding
-     *
-     * @return string
-     */
     public function getEncoding()
     {
         return $this->encoding;
@@ -200,15 +172,10 @@ abstract class AbstractAddressList implements HeaderInterface
         return $this->addressList;
     }
 
-    /**
-     * Serialize to string
-     *
-     * @return string
-     */
     public function toString()
     {
         $name  = $this->getFieldName();
-        $value = $this->getFieldValue();
+        $value = $this->getFieldValue(HeaderInterface::FORMAT_ENCODED);
         return (empty($value)) ? '' : sprintf('%s: %s', $name, $value);
     }
 }

--- a/library/Zend/Mail/Header/ContentType.php
+++ b/library/Zend/Mail/Header/ContentType.php
@@ -49,13 +49,6 @@ class ContentType implements HeaderInterface
      */
     protected $parameters = array();
 
-    /**
-     * Factory: create Content-Type header object from string
-     *
-     * @param  string $headerLine
-     * @throws Exception\InvalidArgumentException
-     * @return ContentType
-     */
     public static function fromString($headerLine)
     {
         $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
@@ -84,22 +77,12 @@ class ContentType implements HeaderInterface
         return $header;
     }
 
-    /**
-     * Get header name
-     * 
-     * @return string
-     */
     public function getFieldName()
     {
         return 'Content-Type';
     }
 
-    /**
-     * Get header value
-     * 
-     * @return string
-     */
-    public function getFieldValue()
+    public function getFieldValue($format = HeaderInterface::FORMAT_RAW)
     {
         $prepared = $this->type;
         if (empty($this->parameters)) {
@@ -110,40 +93,24 @@ class ContentType implements HeaderInterface
         foreach ($this->parameters as $attribute => $value) {
             $values[] = sprintf('%s="%s"', $attribute, $value);
         }
-        $value = implode(';' . Headers::FOLDING, $values);
-        return $value;
+
+        return implode(';' . Headers::FOLDING, $values);
     }
 
-    /**
-     * Set header encoding
-     * 
-     * @param  string $encoding 
-     * @return ContentType
-     */
     public function setEncoding($encoding) 
     {
         $this->encoding = $encoding;
         return $this;
     }
 
-    /**
-     * Get header encoding
-     * 
-     * @return string
-     */
     public function getEncoding()
     {
         return $this->encoding;
     }
 
-    /**
-     * Serialize header to string
-     * 
-     * @return string
-     */
     public function toString()
     {
-        return 'Content-Type: ' . $this->getFieldValue();
+        return 'Content-Type: ' . $this->getFieldValue(HeaderInterface::FORMAT_RAW);
     }
 
     /**

--- a/library/Zend/Mail/Header/Date.php
+++ b/library/Zend/Mail/Header/Date.php
@@ -43,13 +43,6 @@ class Date implements HeaderInterface
      */
     protected $encoding = 'ASCII';
 
-    /**
-     * Factory: create header object from string
-     * 
-     * @param  string $headerLine 
-     * @return Date
-     * @throws Exception\InvalidArgumentException
-     */
     public static function fromString($headerLine)
     {
         list($name, $value) = explode(': ', $headerLine, 2);
@@ -65,55 +58,29 @@ class Date implements HeaderInterface
         return $header;
     }
 
-    /**
-     * Get the header name 
-     * 
-     * @return string
-     */
     public function getFieldName()
     {
         return 'Date';
     }
 
-    /**
-     * Get the header value
-     * 
-     * @return string
-     */
-    public function getFieldValue()
+    public function getFieldValue($format = HeaderInterface::FORMAT_RAW)
     {
         return $this->value;
     }
 
-    /**
-     * Set header encoding
-     * 
-     * @param  string $encoding 
-     * @return AbstractAddressList
-     */
     public function setEncoding($encoding) 
     {
         $this->encoding = $encoding;
         return $this;
     }
 
-    /**
-     * Get header encoding
-     * 
-     * @return string
-     */
     public function getEncoding()
     {
         return $this->encoding;
     }
 
-    /**
-     * Serialize header to string
-     * 
-     * @return string
-     */
     public function toString()
     {
-        return 'Date: ' . $this->getFieldValue();
+        return 'Date: ' . $this->getFieldValue(HeaderInterface::FORMAT_RAW);
     }
 }

--- a/library/Zend/Mail/Header/GenericHeader.php
+++ b/library/Zend/Mail/Header/GenericHeader.php
@@ -28,7 +28,7 @@ namespace Zend\Mail\Header;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class GenericHeader implements HeaderInterface
+class GenericHeader implements HeaderInterface, UnstructuredInterface
 {
     /**
      * @var string
@@ -47,20 +47,17 @@ class GenericHeader implements HeaderInterface
      */
     protected $encoding = 'ASCII';
 
-    /**
-     * Factory to generate a header object from a string
-     *
-     * @param string $headerLine
-     * @return GenericHeader
-     */
     public static function fromString($headerLine)
     {
-        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-        $parts = explode(': ', $headerLine, 2);
+        $decodedLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
+        $parts = explode(': ', $decodedLine, 2);
         if (count($parts) != 2) {
             throw new Exception\InvalidArgumentException('Header must match with the format "name: value"');
         }
         $header = new static($parts[0], $parts[1]);
+        if ($decodedLine != $headerLine) {
+            $header->setEncoding('UTF-8');
+        }
         return $header;
     }
 
@@ -108,11 +105,6 @@ class GenericHeader implements HeaderInterface
         return $this;
     }
 
-    /**
-     * Retrieve header name
-     *
-     * @return string
-     */
     public function getFieldName()
     {
         return $this->fieldName;
@@ -136,49 +128,30 @@ class GenericHeader implements HeaderInterface
         return $this;
     }
 
-    /**
-     * Retrieve header value
-     * 
-     * @return string
-     */
-    public function getFieldValue()
+    public function getFieldValue($format = HeaderInterface::FORMAT_RAW)
     {
+        if (HeaderInterface::FORMAT_ENCODED) {
+            return HeaderWrap::wrap($this->fieldValue, $this);
+        }
+
         return $this->fieldValue;
     }
 
-    /**
-     * Set header encoding
-     * 
-     * @param  string $encoding 
-     * @return GenericHeader
-     */
     public function setEncoding($encoding) 
     {
         $this->encoding = $encoding;
         return $this;
     }
 
-    /**
-     * Get header encoding
-     * 
-     * @return string
-     */
     public function getEncoding()
     {
         return $this->encoding;
     }
 
-    /**
-     * Cast to string
-     *
-     * Returns in form of "NAME: VALUE"
-     *
-     * @return string
-     */
     public function toString()
     {
         $name  = $this->getFieldName();
-        $value = $this->getFieldValue();
+        $value = $this->getFieldValue(HeaderInterface::FORMAT_ENCODED);
 
         return $name. ': ' . $value;
     }

--- a/library/Zend/Mail/Header/GenericMultiHeader.php
+++ b/library/Zend/Mail/Header/GenericMultiHeader.php
@@ -32,16 +32,10 @@ namespace Zend\Mail\Header;
  */
 class GenericMultiHeader extends GenericHeader implements MultipleHeadersInterface
 {
-    /**
-     * Unserialize from a string
-     * 
-     * @param  string $headerLine 
-     * @return GenericMultiHeader|GenericMultiHeader[]
-     */
     public static function fromString($headerLine)
     {
-        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-        $parts = explode(': ', $headerLine, 2);
+        $decodedLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
+        $parts = explode(': ', $decodedLine, 2);
         if (count($parts) != 2) {
             throw new Exception\InvalidArgumentException('Header must match with the format "name: value"');
         }
@@ -49,12 +43,18 @@ class GenericMultiHeader extends GenericHeader implements MultipleHeadersInterfa
 
         if (strpos($fieldValue, ',')) {
             $headers = array();
+            $encoding = ($decodedLine != $headerLine) ? 'UTF-8' : 'ASCII';
             foreach (explode(',', $fieldValue) as $multiValue) {
-                $headers[] = new static($fieldName, $multiValue);
+                $header = new static($fieldName, $multiValue);
+                $headers[] = $header->setEncoding($encoding);
+
             }
             return $headers;
         } else {
             $header = new static($fieldName, $fieldValue);
+            if ($decodedLine != $headerLine) {
+                $header->setEncoding('UTF-8');
+            }
             return $header;
         }
     }
@@ -69,14 +69,14 @@ class GenericMultiHeader extends GenericHeader implements MultipleHeadersInterfa
     public function toStringMultipleHeaders(array $headers)
     {
         $name  = $this->getFieldName();
-        $values = array($this->getFieldValue());
+        $values = array($this->getFieldValue(HeaderInterface::FORMAT_ENCODED));
         foreach ($headers as $header) {
             if (!$header instanceof static) {
                 throw new Exception\InvalidArgumentException(
                     'This method toStringMultipleHeaders was expecting an array of headers of the same type'
                 );
             }
-            $values[] = $header->getFieldValue();
+            $values[] = $header->getFieldValue(HeaderInterface::FORMAT_ENCODED);
         }
         return $name. ': ' . implode(',', $values);
     }

--- a/library/Zend/Mail/Header/HeaderInterface.php
+++ b/library/Zend/Mail/Header/HeaderInterface.php
@@ -30,10 +30,65 @@ namespace Zend\Mail\Header;
  */
 interface HeaderInterface
 {
+    /**
+     * Format value in Mime-Encoding if not US-ASCII encoding is used
+     *
+     * @var boolean
+     */
+    const FORMAT_ENCODED = true;
+
+    /**
+     * Return value with the interval ZF2 value (UTF-8 non-encoded)
+     *
+     * @var boolean
+     */
+    const FORMAT_RAW     = false;
+
+
+    /**
+     * Factory to generate a header object from a string
+     *
+     * @param string $headerLine
+     * @return self
+     */
     public static function fromString($headerLine);
+
+    /**
+     * Retrieve header name
+     *
+     * @return string
+     */
     public function getFieldName();
-    public function getFieldValue();
+
+    /**
+     * Retrieve header value
+     *
+     * @param  boolean $format Return the value in Mime::Encoded or in Raw format
+     * @return string
+     */
+    public function getFieldValue($format = HeaderInterface::FORMAT_RAW);
+
+    /**
+     * Set header encoding
+     *
+     * @param  string $encoding
+     * @return self
+     */
     public function setEncoding($encoding);
+
+    /**
+     * Get header encoding
+     *
+     * @return string
+     */
     public function getEncoding();
+
+    /**
+     * Cast to string
+     *
+     * Returns in form of "NAME: VALUE"
+     *
+     * @return string
+     */
     public function toString();
 }

--- a/library/Zend/Mail/Header/MimeVersion.php
+++ b/library/Zend/Mail/Header/MimeVersion.php
@@ -35,13 +35,6 @@ class MimeVersion implements HeaderInterface
      */
     protected $version = '1.0';
 
-    /**
-     * Unserialize from string
-     *
-     * @param  string $headerLine
-     * @throws Exception\InvalidArgumentException
-     * @return MimeVersion
-     */
     public static function fromString($headerLine)
     {
         list($name, $value) = explode(': ', $headerLine, 2);
@@ -60,53 +53,29 @@ class MimeVersion implements HeaderInterface
         return $header;
     }
 
-    /**
-     * Get the field name
-     *
-     * @return string
-     */
     public function getFieldName()
     {
         return 'MIME-Version';
     }
 
-    /**
-     * Get the field value (version string)
-     *
-     * @return string
-     */
-    public function getFieldValue()
+    public function getFieldValue($format = HeaderInterface::FORMAT_RAW)
     {
         return $this->version;
     }
 
-    /**
-     * Set character encoding
-     *
-     * @param  string $encoding
-     */
     public function setEncoding($encoding)
     {
         // irrelevant to this implementation
     }
 
-    /**
-     * Get character encoding
-     *
-     */
     public function getEncoding()
     {
         // irrelevant to this implementation
     }
 
-    /**
-     * Serialize to string
-     *
-     * @return string
-     */
     public function toString()
     {
-        return 'MIME-Version: ' . $this->getFieldValue();
+        return 'MIME-Version: ' . $this->getFieldValue(HeaderInterface::FORMAT_RAW);
     }
 
     /**

--- a/library/Zend/Mail/Header/Received.php
+++ b/library/Zend/Mail/Header/Received.php
@@ -45,13 +45,6 @@ class Received implements HeaderInterface, MultipleHeadersInterface
      */
     protected $encoding = 'ASCII';
 
-    /**
-     * Factory: create Received header object from string
-     * 
-     * @param  string $headerLine 
-     * @return Received
-     * @throws Exception\InvalidArgumentException
-     */
     public static function fromString($headerLine)
     {
         list($name, $value) = explode(': ', $headerLine, 2);
@@ -67,56 +60,30 @@ class Received implements HeaderInterface, MultipleHeadersInterface
         return $header;
     }
 
-    /**
-     * Get header name
-     * 
-     * @return string
-     */
     public function getFieldName()
     {
         return 'Received';
     }
 
-    /**
-     * Get header value
-     * 
-     * @return string
-     */
-    public function getFieldValue()
+    public function getFieldValue($format = HeaderInterface::FORMAT_RAW)
     {
         return $this->value;
     }
 
-    /**
-     * Set header encoding
-     * 
-     * @param  string $encoding 
-     * @return AbstractAddressList
-     */
     public function setEncoding($encoding) 
     {
         $this->encoding = $encoding;
         return $this;
     }
 
-    /**
-     * Get header encoding
-     * 
-     * @return string
-     */
     public function getEncoding()
     {
         return $this->encoding;
     }
 
-    /**
-     * Serialize to string
-     * 
-     * @return string
-     */
     public function toString()
     {
-        return 'Received: ' . $this->getFieldValue();
+        return 'Received: ' . $this->getFieldValue(HeaderInterface::FORMAT_RAW);
     }
 
     /**

--- a/library/Zend/Mail/Header/Sender.php
+++ b/library/Zend/Mail/Header/Sender.php
@@ -44,17 +44,10 @@ class Sender implements HeaderInterface
      */
     protected $encoding = 'ASCII';
 
-    /**
-     * Factory: create Sender header object from string
-     *
-     * @param  string $headerLine
-     * @return Sender
-     * @throws Exception\InvalidArgumentException on invalid header line
-     */
     public static function fromString($headerLine)
     {
-        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-        list($name, $value) = explode(': ', $headerLine, 2);
+        $decodedLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
+        list($name, $value) = explode(': ', $decodedLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'sender') {
@@ -62,6 +55,9 @@ class Sender implements HeaderInterface
         }
 
         $header = new static();
+        if ($decodedLine != $headerLine) {
+            $header->setEncoding('UTF-8');
+        }
 
         // Check for address, and set if found
         if (preg_match('^(?P<name>.*?)<(?P<email>[^>]+)>$', $value, $matches)) {
@@ -77,22 +73,12 @@ class Sender implements HeaderInterface
         return $header;
     }
 
-    /**
-     * Get header name
-     *
-     * @return string
-     */
     public function getFieldName()
     {
         return 'Sender';
     }
 
-    /**
-     * Get header value
-     *
-     * @return string
-     */
-    public function getFieldValue()
+    public function getFieldValue($format = HeaderInterface::FORMAT_RAW)
     {
         if (!$this->address instanceof Mail\Address\AddressInterface) {
             return '';
@@ -102,7 +88,9 @@ class Sender implements HeaderInterface
         $name  = $this->address->getName();
         if (!empty($name)) {
             $encoding = $this->getEncoding();
-            if ('ASCII' !== $encoding) {
+            if ($format == HeaderInterface::FORMAT_ENCODED
+                && 'ASCII' !== $encoding
+            ) {
                 $name  = HeaderWrap::mimeEncodeValue($name, $encoding);
             }
             $email = sprintf('%s %s', $name, $email);
@@ -110,36 +98,20 @@ class Sender implements HeaderInterface
         return $email;
     }
 
-    /**
-     * Set header encoding
-     *
-     * @param  string $encoding
-     * @return Sender
-     */
     public function setEncoding($encoding)
     {
         $this->encoding = $encoding;
         return $this;
     }
 
-    /**
-     * Get header encoding
-     *
-     * @return string
-     */
     public function getEncoding()
     {
         return $this->encoding;
     }
 
-    /**
-     * Serialize to string
-     *
-     * @return string
-     */
     public function toString()
     {
-        return 'Sender: ' . $this->getFieldValue();
+        return 'Sender: ' . $this->getFieldValue(HeaderInterface::FORMAT_ENCODED);
     }
 
     /**

--- a/library/Zend/Mail/Header/Subject.php
+++ b/library/Zend/Mail/Header/Subject.php
@@ -42,17 +42,10 @@ class Subject implements UnstructuredInterface
      */
     protected $encoding = 'ASCII';
 
-    /**
-     * Factory from header line
-     *
-     * @param  string $headerLine
-     * @throws Exception\InvalidArgumentException
-     * @return Subject
-     */
     public static function fromString($headerLine)
     {
-        $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-        list($name, $value) = explode(': ', $headerLine, 2);
+        $decodedLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
+        list($name, $value) = explode(': ', $decodedLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'subject') {
@@ -60,72 +53,47 @@ class Subject implements UnstructuredInterface
         }
 
         $header = new static();
+        if ($decodedLine != $headerLine) {
+            $header->setEncoding('UTF-8');
+        }
         $header->setSubject($value);
         
         return $header;
     }
 
-    /**
-     * Get the header name
-     * 
-     * @return string
-     */
     public function getFieldName()
     {
         return 'Subject';
     }
 
-    /**
-     * Get the header value
-     * 
-     * @return string
-     */
-    public function getFieldValue()
+    public function getFieldValue($format = HeaderInterface::FORMAT_RAW)
     {
-        return HeaderWrap::wrap($this->subject, $this);
+        if (HeaderInterface::FORMAT_ENCODED) {
+            return HeaderWrap::wrap($this->subject, $this);
+        }
+
+        return $this->subject;
     }
 
-    /**
-     * Set header encoding
-     * 
-     * @param  string $encoding 
-     * @return Subject
-     */
     public function setEncoding($encoding) 
     {
         $this->encoding = $encoding;
         return $this;
     }
 
-    /**
-     * Get header encoding
-     * 
-     * @return string
-     */
     public function getEncoding()
     {
         return $this->encoding;
     }
 
-    /**
-     * Set the value of the header
-     * 
-     * @param  string $subject 
-     * @return Subject
-     */
     public function setSubject($subject)
     {
         $this->subject = (string) $subject;
         return $this;
     }
 
-    /**
-     * String representation of header
-     * 
-     * @return string
-     */
     public function toString()
     {
-        return 'Subject: ' . $this->getFieldValue();
+        return 'Subject: ' . $this->getFieldValue(HeaderInterface::FORMAT_ENCODED);
     }
 }

--- a/library/Zend/Mail/Headers.php
+++ b/library/Zend/Mail/Headers.php
@@ -244,10 +244,11 @@ class Headers implements Iterator, Countable
     public function addHeader(Header\HeaderInterface $header)
     {
         $key = $this->normalizeFieldName($header->getFieldName());
-
         $this->headersKeys[] = $key;
         $this->headers[] = $header;
-        $header->setEncoding($this->getEncoding());
+        if ($this->getEncoding() !== 'ASCII') {
+            $header->setEncoding($this->getEncoding());
+        }
         return $this;
     }
 
@@ -461,7 +462,7 @@ class Headers implements Iterator, Countable
         /* @var $class Header\HeaderInterface */
         $class = ($this->getPluginClassLoader()->load($key)) ?: 'Zend\Mail\Header\GenericHeader';
 
-        $encoding = $this->getEncoding();
+        $encoding = $current->getEncoding();
         $headers  = $class::fromString($current->toString());
         if (is_array($headers)) {
             $current = array_shift($headers);

--- a/library/Zend/Mail/Message.php
+++ b/library/Zend/Mail/Message.php
@@ -365,7 +365,7 @@ class Message
             return null;
         }
         $header = $headers->get('subject');
-        return $header->getFieldValue();
+        return $header->getFieldValue(Header\HeaderInterface::FORMAT_ENCODED);
     }
 
     /**

--- a/library/Zend/Mail/Storage/Part.php
+++ b/library/Zend/Mail/Storage/Part.php
@@ -318,11 +318,12 @@ class Part implements RecursiveIterator, Part\PartInterface
         switch ($format) {
             case 'string':
                 if ($header instanceof HeaderInterface) {
-                    $return = $header->getFieldValue();
+                    $return = $header->getFieldValue(HeaderInterface::FORMAT_RAW);
                 } else {
                     $return = '';
                     foreach ($header as $h) {
-                        $return .= $h->getFieldValue() . Mime\Mime::LINEEND;
+                        $return .= $h->getFieldValue(HeaderInterface::FORMAT_RAW)
+                                 . Mime\Mime::LINEEND;
                     }
                     $return = trim($return, Mime\Mime::LINEEND);
                 }
@@ -333,7 +334,7 @@ class Part implements RecursiveIterator, Part\PartInterface
                 } else {
                     $return = array();
                     foreach ($header as $h) {
-                        $return[] = $h->getFieldValue();
+                        $return[] = $h->getFieldValue(HeaderInterface::FORMAT_RAW);
                     }
                 }
                 break;

--- a/library/Zend/Mail/Storage/Part.php
+++ b/library/Zend/Mail/Storage/Part.php
@@ -112,18 +112,14 @@ class Part implements RecursiveIterator, Part\PartInterface
         }
 
         if (isset($params['raw'])) {
-            Mime\Decode::splitMessage($params['raw'], $headers, $this->_content);
-            $this->_headers = new Headers();
-            $this->_headers->addHeaders($headers);
+            Mime\Decode::splitMessage($params['raw'], $this->_headers, $this->_content);
         } elseif (isset($params['headers'])) {
             if (is_array($params['headers'])) {
                 $this->_headers = new Headers();
                 $this->_headers->addHeaders($params['headers']);
             } else {
                 if (empty($params['noToplines'])) {
-                    $this->_headers = new Headers();
-                    Mime\Decode::splitMessage($params['headers'], $headers, $this->_topLines);
-                    $this->_headers->addHeaders($headers);
+                    Mime\Decode::splitMessage($params['headers'], $this->_headers, $this->_topLines);
                 } else {
                     $this->_headers = Headers::fromString($params['headers']);
                 }

--- a/library/Zend/Mail/Transport/Sendmail.php
+++ b/library/Zend/Mail/Transport/Sendmail.php
@@ -26,7 +26,8 @@ use Zend\Mail\Address\AddressInterface;
 use Traversable,
     Zend\Mail,
     Zend\Mail\Exception,
-    Zend\Mail\Headers;
+    Zend\Mail\Headers,
+    Zend\Mail\Header\HeaderInterface;
 
 /**
  * Class for sending email via the PHP internal mail() function
@@ -172,7 +173,7 @@ class Sendmail implements TransportInterface
 
         // If not on Windows, return normal string
         if (!$this->isWindowsOs()) {
-            return $to->getFieldValue();
+            return $to->getFieldValue(HeaderInterface::FORMAT_ENCODED);
         }
 
         // Otherwise, return list of emails

--- a/library/Zend/Mime/Decode.php
+++ b/library/Zend/Mime/Decode.php
@@ -20,6 +20,8 @@
 
 namespace Zend\Mime;
 
+use Zend\Mail\Headers;
+
 /**
  * @category   Zend
  * @package    Zend_Mime
@@ -106,14 +108,17 @@ class Decode
      *
      * The charset of the returned headers depend on your iconv settings.
      *
-     * @param  string $message raw message with header and optional content
-     * @param  array  $headers output param, array with headers as array(name => value)
-     * @param  string $body    output param, content of message
-     * @param  string $EOL EOL string; defaults to {@link Zend_Mime::LINEEND}
+     * @param  string|Headers  $message raw message with header and optional content
+     * @param  Headers         $headers output param, headers container
+     * @param  string          $body    output param, content of message
+     * @param  string          $EOL EOL string; defaults to {@link Zend_Mime::LINEEND}
      * @return null
      */
     public static function splitMessage($message, &$headers, &$body, $EOL = Mime::LINEEND)
     {
+        if ($message instanceof Headers) {
+            $message = $message->toString();
+        }
         // check for valid header at first line
         $firstline = strtok($message, "\n");
         if (!preg_match('%^[^\s]+[^:]*:%', $firstline)) {
@@ -138,30 +143,7 @@ class Decode
             @list($headers, $body) = @preg_split("%([\r\n]+)\\1%U", $message, 2);
         }
 
-        $headers = iconv_mime_decode_headers($headers, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-
-        if ($headers === false) {
-            // an error occurs during the decoding
-            return;
-        }
-
-        // normalize header names
-        foreach ($headers as $name => $header) {
-            $lower = strtolower($name);
-            if ($lower == $name) {
-                continue;
-            }
-            unset($headers[$name]);
-            if (!isset($headers[$lower])) {
-                $headers[$lower] = $header;
-                continue;
-            }
-            if (is_array($headers[$lower])) {
-                $headers[$lower][] = $header;
-                continue;
-            }
-            $headers[$lower] = array($headers[$lower], $header);
-        }
+        $headers = Headers::fromString($headers, $EOL);
     }
 
     /**

--- a/library/Zend/Mime/Message.php
+++ b/library/Zend/Mime/Message.php
@@ -237,34 +237,38 @@ class Message
         foreach ($parts as $part) {
             // now we build a new MimePart for the current Message Part:
             $newPart = new Part($part['body']);
-            foreach ($part['header'] as $key => $value) {
+            foreach ($part['header'] as $header) {
+                /** @var \Zend\Mail\Header\HeaderInterface $header */
                 /**
                  * @todo check for characterset and filename
                  */
-                switch(strtolower($key)) {
+
+                $fieldName  = $header->getFieldName();
+                $fieldValue = $header->getFieldValue();
+                switch (strtolower($fieldName)) {
                     case 'content-type':
-                        $newPart->type = $value;
+                        $newPart->type = $fieldValue;
                         break;
                     case 'content-transfer-encoding':
-                        $newPart->encoding = $value;
+                        $newPart->encoding = $fieldValue;
                         break;
                     case 'content-id':
-                        $newPart->id = trim($value,'<>');
+                        $newPart->id = trim($fieldValue,'<>');
                         break;
                     case 'content-disposition':
-                        $newPart->disposition = $value;
+                        $newPart->disposition = $fieldValue;
                         break;
                     case 'content-description':
-                        $newPart->description = $value;
+                        $newPart->description = $fieldValue;
                         break;
                     case 'content-location':
-                        $newPart->location = $value;
+                        $newPart->location = $fieldValue;
                         break;
                     case 'content-language':
-                        $newPart->language = $value;
+                        $newPart->language = $fieldValue;
                         break;
                     default:
-                        throw new Exception\RuntimeException('Unknown header ignored for MimePart:' . $key);
+                        throw new Exception\RuntimeException('Unknown header ignored for MimePart:' . $fieldName);
                 }
             }
             $res->addPart($newPart);

--- a/tests/Zend/Mail/Storage/MessageTest.php
+++ b/tests/Zend/Mail/Storage/MessageTest.php
@@ -243,14 +243,14 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $body   = 'body';
         $newlines = array("\r\n", "\n\r", "\n", "\r");
 
-        $decoded_body   = null; // "Declare" variable before first "read" usage to avoid IDEs warning
-        $decoded_header = null; // "Declare" variable before first "read" usage to avoid IDEs warning
+        $decoded_body    = null; // "Declare" variable before first "read" usage to avoid IDEs warning
+        $decoded_headers = null; // "Declare" variable before first "read" usage to avoid IDEs warning
 
         foreach ($newlines as $contentEOL) {
             foreach ($newlines as $decodeEOL) {
                 $content = $header . $contentEOL . $contentEOL . $body;
-                $decoded = Mime\Decode::splitMessage($content, $decoded_header, $decoded_body, $decodeEOL);
-                $this->assertEquals(array('test' => 'test'), $decoded_header);
+                Mime\Decode::splitMessage($content, $decoded_headers, $decoded_body, $decodeEOL);
+                $this->assertEquals(array('Test' => 'test'), $decoded_headers->toArray());
                 $this->assertEquals($body, $decoded_body);
             }
         }


### PR DESCRIPTION
- Use Zend\Mail\Headers for return the headers in Zend\Mime\Decode
- Allow to each header to set his own encoding from the raw string
- Add a switch to get the field value in Mime-Encoding (for non US-ASCII) or ZF2 Internal (PHP string UTF-8)

[![Build Status](https://secure.travis-ci.org/Maks3w/zf2.png?branch=use-headers-container-in-zend-mime)](http://travis-ci.org/Maks3w/zf2)
