### PR TITLE
Update FlashMessenger controller plugin to extend AbstractPlugin

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/FlashMessenger.php
+++ b/library/Zend/Mvc/Controller/Plugin/FlashMessenger.php
@@ -38,7 +38,7 @@ use Zend\Stdlib\SplQueue;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class FlashMessenger implements IteratorAggregate, Countable
+class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Countable
 {
     /**
      * @var Container


### PR DESCRIPTION
When using FlashMesenger plugin the following exception is raised:

```
Plugin of type Zend\Mvc\Controller\Plugin\FlashMessenger is invalid; must implement Zend\Mvc\Controller\Plugin\PluginInterface
```

Fixed by updating FlashMessenger to extend AbstractPlugin
