### PR TITLE
Move is_subclass_of code to Zend\Stdlib

### DIFF
--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -3,6 +3,7 @@
 namespace Zend\Di;
 
 use Closure;
+use Zend\Stdlib\SubClass;
 
 class Di implements DependencyInjectionInterface
 {
@@ -301,7 +302,7 @@ class Di implements DependencyInjectionInterface
                                         if ($methodParams) {
                                             foreach ($methodParams as $methodParam) {
                                                 $objectToInjectClass = $this->getClass($objectToInject);
-                                                if ($objectToInjectClass == $methodParam[1] || $this->isSubclassOf($objectToInjectClass, $methodParam[1])) {
+                                                if ($objectToInjectClass == $methodParam[1] || SubClass::isSubclassOf($objectToInjectClass, $methodParam[1])) {
                                                     if ($this->resolveAndCallInjectionMethodForInstance($instance, $typeInjectionMethod, array($methodParam[0] => $objectToInject), $instanceAlias, true, $type)) {
                                                         $calledMethods[$typeInjectionMethod] = true;
                                                     }
@@ -574,7 +575,7 @@ class Di implements DependencyInjectionInterface
                     }
                     $pInstanceClass = ($this->instanceManager->hasAlias($pInstance)) ?
                          $this->instanceManager->getClassFromAlias($pInstance) : $pInstance;
-                    if ($pInstanceClass === $type || $this->isSubclassOf($pInstanceClass, $type)) {
+                    if ($pInstanceClass === $type || SubClass::isSubclassOf($pInstanceClass, $type)) {
                         $computedParams['required'][$fqParamPos] = array($pInstance, $pInstanceClass);
                         continue 2;
                     }
@@ -591,7 +592,7 @@ class Di implements DependencyInjectionInterface
                     }
                     $pInstanceClass = ($this->instanceManager->hasAlias($pInstance)) ?
                          $this->instanceManager->getClassFromAlias($pInstance) : $pInstance;
-                    if ($pInstanceClass === $type || $this->isSubclassOf($pInstanceClass, $type)) {
+                    if ($pInstanceClass === $type || SubClass::isSubclassOf($pInstanceClass, $type)) {
                         $computedParams['required'][$fqParamPos] = array($pInstance, $pInstanceClass);
                         continue 2;
                     }
@@ -671,28 +672,6 @@ class Di implements DependencyInjectionInterface
     protected function getClass($instance)
     {
         return get_class($instance);
-    }
-
-    /**
-     * @see https://bugs.php.net/bug.php?id=53727
-     *
-     * @param $class
-     * @param $type
-     * @return bool
-     */
-    protected function isSubclassOf($class, $type)
-    {
-        /* @var $isSubclassFunc Closure */
-        static $isSubclassFuncCache = null; // null as unset, array when set
-
-        if ($isSubclassFuncCache === null) {
-            $isSubclassFuncCache = array();
-        }
-
-        if (!array_key_exists($class, $isSubclassFuncCache)) {
-            $isSubclassFuncCache[$class] = class_parents($class, true) + class_implements($class, true);
-        }
-        return (isset($isSubclassFuncCache[$class][$type]));
     }
 
 }

--- a/library/Zend/Form/Annotation/AnnotationBuilder.php
+++ b/library/Zend/Form/Annotation/AnnotationBuilder.php
@@ -33,6 +33,7 @@ use Zend\EventManager\EventManagerInterface;
 use Zend\Form\Exception;
 use Zend\Form\Factory;
 use Zend\Stdlib\ArrayUtils;
+use Zend\Stdlib\SubClass;
 
 /**
  * Parses a class' properties for annotations in order to create a form and
@@ -339,7 +340,7 @@ class AnnotationBuilder implements EventManagerAwareInterface
             : 'Zend\Form\Element';
 
         // Compose as a fieldset or an element, based on specification type
-        if ($this->isFieldset($type)) {
+        if (SubClass::isSubclassOf($type, 'Zend\Form\FieldsetInterface')) {
             if (!isset($formSpec['fieldsets'])) {
                 $formSpec['fieldsets'] = array();
             }
@@ -386,23 +387,4 @@ class AnnotationBuilder implements EventManagerAwareInterface
         return (bool) $results->last();
     }
 
-    /**
-     * Determine if the type represents a fieldset
-     *
-     * For PHP versions >= 5.3.7, uses is_subclass_of; otherwise, uses
-     * reflection to determine the interfaces implemented.
-     *
-     * @param  string $type
-     * @return bool
-     */
-    protected function isFieldset($type)
-    {
-        if (version_compare(PHP_VERSION, '5.3.7', 'gte')) {
-            return is_subclass_of($type, 'Zend\Form\FieldsetInterface');
-        }
-
-        $r = new ClassReflection($type);
-        $interfaces = $r->getInterfaceNames();
-        return (in_array('Zend\Form\FieldsetInterface', $interfaces));
-    }
 }

--- a/library/Zend/Form/Factory.php
+++ b/library/Zend/Form/Factory.php
@@ -27,6 +27,7 @@ use Zend\InputFilter\Factory as InputFilterFactory;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\Hydrator;
+use Zend\Stdlib\SubClass;
 
 /**
  * @category   Zend
@@ -84,33 +85,20 @@ class Factory
         $spec = $this->validateSpecification($spec, __METHOD__);
         $type = isset($spec['type']) ? $spec['type'] : 'Zend\Form\Element';
 
-        if ($type instanceof FormInterface) {
+        if (SubClass::isSubclassOf($type, 'Zend\Form\FormInterface')) {
             return $this->createForm($spec);
         }
 
-        if ($type instanceof FieldsetInterface) {
+        if (SubClass::isSubclassOf($type, 'Zend\Form\FieldsetInterface')) {
             return $this->createFieldset($spec);
         }
 
-        if ($type instanceof ElementInterface) {
+        if (SubClass::isSubclassOf($type, 'Zend\Form\ElementInterface')) {
             return $this->createElement($spec);
         }
 
-        if (is_string($type) && class_exists($type)) {
-            $reflection = new ReflectionClass($type);
-            if ($reflection->implementsInterface('Zend\Form\FormInterface')) {
-                return $this->createForm($spec);
-            }
-            if ($reflection->implementsInterface('Zend\Form\FieldsetInterface')) {
-                return $this->createFieldset($spec);
-            }
-            if ($reflection->implementsInterface('Zend\Form\ElementInterface')) {
-                return $this->createElement($spec);
-            }
-        }
-
         throw new Exception\DomainException(sprintf(
-            '%s expects the $spec["type"] to implement one of %s, %s, %s, or a valid full qualified class name; received %s',
+            '%s expects the $spec["type"] to implement one of %s, %s, or %s; received %s',
             __METHOD__,
             'Zend\Form\ElementInterface',
             'Zend\Form\FieldsetInterface',

--- a/library/Zend/InfoCard/XML/AbstractElement.php
+++ b/library/Zend/InfoCard/XML/AbstractElement.php
@@ -23,6 +23,7 @@ namespace Zend\InfoCard\XML;
 
 use DOMElement;
 use SimpleXMLElement;
+use Zend\Stdlib\SubClass;
 
 /**
  * An abstract class representing a an XML data block
@@ -80,7 +81,7 @@ abstract class AbstractElement extends SimpleXMLElement implements ElementInterf
             throw new Exception\InvalidArgumentException('Class provided for converting does not exist');
         }
 
-        if(!is_subclass_of($classname, 'Zend\InfoCard\XML\ElementInterface')) {
+        if (!SubClass::isSubclassOf($classname, 'Zend\InfoCard\XML\ElementInterface')) {
             throw new Exception\InvalidArgumentException("DOM element must be converted to an instance of Zend_InfoCard_Xml_Element");
         }
 

--- a/library/Zend/Loader/AutoloaderFactory.php
+++ b/library/Zend/Loader/AutoloaderFactory.php
@@ -102,15 +102,12 @@ abstract class AutoloaderFactory
                     );
                 }
 
-                // unfortunately is_subclass_of is broken on some 5.3 versions
-                // additionally instanceof is also broken for this use case
-                if (version_compare(PHP_VERSION, '5.3.7', '>=')) {
-                    if (!is_subclass_of($class, 'Zend\Loader\SplAutoloader')) {
-                        require_once 'Exception/InvalidArgumentException.php';
-                        throw new Exception\InvalidArgumentException(
-                            sprintf('Autoloader class %s must implement Zend\\Loader\\SplAutoloader', $class)
-                        );
-                    }
+                require_once 'Zend\Stdlib\SubClass.php';
+                if (!\Zend\Stdlib\SubClass::isSubclassOf($class, 'Zend\Loader\SplAutoloader')) {
+                    require_once 'Exception/InvalidArgumentException.php';
+                    throw new Exception\InvalidArgumentException(
+                        sprintf('Autoloader class %s must implement Zend\\Loader\\SplAutoloader', $class)
+                    );
                 }
 
                 if ($class === static::STANDARD_AUTOLOADER) {

--- a/library/Zend/Loader/AutoloaderFactory.php
+++ b/library/Zend/Loader/AutoloaderFactory.php
@@ -102,7 +102,7 @@ abstract class AutoloaderFactory
                     );
                 }
 
-                require_once 'Zend\Stdlib\SubClass.php';
+                require_once __DIR__ . '/../Stdlib/SubClass.php';
                 if (!\Zend\Stdlib\SubClass::isSubclassOf($class, 'Zend\Loader\SplAutoloader')) {
                     require_once 'Exception/InvalidArgumentException.php';
                     throw new Exception\InvalidArgumentException(

--- a/library/Zend/Mvc/Router/RoutePluginManager.php
+++ b/library/Zend/Mvc/Router/RoutePluginManager.php
@@ -21,6 +21,7 @@
 
 namespace Zend\Mvc\Router;
 
+use Zend\Stdlib\SubClass;
 use Zend\ServiceManager\AbstractPluginManager;
 
 /**
@@ -92,7 +93,7 @@ class RoutePluginManager extends AbstractPluginManager
             ));
         }
 
-        if (!$this->isSubclassOf($invokable, __NAMESPACE__ . '\RouteInterface')) {
+        if (!SubClass::isSubclassOf($invokable, __NAMESPACE__ . '\RouteInterface')) {
             throw new Exception\RuntimeException(sprintf(
                 '%s: failed retrieving "%s%s" via invokable class "%s"; class does not implement %s\RouteInterface',
                 __METHOD__,

--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -20,8 +20,6 @@
 
 namespace Zend\ServiceManager;
 
-use Zend\Code\Reflection\ClassReflection;
-
 /**
  * ServiceManager implementation for managing plugins
  *
@@ -194,24 +192,4 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
         return $instance;
     }
 
-    /**
-     * Determine if a class implements a given interface
-     *
-     * For PHP versions >= 5.3.7, uses is_subclass_of; otherwise, uses
-     * reflection to determine the interfaces implemented.
-     *
-     * @param  string $class
-     * @param  string $type
-     * @return bool
-     */
-    protected function isSubclassOf($class, $type)
-    {
-        if (version_compare(PHP_VERSION, '5.3.7', 'gte')) {
-            return is_subclass_of($class, $type);
-        }
-
-        $r = new ClassReflection($class);
-        $interfaces = $r->getInterfaceNames();
-        return (in_array($type, $interfaces));
-    }
 }

--- a/library/Zend/Stdlib/SubClass.php
+++ b/library/Zend/Stdlib/SubClass.php
@@ -36,7 +36,7 @@ abstract class SubClass
             return is_subclass_of($object, $type);
         }
         if (is_object($object)) {
-            $className = get_class($object);
+            return ($object instanceof $type);
         } else {
             $className = $object;
         }

--- a/library/Zend/Stdlib/SubClass.php
+++ b/library/Zend/Stdlib/SubClass.php
@@ -24,13 +24,16 @@ abstract class SubClass
             return is_subclass_of($object, $type);
         }
         if (is_object($object)) {
-            $object = get_class($object);
+            $className = get_class($object);
+        } else {
+            $className = $object;
         }
