### PR TITLE
Zend\Escaper integration into Zend\View (BC break since Escape helper is now EscapeHtml)

### DIFF
--- a/library/Zend/View/Helper/EscapeCss.php
+++ b/library/Zend/View/Helper/EscapeCss.php
@@ -34,54 +34,16 @@ use Zend\View\Exception;
  */
 class EscapeCss extends Escaper\AbstractHelper
 {
-    /**@+
-     * @const Recursion constants
-     */
-    const RECURSE_NONE   = 0x00;
-    const RECURSE_ARRAY  = 0x01;
-    const RECURSE_OBJECT = 0x02;
-    /**@-*/
-
+    
     /**
-     * Invoke this helper: escape a value
-     * 
-     * @param  mixed $value 
-     * @param  int $recurse Expects one of the recursion constants; used to decide whether or not to recurse the given value when escaping
-     * @return mixed Given a scalar, a scalar value is returned. Given an object, with the $recurse flag not allowing object recursion, returns a string. Otherwise, returns an array.
-     * @throws Exception\InvalidArgumentException
+     * Escape a value for current escaping strategy
+     *
+     * @param string $value
+     * @return string
      */
-    public function __invoke($value, $recurse = self::RECURSE_NONE)
+    protected function escape($value)
     {
-        if (is_string($value)) {
-            return $this->getEscaper()->escapeCss($value);
-        }
-        if (is_array($value)) {
-            if (!(self::RECURSE_ARRAY & $recurse)) {
-                throw new Exception\InvalidArgumentException(
-                    'Array provided to Escape helper, but flags do not allow recursion'
-                );
-            }
-            foreach ($value as $k => $v) {
-                $value[$k] = $this->__invoke($v, $recurse);
-            }
-            return $value;
-        }
-        if (is_object($value)) {
-            if (!(self::RECURSE_OBJECT & $recurse)) {
-                // Attempt to cast it to a string
-                if (method_exists($value, '__toString')) {
-                    return $this->getEscaper()->escapeCss((string) $value);
-                }
-                throw new Exception\InvalidArgumentException(
-                    'Object provided to Escape helper, but flags do not allow recursion'
-                );
-            }
-            if (method_exists($value, 'toArray')) {
-                return $this->__invoke($value->toArray(), $recurse | self::RECURSE_ARRAY);
-            }
-            return $this->__invoke((array) $value, $recurse | self::RECURSE_ARRAY);
-        }
-        // At this point, we have a scalar; simply return it
-        return $value;
+        return $this->getEscaper()->escapeCss($value);
     }
+    
 }

--- a/library/Zend/View/Helper/EscapeHtml.php
+++ b/library/Zend/View/Helper/EscapeHtml.php
@@ -34,54 +34,16 @@ use Zend\View\Exception;
  */
 class EscapeHtml extends Escaper\AbstractHelper
 {
-    /**@+
-     * @const Recursion constants
-     */
-    const RECURSE_NONE   = 0x00;
-    const RECURSE_ARRAY  = 0x01;
-    const RECURSE_OBJECT = 0x02;
-    /**@-*/
-
+    
     /**
-     * Invoke this helper: escape a value
-     * 
-     * @param  mixed $value 
-     * @param  int $recurse Expects one of the recursion constants; used to decide whether or not to recurse the given value when escaping
-     * @return mixed Given a scalar, a scalar value is returned. Given an object, with the $recurse flag not allowing object recursion, returns a string. Otherwise, returns an array.
-     * @throws Exception\InvalidArgumentException
+     * Escape a value for current escaping strategy
+     *
+     * @param string $value
+     * @return string
      */
-    public function __invoke($value, $recurse = self::RECURSE_NONE)
+    protected function escape($value)
     {
-        if (is_string($value)) {
-            return $this->getEscaper()->escapeHtml($value);
-        }
-        if (is_array($value)) {
-            if (!(self::RECURSE_ARRAY & $recurse)) {
-                throw new Exception\InvalidArgumentException(
-                    'Array provided to Escape helper, but flags do not allow recursion'
-                );
-            }
-            foreach ($value as $k => $v) {
-                $value[$k] = $this->__invoke($v, $recurse);
-            }
-            return $value;
-        }
-        if (is_object($value)) {
-            if (!(self::RECURSE_OBJECT & $recurse)) {
-                // Attempt to cast it to a string
-                if (method_exists($value, '__toString')) {
-                    return $this->getEscaper()->escapeHtml((string) $value);
-                }
-                throw new Exception\InvalidArgumentException(
-                    'Object provided to Escape helper, but flags do not allow recursion'
-                );
-            }
-            if (method_exists($value, 'toArray')) {
-                return $this->__invoke($value->toArray(), $recurse | self::RECURSE_ARRAY);
-            }
-            return $this->__invoke((array) $value, $recurse | self::RECURSE_ARRAY);
-        }
-        // At this point, we have a scalar; simply return it
-        return $value;
+        return $this->getEscaper()->escapeHtml($value);
     }
+
 }

