### PR TITLE
Feature/controller loader security

### DIFF
--- a/library/Zend/Mvc/Controller/ControllerManager.php
+++ b/library/Zend/Mvc/Controller/ControllerManager.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace Zend\Mvc\Controller;
+
+use Zend\EventManager\EventManagerAwareInterface;
+use Zend\Mvc\Exception;
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\ConfigurationInterface;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\Stdlib\DispatchableInterface;
+
+/**
+ * Manager for loading controllers
+ *
+ * Does not define any controllers by default, but does add a validator.
+ *
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage Controller
+ */
+class ControllerManager extends AbstractPluginManager
+{
+    /**
+     * We do not want arbitrary classes instantiated as controllers.
+     * 
+     * @var bool
+     */
+    protected $autoAddInvokableClass = false;
+
+    /**
+     * Constructor
+     *
+     * After invoking parent constructor, add an initializer to inject the
+     * service manager, event manager, and plugin manager
+     *
+     * @param  null|ConfigurationInterface $configuration
+     * @return void
+     */
+    public function __construct(ConfigurationInterface $configuration = null)
+    {
+        parent::__construct($configuration);
+        $this->addInitializer(array($this, 'injectControllerDependencies'));
+    }
+
+    /**
+     * Inject required dependencies into the controller.
+     *
+     * @param  DispatchableInterface $controller
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @return void
+     */
+    public function injectControllerDependencies($controller, ServiceLocatorInterface $serviceLocator)
+    {
+        if (!$controller instanceof DispatchableInterface) {
+            return;
+        }
+
+        $parentLocator = $serviceLocator->getServiceLocator();
+
+        if ($controller instanceof ServiceLocatorAwareInterface) {
+            $controller->setServiceLocator($parentLocator->get('Zend\ServiceManager\ServiceLocatorInterface'));
+        }
+
+        if ($controller instanceof EventManagerAwareInterface) {
+            $controller->setEventManager($parentLocator->get('EventManager'));
+        }
+
+        if (method_exists($controller, 'setPluginManager')) {
+            $controller->setPluginManager($parentLocator->get('ControllerPluginBroker'));
+        }
+    }
+
+    /**
+     * Validate the plugin
+     *
+     * Ensure we have a dispatchable.
+     *
+     * @param  mixed $plugin
+     * @return true
+     * @throws Exception\DomainException
+     */
+    public function validatePlugin($plugin)
+    {
+        if ($plugin instanceof DispatchableInterface) {
+            // we're okay
+            return;
+        }
+
+        throw new Exception\DomainException(sprintf(
+            'Controller of type %s is invalid; must implement Zend\Stdlib\DispatchableInterface',
+            (is_object($plugin) ? get_class($plugin) : gettype($plugin))
+        ));
+    }
+
+    /**
+     * Override: do not use peering service manager to retrieve controller
+     * 
+     * @param  string $name 
+     * @param  array $options 
+     * @param  bool $usePeeringServiceManagers 
+     * @return mixed
+     */
+    public function get($name, $options = array(), $usePeeringServiceManagers = false)
+    {
+        return parent::get($name, $options, $usePeeringServiceManagers);
+    }
+}

--- a/library/Zend/Mvc/Controller/ControllerManager.php
+++ b/library/Zend/Mvc/Controller/ControllerManager.php
@@ -86,7 +86,7 @@ class ControllerManager extends AbstractPluginManager
      *
      * @param  mixed $plugin
      * @return true
-     * @throws Exception\DomainException
+     * @throws Exception\InvalidControllerException
      */
     public function validatePlugin($plugin)
     {
@@ -95,7 +95,7 @@ class ControllerManager extends AbstractPluginManager
             return;
         }
 
