### PR TITLE
Make request params retrieval more user-friendly

### DIFF
--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -266,18 +266,24 @@ class Request extends Message implements RequestInterface
         return $this;
     }
 
-    /**
-     * Return the parameter container responsible for query parameters
-     *
-     * @return \Zend\Stdlib\ParametersInterface
-     */
-    public function getQuery()
+	/**
+	 * Return the parameter container responsible for query parameters or a single query parameter
+	 *
+	 * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
+	 * @param mixed|null            $default         Default value to use when the parameter is missing.
+	 * @return \Zend\Stdlib\ParametersInterface|mixed
+	 */
+    public function getQuery($name = null, $default = null)
     {
         if ($this->queryParams === null) {
             $this->queryParams = new Parameters();
         }
 
-        return $this->queryParams;
+        if($name === null){
+			return $this->queryParams;
+		}else{
+			return $this->queryParams->get($name, $default);
+		}
     }
 
     /**
@@ -294,17 +300,23 @@ class Request extends Message implements RequestInterface
     }
 
     /**
-     * Return the parameter container responsible for post parameters
+     * Return the parameter container responsible for post parameters or a single post parameter.
      *
-     * @return \Zend\Stdlib\ParametersInterface
+	 * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
+	 * @param mixed|null            $default         Default value to use when the parameter is missing.
+	 * @return \Zend\Stdlib\ParametersInterface|mixed
      */
-    public function getPost()
+    public function getPost($name = null, $default = null)
     {
         if ($this->postParams === null) {
             $this->postParams = new Parameters();
         }
 
-        return $this->postParams;
+        if($name === null){
+			return $this->postParams;
+		}else{
+			return $this->postParams->get($name, $default);
+		}
     }
 
     /**
@@ -332,17 +344,23 @@ class Request extends Message implements RequestInterface
     }
 
     /**
-     * Return the parameter container responsible for file parameters
-     *
-     * @return ParametersInterface
+     * Return the parameter container responsible for file parameters or a single file.
+	 *
+	 * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
+	 * @param mixed|null            $default         Default value to use when the parameter is missing.
+     * @return ParametersInterface|mixed
      */
-    public function getFile()
+    public function getFile($name = null, $default = null)
     {
         if ($this->fileParams === null) {
             $this->fileParams = new Parameters();
         }
 
-        return $this->fileParams;
+        if($name === null){
+			return $this->fileParams;
+		}else{
+			return $this->fileParams->get($name, $default);
+		}
     }
 
     /**
@@ -359,18 +377,24 @@ class Request extends Message implements RequestInterface
     }
 
     /**
-     * Return the parameter container responsible for server parameters
+     * Return the parameter container responsible for server parameters or a single parameter value.
      *
+	 * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
+	 * @param mixed|null            $default         Default value to use when the parameter is missing.
      * @see http://www.faqs.org/rfcs/rfc3875.html
-     * @return \Zend\Stdlib\ParametersInterface
+     * @return \Zend\Stdlib\ParametersInterface|mixed
      */
-    public function getServer()
+    public function getServer($name = null, $default = null)
     {
         if ($this->serverParams === null) {
             $this->serverParams = new Parameters();
         }
 
-        return $this->serverParams;
+        if($name === null){
+			return $this->serverParams;
+		}else{
+			return $this->serverParams->get($name, $default);
+		}
     }
 
     /**
@@ -387,17 +411,23 @@ class Request extends Message implements RequestInterface
     }
 
     /**
-     * Return the parameter container responsible for env parameters
-     *
-     * @return \Zend\Stdlib\ParametersInterface
+     * Return the parameter container responsible for env parameters or a single parameter value.
+	 *
+	 * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
+	 * @param mixed|null            $default         Default value to use when the parameter is missing.     * @return \Zend\Stdlib\ParametersInterface
+	 * @return \Zend\Stdlib\ParametersInterface|mixed
      */
