### PR TITLE
Unify form view helpers

### DIFF
--- a/library/Zend/Form/Element/Checkbox.php
+++ b/library/Zend/Form/Element/Checkbox.php
@@ -25,6 +25,8 @@ use Traversable;
 use Zend\Form\Element;
 use Zend\Form\Exception;
 use Zend\InputFilter\InputProviderInterface;
+use Zend\Validator\InArray as InArrayValidator;
+use Zend\Validator\ValidatorInterface;
 
 /**
  * @category   Zend
@@ -43,6 +45,11 @@ class Checkbox extends Element implements InputProviderInterface
     protected $attributes = array(
         'type' => 'checkbox'
     );
+
+    /**
+     * @var ValidatorInterface
+     */
+    protected $validator;
 
     /**
      * @var bool
@@ -154,6 +161,22 @@ class Checkbox extends Element implements InputProviderInterface
     }
 
     /**
+     * Get validator
+     *
+     * @return ValidatorInterface
+     */
+    protected function getValidator()
+    {
+        if (null === $this->validator) {
+            $this->validator = new InArrayValidator(array(
+                'haystack' => array($this->checkedValue, $this->uncheckedValue),
+                'strict'   => false
+            ));
+        }
+        return $this->validator;
+    }
+
+    /**
      * Provide default input rules for this element
      *
      * Attaches the captcha as a validator.
@@ -164,7 +187,8 @@ class Checkbox extends Element implements InputProviderInterface
     {
         $spec = array(
             'name' => $this->getName(),
-            'required' => true
+            'required' => true,
+            'validators' => $this->getValidator()
         );
 
         return $spec;

--- a/library/Zend/Form/Element/Checkbox.php
+++ b/library/Zend/Form/Element/Checkbox.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Element
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\Element;
+
+use Traversable;
+use Zend\Form\Element;
+use Zend\Form\Exception;
+use Zend\InputFilter\InputProviderInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Element
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Checkbox extends Element implements InputProviderInterface
+{
+    /**
+     * @var bool
+     */
+    protected $useHiddenElement = true;
+
+    /**
+     * @var string
+     */
+    protected $uncheckedValue = '0';
+
+    /**
+     * @var string
+     */
+    protected $checkedValue = '1';
+
+    /**
+     * Accepted options for MultiCheckbox:
+     * - use_hidden_element: do we render hidden element?
+     * - unchecked_value: value for checkbox when unchecked
+     * - checked_value: value for checkbox when checked
+     *
+     * @param  array|\Traversable $options
+     * @return Checkbox
+     */
+    public function setOptions($options)
+    {
+        parent::setOptions($options);
+
+        if (isset($options['use_hidden_element'])) {
+            $this->setUseHiddenElement($options['use_hidden_element']);
+        }
+
+        if (isset($options['unchecked_value'])) {
+            $this->setUncheckedValue($options['unchecked_value']);
+        }
+
+        if (isset($options['checked_value'])) {
+            $this->setCheckedValue($options['checked_value']);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Do we render hidden element?
+     *
+     * @param  bool $useHiddenElement
+     * @return Checkbox
+     */
+    public function setUseHiddenElement($useHiddenElement)
+    {
+        $this->useHiddenElement = (bool)$useHiddenElement;
+        return $this;
+    }
+
+    /**
+     * Do we render hidden element?
+     *
+     * @return bool
+     */
+    public function useHiddenElement()
+    {
+        return $this->useHiddenElement;
+    }
+
+    /**
+     * Set the value to use when checkbox is unchecked
+     *
+     * @param $uncheckedValue
+     * @return Checkbox
+     */
+    public function setUncheckedValue($uncheckedValue)
+    {
+        $this->uncheckedValue = $uncheckedValue;
+        return $this;
+    }
+
+    /**
+     * Get the value to use when checkbox is unchecked
+     *
+     * @return string
+     */
+    public function getUncheckedValue()
+    {
+        return $this->uncheckedValue;
+    }
+
+    /**
+     * Set the value to use when checkbox is checked
+     *
+     * @param $checkedValue
+     * @return Checkbox
+     */
+    public function setCheckedValue($checkedValue)
+    {
+        $this->checkedValue = $checkedValue;
+        return $this;
+    }
+
+    /**
+     * Get the value to use when checkbox is checked
+     *
+     * @return string
+     */
+    public function getCheckedValue()
+    {
+        return $this->checkedValue;
+    }
+
+    /**
+     * Provide default input rules for this element
+     *
+     * Attaches the captcha as a validator.
+     *
+     * @return array
+     */
+    public function getInputSpecification()
+    {
+        $spec = array(
+            'name' => $this->getName(),
+            'required' => true
+        );
+
+        return $spec;
+    }
+}

--- a/library/Zend/Form/Element/Checkbox.php
+++ b/library/Zend/Form/Element/Checkbox.php
@@ -36,6 +36,15 @@ use Zend\InputFilter\InputProviderInterface;
 class Checkbox extends Element implements InputProviderInterface
 {
     /**
+     * Seed attributes
+     *
+     * @var array
+     */
+    protected $attributes = array(
+        'type' => 'checkbox'
+    );
+
+    /**
      * @var bool
      */
     protected $useHiddenElement = true;

--- a/library/Zend/Form/Element/Checkbox.php
+++ b/library/Zend/Form/Element/Checkbox.php
@@ -188,7 +188,9 @@ class Checkbox extends Element implements InputProviderInterface
         $spec = array(
             'name' => $this->getName(),
             'required' => true,
-            'validators' => $this->getValidator()
+            'validators' => array(
+                $this->getValidator()
+            )
         );
 
         return $spec;

--- a/library/Zend/Form/Element/MultiCheckbox.php
+++ b/library/Zend/Form/Element/MultiCheckbox.php
@@ -21,11 +21,6 @@
 
 namespace Zend\Form\Element;
 
-use Traversable;
-use Zend\Form\Element;
-use Zend\Form\Exception;
-use Zend\InputFilter\InputProviderInterface;
-
 /**
  * @category   Zend
  * @package    Zend_Form
@@ -33,131 +28,10 @@ use Zend\InputFilter\InputProviderInterface;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class MultiCheckbox extends Element implements InputProviderInterface
+class MultiCheckbox extends Checkbox
 {
     /**
      * @var bool
      */
-    protected $useHiddenElement;
-
-    /**
-     * @var string
-     */
-    protected $uncheckedValue;
-
-    /**
-     * @var array
-     */
-    protected $labelAttributes;
-
-    /**
-     * Accepted options for MultiCheckbox:
-     * - use_hidden_element: do we render hidden element?
-     * - unchecked_value: value for checkbox when unchecked
-     * - label_attributes: attributes to use for the label
-     *
-     * @param  array|\Traversable $options
-     * @return MultiCheckbox
-     */
-    public function setOptions($options)
-    {
-        parent::setOptions($options);
-
-        if (isset($options['use_hidden_element'])) {
-            $this->setUseHiddenElement($options['use_hidden_element']);
-        }
-
-        if (isset($options['unchecked_value'])) {
-            $this->setUncheckedValue($options['unchecked_value']);
-        }
-
-        if (isset($options['label_attributes'])) {
-            $this->setLabelAttributes($options['label_attributes']);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Do we render hidden element?
-     *
-     * @param  bool $useHiddenElement
-     * @return MultiCheckbox
-     */
-    public function setUseHiddenElement($useHiddenElement)
-    {
-        $this->useHiddenElement = (bool)$useHiddenElement;
-        return $this;
-    }
-
-    /**
-     * Do we render hidden element?
-     *
-     * @return bool
-     */
-    public function useHiddenElement()
-    {
-        return $this->useHiddenElement;
-    }
-
-    /**
-     * Set the value to use when checkbox is unchecked
-     *
-     * @param $uncheckedValue
-     * @return MultiCheckbox
-     */
-    public function setUncheckedValue($uncheckedValue)
-    {
-        $this->uncheckedValue = $uncheckedValue;
-        return $this;
-    }
-
-    /**
-     * Get the value to use when checkbox is unchecked
-     *
-     * @return string
-     */
-    public function getUncheckedValue()
-    {
-        return $this->uncheckedValue;
-    }
-
-    /**
-     * Set the label attributes
-     *
-     * @param  array $labelAttributes
-     * @return MultiCheckbox
-     */
-    public function setLabelAttributes(array $labelAttributes)
-    {
-        $this->labelAttributes = $labelAttributes;
-        return $this;
-    }
-
-    /**
-     * Get the label attributes
-     *
-     * @return array
-     */
-    public function getLabelAttributes()
-    {
-        return $this->labelAttributes;
-    }
-
-    /**
-     * Provide default input rules for this element
-     *
-     * Attaches the captcha as a validator.
-     *
-     * @return array
-     */
-    public function getInputSpecification()
-    {
-        $spec = array(
-            'name' => $this->getName(),
-            'required' => true
-        );
-
-        return $spec;
-    }
+    protected $useHiddenElement = false;
 }

--- a/library/Zend/Form/Element/Radio.php
+++ b/library/Zend/Form/Element/Radio.php
@@ -30,4 +30,12 @@ namespace Zend\Form\Element;
  */
 class Radio extends MultiCheckbox
 {
+    /**
+     * Seed attributes
+     *
+     * @var array
+     */
+    protected $attributes = array(
+        'type' => 'radio'
+    );
 }

--- a/library/Zend/Form/Element/Radio.php
+++ b/library/Zend/Form/Element/Radio.php
@@ -21,7 +21,6 @@
 
 namespace Zend\Form\Element;
 
-
 /**
  * @category   Zend
  * @package    Zend_Form

--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -35,46 +35,10 @@ use Zend\Form\Exception;
 class FormCheckbox extends FormInput
 {
     /**
-     * @var boolean
-     */
-    protected $useHiddenElement = true;
-
-    /**
-     * @var array
-     */
-    protected $defaultStateValues = array(
-        'checkedValue'   => '1',
-        'uncheckedValue' => '0',
-    );
-
-    /**
-     * Returns the option for prefixing the element with a hidden element
-     * for the unset value.
-     *
-     * @return boolean
-     */
-    public function getUseHiddenElement()
-    {
-        return $this->useHiddenElement;
-    }
-
-    /**
-     * Sets the option for prefixing the element with a hidden element
-     * for the unset value.
-     *
-     * @param  boolean $useHiddenElement
-     * @return FormCheckbox
-     */
-    public function setUseHiddenElement($useHiddenElement)
-    {
-        $this->useHiddenElement = (bool) $useHiddenElement;
-        return $this;
-    }
-
-    /**
      * Render a form <input> element from the provided $element
      *
      * @param  ElementInterface $element
+     * @throws \Zend\Form\Exception\DomainException
      * @return string
      */
     public function render(ElementInterface $element)
@@ -87,36 +51,16 @@ class FormCheckbox extends FormInput
             ));
         }
 
