### PR TITLE
[Session] Configuration -> Config

### DIFF
--- a/library/Zend/Session/AbstractManager.php
+++ b/library/Zend/Session/AbstractManager.php
@@ -26,7 +26,7 @@ use Zend\Session\Storage\StorageInterface as Storage;
 abstract class AbstractManager implements Manager
 {
     /**
-     * @var Configuration
+     * @var Config
      */
     protected $config;
 
@@ -80,9 +80,9 @@ abstract class AbstractManager implements Manager
                     __NAMESPACE__
                 ));
             }
-
-            $this->config = $config;
         }
+
+        $this->config = $config;
 
         // init storage
         if ($storage === null) {
@@ -102,12 +102,13 @@ abstract class AbstractManager implements Manager
                     __NAMESPACE__
                 ));
             }
-
-            $this->storage = $storage;
         }
 
+        $this->storage = $storage;
+
+        // save handler
         if ($saveHandler !== null) {
-            $this->setSaveHandler($saveHandler);
+            $this->saveHandler = $saveHandler;
         }
     }
 

--- a/library/Zend/Session/AbstractManager.php
+++ b/library/Zend/Session/AbstractManager.php
@@ -34,7 +34,7 @@ abstract class AbstractManager implements Manager
      * Default configuration class to use when no configuration provided
      * @var string
      */
-    protected $configDefaultClass = 'Zend\\Session\\Configuration\\SessionConfiguration';
+    protected $defaultConfigClass = 'Zend\Session\Config\SessionConfig';
 
     /**
      * @var Storage
@@ -45,30 +45,68 @@ abstract class AbstractManager implements Manager
      * Default storage class to use when no storage provided
      * @var string
      */
-    protected $storageDefaultClass = 'Zend\\Session\\Storage\\SessionStorage';
+    protected $defaultStorageClass = 'Zend\Session\Storage\SessionStorage';
 
     /**
      * @var SaveHandler
      */
     protected $saveHandler;
 
