### PR TITLE
Remove recursive extract

### DIFF
--- a/library/Zend/Filter/FilterChain.php
+++ b/library/Zend/Filter/FilterChain.php
@@ -193,6 +193,21 @@ class FilterChain extends AbstractFilter implements Countable
     }
 
     /**
+     * Merge the filter chain with the one given in parameter
+     *
+     * @param FilterChain $filterChain
+     * @return FilterChain
+     */
+    public function merge(FilterChain $filterChain)
+    {
+        foreach ($filterChain->filters as $filter) {
+            $this->attach($filter);
+        }
+
+        return $this;
+    }
+
+    /**
      * Get all the filters
      *
      * @return SplPriorityQueue

--- a/library/Zend/Form/Annotation/AnnotationBuilder.php
+++ b/library/Zend/Form/Annotation/AnnotationBuilder.php
@@ -81,6 +81,7 @@ class AnnotationBuilder implements EventManagerAwareInterface
         'Input',
         'InputFilter',
         'Name',
+        'Object',
         'Options',
         'Required',
         'Type',
@@ -244,6 +245,19 @@ class AnnotationBuilder implements EventManagerAwareInterface
         $formSpec    = ArrayUtils::iteratorToArray($this->getFormSpecification($entity));
         $formFactory = $this->getFormFactory();
         return $formFactory->createForm($formSpec);
+    }
+
+    /**
+     * Create a fieldset from an object
+     *
+     * @param $entity
+     * @return \Zend\Form\Fieldset
+     */
+    public function createFieldset($entity)
+    {
+        $fieldsetSpec = ArrayUtils::iteratorToArray($this->getFormSpecification($entity));
+        $formFactory  = $this->getFormFactory();
+        return $formFactory->createFieldset($fieldsetSpec);
     }
 
     /**

--- a/library/Zend/Form/Annotation/AnnotationBuilder.php
+++ b/library/Zend/Form/Annotation/AnnotationBuilder.php
@@ -85,7 +85,8 @@ class AnnotationBuilder implements EventManagerAwareInterface
         'Options',
         'Required',
         'Type',
-        'Validator',
+        'ValidationGroup',
+        'Validator'
     );
 
     /**
@@ -245,19 +246,6 @@ class AnnotationBuilder implements EventManagerAwareInterface
         $formSpec    = ArrayUtils::iteratorToArray($this->getFormSpecification($entity));
         $formFactory = $this->getFormFactory();
         return $formFactory->createForm($formSpec);
-    }
-
-    /**
-     * Create a fieldset from an object
-     *
-     * @param $entity
-     * @return \Zend\Form\Fieldset
-     */
-    public function createFieldset($entity)
-    {
-        $fieldsetSpec = ArrayUtils::iteratorToArray($this->getFormSpecification($entity));
-        $formFactory  = $this->getFormFactory();
-        return $formFactory->createFieldset($fieldsetSpec);
     }
 
     /**

--- a/library/Zend/Form/Annotation/ElementAnnotationsListener.php
+++ b/library/Zend/Form/Annotation/ElementAnnotationsListener.php
@@ -35,6 +35,8 @@ use Zend\EventManager\EventManagerInterface;
  * - Filter
  * - Flags
  * - Input
+ * - Hydrator
+ * - Object
  * - Required
  * - Type
  * - Validator
@@ -65,7 +67,9 @@ class ElementAnnotationsListener extends AbstractAnnotationsListener
         $this->listeners[] = $events->attach('configureElement', array($this, 'handleErrorMessageAnnotation'));
         $this->listeners[] = $events->attach('configureElement', array($this, 'handleFilterAnnotation'));
         $this->listeners[] = $events->attach('configureElement', array($this, 'handleFlagsAnnotation'));
+        $this->listeners[] = $events->attach('configureElement', array($this, 'handleHydratorAnnotation'));
         $this->listeners[] = $events->attach('configureElement', array($this, 'handleInputAnnotation'));
+        $this->listeners[] = $events->attach('configureElement', array($this, 'handleObjectAnnotation'));
         $this->listeners[] = $events->attach('configureElement', array($this, 'handleOptionsAnnotation'));
         $this->listeners[] = $events->attach('configureElement', array($this, 'handleRequiredAnnotation'));
         $this->listeners[] = $events->attach('configureElement', array($this, 'handleTypeAnnotation'));
@@ -229,6 +233,25 @@ class ElementAnnotationsListener extends AbstractAnnotationsListener
     }
 
     /**
+     * Handle the Hydrator annotation
+     *
+     * Sets the hydrator class to use in the fieldset specification.
+     *
+     * @param  \Zend\EventManager\EventInterface $e
+     * @return void
+     */
+    public function handleHydratorAnnotation($e)
+    {
+        $annotation = $e->getParam('annotation');
+        if (!$annotation instanceof Hydrator) {
+            return;
+        }
+
+        $elementSpec = $e->getParam('element');
+        $elementSpec['hydrator'] = $annotation->getHydrator();
+    }
+
+    /**
      * Handle the Input annotation
      *
      * Sets the filter specification for the current element to the specified 
@@ -247,6 +270,25 @@ class ElementAnnotationsListener extends AbstractAnnotationsListener
         $name       = $e->getParam('name');
         $filterSpec = $e->getParam('filterSpec');
         $filterSpec[$name] = $annotation->getInput();
+    }
+
+    /**
+     * Handle the Object annotation
+     *
+     * Sets the object to bind to the form or fieldset
+     *
+     * @param  \Zend\EventManager\EventInterface $e
+     * @return void
+     */
+    public function handleObjectAnnotation($e)
+    {
+        $annotation = $e->getParam('annotation');
+        if (!$annotation instanceof Object) {
+            return;
+        }
+
+        $elementSpec = $e->getParam('elementSpec');
+        $elementSpec['object'] = $annotation->getObject();
     }
 
     /**

--- a/library/Zend/Form/Annotation/FormAnnotationsListener.php
+++ b/library/Zend/Form/Annotation/FormAnnotationsListener.php
@@ -32,6 +32,7 @@ use Zend\EventManager\EventManagerInterface;
  * - Attributes
  * - Flags
  * - Hydrator
+ * - Object
  * - InputFilter
  * - Type
  *
@@ -59,6 +60,7 @@ class FormAnnotationsListener extends AbstractAnnotationsListener
         $this->listeners[] = $events->attach('configureForm', array($this, 'handleFlagsAnnotation'));
         $this->listeners[] = $events->attach('configureForm', array($this, 'handleHydratorAnnotation'));
         $this->listeners[] = $events->attach('configureForm', array($this, 'handleInputFilterAnnotation'));
+        $this->listeners[] = $events->attach('configureForm', array($this, 'handleObjectAnnotation'));
         $this->listeners[] = $events->attach('configureForm', array($this, 'handleOptionsAnnotation'));
         $this->listeners[] = $events->attach('configureForm', array($this, 'handleTypeAnnotation'));
 
@@ -140,6 +142,25 @@ class FormAnnotationsListener extends AbstractAnnotationsListener
 
         $formSpec = $e->getParam('formSpec');
         $formSpec['input_filter'] = $annotation->getInputFilter();
+    }
+
+    /**
+     * Handle the Object annotation
+     *
+     * Sets the object to bind to the form or fieldset
+     *
+     * @param  \Zend\EventManager\EventInterface $e
+     * @return void
+     */
+    public function handleObjectAnnotation($e)
+    {
+        $annotation = $e->getParam('annotation');
+        if (!$annotation instanceof Object) {
+            return;
+        }
+
+        $formSpec = $e->getParam('formSpec');
+        $formSpec['object'] = $annotation->getObject();
     }
 
     /**

--- a/library/Zend/Form/Annotation/FormAnnotationsListener.php
+++ b/library/Zend/Form/Annotation/FormAnnotationsListener.php
@@ -35,6 +35,7 @@ use Zend\EventManager\EventManagerInterface;
  * - Object
  * - InputFilter
  * - Type
+ * - ValidationGroup
  *
  * See the individual annotation classes for more details. The handlers 
  * registered work with the annotation values, as well as the form 
@@ -63,6 +64,7 @@ class FormAnnotationsListener extends AbstractAnnotationsListener
         $this->listeners[] = $events->attach('configureForm', array($this, 'handleObjectAnnotation'));
         $this->listeners[] = $events->attach('configureForm', array($this, 'handleOptionsAnnotation'));
         $this->listeners[] = $events->attach('configureForm', array($this, 'handleTypeAnnotation'));
+        $this->listeners[] = $events->attach('configureForm', array($this, 'handleValidationGroupAnnotation'));
 
         $this->listeners[] = $events->attach('discoverName', array($this, 'handleNameAnnotation'));
         $this->listeners[] = $events->attach('discoverName', array($this, 'discoverFallbackName'));
@@ -199,5 +201,24 @@ class FormAnnotationsListener extends AbstractAnnotationsListener
 
         $formSpec = $e->getParam('formSpec');
         $formSpec['type'] = $annotation->getType();
+    }
+
+    /**
+     * Handle the ValidationGroup annotation
+     *
+     * Sets the validation group to use in the form specification.
+     *
+     * @param  \Zend\EventManager\EventInterface $e
+     * @return void
+     */
+    public function handleValidationGroupAnnotation($e)
+    {
+        $annotation = $e->getParam('annotation');
+        if (!$annotation instanceof ValidationGroup) {
+            return;
+        }
+
+        $formSpec = $e->getParam('formSpec');
+        $formSpec['validation_group'] = $annotation->getValidationGroup();
     }
 }

