### PR TITLE
Add file for all annotations

### DIFF
--- a/library/Zend/Form/Annotation/ZendAnnotations.php
+++ b/library/Zend/Form/Annotation/ZendAnnotations.php
@@ -1,0 +1,19 @@
+<?php
+
+require_once __DIR__.'/AllowEmpty.php';
+require_once __DIR__.'/Attributes.php';
+require_once __DIR__.'/ComposedObject.php';
+require_once __DIR__.'/ErrorMessage.php';
+require_once __DIR__.'/Exclude.php';
+require_once __DIR__.'/Filter.php';
+require_once __DIR__.'/Flags.php';
+require_once __DIR__.'/Hydrator.php';
+require_once __DIR__.'/Input.php';
+require_once __DIR__.'/InputFilter.php';
+require_once __DIR__.'/Name.php';
+require_once __DIR__.'/Object.php';
+require_once __DIR__.'/Options.php';
+require_once __DIR__.'/Required.php';
+require_once __DIR__.'/Type.php';
+require_once __DIR__.'/ValidationGroup.php';
+require_once __DIR__.'/Validator.php';


### PR DESCRIPTION
When an Entity is mixed with Doctrine 2 annotations and Zend annotation, an exception is thrown saying that the annotations could not be found and should be autoloaded.

This file is therefore needed for Doctrine Module to autoload the annotations.
