### PR TITLE
Element values

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -44,6 +44,10 @@ class Element implements ElementInterface
      */
     protected $options = array();
 
+    /**
+     * @var mixed
+     */
+    protected $value;
 
     /**
      * @param  null|int|string  $name    Optional name for the element
@@ -149,6 +153,11 @@ class Element implements ElementInterface
      */
     public function setAttribute($key, $value)
     {
+        // Do not include the value in the list of attributes
+        if ($key === 'value') {
+            $this->setValue($value);
+            return $this;
+        }
         $this->attributes[$key] = $value;
         return $this;
     }
@@ -221,6 +230,28 @@ class Element implements ElementInterface
     {
         $this->attributes = array();
         return $this;
+    }
+
+    /**
+     * Set the element value
+     * 
+     * @param  mixed $value 
+     * @return Element
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    /**
+     * Retrieve the element value
+     * 
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
     }
 
     /**

--- a/library/Zend/Form/Element/Csrf.php
+++ b/library/Zend/Form/Element/Csrf.php
@@ -51,38 +51,14 @@ class Csrf extends Element implements InputProviderInterface, ElementPrepareAwar
     }
 
     /**
-     * Override: set a single element attribute
+     * Retrieve value
      *
-     * Does not allow setting value attribute; this will always be
-     * retrieved from the validator.
-     *
-     * @param  string $name
-     * @param  mixed $value
-     * @return Csrf
+     * Retrieves the hash from the validator
+     * 
+     * @return void
      */
-    public function setAttribute($name, $value)
+    public function getValue()
     {
-        if ('value' == $name) {
-            // Do not allow setting this
-            return;
-        }
-        return parent::setAttribute($name, $value);
-    }
-
-    /**
-     * Override: retrieve a single element attribute
-     *
-     * Retrieves validator hash when asked for 'value' attribute;
-     * otherwise, proxies to parent.
-     *
-     * @param  string $name
-     * @return mixed
-     */
-    public function getAttribute($name)
-    {
-        if ($name != 'value') {
-            return parent::getAttribute($name);
-        }
         $validator = $this->getValidator();
         return $validator->getHash();
     }

--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -37,9 +37,62 @@ class DateTime extends Element implements InputProviderInterface
     );
 
     /**
+     * Date format to use for DateTime values. By default, this is RFC-3339, 
+     * which is what HTML5 dictates.
+     * 
+     * @var string
+     */
+    protected $format = PhpDateTime::RFC3339;
+
+    /**
      * @var array
      */
     protected $validators;