-        $type = strtolower($type);
-        $object = strtolower($object);
-        if (!array_key_exists($object, self::$cache)) {
-            self::$cache[$object] = class_parents($object, true) + class_implements($object, true);
+        if (!array_key_exists(strtolower($className), self::$cache)) {
+            $parents = class_parents($className, true) + class_implements($className, true);
+            foreach ($parents as $parent) {
+                self::$cache[strtolower($className)] = strtolower($parent);
+            }
         }
-        return (isset(self::$cache[$object][$type]));
+        return (isset(self::$cache[strtolower($className)][strtolower($type)]));
     }
 }

--- a/library/Zend/Stdlib/SubClass.php
+++ b/library/Zend/Stdlib/SubClass.php
@@ -43,7 +43,7 @@ abstract class SubClass
         if (is_subclass_of($className, $type)) {
             return true;
         }
-        if (!class_exists($type)) {
+        if (!interface_exists($type)) {
             return false;
         }
         $r = new ReflectionClass($className);

--- a/library/Zend/Stdlib/SubClass.php
+++ b/library/Zend/Stdlib/SubClass.php
@@ -1,7 +1,22 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
 
 namespace Zend\Stdlib;
 
+/**
+ * @see https://bugs.php.net/bug.php?id=53727
+ *
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage SubClass
+ */
 abstract class SubClass
 {
 
@@ -23,6 +38,8 @@ abstract class SubClass
         } else {
             $className = $object;
         }
+        $className = ltrim($className, '\\');
+        $type = ltrim($type, '\\');
         static $isSubclassFuncCache = null; // null as unset, array when set
         if ($isSubclassFuncCache === null) {
             $isSubclassFuncCache = array();

--- a/library/Zend/Stdlib/SubClass.php
+++ b/library/Zend/Stdlib/SubClass.php
@@ -43,7 +43,10 @@ abstract class SubClass
         if (is_subclass_of($className, $type)) {
             return true;
         }
-        $r = new ReflectionClass($className);
+        if (!class_exists($type)) {
+            return false;
+        }
+        $r = new ReflectionClass($object);
         return $r->implementsInterface($type);
     }
 }

