### PR TITLE
SharedEventManager -> static instance

### DIFF
--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -85,6 +85,7 @@ class EventManager implements EventManagerInterface
     public function setSharedManager(SharedEventManagerInterface $sharedEventManager)
     {
         $this->sharedManager = $sharedEventManager;
+        StaticEventManager::setInstance($sharedEventManager);
         return $this;
     }
 
@@ -101,13 +102,27 @@ class EventManager implements EventManagerInterface
     /**
      * Get shared event manager
      *
+     * If one is not defined, but we have a static instance in 
+     * StaticEventManager, that one will be used and set in this instance.
+     *
+     * If none is available in the StaticEventManager, a boolean false is 
+     * returned.
+     *
      * @return false|SharedEventManagerInterface
      */
     public function getSharedManager()
     {
-        if (null === $this->sharedManager) {
-            $this->setSharedManager(StaticEventManager::getInstance());
+        if (false === $this->sharedManager
+            || $this->sharedManager instanceof SharedEventManagerInterface
+        ) {
+            return $this->sharedManager;
         }
+
+        if (!StaticEventManager::hasInstance()) {
+            return false;
+        }
+
+        $this->sharedManager = StaticEventManager::getInstance();
         return $this->sharedManager;
     }
 

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -112,6 +112,7 @@ class EventManager implements EventManagerInterface
      */
     public function getSharedManager()
     {
+        // "false" means "I do not want a shared manager; don't try and fetch one"
         if (false === $this->sharedManager
             || $this->sharedManager instanceof SharedEventManagerInterface
         ) {

--- a/library/Zend/EventManager/StaticEventManager.php
+++ b/library/Zend/EventManager/StaticEventManager.php
@@ -51,9 +51,30 @@ class StaticEventManager extends SharedEventManager
     public static function getInstance()
     {
         if (null === static::$instance) {
-            static::$instance = new static();
+            static::setInstance(new static());
         }
         return static::$instance;
+    }
+
+    /**
+     * Set the singleton to a specific SharedEventManagerInterface instance
+     * 
+     * @param SharedEventManagerInterface $instance 
+     * @return void
+     */
+    public static function setInstance(SharedEventManagerInterface $instance)
+    {
+        static::$instance = $instance;
+    }
+
+    /**
+     * Is a singleton instance defined?
+     * 
+     * @return bool
+     */
+    public static function hasInstance()
+    {
+        return (static::$instance instanceof SharedEventManagerInterface);
     }
 
     /**

--- a/tests/Zend/EventManager/EventManagerTest.php
+++ b/tests/Zend/EventManager/EventManagerTest.php
@@ -16,6 +16,7 @@ use Zend\EventManager\Event;
 use Zend\EventManager\EventInterface;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\ResponseCollection;
+use Zend\EventManager\SharedEventManager;
 use Zend\EventManager\StaticEventManager;
 use Zend\Stdlib\CallbackHandler;
 
@@ -35,6 +36,12 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
             unset($this->message);
         }
         $this->events = new EventManager;
+        StaticEventManager::resetInstance();
+    }
+
+    public function tearDown()
+    {
+        StaticEventManager::resetInstance();
     }
 
     public function testAttachShouldReturnCallbackHandler()
@@ -595,5 +602,19 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
             $this->events->trigger($event);
             $this->assertContains($event, $test->events);
         }
+    }
+
+    public function testSettingSharedEventManagerSetsStaticEventManagerInstance()
+    {
+        $shared = new SharedEventManager();
+        $this->events->setSharedManager($shared);
+        $this->assertSame($shared, $this->events->getSharedManager());
+        $this->assertSame($shared, StaticEventManager::getInstance());
+    }
+
+    public function testDoesNotCreateStaticInstanceIfNonePresent()
+    {
+        StaticEventManager::resetInstance();
+        $this->assertFalse($this->events->getSharedManager());
     }
 }

--- a/tests/Zend/Mvc/Controller/Plugin/ForwardTest.php
+++ b/tests/Zend/Mvc/Controller/Plugin/ForwardTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Mvc\Controller\Plugin;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use stdClass;
+use Zend\EventManager\StaticEventManager;
 use Zend\Http\Request;
 use Zend\Http\Response;
 use Zend\Mvc\Controller\Plugin\Forward as ForwardPlugin;
@@ -27,6 +28,7 @@ class ForwardTest extends TestCase
 {
     public function setUp()
     {
+        StaticEventManager::resetInstance();
         $event   = new MvcEvent();
         $event->setRequest(new Request());
         $event->setResponse(new Response());
@@ -42,6 +44,11 @@ class ForwardTest extends TestCase
         $this->controller->setServiceLocator($locator);
 
         $this->plugin = $this->controller->plugin('forward');
+    }
+
+    public function tearDown()
+    {
+        StaticEventManager::resetInstance();
     }
 
     public function testPluginWithoutEventAwareControllerRaisesDomainException()


### PR DESCRIPTION
Due to a number of issues that have arisen, in many cases due to user
expectations, it makes sense to make the initial shared event manager instance
the seed for the StaticEventManager. As such, the following changes were made:
- StaticEventManager:
  - Adds setInstance() and hasInstance() methods; former takes a
    SharedEventManagerInterface, and latter indicates whether the instance is
    populated.
- EventManager:
  - setSharedManager() seeds the StaticEventManager
  - getSharedManager() now tests for an instance in StaticEventManager, using it
    if populated
- Updated the Forward MVC controller plugin tests to ensure the SEM instance is
  reset, ensuring tests run correctly as part of a suite.
