### PR TITLE
Remove recursion in ClassMethodsHydrator

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -163,6 +163,28 @@ class Collection extends Fieldset
     }
 
     /**
+     * Bind values to the object
+     *
+     * @param array $values
+     * @return array|mixed|void
+     */
+    public function bindValues(array $values = array())
+    {
+        $collection = array();
+        foreach ($values as $name => $value) {
+            $element = $this->get($name);
+
+            if ($element instanceof FieldsetInterface) {
+                $collection[] = $element->bindValues($value);
+            } else {
+                $collection[] = $value;
+            }
+        }
+
+        return $collection;
+    }
+
+    /**
      * Set the initial count of target element
      *
      * @param $count

--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -331,6 +331,27 @@ class Collection extends Fieldset
     }
 
     /**
+     * @return array
+     */
+    public function extract()
+    {
+        // In this specific situation, object holds the data, that is too say an array
+        if (!is_array($this->object)) {
+            return array();
+        }
+
+        $values = array();
+        foreach ($this->object as $key => $value) {
+            if ($value instanceof $this->targetElement->object) {
+                $this->targetElement->object = $value;
+                $values[$key] = $this->targetElement->extract();
+            }
+        }
+
+        return $values;
+    }
+
+    /**
      * If both count and targetElement are set, add them to the fieldset
      *
      * @return void

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -540,6 +540,37 @@ class Fieldset extends Element implements FieldsetInterface
     }
 
     /**
+     * Extract values from the bound object and populate
+     * the fieldset elements
+     *
+     * @return void
+     */
+    protected function extract()
+    {
+        if (!is_object($this->object)) {
+            return;
+        }
+        $hydrator = $this->getHydrator();
+        if (!$hydrator instanceof Hydrator\HydratorInterface) {
+            return;
+        }
+
+        $values = $hydrator->extract($this->object);
+        if (!is_array($values)) {
+            // Do nothing if the hydrator returned a non-array
+            return;
+        }
+
+        // Recursively extract and populate values for nested fieldsets
+        foreach ($this->fieldsets as $fieldset) {
+            $fieldset->extract();
+            unset($values[$fieldset->getName()]);
+        }
+
+        $this->populateValues($values);
+    }
+
+    /**
      * Make a deep clone of a fieldset
      *
      * @return void

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -540,34 +540,45 @@ class Fieldset extends Element implements FieldsetInterface
     }
 
     /**
-     * Extract values from the bound object and populate
-     * the fieldset elements
+     * Extract values from the bound object
      *
-     * @return void
+     * @return array
      */
     protected function extract()
     {
         if (!is_object($this->object)) {
-            return;
+            return array();
         }
         $hydrator = $this->getHydrator();
         if (!$hydrator instanceof Hydrator\HydratorInterface) {
-            return;
+            return array();
         }
 
         $values = $hydrator->extract($this->object);
+
         if (!is_array($values)) {
             // Do nothing if the hydrator returned a non-array
-            return;
+            return array();
         }
 
         // Recursively extract and populate values for nested fieldsets
         foreach ($this->fieldsets as $fieldset) {
-            $fieldset->extract();
-            unset($values[$fieldset->getName()]);
+            $name = $fieldset->getName();
+
+            if (isset($values[$name])) {
+                $object = $values[$name];
+
+                // Is the object bound to the fieldset of the same type ? Note that we are using a little hack
+                // here, as in case of collection, we bind array to object instance, and let the collection extract
+                // the data
+                if ($fieldset instanceof Collection || (is_object($object) && $object instanceof $fieldset->object)) {
+                    $fieldset->object = $object;
+                    $values[$name] = $fieldset->extract();
+                }
+            }
         }
 
-        $this->populateValues($values);
+        return $values;
     }
 
     /**

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -498,15 +498,8 @@ class Fieldset extends Element implements FieldsetInterface
             $element = $this->byName[$name];
 
             if ($element instanceof Collection) {
-                $collection = array();
-                foreach ($value as $subName => $subValue) {
-                    $collection[] = $element->get($subName)->bindValues($subValue);
-                }
-
-                $value = $collection;
-            }
-
-            if ($element instanceof FieldsetInterface && is_object($element->object)) {
+                $value = $element->bindValues($value);
+            } elseif ($element instanceof FieldsetInterface && is_object($element->object)) {
                 $value = $element->bindValues($value);
             }
 

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -614,29 +614,15 @@ class Form extends Fieldset implements FormInterface
     /**
      * Extract values from the bound object and populate
      * the form elements
-     * 
+     *
      * @return void
      */
     protected function extract()
     {
-        if (!is_object($this->object)) {
-            return;
-        }
-        $hydrator = $this->getHydrator();
-        if (!$hydrator instanceof Hydrator\HydratorInterface) {
-            return;
-        }
-
-        $values = $hydrator->extract($this->object);
-        if (!is_array($values)) {
-            // Do nothing if the hydrator returned a non-array
-            return;
-        }
-
         if (null !== $this->baseFieldset) {
-            $this->baseFieldset->populateValues($values);
+            $this->baseFieldset->extract();
         } else {
-            $this->populateValues($values);
+            parent::extract();
         }
     }
 }

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -341,14 +341,7 @@ class Form extends Fieldset implements FormInterface
         }
 
         if (!is_array($this->data)) {
-            $hydrator = $this->getHydrator();
-            if (!$hydrator instanceof Hydrator\HydratorInterface) {
-                throw new Exception\DomainException(sprintf(
-                    '%s is unable to validate as there is no data currently set',
-                    __METHOD__
-                ));
-            }
-            $data = $hydrator->extract($this->object);
+            $data = $this->extract();
             if (!is_array($data)) {
                 throw new Exception\DomainException(sprintf(
                     '%s is unable to validate as there is no data currently set',
@@ -493,8 +486,8 @@ class Form extends Fieldset implements FormInterface
 
     /**
      * Set the input filter used by this form
-     * 
-     * @param  InputFilterInterface $inputFilter 
+     *
+     * @param  InputFilterInterface $inputFilter
      * @return FormInterface
      */
     public function setInputFilter(InputFilterInterface $inputFilter)
@@ -506,7 +499,7 @@ class Form extends Fieldset implements FormInterface
 
     /**
      * Retrieve input filter used by this form
-     * 
+     *
      * @return null|InputFilterInterface
      */
     public function getInputFilter()
@@ -562,10 +555,6 @@ class Form extends Fieldset implements FormInterface
             }
 
             $name = $element->getName();
-            if ($inputFilter->has($name)) {
-                // if we already have an input by this name, use it
-                continue;
-            }
 
             // Create an input based on the specification returned from the element
             $spec  = $element->getInputSpecification();
@@ -612,17 +601,21 @@ class Form extends Fieldset implements FormInterface
     }
 
     /**
-     * Extract values from the bound object and populate
-     * the form elements
+     * Recursively extract values for elements and sub-fieldsets, and populate form values
      *
-     * @return void
+     * @return array
      */
     protected function extract()
     {
         if (null !== $this->baseFieldset) {
-            $this->baseFieldset->extract();
+            $name = $this->baseFieldset->getName();
+            $values[$name] = $this->baseFieldset->extract();
+            $this->baseFieldset->populateValues($values[$name]);
         } else {
-            parent::extract();
+            $values = parent::extract();
+            $this->populateValues($values);
         }
+
+        return $values;
     }
 }

--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -85,20 +85,7 @@ class ClassMethods implements HydratorInterface
                     $attribute = preg_replace_callback('/([A-Z])/', $transform, $attribute);
                 }
 
