### PR TITLE
[WIP] - Hotfix/view strategy match priority

### DIFF
--- a/library/Zend/View/Strategy/FeedStrategy.php
+++ b/library/Zend/View/Strategy/FeedStrategy.php
@@ -37,6 +37,11 @@ class FeedStrategy implements ListenerAggregateInterface
     protected $renderer;
 
     /**
+     * @var double
+     */
+    protected $matchPriority = 0;
+
+    /**
      * Constructor
      *
      * @param  FeedRenderer $renderer
@@ -45,6 +50,16 @@ class FeedStrategy implements ListenerAggregateInterface
     public function __construct(FeedRenderer $renderer)
     {
         $this->renderer = $renderer;
+    }
+
+    /**
+     * Retrieve the composed renderer
+     *
+     * @return PhpRenderer
+     */
+    public function getRenderer()
+    {
+        return $this->renderer;
     }
 
     /**
@@ -76,6 +91,16 @@ class FeedStrategy implements ListenerAggregateInterface
     }
 
     /**
+     * The match priority, normally a double between 0 and 1
+     *
+     * @return double
+     */
+    public function getMatchPriority()
+    {
+        return $this->matchPriority;
+    }
+
+    /**
      * Detect if we should use the FeedRenderer based on model type and/or
      * Accept header
      *
@@ -88,7 +113,8 @@ class FeedStrategy implements ListenerAggregateInterface
 
         if ($model instanceof Model\FeedModel) {
             // FeedModel found
-            return $this->renderer;
+            $this->matchPriority = 1;
+            return $this;
         }
 
         $request = $e->getRequest();
@@ -106,15 +132,16 @@ class FeedStrategy implements ListenerAggregateInterface
         if (($match = $accept->match('application/rss+xml, application/atom+xml')) == false) {
             return;
         }
+        $this->matchPriority = $match->getPriority();
 
         if ($match->getTypeString() == 'application/rss+xml') {
             $this->renderer->setFeedType('rss');
-            return $this->renderer;
+            return $this;
         }
 
         if ($match->getTypeString() == 'application/atom+xml') {
             $this->renderer->setFeedType('atom');
-            return $this->renderer;
+            return $this;
         }
 
     }

--- a/library/Zend/View/Strategy/FeedStrategy.php
+++ b/library/Zend/View/Strategy/FeedStrategy.php
@@ -24,7 +24,7 @@ use Zend\View\ViewEvent;
  * @package    Zend_View
  * @subpackage Strategy
  */
