### PR TITLE
Hotfix/zf2 423 - bugfix for Zend\Navigation\Page::isActive()

### DIFF
--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -106,21 +106,7 @@ class Mvc extends AbstractPage
     public function isActive($recursive = false)
     {
         if (!$this->active) {
-            $reqParams = array();
-            if ($this->routeMatch instanceof RouteMatch) {
-                $reqParams = $this->routeMatch->getParams();
-
-                if (null !== $this->getRoute()
-                    && $this->routeMatch->getMatchedRouteName() === $this->getRoute()
-                ) {
-                    $this->active = true;
-                    return true;
-                }
-            }
-
-
             $myParams = $this->params;
-
             if (null !== $this->controller) {
                 $myParams['controller'] = $this->controller;
             } else {
@@ -129,21 +115,30 @@ class Mvc extends AbstractPage
                  */
                 $myParams['controller'] = 'index';
             }
-
             if (null !== $this->action) {
                 $myParams['action'] = $this->action;
             } else {
                 /**
                  * @todo In ZF1, this was configurable and pulled from the front controller
                  */
-                $myParams['action'] = 'action';
+                $myParams['action'] = 'index';
             }
 
-            if (count(array_intersect_assoc($reqParams, $myParams)) ==
-                count($myParams)
-            ) {
-                $this->active = true;
-                return true;
+            if ($this->routeMatch instanceof RouteMatch) {
+                $reqParams = $this->routeMatch->getParams();
+                if($this->getRoute() !== null) {
+                    $routeName  = $this->getRoute();
+                } else {
+                    $routeName  = $this->routeMatch->getMatchedRouteName();
+                }
+
+                if ($this->routeMatch->getMatchedRouteName() === $routeName
+                    && (count($reqParams) == count($myParams))
+                    && (count(array_intersect_assoc($reqParams, $myParams)) == count($myParams))
+                ) {
+                    $this->active = true;
+                    return true;
+                }
             }
         }
 

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -105,7 +105,7 @@ class Mvc extends AbstractPage
      */
     public function isActive($recursive = false)
     {
-        if (!$this->active) {
+        if (!$this->active && $this->routeMatch instanceof RouteMatch) {
             $myParams = $this->params;
             if (null !== $this->controller) {
                 $myParams['controller'] = $this->controller;
@@ -124,24 +124,21 @@ class Mvc extends AbstractPage
                 $myParams['action'] = 'index';
             }
 
-            if ($this->routeMatch instanceof RouteMatch) {
-                $reqParams = $this->routeMatch->getParams();
-                if($this->getRoute() !== null) {
-                    $routeName  = $this->getRoute();
-                } else {
-                    $routeName  = $this->routeMatch->getMatchedRouteName();
-                }
+            $reqParams = $this->routeMatch->getParams();
+            if($this->getRoute() !== null) {
+                $routeName  = $this->getRoute();
+            } else {
+                $routeName  = $this->routeMatch->getMatchedRouteName();
+            }
 
-                if ($this->routeMatch->getMatchedRouteName() === $routeName
-                    && (count($reqParams) == count($myParams))
-                    && (count(array_intersect_assoc($reqParams, $myParams)) == count($myParams))
-                ) {
-                    $this->active = true;
-                    return true;
-                }
+            if ($this->routeMatch->getMatchedRouteName() === $routeName
+                && (count($reqParams) == count($myParams))
+                && (count(array_intersect_assoc($reqParams, $myParams)) == count($myParams))
+            ) {
+                $this->active = true;
+                return true;
             }
         }
-
         return parent::isActive($recursive);
     }
 

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -105,8 +105,30 @@ class Mvc extends AbstractPage
      */
     public function isActive($recursive = false)
     {
-        if (!$this->active && $this->routeMatch instanceof RouteMatch) {
+        if (!$this->active) {
+            $reqParams = array();
+            if ($this->routeMatch instanceof RouteMatch) {
+                $reqParams  = $this->routeMatch->getParams();
+
+                $myParams   = $this->params;
+                if (null !== $this->controller) {
+                    $myParams['controller'] = $this->controller;
+                }
+                if (null !== $this->action) {
+                    $myParams['action'] = $this->action;
+                }
+
+                if (null !== $this->getRoute()
+                    && $this->routeMatch->getMatchedRouteName() === $this->getRoute()
+                    && (count(array_intersect_assoc($reqParams, $myParams)) == count($myParams))
+                ) {
+                    $this->active = true;
+                    return true;
+                }
+            }
+
             $myParams = $this->params;
+
             if (null !== $this->controller) {
                 $myParams['controller'] = $this->controller;
             } else {
@@ -115,6 +137,7 @@ class Mvc extends AbstractPage
                  */
                 $myParams['controller'] = 'index';
             }
+
             if (null !== $this->action) {
                 $myParams['action'] = $this->action;
             } else {
@@ -124,21 +147,12 @@ class Mvc extends AbstractPage
                 $myParams['action'] = 'index';
             }
 
-            $reqParams = $this->routeMatch->getParams();
-            if($this->getRoute() !== null) {
-                $routeName  = $this->getRoute();
-            } else {
-                $routeName  = $this->routeMatch->getMatchedRouteName();
-            }
-
-            if ($this->routeMatch->getMatchedRouteName() === $routeName
-                && (count($reqParams) == count($myParams))
-                && (count(array_intersect_assoc($reqParams, $myParams)) == count($myParams))
-            ) {
+            if (count(array_intersect_assoc($reqParams, $myParams)) == count($myParams)) {
                 $this->active = true;
                 return true;
             }
         }
+
         return parent::isActive($recursive);
     }
 


### PR DESCRIPTION
## Zend\Navigation\Page\Mvc::isActive() bugfix

A hotfix for ZF2-423 (and possibly also for ZF2-126).
- Removed bug: Route name match was sufficient to mark a MVC page as active (the eventual route parameters were not taken into account).
- Change: The page is tested for activity only when the RouteMatch object is present.
- Change: If a route name is not set in the page, uses the currently matched route name
- Change: A stronger condition when comparing the route parameters match. Formerly there was always a false positive (page marked as active) in case the page had no parameters set
- Default action name changed from 'action' to 'index'

There is a problem though: To successfully match against the current RouteMatch, the MVC page has to have all the route paramteres explicitly set even though the route might define defaults. In other words if we had a route '/some-path/:action' and there was a default controller 'MyModule\Controller\MyController' preset in that route, it would still be necessary to set the controller param in the MVC page explicitly to 'MyModule\Controller\MyController' (even though it is not necessary to build the href).

There is no way (AFAIK) to get to the route defaults and use them when assessing the active/inactive state from the MVC page. Neither the RouteMatch object nor the Router object which are available in the MVC page provide access to the route defaults.
