### PR TITLE
Improved the doc2rst conversion + minor fixes

### DIFF
--- a/bin/doc2rst.php
+++ b/bin/doc2rst.php
@@ -1,22 +1,13 @@
 #!/usr/bin/env php
 <?php
 /**
- * Zend Framework
+ * Zend Framework (http://framework.zend.com/)
  *
- * LICENSE
- *
- * This source file is subject to the new BSD license that is bundled
- * with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://framework.zend.com/license/new-bsd
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@zend.com so we can send you a copy immediately.
- *
- * @category   Zend
- * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace ZendBin;
 
 use Zend\Console;
@@ -25,12 +16,15 @@ use Zend\Loader\StandardAutoloader;
 use Zend\Text\Table;
 
 /*
- * Convert the ZF documentation from DocBook to reStructuredText format
- *
+ * Convert a file from DocBook to reStructuredText format
+ * 
+ * Note: this script has been created to convert the Zend Framework
+ * documentation. We have not tested it with other docBook file formats.
+ * 
  * Usage:
  * --help|-h        Get usage message
  * --docbook|-d     Docbook file to convert
- * --output|-o      File output in reStructuredText format; By default,
+ * --output|-o      Output file in reStructuredText format; By default,
  *                  assumes <docbook>.rst
  */
 echo "DocBook to reStructuredText conversion for ZF documentation\n";
