### PR TITLE
Zend\Db\Sql\Delete: Where combination fixed

### DIFF
--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -124,9 +124,9 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
                     } else {
                         $predicate = new Predicate\Expression($pvalue);
                     }
+                    $this->where->addPredicate($predicate, $combination);
                 }
             }
-            $this->where->addPredicate($predicate, $combination);
         }
         return $this;
     }


### PR DESCRIPTION
```
<?php
$delete->where(array(
    'user' => $userId,
    'response' => $this->id,
));
```

worked as

```
<?php
$delete->where(array(
    'response' => $this->id,
));
```

only last array element was applied.
