### PR TITLE
ZF2-421 notEqualTo is missing in Predicate

### DIFF
--- a/library/Zend/Db/Sql/Predicate/Predicate.php
+++ b/library/Zend/Db/Sql/Predicate/Predicate.php
@@ -90,6 +90,28 @@ class Predicate extends PredicateSet
     }
 
     /**
+     * Create "Not Equal To" predicate
+     *
+     * Utilizes Operator predicate
+     *
+     * @param  scalar $left
+     * @param  scalar $right
+     * @param  TYPE_IDENTIFIER|TYPE_VALUE $leftType
+     * @param  TYPE_IDENTIFIER|TYPE_VALUE $rightType
+     * @return Predicate
+     */
+    public function notEqualTo($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
+    {
+        $this->addPredicate(
+            new Operator($left, Operator::OPERATOR_NOT_EQUAL_TO, $right, $leftType, $rightType),
+            ($this->nextPredicateCombineOperator) ?: $this->defaultCombination
+        );
+        $this->nextPredicateCombineOperator = null;
+
+        return $this;
+    }
+
+    /**
      * Create "Less Than" predicate
      *
      * Utilizes Operator predicate

--- a/tests/Zend/Db/Sql/Predicate/PredicateTest.php
+++ b/tests/Zend/Db/Sql/Predicate/PredicateTest.php
@@ -27,6 +27,17 @@ class PredicateTest extends TestCase
         $this->assertContains(array('foo.bar', 'bar'), $parts[0]);
     }
 
+    public function testNotEqualToCreatesOperatorPredicate()
+    {
+        $predicate = new Predicate();
+        $predicate->notEqualTo('foo.bar', 'bar');
+        $parts = $predicate->getExpressionData();
+        $this->assertEquals(1, count($parts));
+        $this->assertContains('%s != %s', $parts[0]);
+        $this->assertContains(array('foo.bar', 'bar'), $parts[0]);
+    }
+
+
     public function testLessThanCreatesOperatorPredicate()
     {
         $predicate = new Predicate();


### PR DESCRIPTION
Added notEqualTo function to Predicate class
Added test to check proper functionality of notEqualTo function