-class FeedStrategy implements ListenerAggregateInterface
+class FeedStrategy implements StrategyInterface, ListenerAggregateInterface
 {
     /**
      * @var \Zend\Stdlib\CallbackHandler[]

--- a/library/Zend/View/Strategy/FeedStrategy.php
+++ b/library/Zend/View/Strategy/FeedStrategy.php
@@ -55,7 +55,7 @@ class FeedStrategy implements ListenerAggregateInterface
     /**
      * Retrieve the composed renderer
      *
-     * @return PhpRenderer
+     * @return FeedRenderer
      */
     public function getRenderer()
     {

--- a/library/Zend/View/Strategy/FeedStrategy.php
+++ b/library/Zend/View/Strategy/FeedStrategy.php
@@ -71,7 +71,7 @@ class FeedStrategy implements StrategyInterface, ListenerAggregateInterface
      */
     public function attach(EventManagerInterface $events, $priority = 1)
     {
-        $this->listeners[] = $events->attach(ViewEvent::EVENT_RENDERER, array($this, 'selectRenderer'), $priority);
+        $this->listeners[] = $events->attach(ViewEvent::EVENT_RENDERER, array($this, 'resolveStrategyPriority'), $priority);
         $this->listeners[] = $events->attach(ViewEvent::EVENT_RESPONSE, array($this, 'injectResponse'), $priority);
     }
 
@@ -107,7 +107,7 @@ class FeedStrategy implements StrategyInterface, ListenerAggregateInterface
      * @param  ViewEvent $e
      * @return null|FeedRenderer
      */
-    public function selectRenderer(ViewEvent $e)
+    public function resolveStrategyPriority(ViewEvent $e)
     {
         $model = $e->getModel();
 

--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -54,7 +54,7 @@ class JsonStrategy implements ListenerAggregateInterface
     /**
      * Retrieve the composed renderer
      *
-     * @return PhpRenderer
+     * @return JsonRenderer
      */
     public function getRenderer()
     {

--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -36,6 +36,11 @@ class JsonStrategy implements ListenerAggregateInterface
     protected $renderer;
 
     /**
+     * @var double
+     */
+    protected $matchPriority = 0;
+
+    /**
      * Constructor
      *
      * @param  JsonRenderer $renderer
@@ -44,6 +49,16 @@ class JsonStrategy implements ListenerAggregateInterface
     public function __construct(JsonRenderer $renderer)
     {
         $this->renderer = $renderer;
+    }
+
+    /**
+     * Retrieve the composed renderer
+     *
+     * @return PhpRenderer
+     */
+    public function getRenderer()
+    {
+        return $this->renderer;
     }
 
     /**
@@ -75,6 +90,16 @@ class JsonStrategy implements ListenerAggregateInterface
     }
 
     /**
+     * The match priority, normally a double between 0 and 1
+     *
+     * @return double
+     */
+    public function getMatchPriority()
+    {
+        return $this->matchPriority;
+    }
+
+    /**
      * Detect if we should use the JsonRenderer based on model type and/or
      * Accept header
      *
@@ -87,7 +112,8 @@ class JsonStrategy implements ListenerAggregateInterface
 
         if ($model instanceof Model\JsonModel) {
             // JsonModel found
-            return $this->renderer;
+            $this->matchPriority = 1;
+            return $this;
         }
 
         $request = $e->getRequest();
@@ -106,10 +132,11 @@ class JsonStrategy implements ListenerAggregateInterface
         if (($match = $accept->match('application/json, application/javascript')) == false) {
             return;
         }
+        $this->matchPriority = $match->getPriority();
 
         if ($match->getFormat() == 'json') {
             // application/json Accept header found
-            return $this->renderer;
+            return $this;
         }
 
         // application/javascript Accept header found
@@ -117,7 +144,7 @@ class JsonStrategy implements ListenerAggregateInterface
             $this->renderer->setJsonpCallback($callback);
         }
 
-        return $this->renderer;
+        return $this;
     }
 
     /**

--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -23,7 +23,7 @@ use Zend\View\ViewEvent;
  * @package    Zend_View
  * @subpackage Strategy
  */
-class JsonStrategy implements ListenerAggregateInterface
+class JsonStrategy implements StrategyInterface, ListenerAggregateInterface
 {
     /**
      * @var \Zend\Stdlib\CallbackHandler[]

--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -70,7 +70,7 @@ class JsonStrategy implements StrategyInterface, ListenerAggregateInterface
      */
     public function attach(EventManagerInterface $events, $priority = 1)
     {
-        $this->listeners[] = $events->attach(ViewEvent::EVENT_RENDERER, array($this, 'selectRenderer'), $priority);
+        $this->listeners[] = $events->attach(ViewEvent::EVENT_RENDERER, array($this, 'resolveStrategyPriority'), $priority);
         $this->listeners[] = $events->attach(ViewEvent::EVENT_RESPONSE, array($this, 'injectResponse'), $priority);
     }
 
@@ -106,7 +106,7 @@ class JsonStrategy implements StrategyInterface, ListenerAggregateInterface
      * @param  ViewEvent $e
      * @return null|JsonRenderer
      */
-    public function selectRenderer(ViewEvent $e)
+    public function resolveStrategyPriority(ViewEvent $e)
     {
         $model = $e->getModel();
 

--- a/library/Zend/View/Strategy/PhpRendererStrategy.php
+++ b/library/Zend/View/Strategy/PhpRendererStrategy.php
@@ -139,17 +139,17 @@ class PhpRendererStrategy implements StrategyInterface, ListenerAggregateInterfa
         $request = $e->getRequest();
         if (!$request instanceof HttpRequest) {
             // Not an HTTP request; cannot autodetermine
-            return;
+            return $this;
         }
 
         $headers = $request->getHeaders();
         if (!$headers->has('accept')) {
-            return;
+            return $this;
         }
 
         $accept  = $headers->get('accept');
         if (($match = $accept->match('*/*')) == false) {
-            return;
+            return $this;
         }
         $this->matchPriority = $match->getPriority();
 

--- a/library/Zend/View/Strategy/PhpRendererStrategy.php
+++ b/library/Zend/View/Strategy/PhpRendererStrategy.php
@@ -148,7 +148,7 @@ class PhpRendererStrategy implements StrategyInterface, ListenerAggregateInterfa
         }
 
         $accept  = $headers->get('accept');
-        if (($match = $accept->match('*/*')) == false) {
+        if (($match = $accept->match('foo')) == false) {
             return $this;
         }
         $this->matchPriority = $match->getPriority();

--- a/library/Zend/View/Strategy/PhpRendererStrategy.php
+++ b/library/Zend/View/Strategy/PhpRendererStrategy.php
@@ -22,7 +22,7 @@ use Zend\View\ViewEvent;
  * @package    Zend_View
  * @subpackage Strategy
  */
-class PhpRendererStrategy implements ListenerAggregateInterface
+class PhpRendererStrategy implements StrategyInterface, ListenerAggregateInterface
 {
     /**
      * @var \Zend\Stdlib\CallbackHandler[]

--- a/library/Zend/View/Strategy/PhpRendererStrategy.php
+++ b/library/Zend/View/Strategy/PhpRendererStrategy.php
@@ -98,7 +98,7 @@ class PhpRendererStrategy implements StrategyInterface, ListenerAggregateInterfa
      */
     public function attach(EventManagerInterface $events, $priority = 1)
     {
-        $this->listeners[] = $events->attach(ViewEvent::EVENT_RENDERER, array($this, 'selectRenderer'), $priority);
+        $this->listeners[] = $events->attach(ViewEvent::EVENT_RENDERER, array($this, 'resolveStrategyPriority'), $priority);
         $this->listeners[] = $events->attach(ViewEvent::EVENT_RESPONSE, array($this, 'injectResponse'), $priority);
     }
 
@@ -134,7 +134,7 @@ class PhpRendererStrategy implements StrategyInterface, ListenerAggregateInterfa
      * @param  ViewEvent $e
      * @return PhpRenderer
      */
-    public function selectRenderer(ViewEvent $e)
+    public function resolveStrategyPriority(ViewEvent $e)
     {
         $request = $e->getRequest();
         if (!$request instanceof HttpRequest) {

--- a/library/Zend/View/Strategy/StrategyInterface.php
+++ b/library/Zend/View/Strategy/StrategyInterface.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_View
+ */
+
+namespace Zend\View\Strategy;
+
+use Zend\View\Renderer\RendererInterface;
+
+/**
+ * Interface class for Zend_View compatible template engine implementations
+ *
+ * @category   Zend
+ * @package    Zend_View
+ */
+interface StrategyInterface
+{
+    /**
+     * Retrieve the composed renderer
+     *
+     * @return RendererInterface
+     */
+    public function getRenderer();
+
+    /**
+     * The match priority, normally a double between 0 and 1
+     *
+     * @return double
+     */
+    public function getMatchPriority();
+}

--- a/library/Zend/View/View.php
+++ b/library/Zend/View/View.php
@@ -175,18 +175,27 @@ class View implements EventManagerAwareInterface
         $event   = $this->getEvent();
         $event->setModel($model);
         $events  = $this->getEventManager();
+
+        // Get valid rendering strategies
         $results = $events->trigger(ViewEvent::EVENT_RENDERER, $event);
+
+        // $results is a ResultCollection (SplStack) of strategies
+        // If the next strategy has greater match priority, it is chosen
         $selectedStrategy = null;
         while (!$results->isEmpty()) {
             $strategy = $results->pop();
             if (!is_null($strategy)) {
                 if (is_null($selectedStrategy)) {
+                    // Select the first valid strategy
                     $selectedStrategy = $strategy;
                 } elseif ($strategy->getMatchPriority() > $selectedStrategy->getMatchPriority()) {
-                     $selectedStrategy = $strategy;
+                    // Select the next strategy if greater match priority
+                    $selectedStrategy = $strategy;
                 }
             }
         }
+
+        // Obtain the renderer from the selected strategy
         $renderer = null;
         if (!is_null($selectedStrategy)) {
             $renderer = $selectedStrategy->getRenderer();

--- a/tests/Zend/View/Strategy/PhpRendererStrategyTest.php
+++ b/tests/Zend/View/Strategy/PhpRendererStrategyTest.php
@@ -40,7 +40,7 @@ class PhpRendererStrategyTest extends TestCase
 
     public function testSelectRendererAlwaysSelectsPhpRenderer()
     {
-        $result = $this->strategy->selectRenderer($this->event);
+        $result = $this->strategy->resolveStrategyPriority($this->event);
         $this->assertSame($this->renderer, $result);
     }
 
@@ -122,7 +122,7 @@ class PhpRendererStrategyTest extends TestCase
         $events = new EventManager();
         $events->attachAggregate($this->strategy);
 
-        foreach (array('renderer' => 'selectRenderer', 'response' => 'injectResponse') as $event => $method) {
+        foreach (array('renderer' => 'resolveStrategyPriority', 'response' => 'injectResponse') as $event => $method) {
             $listeners        = $events->getListeners($event);
             $expectedCallback = array($this->strategy, $method);
             $expectedPriority = 1;
@@ -145,7 +145,7 @@ class PhpRendererStrategyTest extends TestCase
         $events = new EventManager();
         $events->attachAggregate($this->strategy, 100);
 
-        foreach (array('renderer' => 'selectRenderer', 'response' => 'injectResponse') as $event => $method) {
+        foreach (array('renderer' => 'resolveStrategyPriority', 'response' => 'injectResponse') as $event => $method) {
             $listeners        = $events->getListeners($event);
             $expectedCallback = array($this->strategy, $method);
             $expectedPriority = 100;


### PR DESCRIPTION
PLEASE DO NOT MERGE YET
## Abstract

Most browsers send */*;q=0.8 as part of the accept header. With the new Accept header implementation, the JsonStrategy was matching all requests. This fix attempts to resolve this by not stopping on the first match and instead compare the priorities of all the strategies that matched.
## Pros
- Evaluates all strategies aka doesn't choose the first match
## Cons
- Evaluates all strategies - this can be a problem when rendering a model with several children
- 2-levels of priorities, the order of strategies registered and the match priority. When the JsonStrategy matched with priority of 0.8 and the PhpRendererStrategy matched with priority of 0.8, it was weird to choose the PhpRendererStrategy even though it was the last strategy registered.
