### PR TITLE
Hotfix/di proxy discovered method parameters fix

### DIFF
--- a/library/Zend/Di/ServiceLocator/DependencyInjectorProxy.php
+++ b/library/Zend/Di/ServiceLocator/DependencyInjectorProxy.php
@@ -143,7 +143,7 @@ class DependencyInjectorProxy extends Di
         $methodClass = $instance->getClass();
         $callParameters = $this->resolveMethodParameters($methodClass, $method, $params, $alias, $methodIsRequired);
 
-        if ($callParameters === false) {
+        if ($callParameters !== false) {
             $instance->addMethod(array(
                 'method' => $method,
                 'params' => $callParameters,

--- a/tests/Zend/Di/ServiceLocator/DependencyInjectorProxyTest.php
+++ b/tests/Zend/Di/ServiceLocator/DependencyInjectorProxyTest.php
@@ -1,0 +1,28 @@
+<?php
+namespace ZendTest\Di\ServiceLocator;
+
+use Zend\Di\Di;
+use Zend\Di\ServiceLocator\DependencyInjectorProxy;
+use ZendTest\Di\TestAsset\SetterInjection\A;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Tests used to verify DependencyInjectorProxy functionality
+ */
+class DependencyInjectorProxyTest extends TestCase
+{
+    public function testWillDiscoverInjectedMethodParameters()
+    {
+        $di = new Di();
+        $a = new A();
+        $di->instanceManager()->setParameters(
+            'ZendTest\Di\TestAsset\SetterInjection\B',
+            array('a' => $a)
+        );
+        $proxy = new DependencyInjectorProxy($di);
+        $b = $proxy->get('ZendTest\Di\TestAsset\SetterInjection\B');
+        $methods = $b->getMethods();
+        $this->assertSame('setA', $methods[0]['method']);
+        $this->assertSame($a, $methods[0]['params'][0]);
+    }
+}


### PR DESCRIPTION
Because of a typo in my last PR about code generation in `Zend\Di`, a feature (discovery of injected method parameters) of the `DependencyInjectorProxy` wasn't working.
Here the failing test case and the associated fix:

[failing test applied](http://travis-ci.org/#!/Ocramius/zf2/jobs/1821551/L234)
[![Build Status](https://secure.travis-ci.org/Ocramius/zf2.png?branch=hotfix/di-proxy-discovered-method-parameters-fix)](http://travis-ci.org/Ocramius/zf2)
