### PR TITLE
Http\Request & Response refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ PLEASE USE AT YOUR OWN RISK.
    - Select-style elements now have options populated as value => label
      pairs instead of label => value pairs. This is done to ensure that
      option values are unique.
+ - Http
+   - set/getServer() and set/getEnv() were removed from Http\Request
+     and now part of Http\PhpEnvironment\Request
+   - set/getFile() methods in Http\PhpEnvironment\Request
+     were renamed to set/getFiles(). Also above methods
+   - When submitted form has file inputs with brackets (name="file[]")
+     $fileParams parameters in Http\PhpEnvironment\Request will be
+     re-structured to have the same look as query/post/server/envParams
 
 Over *XXX* pull requests for a variety of features and bugfixes were handled
 since beta5!

--- a/library/Zend/Http/AbstractMessage.php
+++ b/library/Zend/Http/AbstractMessage.php
@@ -24,8 +24,8 @@ abstract class AbstractMessage extends Message
     /**#@+
      * @const string Version constant numbers
      */
-    const VERSION_11 = '1.1';
     const VERSION_10 = '1.0';
+    const VERSION_11 = '1.1';
     /**#@-*/
 
     /**
@@ -34,20 +34,21 @@ abstract class AbstractMessage extends Message
     protected $version = self::VERSION_11;
 
     /**
-     * @var Headers|string
+     * @var Headers|null
      */
     protected $headers = null;
 
     /**
-     * Set the HTTP version for this object, one of 1.0 or 1.1 (Request::VERSION_10, Request::VERSION_11)
+     * Set the HTTP version for this object, one of 1.0 or 1.1
+     * (AbstractMessage::VERSION_10, AbstractMessage::VERSION_11)
      *
-     * @throws Exception\InvalidArgumentException
      * @param  string $version (Must be 1.0 or 1.1)
-     * @return Request
+     * @return AbstractMessage
+     * @throws Exception\InvalidArgumentException
      */
     public function setVersion($version)
     {
-        if ($version != self::VERSION_11 && $version != self::VERSION_10) {
+        if ($version != self::VERSION_10 && $version != self::VERSION_11) {
             throw new Exception\InvalidArgumentException(
                 'Not valid or not supported HTTP version: ' . $version
             );
@@ -68,11 +69,11 @@ abstract class AbstractMessage extends Message
 
     /**
      * Provide an alternate Parameter Container implementation for headers in this object,
-     * (this is NOT the primary API for value setting, for that see headers())
+     * (this is NOT the primary API for value setting, for that see getHeaders())
      *
-     * @see    headers()
+     * @see    getHeaders()
      * @param  Headers $headers
-     * @return Request|Response
+     * @return AbstractMessage
      */
     public function setHeaders(Headers $headers)
     {
@@ -94,7 +95,6 @@ abstract class AbstractMessage extends Message
 
         return $this->headers;
     }
-
 
     /**
      * Allow PHP casting of this object

--- a/library/Zend/Http/AbstractMessage.php
+++ b/library/Zend/Http/AbstractMessage.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
+
+namespace Zend\Http;
+
+use Zend\Stdlib\Message;
+
+/**
+ * HTTP standard message (Request/Response)
+ *
+ * @category  Zend
+ * @package   Zend_Http
+ * @link      http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4
+ */
+abstract class AbstractMessage extends Message
+{
+    /**#@+
+     * @const string Version constant numbers
+     */
+    const VERSION_11 = '1.1';
+    const VERSION_10 = '1.0';
+    /**#@-*/
+
+    /**
+     * @var string
+     */
+    protected $version = self::VERSION_11;
+
+    /**
+     * @var Headers|string
+     */
+    protected $headers = null;
+
+    /**
+     * Set the HTTP version for this object, one of 1.0 or 1.1 (Request::VERSION_10, Request::VERSION_11)
+     *
+     * @throws Exception\InvalidArgumentException
+     * @param  string $version (Must be 1.0 or 1.1)
+     * @return Request
+     */
+    public function setVersion($version)
+    {
+        if ($version != self::VERSION_11 && $version != self::VERSION_10) {
+            throw new Exception\InvalidArgumentException(
+                'Not valid or not supported HTTP version: ' . $version
+            );
+        }
+        $this->version = $version;
+        return $this;
+    }
+
+    /**
+     * Return the HTTP version for this request
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * Provide an alternate Parameter Container implementation for headers in this object,
+     * (this is NOT the primary API for value setting, for that see headers())
+     *
+     * @see    headers()
+     * @param  Headers $headers
+     * @return Request|Response
+     */
+    public function setHeaders(Headers $headers)
+    {
+        $this->headers = $headers;
+        return $this;
+    }
+
+    /**
+     * Return the header container responsible for headers
+     *
+     * @return Headers
+     */
+    public function getHeaders()
+    {
+        if ($this->headers === null || is_string($this->headers)) {
+            // this is only here for fromString lazy loading
+            $this->headers = (is_string($this->headers)) ? Headers::fromString($this->headers) : new Headers();
+        }
+
+        return $this->headers;
+    }
+
+
+    /**
+     * Allow PHP casting of this object
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toString();
+    }
+}

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -578,7 +578,7 @@ class Client implements Stdlib\DispatchableInterface
      */
     public function getStream()
     {
-        return $this->config["outputstream"];
+        return $this->config['outputstream'];
     }
 
     /**
@@ -934,7 +934,7 @@ class Client implements Stdlib\DispatchableInterface
             }
         }
 
-        $this->getRequest()->getFile()->set($filename, array(
+        $this->getRequest()->getFiles()->set($filename, array(
             'formname' => $formname,
             'filename' => basename($filename),
             'ctype' => $ctype,
@@ -952,9 +952,9 @@ class Client implements Stdlib\DispatchableInterface
      */
     public function removeFileUpload($filename)
     {
-        $file = $this->getRequest()->getFile()->get($filename);
+        $file = $this->getRequest()->getFiles()->get($filename);
         if (!empty($file)) {
-            $this->getRequest()->getFile()->set($filename, null);
+            $this->getRequest()->getFiles()->set($filename, null);
             return true;
         }
         return false;
@@ -1096,7 +1096,7 @@ class Client implements Stdlib\DispatchableInterface
         $totalFiles = 0;
 
         if (!$this->getRequest()->getHeaders()->has('Content-Type')) {
-            $totalFiles = count($this->getRequest()->getFile()->toArray());
+            $totalFiles = count($this->getRequest()->getFiles()->toArray());
             // If we have files to upload, force encType to multipart/form-data
             if ($totalFiles > 0) {
                 $this->setEncType(self::ENC_FORMDATA);
@@ -1118,7 +1118,7 @@ class Client implements Stdlib\DispatchableInterface
                 }
 
                 // Encode files
-                foreach ($this->getRequest()->getFile()->toArray() as $key => $file) {
+                foreach ($this->getRequest()->getFiles()->toArray() as $key => $file) {
                     $fhead = array('Content-Type' => $file['ctype']);
                     $body .= $this->encodeFormData($boundary, $file['formname'], $file['data'], $file['filename'], $fhead);
                 }

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -46,27 +46,60 @@ class Request extends HttpRequest
     protected $requestUri;
 
     /**
+     * PHP server params ($_SERVER)
+     *
+     * @var ParametersInterface
+     */
+    protected $serverParams = null;
+
+    /**
+     * PHP environment params ($_ENV)
+     *
+     * @var ParametersInterface
+     */
+    protected $envParams = null;
+
+    /**
      * Construct
      * Instantiates request.
      */
     public function __construct()
     {
         $this->setEnv(new Parameters($_ENV));
-        $this->setPost(new Parameters($_POST));
-        $this->setQuery(new Parameters($_GET));
-        $this->setServer(new Parameters($_SERVER));
+
+        if ($_GET) {
+            $this->setPost(new Parameters($_POST));
+        }
+        if ($_POST) {
+            $this->setQuery(new Parameters($_GET));
+        }
         if ($_COOKIE) {
             $this->setCookies(new Parameters($_COOKIE));
         }
-
         if ($_FILES) {
-            $this->setFile(new Parameters($_FILES));
+            // convert PHP $_FILES superglobal
+            $files = $this->mapPhpFiles();
+            $this->setFiles(new Parameters($files));
         }
 
-        $requestBody = file_get_contents('php://input');
-        if(strlen($requestBody) > 0){
-            $this->setContent($requestBody);
+        $this->setServer(new Parameters($_SERVER));
+    }
+
+    /**
+     * Get raw request body
+     *
+     * @return string
+     */
+    public function getContent()
+    {
+        if (empty($this->content)) {
+            $requestBody = file_get_contents('php://input');
+            if (strlen($requestBody) > 0){
+                $this->content = $requestBody;
+            }
         }
+
+        return $this->content;
     }
 
     /**
@@ -103,7 +136,7 @@ class Request extends HttpRequest
     public function getRequestUri()
     {
         if ($this->requestUri === null) {
-            $this->setRequestUri($this->detectRequestUri());
+            $this->requestUri = $this->detectRequestUri();
         }
         return $this->requestUri;
     }
@@ -160,10 +193,10 @@ class Request extends HttpRequest
     }
 
     /**
-     * Provide an alternate Parameter Container implementation for server parameters in this object, (this is NOT the
-     * primary API for value setting, for that see server())
+     * Provide an alternate Parameter Container implementation for server parameters in this object,
+     * (this is NOT the primary API for value setting, for that see getServer())
      *
-     * @param ParametersInterface $server
+     * @param  ParametersInterface $server
      * @return Request
      */
     public function setServer(ParametersInterface $server)
@@ -173,65 +206,14 @@ class Request extends HttpRequest
         // This seems to be the only way to get the Authorization header on Apache
         if (function_exists('apache_request_headers')) {
             $apacheRequestHeaders = apache_request_headers();
-            if (isset($apacheRequestHeaders['Authorization'])) {
-                if (!$this->serverParams->get('HTTP_AUTHORIZATION')) {
-                    $this->serverParams->set('HTTP_AUTHORIZATION', $apacheRequestHeaders['Authorization']);
-                }
+            if (!isset($this->serverParams['HTTP_AUTHORIZATION'])
+                && isset($apacheRequestHeaders['Authorization'])
+            ) {
+                $this->serverParams->set('HTTP_AUTHORIZATION', $apacheRequestHeaders['Authorization']);
             }
         }
 
-        $this->getHeaders()->addHeaders($this->serverToHeaders($this->serverParams));
-
-        if (isset($this->serverParams['REQUEST_METHOD'])) {
-            $this->setMethod($this->serverParams['REQUEST_METHOD']);
-        }
-
-        if (isset($this->serverParams['SERVER_PROTOCOL'])
-            && strpos($this->serverParams['SERVER_PROTOCOL'], '1.0') !== false) {
-            $this->setVersion('1.0');
-        }
-
-        $this->setUri($uri = new HttpUri());
-
-        if (isset($this->serverParams['HTTPS']) && $this->serverParams['HTTPS'] === 'on') {
-            $uri->setScheme('https');
-        } else {
-            $uri->setScheme('http');
-        }
-
-        if (isset($this->serverParams['QUERY_STRING'])) {
-            $uri->setQuery($this->serverParams['QUERY_STRING']);
-        }
-
-        if ($this->getHeaders()->get('host')) {
-            //TODO handle IPv6 with port
-            if (preg_match('|^([^:]+):([^:]+)$|', $this->getHeaders()->get('host')->getFieldValue(), $match)) {
-                $uri->setHost($match[1]);
-                $uri->setPort($match[2]);
-            } else {
-                $uri->setHost($this->getHeaders()->get('host')->getFieldValue());
-            }
-        } elseif (isset($this->serverParams['SERVER_NAME'])) {
-            $uri->setHost($this->serverParams['SERVER_NAME']);
-            if (isset($this->serverParams['SERVER_PORT'])) {
-                $uri->setPort($this->serverParams['SERVER_PORT']);
-            }
-        }
-
-        $requestUri = $this->getRequestUri();
-        $uri->setPath(substr($requestUri, 0, strpos($requestUri, '?') ?: strlen($requestUri)));
-
-        return $this;
-    }
-
-    /**
-     * Grab headers from array or Traversable
-     *
-     * @param array|\Traversable $server
-     * @return array
-     */
-    protected function serverToHeaders($server)
-    {
+        // set headers
         $headers = array();
 
         foreach ($server as $key => $value) {
@@ -243,7 +225,7 @@ class Request extends HttpRequest
                 $name = strtr(substr($key, 5), '_', ' ');
                 $name = strtr(ucwords(strtolower($name)), ' ', '-');
             } elseif ($value && strpos($key, 'CONTENT_') === 0) {
-                $name = substr($key, 8);
+                $name = substr($key, 8); // Content-
                 $name = 'Content-' . (($name == 'MD5') ? $name : ucfirst(strtolower($name)));
             } else {
                 continue;
@@ -252,7 +234,143 @@ class Request extends HttpRequest
             $headers[$name] = $value;
         }
 
-        return $headers;
+        $this->getHeaders()->addHeaders($headers);
+
+        // set method
+        if (isset($this->serverParams['REQUEST_METHOD'])) {
+            $this->setMethod($this->serverParams['REQUEST_METHOD']);
+        }
+
+        // set HTTP version
+        if (isset($this->serverParams['SERVER_PROTOCOL'])
+            && strpos($this->serverParams['SERVER_PROTOCOL'], '1.0') !== false
+        ) {
+            $this->setVersion('1.0');
+        }
+
+        // set URI
+        $uri = new HttpUri();
+
+        // URI scheme
+        $scheme = (!empty($this->serverParams['HTTPS'])
+                   && $this->serverParams['HTTPS'] !== 'off') ? 'https' : 'http';
+        $uri->setScheme($scheme);
+
+        // URI host & port
+        $host = null;
+        $port = null;
+        if (isset($this->serverParams['SERVER_NAME'])) {
+            $host = $this->serverParams['SERVER_NAME'];
+            if (isset($this->serverParams['SERVER_PORT'])) {
+                $port = $this->serverParams['SERVER_PORT'];
+            }
+        } elseif ($this->getHeaders()->get('host')) {
+            $host = $this->getHeaders()->get('host')->getFieldValue();
+            // works for regname, IPv4 & IPv6
+            if (preg_match('|\:(\d+)$|', $host, $matches)) {
+                $port = $matches[1];
+                $host = substr($host, 0, -1 * (strlen($port) + 1));
+            }
+        }
+        $uri->setHost($host);
+        $uri->setPort($port);
+
+        // URI path
+        $requestUri = $this->getRequestUri();
+        $uri->setPath(substr($requestUri, 0, strpos($requestUri, '?') ?: strlen($requestUri)));
+
+        // URI query
+        if (isset($this->serverParams['QUERY_STRING'])) {
+            $uri->setQuery($this->serverParams['QUERY_STRING']);
+        }
+
+        $this->setUri($uri);
+
+        return $this;
+    }
+
+    /**
+     * Return the parameter container responsible for server parameters
+     *
+     * @see http://www.faqs.org/rfcs/rfc3875.html
+     * @return ParametersInterface
+     */
+    public function getServer()
+    {
+        if ($this->serverParams === null) {
+            $this->serverParams = new Parameters();
+        }
+
+        return $this->serverParams;
+    }
+
+    /**
+     * Provide an alternate Parameter Container implementation for env parameters in this object,
+     * (this is NOT the primary API for value setting, for that see env())
+     *
+     * @param  ParametersInterface $env
+     * @return Request
+     */
+    public function setEnv(ParametersInterface $env)
+    {
+        $this->envParams = $env;
+        return $this;
+    }
+
+    /**
+     * Return the parameter container responsible for env parameters
+     *
+     * @return ParametersInterface
+     */
+    public function getEnv()
+    {
+        if ($this->envParams === null) {
+            $this->envParams = new Parameters();
+        }
+
+        return $this->envParams;
+    }
+
+    /**
+     * Convert PHP superglobal $_FILES into more sane parameter=value structure
+     * This handles form file input with brackets (name=files[])
+     *
+     * @return array
+     */
+    protected function mapPhpFiles()
+    {
+        $files = array();
+        foreach ($_FILES as $fileName => $fileParams) {
+            $files[$fileName] = array();
+            foreach ($fileParams as $param => $data) {
+                if (!is_array($data)) {
+                    $files[$fileName][$param] = $data;
+                } else {
+                    foreach ($data as $i => $v) {
+                        $this->mapPhpFileParam($files[$fileName], $param, $i, $v);
+                    }
+                }
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * @param array        $array
+     * @param string       $paramName
+     * @param int|string   $index
+     * @param string|array $value
+     */
+    protected function mapPhpFileParam(&$array, $paramName, $index, $value)
+    {
+        if (!is_array($value)) {
+            $array[$index][$paramName] = $value;
+        } else {
+            foreach ($value as $i => $v) {
+                $this->mapPhpFileParam($array[$index], $paramName, $i, $v);
+            }
+        }
     }
 
     /**
@@ -266,45 +384,42 @@ class Request extends HttpRequest
     protected function detectRequestUri()
     {
         $requestUri = null;
+        $server     = $this->getServer();
 
         // Check this first so IIS will catch.
-        $httpXRewriteUrl = $this->getServer()->get('HTTP_X_REWRITE_URL');
+        $httpXRewriteUrl = $server->get('HTTP_X_REWRITE_URL');
         if ($httpXRewriteUrl !== null) {
             $requestUri = $httpXRewriteUrl;
         }
 
         // Check for IIS 7.0 or later with ISAPI_Rewrite
-        $httpXOriginalUrl = $this->getServer()->get('HTTP_X_ORIGINAL_URL');
+        $httpXOriginalUrl = $server->get('HTTP_X_ORIGINAL_URL');
         if ($httpXOriginalUrl !== null) {
             $requestUri = $httpXOriginalUrl;
         }
 
         // IIS7 with URL Rewrite: make sure we get the unencoded url
         // (double slash problem).
-        $iisUrlRewritten = $this->getServer()->get('IIS_WasUrlRewritten');
-        $unencodedUrl    = $this->getServer()->get('UNENCODED_URL', '');
+        $iisUrlRewritten = $server->get('IIS_WasUrlRewritten');
+        $unencodedUrl    = $server->get('UNENCODED_URL', '');
         if ('1' == $iisUrlRewritten && '' !== $unencodedUrl) {
             return $unencodedUrl;
         }
 
-        // HTTP proxy requests setup request URI with scheme and host
-        // [and port] + the URL path, only use URL path.
+        // HTTP proxy requests setup request URI with scheme and host [and port]
+        // + the URL path, only use URL path.
         if (!$httpXRewriteUrl) {
-            $requestUri = $this->getServer()->get('REQUEST_URI');
+            $requestUri = $server->get('REQUEST_URI');
         }
-        if ($requestUri !== null) {
-            $schemeAndHttpHost = $this->getUri()->getScheme() . '://' . $this->getUri()->getHost();
 
-            if (strpos($requestUri, $schemeAndHttpHost) === 0) {
-                $requestUri = substr($requestUri, strlen($schemeAndHttpHost));
-            }
-            return $requestUri;
+        if ($requestUri !== null) {
+            return preg_replace('#^[^:]+://[^/]+#', '', $requestUri);
         }
 
         // IIS 5.0, PHP as CGI.
-        $origPathInfo = $this->getServer()->get('ORIG_PATH_INFO');
+        $origPathInfo = $server->get('ORIG_PATH_INFO');
         if ($origPathInfo !== null) {
-            $queryString = $this->getServer()->get('QUERY_STRING', '');
+            $queryString = $server->get('QUERY_STRING', '');
             if ($queryString !== '') {
                 $origPathInfo .= '?' . $queryString;
             }
@@ -344,8 +459,8 @@ class Request extends HttpRequest
             // matching PHP_SELF.
 
             $basename = basename($filename);
-            $path = ($phpSelf ? trim($phpSelf, '/') : '');
-            $baseUrl = '/'. substr($path, 0, strpos($path, $basename)) . $basename;
+            $path     = ($phpSelf ? trim($phpSelf, '/') : '');
+            $baseUrl  = '/'. substr($path, 0, strpos($path, $basename)) . $basename;
         }
 
         // Does the base URL have anything in common with the request URI?

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -243,9 +243,9 @@ class Request extends HttpRequest
 
         // set HTTP version
         if (isset($this->serverParams['SERVER_PROTOCOL'])
-            && strpos($this->serverParams['SERVER_PROTOCOL'], '1.0') !== false
+            && strpos($this->serverParams['SERVER_PROTOCOL'], self::VERSION_10) !== false
         ) {
-            $this->setVersion('1.0');
+            $this->setVersion(self::VERSION_10);
         }
 
         // set URI
@@ -262,14 +262,14 @@ class Request extends HttpRequest
         if (isset($this->serverParams['SERVER_NAME'])) {
             $host = $this->serverParams['SERVER_NAME'];
             if (isset($this->serverParams['SERVER_PORT'])) {
-                $port = $this->serverParams['SERVER_PORT'];
+                $port = (int) $this->serverParams['SERVER_PORT'];
             }
         } elseif ($this->getHeaders()->get('host')) {
             $host = $this->getHeaders()->get('host')->getFieldValue();
             // works for regname, IPv4 & IPv6
             if (preg_match('|\:(\d+)$|', $host, $matches)) {
-                $port = $matches[1];
-                $host = substr($host, 0, -1 * (strlen($port) + 1));
+                $host = substr($host, 0, -1 * (strlen($matches[1]) + 1));
+                $port = (int) $matches[1];
             }
         }
         $uri->setHost($host);
@@ -277,7 +277,11 @@ class Request extends HttpRequest
 
         // URI path
         $requestUri = $this->getRequestUri();
-        $uri->setPath(substr($requestUri, 0, strpos($requestUri, '?') ?: strlen($requestUri)));
+        if (($qpos = strpos($requestUri, '?')) !== false) {
+            $requestUri = substr($requestUri, 0, $qpos);
+        }
+
+        $uri->setPath($requestUri);
 
         // URI query
         if (isset($this->serverParams['QUERY_STRING'])) {

--- a/library/Zend/Http/PhpEnvironment/Response.php
+++ b/library/Zend/Http/PhpEnvironment/Response.php
@@ -14,26 +14,45 @@ use Zend\Http\Header\MultipleHeaderInterface;
 use Zend\Http\Response as HttpResponse;
 use Zend\Stdlib\Parameters;
 
+/**
+ * HTTP Response for current PHP environment
+ *
+ * @category   Zend
+ * @package    Zend_Http
+ */
 class Response extends HttpResponse
 {
+    /**
+     * @var bool
+     */
     protected $headersSent = false;
 
+    /**
+     * @var bool
+     */
     protected $contentSent = false;
 
-    public function __construct()
-    {
-    }
-
+    /**
+     * @return bool
+     */
     public function headersSent()
     {
         return $this->headersSent;
     }
 
+    /**
+     * @return bool
+     */
     public function contentSent()
     {
         return $this->contentSent;
     }
 
+    /**
+     * Send HTTP headers
+     *
+     * @return Response
+     */
     public function sendHeaders()
     {
         if ($this->headersSent()) {
@@ -55,22 +74,32 @@ class Response extends HttpResponse
         return $this;
     }
 
+    /**
+     * Send content
+     *
+     * @return Response
+     */
     public function sendContent()
     {
         if ($this->contentSent()) {
             return $this;
         }
+
         echo $this->getContent();
         $this->contentSent = true;
         return $this;
     }
 
+    /**
+     * Send HTTP response
+     *
+     * @return Response
+     */
     public function send()
     {
         $this->sendHeaders()
              ->sendContent();
         return $this;
     }
-
 }
 

--- a/library/Zend/Http/PhpEnvironment/Response.php
+++ b/library/Zend/Http/PhpEnvironment/Response.php
@@ -12,7 +12,6 @@ namespace Zend\Http\PhpEnvironment;
 
 use Zend\Http\Header\MultipleHeaderInterface;
 use Zend\Http\Response as HttpResponse;
-use Zend\Stdlib\Parameters;
 
 /**
  * HTTP Response for current PHP environment
@@ -62,6 +61,7 @@ class Response extends HttpResponse
         $status  = $this->renderStatusLine();
         header($status);
 
+        /** @var \Zend\Http\Header\HeaderInterface $header */
         foreach ($this->getHeaders() as $header) {
             if ($header instanceof MultipleHeaderInterface) {
                 header($header->toString(), false);
@@ -102,4 +102,3 @@ class Response extends HttpResponse
         return $this;
     }
 }
-

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -84,10 +84,12 @@ class Request extends AbstractMessage implements RequestInterface
             self::METHOD_PUT, self::METHOD_DELETE, self::METHOD_TRACE, self::METHOD_CONNECT,
             self::METHOD_PATCH
         ));
-        $regex = '^(?P<method>' . $methods . ')\s(?P<uri>[^ ]*)(?:\sHTTP\/(?P<version>\d+\.\d+)){0,1}';
+        $regex     = '#^(?P<method>' . $methods . ')\s(?P<uri>[^ ]*)(?:\sHTTP\/(?P<version>\d+\.\d+)){0,1}#';
         $firstLine = array_shift($lines);
-        if (!preg_match('#' . $regex . '#', $firstLine, $matches)) {
-            throw new Exception\InvalidArgumentException('A valid request line was not found in the provided string');
+        if (!preg_match($regex, $firstLine, $matches)) {
+            throw new Exception\InvalidArgumentException(
+                'A valid request line was not found in the provided string'
+            );
         }
 
         $request->setMethod($matches['method']);
@@ -168,13 +170,15 @@ class Request extends AbstractMessage implements RequestInterface
                 $uri = new HttpUri($uri);
             } catch (UriException\InvalidUriPartException $e) {
                 throw new Exception\InvalidArgumentException(
-                        sprintf('Invalid URI passed as string (%s)', (string) $uri),
-                        $e->getCode(),
-                        $e
+                    sprintf('Invalid URI passed as string (%s)', (string) $uri),
+                    $e->getCode(),
+                    $e
                 );
             }
         } elseif (!($uri instanceof HttpUri)) {
-            throw new Exception\InvalidArgumentException('URI must be an instance of Zend\Uri\Http or a string');
+            throw new Exception\InvalidArgumentException(
+                'URI must be an instance of Zend\Uri\Http or a string'
+            );
         }
         $this->uri = $uri;
 

--- a/tests/Zend/Authentication/Adapter/Http/AuthTest.php
+++ b/tests/Zend/Authentication/Adapter/Http/AuthTest.php
@@ -55,7 +55,7 @@ class AuthTest extends \PHPUnit_Framework_TestCase
     /**
      * File resolver setup against with HTTP Basic auth file
      *
-     * @var Zend_Auth_Adapter_Http_Resolver_File
+     * @var Http\FileResolver
      */
     protected $_basicResolver;
 
@@ -129,6 +129,7 @@ class AuthTest extends \PHPUnit_Framework_TestCase
         // should result in a 401 reply with at least one Www-Authenticate
         // header, and a false result.
 
+        $result = $status = $headers = null;
         $data = $this->_doAuth('', 'both');
         extract($data); // $result, $status, $headers
 
@@ -327,9 +328,10 @@ class AuthTest extends \PHPUnit_Framework_TestCase
         // Set stub method return values
         $request->setUri('http://localhost/');
         $request->setMethod('GET');
-        $request->setServer(new Parameters(array('HTTP_USER_AGENT' => 'PHPUnit')));
+
         $headers = $request->getHeaders();
         $headers->addHeaderLine('Authorization', $clientHeader);
+        $headers->addHeaderLine('User-Agent', 'PHPUnit');
 
         // Select an Authentication scheme
         switch ($scheme) {
@@ -414,6 +416,7 @@ class AuthTest extends \PHPUnit_Framework_TestCase
      */
     protected function _checkUnauthorized($data, $expected)
     {
+        $result = $status = $headers = null;
         extract($data); // $result, $status, $headers
 
         // Make sure the result is false
@@ -448,6 +451,7 @@ class AuthTest extends \PHPUnit_Framework_TestCase
      */
     protected function _checkOK($data)
     {
+        $result = $status = $headers = null;
         extract($data); // $result, $status, $headers
 
         // Make sure the result is true
@@ -466,6 +470,7 @@ class AuthTest extends \PHPUnit_Framework_TestCase
      */
     protected function _checkBadRequest($data)
     {
+        $result = $status = $headers = null;
         extract($data); // $result, $status, $headers
 
         // Make sure the result is false

--- a/tests/Zend/Authentication/Adapter/Http/ObjectTest.php
+++ b/tests/Zend/Authentication/Adapter/Http/ObjectTest.php
@@ -56,14 +56,14 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
     /**
      * File resolver setup against with HTTP Basic auth file
      *
-     * @var Zend_Auth_Adapter_Http_Resolver_File
+     * @var Http\FileResolver
      */
     protected $_basicResolver;
 
     /**
      * File resolver setup against with HTTP Digest auth file
      *
-     * @var Zend_Auth_Adapter_Http_Resolver_File
+     * @var Http\FileResolver
      */
     protected $_digestResolver;
 
@@ -214,12 +214,13 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
         $request->setHeaders($headers);
 
         // Test a Digest auth process while the request is containing a Basic auth header
-        $a = new Adapter\Http($this->_digestConfig);
-        $a->setDigestResolver($this->_digestResolver)
-          ->setRequest($request)
-          ->setResponse($response);
-        $result = $a->authenticate();
-        $this->assertEquals($result->getCode(),Authentication\Result::FAILURE_CREDENTIAL_INVALID);
+        $adapter = new Adapter\Http($this->_digestConfig);
+        $adapter->setDigestResolver($this->_digestResolver)
+                ->setRequest($request)
+                ->setResponse($response);
+        $result = $adapter->authenticate();
+
+        $this->assertEquals($result->getCode(), Authentication\Result::FAILURE_CREDENTIAL_INVALID);
     }
 
     public function testUnsupportedScheme()
@@ -227,6 +228,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
         $response = new Response();
         $headers  = new Headers();
         $request  = new Request();
+
         $headers->addHeaderLine('Authorization', 'NotSupportedScheme <followed by a space character');
         $request->setHeaders($headers);
 

--- a/tests/Zend/Authentication/Adapter/Http/ProxyTest.php
+++ b/tests/Zend/Authentication/Adapter/Http/ProxyTest.php
@@ -315,11 +315,11 @@ class ProxyTest extends \PHPUnit_Framework_TestCase
 
         $headers  = new Headers();
         $headers->addHeaderLine('Proxy-Authorization', $clientHeader);
+        $headers->addHeaderLine('User-Agent', 'PHPUnit');
 
         $request  = new Request();
         $request->setUri('http://localhost/');
         $request->setMethod('GET');
-        $request->setServer(new Parameters(array('HTTP_USER_AGENT' => 'PHPUnit')));
         $request->setHeaders($headers);
 
         // Select an Authentication scheme

--- a/tests/Zend/Http/PhpEnvironment/RequestTest.php
+++ b/tests/Zend/Http/PhpEnvironment/RequestTest.php
@@ -348,4 +348,237 @@ class RequestTest extends TestCase
         $requestUri = $request->getRequestUri();
         $this->assertEquals($expectedRequestUri, $requestUri);
     }
+
+    /**
+     * Data provider for testing mapping $_FILES
+     *
+     * @return array
+     */
+    public static function filesProvider()
+    {
+        return array(
+            // single file
+            array(
+                array(
+                    'file' => array (
+                        'name' => 'test1.txt',
+                        'type' => 'text/plain',
+                        'tmp_name' => '/tmp/phpXXX',
+                        'error' => 0,
+                        'size' => 1,
+                    ),
+                ),
+                array(
+                    'file' => array (
+                        'name' => 'test1.txt',
+                        'type' => 'text/plain',
+                        'tmp_name' => '/tmp/phpXXX',
+                        'error' => 0,
+                        'size' => 1,
+                    ),
+                ),
+            ),
+
+            // file name with brackets and int keys
+            // file[], file[]
+            array(
+                array(
+                    'file' => array (
+                        'name' => array (
+                            0 => 'test1.txt',
+                            1 => 'test2.txt',
+                        ),
+                        'type' => array (
+                            0 => 'text/plain',
+                            1 => 'text/plain',
+                        ),
+                        'tmp_name' => array (
+                            0 => '/tmp/phpXXX',
+                            1 => '/tmp/phpXXX',
+                        ),
+                        'error' => array (
+                            0 => 0,
+                            1 => 0,
+                        ),
+                        'size' => array (
+                            0 => 1,
+                            1 => 1,
+                        ),
+                    ),
+                ),
+                array(
+                    'file' => array (
+                        0 => array(
+                            'name' => 'test1.txt',
+                            'type' => 'text/plain',
+                            'tmp_name' => '/tmp/phpXXX',
+                            'error' => 0,
+                            'size' => 1,
+                        ),
+                        1 => array(
+                            'name' => 'test2.txt',
+                            'type' => 'text/plain',
+                            'tmp_name' => '/tmp/phpXXX',
+                            'error' => 0,
+                            'size' => 1,
+                        ),
+                    ),
+                ),
+            ),
+
+            // file name with brackets and string keys
+            // file[one], file[two]
+            array(
+                array(
+                    'file' => array (
+                        'name' => array (
+                            'one' => 'test1.txt',
+                            'two' => 'test2.txt',
+                        ),
+                        'type' => array (
+                            'one' => 'text/plain',
+                            'two' => 'text/plain',
+                        ),
+                        'tmp_name' => array (
+                            'one' => '/tmp/phpXXX',
+                            'two' => '/tmp/phpXXX',
+                        ),
+                        'error' => array (
+                            'one' => 0,
+                            'two' => 0,
+                        ),
+                        'size' => array (
+                            'one' => 1,
+                            'two' => 1,
+                        ),
+                      ),
+                ),
+                array(
+                    'file' => array (
+                        'one' => array(
+                            'name' => 'test1.txt',
+                            'type' => 'text/plain',
+                            'tmp_name' => '/tmp/phpXXX',
+                            'error' => 0,
+                            'size' => 1,
+                        ),
+                        'two' => array(
+                            'name' => 'test2.txt',
+                            'type' => 'text/plain',
+                            'tmp_name' => '/tmp/phpXXX',
+                            'error' => 0,
+                            'size' => 1,
+                        ),
+                    ),
+                ),
+            ),
+
+            // multilevel file name
+            // file[], file[][], file[][][]
+            array(
+                array (
+                    'file' => array (
+                        'name' => array (
+                            0 => 'test_0.txt',
+                            1 => array (
+                                0 => 'test_10.txt',
+                            ),
+                            2 => array (
+                                0 => array(
+                                    0 => 'test_200.txt',
+                                ),
+                            ),
+                        ),
+                        'type' => array(
+                            0 => 'text/plain',
+                            1 => array(
+                                0 => 'text/plain',
+                            ),
+                            2 => array(
+                                0 => array(
+                                    0 => 'text/plain',
+                                ),
+                            ),
+                        ),
+                        'tmp_name' => array (
+                            0 => '/tmp/phpXXX',
+                            1 => array(
+                                0 => '/tmp/phpXXX',
+                            ),
+                            2 => array (
+                                0 => array(
+                                    0 => '/tmp/phpXXX',
+                                ),
+                            ),
+                        ),
+                        'error' => array(
+                            0 => 0,
+                            1 => array(
+                                0 => 0,
+                            ),
+                            2 => array (
+                                0 => array(
+                                    0 => 0,
+                                ),
+                            ),
+                        ),
+                        'size' => array(
+                            0 => 1,
+                            1 => array(
+                                0 => 1,
+                            ),
+                            2 => array(
+                                0 => array(
+                                    0 => 1,
+                                ),
+                            ),
+                        ),
+                    )
+                ),
+                array(
+                    'file' => array(
+                        0 => array(
+                            'name' => 'test_0.txt',
+                            'type' => 'text/plain',
+                            'tmp_name' => '/tmp/phpXXX',
+                            'error' => 0,
+                            'size' => 1,
+                        ),
+                        1 => array(
+                            0 => array(
+                                'name' => 'test_10.txt',
+                                'type' => 'text/plain',
+                                'tmp_name' => '/tmp/phpXXX',
+                                'error' => 0,
+                                'size' => 1,
+                            ),
+                        ),
+                        2 => array(
+                            0 => array(
+                                0 => array(
+                                    'name' => 'test_200.txt',
+                                    'type' => 'text/plain',
+                                    'tmp_name' => '/tmp/phpXXX',
+                                    'error' => 0,
+                                    'size' => 1,
+                                ),
+                            ),
+                        ),
+                    )
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @param array $files
+     * @param array $expectedFiles
+     * @dataProvider filesProvider
+     */
+    public function testRequestMapsPhpFies(array $files, array $expectedFiles)
+    {
+        $_FILES = $files;
+        $request = new Request();
+        $this->assertEquals($expectedFiles, $request->getFiles()->toArray());
+    }
 }

--- a/tests/Zend/Http/PhpEnvironment/RequestTest.php
+++ b/tests/Zend/Http/PhpEnvironment/RequestTest.php
@@ -33,6 +33,7 @@ class RequestTest extends TestCase
             'cookie' => $_COOKIE,
             'server' => $_SERVER,
             'env'    => $_ENV,
+            'files'  => $_FILES,
         );
 
         $_POST   = array();
@@ -40,6 +41,7 @@ class RequestTest extends TestCase
         $_COOKIE = array();
         $_SERVER = array();
         $_ENV    = array();
+        $_FILES  = array();
     }
 
     /**
@@ -52,6 +54,7 @@ class RequestTest extends TestCase
         $_COOKIE = $this->originalEnvironment['cookie'];
         $_SERVER = $this->originalEnvironment['server'];
         $_ENV    = $this->originalEnvironment['env'];
+        $_FILES  = $this->originalEnvironment['files'];
     }
 
     /**

--- a/tests/Zend/Http/RequestTest.php
+++ b/tests/Zend/Http/RequestTest.php
@@ -31,9 +31,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->getQuery());
         $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->getPost());
-        $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->getFile());
-        $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->getServer());
-        $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->getEnv());
+        $this->assertInstanceOf('Zend\Stdlib\Parameters', $request->getFiles());
     }
 
     public function testRequestAllowsSettingOfParameterContainer()
@@ -42,15 +40,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $p = new \Zend\Stdlib\Parameters();
         $request->setQuery($p);
         $request->setPost($p);
-        $request->setFile($p);
-        $request->setServer($p);
-        $request->setEnv($p);
+        $request->setFiles($p);
 
         $this->assertSame($p, $request->getQuery());
         $this->assertSame($p, $request->getPost());
-        $this->assertSame($p, $request->getFile());
-        $this->assertSame($p, $request->getServer());
-        $this->assertSame($p, $request->getEnv());
+        $this->assertSame($p, $request->getFiles());
     }
 
     public function testRequestPersistsRawBody()
@@ -132,7 +126,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request();
 
-        $this->setExpectedException('Zend\Http\Exception\InvalidArgumentException', 'not a valid version');
+        $this->setExpectedException('Zend\Http\Exception\InvalidArgumentException',
+                                    'Not valid or not supported HTTP version');
         $request->setVersion('1.2');
     }
 
@@ -208,5 +203,4 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         }
         return $return;
     }
-
 }


### PR DESCRIPTION
refactoring of Http\Request discussed previously on ML
- `Http\AbstractMessage` RFC HTTP message 
  with common methods for setting/accessing headers & version
- `Http\Request`: `serverParams` and `envParams`
  moved to `Http\PhpEnvironment\Request` as not specific to HTTP RFC
- `Http\PhpEnvironment\Request`: internally reorder `fileParams` 
  when `$_FILES` superglobal contains multilevel arrays
  so in case of form input `name="file[]"` 
  `fileParams` will have same structure as query/post/server/env params
- fixes in dependent components
- CS
