### PR TITLE
[WIP] I18n translation support for Form labels and validation errors

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -11,6 +11,7 @@
 namespace Zend\Form;
 
 use Traversable;
+use Zend\I18n\Translator\Translator;
 use Zend\Stdlib\ArrayUtils;
 
 /**
@@ -38,6 +39,31 @@ class Element implements ElementInterface
      * @var array Validation error messages
      */
     protected $messages = array();
+
+    /**
+     * Default translation object for all element labels
+     * and default validators.
+     * @var Translator
+     */
+    protected static $defaultTranslator;
+
+    /**
+     * Translation object to use for label/validator translation
+     * @var Translator
+     */
+    protected $translator;
+
+    /**
+     * Translation text domain to use for translations
+     * @var string
+     */
+    protected $translatorTextDomain = 'default';
+
+    /**
+     * Is translation disabled?
+     * @var boolean
+     */
+    protected $translatorDisabled = false;
 
 
     /**
@@ -103,6 +129,16 @@ class Element implements ElementInterface
 
         if (isset($options['label_attributes'])) {
             $this->setLabelAttributes($options['label_attributes']);
+        }
+
+        if (isset($options['translator'])) {
+            $this->setTranslator($options['translator']);
+        }
+        if (isset($options['translator_text_domain'])) {
+            $this->setTranslatorTextDomain($options['translator_text_domain']);
+        }
+        if (isset($options['translator_disabled'])) {
+            $this->setTranslatorDisabled($options['translator_disabled']);
         }
 
         return $this;
@@ -212,7 +248,14 @@ class Element implements ElementInterface
      */
     public function getLabel()
     {
-        return $this->label;
+        $translator = $this->getTranslator();
+        if (!$translator) {
+            return $this->label;
+        }
+
+        return $translator->translate(
+            $this->label, $this->getTranslatorTextDomain()
+        );
     }
 
     /**
@@ -268,5 +311,120 @@ class Element implements ElementInterface
     public function getMessages()
     {
         return $this->messages;
+    }
+
+    /**
+     * Set translation object
+     *
+     * @param  Translator|null $translator
+     * @return Element
+     */
+    public function setTranslator(Translator $translator = null)
+    {
+        $this->translator = $translator;
+        return $this;
+    }
+
+    /**
+     * Return translation object
+     *
+     * @return Translator|null
+     */
+    public function getTranslator()
+    {
+        if ($this->isTranslatorDisabled()) {
+            return null;
+        }
+
+        if (null === $this->translator) {
+            return self::getDefaultTranslator();
+        }
+
+        return $this->translator;
+    }
+
+    /**
+     * Does this validator have its own specific translator?
+     *
+     * @return bool
+     */
+    public function hasTranslator()
+    {
+        return (bool)$this->translator;
+    }
+
+    /**
+     * Set translation text domain
+     *
+     * @param  string $textDomain
+     * @return Element
+     */
+    public function setTranslatorTextDomain($textDomain = 'default')
+    {
+        $this->translatorTextDomain = $textDomain;
+        return $this;
+    }
+
+    /**
+     * Return the translation text domain
+     *
+     * @return string
+     */
+    public function getTranslatorTextDomain()
+    {
+        return $this->translatorTextDomain;
+    }
+
+    /**
+     * Set default translation object for all validate objects
+     *
+     * @param  Translator|null $translator
+     * @return void
+     */
+    public static function setDefaultTranslator(Translator $translator = null)
+    {
+        self::$defaultTranslator = $translator;
+    }
+
+    /**
+     * Get default translation object for all validate objects
+     *
+     * @return Translator|null
+     */
+    public static function getDefaultTranslator()
+    {
+        return self::$defaultTranslator;
+    }
+
+    /**
+     * Is there a default translation object set?
+     *
+     * @return boolean
+     */
+    public static function hasDefaultTranslator()
+    {
+        return (bool) self::$defaultTranslator;
+    }
+
+    /**
+     * Indicate whether or not translation should be disabled
+     *
+     * @param  bool $flag
+     * @return Element
+     */
+    public function setTranslatorDisabled($flag)
+    {
+        $this->translatorDisabled = (bool) $flag;
+        return $this;
+    }
+
+    /**
+     * Is translation disabled?
+     *
+     * @return bool
+     */
+    public function isTranslatorDisabled()
+    {
+        return $this->translatorDisabled;
     }
 }

--- a/library/Zend/Form/Element/Color.php
+++ b/library/Zend/Form/Element/Color.php
@@ -45,6 +45,9 @@ class Color extends Element implements InputProviderInterface
     {
         if (null === $this->validator) {
             $this->validator = new RegexValidator('/^#[0-9a-fA-F]{6}$/');
+            $this->validator
+                ->setTranslator($this->getTranslator())
+                ->setTranslatorTextDomain($this->getTranslatorTextDomain());
         }
         return $this->validator;
     }

