### PR TITLE
[Hotfix][ZF-11376][ZF-12106] Dom -  (sync svn r24794,r24830)

### DIFF
--- a/library/Zend/Dom/Query.php
+++ b/library/Zend/Dom/Query.php
@@ -118,6 +118,10 @@ class Query
         }
         // breaking XML declaration to make syntax highlighting work
         if ('<' . '?xml' == substr(trim($document), 0, 5)) {
+            if (preg_match('/<html[^>]*xmlns="([^"]+)"[^>]*>/i', $document, $matches)) {
+                $this->_xpathNamespaces[] = $matches[1];
+                return $this->setDocumentXhtml($document, $encoding);
+            }
             return $this->setDocumentXml($document, $encoding);
         }
         if (strstr($document, 'DTD XHTML')) {

--- a/tests/Zend/Dom/QueryTest.php
+++ b/tests/Zend/Dom/QueryTest.php
@@ -282,4 +282,42 @@ EOF;
         $this->assertEquals('utf-8', $doc->encoding);
     }
 
+    /**
+     * @group ZF-11376
+     */
+    public function testXhtmlDocumentWithXmlDeclaration()
+    {
+        $xhtmlWithXmlDecl = <<<EOB
+<?xml version="1.0" encoding="UTF-8" ?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head><title /></head>
+    <body><p>Test paragraph.</p></body>
+</html>
+EOB;
+        $this->query->setDocument($xhtmlWithXmlDecl, 'utf-8');
+        $this->assertEquals(1, $this->query->execute('//p')->count());
+    }
+
+    /**
+     * @group ZF-12106
+     */
+    public function testXhtmlDocumentWithXmlAndDoctypeDeclaration()
+    {
+        $xhtmlWithXmlDecl = <<<EOB
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html 
+     PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <title>Virtual Library</title>
+  </head>
+  <body>
+    <p>Moved to <a href="http://example.org/">example.org</a>.</p>
+  </body>
+</html>
+EOB;
+        $this->query->setDocument($xhtmlWithXmlDecl, 'utf-8');
+        $this->assertEquals(1, $this->query->execute('//p')->count());
+    }
 }


### PR DESCRIPTION
[r24794](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=24794) 2012-05-12T00:20:01.497872Z

<pre>ZF-11376: Fix XHTML document detection when beginning with XML declaration
</pre>

- {M} [library/Zend/Dom/Query.php](http://framework.zend.com/code/diff.php?repname=Zend+Framework&path=%2Ftrunk%2Flibrary%2FZend%2FDom%2FQuery.php&rev=24794)
- {M} [tests/Zend/Dom/QueryTest.php](http://framework.zend.com/code/diff.php?repname=Zend+Framework&path=%2Ftrunk%2Ftests%2FZend%2FDom%2FQueryTest.php&rev=24794)

---

[r24830](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=24830) 2012-05-30T12:40:05.018995Z 

<pre>ZF-12106: DomQuery fails to evaluate XPath when there are warnings
</pre>

- {M} [library/Zend/Dom/Query.php](http://framework.zend.com/code/diff.php?repname=Zend+Framework&path=%2Ftrunk%2Flibrary%2FZend%2FDom%2FQuery.php&rev=24830)
- {M} [tests/Zend/Dom/QueryTest.php](http://framework.zend.com/code/diff.php?repname=Zend+Framework&path=%2Ftrunk%2Ftests%2FZend%2FDom%2FQueryTest.php&rev=24830)
