### PR TITLE
Allow to merge inputs

### DIFF
--- a/library/Zend/Filter/FilterChain.php
+++ b/library/Zend/Filter/FilterChain.php
@@ -193,6 +193,21 @@ class FilterChain extends AbstractFilter implements Countable
     }
 
     /**
+     * Merge the filter chain with the one given in parameter
+     *
+     * @param FilterChain $filterChain
+     * @return FilterChain
+     */
+    public function merge(FilterChain $filterChain)
+    {
+        foreach ($filterChain->filters as $filter) {
+            $this->attach($filter);
+        }
+
+        return $this;
+    }
+
+    /**
      * Get all the filters
      *
      * @return SplPriorityQueue

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -562,10 +562,6 @@ class Form extends Fieldset implements FormInterface
             }
 
             $name = $element->getName();
-            if ($inputFilter->has($name)) {
-                // if we already have an input by this name, use it
-                continue;
-            }
 
             // Create an input based on the specification returned from the element
             $spec  = $element->getInputSpecification();

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -54,9 +54,10 @@ class BaseInputFilter implements InputFilterInterface
 
     /**
      * Add an input to the input filter
-     * 
-     * @param  InputInterface|InputFilterInterface $input 
-     * @param  null|string $name Name used to retrieve this input
+     *
+     * @param  InputInterface|InputFilterInterface $input
+     * @param  null|string                         $name Name used to retrieve this input
+     * @throws Exception\InvalidArgumentException
      * @return InputFilterInterface
      */
     public function add($input, $name = null)
@@ -74,6 +75,13 @@ class BaseInputFilter implements InputFilterInterface
         if (is_null($name) || $name === '') {
             $name = $input->getName();
         }
+
+        if (isset($this->inputs[$name]) && $this->inputs[$name] instanceof InputInterface) {
+            // The element already exists, so merge the config. Please note that the order is important (already existing
+            // input is merged with the parameter given)
+            $input->merge($this->inputs[$name]);
+        }
+
         $this->inputs[$name] = $input;
         return $this;
     }

--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -95,7 +95,6 @@ class Input implements InputInterface
         return $this;
     }
 
-
     public function allowEmpty()
     {
         return $this->allowEmpty;
@@ -104,6 +103,11 @@ class Input implements InputInterface
     public function breakOnFailure()
     {
         return $this->breakOnFailure;
+    }
+
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
     }
 
     public function getFilterChain()
@@ -141,6 +145,21 @@ class Input implements InputInterface
     {
         $filter = $this->getFilterChain();
         return $filter->filter($this->value);
+    }
+
+    public function merge(InputInterface $input)
+    {
+        $this->setAllowEmpty($input->allowEmpty());
+        $this->setBreakOnFailure($input->breakOnFailure());
+        $this->setErrorMessage($input->getErrorMessage());
+        $this->setName($input->getName());
+        $this->setRequired($input->isRequired());
+
+        $filterChain = $input->getFilterChain();
+        $this->getFilterChain()->merge($filterChain);
+
+        $validatorChain = $input->getValidatorChain();
+        $this->getValidatorChain()->merge($validatorChain);
     }
 
     public function isValid($context = null)

--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -154,6 +154,7 @@ class Input implements InputInterface
         $this->setErrorMessage($input->getErrorMessage());
         $this->setName($input->getName());
         $this->setRequired($input->isRequired());
+        $this->setValue($input->getValue());
 
         $filterChain = $input->getFilterChain();
         $this->getFilterChain()->merge($filterChain);

--- a/library/Zend/InputFilter/InputInterface.php
+++ b/library/Zend/InputFilter/InputInterface.php
@@ -39,9 +39,11 @@ interface InputInterface
     public function setRequired($required);
     public function setValidatorChain(ValidatorChain $validatorChain);
     public function setValue($value);
+    public function merge(InputInterface $input);
 
     public function allowEmpty();
     public function breakOnFailure();
+    public function getErrorMessage();
     public function getFilterChain();
     public function getName();
     public function getRawValue();

--- a/library/Zend/Validator/ValidatorChain.php
+++ b/library/Zend/Validator/ValidatorChain.php
@@ -198,6 +198,21 @@ class ValidatorChain implements
     }
 
     /**
+     * Merge the validator chain with the one given in parameter
+     *
+     * @param ValidatorChain $validatorChain
+     * @return ValidatorChain
+     */
+    public function merge(ValidatorChain $validatorChain)
+    {
+        foreach ($validatorChain->validators as $validator) {
+            $this->validators[] = $validator;
+        }
+
+        return $this;
+    }
+
+    /**
      * Returns array of validation failure messages
      *
      * @return array


### PR DESCRIPTION
This PR allow to input filter to be merged instead of being overrided. This allows for example to override some default behaviors of HTML 5 element (that are all required = true by default), or adding other filters/validators while still being able to use HTML5 elements.