--- a/library/Zend/Stdlib/SubClass.php
+++ b/library/Zend/Stdlib/SubClass.php
@@ -26,6 +26,8 @@ abstract class SubClass
         if (is_object($object)) {
             $object = get_class($object);
         }
+        $type = strtolower($type);
+        $object = strtolower($object);
         if (!array_key_exists($object, self::$cache)) {
             self::$cache[$object] = class_parents($object, true) + class_implements($object, true);
         }

--- a/library/Zend/Stdlib/SubClass.php
+++ b/library/Zend/Stdlib/SubClass.php
@@ -27,18 +27,13 @@ abstract class SubClass
      *
      * @see https://bugs.php.net/bug.php?id=53727
      *
-     * @param object|string $object
+     * @param string $className
      * @param string $type
      */
-    public static function isSubclassOf($object, $type)
+    public static function isSubclassOf($className, $type)
     {
         if (version_compare(PHP_VERSION, '5.3.7', '>=')) {
-            return is_subclass_of($object, $type);
-        }
-        if (is_object($object)) {
-            return ($object instanceof $type);
-        } else {
-            $className = $object;
+            return is_subclass_of($className, $type);
         }
         if (is_subclass_of($className, $type)) {
             return true;

--- a/library/Zend/Stdlib/SubClass.php
+++ b/library/Zend/Stdlib/SubClass.php
@@ -28,8 +28,14 @@ abstract class SubClass
             $isSubclassFuncCache = array();
         }
         if (!array_key_exists($className, $isSubclassFuncCache)) {
-            $isSubclassFuncCache[$className] = class_parents($className, true) + class_implements($className, true);
+            $parents = class_parents($className, true) + class_implements($className, true);
+            $caseInsensitiveParents = array();
+            foreach ($parents as $parent) {
+                $caseInsensitiveParent = strtolower($parent);
+                $caseInsensitiveParents[$caseInsensitiveParent] = $caseInsensitiveParent;
+            }
+            $isSubclassFuncCache[strtolower($className)] = $caseInsensitiveParents;
         }
-        return (isset($isSubclassFuncCache[$className][$type]));
+        return (isset($isSubclassFuncCache[strtolower($className)][strtolower($type)]));
     }
 }

