### PR TITLE
[ZF-10848][Code/Generator] sync svn r23559

### DIFF
--- a/library/Zend/Code/Generator/DocBlockGenerator.php
+++ b/library/Zend/Code/Generator/DocBlockGenerator.php
@@ -219,7 +219,11 @@ class DocBlockGenerator extends AbstractGenerator
         $content = wordwrap($content, 80, self::LINE_FEED);
         $lines   = explode(self::LINE_FEED, $content);
         foreach ($lines as $line) {
-            $output .= $indent . ' * ' . $line . self::LINE_FEED;
+            $output .= $indent . ' *';
+            if ($line) {
+                $output .= " $line";
+            }
+            $output .= self::LINE_FEED;
         }
         $output .= $indent . ' */' . self::LINE_FEED;
         return $output;

--- a/tests/Zend/Code/Generator/MethodGeneratorTest.php
+++ b/tests/Zend/Code/Generator/MethodGeneratorTest.php
@@ -81,9 +81,9 @@ class PhpMethodTest extends \PHPUnit_Framework_TestCase
         $target = <<<EOS
     /**
      * Enter description here...
-     * 
+     *
      * @return bool
-     * 
+     *
      */
     public function someMethod()
     {


### PR DESCRIPTION
http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=23559
ZF-10848 removing trailing whitespace from docblocks generated.
tests/Zend/Code/Generator/MethodGeneratorTest's testMethodFromReflection fixed, too (space removed).