-
     /**
      * Constructor
      *
-     * Allow passing a configuration object or class name, a storage object or
-     * class name, or an array of configuration.
-     *
-     * @param  Configuration $config
-     * @param  Storage $storage
-     * @param  SaveHandler $saveHandler
-     * @return void
+     * @param  Config|null $config
+     * @param  Storage|null $storage
+     * @param  SaveHandler|null $saveHandler
+     * @throws Exception\RuntimeException
      */
     public function __construct(Config $config = null, Storage $storage = null, SaveHandler $saveHandler = null)
     {
-        $this->setOptions($config);
-        $this->setStorage($storage);
-        if ($saveHandler) {
+        // init config
+        if ($config === null) {
+            if (!class_exists($this->defaultConfigClass)) {
+                throw new Exception\RuntimeException(sprintf(
+                    'Unable to locate config class "%s"; class does not exist',
+                    $this->defaultConfigClass
+                ));
+            }
+
+            $config = new $this->defaultConfigClass();
+
+            if (!$config instanceof Config) {
+                throw new Exception\RuntimeException(sprintf(
+                    'Default config class %s is invalid; must implement %s\Config\ConfigInterface',
+                    $this->defaultConfigClass,
+                    __NAMESPACE__
+                ));
+            }
+
+            $this->config = $config;
+        }
+
+        // init storage
+        if ($storage === null) {
+            if (!class_exists($this->defaultStorageClass)) {
+                throw new Exception\RuntimeException(sprintf(
+                    'Unable to locate storage class "%s"; class does not exist',
+                    $this->defaultStorageClass
+                ));
+            }
+
+            $storage = new $this->defaultStorageClass();
+
+            if (!$storage instanceof Storage) {
+                throw new Exception\RuntimeException(sprintf(
+                    'Default storage class %s is invalid; must implement %s\Storage\StorageInterface',
+                    $this->defaultConfigClass,
+                    __NAMESPACE__
+                ));
+            }
+
+            $this->storage = $storage;
+        }
+
+        if ($saveHandler !== null) {
             $this->setSaveHandler($saveHandler);
         }
     }
@@ -76,27 +114,19 @@ abstract class AbstractManager implements Manager
     /**
      * Set configuration object
      *
-     * @param  null|Configuration $config
-     * @return void
+     * @param  Config $config
+     * @return AbstractManager
      */
-    public function setOptions(Config $config = null)
+    public function setConfig(Config $config)
     {
-        if (null === $config) {
-            $config = new $this->configDefaultClass();
-            if (!$config instanceof Config) {
-                throw new Exception\InvalidArgumentException(
-                    'Default configuration type provided is invalid; must implement Zend\\Session\\Configuration'
-                );
-            }
-        }
-
         $this->config = $config;
+        return $this;
     }
 
     /**
      * Retrieve configuration object
      *
-     * @return Configuration
+     * @return Config
      */
     public function getConfig()
     {
@@ -106,21 +136,13 @@ abstract class AbstractManager implements Manager
     /**
      * Set session storage object
      *
-     * @param  null|Storage $storage
-     * @return void
+     * @param  Storage $storage
+     * @return AbstractManager
      */
-    public function setStorage(Storage $storage = null)
+    public function setStorage(Storage $storage)
     {
-        if (null === $storage) {
-            $storage = new $this->storageDefaultClass();
-            if (!$storage instanceof Storage) {
-                throw new Exception\InvalidArgumentException(
-                    'Default storage type provided is invalid; must implement Zend\\Session\\Storage'
-                );
-            }
-        }
-
         $this->storage = $storage;
+        return $this;
     }
 
     /**
@@ -136,15 +158,13 @@ abstract class AbstractManager implements Manager
     /**
      * Set session save handler object
      *
-     * @param SaveHandler $saveHandler
-     * @return void
+     * @param  SaveHandler $saveHandler
+     * @return AbstractManager
      */
     public function setSaveHandler(SaveHandler $saveHandler)
     {
-        if ($saveHandler === null) {
-            return ;
-        }
         $this->saveHandler = $saveHandler;
+        return $this;
     }
 
     /**

--- a/library/Zend/Session/AbstractManager.php
+++ b/library/Zend/Session/AbstractManager.php
@@ -10,7 +10,7 @@
 
 namespace Zend\Session;
 
-use Zend\Session\Configuration\ConfigurationInterface as Configuration;
+use Zend\Session\Config\ConfigInterface as Config;
 use Zend\Session\ManagerInterface as Manager;
 use Zend\Session\SaveHandler\SaveHandlerInterface as SaveHandler;
 use Zend\Session\Storage\StorageInterface as Storage;
@@ -64,7 +64,7 @@ abstract class AbstractManager implements Manager
      * @param  SaveHandler $saveHandler
      * @return void
      */
-    public function __construct(Configuration $config = null, Storage $storage = null, SaveHandler $saveHandler = null)
+    public function __construct(Config $config = null, Storage $storage = null, SaveHandler $saveHandler = null)
     {
         $this->setOptions($config);
         $this->setStorage($storage);
@@ -79,12 +79,14 @@ abstract class AbstractManager implements Manager
      * @param  null|Configuration $config
      * @return void
      */
-    public function setOptions(Configuration $config = null)
+    public function setOptions(Config $config = null)
     {
         if (null === $config) {
             $config = new $this->configDefaultClass();
-            if (!$config instanceof Configuration) {
-                throw new Exception\InvalidArgumentException('Default configuration type provided is invalid; must implement Zend\\Session\\Configuration');
+            if (!$config instanceof Config) {
+                throw new Exception\InvalidArgumentException(
+                    'Default configuration type provided is invalid; must implement Zend\\Session\\Configuration'
+                );
             }
         }
 
@@ -112,7 +114,9 @@ abstract class AbstractManager implements Manager
         if (null === $storage) {
             $storage = new $this->storageDefaultClass();
             if (!$storage instanceof Storage) {
-                throw new Exception\InvalidArgumentException('Default storage type provided is invalid; must implement Zend\\Session\\Storage');
+                throw new Exception\InvalidArgumentException(
+                    'Default storage type provided is invalid; must implement Zend\\Session\\Storage'
+                );
             }
         }
 

--- a/library/Zend/Session/Config/ConfigInterface.php
+++ b/library/Zend/Session/Config/ConfigInterface.php
@@ -8,7 +8,7 @@
  * @package   Zend_Session
  */
 
-namespace Zend\Session\Configuration;
+namespace Zend\Session\Config;
 
 /**
  * Standard session configuration
@@ -16,7 +16,7 @@ namespace Zend\Session\Configuration;
  * @category   Zend
  * @package    Zend_Session
  */
-interface ConfigurationInterface
+interface ConfigInterface
 {
     public function setOptions(array $options);
     public function setOption($option, $value);
@@ -24,11 +24,11 @@ interface ConfigurationInterface
     public function getOption($option);
     public function toArray();
 
-    public function setSavePath($savePath);
-    public function getSavePath();
-
     public function setName($name);
     public function getName();
+
+    public function setSavePath($savePath);
+    public function getSavePath();
 
     public function setCookieLifetime($cookieLifetime);
     public function getCookieLifetime();

--- a/library/Zend/Session/Config/ConfigInterface.php
+++ b/library/Zend/Session/Config/ConfigInterface.php
@@ -18,10 +18,10 @@ namespace Zend\Session\Config;
  */
 interface ConfigInterface
 {
-    public function setOptions(array $options);
+    public function setOptions($options);
     public function setOption($option, $value);
-    public function hasOption($option);
     public function getOption($option);
+    public function hasOption($option);
     public function toArray();
 
     public function setName($name);
@@ -40,8 +40,10 @@ interface ConfigInterface
     public function getCookieSecure();
     public function setCookieHttpOnly($cookieHttpOnly);
     public function getCookieHttpOnly();
+
     public function setUseCookies($useCookies);
     public function getUseCookies();
+
     public function setRememberMeSeconds($rememberMeSeconds);
     public function getRememberMeSeconds();
 }

--- a/library/Zend/Session/Config/ConfigInterface.php
+++ b/library/Zend/Session/Config/ConfigInterface.php
@@ -19,9 +19,12 @@ namespace Zend\Session\Config;
 interface ConfigInterface
 {
     public function setOptions($options);
+    public function getOptions();
+
     public function setOption($option, $value);
     public function getOption($option);
     public function hasOption($option);
+
     public function toArray();
 
     public function setName($name);
@@ -32,12 +35,16 @@ interface ConfigInterface
 
     public function setCookieLifetime($cookieLifetime);
     public function getCookieLifetime();
+
     public function setCookiePath($cookiePath);
     public function getCookiePath();
+
     public function setCookieDomain($cookieDomain);
     public function getCookieDomain();
+
     public function setCookieSecure($cookieSecure);
     public function getCookieSecure();
+
     public function setCookieHttpOnly($cookieHttpOnly);
     public function getCookieHttpOnly();
 

--- a/library/Zend/Session/Config/SessionConfig.php
+++ b/library/Zend/Session/Config/SessionConfig.php
@@ -8,7 +8,7 @@
  * @package   Zend_Session
  */
 
-namespace Zend\Session\Configuration;
+namespace Zend\Session\Config;
 
 use Zend\Session\Exception;
 use Zend\Validator\Hostname as HostnameValidator;
@@ -20,7 +20,7 @@ use Zend\Validator\Hostname as HostnameValidator;
  * @package    Zend_Session
  * @subpackage Configuration
  */
-class SessionConfiguration extends StandardConfiguration
+class SessionConfig extends StandardConfig
 {
     /**
      * Used with {@link handleError()}; stores PHP error code

--- a/library/Zend/Session/Config/SessionConfig.php
+++ b/library/Zend/Session/Config/SessionConfig.php
@@ -107,8 +107,6 @@ class SessionConfig extends StandardConfig
      */
     public function getStorageOption($storageOption)
     {
-        $key       = false;
-        $transform = false;
         switch ($storageOption) {
             case 'remember_me_seconds':
                 // No remote storage option; just return the current value
@@ -128,19 +126,6 @@ class SessionConfig extends StandardConfig
     }
 
     /**
-     * Handle PHP errors
-     *
-     * @param  int $code
-     * @param  string $message
-     * @return void
-     */
-    protected function handleError($code, $message)
-    {
-        $this->phpErrorCode    = $code;
-        $this->phpErrorMessage = $message;
-    }
-
-    /**
      * Set session.save_handler
      *
      * @param  string $phpSaveHandler
@@ -154,7 +139,9 @@ class SessionConfig extends StandardConfig
         ini_set('session.save_handler', $phpSaveHandler);
         restore_error_handler();
         if ($this->phpErrorCode >= E_WARNING) {
-            throw new Exception\InvalidArgumentException('Invalid save handler specified');
+            throw new Exception\InvalidArgumentException(
+                'Invalid save handler specified: ' . $this->phpErrorMessage
+            );
         }
 
         $this->setOption('save_handler', $phpSaveHandler);
@@ -204,24 +191,6 @@ class SessionConfig extends StandardConfig
     }
 
     /**
-     * Retrieve list of valid hash functions
-     *
-     * @return array
-     */
-    protected function getHashFunctions()
-    {
-        if (empty($this->validHashFunctions)) {
-            /**
-             * @see http://php.net/manual/en/session.configuration.php#ini.session.hash-function
-             * "0" and "1" refer to MD5-128 and SHA1-160, respectively, and are
-             * valid in addition to whatever is reported by hash_algos()
-             */
-            $this->validHashFunctions = array('0', '1') + hash_algos();
-        }
-        return $this->validHashFunctions;
-    }
-
-    /**
      * Set session.hash_function
      *
      * @param  string|int $hashFunction
@@ -260,5 +229,36 @@ class SessionConfig extends StandardConfig
         $this->setOption('hash_bits_per_character', $hashBitsPerCharacter);
         ini_set('session.hash_bits_per_character', $hashBitsPerCharacter);
         return $this;
+    }
+
+    /**
+     * Retrieve list of valid hash functions
+     *
+     * @return array
+     */
+    protected function getHashFunctions()
+    {
+        if (empty($this->validHashFunctions)) {
+            /**
+             * @link http://php.net/manual/en/session.configuration.php#ini.session.hash-function
+             * "0" and "1" refer to MD5-128 and SHA1-160, respectively, and are
+             * valid in addition to whatever is reported by hash_algos()
+             */
+            $this->validHashFunctions = array('0', '1') + hash_algos();
+        }
+        return $this->validHashFunctions;
+    }
+
+    /**
+     * Handle PHP errors
+     *
+     * @param  int $code
+     * @param  string $message
+     * @return void
+     */
+    protected function handleError($code, $message)
+    {
+        $this->phpErrorCode    = $code;
+        $this->phpErrorMessage = $message;
     }
 }

--- a/library/Zend/Session/Config/StandardConfig.php
+++ b/library/Zend/Session/Config/StandardConfig.php
@@ -8,10 +8,10 @@
  * @package   Zend_Session
  */
 
-namespace Zend\Session\Configuration;
+namespace Zend\Session\Config;
 
 use Zend\Filter\Word\CamelCaseToUnderscore as CamelCaseToUnderscoreFilter;
-use Zend\Session\Configuration\ConfigurationInterface as Configurable;
+use Zend\Session\Config\ConfigInterface;
 use Zend\Session\Exception;
 use Zend\Validator\Hostname as HostnameValidator;
 
@@ -22,10 +22,12 @@ use Zend\Validator\Hostname as HostnameValidator;
  * @package    Zend_Session
  * @subpackage Configuration
  */
-class StandardConfiguration implements Configurable
+class StandardConfig implements ConfigInterface
 {
     /**
-     * @var Zend\Filter Filter to convert CamelCase to underscore_separated
+     * Filter to convert CamelCase to underscore_separated
+     *
+     * @var Zend\Filter
      */
     protected $camelCaseToUnderscoreFilter;
 
@@ -116,8 +118,12 @@ class StandardConfiguration implements Configurable
     public function setSavePath($savePath)
     {
         if (!is_dir($savePath)) {
-            throw new Exception\InvalidArgumentException('Invalid save_path provided');
+            throw new Exception\InvalidArgumentException('Invalid save_path; not a directory');
         }
+        if (!is_writable($savePath)) {
+            throw new Exception\InvalidArgumentException('Invalid save_path; not writable');
+        }
+
         $this->savePath = $savePath;
         $this->setStorageOption('save_path', $savePath);
         return $this;
@@ -244,7 +250,9 @@ class StandardConfiguration implements Configurable
             throw new Exception\InvalidArgumentException('Invalid cookie_lifetime; must be numeric');
         }
         if (0 > $cookieLifetime) {
-            throw new Exception\InvalidArgumentException('Invalid cookie_lifetime; must be a positive integer or zero');
+            throw new Exception\InvalidArgumentException(
+                'Invalid cookie_lifetime; must be a positive integer or zero'
+            );
         }
 
         $this->cookieLifetime = (int) $cookieLifetime;
@@ -315,7 +323,9 @@ class StandardConfiguration implements Configurable
         $validator = new HostnameValidator(HostnameValidator::ALLOW_ALL);
 
         if (!empty($cookieDomain) && !$validator->isValid($cookieDomain)) {
-            throw new Exception\InvalidArgumentException('Invalid cookie domain: ' . implode('; ', $validator->getMessages()));
+            throw new Exception\InvalidArgumentException(
+                'Invalid cookie domain: ' . implode('; ', $validator->getMessages())
+            );
         }
 
         $this->cookieDomain = $cookieDomain;

--- a/library/Zend/Session/Config/StandardConfig.php
+++ b/library/Zend/Session/Config/StandardConfig.php
@@ -227,7 +227,7 @@ class StandardConfig implements ConfigInterface
      * Set session.save_path
      *
      * @param  string $savePath
-     * @return StandardConfiguration
+     * @return StandardConfig
      * @throws Exception\InvalidArgumentException on invalid path
      */
     public function setSavePath($savePath)
@@ -261,7 +261,7 @@ class StandardConfig implements ConfigInterface
      * Set session.name
      *
      * @param  string $name
-     * @return StandardConfiguration
+     * @return StandardConfig
      * @throws Exception\InvalidArgumentException
      */
     public function setName($name)
@@ -291,7 +291,7 @@ class StandardConfig implements ConfigInterface
      * Set session.gc_probability
      *
      * @param  int $gcProbability
-     * @return StandardConfiguration
+     * @return StandardConfig
      * @throws Exception\InvalidArgumentException
      */
     public function setGcProbability($gcProbability)
@@ -309,10 +309,24 @@ class StandardConfig implements ConfigInterface
     }
 
     /**
+     * Get session.gc_probability
+     *
+     * @return int
+     */
+    public function getGcProbability()
+    {
+        if (!isset($this->options['gc_probability'])) {
+            $this->options['gc_probability'] = $this->getStorageOption('gc_probability');
+        }
+
+        return $this->options['gc_probability'];
+    }
+
+    /**
      * Set session.gc_divisor
      *
      * @param  int $gcDivisor
-     * @return StandardConfiguration
+     * @return StandardConfig
      * @throws Exception\InvalidArgumentException
      */
     public function setGcDivisor($gcDivisor)
@@ -330,10 +344,24 @@ class StandardConfig implements ConfigInterface
     }
 
     /**
-     * Set gc.maxlifetime
+     * Get session.gc_divisor
+     *
+     * @return int
+     */
+    public function getGcDivisor()
+    {
+        if (!isset($this->options['gc_divisor'])) {
+            $this->options['gc_divisor'] = $this->getStorageOption('gc_divisor');
+        }
+
+        return $this->options['gc_divisor'];
+    }
+
+    /**
+     * Set gc_maxlifetime
      *
      * @param  int $gcMaxlifetime
-     * @return StandardConfiguration
+     * @return StandardConfig
      * @throws Exception\InvalidArgumentException
      */
     public function setGcMaxlifetime($gcMaxlifetime)
@@ -353,10 +381,24 @@ class StandardConfig implements ConfigInterface
     }
 
     /**
+     * Get session.gc_maxlifetime
+     *
+     * @return int
+     */
+    public function getGcMaxlifetime()
+    {
+        if (!isset($this->options['gc_maxlifetime'])) {
+            $this->options['gc_maxlifetime'] = $this->getStorageOption('gc_maxlifetime');
+        }
+
+        return $this->options['gc_maxlifetime'];
+    }
+
+    /**
      * Set session.cookie_lifetime
      *
      * @param  int $cookieLifetime
-     * @return StandardConfiguration
+     * @return StandardConfig
      * @throws Exception\InvalidArgumentException
      */
     public function setCookieLifetime($cookieLifetime)
@@ -392,7 +434,7 @@ class StandardConfig implements ConfigInterface
      * Set session.cookie_path
      *
      * @param  string $cookiePath
-     * @return StandardConfiguration
+     * @return StandardConfig
      * @throws Exception\InvalidArgumentException
      */
     public function setCookiePath($cookiePath)
@@ -426,7 +468,7 @@ class StandardConfig implements ConfigInterface
      * Set session.cookie_domain
      *
      * @param  string $cookieDomain
-     * @return StandardConfiguration
+     * @return StandardConfig
      * @throws Exception\InvalidArgumentException
      */
     public function setCookieDomain($cookieDomain)
@@ -465,7 +507,7 @@ class StandardConfig implements ConfigInterface
      * Set session.cookie_secure
      *
      * @param  bool $cookieSecure
-     * @return StandardConfiguration
+     * @return StandardConfig
      */
     public function setCookieSecure($cookieSecure)
     {
@@ -520,7 +562,7 @@ class StandardConfig implements ConfigInterface
      * Set session.use_cookies
      *
      * @param  bool $useCookies
-     * @return StandardConfiguration
+     * @return StandardConfig
      */
     public function setUseCookies($useCookies)
     {
@@ -546,24 +588,42 @@ class StandardConfig implements ConfigInterface
      * Set session.entropy_file
      *
      * @param  string $entropyFile
-     * @return StandardConfiguration
+     * @return StandardConfig
      * @throws Exception\InvalidArgumentException
      */
     public function setEntropyFile($entropyFile)
     {
-        if (is_dir($entropyFile) || !is_readable($entropyFile)) {
-            throw new Exception\InvalidArgumentException('Invalid entropy_file provided');
+        if (!is_file($entropyFile) || !is_readable($entropyFile)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                "entropy_file '%s' doesn't exist or not readable",
+                $entropyFile
+            ));
         }
+
         $this->setOption('entropy_file', $entropyFile);
         $this->setStorageOption('entropy_file', $entropyFile);
         return $this;
     }
 
     /**
+     * Get session.entropy_file
+     *
+     * @return string
+     */
+    public function getEntropyFile()
+    {
+        if (!isset($this->options['entropy_file'])) {
+            $this->options['entropy_file'] = $this->getStorageOption('entropy_file');
+        }
+
+        return $this->options['entropy_file'];
+    }
+
+    /**
      * set session.entropy_length
      *
      * @param  int $entropyLength
-     * @return StandardConfiguration
+     * @return StandardConfig
      * @throws Exception\InvalidArgumentException
      */
     public function setEntropyLength($entropyLength)
@@ -581,10 +641,24 @@ class StandardConfig implements ConfigInterface
     }
 
     /**
+     * Get session.entropy_length
+     *
+     * @return string
+     */
+    public function getEntropyLength()
+    {
+        if (!isset($this->options['entropy_length'])) {
+            $this->options['entropy_length'] = $this->getStorageOption('entropy_length');
+        }
+
+        return $this->options['entropy_length'];
+    }
+
+    /**
      * Set session.cache_expire
      *
      * @param  int $cacheExpire
-     * @return StandardConfiguration
+     * @return StandardConfig
      * @throws Exception\InvalidArgumentException
      */
     public function setCacheExpire($cacheExpire)
@@ -604,10 +678,24 @@ class StandardConfig implements ConfigInterface
     }
 
     /**
+     * Get session.cache_expire
+     *
+     * @return string
+     */
+    public function getCacheExpire()
+    {
+        if (!isset($this->options['cache_expire'])) {
+            $this->options['cache_expire'] = $this->getStorageOption('cache_expire');
+        }
+
+        return $this->options['cache_expire'];
+    }
+
+    /**
      * Set session.hash_bits_per_character
      *
      * @param  int $hashBitsPerCharacter
-     * @return StandardConfiguration
+     * @return StandardConfig
      * @throws Exception\InvalidArgumentException
      */
     public function setHashBitsPerCharacter($hashBitsPerCharacter)
@@ -622,10 +710,24 @@ class StandardConfig implements ConfigInterface
     }
 
     /**
+     * Get session.hash_bits_per_character
+     *
+     * @return string
+     */
+    public function getHashBitsPerCharacter()
+    {
+        if (!isset($this->options['hash_bits_per_character'])) {
+            $this->options['hash_bits_per_character'] = $this->getStorageOption('hash_bits_per_character');
+        }
+
+        return $this->options['hash_bits_per_character'];
+    }
+
+    /**
      * Set remember_me_seconds
      *
      * @param  int $rememberMeSeconds
-     * @return StandardConfiguration
+     * @return StandardConfig
      * @throws Exception\InvalidArgumentException
      */
     public function setRememberMeSeconds($rememberMeSeconds)
@@ -664,7 +766,6 @@ class StandardConfig implements ConfigInterface
      */
     public function toArray()
     {
-        $options = $this->options;
         $extraOpts = array(
             'cookie_domain'       => $this->getCookieDomain(),
             'cookie_httponly'     => $this->getCookieHttpOnly(),
@@ -676,37 +777,6 @@ class StandardConfig implements ConfigInterface
             'save_path'           => $this->getSavePath(),
             'use_cookies'         => $this->getUseCookies(),
         );
-        return array_merge($options, $extraOpts);
-    }
-
-    /**
-     * Intercept get*() and set*() methods
-     *
-     * Intercepts getters and setters and passes them to getOption() and setOption(),
-     * respectively.
-     *
-     * @param  string $method
-     * @param  array $args
-     * @return mixed
-     * @throws Exception\BadMethodCallException on non-getter/setter method
-     */
-    public function __call($method, $args)
-    {
-        if ('get' == substr($method, 0, 3)) {
-            // Call to a getter; return matching option.
-            // Transform method from MixedCase to underscore_separated.
-            $option = substr($method, 3);
-            $key    = $this->getCamelCaseToUnderscoreFilter()->filter($option);
-            return $this->getOption($key);
-        }
-        if ('set' == substr($method, 0, 3)) {
-            // Call to a setter; return matching option.
-            // Transform method from MixedCase to underscore_separated.
-            $option = substr($method, 3);
-            $key    = $this->getCamelCaseToUnderscoreFilter()->filter($option);
-            $value  = array_shift($args);
-            return $this->setOption($key, $value);
-        }
-        throw new Exception\BadMethodCallException(sprintf('Method "%s" does not exist', $method));
+        return array_merge($this->options, $extraOpts);
     }
 }

--- a/library/Zend/Session/Container.php
+++ b/library/Zend/Session/Container.php
@@ -29,7 +29,9 @@ use Zend\Session\Storage\StorageInterface as Storage;
 class Container extends ArrayObject
 {
     /**
-     * @var string Container name
+     * Container name
+     *
+     * @var string
      */
     protected $name;
 
@@ -39,12 +41,16 @@ class Container extends ArrayObject
     protected $manager;
 
     /**
-     * @var string default manager class to use if no manager has been provided
+     * Default manager class to use if no manager has been provided
+     *
+     * @var string
      */
     protected static $managerDefaultClass = 'Zend\\Session\\SessionManager';
 
     /**
-     * @var Manager Default manager to use when instantiating a container without providing a ManagerInterface
+     * Default manager to use when instantiating a container without providing a ManagerInterface
+     *
+     * @var Manager
      */
     protected static $defaultManager;
 
@@ -55,12 +61,14 @@ class Container extends ArrayObject
      *
      * @param  null|string $name
      * @param  Manager $manager
-     * @return void
+     * @throws Exception\InvalidArgumentException
      */
     public function __construct($name = 'Default', Manager $manager = null)
     {
         if (!preg_match('/^[a-z][a-z0-9_\\\]+$/i', $name)) {
-            throw new Exception\InvalidArgumentException('Name passed to container is invalid; must consist of alphanumerics, backslashes and underscores only');
+            throw new Exception\InvalidArgumentException(
+                'Name passed to container is invalid; must consist of alphanumerics, backslashes and underscores only'
+            );
         }
         $this->name = $name;
         $this->setManager($manager);
@@ -96,7 +104,9 @@ class Container extends ArrayObject
         if (null === self::$defaultManager) {
             $manager = new self::$managerDefaultClass();
             if (!$manager instanceof Manager) {
-                throw new Exception\InvalidArgumentException('Invalid default manager type provided; must implement ManagerInterface');
+                throw new Exception\InvalidArgumentException(
+                    'Invalid default manager type provided; must implement ManagerInterface'
+                );
             }
             self::$defaultManager = $manager;
         }
@@ -128,13 +138,16 @@ class Container extends ArrayObject
      *
      * @param  null|Manager $manager
      * @return Container
+     * @throws Exception\InvalidArgumentException
      */
     protected function setManager(Manager $manager = null)
     {
         if (null === $manager) {
             $manager = self::getDefaultManager();
             if (!$manager instanceof Manager) {
-                throw new Exception\InvalidArgumentException('Manager provided is invalid; must implement ManagerInterface interface');
+                throw new Exception\InvalidArgumentException(
+                    'Manager provided is invalid; must implement ManagerInterface interface'
+                );
             }
         }
         $this->manager = $manager;
@@ -382,7 +395,7 @@ class Container extends ArrayObject
         if (null === ($storage = $this->verifyNamespace(false))) {
             return false;
         }
-        $name    = $this->getName();
+        $name = $this->getName();
 
         // Return early if the key isn't set
         if (!isset($storage[$name][$key])) {
@@ -444,8 +457,9 @@ class Container extends ArrayObject
      * Set the TTL for the entire container, a single key, or a set of keys.
      *
      * @param  int $ttl TTL in seconds
-     * @param  null|string|array $vars
+     * @param  string|array|null $vars
      * @return Container
+     * @throws Exception\InvalidArgumentException
      */
     public function setExpirationSeconds($ttl, $vars = null)
     {
@@ -475,7 +489,9 @@ class Container extends ArrayObject
             // Create metadata array to merge in
             $data = array('EXPIRE_KEYS' => $expires);
         } else {
-            throw new Exception\InvalidArgumentException('Unknown data provided as second argument to ' . __METHOD__);
+            throw new Exception\InvalidArgumentException(
+                'Unknown data provided as second argument to ' . __METHOD__
+            );
         }
 
         $storage->setMetadata(
@@ -521,7 +537,9 @@ class Container extends ArrayObject
             // Create metadata array to merge in
             $data = array('EXPIRE_HOPS_KEYS' => $expires);
         } else {
-            throw new Exception\InvalidArgumentException('Unknown data provided as second argument to ' . __METHOD__);
+            throw new Exception\InvalidArgumentException(
+                'Unknown data provided as second argument to ' . __METHOD__
+            );
         }
 
         $storage->setMetadata(

--- a/library/Zend/Session/Container.php
+++ b/library/Zend/Session/Container.php
@@ -124,16 +124,6 @@ class Container extends ArrayObject
     }
 
     /**
-     * Get manager instance
-     *
-     * @return Manager
-     */
-    public function getManager()
-    {
-        return $this->manager;
-    }
-
-    /**
      * Set session manager
      *
      * @param  null|Manager $manager
@@ -152,6 +142,16 @@ class Container extends ArrayObject
         }
         $this->manager = $manager;
         return $this;
+    }
+
+    /**
+     * Get manager instance
+     *
+     * @return Manager
+     */
+    public function getManager()
+    {
+        return $this->manager;
     }
 
     /**

--- a/library/Zend/Session/Exception/BadMethodCallException.php
+++ b/library/Zend/Session/Exception/BadMethodCallException.php
@@ -10,7 +10,6 @@
 
 namespace Zend\Session\Exception;
 
-class BadMethodCallException
-    extends \BadMethodCallException
-    implements ExceptionInterface
+class BadMethodCallException extends \BadMethodCallException implements
+    ExceptionInterface
 {}

--- a/library/Zend/Session/Exception/ExceptionInterface.php
+++ b/library/Zend/Session/Exception/ExceptionInterface.php
@@ -17,39 +17,4 @@ namespace Zend\Session\Exception;
  * @package    Zend_Session
  */
 interface ExceptionInterface
-{
-    /**
-     * sessionStartError
-     *
-     * @see http://framework.zend.com/issues/browse/ZF-1325
-     * @var string PHP Error Message
-     */
-    //static public $sessionStartError = null;
-
-    /**
-     * handleSessionStartError() - interface for set_error_handler()
-     *
-     * @see    http://framework.zend.com/issues/browse/ZF-1325
-     * @param  int    $errno
-     * @param  string $errstr
-     * @return void
-     */
-//    static public function handleSessionStartError($errno, $errstr, $errfile, $errline, $errcontext)
-//    {
-//        self::$sessionStartError = $errfile . '(Line:' . $errline . '): Error #' . $errno . ' ' . $errstr . ' ' . $errcontext;
-//    }
-
-    /**
-     * handleSilentWriteClose() - interface for set_error_handler()
-     *
-     * @see    http://framework.zend.com/issues/browse/ZF-1325
-     * @param  int    $errno
-     * @param  string $errstr
-     * @return void
-     */
-//    static public function handleSilentWriteClose($errno, $errstr, $errfile, $errline, $errcontext)
-//    {
-//        self::$sessionStartError .= PHP_EOL . $errfile . '(Line:' . $errline . '): Error #' . $errno . ' ' . $errstr . ' ' . $errcontext;
-//    }
-}
-
+{}

--- a/library/Zend/Session/Exception/InvalidArgumentException.php
+++ b/library/Zend/Session/Exception/InvalidArgumentException.php
@@ -10,7 +10,6 @@
 
 namespace Zend\Session\Exception;
 
-class InvalidArgumentException
-    extends \InvalidArgumentException
-    implements ExceptionInterface
+class InvalidArgumentException extends \InvalidArgumentException implements
+    ExceptionInterface
 {}

--- a/library/Zend/Session/Exception/RuntimeException.php
+++ b/library/Zend/Session/Exception/RuntimeException.php
@@ -10,7 +10,5 @@
 
 namespace Zend\Session\Exception;
 
-class RuntimeException
-    extends \RuntimeException
-    implements ExceptionInterface
+class RuntimeException extends \RuntimeException implements ExceptionInterface
 {}

--- a/library/Zend/Session/ManagerInterface.php
+++ b/library/Zend/Session/ManagerInterface.php
@@ -23,10 +23,13 @@ use Zend\Session\Storage\StorageInterface as Storage;
  */
 interface ManagerInterface
 {
-    public function __construct(Config $config = null, Storage $storage = null, SaveHandler $saveHandler = null);
-
+    public function setConfig(Config $config);
     public function getConfig();
+
+    public function setStorage(Storage $storage);
     public function getStorage();
+
+    public function setSaveHandler(SaveHandler $saveHandler);
     public function getSaveHandler();
 
     public function sessionExists();
@@ -36,6 +39,7 @@ interface ManagerInterface
 
     public function setName($name);
     public function getName();
+
     public function setId($id);
     public function getId();
     public function regenerateId();

--- a/library/Zend/Session/ManagerInterface.php
+++ b/library/Zend/Session/ManagerInterface.php
@@ -11,7 +11,7 @@
 namespace Zend\Session;
 
 use Zend\EventManager\EventManagerInterface;
-use Zend\Session\Configuration\ConfigurationInterface as Configuration;
+use Zend\Session\Config\ConfigInterface as Config;
 use Zend\Session\SaveHandler\SaveHandlerInterface as SaveHandler;
 use Zend\Session\Storage\StorageInterface as Storage;
 
@@ -23,7 +23,7 @@ use Zend\Session\Storage\StorageInterface as Storage;
  */
 interface ManagerInterface
 {
-    public function __construct(Configuration $config = null, Storage $storage = null, SaveHandler $saveHandler = null);
+    public function __construct(Config $config = null, Storage $storage = null, SaveHandler $saveHandler = null);
 
     public function getConfig();
     public function getStorage();
@@ -34,10 +34,10 @@ interface ManagerInterface
     public function destroy();
     public function writeClose();
 
-    public function getName();
     public function setName($name);
-    public function getId();
+    public function getName();
     public function setId($id);
+    public function getId();
     public function regenerateId();
 
     public function rememberMe($ttl = null);

--- a/library/Zend/Session/SaveHandler/Cache.php
+++ b/library/Zend/Session/SaveHandler/Cache.php
@@ -12,7 +12,6 @@ namespace Zend\Session\SaveHandler;
 
 use Zend\Cache\Storage\ClearExpiredInterface as ClearExpiredCacheStorage;
 use Zend\Cache\Storage\StorageInterface as CacheStorage;
-use Zend\Sessin\Exception;
 
 /**
  * Cache session save handler
@@ -47,8 +46,6 @@ class Cache implements SaveHandlerInterface
      * Constructor
      *
      * @param  CacheStorage $cacheStorage
-     * @return void
-     * @throws Exception\ExceptionInterface
      */
     public function __construct(CacheStorage $cacheStorage)
     {
@@ -58,7 +55,7 @@ class Cache implements SaveHandlerInterface
     /**
      * Open Session
      *
-     * @param string $save_path
+     * @param string $savePath
      * @param string $name
      * @return boolean
      */
@@ -133,12 +130,13 @@ class Cache implements SaveHandlerInterface
     /**
      * Set cache storage
      *
-     * @param CacheStorage
-     * @return void
+     * @param  CacheStorage $cacheStorage
+     * @return Cache
      */
     public function setCacheStorage(CacheStorage $cacheStorage)
     {
         $this->cacheStorage = $cacheStorage;
+        return $this;
     }
 
     /**

--- a/library/Zend/Session/SaveHandler/DbTableGateway.php
+++ b/library/Zend/Session/SaveHandler/DbTableGateway.php
@@ -57,20 +57,20 @@ class DbTableGateway implements SaveHandlerInterface
     /**
      * Constructor
      *
-     * @param  Zend\Db\Adapter\Adapter $adapter
-     * @param  DbTableGatewayOptions $options
+     * @param TableGateway $tableGateway
+     * @param DbTableGatewayOptions $options
      */
     public function __construct(TableGateway $tableGateway, DbTableGatewayOptions $options)
     {
         $this->tableGateway = $tableGateway;
-        $this->options = $options;
+        $this->options      = $options;
     }
 
     /**
      * Open Session
      *
-     * @param string $save_path
-     * @param string $name
+     * @param  string $savePath
+     * @param  string $name
      * @return boolean
      */
     public function open($savePath, $name)
@@ -102,7 +102,7 @@ class DbTableGateway implements SaveHandlerInterface
     {
 
         $rows = $this->tableGateway->select(array(
-            $this->options->getIdColumn() => $id,
+            $this->options->getIdColumn()   => $id,
             $this->options->getNameColumn() => $this->sessionName,
         ));
 
@@ -150,13 +150,13 @@ class DbTableGateway implements SaveHandlerInterface
     /**
      * Destroy session
      *
-     * @param string $id
+     * @param  string $id
      * @return boolean
      */
     public function destroy($id)
     {
         return (bool) $this->tableGateway->delete(array(
-            $this->options->getIdColumn() => $id,
+            $this->options->getIdColumn()   => $id,
             $this->options->getNameColumn() => $this->sessionName,
         ));
     }

--- a/library/Zend/Session/SaveHandler/DbTableGatewayOptions.php
+++ b/library/Zend/Session/SaveHandler/DbTableGatewayOptions.php
@@ -53,16 +53,6 @@ class DbTableGatewayOptions extends AbstractOptions
     protected $nameColumn = 'name';
 
     /**
-     * Get Data Column
-     *
-     * @return string
-     */
-    public function getDataColumn()
-    {
-        return $this->dataColumn;
-    }
-
-    /**
      * Set Data Column
      *
      * @param string $dataColumn
@@ -80,13 +70,13 @@ class DbTableGatewayOptions extends AbstractOptions
     }
 
     /**
-     * Get Id Column
+     * Get Data Column
      *
      * @return string
      */
-    public function getIdColumn()
+    public function getDataColumn()
     {
-        return $this->idColumn;
+        return $this->dataColumn;
     }
 
     /**
@@ -104,6 +94,16 @@ class DbTableGatewayOptions extends AbstractOptions
         }
         $this->idColumn = $idColumn;
         return $this;
+    }
+
+    /**
+     * Get Id Column
+     *
+     * @return string
+     */
+    public function getIdColumn()
+    {
+        return $this->idColumn;
     }
 
     /**
@@ -134,16 +134,6 @@ class DbTableGatewayOptions extends AbstractOptions
     }
 
     /**
-     * Get Modified Column
-     *
-     * @return string
-     */
-    public function getModifiedColumn()
-    {
-        return $this->modifiedColumn;
-    }
-
-    /**
      * Set Modified Column
      *
      * @param string $modifiedColumn
@@ -161,13 +151,13 @@ class DbTableGatewayOptions extends AbstractOptions
     }
 
     /**
-     * Get Name Column
+     * Get Modified Column
      *
      * @return string
      */
-    public function getNameColumn()
+    public function getModifiedColumn()
     {
-        return $this->nameColumn;
+        return $this->modifiedColumn;
     }
 
     /**
@@ -185,5 +175,15 @@ class DbTableGatewayOptions extends AbstractOptions
         }
         $this->nameColumn = $nameColumn;
         return $this;
+    }
+
+    /**
+     * Get Name Column
+     *
+     * @return string
+     */
+    public function getNameColumn()
+    {
+        return $this->nameColumn;
     }
 }

--- a/library/Zend/Session/SaveHandler/DbTableGatewayOptions.php
+++ b/library/Zend/Session/SaveHandler/DbTableGatewayOptions.php
@@ -23,16 +23,22 @@ use Zend\Stdlib\AbstractOptions;
 class DbTableGatewayOptions extends AbstractOptions
 {
     /**
-     * Data Column
-     * @var string
-     */
-    protected $dataColumn = 'data';
-
-    /**
      * ID Column
      * @var string
      */
     protected $idColumn = 'id';
+
+    /**
+     * Name Column
+     * @var string
+     */
+    protected $nameColumn = 'name';
+
+    /**
+     * Data Column
+     * @var string
+     */
+    protected $dataColumn = 'data';
 
     /**
      * Lifetime Column
@@ -46,38 +52,6 @@ class DbTableGatewayOptions extends AbstractOptions
      */
     protected $modifiedColumn = 'modified';
 
-    /**
-     * Name Column
-     * @var string
-     */
-    protected $nameColumn = 'name';
-
-    /**
-     * Set Data Column
-     *
-     * @param string $dataColumn
-     * @return DbTableGatewayOptions
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setDataColumn($dataColumn)
-    {
-        $dataColumn = (string) $dataColumn;
-        if (strlen($dataColumn) === 0) {
-            throw new Exception\InvalidArgumentException('$dataColumn must be a non-empty string');
-        }
-        $this->dataColumn = $dataColumn;
-        return $this;
-    }
-
-    /**
-     * Get Data Column
-     *
-     * @return string
-     */
-    public function getDataColumn()
-    {
-        return $this->dataColumn;
-    }
 
     /**
      * Set Id Column
@@ -107,13 +81,57 @@ class DbTableGatewayOptions extends AbstractOptions
     }
 
     /**
-     * Get Lifetime Column
+     * Set Name Column
+     *
+     * @param string $nameColumn
+     * @return DbTableGatewayOptions
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setNameColumn($nameColumn)
+    {
+        $nameColumn = (string) $nameColumn;
+        if (strlen($nameColumn) === 0) {
+            throw new Exception\InvalidArgumentException('$nameColumn must be a non-empty string');
+        }
+        $this->nameColumn = $nameColumn;
+        return $this;
+    }
+
+    /**
+     * Get Name Column
      *
      * @return string
      */
-    public function getLifetimeColumn()
+    public function getNameColumn()
     {
-        return $this->lifetimeColumn;
+        return $this->nameColumn;
+    }
+
+    /**
+     * Set Data Column
+     *
+     * @param string $dataColumn
+     * @return DbTableGatewayOptions
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setDataColumn($dataColumn)
+    {
+        $dataColumn = (string) $dataColumn;
+        if (strlen($dataColumn) === 0) {
+            throw new Exception\InvalidArgumentException('$dataColumn must be a non-empty string');
+        }
+        $this->dataColumn = $dataColumn;
+        return $this;
+    }
+
+    /**
+     * Get Data Column
+     *
+     * @return string
+     */
+    public function getDataColumn()
+    {
+        return $this->dataColumn;
     }
 
     /**
@@ -131,6 +149,16 @@ class DbTableGatewayOptions extends AbstractOptions
         }
         $this->lifetimeColumn = $lifetimeColumn;
         return $this;
+    }
+
+    /**
+     * Get Lifetime Column
+     *
+     * @return string
+     */
+    public function getLifetimeColumn()
+    {
+        return $this->lifetimeColumn;
     }
 
     /**
@@ -158,32 +186,5 @@ class DbTableGatewayOptions extends AbstractOptions
     public function getModifiedColumn()
     {
         return $this->modifiedColumn;
-    }
-
-    /**
-     * Set Name Column
-     *
-     * @param string $nameColumn
-     * @return DbTableGatewayOptions
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setNameColumn($nameColumn)
-    {
-        $nameColumn = (string) $nameColumn;
-        if (strlen($nameColumn) === 0) {
-            throw new Exception\InvalidArgumentException('$nameColumn must be a non-empty string');
-        }
-        $this->nameColumn = $nameColumn;
-        return $this;
-    }
-
-    /**
-     * Get Name Column
-     *
-     * @return string
-     */
-    public function getNameColumn()
-    {
-        return $this->nameColumn;
     }
 }

--- a/library/Zend/Session/SaveHandler/SaveHandlerInterface.php
+++ b/library/Zend/Session/SaveHandler/SaveHandlerInterface.php
@@ -22,7 +22,7 @@ interface SaveHandlerInterface
     /**
      * Open Session - retrieve resources
      *
-     * @param string $save_path
+     * @param string $savePath
      * @param string $name
      */
     public function open($savePath, $name);

--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -91,9 +91,7 @@ class SessionManager extends AbstractManager
 
         // Since session is starting, we need to potentially repopulate our
         // session storage
-        if ($storage instanceof Storage\SessionStorage
-            && $_SESSION !== $storage
-        ) {
+        if ($storage instanceof Storage\SessionStorage && $_SESSION !== $storage) {
             if (!$preserveStorage) {
                 $storage->fromArray($_SESSION);
             }
@@ -132,7 +130,7 @@ class SessionManager extends AbstractManager
     /**
      * Write session to save handler and close
      *
-     * Once done, the Storage object will be marked as immutable.
+     * Once done, the Storage object will be marked as isImmutable.
      *
      * @return void
      */
@@ -148,31 +146,12 @@ class SessionManager extends AbstractManager
         // Additionally, while you _can_ write to $_SESSION following a
         // session_write_close() operation, no changes made to it will be
         // flushed to the session handler. As such, we now mark the storage
-        // object immutable.
+        // object isImmutable.
         $storage  = $this->getStorage();
         $_SESSION = (array) $storage;
         session_write_close();
         $storage->fromArray($_SESSION);
         $storage->markImmutable();
-    }
-
-    /**
-     * Get session name
-     *
-     * Proxies to {@link session_name()}.
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        if (null === $this->name) {
-            // If we're grabbing via session_name(), we don't need our
-            // validation routine; additionally, calling setName() after
-            // session_start() can lead to issues, and often we just need the name
-            // in order to do things such as setting cookies.
-            $this->name = session_name();
-        }
-        return $this->name;
     }
 
     /**
@@ -205,15 +184,22 @@ class SessionManager extends AbstractManager
     }
 
     /**
-     * Get session ID
+     * Get session name
      *
-     * Proxies to {@link session_id()}
+     * Proxies to {@link session_name()}.
      *
      * @return string
      */
-    public function getId()
+    public function getName()
     {
-        return session_id();
+        if (null === $this->name) {
+            // If we're grabbing via session_name(), we don't need our
+            // validation routine; additionally, calling setName() after
+            // session_start() can lead to issues, and often we just need the name
+            // in order to do things such as setting cookies.
+            $this->name = session_name();
+        }
+        return $this->name;
     }
 
     /**
@@ -234,6 +220,18 @@ class SessionManager extends AbstractManager
         session_id($id);
         $this->start();
         return $this;
+    }
+
+    /**
+     * Get session ID
+     *
+     * Proxies to {@link session_id()}
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return session_id();
     }
 
     /**
@@ -300,7 +298,7 @@ class SessionManager extends AbstractManager
      *
      * By default, uses an instance of {@link ValidatorChain}.
      *
-     * @return void
+     * @return EventManagerInterface
      */
     public function getValidatorChain()
     {

--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -168,7 +168,7 @@ class SessionManager extends AbstractManager
     {
         if ($this->sessionExists()) {
             throw new Exception\InvalidArgumentException(
-                'Cannot set session name after a session has already started'
+                'Can not set session name; session has already started'
             );
         }
 

--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -168,7 +168,7 @@ class SessionManager extends AbstractManager
     {
         if ($this->sessionExists()) {
             throw new Exception\InvalidArgumentException(
-                'Can not set session name; session has already started'
+                'Cannot set session name after a session has already started'
             );
         }
 

--- a/library/Zend/Session/Storage/ArrayStorage.php
+++ b/library/Zend/Session/Storage/ArrayStorage.php
@@ -17,7 +17,7 @@ use Zend\Session\Exception;
  * Array session storage
  *
  * Defines an ArrayObject interface for accessing session storage, with options
- * for setting metadata, locking, and marking as immutable.
+ * for setting metadata, locking, and marking as isImmutable.
  *
  * @category   Zend
  * @package    Zend_Session
@@ -26,10 +26,10 @@ use Zend\Session\Exception;
 class ArrayStorage extends ArrayObject implements StorageInterface
 {
     /**
-     * Is storage marked immutable?
+     * Is storage marked isImmutable?
      * @var bool
      */
-    protected $_immutable = false;
+    protected $isImmutable = false;
 
     /**
      * Constructor
@@ -37,13 +37,15 @@ class ArrayStorage extends ArrayObject implements StorageInterface
      * Instantiates storage as an ArrayObject, allowing property access.
      * Also sets the initial request access time.
      *
-     * @param  array|ArrayAccess $input
+     * @param  array $input
      * @param  int $flags
      * @param  string $iteratorClass
-     * @return void
      */
-    public function __construct($input = array(), $flags = \ArrayObject::ARRAY_AS_PROPS, $iteratorClass = '\\ArrayIterator')
-    {
+    public function __construct(
+        $input = array(),
+        $flags = ArrayObject::ARRAY_AS_PROPS,
+        $iteratorClass = '\\ArrayIterator'
+    ) {
         parent::__construct($input, $flags, $iteratorClass);
         $this->setMetadata('_REQUEST_ACCESS_TIME', microtime(true));
     }
@@ -61,22 +63,33 @@ class ArrayStorage extends ArrayObject implements StorageInterface
     /**
      * Set a value in the storage object
      *
-     * If the object is marked as immutable, or the object or key is marked as
+     * If the object is marked as isImmutable, or the object or key is marked as
      * locked, raises an exception.
      *
      * @param  string $key
      * @param  mixed $value
      * @return void
      */
+
+    /**
+     * @param  mixed $key
+     * @param  mixed $value
+     * @throws Exception\RuntimeException
+     */
     public function offsetSet($key, $value)
     {
         if ($this->isImmutable()) {
-            throw new Exception\RuntimeException('Cannot set key "' . $key . '" as storage is marked immutable');
+            throw new Exception\RuntimeException(sprintf(
+                'Cannot set key "%s" as storage is marked isImmutable', $key
+            ));
         }
         if ($this->isLocked($key)) {
-            throw new Exception\RuntimeException('Cannot set key "' . $key . '" due to locking');
+            throw new Exception\RuntimeException(sprintf(
+                'Cannot set key "%s" due to locking', $key
+            ));
         }
-        return parent::offsetSet($key, $value);
+
+        parent::offsetSet($key, $value);
     }
 
     /**
@@ -107,7 +120,7 @@ class ArrayStorage extends ArrayObject implements StorageInterface
     public function isLocked($key = null)
     {
         if ($this->isImmutable()) {
-            // immutable trumps all
+            // isImmutable trumps all
             return true;
         }
 
@@ -167,24 +180,24 @@ class ArrayStorage extends ArrayObject implements StorageInterface
     }
 
     /**
-     * Mark the storage container as immutable
+     * Mark the storage container as isImmutable
      *
      * @return ArrayStorage
      */
     public function markImmutable()
     {
-        $this->_immutable = true;
+        $this->isImmutable = true;
         return $this;
     }
 
     /**
-     * Is the storage container marked as immutable?
+     * Is the storage container marked as isImmutable?
      *
      * @return bool
      */
     public function isImmutable()
     {
-        return $this->_immutable;
+        return $this->isImmutable;
     }
 
     /**
@@ -201,11 +214,14 @@ class ArrayStorage extends ArrayObject implements StorageInterface
      * @param  mixed $value
      * @param  bool $overwriteArray Whether to overwrite or merge array values; by default, merges
      * @return ArrayStorage
+     * @throws Exception\RuntimeException
      */
     public function setMetadata($key, $value, $overwriteArray = false)
     {
-        if ($this->_immutable) {
-            throw new Exception\InvalidArgumentException('Cannot set metadata key "' . $key . '" as storage is marked immutable');
+        if ($this->isImmutable) {
+            throw new Exception\RuntimeException(sprintf(
+                'Cannot set key "%s" as storage is marked isImmutable', $key
+            ));
         }
 
         if (!isset($this['__ZF'])) {
@@ -265,6 +281,7 @@ class ArrayStorage extends ArrayObject implements StorageInterface
      *
      * @param  null|int|string $key
      * @return ArrayStorage
+     * @throws Exception\RuntimeException
      */
     public function clear($key = null)
     {
@@ -291,6 +308,20 @@ class ArrayStorage extends ArrayObject implements StorageInterface
     }
 
     /**
+     * Load the storage from another array
+     *
+     * Overwrites any data that was previously set.
+     *
+     * @param  array $array
+     * @return ArrayStorage
+     */
+    public function fromArray(array $array)
+    {
+        $this->exchangeArray($array);
+        return $this;
+    }
+
+    /**
      * Cast the object to an array
      *
      * Returns data only, no metadata.
@@ -304,19 +335,5 @@ class ArrayStorage extends ArrayObject implements StorageInterface
             unset($values['__ZF']);
         }
         return $values;
-    }
-
-    /**
-     * Load the storage from another array
-     *
-     * Overwrites any data that was previously set.
-     *
-     * @param  array $array
-     * @return ArrayStorage
-     */
-    public function fromArray(array $array)
-    {
-        $this->exchangeArray($array);
-        return $this;
     }
 }

--- a/library/Zend/Session/Storage/SessionStorage.php
+++ b/library/Zend/Session/Storage/SessionStorage.php
@@ -10,6 +10,8 @@
 
 namespace Zend\Session\Storage;
 
+use ArrayObject;
+
 /**
  * Session storage in $_SESSION
  *
@@ -28,12 +30,11 @@ class SessionStorage extends ArrayStorage
      * Sets the $_SESSION superglobal to an ArrayObject, maintaining previous
      * values if any discovered.
      *
-     * @param  null|array|ArrayAccess $input
+     * @param  array|null $input
      * @param  int $flags
      * @param  string $iteratorClass
-     * @return void
      */
-    public function __construct($input = null, $flags = \ArrayObject::ARRAY_AS_PROPS, $iteratorClass = '\\ArrayIterator')
+    public function __construct($input = null, $flags = ArrayObject::ARRAY_AS_PROPS, $iteratorClass = '\\ArrayIterator')
     {
         $resetSession = true;
         if ((null === $input) && isset($_SESSION)) {
@@ -83,17 +84,18 @@ class SessionStorage extends ArrayStorage
     }
 
     /**
-     * Mark object as immutable
+     * Mark object as isImmutable
      *
-     * @return void
+     * @return SessionStorage
      */
     public function markImmutable()
     {
         $this['_IMMUTABLE'] = true;
+        return $this;
     }
 
     /**
-     * Determine if this object is immutable
+     * Determine if this object is isImmutable
      *
      * @return bool
      */

--- a/library/Zend/Session/Storage/StorageInterface.php
+++ b/library/Zend/Session/Storage/StorageInterface.php
@@ -10,10 +10,10 @@
 
 namespace Zend\Session\Storage;
 
-use ArrayAccess;
-use Countable;
-use Serializable;
 use Traversable;
+use ArrayAccess;
+use Serializable;
+use Countable;
 
 /**
  * Session storage interface
@@ -27,9 +27,11 @@ use Traversable;
 interface StorageInterface extends Traversable, ArrayAccess, Serializable, Countable
 {
     public function getRequestAccessTime();
+
     public function lock($key = null);
     public function isLocked($key = null);
     public function unlock($key = null);
+
     public function markImmutable();
     public function isImmutable();
 
@@ -38,6 +40,6 @@ interface StorageInterface extends Traversable, ArrayAccess, Serializable, Count
 
     public function clear($key = null);
 
-    public function toArray();
     public function fromArray(array $array);
+    public function toArray();
 }

--- a/library/Zend/Session/Validator/HttpUserAgent.php
+++ b/library/Zend/Session/Validator/HttpUserAgent.php
@@ -18,10 +18,17 @@ namespace Zend\Session\Validator;
 class HttpUserAgent implements ValidatorInterface
 {
     /**
-     * Constructor - get the current user agent and store it in the session
-     * as 'valid data'
+     * Internal data
      *
-     * @return void
+     * @var string
+     */
+    protected $data;
+
+    /**
+     * Constructor
+     * get the current user agent and store it in the session as 'valid data'
+     *
+     * @param string|null $data
      */
     public function __construct($data = null)
     {
@@ -30,7 +37,7 @@ class HttpUserAgent implements ValidatorInterface
                   ? $_SERVER['HTTP_USER_AGENT']
                   : null;
         }
-        $this->_data = $data;
+        $this->data = $data;
     }
 
     /**
@@ -45,7 +52,7 @@ class HttpUserAgent implements ValidatorInterface
                    ? $_SERVER['HTTP_USER_AGENT']
                    : null;
 
-        return $userAgent === $this->getData();
+        return ($userAgent === $this->getData());
     }
 
     /**
@@ -55,7 +62,7 @@ class HttpUserAgent implements ValidatorInterface
      */
     public function getData()
     {
-        return $this->_data;
+        return $this->data;
     }
 
     /**

--- a/library/Zend/Session/Validator/RemoteAddr.php
+++ b/library/Zend/Session/Validator/RemoteAddr.php
@@ -22,7 +22,7 @@ class RemoteAddr implements SessionValidator
     /**
      * Internal data.
      *
-     * @var int
+     * @var string
      */
     protected $data;
 
@@ -39,10 +39,8 @@ class RemoteAddr implements SessionValidator
     protected static $useProxy = false;
 
     /**
-     * Constructor - get the current user IP and store it in the session
-     * as 'valid data'
-     *
-     * @return void
+     * Constructor
+     * get the current user IP and store it in the session as 'valid data'
      */
     public function __construct($data = null)
     {
@@ -60,7 +58,7 @@ class RemoteAddr implements SessionValidator
      */
     public function isValid()
     {
-        return $this->getIpAddress() === $this->getData();
+        return ($this->getIpAddress() === $this->getData());
     }
 
     /**

--- a/library/Zend/Session/ValidatorChain.php
+++ b/library/Zend/Session/ValidatorChain.php
@@ -32,8 +32,7 @@ class ValidatorChain extends EventManager
      *
      * Retrieves validators from session storage and attaches them.
      *
-     * @param  Storage $storage
-     * @return void
+     * @param Storage $storage
      */
     public function __construct(Storage $storage)
     {
@@ -57,6 +56,7 @@ class ValidatorChain extends EventManager
      */
     public function attach($event, $callback = null, $priority = 1)
     {
+        /** @var Validator $context  */
         $context = null;
         if ($callback instanceof Validator) {
             $context = $callback;

--- a/library/Zend/Session/composer.json
+++ b/library/Zend/Session/composer.json
@@ -17,7 +17,6 @@
     },
     "suggest": {
         "zendframework/zend-validator": "Zend\\Validator component",
-        "zendframework/zend-filter": "Zend\\Filter component",
         "zendframework/zend-eventmanager": "Zend\\EventManager component"
     }
 }

--- a/tests/Zend/Session/Config/SessionConfigTest.php
+++ b/tests/Zend/Session/Config/SessionConfigTest.php
@@ -10,19 +10,25 @@
 
 namespace ZendTest\Session;
 
-use Zend\Session\Configuration\StandardConfiguration;
+use Zend\Session\Config\SessionConfig;
 
 /**
  * @category   Zend
  * @package    Zend_Session
  * @subpackage UnitTests
  * @group      Zend_Session
+ * @runTestsInSeparateProcesses
  */
-class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
+class SessionConfigTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var SessionConfig
+     */
+    protected $config;
+
     public function setUp()
     {
-        $this->config = new StandardConfiguration;
+        $this->config = new SessionConfig;
     }
 
     // session.save_path
@@ -33,12 +39,29 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->config->setSavePath(__DIR__ . '/foobarboguspath');
     }
 
+    public function testSavePathDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.save_path'), $this->config->getSavePath());
+    }
+
     public function testSavePathIsMutable()
     {
         $this->config->setSavePath(__DIR__);
         $this->assertEquals(__DIR__, $this->config->getSavePath());
     }
+
+    public function testSavePathAltersIniSetting()
+    {
+        $this->config->setSavePath(__DIR__);
+        $this->assertEquals(__DIR__, ini_get('session.save_path'));
+    }
+
     // session.name
+
+    public function testNameDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.name'), $this->config->getName());
+    }
 
     public function testNameIsMutable()
     {
@@ -46,7 +69,18 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('FOOBAR', $this->config->getName());
     }
 
+    public function testNameAltersIniSetting()
+    {
+        $this->config->setName('FOOBAR');
+        $this->assertEquals('FOOBAR', ini_get('session.name'));
+    }
+
     // session.save_handler
+
+    public function testSaveHandlerDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.save_handler'), $this->config->getSaveHandler(), var_export($this->config->toArray(), 1));
+    }
 
     public function testSaveHandlerIsMutable()
     {
@@ -54,12 +88,35 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('user', $this->config->getSaveHandler());
     }
 
+    public function testSaveHandlerAltersIniSetting()
+    {
+        $this->config->setSaveHandler('user');
+        $this->assertEquals('user', ini_get('session.save_handler'));
+    }
+
+    public function testSettingInvalidSaveHandlerRaisesException()
+    {
+        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid save handler specified');
+        $this->config->setPhpSaveHandler('foobar_bogus');
+    }
+
     // session.gc_probability
+
+    public function testGcProbabilityDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.gc_probability'), $this->config->getGcProbability());
+    }
 
     public function testGcProbabilityIsMutable()
     {
         $this->config->setGcProbability(20);
         $this->assertEquals(20, $this->config->getGcProbability());
+    }
+
+    public function testGcProbabilityAltersIniSetting()
+    {
+        $this->config->setGcProbability(24);
+        $this->assertEquals(24, ini_get('session.gc_probability'));
     }
 
     public function testSettingInvalidGcProbabilityRaisesException()
@@ -82,10 +139,21 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
 
     // session.gc_divisor
 
+    public function testGcDivisorDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.gc_divisor'), $this->config->getGcDivisor());
+    }
+
     public function testGcDivisorIsMutable()
     {
         $this->config->setGcDivisor(20);
         $this->assertEquals(20, $this->config->getGcDivisor());
+    }
+
+    public function testGcDivisorAltersIniSetting()
+    {
+        $this->config->setGcDivisor(24);
+        $this->assertEquals(24, ini_get('session.gc_divisor'));
     }
 
     public function testSettingInvalidGcDivisorRaisesException()
@@ -102,10 +170,21 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
 
     // session.gc_maxlifetime
 
+    public function testGcMaxlifetimeDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.gc_maxlifetime'), $this->config->getGcMaxlifetime());
+    }
+
     public function testGcMaxlifetimeIsMutable()
     {
         $this->config->setGcMaxlifetime(20);
         $this->assertEquals(20, $this->config->getGcMaxlifetime());
+    }
+
+    public function testGcMaxlifetimeAltersIniSetting()
+    {
+        $this->config->setGcMaxlifetime(24);
+        $this->assertEquals(24, ini_get('session.gc_maxlifetime'));
     }
 
     public function testSettingInvalidGcMaxlifetimeRaisesException()
@@ -122,6 +201,11 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
 
     // session.serialize_handler
 
+    public function testSerializeHandlerDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.serialize_handler'), $this->config->getSerializeHandler());
+    }
+
     public function testSerializeHandlerIsMutable()
     {
         $value = extension_loaded('wddx') ? 'wddx' : 'php_binary';
@@ -129,7 +213,25 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($value, $this->config->getSerializeHandler());
     }
 
+    public function testSerializeHandlerAltersIniSetting()
+    {
+        $value = extension_loaded('wddx') ? 'wddx' : 'php_binary';
+        $this->config->setSerializeHandler($value);
+        $this->assertEquals($value, ini_get('session.serialize_handler'));
+    }
+
+    public function testSettingInvalidSerializeHandlerRaisesException()
+    {
+        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid serialize handler specified');
+        $this->config->setSerializeHandler('foobar_bogus');
+    }
+
     // session.cookie_lifetime
+
+    public function testCookieLifetimeDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.cookie_lifetime'), $this->config->getCookieLifetime());
+    }
 
     public function testCookieLifetimeIsMutable()
     {
@@ -137,10 +239,16 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(20, $this->config->getCookieLifetime());
     }
 
+    public function testCookieLifetimeAltersIniSetting()
+    {
+        $this->config->setCookieLifetime(24);
+        $this->assertEquals(24, ini_get('session.cookie_lifetime'));
+    }
+
     public function testCookieLifetimeCanBeZero()
     {
         $this->config->setCookieLifetime(0);
-        $this->assertEquals(0, $this->config->getCookieLifetime());
+        $this->assertEquals(0, ini_get('session.cookie_lifetime'));
     }
 
     public function testSettingInvalidCookieLifetimeRaisesException()
@@ -157,10 +265,21 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
 
     // session.cookie_path
 
+    public function testCookiePathDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.cookie_path'), $this->config->getCookiePath());
+    }
+
     public function testCookiePathIsMutable()
     {
         $this->config->setCookiePath('/foo');
         $this->assertEquals('/foo', $this->config->getCookiePath());
+    }
+
+    public function testCookiePathAltersIniSetting()
+    {
+        $this->config->setCookiePath('/bar');
+        $this->assertEquals('/bar', ini_get('session.cookie_path'));
     }
 
     public function testSettingInvalidCookiePathRaisesException()
@@ -183,6 +302,11 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
 
     // session.cookie_domain
 
+    public function testCookieDomainDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.cookie_domain'), $this->config->getCookieDomain());
+    }
+
     public function testCookieDomainIsMutable()
     {
         $this->config->setCookieDomain('example.com');
@@ -193,6 +317,12 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $this->config->setCookieDomain('');
         $this->assertEquals('', $this->config->getCookieDomain());
+    }
+
+    public function testCookieDomainAltersIniSetting()
+    {
+        $this->config->setCookieDomain('localhost');
+        $this->assertEquals('localhost', ini_get('session.cookie_domain'));
     }
 
     public function testSettingInvalidCookieDomainRaisesException()
@@ -209,48 +339,111 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
 
     // session.cookie_secure
 
+    public function testCookieSecureDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.cookie_secure'), $this->config->getCookieSecure());
+    }
+
     public function testCookieSecureIsMutable()
     {
-        $this->config->setCookieSecure(true);
-        $this->assertEquals(true, $this->config->getCookieSecure());
+        $value = ini_get('session.cookie_secure') ? false : true;
+        $this->config->setCookieSecure($value);
+        $this->assertEquals($value, $this->config->getCookieSecure());
+    }
+
+    public function testCookieSecureAltersIniSetting()
+    {
+        $value = ini_get('session.cookie_secure') ? false : true;
+        $this->config->setCookieSecure($value);
+        $this->assertEquals($value, ini_get('session.cookie_secure'));
     }
 
     // session.cookie_httponly
 
+    public function testCookieHttpOnlyDefaultsToIniSettings()
+    {
+        $this->assertSame((bool) ini_get('session.cookie_httponly'), $this->config->getCookieHttpOnly());
+    }
+
     public function testCookieHttpOnlyIsMutable()
     {
-        $this->config->setCookieHttpOnly(true);
-        $this->assertEquals(true, $this->config->getCookieHttpOnly());
+        $value = ini_get('session.cookie_httponly') ? false : true;
+        $this->config->setCookieHttpOnly($value);
+        $this->assertEquals($value, $this->config->getCookieHttpOnly());
+    }
+
+    public function testCookieHttpOnlyAltersIniSetting()
+    {
+        $value = ini_get('session.cookie_httponly') ? false : true;
+        $this->config->setCookieHttpOnly($value);
+        $this->assertEquals($value, ini_get('session.cookie_httponly'));
     }
 
     // session.use_cookies
 
+    public function testUseCookiesDefaultsToIniSettings()
+    {
+        $this->assertSame((bool) ini_get('session.use_cookies'), $this->config->getUseCookies());
+    }
+
     public function testUseCookiesIsMutable()
     {
-        $this->config->setUseCookies(true);
-        $this->assertEquals(true, (bool) $this->config->getUseCookies());
+        $value = ini_get('session.use_cookies') ? false : true;
+        $this->config->setUseCookies($value);
+        $this->assertEquals($value, (bool) $this->config->getUseCookies());
+    }
+
+    public function testUseCookiesAltersIniSetting()
+    {
+        $value = ini_get('session.use_cookies') ? false : true;
+        $this->config->setUseCookies($value);
+        $this->assertEquals($value, (bool) ini_get('session.use_cookies'));
     }
 
     // session.use_only_cookies
 
+    public function testUseOnlyCookiesDefaultsToIniSettings()
+    {
+        $this->assertSame((bool) ini_get('session.use_only_cookies'), $this->config->getUseOnlyCookies());
+    }
+
     public function testUseOnlyCookiesIsMutable()
     {
-        $this->config->setUseOnlyCookies(true);
-        $this->assertEquals(true, (bool) $this->config->getUseOnlyCookies());
+        $value = ini_get('session.use_only_cookies') ? false : true;
+        $this->config->setOption('use_only_cookies', $value);
+        $this->assertEquals($value, (bool) $this->config->getOption('use_only_cookies'));
+    }
+
+    public function testUseOnlyCookiesAltersIniSetting()
+    {
+        $value = ini_get('session.use_only_cookies') ? false : true;
+        $this->config->setOption('use_only_cookies', $value);
+        $this->assertEquals($value, (bool) ini_get('session.use_only_cookies'));
     }
 
     // session.referer_check
 
+    public function testRefererCheckDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.referer_check'), $this->config->getRefererCheck());
+    }
+
     public function testRefererCheckIsMutable()
     {
-        $this->config->setRefererCheck('FOOBAR');
-        $this->assertEquals('FOOBAR', $this->config->getRefererCheck());
+        $this->config->setOption('referer_check', 'FOOBAR');
+        $this->assertEquals('FOOBAR', $this->config->getOption('referer_check'));
     }
 
     public function testRefererCheckMayBeEmpty()
     {
-        $this->config->setRefererCheck('');
-        $this->assertEquals('', $this->config->getRefererCheck());
+        $this->config->setOption('referer_check', '');
+        $this->assertEquals('', $this->config->getOption('referer_check'));
+    }
+
+    public function testRefererCheckAltersIniSetting()
+    {
+        $this->config->setOption('referer_check', 'BARBAZ');
+        $this->assertEquals('BARBAZ', ini_get('session.referer_check'));
     }
 
     // session.entropy_file
@@ -267,13 +460,29 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->config->setEntropyFile(__DIR__);
     }
 
+    public function testEntropyFileDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.entropy_file'), $this->config->getEntropyFile());
+    }
+
     public function testEntropyFileIsMutable()
     {
         $this->config->setEntropyFile(__FILE__);
         $this->assertEquals(__FILE__, $this->config->getEntropyFile());
     }
 
+    public function testEntropyFileAltersIniSetting()
+    {
+        $this->config->setEntropyFile(__FILE__);
+        $this->assertEquals(__FILE__, ini_get('session.entropy_file'));
+    }
+
     // session.entropy_length
+
+    public function testEntropyLengthDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.entropy_length'), $this->config->getEntropyLength());
+    }
 
     public function testEntropyLengthIsMutable()
     {
@@ -281,21 +490,29 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(20, $this->config->getEntropyLength());
     }
 
+    public function testEntropyLengthAltersIniSetting()
+    {
+        $this->config->setEntropyLength(24);
+        $this->assertEquals(24, ini_get('session.entropy_length'));
+    }
+
     public function testEntropyLengthCanBeZero()
     {
         $this->config->setEntropyLength(0);
-        $this->assertEquals(0, $this->config->getEntropyLength());
+        $this->assertEquals(0, ini_get('session.entropy_length'));
     }
 
     public function testSettingInvalidEntropyLengthRaisesException()
     {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid entropy_length; must be numeric');
+        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException',
+                                    'Invalid entropy_length; must be numeric');
         $this->config->setEntropyLength('foobar_bogus');
     }
 
     public function testSettingInvalidEntropyLengthRaisesException2()
     {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid entropy_length; must be a positive integer or zero');
+        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException',
+                                    'Invalid entropy_length; must be a positive integer or zero');
         $this->config->setEntropyLength(-1);
     }
 
@@ -311,6 +528,11 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testCacheLimiterDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.cache_limiter'), $this->config->getCacheLimiter());
+    }
+
     /**
      * @dataProvider cacheLimiters
      */
@@ -320,12 +542,38 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($cacheLimiter, $this->config->getCacheLimiter());
     }
 