--- a/library/Zend/Stdlib/SubClass.php
+++ b/library/Zend/Stdlib/SubClass.php
@@ -6,11 +6,6 @@ abstract class SubClass
 {
 
     /**
-     * @var array
-     */
-    protected static $cache = array();
-
-    /**
      * Checks if the object has this class as one of its parents
      *
      * @see https://bugs.php.net/bug.php?id=53727
@@ -28,12 +23,13 @@ abstract class SubClass
         } else {
             $className = $object;
         }
-        if (!array_key_exists(strtolower($className), self::$cache)) {
-            $parents = class_parents($className, true) + class_implements($className, true);
-            foreach ($parents as $parent) {
-                self::$cache[strtolower($className)] = strtolower($parent);
-            }
+        static $isSubclassFuncCache = null; // null as unset, array when set
+        if ($isSubclassFuncCache === null) {
+            $isSubclassFuncCache = array();
         }
-        return (isset(self::$cache[strtolower($className)][strtolower($type)]));
+        if (!array_key_exists($className, $isSubclassFuncCache)) {
+            $isSubclassFuncCache[$className] = class_parents($className, true) + class_implements($className, true);
+        }
+        return (isset($isSubclassFuncCache[$className][$type]));
     }
 }

--- a/library/Zend/Stdlib/SubClass.php
+++ b/library/Zend/Stdlib/SubClass.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Zend\Stdlib;
+
+abstract class SubClass
+{
+
+    /**
+     * @var array
+     */
+    protected static $cache = array();
+
+    /**
+     * Checks if the object has this class as one of its parents
+     *
+     * @see https://bugs.php.net/bug.php?id=53727
+     *
+     * @param object|string $object
+     * @param string $type
+     */
+    public static function isSubclassOf($object, $type)
+    {
+        if (version_compare(PHP_VERSION, '5.3.7', '>=')) {
+            return is_subclass_of($object, $type);
+        }
+        if (is_object($object)) {
+            $object = get_class($object);
+        }
+        if (!array_key_exists($object, self::$cache)) {
+            self::$cache[$object] = class_parents($object, true) + class_implements($object, true);
+        }
+        return (isset(self::$cache[$object][$type]));
+    }
+}

