### PR TITLE
Make __invoke args on params controller plugin optional

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/Params.php
+++ b/library/Zend/Mvc/Controller/Plugin/Params.php
@@ -41,8 +41,11 @@ class Params extends AbstractPlugin
      * @param mixed $default
      * @return mixed
      */
-    public function __invoke($param, $default = null)
+    public function __invoke($param = NULL, $default = null)
     {
+        if ($param === NULL) {
+            return $this;
+        }
         return $this->fromRoute($param, $default);
     }
 

--- a/tests/Zend/Mvc/Controller/Plugin/ParamsTest.php
+++ b/tests/Zend/Mvc/Controller/Plugin/ParamsTest.php
@@ -76,6 +76,11 @@ class ParamsTest extends TestCase
         $this->assertEquals($value, 'post:1234');
     }
 
+    public function testInvokeWithNoArgumentsReturnsInstance()
+    {
+        $this->assertSame($this->plugin, $this->plugin->__invoke());
+    }
+
     protected function setQuery()
     {
         $this->request->setMethod(Request::METHOD_GET);


### PR DESCRIPTION
This will allow us to do this:

```
$this->params()->fromQuery('foo');
```

...instead of this:

```
$this->plugin('params')->fromQuery('foo');
```