+    /**
+     * @dataProvider cacheLimiters
+     */
+    public function testCacheLimiterAltersIniSetting($cacheLimiter)
+    {
+        $this->config->setCacheLimiter($cacheLimiter);
+        $this->assertEquals($cacheLimiter, ini_get('session.cache_limiter'));
+    }
+
+    public function testSettingInvalidCacheLimiterRaisesException()
+    {
+        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid cache limiter provided');
+        $this->config->setCacheLimiter('foobar_bogus');
+    }
+
     // session.cache_expire
+
+    public function testCacheExpireDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.cache_expire'), $this->config->getCacheExpire());
+    }
 
     public function testCacheExpireIsMutable()
     {
         $this->config->setCacheExpire(20);
         $this->assertEquals(20, $this->config->getCacheExpire());
+    }
+
+    public function testCacheExpireAltersIniSetting()
+    {
+        $this->config->setCacheExpire(24);
+        $this->assertEquals(24, ini_get('session.cache_expire'));
     }
 
     public function testSettingInvalidCacheExpireRaisesException()
@@ -342,10 +590,23 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
 
     // session.use_trans_sid
 
+    public function testUseTransSidDefaultsToIniSettings()
+    {
+        $this->assertSame((bool) ini_get('session.use_trans_sid'), $this->config->getUseTransSid());
+    }
+
     public function testUseTransSidIsMutable()
     {
-        $this->config->setUseTransSid(true);
-        $this->assertEquals(true, (bool) $this->config->getUseTransSid());
+        $value = ini_get('session.use_trans_sid') ? false : true;
+        $this->config->setOption('use_trans_sid', $value);
+        $this->assertEquals($value, (bool) $this->config->getOption('use_trans_sid'));
+    }
+
+    public function testUseTransSidAltersIniSetting()
+    {
+        $value = ini_get('session.use_trans_sid') ? false : true;
+        $this->config->setOption('use_trans_sid', $value);
+        $this->assertEquals($value, (bool) ini_get('session.use_trans_sid'));
     }
 
     // session.hash_function
