### PR TITLE
Fixed EventManager issue introduced in zendframework/zf2#1976.

### DIFF
--- a/library/Zend/ModuleManager/Listener/ServiceListener.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListener.php
@@ -12,7 +12,6 @@ namespace Zend\ModuleManager\Listener;
 
 use Traversable;
 use Zend\EventManager\EventManagerInterface;
-use Zend\EventManager\ListenerAggregateInterface;
 use Zend\ModuleManager\Feature\ServiceProviderInterface;
 use Zend\ModuleManager\ModuleEvent;
 use Zend\ServiceManager\Config as ServiceConfig;
@@ -24,7 +23,7 @@ use Zend\Stdlib\ArrayUtils;
  * @package    Zend_ModuleManager
  * @subpackage Listener
  */
-class ServiceListener implements ListenerAggregateInterface, ServiceListenerInterface
+class ServiceListener implements ServiceListenerInterface
 {
     /**
      * @var bool

--- a/library/Zend/ModuleManager/Listener/ServiceListenerInterface.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListenerInterface.php
@@ -10,12 +10,14 @@
 
 namespace Zend\ModuleManager\Listener;
 
+use Zend\EventManager\ListenerAggregateInterface;
+
 /**
  * @category   Zend
  * @package    Zend_ModuleManager
  * @subpackage Listener
  */
-interface ServiceListenerInterface
+interface ServiceListenerInterface extends ListenerAggregateInterface
 {
     /**
      * @param  ServiceManager|string $serviceManager  Service Manager instance or name


### PR DESCRIPTION
The ServiceListenerInterface must extend ListenerAggregateInterface, because it is attached to the EventManager.
