### PR TITLE
Convert route match to class name

### DIFF
--- a/library/Zend/Mvc/ModuleRouteListener.php
+++ b/library/Zend/Mvc/ModuleRouteListener.php
@@ -94,7 +94,7 @@ class ModuleRouteListener implements ListenerAggregateInterface
 
         // Prepend the controllername with the module, and replace it in the
         // matches
-        $controller = $module . '\\' . $controller;
+        $controller = $module . '\\' . str_replace(' ', '', ucwords(str_replace('-', ' ', $controller)));
         $matches->setParam('controller', $controller);
     }
 }

--- a/tests/Zend/Mvc/ModuleRouteListenerTest.php
+++ b/tests/Zend/Mvc/ModuleRouteListenerTest.php
@@ -104,4 +104,32 @@ class ModuleRouteListenerTest extends TestCase
         $this->assertEquals('Foo\Index', $matches->getParam('controller'));
         $this->assertEquals('Index', $matches->getParam(ModuleRouteListener::ORIGINAL_CONTROLLER));
     }
+
+    public function testRouteMatchIsTransformedToProperControllerClassName()
+    {
+        $moduleListener = new ModuleRouteListener();
+        $this->events->attach($moduleListener);
+
+        $this->router->addRoute('foo', array(
+            'type' => 'Literal',
+            'options' => array(
+                'route'    => '/foo',
+                'defaults' => array(
+                    ModuleRouteListener::MODULE_NAMESPACE => 'Foo',
+                    'controller' => 'some-index',
+                ),
+            ),
+        ));
+
+        $this->request->setUri('/foo');
+        $event = new MvcEvent();
+        $event->setRouter($this->router);
+        $event->setRequest($this->request);
+        $this->events->trigger('route', $event);
+
+        $matches = $event->getRouteMatch();
+        $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $matches);
+        $this->assertEquals('Foo\SomeIndex', $matches->getParam('controller'));
+        $this->assertEquals('some-index', $matches->getParam(ModuleRouteListener::ORIGINAL_CONTROLLER));
+    }
 }


### PR DESCRIPTION
When using the ModuleRouteListener, we should convert the route match to
a class name. For example, the match might be foo-bar, which should
resolve to FooBar.
