### PR TITLE
[Form] MultiCheckbox and Radio Elements default validators

### DIFF
--- a/library/Zend/Form/Element/MultiCheckbox.php
+++ b/library/Zend/Form/Element/MultiCheckbox.php
@@ -10,6 +10,10 @@
 
 namespace Zend\Form\Element;
 
+use Zend\Validator\Explode as ExplodeValidator;
+use Zend\Validator\InArray as InArrayValidator;
+use Zend\Validator\ValidatorInterface;
+
 /**
  * @category   Zend
  * @package    Zend_Form
@@ -21,4 +25,48 @@ class MultiCheckbox extends Checkbox
      * @var bool
      */
     protected $useHiddenElement = false;
+
+    /**
+     * @var string
+     */
+    protected $uncheckedValue = '';
+
+    /**
+     * Get validator
+     *
+     * @return ValidatorInterface
+     */
+    protected function getValidator()
+    {
+        if (null === $this->validator) {
+            $inArrayValidator = new InArrayValidator(array(
+                'haystack'  => $this->getOptionAttributeValues(),
+                'strict'    => false,
+            ));
+            $this->validator = new ExplodeValidator(array(
+                'validator'      => $inArrayValidator,
+                'valueDelimiter' => null, // skip explode if only one value
+            ));
+        }
+        return $this->validator;
+    }
+
+    /**
+     * Get only the values from the options attribute
+     *
+     * @return array
+     */
+    protected function getOptionAttributeValues()
+    {
+        $values = array();
+        $options = $this->getAttribute('options');
+        foreach ($options as $key => $optionSpec) {
+            $value = (is_array($optionSpec)) ? $optionSpec['value'] : $optionSpec;
+            $values[] = $value;
+        }
+        if ($this->useHiddenElement()) {
+            $values[] = $this->getUncheckedValue();
+        }
+        return $values;
+    }
 }

--- a/library/Zend/Form/Element/Radio.php
+++ b/library/Zend/Form/Element/Radio.php
@@ -10,6 +10,9 @@
 
 namespace Zend\Form\Element;
 
+use Zend\Validator\InArray as InArrayValidator;
+use Zend\Validator\ValidatorInterface;
+
 /**
  * @category   Zend
  * @package    Zend_Form
@@ -25,4 +28,20 @@ class Radio extends MultiCheckbox
     protected $attributes = array(
         'type' => 'radio'
     );
+
+    /**
+     * Get validator
+     *
+     * @return ValidatorInterface
+     */
+    protected function getValidator()
+    {
+        if (null === $this->validator) {
+            $this->validator = new InArrayValidator(array(
+                'haystack'  => $this->getOptionAttributeValues(),
+                'strict'    => false,
+            ));
+        }
+        return $this->validator;
+    }
 }

