### PR TITLE
Zend\Json Improvements

### DIFF
--- a/library/Zend/Json/Decoder.php
+++ b/library/Zend/Json/Decoder.php
@@ -462,7 +462,13 @@ class Decoder
                     // single, escaped unicode character
                     $utf16 = chr(hexdec(substr($chrs, ($i + 2), 2)))
                            . chr(hexdec(substr($chrs, ($i + 4), 2)));
-                    $utf8 .= self::_utf162utf8($utf16);
+                    $utf8char = self::_utf162utf8($utf16);
+                    $search  = array('\\', "\n", "\t", "\r", chr(0x08), chr(0x0C), '"', '\'', '/');
+                    if (in_array($utf8char, $search)) {
+                        $replace = array('\\\\', '\\n', '\\t', '\\r', '\\b', '\\f', '\\"', '\\\'', '\\/');
+                        $utf8char  = str_replace($search, $replace, $utf8char);
+                    }
+                    $utf8 .= $utf8char;
                     $i += 5;
                     break;
                 case ($ord_chrs_c >= 0x20) && ($ord_chrs_c <= 0x7F):

--- a/library/Zend/Json/Encoder.php
+++ b/library/Zend/Json/Encoder.php
@@ -248,10 +248,10 @@ class Encoder
      */
     protected function _encodeString(&$string)
     {
-        // Escape these characters with a backslash:
+        // Escape these characters with a backslash or unicode escape:
         // " \ / \n \r \t \b \f
-        $search  = array('\\', "\n", "\t", "\r", "\b", "\f", '"', '/');
-        $replace = array('\\\\', '\\n', '\\t', '\\r', '\\b', '\\f', '\"', '\\/');
+        $search  = array('\\', "\n", "\t", "\r", "\b", "\f", '"', '\'', '&', '<', '>', '/');
+        $replace = array('\\\\', '\\n', '\\t', '\\r', '\\b', '\\f', '\\u0022', '\\u0027', '\\u0026',  '\\u003C', '\\u003E', '\\/');
         $string  = str_replace($search, $replace, $string);
 
         // Escape certain ASCII characters:

--- a/library/Zend/Json/Json.php
+++ b/library/Zend/Json/Json.php
@@ -118,7 +118,10 @@ class Json
 
         // Encoding
         if (function_exists('json_encode') && self::$useBuiltinEncoderDecoder !== true) {
-            $encodedResult = json_encode($valueToEncode);
+            $encodedResult = json_encode(
+                $valueToEncode,
+                JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+            );
         } else {
             $encodedResult = Encoder::encode($valueToEncode, $cycleCheck, $options);
         }

--- a/tests/Zend/Json/JsonTest.php
+++ b/tests/Zend/Json/JsonTest.php
@@ -147,12 +147,45 @@ class JsonTest extends \PHPUnit_Framework_TestCase
      */
     public function testString5()
     {
-        $expected = '"INFO: Path \u0022Some more\u0022"';
+        $expected = '"INFO: Path \\u0022Some more\\u0022"';
         $string   = 'INFO: Path "Some more"';
         $encoded  = Json\Encoder::encode($string);
-        $this->assertEquals($expected, $encoded, 'Quote encoding incorrect: expected ' . serialize($expected) . '; received: ' . serialize($encoded) . "\n");
+        $this->assertEquals(
+            $expected,
+            $encoded,
+            'Quote encoding incorrect: expected ' . serialize($expected) . '; received: ' . serialize($encoded) . "\n"
+        );
         $this->assertEquals($string, Json\Decoder::decode($encoded)); // Bug: does not accept \u0022 as token!
     }
+
+    /**
+     * Test decoding of unicode escaped special characters
+     */
+    public function testStringOfHtmlSpecialCharsEncodedToUnicodeEscapes()
+    {
+        $expected = '"\\u003C\\u003E\\u0026\\u0027\\u0022"';
+        $string   = '<>&\'"';
+        $encoded  = Json\Encoder::encode($string);
+        $this->assertEquals(
+            $expected,
+            $encoded,
+            'Encoding error: expected ' . serialize($expected) . '; received: ' . serialize($encoded) . "\n"
+        );
+        $this->assertEquals($string, Json\Decoder::decode($encoded));
+    }
+
+    /**
+     * Test decoding of unicode escaped ASCII (non-HTML special) characters
+     *
+     * Note: covers chars that MUST be escaped. Does not test any other non-printables.
+     */
+    public function testStringOfOtherSpecialCharsEncodedToUnicodeEscapes()
+    {
+        $string   = "\\ - \n - \t - \r - " .chr(0x08). " - " .chr(0x0C). " - /";
+        $encoded  = '"\u005C - \u000A - \u0009 - \u000D - \u0008 - \u000C - \u002F"';
+        $this->assertEquals($string, Json\Decoder::decode($encoded));
+    }
+
 
     /**
      * test indexed array encoding/decoding

--- a/tests/Zend/Json/JsonTest.php
+++ b/tests/Zend/Json/JsonTest.php
@@ -147,11 +147,11 @@ class JsonTest extends \PHPUnit_Framework_TestCase
      */
     public function testString5()
     {
-        $expected = '"INFO: Path \"Some more\""';
+        $expected = '"INFO: Path \u0022Some more\u0022"';
         $string   = 'INFO: Path "Some more"';
         $encoded  = Json\Encoder::encode($string);
         $this->assertEquals($expected, $encoded, 'Quote encoding incorrect: expected ' . serialize($expected) . '; received: ' . serialize($encoded) . "\n");
-        $this->assertEquals($string, Json\Decoder::decode($encoded));
+        $this->assertEquals($string, Json\Decoder::decode($encoded)); // Bug: does not accept \u0022 as token!
     }
 
     /**
@@ -704,7 +704,17 @@ class JsonTest extends \PHPUnit_Framework_TestCase
     public function testNativeJSONEncoderWillProperlyEncodeSolidusInStringValues()
     {
         $source = "</foo><foo>bar</foo>";
-        $target = '"<\\/foo><foo>bar<\\/foo>"';
+        $target = '"\u003C\/foo\u003E\u003Cfoo\u003Ebar\u003C\/foo\u003E"';
+        
+        // first test ext/json
+        Json\Json::$useBuiltinEncoderDecoder = false;
+        $this->assertEquals($target, Json\Json::encode($source));
+    }
+
+    public function testNativeJSONEncoderWillProperlyEncodeHtmlSpecialCharsInStringValues()
+    {
+        $source = "<>&'\"";
+        $target = '"\u003C\u003E\u0026\u0027\u0022"';
         
         // first test ext/json
         Json\Json::$useBuiltinEncoderDecoder = false;
@@ -717,7 +727,17 @@ class JsonTest extends \PHPUnit_Framework_TestCase
     public function testBuiltinJSONEncoderWillProperlyEncodeSolidusInStringValues()
     {
         $source = "</foo><foo>bar</foo>";
-        $target = '"<\\/foo><foo>bar<\\/foo>"';
+        $target = '"\u003C\/foo\u003E\u003Cfoo\u003Ebar\u003C\/foo\u003E"';
+        
+        // first test ext/json
+        Json\Json::$useBuiltinEncoderDecoder = true;
+        $this->assertEquals($target, Json\Json::encode($source));
+    }
+
+    public function testBuiltinJSONEncoderWillProperlyEncodeHtmlSpecialCharsInStringValues()
+    {
+        $source = "<>&'\"";
+        $target = '"\u003C\u003E\u0026\u0027\u0022"';
         
         // first test ext/json
         Json\Json::$useBuiltinEncoderDecoder = true;
@@ -782,7 +802,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase
         $expected = <<<EOB
 {
  "simple":"simple test string",
- "stringwithjsonchars":"\\\\\\"[1,2]",
+ "stringwithjsonchars":"\\\\\\u0022[1,2]",
  "complex":{
   "foo":"bar",
   "far":"boo",

--- a/tests/Zend/Json/JsonTest.php
+++ b/tests/Zend/Json/JsonTest.php
@@ -163,6 +163,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase
      */
     public function testStringOfHtmlSpecialCharsEncodedToUnicodeEscapes()
     {
+        Json\Json::$useBuiltinEncoderDecoder = false;
         $expected = '"\\u003C\\u003E\\u0026\\u0027\\u0022"';
         $string   = '<>&\'"';
         $encoded  = Json\Encoder::encode($string);
@@ -181,8 +182,9 @@ class JsonTest extends \PHPUnit_Framework_TestCase
      */
     public function testStringOfOtherSpecialCharsEncodedToUnicodeEscapes()
     {
-        $string   = "\\ - \n - \t - \r - " .chr(0x08). " - " .chr(0x0C). " - /";
-        $encoded  = '"\u005C - \u000A - \u0009 - \u000D - \u0008 - \u000C - \u002F"';
+        Json\Json::$useBuiltinEncoderDecoder = false;
+        $string   = "\\ - \n - \t - \r - " .chr(0x08). " - " .chr(0x0C). " - / - \v";
+        $encoded  = '"\u005C - \u000A - \u0009 - \u000D - \u0008 - \u000C - \u002F - \u000B"';
         $this->assertEquals($string, Json\Decoder::decode($encoded));
     }
 


### PR DESCRIPTION
Changes:
1. Enables a number of optional json_encode() flags available since PHP 5.3 which additionally escape certain HTML special characters (increases security on JSON included in HTML script tags).
2. Ported the additional escaping over to the PHP encoder
3. PHP decoder unicode unescapes before parsing JSON. This means that unicode escaped special characters like newlines, quotes, slashes, etc. have their ASCII literals injected into JSON strings in an unescaped form leading to parsing errors and potentially other problems.
