### PR TITLE
Use Same Shared Event Manager across the board

### DIFF
--- a/library/Zend/Mvc/Service/ServiceManagerConfig.php
+++ b/library/Zend/Mvc/Service/ServiceManagerConfig.php
@@ -28,9 +28,7 @@ class ServiceManagerConfig implements ConfigInterface
      *
      * @var array
      */
-    protected $invokables = array(
-        'SharedEventManager' => 'Zend\EventManager\SharedEventManager',
-    );
+    protected $invokables = array();
 
     /**
      * Service factories
@@ -40,6 +38,7 @@ class ServiceManagerConfig implements ConfigInterface
     protected $factories = array(
         'EventManager'  => 'Zend\Mvc\Service\EventManagerFactory',
         'ModuleManager' => 'Zend\Mvc\Service\ModuleManagerFactory',
+        'SharedEventManager' => 'Zend\Mvc\Service\SharedEventManagerFactory'
     );
 
     /**

--- a/library/Zend/Mvc/Service/SharedEventManagerFactory.php
+++ b/library/Zend/Mvc/Service/SharedEventManagerFactory.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace Zend\Mvc\Service;
+
+use Zend\EventManager\EventManager;
+use Zend\EventManager\StaticEventManager;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage Service
+ */
+class SharedEventManagerFactory implements FactoryInterface
+{
+    /**
+     * Create an SharedEventManager instance
+     *
+     * Creates a new EventManager instance, seeding it with a shared instance
+     * of SharedEventManager.
+     *
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @return EventManager
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return StaticEventManager::getInstance();
+    }
+}

--- a/tests/Zend/Mvc/Controller/ActionControllerTest.php
+++ b/tests/Zend/Mvc/Controller/ActionControllerTest.php
@@ -17,6 +17,7 @@ use Zend\Http\Response;
 use Zend\Mvc\Controller\PluginManager;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;
+use Zend\EventManager\StaticEventManager;
 
 class ActionControllerTest extends TestCase
 {
@@ -33,6 +34,8 @@ class ActionControllerTest extends TestCase
         $this->event      = new MvcEvent();
         $this->event->setRouteMatch($this->routeMatch);
         $this->controller->setEvent($this->event);
+
+        StaticEventManager::resetInstance();
     }
 
     public function testDispatchInvokesNotFoundActionWhenNoActionPresentInRouteMatch()

--- a/tests/Zend/Mvc/Service/ServiceManagerConfigTest.php
+++ b/tests/Zend/Mvc/Service/ServiceManagerConfigTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc\Service;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\EventManager\EventManager;
+use Zend\Mvc\Service\ServiceManagerConfig;
+use Zend\ServiceManager\ServiceManager;
+
+
+class ServiceManagerConfigTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->serviceManager = new ServiceManager(
+            new ServiceManagerConfig()
+        );
+
+    }
+
+    public function testEventManagerSharedEventManagerMatchesServiceManagerSharedEventManger()
+    {
+        $em = new EventManager;
+        $emSharedEventManager = $em->getSharedManager();
+
+        $emSharedEventManager->attach(__CLASS__, 'test', function($e) { return; });
+
+        $smSharedEventManager = $this->serviceManager->get('SharedEventManager');
+        $this->assertSame($emSharedEventManager, $smSharedEventManager);
+    }
+}


### PR DESCRIPTION
Make sure that at all points where the SharedEventManager is
being initialised, it is using the same method.

This change makes it so that when calling

``` php
$serviceManager->get('SharedEventManager');
```

It will initialise in the same manner as if we were to call

``` php
$eventManager->getSharedManager();
```

Without having first set the Shared Manager in the Event Manager

This also affected the ActionControllerTest - as it was expecting the
SharedEventManager to be reset between requests.