--- a/library/Zend/View/Helper/EscapeHtmlAttr.php
+++ b/library/Zend/View/Helper/EscapeHtmlAttr.php
@@ -34,54 +34,16 @@ use Zend\View\Exception;
  */
 class EscapeHtmlAttr extends Escaper\AbstractHelper
 {
-    /**@+
-     * @const Recursion constants
-     */
-    const RECURSE_NONE   = 0x00;
-    const RECURSE_ARRAY  = 0x01;
-    const RECURSE_OBJECT = 0x02;
-    /**@-*/
-
+    
     /**
-     * Invoke this helper: escape a value
-     * 
-     * @param  mixed $value 
-     * @param  int $recurse Expects one of the recursion constants; used to decide whether or not to recurse the given value when escaping
-     * @return mixed Given a scalar, a scalar value is returned. Given an object, with the $recurse flag not allowing object recursion, returns a string. Otherwise, returns an array.
-     * @throws Exception\InvalidArgumentException
+     * Escape a value for current escaping strategy
+     *
+     * @param string $value
+     * @return string
      */
-    public function __invoke($value, $recurse = self::RECURSE_NONE)
+    protected function escape($value)
     {
-        if (is_string($value)) {
-            return $this->getEscaper()->escapeHtmlAttr($value);
-        }
-        if (is_array($value)) {
-            if (!(self::RECURSE_ARRAY & $recurse)) {
-                throw new Exception\InvalidArgumentException(
-                    'Array provided to Escape helper, but flags do not allow recursion'
-                );
-            }
-            foreach ($value as $k => $v) {
-                $value[$k] = $this->__invoke($v, $recurse);
-            }
-            return $value;
-        }
-        if (is_object($value)) {
-            if (!(self::RECURSE_OBJECT & $recurse)) {
-                // Attempt to cast it to a string
-                if (method_exists($value, '__toString')) {
-                    return $this->getEscaper()->escapeHtmlAttr((string) $value);
-                }
-                throw new Exception\InvalidArgumentException(
-                    'Object provided to Escape helper, but flags do not allow recursion'
-                );
-            }
-            if (method_exists($value, 'toArray')) {
-                return $this->__invoke($value->toArray(), $recurse | self::RECURSE_ARRAY);
-            }
-            return $this->__invoke((array) $value, $recurse | self::RECURSE_ARRAY);
-        }
-        // At this point, we have a scalar; simply return it
-        return $value;
+        return $this->getEscaper()->escapeHtmlAttr($value);
     }
+
 }