--- a/library/Zend/Form/Annotation/Object.php
+++ b/library/Zend/Form/Annotation/Object.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Annotation
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\Annotation;
+
+use Zend\Form\Exception\UnexpectedValueException;
+
+/**
+ * Object annotation
+ *
+ * Use this annotation to specify an object to use as the bound object of a form or fieldset
+ *
+ * @Annotation
+ * @package    Zend_Form
+ * @subpackage Annotation
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Object extends AbstractStringAnnotation
+{
+    /**
+     * Retrieve the object
+     *
+     * @return null|string
+     */
+    public function getObject()
+    {
+        return $this->value;
+    }
+}

--- a/library/Zend/Form/Annotation/ValidationGroup.php
+++ b/library/Zend/Form/Annotation/ValidationGroup.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Annotation
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\Annotation;
+
+/**
+ * ValidationGroup annotation
+ *
+ * Allows passing validation group to the form
+ *
+ * The value should be an associative array.
+ *
+ * @Annotation
+ * @package    Zend_Form
+ * @subpackage Annotation
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class ValidationGroup extends AbstractArrayAnnotation
+{
+    /**
+     * Retrieve the options
+     *
+     * @return null|array
+     */
+    public function getValidationGroup()
+    {
+        return $this->value;
+    }
+}

--- a/library/Zend/Form/Annotation/ZendAnnotations.php
+++ b/library/Zend/Form/Annotation/ZendAnnotations.php
@@ -1,0 +1,19 @@
+<?php
+
+require_once __DIR__.'/AllowEmpty.php';
+require_once __DIR__.'/Attributes.php';
+require_once __DIR__.'/ComposedObject.php';
+require_once __DIR__.'/ErrorMessage.php';
+require_once __DIR__.'/Exclude.php';
+require_once __DIR__.'/Filter.php';
+require_once __DIR__.'/Flags.php';
+require_once __DIR__.'/Hydrator.php';
+require_once __DIR__.'/Input.php';
+require_once __DIR__.'/InputFilter.php';
+require_once __DIR__.'/Name.php';
+require_once __DIR__.'/Object.php';
+require_once __DIR__.'/Options.php';
+require_once __DIR__.'/Required.php';
+require_once __DIR__.'/Type.php';
+require_once __DIR__.'/ValidationGroup.php';
+require_once __DIR__.'/Validator.php';

