### PR TITLE
Custom Service Listener support.

### DIFF
--- a/library/Zend/ModuleManager/Listener/ServiceListenerInterface.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListenerInterface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_ModuleManager
+ */
+
+namespace Zend\ModuleManager\Listener;
+
+/**
+ * @category   Zend
+ * @package    Zend_ModuleManager
+ * @subpackage Listener
+ */
+interface ServiceListenerInterface
+{
+    /**
+     * @param  ServiceManager|string $serviceManager  Service Manager instance or name
+     * @param  string                $key             Configuration key
+     * @param  string                $moduleInterface FQCN as string
+     * @param  string                $method          Method name
+     * @return ServiceListenerInterface
+     */
+    public function addServiceManager($serviceManager, $key, $moduleInterface, $method);
+
+    /**
+     * @param  array $configuration
+     * @return ServiceListenerInterface
+     */
+    public function setDefaultServiceConfig($configuration);
+}

--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -227,8 +227,10 @@ class Application implements
      * Static method for quick and easy initialization of the Application.
      *
      * If you use this init() method, you cannot specify a service with the
-     * name of 'ApplicationConfig' in your service manager config. That
-     * name is reserved to hold the array from application.config.php
+     * name of 'ApplicationConfig' and 'ServiceListener' in your service
+     * manager config. These names are reserved to hold the array from
+     * application.config.php and creating an instance of
+     * Zend\Mvc\Service\ServiceListenerFactory
      *
      * The following services can only be overridden from application.config.php:
      *
@@ -247,6 +249,7 @@ class Application implements
         $smConfig = isset($configuration['service_manager']) ? $configuration['service_manager'] : array();
         $serviceManager = new ServiceManager(new Service\ServiceManagerConfig($smConfig));
         $serviceManager->setService('ApplicationConfig', $configuration);
+        $serviceManager->setFactory('ServiceListener', 'Zend\Mvc\Service\ServiceListenerFactory');
         $serviceManager->get('ModuleManager')->loadModules();
         return $serviceManager->get('Application')->bootstrap();
     }

--- a/library/Zend/Mvc/Service/ModuleManagerFactory.php
+++ b/library/Zend/Mvc/Service/ModuleManagerFactory.php
@@ -87,18 +87,37 @@ class ModuleManagerFactory implements FactoryInterface
         $configuration    = $serviceLocator->get('ApplicationConfig');
         $listenerOptions  = new ListenerOptions($configuration['module_listener_options']);
         $defaultListeners = new DefaultListenerAggregate($listenerOptions);
-        $serviceListener  = new ServiceListener($serviceLocator, $this->defaultServiceConfig);
+        $serviceListener  = $serviceLocator->get('ServiceListener');
 
-        $serviceListener->addServiceManager($serviceLocator, 'service_manager', 'Zend\ModuleManager\Feature\ServiceProviderInterface', 'getServiceConfig');
-        $serviceListener->addServiceManager('ControllerLoader', 'controllers', 'Zend\ModuleManager\Feature\ControllerProviderInterface', 'getControllerConfig');
-        $serviceListener->addServiceManager('ControllerPluginManager', 'controller_plugins', 'Zend\ModuleManager\Feature\ControllerPluginProviderInterface', 'getControllerPluginConfig');
-        $serviceListener->addServiceManager('ViewHelperManager', 'view_helpers', 'Zend\ModuleManager\Feature\ViewHelperProviderInterface', 'getViewHelperConfig');
+        $serviceListener->addServiceManager($serviceLocator,
+            'service_manager',
+            'Zend\ModuleManager\Feature\ServiceProviderInterface',
+            'getServiceConfig'
+        );
+        $serviceListener->addServiceManager(
+            'ControllerLoader',
+            'controllers',
+            'Zend\ModuleManager\Feature\ControllerProviderInterface',
+            'getControllerConfig'
+        );
+        $serviceListener->addServiceManager(
+            'ControllerPluginManager',
+            'controller_plugins',
+            'Zend\ModuleManager\Feature\ControllerPluginProviderInterface',
+            'getControllerPluginConfig'
+        );
+        $serviceListener->addServiceManager(
+            'ViewHelperManager',
+            'view_helpers',
+            'Zend\ModuleManager\Feature\ViewHelperProviderInterface',
+            'getViewHelperConfig'
+        );
 
