### PR TITLE
Module load disruption bugfix

### DIFF
--- a/library/Zend/ModuleManager/ModuleManager.php
+++ b/library/Zend/ModuleManager/ModuleManager.php
@@ -38,6 +38,11 @@ class ModuleManager implements ModuleManagerInterface
     protected $event;
 
     /**
+     * @var boolean
+     */
+    protected $loadFinished;
+
+    /**
      * modules
      *
      * @var array|Traversable
@@ -119,8 +124,10 @@ class ModuleManager implements ModuleManagerInterface
             return $this->loadedModules[$moduleName];
         }
 
-        $event = $this->getEvent();
+        $event = ($this->loadFinished === false) ? clone $this->getEvent() : $this->getEvent();
         $event->setModuleName($moduleName);
+
+        $this->loadFinished = false;
 
         $result = $this->getEventManager()->trigger(ModuleEvent::EVENT_LOAD_MODULE_RESOLVE, $this, $event, function ($r) {
             return (is_object($r));
@@ -138,6 +145,9 @@ class ModuleManager implements ModuleManagerInterface
 
         $this->getEventManager()->trigger(ModuleEvent::EVENT_LOAD_MODULE, $this, $event);
         $this->loadedModules[$moduleName] = $module;
+
+        $this->loadFinished = true;
+
         return $module;
     }
 

--- a/tests/Zend/ModuleManager/ModuleManagerTest.php
+++ b/tests/Zend/ModuleManager/ModuleManagerTest.php
@@ -131,4 +131,16 @@ class ModuleManagerTest extends TestCase
         $moduleManager = new ModuleManager(array('NotFoundModule'));
         $moduleManager->loadModules();
     }
+
+    public function testCanLoadModuleDuringTheLoadModuleEvent()
+    {
+        $configListener = $this->defaultListeners->getConfigListener();
+        $moduleManager  = new ModuleManager(array('LoadOtherModule', 'BarModule'));
+        $moduleManager->getEventManager()->attachAggregate($this->defaultListeners);
+        $moduleManager->loadModules();
+
+        $config = $configListener->getMergedConfig();
+        $this->assertTrue(isset($config['loaded']));
+        $this->assertSame('oh, yeah baby!', $config['loaded']);
+    }
 }

--- a/tests/Zend/ModuleManager/TestAsset/LoadOtherModule/Module.php
+++ b/tests/Zend/ModuleManager/TestAsset/LoadOtherModule/Module.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_ModuleManager
+ */
+
+namespace LoadOtherModule;
+
+use Zend\Config\Config;
+
+class Module
+{
+    public function init($moduleManager)
+    {
+        $moduleManager->loadModule('BarModule');
+    }
+
+    public function getConfig()
+    {
+        return array('loaded' => 'oh, yeah baby!');
+    }
+}


### PR DESCRIPTION
It is now possbile to load another module during the loadModule(ModuleEvent) event, without disrupting the current module load.

The following is not longer needed.

```
public function init($moduleManager)
{
    $e = $moduleManager->getEvent();
    $moduleManager->setEvent(clone $e);
    $moduleManager->loadModule('ZfcUser');
    $moduleManager->setEvent($e);
}
```