@@ -55,7 +49,7 @@ $loader->register();
 $rules = array(
     'help|h'      => 'Get usage message',
     'docbook|d-s' => 'Docbook file to convert',
-    'output|o-s'  => 'Output dir; if not provided, assumes normalize(<docbook>).rst"',
+    'output|o-s'  => 'Output file in reStructuredText format; By default assumes <docbook>.rst"',
 );
 
 try {
@@ -79,12 +73,11 @@ if (!file_exists($docbook)) {
 
 $rstFile = $opts->getOption('o');
 if (empty($rstFile)) {
-    $rstFile = '.';
-}
-
-if (is_dir($rstFile)) {
-    $rstFile = realpath($rstFile) . DIRECTORY_SEPARATOR;
-    $rstFile .= RstConvert::xmlFileNameToRst(basename($docbook));
+    $rstFile = $docbook;
+    if ('.xml' === substr($rstFile, -4)) {
+        $rstFile = substr($rstFile, 0, strlen($docbook)-4);
+    }
+    $rstFile .= '.rst';
 }
 
 // Load the docbook file (input)

--- a/bin/doc2rst.xsl
+++ b/bin/doc2rst.xsl
@@ -8,60 +8,53 @@
 <xsl:strip-space elements="*"/>
 
 <xsl:template match="//text()" name="text">
-<xsl:value-of select="php:function('ZendBin\RstConvert::formatText', string(.), preceding-sibling::*[1], following-sibling::*[1])" />
+    <xsl:value-of select="php:function('ZendBin\RstConvert::formatText', string(.), preceding-sibling::*[1], following-sibling::*[1])" />
 </xsl:template>
-<xsl:template match="//text()" mode="indent"><xsl:call-template name="text" /></xsl:template>
+<xsl:template match="//text()" mode="indent">
+    <xsl:call-template name="text" />
+</xsl:template>
 
 <xsl:template name="formatText">
-<xsl:value-of select="php:function('ZendBin\RstConvert::formatText', string(.))" />
+    <xsl:value-of select="php:function('ZendBin\RstConvert::formatText', string(.))" />
+</xsl:template>
+
+<!-- root -->
+<xsl:template match="/">
+    <xsl:apply-templates />
 </xsl:template>
 
 <!-- Id -->
 <xsl:template match="*[@xml:id]">
 .. _<xsl:value-of select="@xml:id" />:
-<xsl:apply-templates />
+    <xsl:apply-templates />
 </xsl:template>
 
-<!-- article title -->
-<xsl:template match="/doc:article/doc:title">
-<xsl:value-of select="php:function('ZendBin\RstConvert::title', string(.), '#', true())" />
+<!-- title -->
+<xsl:template match="//doc:title">
+    <xsl:choose>
+        <xsl:when test=".. = /">
+            <xsl:value-of select="php:function('ZendBin\RstConvert::title', string(.), '=')" />
+        </xsl:when>
+        <xsl:when test="../.. = /">
+            <xsl:value-of select="php:function('ZendBin\RstConvert::title', string(.), '-')" />
+        </xsl:when>
+        <xsl:when test="../../.. = /">
+            <xsl:value-of select="php:function('ZendBin\RstConvert::title', string(.), '^')" />
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="php:function('ZendBin\RstConvert::title', string(.), '^')" />
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
-
-<!-- chapter title -->
-<xsl:template match="//doc:chapter/doc:title|//doc:appendix/doc:title">
-<xsl:value-of select="php:function('ZendBin\RstConvert::title', string(.), '*', true())" />
-</xsl:template>
-
-<!-- section title -->
-<xsl:template match="/doc:section/doc:title">
-<xsl:value-of select="php:function('ZendBin\RstConvert::title', string(.), '=')" />
-</xsl:template>
-
-<!-- subsection title -->
-<xsl:template match="/*//doc:section/doc:title">
-<xsl:value-of select="php:function('ZendBin\RstConvert::title', string(.), '-')" />
-</xsl:template>
-
-<!-- subsection title -->
-<xsl:template match="/*/*//doc:section/doc:title">
-<xsl:value-of select="php:function('ZendBin\RstConvert::title', string(.), '^')" />
-</xsl:template>
-
-<!-- rest of titles -->
-<xsl:template match="//doc:title" priority="-1" name="default_title">
-<xsl:value-of select="php:function('ZendBin\RstConvert::title', string(.))" />
-</xsl:template>
-<xsl:template match="//doc:title" priority="-1" mode="indent"><xsl:call-template name="default_title" /></xsl:template>
 
 <!-- para, simpara -->
 <xsl:template match="doc:para|doc:simpara">
-<xsl:apply-templates/>
-<xsl:text>
-
+    <xsl:apply-templates/>
+    <xsl:text>
+        
 </xsl:text>
 </xsl:template>
 
-<!-- para, simpara -->
 <xsl:template match="doc:para|doc:simpara" mode="indent">
 <xsl:text>   </xsl:text><xsl:apply-templates mode="indent"/>
 <xsl:text>
@@ -71,13 +64,18 @@
 
 <!-- link, uri, xref -->
 <xsl:template match="//doc:link|//doc:uri|//doc:xref" name="link">
-<xsl:value-of select="php:function('ZendBin\RstConvert::link', .)" /><xsl:if test="name(following-sibling::node()[1]) != ''"><xsl:text> </xsl:text></xsl:if>
+    <xsl:value-of select="php:function('ZendBin\RstConvert::link', .)" /><xsl:if test="name(following-sibling::node()[1]) != ''"><xsl:text> </xsl:text></xsl:if>
 </xsl:template>
-<xsl:template match="//doc:link|//doc:uri|//doc:xref" mode="indent"><xsl:call-template name="link"/></xsl:template>
+<xsl:template match="//doc:link|//doc:uri|//doc:xref" mode="indent">
+    <xsl:call-template name="link"/>
+</xsl:template>
 
 <!-- footnote -->
 <xsl:template match="//doc:footnote" name="footnote">
-<xsl:value-of select="php:function('ZendBin\RstConvert::footnote', string(.))" /><xsl:if test="name(following-sibling::node()[1]) != ''"><xsl:text> </xsl:text></xsl:if>
+    <xsl:value-of select="php:function('ZendBin\RstConvert::footnote', string(.))" />
+    <xsl:if test="name(following-sibling::node()[1]) != ''">
+        <xsl:text> </xsl:text>
+    </xsl:if>
 </xsl:template>
 <xsl:template match="//doc:link|//doc:uri" mode="indent"><xsl:call-template name="link"/></xsl:template>
 
@@ -131,21 +129,19 @@
 
 <!-- literallayout -->
 <xsl:template match="//doc:literallayout">
-<xsl:text>
+    <xsl:text>
 </xsl:text>
 ::
-<xsl:value-of select="php:function('ZendBin\RstConvert::indent', string(.))" />
-<xsl:text>
+    <xsl:value-of select="php:function('ZendBin\RstConvert::indent', string(.))" />
+    <xsl:text>
 </xsl:text>
 </xsl:template>
 
 <!-- programlisting -->
 <xsl:template match="//doc:programlisting">
-<xsl:text>
-</xsl:text>
 .. code-block:: <xsl:value-of select="string(@language)" />
    :linenos:
-<xsl:value-of select="php:function('ZendBin\RstConvert::indent', string(.))" />
+    <xsl:value-of select="php:function('ZendBin\RstConvert::indent', string(.))" />
 </xsl:template>
 
 <!-- programlisting -->
@@ -154,49 +150,49 @@
 </xsl:text>
    .. code-block:: <xsl:value-of select="string(@language)" />
       :linenos:
-<xsl:value-of select="php:function('ZendBin\RstConvert::indent', php:function('ZendBin\RstConvert::indent', string(.)))" />
+    <xsl:value-of select="php:function('ZendBin\RstConvert::indent', php:function('ZendBin\RstConvert::indent', string(.)))" />
 </xsl:template>
 
 <!-- varlistentry/term -->
 <xsl:template match="//doc:varlistentry/doc:term">
 **<xsl:call-template name="formatText" />**
-<xsl:text>
+    <xsl:text>
 </xsl:text>
 </xsl:template>
 
 <!-- varlistentry/term -->
 <xsl:template match="//doc:varlistentry/doc:term" mode="indent">
    **<xsl:call-template name="formatText" />**
-<xsl:text>
+    <xsl:text>
 </xsl:text>
 </xsl:template>
 
 <!-- refentry -->
 <xsl:template match="//doc:refentry">
 .. _<xsl:value-of select="@xml:id" />:
-<xsl:text>
+    <xsl:text>
 </xsl:text>
-<xsl:apply-templates select="doc:refnamediv/doc:refname" />
-<xsl:text>
+    <xsl:apply-templates select="doc:refnamediv/doc:refname" />
+    <xsl:text>
 </xsl:text>
-<xsl:apply-templates select="doc:refnamediv/doc:refpurpose" mode="indent" />
-<xsl:text>
+    <xsl:apply-templates select="doc:refnamediv/doc:refpurpose" mode="indent" />
+    <xsl:text>
 </xsl:text>
-<xsl:apply-templates select="doc:refsynopsisdiv/doc:methodsynopsis" mode="indent" />
+    <xsl:apply-templates select="doc:refsynopsisdiv/doc:methodsynopsis" mode="indent" />
 
-<xsl:apply-templates select="doc:refsection" mode="indent" />
-<xsl:text>
+    <xsl:apply-templates select="doc:refsection" mode="indent" />
+    <xsl:text>
 </xsl:text>
 </xsl:template>
 
 <!-- refpurpose -->
 <xsl:template match="//doc:refpurpose" mode="indent">
-<xsl:text>   </xsl:text><xsl:apply-templates mode="indent"/>
+    <xsl:text>   </xsl:text><xsl:apply-templates mode="indent"/>
 </xsl:template>
 
 <!-- methodsynopsis -->
 <xsl:template match="//doc:methodsynopsis" name="methodsynopsis">.. c:function:: <xsl:if test="doc:type != ''"><xsl:value-of select="doc:type" /></xsl:if> <xsl:value-of select="doc:methodname" />(<xsl:value-of select="php:function('ZendBin\RstConvert::formatText', string(*//doc:funcparams))" />)
-<xsl:text>
+    <xsl:text>
 </xsl:text>
 </xsl:template>
 <xsl:template match="//doc:methodsynopsis" mode="indent"><xsl:text>   </xsl:text><xsl:call-template name="methodsynopsis" /></xsl:template>
@@ -204,47 +200,51 @@
 <!-- refsection -->
 <xsl:template match="//doc:refsection/doc:title" name="refsection_title">
    **<xsl:call-template name="formatText" />**
-<xsl:text>
+    <xsl:text>
 </xsl:text>
 </xsl:template>
-<xsl:template match="//doc:refsection/doc:title" mode="indent">
-<xsl:text>   </xsl:text><xsl:call-template name="refsection_title" />
-</xsl:template>
 
+<xsl:template match="//doc:refsection/doc:title" mode="indent">
+    <xsl:text>   </xsl:text><xsl:call-template name="refsection_title" />
+</xsl:template>
 
 <!-- orderedlist|itemizedlist -->
 <xsl:template match="//doc:orderedlist|//doc:itemizedlist">
-<xsl:text>
+    <xsl:text>
 </xsl:text>
-<xsl:apply-templates />
+    <xsl:apply-templates />
 </xsl:template>
 
 <!-- orderedlist|itemizedlist -->
 <xsl:template match="//doc:orderedlist|//doc:itemizedlist" mode="indent">
-<xsl:text>
+    <xsl:text>
 </xsl:text>
-<xsl:apply-templates mode="indent" />
+    <xsl:apply-templates mode="indent" />
 </xsl:template>
 
 <!-- listitem -->
 <xsl:template match="//doc:listitem">- <xsl:apply-templates select="*[1]" />
-<xsl:if test="*[position()>1] != ''"><xsl:apply-templates select="*[position()>1]" mode="indent"/></xsl:if>
+    <xsl:if test="*[position()>1] != ''">
+        <xsl:apply-templates select="*[position()>1]" mode="indent"/>
+    </xsl:if>
 </xsl:template>
 
 <!-- listitem -->
 <xsl:template match="//doc:listitem" mode="indent">   - <xsl:apply-templates select="*[1]" />
 <!-- Indent with 2 spaces -->
-<xsl:if test="*[position()>1] != ''"><xsl:text>  </xsl:text><xsl:apply-templates select="*[position()>1]" mode="indent"/></xsl:if>
+    <xsl:if test="*[position()>1] != ''">
+        <xsl:text>  </xsl:text><xsl:apply-templates select="*[position()>1]" mode="indent"/>
+    </xsl:if>
 </xsl:template>
 
 <!-- ordered listitem -->
 <xsl:template match="//doc:orderedlist/doc:listitem"><xsl:value-of select="position()" />. <xsl:apply-templates select="*[1]" />
-<xsl:apply-templates select="*[position()>1]" mode="indent"/>
+    <xsl:apply-templates select="*[position()>1]" mode="indent"/>
 </xsl:template>
 
 <!-- ordered listitem -->
 <xsl:template match="//doc:orderedlist/doc:listitem" mode="indent">   <xsl:value-of select="position()" />. <xsl:apply-templates select="*[1]" />
-<xsl:text>   </xsl:text><xsl:apply-templates select="*[position()>1]" mode="indent"/>
+    <xsl:text>   </xsl:text><xsl:apply-templates select="*[position()>1]" mode="indent"/>
 </xsl:template>
 
 <!--
@@ -254,26 +254,26 @@
  -->
 <!-- normal -->
 <xsl:template match="//doc:caution|//doc:important|//doc:note|//doc:tip|//doc:warning">
-<xsl:text>
+    <xsl:text>
 </xsl:text>
 .. <xsl:value-of select="name()" />::
-<xsl:if test="doc:title != '' or doc:info/doc:title != ''">   **<xsl:value-of select="php:function('ZendBin\RstConvert::formatText', string(doc:info/doc:title|doc:title))" />**
-<xsl:text>
+    <xsl:if test="doc:title != '' or doc:info/doc:title != ''">   **<xsl:value-of select="php:function('ZendBin\RstConvert::formatText', string(doc:info/doc:title|doc:title))" />**
+    <xsl:text>
 </xsl:text>
-</xsl:if>
-<xsl:apply-templates select="*[(name(.) != 'title') and (name(.) != 'info')]" mode="indent"/>
+    </xsl:if>
+    <xsl:apply-templates select="*[(name(.) != 'title') and (name(.) != 'info')]" mode="indent"/>
 </xsl:template>
 
 <!-- indent -->
 <xsl:template match="//doc:caution|//doc:important|//doc:note|//doc:tip|//doc:warning" mode="indent">
-<xsl:text>
+    <xsl:text>
 </xsl:text>
    .. <xsl:value-of select="name()" />::
-<xsl:if test="doc:title != '' or doc:info/doc:title != ''">      **<xsl:value-of select="php:function('ZendBin\RstConvert::formatText', string(doc:info/doc:title|doc:title))" />**
-<xsl:text>
+    <xsl:if test="doc:title != '' or doc:info/doc:title != ''">      **<xsl:value-of select="php:function('ZendBin\RstConvert::formatText', string(doc:info/doc:title|doc:title))" />**
+    <xsl:text>
 </xsl:text>
-</xsl:if>
-<xsl:text>   </xsl:text><xsl:apply-templates select="*[(name(.) != 'title') and (name(.) != 'info')]" mode="indent"/>
+    </xsl:if>
+    <xsl:text>   </xsl:text><xsl:apply-templates select="*[(name(.) != 'title') and (name(.) != 'info')]" mode="indent"/>
 </xsl:template>
 
 <!--
@@ -324,20 +324,4 @@
 <xsl:value-of select="php:function('ZendBin\RstConvert::indent', php:function('ZendBin\RstConvert::indent', php:function('ZendBin\RstConvert::table', .)))" />
 </xsl:template>
 
-<!--
-    <xsl:template
-            match="*[not(name()='refname') and not(name()='variablelist') and not(name()='varlistentry') and not(name()='table') and not(name()='example') and not(name()='inlinemediaobject') and not(name()='imageobject') ]"
-            priority="-99">
-        <xsl:text>ERROR </xsl:text>"<xsl:value-of select="name()"/>"
-        <xsl:apply-templates/>
-    </xsl:template>
-
-    <xsl:template
-            match="*[not(name()='refsection') and not(name()='refname') and not(name()='variablelist') and not(name()='varlistentry') and not(name()='table') and not(name()='example') and not(name()='inlinemediaobject') and not(name()='imageobject') ]"
-            mode="indent"
-            priority="-99">
-        <xsl:text>ERROR (indent) </xsl:text>"<xsl:value-of select="name()"/>"
-        <xsl:apply-templates mode="indent"/>
-    </xsl:template>
--->
 </xsl:stylesheet>


### PR DESCRIPTION
I simplified the XLST using 3 level of sections:
=, for sections
-, for subsections
^, for subsubsections (and sub-others)
I used the xsl:choose tag in the XSL to manage different titles.
I write the .xsl file using indentation.
I changed the usage of the option -o (output) of doc2rst.php. Now the -o specify the output file name. If not provided it will use the <docbook>.rst name. I did this change because, theoretically, the doc2rst.php can be used to convert any DocBook file to reStructuredText format, and not only ZF docs. 
