### PR TITLE
Normalize 'Configuration' to 'Config'

### DIFF
--- a/library/Zend/Di/Config.php
+++ b/library/Zend/Di/Config.php
@@ -21,7 +21,7 @@ use Zend\Di\Definition\RuntimeDefinition;
  * @category   Zend
  * @package    Zend_Di
  */
-class Configuration
+class Config
 {
     /**
      * @var array
@@ -42,7 +42,7 @@ class Configuration
 
         if (!is_array($options)) {
             throw new Exception\InvalidArgumentException(
-                'Configuration data must be of type Traversable or an array'
+                'Config data must be of type Traversable or an array'
             );
         }
         $this->data = $options;

--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -55,9 +55,9 @@ class Di implements DependencyInjectionInterface
      *
      * @param null|DefinitionList  $definitions
      * @param null|InstanceManager $instanceManager
-     * @param null|Configuration   $config
+     * @param null|Config   $config
      */
-    public function __construct(DefinitionList $definitions = null, InstanceManager $instanceManager = null, Configuration $config = null)
+    public function __construct(DefinitionList $definitions = null, InstanceManager $instanceManager = null, Config $config = null)
     {
         $this->definitions = ($definitions) ?: new DefinitionList(new Definition\RuntimeDefinition());
         $this->instanceManager = ($instanceManager) ?: new InstanceManager();
@@ -70,10 +70,10 @@ class Di implements DependencyInjectionInterface
     /**
      * Provide a configuration object to configure this instance
      *
-     * @param  Configuration $config
+     * @param  Config $config
      * @return void
      */
-    public function configure(Configuration $config)
+    public function configure(Config $config)
     {
         $config->configure($this);
     }
@@ -296,11 +296,11 @@ class Di implements DependencyInjectionInterface
             }
 
             if ($requestedName) {
-                $instanceConfiguration = $instanceManager->getConfiguration($requestedName);
+                $instanceConfig = $instanceManager->getConfig($requestedName);
 
-                if ($instanceConfiguration['injections']) {
+                if ($instanceConfig['injections']) {
                     $objectsToInject = $methodsToCall = array();
-                    foreach ($instanceConfiguration['injections'] as $injectName => $injectValue) {
+                    foreach ($instanceConfig['injections'] as $injectName => $injectValue) {
                         if (is_int($injectName) && is_string($injectValue)) {
                             $objectsToInject[] = $this->get($injectValue, $params);
                         } elseif (is_string($injectName) && is_array($injectValue)) {
@@ -483,13 +483,13 @@ class Di implements DependencyInjectionInterface
         $aliases = $this->instanceManager->getAliases();
 
         // for the alias in the dependency tree
-        if ($alias && $this->instanceManager->hasConfiguration($alias)) {
-            $iConfig['thisAlias'] = $this->instanceManager->getConfiguration($alias);
+        if ($alias && $this->instanceManager->hasConfig($alias)) {
+            $iConfig['thisAlias'] = $this->instanceManager->getConfig($alias);
         }
 
         // for the current class in the dependency tree
-        if ($this->instanceManager->hasConfiguration($class)) {
-            $iConfig['thisClass'] = $this->instanceManager->getConfiguration($class);
+        if ($this->instanceManager->hasConfig($class)) {
+            $iConfig['thisClass'] = $this->instanceManager->getConfig($class);
         }
 
         // for the parent class, provided we are deeper than one node
@@ -501,10 +501,10 @@ class Di implements DependencyInjectionInterface
             $requestedClass = $requestedAlias = null;
         }
 
-        if ($requestedClass != $class && $this->instanceManager->hasConfiguration($requestedClass)) {
-            $iConfig['requestedClass'] = $this->instanceManager->getConfiguration($requestedClass);
+        if ($requestedClass != $class && $this->instanceManager->hasConfig($requestedClass)) {
+            $iConfig['requestedClass'] = $this->instanceManager->getConfig($requestedClass);
             if ($requestedAlias) {
-                $iConfig['requestedAlias'] = $this->instanceManager->getConfiguration($requestedAlias);
+                $iConfig['requestedAlias'] = $this->instanceManager->getConfig($requestedAlias);
             }
         }
 
@@ -664,7 +664,7 @@ class Di implements DependencyInjectionInterface
                     );
                 }
                 array_push($this->currentDependencies, $class);
-                $dConfig = $this->instanceManager->getConfiguration($computedParams['required'][$fqParamPos][0]);
+                $dConfig = $this->instanceManager->getConfig($computedParams['required'][$fqParamPos][0]);
                 if ($dConfig['shared'] === false) {
                     $resolvedParams[$index] = $this->newInstance($computedParams['required'][$fqParamPos][0], $callTimeUserParams, false);
                 } else {

--- a/library/Zend/Di/InstanceManager.php
+++ b/library/Zend/Di/InstanceManager.php
@@ -275,7 +275,7 @@ class InstanceManager /* implements InstanceManagerInterface */
      * @param  string $aliasOrClass
      * @return bool
      */
-    public function hasConfiguration($aliasOrClass)
+    public function hasConfig($aliasOrClass)
     {
         $key = ($this->hasAlias($aliasOrClass)) ? 'alias:' . $this->getBaseAlias($aliasOrClass) : $aliasOrClass;
         if (!isset($this->configurations[$key])) {
@@ -295,7 +295,7 @@ class InstanceManager /* implements InstanceManagerInterface */
      * @param array  $configuration
      * @param bool   $append
      */
-    public function setConfiguration($aliasOrClass, array $configuration, $append = false)
+    public function setConfig($aliasOrClass, array $configuration, $append = false)
     {
         $key = ($this->hasAlias($aliasOrClass)) ? 'alias:' . $this->getBaseAlias($aliasOrClass) : $aliasOrClass;
         if (!isset($this->configurations[$key]) || !$append) {
@@ -330,7 +330,7 @@ class InstanceManager /* implements InstanceManagerInterface */
      * @param  string $aliasOrClass
      * @return array
      */
-    public function getConfiguration($aliasOrClass)
+    public function getConfig($aliasOrClass)
     {
         $key = ($this->hasAlias($aliasOrClass)) ? 'alias:' . $this->getBaseAlias($aliasOrClass) : $aliasOrClass;
         if (isset($this->configurations[$key])) {
@@ -342,7 +342,7 @@ class InstanceManager /* implements InstanceManagerInterface */
 
     /**
      * setParameters() is a convenience method for:
-     *    setConfiguration($type, array('parameters' => array(...)), true);
+     *    setConfig($type, array('parameters' => array(...)), true);
      *
      * @param  string $aliasOrClass Alias or Class
      * @param  array  $parameters   Multi-dim array of parameters and their values
@@ -350,12 +350,12 @@ class InstanceManager /* implements InstanceManagerInterface */
      */
     public function setParameters($aliasOrClass, array $parameters)
     {
-        $this->setConfiguration($aliasOrClass, array('parameters' => $parameters), true);
+        $this->setConfig($aliasOrClass, array('parameters' => $parameters), true);
     }
 
     /**
      * setInjections() is a convenience method for:
-     *    setConfiguration($type, array('injections' => array(...)), true);
+     *    setConfig($type, array('injections' => array(...)), true);
      *
      * @param  string $aliasOrClass Alias or Class
      * @param  array  $injections   Multi-dim array of methods and their parameters
@@ -363,7 +363,7 @@ class InstanceManager /* implements InstanceManagerInterface */
      */
     public function setInjections($aliasOrClass, array $injections)
     {
-        $this->setConfiguration($aliasOrClass, array('injections' => $injections), true);
+        $this->setConfig($aliasOrClass, array('injections' => $injections), true);
     }
 
     /**
@@ -375,7 +375,7 @@ class InstanceManager /* implements InstanceManagerInterface */
      */
     public function setShared($aliasOrClass, $isShared)
     {
-        $this->setConfiguration($aliasOrClass, array('shared' => (bool) $isShared), true);
+        $this->setConfig($aliasOrClass, array('shared' => (bool) $isShared), true);
     }
 
     /**

--- a/library/Zend/Form/View/HelperConfig.php
+++ b/library/Zend/Form/View/HelperConfig.php
@@ -10,7 +10,7 @@
 
 namespace Zend\Form\View;
 
-use Zend\ServiceManager\ConfigurationInterface;
+use Zend\ServiceManager\ConfigInterface;
 use Zend\ServiceManager\ServiceManager;
 
 /**
@@ -20,7 +20,7 @@ use Zend\ServiceManager\ServiceManager;
  * @package    Zend_Form
  * @subpackage View
  */
-class HelperConfiguration implements ConfigurationInterface
+class HelperConfig implements ConfigInterface
 {
     /**
      * @var array Pre-aliased view helpers

--- a/library/Zend/I18n/View/HelperConfig.php
+++ b/library/Zend/I18n/View/HelperConfig.php
@@ -10,7 +10,7 @@
 
 namespace Zend\I18n\View;
 
-use Zend\ServiceManager\ConfigurationInterface;
+use Zend\ServiceManager\ConfigInterface;
 use Zend\ServiceManager\ServiceManager;
 
 /**
@@ -20,7 +20,7 @@ use Zend\ServiceManager\ServiceManager;
  * @package    Zend_I18n
  * @subpackage View
  */
-class HelperConfiguration implements ConfigurationInterface
+class HelperConfig implements ConfigInterface
 {
     /**
      * @var array Pre-aliased view helpers

--- a/library/Zend/ModuleManager/Feature/ControllerPluginProviderInterface.php
+++ b/library/Zend/ModuleManager/Feature/ControllerPluginProviderInterface.php
@@ -23,5 +23,5 @@ interface ControllerPluginProviderInterface
      *
      * @return array|\Zend\ServiceManager\Configuration
      */
-    public function getControllerPluginConfiguration();
+    public function getControllerPluginConfig();
 }

--- a/library/Zend/ModuleManager/Feature/ControllerProviderInterface.php
+++ b/library/Zend/ModuleManager/Feature/ControllerProviderInterface.php
@@ -23,5 +23,5 @@ interface ControllerProviderInterface
      *
      * @return array|\Zend\ServiceManager\Configuration
      */
-    public function getControllerConfiguration();
+    public function getControllerConfig();
 }

--- a/library/Zend/ModuleManager/Feature/ViewHelperProviderInterface.php
+++ b/library/Zend/ModuleManager/Feature/ViewHelperProviderInterface.php
@@ -23,5 +23,5 @@ interface ViewHelperProviderInterface
      *
      * @return array|\Zend\ServiceManager\Configuration
      */
-    public function getViewHelperConfiguration();
+    public function getViewHelperConfig();
 }

--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -118,9 +118,9 @@ class Application implements
      *
      * @return array|object
      */
-    public function getConfiguration()
+    public function getConfig()
     {
-        return $this->serviceManager->get('Configuration');
+        return $this->serviceManager->get('Config');
     }
 
     /**
@@ -227,7 +227,7 @@ class Application implements
      * Static method for quick and easy initialization of the Application.
      *
      * If you use this init() method, you cannot specify a service with the
-     * name of 'ApplicationConfiguration' in your service manager config. That
+     * name of 'ApplicationConfig' in your service manager config. That
      * name is reserved to hold the array from application.config.php
      *
      * The following services can only be overridden from application.config.php:
@@ -245,8 +245,8 @@ class Application implements
     public static function init($configuration = array())
     {
         $smConfig = isset($configuration['service_manager']) ? $configuration['service_manager'] : array();
-        $serviceManager = new ServiceManager(new Service\ServiceManagerConfiguration($smConfig));
-        $serviceManager->setService('ApplicationConfiguration', $configuration);
+        $serviceManager = new ServiceManager(new Service\ServiceManagerConfig($smConfig));
+        $serviceManager->setService('ApplicationConfig', $configuration);
         $serviceManager->get('ModuleManager')->loadModules();
         return $serviceManager->get('Application')->bootstrap();
     }

--- a/library/Zend/Mvc/Service/AbstractPluginManagerFactory.php
+++ b/library/Zend/Mvc/Service/AbstractPluginManagerFactory.php
@@ -37,7 +37,7 @@ abstract class AbstractPluginManagerFactory implements FactoryInterface
         $pluginManagerClass = static::PLUGIN_MANAGER_CLASS;
         $plugins = new $pluginManagerClass;
         $plugins->setServiceLocator($serviceLocator);
-        $configuration    = $serviceLocator->get('Configuration');
+        $configuration    = $serviceLocator->get('Config');
         if (isset($configuration['di']) && $serviceLocator->has('Di')) {
             $di = $serviceLocator->get('Di');
             $plugins->addAbstractFactory(

--- a/library/Zend/Mvc/Service/ApplicationFactory.php
+++ b/library/Zend/Mvc/Service/ApplicationFactory.php
@@ -32,6 +32,6 @@ class ApplicationFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return new Application($serviceLocator->get('Configuration'), $serviceLocator);
+        return new Application($serviceLocator->get('Config'), $serviceLocator);
     }
 }

--- a/library/Zend/Mvc/Service/ConfigFactory.php
+++ b/library/Zend/Mvc/Service/ConfigFactory.php
@@ -18,7 +18,7 @@ use Zend\ServiceManager\ServiceLocatorInterface;
  * @package    Zend_Mvc
  * @subpackage Service
  */
-class ConfigurationFactory implements FactoryInterface
+class ConfigFactory implements FactoryInterface
 {
     /**
      * Create the application configuration service

--- a/library/Zend/Mvc/Service/ControllerLoaderFactory.php
+++ b/library/Zend/Mvc/Service/ControllerLoaderFactory.php
@@ -47,7 +47,7 @@ class ControllerLoaderFactory implements FactoryInterface
 
         $controllerLoader = $serviceLocator->createScopedServiceManager();
 
-        $configuration    = $serviceLocator->get('Configuration');
+        $configuration    = $serviceLocator->get('Config');
         if (isset($configuration['di']) && $serviceLocator->has('Di')) {
             $di = $serviceLocator->get('Di');
             $controllerLoader->addAbstractFactory(

--- a/library/Zend/Mvc/Service/DiFactory.php
+++ b/library/Zend/Mvc/Service/DiFactory.php
@@ -10,7 +10,7 @@
 
 namespace Zend\Mvc\Service;
 
-use Zend\Di\Configuration as DiConfiguration;
+use Zend\Di\Config as DiConfig;
 use Zend\Di\Di;
 use Zend\ServiceManager\Di\DiAbstractServiceFactory;
 use Zend\ServiceManager\FactoryInterface;
@@ -29,7 +29,7 @@ class DiFactory implements FactoryInterface
      *
      * Creates and returns an abstract factory seeded by the dependency
      * injector. If the "di" key of the configuration service is set, that
-     * sub-array is passed to a DiConfiguration object and used to configure
+     * sub-array is passed to a DiConfig object and used to configure
      * the DI instance. The DI instance is then used to seed the
      * DiAbstractServiceFactory, which is then registered with the service
      * manager.
@@ -41,9 +41,9 @@ class DiFactory implements FactoryInterface
     {
         $di     = new Di();
 
-        $config = $serviceLocator->get('Configuration');
+        $config = $serviceLocator->get('Config');
         if (isset($config['di'])) {
-            $di->configure(new DiConfiguration($config['di']));
+            $di->configure(new DiConfig($config['di']));
         }
 
         if ($serviceLocator instanceof ServiceManager) {

--- a/library/Zend/Mvc/Service/ModuleManagerFactory.php
+++ b/library/Zend/Mvc/Service/ModuleManagerFactory.php
@@ -82,10 +82,10 @@ class ModuleManagerFactory implements FactoryInterface
         $defaultListeners = new DefaultListenerAggregate($listenerOptions);
         $serviceListener  = new ServiceListener($serviceLocator, $this->defaultServiceConfiguration);
 
-        $serviceListener->addServiceManager($serviceLocator, 'service_manager', 'Zend\ModuleManager\Feature\ServiceProviderInterface', 'getServiceConfiguration');
-        $serviceListener->addServiceManager('ControllerLoader', 'controllers', 'Zend\ModuleManager\Feature\ControllerProviderInterface', 'getControllerConfiguration');
-        $serviceListener->addServiceManager('ControllerPluginManager', 'controller_plugins', 'Zend\ModuleManager\Feature\ControllerPluginProviderInterface', 'getControllerPluginConfiguration');
-        $serviceListener->addServiceManager('ViewHelperManager', 'view_helpers', 'Zend\ModuleManager\Feature\ViewHelperProviderInterface', 'getViewHelperConfiguration');
+        $serviceListener->addServiceManager($serviceLocator, 'service_manager', 'Zend\ModuleManager\Feature\ServiceProviderInterface', 'getServiceConfig');
+        $serviceListener->addServiceManager('ControllerLoader', 'controllers', 'Zend\ModuleManager\Feature\ControllerProviderInterface', 'getControllerConfig');
+        $serviceListener->addServiceManager('ControllerPluginManager', 'controller_plugins', 'Zend\ModuleManager\Feature\ControllerPluginProviderInterface', 'getControllerPluginConfig');
+        $serviceListener->addServiceManager('ViewHelperManager', 'view_helpers', 'Zend\ModuleManager\Feature\ViewHelperProviderInterface', 'getViewHelperConfig');
 
         $events        = $serviceLocator->get('EventManager');
         $events->attach($defaultListeners);

--- a/library/Zend/Mvc/Service/ModuleManagerFactory.php
+++ b/library/Zend/Mvc/Service/ModuleManagerFactory.php
@@ -30,7 +30,7 @@ class ModuleManagerFactory implements FactoryInterface
      *
      * @var array
      */
-    protected $defaultServiceConfiguration = array(
+    protected $defaultServiceConfig = array(
         'invokables' => array(
             'DispatchListener' => 'Zend\Mvc\DispatchListener',
             'Request'          => 'Zend\Http\PhpEnvironment\Request',
@@ -40,7 +40,7 @@ class ModuleManagerFactory implements FactoryInterface
         ),
         'factories' => array(
             'Application'             => 'Zend\Mvc\Service\ApplicationFactory',
-            'Configuration'           => 'Zend\Mvc\Service\ConfigurationFactory',
+            'Config'                  => 'Zend\Mvc\Service\ConfigFactory',
             'ControllerLoader'        => 'Zend\Mvc\Service\ControllerLoaderFactory',
             'ControllerPluginManager' => 'Zend\Mvc\Service\ControllerPluginManagerFactory',
             'DependencyInjector'      => 'Zend\Mvc\Service\DiFactory',
@@ -52,7 +52,7 @@ class ModuleManagerFactory implements FactoryInterface
             'ViewJsonStrategy'        => 'Zend\Mvc\Service\ViewJsonStrategyFactory',
         ),
         'aliases' => array(
-            'Config'                            => 'Configuration',
+            'Configuration'                     => 'Config',
             'ControllerPluginBroker'            => 'ControllerPluginManager',
             'Di'                                => 'DependencyInjector',
             'Zend\Di\LocatorInterface'          => 'DependencyInjector',
@@ -65,7 +65,7 @@ class ModuleManagerFactory implements FactoryInterface
      * Creates and returns the module manager
      *
      * Instantiates the default module listeners, providing them configuration
-     * from the "module_listener_options" key of the ApplicationConfiguration
+     * from the "module_listener_options" key of the ApplicationConfig
      * service. Also sets the default config glob path.
      *
      * Module manager is instantiated and provided with an EventManager, to which
@@ -77,10 +77,10 @@ class ModuleManagerFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $configuration    = $serviceLocator->get('ApplicationConfiguration');
+        $configuration    = $serviceLocator->get('ApplicationConfig');
         $listenerOptions  = new ListenerOptions($configuration['module_listener_options']);
         $defaultListeners = new DefaultListenerAggregate($listenerOptions);
-        $serviceListener  = new ServiceListener($serviceLocator, $this->defaultServiceConfiguration);
+        $serviceListener  = new ServiceListener($serviceLocator, $this->defaultServiceConfig);
 
         $serviceListener->addServiceManager($serviceLocator, 'service_manager', 'Zend\ModuleManager\Feature\ServiceProviderInterface', 'getServiceConfig');
         $serviceListener->addServiceManager('ControllerLoader', 'controllers', 'Zend\ModuleManager\Feature\ControllerProviderInterface', 'getControllerConfig');

--- a/library/Zend/Mvc/Service/RouterFactory.php
+++ b/library/Zend/Mvc/Service/RouterFactory.php
@@ -24,7 +24,7 @@ class RouterFactory implements FactoryInterface
     /**
      * Create and return the router
      *
-     * Retrieves the "router" key of the Configuration service, and uses it
+     * Retrieves the "router" key of the Config service, and uses it
      * to instantiate the router. Uses the TreeRouteStack implementation by
      * default.
      *

--- a/library/Zend/Mvc/Service/ServiceManagerConfig.php
+++ b/library/Zend/Mvc/Service/ServiceManagerConfig.php
@@ -12,7 +12,7 @@ namespace Zend\Mvc\Service;
 
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
-use Zend\ServiceManager\ConfigurationInterface;
+use Zend\ServiceManager\ConfigInterface;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\ServiceManagerAwareInterface;
 
@@ -21,7 +21,7 @@ use Zend\ServiceManager\ServiceManagerAwareInterface;
  * @package    Zend_Mvc
  * @subpackage Service
  */
-class ServiceManagerConfiguration implements ConfigurationInterface
+class ServiceManagerConfig implements ConfigInterface
 {
     /**
      * Services that can be instantiated without factories

--- a/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
+++ b/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
@@ -12,7 +12,7 @@ namespace Zend\Mvc\Service;
 
 use Zend\Mvc\Exception;
 use Zend\Mvc\Router\RouteMatch;
-use Zend\ServiceManager\ConfigurationInterface;
+use Zend\ServiceManager\ConfigInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\View\Helper as ViewHelper;
 
@@ -31,9 +31,9 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
      * @var array
      */
     protected $defaultHelperMapClasses = array(
-        'Zend\Form\View\HelperConfiguration',
-        'Zend\I18n\View\HelperConfiguration',
-        'Zend\Navigation\View\HelperConfiguration'
+        'Zend\Form\View\HelperConfig',
+        'Zend\I18n\View\HelperConfig',
+        'Zend\Navigation\View\HelperConfig'
     );
 
     /**
@@ -51,11 +51,11 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
                 $config = new $configClass;
             }
 
-            if (!$config instanceof ConfigurationInterface) {
+            if (!$config instanceof ConfigInterface) {
                 throw new Exception\RuntimeException(sprintf(
                     'Invalid service manager configuration class provided; received "%s", expected class implementing %s',
                     $configClass,
-                    'Zend\ServiceManager\ConfigurationInterface'
+                    'Zend\ServiceManager\ConfigInterface'
                 ));
             }
 
@@ -80,7 +80,7 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
         });
 
         $plugins->setFactory('basepath', function($sm) use($serviceLocator) {
-            $config = $serviceLocator->get('Configuration');
+            $config = $serviceLocator->get('Config');
             $config = $config['view_manager'];
             $basePathHelper = new ViewHelper\BasePath;
             if (isset($config['base_path'])) {
@@ -99,7 +99,7 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
          * based on. This is why it must be set early instead of later in the layout phtml.
          */
         $plugins->setFactory('doctype', function($sm) use($serviceLocator) {
-            $config = $serviceLocator->get('Configuration');
+            $config = $serviceLocator->get('Config');
             $config = $config['view_manager'];
             $doctypeHelper = new ViewHelper\Doctype;
             if (isset($config['doctype'])) {

--- a/library/Zend/Mvc/View/ViewManager.php
+++ b/library/Zend/Mvc/View/ViewManager.php
@@ -18,7 +18,7 @@ use Zend\Mvc\ApplicationInterface;
 use Zend\Mvc\Exception;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;
-use Zend\ServiceManager\ConfigurationInterface;
+use Zend\ServiceManager\ConfigInterface;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Stdlib\ArrayUtils;
 use Zend\View\Helper as ViewHelper;
@@ -122,7 +122,7 @@ class ViewManager implements ListenerAggregateInterface
     {
         $application  = $event->getApplication();
         $services     = $application->getServiceManager();
-        $config       = $services->get('Configuration');
+        $config       = $services->get('Config');
         $events       = $application->getEventManager();
         $sharedEvents = $events->getSharedManager();
 

--- a/library/Zend/Navigation/View/HelperConfig.php
+++ b/library/Zend/Navigation/View/HelperConfig.php
@@ -10,7 +10,7 @@
 
 namespace Zend\Navigation\View;
 
-use Zend\ServiceManager\ConfigurationInterface;
+use Zend\ServiceManager\ConfigInterface;
 use Zend\ServiceManager\ServiceManager;
 use Zend\View\HelperPluginManager;
 
@@ -21,7 +21,7 @@ use Zend\View\HelperPluginManager;
  * @package    Zend_Navigation
  * @subpackage View
  */
-class HelperConfiguration implements ConfigurationInterface
+class HelperConfig implements ConfigInterface
 {
     /**
      * Configure the provided service manager instance with the configuration

--- a/library/Zend/ServiceManager/Config.php
+++ b/library/Zend/ServiceManager/Config.php
@@ -10,53 +10,53 @@
 
 namespace Zend\ServiceManager;
 
-class Configuration implements ConfigurationInterface
+class Config implements ConfigInterface
 {
-    protected $configuration = array();
+    protected $config = array();
 
-    public function __construct($configuration = array())
+    public function __construct($config = array())
     {
-        $this->configuration = $configuration;
+        $this->config = $config;
     }
 
     public function getAllowOverride()
     {
-        return (isset($this->configuration['allow_override'])) ? $this->configuration['allow_override'] : null;
+        return (isset($this->config['allow_override'])) ? $this->config['allow_override'] : null;
     }
 
     public function getFactories()
     {
-        return (isset($this->configuration['factories'])) ? $this->configuration['factories'] : array();
+        return (isset($this->config['factories'])) ? $this->config['factories'] : array();
     }
 
     public function getAbstractFactories()
     {
-        return (isset($this->configuration['abstract_factories'])) ? $this->configuration['abstract_factories'] : array();
+        return (isset($this->config['abstract_factories'])) ? $this->config['abstract_factories'] : array();
     }
 
     public function getInvokables()
     {
-        return (isset($this->configuration['invokables'])) ? $this->configuration['invokables'] : array();
+        return (isset($this->config['invokables'])) ? $this->config['invokables'] : array();
     }
 
     public function getServices()
     {
-        return (isset($this->configuration['services'])) ? $this->configuration['services'] : array();
+        return (isset($this->config['services'])) ? $this->config['services'] : array();
     }
 
     public function getAliases()
     {
-        return (isset($this->configuration['aliases'])) ? $this->configuration['aliases'] : array();
+        return (isset($this->config['aliases'])) ? $this->config['aliases'] : array();
     }
 
     public function getInitializers()
     {
-        return (isset($this->configuration['initializers'])) ? $this->configuration['initializers'] : array();
+        return (isset($this->config['initializers'])) ? $this->config['initializers'] : array();
     }
 
     public function getShared()
     {
-        return (isset($this->configuration['shared'])) ? $this->configuration['shared'] : array();
+        return (isset($this->config['shared'])) ? $this->config['shared'] : array();
     }
 
     public function configureServiceManager(ServiceManager $serviceManager)

--- a/library/Zend/ServiceManager/ConfigInterface.php
+++ b/library/Zend/ServiceManager/ConfigInterface.php
@@ -10,7 +10,7 @@
 
 namespace Zend\ServiceManager;
 
-interface ConfigurationInterface
+interface ConfigInterface
 {
     public function configureServiceManager(ServiceManager $serviceManager);
 }

--- a/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
+++ b/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
@@ -53,7 +53,7 @@ class DiAbstractServiceFactory extends DiServiceFactory implements AbstractFacto
     {
         return $this->instanceManager->hasSharedInstance($requestedName)
             || $this->instanceManager->hasAlias($requestedName)
-            || $this->instanceManager->hasConfiguration($requestedName)
+            || $this->instanceManager->hasConfig($requestedName)
             || $this->instanceManager->hasTypePreferences($requestedName)
             || $this->definitions->hasClass($requestedName);
     }

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -97,12 +97,12 @@ class ServiceManager implements ServiceLocatorInterface
     protected $throwExceptionInCreate = true;
 
     /**
-     * @param ConfigurationInterface $configuration
+     * @param ConfigInterface $config
      */
-    public function __construct(ConfigurationInterface $configuration = null)
+    public function __construct(ConfigInterface $config = null)
     {
-        if ($configuration) {
-            $configuration->configureServiceManager($this);
+        if ($config) {
+            $config->configureServiceManager($this);
         }
     }
 

--- a/tests/Zend/Di/ConfigTest.php
+++ b/tests/Zend/Di/ConfigTest.php
@@ -10,17 +10,17 @@
 
 namespace ZendTest\Di;
 
-use Zend\Di\Configuration;
+use Zend\Di\Config;
 use Zend\Di\Di;
 use Zend\Config\Factory as ConfigFactory;
 use PHPUnit_Framework_TestCase as TestCase;
 
-class ConfigurationTest extends TestCase
+class ConfigTest extends TestCase
 {
-    public function testConfigurationCanConfigureInstanceManagerWithIniFile()
+    public function testConfigCanConfigureInstanceManagerWithIniFile()
     {
         $ini = ConfigFactory::fromFile(__DIR__ . '/_files/sample.ini', true)->get('section-a');
-        $config = new Configuration($ini->di);
+        $config = new Config($ini->di);
         $di = new Di();
         $di->configure($config);
 
@@ -41,20 +41,20 @@ class ConfigurationTest extends TestCase
         $this->assertTrue($im->hasTypePreferences('my-mapper'));
         $this->assertContains('my-dbAdapter', $im->getTypePreferences('my-mapper'));
 
-        $this->assertTrue($im->hasConfiguration('My\DbAdapter'));
+        $this->assertTrue($im->hasConfig('My\DbAdapter'));
         $expected = array('parameters' => array('username' => 'readonly', 'password' => 'mypassword'), 'injections' => array(), 'shared' => true);
-        $this->assertEquals($expected, $im->getConfiguration('My\DbAdapter'));
+        $this->assertEquals($expected, $im->getConfig('My\DbAdapter'));
 
-        $this->assertTrue($im->hasConfiguration('my-dbAdapter'));
+        $this->assertTrue($im->hasConfig('my-dbAdapter'));
         $expected = array('parameters' => array('username' => 'readwrite'), 'injections' => array(), 'shared' => true);
-        $this->assertEquals($expected, $im->getConfiguration('my-dbAdapter'));
+        $this->assertEquals($expected, $im->getConfig('my-dbAdapter'));
     }
 
-    public function testConfigurationCanConfigureBuilderDefinitionFromIni()
+    public function testConfigCanConfigureBuilderDefinitionFromIni()
     {
         $this->markTestIncomplete('Builder not updated to new DI yet');
         $ini = ConfigFactory::fromFile(__DIR__ . '/_files/sample.ini', true)->get('section-b');
-        $config = new Configuration($ini->di);
+        $config = new Config($ini->di);
         $di = new Di($config);
         $definition = $di->getDefinition();
 
@@ -81,10 +81,10 @@ class ConfigurationTest extends TestCase
 
     }
 
-    public function testConfigurationCanConfigureRuntimeDefinitionDefaultFromIni()
+    public function testConfigCanConfigureRuntimeDefinitionDefaultFromIni()
     {
         $ini = ConfigFactory::fromFile(__DIR__ . '/_files/sample.ini', true)->get('section-c');
-        $config = new Configuration($ini->di);
+        $config = new Config($ini->di);
         $di = new Di();
         $di->configure($config);
         $definition = $di->definitions()->getDefinitionByType('Zend\Di\Definition\RuntimeDefinition');
@@ -92,30 +92,30 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($definition->getIntrospectionStrategy()->getUseAnnotations());
     }
 
-    public function testConfigurationCanConfigureRuntimeDefinitionDisabledFromIni()
+    public function testConfigCanConfigureRuntimeDefinitionDisabledFromIni()
     {
         $ini = ConfigFactory::fromFile(__DIR__ . '/_files/sample.ini', true)->get('section-d');
-        $config = new Configuration($ini->di);
+        $config = new Config($ini->di);
         $di = new Di();
         $di->configure($config);
         $definition = $di->definitions()->getDefinitionByType('Zend\Di\Definition\RuntimeDefinition');
         $this->assertFalse($definition);
     }
 
-    public function testConfigurationCanConfigureRuntimeDefinitionUseAnnotationFromIni()
+    public function testConfigCanConfigureRuntimeDefinitionUseAnnotationFromIni()
     {
         $ini = ConfigFactory::fromFile(__DIR__ . '/_files/sample.ini', true)->get('section-e');
-        $config = new Configuration($ini->di);
+        $config = new Config($ini->di);
         $di = new Di();
         $di->configure($config);
         $definition = $di->definitions()->getDefinitionByType('Zend\Di\Definition\RuntimeDefinition');
         $this->assertTrue($definition->getIntrospectionStrategy()->getUseAnnotations());
     }
 
-    public function testConfigurationCanConfigureCompiledDefinition()
+    public function testConfigCanConfigureCompiledDefinition()
     {
         $config = ConfigFactory::fromFile(__DIR__ . '/_files/sample.php', true);
-        $config = new Configuration($config->di);
+        $config = new Config($config->di);
         $di = new Di();
         $di->configure($config);
         $definition = $di->definitions()->getDefinitionByType('Zend\Di\Definition\ArrayDefinition');

--- a/tests/Zend/Di/DiTest.php
+++ b/tests/Zend/Di/DiTest.php
@@ -13,7 +13,7 @@ namespace ZendTest\Di;
 use Zend\Di\Di;
 use Zend\Di\DefinitionList;
 use Zend\Di\InstanceManager;
-use Zend\Di\Configuration;
+use Zend\Di\Config;
 use Zend\Di\Definition;
 
 
@@ -35,7 +35,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
     {
         $dl = new DefinitionList(array());
         $im = new InstanceManager();
-        $cg = new Configuration(array());
+        $cg = new Config(array());
         $di = new Di($dl, $im, $cg);
 
         $this->assertSame($dl, $di->definitions());
@@ -155,7 +155,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
 
 //    public function testCanSetInstantiatorToStaticFactory()
 //    {
-//        $config = new Configuration(array(
+//        $config = new Config(array(
 //            'definition' => array(
 //                'class' => array(
 //                    'ZendTest\Di\TestAsset\DummyParams' => array(
@@ -605,7 +605,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
     public function testMarkingClassAsNotSharedInjectsNewInstanceIntoAllRequestersButDependentsAreShared()
     {
         $di = new Di();
-        $di->configure(new Configuration(array(
+        $di->configure(new Config(array(
             'instance' => array(
                 'ZendTest\Di\TestAsset\SharedInstance\Lister' => array(
                     'shared' => false

--- a/tests/Zend/Di/InstanceManagerTest.php
+++ b/tests/Zend/Di/InstanceManagerTest.php
@@ -69,19 +69,19 @@ class InstanceManagerTest extends TestCase
     /**
      * @group AliasAlias
      */
-    public function testInstanceManagerResolvesRecursiveAliasesForConfiguration()
+    public function testInstanceManagerResolvesRecursiveAliasesForConfig()
     {
         $config = array('parameters' => array('username' => 'my-username'));
 
         $im = new InstanceManager;
         $im->addAlias('bar-alias', 'Some\Class');
         $im->addAlias('foo-alias', 'bar-alias');
-        $im->setConfiguration('bar-alias', $config);
+        $im->setConfig('bar-alias', $config);
 
         $config['injections'] = array();
         $config['shared'] = true;
 
-        $this->assertEquals($config, $im->getConfiguration('foo-alias'));
+        $this->assertEquals($config, $im->getConfig('foo-alias'));
     }
 
 }

--- a/tests/Zend/Di/ServiceLocator/GeneratorTest.php
+++ b/tests/Zend/Di/ServiceLocator/GeneratorTest.php
@@ -11,7 +11,7 @@
 namespace ZendTest\Di\ServiceLocator;
 
 use Zend\Di\Di;
-use Zend\Di\Configuration;
+use Zend\Di\Config;
 use Zend\Di\ServiceLocator\Generator as ContainerGenerator;
 use Zend\Di\Definition\BuilderDefinition as Definition;
 use Zend\Di\Definition\Builder;
@@ -92,7 +92,7 @@ class GeneratorTest extends TestCase
                 )),
             ),
         );
-        $configuration = new Configuration($data);
+        $configuration = new Config($data);
         $configuration->configure($this->di);
     }
 
@@ -261,7 +261,7 @@ class GeneratorTest extends TestCase
         $def->addClass($opt);
         $this->di->setDefinition($def);
 
-        $cfg = new Configuration(array(
+        $cfg = new Config(array(
             'instance' => array(
                 'alias' => array('optional' => 'ZendTest\Di\TestAsset\OptionalArg'),
             ),
@@ -311,7 +311,7 @@ class GeneratorTest extends TestCase
 
         $this->di->setDefinition($def);
 
-        $cfg = new Configuration(array(
+        $cfg = new Config(array(
             'instance' => array(
                 'alias' => array(
                     'struct'  => 'ZendTest\Di\TestAsset\Struct',
@@ -360,7 +360,7 @@ class GeneratorTest extends TestCase
         $def->addClass($opt);
         $this->di->setDefinition($def);
 
-        $cfg = new Configuration(array(
+        $cfg = new Config(array(
             'instance' => array(
                 'alias' => array('optional' => 'ZendTest\Di\TestAsset\OptionalArg'),
             ),

--- a/tests/Zend/Form/View/Helper/CommonTestCase.php
+++ b/tests/Zend/Form/View/Helper/CommonTestCase.php
@@ -11,7 +11,7 @@
 namespace ZendTest\Form\View\Helper;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\Form\View\HelperConfiguration;
+use Zend\Form\View\HelperConfig;
 use Zend\View\Helper\Doctype;
 use Zend\View\Renderer\PhpRenderer;
 
@@ -33,7 +33,7 @@ abstract class CommonTestCase extends TestCase
 
         $this->renderer = new PhpRenderer;
         $helpers = $this->renderer->getHelperPluginManager();
-        $config  = new HelperConfiguration();
+        $config  = new HelperConfig();
         $config->configureServiceManager($helpers);
 
         $this->helper->setView($this->renderer);

--- a/tests/Zend/Form/View/Helper/FormCollectionTest.php
+++ b/tests/Zend/Form/View/Helper/FormCollectionTest.php
@@ -12,7 +12,7 @@ namespace ZendTest\Form\View\Helper;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element;
-use Zend\Form\View\HelperConfiguration;
+use Zend\Form\View\HelperConfig;
 use Zend\Form\View\Helper\FormCollection as FormCollectionHelper;
 use Zend\View\Helper\Doctype;
 use Zend\View\Renderer\PhpRenderer;
@@ -37,7 +37,7 @@ class FormCollectionTest extends TestCase
 
         $this->renderer = new PhpRenderer;
         $helpers = $this->renderer->getHelperPluginManager();
-        $config  = new HelperConfiguration();
+        $config  = new HelperConfig();
         $config->configureServiceManager($helpers);
 
         $this->helper->setView($this->renderer);

--- a/tests/Zend/Form/View/Helper/FormElementTest.php
+++ b/tests/Zend/Form/View/Helper/FormElementTest.php
@@ -13,7 +13,7 @@ namespace ZendTest\Form\View\Helper;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Captcha;
 use Zend\Form\Element;
-use Zend\Form\View\HelperConfiguration;
+use Zend\Form\View\HelperConfig;
 use Zend\Form\View\Helper\FormElement as FormElementHelper;
 use Zend\View\Helper\Doctype;
 use Zend\View\Renderer\PhpRenderer;
@@ -36,7 +36,7 @@ class FormElementTest extends TestCase
 
         $this->renderer = new PhpRenderer;
         $helpers = $this->renderer->getHelperPluginManager();
-        $config  = new HelperConfiguration();
+        $config  = new HelperConfig();
         $config->configureServiceManager($helpers);
 
         $this->helper->setView($this->renderer);

--- a/tests/Zend/Form/View/Helper/FormRowTest.php
+++ b/tests/Zend/Form/View/Helper/FormRowTest.php
@@ -12,7 +12,7 @@ namespace ZendTest\Form\View\Helper;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element;
-use Zend\Form\View\HelperConfiguration;
+use Zend\Form\View\HelperConfig;
 use Zend\Form\View\Helper\FormRow as FormRowHelper;
 use Zend\View\Renderer\PhpRenderer;
 
@@ -32,7 +32,7 @@ class FormRowTest extends TestCase
 
         $this->renderer = new PhpRenderer;
         $helpers = $this->renderer->getHelperPluginManager();
-        $config  = new HelperConfiguration();
+        $config  = new HelperConfig();
         $config->configureServiceManager($helpers);
 
         $this->helper->setView($this->renderer);

--- a/tests/Zend/ModuleManager/Listener/ServiceListenerTest.php
+++ b/tests/Zend/ModuleManager/Listener/ServiceListenerTest.php
@@ -16,7 +16,7 @@ use stdClass;
 use Zend\ModuleManager\Listener\ConfigListener;
 use Zend\ModuleManager\Listener\ServiceListener;
 use Zend\ModuleManager\ModuleEvent;
-use Zend\ServiceManager\Configuration as ServiceConfig;
+use Zend\ServiceManager\Config as ServiceConfig;
 use Zend\ServiceManager\ServiceManager;
 
 class ServiceListenerTest extends TestCase

--- a/tests/Zend/ModuleManager/Listener/ServiceListenerTest.php
+++ b/tests/Zend/ModuleManager/Listener/ServiceListenerTest.php
@@ -16,7 +16,7 @@ use stdClass;
 use Zend\ModuleManager\Listener\ConfigListener;
 use Zend\ModuleManager\Listener\ServiceListener;
 use Zend\ModuleManager\ModuleEvent;
-use Zend\ServiceManager\Configuration as ServiceConfiguration;
+use Zend\ServiceManager\Configuration as ServiceConfig;
 use Zend\ServiceManager\ServiceManager;
 
 class ServiceListenerTest extends TestCase
@@ -36,7 +36,7 @@ class ServiceListenerTest extends TestCase
     {
         $this->services = new ServiceManager();
         $this->listener = new ServiceListener($this->services);
-        $this->listener->addServiceManager($this->services, 'service_manager', 'Zend\ModuleManager\Feature\ServiceProviderInterface', 'getServiceConfiguration');
+        $this->listener->addServiceManager($this->services, 'service_manager', 'Zend\ModuleManager\Feature\ServiceProviderInterface', 'getServiceConfig');
         $this->event    = new ModuleEvent();
         $this->configListener = new ConfigListener();
         $this->event->setConfigListener($this->configListener);
@@ -64,7 +64,7 @@ class ServiceListenerTest extends TestCase
         }
     }
 
-    public function getServiceConfiguration()
+    public function getServiceConfig()
     {
         return array(
             'invokables' => array(__CLASS__ => __CLASS__),
@@ -87,7 +87,7 @@ class ServiceListenerTest extends TestCase
     public function assertServiceManagerIsConfigured()
     {
         $this->listener->onLoadModulesPost($this->event);
-        foreach ($this->getServiceConfiguration() as $prop => $expected) {
+        foreach ($this->getServiceConfig() as $prop => $expected) {
             if ($prop == 'invokables') {
                 $prop = 'invokableClasses';
                 foreach ($expected as $key => $value) {
@@ -106,7 +106,7 @@ class ServiceListenerTest extends TestCase
 
     public function testModuleReturningArrayConfiguresServiceManager()
     {
-        $config = $this->getServiceConfiguration();
+        $config = $this->getServiceConfig();
         $module = new TestAsset\ServiceProviderModule($config);
         $this->event->setModule($module);
         $this->listener->onLoadModule($this->event);
@@ -115,7 +115,7 @@ class ServiceListenerTest extends TestCase
 
     public function testModuleReturningTraversableConfiguresServiceManager()
     {
-        $config = $this->getServiceConfiguration();
+        $config = $this->getServiceConfig();
         $config = new ArrayObject($config);
         $module = new TestAsset\ServiceProviderModule($config);
         $this->event->setModule($module);
@@ -123,19 +123,19 @@ class ServiceListenerTest extends TestCase
         $this->assertServiceManagerIsConfigured();
     }
 
-    public function testModuleReturningServiceConfigurationConfiguresServiceManager()
+    public function testModuleReturningServiceConfigConfiguresServiceManager()
     {
-        $config = $this->getServiceConfiguration();
-        $config = new ServiceConfiguration($config);
+        $config = $this->getServiceConfig();
+        $config = new ServiceConfig($config);
         $module = new TestAsset\ServiceProviderModule($config);
         $this->event->setModule($module);
         $this->listener->onLoadModule($this->event);
         $this->assertServiceManagerIsConfigured();
     }
 
-    public function testMergedConfigurationContainingServiceManagerKeyWillConfigureServiceManagerPostLoadModules()
+    public function testMergedConfigContainingServiceManagerKeyWillConfigureServiceManagerPostLoadModules()
     {
-        $config = array('service_manager' => $this->getServiceConfiguration());
+        $config = array('service_manager' => $this->getServiceConfig());
         $configListener = new ConfigListener();
         $configListener->setMergedConfig($config);
         $this->event->setConfigListener($configListener);

--- a/tests/Zend/ModuleManager/Listener/TestAsset/ServiceProviderModule.php
+++ b/tests/Zend/ModuleManager/Listener/TestAsset/ServiceProviderModule.php
@@ -24,7 +24,7 @@ class ServiceProviderModule
         $this->config = $config;
     }
 
-    public function getServiceConfiguration()
+    public function getServiceConfig()
     {
         return $this->config;
     }

--- a/tests/Zend/Mvc/ApplicationTest.php
+++ b/tests/Zend/Mvc/ApplicationTest.php
@@ -21,7 +21,7 @@ use Zend\Modulemanager\ModuleManager;
 use Zend\Mvc\Application;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router;
-use Zend\Mvc\Service\ServiceManagerConfiguration;
+use Zend\Mvc\Service\ServiceManagerConfig;
 use Zend\Mvc\View\ViewManager;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
@@ -58,7 +58,7 @@ class ApplicationTest extends TestCase
             ));
         };
         $sm = $this->serviceManager = new ServiceManager(
-            new ServiceManagerConfiguration(array(
+            new ServiceManagerConfig(array(
                 'invokables' => array(
                     'DispatchListener' => 'Zend\Mvc\DispatchListener',
                     'Request'          => 'Zend\Http\PhpEnvironment\Request',
@@ -71,14 +71,15 @@ class ApplicationTest extends TestCase
                     'ControllerPluginManager' => 'Zend\Mvc\Service\ControllerPluginManagerFactory',
                     'Application'             => 'Zend\Mvc\Service\ApplicationFactory',
                     'Router'                  => 'Zend\Mvc\Service\RouterFactory',
-                    'Configuration'           => $config,
+                    'Config'                  => $config,
                 ),
                 'aliases' => array(
+                    'Configuration'          => 'Config',
                     'ControllerPluginBroker' => 'ControllerPluginManager',
                 ),
             ))
         );
-        $sm->setService('ApplicationConfiguration', $appConfig);
+        $sm->setService('ApplicationConfig', $appConfig);
         $sm->setAllowOverride(true);
 
         $this->application = $sm->get('Application');
@@ -143,10 +144,10 @@ class ApplicationTest extends TestCase
         $this->assertSame($this->serviceManager, $this->application->getServiceManager());
     }
 
-    public function testConfigurationIsPopulated()
+    public function testConfigIsPopulated()
     {
-        $smConfig  = $this->serviceManager->get('Configuration');
-        $appConfig = $this->application->getConfiguration();
+        $smConfig  = $this->serviceManager->get('Config');
+        $appConfig = $this->application->getConfig();
         $this->assertEquals($smConfig, $appConfig, sprintf('SM config: %s; App config: %s', var_export($smConfig, 1), var_export($appConfig, 1)));
     }
 

--- a/tests/Zend/Navigation/ServiceFactoryTest.php
+++ b/tests/Zend/Navigation/ServiceFactoryTest.php
@@ -12,7 +12,7 @@ namespace ZendTest\Navigation;
 
 use Zend\Config;
 use Zend\Mvc\Router\RouteMatch;
-use Zend\Mvc\Service\ServiceManagerConfiguration;
+use Zend\Mvc\Service\ServiceManagerConfig;
 use Zend\Navigation;
 use Zend\Navigation\Page\Mvc as MvcPage;
 use Zend\Navigation\Service\ConstructedNavigationFactory;
@@ -48,7 +48,7 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
                 'extra_config'         => array(
                     'service_manager' => array(
                         'factories' => array(
-                            'Configuration' => function() {
+                            'Config' => function() {
                                 return array(
                                     'navigation' => array(
                                         'file'    => __DIR__ . '/_files/navigation.xml',
@@ -81,8 +81,8 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
             ),
         );
 
-        $sm = $this->serviceManager = new ServiceManager(new ServiceManagerConfiguration);
-        $sm->setService('ApplicationConfiguration', $config);
+        $sm = $this->serviceManager = new ServiceManager(new ServiceManagerConfig);
+        $sm->setService('ApplicationConfig', $config);
         $sm->get('ModuleManager')->loadModules();
         $sm->get('Application')->bootstrap();
 

--- a/tests/Zend/ServiceManager/Di/DiAbstractServiceFactoryTest.php
+++ b/tests/Zend/ServiceManager/Di/DiAbstractServiceFactoryTest.php
@@ -86,7 +86,7 @@ class DiAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
         // will check instance configurations
         $this->assertFalse($instance->canCreateServiceWithName($locator, __NAMESPACE__ . '\Non\Existing', __NAMESPACE__ . '\Non\Existing'));
-        $im->setConfiguration(__NAMESPACE__ . '\Non\Existing', array('parameters' => array('a' => 'b')));
+        $im->setConfig(__NAMESPACE__ . '\Non\Existing', array('parameters' => array('a' => 'b')));
         $this->assertTrue($instance->canCreateServiceWithName($locator, __NAMESPACE__ . '\Non\Existing', __NAMESPACE__ . '\Non\Existing'));
 
         // will check preferences for abstract types

--- a/tests/Zend/ServiceManager/ServiceManagerTest.php
+++ b/tests/Zend/ServiceManager/ServiceManagerTest.php
@@ -432,7 +432,7 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
     {
         $di = $this->getMock('Zend\Di\Di');
         $factory = new DiAbstractServiceFactory($di);
-        $factory->instanceManager()->setConfiguration('ZendTest\ServiceManager\TestAsset\Bar', array('parameters' => array('foo' => array('a'))));
+        $factory->instanceManager()->setConfig('ZendTest\ServiceManager\TestAsset\Bar', array('parameters' => array('foo' => array('a'))));
         $this->serviceManager->addAbstractFactory($factory);
 
         $this->assertTrue($this->serviceManager->has('ZendTest\ServiceManager\TestAsset\Bar', true));

--- a/tests/Zend/ServiceManager/ServiceManagerTest.php
+++ b/tests/Zend/ServiceManager/ServiceManagerTest.php
@@ -15,7 +15,7 @@ use Zend\Mvc\Service\DiFactory;
 use Zend\ServiceManager\Di\DiAbstractServiceFactory;
 use Zend\ServiceManager\Exception;
 use Zend\ServiceManager\ServiceManager;
-use Zend\ServiceManager\Configuration;
+use Zend\ServiceManager\Config;
 
 class ServiceManagerTest extends \PHPUnit_Framework_TestCase
 {
@@ -33,9 +33,9 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\ServiceManager\ServiceManager::__construct
      */
-    public function testConstructorConfiguration()
+    public function testConstructorConfig()
     {
-        $config = new Configuration(array('services' => array('foo' => 'bar')));
+        $config = new Config(array('services' => array('foo' => 'bar')));
         $serviceManager = new ServiceManager($config);
         $this->assertEquals('bar', $serviceManager->get('foo'));
     }
@@ -407,7 +407,7 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testConfigureWithInvokableClass()
     {
-        $config = new Configuration(array(
+        $config = new Config(array(
             'invokables' => array(
                 'foo' => 'ZendTest\ServiceManager\TestAsset\Foo',
             ),
@@ -457,7 +457,7 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testCannotUseUnknownServiceNameForAbstractFactory()
     {
-        $config = new Configuration(array(
+        $config = new Config(array(
             'abstract_factories' => array(
                 'ZendTest\ServiceManager\TestAsset\FooAbstractFactory',
             ),

--- a/tests/Zend/View/Helper/Navigation/AbstractTest.php
+++ b/tests/Zend/View/Helper/Navigation/AbstractTest.php
@@ -16,7 +16,7 @@ use Zend\Acl\Role\GenericRole;
 use Zend\Acl\Resource\GenericResource;
 use Zend\Config\Factory as ConfigFactory;
 use Zend\Mvc\Router\RouteMatch;
-use Zend\Mvc\Service\ServiceManagerConfiguration;
+use Zend\Mvc\Service\ServiceManagerConfig;
 use Zend\ServiceManager\ServiceManager;
 use Zend\I18n\Translator\Translator;
 use Zend\View\Renderer\PhpRenderer;
@@ -114,7 +114,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
                 'extra_config'         => array(
                     'service_manager' => array(
                         'factories' => array(
-                            'Configuration' => function() use ($config) {
+                            'Config' => function() use ($config) {
                                 return array(
                                     'navigation' => array(
                                         'default' => $config->get('nav_test1'),
@@ -127,8 +127,8 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
             ),
         );
 
-        $sm = $this->serviceManager = new ServiceManager(new ServiceManagerConfiguration);
-        $sm->setService('ApplicationConfiguration', $smConfig);
+        $sm = $this->serviceManager = new ServiceManager(new ServiceManagerConfig);
+        $sm->setService('ApplicationConfig', $smConfig);
         $sm->get('ModuleManager')->loadModules();
         $sm->get('Application')->bootstrap();
         $sm->setFactory('Navigation', 'Zend\Navigation\Service\DefaultNavigationFactory');


### PR DESCRIPTION
# BC BREAKS!!
## Module Class
- getServiceConfiguration() is now getServiceConfig()
- getViewHelperConfiguration() is now getViewHelperConfig()
- getControllerPluginConfiguration() is now getControllerPluginConfig()
- getControllerConfiguration() is now getControllerConfig()
## Renamed Classes
- `Zend\Di\Configuration` → `Zend\Di\Config`
- `Zend\Form\View\HelperConfiguration` → `Zend\Form\View\HelperConfig`
- `Zend\I18n\View\HelperConfiguration` → `Zend\I18n\View\HelperConfig`
- `Zend\Mvc\Service\ConfigurationFactory` → `Zend\Mvc\Service\ConfigFactory`
- `Zend\Mvc\Service\ServiceManagerConfiguration` → `Zend\Mvc\Service\ServiceManagerConfig`
- `Zend\Navigation\View\HelperConfiguration` → `Zend\Navigation\View\HelperConfig`
- `Zend\ServiceManager\Configuration` → `Zend\ServiceManager\Config`
- `Zend\ServiceManager\ConfigurationInterface` → `Zend\ServiceManager\ConfigInterface`
## Updated Components
- Zend\ModuleManager [done]
- Zend\ServiceManager [done]
- Zend\Di [done]
- Zend\Form [done]
- Zend\I18n [done]
- Zend\Navigation [done]
- Zend\Mvc [done]
- Zend\Session [done - [PR #1888](https://github.com/zendframework/zf2/pull/1888)]

All unit tests are updated to reflect the changes.
