### PR TITLE
Validation group support for Fieldset and Collection

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -133,27 +133,15 @@ class Collection extends Fieldset
      */
     public function populateValues($data)
     {
-        $count = $this->count;
-
         if ($this->targetElement instanceof FieldsetInterface) {
-            foreach ($data as $key => $value) {
-                if ($count > 0) {
-                    $this->fieldsets[$key]->populateValues($value);
-                    unset($data[$key]);
-
-                }
-
-                $count--;
+            foreach ($this->byName as $name => $fieldset) {
+                $fieldset->populateValues($data[$name]);
+                unset($data[$name]);
             }
         } else {
-            foreach ($data as $key => $value) {
-                if ($count > 0) {
-                    $this->elements[$key]->setAttribute('value', $value);
-                    unset($data[$key]);
-
-                }
-
-                $count--;
+            foreach ($this->byName as $name => $element) {
+                $element->setAttribute('value', $data[$name]);
+                unset($data[$name]);
             }
         }
 

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -105,6 +105,13 @@ class Form extends Fieldset implements FormInterface
     protected $isValid = false;
 
     /**
+     * Is the form prepared ?
+     *
+     * @var bool
+     */
+    protected $isPrepared = false;
+
+    /**
      * Validation group, if any
      *
      * @var null|array
@@ -155,12 +162,16 @@ class Form extends Fieldset implements FormInterface
      */
     public function prepare()
     {
-        $this->getInputFilter();
+        if (!$this->isPrepared) {
+            $this->getInputFilter();
 
-        foreach ($this->getIterator() as $elementOrFieldset) {
-            if ($elementOrFieldset instanceof ElementPrepareAwareInterface) {
-                $elementOrFieldset->prepareElement($this);
+            foreach ($this->getIterator() as $elementOrFieldset) {
+                if ($elementOrFieldset instanceof ElementPrepareAwareInterface) {
+                    $elementOrFieldset->prepareElement($this);
+                }
             }
+
+            $this->isPrepared = true;
         }
     }
 

--- a/library/Zend/Form/View/Helper/FormElementErrors.php
+++ b/library/Zend/Form/View/Helper/FormElementErrors.php
@@ -170,6 +170,10 @@ class FormElementErrors extends AbstractHelper
             $messagesToPrint[] = $escape($item);
         });
 
+        if (empty($messagesToPrint)) {
+            return '';
+        }
+
         // Generate markup
         $markup  = sprintf($this->getMessageOpenFormat(), $attributes);
         $markup .= implode($this->getMessageSeparatorString(), $messagesToPrint);

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -149,7 +149,7 @@ class BaseInputFilter implements InputFilterInterface
         $valid               = true;
         
         $inputs = $this->validationGroup ?: array_keys($this->inputs);
-        var_dump($inputs);
+        //var_dump($inputs);
         foreach ($inputs as $name) {
             $input = $this->inputs[$name]; 
             if (!array_key_exists($name, $this->data) || (is_string($this->data[$name]) && strlen($this->data[$name]) === 0)) {

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -149,6 +149,7 @@ class BaseInputFilter implements InputFilterInterface
         $valid               = true;
         
         $inputs = $this->validationGroup ?: array_keys($this->inputs);
+        var_dump($inputs);
         foreach ($inputs as $name) {
             $input = $this->inputs[$name]; 
             if (!array_key_exists($name, $this->data) || (is_string($this->data[$name]) && strlen($this->data[$name]) === 0)) {
@@ -218,14 +219,30 @@ class BaseInputFilter implements InputFilterInterface
         }
 
         if (is_array($name)) {
-            $this->validateValidationGroup($name);
-            $this->validationGroup = $name;
+            $inputs = array();
+            foreach ($name as $key => $value) {
+                if (!$this->has($key)) {
+                    $inputs[] = $value;
+                } else {
+                    $inputs[] = $key;
+
+                    // Recursively populate validation groups for sub input filters
+                    $this->inputs[$key]->setValidationGroup($value);
+                }
+            }
+
+            if (!empty($inputs)) {
+                $this->validateValidationGroup($inputs);
+                $this->validationGroup = $inputs;
+            }
+
             return $this;
         }
 
         $inputs = func_get_args();
         $this->validateValidationGroup($inputs);
         $this->validationGroup = $inputs;
+
         return $this;
     }
 

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -214,6 +214,26 @@ class FormTest extends TestCase
         $this->assertTrue($this->form->isValid());
     }
 
+    public function testSpecifyingValidationGroupForNestedFieldsetsForcesPartialValidation()
+    {
+        $form = new TestAsset\NewProductForm();
+        $form->setData(array(
+            'product' => array(
+                'name' => 'Chair'
+            )
+        ));
+
+        $this->assertFalse($form->isValid());
+
+        $form->setValidationGroup(array(
+            'product' => array(
+                'name'
+            )
+        ));
+
+        $this->assertTrue($form->isValid());
+    }
+
     public function testSettingValidateAllFlagAfterPartialValidationForcesFullValidation()
     {
         $this->populateForm();


### PR DESCRIPTION
This is the last PR for Form for beta 5.

Basically, it extends validation groups for Collection and Fieldsets (it also works when elements in collection are added on the fly).

The usage is quite simple. In the form, just do :

$this->setValidationGroup('username', 'profile' => array('facebook'));

This will only validate username, and the 'facebook' input in the profile nested fieldset.

I have added some code to make it working (it was not that trivial...), if someone wants to review the code where we can optimize/simplify things, feel free to do it ;-) !
