### PR TITLE
Fix controller param in Url helper

### DIFF
--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -93,13 +93,13 @@ class Url extends AbstractHelper
         }
 
         if ($reuseMatchedParams && $this->routeMatch !== null) {
-            $paramOriginalController = $this->routeMatch->getParam(ModuleRouteListener::ORIGINAL_CONTROLLER);
+            $paramsRouteMatch = $this->routeMatch->getParams();
 
-            if(null !== $paramOriginalController) {
-                $this->routeMatch->setParam('controller', $paramOriginalController);
+            if (isset($paramsRouteMatch[ModuleRouteListener::ORIGINAL_CONTROLLER])) {
+                $paramsRouteMatch['controller'] = $paramsRouteMatch[ModuleRouteListener::ORIGINAL_CONTROLLER];
             }
 
-            $params = array_merge($this->routeMatch->getParams(), $params);
+            $params = array_merge($paramsRouteMatch, $params);
         }
 
         $options['name'] = $name;

--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -24,21 +24,21 @@ class Url extends AbstractHelper
 {
     /**
      * RouteStackInterface instance.
-     * 
+     *
      * @var RouteStackInterface
      */
     protected $router;
-    
+
     /**
      * RouteInterface match returned by the router.
-     * 
+     *
      * @var RouteMatch.
      */
     protected $routeMatch;
 
     /**
      * Set the router to use for assembling.
-     * 
+     *
      * @param RouteStackInterface $router
      * @return Url
      */
@@ -47,10 +47,10 @@ class Url extends AbstractHelper
         $this->router = $router;
         return $this;
     }
-    
+
     /**
      * Set route match returned by the router.
-     * 
+     *
      * @param  RouteMatch $routeMatch
      * @return self
      */
@@ -83,18 +83,22 @@ class Url extends AbstractHelper
             if ($this->routeMatch === null) {
                 throw new Exception\RuntimeException('No RouteMatch instance provided');
             }
-            
+
             $name = $this->routeMatch->getMatchedRouteName();
-            
+
             if ($name === null) {
                 throw new Exception\RuntimeException('RouteMatch does not contain a matched route name');
             }
         }
-        
+
         if ($reuseMatchedParams && $this->routeMatch !== null) {
             $params = array_merge($this->routeMatch->getParams(), $params);
+
+            if(isset($params[\Zend\Mvc\ModuleRouteListener::ORIGINAL_CONTROLLER])) {
+                $params['controller'] = $params[\Zend\Mvc\ModuleRouteListener::ORIGINAL_CONTROLLER];
+            }
         }
-        
+
         $options['name'] = $name;
 
         return $this->router->assemble($params, $options);

--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -92,11 +92,13 @@ class Url extends AbstractHelper
         }
 
         if ($reuseMatchedParams && $this->routeMatch !== null) {
-            $params = array_merge($this->routeMatch->getParams(), $params);
+            $paramOriginalController = $this->routeMatch->getParam(\Zend\Mvc\ModuleRouteListener::ORIGINAL_CONTROLLER);
 
-            if(isset($params[\Zend\Mvc\ModuleRouteListener::ORIGINAL_CONTROLLER])) {
-                $params['controller'] = $params[\Zend\Mvc\ModuleRouteListener::ORIGINAL_CONTROLLER];
+            if(null !== $paramOriginalController) {
+                $this->routeMatch->setParam('controller', $paramOriginalController);
             }
+
+            $params = array_merge($this->routeMatch->getParams(), $params);
         }
 
         $options['name'] = $name;

--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -10,6 +10,7 @@
 
 namespace Zend\View\Helper;
 
+use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\Router\RouteStackInterface;
 use Zend\View\Exception;
@@ -92,7 +93,7 @@ class Url extends AbstractHelper
         }
 
         if ($reuseMatchedParams && $this->routeMatch !== null) {
-            $paramOriginalController = $this->routeMatch->getParam(\Zend\Mvc\ModuleRouteListener::ORIGINAL_CONTROLLER);
+            $paramOriginalController = $this->routeMatch->getParam(ModuleRouteListener::ORIGINAL_CONTROLLER);
 
             if(null !== $paramOriginalController) {
                 $this->routeMatch->setParam('controller', $paramOriginalController);


### PR DESCRIPTION
When <code>$reuseMatchedParams</code> is true, controller param must be replaced by original controller param.

Example:
Before <code>/section/BcomCrm%5CController%5Cfield/add</code>, after <code>/section/field/add</code>
