### PR TITLE
FirePhp Log Writer

### DIFF
--- a/library/Zend/Log/Formatter/FirePhp.php
+++ b/library/Zend/Log/Formatter/FirePhp.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage Formatter
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Log\Formatter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage Formatter
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FirePhp implements FormatterInterface
+{
+    /**
+     * Formats the given evevnt data into a single line to be written by the writer.
+     *
+     * @param array $event The event data which should be formatted.
+     * @return string
+     */
+    public function format($event)
+    {
+        return $event['message'];
+    }
+}

--- a/library/Zend/Log/Formatter/FirePhp.php
+++ b/library/Zend/Log/Formatter/FirePhp.php
@@ -1,22 +1,11 @@
 <?php
 /**
- * Zend Framework
+ * Zend Framework (http://framework.zend.com/)
  *
- * LICENSE
- *
- * This source file is subject to the new BSD license that is bundled
- * with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://framework.zend.com/license/new-bsd
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@zend.com so we can send you a copy immediately.
- *
- * @category   Zend
- * @package    Zend_Log
- * @subpackage Formatter
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Log
  */
 
 namespace Zend\Log\Formatter;
@@ -25,8 +14,6 @@ namespace Zend\Log\Formatter;
  * @category   Zend
  * @package    Zend_Log
  * @subpackage Formatter
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class FirePhp implements FormatterInterface
 {

--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -10,6 +10,8 @@
 
 namespace Zend\Log\Writer;
 
+use FB;
+use FirePhp as FirePhpInstance;
 use Zend\Log\Formatter\FirePhp as FirePhpFormatter;
 use Zend\Log\Logger;
 
@@ -21,18 +23,23 @@ use Zend\Log\Logger;
 class FirePhp extends AbstractWriter
 {
     /**
-     * Whether or not the writer is enabled.
+     * The instance of FirePhp that is used to log messages to.
      * 
-     * @var bool
+     * @var FB
      */
-    private $enabled;
+    private $firephp;
 
     /**
      * Initializes a new instance of this class.
      */
-    public function __construct()
+    public function __construct(FirePhpInstance $instance = null)
     {
-        $this->enabled = true;
+        if ($instance === null) {
+            $this->firephp = FirePhpInstance::getInstance(true);
+        } else {
+            $this->firephp = $instance;
+        }
+        
         $this->formatter = new FirePhpFormatter();
     }
 
@@ -44,7 +51,7 @@ class FirePhp extends AbstractWriter
      */
     protected function doWrite(array $event)
     {
-        if (!$this->isEnabled()) {
+        if (!$this->firephp->getEnabled()) {
             return;
         }
 
@@ -55,43 +62,43 @@ class FirePhp extends AbstractWriter
             case Logger::ALERT:
             case Logger::CRIT:
             case Logger::ERR:
-                \FB::error($line);
+                $this->firephp->error($line);
                 break;
             case Logger::WARN:
-                \FB::warn($line);
+                $this->firephp->warn($line);
                 break;
             case Logger::NOTICE:
             case Logger::INFO:
-                \FB::info($line);
+                $this->firephp->info($line);
                 break;
             case Logger::DEBUG:
-                \FB::trace($line);
+                $this->firephp->trace($line);
                 break;
             default:
-                \FB::log($line);
+                $this->firephp->log($line);
                 break;
         }
     }
 
     /**
-     * Checks whether or not the writer is enabled.
+     * Gets the FirePhp instance that is used for logging.
      * 
-     * @return bool
+     * @return FirePhpInstance
      */
-    public function isEnabled()
+    public function getFirePhp()
     {
-        return $this->enabled;
+        return $this->firephp;
     }
 
     /**
-     * Enables or disables the writer.
+     * Sets the FirePhp instance that is used for logging.
      * 
-     * @param bool $enabled The flag to set.
+     * @param FirePhpInstance $instance The FirePhp instance to set.
      * @return FirePhp
      */
-    public function setEnabled($enabled)
+    public function setFirePhp(FirePhpInstance $instance)
     {
-        $this->enabled = $enabled;
+        $this->firephp = $instance;
         return $this;
     }
 

--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -1,22 +1,11 @@
 <?php
 /**
- * Zend Framework
+ * Zend Framework (http://framework.zend.com/)
  *
- * LICENSE
- *
- * This source file is subject to the new BSD license that is bundled
- * with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://framework.zend.com/license/new-bsd
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@zend.com so we can send you a copy immediately.
- *
- * @category   Zend
- * @package    Zend_Log
- * @subpackage Writer
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Log
  */
 
 namespace Zend\Log\Writer;
@@ -28,8 +17,6 @@ use Zend\Log\Logger;
  * @category   Zend
  * @package    Zend_Log
  * @subpackage Writer
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class FirePhp extends AbstractWriter
 {

--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -24,9 +24,9 @@ class FirePhp extends AbstractWriter
     /**
      * The instance of FirePhp that is used to log messages to.
      * 
-     * @var FB
+     * @var FirePhpInstance
      */
-    private $firephp;
+    protected $firephp;
 
     /**
      * Initializes a new instance of this class.

--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -65,14 +65,8 @@ class FirePhp extends AbstractWriter
 
         switch ($event['priority']) {
             case Logger::EMERG:
-                \FB::log($line);
-                break;
             case Logger::ALERT:
-                \FB::log($line);
-                break;
             case Logger::CRIT:
-                \FB::log($line);
-                break;
             case Logger::ERR:
                 \FB::error($line);
                 break;
@@ -80,8 +74,6 @@ class FirePhp extends AbstractWriter
                 \FB::warn($line);
                 break;
             case Logger::NOTICE:
-                \FB::log($line);
-                break;
             case Logger::INFO:
                 \FB::info($line);
                 break;

--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -30,6 +30,8 @@ class FirePhp extends AbstractWriter
 
     /**
      * Initializes a new instance of this class.
+     * 
+     * @param FirePhpInstance $instance An (optional) instance of FirePhp that should be used for logging.
      */
     public function __construct(FirePhpInstance $instance = null)
     {
@@ -100,5 +102,4 @@ class FirePhp extends AbstractWriter
         $this->firephp = $instance;
         return $this;
     }
-
 }

--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -10,7 +10,6 @@
 
 namespace Zend\Log\Writer;
 
-use FB;
 use FirePhp as FirePhpInstance;
 use Zend\Log\Formatter\FirePhp as FirePhpFormatter;
 use Zend\Log\Logger;

--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage Writer
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Log\Writer;
+
+use Zend\Log\Formatter\FirePhp as FirePhpFormatter;
+use Zend\Log\Logger;
+
+/**
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage Writer
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class FirePhp extends AbstractWriter
+{
+    /**
+     * Initializes a new instance of this class.
+     */
+    public function __construct()
+    {
+        $this->formatter = new FirePhpFormatter();
+    }
+
+    /**
+     * Write a message to the log.
+     *
+     * @param array $event event data
+     * @return void
+     * @throws Exception\RuntimeException
+     */
+    protected function doWrite(array $event)
+    {
+        $line = $this->formatter->format($event);
+
+        switch ($event['priority']) {
+            case Logger::EMERG:
+                \FB::log($line);
+                break;
+            case Logger::ALERT:
+                \FB::log($line);
+                break;
+            case Logger::CRIT:
+                \FB::log($line);
+                break;
+            case Logger::ERR:
+                \FB::error($line);
+                break;
+            case Logger::WARN:
+                \FB::warn($line);
+                break;
+            case Logger::NOTICE:
+                \FB::log($line);
+                break;
+            case Logger::INFO:
+                \FB::info($line);
+                break;
+            case Logger::DEBUG:
+                \FB::log($line);
+                break;
+            default:
+                \FB::log($line);
+                break;
+        }
+    }
+}

--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -86,7 +86,7 @@ class FirePhp extends AbstractWriter
                 \FB::info($line);
                 break;
             case Logger::DEBUG:
-                \FB::log($line);
+                \FB::trace($line);
                 break;
             default:
                 \FB::log($line);

--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -10,7 +10,6 @@
 
 namespace Zend\Log\Writer;
 
-use FirePhp as FirePhpInstance;
 use Zend\Log\Formatter\FirePhp as FirePhpFormatter;
 use Zend\Log\Logger;
 
@@ -31,16 +30,12 @@ class FirePhp extends AbstractWriter
     /**
      * Initializes a new instance of this class.
      * 
-     * @param FirePhpInstance $instance An (optional) instance of FirePhp that should be used for logging.
+     * @param FirePhpInterface $instance An instance of FirePhpInterface
+     *        that should be used for logging
      */
-    public function __construct(FirePhpInstance $instance = null)
+    public function __construct(FirePhpInterface $instance)
     {
-        if ($instance === null) {
-            $this->firephp = FirePhpInstance::getInstance(true);
-        } else {
-            $this->firephp = $instance;
-        }
-        
+        $this->firephp   = $instance;
         $this->formatter = new FirePhpFormatter();
     }
 
@@ -94,10 +89,10 @@ class FirePhp extends AbstractWriter
     /**
      * Sets the FirePhp instance that is used for logging.
      * 
-     * @param FirePhpInstance $instance The FirePhp instance to set.
+     * @param  FirePhpInterface $instance The FirePhp instance to set.
      * @return FirePhp
      */
-    public function setFirePhp(FirePhpInstance $instance)
+    public function setFirePhp(FirePhpInterface $instance)
     {
         $this->firephp = $instance;
         return $this;

--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -34,10 +34,18 @@ use Zend\Log\Logger;
 class FirePhp extends AbstractWriter
 {
     /**
+     * Whether or not the writer is enabled.
+     * 
+     * @var bool
+     */
+    private $enabled;
+
+    /**
      * Initializes a new instance of this class.
      */
     public function __construct()
     {
+        $this->enabled = true;
         $this->formatter = new FirePhpFormatter();
     }
 
@@ -46,10 +54,13 @@ class FirePhp extends AbstractWriter
      *
      * @param array $event event data
      * @return void
-     * @throws Exception\RuntimeException
      */
     protected function doWrite(array $event)
     {
+        if (!$this->isEnabled()) {
+            return;
+        }
+
         $line = $this->formatter->format($event);
 
         switch ($event['priority']) {
@@ -82,4 +93,27 @@ class FirePhp extends AbstractWriter
                 break;
         }
     }
+
+    /**
+     * Checks whether or not the writer is enabled.
+     * 
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * Enables or disables the writer.
+     * 
+     * @param bool $enabled The flag to set.
+     * @return FirePhp
+     */
+    public function setEnabled($enabled)
+    {
+        $this->enabled = $enabled;
+        return $this;
+    }
+
 }

--- a/library/Zend/Log/Writer/FirePhpInterface.php
+++ b/library/Zend/Log/Writer/FirePhpInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Log
+ */
+namespace Zend\Log\Writer;
+
+/**
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage Writer
+ */
+
+interface FirePhpInterface
+{
+    public function getEnabled();
+    public function error($line);
+    public function warn($line);
+    public function info($line);
+    public function trace($line);
+    public function log($line);
+}

--- a/tests/Zend/Log/Formatter/FirePhpTest.php
+++ b/tests/Zend/Log/Formatter/FirePhpTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Log\Formatter;
+
+use Zend\Log\Formatter\FirePhp;
+
+/**
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Zend_Log
+ */
+class FirePhpTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFormat()
+    {
+        $fields = array( 'message' => 'foo' );
+
+        $f = new FirePhp();
+        $line = $f->format($fields);
+
+        $this->assertContains($fields['message'], $line);
+    }    
+}

--- a/tests/Zend/Log/TestAsset/MockFirePhp.php
+++ b/tests/Zend/Log/TestAsset/MockFirePhp.php
@@ -1,0 +1,45 @@
+<?php
+namespace ZendTest\Log\TestAsset;
+
+use Zend\Log\Writer\FirePhpInterface;
+
+class MockFirePhp implements FirePhpInterface {
+    
+    public $calls = array();
+   
+    protected $enabled;
+    
+    public function __construct($enabled = true) {
+        $this->enabled = $enabled;
+    }
+    
+    public function getEnabled()
+    {
+        return $this->enabled;
+    }
+    
+    public function error($line)
+    {
+        $this->calls['error'][] = $line;
+    }
+    
+    public function warn($line)
+    {
+        $this->calls['warn'][] = $line;
+    }
+    
+    public function info($line)
+    {
+        $this->calls['info'][] = $line;
+    }
+    
+    public function trace($line)
+    {
+        $this->calls['trace'][] = $line;
+    }
+    
+    public function log($line)
+    {
+        $this->calls['log'][] = $line;
+    }
+}

--- a/tests/Zend/Log/Writer/FirePhpTest.php
+++ b/tests/Zend/Log/Writer/FirePhpTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Log\Writer;
+
+use ZendTest\Log\TestAsset\MockFirePhp;
+use Zend\Log\Writer\FirePhp;
+use Zend\Log\Writer\FirePhpInterface;
+use Zend\Log\Logger;
+
+/**
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Zend_Log
+ */
+class FirePhpTest extends \PHPUnit_Framework_TestCase
+{
+    protected $firephp;
+    
+    public function setUp()
+    {
+        $this->firephp = new MockFirePhp();
+        
+    }
+    /**
+     * Test get FirePhp
+     */
+    public function testGetFirePhp()
+    {
+        $writer = new FirePhp($this->firephp);
+        $this->assertTrue($writer->getFirePhp() instanceof FirePhpInterface);
+    }
+    /**
+     * Test set firephp
+     */
+    public function testSetFirePhp()
+    {
+        $writer   = new FirePhp($this->firephp);
+        $firephp2 = new MockFirePhp();
+        
+        $writer->setFirePhp($firephp2);
+        $this->assertTrue($writer->getFirePhp() instanceof FirePhpInterface);
+        $this->assertEquals($firephp2, $writer->getFirePhp());
+    }
+    /**
+     * Test write
+     */
+    public function testWrite()
+    {
+        $writer = new FirePhp($this->firephp);
+        $writer->write(array(
+            'message' => 'my msg',
+            'priority' => Logger::DEBUG
+        ));
+        $this->assertEquals('my msg', $this->firephp->calls['trace'][0]);
+    }
+    /**
+     * Test write with FirePhp disabled
+     */
+    public function testWriteDisabled()
+    {
+        $firephp = new MockFirePhp(false);
+        $writer = new FirePhp($firephp);
+        $writer->write(array(
+            'message' => 'my msg',
+            'priority' => Logger::DEBUG
+        ));
+        $this->assertTrue(empty($this->firephp->calls));
+    }
+}


### PR DESCRIPTION
Evan came with the idea to use FirePhp directly instead of using the Wildfire component. I'm in favor of doing so. I did some research on the current Wildfire component and came to the conclusion that the component is just to tangled to ZF1. This basically means that we would have to rewrite the component entirely. So why not use FirePhp directly?

FirePhp can be installed with Composer so it's easy to use. Within minutes I managed to create the following: http://grab.by/eCGM

Features that are not supported yet:
- Grouping of messages; to do this in a nice way we need to do some refactoring on the Log component.
- Logging of tables; to do this in a nice way we need to do some refactoring on the Log component.
- Exception logging; afaik there can be only one exception handler function. The MVC component owns this now.
