### PR TITLE
DB session handling: DbTableGateway, fix for wrong calling destroy()  method

### DIFF
--- a/library/Zend/Session/SaveHandler/DbTableGateway.php
+++ b/library/Zend/Session/SaveHandler/DbTableGateway.php
@@ -123,7 +123,7 @@ class DbTableGateway implements SaveHandlerInterface
                 $row->{$this->options->getLifetimeColumn()} > time()) {
                 return $row->{$this->options->getDataColumn()};
             }
-            $this->destroy();
+            $this->destroy($id);
         }
         return '';
     }


### PR DESCRIPTION
DB session handling: DbTableGateway, fix for calling destroy() without arguments, this resulted in an error when session has timeout and we tried read session data
