### PR TITLE
Zend\Db: Fixes changes introduced in #1476

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -30,7 +30,6 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     const SPECIFICATION_SELECT = 'select';
     const SPECIFICATION_JOIN = 'join';
-    const SPECIFICATION_JOIN_ALIAS = 'joinAlias';
     const SPECIFICATION_WHERE = 'where';
     const SPECIFICATION_GROUP = 'group';
     const SPECIFICATION_HAVING = 'having';
@@ -166,8 +165,8 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             throw new Exception\InvalidArgumentException('$table must be a string, array, or an instance of TableIdentifier');
         }
 
-        if (is_array($table)) {
-            $table = new TableIdentifier($table);
+        if (is_array($table) && (!is_string(key($table)) || count($table) !== 1)) {
+            throw new Exception\InvalidArgumentException('from() expects $table as an array is a single element associative array');
         }
 
         $this->table = $table;
@@ -209,6 +208,9 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     public function join($name, $on, $columns = self::SQL_STAR, $type = self::JOIN_INNER)
     {
+        if (is_array($name) && (!is_string(key($name)) || count($name) !== 1)) {
+            throw new Exception\InvalidArgumentException('join() expects $name as an array is a single element associative array');
+        }
         if (!is_array($columns)) {
             $columns = array($columns);
         }
@@ -423,30 +425,32 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             return null;
         }
 
-        // create quoted table name to use in columns processing
-        if ($this->table instanceof TableIdentifier) {
-            list($table, $schema, $alias) = $this->table->getTableAndSchema();
-            $table = $platform->quoteIdentifier($table);
-            if ($schema) {
-                $table = $platform->quoteIdentifier($schema) . $platform->getIdentifierSeparator() . $table;
-            }
-            
-            if ($alias) {
-                $alias = $platform->quoteIdentifier($alias);
-                $table = $table . ' AS ' . $alias;
-            }
-        } else {
-            $table = $platform->quoteIdentifier($this->table);
+        $table = $this->table;
+        $schema = $alias = null;
+
+        if (is_array($table)) {
+            $alias = key($this->table);
+            $table = current($this->table);
         }
 
-        $quotedTable = '';
-        if ($this->prefixColumnsWithTable) {
-            if (isset($alias)) {
-                $quotedTable = $alias . $platform->getIdentifierSeparator();
-            } else {
-                $quotedTable = $table . $platform->getIdentifierSeparator();
-            }
+        // create quoted table name to use in columns processing
+        if ($table instanceof TableIdentifier) {
+            list($table, $schema) = $table->getTableAndSchema();
         }
+
+        $table = $platform->quoteIdentifier($table);
+        if ($schema) {
+            $table = $platform->quoteIdentifier($schema) . $platform->getIdentifierSeparator() . $table;
+        }
+
+        if ($alias) {
+            $fromTable = $platform->quoteIdentifier($alias);
+            $table .= ' AS ' . $fromTable;
+        } else {
+            $fromTable = ($this->prefixColumnsWithTable) ? $table : '';
+        }
+
+        $fromTable .= $platform->getIdentifierSeparator();
 
         // process table columns
         $columns = array();
@@ -454,7 +458,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
             $columnName = '';
             if ($column === self::SQL_STAR) {
-                $columns[] = array($quotedTable . self::SQL_STAR);
+                $columns[] = array($fromTable . self::SQL_STAR);
                 continue;
             } 
 
@@ -470,7 +474,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 }
                 $columnName .= $columnParts['sql'];
             } else {
-                $columnName .= $quotedTable . $platform->quoteIdentifier($column);
+                $columnName .= $fromTable . $platform->quoteIdentifier($column);
             }
 
             // process As portion
@@ -488,12 +492,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         foreach ($this->joins as $join) {
             foreach ($join['columns'] as $jKey => $jColumn) {
                 $jColumns = array();
-                if (is_array($join['name'])) {
-                    $keys = array_keys($join['name']);
-                    $name = array_pop($keys);
-                } else {
-                    $name = $join['name'];
-                }
+                $name = (is_array($join['name'])) ? key($join['name']) : $name = $join['name'];
                 $jColumns[] = $platform->quoteIdentifier($name) . $separator . $platform->quoteIdentifierInFragment($jColumn);
                 if (is_string($jKey)) {
                     $jColumns[] = $platform->quoteIdentifier($jKey);
@@ -516,20 +515,11 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         // process joins
         $joinSpecArgArray = array();
         foreach ($this->joins as $j => $join) {
-
-            if (is_array($join['name'])) {
-                $keys = array_keys($join['name']);
-                $alias = array_pop($keys);
-                $name = $join['name'][$alias];
-
-                $nameArg = $platform->quoteIdentifier($name) . ' AS ' . $platform->quoteIdentifier($alias);
-            } else {
-                $nameArg = $platform->quoteIdentifier($join['name']);
-            }
-
             $joinSpecArgArray[$j] = array();
             $joinSpecArgArray[$j][] = strtoupper($join['type']); // type
-            $joinSpecArgArray[$j][] = $nameArg; // table
+            $joinSpecArgArray[$j][] = (is_array($join['name']))
+                ? $platform->quoteIdentifier(current($join['name'])) . ' AS ' . $platform->quoteIdentifier(key($join['name']))
+                : $platform->quoteIdentifier($join['name']); // table
             $joinSpecArgArray[$j][] = $platform->quoteIdentifierInFragment($join['on'], array('=', 'AND', 'OR', '(', ')', 'BETWEEN')); // on
         }
 

--- a/library/Zend/Db/Sql/TableIdentifier.php
+++ b/library/Zend/Db/Sql/TableIdentifier.php
@@ -27,22 +27,11 @@ class TableIdentifier
     protected $schema;
 
     /**
-     * @var string
-     */
-    protected $alias;
-
-    /**
      * @param string $table
      * @param string $schema
      */
     public function __construct($table, $schema = null)
     {
-        if (is_array($table)) {
-            $keys = array_keys($table);
-            $this->alias = array_pop($keys) ?: null;
-
-            $table = $table[$this->alias];
-        }
         $this->table = $table;
         $this->schema = $schema;
     }
@@ -87,33 +76,9 @@ class TableIdentifier
         return $this->schema;
     }
 
-    /**
-     * @return bool
-     */
-    public function hasAlias()
-    {
-        return ($this->alias != null);
-    }
-
-    /**
-     * @return null|string
-     */
-    public function getAlias()
-    {
-        return $this->alias;
-    }
-
-    /**
-     * @param string $alias
-     */
-    public function setAlias($alias)
-    {
-        $this->alias = $alias;
-    }
-
     public function getTableAndSchema()
     {
-        return array($this->table, $this->schema, $this->alias);
+        return array($this->table, $this->schema);
     }
 
 }

--- a/tests/Zend/Db/Sql/SelectTest.php
+++ b/tests/Zend/Db/Sql/SelectTest.php
@@ -136,7 +136,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
      * @testdox unit test: Test where() will accept any array with string key (without ?) to be used as Operator predicate
      * @covers Zend\Db\Sql\Select::where
      */
-    public function testWhereArugment1IsAssociativeArrayNotContainingReplacementCharacter()
+    public function testWhereArgument1IsAssociativeArrayNotContainingReplacementCharacter()
     {
         $select = new Select;
         $select->where(array('name' => 'Ralph', 'age' => 33));
@@ -161,7 +161,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
      * @testdox unit test: Test where() will accept an indexed array to be used by joining string expressions
      * @covers Zend\Db\Sql\Select::where
      */
-    public function testWhereArugment1IsIndexedArray()
+    public function testWhereArgument1IsIndexedArray()
     {
         $select = new Select;
         $select->where(array('name = "Ralph"'));
@@ -180,7 +180,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
      * @testdox unit test: Test where() will accept an indexed array to be used by joining string expressions, combined by OR
      * @covers Zend\Db\Sql\Select::where
      */
-    public function testWhereArugment1IsIndexedArrayArgument2IsOr()
+    public function testWhereArgument1IsIndexedArrayArgument2IsOr()
     {
         $select = new Select;
         $select->where(array('name = "Ralph"'), Where::OP_OR);
@@ -199,7 +199,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
      * @testdox unit test: Test where() will accept a closure to be executed with Where object as argument
      * @covers Zend\Db\Sql\Select::where
      */
-    public function testWhereArugment1IsClosure()
+    public function testWhereArgument1IsClosure()
     {
         $select = new Select;
         $where = $select->getRawState('where');
@@ -214,7 +214,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
      * @testdox unit test: Test where() will accept a Where object
      * @covers Zend\Db\Sql\Select::where
      */
-    public function testWhereArugment1IsWhereObject()
+    public function testWhereArgument1IsWhereObject()
     {
         $select = new Select;
         $select->where($newWhere = new Where);
@@ -340,7 +340,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         );
 
         // table as TableIdentifier
-        $select1 = new Select();
+        $select1 = new Select;
         $select1->from(new TableIdentifier('foo', 'bar'));
         $sqlPrep1 = // same
         $sqlStr1 = 'SELECT "bar"."foo".* FROM "bar"."foo"';
@@ -349,8 +349,8 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         );
 
         // table with alias
-        $select2 = new Select();
-        $select2->from(array('f'=>'foo'));
+        $select2 = new Select;
+        $select2->from(array('f' => 'foo'));
         $sqlPrep2 = // same
         $sqlStr2 = 'SELECT "f".* FROM "foo" AS "f"';
         $internalTests2 = array(
@@ -358,8 +358,8 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         );
 
         // table with alias with table as TableIdentifier
-        $select3 = new Select();
-        $select3->from(new TableIdentifier(array('f'=>'foo')));
+        $select3 = new Select;
+        $select3->from(array('f' => new TableIdentifier('foo')));
         $sqlPrep3 = // same
         $sqlStr3 = 'SELECT "f".* FROM "foo" AS "f"';
         $internalTests3 = array(


### PR DESCRIPTION
Zend\Db: Fixes changes introduced in #1476
- Removes concept of alias from TableIdentifier
- Cleans up tests
- Corrects use cases of TableIdentifier when alises is used
