### PR TITLE
Updated default htmlentities() call in Zend\Filter\HtmlEntities to use ENT_QUOTES

### DIFF
--- a/library/Zend/Filter/HtmlEntities.php
+++ b/library/Zend/Filter/HtmlEntities.php
@@ -61,7 +61,7 @@ class HtmlEntities extends AbstractFilter
         }
 
         if (!isset($options['quotestyle'])) {
-            $options['quotestyle'] = ENT_COMPAT;
+            $options['quotestyle'] = ENT_QUOTES;
         }
 
         if (!isset($options['encoding'])) {

--- a/tests/Zend/Filter/HtmlEntitiesTest.php
+++ b/tests/Zend/Filter/HtmlEntitiesTest.php
@@ -49,7 +49,7 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
             'string' => 'string',
             '<'      => '&lt;',
             '>'      => '&gt;',
-            '\''     => '\'',
+            '\''     => '&#039;',
             '"'      => '&quot;',
             '&'      => '&amp;'
             );
@@ -66,7 +66,7 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetQuoteStyle()
     {
-        $this->assertEquals(ENT_COMPAT, $this->_filter->getQuoteStyle());
+        $this->assertEquals(ENT_QUOTES, $this->_filter->getQuoteStyle());
     }
 
     /**


### PR DESCRIPTION
Ensures escaping of single quotes in line with recommended usage for htmlspecialchars() elsewhere.
