### PR TITLE
Event get/set Param removal for frequently accessed values.

### DIFF
--- a/library/Zend/ModuleManager/Listener/ConfigListener.php
+++ b/library/Zend/ModuleManager/Listener/ConfigListener.php
@@ -135,7 +135,7 @@ class ConfigListener extends AbstractListener implements
      */
     public function onLoadModule(ModuleEvent $e)
     {
-        $module = $e->getParam('module');
+        $module = $e->getModule();
 
         if (!$module instanceof ConfigProviderInterface
             && !is_callable(array($module, 'getConfig'))

--- a/library/Zend/ModuleManager/ModuleEvent.php
+++ b/library/Zend/ModuleManager/ModuleEvent.php
@@ -30,13 +30,28 @@ class ModuleEvent extends Event
     CONST EVENT_LOAD_MODULES_POST   = 'loadModules.post';
 
     /**
+     * @var mixed
+     */
+    protected $module;
+
+    /**
+     * @var string
+     */
+    protected $moduleName;
+
+    /**
+     * @var Listener\ConfigMergerInterface
+     */
+    protected $configListener;
+
+    /**
      * Get the name of a given module
      *
      * @return string
      */
     public function getModuleName()
     {
-        return $this->getParam('moduleName');
+        return $this->moduleName;
     }
 
     /**
@@ -53,7 +68,9 @@ class ModuleEvent extends Event
                 ,__METHOD__, gettype($moduleName)
             ));
         }
-        $this->setParam('moduleName', $moduleName);
+        // Performance tweak, dont add it as param.
+        $this->moduleName = $moduleName;
+
         return $this;
     }
 
@@ -64,7 +81,7 @@ class ModuleEvent extends Event
      */
     public function getModule()
     {
-        return $this->getParam('module');
+        return $this->module;
     }
 
     /**
@@ -81,7 +98,9 @@ class ModuleEvent extends Event
                 ,__METHOD__, gettype($module)
             ));
         }
-        $this->setParam('module', $module);
+        // Performance tweak, dont add it as param.
+        $this->module = $module;
+
         return $this;
     }
 
@@ -92,7 +111,7 @@ class ModuleEvent extends Event
      */
     public function getConfigListener()
     {
-        return $this->getParam('configListener');
+        return $this->configListener;
     }
 
     /**
@@ -104,6 +123,8 @@ class ModuleEvent extends Event
     public function setConfigListener(Listener\ConfigMergerInterface $configListener)
     {
         $this->setParam('configListener', $configListener);
+        $this->configListener = $configListener;
+
         return $this;
     }
 }

--- a/library/Zend/Mvc/MvcEvent.php
+++ b/library/Zend/Mvc/MvcEvent.php
@@ -95,7 +95,7 @@ class MvcEvent extends Event
      */
     public function getRouter()
     {
-        return $this->getParam('router');
+        return $this->router;
     }
 
     /**
@@ -118,7 +118,7 @@ class MvcEvent extends Event
      */
     public function getRouteMatch()
     {
-        return $this->getParam('route-match');
+        return $this->routeMatch;
     }
 
     /**
@@ -141,7 +141,7 @@ class MvcEvent extends Event
      */
     public function getRequest()
     {
-        return $this->getParam('request');
+        return $this->request;
     }
 
     /**
@@ -164,7 +164,7 @@ class MvcEvent extends Event
      */
     public function getResponse()
     {
-        return $this->getParam('response');
+        return $this->response;
     }
 
     /**
@@ -212,7 +212,7 @@ class MvcEvent extends Event
      */
     public function getResult()
     {
-        return $this->getParam('__RESULT__');
+        return $this->result;
     }
 
     /**


### PR DESCRIPTION
Removed the `setParam` and `getParam` calls inside Events for frequently accessed values. 

I've banchmarked it with the Skeleton Application and 20 [Dummy Modules](https://gist.github.com/3165780) – all features enabled.

Benchmark (best of 10 requests):
- Master:
  - Best: http://i.imgur.com/U9MxO.png 
  - Worst: http://i.imgur.com/Izv5L.png
- Patch:
  - Best: http://i.imgur.com/VAWk0.png
  - Worst: http://i.imgur.com/QVZTK.png
