### PR TITLE
Fix service config merge order in ServiceListener

### DIFF
--- a/library/Zend/ModuleManager/Listener/ServiceListener.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListener.php
@@ -79,6 +79,7 @@ class ServiceListener implements ListenerAggregateInterface
                 (string) $serviceManager
             ));
         }
+
         $this->serviceManagers[$smKey] = array(
             'service_manager'        => $serviceManager,
             'config_key'             => $key,
@@ -86,6 +87,11 @@ class ServiceListener implements ListenerAggregateInterface
             'module_class_method'    => $method,
             'configuration'          => array(),
         );
+
+        if ($key === 'service_manager' && $this->defaultServiceConfig) {
+            $this->serviceManagers[$smKey]['configuration']['default_config'] = $this->defaultServiceConfig;
+        }
+
         return $this;
     }
 
@@ -174,19 +180,7 @@ class ServiceListener implements ListenerAggregateInterface
         $configListener = $e->getConfigListener();
         $config         = $configListener->getMergedConfig(false);
 
-        if ($this->defaultServiceConfig) {
-            $defaultConfig = array('service_manager' => $this->defaultServiceConfig);
-        }
-
         foreach ($this->serviceManagers as $key => $sm) {
-
-            if (isset($defaultConfig[$sm['config_key']])
-                && is_array($defaultConfig[$sm['config_key']])
-                && !empty($defaultConfig[$sm['config_key']])
-            ) {
-                $this->serviceManagers[$key]['configuration']['default_config'] = $defaultConfig[$sm['config_key']];
-            }
-
             if (isset($config[$sm['config_key']])
                 && is_array($config[$sm['config_key']])
                 && !empty($config[$sm['config_key']])

--- a/tests/Zend/ModuleManager/Listener/ServiceListenerTest.php
+++ b/tests/Zend/ModuleManager/Listener/ServiceListenerTest.php
@@ -123,6 +123,18 @@ class ServiceListenerTest extends TestCase
         $this->assertServiceManagerIsConfigured();
     }
 
+    public function testModuleServiceConfigOverridesGlobalConfig()
+    {
+        $this->listener = new ServiceListener($this->services, array('aliases' => array('foo' => 'bar')));
+        $this->listener->addServiceManager($this->services, 'service_manager', 'Zend\ModuleManager\Feature\ServiceProviderInterface', 'getServiceConfig');
+        $config = array('aliases' => array('foo' => 'baz'));
+        $module = new TestAsset\ServiceProviderModule($config);
+        $this->event->setModule($module);
+        $this->listener->onLoadModule($this->event);
+        $this->listener->onLoadModulesPost($this->event);
+        $this->assertAttributeEquals($config['aliases'], 'aliases', $this->services, "aliases assertion failed - module config did not override main config");
+    }
+
     public function testModuleReturningServiceConfigConfiguresServiceManager()
     {
         $config = $this->getServiceConfig();


### PR DESCRIPTION
Without this fix, the default service manager config is merged over top
of the config provided by module's getServiceConfiguration() methods.
