### PR TITLE
Hotfix/unittest view windows

### DIFF
--- a/library/Zend/View/Helper/AbstractHtmlElement.php
+++ b/library/Zend/View/Helper/AbstractHtmlElement.php
@@ -33,7 +33,7 @@ abstract class AbstractHtmlElement extends AbstractHelper
     /**
      * EOL character
      */
-    const EOL = "\n";
+    const EOL = PHP_EOL;
 
     /**
      * The tag closing bracket

--- a/library/Zend/View/Helper/HtmlList.php
+++ b/library/Zend/View/Helper/HtmlList.php
@@ -52,8 +52,9 @@ class HtmlList extends FormElement
                 }
                 $list .= '<li>' . $item . '</li>' . self::EOL;
             } else {
-                if (6 < strlen($list)) {
-                    $list = substr($list, 0, strlen($list) - 6)
+                $itemLength = 5 + strlen(self::EOL);
+                if ($itemLength < strlen($list)) {
+                    $list = substr($list, 0, strlen($list) - $itemLength)
                      . $this($item, $ordered, $attribs, $escape) . '</li>' . self::EOL;
                 } else {
                     $list .= '<li>' . $this($item, $ordered, $attribs, $escape) . '</li>' . self::EOL;

--- a/library/Zend/View/Helper/Navigation/Sitemap.php
+++ b/library/Zend/View/Helper/Navigation/Sitemap.php
@@ -448,7 +448,7 @@ class Sitemap extends AbstractHelper
                $dom->saveXML() :
                $dom->saveXML($dom->documentElement);
 
-        // Replace all new line characters with the correct system EOL character. This is needed
+        // DOMDocument ends lines with a "\n" character. We want this to be the PHP_EOL character
         // in order to keep unit tests working.
         return str_replace("\n", PHP_EOL, rtrim($xml, PHP_EOL) );
     }

--- a/library/Zend/View/Helper/Navigation/Sitemap.php
+++ b/library/Zend/View/Helper/Navigation/Sitemap.php
@@ -448,6 +448,8 @@ class Sitemap extends AbstractHelper
                $dom->saveXML() :
                $dom->saveXML($dom->documentElement);
 
-        return rtrim($xml, PHP_EOL);
+        // Replace all new line characters with the correct system EOL character. This is needed
+        // in order to keep unit tests working.
+        return str_replace("\n", PHP_EOL, rtrim($xml, PHP_EOL) );
     }
 }

--- a/tests/Zend/View/Helper/Navigation/SitemapTest.php
+++ b/tests/Zend/View/Helper/Navigation/SitemapTest.php
@@ -231,7 +231,9 @@ class SitemapTest extends AbstractTest
         $this->_helper->setServerUrl('http://sub.example.org');
 
         $expected = $this->_getExpected('sitemap/serverurl1.xml');
-        $this->assertEquals($expected, $this->_helper->render());
+        $got = str_replace("\n", PHP_EOL, $this->_helper->render());
+        
+        $this->assertEquals($expected, $got);
     }
 
     public function testSetServerUrlWithSchemeAndPortAndHostAndPath()

--- a/tests/Zend/View/Helper/Navigation/SitemapTest.php
+++ b/tests/Zend/View/Helper/Navigation/SitemapTest.php
@@ -211,7 +211,9 @@ class SitemapTest extends AbstractTest
         $this->_helper->setUseSitemapValidators(false);
 
         $expected = $this->_getExpected('sitemap/invalid.xml');
-        $this->assertEquals($expected, $this->_helper->render($nav));
+        $got = str_replace("\n", PHP_EOL, $this->_helper->render($nav));
+        
+        $this->assertEquals($expected, $got);
     }
 
     public function testSetServerUrlRequiresValidUri()

--- a/tests/Zend/View/Helper/Navigation/SitemapTest.php
+++ b/tests/Zend/View/Helper/Navigation/SitemapTest.php
@@ -139,9 +139,7 @@ class SitemapTest extends AbstractTest
         $this->_helper->setRole($acl['role']);
 
         $expected = $this->_getExpected('sitemap/acl.xml');
-        $got = str_replace("\n", PHP_EOL, $this->_helper->render());
-        
-        $this->assertEquals($expected, $got);
+        $this->assertEquals($expected, $this->_helper->render());
     }
 
     public function testUseAclButNoRole()
@@ -151,9 +149,7 @@ class SitemapTest extends AbstractTest
         $this->_helper->setRole(null);
 
         $expected = $this->_getExpected('sitemap/acl2.xml');
-        $got = str_replace("\n", PHP_EOL, $this->_helper->render());
-        
-        $this->assertEquals($expected, $got);
+        $this->assertEquals($expected, $this->_helper->render());
     }
 
     public function testSettingMaxDepth()
@@ -161,9 +157,7 @@ class SitemapTest extends AbstractTest
         $this->_helper->setMaxDepth(0);
 
         $expected = $this->_getExpected('sitemap/depth1.xml');
-        $got = str_replace("\n", PHP_EOL, $this->_helper->render());
-        
-        $this->assertEquals($expected, $got);
+        $this->assertEquals($expected, $this->_helper->render());
     }
 
     public function testSettingMinDepth()
@@ -171,9 +165,7 @@ class SitemapTest extends AbstractTest
         $this->_helper->setMinDepth(1);
 
         $expected = $this->_getExpected('sitemap/depth2.xml');
-        $got = str_replace("\n", PHP_EOL, $this->_helper->render());
-        
-        $this->assertEquals($expected, $got);
+        $this->assertEquals($expected, $this->_helper->render());
     }
 
     public function testSettingBothDepths()
@@ -181,9 +173,7 @@ class SitemapTest extends AbstractTest
         $this->_helper->setMinDepth(1)->setMaxDepth(2);
 
         $expected = $this->_getExpected('sitemap/depth3.xml');
-        $got = str_replace("\n", PHP_EOL, $this->_helper->render());
-        
-        $this->assertEquals($expected, $got);
+        $this->assertEquals($expected, $this->_helper->render());
     }
 
     public function testDropXmlDeclaration()
@@ -191,9 +181,7 @@ class SitemapTest extends AbstractTest
         $this->_helper->setUseXmlDeclaration(false);
 
         $expected = $this->_getExpected('sitemap/nodecl.xml');
-        $got = str_replace("\n", PHP_EOL, $this->_helper->render($this->_nav2));
-        
-        $this->assertEquals($expected, $got);
+        $this->assertEquals($expected, $this->_helper->render($this->_nav2));
     }
 
     public function testThrowExceptionOnInvalidLoc()
@@ -223,9 +211,7 @@ class SitemapTest extends AbstractTest
         $this->_helper->setUseSitemapValidators(false);
 
         $expected = $this->_getExpected('sitemap/invalid.xml');
-        $got = str_replace("\n", PHP_EOL, $this->_helper->render($nav));
-        
-        $this->assertEquals($expected, $got);
+        $this->assertEquals($expected, $this->_helper->render($nav));
     }
 
     public function testSetServerUrlRequiresValidUri()
@@ -245,9 +231,7 @@ class SitemapTest extends AbstractTest
         $this->_helper->setServerUrl('http://sub.example.org');
 
         $expected = $this->_getExpected('sitemap/serverurl1.xml');
-        $got = str_replace("\n", PHP_EOL, $this->_helper->render());
-        
-        $this->assertEquals($expected, $got);
+        $this->assertEquals($expected, $this->_helper->render());
     }
 
     public function testSetServerUrlWithSchemeAndPortAndHostAndPath()
@@ -255,9 +239,7 @@ class SitemapTest extends AbstractTest
         $this->_helper->setServerUrl('http://sub.example.org:8080/foo/');
 
         $expected = $this->_getExpected('sitemap/serverurl2.xml');
-        $got = str_replace("\n", PHP_EOL, $this->_helper->render());
-        
-        $this->assertEquals($expected, $got);
+        $this->assertEquals($expected, $this->_helper->render());
     }
 
     public function testGetUserSchemaValidation()

--- a/tests/Zend/View/Helper/Navigation/SitemapTest.php
+++ b/tests/Zend/View/Helper/Navigation/SitemapTest.php
@@ -239,7 +239,9 @@ class SitemapTest extends AbstractTest
         $this->_helper->setServerUrl('http://sub.example.org:8080/foo/');
 
         $expected = $this->_getExpected('sitemap/serverurl2.xml');
-        $this->assertEquals($expected, $this->_helper->render());
+        $got = str_replace("\n", PHP_EOL, $this->_helper->render());
+        
+        $this->assertEquals($expected, $got);
     }
 
     public function testGetUserSchemaValidation()

--- a/tests/Zend/View/Helper/Navigation/SitemapTest.php
+++ b/tests/Zend/View/Helper/Navigation/SitemapTest.php
@@ -165,7 +165,9 @@ class SitemapTest extends AbstractTest
         $this->_helper->setMinDepth(1);
 
         $expected = $this->_getExpected('sitemap/depth2.xml');
-        $this->assertEquals($expected, $this->_helper->render());
+        $got = str_replace("\n", PHP_EOL, $this->_helper->render());
+        
+        $this->assertEquals($expected, $got);
     }
 
     public function testSettingBothDepths()

--- a/tests/Zend/View/Helper/Navigation/SitemapTest.php
+++ b/tests/Zend/View/Helper/Navigation/SitemapTest.php
@@ -149,7 +149,9 @@ class SitemapTest extends AbstractTest
         $this->_helper->setRole(null);
 
         $expected = $this->_getExpected('sitemap/acl2.xml');
-        $this->assertEquals($expected, $this->_helper->render());
+        $got = str_replace("\n", PHP_EOL, $this->_helper->render());
+        
+        $this->assertEquals($expected, $got);
     }
 
     public function testSettingMaxDepth()

--- a/tests/Zend/View/Helper/Navigation/SitemapTest.php
+++ b/tests/Zend/View/Helper/Navigation/SitemapTest.php
@@ -173,7 +173,9 @@ class SitemapTest extends AbstractTest
         $this->_helper->setMinDepth(1)->setMaxDepth(2);
 
         $expected = $this->_getExpected('sitemap/depth3.xml');
-        $this->assertEquals($expected, $this->_helper->render());
+        $got = str_replace("\n", PHP_EOL, $this->_helper->render());
+        
+        $this->assertEquals($expected, $got);
     }
 
     public function testDropXmlDeclaration()

--- a/tests/Zend/View/Helper/Navigation/SitemapTest.php
+++ b/tests/Zend/View/Helper/Navigation/SitemapTest.php
@@ -139,7 +139,9 @@ class SitemapTest extends AbstractTest
         $this->_helper->setRole($acl['role']);
 
         $expected = $this->_getExpected('sitemap/acl.xml');
-        $this->assertEquals($expected, $this->_helper->render());
+        $got = str_replace("\n", PHP_EOL, $this->_helper->render());
+        
+        $this->assertEquals($expected, $got);
     }
 
     public function testUseAclButNoRole()

--- a/tests/Zend/View/Helper/Navigation/SitemapTest.php
+++ b/tests/Zend/View/Helper/Navigation/SitemapTest.php
@@ -181,7 +181,9 @@ class SitemapTest extends AbstractTest
         $this->_helper->setUseXmlDeclaration(false);
 
         $expected = $this->_getExpected('sitemap/nodecl.xml');
-        $this->assertEquals($expected, $this->_helper->render($this->_nav2));
+        $got = str_replace("\n", PHP_EOL, $this->_helper->render($this->_nav2));
+        
+        $this->assertEquals($expected, $got);
     }
 
     public function testThrowExceptionOnInvalidLoc()

--- a/tests/Zend/View/Helper/Navigation/SitemapTest.php
+++ b/tests/Zend/View/Helper/Navigation/SitemapTest.php
@@ -157,7 +157,9 @@ class SitemapTest extends AbstractTest
         $this->_helper->setMaxDepth(0);
 
         $expected = $this->_getExpected('sitemap/depth1.xml');
-        $this->assertEquals($expected, $this->_helper->render());
+        $got = str_replace("\n", PHP_EOL, $this->_helper->render());
+        
+        $this->assertEquals($expected, $got);
     }
 
     public function testSettingMinDepth()

--- a/tests/Zend/View/Helper/Navigation/_files/mvc/views/menu.phtml
+++ b/tests/Zend/View/Helper/Navigation/_files/mvc/views/menu.phtml
@@ -9,5 +9,5 @@ foreach ($this->vars('container') as $page) {
 }
 $pages = implode(', ', $pages);
 ?>
-Is a container: <?php echo $isContainer . "\n"; ?>
+Is a container: <?php echo $isContainer . PHP_EOL; ?>
 Pages: <?php echo $pages; ?>

--- a/tests/Zend/View/Helper/RenderChildModelTest.php
+++ b/tests/Zend/View/Helper/RenderChildModelTest.php
@@ -140,7 +140,7 @@ class RenderChildModelTest extends TestCase
         $renderer = new PhpRenderer();
         $renderer->setResolver($this->resolver);
         $this->setExpectedException('Zend\View\Exception\RuntimeException', 'no view model');
-        $this->expectOutputString("Layout start\n\n");
+        $this->expectOutputString("Layout start" . PHP_EOL . PHP_EOL);
         $renderer->render('layout');
     }
 }

--- a/tests/Zend/View/Helper/RenderToPlaceholderTest.php
+++ b/tests/Zend/View/Helper/RenderToPlaceholderTest.php
@@ -48,7 +48,7 @@ class RenderToPlaceholderTest extends \PHPUnit_Framework_TestCase
     {
         $this->_view->plugin('renderToPlaceholder')->__invoke('rendertoplaceholderscript.phtml', 'fooPlaceholder');
         $placeholder = new PlaceholderHelper();
-        $this->assertEquals("Foo Bar\n", $placeholder->__invoke('fooPlaceholder')->getValue());
+        $this->assertEquals("Foo Bar" . PHP_EOL, $placeholder->__invoke('fooPlaceholder')->getValue());
     }
 
 }

--- a/tests/Zend/View/PhpRendererTest.php
+++ b/tests/Zend/View/PhpRendererTest.php
@@ -208,7 +208,7 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
      */
     public function testNestedRenderingRestoresVariablesCorrectly()
     {
-        $expected = "inner\n<p>content</p>";
+        $expected = "inner" . PHP_EOL . "<p>content</p>";
         $this->renderer->resolver()->addPath(__DIR__ . '/_templates');
         $test = $this->renderer->render('testNestedOuter.phtml', array('content' => '<p>content</p>'));
         $this->assertEquals($expected, $test);

--- a/tests/Zend/View/TemplatePathStackTest.php
+++ b/tests/Zend/View/TemplatePathStackTest.php
@@ -238,10 +238,16 @@ class TemplatePathStackTest extends \PHPUnit_Framework_TestCase
 
     public function testAllowsRelativePharPath()
     {
-        $path = 'phar://' . __DIR__ . '/_templates/view.phar/start/../views';
+        $path = 'phar://' . __DIR__ 
+            . DIRECTORY_SEPARATOR . '_templates' 
+            . DIRECTORY_SEPARATOR . 'view.phar' 
+            . DIRECTORY_SEPARATOR . 'start' 
+            . DIRECTORY_SEPARATOR . '..' 
+            . DIRECTORY_SEPARATOR . 'views';
+        
         $this->stack->addPath($path);
-        $test = $this->stack->resolve('foo/hello.phtml');
-        $this->assertEquals($path . '/foo/hello.phtml', $test);
+        $test = $this->stack->resolve('foo' . DIRECTORY_SEPARATOR . 'hello.phtml');
+        $this->assertEquals($path . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR . 'hello.phtml', $test);
     }
 
     public function testDefaultFileSuffixIsPhtml()


### PR DESCRIPTION
The Zend/View unit tests were breaking on Windows machines due to new line and directory separator inconsistencies. I'm not entirely sure the changes I did are the way to go but it fixes the problem.

Please pay attention to the change in library/Zend/View/Helper/Navigation/Sitemap.php
