### PR TITLE
Get class content with multiline class declaration

### DIFF
--- a/library/Zend/Code/Reflection/ClassReflection.php
+++ b/library/Zend/Code/Reflection/ClassReflection.php
@@ -120,7 +120,10 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
         $startnum  = $this->getStartLine($includeDocBlock);
         $endnum    = $this->getEndLine() - $this->getStartLine();
 
-        return implode('', array_splice($filelines, $startnum, $endnum, true));
+        // Ensure we get between the open and close braces
+        $lines = array_slice($filelines, $startnum, $endnum);
+        array_unshift($lines, $filelines[$startnum-1]);
+        return strstr(implode('', $lines), '{');
     }
 
     /**

--- a/tests/Zend/Code/Reflection/ClassReflectionTest.php
+++ b/tests/Zend/Code/Reflection/ClassReflectionTest.php
@@ -122,6 +122,39 @@ EOS;
         $this->assertEquals(trim($target), trim($contents));
     }
 
+    public function testGetContentsReturnsContentsWithImplementsOnSeparateLine()
+    {
+        $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass9');
+        $target = <<<EOS
+{
+    protected \$_prop1 = null;
+
+    /**
+     * @Sample({"foo":"bar"})
+     */
+    protected \$_prop2 = null;
+
+    public function getProp1()
+    {
+        return \$this->_prop1;
+    }
+
+    public function getProp2(\$param1, TestSampleClass \$param2)
+    {
+        return \$this->_prop2;
+    }
+
+    public function getIterator()
+    {
+        return array();
+    }
+
+}
+EOS;
+        $contents = $reflectionClass->getContents();
+        $this->assertEquals(trim($target), trim($contents));
+    }
+
     public function testStartLine()
     {
         $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');

--- a/tests/Zend/Code/Reflection/TestAsset/TestSampleClass9.php
+++ b/tests/Zend/Code/Reflection/TestAsset/TestSampleClass9.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ZendTest\Code\Reflection\TestAsset;
+
+use ZendTest\Code\Reflection\TestAsset\SampleAnnotation as Sample;
+
+class TestSampleClass9
+    extends Sample
+    implements \IteratorAggregate
+{
+    protected $_prop1 = null;
+
+    /**
+     * @Sample({"foo":"bar"})
+     */
+    protected $_prop2 = null;
+
+    public function getProp1()
+    {
+        return $this->_prop1;
+    }
+
+    public function getProp2($param1, TestSampleClass $param2)
+    {
+        return $this->_prop2;
+    }
+
+    public function getIterator()
+    {
+        return array();
+    }
+
+}


### PR DESCRIPTION
When you have a class declared such as:

class Foo
   extends Bar
   implements Baz
{
    /\* ... */
}

The ClassReflection::getContent() method would not work properly, as
getStartLine() returns the line number immediately following the 'class'
keyword, regardless of how many lines the class declaration is spanned
over. Thus, you'd end up with some of the class declaration sometimes.
This patch starts at the 'class' keyword, and finds the first '{', and
considers that the start of the class. This is not 100% perfect, but
should cover 99% of cases.

Also, the getContent() method was using array_splice(), however,
array_slice() is more appropriate.
