### PR TITLE
CaptureCache fixes

### DIFF
--- a/library/Zend/Cache/Pattern/CaptureCache.php
+++ b/library/Zend/Cache/Pattern/CaptureCache.php
@@ -195,6 +195,10 @@ class CaptureCache extends AbstractPattern
      */
     protected function detectPageId()
     {
+        if (!isset($_SERVER['REQUEST_URI'])) {
+            throw new Exception\RuntimeException("Can't auto-detect current page identity");
+        }
+
         return $_SERVER['REQUEST_URI'];
     }
 
@@ -206,13 +210,11 @@ class CaptureCache extends AbstractPattern
      */
     protected function pageId2Filename($pageId)
     {
-        $filename = basename($pageId);
-
-        if ($filename === '') {
-            $filename = $this->getOptions()->getIndexFilename();
+        if (substr($pageId, -1) === '/') {
+            return $this->getOptions()->getIndexFilename();
         }
 
-        return $filename;
+        return basename($pageId);
     }
 
     /**
@@ -223,7 +225,11 @@ class CaptureCache extends AbstractPattern
      */
     protected function pageId2Path($pageId)
     {
-        $path = rtrim(dirname($pageId), '/');
+        if (substr($pageId, -1) == '/') {
+            $path = rtrim($pageId, '/');
+        } else {
+            $path = dirname($pageId);
+        }
 
         // convert requested "/" to the valid local directory separator
         if ('/' != \DIRECTORY_SEPARATOR) {

--- a/library/Zend/Cache/Pattern/CaptureCache.php
+++ b/library/Zend/Cache/Pattern/CaptureCache.php
@@ -31,10 +31,9 @@ class CaptureCache extends AbstractPattern
      * Start the cache
      *
      * @param  string $pageId  Page identifier
-     * @param  array  $options Options
      * @return boolean false
      */
-    public function start($pageId = null, array $options = array())
+    public function start($pageId = null)
     {
         if ($this->pageId !== null) {
             throw new Exception\RuntimeException("Capturing already stated with page id '{$this->pageId}'");
@@ -55,11 +54,10 @@ class CaptureCache extends AbstractPattern
      * Get from cache
      *
      * @param  null|string $pageId
-     * @param  array $options
      * @return bool|string
      * @throws Exception\RuntimeException
      */
-    public function get($pageId = null, array $options = array())
+    public function get($pageId = null)
     {
         if (($pageId = (string) $pageId) === '') {
             $pageId = $this->detectPageId();
@@ -87,10 +85,9 @@ class CaptureCache extends AbstractPattern
      * Checks if a cache with given id exists
      *
      * @param  null|string $pageId
-     * @param  array $options
      * @return bool
      */
-    public function exists($pageId = null, array $options = array())
+    public function exists($pageId = null)
     {
         if (($pageId = (string) $pageId) === '') {
             $pageId = $this->detectPageId();
@@ -107,11 +104,10 @@ class CaptureCache extends AbstractPattern
      * Remove from cache
      *
      * @param  null|string $pageId
-     * @param  array $options
      * @throws Exception\RuntimeException
      * @return void
      */
-    public function remove($pageId = null, array $options = array())
+    public function remove($pageId = null)
     {
         if (($pageId = (string)$pageId) === '') {
             $pageId = $this->detectPageId();

--- a/library/Zend/Cache/Pattern/CaptureCache.php
+++ b/library/Zend/Cache/Pattern/CaptureCache.php
@@ -68,12 +68,13 @@ class CaptureCache extends AbstractPattern
               . \DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
 
         if (file_exists($file)) {
-            ErrorHandler::start(E_WARNING);
+            ErrorHandler::start();
             $content = file_get_contents($file);
-            ErrorHandler::stop();
+            $error   = ErrorHandler::stop();
             if ($content === false) {
-                $lastErr = error_get_last();
-                throw new Exception\RuntimeException("Failed to read cached pageId '{$pageId}': {$lastErr['message']}");
+                throw new Exception\RuntimeException(
+                    "Failed to read cached pageId '{$pageId}'", 0, $error
+                );
             }
             return $content;
         }
@@ -118,9 +119,13 @@ class CaptureCache extends AbstractPattern
               . \DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
 
         if (file_exists($file)) {
-            if (!@unlink($file)) {
-                $lastErr = error_get_last();
-                throw new Exception\RuntimeException("Failed to remove cached pageId '{$pageId}': {$lastErr['message']}");
+            ErrorHandler::start();
+            $res = unlink($file);
+            $err = ErrorHandler::stop();
+            if (!$res) {
+                throw new Exception\RuntimeException(
+                    "Failed to remove cached pageId '{$pageId}'", 0, $err
+                );
             }
         }
     }

--- a/library/Zend/Cache/Pattern/CaptureCache.php
+++ b/library/Zend/Cache/Pattern/CaptureCache.php
@@ -53,14 +53,17 @@ class CaptureCache extends AbstractPattern
      */
     public function set($content, $pageId = null)
     {
+        $publicDir = $this->getOptions()->getPublicDir();
+        if ($publicDir === null) {
+            throw new Exception\LogicException("Option 'public_dir' no set");
+        }
+
         if ($pageId === null) {
             $pageId = $this->detectPageId();
         }
 
-        $options   = $this->getOptions();
-        $publicDir = $options->getPublicDir();
-        $path      = $this->pageId2Path($pageId);
-        $file      = $path . \DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
+        $path = $this->pageId2Path($pageId);
+        $file = $path . \DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
 
         $this->createDirectoryStructure($publicDir . \DIRECTORY_SEPARATOR . $path);
         $this->putFileContent($publicDir . \DIRECTORY_SEPARATOR . $file, $content);
@@ -75,13 +78,18 @@ class CaptureCache extends AbstractPattern
      */
     public function get($pageId = null)
     {
+        $publicDir = $this->getOptions()->getPublicDir();
+        if ($publicDir === null) {
+            throw new Exception\LogicException("Option 'public_dir' no set");
+        }
+
         if ($pageId === null) {
             $pageId = $this->detectPageId();
         }
 
-        $file = $this->getOptions()->getPublicDir()
-              . \DIRECTORY_SEPARATOR . $this->pageId2Path($pageId)
-              . \DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
+        $file = $publicDir
+            . \DIRECTORY_SEPARATOR . $this->pageId2Path($pageId)
+            . \DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
 
         if (file_exists($file)) {
             ErrorHandler::start();
@@ -104,13 +112,18 @@ class CaptureCache extends AbstractPattern
      */
     public function has($pageId = null)
     {
+        $publicDir = $this->getOptions()->getPublicDir();
+        if ($publicDir === null) {
+            throw new Exception\LogicException("Option 'public_dir' no set");
+        }
+
         if ($pageId === null) {
             $pageId = $this->detectPageId();
         }
 
-        $file = $this->getOptions()->getPublicDir()
-              . \DIRECTORY_SEPARATOR . $this->pageId2Path($pageId)
-              . \DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
+        $file = $publicDir
+            . \DIRECTORY_SEPARATOR . $this->pageId2Path($pageId)
+            . \DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
 
         return file_exists($file);
     }
@@ -124,13 +137,18 @@ class CaptureCache extends AbstractPattern
      */
     public function remove($pageId = null)
     {
+        $publicDir = $this->getOptions()->getPublicDir();
+        if ($publicDir === null) {
+            throw new Exception\LogicException("Option 'public_dir' no set");
+        }
+
         if ($pageId === null) {
             $pageId = $this->detectPageId();
         }
 
-        $file = $this->getOptions()->getPublicDir()
-              . \DIRECTORY_SEPARATOR . $this->pageId2Path($pageId)
-              . \DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
+        $file = $publicDir
+            . \DIRECTORY_SEPARATOR . $this->pageId2Path($pageId)
+            . \DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
 
         if (file_exists($file)) {
             ErrorHandler::start();
@@ -148,11 +166,26 @@ class CaptureCache extends AbstractPattern
     }
 
     /**
-     * Clear cache
+     * Clear cached pages matching glob pattern
+     *
+     * @param string $pattern
      */
-    public function clear(/*TODO*/)
+    public function clearByGlob($pattern = '**')
     {
-        // TODO
+        $publicDir = $this->getOptions()->getPublicDir();
+        if ($publicDir === null) {
+            throw new Exception\LogicException("Option 'public_dir' no set");
+        }
+
+        $it = new \GlobIterator(
+            $publicDir . '/' . $pattern,
+            \GlobIterator::CURRENT_AS_SELF | \GlobIterator::SKIP_DOTS | \GlobIterator::UNIX_PATHS
+        );
+        foreach ($it as $pathname => $entry) {
+            if ($entry->isFile()) {
+                unlink($pathname);
+            }
+        }
     }
 
     /**

--- a/library/Zend/Cache/Pattern/CaptureCache.php
+++ b/library/Zend/Cache/Pattern/CaptureCache.php
@@ -40,17 +40,6 @@ class CaptureCache extends AbstractPattern
             throw new Exception\RuntimeException("Capturing already stated with page id '{$this->pageId}'");
         }
 
-        $classOptions = $this->getOptions();
-
-        if (isset($options['tags'])) {
-            $classOptions->setTags($options['tags']);
-            unset($options['tags']);
-        }
-
-        if ($classOptions->getTags() && !$classOptions->getTagStorage()) {
-            throw new Exception\RuntimeException('Tags are defined but missing a tag storage');
-        }
-
         if (($pageId = (string) $pageId) === '') {
             $pageId = $this->detectPageId();
         }
@@ -77,8 +66,8 @@ class CaptureCache extends AbstractPattern
         }
 
         $file = $this->getOptions()->getPublicDir()
-              . DIRECTORY_SEPARATOR . $this->pageId2Path($pageId)
-              . DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
+              . \DIRECTORY_SEPARATOR . $this->pageId2Path($pageId)
+              . \DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
 
         if (file_exists($file)) {
             ErrorHandler::start(E_WARNING);
@@ -108,8 +97,8 @@ class CaptureCache extends AbstractPattern
         }
 
         $file = $this->getOptions()->getPublicDir()
-              . DIRECTORY_SEPARATOR . $this->pageId2Path($pageId)
-              . DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
+              . \DIRECTORY_SEPARATOR . $this->pageId2Path($pageId)
+              . \DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
 
         return file_exists($file);
     }
@@ -129,8 +118,8 @@ class CaptureCache extends AbstractPattern
         }
 
         $file = $this->getOptions()->getPublicDir()
-              . DIRECTORY_SEPARATOR . $this->pageId2Path($pageId)
-              . DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
+              . \DIRECTORY_SEPARATOR . $this->pageId2Path($pageId)
+              . \DIRECTORY_SEPARATOR . $this->pageId2Filename($pageId);
 
         if (file_exists($file)) {
             if (!@unlink($file)) {
@@ -186,8 +175,8 @@ class CaptureCache extends AbstractPattern
         $path = rtrim(dirname($pageId), '/');
 
         // convert requested "/" to the valid local directory separator
-        if ('/' != DIRECTORY_SEPARATOR) {
-            $path = str_replace('/', DIRECTORY_SEPARATOR, $path);
+        if ('/' != \DIRECTORY_SEPARATOR) {
+            $path = str_replace('/', \DIRECTORY_SEPARATOR, $path);
         }
 
         return $path;
@@ -223,25 +212,6 @@ class CaptureCache extends AbstractPattern
 
         $this->createDirectoryStructure($publicDir . \DIRECTORY_SEPARATOR . $path);
         $this->putFileContent($publicDir . \DIRECTORY_SEPARATOR . $file, $output);
-
-        $tagStorage = $options->getTagStorage();
-        if ($tagStorage) {
-            $tagKey     = $options->getTagKey();
-            $tagIndex = $tagStorage->getTagStorage()->getItem($tagKey);
-            if (!$tagIndex) {
-                $tagIndex = null;
-            }
-
-            if ($this->tags) {
-                $tagIndex[$file] = &$this->tags;
-            } elseif ($tagIndex) {
-                unset($tagIndex[$file]);
-            }
-
-            if ($tagIndex !== null) {
-                $tagStorage->setItem($tagKey, $tagIndex);
-            }
-        }
     }
 
     /**

--- a/library/Zend/Cache/Pattern/PatternOptions.php
+++ b/library/Zend/Cache/Pattern/PatternOptions.php
@@ -697,9 +697,7 @@ class PatternOptions extends AbstractOptions
      */
     protected function recursiveStrtolower(array $array)
     {
-        return array_values(array_unique(array_map(function($value) {
-            return strtolower($value);
-        }, $array)));
+        return array_values(array_unique(array_map('strtolower', $array)));
     }
 
     /**

--- a/library/Zend/Cache/Pattern/PatternOptions.php
+++ b/library/Zend/Cache/Pattern/PatternOptions.php
@@ -148,27 +148,6 @@ class PatternOptions extends AbstractOptions
     protected $storage;
 
     /**
-     * Used by:
-     * - CaptureCache
-     * @var string
-     */
-    protected $tagKey = 'ZendCachePatternCaptureCache_Tags';
-
-    /**
-     * Used by:
-     * - CaptureCache
-     * @var array
-     */
-    protected $tags = array();
-
-    /**
-     * Used by:
-     * - CaptureCache
-     * @var null|Storage
-     */
-    protected $tagStorage;
-
-    /**
      * Constructor
      *
      * @param  array|Traversable|null $options
@@ -707,88 +686,6 @@ class PatternOptions extends AbstractOptions
     public function getStorage()
     {
         return $this->storage;
-    }
-
-    /**
-     * Set tag key
-     *
-     * @param  string $tagKey
-     * @return PatternOptions
-     */
-    public function setTagKey($tagKey)
-    {
-        if (($tagKey = (string)$tagKey) === '') {
-            throw new Exception\InvalidArgumentException("Missing tag key '{$tagKey}'");
-        }
-
-        $this->tagKey = $tagKey;
-        return $this;
-    }
-
-    /**
-     * Get tag key
-     *
-     * @return string
-     */
-    public function getTagKey()
-    {
-        return $this->tagKey;
-    }
-
-    /**
-     * Set tags
-     *
-     * Used by:
-     * - CaptureCache
-     *
-     * @param  array $tags
-     * @return PatternOptions
-     */
-    public function setTags(array $tags)
-    {
-        $this->tags = $tags;
-        return $this;
-    }
-
-    /**
-     * Get tags
-     *
-     * Used by:
-     * - CaptureCache
-     *
-     * @return array
-     */
-    public function getTags()
-    {
-        return $this->tags;
-    }
-
-    /**
-     * Set storage adapter for tags
-     *
-     * Used by:
-     * - CaptureCache
-     *
-     * @param  string|array|Storage $tagStorage
-     * @return PatternOptions
-     */
-    public function setTagStorage($tagStorage)
-    {
-        $this->tagStorage = $this->storageFactory($tagStorage);
-        return $this;
-    }
-
-    /**
-     * Get storage adapter for tags
-     *
-     * Used by:
-     * - CaptureCache
-     *
-     * @return null|Storage
-     */
-    public function getTagStorage()
-    {
-        return $this->tagStorage;
     }
 
     /**

--- a/library/Zend/Cache/Pattern/PatternOptions.php
+++ b/library/Zend/Cache/Pattern/PatternOptions.php
@@ -723,30 +723,6 @@ class PatternOptions extends AbstractOptions
     }
 
     /**
-     * Normalize a umask
-     *
-     * Allows specifying a umask as either an octal or integer. If the umask
-     * fails required permissions, raises an exception.
-     *
-     * @param  int|string $umask
-     * @param  callable   $comparison Callback used to verify the umask is acceptable for the given purpose
-     * @return int
-     * @throws Exception\InvalidArgumentException
-     */
-    protected function normalizeUmask($umask, $comparison)
-    {
-        if (is_string($umask)) {
-            $umask = octdec($umask);
-        } else {
-            $umask = (int)$umask;
-        }
-
-        $comparison($umask);
-
-        return $umask;
-    }
-
-    /**
      * Create a storage object from a given specification
      *
      * @param  array|string|Storage $storage

--- a/library/Zend/Cache/Pattern/PatternOptions.php
+++ b/library/Zend/Cache/Pattern/PatternOptions.php
@@ -637,7 +637,23 @@ class PatternOptions extends AbstractOptions
      */
     public function setPublicDir($publicDir)
     {
-        $this->publicDir = (string) $publicDir;
+        $publicDir = (string) $publicDir;
+
+        if (!is_dir($publicDir)) {
+            throw new Exception\InvalidArgumentException(
+                "Public directory '{$publicDir}' not found or not a directoy"
+            );
+        } elseif (!is_writable($publicDir)) {
+            throw new Exception\InvalidArgumentException(
+                "Public directory '{$publicDir}' not writable"
+            );
+        } elseif (!is_readable($publicDir)) {
+            throw new Exception\InvalidArgumentException(
+                "Public directory '{$publicDir}' not readable"
+            );
+        }
+
+        $this->publicDir = rtrim(realpath($publicDir), \DIRECTORY_SEPARATOR);
         return $this;
     }
 

--- a/tests/Zend/Cache/Pattern/CaptureCacheTest.php
+++ b/tests/Zend/Cache/Pattern/CaptureCacheTest.php
@@ -21,10 +21,27 @@ use Zend\Cache;
 class CaptureCacheTest extends CommonPatternTest
 {
 
+    protected $_tmpCacheDir;
+    protected $_umask;
+
     public function setUp()
     {
+        $this->_umask = umask();
+
+        $this->_tmpCacheDir = @tempnam(sys_get_temp_dir(), 'zend_cache_test_');
+        if (!$this->_tmpCacheDir) {
+            $err = error_get_last();
+            $this->fail("Can't create temporary cache directory-file: {$err['message']}");
+        } elseif (!@unlink($this->_tmpCacheDir)) {
+            $err = error_get_last();
+            $this->fail("Can't remove temporary cache directory-file: {$err['message']}");
+        } elseif (!@mkdir($this->_tmpCacheDir, 0777)) {
+            $err = error_get_last();
+            $this->fail("Can't create temporary cache directory: {$err['message']}");
+        }
+
         $this->_options = new Cache\Pattern\PatternOptions(array(
-            // TODO
+            'public_dir' => $this->_tmpCacheDir
         ));
         $this->_pattern = new Cache\Pattern\CaptureCache();
         $this->_pattern->setOptions($this->_options);
@@ -34,7 +51,82 @@ class CaptureCacheTest extends CommonPatternTest
 
     public function tearDown()
     {
-        // TODO
+        $this->_removeRecursive($this->_tmpCacheDir);
+
+        if ($this->_umask != umask()) {
+            umask($this->_umask);
+            $this->fail("Umask wasn't reset");
+        }
+
         parent::tearDown();
+    }
+
+    protected function _removeRecursive($dir)
+    {
+        if (file_exists($dir)) {
+            $dirIt = new \DirectoryIterator($dir);
+            foreach ($dirIt as $entry) {
+                $fname = $entry->getFilename();
+                if ($fname == '.' || $fname == '..') {
+                    continue;
+                }
+
+                if ($entry->isFile()) {
+                    unlink($entry->getPathname());
+                } else {
+                    $this->_removeRecursive($entry->getPathname());
+                }
+            }
+
+            rmdir($dir);
+        }
+    }
+
+    public function testSetThrowsLogicExceptionOnMissingPublicDir()
+    {
+        $captureCache = new Cache\Pattern\CaptureCache();
+
+        $this->setExpectedException('Zend\Cache\Exception\LogicException');
+        $captureCache->set('content', '/pageId');
+    }
+
+    public function testSetWithNormalPageId()
+    {
+        $this->_pattern->set('content', '/dir1/dir2/file');
+        $this->assertTrue(file_exists($this->_tmpCacheDir . '/dir1/dir2/file'));
+        $this->assertSame(file_get_contents($this->_tmpCacheDir . '/dir1/dir2/file'), 'content');
+    }
+
+    public function testSetWithIndexFilename()
+    {
+        $this->_options->setIndexFilename('test.html');
+
+        $this->_pattern->set('content', '/dir1/dir2/');
+        $this->assertTrue(file_exists($this->_tmpCacheDir . '/dir1/dir2/test.html'));
+        $this->assertSame(file_get_contents($this->_tmpCacheDir . '/dir1/dir2/test.html'), 'content');
+    }
+
+    public function testGetThrowsLogicExceptionOnMissingPublicDir()
+    {
+        $captureCache = new Cache\Pattern\CaptureCache();
+
+        $this->setExpectedException('Zend\Cache\Exception\LogicException');
+        $captureCache->get('/pageId');
+    }
+
+    public function testHasThrowsLogicExceptionOnMissingPublicDir()
+    {
+        $captureCache = new Cache\Pattern\CaptureCache();
+
+        $this->setExpectedException('Zend\Cache\Exception\LogicException');
+        $captureCache->has('/pageId');
+    }
+
+    public function testRemoveThrowsLogicExceptionOnMissingPublicDir()
+    {
+        $captureCache = new Cache\Pattern\CaptureCache();
+
+        $this->setExpectedException('Zend\Cache\Exception\LogicException');
+        $captureCache->remove('/pageId');
     }
 }


### PR DESCRIPTION
fixes also #1854
- better handling of file/directory permissions using umask and/or chmod
- removed tagging support because of clearing by glob
- no need to create a closure to lower case all elements of an array
- removed unused $options argument
- fixed ErrorHandler usage
- some method normalizations:
  - protected save($output) -> public set($content, $pageId = null)
  - exists($pageId) -> has($pageId = null)
  - replaced protected method flush with an closure
  - no longer return false on method start
  - return boolean on method remove
- validate public_dir + implemented clearByGlob 
- fixed and tested pageId detection and output filename generation
