### PR TITLE
Allow to retrieve any inputs

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -145,7 +145,6 @@ class BaseInputFilter implements InputFilterInterface
         $valid               = true;
 
         $inputs = $this->validationGroup ?: array_keys($this->inputs);
-        //var_dump($inputs);
         foreach ($inputs as $name) {
             $input = $this->inputs[$name];
             if (!array_key_exists($name, $this->data) || (is_string($this->data[$name]) && strlen($this->data[$name]) === 0)) {
@@ -394,21 +393,17 @@ class BaseInputFilter implements InputFilterInterface
      */
     protected function populate()
     {
-        foreach (array_keys($this->inputs) as $name) {
-            $input = $this->inputs[$name];
-
-            if (!isset($this->data[$name])) {
-                // No value; clear value in this input
-                if ($input instanceof InputFilterInterface) {
-                    $input->setData(array());
-                    continue;
+        foreach ($this->data as $key => $value) {
+            // If the input does not exist, we construct an empty one
+            if (!isset($this->inputs[$key])) {
+                if (is_array($value)) {
+                    $this->add(new InputFilter($key));
+                } else {
+                    $this->add(new Input($key));
                 }
-
-                $input->setValue(null);
-                continue;
             }
 
-            $value = $this->data[$name];
+            $input = $this->inputs[$key];
 
             if ($input instanceof InputFilterInterface) {
                 $input->setData($value);

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -402,15 +402,30 @@ class BaseInputFilter implements InputFilterInterface
                     $this->add(new Input($key));
                 }
             }
+        }
 
-            $input = $this->inputs[$key];
+        foreach (array_keys($this->inputs) as $name) {
+            $input = $this->inputs[$name];
 
-            if ($input instanceof InputFilterInterface) {
-                $input->setData($value);
+            if (!isset($this->data[$name])) {
+                // No value; clear value in this input
+                if ($input instanceof InputFilterInterface) {
+                    $input->setData(array());
+                    continue;
+                }
+
+                $input->setValue(null);
                 continue;
             }
 
-            $input->setValue($value);
+            $input = $this->inputs[$name];
+
+            if ($input instanceof InputFilterInterface) {
+                $input->setData($this->data[$name]);
+                continue;
+            }
+
+            $input->setValue($this->data[$name]);
         }
     }
 }

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -169,7 +169,6 @@ class FormTest extends TestCase
         $form->setData(array());
         $form->isValid();
 
-
         $this->assertTrue($form->hasValidated());
     }
 

--- a/tests/Zend/InputFilter/BaseInputFilterTest.php
+++ b/tests/Zend/InputFilter/BaseInputFilterTest.php
@@ -498,4 +498,15 @@ class BaseInputFilterTest extends TestCase
         $this->assertArrayHasKey('foo', $messages);
         $this->assertNotEmpty($messages['foo']);
     }
+
+    public function testGetValuesEvenIfNoInputWasSpecified()
+    {
+        $filter = new InputFilter();
+
+        $data = array('foo' => 'bar');
+        $filter->setData($data);
+
+        $this->assertTrue($filter->isValid());
+        $this->assertEquals('bar', $filter->getValue('foo'));
+    }
 }


### PR DESCRIPTION
A lot of people were complaining that if no input were added in the input filter for form, they were not getting back any values. We had two choices : either throws an exception, or automatically add a new input/input filter for data. This is what I've done in this PR.

However, I think we should emphasize that user should use this feature with care, as those empty inputs have neither validation or filtering attached to them. 