-    public function getEnv()
+    public function getEnv($name = null, $default = null)
     {
         if ($this->envParams === null) {
             $this->envParams = new Parameters();
         }
 
-        return $this->envParams;
+        if($name === null){
+			return $this->envParams;
+		}else{
+			return $this->envParams->get($name, $default);
+		}
     }
 
     /**
@@ -414,18 +444,40 @@ class Request extends Message implements RequestInterface
     }
 
     /**
-     * Return the header container responsible for headers
-     *
-     * @return \Zend\Http\Headers
-     */
-    public function getHeaders()
+     * Return the header container responsible for headers or all headers of a certain name/type
+	 *
+	 * @see \Zend\Http\Headers::get()
+	 * @param string|null           $name            Header name to retrieve, or null to get the whole container.
+	 * @param mixed|null            $default         Default value to use when the requested header is missing.
+	 * @return \Zend\Http\Headers|bool|\Zend\Http\Header\HeaderInterface|\ArrayIterator
+	 */
+    public function getHeaders($name = null, $default = false)
     {
         if ($this->headers === null || is_string($this->headers)) {
             // this is only here for fromString lazy loading
             $this->headers = (is_string($this->headers)) ? Headers::fromString($this->headers) : new Headers();
         }
 
-        return $this->headers;
+        if($name === null){
+			return $this->headers;
+		}elseif($this->headers->has($name)){
+			return $this->headers->get($name);
+		}else{
+			return $default;
+		}
+    }
+
+    /**
+     * Get all headers of a certain name/type.
+	 *
+	 * @see Request::getHeaders()
+	 * @param string|null           $name            Header name to retrieve, or null to get the whole container.
+	 * @param mixed|null            $default         Default value to use when the requested header is missing.
+	 * @return \Zend\Http\Headers|bool|\Zend\Http\Header\HeaderInterface|\ArrayIterator
+     */
+    public function getHeader($name, $default = false)
+    {
+        return $this->getHeaders($name, $default);
     }
 
     /**

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -281,9 +281,9 @@ class Request extends Message implements RequestInterface
 
         if($name === null){
             return $this->queryParams;
-        }else{
-            return $this->queryParams->get($name, $default);
         }
+
+        return $this->queryParams->get($name, $default);
     }
 
     /**
@@ -314,9 +314,9 @@ class Request extends Message implements RequestInterface
 
         if($name === null){
             return $this->postParams;
-        }else{
-            return $this->postParams->get($name, $default);
         }
+
+        return $this->postParams->get($name, $default);
     }
 
     /**
@@ -358,9 +358,9 @@ class Request extends Message implements RequestInterface
 
         if($name === null){
             return $this->fileParams;
-        }else{
-            return $this->fileParams->get($name, $default);
         }
+
+        return $this->fileParams->get($name, $default);
     }
 
     /**
@@ -392,9 +392,9 @@ class Request extends Message implements RequestInterface
 
         if($name === null){
             return $this->serverParams;
-        }else{
-            return $this->serverParams->get($name, $default);
         }
+
+        return $this->serverParams->get($name, $default);
     }
 
     /**
@@ -425,9 +425,9 @@ class Request extends Message implements RequestInterface
 
         if($name === null){
             return $this->envParams;
-        }else{
-            return $this->envParams->get($name, $default);
         }
+
+        return $this->envParams->get($name, $default);
     }
 
     /**
@@ -460,11 +460,13 @@ class Request extends Message implements RequestInterface
 
         if($name === null){
             return $this->headers;
-        }elseif($this->headers->has($name)){
-            return $this->headers->get($name);
-        }else{
-            return $default;
         }
+
+        if($this->headers->has($name)){
+            return $this->headers->get($name);
+        }
+
+        return $default;
     }
 
     /**

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -266,13 +266,13 @@ class Request extends Message implements RequestInterface
         return $this;
     }
 
-	/**
-	 * Return the parameter container responsible for query parameters or a single query parameter
-	 *
-	 * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
-	 * @param mixed|null            $default         Default value to use when the parameter is missing.
-	 * @return \Zend\Stdlib\ParametersInterface|mixed
-	 */
+    /**
+     * Return the parameter container responsible for query parameters or a single query parameter
+     *
+     * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
+     * @param mixed|null            $default         Default value to use when the parameter is missing.
+     * @return \Zend\Stdlib\ParametersInterface|mixed
+     */
     public function getQuery($name = null, $default = null)
     {
         if ($this->queryParams === null) {
@@ -280,10 +280,10 @@ class Request extends Message implements RequestInterface
         }
 
         if($name === null){
-			return $this->queryParams;
-		}else{
-			return $this->queryParams->get($name, $default);
-		}
+            return $this->queryParams;
+        }else{
+            return $this->queryParams->get($name, $default);
+        }
     }
 
     /**
@@ -302,9 +302,9 @@ class Request extends Message implements RequestInterface
     /**
      * Return the parameter container responsible for post parameters or a single post parameter.
      *
-	 * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
-	 * @param mixed|null            $default         Default value to use when the parameter is missing.
-	 * @return \Zend\Stdlib\ParametersInterface|mixed
+     * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
+     * @param mixed|null            $default         Default value to use when the parameter is missing.
+     * @return \Zend\Stdlib\ParametersInterface|mixed
      */
     public function getPost($name = null, $default = null)
     {
@@ -313,10 +313,10 @@ class Request extends Message implements RequestInterface
         }
 
         if($name === null){
-			return $this->postParams;
-		}else{
-			return $this->postParams->get($name, $default);
-		}
+            return $this->postParams;
+        }else{
+            return $this->postParams->get($name, $default);
+        }
     }
 
     /**
@@ -345,9 +345,9 @@ class Request extends Message implements RequestInterface
 
     /**
      * Return the parameter container responsible for file parameters or a single file.
-	 *
-	 * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
-	 * @param mixed|null            $default         Default value to use when the parameter is missing.
+     *
+     * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
+     * @param mixed|null            $default         Default value to use when the parameter is missing.
      * @return ParametersInterface|mixed
      */
     public function getFile($name = null, $default = null)
