### PR TITLE
View helper / controller plugin managers should not peer with main SM

### DIFF
--- a/library/Zend/Mvc/Service/ControllerPluginManagerFactory.php
+++ b/library/Zend/Mvc/Service/ControllerPluginManagerFactory.php
@@ -47,11 +47,7 @@ class ControllerPluginManagerFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $plugins = new ControllerPluginManager();
-
-        if ($serviceLocator instanceof ServiceManager) {
-            $plugins->addPeeringServiceManager($serviceLocator);
-        }
-
+        $plugins->setServiceLocator($serviceLocator);
         return $plugins;
     }
 }

--- a/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
+++ b/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
@@ -57,7 +57,8 @@ class ViewHelperManagerFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $plugins = new ViewHelperManager(null, $serviceLocator);
+        $plugins = new ViewHelperManager();
+        $plugins->setServiceLocator($serviceLocator);
 
         foreach ($this->defaultHelperMapClasses as $configClass) {
             if (is_string($configClass) && class_exists($configClass)) {
@@ -115,10 +116,6 @@ class ViewHelperManagerFactory implements FactoryInterface
             }
             return $doctypeHelper;
         });
-
-        if ($serviceLocator instanceof ServiceManager) {
-            $plugins->addPeeringServiceManager($serviceLocator);
-        }
 
         return $plugins;
     }

--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -37,7 +37,7 @@ use Zend\Code\Reflection\ClassReflection;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class AbstractPluginManager extends ServiceManager
+abstract class AbstractPluginManager extends ServiceManager implements ServiceLocatorAwareInterface
 {
     /**
      * Allow overriding by default
@@ -52,11 +52,11 @@ abstract class AbstractPluginManager extends ServiceManager
     protected $creationOptions = null;
 
     /**
-     * Enable this by default to allow overriding the default plugins
+     * The main service locator
      *
-     * @var bool
+     * @var ServiceLocatorInterface
      */
-    protected $retrieveFromPeeringManagerFirst = true;
+    protected $serviceLocator;
 
     /**
      * Constructor
@@ -135,6 +135,28 @@ abstract class AbstractPluginManager extends ServiceManager
         }
         parent::setService($name, $service, $shared);
         return $this;
+    }
+
+    /**
+     * Set the main service locator so factories can have access to it to pull deps
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return AbstractPluginManager
+     */
+    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+        return $this;
+    }
+
+    /**
+     * Get the main plugin manager. Useful for fetching dependencies from within factories.
+     *
+     * @return mixed
+     */
+    public function getServiceLocator()
+    {
+        return $this->serviceLocator;
     }
 
     /**


### PR DESCRIPTION
Added getter/setter for the main ServiceManager in the
AbstractPluginManager so that factories can still have access to the
main SM if needed.
