### PR TITLE
Json strategy should only be matched for application/json and application/javascript

### DIFF
--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -107,17 +107,18 @@ class JsonStrategy implements ListenerAggregateInterface
             return;
         }
 
-        if ($match->getFormat() == 'json') {
+        if ($match->getTypeString() == 'application/json') {
             // application/json Accept header found
             return $this->renderer;
         }
 
-        // application/javascript Accept header found
-        if (false != ($callback = $request->getQuery()->get('callback'))) {
-            $this->renderer->setJsonpCallback($callback);
+        if ($match->getTypeString() == 'application/javascript') {
+            // application/javascript Accept header found
+            if (false != ($callback = $request->getQuery()->get('callback'))) {
+                $this->renderer->setJsonpCallback($callback);
+            }
+            return $this->renderer;
         }
-
-        return $this->renderer;
     }
 
     /**


### PR DESCRIPTION
Related to https://github.com/zendframework/zf2/pull/1929
Related to https://github.com/zendframework/zf2/pull/1925
## Abstract

This also resolves the same issue as PR 1929 and 1925, but is much simpler. Furthermore, it is pretty much identical behavior from before the changes to Accept header. You'll notice that it only changes the JsonStrategy because the FeedStrategy already only matches a very specific header. I feel like if we go with either of the above solutions, an RFC should be submitted and talked / voted on in a meeting.
## Pros
- Simple - JsonStrategy is only used for application/json and application/javascript
- JsonStrategy now matches behavior of FeedStrategy
## Cons
- May not be 100% correct according to RFC2616
