### PR TITLE
[2.1] Adding simple Zend/I18n/Loader/Tmx

### DIFF
--- a/library/Zend/I18n/Translator/Loader/Tmx.php
+++ b/library/Zend/I18n/Translator/Loader/Tmx.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_I18n
+ */
+
+namespace Zend\I18n\Translator\Loader;
+
+use Zend\I18n\Exception;
+use Zend\I18n\Translator\Plural\Rule as PluralRule;
+use Zend\I18n\Translator\TextDomain;
+
+/**
+ * Tmx loader.
+ *
+ * @category   Zend
+ * @package    Zend_I18n
+ * @subpackage Translator
+ */
+class Tmx implements LoaderInterface
+{
+    /**
+     * load(): defined by LoaderInterface.
+     *
+     * @see    LoaderInterface::load()
+     * @param  string $filename
+     * @param  string $locale
+     * @return TextDomain
+     * @throws Exception\InvalidArgumentException
+     */
+    public function load($filename, $locale)
+    {
+        if (!is_file($filename) || !is_readable($filename)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Could not open file %s for reading',
+                $filename
+            ));
+        }
+
+        $textDomain = new TextDomain();
+
+        libxml_use_internal_errors(true);
+
+        $xml = simplexml_load_file($filename);
+
+        if(!$xml) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s is not a valid tmx file',
+                $filename
+            ));            
+        }
+
+        $result = $xml->xpath('/tmx/body/tu/tuv[@xml:lang=\''.$locale.'\']/..');
+
+        foreach($result as $node) {
+            $attributes = $node->attributes();
+            // Silently skip the nodes that does not have the 'tuid' attribute
+            if(isset($attributes['tuid'])) {
+                $textDomain[(string) $attributes['tuid']] = (string) $node->tuv->seg;
+            }
+        }
+
+        return $textDomain;
+    }
+}

--- a/tests/Zend/I18n/Translator/Loader/TmxTest.php
+++ b/tests/Zend/I18n/Translator/Loader/TmxTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_I18n
+ */
+
+namespace ZendTest\I18n\Translator\Loader;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Locale;
+use Zend\I18n\Translator\Translator;
+use Zend\I18n\Translator\Loader\Tmx as TmxLoader;
+
+class TmxTest extends TestCase
+{
+    protected $testFilesDir;
+    protected $originalLocale;
+
+    public function setUp()
+    {
+        $this->originalLocale = Locale::getDefault();
+        Locale::setDefault('en_EN');
+
+        $this->testFilesDir = realpath(__DIR__ . '/../_files');
+    }
+
+    public function tearDown()
+    {
+        Locale::setDefault($this->originalLocale);
+    }
+
+    public function testLoaderFailsToLoadMissingFile()
+    {
+        $loader = new TmxLoader();
+        $this->setExpectedException('Zend\I18n\Exception\InvalidArgumentException', 'Could not open file');
+        $loader->load('missing', 'en_EN');
+    }
+
+    public function testLoaderFailsToLoadBadFile()
+    {
+        $loader = new TmxLoader();
+        $this->setExpectedException('Zend\I18n\Exception\InvalidArgumentException',
+                                    'is not a valid tmx file');
+        $loader->load($this->testFilesDir . '/failed.tmx', 'en_EN');
+    }
+
+    public function testLoaderLoadsEmptyFile()
+    {
+        $loader = new TmxLoader();
+        $domain = $loader->load($this->testFilesDir . '/translation_empty.tmx', 'en_EN');
+        $this->assertInstanceOf('Zend\I18n\Translator\TextDomain', $domain);
+    }
+
+    public function testLoaderReturnsValidTextDomain()
+    {
+        $loader = new TmxLoader();
+        $textDomain = $loader->load($this->testFilesDir . '/translation_en.tmx', 'en_EN');
+
+        $this->assertEquals('Message 1 (en)', $textDomain['Message 1']);
+        $this->assertEquals('Message 4 (en)', $textDomain['Message 4']);
+    }
+}

--- a/tests/Zend/I18n/Translator/_files/failed.tmx
+++ b/tests/Zend/I18n/Translator/_files/failed.tmx
@@ -1,0 +1,30 @@
+&#<?xml version="1.0" ?>
+<!DOCTYPE tmx SYSTEM "tmx14.dtd">
+<tmx version="1.4">
+    <header creationtoolversion="1.0.0" datatype="winres" segtype="sentence"
+        adminlang="en-us" srclang="en_EN" o-tmf="abc"
+        creationtool="XYZTool" >
+    </header>
+    <body>
+        <tu tuid='Message 1'>
+            <tuv xml:lang="en_EN">
+                <seg>Message 1 (en)</seg>
+            </tuv>
+        </tu>
+        <tu tuid='Message 2'>
+            <tuv xml:lang="en_EN">
+                <seg>Message 2 (en)</seg>
+            </tuv>
+        </tu>
+        <tu tuid='Message 3'>
+            <tuv xml:lang="en_EN">
+                <seg>Message 3 (en)</seg>
+            </tuv>
+        </tu>
+        <tu tuid='Message 4'>
+            <tuv xml:lang="en_EN">
+                <seg>Message 4 (en)</seg>
+            </tuv>
+        </tu>
+    </body>
+</tmx>

--- a/tests/Zend/I18n/Translator/_files/translation_empty.tmx
+++ b/tests/Zend/I18n/Translator/_files/translation_empty.tmx
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<!DOCTYPE tmx SYSTEM "tmx14.dtd">
+<tmx version="1.4">
+    <header creationtoolversion="1.0.0" datatype="winres" segtype="sentence"
+        adminlang="en-us" srclang="en_EN" o-tmf="abc"
+        creationtool="XYZTool" >
+    </header>
+    <body>
+    </body>
+</tmx>

--- a/tests/Zend/I18n/Translator/_files/translation_en.tmx
+++ b/tests/Zend/I18n/Translator/_files/translation_en.tmx
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<!DOCTYPE tmx SYSTEM "tmx14.dtd">
+<tmx version="1.4">
+    <header creationtoolversion="1.0.0" datatype="winres" segtype="sentence"
+        adminlang="en-us" srclang="en_EN" o-tmf="abc"
+        creationtool="XYZTool" >
+    </header>
+    <body>
+        <tu tuid='Message 1'>
+            <tuv xml:lang="en_EN">
+                <seg>Message 1 (en)</seg>
+            </tuv>
+        </tu>
+        <tu tuid='Message 2'>
+            <tuv xml:lang="en_EN">
+                <seg>Message 2 (en)</seg>
+            </tuv>
+        </tu>
+        <tu tuid='Message 3'>
+            <tuv xml:lang="en_EN">
+                <seg>Message 3 (en)</seg>
+            </tuv>
+        </tu>
+        <tu tuid='Message 4'>
+            <tuv xml:lang="en_EN">
+                <seg>Message 4 (en)</seg>
+            </tuv>
+        </tu>
+    </body>
+</tmx>


### PR DESCRIPTION
A simple version of loader plus tests. I choose SimpleXML because the solution implemented into version 1 seemed for me over-complicated and libxml is enabled by default. I'm not an xpatch expert so there may be a better way of implementing it.
I not sure if the loader should report any incompatibilities with the standard eg. missing tuid attribute or seg node so I skipped it for now.