-        throw new Exception\DomainException(sprintf(
+        throw new Exception\InvalidControllerException(sprintf(
             'Controller of type %s is invalid; must implement Zend\Stdlib\DispatchableInterface',
             (is_object($plugin) ? get_class($plugin) : gettype($plugin))
         ));

--- a/library/Zend/Mvc/Exception/InvalidControllerException.php
+++ b/library/Zend/Mvc/Exception/InvalidControllerException.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace Zend\Mvc\Exception;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage Exception
+ */
+class InvalidControllerException extends \Exception implements ExceptionInterface
+{
+}

--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -35,6 +35,13 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
     protected $allowOverride   = true;
 
     /**
+     * Whether or not to auto-add a class as an invokable class if it exists
+     * 
+     * @var bool
+     */
+    protected $autoAddInvokableClass = true;
+
+    /**
      * @var mixed Options to use when creating an instance
      */
     protected $creationOptions = null;
@@ -93,7 +100,7 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
     public function get($name, $options = array(), $usePeeringServiceManagers = true)
     {
         // Allow specifying a class name directly; registers as an invokable class
-        if (!$this->has($name) && class_exists($name)) {
+        if (!$this->has($name) && $this->autoAddInvokableClass && class_exists($name)) {
             $this->setInvokableClass($name, $name);
         }
 

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -434,6 +434,7 @@ class ServiceManager implements ServiceLocatorInterface
             $cName = $this->canonicalizeName($rName);
         }
 
+
         if (isset($this->factories[$cName])) {
             $instance = $this->createFromFactory($cName, $rName);
         }

--- a/tests/Zend/Mvc/ApplicationTest.php
+++ b/tests/Zend/Mvc/ApplicationTest.php
@@ -439,7 +439,6 @@ class ApplicationTest extends TestCase
         $this->application->run();
         $this->assertContains(Application::ERROR_CONTROLLER_INVALID, $response->getContent());
         $this->assertContains('bad', $response->getContent());
-        $this->assertContains('stdClass', $response->getContent());
     }
 
     /**

--- a/tests/Zend/Mvc/Service/ControllerLoaderFactoryTest.php
+++ b/tests/Zend/Mvc/Service/ControllerLoaderFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc\Service;
+
+use ArrayObject;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mvc\Service\ControllerLoaderFactory;
+use Zend\Mvc\Service\ControllerPluginManagerFactory;
+use Zend\Mvc\Service\DiFactory;
+use Zend\Mvc\Service\EventManagerFactory;
+use Zend\ServiceManager\ServiceManager;
+
+class ControllerLoaderFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $loaderFactory  = new ControllerLoaderFactory();
+        $config         = new ArrayObject(array('di' => array()));
+        $this->services = new ServiceManager();
+        $this->services->setService('Zend\ServiceManager\ServiceLocatorInterface', $this->services);
+        $this->services->setFactory('ControllerLoader', $loaderFactory);
+        $this->services->setService('Config', $config);
+        $this->services->setFactory('ControllerPluginBroker', new ControllerPluginManagerFactory());
+        $this->services->setFactory('Di', new DiFactory());
+        $this->services->setFactory('EventManager', new EventManagerFactory());
+
+        $this->loader = $this->services->get('ControllerLoader');
+    }
+
+    public function testCannotLoadInvalidDispatchable()
+    {
+        // Ensure the class exists and can be autoloaded
+        $this->assertTrue(class_exists('ZendTest\Mvc\Service\TestAsset\InvalidDispatchableClass'));
+
+        try {
+            $this->loader->get('ZendTest\Mvc\Service\TestAsset\InvalidDispatchableClass');
+            $this->fail('Retrieving the invalid dispatchable should fail');
+        } catch (\Exception $e) {
+            $this->assertNotContains('Should not instantiate this', $e->getMessage());
+        }
+    }
+}

--- a/tests/Zend/Mvc/Service/ControllerLoaderFactoryTest.php
+++ b/tests/Zend/Mvc/Service/ControllerLoaderFactoryTest.php
@@ -44,7 +44,9 @@ class ControllerLoaderFactoryTest extends TestCase
             $this->loader->get('ZendTest\Mvc\Service\TestAsset\InvalidDispatchableClass');
             $this->fail('Retrieving the invalid dispatchable should fail');
         } catch (\Exception $e) {
-            $this->assertNotContains('Should not instantiate this', $e->getMessage());
+            do {
+                $this->assertNotContains('Should not instantiate this', $e->getMessage());
+            } while ($e = $e->getPrevious());
         }
     }
 }

--- a/tests/Zend/Mvc/Service/TestAsset/Dispatchable.php
+++ b/tests/Zend/Mvc/Service/TestAsset/Dispatchable.php
@@ -1,0 +1,8 @@
+<?php
+namespace ZendTest\Mvc\Service\TestAsset;
+
+use Zend\Mvc\Controller\AbstractActionController;
+
+class Dispatchable extends AbstractActionController
+{
+}

--- a/tests/Zend/Mvc/Service/TestAsset/InvalidDispatchableClass.php
+++ b/tests/Zend/Mvc/Service/TestAsset/InvalidDispatchableClass.php
@@ -1,0 +1,12 @@
+<?php
+namespace ZendTest\Mvc\Service\TestAsset;
+
+use DomainException;
+
+class InvalidDispatchableClass
+{
+    public function __construct()
+    {
+        throw new DomainException('Should not instantiate this!');
+    }
+}


### PR DESCRIPTION
This PR addresses a potential security issue in how controllers are loaded. It does so using the following approach:
- Controllers now have their own plugin manager, Zend\Mvc\Controller\ControllerManager. It still accepts the same configuration as for beta5. It validates instances to ensure we have a Dispatchable, raising an InvalidControllerException if not.
- The ControllerManager peers against the main ServiceManager, but instructs not to pull controller instances from the peering manager; however, dependencies _can_ be retrieved from it.
- The ControllerLoader service factory does not add DI as an AbstractFactory to the ControllerManager. This prevents the ability to load arbitrary classes. This is the only BC break at this time; developers who wish to use DI to grab controllers should drop in their own ControllerManager or ControllerLoaderFactory.