@@ -360,6 +621,11 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
         return $provider;
     }
 
+    public function testHashFunctionDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.hash_function'), $this->config->getHashFunction());
+    }
+
     /**
      * @dataProvider hashFunctions
      */
@@ -367,6 +633,21 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $this->config->setHashFunction($hashFunction);
         $this->assertEquals($hashFunction, $this->config->getHashFunction());
+    }
+
+    /**
+     * @dataProvider hashFunctions
+     */
+    public function testHashFunctionAltersIniSetting($hashFunction)
+    {
+        $this->config->setHashFunction($hashFunction);
+        $this->assertEquals($hashFunction, ini_get('session.hash_function'));
+    }
+
+    public function testSettingInvalidHashFunctionRaisesException()
+    {
+        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid hash function provided');
+        $this->config->setHashFunction('foobar_bogus');
     }
 
     // session.hash_bits_per_character
@@ -380,6 +661,11 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testHashBitsPerCharacterDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.hash_bits_per_character'), $this->config->getHashBitsPerCharacter());
+    }
+
     /**
      * @dataProvider hashBitsPerCharacters
      */
@@ -389,13 +675,28 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($hashBitsPerCharacter, $this->config->getHashBitsPerCharacter());
     }
 
+    /**
+     * @dataProvider hashBitsPerCharacters
+     */
+    public function testHashBitsPerCharacterAltersIniSetting($hashBitsPerCharacter)
+    {
+        $this->config->setHashBitsPerCharacter($hashBitsPerCharacter);
+        $this->assertEquals($hashBitsPerCharacter, ini_get('session.hash_bits_per_character'));
+    }
+
     public function testSettingInvalidHashBitsPerCharacterRaisesException()
     {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid hash bits per character provided');
+        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException',
+                                    'Invalid hash bits per character provided');
         $this->config->setHashBitsPerCharacter('foobar_bogus');
     }
 
     // url_rewriter.tags
