### PR TITLE
Make sure AbstractRowGateway allows access to generated primary key...

### DIFF
--- a/library/Zend/Db/RowGateway/AbstractRowGateway.php
+++ b/library/Zend/Db/RowGateway/AbstractRowGateway.php
@@ -176,7 +176,8 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
         $rowData = $result->current();
         unset($statement, $result); // cleanup
 
-        $this->populateOriginalData($rowData);
+        // make sure data and original data are in sync after save
+        $this->populate($rowData, true);
 
         // return rows affected
         return $rowsAffected;

--- a/tests/Zend/Db/RowGateway/RowGatewayTest.php
+++ b/tests/Zend/Db/RowGateway/RowGatewayTest.php
@@ -24,6 +24,7 @@ class RowGatewayTest extends \PHPUnit_Framework_TestCase
     {
         // mock the adapter, driver, and parts
         $mockResult = $this->getMock('Zend\Db\Adapter\Driver\ResultInterface');
+        $mockResult->expects($this->any())->method('current')->will($this->returnValue(array('id' => 'example')));
         $mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
         $mockStatement->expects($this->any())->method('execute')->will($this->returnValue($mockResult));
         $mockConnection = $this->getMock('Zend\Db\Adapter\Driver\ConnectionInterface');
@@ -53,4 +54,15 @@ class RowGatewayTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('test', $row['testColumn']);
     }
 
+    public function testSave()
+    {
+        // If we insert a new row, we should be able to read the ID after saving it.
+        // For the purposes of this test, the mocks are set up to always generate an
+        // id of "example" (see setup method above).
+        $row = new RowGateway('id', 'fake', $this->mockAdapter);
+        $row->foo = 'bar';
+        $row->save();
+        $this->assertEquals('example', $row->id);
+        $this->assertEquals('example', $row['id']);
+    }
 }


### PR DESCRIPTION
after calls to save() by synchronizing the data and originalData properties.

Without this patch, there seems to be no way to figure out the ID of the row you have created when you use save() to perform an insert operation.  The included unit test demonstrates the problem.
