### PR TITLE
Zend\Db: Fix for ZF2-386, also added Expression support to Zend\Db\Sql\Select join() on clause

### DIFF
--- a/library/Zend/Db/Adapter/Platform/Mysql.php
+++ b/library/Zend/Db/Adapter/Platform/Mysql.php
@@ -119,7 +119,7 @@ class Mysql implements PlatformInterface
      */
     public function quoteIdentifierInFragment($identifier, array $safeWords = array())
     {
-        $parts = preg_split('#([\.\s])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         foreach($parts as $i => $part) {
             if ($safeWords && in_array($part, $safeWords)) {
                 continue;

--- a/library/Zend/Db/Adapter/Platform/Postgresql.php
+++ b/library/Zend/Db/Adapter/Platform/Postgresql.php
@@ -118,7 +118,7 @@ class Postgresql implements PlatformInterface
      */
     public function quoteIdentifierInFragment($identifier, array $safeWords = array())
     {
-        $parts = preg_split('#([\.\s])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         foreach($parts as $i => $part) {
             if ($safeWords && in_array($part, $safeWords)) {
                 continue;

--- a/library/Zend/Db/Adapter/Platform/Sql92.php
+++ b/library/Zend/Db/Adapter/Platform/Sql92.php
@@ -118,11 +118,13 @@ class Sql92 implements PlatformInterface
      */
     public function quoteIdentifierInFragment($identifier, array $safeWords = array())
     {
-        $parts = preg_split('#([\.\s])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+
         foreach($parts as $i => $part) {
             if ($safeWords && in_array($part, $safeWords)) {
                 continue;
             }
+
             switch ($part) {
                 case ' ':
                 case '.':
@@ -136,6 +138,7 @@ class Sql92 implements PlatformInterface
                     $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
             }
         }
+
         return implode('', $parts);
     }
 

--- a/library/Zend/Db/Adapter/Platform/SqlServer.php
+++ b/library/Zend/Db/Adapter/Platform/SqlServer.php
@@ -118,7 +118,7 @@ class SqlServer implements PlatformInterface
      */
     public function quoteIdentifierInFragment($identifier, array $safeWords = array())
     {
-        $parts = preg_split('#([\.\s])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         foreach($parts as $i => $part) {
             if ($safeWords && in_array($part, $safeWords)) {
                 continue;

--- a/library/Zend/Db/Adapter/Platform/Sqlite.php
+++ b/library/Zend/Db/Adapter/Platform/Sqlite.php
@@ -119,7 +119,7 @@ class Sqlite implements PlatformInterface
      */
     public function quoteIdentifierInFragment($identifier, array $safeWords = array())
     {
-        $parts = preg_split('#([\.\s])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         foreach($parts as $i => $part) {
             if ($safeWords && in_array($part, $safeWords)) {
                 continue;

--- a/tests/Zend/Db/Adapter/Platform/MysqlTest.php
+++ b/tests/Zend/Db/Adapter/Platform/MysqlTest.php
@@ -104,4 +104,13 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('`foo`.`bar`', $this->platform->quoteIdentifierInFragment('foo.bar'));
         $this->assertEquals('`foo` as `bar`', $this->platform->quoteIdentifierInFragment('foo as bar'));
     }
+
+    /**
+     * @group ZF2-386
+     * @covers Zend\Db\Adapter\Platform\Mysql::quoteIdentifierInFragment
+     */
+    public function testQuoteIdentifierInFragmentIgnoresSingleCharSafeWords()
+    {
+        $this->assertEquals('(`foo`.`bar` = `boo`.`baz`)', $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz)', array('(', ')', '=')));
+    }
 }

--- a/tests/Zend/Db/Adapter/Platform/PostgresqlTest.php
+++ b/tests/Zend/Db/Adapter/Platform/PostgresqlTest.php
@@ -104,4 +104,13 @@ class PostgresqlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('"foo"."bar"', $this->platform->quoteIdentifierInFragment('foo.bar'));
         $this->assertEquals('"foo" as "bar"', $this->platform->quoteIdentifierInFragment('foo as bar'));
     }
+
+    /**
+     * @group ZF2-386
+     * @covers Zend\Db\Adapter\Platform\Postgresql::quoteIdentifierInFragment
+     */
+    public function testQuoteIdentifierInFragmentIgnoresSingleCharSafeWords()
+    {
+        $this->assertEquals('("foo"."bar" = "boo"."baz")', $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz)', array('(', ')', '=')));
+    }
 }

--- a/tests/Zend/Db/Adapter/Platform/Sql92Test.php
+++ b/tests/Zend/Db/Adapter/Platform/Sql92Test.php
@@ -104,4 +104,14 @@ class Sql92Test extends \PHPUnit_Framework_TestCase
         $this->assertEquals('"foo"."bar"', $this->platform->quoteIdentifierInFragment('foo.bar'));
         $this->assertEquals('"foo" as "bar"', $this->platform->quoteIdentifierInFragment('foo as bar'));
     }
+
+    /**
+     * @group ZF2-386
+     * @covers Zend\Db\Adapter\Platform\Sql92::quoteIdentifierInFragment
+     */
+    public function testQuoteIdentifierInFragmentIgnoresSingleCharSafeWords()
+    {
+        $this->assertEquals('("foo"."bar" = "boo"."baz")', $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz)', array('(', ')', '=')));
+    }
+
 }

--- a/tests/Zend/Db/Adapter/Platform/SqlServerTest.php
+++ b/tests/Zend/Db/Adapter/Platform/SqlServerTest.php
@@ -104,4 +104,13 @@ class SqlServerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('[foo].[bar]', $this->platform->quoteIdentifierInFragment('foo.bar'));
         $this->assertEquals('[foo] as [bar]', $this->platform->quoteIdentifierInFragment('foo as bar'));
     }
+
+    /**
+     * @group ZF2-386
+     * @covers Zend\Db\Adapter\Platform\SqlServer::quoteIdentifierInFragment
+     */
+    public function testQuoteIdentifierInFragmentIgnoresSingleCharSafeWords()
+    {
+        $this->assertEquals('([foo].[bar] = [boo].[baz])', $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz)', array('(', ')', '=')));
+    }
 }

--- a/tests/Zend/Db/Adapter/Platform/SqliteTest.php
+++ b/tests/Zend/Db/Adapter/Platform/SqliteTest.php
@@ -104,4 +104,14 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('"foo"."bar"', $this->platform->quoteIdentifierInFragment('foo.bar'));
         $this->assertEquals('"foo" as "bar"', $this->platform->quoteIdentifierInFragment('foo as bar'));
     }
+
+    /**
+     * @group ZF2-386
+     * @covers Zend\Db\Adapter\Platform\Postgresql::quoteIdentifierInFragment
+     */
+    public function testQuoteIdentifierInFragmentIgnoresSingleCharSafeWords()
+    {
+        $this->assertEquals('("foo"."bar" = "boo"."baz")', $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz)', array('(', ')', '=')));
+    }
+
 }

--- a/tests/Zend/Db/Sql/SelectTest.php
+++ b/tests/Zend/Db/Sql/SelectTest.php
@@ -620,12 +620,12 @@ class SelectTest extends \PHPUnit_Framework_TestCase
 
         // joins with a few keywords in the on clause
         $select28 = new Select;
-        $select28->from('foo')->join('zac', 'm = n AND c.x BETWEEN x AND y.z');
+        $select28->from('foo')->join('zac', '(m = n AND c.x) BETWEEN x AND y.z');
         $sqlPrep28 = // same
-        $sqlStr28 = 'SELECT "foo".*, "zac".* FROM "foo" INNER JOIN "zac" ON "m" = "n" AND "c"."x" BETWEEN "x" AND "y"."z"';
+        $sqlStr28 = 'SELECT "foo".*, "zac".* FROM "foo" INNER JOIN "zac" ON ("m" = "n" AND "c"."x") BETWEEN "x" AND "y"."z"';
         $internalTests28 = array(
             'processSelect' => array(array(array('"foo".*'), array('"zac".*')), '"foo"'),
-            'processJoin'   => array(array(array('INNER', '"zac"', '"m" = "n" AND "c"."x" BETWEEN "x" AND "y"."z"')))
+            'processJoin'   => array(array(array('INNER', '"zac"', '("m" = "n" AND "c"."x") BETWEEN "x" AND "y"."z"')))
         );
 
         // order with compound name
@@ -646,6 +646,16 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $internalTests30 = array(
             'processSelect' => array(array(array('"foo".*')), '"foo"'),
             'processGroup'  => array(array('"c1"."d2"'))
+        );
+
+        // join with expression in ON part
+        $select31 = new Select;
+        $select31->from('foo')->join('zac', new Expression('(m = n AND c.x) BETWEEN x AND y.z'));
+        $sqlPrep31 = // same
+        $sqlStr31 = 'SELECT "foo".*, "zac".* FROM "foo" INNER JOIN "zac" ON (m = n AND c.x) BETWEEN x AND y.z';
+        $internalTests31 = array(
+            'processSelect' => array(array(array('"foo".*'), array('"zac".*')), '"foo"'),
+            'processJoin'   => array(array(array('INNER', '"zac"', '(m = n AND c.x) BETWEEN x AND y.z')))
         );
 
         /**
@@ -688,6 +698,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             array($select28, $sqlPrep28, array(),    $sqlStr28, $internalTests28),
             array($select29, $sqlPrep29, array(),    $sqlStr29, $internalTests29),
             array($select30, $sqlPrep30, array(),    $sqlStr30, $internalTests30),
+            array($select31, $sqlPrep31, array(),    $sqlStr31, $internalTests31),
         );
     }
 


### PR DESCRIPTION
Fix for ZF2-386 - Proper handling of single character safe words in platforms, also, feature for expressions in join ON clause.