+
+    /**
+     * Retrieve the element value
+     *
+     * If the value is a DateTime object, and $returnFormattedValue is true 
+     * (the default), we return the string
+     * representation using the currently registered format.
+     *
+     * If $returnFormattedValue is false, the original value will be
+     * returned, regardless of type.
+     * 
+     * @param  bool $returnFormattedValue
+     * @return mixed
+     */
+    public function getValue($returnFormattedValue = true)
+    {
+        $value = parent::getValue();
+        if (!$value instanceof PhpDateTime || !$returnFormattedValue) {
+            return $value;
+        }
+        $format = $this->getFormat();
+        return $value->format($format);
+    }
+
+    /**
+     * Set value for format
+     *
+     * @param  string format
+     * @return DateTime
+     */
+    public function setFormat($format)
+    {
+        $this->format = (string) $format;
+        return $this;
+    }
+    
+    /**
+     * Retrieve the DateTime format to use for the value
+     *
+     * @return string
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
 
     /**
      * Get validators

--- a/library/Zend/Form/ElementInterface.php
+++ b/library/Zend/Form/ElementInterface.php
@@ -100,6 +100,21 @@ interface ElementInterface
     public function getAttributes();
 
     /**
+     * Set the value of the element
+     * 
+     * @param  mixed $value 
+     * @return ElementInterface
+     */
+    public function setValue($value);
+
+    /**
+     * Retrieve the element value
+     * 
+     * @return mixed
+     */
+    public function getValue();
+
+    /**
      * Set the label (if any) used for this element
      *
      * @param  $label

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -391,7 +391,7 @@ class Fieldset extends Element implements FieldsetInterface
                 continue;
             }
 
-            $element->setAttribute('value', $value);
+            $element->setValue($value);
         }
     }
 

--- a/library/Zend/Form/View/Helper/FormButton.php
+++ b/library/Zend/Form/View/Helper/FormButton.php
@@ -84,9 +84,10 @@ class FormButton extends FormInput
             ));
         }
 
-        $attributes         = $element->getAttributes();
-        $attributes['name'] = $name;
-        $attributes['type'] = $this->getType($element);
+        $attributes          = $element->getAttributes();
+        $attributes['name']  = $name;
+        $attributes['type']  = $this->getType($element);
+        $attributes['value'] = $element->getValue();
 
         return sprintf(
             '<button %s>',

--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -44,7 +44,8 @@ class FormCheckbox extends FormInput
         $attributes['type']    = $this->getInputType();
         $closingBracket        = $this->getInlineClosingBracket();
 
-        if (isset($attributes['value']) && $attributes['value'] == $element->getCheckedValue()) {
+        $value = $element->getValue();
+        if ($value === $element->getCheckedValue()) {
             $attributes['checked'] = 'checked';
         }
         $attributes['value'] = $element->getCheckedValue();

--- a/library/Zend/Form/View/Helper/FormInput.php
+++ b/library/Zend/Form/View/Helper/FormInput.php
@@ -106,9 +106,10 @@ class FormInput extends AbstractHelper
             ));
         }
 
-        $attributes         = $element->getAttributes();
-        $attributes['name'] = $name;
-        $attributes['type'] = $this->getType($element);
+        $attributes          = $element->getAttributes();
+        $attributes['name']  = $name;
+        $attributes['type']  = $this->getType($element);
+        $attributes['value'] = $element->getValue();
 
         return sprintf(
             '<input %s%s',

--- a/library/Zend/Form/View/Helper/FormMultiCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormMultiCheckbox.php
@@ -214,12 +214,7 @@ class FormMultiCheckbox extends FormInput
 
         $attributes['name'] = $name;
         $attributes['type'] = $this->getInputType();
-
-        $selectedOptions = array();
-        if (isset($attributes['value'])) {
-            $selectedOptions = (array) $attributes['value'];
-            unset($attributes['value']);
-        }
+        $selectedOptions    = (array) $element->getValue();
 
         $rendered = $this->renderOptions($element, $options, $selectedOptions, $attributes);
 

--- a/library/Zend/Form/View/Helper/FormSelect.php
+++ b/library/Zend/Form/View/Helper/FormSelect.php
@@ -82,12 +82,7 @@ class FormSelect extends AbstractHelper
         $options = (array) $attributes['options'];
         unset($attributes['options']);
 
-        $value = array();
-        if (isset($attributes['value'])) {
-            $value = $attributes['value'];
-            $value = $this->validateMultiValue($value, $attributes);
-            unset($attributes['value']);
-        };
+        $value = $this->validateMultiValue($element->getValue(), $attributes);
 
         $attributes['name'] = $name;
         if (array_key_exists('multiple', $attributes) && $attributes['multiple']) {
@@ -245,6 +240,10 @@ class FormSelect extends AbstractHelper
      */
     protected function validateMultiValue($value, array $attributes)
     {
+        if (null === $value) {
+            return array();
+        }
+
         if (!is_array($value)) {
             return (array) $value;
         }

--- a/library/Zend/Form/View/Helper/FormTextarea.php
+++ b/library/Zend/Form/View/Helper/FormTextarea.php
@@ -58,7 +58,7 @@ class FormTextarea extends AbstractHelper
 
         $attributes         = $element->getAttributes();
         $attributes['name'] = $name;
-        $content            = (string) $element->getAttribute('value');
+        $content            = (string) $element->getValue();
         $escapeHtml         = $this->getEscapeHtmlHelper();
 
         return sprintf(

--- a/tests/Zend/Form/Element/DateTimeTest.php
+++ b/tests/Zend/Form/Element/DateTimeTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\Form\Element;
 
+use DateTime;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element\DateTime as DateTimeElement;
 use Zend\Form\Factory;
@@ -56,5 +57,36 @@ class DateTimeTest extends TestCase
                     break;
             }
         }
+    }
+
+    public function testUsesRfc3339FormatByDefault()
+    {
+        $element = new DateTimeElement('foo');
+        $this->assertEquals(DateTime::RFC3339, $element->getFormat());
+    }
+
+    public function testSpecifyingADateTimeValueWillReturnRfc3339FormattedStringByDefault()
+    {
+        $date = new DateTime();
+        $element = new DateTimeElement('foo');
+        $element->setValue($date);
+        $this->assertEquals($date->format($date::RFC3339), $element->getValue());
+    }
+
+    public function testValueIsFormattedAccordingToFormatInElement()
+    {
+        $date = new DateTime();
+        $element = new DateTimeElement('foo');
+        $element->setFormat($date::RFC2822);
+        $element->setValue($date);
+        $this->assertEquals($date->format($date::RFC2822), $element->getValue());
+    }
+
+    public function testCanRetrieveDateTimeObjectByPassingBooleanFalseToGetValue()
+    {
+        $date = new DateTime();
+        $element = new DateTimeElement('foo');
+        $element->setValue($date);
+        $this->assertSame($date, $element->getValue(false));
     }
 }

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -491,7 +491,7 @@ class FormTest extends TestCase
         $this->assertSame($model->getInputFilter(), $this->form->getInputFilter());
     }
 