-        $events        = $serviceLocator->get('EventManager');
+        $events = $serviceLocator->get('EventManager');
         $events->attach($defaultListeners);
         $events->attach($serviceListener);
 
-        $moduleEvent   = new ModuleEvent;
+        $moduleEvent = new ModuleEvent;
         $moduleEvent->setParam('ServiceManager', $serviceLocator);
 
         $moduleManager = new ModuleManager($configuration['modules'], $events);

--- a/library/Zend/Mvc/Service/ServiceListenerFactory.php
+++ b/library/Zend/Mvc/Service/ServiceListenerFactory.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace Zend\Mvc\Service;
+
+use Zend\Mvc\Exception\RuntimeException;
+use Zend\Mvc\Exception\InvalidArgumentException;
+use Zend\ModuleManager\Listener\ServiceListener;
+use Zend\ModuleManager\Listener\ServiceListenerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage Service
+ */
+class ServiceListenerFactory implements FactoryInterface
+{
+    /**
+     * @var string
+     */
+    const MISSING_KEY_ERROR = 'Invalid service listener options detected, %s array must contain %s key.';
+
+    /**
+     * @var string
+     */
+    const VALUE_TYPE_ERROR = 'Invalid service listener options detected, %s must be a string, %s given.';
+
+    /**
+     * Default mvc-related service configuration -- can be overridden by modules.
+     *
+     * @var array
+     */
+    protected $defaultServiceConfig = array(
+        'invokables' => array(
+            'DispatchListener' => 'Zend\Mvc\DispatchListener',
+            'Request'          => 'Zend\Http\PhpEnvironment\Request',
+            'Response'         => 'Zend\Http\PhpEnvironment\Response',
+            'RouteListener'    => 'Zend\Mvc\RouteListener',
+            'ViewManager'      => 'Zend\Mvc\View\ViewManager',
+        ),
+        'factories' => array(
+            'Application'             => 'Zend\Mvc\Service\ApplicationFactory',
+            'Config'                  => 'Zend\Mvc\Service\ConfigFactory',
+            'ControllerLoader'        => 'Zend\Mvc\Service\ControllerLoaderFactory',
+            'ControllerPluginManager' => 'Zend\Mvc\Service\ControllerPluginManagerFactory',
+            'DependencyInjector'      => 'Zend\Mvc\Service\DiFactory',
+            'Router'                  => 'Zend\Mvc\Service\RouterFactory',
+            'ViewHelperManager'       => 'Zend\Mvc\Service\ViewHelperManagerFactory',
+            'ViewFeedRenderer'        => 'Zend\Mvc\Service\ViewFeedRendererFactory',
+            'ViewFeedStrategy'        => 'Zend\Mvc\Service\ViewFeedStrategyFactory',
+            'ViewJsonRenderer'        => 'Zend\Mvc\Service\ViewJsonRendererFactory',
+            'ViewJsonStrategy'        => 'Zend\Mvc\Service\ViewJsonStrategyFactory',
+            'ViewResolver'            => 'Zend\Mvc\Service\ViewResolverFactory',
+            'ViewTemplateMapResolver' => 'Zend\Mvc\Service\ViewTemplateMapResolverFactory',
+            'ViewTemplatePathStack'   => 'Zend\Mvc\Service\ViewTemplatePathStackFactory',
+        ),
+        'aliases' => array(
+            'Configuration'                          => 'Config',
+            'ControllerPluginBroker'                 => 'ControllerPluginManager',
+            'Di'                                     => 'DependencyInjector',
+            'Zend\Di\LocatorInterface'               => 'DependencyInjector',
+            'Zend\Mvc\Controller\PluginBroker'       => 'ControllerPluginBroker',
+            'Zend\Mvc\Controller\PluginManager'      => 'ControllerPluginManager',
+            'Zend\View\Resolver\TemplateMapResolver' => 'ViewTemplateMapResolver',
+            'Zend\View\Resolver\TemplatePathStack'   => 'ViewTemplatePathStack',
+            'Zend\View\Resolver\AggregateResolver'   => 'ViewResolver',
+            'Zend\View\Resolver\ResolverInterface'   => 'ViewResolver',
+        ),
+    );
+
+    /**
+     * Create the service listener service
+     *
+     * Tries to get a service named ServiceListenerInterface from the service
+     * locator, otherwise creates a Zend\ModuleManager\Listener\ServiceListener
+     * service, passing it the service locator instance and the default service
+     * configuration, which can be overridden by modules.
+     *
+     * It looks for the 'service_listener_options' key in the application
+     * config and tries to add service manager as configured. The value of
+     * 'service_listener_options' must be a list (array) which contains the
+     * following keys:
+     *   - service_manager: the name of the service manage to create as string
+     *   - config_key: the name of the configuration key to search for as string
+     *   - interface: the name of the interface that modules can implement as string
+     *   - method: the name of the method that modules have to implement as string
+     *
+     * @param  ServiceLocatorInterface  $serviceLocator
+     * @throws InvalidArgumentException For invalid configurations.
+     * @return ServiceListener
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $configuration   = $serviceLocator->get('ApplicationConfig');
+
+        if ($serviceLocator->has('ServiceListenerInterface')) {
+            $serviceListener = $serviceLocator->get('ServiceListenerInterface');
+
+            if (!$serviceListener instanceof ServiceListenerInterface) {
+                throw new RuntimeException(
+                    'The service named ServiceListenerInterface must implement ' .
+                    'Zend\ModuleManager\Listener\ServiceListenerInterface'
+                );
+            }
+
+            $serviceListener->setDefaultServiceConfig($this->defaultServiceConfig);
+        } else {
+            $serviceListener = new ServiceListener($serviceLocator, $this->defaultServiceConfig);
+        }
+
+        if (isset($configuration['service_listener_options'])) {
+            if (!is_array($configuration['service_listener_options'])) {
+                throw new InvalidArgumentException(sprintf(
+                    'The value of service_listener_options must be an array, %s given.',
+                    gettype($configuration['service_listener_options'])
+                ));
+            }
+
+            foreach ($configuration['service_listener_options'] as $key => $newServiceManager) {
+                if (!isset($newServiceManager['service_manager'])) {
+                    throw new InvalidArgumentException(sprintf(self::MISSING_KEY_ERROR, $key, 'service_manager'));
+                } elseif (!is_string($newServiceManager['service_manager'])) {
+                    throw new InvalidArgumentException(sprintf(
+                        self::VALUE_TYPE_ERROR,
+                        'service_manager',
+                        gettype($newServiceManager['service_manager'])
+                    ));
+                }
+                if (!isset($newServiceManager['config_key'])) {
+                    throw new InvalidArgumentException(sprintf(self::MISSING_KEY_ERROR, $key, 'config_key'));
+                } elseif (!is_string($newServiceManager['config_key'])) {
+                    throw new InvalidArgumentException(sprintf(
+                        self::VALUE_TYPE_ERROR,
+                        'config_key',
+                        gettype($newServiceManager['config_key'])
+                    ));
+                }
+                if (!isset($newServiceManager['interface'])) {
+                    throw new InvalidArgumentException(sprintf(self::MISSING_KEY_ERROR, $key, 'interface'));
+                } elseif (!is_string($newServiceManager['interface'])) {
+                    throw new InvalidArgumentException(sprintf(
+                        self::VALUE_TYPE_ERROR,
+                        'interface',
+                        gettype($newServiceManager['interface'])
+                    ));
+                }
+                if (!isset($newServiceManager['method'])) {
+                    throw new InvalidArgumentException(sprintf(self::MISSING_KEY_ERROR, $key, 'method'));
+                } elseif (!is_string($newServiceManager['method'])) {
+                    throw new InvalidArgumentException(sprintf(
+                        self::VALUE_TYPE_ERROR,
+                        'method',
+                        gettype($newServiceManager['method'])
+                    ));
+                }
+
+                $serviceListener->addServiceManager(
+                    $newServiceManager['service_manager'],
+                    $newServiceManager['config_key'],
+                    $newServiceManager['interface'],
+                    $newServiceManager['method']
+                );
+            }
+        }
+
+        return $serviceListener;
+    }
+}

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -721,7 +721,7 @@ class ServiceManager implements ServiceLocatorInterface
      * @return array $canonicalNames
      * @return ServiceManager
      */
-    public function getCanonicalNames($canonicalNames)
+    public function setCanonicalNames($canonicalNames)
     {
         $this->canonicalNames = $canonicalNames;
     }

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -705,6 +705,28 @@ class ServiceManager implements ServiceLocatorInterface
     }
 
     /**
+     * Retrieve a keyed list of all canonical names. Handy for debugging!
+     *
+     * @return array
+     */
+    public function getCanonicalNames()
+    {
+        return $this->canonicalNames;
+    }
+
+    /**
+     * Allows to override the canonical names lookup map with predefined
+     * values.
+     *
+     * @return array $canonicalNames
+     * @return ServiceManager
+     */
+    public function getCanonicalNames($canonicalNames)
+    {
+        $this->canonicalNames = $canonicalNames;
+    }
+
+    /**
      * Attempt to retrieve an instance via a peering manager
      *
      * @param  string $name

--- a/tests/Zend/Mvc/ApplicationTest.php
+++ b/tests/Zend/Mvc/ApplicationTest.php
@@ -80,6 +80,7 @@ class ApplicationTest extends TestCase
             ))
         );
         $sm->setService('ApplicationConfig', $appConfig);
+        $sm->setFactory('ServiceListener', 'Zend\Mvc\Service\ServiceListenerFactory');
         $sm->setAllowOverride(true);
 
         $this->application = $sm->get('Application');

--- a/tests/Zend/Mvc/Service/ServiceListenerFactoryTest.php
+++ b/tests/Zend/Mvc/Service/ServiceListenerFactoryTest.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc\Service;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mvc\Service\ServiceListenerFactory;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mvc_Service
+ * @subpackage UnitTest
+ */
+class ServiceListenerFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $sm = $this->sm = $this->getMockBuilder('Zend\ServiceManager\ServiceManager')
+                               ->setMethods(array('get'))
+                               ->getMock();
+
+        $this->factory  = new ServiceListenerFactory();
+    }
+
+    /**
+     * @expectedException        Zend\Mvc\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The value of service_listener_options must be an array, string given.
+     */
+    public function testInvalidOptionType()
+    {
+        $this->sm->expects($this->once())
+                 ->method('get')
+                 ->will($this->returnValue(array('service_listener_options' => 'string')));
+
+        $this->factory->createService($this->sm);
+    }
+
+    /**
+     * @expectedException        Zend\Mvc\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid service listener options detected, 0 array must contain service_manager key.
+     */
+    public function testMissingServiceManager()
+    {
+        $config['service_listener_options'][0]['service_manager'] = null;
+        $config['service_listener_options'][0]['config_key']      = 'test';
+        $config['service_listener_options'][0]['interface']       = 'test';
+        $config['service_listener_options'][0]['method']          = 'test';
+
+        $this->sm->expects($this->once())
+                 ->method('get')
+                 ->will($this->returnValue($config));
+
+        $this->factory->createService($this->sm);
+    }
+
+    /**
+     * @expectedException        Zend\Mvc\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid service listener options detected, service_manager must be a string, integer given.
+     */
+    public function testInvalidTypeServiceManager()
+    {
+        $config['service_listener_options'][0]['service_manager'] = 1;
+        $config['service_listener_options'][0]['config_key']      = 'test';
+        $config['service_listener_options'][0]['interface']       = 'test';
+        $config['service_listener_options'][0]['method']          = 'test';
+
+        $this->sm->expects($this->once())
+                 ->method('get')
+                 ->will($this->returnValue($config));
+
+        $this->factory->createService($this->sm);
+    }
+
+    /**
+     * @expectedException        Zend\Mvc\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid service listener options detected, 0 array must contain config_key key.
+     */
+    public function testMissingConfigKey()
+    {
+        $config['service_listener_options'][0]['service_manager'] = 'test';
+        $config['service_listener_options'][0]['config_key']      = null;
+        $config['service_listener_options'][0]['interface']       = 'test';
+        $config['service_listener_options'][0]['method']          = 'test';
+
+        $this->sm->expects($this->once())
+                 ->method('get')
+                 ->will($this->returnValue($config));
+
+        $this->factory->createService($this->sm);
+    }
+
+    /**
+     * @expectedException        Zend\Mvc\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid service listener options detected, config_key must be a string, integer given.
+     */
+    public function testInvalidTypeConfigKey()
+    {
+        $config['service_listener_options'][0]['service_manager'] = 'test';
+        $config['service_listener_options'][0]['config_key']      = 1;
+        $config['service_listener_options'][0]['interface']       = 'test';
+        $config['service_listener_options'][0]['method']          = 'test';
+
+        $this->sm->expects($this->once())
+                 ->method('get')
+                 ->will($this->returnValue($config));
+
+        $this->factory->createService($this->sm);
+    }
+
+    /**
+     * @expectedException        Zend\Mvc\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid service listener options detected, 0 array must contain interface key.
+     */
+    public function testMissingInterface()
+    {
+        $config['service_listener_options'][0]['service_manager'] = 'test';
+        $config['service_listener_options'][0]['config_key']      = 'test';
+        $config['service_listener_options'][0]['interface']       = null;
+        $config['service_listener_options'][0]['method']          = 'test';
+
+        $this->sm->expects($this->once())
+                 ->method('get')
+                 ->will($this->returnValue($config));
+
+        $this->factory->createService($this->sm);
+    }
+
+    /**
+     * @expectedException        Zend\Mvc\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid service listener options detected, interface must be a string, integer given.
+     */
+    public function testInvalidTypeInterface()
+    {
+        $config['service_listener_options'][0]['service_manager'] = 'test';
+        $config['service_listener_options'][0]['config_key']      = 'test';
+        $config['service_listener_options'][0]['interface']       = 1;
+        $config['service_listener_options'][0]['method']          = 'test';
+
+        $this->sm->expects($this->once())
+                 ->method('get')
+                 ->will($this->returnValue($config));
+
+        $this->factory->createService($this->sm);
+    }
+
+    /**
+     * @expectedException        Zend\Mvc\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid service listener options detected, 0 array must contain method key.
+     */
+    public function testMissingMethod()
+    {
+        $config['service_listener_options'][0]['service_manager'] = 'test';
+        $config['service_listener_options'][0]['config_key']      = 'test';
+        $config['service_listener_options'][0]['interface']       = 'test';
+        $config['service_listener_options'][0]['method']          = null;
+
+        $this->sm->expects($this->once())
+                 ->method('get')
+                 ->will($this->returnValue($config));
+
+        $this->factory->createService($this->sm);
+    }
+
+    /**
+     * @expectedException        Zend\Mvc\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid service listener options detected, method must be a string, integer given.
+     */
+    public function testInvalidTypeMethod()
+    {
+        $config['service_listener_options'][0]['service_manager'] = 'test';
+        $config['service_listener_options'][0]['config_key']      = 'test';
+        $config['service_listener_options'][0]['interface']       = 'test';
+        $config['service_listener_options'][0]['method']          = 1;
+
+        $this->sm->expects($this->once())
+                 ->method('get')
+                 ->will($this->returnValue($config));
+
+        $this->factory->createService($this->sm);
+    }
+}

