### PR TITLE
Zend/Mvc/Controller/AbstractActionController - Doc

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractActionController.php
+++ b/library/Zend/Mvc/Controller/AbstractActionController.php
@@ -234,7 +234,7 @@ abstract class AbstractActionController implements
      *
      * Will create a new MvcEvent if none provided.
      *
-     * @return Event
+     * @return MvcEvent
      */
     public function getEvent()
     {


### PR DESCRIPTION
changes DocBlock to "@return MvcEvent" for AbstractActionController:getEvent()
