### PR TITLE
[WIP] loadModule event and ServiceListener support for Modules

### DIFF
--- a/library/Zend/ModuleManager/Feature/LoadModuleListenerInterface.php
+++ b/library/Zend/ModuleManager/Feature/LoadModuleListenerInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_ModuleManager
+ */
+
+namespace Zend\ModuleManager\Feature;
+
+use Zend\EventManager\EventInterface;
+
+/**
+ * LoadModule listener provider interface
+ *
+ * @category   Zend
+ * @package    Zend_ModuleManager
+ * @subpackage Feature
+ */
+interface LoadModuleListenerInterface
+{
+    /**
+     * Listen to the loadModule event
+     *
+     * @return array
+     */
+    public function onLoadModule(EventInterface $e);
+}

--- a/library/Zend/ModuleManager/Feature/ServiceManagerProviderInterface.php
+++ b/library/Zend/ModuleManager/Feature/ServiceManagerProviderInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_ModuleManager
+ */
+
+namespace Zend\ModuleManager\Feature;
+
+use Zend\EventManager\EventInterface;
+use Zend\ModuleManager\Listener\ServiceListener;
+
+/**
+ * LoadModule listener provider interface
+ *
+ * @category   Zend
+ * @package    Zend_ModuleManager
+ * @subpackage Feature
+ */
+interface ServiceManagerProviderInterface
+{
+    /**
+     * Adds a service manager to the service listener
+     *
+     * @return ServiceListener
+     */
+    public function addServiceManager(ServiceListener $serviceListener);
+}

--- a/library/Zend/ModuleManager/Listener/DefaultListenerAggregate.php
+++ b/library/Zend/ModuleManager/Listener/DefaultListenerAggregate.php
@@ -51,7 +51,9 @@ class DefaultListenerAggregate extends AbstractListener implements
 
         // High priority, we assume module autoloading (for FooNamespace\Module classes) should be available before anything else
         $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULES, array($moduleAutoloader, 'register'), 9000);
-        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE_RESOLVE, new ModuleResolverListener);
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE_RESOLVE, new ModuleResolverListener($options));
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_PRELOAD_MODULE, new ServiceManagerTrigger($options));
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_PRELOAD_MODULE, new OnLoadModuleListener($options));
         // High priority, because most other loadModule listeners will assume the module's classes are available via autoloading
         $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, new AutoloaderListener($options), 9000);
         $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, new InitTrigger($options));

--- a/library/Zend/ModuleManager/Listener/OnLoadModuleListener.php
+++ b/library/Zend/ModuleManager/Listener/OnLoadModuleListener.php
@@ -10,19 +10,18 @@
 
 namespace Zend\ModuleManager\Listener;
 
-use Zend\ModuleManager\Feature\BootstrapListenerInterface;
 use Zend\ModuleManager\ModuleEvent;
+use Zend\ModuleManager\Feature\LoadModuleListenerInterface;
 
 /**
- * Bootstrap listener
+ * Load module listener
  *
  * @category   Zend
  * @package    Zend_ModuleManager
  * @subpackage Listener
  */
