### PR TITLE
Added package zendframework/zend-loader as a suggested dependency

### DIFF
--- a/library/Zend/Mail/composer.json
+++ b/library/Zend/Mail/composer.json
@@ -16,6 +16,6 @@
     },
     "suggest": {
         "zendframework/zend-validator": "Zend\\Validator component",
-        "zendframework/zend-loader": "Zend\\Loader component"
+        "zendframework/zend-servicemanager": "Zend\\ServiceManager component"
     }
 }

--- a/library/Zend/Mail/composer.json
+++ b/library/Zend/Mail/composer.json
@@ -15,6 +15,7 @@
         "zendframework/zend-mime": "self.version"
     },
     "suggest": {
-        "zendframework/zend-validator": "Zend\\Validator component"
+        "zendframework/zend-validator": "Zend\\Validator component",
+        "zendframework/zend-loader": "Zend\\Loader component"
     }
 }


### PR DESCRIPTION
The SMTP transport requires it, so it seems to me it would be beneficial to at least make Zend\Loader a suggested dependency.

I first thought about adding it as a required dependency, but since not everyone uses SMTP as a transport, that probably wouldn't make sense.

If requested, I can change that, of course.
