### PR TITLE
Use same Shared Event Manager across the board

### DIFF
--- a/library/Zend/Mvc/Service/ServiceManagerConfig.php
+++ b/library/Zend/Mvc/Service/ServiceManagerConfig.php
@@ -24,15 +24,6 @@ use Zend\ServiceManager\ServiceManagerAwareInterface;
 class ServiceManagerConfig implements ConfigInterface
 {
     /**
-     * Services that can be instantiated without factories
-     *
-     * @var array
-     */
-    protected $invokables = array(
-        'SharedEventManager' => 'Zend\EventManager\SharedEventManager',
-    );
-
-    /**
      * Service factories
      *
      * @var array
@@ -40,6 +31,7 @@ class ServiceManagerConfig implements ConfigInterface
     protected $factories = array(
         'EventManager'  => 'Zend\Mvc\Service\EventManagerFactory',
         'ModuleManager' => 'Zend\Mvc\Service\ModuleManagerFactory',
+        'SharedEventManager' => 'Zend\Mvc\Service\SharedEventManagerFactory'
     );
 
     /**

--- a/library/Zend/Mvc/Service/ServiceManagerConfig.php
+++ b/library/Zend/Mvc/Service/ServiceManagerConfig.php
@@ -24,6 +24,13 @@ use Zend\ServiceManager\ServiceManagerAwareInterface;
 class ServiceManagerConfig implements ConfigInterface
 {
     /**
+     * Services that can be instantiated without factories
+     *
+     * @var array
+     */
+    protected $invokables = array();
+
+    /**
      * Service factories
      *
      * @var array

--- a/library/Zend/Mvc/Service/SharedEventManagerFactory.php
+++ b/library/Zend/Mvc/Service/SharedEventManagerFactory.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace Zend\Mvc\Service;
+
+use Zend\EventManager\EventManager;
+use Zend\EventManager\StaticEventManager;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage Service
+ */
+class SharedEventManagerFactory implements FactoryInterface
+{
+    /**
+     * Create an SharedEventManager instance
+     *
+     * Creates a new EventManager instance, seeding it with a shared instance
+     * of SharedEventManager.
+     *
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @return EventManager
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return StaticEventManager::getInstance();
+    }
+}


### PR DESCRIPTION
Make sure that at all points where the SharedEventManager is
being initialised, it is using the same method.

This change makes it so that when calling

``` php
$serviceManager->get('SharedEventManager');
```

It will initialise in the same manner as if we were to call

``` php
$eventManager->getSharedManager();
```

Without having first set the Shared Manager in the Event Manager