-        $attributes = $element->getAttributes();
-        if (empty($attributes['options'])) {
-            $attributes['options'] = array();
-        }
-        $options = $attributes['options'];
-        unset($attributes['options']);
-
-        // default checked/unchecked values
-        foreach ($this->defaultStateValues as $key => $value) {
-            if (empty($options[$key])) {
-                $options[$key] = $value;
-            }
-        }
-
-        if (!is_array($options) && !$options instanceof Traversable) {
-            throw new Exception\DomainException(sprintf(
-                '%s requires that the element has an array or Traversable "options" attribute.',
-                __METHOD__
-            ));
-        }
-
+        $attributes            = $element->getAttributes();
         $attributes['name']    = $name;
         $attributes['checked'] = '';
         $attributes['type']    = $this->getInputType();
         $closingBracket        = $this->getInlineClosingBracket();
 
-        if (isset($attributes['value']) && $attributes['value'] == $options['checkedValue']) {
+        if (isset($attributes['value']) && $attributes['value'] == $element->getCheckedValue()) {
             $attributes['checked'] = 'checked';
         }
-        $attributes['value'] = $options['checkedValue'];
+        $attributes['value'] = $element->getCheckedValue();
 
         $rendered = sprintf(
             '<input %s%s',
@@ -124,21 +68,19 @@ class FormCheckbox extends FormInput
             $closingBracket
         );
 
-        $useHiddenElement = isset($attributes['useHiddenElement'])
-            ? (bool) $attributes['useHiddenElement']
-            : $this->useHiddenElement;
+        $useHiddenElement = $element->useHiddenElement();
 
         if ($useHiddenElement) {
             $hiddenAttributes = array(
                 'name'  => $attributes['name'],
-                'value' => $options['uncheckedValue'],
+                'value' => $element->getUncheckedValue()
             );
 
-            $rendered = sprintf(
+            $rendered = $rendered . sprintf(
                 '<input type="hidden" %s%s',
                 $this->createAttributesString($hiddenAttributes),
                 $closingBracket
-            ) . $rendered;
+            );
         }
 
         return $rendered;

--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -76,11 +76,11 @@ class FormCheckbox extends FormInput
                 'value' => $element->getUncheckedValue()
             );
 
