### PR TITLE
Added Patch Method support to the Curl Http Adapter

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -300,6 +300,11 @@ class Curl implements HttpAdapter, StreamInterface
                 }
                 break;
 
+            case 'PATCH' :
+                $curlMethod = CURLOPT_CUSTOMREQUEST;
+                $curlValue = "PATCH";
+                break;
+
             case 'DELETE' :
                 $curlMethod = CURLOPT_CUSTOMREQUEST;
                 $curlValue = "DELETE";

--- a/tests/Zend/Http/Client/CurlTest.php
+++ b/tests/Zend/Http/Client/CurlTest.php
@@ -54,19 +54,6 @@ class CurlTest extends CommonHttpTests
         parent::setUp();
     }
 
-    public function testSimpleRequests()
-    {
-        $this->markTestSkipped('Method PATCH not implemented.');
-    }
-
-    /**
-     * @dataProvider parameterArrayProvider
-     */
-    public function testPatchData($params)
-    {
-        $this->markTestSkipped('Method PATCH not implemented.');
-    }
-
     /**
      * Off-line common adapter tests
      */


### PR DESCRIPTION
Added support for the PATCH method in the Curl Http Adapter
so it supports partial modifications to a resource according to RFC 5789

enabled the tests for the PATCH method in CurlTest
