### PR TITLE
ZF2-418 AbstractTableGateway update with no where throws exception

### DIFF
--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -124,6 +124,10 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {
+        if ($predicate == null) {
+            return $this;
+        }
+
         if ($predicate instanceof Where) {
             $this->where = $predicate;
         } elseif ($predicate instanceof \Closure) {

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -124,8 +124,8 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {
-        if ($predicate == null) {
-            return $this;
+        if (is_null($predicate)) {
+            throw new \Zend\Db\Sql\Exception\InvalidArgumentException('Predicate cannot be null');
         }
 
         if ($predicate instanceof Where) {

--- a/library/Zend/Db/TableGateway/AbstractTableGateway.php
+++ b/library/Zend/Db/TableGateway/AbstractTableGateway.php
@@ -314,7 +314,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
         $sql = $this->sql;
         $update = $sql->update();
         $update->set($set);
-        $update->where($where);
+        if (!is_null($where)) $update->where($where);
         return $this->executeUpdate($update);
     }
 

--- a/tests/Zend/Db/Sql/UpdateTest.php
+++ b/tests/Zend/Db/Sql/UpdateTest.php
@@ -93,15 +93,6 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
         });
     }
 
-    public function testBlankWhere()
-    {
-        $update = clone $this->update;
-        $update->table('foo')
-            ->set(array('bar' => 'baz'))
-            ->where(null);
-        $this->assertEquals('UPDATE "foo" SET "bar" = \'baz\'', $update->getSqlString());
-    }
-
     /**
      * @covers Zend\Db\Sql\Update::prepareStatement
      */

--- a/tests/Zend/Db/Sql/UpdateTest.php
+++ b/tests/Zend/Db/Sql/UpdateTest.php
@@ -93,6 +93,15 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
         });
     }
 
+    public function testBlankWhere()
+    {
+        $update = clone $this->update;
+        $update->table('foo')
+            ->set(array('bar' => 'baz'))
+            ->where(null);
+        $this->assertEquals('UPDATE "foo" SET "bar" = \'baz\'', $update->getSqlString());
+    }
+
     /**
      * @covers Zend\Db\Sql\Update::prepareStatement
      */

--- a/tests/Zend/Db/TableGateway/AbstractTableGatewayTest.php
+++ b/tests/Zend/Db/TableGateway/AbstractTableGatewayTest.php
@@ -205,6 +205,19 @@ class AbstractTableGatewayTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Zend\Db\TableGateway\AbstractTableGateway::update
+     * @covers Zend\Db\TableGateway\AbstractTableGateway::updateWith
+     * @covers Zend\Db\TableGateway\AbstractTableGateway::executeUpdate
+     */
+    public function testUpdateWithNoCriteria()
+    {
+        $mockUpdate = $this->mockSql->update();
+
+        $affectedRows = $this->table->update(array('foo' => 'bar'));
+        $this->assertEquals(5, $affectedRows);
+    }
+
+    /**
      * @covers Zend\Db\TableGateway\AbstractTableGateway::delete
      * @covers Zend\Db\TableGateway\AbstractTableGateway::deleteWith
      * @covers Zend\Db\TableGateway\AbstractTableGateway::executeDelete


### PR DESCRIPTION
If a where is called with a null value on update, you will no longer get a fatal error.
Added the test case to check for this scenario.
