### PR TITLE
Allow elements to be removed in collection

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -116,9 +116,9 @@ class Element implements ElementInterface
     }
 
     /**
-     * get defined options
+     * Get defined options
      *
-     * @return array()
+     * @return array
      */
     public function getOptions()
     {
@@ -126,10 +126,10 @@ class Element implements ElementInterface
     }
 
     /**
-     * return the specified option
+     * Return the specified option
      * 
      * @param string $option
-     * @return NULL|multitype:
+     * @return NULL|mixed
      */
     public function getOption($option)
     {

--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -129,6 +129,9 @@ class Collection extends Fieldset
      * Populate values
      *
      * @param array|\Traversable $data
+     * @throws \Zend\Form\Exception\InvalidArgumentException
+     * @throws \Zend\Form\Exception\DomainException
+     * @return void
      */
     public function populateValues($data)
     {
@@ -142,8 +145,28 @@ class Collection extends Fieldset
 
         // Can't do anything with empty data
         if (empty($data)) {
-
             return;
+        }
+
+        if (count($data) < $this->getCount()) {
+            if (!$this->allowRemove) {
+                throw new Exception\DomainException(sprintf(
+                    'There are less elements than specified in collection %s. Either set allow_remove option ' .
+                    'to true, or re-submit the form.',
+                    get_class($this)
+                    )
+                );
+            }
+
+            // If there are less data and that allowRemove is true, we remove elements that are not presents
+            $this->setCount(count($data));
+            foreach ($this->byName as $name => $elementOrFieldset) {
+                if (isset($data[$name])) {
+                    continue;
+                }
+
+                $this->remove($name);
+            }
         }
 
         if ($this->targetElement instanceof FieldsetInterface) {

--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -151,7 +151,7 @@ class Collection extends Fieldset
         if (count($data) < $this->getCount()) {
             if (!$this->allowRemove) {
                 throw new Exception\DomainException(sprintf(
-                    'There are less elements than specified in collection %s. Either set allow_remove option ' .
+                    'There are fewer elements than specified in the collection (%s). Either set the allow_remove option ' .
                     'to true, or re-submit the form.',
                     get_class($this)
                     )
@@ -299,7 +299,7 @@ class Collection extends Fieldset
      *
      * @return bool
      */
-    public function getAllowAdd()
+    public function allowAdd()
     {
         return $this->allowAdd;
     }
@@ -317,7 +317,7 @@ class Collection extends Fieldset
     /**
      * @return bool
      */
-    public function getAllowRemove()
+    public function allowRemove()
     {
         return $this->allowRemove;
     }

--- a/library/Zend/Form/ElementInterface.php
+++ b/library/Zend/Form/ElementInterface.php
@@ -48,12 +48,12 @@ interface ElementInterface
      * @return array
      */
     public function getOptions();
-    
+
     /**
      * return the specified option
-     * 
+     *
      * @param string $option
-     * @return NULL|multitype
+     * @return null|mixed
      */
     public function getOption($option);
 

--- a/tests/Zend/Form/Element/CollectionTest.php
+++ b/tests/Zend/Form/Element/CollectionTest.php
@@ -122,4 +122,62 @@ class CollectionTest extends TestCase
 
         $this->assertEquals(true, $this->form->isValid());
     }
+
+    public function testThrowExceptionIfThereAreLessElementsAndAllowRemoveNotAllowed()
+    {
+        $this->setExpectedException('Zend\Form\Exception\DomainException');
+
+        $collection = $this->form->get('colors');
+        $collection->setAllowRemove(false);
+
+        $this->form->setData(array(
+            'colors' => array(
+                '#ffffff'
+            ),
+            'fieldsets' => array(
+                array(
+                    'field' => 'oneValue',
+                    'nested_fieldset' => array(
+                        'anotherField' => 'anotherValue'
+                    )
+                ),
+                array(
+                    'field' => 'twoValue',
+                    'nested_fieldset' => array(
+                        'anotherField' => 'anotherValue'
+                    )
+                )
+            )
+        ));
+
+        $this->form->isValid();
+    }
+
+    public function testCanValidateLessThanSpecifiedCount()
+    {
+        $collection = $this->form->get('colors');
+        $collection->setAllowRemove(true);
+
+        $this->form->setData(array(
+            'colors' => array(
+                '#ffffff'
+            ),
+            'fieldsets' => array(
+                array(
+                    'field' => 'oneValue',
+                    'nested_fieldset' => array(
+                        'anotherField' => 'anotherValue'
+                    )
+                ),
+                array(
+                    'field' => 'twoValue',
+                    'nested_fieldset' => array(
+                        'anotherField' => 'anotherValue'
+                    )
+                )
+            )
+        ));
+
+        $this->assertEquals(true, $this->form->isValid());
+    }
 }


### PR DESCRIPTION
This PR adds a new feature for Collection element in Forms : if the allow_remove option is set to true, the form will still validate even if there are less elements in the collection than initially defined (otherwise, it will throw an exception as this is an unexpected situation).

This is useful especially if we provide a specific number of elements, and let the user remove them using JavaScript.

It also allows the Collection element to use its own hydrator to extract/hydrate element, instead of always relying on the hydrator of the target element.
