### PR TITLE
adding rel attribute  to the forminput view helper

### DIFF
--- a/library/Zend/Form/View/Helper/FormInput.php
+++ b/library/Zend/Form/View/Helper/FormInput.php
@@ -69,6 +69,7 @@ class FormInput extends AbstractHelper
         'type'           => true,
         'value'          => true,
         'width'          => true,
+	'rel'		 => true,
     );
 
     /**


### PR DESCRIPTION
Hello ZF folks 
I think rel attr must be added to the `formInput` view helper since twitter bootstrap and many jquery developers  depending  on rel attr 