--- a/library/Zend/View/Helper/EscapeHtmlAttr.php
+++ b/library/Zend/View/Helper/EscapeHtmlAttr.php
@@ -32,7 +32,7 @@ use Zend\View\Exception;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class EscapeCss extends Escaper\AbstractHelper
+class EscapeHtmlAttr extends Escaper\AbstractHelper
 {
     /**@+
      * @const Recursion constants

--- a/library/Zend/View/Helper/EscapeJs.php
+++ b/library/Zend/View/Helper/EscapeJs.php
@@ -34,54 +34,16 @@ use Zend\View\Exception;
  */
 class EscapeJs extends Escaper\AbstractHelper
 {
-    /**@+
-     * @const Recursion constants
-     */
-    const RECURSE_NONE   = 0x00;
-    const RECURSE_ARRAY  = 0x01;
-    const RECURSE_OBJECT = 0x02;
-    /**@-*/
-
+    
     /**
-     * Invoke this helper: escape a value
-     * 
-     * @param  mixed $value 
-     * @param  int $recurse Expects one of the recursion constants; used to decide whether or not to recurse the given value when escaping
-     * @return mixed Given a scalar, a scalar value is returned. Given an object, with the $recurse flag not allowing object recursion, returns a string. Otherwise, returns an array.
-     * @throws Exception\InvalidArgumentException
+     * Escape a value for current escaping strategy
+     *
+     * @param string $value
+     * @return string
      */
-    public function __invoke($value, $recurse = self::RECURSE_NONE)
+    protected function escape($value)
     {
-        if (is_string($value)) {
-            return $this->getEscaper()->escapeJs($value);
-        }
-        if (is_array($value)) {
-            if (!(self::RECURSE_ARRAY & $recurse)) {
-                throw new Exception\InvalidArgumentException(
-                    'Array provided to Escape helper, but flags do not allow recursion'
-                );
-            }
-            foreach ($value as $k => $v) {
-                $value[$k] = $this->__invoke($v, $recurse);
-            }
-            return $value;
-        }
-        if (is_object($value)) {
-            if (!(self::RECURSE_OBJECT & $recurse)) {
-                // Attempt to cast it to a string
-                if (method_exists($value, '__toString')) {
-                    return $this->getEscaper()->escapeJs((string) $value);
-                }
-                throw new Exception\InvalidArgumentException(
-                    'Object provided to Escape helper, but flags do not allow recursion'
-                );
-            }
-            if (method_exists($value, 'toArray')) {
-                return $this->__invoke($value->toArray(), $recurse | self::RECURSE_ARRAY);
-            }
-            return $this->__invoke((array) $value, $recurse | self::RECURSE_ARRAY);
-        }
-        // At this point, we have a scalar; simply return it
-        return $value;
+        return $this->getEscaper()->escapeJs($value);
     }
+
 }

--- a/library/Zend/View/Helper/EscapeUrl.php
+++ b/library/Zend/View/Helper/EscapeUrl.php
@@ -32,7 +32,7 @@ use Zend\View\Exception;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class EscapeCss extends Escaper\AbstractHelper
+class EscapeUrl extends Escaper\AbstractHelper
 {
     /**@+
      * @const Recursion constants

--- a/library/Zend/View/Helper/EscapeUrl.php
+++ b/library/Zend/View/Helper/EscapeUrl.php
@@ -34,54 +34,16 @@ use Zend\View\Exception;
  */
 class EscapeUrl extends Escaper\AbstractHelper
 {
-    /**@+
-     * @const Recursion constants
-     */
-    const RECURSE_NONE   = 0x00;
-    const RECURSE_ARRAY  = 0x01;
-    const RECURSE_OBJECT = 0x02;
-    /**@-*/
-
+    
     /**
-     * Invoke this helper: escape a value
-     * 
-     * @param  mixed $value 
-     * @param  int $recurse Expects one of the recursion constants; used to decide whether or not to recurse the given value when escaping
-     * @return mixed Given a scalar, a scalar value is returned. Given an object, with the $recurse flag not allowing object recursion, returns a string. Otherwise, returns an array.
-     * @throws Exception\InvalidArgumentException
+     * Escape a value for current escaping strategy
+     *
+     * @param string $value
+     * @return string
      */
-    public function __invoke($value, $recurse = self::RECURSE_NONE)
+    protected function escape($value)
     {
-        if (is_string($value)) {
-            return $this->getEscaper()->escapeUrl($value);
-        }
-        if (is_array($value)) {
-            if (!(self::RECURSE_ARRAY & $recurse)) {
-                throw new Exception\InvalidArgumentException(
-                    'Array provided to Escape helper, but flags do not allow recursion'
-                );
-            }
-            foreach ($value as $k => $v) {
-                $value[$k] = $this->__invoke($v, $recurse);
-            }
-            return $value;
-        }
-        if (is_object($value)) {
-            if (!(self::RECURSE_OBJECT & $recurse)) {
-                // Attempt to cast it to a string
-                if (method_exists($value, '__toString')) {
-                    return $this->getEscaper()->escapeUrl((string) $value);
-                }
-                throw new Exception\InvalidArgumentException(
-                    'Object provided to Escape helper, but flags do not allow recursion'
-                );
-            }
-            if (method_exists($value, 'toArray')) {
-                return $this->__invoke($value->toArray(), $recurse | self::RECURSE_ARRAY);
-            }
-            return $this->__invoke((array) $value, $recurse | self::RECURSE_ARRAY);
-        }
-        // At this point, we have a scalar; simply return it
-        return $value;
+        return $this->getEscaper()->escapeUrl($value);
     }
+
 }

--- a/library/Zend/View/Helper/Escaper/AbstractHelper.php
+++ b/library/Zend/View/Helper/Escaper/AbstractHelper.php
@@ -36,32 +36,32 @@ use Zend\Escaper;
 abstract class AbstractHelper extends Helper\AbstractHelper
 {
 
-	/**
-	 * @var Escaper\Escaper
-	 */
-	protected $escaper = null;
+    /**
+     * @var Escaper\Escaper
+     */
+    protected $escaper = null;
 
-	/**
+    /**
      * @var string Encoding
      */
     protected $encoding = 'UTF-8';
 
-	public function setEscaper(Escaper\Escaper $escaper)
-	{
-		$this->escaper = $escaper;
-		$this->encoding = $escaper->getEncoding();
-		return $this;
-	}
+    public function setEscaper(Escaper\Escaper $escaper)
+    {
+        $this->escaper = $escaper;
+        $this->encoding = $escaper->getEncoding();
+        return $this;
+    }
 
-	public function getEscaper()
-	{
-		if (null === $this->escaper) {
-			$this->setEscaper(new Escaper\Escaper($this->getEncoding()));
-		}
-		return $this->escaper;
-	}
+    public function getEscaper()
+    {
+        if (null === $this->escaper) {
+            $this->setEscaper(new Escaper\Escaper($this->getEncoding()));
+        }
+        return $this->escaper;
+    }
 
-	/**
+    /**
      * Set the encoding to use for escape operations
      * 
      * @param  string $encoding 
@@ -69,12 +69,12 @@ abstract class AbstractHelper extends Helper\AbstractHelper
      */
     public function setEncoding($encoding)
     {
-    	if (!is_null($this->escaper)) {
-    		throw new Exception\InvalidArgumentException(
-    			'Encoding cannot be changed once a Zend\Escaper\Escaper object has been'
-    			. ' instantiated by or injected into this Helper.'
-    		);
-    	}
+        if (!is_null($this->escaper)) {
+            throw new Exception\InvalidArgumentException(
+                'Encoding cannot be changed once a Zend\Escaper\Escaper object has been'
+                . ' instantiated by or injected into this Helper.'
+            );
+        }
         $this->encoding = $encoding;
         return $this;
     }

--- a/library/Zend/View/Helper/Escaper/AbstractHelper.php
+++ b/library/Zend/View/Helper/Escaper/AbstractHelper.php
@@ -71,8 +71,8 @@ abstract class AbstractHelper extends Helper\AbstractHelper
     {
         if (!is_null($this->escaper)) {
             throw new Exception\InvalidArgumentException(
-                'Encoding cannot be changed once a Zend\Escaper\Escaper object has been'
-                . ' instantiated by or injected into this Helper.'
+                'Character encoding settings cannot be changed once the Helper has been used or '
+                . ' if a Zend\Escaper\Escaper object (with preset encoding option) is set.'
             );
         }
         $this->encoding = $encoding;

--- a/library/Zend/View/Helper/Escaper/AbstractHelper.php
+++ b/library/Zend/View/Helper/Escaper/AbstractHelper.php
@@ -36,6 +36,14 @@ use Zend\Escaper;
 abstract class AbstractHelper extends Helper\AbstractHelper
 {
 
+    /**@+
+     * @const Recursion constants
+     */
+    const RECURSE_NONE   = 0x00;
+    const RECURSE_ARRAY  = 0x01;
+    const RECURSE_OBJECT = 0x02;
+    /**@-*/
+
     /**
      * @var Escaper\Escaper
      */
@@ -88,5 +96,56 @@ abstract class AbstractHelper extends Helper\AbstractHelper
     {
         return $this->encoding;
     }
+
+    /**
+     * Invoke this helper: escape a value
+     * 
+     * @param  mixed $value 
+     * @param  int $recurse Expects one of the recursion constants; used to decide whether or not to recurse the given value when escaping
+     * @return mixed Given a scalar, a scalar value is returned. Given an object, with the $recurse flag not allowing object recursion, returns a string. Otherwise, returns an array.
+     * @throws Exception\InvalidArgumentException
+     */
+    public function __invoke($value, $recurse = self::RECURSE_NONE)
+    {
+        if (is_string($value)) {
+            return $this->escape($value);
+        }
+        if (is_array($value)) {
+            if (!(self::RECURSE_ARRAY & $recurse)) {
+                throw new Exception\InvalidArgumentException(
+                    'Array provided to Escape helper, but flags do not allow recursion'
+                );
+            }
+            foreach ($value as $k => $v) {
+                $value[$k] = $this->__invoke($v, $recurse);
+            }
+            return $value;
+        }
+        if (is_object($value)) {
+            if (!(self::RECURSE_OBJECT & $recurse)) {
+                // Attempt to cast it to a string
+                if (method_exists($value, '__toString')) {
+                    return $this->escape((string) $value);
+                }
+                throw new Exception\InvalidArgumentException(
+                    'Object provided to Escape helper, but flags do not allow recursion'
+                );
+            }
+            if (method_exists($value, 'toArray')) {
+                return $this->__invoke($value->toArray(), $recurse | self::RECURSE_ARRAY);
+            }
+            return $this->__invoke((array) $value, $recurse | self::RECURSE_ARRAY);
+        }
+        // At this point, we have a scalar; simply return it
+        return $value;
+    }
+
+    /**
+     * Escape a value for current escaping strategy
+     *
+     * @param string $value
+     * @return string
+     */
+    protected abstract function escape($value);
 
 }

--- a/tests/Zend/View/Helper/EscapeCssTest.php
+++ b/tests/Zend/View/Helper/EscapeCssTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace ZendTest\View\Helper;
+
+use PHPUnit_Framework_TestCase as TestCase,
+    stdClass,
+    Zend\View\Helper\EscapeCss as EscapeHelper;
+
+class EscapeCssTest extends TestCase
+{
+
+    protected $supportedEncodings = array(
+        'iso-8859-1',   'iso8859-1',    'iso-8859-5',   'iso8859-5',
+        'iso-8859-15',  'iso8859-15',   'utf-8',        'cp866',
+        'ibm866',       '866',          'cp1251',       'windows-1251',
+        'win-1251',     '1251',         'cp1252',       'windows-1252',
+        '1252',         'koi8-r',       'koi8-ru',      'koi8r',
+        'big5',         '950',          'gb2312',       '936',
+        'big5-hkscs',   'shift_jis',    'sjis',         'sjis-win',
+        'cp932',        '932',          'euc-jp',       'eucjp',
+        'eucjp-win',    'macroman'
+    );
+
+    public function setUp()
+    {
+        $this->helper = new EscapeHelper;
+    }
+
+    public function testUsesUtf8EncodingByDefault()
+    {
+        $this->assertEquals('UTF-8', $this->helper->getEncoding());
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     */
+    public function testEncodingIsImmutable()
+    {
+        $this->helper->setEncoding('BIG5-HKSCS');
+        $this->helper->getEscaper();
+        $this->helper->setEncoding('UTF-8');
+    }
+
+    public function testGetEscaperCreatesDefaultInstanceWithCorrectEncoding()
+    {
+        $this->helper->setEncoding('BIG5-HKSCS');
+        $escaper = $this->helper->getEscaper();
+        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertEquals('big5-hkscs', $escaper->getEncoding());
+    }
+
+    public function testSettingEscaperObjectAlsoSetsEncoding()
+    {
+        $escaper = new \Zend\Escaper\Escaper('big5-hkscs');
+        $this->helper->setEscaper($escaper);
+        $escaper = $this->helper->getEscaper();
+        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertEquals('big5-hkscs', $escaper->getEncoding());
+    }
+
+    public function testEscapehtmlCalledOnEscaperObject()
+    {
+        $escaper = $this->getMock('\\Zend\\Escaper\\Escaper');
+        $escaper->expects($this->any())->method('escapeCss');
+        $this->helper->setEscaper($escaper);
+        $this->helper->__invoke('foo');
+    }
+
+    public function testAllowsRecursiveEscapingOfArrays()
+    {
+        $original = array(
+            'foo' => '<b>bar</b>',
+            'baz' => array(
+                '<em>bat</em>',
+                'second' => array(
+                    '<i>third</i>',
+                ),
+            ),
+        );
+        $expected = array(
+            'foo' => '\3C b\3E bar\3C \2F b\3E ',
+            'baz' => array(
+                '\3C em\3E bat\3C \2F em\3E ',
+                'second' => array(
+                    '\3C i\3E third\3C \2F i\3E ',
+                ),
+            ),
+        );
+        $test = $this->helper->__invoke($original, EscapeHelper::RECURSE_ARRAY);
+        $this->assertEquals($expected, $test);
+    }
+
+    public function testWillCastObjectsToStringsBeforeEscaping()
+    {
+        $object = new TestAsset\Stringified;
+        $test = $this->helper->__invoke($object);
+        $this->assertEquals(
+            'ZendTest\5C View\5C Helper\5C TestAsset\5C Stringified',
+            $test
+        );
+    }
+
+    public function testCanRecurseObjectImplementingToArray()
+    {
+        $original = array(
+            'foo' => '<b>bar</b>',
+            'baz' => array(
+                '<em>bat</em>',
+                'second' => array(
+                    '<i>third</i>',
+                ),
+            ),
+        );
+        $object = new TestAsset\ToArray();
+        $object->array = $original;
+
+        $expected = array(
+            'foo' => '\3C b\3E bar\3C \2F b\3E ',
+            'baz' => array(
+                '\3C em\3E bat\3C \2F em\3E ',
+                'second' => array(
+                    '\3C i\3E third\3C \2F i\3E ',
+                ),
+            ),
+        );
+        $test = $this->helper->__invoke($object, EscapeHelper::RECURSE_OBJECT);
+        $this->assertEquals($expected, $test);
+    }
+
+    public function testCanRecurseObjectProperties()
+    {
+        $original = array(
+            'foo' => '<b>bar</b>',
+            'baz' => array(
+                '<em>bat</em>',
+                'second' => array(
+                    '<i>third</i>',
+                ),
+            ),
+        );
+        $object = new stdClass();
+        foreach ($original as $key => $value) {
+            $object->$key = $value;
+        }
+
+        $expected = array(
+            'foo' => '\3C b\3E bar\3C \2F b\3E ',
+            'baz' => array(
+                '\3C em\3E bat\3C \2F em\3E ',
+                'second' => array(
+                    '\3C i\3E third\3C \2F i\3E ',
+                ),
+            ),
+        );
+        $test = $this->helper->__invoke($object, EscapeHelper::RECURSE_OBJECT);
+        $this->assertEquals($expected, $test);
+    }
+
+    /**
+     * @expectedException \Zend\Escaper\Exception\InvalidArgumentException
+     * 
+     * PHP 5.3 instates default encoding on empty string instead of the expected
+     * warning level error for htmlspecialchars() encoding param. PHP 5.4 attempts
+     * to guess the encoding or take it from php.ini default_charset when an empty
+     * string is set. Both are insecure behaviours.
+     */
+    public function testSettingEncodingToEmptyStringShouldThrowException()
+    {
+        $this->helper->setEncoding('');
+        $this->helper->getEscaper();
+    }
+
+    public function testSettingValidEncodingShouldNotThrowExceptions()
+    {
+        foreach ($this->supportedEncodings as $value) {
+            $helper = new EscapeHelper;
+            $helper->setEncoding($value);
+            $helper->getEscaper();
+        }
+    }
+
+    /**
+     * @expectedException \Zend\Escaper\Exception\InvalidArgumentException
+     * 
+     * All versions of PHP - when an invalid encoding is set on htmlspecialchars()
+     * a warning level error is issued and escaping continues with the default encoding
+     * for that PHP version. Preventing the continuation behaviour offsets display_errors
+     * off in production env.
+     */
+    public function testSettingEncodingToInvalidValueShouldThrowException()
+    {
+        $this->helper->setEncoding('completely-invalid');
+        $this->helper->getEscaper();
+    }
+}

--- a/tests/Zend/View/Helper/EscapeHtmlAttrTest.php
+++ b/tests/Zend/View/Helper/EscapeHtmlAttrTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace ZendTest\View\Helper;
+
+use PHPUnit_Framework_TestCase as TestCase,
+    stdClass,
+    Zend\View\Helper\EscapeHtmlAttr as EscapeHelper;
+
+class EscapeHtmlAttrTest extends TestCase
+{
+
+    protected $supportedEncodings = array(
+        'iso-8859-1',   'iso8859-1',    'iso-8859-5',   'iso8859-5',
+        'iso-8859-15',  'iso8859-15',   'utf-8',        'cp866',
+        'ibm866',       '866',          'cp1251',       'windows-1251',
+        'win-1251',     '1251',         'cp1252',       'windows-1252',
+        '1252',         'koi8-r',       'koi8-ru',      'koi8r',
+        'big5',         '950',          'gb2312',       '936',
+        'big5-hkscs',   'shift_jis',    'sjis',         'sjis-win',
+        'cp932',        '932',          'euc-jp',       'eucjp',
+        'eucjp-win',    'macroman'
+    );
+
+    public function setUp()
+    {
+        $this->helper = new EscapeHelper;
+    }
+
+    public function testUsesUtf8EncodingByDefault()
+    {
+        $this->assertEquals('UTF-8', $this->helper->getEncoding());
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     */
+    public function testEncodingIsImmutable()
+    {
+        $this->helper->setEncoding('BIG5-HKSCS');
+        $this->helper->getEscaper();
+        $this->helper->setEncoding('UTF-8');
+    }
+
+    public function testGetEscaperCreatesDefaultInstanceWithCorrectEncoding()
+    {
+        $this->helper->setEncoding('BIG5-HKSCS');
+        $escaper = $this->helper->getEscaper();
+        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertEquals('big5-hkscs', $escaper->getEncoding());
+    }
+
+    public function testSettingEscaperObjectAlsoSetsEncoding()
+    {
+        $escaper = new \Zend\Escaper\Escaper('big5-hkscs');
+        $this->helper->setEscaper($escaper);
+        $escaper = $this->helper->getEscaper();
+        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertEquals('big5-hkscs', $escaper->getEncoding());
+    }
+
+    public function testEscapehtmlCalledOnEscaperObject()
+    {
+        $escaper = $this->getMock('\\Zend\\Escaper\\Escaper');
+        $escaper->expects($this->any())->method('escapeHtmlAttr');
+        $this->helper->setEscaper($escaper);
+        $this->helper->__invoke('foo');
+    }
+
+    public function testAllowsRecursiveEscapingOfArrays()
+    {
+        $original = array(
+            'foo' => '<b>bar</b>',
+            'baz' => array(
+                '<em>bat</em>',
+                'second' => array(
+                    '<i>third</i>',
+                ),
+            ),
+        );
+        $expected = array(
+            'foo' => '&lt;b&gt;bar&lt;&#x2F;b&gt;',
+            'baz' => array(
+                '&lt;em&gt;bat&lt;&#x2F;em&gt;',
+                'second' => array(
+                    '&lt;i&gt;third&lt;&#x2F;i&gt;',
+                ),
+            ),
+        );
+        $test = $this->helper->__invoke($original, EscapeHelper::RECURSE_ARRAY);
+        $this->assertEquals($expected, $test);
+    }
+
+    public function testWillCastObjectsToStringsBeforeEscaping()
+    {
+        $object = new TestAsset\Stringified;
+        $test = $this->helper->__invoke($object);
+        $this->assertEquals(
+            'ZendTest&#x5C;View&#x5C;Helper&#x5C;TestAsset&#x5C;Stringified',
+            $test
+        );
+    }
+
+    public function testCanRecurseObjectImplementingToArray()
+    {
+        $original = array(
+            'foo' => '<b>bar</b>',
+            'baz' => array(
+                '<em>bat</em>',
+                'second' => array(
+                    '<i>third</i>',
+                ),
+            ),
+        );
+        $object = new TestAsset\ToArray();
+        $object->array = $original;
+
+        $expected = array(
+            'foo' => '&lt;b&gt;bar&lt;&#x2F;b&gt;',
+            'baz' => array(
+                '&lt;em&gt;bat&lt;&#x2F;em&gt;',
+                'second' => array(
+                    '&lt;i&gt;third&lt;&#x2F;i&gt;',
+                ),
+            ),
+        );
+        $test = $this->helper->__invoke($object, EscapeHelper::RECURSE_OBJECT);
+        $this->assertEquals($expected, $test);
+    }
+
+    public function testCanRecurseObjectProperties()
+    {
+        $original = array(
+            'foo' => '<b>bar</b>',
+            'baz' => array(
+                '<em>bat</em>',
+                'second' => array(
+                    '<i>third</i>',
+                ),
+            ),
+        );
+        $object = new stdClass();
+        foreach ($original as $key => $value) {
+            $object->$key = $value;
+        }
+
+        $expected = array(
+            'foo' => '&lt;b&gt;bar&lt;&#x2F;b&gt;',
+            'baz' => array(
+                '&lt;em&gt;bat&lt;&#x2F;em&gt;',
+                'second' => array(
+                    '&lt;i&gt;third&lt;&#x2F;i&gt;',
+                ),
+            ),
+        );
+        $test = $this->helper->__invoke($object, EscapeHelper::RECURSE_OBJECT);
+        $this->assertEquals($expected, $test);
+    }
+
+    /**
+     * @expectedException \Zend\Escaper\Exception\InvalidArgumentException
+     * 
+     * PHP 5.3 instates default encoding on empty string instead of the expected
+     * warning level error for htmlspecialchars() encoding param. PHP 5.4 attempts
+     * to guess the encoding or take it from php.ini default_charset when an empty
+     * string is set. Both are insecure behaviours.
+     */
+    public function testSettingEncodingToEmptyStringShouldThrowException()
+    {
+        $this->helper->setEncoding('');
+        $this->helper->getEscaper();
+    }
+
+    public function testSettingValidEncodingShouldNotThrowExceptions()
+    {
+        foreach ($this->supportedEncodings as $value) {
+            $helper = new EscapeHelper;
+            $helper->setEncoding($value);
+            $helper->getEscaper();
+        }
+    }
+
+    /**
+     * @expectedException \Zend\Escaper\Exception\InvalidArgumentException
+     * 
+     * All versions of PHP - when an invalid encoding is set on htmlspecialchars()
+     * a warning level error is issued and escaping continues with the default encoding
+     * for that PHP version. Preventing the continuation behaviour offsets display_errors
+     * off in production env.
+     */
+    public function testSettingEncodingToInvalidValueShouldThrowException()
+    {
+        $this->helper->setEncoding('completely-invalid');
+        $this->helper->getEscaper();
+    }
+}

--- a/tests/Zend/View/Helper/EscapeJsTest.php
+++ b/tests/Zend/View/Helper/EscapeJsTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace ZendTest\View\Helper;
+
+use PHPUnit_Framework_TestCase as TestCase,
+    stdClass,
+    Zend\View\Helper\EscapeJs as EscapeHelper;
+
+class EscapeJsTest extends TestCase
+{
+
+    protected $supportedEncodings = array(
+        'iso-8859-1',   'iso8859-1',    'iso-8859-5',   'iso8859-5',
+        'iso-8859-15',  'iso8859-15',   'utf-8',        'cp866',
+        'ibm866',       '866',          'cp1251',       'windows-1251',
+        'win-1251',     '1251',         'cp1252',       'windows-1252',
+        '1252',         'koi8-r',       'koi8-ru',      'koi8r',
+        'big5',         '950',          'gb2312',       '936',
+        'big5-hkscs',   'shift_jis',    'sjis',         'sjis-win',
+        'cp932',        '932',          'euc-jp',       'eucjp',
+        'eucjp-win',    'macroman'
+    );
+
+    public function setUp()
+    {
+        $this->helper = new EscapeHelper;
+    }
+
+    public function testUsesUtf8EncodingByDefault()
+    {
+        $this->assertEquals('UTF-8', $this->helper->getEncoding());
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     */
+    public function testEncodingIsImmutable()
+    {
+        $this->helper->setEncoding('BIG5-HKSCS');
+        $this->helper->getEscaper();
+        $this->helper->setEncoding('UTF-8');
+    }
+
+    public function testGetEscaperCreatesDefaultInstanceWithCorrectEncoding()
+    {
+        $this->helper->setEncoding('BIG5-HKSCS');
+        $escaper = $this->helper->getEscaper();
+        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertEquals('big5-hkscs', $escaper->getEncoding());
+    }
+
+    public function testSettingEscaperObjectAlsoSetsEncoding()
+    {
+        $escaper = new \Zend\Escaper\Escaper('big5-hkscs');
+        $this->helper->setEscaper($escaper);
+        $escaper = $this->helper->getEscaper();
+        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertEquals('big5-hkscs', $escaper->getEncoding());
+    }
+
+    public function testEscapehtmlCalledOnEscaperObject()
+    {
+        $escaper = $this->getMock('\\Zend\\Escaper\\Escaper');
+        $escaper->expects($this->any())->method('escapeJs');
+        $this->helper->setEscaper($escaper);
+        $this->helper->__invoke('foo');
+    }
+
+    public function testAllowsRecursiveEscapingOfArrays()
+    {
+        $original = array(
+            'foo' => '<b>bar</b>',
+            'baz' => array(
+                '<em>bat</em>',
+                'second' => array(
+                    '<i>third</i>',
+                ),
+            ),
+        );
+        $expected = array(
+            'foo' => '\x3Cb\x3Ebar\x3C\x2Fb\x3E',
+            'baz' => array(
+                '\x3Cem\x3Ebat\x3C\x2Fem\x3E',
+                'second' => array(
+                    '\x3Ci\x3Ethird\x3C\x2Fi\x3E',
+                ),
+            ),
+        );
+        $test = $this->helper->__invoke($original, EscapeHelper::RECURSE_ARRAY);
+        $this->assertEquals($expected, $test);
+    }
+
+    public function testWillCastObjectsToStringsBeforeEscaping()
+    {
+        $object = new TestAsset\Stringified;
+        $test = $this->helper->__invoke($object);
+        $this->assertEquals(
+            'ZendTest\x5CView\x5CHelper\x5CTestAsset\x5CStringified',
+            $test
+        );
+    }
+
+    public function testCanRecurseObjectImplementingToArray()
+    {
+        $original = array(
+            'foo' => '<b>bar</b>',
+            'baz' => array(
+                '<em>bat</em>',
+                'second' => array(
+                    '<i>third</i>',
+                ),
+            ),
+        );
+        $object = new TestAsset\ToArray();
+        $object->array = $original;
+
+        $expected = array(
+            'foo' => '\x3Cb\x3Ebar\x3C\x2Fb\x3E',
+            'baz' => array(
+                '\x3Cem\x3Ebat\x3C\x2Fem\x3E',
+                'second' => array(
+                    '\x3Ci\x3Ethird\x3C\x2Fi\x3E',
+                ),
+            ),
+        );
+        $test = $this->helper->__invoke($object, EscapeHelper::RECURSE_OBJECT);
+        $this->assertEquals($expected, $test);
+    }
+
+    public function testCanRecurseObjectProperties()
+    {
+        $original = array(
+            'foo' => '<b>bar</b>',
+            'baz' => array(
+                '<em>bat</em>',
+                'second' => array(
+                    '<i>third</i>',
+                ),
+            ),
+        );
+        $object = new stdClass();
+        foreach ($original as $key => $value) {
+            $object->$key = $value;
+        }
+
+        $expected = array(
+            'foo' => '\x3Cb\x3Ebar\x3C\x2Fb\x3E',
+            'baz' => array(
+                '\x3Cem\x3Ebat\x3C\x2Fem\x3E',
+                'second' => array(
+                    '\x3Ci\x3Ethird\x3C\x2Fi\x3E',
+                ),
+            ),
+        );
+        $test = $this->helper->__invoke($object, EscapeHelper::RECURSE_OBJECT);
+        $this->assertEquals($expected, $test);
+    }
+
+    /**
+     * @expectedException \Zend\Escaper\Exception\InvalidArgumentException
+     * 
+     * PHP 5.3 instates default encoding on empty string instead of the expected
+     * warning level error for htmlspecialchars() encoding param. PHP 5.4 attempts
+     * to guess the encoding or take it from php.ini default_charset when an empty
+     * string is set. Both are insecure behaviours.
+     */
+    public function testSettingEncodingToEmptyStringShouldThrowException()
+    {
+        $this->helper->setEncoding('');
+        $this->helper->getEscaper();
+    }
+
+    public function testSettingValidEncodingShouldNotThrowExceptions()
+    {
+        foreach ($this->supportedEncodings as $value) {
+            $helper = new EscapeHelper;
+            $helper->setEncoding($value);
+            $helper->getEscaper();
+        }
+    }
+
+    /**
+     * @expectedException \Zend\Escaper\Exception\InvalidArgumentException
+     * 
+     * All versions of PHP - when an invalid encoding is set on htmlspecialchars()
+     * a warning level error is issued and escaping continues with the default encoding
+     * for that PHP version. Preventing the continuation behaviour offsets display_errors
+     * off in production env.
+     */
+    public function testSettingEncodingToInvalidValueShouldThrowException()
+    {
+        $this->helper->setEncoding('completely-invalid');
+        $this->helper->getEscaper();
+    }
+}

--- a/tests/Zend/View/Helper/EscapeUrlTest.php
+++ b/tests/Zend/View/Helper/EscapeUrlTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace ZendTest\View\Helper;
+
+use PHPUnit_Framework_TestCase as TestCase,
+    stdClass,
+    Zend\View\Helper\EscapeUrl as EscapeHelper;
+
+class EscapeUrlTest extends TestCase
+{
+
+    protected $supportedEncodings = array(
+        'iso-8859-1',   'iso8859-1',    'iso-8859-5',   'iso8859-5',
+        'iso-8859-15',  'iso8859-15',   'utf-8',        'cp866',
+        'ibm866',       '866',          'cp1251',       'windows-1251',
+        'win-1251',     '1251',         'cp1252',       'windows-1252',
+        '1252',         'koi8-r',       'koi8-ru',      'koi8r',
+        'big5',         '950',          'gb2312',       '936',
+        'big5-hkscs',   'shift_jis',    'sjis',         'sjis-win',
+        'cp932',        '932',          'euc-jp',       'eucjp',
+        'eucjp-win',    'macroman'
+    );
+
+    public function setUp()
+    {
+        $this->helper = new EscapeHelper;
+    }
+
+    public function testUsesUtf8EncodingByDefault()
+    {
+        $this->assertEquals('UTF-8', $this->helper->getEncoding());
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     */
+    public function testEncodingIsImmutable()
+    {
+        $this->helper->setEncoding('BIG5-HKSCS');
+        $this->helper->getEscaper();
+        $this->helper->setEncoding('UTF-8');
+    }
+
+    public function testGetEscaperCreatesDefaultInstanceWithCorrectEncoding()
+    {
+        $this->helper->setEncoding('BIG5-HKSCS');
+        $escaper = $this->helper->getEscaper();
+        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertEquals('big5-hkscs', $escaper->getEncoding());
+    }
+
+    public function testSettingEscaperObjectAlsoSetsEncoding()
+    {
+        $escaper = new \Zend\Escaper\Escaper('big5-hkscs');
+        $this->helper->setEscaper($escaper);
+        $escaper = $this->helper->getEscaper();
+        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertEquals('big5-hkscs', $escaper->getEncoding());
+    }
+
+    public function testEscapehtmlCalledOnEscaperObject()
+    {
+        $escaper = $this->getMock('\\Zend\\Escaper\\Escaper');
+        $escaper->expects($this->any())->method('escapeUrl');
+        $this->helper->setEscaper($escaper);
+        $this->helper->__invoke('foo');
+    }
+
+    public function testAllowsRecursiveEscapingOfArrays()
+    {
+        $original = array(
+            'foo' => '<b>bar</b>',
+            'baz' => array(
+                '<em>bat</em>',
+                'second' => array(
+                    '<i>third</i>',
+                ),
+            ),
+        );
+        $expected = array(
+            'foo' => '%3Cb%3Ebar%3C%2Fb%3E',
+            'baz' => array(
+                '%3Cem%3Ebat%3C%2Fem%3E',
+                'second' => array(
+                    '%3Ci%3Ethird%3C%2Fi%3E',
+                ),
+            ),
+        );
+        $test = $this->helper->__invoke($original, EscapeHelper::RECURSE_ARRAY);
+        $this->assertEquals($expected, $test);
+    }
+
+    public function testWillCastObjectsToStringsBeforeEscaping()
+    {
+        $object = new TestAsset\Stringified;
+        $test = $this->helper->__invoke($object);
+        $this->assertEquals(
+            'ZendTest%5CView%5CHelper%5CTestAsset%5CStringified',
+            $test
+        );
+    }
+
+    public function testCanRecurseObjectImplementingToArray()
+    {
+        $original = array(
+            'foo' => '<b>bar</b>',
+            'baz' => array(
+                '<em>bat</em>',
+                'second' => array(
+                    '<i>third</i>',
+                ),
+            ),
+        );
+        $object = new TestAsset\ToArray();
+        $object->array = $original;
+
+        $expected = array(
+            'foo' => '%3Cb%3Ebar%3C%2Fb%3E',
+            'baz' => array(
+                '%3Cem%3Ebat%3C%2Fem%3E',
+                'second' => array(
+                    '%3Ci%3Ethird%3C%2Fi%3E',
+                ),
+            ),
+        );
+        $test = $this->helper->__invoke($object, EscapeHelper::RECURSE_OBJECT);
+        $this->assertEquals($expected, $test);
+    }
+
+    public function testCanRecurseObjectProperties()
+    {
+        $original = array(
+            'foo' => '<b>bar</b>',
+            'baz' => array(
+                '<em>bat</em>',
+                'second' => array(
+                    '<i>third</i>',
+                ),
+            ),
+        );
+        $object = new stdClass();
+        foreach ($original as $key => $value) {
+            $object->$key = $value;
+        }
+
+        $expected = array(
+            'foo' => '%3Cb%3Ebar%3C%2Fb%3E',
+            'baz' => array(
+                '%3Cem%3Ebat%3C%2Fem%3E',
+                'second' => array(
+                    '%3Ci%3Ethird%3C%2Fi%3E',
+                ),
+            ),
+        );
+        $test = $this->helper->__invoke($object, EscapeHelper::RECURSE_OBJECT);
+        $this->assertEquals($expected, $test);
+    }
+
+    /**
+     * @expectedException \Zend\Escaper\Exception\InvalidArgumentException
+     * 
+     * PHP 5.3 instates default encoding on empty string instead of the expected
+     * warning level error for htmlspecialchars() encoding param. PHP 5.4 attempts
+     * to guess the encoding or take it from php.ini default_charset when an empty
+     * string is set. Both are insecure behaviours.
+     */
+    public function testSettingEncodingToEmptyStringShouldThrowException()
+    {
+        $this->helper->setEncoding('');
+        $this->helper->getEscaper();
+    }
+
+    public function testSettingValidEncodingShouldNotThrowExceptions()
+    {
+        foreach ($this->supportedEncodings as $value) {
+            $helper = new EscapeHelper;
+            $helper->setEncoding($value);
+            $helper->getEscaper();
+        }
+    }
+
+    /**
+     * @expectedException \Zend\Escaper\Exception\InvalidArgumentException
+     * 
+     * All versions of PHP - when an invalid encoding is set on htmlspecialchars()
+     * a warning level error is issued and escaping continues with the default encoding
+     * for that PHP version. Preventing the continuation behaviour offsets display_errors
+     * off in production env.
+     */
+    public function testSettingEncodingToInvalidValueShouldThrowException()
+    {
+        $this->helper->setEncoding('completely-invalid');
+        $this->helper->getEscaper();
+    }
+}


### PR DESCRIPTION
Integrates Zend\Escaper across Zend\View helpers. Replaces Escape helper with EscapeHtml, EscapeHtmlAttr, EscapeJs, EscapeCSS and EscapeUrl helpers instead. Tests checked for Zend\View and Zend\Escaper.

Other background:
1. 2nd parameter to __invoke() on Escape\* classes has been preserved.
2. Rationale for Escape helper deprecation is to enforce selection of correct Escape\* helper per agreed RFC.
3. A Placeholder class had an inconsistent use of htmlspecialchars() directly (not via Escape helper). This was replaced with an instance of Zend\Escaper\Escaper.
4. Helpers can likely be refactored a bit further into the Helper\Escaper\AbstractHelper class.
5. Helpers likely still need a brief security review (there's a usage of Zend\Json instead of a true Javascript escaper but is likely safe - will review post-beta).
