### PR TITLE
Fix merging of identifiers for Zend\EventManager

### DIFF
--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -148,7 +148,7 @@ class EventManager implements EventManagerInterface
         if (is_array($identifiers) || $identifiers instanceof \Traversable) {
             $this->identifiers = array_unique($this->identifiers + (array) $identifiers);
         } elseif ($identifiers !== null) {
-            $this->identifiers = array_unique($this->identifiers + array($identifiers));
+            $this->identifiers = array_unique(array_merge($this->identifiers, array($identifiers)));
         }
         return $this;
     }

--- a/tests/Zend/EventManager/EventManagerTest.php
+++ b/tests/Zend/EventManager/EventManagerTest.php
@@ -550,6 +550,29 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($identifiers[0], __CLASS__);
     }
 
+    public function testIdentifierGetterSettersWorkWithStrings()
+    {
+        $identifier1 = 'foo';
+        $identifiers = array($identifier1);
+        $this->assertInstanceOf('Zend\EventManager\EventManager', $this->events->setIdentifiers($identifier1));
+        $this->assertSame($this->events->getIdentifiers(), $identifiers);
+        $identifier2 = 'baz';
+        $identifiers = array($identifier1, $identifier2);
+        $this->assertInstanceOf('Zend\EventManager\EventManager', $this->events->addIdentifiers($identifier2));
+        $this->assertSame($this->events->getIdentifiers(), $identifiers);
+    }
+
+    public function testIdentifierGetterSettersWorkWithNewArrays()
+    {
+        $identifiers = array('foo', 'bar');
+        $this->assertInstanceOf('Zend\EventManager\EventManager', $this->events->setIdentifiers($identifiers));
+        $this->assertSame($this->events->getIdentifiers(), $identifiers);
+        $identifier  = 'baz';
+        $identifiers = array_merge($identifiers, array($identifier));
+        $this->assertInstanceOf('Zend\EventManager\EventManager', $this->events->addIdentifiers($identifier));
+        $this->assertSame($this->events->getIdentifiers(), $identifiers);
+    }
+
     public function testIdentifierGetterSettersWorkWithArrays()
     {
         $identifiers = array('foo', 'bar');

--- a/tests/Zend/EventManager/EventManagerTest.php
+++ b/tests/Zend/EventManager/EventManagerTest.php
@@ -562,17 +562,6 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->events->getIdentifiers(), $identifiers);
     }
 
-    public function testIdentifierGetterSettersWorkWithNewArrays()
-    {
-        $identifiers = array('foo', 'bar');
-        $this->assertInstanceOf('Zend\EventManager\EventManager', $this->events->setIdentifiers($identifiers));
-        $this->assertSame($this->events->getIdentifiers(), $identifiers);
-        $identifier  = 'baz';
-        $identifiers = array_merge($identifiers, array($identifier));
-        $this->assertInstanceOf('Zend\EventManager\EventManager', $this->events->addIdentifiers($identifier));
-        $this->assertSame($this->events->getIdentifiers(), $identifiers);
-    }
-
     public function testIdentifierGetterSettersWorkWithArrays()
     {
         $identifiers = array('foo', 'bar');


### PR DESCRIPTION
The `+` operator does not work in this context of strings, because the new array has a key of `0`. The `+` operator therefore does not merge the `array($stringValue)` with the original identifiers.

Tests are created, code is modified to pass the tests again.
