### PR TITLE
Allow passing initializer class names in configuration

### DIFF
--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -188,28 +188,4 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
 
         return $instance;
     }
-
-    /**
-     * Checks if the object has this class as one of its parents
-     *
-     * @see https://bugs.php.net/bug.php?id=53727
-     * @see https://github.com/zendframework/zf2/pull/1807
-     *
-     * @param string $className
-     * @param string $type
-     */
-    protected static function isSubclassOf($className, $type)
-    {
-        if (is_subclass_of($className, $type)) {
-            return true;
-        }
-        if (version_compare(PHP_VERSION, '5.3.7', '>=')) {
-            return false;
-        }
-        if (!interface_exists($type)) {
-            return false;
-        }
-        $r = new ReflectionClass($className);
-        return $r->implementsInterface($type);
-    }
 }

--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -10,8 +10,6 @@
 
 namespace Zend\ServiceManager;
 
-use ReflectionClass;
-
 /**
  * ServiceManager implementation for managing plugins
  *

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -10,6 +10,8 @@
 
 namespace Zend\ServiceManager;
 
+use ReflectionClass;
+
 class ServiceManager implements ServiceLocatorInterface
 {
 

--- a/tests/Zend/ServiceManager/ServiceManagerTest.php
+++ b/tests/Zend/ServiceManager/ServiceManagerTest.php
@@ -509,4 +509,16 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $foo = $sm->get('foo');
         $this->assertSame($abstractFactory->expectedInstance, $foo);
     }
+
+    public function testShouldAllowAddingInitializersAsClassNames()
+    {
+        $result = $this->serviceManager->addInitializer('ZendTest\ServiceManager\TestAsset\FooInitializer');
+        $this->assertSame($this->serviceManager, $result);
+    }
+
+    public function testShouldRaiseExceptionIfInitializerClassIsNotAnInitializerInterfaceImplementation()
+    {
+        $this->setExpectedException('Zend\ServiceManager\Exception\InvalidArgumentException');
+        $result = $this->serviceManager->addInitializer(get_class($this));
+    }
 }


### PR DESCRIPTION
- Moves isSubclassOf to ServiceManager from AbstractPluginManager
- Tests the $initializer to see if it's a subclass of InitializerInterface, and
  instantiates it if so
