### PR TITLE
Controller plugin for Post/Redirect/Get

### DIFF
--- a/documentation/manual/en/module_specs/Zend_Mvc-Plugins.xml
+++ b/documentation/manual/en/module_specs/Zend_Mvc-Plugins.xml
@@ -287,6 +287,27 @@ return array(
         to match a route before redirecting to a URL.
       </para>
     </listitem>
+
+    <para>
+      Usage example:
+    </para>
+
+    <para>
+	// Pass in the route/url you want to redirect to after the POST
+	$prg = $this->prg('/user/register');
+
+	if ($prg instanceof \Zend\Http\PhpEnvironment\Response) {
+	    // returned a response to redirect us
+	    return $prg;
+	} else if ($prg === false) {
+	    // this wasn't a POST request, but there were no params in the flash messenger
+	    // probably this is the first time the form was loaded
+	    return array('form' => $myForm);
+	}
+
+	// $prg is an array containing the POST params from the previous request
+	$form->setData($prg);
+    </para>
   </section>
 
   <section xml:id="zend.mvc.controller-plugins.redirect">

--- a/documentation/manual/en/module_specs/Zend_Mvc-Plugins.xml
+++ b/documentation/manual/en/module_specs/Zend_Mvc-Plugins.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Reviewed: no -->
-<section 
+<section
     xmlns="http://docbook.org/ns/docbook" version="5.0"
     xml:id="zend.mvc.controller-plugins">
   <title>Controller Plugins</title>
@@ -29,6 +29,12 @@
     <listitem>
       <para>
         <classname>Zend\Mvc\Controller\Plugin\Forward</classname>
+      </para>
+    </listitem>
+
+    <listitem>
+      <para>
+        <classname>Zend\Mvc\Controller\Plugin\PostRedirectGet</classname>
       </para>
     </listitem>
 
@@ -257,6 +263,30 @@ return array(
     'foo'     => $foo,
 );
 ]]></programlisting>
+  </section>
+
+  <section xml:id="zend.mvc.controller-plugins.postredirectget">
+    <title>The Post/Redirect/Get Plugin</title>
+
+    <para>
+      When a user POSTs data to a page, their browser will try to protect them
+      from sending the POST again, breaking the back button and causing browser
+      warning pop-ups. Instead, when receiving a POST, we should store the data
+      and redirect the user to a page using a GET request. For this, we will use
+      the FlashMessenger plugin to store data across requests.
+    </para>
+
+    <para>
+      This plugin can be invoked with one argument:
+    </para>
+
+    <listitem>
+      <para>
+        <varname>$redirect</varname> is a string containing either the name of the
+        named route or the URL the user should be directed to. The plugin will try
+        to match a route before redirecting to a URL.
+      </para>
+    </listitem>
   </section>
 
   <section xml:id="zend.mvc.controller-plugins.redirect">