--- a/tests/Zend/Navigation/ServiceFactoryTest.php
+++ b/tests/Zend/Navigation/ServiceFactoryTest.php
@@ -83,6 +83,7 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
         $sm = $this->serviceManager = new ServiceManager(new ServiceManagerConfig);
         $sm->setService('ApplicationConfig', $config);
+        $sm->setFactory('ServiceListener', 'Zend\Mvc\Service\ServiceListenerFactory');
         $sm->get('ModuleManager')->loadModules();
         $sm->get('Application')->bootstrap();
 

--- a/tests/Zend/View/Helper/Navigation/AbstractTest.php
+++ b/tests/Zend/View/Helper/Navigation/AbstractTest.php
@@ -129,6 +129,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
 
         $sm = $this->serviceManager = new ServiceManager(new ServiceManagerConfig);
         $sm->setService('ApplicationConfig', $smConfig);
+        $sm->setFactory('ServiceListener', 'Zend\Mvc\Service\ServiceListenerFactory');
         $sm->get('ModuleManager')->loadModules();
         $sm->get('Application')->bootstrap();
         $sm->setFactory('Navigation', 'Zend\Navigation\Service\DefaultNavigationFactory');


### PR DESCRIPTION
Changed the Service Listener to allow a more flexible handling. It is now possible to add own service listeners in the `application.config.php` and even to override the default `ServiceListener` without having to change `ModuleMangerFactory`. Unlike [PR #1949](https://github.com/zendframework/zf2/pull/1949) is the footprint minimal to non-existent. 

Added the ability to populate the canonical names lookup map with predefined values, to speed things up a bit.