--- a/library/Zend/Form/Element/Checkbox.php
+++ b/library/Zend/Form/Element/Checkbox.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Element
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\Element;
+
+use Traversable;
+use Zend\Form\Element;
+use Zend\Form\Exception;
+use Zend\InputFilter\InputProviderInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage Element
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Checkbox extends Element implements InputProviderInterface
+{
+    /**
+     * @var bool
+     */
+    protected $useHiddenElement = true;
+
+    /**
+     * @var string
+     */
+    protected $uncheckedValue = '0';
+
+    /**
+     * @var string
+     */
+    protected $checkedValue = '1';
+
+    /**
+     * Accepted options for MultiCheckbox:
+     * - use_hidden_element: do we render hidden element?
+     * - unchecked_value: value for checkbox when unchecked
+     * - checked_value: value for checkbox when checked
+     *
+     * @param  array|\Traversable $options
+     * @return Checkbox
+     */
+    public function setOptions($options)
+    {
+        parent::setOptions($options);
+
+        if (isset($options['use_hidden_element'])) {
+            $this->setUseHiddenElement($options['use_hidden_element']);
+        }
+
+        if (isset($options['unchecked_value'])) {
+            $this->setUncheckedValue($options['unchecked_value']);
+        }
+
+        if (isset($options['checked_value'])) {
+            $this->setCheckedValue($options['checked_value']);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Do we render hidden element?
+     *
+     * @param  bool $useHiddenElement
+     * @return Checkbox
+     */
+    public function setUseHiddenElement($useHiddenElement)
+    {
+        $this->useHiddenElement = (bool)$useHiddenElement;
+        return $this;
+    }
+
+    /**
+     * Do we render hidden element?
+     *
+     * @return bool
+     */
+    public function useHiddenElement()
+    {
+        return $this->useHiddenElement;
+    }
+
+    /**
+     * Set the value to use when checkbox is unchecked
+     *
+     * @param $uncheckedValue
+     * @return Checkbox
+     */
+    public function setUncheckedValue($uncheckedValue)
+    {
+        $this->uncheckedValue = $uncheckedValue;
+        return $this;
+    }
+
+    /**
+     * Get the value to use when checkbox is unchecked
+     *
+     * @return string
+     */
+    public function getUncheckedValue()
+    {
+        return $this->uncheckedValue;
+    }
+
+    /**
+     * Set the value to use when checkbox is checked
+     *
+     * @param $checkedValue
+     * @return Checkbox
+     */
+    public function setCheckedValue($checkedValue)
+    {
+        $this->checkedValue = $checkedValue;
+        return $this;
+    }
+
+    /**
+     * Get the value to use when checkbox is checked
+     *
+     * @return string
+     */
+    public function getCheckedValue()
+    {
+        return $this->checkedValue;
+    }
+
+    /**
+     * Provide default input rules for this element
+     *
+     * Attaches the captcha as a validator.
+     *
+     * @return array
+     */
+    public function getInputSpecification()
+    {
+        $spec = array(
+            'name' => $this->getName(),
+            'required' => true
+        );
+
+        return $spec;
+    }
+}

--- a/library/Zend/Form/Element/Checkbox.php
+++ b/library/Zend/Form/Element/Checkbox.php
@@ -36,6 +36,15 @@ use Zend\InputFilter\InputProviderInterface;
 class Checkbox extends Element implements InputProviderInterface
 {
     /**
+     * Seed attributes
+     *
+     * @var array
+     */
+    protected $attributes = array(
+        'type' => 'checkbox'
+    );
+
+    /**
      * @var bool
      */
     protected $useHiddenElement = true;

--- a/library/Zend/Form/Element/MultiCheckbox.php
+++ b/library/Zend/Form/Element/MultiCheckbox.php
@@ -21,11 +21,6 @@
 
 namespace Zend\Form\Element;
 
-use Traversable;
-use Zend\Form\Element;
-use Zend\Form\Exception;
-use Zend\InputFilter\InputProviderInterface;
-
 /**
  * @category   Zend
  * @package    Zend_Form
@@ -33,131 +28,10 @@ use Zend\InputFilter\InputProviderInterface;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class MultiCheckbox extends Element implements InputProviderInterface
+class MultiCheckbox extends Checkbox
 {
     /**
      * @var bool
      */
-    protected $useHiddenElement;
-
-    /**
-     * @var string
-     */
-    protected $uncheckedValue;
-
-    /**
-     * @var array
-     */
-    protected $labelAttributes;
-
-    /**
-     * Accepted options for MultiCheckbox:
-     * - use_hidden_element: do we render hidden element?
-     * - unchecked_value: value for checkbox when unchecked
-     * - label_attributes: attributes to use for the label
-     *
-     * @param  array|\Traversable $options
-     * @return MultiCheckbox
-     */
-    public function setOptions($options)
-    {
-        parent::setOptions($options);
-
-        if (isset($options['use_hidden_element'])) {
-            $this->setUseHiddenElement($options['use_hidden_element']);
-        }
-
-        if (isset($options['unchecked_value'])) {
-            $this->setUncheckedValue($options['unchecked_value']);
-        }
-
-        if (isset($options['label_attributes'])) {
-            $this->setLabelAttributes($options['label_attributes']);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Do we render hidden element?
-     *
-     * @param  bool $useHiddenElement
-     * @return MultiCheckbox
-     */
-    public function setUseHiddenElement($useHiddenElement)
-    {
-        $this->useHiddenElement = (bool)$useHiddenElement;
-        return $this;
-    }
-
-    /**
-     * Do we render hidden element?
-     *
-     * @return bool
-     */
-    public function useHiddenElement()
-    {
-        return $this->useHiddenElement;
-    }
-
-    /**
-     * Set the value to use when checkbox is unchecked
-     *
-     * @param $uncheckedValue
-     * @return MultiCheckbox
-     */
-    public function setUncheckedValue($uncheckedValue)
-    {
-        $this->uncheckedValue = $uncheckedValue;
-        return $this;
-    }
-
-    /**
-     * Get the value to use when checkbox is unchecked
-     *
-     * @return string
-     */
-    public function getUncheckedValue()
-    {
-        return $this->uncheckedValue;
-    }
-
-    /**
-     * Set the label attributes
-     *
-     * @param  array $labelAttributes
-     * @return MultiCheckbox
-     */
-    public function setLabelAttributes(array $labelAttributes)
-    {
-        $this->labelAttributes = $labelAttributes;
-        return $this;
-    }
-
-    /**
-     * Get the label attributes
-     *
-     * @return array
-     */
-    public function getLabelAttributes()
-    {
-        return $this->labelAttributes;
-    }
-
-    /**
-     * Provide default input rules for this element
-     *
-     * Attaches the captcha as a validator.
-     *
-     * @return array
-     */
-    public function getInputSpecification()
-    {
-        $spec = array(
-            'name' => $this->getName(),
-            'required' => true
-        );
-
-        return $spec;
-    }
+    protected $useHiddenElement = false;
 }

--- a/library/Zend/Form/Element/Radio.php
+++ b/library/Zend/Form/Element/Radio.php
@@ -30,4 +30,12 @@ namespace Zend\Form\Element;
  */
 class Radio extends MultiCheckbox
 {
+    /**
+     * Seed attributes
+     *
+     * @var array
+     */
+    protected $attributes = array(
+        'type' => 'radio'
+    );
 }

--- a/library/Zend/Form/Element/Radio.php
+++ b/library/Zend/Form/Element/Radio.php
@@ -21,7 +21,6 @@
 
 namespace Zend\Form\Element;
 
-
 /**
  * @category   Zend
  * @package    Zend_Form

--- a/library/Zend/Form/Factory.php
+++ b/library/Zend/Form/Factory.php
@@ -256,6 +256,10 @@ class Factory
             $this->prepareAndInjectInputFilter($spec['input_filter'], $form, __METHOD__);
         }
 
+        if (isset($spec['validation_group'])) {
+            $this->prepareAndInjectValidationGroup($spec['validation_group'], $form, __METHOD__);
+        }
+
         return $form;
     }
 
@@ -334,6 +338,81 @@ class Factory
     }
 
     /**
+     * Prepare and inject an object
+     *
+     * Takes a string indicating a class name, instantiates the class
+     * by that name, and injects the class instance as the bound object.
+     *
+     * @param  string           $objectName
+     * @param  FieldsetInterface $fieldset
+     * @param  string           $method
+     * @throws Exception\DomainException
+     * @return void
+     */
+    protected function prepareAndInjectObject($objectName, FieldsetInterface $fieldset, $method)
+    {
+        if (!is_string($objectName)) {
+            throw new Exception\DomainException(sprintf(
+                '%s expects string class name; received "%s"',
+                $method,
+                (is_object($objectName) ? get_class($objectName) : gettype($objectName))
+            ));
+        }
+
+        if (!class_exists($objectName)) {
+            throw new Exception\DomainException(sprintf(
+                '%s expects string class name to be a valid class name; received "%s"',
+                $method,
+                $objectName
+            ));
+        }
+
+        $fieldset->setObject(new $objectName);
+    }
+
+    /**
+     * Prepare and inject a named hydrator
+     *
+     * Takes a string indicating a hydrator class name, instantiates the class
+     * by that name, and injects the hydrator instance into the form.
+     *
+     * @param  string $hydratorName
+     * @param  FieldsetInterface $fieldset
+     * @param  string $method
+     * @return void
+     * @throws Exception\DomainException if $hydratorName is not a string, does not resolve to a known class, or the class does not implement Hydrator\HydratorInterface
+     */
+    protected function prepareAndInjectHydrator($hydratorName, FieldsetInterface $fieldset, $method)
+    {
+        if (!is_string($hydratorName)) {
+            throw new Exception\DomainException(sprintf(
+                '%s expects string hydrator class name; received "%s"',
+                $method,
+                (is_object($hydratorName) ? get_class($hydratorName) : gettype($hydratorName))
+            ));
+        }
+
+        if (!class_exists($hydratorName)) {
+            throw new Exception\DomainException(sprintf(
+                '%s expects string hydrator name to be a valid class name; received "%s"',
+                $method,
+                $hydratorName
+            ));
+        }
+
+        $hydrator = new $hydratorName;
+        if (!$hydrator instanceof Hydrator\HydratorInterface) {
+            throw new Exception\DomainException(sprintf(
+                '%s expects a valid implementation of Zend\Form\Hydrator\HydratorInterface; received "%s"',
+                $method,
+                $hydratorName
+            ));
+        }
+
+        $fieldset->setHydrator($hydrator);
+    }
+
+    /**
      * Prepare an input filter instance and inject in the provided form
      *
      * If the input filter specified is a string, assumes it is a class name,
@@ -377,80 +456,28 @@ class Factory
     }
 
     /**
-     * Prepare and inject an object
+     * Prepare a validaiton group and inject in the provided form
      *
-     * Takes a string indicating a class name, instantiates the class
-     * by that name, and injects the class instance as the bound object.
+     * Takes an array of elements names
      *
-     * @param  string           $objectName
-     * @param  FieldsetInterface $fieldset
-     * @param  string           $method
-     * @throws Exception\DomainException
-     * @return void
-     */
-    protected function prepareAndInjectObject($objectName, FieldsetInterface $fieldset, $method)
-    {
-        if (!is_string($objectName)) {
-            throw new Exception\DomainException(sprintf(
-                '%s expects string class name; received "%s"',
-                $method,
-                (is_object($objectName) ? get_class($objectName) : gettype($objectName))
-            ));
-        }
-
-        if (!class_exists($objectName)) {
-            throw new Exception\DomainException(sprintf(
-                '%s expects string class name to be a valid class name; received "%s"',
-                $method,
-                $objectName
-            ));
-        }
-
-        $fieldset->setObject(new $objectName);
-
-        return;
-    }
-
-    /**
-     * Prepare and inject a named hydrator
-     *
-     * Takes a string indicating a hydrator class name, instantiates the class
-     * by that name, and injects the hydrator instance into the form.
-     *
-     * @param  string $hydratorName
-     * @param  FieldsetInterface $fieldset
+     * @param  string|array|Traversable $spec
+     * @param  FormInterface $form
      * @param  string $method
      * @return void
-     * @throws Exception\DomainException if $hydratorName is not a string, does not resolve to a known class, or the class does not implement Hydrator\HydratorInterface
+     * @throws Exception\DomainException if validation group given is not an array
      */
-    protected function prepareAndInjectHydrator($hydratorName, FieldsetInterface $fieldset, $method)
+    protected function prepareAndInjectValidationGroup($spec, FormInterface $form, $method)
     {
-        if (!is_string($hydratorName)) {
-            throw new Exception\DomainException(sprintf(
-                '%s expects string hydrator class name; received "%s"',
-                $method,
-                (is_object($hydratorName) ? get_class($hydratorName) : gettype($hydratorName))
-            ));
+        if (!is_array($spec)) {
+            if (!class_exists($spec)) {
+                throw new Exception\DomainException(sprintf(
+                    '%s expects an array for validation group; received "%s"',
+                    $method,
+                    $spec
+                ));
+            }
         }
 
-        if (!class_exists($hydratorName)) {
-            throw new Exception\DomainException(sprintf(
-                '%s expects string hydrator name to be a valid class name; received "%s"',
-                $method,
-                $hydratorName
-            ));
-        }
-
-        $hydrator = new $hydratorName;
-        if (!$hydrator instanceof Hydrator\HydratorInterface) {
-            throw new Exception\DomainException(sprintf(
-                '%s expects a valid implementation of Zend\Form\Hydrator\HydratorInterface; received "%s"',
-                $method,
-                $hydratorName
-            ));
-        }
-
-        $fieldset->setHydrator($hydrator);
-        return;
+        $form->setValidationGroup($spec);
     }
 }

--- a/library/Zend/Form/Factory.php
+++ b/library/Zend/Form/Factory.php
@@ -202,6 +202,14 @@ class Factory
             ));
         }
 
+        if (isset($spec['object'])) {
+            $this->prepareAndInjectObject($spec['object'], $fieldset, __METHOD__);
+        }
+
+        if (isset($spec['hydrator'])) {
+            $this->prepareAndInjectHydrator($spec['hydrator'], $fieldset, __METHOD__);
+        }
+
         if (isset($spec['elements'])) {
             $this->prepareAndInjectElements($spec['elements'], $fieldset, __METHOD__);
         }
@@ -246,10 +254,6 @@ class Factory
 
         if (isset($spec['input_filter'])) {
             $this->prepareAndInjectInputFilter($spec['input_filter'], $form, __METHOD__);
-        }
-
-        if (isset($spec['hydrator'])) {
-            $this->prepareAndInjectHydrator($spec['hydrator'], $form, __METHOD__);
         }
 
         return $form;
@@ -373,18 +377,53 @@ class Factory
     }
 
     /**
+     * Prepare and inject an object
+     *
+     * Takes a string indicating a class name, instantiates the class
+     * by that name, and injects the class instance as the bound object.
+     *
+     * @param  string           $objectName
+     * @param  FieldsetInterface $fieldset
+     * @param  string           $method
+     * @throws Exception\DomainException
+     * @return void
+     */
+    protected function prepareAndInjectObject($objectName, FieldsetInterface $fieldset, $method)
+    {
+        if (!is_string($objectName)) {
+            throw new Exception\DomainException(sprintf(
+                '%s expects string class name; received "%s"',
+                $method,
+                (is_object($objectName) ? get_class($objectName) : gettype($objectName))
+            ));
+        }
+
+        if (!class_exists($objectName)) {
+            throw new Exception\DomainException(sprintf(
+                '%s expects string class name to be a valid class name; received "%s"',
+                $method,
+                $objectName
+            ));
+        }
+
+        $fieldset->setObject(new $objectName);
+
+        return;
+    }
+
+    /**
      * Prepare and inject a named hydrator
      *
      * Takes a string indicating a hydrator class name, instantiates the class
      * by that name, and injects the hydrator instance into the form.
      *
      * @param  string $hydratorName
-     * @param  FormInterface $form
+     * @param  FieldsetInterface $fieldset
      * @param  string $method
      * @return void
      * @throws Exception\DomainException if $hydratorName is not a string, does not resolve to a known class, or the class does not implement Hydrator\HydratorInterface
      */