-class OnBootstrapListener extends AbstractListener
+class OnLoadModuleListener extends AbstractListener
 {
-
     /**
      * @param  ModuleEvent $e
      * @return void
@@ -30,15 +29,15 @@ class OnBootstrapListener extends AbstractListener
     public function __invoke(ModuleEvent $e)
     {
         $module = $e->getModule();
-        if (!$module instanceof BootstrapListenerInterface
-            && !method_exists($module, 'onBootstrap')
+
+        if (!$module instanceof LoadModuleListenerInterface
+            && !method_exists($module, 'onLoadModule')
         ) {
             return;
         }
 
         $moduleManager = $e->getTarget();
         $events        = $moduleManager->getEventManager();
-        $sharedEvents  = $events->getSharedManager();
-        $sharedEvents->attach('application', 'bootstrap', array($module, 'onBootstrap'));
+        $events->attach(ModuleEvent::EVENT_LOAD_MODULE, array($module, 'onLoadModule'));
     }
 }

--- a/library/Zend/ModuleManager/Listener/ServiceListener.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListener.php
@@ -117,10 +117,13 @@ class ServiceListener implements ListenerAggregateInterface
      * Retrieve service manager configuration from module, and
      * configure the service manager.
      *
-     * If the module does not implement ServiceProviderInterface and does not
-     * implement the "getServiceConfig()" method, does nothing. Also,
-     * if the return value of that method is not a ServiceConfig object,
-     * or not an array or Traversable that can seed one, does nothing.
+     * If the module does not implement a specific interface and does not
+     * implement a specific method, does nothing. Also, if the return value
+     * of that method is not a ServiceConfig object, or not an array or
+     * Traversable that can seed one, does nothing.
+     *
+     * The interface and method name can be set by adding a new service manager
+     * via the addServiceManager() method.
      *
      * @param  ModuleEvent $e
      * @return void
@@ -155,7 +158,8 @@ class ServiceListener implements ListenerAggregateInterface
             // We're keeping track of which modules provided which configuration to which serivce managers.
             // The actual merging takes place later. Doing it this way will enable us to provide more powerful
             // debugging tools for showing which modules overrode what.
-            $this->serviceManagers[$key]['configuration'][$e->getModuleName() . '::' . $sm['module_class_method'] . '()'] = $config;
+            $fullname = $e->getModuleName() . '::' . $sm['module_class_method'] . '()';
+            $this->serviceManagers[$key]['configuration'][$fullname] = $config;
         }
     }
 
@@ -240,7 +244,8 @@ class ServiceListener implements ListenerAggregateInterface
 
         if (!$config instanceof ServiceConfig) {
             throw new Exception\RuntimeException(sprintf(
-                'Invalid service manager configuration class provided; received "%s", expected an instance of Zend\ServiceManager\Config',
+                'Invalid service manager configuration class provided; received'
+                . ' "%s", expected an instance of Zend\ServiceManager\Config',
                 $class
             ));
         }

--- a/library/Zend/ModuleManager/Listener/ServiceManagerTrigger.php
+++ b/library/Zend/ModuleManager/Listener/ServiceManagerTrigger.php
@@ -10,19 +10,18 @@
 
 namespace Zend\ModuleManager\Listener;
 
-use Zend\ModuleManager\Feature\BootstrapListenerInterface;
 use Zend\ModuleManager\ModuleEvent;
+use Zend\ModuleManager\Feature\ServiceManagerProviderInterface;
 
 /**
- * Bootstrap listener
+ * Service manager trigger
  *
  * @category   Zend
  * @package    Zend_ModuleManager
  * @subpackage Listener
  */
-class OnBootstrapListener extends AbstractListener
+class ServiceManagerTrigger extends AbstractListener
 {
-
     /**
      * @param  ModuleEvent $e
      * @return void
@@ -30,15 +29,18 @@ class OnBootstrapListener extends AbstractListener
     public function __invoke(ModuleEvent $e)
     {
         $module = $e->getModule();
-        if (!$module instanceof BootstrapListenerInterface
-            && !method_exists($module, 'onBootstrap')
+        if (!$module instanceof ServiceManagerProviderInterface
+            && !method_exists($module, 'addServiceManager')
         ) {
             return;
         }
 
-        $moduleManager = $e->getTarget();
-        $events        = $moduleManager->getEventManager();
-        $sharedEvents  = $events->getSharedManager();
-        $sharedEvents->attach('application', 'bootstrap', array($module, 'onBootstrap'));
+        $serviceManager = $e->getParam('ServiceManager');
+
+        if ($serviceManager === null) {
+            throw new Exception\RuntimeException('Unable to access ServiceManager via ModuleEvent.');
+        }
+
+        $module->addServiceManager($serviceManager->get('ServiceListener'));
     }
 }

--- a/library/Zend/ModuleManager/ModuleEvent.php
+++ b/library/Zend/ModuleManager/ModuleEvent.php
@@ -28,6 +28,7 @@ class ModuleEvent extends Event
     CONST EVENT_LOAD_MODULE_RESOLVE = 'loadModule.resolve';
     CONST EVENT_LOAD_MODULE         = 'loadModule';
     CONST EVENT_LOAD_MODULES_POST   = 'loadModules.post';
+    CONST EVENT_PRELOAD_MODULE      = 'preloadModule';
 
     /**
      * Get the name of a given module

--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -247,6 +247,8 @@ class Application implements
         $smConfig = isset($configuration['service_manager']) ? $configuration['service_manager'] : array();
         $serviceManager = new ServiceManager(new Service\ServiceManagerConfig($smConfig));
         $serviceManager->setService('ApplicationConfig', $configuration);
+        $serviceManager->setFactory('ListenerOptions', 'Zend\Mvc\Service\ListenerOptionsFactory');
+        $serviceManager->setFactory('ServiceListener', 'Zend\Mvc\Service\ServiceListenerFactory');
         $serviceManager->get('ModuleManager')->loadModules();
         return $serviceManager->get('Application')->bootstrap();
     }

--- a/library/Zend/Mvc/Service/ListenerOptionsFactory.php
+++ b/library/Zend/Mvc/Service/ListenerOptionsFactory.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace Zend\Mvc\Service;
+
+use Zend\ModuleManager\Listener\ListenerOptions;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage Service
+ */
+class ListenerOptionsFactory implements FactoryInterface
+{
+    /**
+     * Create the listener options service
+     *
+     * Creates a Zend\ModuleManager\Listener\ListenerOptions service, passing
+     * it the options from the appliaction configuration service.
+     *
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @return ListenerOptions
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $config = $serviceLocator->get('ApplicationConfig');
+
+        return new ListenerOptions($config['module_listener_options']);
+    }
+}

--- a/library/Zend/Mvc/Service/ModuleManagerFactory.php
+++ b/library/Zend/Mvc/Service/ModuleManagerFactory.php
@@ -11,7 +11,6 @@
 namespace Zend\Mvc\Service;
 
 use Zend\ModuleManager\Listener\DefaultListenerAggregate;
-use Zend\ModuleManager\Listener\ListenerOptions;
 use Zend\ModuleManager\Listener\ServiceListener;
 use Zend\ModuleManager\ModuleEvent;
 use Zend\ModuleManager\ModuleManager;
@@ -25,42 +24,6 @@ use Zend\ServiceManager\ServiceLocatorInterface;
  */
 class ModuleManagerFactory implements FactoryInterface
 {
-    /**
-     * Default mvc-related service configuration -- can be overridden by modules.
-     *
-     * @var array
-     */
-    protected $defaultServiceConfig = array(
-        'invokables' => array(
-            'DispatchListener' => 'Zend\Mvc\DispatchListener',
-            'Request'          => 'Zend\Http\PhpEnvironment\Request',
-            'Response'         => 'Zend\Http\PhpEnvironment\Response',
-            'RouteListener'    => 'Zend\Mvc\RouteListener',
-            'ViewManager'      => 'Zend\Mvc\View\ViewManager',
-        ),
-        'factories' => array(
-            'Application'             => 'Zend\Mvc\Service\ApplicationFactory',
-            'Config'                  => 'Zend\Mvc\Service\ConfigFactory',
-            'ControllerLoader'        => 'Zend\Mvc\Service\ControllerLoaderFactory',
-            'ControllerPluginManager' => 'Zend\Mvc\Service\ControllerPluginManagerFactory',
-            'DependencyInjector'      => 'Zend\Mvc\Service\DiFactory',
-            'Router'                  => 'Zend\Mvc\Service\RouterFactory',
-            'ViewHelperManager'       => 'Zend\Mvc\Service\ViewHelperManagerFactory',
-            'ViewFeedRenderer'        => 'Zend\Mvc\Service\ViewFeedRendererFactory',
-            'ViewFeedStrategy'        => 'Zend\Mvc\Service\ViewFeedStrategyFactory',
-            'ViewJsonRenderer'        => 'Zend\Mvc\Service\ViewJsonRendererFactory',
-            'ViewJsonStrategy'        => 'Zend\Mvc\Service\ViewJsonStrategyFactory',
-        ),
-        'aliases' => array(
-            'Configuration'                     => 'Config',
-            'ControllerPluginBroker'            => 'ControllerPluginManager',
-            'Di'                                => 'DependencyInjector',
-            'Zend\Di\LocatorInterface'          => 'DependencyInjector',
-            'Zend\Mvc\Controller\PluginBroker'  => 'ControllerPluginBroker',
-            'Zend\Mvc\Controller\PluginManager' => 'ControllerPluginManager',
-        ),
-    );
-
     /**
      * Creates and returns the module manager
      *
@@ -78,20 +41,41 @@ class ModuleManagerFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $configuration    = $serviceLocator->get('ApplicationConfig');
-        $listenerOptions  = new ListenerOptions($configuration['module_listener_options']);
+        // The ServiceListener must be requested first,so that the default services can be loaded.
+        $serviceListener  = $serviceLocator->get('ServiceListener');
+        $listenerOptions  = $serviceLocator->get('ListenerOptions');
         $defaultListeners = new DefaultListenerAggregate($listenerOptions);
-        $serviceListener  = new ServiceListener($serviceLocator, $this->defaultServiceConfig);
 
-        $serviceListener->addServiceManager($serviceLocator, 'service_manager', 'Zend\ModuleManager\Feature\ServiceProviderInterface', 'getServiceConfig');
-        $serviceListener->addServiceManager('ControllerLoader', 'controllers', 'Zend\ModuleManager\Feature\ControllerProviderInterface', 'getControllerConfig');
-        $serviceListener->addServiceManager('ControllerPluginManager', 'controller_plugins', 'Zend\ModuleManager\Feature\ControllerPluginProviderInterface', 'getControllerPluginConfig');
-        $serviceListener->addServiceManager('ViewHelperManager', 'view_helpers', 'Zend\ModuleManager\Feature\ViewHelperProviderInterface', 'getViewHelperConfig');
+        $serviceListener->addServiceManager(
+            $serviceLocator,
+            'service_manager',
+            'Zend\ModuleManager\Feature\ServiceProviderInterface',
+            'getServiceConfig'
+        );
+        $serviceListener->addServiceManager(
+            'ControllerLoader',
+            'controllers',
+            'Zend\ModuleManager\Feature\ControllerProviderInterface',
+            'getControllerConfig'
+        );
+        $serviceListener->addServiceManager(
+            'ControllerPluginManager',
+            'controller_plugins',
+            'Zend\ModuleManager\Feature\ControllerPluginProviderInterface',
+            'getControllerPluginConfig'
+        );
+        $serviceListener->addServiceManager(
+            'ViewHelperManager',
+            'view_helpers',
+            'Zend\ModuleManager\Feature\ViewHelperProviderInterface',
+            'getViewHelperConfig'
+        );
 
-        $events        = $serviceLocator->get('EventManager');
+        $events = $serviceLocator->get('EventManager');
         $events->attach($defaultListeners);
         $events->attach($serviceListener);
 
-        $moduleEvent   = new ModuleEvent;
+        $moduleEvent = new ModuleEvent;
         $moduleEvent->setParam('ServiceManager', $serviceLocator);
 
         $moduleManager = new ModuleManager($configuration['modules'], $events);

--- a/library/Zend/Mvc/Service/ServiceListenerFactory.php
+++ b/library/Zend/Mvc/Service/ServiceListenerFactory.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace Zend\Mvc\Service;
+
+use Zend\ModuleManager\Listener\ServiceListener;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage Service
+ */
+class ServiceListenerFactory implements FactoryInterface
+{
+    /**
+     * Default mvc-related service configuration -- can be overridden by modules.
+     *
+     * @var array
+     */
+    protected $defaultServiceConfig = array(
+        'invokables' => array(
+            'DispatchListener' => 'Zend\Mvc\DispatchListener',
+            'Request'          => 'Zend\Http\PhpEnvironment\Request',
+            'Response'         => 'Zend\Http\PhpEnvironment\Response',
+            'RouteListener'    => 'Zend\Mvc\RouteListener',
+            'ViewManager'      => 'Zend\Mvc\View\ViewManager',
+        ),
+        'factories' => array(
+            'Application'             => 'Zend\Mvc\Service\ApplicationFactory',
+            'Config'                  => 'Zend\Mvc\Service\ConfigFactory',
+            'ControllerLoader'        => 'Zend\Mvc\Service\ControllerLoaderFactory',
+            'ControllerPluginManager' => 'Zend\Mvc\Service\ControllerPluginManagerFactory',
+            'DependencyInjector'      => 'Zend\Mvc\Service\DiFactory',
+            'Router'                  => 'Zend\Mvc\Service\RouterFactory',
+            'ViewHelperManager'       => 'Zend\Mvc\Service\ViewHelperManagerFactory',
+            'ViewFeedRenderer'        => 'Zend\Mvc\Service\ViewFeedRendererFactory',
+            'ViewFeedStrategy'        => 'Zend\Mvc\Service\ViewFeedStrategyFactory',
+            'ViewJsonRenderer'        => 'Zend\Mvc\Service\ViewJsonRendererFactory',
+            'ViewJsonStrategy'        => 'Zend\Mvc\Service\ViewJsonStrategyFactory',
+        ),
+        'aliases' => array(
+            'Configuration'                     => 'Config',
+            'ControllerPluginBroker'            => 'ControllerPluginManager',
+            'Di'                                => 'DependencyInjector',
+            'Zend\Di\LocatorInterface'          => 'DependencyInjector',
+            'Zend\Mvc\Controller\PluginBroker'  => 'ControllerPluginBroker',
+            'Zend\Mvc\Controller\PluginManager' => 'ControllerPluginManager',
+        ),
+    );
+
+    /**
+     * Create the service listener service
+     *
+     * Creates a Zend\ModuleManager\Listener\ServiceListener service, passing
+     * it the service locator instance and the default service configuration,
+     * which can be overridden by modules.
+     *
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @return ServiceListener
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return new ServiceListener($serviceLocator, $this->defaultServiceConfig);
+    }
+}


### PR DESCRIPTION
Adds the ability for modules to listen to the `loadModule(ModuleEvent)` and to add an own Service Manager to the `ServiceListener`.

While this is nice to have, it adds some overhead which might not be necessary considering the rare use case. The overhead is mainly caused by the Event Manager/Listeners, and not by the Module Manager.

Benchmark (best of 10 requests):
- 1 Module (ZendSkeletonApplication):
  - Current: http://i.imgur.com/G2P93.jpg
  - Patch:   http://i.imgur.com/3G68I.jpg
- 1 Module (ZendSkeletonApplication) + [20 Dummy Modules](https://gist.github.com/3156434#file_dummy+module):
  - Current: http://i.imgur.com/omWTk.png
  - Patch:   http://i.imgur.com/zPL4u.png

**Imho, this should only be merged, if we can squeeze some performance out of ZF2.**
