### PR TITLE
[Validator] Add support for strings validation against 0 in non-strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ PLEASE USE AT YOUR OWN RISK.
      option values are unique.
  - Moved Zend\I18n\Validator\Iban to Zend\Validator\Iban
    and replaced the option "locale" with "country_code"
+ - Validator:
+   - [InArray] Support for validate strings against 0 & 0.0 without false positives
+
 
 
 Over *XXX* pull requests for a variety of features and bugfixes were handled


### PR DESCRIPTION
- Add support for validate 0 & 0.0 in both sides of InArray Validation (value side and haystack side) in non-strict mode without false positives.
- Is not supported validate strings representing double values with leading zeroes in the integer part or trailing zeroes in the decimal part (Ex: haystack(array(1.1)) not validate against '1.10'
