### PR TITLE
Math\Rand own class namespace

### DIFF
--- a/library/Zend/Crypt/Password/Bcrypt.php
+++ b/library/Zend/Crypt/Password/Bcrypt.php
@@ -90,7 +90,7 @@ class Bcrypt implements PasswordInterface
             // check if the password contains 8-bit character
             if (preg_match('/[\x80-\xFF]/', $password)) {
                 throw new Exception\RuntimeException(
-                    'The bcrypt implementation used by PHP can contains a security flaw' .
+                    'The bcrypt implementation used by PHP can contains a security flaw ' .
                     'using password with 8-bit character. ' .
                     'We suggest to upgrade to PHP 5.3.7+ or use passwords with only 7-bit characters'
                 );

--- a/library/Zend/Math/Rand.php
+++ b/library/Zend/Math/Rand.php
@@ -107,7 +107,7 @@ abstract class Rand
             $rnd = $rnd & $filter;
         } while ($rnd > $range);
 
-        return $min + $rnd;
+        return ($min + $rnd);
     }
 
     /**
@@ -125,11 +125,11 @@ abstract class Rand
     public static function getFloat($strong = false)
     {
         $bytes    = static::getBytes(7, $strong);
-        $bytes[6] = $bytes[6] | chr(0xF0);  
+        $bytes[6] = $bytes[6] | chr(0xF0);
         $bytes   .= chr(63); // exponent bias (1023)
         list(, $float) = unpack('d', $bytes);
         
-        return $float - 1;
+        return ($float - 1);
     }
 
     /**

--- a/library/Zend/Math/Rand.php
+++ b/library/Zend/Math/Rand.php
@@ -71,7 +71,7 @@ abstract class Rand
     public static function getBoolean($strong = false)
     {
         $byte = static::getBytes(1, $strong);
-        return (boolean) ((ord($byte) + 1) % 2);
+        return (boolean) (ord($byte) % 2);
     }
 
     /**

--- a/tests/Zend/Crypt/Password/BcryptTest.php
+++ b/tests/Zend/Crypt/Password/BcryptTest.php
@@ -128,10 +128,12 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
         $this->bcrypt->setSalt($this->salt);
 
         if (version_compare(PHP_VERSION, '5.3.7') >= 0) {
-            $this->assertEquals('$2y$14$MTIzNDU2Nzg5MDEyMzQ1NexAbOIUHkG6Ra.TK9QxHOVUhDxOe4dkW', $this->bcrypt->create($password));
+            $this->assertEquals('$2y$14$MTIzNDU2Nzg5MDEyMzQ1NexAbOIUHkG6Ra.TK9QxHOVUhDxOe4dkW',
+                                $this->bcrypt->create($password));
         } else {
             $this->setExpectedException('Zend\Crypt\Password\Exception\RuntimeException',
-                'The bcrypt implementation used by PHP can contains a security flaw using password with 8-bit character. ' .
+                'The bcrypt implementation used by PHP can contains a security flaw ' .
+                'using password with 8-bit character. ' .
                 'We suggest to upgrade to PHP 5.3.7+ or use passwords with only 7-bit characters'
             );
             $output = $this->bcrypt->create($password);


### PR DESCRIPTION
Have @ezimuel approval on this one. PR includes:
- static class for Math\Rand
- extra methods for getting random boolean, float string
- Zend\Math\Math removed, had only rand related  methods
- more tests for new Rand\Math methods
- Crypt and Validator\Csrf updated