+
+    public function testUrlRewriterTagsDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('url_rewriter.tags'), $this->config->getUrlRewriterTags());
+    }
 
     public function testUrlRewriterTagsIsMutable()
     {
@@ -403,27 +704,40 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('a=href,form=action', $this->config->getUrlRewriterTags());
     }
 
+    public function testUrlRewriterTagsAltersIniSetting()
+    {
+        $this->config->setUrlRewriterTags('a=href,fieldset=');
+        $this->assertEquals('a=href,fieldset=', ini_get('url_rewriter.tags'));
+    }
+
     // remember_me_seconds
+
+    public function testRememberMeSecondsDefaultsToTwoWeeks()
+    {
+        $this->assertEquals(1209600, $this->config->getRememberMeSeconds());
+    }
 
     public function testRememberMeSecondsIsMutable()
     {
-        $this->config->setRememberMeSeconds(20);
-        $this->assertEquals(20, $this->config->getRememberMeSeconds());
-    }
-
-    public function testSettingInvalidRememberMeSecondsRaisesException()
-    {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid remember_me_seconds; must be numeric');
-        $this->config->setRememberMeSeconds('foobar_bogus');
-    }
-
-    public function testSettingInvalidRememberMeSecondsRaisesException2()
-    {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid remember_me_seconds; must be a positive integer');
-        $this->config->setRememberMeSeconds(-1);
+        $this->config->setRememberMeSeconds(604800);
+        $this->assertEquals(604800, $this->config->getRememberMeSeconds());
     }
 
     // setOptions
