### PR TITLE
PHP 5.4 Static string callback bugfix

### DIFF
--- a/library/Zend/Stdlib/CallbackHandler.php
+++ b/library/Zend/Stdlib/CallbackHandler.php
@@ -41,7 +41,7 @@ class CallbackHandler
      * PHP version is greater as 5.4rc1?
      * @var boolean
      */
-    protected $isPhp54;
+    protected static $isPhp54;
 
     /**
      * Constructor
@@ -163,13 +163,13 @@ class CallbackHandler
         }
 
         // Minor performance tweak, if the callback gets called more than once
-        if (!isset($this->isPhp54)) {
-            $this->isPhp54 = version_compare(PHP_VERSION, '5.4.0rc1', '>=');
+        if (!isset(self::$isPhp54)) {
+            self::$isPhp54 = version_compare(PHP_VERSION, '5.4.0rc1', '>=');
         }
 
         $argCount = count($args);
 
-        if ($this->isPhp54 && is_string($callback)) {
+        if (self::$isPhp54 && is_string($callback)) {
             $result = $this->validateStringCallbackFor54($callback);
 
             if ($result !== true && $argCount <= 3) {
@@ -184,19 +184,19 @@ class CallbackHandler
         // reached
         switch ($argCount) {
             case 0:
-                if ($this->isPhp54) {
+                if (self::$isPhp54) {
                     return $callback();
                 }
                 return call_user_func($callback);
             case 1:
-                if ($this->isPhp54) {
+                if (self::$isPhp54) {
                     return $callback(array_shift($args));
                 }
                 return call_user_func($callback, array_shift($args));
             case 2:
                 $arg1 = array_shift($args);
                 $arg2 = array_shift($args);
-                if ($this->isPhp54) {
+                if (self::$isPhp54) {
                     return $callback($arg1, $arg2);
                 }
                 return call_user_func($callback, $arg1, $arg2);
@@ -204,7 +204,7 @@ class CallbackHandler
                 $arg1 = array_shift($args);
                 $arg2 = array_shift($args);
                 $arg3 = array_shift($args);
-                if ($this->isPhp54) {
+                if (self::$isPhp54) {
                     return $callback($arg1, $arg2, $arg3);
                 }
                 return call_user_func($callback, $arg1, $arg2, $arg3);

--- a/library/Zend/Stdlib/CallbackHandler.php
+++ b/library/Zend/Stdlib/CallbackHandler.php
@@ -167,17 +167,19 @@ class CallbackHandler
             $this->isPhp54 = version_compare(PHP_VERSION, '5.4.0rc1', '>=');
         }
 
+        $argCount = count($args);
+
         if ($this->isPhp54 && is_string($callback)) {
             $result = $this->validateStringCallbackFor54($callback);
 
-            if ($result !== true) {
+            if ($result !== true && $argCount <= 3) {
                 $callback = $result;
             }
         }
 
         // Minor performance tweak; use call_user_func() until > 3 arguments
         // reached
-        switch (count($args)) {
+        switch ($argCount) {
             case 0:
                 if ($this->isPhp54) {
                     return $callback();

--- a/library/Zend/Stdlib/CallbackHandler.php
+++ b/library/Zend/Stdlib/CallbackHandler.php
@@ -162,7 +162,7 @@ class CallbackHandler
             return null;
         }
 
-        // Minor performance tweak, if the callback gets called more the once
+        // Minor performance tweak, if the callback gets called more than once
         if (!isset($this->isPhp54)) {
             $this->isPhp54 = version_compare(PHP_VERSION, '5.4.0rc1', '>=');
         }
@@ -175,7 +175,7 @@ class CallbackHandler
             if ($result !== true && $argCount <= 3) {
                 $callback       = $result;
                 // Minor performance tweak, if the callback gets called more
-                // then once
+                // than once
                 $this->callback = $result;
             }
         }

--- a/library/Zend/Stdlib/CallbackHandler.php
+++ b/library/Zend/Stdlib/CallbackHandler.php
@@ -173,7 +173,10 @@ class CallbackHandler
             $result = $this->validateStringCallbackFor54($callback);
 
             if ($result !== true && $argCount <= 3) {
-                $callback = $result;
+                $callback       = $result;
+                // Minor performance tweak, if the callback gets called more
+                // then once
+                $this->callback = $result;
             }
         }
 

--- a/library/Zend/Stdlib/CallbackHandler.php
+++ b/library/Zend/Stdlib/CallbackHandler.php
@@ -38,6 +38,12 @@ class CallbackHandler
     protected $metadata;
 
     /**
+     * PHP version is greater as 5.4rc1?
+     * @var boolean
+     */
+    protected $isPhp54;
+
+    /**
      * Constructor
      *
      * @param  string $event Event to which slot is subscribed
@@ -156,29 +162,36 @@ class CallbackHandler
             return null;
         }
 
-        $isPhp54 = version_compare(PHP_VERSION, '5.4.0rc1', '>=');
+        // Minor performance tweak, if the callback gets called more the once
+        if (!isset($this->isPhp54)) {
+            $this->isPhp54 = version_compare(PHP_VERSION, '5.4.0rc1', '>=');
+        }
 
-        if ($isPhp54 && is_string($callback)) {
-            $this->validateStringCallbackFor54($callback);
+        if ($this->isPhp54 && is_string($callback)) {
+            $result = $this->validateStringCallbackFor54($callback);
+
+            if ($result !== true) {
+                $callback = $result;
+            }
         }
 
         // Minor performance tweak; use call_user_func() until > 3 arguments
         // reached
         switch (count($args)) {
             case 0:
-                if ($isPhp54) {
+                if ($this->isPhp54) {
                     return $callback();
                 }
                 return call_user_func($callback);
             case 1:
-                if ($isPhp54) {
+                if ($this->isPhp54) {
                     return $callback(array_shift($args));
                 }
                 return call_user_func($callback, array_shift($args));
             case 2:
                 $arg1 = array_shift($args);
                 $arg2 = array_shift($args);
-                if ($isPhp54) {
+                if ($this->isPhp54) {
                     return $callback($arg1, $arg2);
                 }
                 return call_user_func($callback, $arg1, $arg2);
@@ -186,7 +199,7 @@ class CallbackHandler
                 $arg1 = array_shift($args);
                 $arg2 = array_shift($args);
                 $arg3 = array_shift($args);
-                if ($isPhp54) {
+                if ($this->isPhp54) {
                     return $callback($arg1, $arg2, $arg3);
                 }
                 return call_user_func($callback, $arg1, $arg2, $arg3);
@@ -235,7 +248,7 @@ class CallbackHandler
      * Validates that a static method call in PHP 5.4 will actually work
      *
      * @param  string $callback
-     * @return true
+     * @return true|array
      * @throws Exception\InvalidCallbackException if invalid
      */
     protected function validateStringCallbackFor54($callback)
