### PR TITLE
Gdata analytics v2.4

### DIFF
--- a/library/Zend/GData/Analytics.php
+++ b/library/Zend/GData/Analytics.php
@@ -10,8 +10,6 @@
 
 namespace Zend\GData;
 
-use Zend\Http\Client;
-
 /**
  * @category   Zend
  * @package    Zend_Gdata
@@ -19,25 +17,26 @@ use Zend\Http\Client;
  */
 class Analytics extends GData
 {
-    const AUTH_SERVICE_NAME = 'analytics';
-    const ANALYTICS_FEED_URI = 'https://www.google.com/analytics/feeds';
-    const ANALYTICS_ACCOUNT_FEED_URI = 'https://www.google.com/analytics/feeds/accounts';
+	const AUTH_SERVICE_NAME = 'analytics';
+	const ANALYTICS_FEED_URI = 'https://www.googleapis.com/analytics/v2.4/data'; 
+	const ANALYTICS_ACCOUNT_FEED_URI = 'https://www.googleapis.com/analytics/v2.4/management/accounts';
 
-    public static $namespaces = array(
-        array('ga', 'http://schemas.google.com/analytics/2009', 1, 0)
+	public static $namespaces = array(
+        array('analytics', 'http://schemas.google.com/analytics/2009', 1, 0),
+        array('ga', 'http://schemas.google.com/ga/2009', 1, 0)
     );
 
     /**
      * Create Gdata object
      *
-     * @param Client $client
+     * @param \Zend\Http\Client $client
      * @param string $applicationId The identity of the app in the form of
      *          Company-AppName-Version
      */
-    public function __construct(Client $client = null, $applicationId = 'MyCompany-MyApp-1.0')
+    public function __construct($client = null, $applicationId = 'MyCompany-MyApp-1.0')
     {
-        $this->registerPackage('Zend_Gdata_Analytics');
-        $this->registerPackage('Zend_Gdata_Analytics_Extension');
+        $this->registerPackage('Zend\Gdata\Analytics');
+        $this->registerPackage('Zend\Gdata\Analytics\Extension');
         parent::__construct($client, $applicationId);
         $this->_httpClient->setParameterPost(array('service' => self::AUTH_SERVICE_NAME));
     }
@@ -45,14 +44,19 @@ class Analytics extends GData
     /**
      * Retrieve account feed object
      *
+     * @param mixed $location
      * @return Analytics\AccountFeed
      */
-    public function getAccountFeed()
+    public function getAccountFeed($location = self::ANALYTICS_ACCOUNT_FEED_URI)
     {
-        $uri = self::ANALYTICS_ACCOUNT_FEED_URI . '/default?prettyprint=true';
+    	if ($location instanceof Query) {
+            $uri = $location->getQueryUrl();
+        } else {
+            $uri = $location;
+        }
         return parent::getFeed($uri, 'Zend\GData\Analytics\AccountFeed');
     }
-
+    
     /**
      * Retrieve data feed object
      *
@@ -77,5 +81,15 @@ class Analytics extends GData
     public function newDataQuery()
     {
         return new Analytics\DataQuery();
+    }
+
+    /**
+     * Returns a new AccountQuery object.
+     *
+     * @return Analytics\AccountQuery
+     */
+    public function newAccountQuery()
+    {
+    	return new Analytics\AccountQuery();
     }
 }

--- a/library/Zend/GData/Analytics.php
+++ b/library/Zend/GData/Analytics.php
@@ -17,11 +17,11 @@ namespace Zend\GData;
  */
 class Analytics extends GData
 {
-	const AUTH_SERVICE_NAME = 'analytics';
-	const ANALYTICS_FEED_URI = 'https://www.googleapis.com/analytics/v2.4/data'; 
-	const ANALYTICS_ACCOUNT_FEED_URI = 'https://www.googleapis.com/analytics/v2.4/management/accounts';
+    const AUTH_SERVICE_NAME = 'analytics';
+    const ANALYTICS_FEED_URI = 'https://www.googleapis.com/analytics/v2.4/data'; 
+    const ANALYTICS_ACCOUNT_FEED_URI = 'https://www.googleapis.com/analytics/v2.4/management/accounts';
 
-	public static $namespaces = array(
+    public static $namespaces = array(
         array('analytics', 'http://schemas.google.com/analytics/2009', 1, 0),
         array('ga', 'http://schemas.google.com/ga/2009', 1, 0)
     );
@@ -33,7 +33,7 @@ class Analytics extends GData
      * @param string $applicationId The identity of the app in the form of
      *          Company-AppName-Version
      */
-    public function __construct($client = null, $applicationId = 'MyCompany-MyApp-1.0')
+    public function __construct(Client $client = null, $applicationId = 'MyCompany-MyApp-1.0')
     {
         $this->registerPackage('Zend\Gdata\Analytics');
         $this->registerPackage('Zend\Gdata\Analytics\Extension');
@@ -44,15 +44,13 @@ class Analytics extends GData
     /**
      * Retrieve account feed object
      *
-     * @param mixed $location
+     * @param mixed $uri
      * @return Analytics\AccountFeed
      */
-    public function getAccountFeed($location = self::ANALYTICS_ACCOUNT_FEED_URI)
+    public function getAccountFeed($uri = self::ANALYTICS_ACCOUNT_FEED_URI)
     {
-    	if ($location instanceof Query) {
-            $uri = $location->getQueryUrl();
-        } else {
-            $uri = $location;
+        if ($uri instanceof Query) {
+            $uri = $uri->getQueryUrl();
         }
         return parent::getFeed($uri, 'Zend\GData\Analytics\AccountFeed');
     }
@@ -60,15 +58,13 @@ class Analytics extends GData
     /**
      * Retrieve data feed object
      *
-     * @param mixed $location
+     * @param mixed $uri
      * @return Analytics\DataFeed
      */
-    public function getDataFeed($location = self::ANALYTICS_FEED_URI)
+    public function getDataFeed($uri = self::ANALYTICS_FEED_URI)
     {
-        if ($location instanceof Query) {
-            $uri = $location->getQueryUrl();
-        } else {
-            $uri = $location;
+        if ($uri instanceof Query) {
+            $uri = $uri->getQueryUrl();
         }
         return parent::getFeed($uri, 'Zend\GData\Analytics\DataFeed');
     }
@@ -90,6 +86,6 @@ class Analytics extends GData
      */
     public function newAccountQuery()
     {
-    	return new Analytics\AccountQuery();
+        return new Analytics\AccountQuery();
     }
 }

--- a/library/Zend/GData/Analytics.php
+++ b/library/Zend/GData/Analytics.php
@@ -10,6 +10,8 @@
 
 namespace Zend\GData;
 
+use Zend\Http\Client;
+
 /**
  * @category   Zend
  * @package    Zend_Gdata
@@ -44,7 +46,7 @@ class Analytics extends GData
     /**
      * Retrieve account feed object
      *
-     * @param mixed $uri
+     * @param string|\Zend\Uri\Uri $uri
      * @return Analytics\AccountFeed
      */
     public function getAccountFeed($uri = self::ANALYTICS_ACCOUNT_FEED_URI)
@@ -58,7 +60,7 @@ class Analytics extends GData
     /**
      * Retrieve data feed object
      *
-     * @param mixed $uri
+     * @param string|\Zend\Uri\Uri $uri
      * @return Analytics\DataFeed
      */
     public function getDataFeed($uri = self::ANALYTICS_FEED_URI)

--- a/library/Zend/GData/Analytics/AccountEntry.php
+++ b/library/Zend/GData/Analytics/AccountEntry.php
@@ -26,6 +26,8 @@ class AccountEntry extends GData\Entry
     protected $_currency;
     protected $_timezone;
     protected $_tableId;
+	protected $_profileName;
+    protected $_goal;
 
     /**
      * @see Zend_Gdata_Entry::__construct()
@@ -43,19 +45,26 @@ class AccountEntry extends GData\Entry
     protected function takeChildFromDOM($child)
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
+        var_dump($absoluteNodeName);
+        var_dump($this->lookupNamespace('ga') . ':' . 'goal');
         switch ($absoluteNodeName){
-            case $this->lookupNamespace('ga') . ':' . 'property';
+            case $this->lookupNamespace('analytics') . ':' . 'property';
                 $property = new Extension\Property();
                 $property->transferFromDOM($child);
                 $this->{$property->getName()} = $property;
                 break;
-            case $this->lookupNamespace('ga') . ':' . 'tableId';
+            case $this->lookupNamespace('analytics') . ':' . 'tableId';
                 $tableId = new Extension\TableId();
                 $tableId->transferFromDOM($child);
                 $this->_tableId = $tableId;
                 break;
-            default:
-                parent::takeChildFromDOM($child);
+        	case $this->lookupNamespace('ga') . ':' . 'goal';
+	            $goal = new Extension\Goal();
+	            $goal->transferFromDOM($child);
+	            $this->_goal = $goal;
+                break;
+        	default:
+            	parent::takeChildFromDOM($child);
                 break;
         }
     }

--- a/library/Zend/GData/Analytics/AccountEntry.php
+++ b/library/Zend/GData/Analytics/AccountEntry.php
@@ -26,7 +26,7 @@ class AccountEntry extends GData\Entry
     protected $_currency;
     protected $_timezone;
     protected $_tableId;
-	protected $_profileName;
+    protected $_profileName;
     protected $_goal;
 
     /**
@@ -45,8 +45,6 @@ class AccountEntry extends GData\Entry
     protected function takeChildFromDOM($child)
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
-        var_dump($absoluteNodeName);
-        var_dump($this->lookupNamespace('ga') . ':' . 'goal');
         switch ($absoluteNodeName){
             case $this->lookupNamespace('analytics') . ':' . 'property';
                 $property = new Extension\Property();
@@ -58,13 +56,13 @@ class AccountEntry extends GData\Entry
                 $tableId->transferFromDOM($child);
                 $this->_tableId = $tableId;
                 break;
-        	case $this->lookupNamespace('ga') . ':' . 'goal';
-	            $goal = new Extension\Goal();
-	            $goal->transferFromDOM($child);
-	            $this->_goal = $goal;
+            case $this->lookupNamespace('ga') . ':' . 'goal';
+                $goal = new Extension\Goal();
+                $goal->transferFromDOM($child);
+                $this->_goal = $goal;
                 break;
-        	default:
-            	parent::takeChildFromDOM($child);
+            default:
+                parent::takeChildFromDOM($child);
                 break;
         }
     }

--- a/library/Zend/GData/Analytics/AccountQuery.php
+++ b/library/Zend/GData/Analytics/AccountQuery.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_GData
+ */
+
+namespace Zend\GData\Analytics;
+
+use Zend\GData;
+
+/**
+ * @category   Zend
+ * @package    Zend_Gdata
+ * @subpackage Analytics
+ */
+class AccountQuery extends GData\Query
+{
+    const ANALYTICS_FEED_URI = 'https://www.googleapis.com/analytics/v2.4/management/accounts';
+
+    /**
+     * The default URI used for feeds.
+     */
+    protected $_defaultFeedUri = self::ANALYTICS_FEED_URI;
+    
+    /**
+     * @var string
+     */
+    protected $_accountId = '~all';
+    /**
+     * @var string
+     */
+    protected $_webpropertyId = '~all';
+    /**
+     * @var string
+     */
+    protected $_profileId = '~all';
+   
+    /**
+     * @var bool
+     */ 
+    protected $_webproperties = false;
+    /**
+     * @var bool
+     */
+    protected $_profiles = false;
+    /**
+     * @var bool
+     */
+    protected $_goals = false;
+    
+    /**
+     * @param string $accountId
+     * @return AccountQuery
+     */
+    public function setAccountId($accountId)
+    {
+        $this->_accountId = $accountId;
+        return $this;
+    }
+    
+    /**
+     * @param string $webpropertyId
+     * @return AccountQuery
+     */
+    public function setWebpropertyId($webpropertyId)
+    {
+        $this->_webpropertyId = $webpropertyId;
+        return $this;
+    }
+    
+    /**
+     * @param string $profileId
+     * @return AccountQuery
+     */
+    public function setProfileId($profileId)
+    {
+        $this->_profileId = $profileId;
+        return $this;
+    }
+    
+    /**
+     * @param string $accountId
+     * @return AccountQuery
+     */
+    public function webproperties($accountId = '~all')
+    {
+        $this->_webproperties = true;
+        $this->setAccountId($accountId);    
+        return $this;
+    }
+    
+    /**
+     * @param string $webpropertyId
+     * @param string $accountId
+     * @return AccountQuery
+     */
+    public function profiles($webpropertyId = '~all', $accountId = '~all')
+    {
+        $this->_profiles = true;
+        if (null !== $accountId) {
+            $this->setAccountId($accountId);    
+        }
+        $this->setWebpropertyId($webpropertyId);
+        return $this;
+    }
+    
+    /**
+     * @param string $webpropertyId
+     * @param string $accountId
+     * @param string $accountId
+     * @return AccountQuery
+     */
+    public function goals($profileId = '~all', $webpropertyId = '~all', $accountId = '~all')
+    {
+        $this->_goals = true;
+        if (null !== $accountId) {
+            $this->setAccountId($accountId);    
+        }
+        if (null !== $webpropertyId) {
+            $this->setWebpropertyId($webpropertyId);    
+        }
+        $this->setProfileId($profileId);
+        return $this;
+    }
+    
+    /**
+     * @return string url
+     */
+    public function getQueryUrl()
+    {
+        $url = $this->_defaultFeedUri;
+        
+        // add account id
+        if ($this->_webproperties or $this->_profiles or $this->_goals) {
+            $url .= '/' . $this->_accountId . '/webproperties';
+        }
+        
+        if ($this->_profiles or $this->_goals) {
+            $url .= '/' . $this->_webpropertyId . '/profiles';
+        }
+        
+        if ($this->_goals) {
+            $url .= '/' . $this->_profileId . '/goals';
+        }
+
+        $url .= $this->getQueryString();
+        return $url;
+    }
+}

--- a/library/Zend/GData/Analytics/AccountQuery.php
+++ b/library/Zend/GData/Analytics/AccountQuery.php
@@ -63,6 +63,14 @@ class AccountQuery extends GData\Query
     }
     
     /**
+     * @return string
+     */
+    public function getAccountId()
+    {
+        return $this->_accountId;
+    }
+
+    /**
      * @param string $webpropertyId
      * @return AccountQuery
      */
@@ -73,6 +81,14 @@ class AccountQuery extends GData\Query
     }
     
     /**
+     * @return string
+     */
+    public function getWebpropertyId()
+    {
+        return $this->_webpropertyId;
+    }
+    
+    /**
      * @param string $profileId
      * @return AccountQuery
      */
@@ -80,6 +96,14 @@ class AccountQuery extends GData\Query
     {
         $this->_profileId = $profileId;
         return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProfileId()
+    {
+        return $this->_profileId;
     }
     
     /**

--- a/library/Zend/GData/Analytics/DataEntry.php
+++ b/library/Zend/GData/Analytics/DataEntry.php
@@ -45,12 +45,12 @@ class DataEntry extends GData\Entry
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('ga') . ':' . 'dimension';
+            case $this->lookupNamespace('analytics') . ':' . 'dimension';
                 $dimension = new Extension\Dimension();
                 $dimension->transferFromDOM($child);
                 $this->_dimensions[] = $dimension;
                 break;
-            case $this->lookupNamespace('ga') . ':' . 'metric';
+            case $this->lookupNamespace('analytics') . ':' . 'metric';
                 $metric = new Extension\Metric();
                 $metric->transferFromDOM($child);
                 $this->_metrics[] = $metric;

--- a/library/Zend/GData/Analytics/DataEntry.php
+++ b/library/Zend/GData/Analytics/DataEntry.php
@@ -20,11 +20,11 @@ use Zend\GData;
 class DataEntry extends GData\Entry
 {
     /**
-     * @var Extension\Dimension
+     * @var Extension\Dimension[]
      */
     protected $_dimensions = array();
     /**
-     * @var Extension\Metric
+     * @var Extension\Metric[]
      */
     protected $_metrics = array();
 

--- a/library/Zend/GData/Analytics/DataEntry.php
+++ b/library/Zend/GData/Analytics/DataEntry.php
@@ -19,14 +19,14 @@ use Zend\GData;
  */
 class DataEntry extends GData\Entry
 {
-    /**
-     * @var Extension\Dimension[]
-     */
-    protected $_dimensions = array();
-    /**
-     * @var Extension\Metric[]
-     */
-    protected $_metrics = array();
+	/**
+	 * @var Extension\Dimension
+	 */
+	protected $_dimensions = array();
+	/**
+     * @var Extension\Metric
+	 */
+	protected $_metrics = array();
 
     /**
      * @param DOMElement $element

--- a/library/Zend/GData/Analytics/DataEntry.php
+++ b/library/Zend/GData/Analytics/DataEntry.php
@@ -19,14 +19,14 @@ use Zend\GData;
  */
 class DataEntry extends GData\Entry
 {
-	/**
-	 * @var Extension\Dimension
-	 */
-	protected $_dimensions = array();
-	/**
+    /**
+     * @var Extension\Dimension
+     */
+    protected $_dimensions = array();
+    /**
      * @var Extension\Metric
-	 */
-	protected $_metrics = array();
+     */
+    protected $_metrics = array();
 
     /**
      * @param DOMElement $element

--- a/library/Zend/GData/Analytics/DataQuery.php
+++ b/library/Zend/GData/Analytics/DataQuery.php
@@ -19,7 +19,7 @@ use Zend\GData;
  */
 class DataQuery extends GData\Query
 {
-    const ANALYTICS_FEED_URI = 'https://www.google.com/analytics/feeds/data';
+    const ANALYTICS_FEED_URI = 'https://www.googleapis.com/analytics/v2.4/data';
 
     /**
      * The default URI used for feeds.

--- a/library/Zend/GData/Analytics/Extension/Goal.php
+++ b/library/Zend/GData/Analytics/Extension/Goal.php
@@ -22,16 +22,15 @@ class Goal extends GData\Extension
     protected $_rootNamespace = 'ga';
     protected $_rootElement = 'goal';
 
-    /**
-     * Constructs a new Zend_Gdata_Calendar_Extension_Timezone object.
-     * @param string $value (optional) The text content of the element.
-     */
-    public function __construct($value = null)
+    public function __construct()
     {
         $this->registerAllNamespaces(GData\Analytics::$namespaces);
         parent::__construct();
     }
     
+    /**
+     * @return string
+     */
     public function __toString()
     {
         $attribs = $this->getExtensionAttributes();

--- a/library/Zend/GData/Analytics/Extension/Goal.php
+++ b/library/Zend/GData/Analytics/Extension/Goal.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_GData
+ */
+
+namespace Zend\GData\Analytics\Extension;
+
+use Zend\GData;
+
+/**
+ * @category   Zend
+ * @package    Zend_Gdata
+ * @subpackage Analytics
+ */
+class Goal extends GData\Extension
+{
+    protected $_rootNamespace = 'ga';
+    protected $_rootElement = 'goal';
+
+    /**
+     * Constructs a new Zend_Gdata_Calendar_Extension_Timezone object.
+     * @param string $value (optional) The text content of the element.
+     */
+    public function __construct($value = null)
+    {
+        $this->registerAllNamespaces(GData\Analytics::$namespaces);
+        parent::__construct();
+    }
+    
+    public function __toString()
+    {
+        $attribs = $this->getExtensionAttributes();
+        return $attribs['name']['value'];
+    }
+}

--- a/library/Zend/GData/Analytics/Extension/Property.php
+++ b/library/Zend/GData/Analytics/Extension/Property.php
@@ -47,7 +47,8 @@ class Property extends GData\Extension
     {
         switch ($attribute->localName) {
             case 'name':
-                $this->_name = end(explode(':', $attribute->nodeValue));
+                $name = explode(':', $attribute->nodeValue);
+                $this->_name = end($name);
                 break;
             case 'value':
                 $this->_value = $attribute->nodeValue;

--- a/library/Zend/GData/Analytics/Extension/Property.php
+++ b/library/Zend/GData/Analytics/Extension/Property.php
@@ -47,8 +47,8 @@ class Property extends GData\Extension
     {
         switch ($attribute->localName) {
             case 'name':
-                $this->_name = substr($attribute->nodeValue, 3);
-                break;
+            	$this->_name = end(explode(':', $attribute->nodeValue));
+    	        break;
             case 'value':
                 $this->_value = $attribute->nodeValue;
                 break;

--- a/library/Zend/GData/Analytics/Extension/Property.php
+++ b/library/Zend/GData/Analytics/Extension/Property.php
@@ -47,8 +47,8 @@ class Property extends GData\Extension
     {
         switch ($attribute->localName) {
             case 'name':
-            	$this->_name = end(explode(':', $attribute->nodeValue));
-    	        break;
+                $this->_name = end(explode(':', $attribute->nodeValue));
+                break;
             case 'value':
                 $this->_value = $attribute->nodeValue;
                 break;

--- a/tests/Zend/GData/Analytics/AccountFeedTest.php
+++ b/tests/Zend/GData/Analytics/AccountFeedTest.php
@@ -27,18 +27,33 @@ class AccountFeedTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->accountFeed = new AccountFeed(
-            file_get_contents(dirname(__FILE__) . '/_files/TestAccountFeed.xml'),
-            true
+        $this->accountFeed = @new AccountFeed(
+            file_get_contents(dirname(__FILE__) . '/_files/TestAccountFeed.xml')
         );
     }
 
     public function testAccountFeed()
     {
-        $this->assertEquals(3, count($this->accountFeed->entries));
-        $this->assertEquals(3, $this->accountFeed->entries->count());
+        $this->assertEquals(2, count($this->accountFeed->entries));
+
         foreach ($this->accountFeed->entries as $entry) {
             $this->assertInstanceOf('Zend\GData\Analytics\AccountEntry', $entry);
         }
+    }
+    
+    public function testFirstAccountProperties()
+    {
+        $account = $this->accountFeed->entries[0];
+        $this->assertEquals(876543, "{$account->accountId}");
+        $this->assertEquals('foobarbaz', "{$account->accountName}");
+        $this->assertInstanceOf('Zend\GData\App\Extension\Link', $account->link[0]);
+    }
+    
+    public function testSecondAccountProperties()
+    {
+        $account = $this->accountFeed->entries[1];
+        $this->assertEquals(23456789, "{$account->accountId}");
+        $this->assertEquals('brain dump', "{$account->accountName}");
+        $this->assertInstanceOf('Zend\GData\App\Extension\Link', $account->link[0]);
     }
 }

--- a/tests/Zend/GData/Analytics/AccountFeedTest.php
+++ b/tests/Zend/GData/Analytics/AccountFeedTest.php
@@ -27,7 +27,7 @@ class AccountFeedTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->accountFeed = @new AccountFeed(
+        $this->accountFeed = new AccountFeed(
             file_get_contents(dirname(__FILE__) . '/_files/TestAccountFeed.xml')
         );
     }

--- a/tests/Zend/GData/Analytics/AccountQueryTest.php
+++ b/tests/Zend/GData/Analytics/AccountQueryTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_GData
+ */
+
+namespace ZendTest\GData\Analytics;
+
+use Zend\GData\Analytics\AccountQuery;
+
+/**
+ * @category   Zend
+ * @package    Zend_GData_Analytics
+ * @subpackage UnitTests
+ * @group      Zend_GData
+ * @group      Zend_GData_Analytics
+ */
+class AccountQueryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AccountQuery
+     */
+    public $accountQuery;
+
+    public function setUp()
+    {
+        $this->accountQuery = new AccountQuery();
+        $this->queryBase = AccountQuery::ANALYTICS_FEED_URI;
+    }
+
+    public function testWebpropertiesAll()
+    {
+        $this->accountQuery->webproperties();
+        $allQuery = $this->accountQuery->getQueryUrl();
+        
+        $this->assertEquals(
+            $this->queryBase . '/~all/webproperties', 
+            $allQuery
+        );
+    }
+    
+    public function testWebpropertiesSpecific()
+    {
+        $this->accountQuery->webproperties(12345678);
+        $specificQuery = $this->accountQuery->getQueryUrl();
+        
+        $this->assertEquals(
+            $this->queryBase . '/12345678/webproperties', 
+            $specificQuery
+        );
+    }
+    
+    public function testProfilesAll()
+    {
+        $this->accountQuery->profiles();
+        $allQuery = $this->accountQuery->getQueryUrl();
+        
+        $this->assertEquals(
+            $this->queryBase . '/~all/webproperties/~all/profiles', 
+            $allQuery
+        );
+    }
+    
+    public function testProfilesSpecific()
+    {
+        $this->accountQuery->profiles('U-87654321-0', 87654321);
+        $specificQuery = $this->accountQuery->getQueryUrl();
+        
+        $this->assertEquals(
+            $this->queryBase . '/87654321/webproperties/U-87654321-0/profiles', 
+            $specificQuery
+        );
+    }
+    
+    public function testGoalsAll()
+    {
+        $this->accountQuery->goals();
+        $allQuery = $this->accountQuery->getQueryUrl();
+        
+        $this->assertEquals(
+            $this->queryBase . '/~all/webproperties/~all/profiles/~all/goals', 
+            $allQuery
+        );
+    }
+    
+    public function testGoalsSpecific()
+    {
+        $this->accountQuery->goals(42, 'U-87654321-0', 87654321);
+        $specificQuery = $this->accountQuery->getQueryUrl();
+        
+        $this->assertEquals(
+            $this->queryBase . '/87654321/webproperties/U-87654321-0/profiles/42/goals', 
+            $specificQuery
+        );
+    }
+    
+    public function testChainedProperties()
+    {
+        $this->accountQuery
+            ->goals(42)
+            ->profiles('U-87654321-0')
+            ->webproperties(87654321);
+        $specificQuery = $this->accountQuery->getQueryUrl();
+        
+        $this->assertEquals(
+            $this->queryBase . '/87654321/webproperties/U-87654321-0/profiles/42/goals', 
+            $specificQuery
+        );
+    }
+}

--- a/tests/Zend/GData/Analytics/DataFeedTest.php
+++ b/tests/Zend/GData/Analytics/DataFeedTest.php
@@ -24,11 +24,10 @@ use Zend\GData\Analytics\DataQuery;
 class Zend_Gdata_Analytics_DataFeedTest extends \PHPUnit_Framework_TestCase
 {
     public $testData = array(
-        'blogger.com' => 68140,
-        'google.com'  => 29666,
-        'stumbleupon.com' => 4012,
-        'google.co.uk' => 2968,
-        'google.co.in' => 2793,
+        'foobarbaz.de' => 12,
+        'foobar.de' => 3,
+        'foobarbaz.ch' => 1,
+        'baz.ch' => 1,
     );
     /** @var DataFeed */
     public $dataFeed;
@@ -36,8 +35,7 @@ class Zend_Gdata_Analytics_DataFeedTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->dataFeed = new DataFeed(
-            file_get_contents(dirname(__FILE__) . '/_files/TestDataFeed.xml'),
-            true
+            file_get_contents(dirname(__FILE__) . '/_files/TestDataFeed.xml')
         );
     }
 

--- a/tests/Zend/GData/Analytics/_files/TestAccountFeed.xml
+++ b/tests/Zend/GData/Analytics/_files/TestAccountFeed.xml
@@ -1,110 +1,32 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<feed xmlns='http://www.w3.org/2005/Atom' xmlns:dxp='http://schemas.google.com/analytics/2009' xmlns:ga='http://schemas.google.com/ga/2009' xmlns:openSearch='http://a9.com/-/spec/opensearch/1.1/' xmlns:gd='http://schemas.google.com/g/2005' gd:etag='W/&quot;DUcCRX47eCp7I2A9WxNbFkk.&quot;' gd:kind='analytics#accounts'>
-        <id>http://www.google.com/analytics/feeds/accounts/abc@test.com</id>
-        <updated>2009-11-19T08:11:04.000-08:00</updated>
-        <title>Profile list for abc@test.com</title>
-        <link rel='self' type='application/atom+xml' href='http://www.google.com/analytics/feeds/accounts/default'/>
-        <author>
-                <name>Google Analytics</name>
-        </author>
-        <generator version='1.0'>Google Analytics</generator>
-        <openSearch:totalResults>41</openSearch:totalResults>
-        <openSearch:startIndex>1</openSearch:startIndex>
-        <openSearch:itemsPerPage>3</openSearch:itemsPerPage>
-        <dxp:segment id='gaid::-1' name='All Visits'>
-                <dxp:definition> </dxp:definition>
-        </dxp:segment>
-        <dxp:segment id='gaid::-2' name='New Visitors'>
-                <dxp:definition>ga:visitorType==New Visitor</dxp:definition>
-        </dxp:segment>
-        <dxp:segment id='gaid::-3' name='Returning Visitors'>
-                <dxp:definition>ga:visitorType==Returning Visitor</dxp:definition>
-        </dxp:segment>
-        <dxp:segment id='gaid::-4' name='Paid Search Traffic'>
-                <dxp:definition>ga:medium==cpa,ga:medium==cpc,ga:medium==cpm,ga:medium==cpp,ga:medium==cpv,ga:medium==ppc</dxp:definition>
-        </dxp:segment>
-        <dxp:segment id='gaid::-5' name='Non-paid Search Traffic'>
-                <dxp:definition>ga:medium==organic</dxp:definition>
-        </dxp:segment>
-        <dxp:segment id='gaid::-6' name='Search Traffic'>
-                <dxp:definition>ga:medium==cpa,ga:medium==cpc,ga:medium==cpm,ga:medium==cpp,ga:medium==cpv,ga:medium==organic,ga:medium==ppc</dxp:definition>
-        </dxp:segment>
-        <dxp:segment id='gaid::-7' name='Direct Traffic'>
-                <dxp:definition>ga:medium==(none)</dxp:definition>
-        </dxp:segment>
-        <dxp:segment id='gaid::-8' name='Referral Traffic'>
-                <dxp:definition>ga:medium==referral</dxp:definition>
-        </dxp:segment>
-        <dxp:segment id='gaid::-9' name='Visits with Conversions'>
-                <dxp:definition>ga:goalCompletionsAll&gt;0</dxp:definition>
-        </dxp:segment>
-        <dxp:segment id='gaid::-10' name='Visits with Transactions'>
-                <dxp:definition>ga:transactions&gt;0</dxp:definition>
-        </dxp:segment>
-        <dxp:segment id='gaid::-11' name='Visits from iPhones'>
-                <dxp:definition>ga:operatingSystem==iPhone</dxp:definition>
-        </dxp:segment>
-        <dxp:segment id='gaid::-12' name='Non-bounce Visits'>
-                <dxp:definition>ga:bounces==0</dxp:definition>
-        </dxp:segment>
-        <dxp:segment id='gaid::0' name='Sources Form Google'>
-                <dxp:definition>ga:source=~^\Qgoogle\E</dxp:definition>
-        </dxp:segment>
-        <entry gd:etag='W/&quot;DUcCRX47eCp7I2A9WxNbFkk.&quot;' gd:kind='analytics#account'>
-                <id>http://www.google.com/analytics/feeds/accounts/ga:1174</id>
-                <updated>2009-11-19T08:11:04.000-08:00</updated>
-                <title>www.googlestore.com</title>
-                <link rel='alternate' type='text/html' href='http://www.google.com/analytics'/>
-                <ga:goal active='true' name='Completing Order' number='1' value='10.0'>
-                        <ga:destination caseSensitive='false' expression='/purchaseComplete.html' matchType='regex' step1Required='false'>
-                                <ga:step name='View Product Categories' number='1' path='/Apps|Accessories'/>
-                                <ga:step name='View Product' number='2' path='/Apps|Accessories/(.*)\.axd'/>
-                                <ga:step name='View Shopping Cart' number='3' path='/shoppingcart.aspx'/>
-                                <ga:step name='Login' number='4' path='/login.html'/>
-                                <ga:step name='Place Order' number='5' path='/placeOrder.html'/>
-                        </ga:destination>
-                </ga:goal>
-                <ga:goal active='true' name='Browsed my site over 5 minutes' number='2' value='0.0'>
-                        <ga:engagement comparison='&gt;' thresholdValue='300' type='timeOnSite'/>
-                </ga:goal>
-                <ga:goal active='true' name='Visited &gt; 4 pages' number='3' value='0.25'>
-                        <ga:engagement comparison='&gt;' thresholdValue='4' type='pagesVisited'/>
-                </ga:goal>
-                <dxp:property name='ga:accountId' value='30481'/>
-                <dxp:property name='ga:accountName' value='Google Store'/>
-                <dxp:property name='ga:profileId' value='1174'/>
-                <dxp:property name='ga:webPropertyId' value='UA-30481-1'/>
-                <dxp:property name='ga:currency' value='USD'/>
-                <dxp:property name='ga:timezone' value='America/Los_Angeles'/>
-                <dxp:tableId>ga:1174</dxp:tableId>
-        </entry>
-        <entry gd:etag='W/&quot;DkEASH47eCp7I2A9WxNbFUo.&quot;' gd:kind='analytics#account'>
-                <id>http://www.google.com/analytics/feeds/accounts/ga:11380020</id>
-                <updated>2009-11-18T12:04:09.000-08:00</updated>
-                <title>Googlestore - overall</title>
-                <link rel='alternate' type='text/html' href='http://www.google.com/analytics'/>
-                <ga:goal active='false' name='goal2.html' number='1' value='0.0'>
-                        <ga:destination caseSensitive='false' expression='/goal2.html' matchType='head' step1Required='false'/>
-                </ga:goal>
-                <dxp:property name='ga:accountId' value='30481'/>
-                <dxp:property name='ga:accountName' value='Google Store'/>
-                <dxp:property name='ga:profileId' value='11380020'/>
-                <dxp:property name='ga:webPropertyId' value='UA-30481-1'/>
-                <dxp:property name='ga:currency' value='USD'/>
-                <dxp:property name='ga:timezone' value='America/Los_Angeles'/>
-                <dxp:tableId>ga:11380020</dxp:tableId>
-        </entry>
-        <entry gd:etag='W/&quot;C04HRn47eCp7I2A9WxJbGUQ.&quot;' gd:kind='analytics#account'>
-                <id>http://www.google.com/analytics/feeds/accounts/ga:11380025</id>
-                <updated>2009-07-30T15:12:17.000-07:00</updated>
-                <title>Googlestore - no filters</title>
-                <link rel='alternate' type='text/html' href='http://www.google.com/analytics'/>
-                <dxp:property name='ga:accountId' value='30481'/>
-                <dxp:property name='ga:accountName' value='Google Store'/>
-                <dxp:property name='ga:profileId' value='11380025'/>
-                <dxp:property name='ga:webPropertyId' value='UA-30481-1'/>
-                <dxp:property name='ga:currency' value='USD'/>
-                <dxp:property name='ga:timezone' value='America/Los_Angeles'/>
-                <dxp:tableId>ga:11380025</dxp:tableId>
-        </entry>
+<?xml version="1.0" encoding="UTF-8"?>
+<feed gd:kind="analytics#accounts" xmlns="http://www.w3.org/2005/Atom" xmlns:dxp="http://schemas.google.com/analytics/2009" xmlns:gd="http://schemas.google.com/g/2005" xmlns:openSearch="http://a9.com/-/spec/opensearch/1.1/">
+    <id>https://www.googleapis.com/analytics/v2.4/management/accounts</id>
+    <updated>2012-07-13T16:53:15.150Z</updated>
+    <title type="text">Google Analytics Accounts for mail@storkki.de</title>
+    <link rel="self" type="application/atom+xml" href="https://www.googleapis.com/analytics/v2.4/management/accounts" />
+    <author>
+        <name>Google Analytics</name>
+    </author>
+    <generator>Google Analytics</generator>
+    <openSearch:totalResults>2</openSearch:totalResults>
+    <openSearch:startIndex>1</openSearch:startIndex>
+    <openSearch:itemsPerPage>1000</openSearch:itemsPerPage>
+    <entry gd:kind="analytics#account">
+        <id>https://www.googleapis.com/analytics/v2.4/management/accounts/876543</id>
+        <updated>2010-03-02T16:04:23.720Z</updated>
+        <title type="text">Google Analytics Account foobarbaz</title>
+        <link rel="self" type="application/atom+xml" href="https://www.googleapis.com/analytics/v2.4/management/accounts/876543" />
+        <link rel="http://schemas.google.com/ga/2009#child" type="application/atom+xml" gd:targetKind="analytics#webproperties" href="https://www.googleapis.com/analytics/v2.4/management/accounts/876543/webproperties" />
+        <dxp:property name="ga:accountId" value="876543" />
+        <dxp:property name="ga:accountName" value="foobarbaz" />
+    </entry>
+    <entry gd:kind="analytics#account">
+        <id>https://www.googleapis.com/analytics/v2.4/management/accounts/23456789</id>
+        <updated>2011-05-17T06:53:24.385Z</updated>
+        <title type="text">Google Analytics Account brain dump</title>
+        <link rel="self" type="application/atom+xml" href="https://www.googleapis.com/analytics/v2.4/management/accounts/23456789" />
+        <link rel="http://schemas.google.com/ga/2009#child" type="application/atom+xml" gd:targetKind="analytics#webproperties" href="https://www.googleapis.com/analytics/v2.4/management/accounts/23456789/webproperties" />
+        <dxp:property name="ga:accountId" value="23456789" />
+        <dxp:property name="ga:accountName" value="brain dump" />
+    </entry>
 </feed>

--- a/tests/Zend/GData/Analytics/_files/TestDataFeed.xml
+++ b/tests/Zend/GData/Analytics/_files/TestDataFeed.xml
@@ -1,79 +1,76 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<feed xmlns='http://www.w3.org/2005/Atom' xmlns:dxp='http://schemas.google.com/analytics/2009' xmlns:openSearch='http://a9.com/-/spec/opensearch/1.1/' xmlns:gd='http://schemas.google.com/g/2005' gd:etag='W/&quot;DUINSHcycSp7I2A9WxRWFEQ.&quot;' gd:kind='analytics#data'>
-        <id>http://www.google.com/analytics/feeds/data?ids=ga:1174&amp;dimensions=ga:medium,ga:source&amp;metrics=ga:bounces,ga:visits&amp;filters=ga:medium%3D%3Dreferral&amp;start-date=2008-10-01&amp;end-date=2008-10-31</id>
-        <updated>2008-10-31T16:59:59.999-07:00</updated>
-        <title>Google Analytics Data for Profile 1174</title>
-        <link rel='self' type='application/atom+xml' href='http://www.google.com/analytics/feeds/data?max-results=5&amp;sort=-ga%3Avisits&amp;end-date=2008-10-31&amp;start-date=2008-10-01&amp;metrics=ga%3Avisits%2Cga%3Abounces&amp;ids=ga%3A1174&amp;dimensions=ga%3Asource%2Cga%3Amedium&amp;filters=ga%3Amedium%3D%3Dreferral'/>
-        <link rel='next' type='application/atom+xml' href='http://www.google.com/analytics/feeds/data?start-index=6&amp;max-results=5&amp;sort=-ga%3Avisits&amp;end-date=2008-10-31&amp;start-date=2008-10-01&amp;metrics=ga%3Avisits%2Cga%3Abounces&amp;ids=ga%3A1174&amp;dimensions=ga%3Asource%2Cga%3Amedium&amp;filters=ga%3Amedium%3D%3Dreferral'/>
-        <author>
-                <name>Google Analytics</name>
-        </author>
-        <generator version='1.0'>Google Analytics</generator>
-        <openSearch:totalResults>6451</openSearch:totalResults>
-        <openSearch:startIndex>1</openSearch:startIndex>
-        <openSearch:itemsPerPage>5</openSearch:itemsPerPage>
-        <dxp:aggregates>
-                <dxp:metric confidenceInterval='0.0' name='ga:visits' type='integer' value='136540'/>
-                <dxp:metric confidenceInterval='0.0' name='ga:bounces' type='integer' value='101535'/>
-        </dxp:aggregates>
-        <dxp:containsSampledData>false</dxp:containsSampledData>
-        <dxp:dataSource>
-                <dxp:property name='ga:profileId' value='1174'/>
-                <dxp:property name='ga:webPropertyId' value='UA-30481-1'/>
-                <dxp:property name='ga:accountName' value='Google Store'/>
-                <dxp:tableId>ga:1174</dxp:tableId>
-                <dxp:tableName>www.googlestore.com</dxp:tableName>
-        </dxp:dataSource>
-        <dxp:endDate>2008-10-31</dxp:endDate>
-        <dxp:startDate>2008-10-01</dxp:startDate>
-        <entry gd:etag='W/&quot;C0UEQX47eSp7I2A9WxRWFEw.&quot;' gd:kind='analytics#datarow'>
-                <id>http://www.google.com/analytics/feeds/data?ids=ga:1174&amp;ga:medium=referral&amp;ga:source=blogger.com&amp;filters=ga:medium%3D%3Dreferral&amp;start-date=2008-10-01&amp;end-date=2008-10-31</id>
-                <updated>2008-10-30T17:00:00.001-07:00</updated>
-                <title>ga:source=blogger.com | ga:medium=referral</title>
-                <link rel='alternate' type='text/html' href='http://www.google.com/analytics'/>
-                <dxp:dimension name='ga:source' value='blogger.com'/>
-                <dxp:dimension name='ga:medium' value='referral'/>
-                <dxp:metric confidenceInterval='0.0' name='ga:visits' type='integer' value='68140'/>
-                <dxp:metric confidenceInterval='0.0' name='ga:bounces' type='integer' value='61095'/>
-        </entry>
-        <entry gd:etag='W/&quot;C0UEQX47eSp7I2A9WxRWFEw.&quot;' gd:kind='analytics#datarow'>
-                <id>http://www.google.com/analytics/feeds/data?ids=ga:1174&amp;ga:medium=referral&amp;ga:source=google.com&amp;filters=ga:medium%3D%3Dreferral&amp;start-date=2008-10-01&amp;end-date=2008-10-31</id>
-                <updated>2008-10-30T17:00:00.001-07:00</updated>
-                <title>ga:source=google.com | ga:medium=referral</title>
-                <link rel='alternate' type='text/html' href='http://www.google.com/analytics'/>
-                <dxp:dimension name='ga:source' value='google.com'/>
-                <dxp:dimension name='ga:medium' value='referral'/>
-                <dxp:metric confidenceInterval='0.0' name='ga:visits' type='integer' value='29666'/>
-                <dxp:metric confidenceInterval='0.0' name='ga:bounces' type='integer' value='14979'/>
-        </entry>
-        <entry gd:etag='W/&quot;C0UEQX47eSp7I2A9WxRWFEw.&quot;' gd:kind='analytics#datarow'>
-                <id>http://www.google.com/analytics/feeds/data?ids=ga:1174&amp;ga:medium=referral&amp;ga:source=stumbleupon.com&amp;filters=ga:medium%3D%3Dreferral&amp;start-date=2008-10-01&amp;end-date=2008-10-31</id>
-                <updated>2008-10-30T17:00:00.001-07:00</updated>
-                <title>ga:source=stumbleupon.com | ga:medium=referral</title>
-                <link rel='alternate' type='text/html' href='http://www.google.com/analytics'/>
-                <dxp:dimension name='ga:source' value='stumbleupon.com'/>
-                <dxp:dimension name='ga:medium' value='referral'/>
-                <dxp:metric confidenceInterval='0.0' name='ga:visits' type='integer' value='4012'/>
-                <dxp:metric confidenceInterval='0.0' name='ga:bounces' type='integer' value='848'/>
-        </entry>
-        <entry gd:etag='W/&quot;C0UEQX47eSp7I2A9WxRWFEw.&quot;' gd:kind='analytics#datarow'>
-                <id>http://www.google.com/analytics/feeds/data?ids=ga:1174&amp;ga:medium=referral&amp;ga:source=google.co.uk&amp;filters=ga:medium%3D%3Dreferral&amp;start-date=2008-10-01&amp;end-date=2008-10-31</id>
-                <updated>2008-10-30T17:00:00.001-07:00</updated>
-                <title>ga:source=google.co.uk | ga:medium=referral</title>
-                <link rel='alternate' type='text/html' href='http://www.google.com/analytics'/>
-                <dxp:dimension name='ga:source' value='google.co.uk'/>
-                <dxp:dimension name='ga:medium' value='referral'/>
-                <dxp:metric confidenceInterval='0.0' name='ga:visits' type='integer' value='2968'/>
-                <dxp:metric confidenceInterval='0.0' name='ga:bounces' type='integer' value='2084'/>
-        </entry>
-        <entry gd:etag='W/&quot;C0UEQX47eSp7I2A9WxRWFEw.&quot;' gd:kind='analytics#datarow'>
-                <id>http://www.google.com/analytics/feeds/data?ids=ga:1174&amp;ga:medium=referral&amp;ga:source=google.co.in&amp;filters=ga:medium%3D%3Dreferral&amp;start-date=2008-10-01&amp;end-date=2008-10-31</id>
-                <updated>2008-10-30T17:00:00.001-07:00</updated>
-                <title>ga:source=google.co.in | ga:medium=referral</title>
-                <link rel='alternate' type='text/html' href='http://www.google.com/analytics'/>
-                <dxp:dimension name='ga:source' value='google.co.in'/>
-                <dxp:dimension name='ga:medium' value='referral'/>
-                <dxp:metric confidenceInterval='0.0' name='ga:visits' type='integer' value='2793'/>
-                <dxp:metric confidenceInterval='0.0' name='ga:bounces' type='integer' value='1891'/>
-        </entry>
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:dxp="http://schemas.google.com/analytics/2009" xmlns:openSearch="http://a9.com/-/spec/opensearch/1.1/">
+    <id>https://www.googleapis.com/analytics/v2.4/data?ids=ga:45678912&amp;dimensions=ga:medium,ga:source,ga:browserVersion,ga:month&amp;metrics=ga:bounces,ga:visits&amp;sort=-ga:visits,ga:bounces&amp;filters=ga:browser%3D%3DFirefox&amp;start-date=2011-05-01&amp;end-date=2011-05-31&amp;start-index=1&amp;max-results=50</id>
+    <updated>2012-07-13T17:05:16.454Z</updated>
+    <title type="text">Google Analytics Data for Profile 45678912</title>
+    <link rel="self" type="application/atom+xml" href="https://www.googleapis.com/analytics/v2.4/data?ids=ga:45678912&amp;dimensions=ga:medium,ga:source,ga:browserVersion,ga:month&amp;metrics=ga:bounces,ga:visits&amp;sort=-ga:visits,ga:bounces&amp;filters=ga:browser%3D%3DFirefox&amp;start-date=2011-05-01&amp;end-date=2011-05-31&amp;start-index=1&amp;max-results=50" />
+    <author>
+        <name>Google Analytics</name>
+    </author>
+    <generator>Google Analytics</generator>
+    <openSearch:totalResults>4</openSearch:totalResults>
+    <openSearch:startIndex>1</openSearch:startIndex>
+    <openSearch:itemsPerPage>50</openSearch:itemsPerPage>
+    <dxp:aggregates>
+        <dxp:metric name="ga:bounces" type="integer" value="9" />
+        <dxp:metric name="ga:visits" type="integer" value="20" />
+    </dxp:aggregates>
+    <dxp:containsSampledData>false</dxp:containsSampledData>
+    <dxp:dataSource>
+        <dxp:property name="ga:profileId" value="45678912" />
+        <dxp:property name="ga:webPropertyId" value="UA-23456789-1" />
+        <dxp:property name="ga:accountName" value="foobar" />
+        <dxp:tableId>ga:45678912</dxp:tableId>
+        <dxp:tableName>www.foobar.de</dxp:tableName>
+    </dxp:dataSource>
+    <dxp:endDate>2011-05-31</dxp:endDate>
+    <dxp:startDate>2011-05-01</dxp:startDate>
+    <entry>
+        <id>https://www.googleapis.com/analytics/v2.4/data?ids=ga:45678912&amp;ga:browserVersion=4.0.1&amp;ga:medium=referral&amp;ga:month=05&amp;ga:source=foobarbaz.de&amp;filters=ga:browser%3D%3DFirefox&amp;start-date=2011-05-01&amp;end-date=2011-05-31</id>
+        <updated>2012-07-13T17:05:16.454Z</updated>
+        <title type="text">ga:medium=referral | ga:source=foobarbaz.de | ga:browserVersion=4.0.1 | ga:month=05</title>
+        <link rel="alternate" type="text/html" href="http://www.google.com/analytics" />
+        <dxp:dimension name="ga:medium" value="referral" />
+        <dxp:dimension name="ga:source" value="foobarbaz.de" />
+        <dxp:dimension name="ga:browserVersion" value="4.0.1" />
+        <dxp:dimension name="ga:month" value="05" />
+        <dxp:metric name="ga:bounces" type="integer" value="5" />
+        <dxp:metric name="ga:visits" type="integer" value="12" />
+    </entry>
+    <entry>
+        <id>https://www.googleapis.com/analytics/v2.4/data?ids=ga:45678912&amp;ga:browserVersion=3.6.17&amp;ga:medium=referral&amp;ga:month=05&amp;ga:source=foobarbaz.de&amp;filters=ga:browser%3D%3DFirefox&amp;start-date=2011-05-01&amp;end-date=2011-05-31</id>
+        <updated>2012-07-13T17:05:16.454Z</updated>
+        <title type="text">ga:medium=referral | ga:source=foobar.de | ga:browserVersion=3.6.17 | ga:month=05</title>
+        <link rel="alternate" type="text/html" href="http://www.google.com/analytics" />
+        <dxp:dimension name="ga:medium" value="referral" />
+        <dxp:dimension name="ga:source" value="foobar.de" />
+        <dxp:dimension name="ga:browserVersion" value="3.6.17" />
+        <dxp:dimension name="ga:month" value="05" />
+        <dxp:metric name="ga:bounces" type="integer" value="1" />
+        <dxp:metric name="ga:visits" type="integer" value="3" />
+    </entry>
+    <entry>
+        <id>https://www.googleapis.com/analytics/v2.4/data?ids=ga:45678912&amp;ga:browserVersion=3.5.19&amp;ga:medium=referral&amp;ga:month=05&amp;ga:source=foobarbaz.ch&amp;filters=ga:browser%3D%3DFirefox&amp;start-date=2011-05-01&amp;end-date=2011-05-31</id>
+        <updated>2012-07-13T17:05:16.454Z</updated>
+        <title type="text">ga:medium=referral | ga:source=foobarbaz.ch | ga:browserVersion=3.5.19 | ga:month=05</title>
+        <link rel="alternate" type="text/html" href="http://www.google.com/analytics" />
+        <dxp:dimension name="ga:medium" value="referral" />
+        <dxp:dimension name="ga:source" value="foobarbaz.ch" />
+        <dxp:dimension name="ga:browserVersion" value="3.5.19" />
+        <dxp:dimension name="ga:month" value="05" />
+        <dxp:metric name="ga:bounces" type="integer" value="1" />
+        <dxp:metric name="ga:visits" type="integer" value="1" />
+    </entry>
+    <entry>
+        <id>https://www.googleapis.com/analytics/v2.4/data?ids=ga:45678912&amp;ga:browserVersion=3.6.17&amp;ga:medium=referral&amp;ga:month=05&amp;ga:source=foobarbaz.ch&amp;filters=ga:browser%3D%3DFirefox&amp;start-date=2011-05-01&amp;end-date=2011-05-31</id>
+        <updated>2012-07-13T17:05:16.454Z</updated>
+        <title type="text">ga:medium=referral | ga:source=baz.ch | ga:browserVersion=3.6.17 | ga:month=05</title>
+        <link rel="alternate" type="text/html" href="http://www.google.com/analytics" />
+        <dxp:dimension name="ga:medium" value="referral" />
+        <dxp:dimension name="ga:source" value="baz.ch" />
+        <dxp:dimension name="ga:browserVersion" value="3.6.17" />
+        <dxp:dimension name="ga:month" value="05" />
+        <dxp:metric name="ga:bounces" type="integer" value="1" />
+        <dxp:metric name="ga:visits" type="integer" value="1" />
+    </entry>
 </feed>


### PR DESCRIPTION
GA API v2.3 is being discontinued and V2.4 is being activated.

https://developers.google.com/analytics/devguides/config/mgmt/v2/#whatsnew
- unify with other GData components
- migrate v2.3 to v2.4
- add ability to query accounts, web properties, profiles and goals
  using Account Query
