### PR TITLE
[Mvc] Separate handling of Restful Data

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -30,7 +30,6 @@ use Zend\Http\PhpEnvironment\Response as HttpResponse;
 use Zend\Mvc\Exception;
 use Zend\Mvc\InjectApplicationEventInterface;
 use Zend\Mvc\MvcEvent;
-use Zend\Mvc\Router\Http\RouteMatch;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Stdlib\DispatchableInterface as Dispatchable;
@@ -254,9 +253,9 @@ abstract class AbstractRestfulController implements
      * Process put data and call update
      * 
      * @param Request $request
-     * @param RouteMatch $routeMatch
+     * @param $routeMatch
      */
-    public function processPutData(Request $request, RouteMatch $routeMatch)
+    public function processPutData(Request $request, $routeMatch)
     {
         if (null === $id = $routeMatch->getParam('id')) {
             if (!($id = $request->getQuery()->get('id', false))) {

--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -218,7 +218,7 @@ abstract class AbstractRestfulController implements
                             throw new \DomainException('Missing identifier');
                         }
                     }
-					$action = 'update';
+                    $action = 'update';
                     $return = $this->update($id, $this->processInputData($request));
                     break;
                 case 'delete':
@@ -244,7 +244,7 @@ abstract class AbstractRestfulController implements
         return $return;
     }
 
-	/**
+    /**
      * Process input data and return as array 
      * 
      * @param Request $request
@@ -252,13 +252,13 @@ abstract class AbstractRestfulController implements
      */
     public function processInputData(Request $request)
     {     
-		if ($request->getMethod() == 'post') {
-			return $request->getPost()->toArray();
-		} else {
-			$content = $request->getContent();
-			parse_str($content, $parsedParams);
-			return $parsedParams;
-		}
+        if ($request->getMethod() == 'post') {
+            return $request->getPost()->toArray();
+        } else {
+            $content = $request->getContent();
+            parse_str($content, $parsedParams);
+            return $parsedParams;
+        }
     }
 
     /**

--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -252,7 +252,7 @@ abstract class AbstractRestfulController implements
      */
     public function processInputData(Request $request)
     {     
-        if ($request->getMethod() == 'post') {
+        if (strtolower($request->getMethod()) == 'post') {
             return $request->getPost()->toArray();
         } else {
             $content = $request->getContent();

--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -210,7 +210,7 @@ abstract class AbstractRestfulController implements
                     break;
                 case 'post':
                     $action = 'create';
-                    $return = $this->create($request->getPost()->toArray());
+                    $return = $this->create($this->processInputData($request));
                     break;
                 case 'put':
                     if (null === $id = $routeMatch->getParam('id')) {
@@ -218,10 +218,8 @@ abstract class AbstractRestfulController implements
                             throw new \DomainException('Missing identifier');
                         }
                     }
-                    $content = $request->getContent();
-                    parse_str($content, $parsedParams);
-                    $action = 'update';
-                    $return = $this->update($id, $parsedParams);
+					$action = 'update';
+                    $return = $this->update($id, $this->processInputData($request));
                     break;
                 case 'delete':
                     if (null === $id = $routeMatch->getParam('id')) {
@@ -244,6 +242,23 @@ abstract class AbstractRestfulController implements
         // If a listener returns a response object, return it immediately
         $e->setResult($return);
         return $return;
+    }
+
+	/**
+     * Process input data and return as array 
+     * 
+     * @param Request $request
+     * @return array 
+     */
+    public function processInputData(Request $request)
+    {     
+		if ($request->getMethod() == 'post') {
+			return $request->getPost()->toArray();
+		} else {
+			$content = $request->getContent();
+			parse_str($content, $parsedParams);
+			return $parsedParams;
+		}
     }
 
     /**


### PR DESCRIPTION
This PR allows for easy/cleaner extension of the AbstractResfulController for handling multiple input types, for example the following based on the Content-Type header;

``` php
class MyAbstractRestfulController extends AbstractRestfulController
{
    public function processInputData(Request $request)
    {
        $contentType = $request->getHeaders()->get('Content-Type')->getFieldValue();
        $rawBody     = $request->getContent();

        switch (true) {
            case (strstr($contentType, 'application/json')):
                return Json::decode($rawBody, Json::TYPE_ARRAY);
                break;
            case (strstr($contentType, 'application/xml')):
                $xml = new Reader\Xml();
                return $xml->fromString($rawBody);
                break;
            default:
                return parent::processInputData($request);
                break;
        }
    }
}
```