-                $result = $object->$method();
-
-                // Recursively extract if object contains itself other objects or arrays of objects
-                if (is_object($result)) {
-                    $result = $this->extract($result);
-                } elseif (is_array($result)) {
-                    foreach ($result as $key => $value) {
-                        if (is_object($value)) {
-                            $result[$key] = $this->extract($value);
-                        }
-                    }
-                }
-
-                $attributes[$attribute] = $result;
+                $attributes[$attribute] = $object->$method();
             }
         }
         

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -775,9 +775,8 @@ class FormTest extends TestCase
         $form->bind($address);
         $form->setBindOnValidate(false);
 
-        if ($form->isValid()) {
-            $this->assertEquals($address, $form->getData());
-        }
+        $this->assertEquals(true, $form->isValid());
+        $this->assertEquals($address, $form->getData());
     }
 
     public function testCanCorrectlyPopulateDataToComposedEntities()
@@ -804,9 +803,8 @@ class FormTest extends TestCase
 
         $form->setData($data);
 
-        if ($form->isValid()) {
-            $this->assertEquals($address, $emptyAddress, var_export($address, 1) . "\n\n" . var_export($emptyAddress, 1));
-        }
+        $this->assertEquals(true, $form->isValid());
+        $this->assertEquals($address, $emptyAddress, var_export($address, 1) . "\n\n" . var_export($emptyAddress, 1));
     }
 
     public function testCanCorrectlyExtractDataFromOneToManyRelationship()
