### PR TITLE
[Bugfix] Form Element Number HTML5 validator format fix

### DIFF
--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -51,7 +51,9 @@ class Number extends Element implements InputProviderInterface
         }
 
         $validators = array();
-        $validators[] = new NumberValidator();
+        $validators[] = new NumberValidator(array(
+            'locale' => 'en_US', // HTML5 uses "100.01" format
+        ));
 
         $inclusive = true;
         if (!empty($this->attributes['inclusive'])) {


### PR DESCRIPTION
When using Zend\Form\Element\Number and Zend\Form\View\Helper\FormNumber in different locales, like fr_FR, the Float Validator would fail. 

HTML5 will always return the number in a "100.001" format (with a period decimal separator) no matter what the browser displays based on it's locale setting. This fix forces the Float validator to always use 'en_US' locale to match this format.