+
+    /**
+     * @dataProvider optionsProvider
+     */
+    public function testSetOptionsTranslatesUnderscoreSeparatedKeys($option, $getter, $value)
+    {
+        $options = array($option => $value);
+        $this->config->setOptions($options);
+        if ('getOption' == $getter) {
+            $this->assertSame($value, $this->config->getOption($option));
+        } else {
+            $this->assertSame($value, $this->config->$getter());
+        }
+    }
 
     public function optionsProvider()
     {
@@ -440,7 +754,7 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 'save_handler',
-                'getSaveHandler',
+                'getOption',
                 'user',
             ),
             array(
@@ -535,7 +849,7 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 'hash_bits_per_character',
-                'getHashBitsPerCharacter',
+                'getOption',
                 5,
             ),
             array(
@@ -544,15 +858,5 @@ class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
                 'a=href',
             ),
         );
-    }
-
-    /**
-     * @dataProvider optionsProvider
-     */
-    public function testSetOptionsTranslatesUnderscoreSeparatedKeys($option, $getter, $value)
-    {
-        $options = array($option => $value);
-        $this->config->setOptions($options);
-        $this->assertSame($value, $this->config->$getter());
     }
 }

--- a/tests/Zend/Session/Config/StandardConfigTest.php
+++ b/tests/Zend/Session/Config/StandardConfigTest.php
@@ -10,20 +10,24 @@
 
 namespace ZendTest\Session;
 