--- a/library/Zend/Validator/AbstractValidator.php
+++ b/library/Zend/Validator/AbstractValidator.php
@@ -43,12 +43,13 @@ abstract class AbstractValidator implements ValidatorInterface
     protected static $messageLength = -1;
 
     protected $abstractOptions = array(
-        'messages'           => array(),  // Array of validation failure messages
-        'messageTemplates'   => array(),  // Array of validation failure message templates
-        'messageVariables'   => array(),  // Array of additional variables available for validation failure messages
-        'translator'         => null,     // Translation object to used -> Zend\I18n\Translator\Translator
-        'translatorDisabled' => false,    // Is translation disabled?
-        'valueObscured'      => false,    // Flag indicating whether or not value should be obfuscated in error messages
+        'messages'             => array(),   // Array of validation failure messages
+        'messageTemplates'     => array(),   // Array of validation failure message templates
+        'messageVariables'     => array(),   // Array of additional variables available for validation failure messages
+        'translator'           => null,      // Translation object to used -> Zend\I18n\Translator\Translator
+        'translatorTextDomain' => 'default', // Translation text domain
+        'translatorDisabled'   => false,     // Is translation disabled?
+        'valueObscured'        => false,     // Flag indicating whether or not value should be obfuscated in error messages
     );
 
     /**
@@ -429,6 +430,28 @@ abstract class AbstractValidator implements ValidatorInterface
     }
 
     /**
+     * Set translation text domain
+     *
+     * @param  string $textDomain
+     * @return AbstractValidator
+     */
+    public function setTranslatorTextDomain($textDomain = 'default')
+    {
+        $this->abstractOptions['translatorTextDomain'] = $textDomain;
+        return $this;
+    }
+
+    /**
+     * Return the translation text domain
+     *
+     * @return string
+     */
+    public function getTranslatorTextDomain()
+    {
+        return $this->abstractOptions['translatorTextDomain'];
+    }
+
+    /**
      * Set default translation object for all validate objects
      *
      * @param  Translator|null $translator
@@ -502,6 +525,13 @@ abstract class AbstractValidator implements ValidatorInterface
         self::$messageLength = $length;
     }
 
+    /**
+     * Translate a validation message
+     *
+     * @param  string $messageKey
+     * @param  string $message
+     * @return string
+     */
     protected function translateMessage($messageKey, $message)
     {
         $translator = $this->getTranslator();
@@ -509,11 +539,15 @@ abstract class AbstractValidator implements ValidatorInterface
             return $message;
         }
 
-        $translated = $translator->translate($messageKey);
+        $translated = $translator->translate(
+            $messageKey, $this->getTranslatorTextDomain()
+        );
         if ($translated !== $messageKey) {
             return $translated;
         }
 
-        return $translator->translate($message);
+        return $translator->translate(
+            $message, $this->getTranslatorTextDomain()
+        );
     }
 }


### PR DESCRIPTION
DO NOT MERGE. Form label translations, looking for feedback. No tests yet.

Borrowed pattern that exists in Zend\Validator\AbstractValidator, applied to Zend\Form\Element, and added support for text domains.

Usage:

``` php
use Zend\I18n\Translator\Translator;
use Zend\Form\Element;
use Zend\Validator\AbstractValidator;
use Zend\Validator\Date as DateValidator;

$translator = new Translator();

//
// To set a global translator for all Elements and Validators:
Element::setDefaultTranslator($translator);
AbstractValidator::setDefaultTranslator($translator);

//
// Element usage:
$element = new Element('foo', array(
    'translator' => $translator,
    'translator_text_domain' => 'myDomain', // default is 'default'
    'translator_disabled' => false, // default is false
));
// or
$element
    ->setTranslator($translator)
    ->setTranslatorTextDomain('myDomain') // default is 'default'
    ->setTranslatorDisabled(false); // default is false

//
// Validator usage:
$validator = new DateValidator(array(
    'translator' => $translator,
    'translatorTextDomain' => 'myDomain', // default is 'default'
    'translatorDisabled' => false, // default is false
)); // options in validators may need underscores/cleanup?

// or
$validator
    ->setTranslator($translator)
    ->setTranslatorTextDomain('myDomain') // default is 'default'
    ->setTranslatorDisabled(false); // default is false

```

Specialized Zend\Form\Element*.php could pass it's translator down to it's default validators (see example in Zend\Form\Element\Color.php).

No changes to Zend\Form\View\Helper\FormLabel. To use this helper with translate, you'd need to do:

``` php
// inside view.phtml
echo $this->formLabel($this->translate('My Label'));
```
