### PR TITLE
ZF2-367 Fix SharedEventManager docblock

### DIFF
--- a/library/Zend/EventManager/SharedEventManager.php
+++ b/library/Zend/EventManager/SharedEventManager.php
@@ -51,7 +51,7 @@ class SharedEventManager implements SharedEventManagerInterface
      * "getAll" event of both an AbstractResource and EntityResource:
      *
      * <code>
-     * SharedEventManager::getInstance()->connect(
+     * $sharedEventManager->attach(
      *     array('My\Resource\AbstractResource', 'My\Resource\EntityResource'),
      *     'getAll',
      *     function ($e) use ($cache) {


### PR DESCRIPTION
SharedEventManager docblock references none existent method SharedEventManager::getInstance()