-    public function testSettingDataShouldSetElementValueAttributes()
+    public function testSettingDataShouldSetElementValues()
     {
         $this->populateForm();
         $data = array(
@@ -507,10 +507,10 @@ class FormTest extends TestCase
         $fieldset = $this->form->get('foobar');
         foreach (array('foo', 'bar') as $name) {
             $element = $this->form->get($name);
-            $this->assertEquals($data[$name], $element->getAttribute('value'));
+            $this->assertEquals($data[$name], $element->getValue());
 
             $element = $fieldset->get($name);
-            $this->assertEquals($data[$name], $element->getAttribute('value'));
+            $this->assertEquals($data[$name], $element->getValue());
         }
     }
 
@@ -524,9 +524,9 @@ class FormTest extends TestCase
         $this->form->bind($object);
 
         $foo = $this->form->get('foo');
-        $this->assertEquals('foobar', $foo->getAttribute('value'));
+        $this->assertEquals('foobar', $foo->getValue());
         $bar = $this->form->get('bar');
-        $this->assertEquals('barbaz', $bar->getAttribute('value'));
+        $this->assertEquals('barbaz', $bar->getValue());
     }
 
     public function testUsesBoundObjectAsDataSourceWhenNoDataSet()

--- a/tests/Zend/Form/View/Helper/FormButtonTest.php
+++ b/tests/Zend/Form/View/Helper/FormButtonTest.php
@@ -178,9 +178,9 @@ class FormButtonTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -192,7 +192,14 @@ class FormButtonTest extends CommonTestCase
         $element = $this->getCompleteElement();
         $element->setAttribute('label', '{button_content}');
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormCheckboxTest.php
+++ b/tests/Zend/Form/View/Helper/FormCheckboxTest.php
@@ -51,11 +51,11 @@ class FormCheckboxTest extends CommonTestCase
     public function testUsesElementValueToDetermineCheckboxStatus()
     {
         $element = $this->getElement();
-        $element->setAttribute('value', 'checked');
+        $element->setValue('checked');
         $markup  = $this->helper->render($element);
 
-        $this->assertRegexp('#value="checked"\s+checked="checked"#', $markup);
-        $this->assertNotRegexp('#value="unchecked"\s+checked="checked"#', $markup);
+        $this->assertRegexp('#checked="checked"\s+value="checked"#', $markup);
+        $this->assertNotRegexp('#checked="checked"\s+value="unchecked"#', $markup);
     }
 
     public function testNoOptionsAttributeCreatesDefaultCheckedAndUncheckedValues()

--- a/tests/Zend/Form/View/Helper/FormColorTest.php
+++ b/tests/Zend/Form/View/Helper/FormColorTest.php
@@ -117,9 +117,9 @@ class FormColorTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormColorTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormDateTest.php
+++ b/tests/Zend/Form/View/Helper/FormDateTest.php
@@ -117,9 +117,9 @@ class FormDateTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormDateTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormDateTimeLocalTest.php
+++ b/tests/Zend/Form/View/Helper/FormDateTimeLocalTest.php
@@ -117,9 +117,9 @@ class FormDateTimeLocalTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormDateTimeLocalTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormDateTimeTest.php
+++ b/tests/Zend/Form/View/Helper/FormDateTimeTest.php
@@ -117,9 +117,9 @@ class FormDateTimeTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormDateTimeTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormEmailTest.php
+++ b/tests/Zend/Form/View/Helper/FormEmailTest.php
@@ -117,9 +117,9 @@ class FormEmailTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormEmailTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormFileTest.php
+++ b/tests/Zend/Form/View/Helper/FormFileTest.php
@@ -117,9 +117,9 @@ class FormFileTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormFileTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormHiddenTest.php
+++ b/tests/Zend/Form/View/Helper/FormHiddenTest.php
@@ -117,9 +117,9 @@ class FormHiddenTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormHiddenTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormImageTest.php
+++ b/tests/Zend/Form/View/Helper/FormImageTest.php
@@ -129,9 +129,9 @@ class FormImageTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -142,7 +142,15 @@ class FormImageTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            // Intentionally allowing fall-through
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormInputTest.php
+++ b/tests/Zend/Form/View/Helper/FormInputTest.php
@@ -305,7 +305,6 @@ class FormInputTest extends CommonTestCase
             'style'              => 'value',
             'tabindex'           => 'value',
             'title'              => 'value',
