### PR TITLE
ZF2-385: Fix problem for predicates containing %

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -236,7 +236,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $predicate($this->where);
         } else {
             if (is_string($predicate)) {
-                $predicate = new Predicate\Expression($predicate);
+                $predicate = new Predicate\Expression(str_replace('%', '%%',$predicate));
                 $this->where->addPredicate($predicate, $combination);
             } elseif (is_array($predicate)) {
                 foreach ($predicate as $pkey => $pvalue) {


### PR DESCRIPTION
As the queries are built using sprintf format - having a where with a %
character is treated as an escape.  This "escapes" the escape -
replacing %'s as %% to print a single %;
