### PR TITLE
Property overloading was not working in ViewModel

### DIFF
--- a/library/Zend/View/Model/ViewModel.php
+++ b/library/Zend/View/Model/ViewModel.php
@@ -100,8 +100,7 @@ class ViewModel implements ModelInterface
      */
     public function __set($name, $value)
     {
-        $variables = $this->getVariables();
-        $variables[$name] = $value;
+        $this->setVariable($name, $value);
     }
 
     /**

--- a/tests/Zend/View/Model/ViewModelTest.php
+++ b/tests/Zend/View/Model/ViewModelTest.php
@@ -233,4 +233,17 @@ class ViewModelTest extends TestCase
         $this->assertFalse(isset($model->foo));
         $this->assertFalse(isset($variables['foo']));
     }
+
+    public function testPropertyOverloadingAllowsWritingPropertiesAfterSetVariablesHasBeenCalled()
+    {
+        $model = new ViewModel();
+        $model->setVariables(array('foo' => 'bar'));
+        $model->bar = 'baz';
+
+        $this->assertTrue(isset($model->bar));
+        $this->assertEquals('baz', $model->bar);
+        $variables = $model->getVariables();
+        $this->assertArrayHasKey('bar', $variables);
+        $this->assertEquals('baz', $variables['bar']);
+    }
 }


### PR DESCRIPTION
- __set() was not actually setting the variable
