### PR TITLE
[View\Helper\PaginatorControl] Adding Missing $_defaultScrollingStyle var

### DIFF
--- a/library/Zend/View/Helper/PaginationControl.php
+++ b/library/Zend/View/Helper/PaginationControl.php
@@ -28,6 +28,13 @@ class PaginationControl extends AbstractHelper
     protected static $_defaultViewPartial = null;
 
     /**
+     * Default Scrolling Style
+     *
+     * @var string
+     */
+    protected static $_defaultScrollingStyle = 'sliding';
+
+    /**
      * Sets the default view partial.
      *
      * @param string|array $partial View partial
@@ -45,6 +52,26 @@ class PaginationControl extends AbstractHelper
     public static function getDefaultViewPartial()
     {
         return self::$_defaultViewPartial;
+    }
+    
+     /**
+     * Gets the default scrolling style
+     *
+     * @return string
+     */
+    public static function getDefaultScrollingStyle()
+    {
+        return self::$_defaultScrollingStyle;
+    }
+
+    /**
+     * Sets the default Scrolling Style
+     *
+     * @param type $style string 'all' | 'elastic' | 'sliding' | 'jumping'
+     */
+    public static function setDefaultScrollingStyle($style)
+    {
+        self::$_defaultScrollingStyle = $style;
     }
 
     /**
@@ -76,6 +103,10 @@ class PaginationControl extends AbstractHelper
             }
 
             $partial = self::$_defaultViewPartial;
+        }
+	
+        if ($scrollingStyle === null) {
+            $scrollingStyle = self::$_defaultScrollingStyle;
         }
 
         $pages = get_object_vars($paginator->getPages($scrollingStyle));

--- a/library/Zend/View/Helper/PaginationControl.php
+++ b/library/Zend/View/Helper/PaginationControl.php
@@ -25,14 +25,14 @@ class PaginationControl extends AbstractHelper
      *
      * @var string|array
      */
-    protected static $_defaultViewPartial = null;
+    protected static $defaultViewPartial = null;
 
     /**
      * Default Scrolling Style
      *
      * @var string
      */
-    protected static $_defaultScrollingStyle = 'sliding';
+    protected static $defaultScrollingStyle = 'sliding';
 
     /**
      * Sets the default view partial.
@@ -41,7 +41,7 @@ class PaginationControl extends AbstractHelper
      */
     public static function setDefaultViewPartial($partial)
     {
-        self::$_defaultViewPartial = $partial;
+        self::$defaultViewPartial = $partial;
     }
 
     /**
@@ -51,9 +51,9 @@ class PaginationControl extends AbstractHelper
      */
     public static function getDefaultViewPartial()
     {
-        return self::$_defaultViewPartial;
+        return self::$defaultViewPartial;
     }
-    
+
      /**
      * Gets the default scrolling style
      *
@@ -61,7 +61,7 @@ class PaginationControl extends AbstractHelper
      */
     public static function getDefaultScrollingStyle()
     {
-        return self::$_defaultScrollingStyle;
+        return self::$defaultScrollingStyle;
     }
 
     /**
@@ -71,7 +71,7 @@ class PaginationControl extends AbstractHelper
      */
     public static function setDefaultScrollingStyle($style)
     {
-        self::$_defaultScrollingStyle = $style;
+        self::$defaultScrollingStyle = $style;
     }
 
     /**
@@ -98,15 +98,15 @@ class PaginationControl extends AbstractHelper
         }
 
         if ($partial === null) {
-            if (self::$_defaultViewPartial === null) {
+            if (self::$defaultViewPartial === null) {
                 throw new Exception\RuntimeException('No view partial provided and no default set');
             }
 
-            $partial = self::$_defaultViewPartial;
+            $partial = self::$defaultViewPartial;
         }
-	
+
         if ($scrollingStyle === null) {
-            $scrollingStyle = self::$_defaultScrollingStyle;
+            $scrollingStyle = self::$defaultScrollingStyle;
         }
 
         $pages = get_object_vars($paginator->getPages($scrollingStyle));


### PR DESCRIPTION
**Completed:** Adding missing defaultScrollingStyle var, and adding get / set, and if no defaultScrollingStyle is passed into the invokable, the default is used - which itself is set to a default value of 'sliding' as before. 