-use Zend\Session\Configuration\SessionConfiguration;
+use Zend\Session\Config\StandardConfig;
 
 /**
  * @category   Zend
  * @package    Zend_Session
  * @subpackage UnitTests
  * @group      Zend_Session
- * @runTestsInSeparateProcesses
  */
-class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
+class StandardConfigTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var StandardConfig
+     */
+    protected $config;
+
     public function setUp()
     {
-        $this->config = new SessionConfiguration;
+        $this->config = new StandardConfig;
     }
 
     // session.save_path
@@ -34,29 +38,12 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->config->setSavePath(__DIR__ . '/foobarboguspath');
     }
 
-    public function testSavePathDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.save_path'), $this->config->getSavePath());
-    }
-
     public function testSavePathIsMutable()
     {
         $this->config->setSavePath(__DIR__);
         $this->assertEquals(__DIR__, $this->config->getSavePath());
     }
-
-    public function testSavePathAltersIniSetting()
-    {
-        $this->config->setSavePath(__DIR__);
-        $this->assertEquals(__DIR__, ini_get('session.save_path'));
-    }
-
     // session.name
-
-    public function testNameDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.name'), $this->config->getName());
-    }
 
     public function testNameIsMutable()
     {
@@ -64,18 +51,7 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('FOOBAR', $this->config->getName());
     }
 
-    public function testNameAltersIniSetting()
-    {
-        $this->config->setName('FOOBAR');
-        $this->assertEquals('FOOBAR', ini_get('session.name'));
-    }
-
     // session.save_handler
-
-    public function testSaveHandlerDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.save_handler'), $this->config->getSaveHandler(), var_export($this->config->toArray(), 1));
-    }
 
     public function testSaveHandlerIsMutable()
     {
@@ -83,35 +59,12 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('user', $this->config->getSaveHandler());
     }
 
-    public function testSaveHandlerAltersIniSetting()
-    {
-        $this->config->setSaveHandler('user');
-        $this->assertEquals('user', ini_get('session.save_handler'));
-    }
-
-    public function testSettingInvalidSaveHandlerRaisesException()
-    {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid save handler specified');
-        $this->config->setPhpSaveHandler('foobar_bogus');
-    }
-
     // session.gc_probability
-
-    public function testGcProbabilityDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.gc_probability'), $this->config->getGcProbability());
-    }
 
     public function testGcProbabilityIsMutable()
     {
         $this->config->setGcProbability(20);
         $this->assertEquals(20, $this->config->getGcProbability());
-    }
-
-    public function testGcProbabilityAltersIniSetting()
-    {
-        $this->config->setGcProbability(24);
-        $this->assertEquals(24, ini_get('session.gc_probability'));
     }
 
     public function testSettingInvalidGcProbabilityRaisesException()
@@ -134,21 +87,10 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
 
     // session.gc_divisor
 
-    public function testGcDivisorDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.gc_divisor'), $this->config->getGcDivisor());
-    }
-
     public function testGcDivisorIsMutable()
     {
         $this->config->setGcDivisor(20);
         $this->assertEquals(20, $this->config->getGcDivisor());
-    }
-
-    public function testGcDivisorAltersIniSetting()
-    {
-        $this->config->setGcDivisor(24);
-        $this->assertEquals(24, ini_get('session.gc_divisor'));
     }
 
     public function testSettingInvalidGcDivisorRaisesException()
@@ -165,21 +107,10 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
 
     // session.gc_maxlifetime
 
-    public function testGcMaxlifetimeDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.gc_maxlifetime'), $this->config->getGcMaxlifetime());
-    }
-
     public function testGcMaxlifetimeIsMutable()
     {
         $this->config->setGcMaxlifetime(20);
         $this->assertEquals(20, $this->config->getGcMaxlifetime());
-    }
-
-    public function testGcMaxlifetimeAltersIniSetting()
-    {
-        $this->config->setGcMaxlifetime(24);
-        $this->assertEquals(24, ini_get('session.gc_maxlifetime'));
     }
 
     public function testSettingInvalidGcMaxlifetimeRaisesException()
@@ -196,11 +127,6 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
 
     // session.serialize_handler
 
-    public function testSerializeHandlerDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.serialize_handler'), $this->config->getSerializeHandler());
-    }
-
     public function testSerializeHandlerIsMutable()
     {
         $value = extension_loaded('wddx') ? 'wddx' : 'php_binary';
@@ -208,25 +134,7 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($value, $this->config->getSerializeHandler());
     }
 
-    public function testSerializeHandlerAltersIniSetting()
-    {
-        $value = extension_loaded('wddx') ? 'wddx' : 'php_binary';
-        $this->config->setSerializeHandler($value);
-        $this->assertEquals($value, ini_get('session.serialize_handler'));
-    }
-
-    public function testSettingInvalidSerializeHandlerRaisesException()
-    {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid serialize handler specified');
-        $this->config->setSerializeHandler('foobar_bogus');
-    }
-
     // session.cookie_lifetime
-
-    public function testCookieLifetimeDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.cookie_lifetime'), $this->config->getCookieLifetime());
-    }
 
     public function testCookieLifetimeIsMutable()
     {
@@ -234,16 +142,10 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(20, $this->config->getCookieLifetime());
     }
 
-    public function testCookieLifetimeAltersIniSetting()
-    {
-        $this->config->setCookieLifetime(24);
-        $this->assertEquals(24, ini_get('session.cookie_lifetime'));
-    }
-
     public function testCookieLifetimeCanBeZero()
     {
         $this->config->setCookieLifetime(0);
-        $this->assertEquals(0, ini_get('session.cookie_lifetime'));
+        $this->assertEquals(0, $this->config->getCookieLifetime());
     }
 
     public function testSettingInvalidCookieLifetimeRaisesException()
@@ -260,21 +162,10 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
 
     // session.cookie_path
 
-    public function testCookiePathDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.cookie_path'), $this->config->getCookiePath());
-    }
-
     public function testCookiePathIsMutable()
     {
         $this->config->setCookiePath('/foo');
         $this->assertEquals('/foo', $this->config->getCookiePath());
-    }
-
-    public function testCookiePathAltersIniSetting()
-    {
-        $this->config->setCookiePath('/bar');
-        $this->assertEquals('/bar', ini_get('session.cookie_path'));
     }
 
     public function testSettingInvalidCookiePathRaisesException()
@@ -297,11 +188,6 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
 
     // session.cookie_domain
 
-    public function testCookieDomainDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.cookie_domain'), $this->config->getCookieDomain());
-    }
-
     public function testCookieDomainIsMutable()
     {
         $this->config->setCookieDomain('example.com');
@@ -312,12 +198,6 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $this->config->setCookieDomain('');
         $this->assertEquals('', $this->config->getCookieDomain());
-    }
-
-    public function testCookieDomainAltersIniSetting()
-    {
-        $this->config->setCookieDomain('localhost');
-        $this->assertEquals('localhost', ini_get('session.cookie_domain'));
     }
 
     public function testSettingInvalidCookieDomainRaisesException()
@@ -334,111 +214,48 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
 
     // session.cookie_secure
 
-    public function testCookieSecureDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.cookie_secure'), $this->config->getCookieSecure());
-    }
-
     public function testCookieSecureIsMutable()
     {
-        $value = ini_get('session.cookie_secure') ? false : true;
-        $this->config->setCookieSecure($value);
-        $this->assertEquals($value, $this->config->getCookieSecure());
-    }
-
-    public function testCookieSecureAltersIniSetting()
-    {
-        $value = ini_get('session.cookie_secure') ? false : true;
-        $this->config->setCookieSecure($value);
-        $this->assertEquals($value, ini_get('session.cookie_secure'));
+        $this->config->setCookieSecure(true);
+        $this->assertEquals(true, $this->config->getCookieSecure());
     }
 
     // session.cookie_httponly
 
-    public function testCookieHttpOnlyDefaultsToIniSettings()
-    {
-        $this->assertSame((bool) ini_get('session.cookie_httponly'), $this->config->getCookieHttpOnly());
-    }
-
     public function testCookieHttpOnlyIsMutable()
     {
-        $value = ini_get('session.cookie_httponly') ? false : true;
-        $this->config->setCookieHttpOnly($value);
-        $this->assertEquals($value, $this->config->getCookieHttpOnly());
-    }
-
-    public function testCookieHttpOnlyAltersIniSetting()
-    {
-        $value = ini_get('session.cookie_httponly') ? false : true;
-        $this->config->setCookieHttpOnly($value);
-        $this->assertEquals($value, ini_get('session.cookie_httponly'));
+        $this->config->setCookieHttpOnly(true);
+        $this->assertEquals(true, $this->config->getCookieHttpOnly());
     }
 
     // session.use_cookies
 
-    public function testUseCookiesDefaultsToIniSettings()
-    {
-        $this->assertSame((bool) ini_get('session.use_cookies'), $this->config->getUseCookies());
-    }
-
     public function testUseCookiesIsMutable()
     {
-        $value = ini_get('session.use_cookies') ? false : true;
-        $this->config->setUseCookies($value);
-        $this->assertEquals($value, (bool) $this->config->getUseCookies());
-    }
-
-    public function testUseCookiesAltersIniSetting()
-    {
-        $value = ini_get('session.use_cookies') ? false : true;
-        $this->config->setUseCookies($value);
-        $this->assertEquals($value, (bool) ini_get('session.use_cookies'));
+        $this->config->setUseCookies(true);
+        $this->assertEquals(true, (bool) $this->config->getUseCookies());
     }
 
     // session.use_only_cookies
 
-    public function testUseOnlyCookiesDefaultsToIniSettings()
-    {
-        $this->assertSame((bool) ini_get('session.use_only_cookies'), $this->config->getUseOnlyCookies());
-    }
-
     public function testUseOnlyCookiesIsMutable()
     {
-        $value = ini_get('session.use_only_cookies') ? false : true;
-        $this->config->setOption('use_only_cookies', $value);
-        $this->assertEquals($value, (bool) $this->config->getOption('use_only_cookies'));
-    }
-
-    public function testUseOnlyCookiesAltersIniSetting()
-    {
-        $value = ini_get('session.use_only_cookies') ? false : true;
-        $this->config->setOption('use_only_cookies', $value);
-        $this->assertEquals($value, (bool) ini_get('session.use_only_cookies'));
+        $this->config->setUseOnlyCookies(true);
+        $this->assertEquals(true, (bool) $this->config->getUseOnlyCookies());
     }
 
     // session.referer_check
 
-    public function testRefererCheckDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.referer_check'), $this->config->getRefererCheck());
-    }
-
     public function testRefererCheckIsMutable()
     {
-        $this->config->setOption('referer_check', 'FOOBAR');
-        $this->assertEquals('FOOBAR', $this->config->getOption('referer_check'));
+        $this->config->setRefererCheck('FOOBAR');
+        $this->assertEquals('FOOBAR', $this->config->getRefererCheck());
     }
 
     public function testRefererCheckMayBeEmpty()
     {
-        $this->config->setOption('referer_check', '');
-        $this->assertEquals('', $this->config->getOption('referer_check'));
-    }
-
-    public function testRefererCheckAltersIniSetting()
-    {
-        $this->config->setOption('referer_check', 'BARBAZ');
-        $this->assertEquals('BARBAZ', ini_get('session.referer_check'));
+        $this->config->setRefererCheck('');
+        $this->assertEquals('', $this->config->getRefererCheck());
     }
 
     // session.entropy_file
@@ -455,29 +272,13 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->config->setEntropyFile(__DIR__);
     }
 
-    public function testEntropyFileDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.entropy_file'), $this->config->getEntropyFile());
-    }
-
     public function testEntropyFileIsMutable()
     {
         $this->config->setEntropyFile(__FILE__);
         $this->assertEquals(__FILE__, $this->config->getEntropyFile());
     }
 
-    public function testEntropyFileAltersIniSetting()
-    {
-        $this->config->setEntropyFile(__FILE__);
-        $this->assertEquals(__FILE__, ini_get('session.entropy_file'));
-    }
-
     // session.entropy_length
-
-    public function testEntropyLengthDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.entropy_length'), $this->config->getEntropyLength());
-    }
 
     public function testEntropyLengthIsMutable()
     {
@@ -485,16 +286,10 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(20, $this->config->getEntropyLength());
     }
 
