### PR TITLE
[Vendors] Whitelist strategy for vendors

### DIFF
--- a/vendor/.gitignore
+++ b/vendor/.gitignore
@@ -1,5 +1,4 @@
+# Add here the vendor path to be whitelisted
+# Ex: for composer directory write here "!composer" (without quotes)
 !.gitignore
-.composer
-composer
-doctrine
-autoload.php
+*


### PR DESCRIPTION
Is better use whitelist strategy in vendors directory for avoid accidental commits of vendors used by new features under development.