@@ -357,10 +357,10 @@ class Request extends Message implements RequestInterface
         }
 
         if($name === null){
-			return $this->fileParams;
-		}else{
-			return $this->fileParams->get($name, $default);
-		}
+            return $this->fileParams;
+        }else{
+            return $this->fileParams->get($name, $default);
+        }
     }
 
     /**
@@ -379,8 +379,8 @@ class Request extends Message implements RequestInterface
     /**
      * Return the parameter container responsible for server parameters or a single parameter value.
      *
-	 * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
-	 * @param mixed|null            $default         Default value to use when the parameter is missing.
+     * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
+     * @param mixed|null            $default         Default value to use when the parameter is missing.
      * @see http://www.faqs.org/rfcs/rfc3875.html
      * @return \Zend\Stdlib\ParametersInterface|mixed
      */
@@ -391,10 +391,10 @@ class Request extends Message implements RequestInterface
         }
 
         if($name === null){
-			return $this->serverParams;
-		}else{
-			return $this->serverParams->get($name, $default);
-		}
+            return $this->serverParams;
+        }else{
+            return $this->serverParams->get($name, $default);
+        }
     }
 
     /**
@@ -412,10 +412,10 @@ class Request extends Message implements RequestInterface
 
     /**
      * Return the parameter container responsible for env parameters or a single parameter value.
-	 *
-	 * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
-	 * @param mixed|null            $default         Default value to use when the parameter is missing.     * @return \Zend\Stdlib\ParametersInterface
-	 * @return \Zend\Stdlib\ParametersInterface|mixed
+     *
+     * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
+     * @param mixed|null            $default         Default value to use when the parameter is missing.     * @return \Zend\Stdlib\ParametersInterface
+     * @return \Zend\Stdlib\ParametersInterface|mixed
      */
     public function getEnv($name = null, $default = null)
     {
@@ -424,10 +424,10 @@ class Request extends Message implements RequestInterface
         }
 
         if($name === null){
-			return $this->envParams;
-		}else{
-			return $this->envParams->get($name, $default);
-		}
+            return $this->envParams;
+        }else{
+            return $this->envParams->get($name, $default);
+        }
     }
 
     /**
@@ -445,12 +445,12 @@ class Request extends Message implements RequestInterface
 
     /**
      * Return the header container responsible for headers or all headers of a certain name/type
-	 *
-	 * @see \Zend\Http\Headers::get()
-	 * @param string|null           $name            Header name to retrieve, or null to get the whole container.
-	 * @param mixed|null            $default         Default value to use when the requested header is missing.
-	 * @return \Zend\Http\Headers|bool|\Zend\Http\Header\HeaderInterface|\ArrayIterator
-	 */
+     *
+     * @see \Zend\Http\Headers::get()
+     * @param string|null           $name            Header name to retrieve, or null to get the whole container.
+     * @param mixed|null            $default         Default value to use when the requested header is missing.
+     * @return \Zend\Http\Headers|bool|\Zend\Http\Header\HeaderInterface|\ArrayIterator
+     */
     public function getHeaders($name = null, $default = false)
     {
         if ($this->headers === null || is_string($this->headers)) {
@@ -459,21 +459,21 @@ class Request extends Message implements RequestInterface
         }
 
         if($name === null){
-			return $this->headers;
-		}elseif($this->headers->has($name)){
-			return $this->headers->get($name);
-		}else{
-			return $default;
-		}
+            return $this->headers;
+        }elseif($this->headers->has($name)){
+            return $this->headers->get($name);
+        }else{
+            return $default;
+        }
     }
 
     /**
      * Get all headers of a certain name/type.
-	 *
-	 * @see Request::getHeaders()
-	 * @param string|null           $name            Header name to retrieve, or null to get the whole container.
-	 * @param mixed|null            $default         Default value to use when the requested header is missing.
-	 * @return \Zend\Http\Headers|bool|\Zend\Http\Header\HeaderInterface|\ArrayIterator
+     *
+     * @see Request::getHeaders()
+     * @param string|null           $name            Header name to retrieve, or null to get the whole container.
+     * @param mixed|null            $default         Default value to use when the requested header is missing.
+     * @return \Zend\Http\Headers|bool|\Zend\Http\Header\HeaderInterface|\ArrayIterator
      */
     public function getHeader($name, $default = false)
     {

--- a/tests/Zend/Http/RequestTest.php
+++ b/tests/Zend/Http/RequestTest.php
@@ -11,6 +11,8 @@
 namespace ZendTest\Http;
 
 use Zend\Http\Request;
+use Zend\Http\Headers;
+use Zend\Http\Header\GenericHeader;
 
 class RequestTest extends \PHPUnit_Framework_TestCase
 {
@@ -51,6 +53,60 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($p, $request->getFile());
         $this->assertSame($p, $request->getServer());
         $this->assertSame($p, $request->getEnv());
+
+        $headers = new Headers();
+        $request->setHeaders($headers);
+        $this->assertSame($headers, $request->getHeaders());
+    }
+    
+    public function testRetrievingASingleValueForParameters()
+    {
+        $request = new Request();
+        $p = new \Zend\Stdlib\Parameters(array(
+        	'foo' => 'bar'
+        ));
+        $request->setQuery($p);
+        $request->setPost($p);
+        $request->setFile($p);
+        $request->setServer($p);
+        $request->setEnv($p);
+
+        $this->assertSame('bar', $request->getQuery('foo'));
+        $this->assertSame('bar', $request->getPost('foo'));
+        $this->assertSame('bar', $request->getFile('foo'));
+        $this->assertSame('bar', $request->getServer('foo'));
+        $this->assertSame('bar', $request->getEnv('foo'));
+
+		$headers = new Headers();
+        $h = new GenericHeader('foo','bar');
+        $headers->addHeader($h);
+
+        $request->setHeaders($headers);
+        $this->assertSame($headers, $request->getHeaders());
+        $this->assertSame($h, $request->getHeaders()->get('foo'));
+        $this->assertSame($h, $request->getHeader('foo'));
+    }
+
+    public function testParameterRetrievalDefaultValue()
+    {
+        $request = new Request();
+        $p = new \Zend\Stdlib\Parameters(array(
+        	'foo' => 'bar'
+        ));
+        $request->setQuery($p);
+        $request->setPost($p);
+        $request->setFile($p);
+        $request->setServer($p);
+        $request->setEnv($p);
+		
+		$default = 15;
+        $this->assertSame($default, $request->getQuery('baz', $default));
+        $this->assertSame($default, $request->getPost('baz', $default));
+        $this->assertSame($default, $request->getFile('baz', $default));
+        $this->assertSame($default, $request->getServer('baz', $default));
+        $this->assertSame($default, $request->getEnv('baz', $default));
+        $this->assertSame($default, $request->getHeaders('baz', $default));
+        $this->assertSame($default, $request->getHeader('baz', $default));
     }
 
     public function testRequestPersistsRawBody()

--- a/tests/Zend/Http/RequestTest.php
+++ b/tests/Zend/Http/RequestTest.php
@@ -63,7 +63,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request();
         $p = new \Zend\Stdlib\Parameters(array(
-        	'foo' => 'bar'
+            'foo' => 'bar'
         ));
         $request->setQuery($p);
         $request->setPost($p);
@@ -77,7 +77,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('bar', $request->getServer('foo'));
         $this->assertSame('bar', $request->getEnv('foo'));
 
-		$headers = new Headers();
+        $headers = new Headers();
         $h = new GenericHeader('foo','bar');
         $headers->addHeader($h);
 
@@ -91,15 +91,15 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request();
         $p = new \Zend\Stdlib\Parameters(array(
-        	'foo' => 'bar'
+            'foo' => 'bar'
         ));
         $request->setQuery($p);
         $request->setPost($p);
         $request->setFile($p);
         $request->setServer($p);
         $request->setEnv($p);
-		
-		$default = 15;
+        
+        $default = 15;
         $this->assertSame($default, $request->getQuery('baz', $default));
         $this->assertSame($default, $request->getPost('baz', $default));
         $this->assertSame($default, $request->getFile('baz', $default));


### PR DESCRIPTION
This PR complements the following request param style:

``` php
$this->getRequest()->getPost()->get('foo');
$this->getRequest()->getQuery()->get('bar');
$this->getRequest()->getHeaders()->get('accept');
```

... with an alternative, simpler and more commonly found  syntax:

``` php
$this->getRequest()->getPost('foo');
$this->getRequest()->getQuery('bar');
$this->getRequest()->getHeaders('accept');
```

It also supports default values for all containers

``` php
$this->getRequest()->getPost('foo','a default value');
$this->getRequest()->getQuery('limit', 10);
$this->getRequest()->getHeader('accept', new GenericHeader('accept','text/json');
```
