### PR TITLE
enable DOMXPath::registerPhpFunctions in Zend\Dom\Query

### DIFF
--- a/library/Zend/Dom/Query.php
+++ b/library/Zend/Dom/Query.php
@@ -69,6 +69,12 @@ class Query
      * @var array
      */
     protected $_xpathNamespaces = array();
+    
+    /**
+     * XPath PHP Functions
+     * @var mixed
+     */
+    protected $_xpathPhpFunctions;
 
     /**
      * Constructor
@@ -279,6 +285,17 @@ class Query
     }
 
     /**
+     * Register PHP Functions to use in internal DOMXPath
+     * 
+     * @param mixed $restrict
+     * @return void
+     */
+    public function registerXpathPhpFunctions($xpathPhpFunctions = true)
+    {
+        $this->_xpathPhpFunctions = $xpathPhpFunctions;
+    }
+
+    /**
      * Prepare node list
      *
      * @param  DOMDocument $document
@@ -290,6 +307,12 @@ class Query
         $xpath      = new DOMXPath($document);
         foreach ($this->_xpathNamespaces as $prefix => $namespaceUri) {
             $xpath->registerNamespace($prefix, $namespaceUri);
+        }
+        if ($this->_xpathPhpFunctions) {
+            $xpath->registerNamespace("php", "http://php.net/xpath");
+            ($this->_xpathPhpFunctions === true) ?
+                $xpath->registerPHPFunctions()
+                : $xpath->registerPHPFunctions($this->_xpathPhpFunctions);
         }
         $xpathQuery = (string) $xpathQuery;
         return $xpath->query($xpathQuery);

--- a/tests/Zend/Dom/QueryTest.php
+++ b/tests/Zend/Dom/QueryTest.php
@@ -201,6 +201,40 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($result), $result->getXpathQuery());
     }
 
+    public function testXpathPhpFunctionsShouldBeDisableByDefault()
+    {
+        $this->loadHtml();
+        try {
+            $this->query->queryXpath('//meta[php:functionString("strtolower", @http-equiv) = "content-type"]');
+        } catch (\Exception $e) {
+            return ;
+        }
+        $this->assertFails('XPath PHPFunctions should be disable by default');
+    }
+
+    public function testXpathPhpFunctionsShouldBeEnableWithoutParameter()
+    {
+        $this->loadHtml();
+        $this->query->registerXpathPhpFunctions();
+        $result = $this->query->queryXpath('//meta[php:functionString("strtolower", @http-equiv) = "content-type"]');
+        $this->assertEquals('content-type', 
+                            strtolower($result->current()->getAttribute('http-equiv')), 
+                            $result->getXpathQuery());
+    }
+
+    public function testXpathPhpFunctionsShouldBeNotCalledWhenSpecifiedFunction()
+    {
+        $this->loadHtml();
+        try {
+            $this->query->registerXpathPhpFunctions('stripos');
+            $this->query->queryXpath('//meta[php:functionString("strtolower", @http-equiv) = "content-type"]');
+        } catch (\Exception $e) {
+            // $e->getMessage() - Not allowed to call handler 'strtolower()
+            return ;
+        }
+        $this->assertFails('Not allowed to call handler strtolower()');
+    }
+
     /**
      * @group ZF-9243
      */


### PR DESCRIPTION
DOMXPath::registerPhpFunctions introduces in PHP 5.3
http://jp2.php.net/manual/en/domxpath.registerphpfunctions.php
http://arr.gr/blog/2010/04/xpath-regular-expression-matching-in-php-5-3/
This feature will offer xpath more easier.
