### PR TITLE
Add FormMultiCheckbox method exist check

### DIFF
--- a/library/Zend/Form/View/Helper/FormMultiCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormMultiCheckbox.php
@@ -238,7 +238,7 @@ class FormMultiCheckbox extends FormInput
         $rendered = $this->renderOptions($element, $options, $selectedOptions, $attributes);
 
         // Render hidden element
-        $useHiddenElement = $element->useHiddenElement()
+        $useHiddenElement = method_exists($element, 'useHiddenElement') && $element->useHiddenElement()
             ? $element->useHiddenElement()
             : $this->useHiddenElement;
 


### PR DESCRIPTION
See my test code:
https://github.com/AlloVince/eva-engine/blob/master/public/zf2libs/multicheckbox.php

if without any method exist check, this will cause:

```
Fatal error: Call to undefined method Zend\Form\Element::useHiddenElement()
```