-    protected function prepareAndInjectHydrator($hydratorName, FormInterface $form, $method)
+    protected function prepareAndInjectHydrator($hydratorName, FieldsetInterface $fieldset, $method)
     {
         if (!is_string($hydratorName)) {
             throw new Exception\DomainException(sprintf(
@@ -411,7 +450,7 @@ class Factory
             ));
         }
 
-        $form->setHydrator($hydrator);
+        $fieldset->setHydrator($hydrator);
         return;
     }
 }

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -540,6 +540,37 @@ class Fieldset extends Element implements FieldsetInterface
     }
 
     /**
+     * Extract values from the bound object and populate
+     * the fieldset elements
+     *
+     * @return void
+     */
+    protected function extract()
+    {
+        if (!is_object($this->object)) {
+            return;
+        }
+        $hydrator = $this->getHydrator();
+        if (!$hydrator instanceof Hydrator\HydratorInterface) {
+            return;
+        }
+
+        $values = $hydrator->extract($this->object);
+        if (!is_array($values)) {
+            // Do nothing if the hydrator returned a non-array
+            return;
+        }
+
+        // Recursively extract and populate values for nested fieldsets
+        foreach ($this->fieldsets as $fieldset) {
+            $fieldset->extract();
+            unset($values[$fieldset->getName()]);
+        }
+
+        $this->populateValues($values);
+    }
+
+    /**
      * Make a deep clone of a fieldset
      *
      * @return void

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -562,10 +562,6 @@ class Form extends Fieldset implements FormInterface
             }
 
             $name = $element->getName();
-            if ($inputFilter->has($name)) {
-                // if we already have an input by this name, use it
-                continue;
-            }
 
             // Create an input based on the specification returned from the element
             $spec  = $element->getInputSpecification();

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -610,29 +610,15 @@ class Form extends Fieldset implements FormInterface
     /**
      * Extract values from the bound object and populate
      * the form elements
-     * 
+     *
      * @return void
      */
     protected function extract()
     {
-        if (!is_object($this->object)) {
-            return;
-        }
-        $hydrator = $this->getHydrator();
-        if (!$hydrator instanceof Hydrator\HydratorInterface) {
-            return;
-        }
-
-        $values = $hydrator->extract($this->object);
-        if (!is_array($values)) {
-            // Do nothing if the hydrator returned a non-array
-            return;
-        }
-
         if (null !== $this->baseFieldset) {
-            $this->baseFieldset->populateValues($values);
+            $this->baseFieldset->extract();
         } else {
-            $this->populateValues($values);
+            parent::extract();
         }
     }
 }