--- a/documentation/manual/en/module_specs/Zend_Mvc-Plugins.xml
+++ b/documentation/manual/en/module_specs/Zend_Mvc-Plugins.xml
@@ -292,14 +292,14 @@ return array(
       Usage example:
     </para>
 
-    <para>
+    <programlisting language="php">
 	// Pass in the route/url you want to redirect to after the POST
 	$prg = $this->prg('/user/register');
 
 	if ($prg instanceof \Zend\Http\PhpEnvironment\Response) {
 	    // returned a response to redirect us
 	    return $prg;
-	} else if ($prg === false) {
+	} elseif ($prg === false) {
 	    // this wasn't a POST request, but there were no params in the flash messenger
 	    // probably this is the first time the form was loaded
 	    return array('form' => $myForm);
@@ -307,7 +307,7 @@ return array(
 
 	// $prg is an array containing the POST params from the previous request
 	$form->setData($prg);
-    </para>
+    </programlisting>
   </section>
 
   <section xml:id="zend.mvc.controller-plugins.redirect">

--- a/documentation/manual/en/module_specs/Zend_Mvc-Plugins.xml
+++ b/documentation/manual/en/module_specs/Zend_Mvc-Plugins.xml
@@ -277,14 +277,18 @@ return array(
     </para>
 
     <para>
-      This plugin can be invoked with one argument:
+      This plugin can be invoked with two arguments:
     </para>
 
     <listitem>
       <para>
         <varname>$redirect</varname> is a string containing either the name of the
-        named route or the URL the user should be directed to. The plugin will try
-        to match a route before redirecting to a URL.
+        named route or the URL the user should be directed to.
+      </para>
+      <para>
+        <varname>$redirectToUrl</varname> is a boolean. Passing true will cause the
+        treat the first parameter as a URL instead of a route name. This argument
+        defaults to false.
       </para>
     </listitem>
 
@@ -294,7 +298,7 @@ return array(
 
     <programlisting language="php">
 	// Pass in the route/url you want to redirect to after the POST
-	$prg = $this->prg('/user/register');
+	$prg = $this->prg('/user/register', true);
 
 	if ($prg instanceof \Zend\Http\PhpEnvironment\Response) {
 	    // returned a response to redirect us

--- a/documentation/manual/en/module_specs/Zend_Mvc-Plugins.xml
+++ b/documentation/manual/en/module_specs/Zend_Mvc-Plugins.xml
@@ -34,12 +34,6 @@
 
     <listitem>
       <para>
-        <classname>Zend\Mvc\Controller\Plugin\PostRedirectGet</classname>
-      </para>
-    </listitem>
-
-    <listitem>
-      <para>
         <classname>Zend\Mvc\Controller\Plugin\Redirect</classname>
       </para>
     </listitem>
@@ -263,55 +257,6 @@ return array(
     'foo'     => $foo,
 );
 ]]></programlisting>
-  </section>
-
-  <section xml:id="zend.mvc.controller-plugins.postredirectget">
-    <title>The Post/Redirect/Get Plugin</title>
-
-    <para>
-      When a user POSTs data to a page, their browser will try to protect them
-      from sending the POST again, breaking the back button and causing browser
-      warning pop-ups. Instead, when receiving a POST, we should store the data
-      and redirect the user to a page using a GET request. For this, we will use
-      the FlashMessenger plugin to store data across requests.
-    </para>
-
-    <para>
-      This plugin can be invoked with two arguments:
-    </para>
-
-    <listitem>
-      <para>
-        <varname>$redirect</varname> is a string containing either the name of the
-        named route or the URL the user should be directed to.
-      </para>
-      <para>
-        <varname>$redirectToUrl</varname> is a boolean. Passing true will cause the
-        treat the first parameter as a URL instead of a route name. This argument
-        defaults to false.
-      </para>
-    </listitem>
-
-    <para>
-      Usage example:
-    </para>
-
-    <programlisting language="php">
-	// Pass in the route/url you want to redirect to after the POST
-	$prg = $this->prg('/user/register', true);
-
-	if ($prg instanceof \Zend\Http\PhpEnvironment\Response) {
-	    // returned a response to redirect us
-	    return $prg;
-	} elseif ($prg === false) {
-	    // this wasn't a POST request, but there were no params in the flash messenger
-	    // probably this is the first time the form was loaded
-	    return array('form' => $myForm);
-	}
-
-	// $prg is an array containing the POST params from the previous request
-	$form->setData($prg);
-    </programlisting>
   </section>
 
   <section xml:id="zend.mvc.controller-plugins.redirect">

--- a/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
@@ -1,9 +1,25 @@
 <?php
 
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
 namespace Zend\Mvc\Controller\Plugin;
 
 use Zend\Mvc\Router\Exception\RuntimeException;
 
+/**
+ * Plugin to help facilitate Post/Redirect/Get (http://en.wikipedia.org/wiki/Post/Redirect/Get)
+ *
+ * @category Zend
+ * @package Zend_Mvc
+ * @subpackage Controller
+ */
 class PostRedirectGet extends AbstractPlugin
 {
     public function __invoke($redirect)

--- a/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Zend\Mvc\Controller\Plugin;
+
+use Zend\Mvc\Router\Exception\RuntimeException;
+
+class PostRedirectGet extends AbstractPlugin
+{
+    public function __invoke($redirect)
+    {
+        $controller = $this->getController();
+        $request = $controller->getRequest();
+        $flashMessenger = $controller->flashMessenger()->setNamespace('prg-post');
+
+        if ($request->isPost()) {
+            $flashMessenger->addMessage($request->getPost()->toArray());
+            try {
+                return $controller->redirect()->toRoute($redirect);
+            } catch (RuntimeException $e) {
+                return $controller->redirect()->toUrl($redirect);
+            }
+        } else {
+            $messages = $flashMessenger->getMessages();
+            if (count($messages)) {
+                return $messages[0];
+            } else {
+                return false;
+            }
+        }
+    }
+}
+

--- a/library/Zend/Mvc/Controller/PluginManager.php
+++ b/library/Zend/Mvc/Controller/PluginManager.php
@@ -33,12 +33,14 @@ class PluginManager extends AbstractPluginManager
      * @var array
      */
     protected $invokableClasses = array(
-        'flashmessenger' => 'Zend\Mvc\Controller\Plugin\FlashMessenger',
-        'forward'        => 'Zend\Mvc\Controller\Plugin\Forward',
-        'layout'         => 'Zend\Mvc\Controller\Plugin\Layout',
-        'params'         => 'Zend\Mvc\Controller\Plugin\Params',
-        'redirect'       => 'Zend\Mvc\Controller\Plugin\Redirect',
-        'url'            => 'Zend\Mvc\Controller\Plugin\Url',
+        'flashmessenger'  => 'Zend\Mvc\Controller\Plugin\FlashMessenger',
+        'forward'         => 'Zend\Mvc\Controller\Plugin\Forward',
+        'layout'          => 'Zend\Mvc\Controller\Plugin\Layout',
+        'params'          => 'Zend\Mvc\Controller\Plugin\Params',
+        'postredirectget' => 'Zend\Mvc\Controller\Plugin\PostRedirectGet',
+        'prg'             => 'Zend\Mvc\Controller\Plugin\PostRedirectGet',
+        'redirect'        => 'Zend\Mvc\Controller\Plugin\Redirect',
+        'url'             => 'Zend\Mvc\Controller\Plugin\Url',
     );
 
     /**

--- a/library/Zend/Mvc/Controller/PluginManager.php
+++ b/library/Zend/Mvc/Controller/PluginManager.php
@@ -38,9 +38,17 @@ class PluginManager extends AbstractPluginManager
         'layout'          => 'Zend\Mvc\Controller\Plugin\Layout',
         'params'          => 'Zend\Mvc\Controller\Plugin\Params',
         'postredirectget' => 'Zend\Mvc\Controller\Plugin\PostRedirectGet',
-        'prg'             => 'Zend\Mvc\Controller\Plugin\PostRedirectGet',
         'redirect'        => 'Zend\Mvc\Controller\Plugin\Redirect',
         'url'             => 'Zend\Mvc\Controller\Plugin\Url',
+    );
+
+    /**
+     * Default set of plugin aliases
+     *
+     * @var array
+     */
+    protected $aliases = array(
+        'prg'             => 'postredirectget',
     );
 
     /**

--- a/tests/Zend/Mvc/Controller/Plugin/PostRedirectGetTest.php
+++ b/tests/Zend/Mvc/Controller/Plugin/PostRedirectGetTest.php
@@ -67,7 +67,7 @@ class PostRedirectGetTest extends TestCase
         )));
 
         $result         = $this->controller->dispatch($this->request, $this->response);
-        $prgResultUrl   = $this->controller->prg('/test/getPage');
+        $prgResultUrl   = $this->controller->prg('/test/getPage', true);
 
         $this->assertInstanceOf('Zend\Http\Response', $prgResultUrl);
         $this->assertTrue($prgResultUrl->getHeaders()->has('Location'));
@@ -95,5 +95,22 @@ class PostRedirectGetTest extends TestCase
         $prgResult = $this->controller->prg('home');
 
         $this->assertFalse($prgResult);
+    }
+
+    /**
+     * @expectedException Zend\Mvc\Exception\RuntimeException
+     */
+    public function testThrowsExceptionOnRouteWithoutRouter()
+    {
+        $controller = $this->controller;
+        $controller = $controller->getEvent()->setRouter(new SimpleRouteStack);
+
+        $this->request->setMethod('POST');
+        $this->request->setPost(new Parameters(array(
+            'postval1' => 'value'
+        )));
+
+        $result = $this->controller->dispatch($this->request, $this->response);
+        $this->controller->prg('some/route');
     }
 }

--- a/tests/Zend/Mvc/Controller/Plugin/PostRedirectGetTest.php
+++ b/tests/Zend/Mvc/Controller/Plugin/PostRedirectGetTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace ZendTest\Mvc\Controller\Plugin;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Http\Request;
+use Zend\Http\Response;
+use Zend\Mvc\MvcEvent;
+use Zend\Mvc\Router\Http\Literal as LiteralRoute;
+use Zend\Mvc\Router\RouteMatch;
+use Zend\Mvc\Router\SimpleRouteStack;
+use Zend\Stdlib\Parameters;
+use ZendTest\Mvc\Controller\TestAsset\SampleController;
+use ZendTest\Session\TestAsset\TestManager as SessionManager;
+
+class PostRedirectGetTest extends TestCase
+{
+    public $controller;
+    public $event;
+    public $request;
+    public $response;
+
+    public function setUp()
+    {
+        $router = new SimpleRouteStack;
+        $router->addRoute('home', LiteralRoute::factory(array(
+            'route'    => '/',
+            'defaults' => array(
+                'controller' => 'ZendTest\Mvc\Controller\TestAsset\SampleController',
+            ),
+        )));
+
+        $this->controller = new SampleController();
+        $this->request    = new Request();
+        $this->event      = new MvcEvent();
+        $this->routeMatch = new RouteMatch(array('controller' => 'controller-sample', 'action' => 'postPage'));
+
+        $this->event->setRequest($this->request);
+        $this->event->setRouteMatch($this->routeMatch);
+        $this->event->setRouter($router);
+
+        $this->sessionManager = new SessionManager();
+
+        $this->controller->setEvent($this->event);
+        $this->controller->flashMessenger()->setSessionManager($this->sessionManager);
+    }
+
+    public function testRedirectsToUrlOnPost()
+    {
+        $this->request->setMethod('POST');
+        $this->request->setPost(new Parameters(array(
+            'postval1' => 'value'
+        )));
+
+        $result         = $this->controller->dispatch($this->request, $this->response);
+        $prgResultUrl   = $this->controller->prg('/test/getPage');
+
+        $this->assertInstanceOf('Zend\Http\Response', $prgResultUrl);
+        $this->assertTrue($prgResultUrl->getHeaders()->has('Location'));
+        $this->assertEquals('/test/getPage', $prgResultUrl->getHeaders()->get('Location')->getUri());
+    }
+
+    public function testRedirectsToRouteOnPost()
+    {
+        $this->request->setMethod('POST');
+        $this->request->setPost(new Parameters(array(
+            'postval1' => 'value'
+        )));
+
+        $result         = $this->controller->dispatch($this->request, $this->response);
+        $prgResultRoute = $this->controller->prg('home');
+
+        $this->assertInstanceOf('Zend\Http\Response', $prgResultRoute);
+        $this->assertTrue($prgResultRoute->getHeaders()->has('Location'));
+        $this->assertEquals('/', $prgResultRoute->getHeaders()->get('Location')->getUri());
+    }
+
+    public function testReturnsFalseOnIntialGet()
+    {
+        $result    = $this->controller->dispatch($this->request, $this->response);
+        $prgResult = $this->controller->prg('home');
+
+        $this->assertFalse($prgResult);
+    }
+}

--- a/tests/Zend/Mvc/Controller/Plugin/PostRedirectGetTest.php
+++ b/tests/Zend/Mvc/Controller/Plugin/PostRedirectGetTest.php
@@ -54,9 +54,18 @@ class PostRedirectGetTest extends TestCase
         $this->event->setRouter($router);
 
         $this->sessionManager = new SessionManager();
+        $this->sessionManager->destroy();
 
         $this->controller->setEvent($this->event);
         $this->controller->flashMessenger()->setSessionManager($this->sessionManager);
+    }
+
+    public function testReturnsFalseOnIntialGet()
+    {
+        $result    = $this->controller->dispatch($this->request, $this->response);
+        $prgResult = $this->controller->prg('home');
+
+        $this->assertFalse($prgResult);
     }
 
     public function testRedirectsToUrlOnPost()
@@ -78,7 +87,7 @@ class PostRedirectGetTest extends TestCase
     {
         $this->request->setMethod('POST');
         $this->request->setPost(new Parameters(array(
-            'postval1' => 'value'
+            'postval1' => 'value1'
         )));
 
         $result         = $this->controller->dispatch($this->request, $this->response);
@@ -87,14 +96,6 @@ class PostRedirectGetTest extends TestCase
         $this->assertInstanceOf('Zend\Http\Response', $prgResultRoute);
         $this->assertTrue($prgResultRoute->getHeaders()->has('Location'));
         $this->assertEquals('/', $prgResultRoute->getHeaders()->get('Location')->getUri());
-    }
-
-    public function testReturnsFalseOnIntialGet()
-    {
-        $result    = $this->controller->dispatch($this->request, $this->response);
-        $prgResult = $this->controller->prg('home');
-
-        $this->assertFalse($prgResult);
     }
 
     /**

--- a/tests/Zend/Mvc/Controller/Plugin/PostRedirectGetTest.php
+++ b/tests/Zend/Mvc/Controller/Plugin/PostRedirectGetTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
 namespace ZendTest\Mvc\Controller\Plugin;
 
 use PHPUnit_Framework_TestCase as TestCase;
@@ -13,6 +22,11 @@ use Zend\Stdlib\Parameters;
 use ZendTest\Mvc\Controller\TestAsset\SampleController;
 use ZendTest\Session\TestAsset\TestManager as SessionManager;
 
+/**
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage UnitTests
+ */
 class PostRedirectGetTest extends TestCase
 {
     public $controller;


### PR DESCRIPTION
For more information about PRG: http://en.wikipedia.org/wiki/Post/Redirect/Get

It's fairly easy to do this yourself in your controller actions, but this plugin will cut down on the amount of code you have to write by a fairly significant amount. It is aliased both to "postredirectget" and "prg" in the controller plugin manager.

Usage example:

```
// Pass in the route/url you want to redirect to after the POST
$prg = $this->prg('/user/register');

if ($prg instanceof \Zend\Http\PhpEnvironment\Response) {
    // returned a response to redirect us
    return $prg;
} else if ($prg === false) {
    // this wasn't a POST request, but there were no params in the flash messenger
    // probably this is the first time the form was loaded
    return array('form' => $myForm);
}

// $prg is an array containing the POST params from the previous request
$form->setData($prg);
```
