### PR TITLE
fix Fieldset issue

### DIFF
--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -552,7 +552,7 @@ class Fieldset extends Element implements FieldsetInterface
                 // Is the object bound to the fieldset of the same type ? Note that we are using a little hack
                 // here, as in case of collection, we bind array to object instance, and let the collection extract
                 // the data
-                if ($fieldset instanceof Collection || (is_object($object) && $object instanceof $fieldset->object)) {
+                if ($fieldset instanceof Collection || (is_object($object) && $fieldset->object && $object instanceof $fieldset->object)) {
                     $fieldset->object = $object;
                     $values[$name] = $fieldset->extract();
                 }

--- a/tests/Zend/Form/FieldsetTest.php
+++ b/tests/Zend/Form/FieldsetTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Form;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element;
+use Zend\Form\Form;
 use Zend\Form\Fieldset;
 
 /**
@@ -245,5 +246,20 @@ class FieldsetTest extends TestCase
             $test[] = $element->getName();
         }
         $this->assertEquals($expected, $test);
+    }
+
+    public function testSubFieldsetsBindObject()
+    {
+        $form = new Form();
+        $fieldset = new Fieldset('foobar');
+        $form->add($fieldset);
+        $value = new \ArrayObject(array(
+            'foobar' => 'abc',
+        ));
+        $value['foobar'] = new \ArrayObject(array(
+            'foo' => 'abc'
+        ));
+        $form->bind($value);
+        $this->assertSame($fieldset, $form->get('foobar'));
     }
 }


### PR DESCRIPTION
refer to https://github.com/zendframework/zf2/pull/1838

In Zend/Form/Fieldset, the $fieldset->object is possible tobe null, should add a null check. or else here will cause

Fatal error: Class name must be a valid object or a string in D:\xampp\htdocs\zf2\vendor\zf2\library\Zend\Form\Fieldset.php on line 555