-            $rendered = $rendered . sprintf(
+            $rendered = sprintf(
                 '<input type="hidden" %s%s',
                 $this->createAttributesString($hiddenAttributes),
                 $closingBracket
-            );
+            ) . $rendered;
         }
 
         return $rendered;

--- a/tests/Zend/Form/Element/CheckboxTest.php
+++ b/tests/Zend/Form/Element/CheckboxTest.php
@@ -33,4 +33,28 @@ class CheckboxTest extends TestCase
         $this->assertEquals('1', $element->getCheckedValue());
         $this->assertEquals('0', $element->getUncheckedValue());
     }
+
+    public function testProvidesInputSpecificationThatIncludesValidatorsBasedOnAttributes()
+    {
+        $element = new CheckboxElement();
+
+        $inputSpec = $element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $this->assertInternalType('array', $inputSpec['validators']);
+
+        $expectedClasses = array(
+            'Zend\Validator\InArray'
+        );
+        foreach ($inputSpec['validators'] as $validator) {
+            $class = get_class($validator);
+            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            switch ($class) {
+                case 'Zend\Validator\InArray':
+                    $this->assertEquals(array($element->getCheckedValue(), $element->getUncheckedValue()), $validator->getHaystack());
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
 }

--- a/tests/Zend/Form/Element/CheckboxTest.php
+++ b/tests/Zend/Form/Element/CheckboxTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\Element;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Element\Checkbox as CheckboxElement;
+use Zend\Form\Factory;
+
+class CheckboxTest extends TestCase
+{
+    public function testProvidesValidDefaultValues()
+    {
+        $element = new CheckboxElement();
+        $this->assertEquals('1', $element->getCheckedValue());
+        $this->assertEquals('0', $element->getUncheckedValue());
+    }
+}

--- a/tests/Zend/Form/View/Helper/FormCheckboxTest.php
+++ b/tests/Zend/Form/View/Helper/FormCheckboxTest.php
@@ -41,19 +41,18 @@ class FormCheckboxTest extends CommonTestCase
 
     public function getElement() 
     {
-        $element = new Element('foo');
+        $element = new Element\Checkbox('foo');
         $options = array(
-            'checkedValue'   => 'checked',
-            'uncheckedValue' => 'unchecked',
+            'checked_value'   => 'checked',
+            'unchecked_value' => 'unchecked',
         );
-        $element->setAttribute('options', $options);
+        $element->setOptions($options);
         return $element;
     }
 
     public function testUsesOptionsAttributeToGenerateCheckedAndUnCheckedValues()
     {
         $element = $this->getElement();
-        $options = $element->getAttribute('options');
         $markup  = $this->helper->render($element);
 
         $this->assertContains('type="checkbox"', $markup);
@@ -74,24 +73,16 @@ class FormCheckboxTest extends CommonTestCase
 
     public function testNoOptionsAttributeCreatesDefaultCheckedAndUncheckedValues()
     {
-        $element = new Element('foo');
+        $element = new Element\Checkbox('foo');
         $markup  = $this->helper->render($element);
         $this->assertRegexp('#type="checkbox"\s+value="1"#', $markup);
         $this->assertRegexp('#type="hidden"\s+name="foo"\s+value="0"#', $markup);
     }
 
-    public function testSetUseHiddenElementDoesNotRenderHiddenInput()
-    {
-        $element = new Element('foo');
-        $markup  = $this->helper->setUseHiddenElement(false)->render($element);
-        $this->assertRegexp('#type="checkbox"\s+value="1"#', $markup);
-        $this->assertNotRegexp('#type="hidden"\s+name="foo"\s+value="0"#', $markup);
-    }
-
     public function testSetUseHiddenElementAttributeDoesNotRenderHiddenInput()
     {
-        $element = new Element('foo');
-        $element->setAttribute('useHiddenElement', false);
+        $element = new Element\Checkbox('foo');
+        $element->setUseHiddenElement(false);
         $markup  = $this->helper->render($element);
         $this->assertRegexp('#type="checkbox"\s+value="1"#', $markup);
         $this->assertNotRegexp('#type="hidden"\s+name="foo"\s+value="0"#', $markup);

--- a/tests/Zend/Form/View/Helper/FormElementTest.php
+++ b/tests/Zend/Form/View/Helper/FormElementTest.php
@@ -91,6 +91,8 @@ class FormElementTest extends TestCase
     {
         if ($type === 'radio') {
             $element = new Element\Radio('foo');
+        } elseif ($type === 'checkbox') {
+            $element = new Element\Checkbox('foo');
         } else {
             $element = new Element('foo');
         }


### PR DESCRIPTION
This PR aims to unify the form view helpers. The checkbox view helper still had options in attributes array, so this is removed now, and checkbox have its own Element with options.

So this is a minor BC. Tests were updated.
