### PR TITLE
For testing of file existing, operator "include" should return 1.

### DIFF
--- a/library/Zend/Loader/AutoloaderFactory.php
+++ b/library/Zend/Loader/AutoloaderFactory.php
@@ -12,7 +12,7 @@ namespace Zend\Loader;
 
 require_once __DIR__ . '/SplAutoloader.php';
 
-if (class_exists('Zend\Loader\AutoloaderFactory')) return;
+if (class_exists('Zend\Loader\AutoloaderFactory')) return 1;
 
 /**
  * @category   Zend

--- a/library/Zend/Loader/SplAutoloader.php
+++ b/library/Zend/Loader/SplAutoloader.php
@@ -10,7 +10,7 @@
 
 namespace Zend\Loader;
 
-if (interface_exists('Zend\Loader\SplAutoloader')) return;
+if (interface_exists('Zend\Loader\SplAutoloader')) return 1;
 
 /**
  * Defines an interface for classes that may register with the spl_autoload 


### PR DESCRIPTION
include 'noreturn.php';  //return 1.
