### PR TITLE
[Form] Bugfix - Date Element

### DIFF
--- a/library/Zend/Form/Element/Date.php
+++ b/library/Zend/Form/Element/Date.php
@@ -66,12 +66,12 @@ class Date extends DateTime
                      ? $this->attributes['step'] : 1; // Days
 
         $baseValue = (isset($this->attributes['min']))
-                     ? $this->attributes['min'] : '1970-01-01T00:00:00Z';
+                     ? $this->attributes['min'] : '1970-01-01';
 
         return new DateStepValidator(array(
-            'format'       => \DateTime::ISO8601,
-            'baseValue'    => $baseValue,
-            'step' => new \DateInterval("P{$stepValue}D"),
+            'format'    => 'Y-m-d',
+            'baseValue' => $baseValue,
+            'step'      => new \DateInterval("P{$stepValue}D"),
         ));
     }
 }

--- a/library/Zend/Validator/DateStep.php
+++ b/library/Zend/Validator/DateStep.php
@@ -264,8 +264,8 @@ class DateStep extends AbstractValidator
 
         $this->setValue($value);
 
-        $baseDate     = $this->convertToDateTime($this->getBaseValue());
-        $step = $this->getStep();
+        $baseDate = $this->convertToDateTime($this->getBaseValue());
+        $step     = $this->getStep();
 
         // Parse the date
         try {

--- a/tests/Zend/Form/Element/DateTest.php
+++ b/tests/Zend/Form/Element/DateTest.php
@@ -22,11 +22,38 @@
 namespace ZendTest\Form\Element;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\Form\Element\DateTime as DateElement;
+use Zend\Form\Element\Date as DateElement;
 use Zend\Form\Factory;
 
 class DateTest extends TestCase
 {
+    public function testProvidesDefaultInputSpecification()
+    {
+        $element = new DateElement('foo');
+
+        $inputSpec = $element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $this->assertInternalType('array', $inputSpec['validators']);
+
+        $expectedClasses = array(
+            'Zend\Validator\Date',
+            'Zend\Validator\DateStep',
+        );
+        foreach ($inputSpec['validators'] as $validator) {
+            $class = get_class($validator);
+            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            switch ($class) {
+                case 'Zend\Validator\DateStep':
+                    $dateInterval = new \DateInterval('P1D');
+                    $this->assertEquals($dateInterval, $validator->getStep());
+                    $this->assertEquals('1970-01-01',  $validator->getBaseValue());
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
     public function testProvidesInputSpecificationThatIncludesValidatorsBasedOnAttributes()
     {
         $element = new DateElement('foo');
@@ -60,8 +87,9 @@ class DateTest extends TestCase
                     $this->assertEquals('2001-01-01', $validator->getMax());
                     break;
                 case 'Zend\Validator\DateStep':
-                    $dateInterval = new \DateInterval('PT1M');
+                    $dateInterval = new \DateInterval('P1D');
                     $this->assertEquals($dateInterval, $validator->getStep());
+                    $this->assertEquals('2000-01-01',  $validator->getBaseValue());
                     break;
                 default:
                     break;


### PR DESCRIPTION
Form Date Element was incorrectly configuring the StepValidator causing valid form input to break. Also, it's Unit tests were incorrectly using the DateTime Element.
