### PR TITLE
Fix error messages in captcha validators

### DIFF
--- a/library/Zend/Captcha/AbstractWord.php
+++ b/library/Zend/Captcha/AbstractWord.php
@@ -100,7 +100,7 @@ abstract class AbstractWord extends AbstractAdapter
      * Error messages
      * @var array
      */
-    protected $_messageTemplates = array(
+    protected $messageTemplates = array(
         self::MISSING_VALUE => 'Empty captcha value',
         self::MISSING_ID    => 'Captcha ID field is missing',
         self::BAD_CAPTCHA   => 'Captcha value is wrong',

--- a/library/Zend/Captcha/ReCaptcha.php
+++ b/library/Zend/Captcha/ReCaptcha.php
@@ -68,7 +68,7 @@ class ReCaptcha extends AbstractAdapter
      * Error messages
      * @var array
      */
-    protected $_messageTemplates = array(
+    protected $messageTemplates = array(
         self::MISSING_VALUE => 'Missing captcha fields',
         self::ERR_CAPTCHA   => 'Failed to validate captcha',
         self::BAD_CAPTCHA   => 'Captcha value is wrong: %value%',

--- a/tests/Zend/Captcha/CommonWordTest.php
+++ b/tests/Zend/Captcha/CommonWordTest.php
@@ -35,4 +35,12 @@ abstract class CommonWordTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Captcha\Exception\InvalidArgumentException', 'not found');
         $wordAdapter->getSession();
     }
+
+    public function testErrorMessages()
+    {
+        $wordAdapter = new $this->wordClass;
+        $this->assertFalse($wordAdapter->isValid('foo'));
+        $messages = $wordAdapter->getMessages();
+        $this->assertFalse(empty($messages));
+    }
 }


### PR DESCRIPTION
- messageTemplates property had been renamed to remove underscore prefix
  in Validator component, but Captcha component was not updated
  accordingly