--- a/library/Zend/Stdlib/SubClass.php
+++ b/library/Zend/Stdlib/SubClass.php
@@ -10,6 +10,8 @@
 
 namespace Zend\Stdlib;
 
+use ReflectionClass;
+
 /**
  * @see https://bugs.php.net/bug.php?id=53727
  *
@@ -38,21 +40,10 @@ abstract class SubClass
         } else {
             $className = $object;
         }
-        $className = ltrim($className, '\\');
-        $type = ltrim($type, '\\');
-        static $isSubclassFuncCache = null; // null as unset, array when set
-        if ($isSubclassFuncCache === null) {
-            $isSubclassFuncCache = array();
+        if (is_subclass_of($className, $type)) {
+            return true;
         }
-        if (!array_key_exists($className, $isSubclassFuncCache)) {
-            $parents = class_parents($className, true) + class_implements($className, true);
-            $caseInsensitiveParents = array();
-            foreach ($parents as $parent) {
-                $caseInsensitiveParent = strtolower($parent);
-                $caseInsensitiveParents[$caseInsensitiveParent] = $caseInsensitiveParent;
-            }
-            $isSubclassFuncCache[strtolower($className)] = $caseInsensitiveParents;
-        }
-        return (isset($isSubclassFuncCache[strtolower($className)][strtolower($type)]));
+        $r = new ReflectionClass($className);
+        return $r->implementsInterface($type);
     }
 }

--- a/library/Zend/Stdlib/SubClass.php
+++ b/library/Zend/Stdlib/SubClass.php
@@ -46,7 +46,7 @@ abstract class SubClass
         if (!class_exists($type)) {
             return false;
         }
-        $r = new ReflectionClass($object);
+        $r = new ReflectionClass($className);
         return $r->implementsInterface($type);
     }
 }

--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -21,10 +21,10 @@
 
 namespace Zend\XmlRpc;
 
-use ReflectionClass;
 use Zend\Server\AbstractServer;
 use Zend\Server\Definition;
 use Zend\Server\Reflection;
+use Zend\Stdlib\SubClass;
 
 /**
  * An XML-RPC server implementation
@@ -452,10 +452,9 @@ class Server extends AbstractServer
      */
     public function setResponseClass($class)
     {
-        if (!class_exists($class) or
-            ($c = new ReflectionClass($class) and !$c->isSubclassOf('Zend\\XmlRpc\\Response'))) {
-
+        if (!class_exists($class) || !SubClass::isSubclassOf($class, 'Zend\XmlRpc\Response')) {
             throw new Server\Exception\InvalidArgumentException('Invalid response class');
+
         }
         $this->responseClass = $class;
         return true;

--- a/tests/Zend/Stdlib/SubClassTest.php
+++ b/tests/Zend/Stdlib/SubClassTest.php
@@ -41,10 +41,4 @@ class SubClassTest extends \PHPUnit_Framework_TestCase
         $test = SubClass::isSubclassOf('ZendTest\Stdlib\TestAsset\chiLdCLAss', 'ZendTest\Stdlib\TestAsset\testinterface');
         $this->assertTrue($test);
     }
-
-    public function testIsSubclassOfObjectToClassNameConversion()
-    {
-        $test = SubClass::isSubclassOf(new TestAsset\ChildClass(), 'ZendTest\Stdlib\TestAsset\testinterface');
-        $this->assertTrue($test);
-    }
 }