-            'value'              => 'value',
             'width'              => 'value',
             'wrap'               => 'value',
             'xml:base'           => 'value',
@@ -317,6 +316,7 @@ class FormInputTest extends CommonTestCase
             'arbitrary'          => 'value',
             'meta'               => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -327,7 +327,14 @@ class FormInputTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormMonthTest.php
+++ b/tests/Zend/Form/View/Helper/FormMonthTest.php
@@ -117,9 +117,9 @@ class FormMonthTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormMonthTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormNumberTest.php
+++ b/tests/Zend/Form/View/Helper/FormNumberTest.php
@@ -117,9 +117,9 @@ class FormNumberTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => '1',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormNumberTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormPasswordTest.php
+++ b/tests/Zend/Form/View/Helper/FormPasswordTest.php
@@ -117,9 +117,9 @@ class FormPasswordTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormPasswordTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormRangeTest.php
+++ b/tests/Zend/Form/View/Helper/FormRangeTest.php
@@ -117,9 +117,9 @@ class FormRangeTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => '1',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormRangeTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormResetTest.php
+++ b/tests/Zend/Form/View/Helper/FormResetTest.php
@@ -117,9 +117,9 @@ class FormResetTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormResetTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormRowTest.php
+++ b/tests/Zend/Form/View/Helper/FormRowTest.php
@@ -85,7 +85,7 @@ class FormRowTest extends TestCase
         $element = new Element('foo');
         $element->setAttribute('type', 'text');
         $markup = $this->helper->render($element);
-        $this->assertRegexp('/<input name="foo" type="text"(\s*\/)?>/', $markup);
+        $this->assertRegexp('/<input name="foo" type="text"[^\/>]*\/?>/', $markup);
     }
 
     public function testCanHandleMultiCheckboxesCorrectly()

--- a/tests/Zend/Form/View/Helper/FormSubmitTest.php
+++ b/tests/Zend/Form/View/Helper/FormSubmitTest.php
@@ -117,9 +117,9 @@ class FormSubmitTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormSubmitTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormTelTest.php
+++ b/tests/Zend/Form/View/Helper/FormTelTest.php
@@ -117,9 +117,9 @@ class FormTelTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormTelTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormTextTest.php
+++ b/tests/Zend/Form/View/Helper/FormTextTest.php
@@ -117,9 +117,9 @@ class FormTextTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormTextTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormTimeTest.php
+++ b/tests/Zend/Form/View/Helper/FormTimeTest.php
@@ -117,9 +117,9 @@ class FormTimeTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormTimeTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormUrlTest.php
+++ b/tests/Zend/Form/View/Helper/FormUrlTest.php
@@ -117,9 +117,9 @@ class FormUrlTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormUrlTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 

--- a/tests/Zend/Form/View/Helper/FormWeekTest.php
+++ b/tests/Zend/Form/View/Helper/FormWeekTest.php
@@ -117,9 +117,9 @@ class FormWeekTest extends CommonTestCase
             'size'               => 'value',
             'src'                => 'value',
             'step'               => 'value',
-            'value'              => 'value',
             'width'              => 'value',
         ));
+        $element->setValue('value');
         return $element;
     }
 
@@ -130,7 +130,14 @@ class FormWeekTest extends CommonTestCase
     {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        switch ($attribute) {
+            case 'value':
+                $expect  = sprintf('%s="%s"', $attribute, $element->getValue());
+                break;
+            default:
+                $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+                break;
+        }
         $this->$assertion($expect, $markup);
     }
 


### PR DESCRIPTION
Changeset created for @WalterTamboer on his suggestions

Element values may or may not be appropriate string values. As an
example, you may want to seed these as DateTime objects or other such
value objects -- which means that when it comes time to render them,
you may run into issues.

As such, I've added "getValue()" and "setValue()" to the
ElementInterface, and made Element proxy setAttribute('value', $value)
to set the element value. View helpers now will pull the value from the
element and add it to the attributes if it should be rendered.

This simplifies the CSRF element, as it can simply override getValue()
at this point. The DateTime element (and those deriving from it) can now
cast a DateTime object using a format (defaulting to RFC-3339, which is
what HTML5 expects). Checkboxes and radios now pull the value, not the
value attribute.
