### PR TITLE
[ZF2-401] Add support for RDFa 1.1 doctype

### DIFF
--- a/library/Zend/View/Helper/Doctype.php
+++ b/library/Zend/View/Helper/Doctype.php
@@ -29,6 +29,7 @@ class Doctype extends AbstractHelper
     const XHTML1_TRANSITIONAL = 'XHTML1_TRANSITIONAL';
     const XHTML1_FRAMESET     = 'XHTML1_FRAMESET';
     const XHTML1_RDFA         = 'XHTML1_RDFA';
+    const XHTML1_RDFA11       = 'XHTML1_RDFA11';
     const XHTML_BASIC1        = 'XHTML_BASIC1';
     const XHTML5              = 'XHTML5';
     const HTML4_STRICT        = 'HTML4_STRICT';
@@ -70,6 +71,7 @@ class Doctype extends AbstractHelper
                 self::XHTML1_TRANSITIONAL => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">',
                 self::XHTML1_FRAMESET     => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">',
                 self::XHTML1_RDFA         => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">',
+                self::XHTML1_RDFA11       => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.1//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-2.dtd">',
                 self::XHTML_BASIC1        => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML Basic 1.0//EN" "http://www.w3.org/TR/xhtml-basic/xhtml-basic10.dtd">',
                 self::XHTML5              => '<!DOCTYPE html>',
                 self::HTML4_STRICT        => '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">',
@@ -124,6 +126,7 @@ class Doctype extends AbstractHelper
                 case self::XHTML1_FRAMESET:
                 case self::XHTML_BASIC1:
                 case self::XHTML1_RDFA:
+                case self::XHTML1_RDFA11:
                 case self::XHTML5:
                 case self::HTML4_STRICT:
                 case self::HTML4_LOOSE:

--- a/tests/Zend/View/Helper/DoctypeTest.php
+++ b/tests/Zend/View/Helper/DoctypeTest.php
@@ -75,6 +75,7 @@ class DoctypeTest extends \PHPUnit_Framework_TestCase
             Helper\Doctype::XHTML1_TRANSITIONAL,
             Helper\Doctype::XHTML1_FRAMESET,
             Helper\Doctype::XHTML1_RDFA,
+            Helper\Doctype::XHTML1_RDFA11,
             Helper\Doctype::XHTML5
         );
 
@@ -139,6 +140,7 @@ class DoctypeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->helper->isRdfa());
 
         $this->assertTrue($this->helper->__invoke(Helper\Doctype::XHTML1_RDFA)->isRdfa());
+        $this->assertTrue($this->helper->__invoke(Helper\Doctype::XHTML1_RDFA11)->isRdfa());
 
         // build-in doctypes
         $doctypes = array(


### PR DESCRIPTION
Since 7. June 2012 RDFa 1.1 is now a formal W3C recommendation:
http://www.w3.org/TR/xhtml-rdfa/