--- a/tests/Zend/Stdlib/SubClassTest.php
+++ b/tests/Zend/Stdlib/SubClassTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+
+namespace ZendTest\Stdlib;
+
+use Zend\Stdlib\SubClass;
+
+class SubClassTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        if (version_compare(PHP_VERSION, '5.3.7', '>=')) {
+            $this->markTestSkipped('Test is only for PHP Versions smaller then 5.3.7');
+        }
+        require_once 'TestAsset/DummySubclasses.php';
+    }
+
+    public function testIsSubclassOf()
+    {
+        $test1 = SubClass::isSubclassOf('ZendTest\Stdlib\TestAsset\ChildClass', 'ZendTest\Stdlib\TestAsset\TestInterface');
+        $test2 = SubClass::isSubclassOf('ZendTest\Stdlib\TestAsset\ParentClass', 'ZendTest\Stdlib\TestAsset\TestInterface');
+        $this->assertTrue($test1);
+        $this->assertTrue($test2);
+    }
+
+    public function testIsSubclassOfStripsTralingNamespaceSeparator()
+    {
+        $test = SubClass::isSubclassOf('\ZendTest\Stdlib\TestAsset\ChildClass', '\ZendTest\Stdlib\TestAsset\TestInterface');
+        $this->assertTrue($test);
+    }
+
+    public function testIsSubclassOfIsCaseInsensitve()
+    {
+        $test = SubClass::isSubclassOf('ZendTest\Stdlib\TestAsset\chiLdCLAss', 'ZendTest\Stdlib\TestAsset\testinterface');
+        $this->assertTrue($test);
+    }
+
+    public function testIsSubclassOfObjectToClassNameConversion()
+    {
+        $test = SubClass::isSubclassOf(new TestAsset\ChildClass(), 'ZendTest\Stdlib\TestAsset\testinterface');
+        $this->assertTrue($test);
+    }
+}

--- a/tests/Zend/Stdlib/SubClassTest.php
+++ b/tests/Zend/Stdlib/SubClassTest.php
@@ -30,15 +30,4 @@ class SubClassTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($test2);
     }
 
-    public function testIsSubclassOfStripsTralingNamespaceSeparator()
-    {
-        $test = SubClass::isSubclassOf('\ZendTest\Stdlib\TestAsset\ChildClass', '\ZendTest\Stdlib\TestAsset\TestInterface');
-        $this->assertTrue($test);
-    }
-
-    public function testIsSubclassOfIsCaseInsensitve()
-    {
-        $test = SubClass::isSubclassOf('ZendTest\Stdlib\TestAsset\chiLdCLAss', 'ZendTest\Stdlib\TestAsset\testinterface');
-        $this->assertTrue($test);
-    }
 }

--- a/tests/Zend/Stdlib/SubClassTest.php
+++ b/tests/Zend/Stdlib/SubClassTest.php
@@ -16,9 +16,6 @@ class SubClassTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        if (version_compare(PHP_VERSION, '5.3.7', '>=')) {
-            $this->markTestSkipped('Test is only for PHP Versions smaller then 5.3.7');
-        }
         require_once 'TestAsset/DummySubclasses.php';
     }
 

--- a/tests/Zend/Stdlib/TestAsset/DummySubclasses.php
+++ b/tests/Zend/Stdlib/TestAsset/DummySubclasses.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ZendTest\Stdlib\TestAsset
+{
+    interface TestInterface
+    {
+    }
+
+    class ParentClass implements TestInterface
+    {
+    }
+
+    class ChildClass extends ParentClass
+    {
+    }
+}


### PR DESCRIPTION
@see https://bugs.php.net/bug.php?id=53727

This code is used to determine the subclass of a given class. Used in Zend\Di, Zend\Form,
Zend\InfoCard, Zend\Loader, Zend\Mvc, Zend\ServiceManager and Zend\XmlRpc