--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -35,46 +35,10 @@ use Zend\Form\Exception;
 class FormCheckbox extends FormInput
 {
     /**
-     * @var boolean
-     */
-    protected $useHiddenElement = true;
-
-    /**
-     * @var array
-     */
-    protected $defaultStateValues = array(
-        'checkedValue'   => '1',
-        'uncheckedValue' => '0',
-    );
-
-    /**
-     * Returns the option for prefixing the element with a hidden element
-     * for the unset value.
-     *
-     * @return boolean
-     */
-    public function getUseHiddenElement()
-    {
-        return $this->useHiddenElement;
-    }
-
-    /**
-     * Sets the option for prefixing the element with a hidden element
-     * for the unset value.
-     *
-     * @param  boolean $useHiddenElement
-     * @return FormCheckbox
-     */
-    public function setUseHiddenElement($useHiddenElement)
-    {
-        $this->useHiddenElement = (bool) $useHiddenElement;
-        return $this;
-    }
-
-    /**
      * Render a form <input> element from the provided $element
      *
      * @param  ElementInterface $element
+     * @throws \Zend\Form\Exception\DomainException
      * @return string
      */
     public function render(ElementInterface $element)
@@ -87,36 +51,16 @@ class FormCheckbox extends FormInput
             ));
         }
 