-    public function testEntropyLengthAltersIniSetting()
-    {
-        $this->config->setEntropyLength(24);
-        $this->assertEquals(24, ini_get('session.entropy_length'));
-    }
-
     public function testEntropyLengthCanBeZero()
     {
         $this->config->setEntropyLength(0);
-        $this->assertEquals(0, ini_get('session.entropy_length'));
+        $this->assertEquals(0, $this->config->getEntropyLength());
     }
 
     public function testSettingInvalidEntropyLengthRaisesException()
@@ -521,11 +316,6 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testCacheLimiterDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.cache_limiter'), $this->config->getCacheLimiter());
-    }
-
     /**
      * @dataProvider cacheLimiters
      */
@@ -535,27 +325,7 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($cacheLimiter, $this->config->getCacheLimiter());
     }
 
-    /**
-     * @dataProvider cacheLimiters
-     */
-    public function testCacheLimiterAltersIniSetting($cacheLimiter)
-    {
-        $this->config->setCacheLimiter($cacheLimiter);
-        $this->assertEquals($cacheLimiter, ini_get('session.cache_limiter'));
-    }
-
-    public function testSettingInvalidCacheLimiterRaisesException()
-    {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid cache limiter provided');
-        $this->config->setCacheLimiter('foobar_bogus');
-    }
-
     // session.cache_expire
-
-    public function testCacheExpireDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.cache_expire'), $this->config->getCacheExpire());
-    }
 
     public function testCacheExpireIsMutable()
     {
@@ -563,43 +333,26 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(20, $this->config->getCacheExpire());
     }
 
-    public function testCacheExpireAltersIniSetting()
-    {
-        $this->config->setCacheExpire(24);
-        $this->assertEquals(24, ini_get('session.cache_expire'));
-    }
-
     public function testSettingInvalidCacheExpireRaisesException()
     {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid cache_expire; must be numeric');
+        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException',
+                                    'Invalid cache_expire; must be numeric');
         $this->config->setCacheExpire('foobar_bogus');
     }
 
     public function testSettingInvalidCacheExpireRaisesException2()
     {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid cache_expire; must be a positive integer');
+        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException',
+                                    'Invalid cache_expire; must be a positive integer');
         $this->config->setCacheExpire(-1);
     }
 
     // session.use_trans_sid
 
-    public function testUseTransSidDefaultsToIniSettings()
-    {
-        $this->assertSame((bool) ini_get('session.use_trans_sid'), $this->config->getUseTransSid());
-    }
-
     public function testUseTransSidIsMutable()
     {
-        $value = ini_get('session.use_trans_sid') ? false : true;
-        $this->config->setOption('use_trans_sid', $value);
-        $this->assertEquals($value, (bool) $this->config->getOption('use_trans_sid'));
-    }
-
-    public function testUseTransSidAltersIniSetting()
-    {
-        $value = ini_get('session.use_trans_sid') ? false : true;
-        $this->config->setOption('use_trans_sid', $value);
-        $this->assertEquals($value, (bool) ini_get('session.use_trans_sid'));
+        $this->config->setUseTransSid(true);
+        $this->assertEquals(true, (bool) $this->config->getUseTransSid());
     }
 
     // session.hash_function
@@ -614,11 +367,6 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
         return $provider;
     }
 
-    public function testHashFunctionDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.hash_function'), $this->config->getHashFunction());
-    }
-
     /**
      * @dataProvider hashFunctions
      */
@@ -626,21 +374,6 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $this->config->setHashFunction($hashFunction);
         $this->assertEquals($hashFunction, $this->config->getHashFunction());
-    }
-
-    /**
-     * @dataProvider hashFunctions
-     */
-    public function testHashFunctionAltersIniSetting($hashFunction)
-    {
-        $this->config->setHashFunction($hashFunction);
-        $this->assertEquals($hashFunction, ini_get('session.hash_function'));
-    }
-
-    public function testSettingInvalidHashFunctionRaisesException()
-    {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid hash function provided');
-        $this->config->setHashFunction('foobar_bogus');
     }
 
     // session.hash_bits_per_character
@@ -654,11 +387,6 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testHashBitsPerCharacterDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('session.hash_bits_per_character'), $this->config->getHashBitsPerCharacter());
-    }
-
     /**
      * @dataProvider hashBitsPerCharacters
      */
@@ -668,27 +396,14 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($hashBitsPerCharacter, $this->config->getHashBitsPerCharacter());
     }
 
-    /**
-     * @dataProvider hashBitsPerCharacters
-     */
-    public function testHashBitsPerCharacterAltersIniSetting($hashBitsPerCharacter)
-    {
-        $this->config->setHashBitsPerCharacter($hashBitsPerCharacter);
-        $this->assertEquals($hashBitsPerCharacter, ini_get('session.hash_bits_per_character'));
-    }
-
     public function testSettingInvalidHashBitsPerCharacterRaisesException()
     {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid hash bits per character provided');
+        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException',
+                                    'Invalid hash bits per character provided');
         $this->config->setHashBitsPerCharacter('foobar_bogus');
     }
 
     // url_rewriter.tags
-
-    public function testUrlRewriterTagsDefaultsToIniSettings()
-    {
-        $this->assertSame(ini_get('url_rewriter.tags'), $this->config->getUrlRewriterTags());
-    }
 
     public function testUrlRewriterTagsIsMutable()
     {
@@ -696,26 +411,39 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('a=href,form=action', $this->config->getUrlRewriterTags());
     }
 
-    public function testUrlRewriterTagsAltersIniSetting()
-    {
-        $this->config->setUrlRewriterTags('a=href,fieldset=');
-        $this->assertEquals('a=href,fieldset=', ini_get('url_rewriter.tags'));
-    }
-
     // remember_me_seconds
-
-    public function testRememberMeSecondsDefaultsToTwoWeeks()
-    {
-        $this->assertEquals(1209600, $this->config->getRememberMeSeconds());
-    }
 
     public function testRememberMeSecondsIsMutable()
     {
-        $this->config->setRememberMeSeconds(604800);
-        $this->assertEquals(604800, $this->config->getRememberMeSeconds());
+        $this->config->setRememberMeSeconds(20);
+        $this->assertEquals(20, $this->config->getRememberMeSeconds());
+    }
+
+    public function testSettingInvalidRememberMeSecondsRaisesException()
+    {
+        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException',
+                                    'Invalid remember_me_seconds; must be numeric');
+        $this->config->setRememberMeSeconds('foobar_bogus');
+    }
+
+    public function testSettingInvalidRememberMeSecondsRaisesException2()
+    {
+        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException',
+                                    'Invalid remember_me_seconds; must be a positive integer');
+        $this->config->setRememberMeSeconds(-1);
     }
 
     // setOptions
+
+    /**
+     * @dataProvider optionsProvider
+     */
+    public function testSetOptionsTranslatesUnderscoreSeparatedKeys($option, $getter, $value)
+    {
+        $options = array($option => $value);
+        $this->config->setOptions($options);
+        $this->assertSame($value, $this->config->$getter());
+    }
 
     public function optionsProvider()
     {
@@ -732,7 +460,7 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 'save_handler',
-                'getOption',
+                'getSaveHandler',
                 'user',
             ),
             array(
@@ -827,7 +555,7 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 'hash_bits_per_character',
-                'getOption',
+                'getHashBitsPerCharacter',
                 5,
             ),
             array(
@@ -836,19 +564,5 @@ class SessionConfigurationTest extends \PHPUnit_Framework_TestCase
                 'a=href',
             ),
         );
-    }
-
-    /**
-     * @dataProvider optionsProvider
-     */
-    public function testSetOptionsTranslatesUnderscoreSeparatedKeys($option, $getter, $value)
-    {
-        $options = array($option => $value);
-        $this->config->setOptions($options);
-        if ('getOption' == $getter) {
-            $this->assertSame($value, $this->config->getOption($option));
-        } else {
-            $this->assertSame($value, $this->config->$getter());
-        }
     }
 }

--- a/tests/Zend/Session/ContainerTest.php
+++ b/tests/Zend/Session/ContainerTest.php
@@ -11,7 +11,7 @@
 namespace ZendTest\Session;
 
 use Zend\Session\Container;
-use Zend\Session\Configuration\StandardConfiguration;
+use Zend\Session\Config\StandardConfig;
 use Zend\Session\ManagerInterface as Manager;
 use Zend\Session;
 
@@ -29,7 +29,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $_SESSION = array();
         Container::setDefaultManager(null);
 
-        $config = new StandardConfiguration(array(
+        $config = new StandardConfig(array(
             'storage' => 'Zend\\Session\\Storage\\ArrayStorage',
         ));
 
@@ -167,14 +167,14 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $manager   = $container->getManager();
         $this->assertTrue($manager instanceof Manager);
         $config  = $manager->getConfig();
-        $this->assertTrue($config instanceof Session\Configuration\SessionConfiguration);
+        $this->assertTrue($config instanceof Session\Config\SessionConfig);
         $storage = $manager->getStorage();
         $this->assertTrue($storage instanceof Session\Storage\SessionStorage);
     }
 
     public function testContainerAllowsInjectingManagerViaConstructor()
     {
-        $config = new StandardConfiguration(array(
+        $config = new StandardConfig(array(
             'storage' => 'Zend\\Session\\Storage\\ArrayStorage',
         ));
         $manager = new TestAsset\TestManager($config);

--- a/tests/Zend/Session/SessionManagerTest.php
+++ b/tests/Zend/Session/SessionManagerTest.php
@@ -57,15 +57,15 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
         return false;
     }
 
-    public function testManagerUsesSessionConfigurationByDefault()
+    public function testManagerUsesSessionConfigByDefault()
     {
         $config = $this->manager->getConfig();
-        $this->assertTrue($config instanceof Session\Configuration\SessionConfiguration);
+        $this->assertTrue($config instanceof Session\Config\SessionConfig);
     }
 
     public function testCanPassConfigurationToConstructor()
     {
-        $config = new Session\Configuration\StandardConfiguration();
+        $config = new Session\Config\StandardConfig();
         $manager = new SessionManager($config);
         $this->assertSame($config, $manager->getConfig());
     }
@@ -229,7 +229,8 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testSettingNameWhenAnActiveSessionExistsRaisesException()
     {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Cannot set session name after a session has already started');
+        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException',
+                                    'Cannot set session name after a session has already started');
         $this->manager->start();
         $this->manager->setName('foobar');
     }

--- a/tests/Zend/Session/StorageTest.php
+++ b/tests/Zend/Session/StorageTest.php
@@ -20,6 +20,11 @@ use Zend\Session\Storage\ArrayStorage;
  */
 class StorageTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ArrayStorage
+     */
+    protected $storage;
+
     public function setUp()
     {
         $this->storage = new ArrayStorage;
@@ -211,7 +216,8 @@ class StorageTest extends \PHPUnit_Framework_TestCase
         $this->storage->foo = 'bar';
         $this->storage->bar = 'baz';
         $this->storage->markImmutable();
-        $this->setExpectedException('Zend\Session\Exception\RuntimeException', 'Cannot clear storage as it is marked immutable');
+        $this->setExpectedException('Zend\Session\Exception\RuntimeException',
+                                    'Cannot clear storage as it is marked immutable');
         $this->storage->clear();
     }
 }

--- a/tests/Zend/Session/TestAsset/TestManager.php
+++ b/tests/Zend/Session/TestAsset/TestManager.php
@@ -12,7 +12,7 @@ namespace ZendTest\Session\TestAsset;
 
 use Zend\EventManager\EventManagerInterface;
 use Zend\Session\AbstractManager;
-use Zend\Session\Configuration\ConfigurationInterface as SessionConfiguration;
+use Zend\Session\Configuration\ConfigurationInterface as SessionConfig;
 use Zend\Session\SaveHandler\SaveHandlerInterface as SessionSaveHandler;
 use Zend\Session\Storage\StorageInterface as SessionStorage;
 
@@ -20,7 +20,7 @@ class TestManager extends AbstractManager
 {
     public $started = false;
 
-    protected $configDefaultClass = 'Zend\\Session\\Configuration\\StandardConfiguration';
+    protected $configDefaultClass = 'Zend\\Session\\Configuration\\StandardConfig';
     protected $storageDefaultClass = 'Zend\\Session\\Storage\\ArrayStorage';
 
     public function start()

--- a/tests/Zend/Validator/CsrfTest.php
+++ b/tests/Zend/Validator/CsrfTest.php
@@ -10,7 +10,7 @@
 
 namespace ZendTest\Validator;
 
-use Zend\Session\Configuration\StandardConfiguration;
+use Zend\Session\Config\StandardConfig;
 use Zend\Session\Container;
 use Zend\Validator\Csrf;
 
@@ -34,7 +34,7 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
     {
         // Setup session handling
         $_SESSION = array();
-        $sessionConfig = new StandardConfiguration(array(
+        $sessionConfig = new StandardConfig(array(
             'storage' => 'Zend\Session\Storage\ArrayStorage',
         ));
         $sessionManager       = new TestAsset\SessionManager($sessionConfig);


### PR DESCRIPTION
- renamed Configuration -> Config
- `Config::setOptions()` to accept Traversable
- simplified magic `_call()`, removal of `Filter\Word\CamelCaseToUnderscore` dependency
- correct session GC in `SaveHandler/DbTableGateway`
- CS fixes
- fixed `Validator\Csrf` tests
