### PR TITLE
Added MongoDB log writer

### DIFF
--- a/library/Zend/Log/Writer/MongoDB.php
+++ b/library/Zend/Log/Writer/MongoDB.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Log
+ */
+
+namespace Zend\Log\Writer;
+
+use Mongo;
+use Zend\Log\Exception\InvalidArgumentException;
+use Zend\Log\Exception\RuntimeException;
+use Zend\Log\Formatter\FormatterInterface;
+
+/**
+ * MongoDB log writer.
+ *
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage Writer
+ */
+class MongoDB extends AbstractWriter
+{
+    /**
+     * MongoCollection instance
+     *
+     * @var MongoCollection
+     */
+    protected $mongoCollection;
+
+    /**
+     * Options used for MongoCollection::save()
+     *
+     * @var array
+     */
+    protected $saveOptions;
+
+    /**
+     * Constructor
+     *
+     * @param Mongo $mongo
+     * @param string $database
+     * @param string $collection
+     * @param array  $saveOptions
+     * @return Zend\Log\Writer\MongoDB
+     */
+    public function __construct(Mongo $mongo, $database, $collection, array $saveOptions = array())
+    {
+        $this->mongoCollection = $mongo->selectCollection($database, $collection);
+        $this->saveOptions = $saveOptions;
+    }
+
+    /**
+     * This writer does not support formatting.
+     *
+     * @param Zend\Log\Formatter\FormatterInterface $formatter
+     * @return void
+     * @throws Zend\Log\Exception\InvalidArgumentException
+     */
+    public function setFormatter(FormatterInterface $formatter)
+    {
+        throw new InvalidArgumentException(get_class() . ' does not support formatting');
+    }
+
+    /**
+     * Write a message to the log.
+     *
+     * @param array $event Event data
+     * @return void
+     * @throws Zend\Log\Exception\RuntimeException
+     */
+    protected function doWrite(array $event)
+    {
+        if (null === $this->mongoCollection) {
+            throw new RuntimeException('MongoCollection must be defined');
+        }
+
+        $this->mongoCollection->save($event, $this->saveOptions);
+    }
+}

--- a/library/Zend/Log/composer.json
+++ b/library/Zend/Log/composer.json
@@ -14,6 +14,7 @@
         "php": ">=5.3.3"
     },
     "suggest": {
+        "ext-mongo": "*",
         "zendframework/zend-mail": "Zend\\Mail component"
     }
 }

--- a/tests/Zend/Log/Writer/MongoDBTest.php
+++ b/tests/Zend/Log/Writer/MongoDBTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Log
+ */
+
+namespace ZendTest\Log\Writer;
+
+use Zend\Log\Logger;
+use Zend\Log\Writer\MongoDB as MongoDBWriter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage UnitTests
+ * @group      Zend_Log
+ */
+class MongoDBTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (!extension_loaded('mongo')) {
+            $this->markTestSkipped('The mongo PHP extension is not available');
+        }
+
+        $this->database = 'zf2_test';
+        $this->collection = 'logs';
+
+        $this->mongo = $this->getMockBuilder('Mongo')
+            ->disableOriginalConstructor()
+            ->setMethods(array('selectCollection'))
+            ->getMock();
+
+        $this->mongoCollection = $this->getMockBuilder('MongoCollection')
+            ->disableOriginalConstructor()
+            ->setMethods(array('save'))
+            ->getMock();
+
+        $this->mongo->expects($this->any())
+            ->method('selectCollection')
+            ->with($this->database, $this->collection)
+            ->will($this->returnValue($this->mongoCollection));
+    }
+
+    /**
+     * @expectedException Zend\Log\Exception\InvalidArgumentException
+     */
+    public function testFormattingIsNotSupported()
+    {
+        $writer = new MongoDBWriter($this->mongo, $this->database, $this->collection);
+
+        $writer->setFormatter($this->getMock('Zend\Log\Formatter\FormatterInterface'));
+    }
+
+    public function testWriteWithDefaultSaveOptions()
+    {
+        $event = array('message'=> 'foo', 'priority' => 42);
+
+        $this->mongoCollection->expects($this->once())
+            ->method('save')
+            ->with($event, array());
+
+        $writer = new MongoDBWriter($this->mongo, $this->database, $this->collection);
+
+        $writer->write($event);
+    }
+
+    public function testWriteWithCustomSaveOptions()
+    {
+        $event = array('message' => 'foo', 'priority' => 42);
+        $saveOptions = array('safe' => false, 'fsync' => false, 'timeout' => 100);
+
+        $this->mongoCollection->expects($this->once())
+            ->method('save')
+            ->with($event, $saveOptions);
+
+        $writer = new MongoDBWriter($this->mongo, $this->database, $this->collection, $saveOptions);
+
+        $writer->write($event);
+    }
+}


### PR DESCRIPTION
This is my first PR, so feel free to scrutinize this thoroughly.

While implementing this, I had a question about the `$event` arguments for the `write()` method. Are all of the values either scalars or an array of scalars? I'm assuming that based on the DB writer's `mapEventIntoColumn()` and `eventIntoColumn()` methods, as array values are handled specially (but only one level in). This obviously isn't a problem for Mongo, although I was curious if objects or other types might end up in `$event` and could benefit from special processing (e.g. converting DateTime instances to MongoDates).