-        $attributes = $element->getAttributes();
-        if (empty($attributes['options'])) {
-            $attributes['options'] = array();
-        }
-        $options = $attributes['options'];
-        unset($attributes['options']);
-
-        // default checked/unchecked values
-        foreach ($this->defaultStateValues as $key => $value) {
-            if (empty($options[$key])) {
-                $options[$key] = $value;
-            }
-        }
-
-        if (!is_array($options) && !$options instanceof Traversable) {
-            throw new Exception\DomainException(sprintf(
-                '%s requires that the element has an array or Traversable "options" attribute.',
-                __METHOD__
-            ));
-        }
-
+        $attributes            = $element->getAttributes();
         $attributes['name']    = $name;
         $attributes['checked'] = '';
         $attributes['type']    = $this->getInputType();
         $closingBracket        = $this->getInlineClosingBracket();
 
-        if (isset($attributes['value']) && $attributes['value'] == $options['checkedValue']) {
+        if (isset($attributes['value']) && $attributes['value'] == $element->getCheckedValue()) {
             $attributes['checked'] = 'checked';
         }
-        $attributes['value'] = $options['checkedValue'];
+        $attributes['value'] = $element->getCheckedValue();
 
         $rendered = sprintf(
             '<input %s%s',
@@ -124,21 +68,19 @@ class FormCheckbox extends FormInput
             $closingBracket
         );
 
-        $useHiddenElement = isset($attributes['useHiddenElement'])
-            ? (bool) $attributes['useHiddenElement']
-            : $this->useHiddenElement;
+        $useHiddenElement = $element->useHiddenElement();
 
         if ($useHiddenElement) {
             $hiddenAttributes = array(
                 'name'  => $attributes['name'],
-                'value' => $options['uncheckedValue'],
+                'value' => $element->getUncheckedValue()
             );
 
-            $rendered = sprintf(
+            $rendered = $rendered . sprintf(
                 '<input type="hidden" %s%s',
                 $this->createAttributesString($hiddenAttributes),
                 $closingBracket
-            ) . $rendered;
+            );
         }
 
         return $rendered;

--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -76,11 +76,11 @@ class FormCheckbox extends FormInput
                 'value' => $element->getUncheckedValue()
             );
 
