### PR TITLE
[WIP] Added the normalize param for internail links and file naming

### DIFF
--- a/bin/doc2rst.xsl
+++ b/bin/doc2rst.xsl
@@ -81,7 +81,14 @@
 
 <!-- include -->
 <xsl:template match="//xi:include">
+    <xsl:choose>
+        <xsl:when test="$normalize = 1">
 .. include:: <xsl:value-of select="php:function('ZendBin\RstConvert::xmlFileNameToRst', string(@href))" />
+        </xsl:when>
+        <xsl:otherwise>
+.. include:: <xsl:value-of select="@href" />
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!--


### PR DESCRIPTION
WIP, DON'T MERGE PLEASE!

Added the normalize parameter (n) for the internal links (xi:include to .. include::) and for the file naming conversion. For instance, Zend_Config-XmlIntro.xml become zend.config.xml-intro.rst.
To convert ZF2 DocBook file the usage of the script is changed in:
$ ./doc2rst.php -d file.xml -o file.rst -n
To convert generic DocBook file the usage is:
$ ./doc2rst.php -d file.xml -o file.rst
