### PR TITLE
Db\Metadata: MySQL ENUM/SET fixes

### DIFF
--- a/library/Zend/Db/Metadata/Source/MysqlMetadata.php
+++ b/library/Zend/Db/Metadata/Source/MysqlMetadata.php
@@ -147,8 +147,14 @@ class MysqlMetadata extends AbstractSource
         foreach ($results->toArray() as $row) {
             $erratas = array();
             $matches = array();
-            if (preg_match('/^(enum|set)\(\'(.+)\'\)$/', $row['COLUMN_TYPE'], $matches)) {
-                $erratas = explode("','", $matches[2]);
+            if (preg_match('/^(?:enum|set)\((.+)\)$/i', $row['COLUMN_TYPE'], $matches)) {
+                $permittedValues = $matches[1];
+                if (preg_match_all("/\\s*'((?:[^']++|'')*+)'\\s*(?:,|\$)/", $permittedValues, $matches, PREG_PATTERN_ORDER)) {
+                    $permittedValues = str_replace("''", "'", $matches[1]);
+                } else {
+                    $permittedValues = array($permittedValues);
+                }
+                $erratas = $permittedValues;
             }
             $columns[$row['COLUMN_NAME']] = array(
                 'ordinal_position'          => $row['ORDINAL_POSITION'],

--- a/library/Zend/Db/Metadata/Source/MysqlMetadata.php
+++ b/library/Zend/Db/Metadata/Source/MysqlMetadata.php
@@ -154,7 +154,7 @@ class MysqlMetadata extends AbstractSource
                 } else {
                     $permittedValues = array($permittedValues);
                 }
-                $erratas = $permittedValues;
+                $erratas['permitted_values'] = $permittedValues;
             }
             $columns[$row['COLUMN_NAME']] = array(
                 'ordinal_position'          => $row['ORDINAL_POSITION'],


### PR DESCRIPTION
- Changes the parsing of `ENUM` and `SET` types to allow for a greater range of values. It was previously unable to properly read values that included the single quote `'` (they would come out doubled) and it would split the values if it contained `','`
- Place the values in the key `permitted_values`. This key name seems ok, but I'm open to suggestions on a better name for it.