-            $rendered = $rendered . sprintf(
+            $rendered = sprintf(
                 '<input type="hidden" %s%s',
                 $this->createAttributesString($hiddenAttributes),
                 $closingBracket
-            );
+            ) . $rendered;
         }
 
         return $rendered;

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -54,9 +54,10 @@ class BaseInputFilter implements InputFilterInterface
 
     /**
      * Add an input to the input filter
-     * 
-     * @param  InputInterface|InputFilterInterface $input 
-     * @param  null|string $name Name used to retrieve this input
+     *
+     * @param  InputInterface|InputFilterInterface $input
+     * @param  null|string                         $name Name used to retrieve this input
+     * @throws Exception\InvalidArgumentException
      * @return InputFilterInterface
      */
     public function add($input, $name = null)
@@ -74,6 +75,13 @@ class BaseInputFilter implements InputFilterInterface
         if (is_null($name) || $name === '') {
             $name = $input->getName();
         }
+
+        if (isset($this->inputs[$name]) && $this->inputs[$name] instanceof InputInterface) {
+            // The element already exists, so merge the config. Please note that the order is important (already existing
+            // input is merged with the parameter given)
+            $input->merge($this->inputs[$name]);
+        }
+
         $this->inputs[$name] = $input;
         return $this;
     }

--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -95,7 +95,6 @@ class Input implements InputInterface
         return $this;
     }
 
-
     public function allowEmpty()
     {
         return $this->allowEmpty;
@@ -104,6 +103,11 @@ class Input implements InputInterface
     public function breakOnFailure()
     {
         return $this->breakOnFailure;
+    }
+
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
     }
 
     public function getFilterChain()
@@ -141,6 +145,21 @@ class Input implements InputInterface
     {
         $filter = $this->getFilterChain();
         return $filter->filter($this->value);
+    }
+
+    public function merge(InputInterface $input)
+    {
+        $this->setAllowEmpty($input->allowEmpty());
+        $this->setBreakOnFailure($input->breakOnFailure());
+        $this->setErrorMessage($input->getErrorMessage());
+        $this->setName($input->getName());
+        $this->setRequired($input->isRequired());
+
+        $filterChain = $input->getFilterChain();
+        $this->getFilterChain()->merge($filterChain);
+
+        $validatorChain = $input->getValidatorChain();
+        $this->getValidatorChain()->merge($validatorChain);
     }
 
     public function isValid($context = null)

--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -154,12 +154,13 @@ class Input implements InputInterface
         $this->setErrorMessage($input->getErrorMessage());
         $this->setName($input->getName());
         $this->setRequired($input->isRequired());
+        $this->setValue($input->getValue());
 
         $filterChain = $input->getFilterChain();
-        $this->getFilterChain()->merge($filterChain);
+        $this->setFilterChain($this->getFilterChain()->merge($filterChain));
 
         $validatorChain = $input->getValidatorChain();
-        $this->getValidatorChain()->merge($validatorChain);
+        $this->setValidatorChain($this->getValidatorChain()->merge($validatorChain));
     }
 
     public function isValid($context = null)

--- a/library/Zend/InputFilter/InputInterface.php
+++ b/library/Zend/InputFilter/InputInterface.php
@@ -39,9 +39,11 @@ interface InputInterface
     public function setRequired($required);
     public function setValidatorChain(ValidatorChain $validatorChain);
     public function setValue($value);
+    public function merge(InputInterface $input);
 
     public function allowEmpty();
     public function breakOnFailure();
+    public function getErrorMessage();
     public function getFilterChain();
     public function getName();
     public function getRawValue();

--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -85,23 +85,10 @@ class ClassMethods implements HydratorInterface
                     $attribute = preg_replace_callback('/([A-Z])/', $transform, $attribute);
                 }
 
-                $result = $object->$method();
-
-                // Recursively extract if object contains itself other objects or arrays of objects
-                if (is_object($result)) {
-                    $result = $this->extract($result);
-                } elseif (is_array($result)) {
-                    foreach ($result as $key => $value) {
-                        if (is_object($value)) {
-                            $result[$key] = $this->extract($value);
-                        }
-                    }
-                }
-
-                $attributes[$attribute] = $result;
+                $attributes[$attribute] = $object->$method();
             }
         }
-        
+
         return $attributes;
     }
 

--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -42,7 +42,7 @@ class ClassMethods implements HydratorInterface
      * Define if extract values will use camel case or name with underscore
      * @param boolean $underscoreSeparatedKeys 
      */
-    public function __construct($underscoreSeparatedKeys = true)
+    public function __construct($underscoreSeparatedKeys = false)
     {
         $this->underscoreSeparatedKeys = $underscoreSeparatedKeys;
     }

