### PR TITLE
[Doc2Rst] Add missing blankline and exclude nested block elements when wrapping paragraphs

### DIFF
--- a/bin/doc2rst.php
+++ b/bin/doc2rst.php
@@ -164,7 +164,17 @@ class RstConvert
      */
     public static function wrap($text)
     {
-        return wordwrap($text, 115 - self::$indentation);
+        $output = '';
+        foreach (explode("\n", $text) as $line) {
+            if (substr($line, 0, 1) != ' ') {
+                $output .= wordwrap($line, 115 - self::$indentation);
+            } else {
+                $output .= $line;
+            }
+            $output .= "\n";
+        }
+
+        return substr($output, 0, -1);
     }
 
     /**

--- a/bin/doc2rst.xsl
+++ b/bin/doc2rst.xsl
@@ -246,6 +246,11 @@
     <xsl:template match="//doc:varlistentry/doc:listitem" priority="1">
         <xsl:apply-templates mode="indent"/>
     </xsl:template>
+    <!-- varlistentry/listitem/methodsynopsys -->
+    <xsl:template match="//doc:varlistentry/doc:listitem/doc:methodsynopsis" priority="1">
+        <xsl:call-template name="methodsynopsis"/>
+        <xsl:text>&#xA;</xsl:text>
+    </xsl:template>
 
     <!--
     #################


### PR DESCRIPTION
- Add missing blankline after methodsynhopsys for varlists
- Add the code necessary for avoid wrap lines in nested block elements like table o programlist