@@ -268,6 +281,9 @@ class CallbackHandler
             ));
         }
 
-        return true;
+        // returning a non boolean value may not be nice for a validate method,
+        // but that allows the usage of a static string callback without using
+        // the call_user_func function.
+        return array($class, $method);
     }
 }

--- a/tests/Zend/Stdlib/CallbackHandlerTest.php
+++ b/tests/Zend/Stdlib/CallbackHandlerTest.php
@@ -130,6 +130,23 @@ class CallbackHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('staticHandler', $result);
     }
 
+    public function testStringStaticCallbackForPhp54WithMoreThan4Args()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0rc1', '<=')) {
+            $this->markTestSkipped('Requires PHP 5.4');
+        }
+
+        $handler = new CallbackHandler('ZendTest\\Stdlib\\SignalHandlers\\InstanceMethod::staticHandler');
+        $error   = false;
+        set_error_handler(function ($errno, $errstr) use (&$error) {
+            $error = true;
+        }, E_STRICT);
+        $result = $handler->call(array(1, 2, 3, 4));
+        restore_error_handler();
+        $this->assertFalse($error);
+        $this->assertSame('staticHandler', $result);
+    }
+
     public function testCallbackToClassImplementingOverloadingButNotInvocableShouldRaiseException()
     {
         $this->setExpectedException('Zend\Stdlib\Exception\InvalidCallbackException');

--- a/tests/Zend/Stdlib/CallbackHandlerTest.php
+++ b/tests/Zend/Stdlib/CallbackHandlerTest.php
@@ -113,6 +113,23 @@ class CallbackHandlerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testStringStaticCallbackForPhp54()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0rc1', '<=')) {
+            $this->markTestSkipped('Requires PHP 5.4');
+        }
+
+        $handler = new CallbackHandler('ZendTest\\Stdlib\\SignalHandlers\\InstanceMethod::staticHandler');
+        $error   = false;
+        set_error_handler(function ($errno, $errstr) use (&$error) {
+            $error = true;
+        }, E_STRICT);
+        $result = $handler->call();
+        restore_error_handler();
+        $this->assertFalse($error);
+        $this->assertSame('staticHandler', $result);
+    }
+
     public function testCallbackToClassImplementingOverloadingButNotInvocableShouldRaiseException()
     {
         $this->setExpectedException('Zend\Stdlib\Exception\InvalidCallbackException');

--- a/tests/Zend/Stdlib/CallbackHandlerTest.php
+++ b/tests/Zend/Stdlib/CallbackHandlerTest.php
@@ -130,7 +130,7 @@ class CallbackHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('staticHandler', $result);
     }
 
-    public function testStringStaticCallbackForPhp54WithMoreThan4Args()
+    public function testStringStaticCallbackForPhp54WithMoreThan3Args()
     {
         if (version_compare(PHP_VERSION, '5.4.0rc1', '<=')) {
             $this->markTestSkipped('Requires PHP 5.4');

--- a/tests/Zend/Stdlib/SignalHandlers/InstanceMethod.php
+++ b/tests/Zend/Stdlib/SignalHandlers/InstanceMethod.php
@@ -16,4 +16,9 @@ class InstanceMethod
     {
         return __FUNCTION__;
     }
+
+    static public function staticHandler()
+    {
+        return __FUNCTION__;
+    }
 }


### PR DESCRIPTION
Fixed static string callback bug for PHP 5.4 or newer. Calling a static method via string, will throw a PHP fatal error - call to undefined function.
