### PR TITLE
Hint on EventInterface instead of Event in BootstrapListenerInterface

### DIFF
--- a/library/Zend/ModuleManager/Feature/BootstrapListenerInterface.php
+++ b/library/Zend/ModuleManager/Feature/BootstrapListenerInterface.php
@@ -10,7 +10,7 @@
 
 namespace Zend\ModuleManager\Feature;
 
-use Zend\EventManager\Event;
+use Zend\EventManager\EventInterface;
 
 /**
  * Boostrap listener provider interface
@@ -26,5 +26,5 @@ interface BootstrapListenerInterface
      *
      * @return array
      */
-    public function onBootstrap(Event $e);
+    public function onBootstrap(EventInterface $e);
 }

--- a/tests/Zend/ModuleManager/TestAsset/ListenerTestModule/Module.php
+++ b/tests/Zend/ModuleManager/TestAsset/ListenerTestModule/Module.php
@@ -13,14 +13,14 @@ namespace ListenerTestModule;
 use Zend\ModuleManager\Feature\AutoloaderProviderInterface;
 use Zend\ModuleManager\Feature\LocatorRegisteredInterface;
 use Zend\ModuleManager\Feature\BootstrapListenerInterface;
-use Zend\EventManager\Event;
+use Zend\EventManager\EventInterface;
 
 /**
  * @category   Zend
  * @package    Zend_ModuleManager
  * @subpackage UnitTest
  */
-class Module implements 
+class Module implements
     AutoloaderProviderInterface,
     LocatorRegisteredInterface,
     BootstrapListenerInterface
@@ -55,7 +55,7 @@ class Module implements
         );
     }
 
-    public function onBootstrap(Event $e)
+    public function onBootstrap(EventInterface $e)
     {
         $this->onBootstrapCalled = true;
     }


### PR DESCRIPTION
Suggested by @juriansluiman.

**NOTE:** This does introduce a small BC break for modules implementing he BootstrapListenerInterface.
