### PR TITLE
Logic fix for translatePlural method.

### DIFF
--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -333,7 +333,7 @@ class Translator
                 );
             }
 
-            return ($number != 1 ? $singular : $plural);
+            return ($number == 1 ? $singular : $plural);
         }
 
         $index = $this->messages[$textDomain][$locale]


### PR DESCRIPTION
...o using the $singular string if $number is 1, and the $plural string otherwise (had been reversed).