--- a/library/Zend/Validator/ValidatorChain.php
+++ b/library/Zend/Validator/ValidatorChain.php
@@ -198,6 +198,21 @@ class ValidatorChain implements
     }
 
     /**
+     * Merge the validator chain with the one given in parameter
+     *
+     * @param ValidatorChain $validatorChain
+     * @return ValidatorChain
+     */
+    public function merge(ValidatorChain $validatorChain)
+    {
+        foreach ($validatorChain->validators as $validator) {
+            $this->validators[] = $validator;
+        }
+
+        return $this;
+    }
+
+    /**
      * Returns array of validation failure messages
      *
      * @return array

--- a/tests/Zend/Form/Annotation/AnnotationBuilderTest.php
+++ b/tests/Zend/Form/Annotation/AnnotationBuilderTest.php
@@ -90,6 +90,9 @@ class AnnotationBuilderTest extends TestCase
         $attributes = $keeper->getAttributes();
         $this->assertArrayHasKey('type', $attributes);
         $this->assertEquals('text', $attributes['type']);
+
+        $this->assertObjectHasAttribute('validationGroup', $form);
+        $this->assertAttributeEquals(array('omit', 'keep'), 'validationGroup', $form);
     }
 
     public function testComplexEntityCreationWithPriorities()

--- a/tests/Zend/Form/FactoryTest.php
+++ b/tests/Zend/Form/FactoryTest.php
@@ -63,6 +63,7 @@ class FactoryTest extends TestCase
     {
         $fieldset = $this->factory->createFieldset(array(
             'name'       => 'foo',
+            'object'     => 'ZendTest\Form\TestAsset\Model',
             'attributes' => array(
                 'type'         => 'fieldset',
                 'class'        => 'foo-class',
@@ -74,6 +75,7 @@ class FactoryTest extends TestCase
         $this->assertEquals('fieldset', $fieldset->getAttribute('type'));
         $this->assertEquals('foo-class', $fieldset->getAttribute('class'));
         $this->assertEquals('my.form.fieldset', $fieldset->getAttribute('data-js-type'));
+        $this->assertEquals(new \ZendTest\Form\TestAsset\Model, $fieldset->getObject());
     }
 
     public function testCanCreateFieldsetsWithElements()
@@ -234,6 +236,7 @@ class FactoryTest extends TestCase
     {
         $form = $this->factory->createForm(array(
             'name'       => 'foo',
+            'object'     => 'ZendTest\Form\TestAsset\Model',
             'attributes' => array(
                 'method' => 'get',
             ),
@@ -241,6 +244,7 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('Zend\Form\FormInterface', $form);
         $this->assertEquals('foo', $form->getName());
         $this->assertEquals('get', $form->getAttribute('method'));
+        $this->assertEquals(new \ZendTest\Form\TestAsset\Model, $form->getObject());
     }
 
     public function testCanCreateFormsWithNamedInputFilters()

--- a/tests/Zend/Form/TestAsset/Annotation/ClassEntity.php
+++ b/tests/Zend/Form/TestAsset/Annotation/ClassEntity.php
@@ -7,6 +7,7 @@ use Zend\Form\Annotation;
  * @Annotation\Name("some_name")
  * @Annotation\Attributes({"legend":"Some Fieldset"})
  * @Annotation\InputFilter("ZendTest\Form\TestAsset\Annotation\InputFilter")
+ * @Annotation\ValidationGroup({"omit", "keep"})
  */
 class ClassEntity
 {

--- a/tests/Zend/Form/View/Helper/FormCheckboxTest.php
+++ b/tests/Zend/Form/View/Helper/FormCheckboxTest.php
@@ -41,19 +41,18 @@ class FormCheckboxTest extends CommonTestCase
 
     public function getElement() 
     {
-        $element = new Element('foo');
+        $element = new Element\Checkbox('foo');
         $options = array(
-            'checkedValue'   => 'checked',
-            'uncheckedValue' => 'unchecked',
+            'checked_value'   => 'checked',
+            'unchecked_value' => 'unchecked',
         );
-        $element->setAttribute('options', $options);
+        $element->setOptions($options);
         return $element;
     }
 
     public function testUsesOptionsAttributeToGenerateCheckedAndUnCheckedValues()
     {
         $element = $this->getElement();
-        $options = $element->getAttribute('options');
         $markup  = $this->helper->render($element);
 
         $this->assertContains('type="checkbox"', $markup);
@@ -74,24 +73,16 @@ class FormCheckboxTest extends CommonTestCase
 
     public function testNoOptionsAttributeCreatesDefaultCheckedAndUncheckedValues()
     {
-        $element = new Element('foo');
+        $element = new Element\Checkbox('foo');
         $markup  = $this->helper->render($element);
         $this->assertRegexp('#type="checkbox"\s+value="1"#', $markup);
         $this->assertRegexp('#type="hidden"\s+name="foo"\s+value="0"#', $markup);
     }
 
-    public function testSetUseHiddenElementDoesNotRenderHiddenInput()
-    {
-        $element = new Element('foo');
-        $markup  = $this->helper->setUseHiddenElement(false)->render($element);
-        $this->assertRegexp('#type="checkbox"\s+value="1"#', $markup);
-        $this->assertNotRegexp('#type="hidden"\s+name="foo"\s+value="0"#', $markup);
-    }
-
     public function testSetUseHiddenElementAttributeDoesNotRenderHiddenInput()
     {
-        $element = new Element('foo');
-        $element->setAttribute('useHiddenElement', false);
+        $element = new Element\Checkbox('foo');
+        $element->setUseHiddenElement(false);
         $markup  = $this->helper->render($element);
         $this->assertRegexp('#type="checkbox"\s+value="1"#', $markup);
         $this->assertNotRegexp('#type="hidden"\s+name="foo"\s+value="0"#', $markup);

--- a/tests/Zend/Form/View/Helper/FormElementTest.php
+++ b/tests/Zend/Form/View/Helper/FormElementTest.php
@@ -91,6 +91,8 @@ class FormElementTest extends TestCase
     {
         if ($type === 'radio') {
             $element = new Element\Radio('foo');
+        } elseif ($type === 'checkbox') {
+            $element = new Element\Checkbox('foo');
         } else {
             $element = new Element('foo');
         }


### PR DESCRIPTION
I added when I was working on Forms to allow an entity to be recursively extracted and hence populate nested fieldsets in form, but this was a really bad idea, as in case of bidirectional-relationships, this hydrator ends up to an infinite recursion.

Therefore, forms with nested fieldsets won't be correctly populated. I'll come up with a better solution for Form later.
