### PR TITLE
fixed CaptureCache issue

### DIFF
--- a/library/Zend/Cache/Pattern/CaptureCache.php
+++ b/library/Zend/Cache/Pattern/CaptureCache.php
@@ -195,7 +195,7 @@ class CaptureCache extends AbstractPattern
      * @param  string $output Buffered output
      * @return boolean FALSE means original input is sent to the browser.
      */
-    protected function flush($output)
+    public function flush($output)
     {
         $this->save($output);
 
@@ -215,6 +215,7 @@ class CaptureCache extends AbstractPattern
         $options  = $this->getOptions();
         $path     = $this->pageId2Path($this->pageId);
         $fullPath = $options->getPublicDir() . DIRECTORY_SEPARATOR . $path;
+        $oldUmask = null;
         if (!file_exists($fullPath)) {
             $oldUmask = umask($options->getDirUmask());
             if (!@mkdir($fullPath, 0777, true)) {


### PR DESCRIPTION
refer to https://github.com/zendframework/zf2/pull/1838

Zend/Cache/Pattern/CaptureCache flush method should be public, see my test demo:

https://github.com/AlloVince/eva-engine/blob/master/public/zf2libs/capturecache.php

This demo show warning because of flush not able to access
Warning: Invalid callback Zend\Cache\Pattern\CaptureCache::flush, cannot access protected method Zend\Cache\Pattern\CaptureCache::flush() in Unknown on line 0

Also because of oldUmask not defined, demo will show a notice:
Notice: Undefined variable: oldUmask in D:\xampp\htdocs\zf2\vendor\zf2\library\Zend\Cache\Pattern\CaptureCache.php on line 228
