### PR TITLE
[WIP] - Feature/lazy Zend\Di abstract factory

### DIFF
--- a/library/Zend/Mvc/Service/DiFactory.php
+++ b/library/Zend/Mvc/Service/DiFactory.php
@@ -40,30 +40,23 @@ class DiFactory implements FactoryInterface
     /**
      * Create and return abstract factory seeded by dependency injector
      *
-     * Creates and returns an abstract factory seeded by the dependency 
+     * Creates and returns an abstract factory seeded by the dependency
      * injector. If the "di" key of the configuration service is set, that
      * sub-array is passed to a DiConfiguration object and used to configure
-     * the DI instance. The DI instance is then used to seed the 
+     * the DI instance. The DI instance is then used to seed the
      * DiAbstractServiceFactory, which is then registered with the service
      * manager.
-     * 
-     * @param  ServiceLocatorInterface $serviceLocator 
+     *
+     * @param  ServiceLocatorInterface $serviceLocator
      * @return Di
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
+        $config = $serviceLocator->get('Configuration');
         $di     = new Di();
 
-        $config = $serviceLocator->get('Configuration');
         if (isset($config['di'])) {
             $di->configure(new DiConfiguration($config['di']));
-        }
-
-        if ($serviceLocator instanceof ServiceManager) {
-            // register as abstract factory as well:
-            $serviceLocator->addAbstractFactory(
-                new DiAbstractServiceFactory($di, DiAbstractServiceFactory::USE_SL_BEFORE_DI)
-            );
         }
 
         return $di;

--- a/library/Zend/Mvc/Service/LazyDiAbstractFactory.php
+++ b/library/Zend/Mvc/Service/LazyDiAbstractFactory.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage Service
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Mvc\Service;
+
+use Zend\ServiceManager\Di\DiAbstractServiceFactory;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage Service
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class LazyDiAbstractFactory implements AbstractFactoryInterface
+{
+    /**
+     * @var DiAbstractServiceFactory
+     */
+    protected $wrappedDiAbstractFactory;
+
+    /**
+     * Initializes the wrapped $wrappedDiAbstractFactory if not already set
+     * @param ServiceLocatorInterface $serviceLocator
+     */
+    protected function initialize(ServiceLocatorInterface $serviceLocator)
+    {
+        if (null !== $this->wrappedDiAbstractFactory) {
+            return;
+        }
+
+        /* @var $di \Zend\Di\Di */
+        $di = $serviceLocator->get('Di');
+        $this->wrappedDiAbstractFactory = new DiAbstractServiceFactory($di, DiAbstractServiceFactory::USE_SL_BEFORE_DI);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        $this->initialize($serviceLocator);
+        return $this->wrappedDiAbstractFactory->canCreateServiceWithName($serviceLocator, $name, $requestedName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        $this->initialize($serviceLocator);
+        return $this->wrappedDiAbstractFactory->createServiceWithName($serviceLocator, $name, $requestedName);
+    }
+}

--- a/library/Zend/Mvc/Service/LazyDiAbstractFactory.php
+++ b/library/Zend/Mvc/Service/LazyDiAbstractFactory.php
@@ -45,13 +45,11 @@ class LazyDiAbstractFactory implements AbstractFactoryInterface
      */
     protected function initialize(ServiceLocatorInterface $serviceLocator)
     {
-        if (null !== $this->wrappedDiAbstractFactory) {
-            return;
+        if (null === $this->wrappedDiAbstractFactory) {
+            /* @var $di \Zend\Di\Di */
+            $di = $serviceLocator->get('Di');
+            $this->wrappedDiAbstractFactory = new DiAbstractServiceFactory($di, DiAbstractServiceFactory::USE_SL_BEFORE_DI);
         }
-
-        /* @var $di \Zend\Di\Di */
-        $di = $serviceLocator->get('Di');
-        $this->wrappedDiAbstractFactory = new DiAbstractServiceFactory($di, DiAbstractServiceFactory::USE_SL_BEFORE_DI);
     }
 
     /**

--- a/library/Zend/Mvc/Service/ServiceManagerConfiguration.php
+++ b/library/Zend/Mvc/Service/ServiceManagerConfiguration.php
@@ -76,7 +76,9 @@ class ServiceManagerConfiguration implements ConfigurationInterface
      *
      * @var array
      */
-    protected $abstractFactories = array();
+    protected $abstractFactories = array(
+        'LazyDiAbstractFactory' => 'Zend\Mvc\Service\LazyDiAbstractFactory',
+    );
 
     /**
      * Aliases

--- a/tests/Zend/Mvc/Service/LazyDiAbstractFactoryTest.php
+++ b/tests/Zend/Mvc/Service/LazyDiAbstractFactoryTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Mvc\Service;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use stdClass;
+use Zend\Mvc\Service\LazyDiAbstractFactory;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class LazyDiAbstractFactoryTest extends TestCase
+{
+    public function testCreateServiceWithName()
+    {
+        $serviceLocator = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $serviceLocator
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('Di'))
+            ->will($this->returnValue($this->getMock('Zend\Di\Di')));
+        $serviceLocator
+            ->expects($this->once())
+            ->method('has')
+            ->will($this->returnValue(false));
+        $factory = new LazyDiAbstractFactory();
+        $instance = $factory->createServiceWithName($serviceLocator, 'stdClass', 'stdClass');
+        $this->assertInstanceOf('stdClass', $instance);
+    }
+
+    public function testCanCreateServiceWithName()
+    {
+        $serviceLocator = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $serviceLocator
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('Di'))
+            ->will($this->returnValue($this->getMock('Zend\Di\Di')));
+        $factory = new LazyDiAbstractFactory();
+        $this->assertFalse(
+            $factory->canCreateServiceWithName(
+                $serviceLocator,
+                __NAMESPACE__ . '\Non\Existing',
+                __NAMESPACE__ . '\Non\Existing'
+            )
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a new Di lazy abstract factory, which can be implemented thanks to the changes in zendframework/zf2#1698 and zendframework/zf2#1709.

The travis build will most probably fail because of the maximum nesting level of 100 reached, but once zendframework/zf2#1709 is merged this PR can be rebased on it. 

Each service that couldn't be instantiated by the `ServiceManager` will now go through this abstract factory instead of the previous weird behaviour that required the user to manually call `$sm->get('Di');` to have a `DiAbstractFactory` configured and attached to `ServiceManager` itself.

Also, calling `$sm->get('Di');` won't initialize the abstract Di factory anymore.

Performance will still be OK until the end user doesn't request a service that requires Di.
Also, the `Di` based initializers in `ControllerLoaderFactory` ( see https://github.com/zendframework/zf2/blob/master/library/Zend/Mvc/Service/ControllerLoaderFactory.php#L61 ) shouldn't be needed anymore.

[![Build Status](https://secure.travis-ci.org/Ocramius/zf2.png?branch=feature/lazy-abstract-di-factory)](http://travis-ci.org/Ocramius/zf2)

Update - merging #1709 seems to be not enough - need to add more test cases