--- a/library/Zend/Validator/Explode.php
+++ b/library/Zend/Validator/Explode.php
@@ -114,25 +114,34 @@ class Explode extends AbstractValidator
     /**
      * Defined by Zend_Validate_Interface
      *
-     * Returns true if and only if $value is a valid list of email addresses
-     * (separated by comma) according to RFC2822
+     * Returns true if all values validate true
      *
-     * @link   http://www.ietf.org/rfc/rfc2822.txt RFC2822
-     * @link   http://www.columbia.edu/kermit/ascii.html US-ASCII characters
-     * @param  string $value
+     * @param  string|array $value
      * @return boolean
      * @throws Exception\RuntimeException
      */
     public function isValid($value)
     {
-        if (!is_string($value)) {
+        if (!is_string($value) && !is_array($value)) {
             $this->error(self::INVALID);
             return false;
         }
 
         $this->setValue($value);
 
-        $values    = explode($this->valueDelimiter, $value);
+        if (!is_array($value)) {
+            $delimiter = $this->getValueDelimiter();
+            // Skip explode if delimiter is null,
+            // used when value is expected to be either an
+            // array when multiple values and a string for
+            // single values (ie. MultiCheckbox form behavior)
+            $values = (null !== $delimiter)
+                      ? explode($this->valueDelimiter, $value)
+                      : array($value);
+        } else {
+            $values = $value;
+        }
+
         $retval    = true;
         $messages  = array();
         $validator = $this->getValidator();

--- a/tests/Zend/Form/Element/MultiCheckboxTest.php
+++ b/tests/Zend/Form/Element/MultiCheckboxTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\Element;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Element\MultiCheckbox as MultiCheckboxElement;
+use Zend\Form\Factory;
+
+class MultiCheckboxTest extends TestCase
+{
+    public function useHiddenAttributeDataProvider()
+    {
+        return array(array(true), array(false));
+    }
+
+    /**
+     * @dataProvider useHiddenAttributeDataProvider
+     */
+    public function testProvidesInputSpecificationThatIncludesValidatorsBasedOnAttributes($useHiddenElement)
+    {
+        $element = new MultiCheckboxElement();
+        $options = array(
+            'Option 1' => '1',
+            'Option 2' => '2',
+            'Option 3' => '3',
+        );
+        $element->setAttributes(array(
+            'options' => $options,
+        ));
+        $element->setUseHiddenElement($useHiddenElement);
+
+        $inputSpec = $element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $this->assertInternalType('array', $inputSpec['validators']);
+
+        $expectedClasses = array(
+            'Zend\Validator\Explode'
+        );
+        foreach ($inputSpec['validators'] as $validator) {
+            $class = get_class($validator);
+            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            switch ($class) {
+                case 'Zend\Validator\Explode':
+                    $inArrayValidator = $validator->getValidator();
+                    $this->assertInstanceOf('Zend\Validator\InArray', $inArrayValidator);
+
+                    $values = array_values($options);
+                    if ($element->useHiddenElement()) {
+                        $values[] = $element->getUncheckedValue();
+                    }
+                    $this->assertEquals($values, $inArrayValidator->getHaystack());
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/tests/Zend/Form/Element/MultiCheckboxTest.php
+++ b/tests/Zend/Form/Element/MultiCheckboxTest.php
@@ -39,9 +39,9 @@ class MultiCheckboxTest extends TestCase
     {
         $element = new MultiCheckboxElement();
         $options = array(
-            'Option 1' => '1',
-            'Option 2' => '2',
-            'Option 3' => '3',
+            '1' => 'Option 1',
+            '2' => 'Option 2',
+            '3' => 'Option 3',
         );
         $element->setAttributes(array(
             'options' => $options,

--- a/tests/Zend/Form/Element/RadioTest.php
+++ b/tests/Zend/Form/Element/RadioTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace ZendTest\Form\Element;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Element\Radio as RadioElement;
+use Zend\Form\Factory;
+
+class RadioTest extends TestCase
+{
+    public function useHiddenAttributeDataProvider()
+    {
+        return array(array(true), array(false));
+    }
+
+    /**
+     * @dataProvider useHiddenAttributeDataProvider
+     */
+    public function testProvidesInputSpecificationThatIncludesValidatorsBasedOnAttributes($useHiddenElement)
+    {
+        $element = new RadioElement();
+        $options = array(
+            'Option 1' => '1',
+            'Option 2' => '2',
+            'Option 3' => '3',
+        );
+        $element->setAttributes(array(
+            'options' => $options,
+        ));
+        $element->setUseHiddenElement($useHiddenElement);
+
+        $inputSpec = $element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $this->assertInternalType('array', $inputSpec['validators']);
+
+        $expectedClasses = array(
+            'Zend\Validator\InArray'
+        );
+        foreach ($inputSpec['validators'] as $validator) {
+            $class = get_class($validator);
+            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            switch ($class) {
+                case 'Zend\Validator\InArray':
+                    $values = array_values($options);
+                    if ($element->useHiddenElement()) {
+                        $values[] = $element->getUncheckedValue();
+                    }
+                    $this->assertEquals($values, $validator->getHaystack());
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/tests/Zend/Form/Element/RadioTest.php
+++ b/tests/Zend/Form/Element/RadioTest.php
@@ -39,9 +39,9 @@ class RadioTest extends TestCase
     {
         $element = new RadioElement();
         $options = array(
-            'Option 1' => '1',
-            'Option 2' => '2',
-            'Option 3' => '3',
+            '1' => 'Option 1',
+            '2' => 'Option 2',
+            '3' => 'Option 3',
         );
         $element->setAttributes(array(
             'options' => $options,

--- a/tests/Zend/Validator/ExplodeTest.php
+++ b/tests/Zend/Validator/ExplodeTest.php
@@ -41,7 +41,10 @@ class ExplodeTest extends \PHPUnit_Framework_TestCase
             array('foo',              ',', false, 1, true,  array(),                   true),
             array('foo',              ',', false, 1, false, array('X'),                false),
             array('foo',              ',', true,  1, false, array('X'),                false),
-            array(array(),            ',', false, 0, true,  array(Explode::INVALID => 'Invalid'), false),
+            array(array('a', 'b'),   null, false, 2, true,  array(),                   true),
+            array(array('a', 'b'),   null, false, 2, false, array('X', 'X'),           false),
+            array('foo',             null, false, 1, true,  array(),                   true),
+            array(1,                  ',', false, 0, true,  array(Explode::INVALID => 'Invalid'), false),
         );
     }
 


### PR DESCRIPTION
MultiCheckbox and Radio elements were adding incorrect validation from Checkbox base class. Fixed this so that they return correct validators.

Added functionality to Explode validator to validate each value in an array, which MultiCheckbox uses to validate each selected value with InArray.
