### PR TITLE
[Auth] Update ResolverInterface with password value

### DIFF
--- a/library/Zend/Authentication/Adapter/Http.php
+++ b/library/Zend/Authentication/Adapter/Http.php
@@ -497,9 +497,11 @@ class Http implements AdapterInterface
         }
 
         $result = $this->_basicResolver->resolve($creds[0], $this->_realm, $creds[1]);
-        if ($result &&
-            !is_array($result) &&
-            $this->_secureStringCompare($result, $creds[1])) {
+        
+        if ($result
+            && !is_array($result)
+            && $this->_secureStringCompare($result, $creds[1])
+        ) {
             $identity = array('username'=>$creds[0], 'realm'=>$this->_realm);
             return new Authentication\Result(Authentication\Result::SUCCESS, $identity);
         } elseif (is_array($result)) {
@@ -555,7 +557,7 @@ class Http implements AdapterInterface
         // This makes no assumptions about how the password hash was
         // constructed beyond that it must have been built in such a way as
         // to be recreatable with the current settings of this object.
-        $ha1 = $this->_digestResolver->resolve($data['username'], $data['realm'], null);
+        $ha1 = $this->_digestResolver->resolve($data['username'], $data['realm']);
         if ($ha1 === false) {
             return $this->_challengeClient();
         }

--- a/library/Zend/Authentication/Adapter/Http.php
+++ b/library/Zend/Authentication/Adapter/Http.php
@@ -496,14 +496,17 @@ class Http implements AdapterInterface
             return $this->_challengeClient();
         }
 
-        $password = $this->_basicResolver->resolve($creds[0], $this->_realm);
-        if ($password && 
-            $this->_secureStringCompare($password, $creds[1])) {
+        $result = $this->_basicResolver->resolve($creds[0], $this->_realm, $creds[1]);
+        if ($result &&
+            !is_array($result) &&
+            $this->_secureStringCompare($result, $creds[1])) {
             $identity = array('username'=>$creds[0], 'realm'=>$this->_realm);
             return new Authentication\Result(Authentication\Result::SUCCESS, $identity);
-        } else {
-            return $this->_challengeClient();
+        } elseif (is_array($result)) {
+            return new Authentication\Result(Authentication\Result::SUCCESS, $result);
         }
+
+        return $this->_challengeClient();
     }
 
     /**
@@ -552,7 +555,7 @@ class Http implements AdapterInterface
         // This makes no assumptions about how the password hash was
         // constructed beyond that it must have been built in such a way as
         // to be recreatable with the current settings of this object.
-        $ha1 = $this->_digestResolver->resolve($data['username'], $data['realm']);
+        $ha1 = $this->_digestResolver->resolve($data['username'], $data['realm'], null);
         if ($ha1 === false) {
             return $this->_challengeClient();
         }

--- a/library/Zend/Authentication/Adapter/Http/FileResolver.php
+++ b/library/Zend/Authentication/Adapter/Http/FileResolver.php
@@ -99,7 +99,7 @@ class FileResolver implements ResolverInterface
      *         realm, false otherwise.
      * @throws Exception\ExceptionInterface
      */
-    public function resolve($username, $realm)
+    public function resolve($username, $realm, $password = null)
     {
         if (empty($username)) {
             throw new Exception\InvalidArgumentException('Username is required');

--- a/library/Zend/Authentication/Adapter/Http/ResolverInterface.php
+++ b/library/Zend/Authentication/Adapter/Http/ResolverInterface.php
@@ -40,8 +40,9 @@ interface ResolverInterface
      *
      * @param  string $username Username
      * @param  string $realm    Authentication Realm
-     * @return string|false User's shared secret, if the user is found in the
-     *         realm, false otherwise.
+     * @param  string $password Password
+     * @return string|array|false User's shared secret as string if found in realm, or User's identity as array
+     *         if resolved, false otherwise.
      */
-    public function resolve($username, $realm);
+    public function resolve($username, $realm, $password);
 }

--- a/library/Zend/Authentication/Adapter/Http/ResolverInterface.php
+++ b/library/Zend/Authentication/Adapter/Http/ResolverInterface.php
@@ -40,9 +40,9 @@ interface ResolverInterface
      *
      * @param  string $username Username
      * @param  string $realm    Authentication Realm
-     * @param  string $password Password
+     * @param  string $password Password (optional)
      * @return string|array|false User's shared secret as string if found in realm, or User's identity as array
      *         if resolved, false otherwise.
      */
-    public function resolve($username, $realm, $password);
+    public function resolve($username, $realm, $password = null);
 }


### PR DESCRIPTION
This PR allows a user to create a custom HTTP Resolver Adapter that uses the password sent by the client and optionally returning an identity object.

This is especially useful in the case that passwords are stored using advanced encryption, such as BCrypt where the origin password is needed in order to retrieve an identity object to return.

[![Build Status](https://secure.travis-ci.org/davidwindell/zf2.png?branch=feature-http-auth-improvements)](http://travis-ci.org/davidwindell/zf2)