@@ -817,9 +815,8 @@ class FormTest extends TestCase
         $form->bind($product);
         $form->setBindOnValidate(false);
 
-        if ($form->isValid()) {
-            $this->assertEquals($product, $form->getData());
-        }
+        $this->assertEquals(true, $form->isValid());
+        $this->assertEquals($product, $form->getData());
     }
 
     public function testCanCorrectlyPopulateDataToOneToManyEntites()
@@ -847,8 +844,7 @@ class FormTest extends TestCase
 
         $form->setData($data);
 
-        if ($form->isValid()) {
-            $this->assertEquals($product, $emptyProduct, var_export($product, 1) . "\n\n" . var_export($emptyProduct, 1));
-        }
+        $this->assertEquals(true, $form->isValid());
+        $this->assertEquals($product, $emptyProduct, var_export($product, 1) . "\n\n" . var_export($emptyProduct, 1));
     }
 }

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -764,7 +764,7 @@ class FormTest extends TestCase
 
         $nestedFieldset = $basicFieldset->get('nested_fieldset');
         $this->assertEquals('basic_fieldset[nested_fieldset][anotherField]', $nestedFieldset->get('anotherField')
-                                                                                            ->getName());
+            ->getName());
     }
 
     public function testCanCorrectlyExtractDataFromComposedEntities()

--- a/tests/Zend/Form/TestAsset/AddressFieldset.php
+++ b/tests/Zend/Form/TestAsset/AddressFieldset.php
@@ -11,7 +11,7 @@ class AddressFieldset extends Fieldset implements InputFilterProviderInterface
     public function __construct()
     {
         parent::__construct('address');
-        $this->setHydrator(new ClassMethodsHydrator())
+        $this->setHydrator(new ClassMethodsHydrator(false))
              ->setObject(new Entity\Address());
 
         $street = new \Zend\Form\Element('street', array('label' => 'Street'));

--- a/tests/Zend/Form/TestAsset/CityFieldset.php
+++ b/tests/Zend/Form/TestAsset/CityFieldset.php
@@ -11,7 +11,7 @@ class CityFieldset extends Fieldset implements InputFilterProviderInterface
     public function __construct()
     {
         parent::__construct('city');
-        $this->setHydrator(new ClassMethodsHydrator())
+        $this->setHydrator(new ClassMethodsHydrator(false))
              ->setObject(new Entity\City());
 
         $name = new \Zend\Form\Element('name', array('label' => 'Name of the city'));

--- a/tests/Zend/Form/TestAsset/CreateAddressForm.php
+++ b/tests/Zend/Form/TestAsset/CreateAddressForm.php
@@ -12,7 +12,7 @@ class CreateAddressForm extends Form
         parent::__construct('create_address');
 
         $this->setAttribute('method', 'post')
-             ->setHydrator(new ClassMethodsHydrator())
+             ->setHydrator(new ClassMethodsHydrator(false))
              ->setInputFilter(new InputFilter());
 
         $address = new AddressFieldset();


### PR DESCRIPTION
I added when I was working on Forms to allow an entity to be recursively extracted and hence populate nested fieldsets in form, but this was a really bad idea, as in case of bidirectional-relationships, this hydrator ends up to an infinite recursion.

So I removed the recursion, and move it where it makes sense, in the form. Now the extract function moved to fieldset and use the hydrator set to the fieldset to extract data.

The tests now passes as before.

EDIT : this PR also contains an important fix for Collection.
