### PR TITLE
Added the normalize parameter to the doc2rst script

### DIFF
--- a/bin/doc2rst.php
+++ b/bin/doc2rst.php
@@ -79,17 +79,15 @@ $normalize = (null !== $opts->getOption('n'));
 
 $rstFile = $opts->getOption('o');
 if (empty($rstFile)) {
-    $rstFile = basename($docbook);
-    if ('.xml' === substr($rstFile, -4)) {
-        $rstFile = substr($rstFile, 0, strlen($docbook)-4);
-    }
+    $pathinfo = pathinfo($docbook);
+    $rstFile  = $pathinfo['filename'];
     if ($normalize) {
         $rstFile = RstConvert::xmlFileNameToRst($rstFile);
     }
     if ('.rst' !== substr($rstFile, -4)) {
         $rstFile .= '.rst';
     }
-    $rstFile = dirname($docbook) . DIRECTORY_SEPARATOR . $rstFile;
+    $rstFile = $pathinfo['dirname'] . DIRECTORY_SEPARATOR . $rstFile;
 }
 
 // Load the docbook file (input)

--- a/bin/doc2rst.xsl
+++ b/bin/doc2rst.xsl
@@ -113,7 +113,7 @@
 <xsl:template match="//xi:include">
     <xsl:choose>
         <xsl:when test="$normalize = 1">
- .. include:: <xsl:value-of select="php:function('ZendBin\RstConvert::xmlFileNameToRst', string(@href))" />
+.. include:: <xsl:value-of select="php:function('ZendBin\RstConvert::xmlFileNameToRst', string(@href))" />
         </xsl:when>
         <xsl:otherwise>
 .. include:: <xsl:value-of select="@href" />

--- a/bin/doc2rst.xsl
+++ b/bin/doc2rst.xsl
@@ -111,7 +111,14 @@
 
 <!-- include -->
 <xsl:template match="//xi:include">
-.. include:: <xsl:value-of select="php:function('ZendBin\RstConvert::xmlFileNameToRst', string(@href))" />
+    <xsl:choose>
+        <xsl:when test="$normalize = 1">
+ .. include:: <xsl:value-of select="php:function('ZendBin\RstConvert::xmlFileNameToRst', string(@href))" />
+        </xsl:when>
+        <xsl:otherwise>
+.. include:: <xsl:value-of select="@href" />
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!--


### PR DESCRIPTION
Added the normalize parameter (n) for the internal links (xi:include to .. include::) and for the file naming conversion. For instance, Zend_Config-XmlIntro.xml become zend.config.xml-intro.rst.
To convert ZF2 DocBook file the usage of the script is changed in:
$ ./doc2rst.php -d file.xml -o file.rst -n
To convert generic DocBook file the usage is:
$ ./doc2rst.php -d file.xml -o file.rst
