### PR TITLE
Console Singleton

### DIFF
--- a/library/Zend/Console/Console.php
+++ b/library/Zend/Console/Console.php
@@ -13,18 +13,24 @@ namespace Zend\Console;
 use Zend\Console\Exception\InvalidArgumentException;
 
 /**
- * An static, utility class for interacting with Console enviromen.
- * Declared abstract to prevent from instantiating.
+ * An static, utility class for interacting with Console environment.
  *
  * @category   Zend
  * @package    Zend_Console
  */
-abstract class Console
+class Console
 {
     /**
      * @var \Zend\Console\Adapter
      */
     protected static $instance;
+    
+    /**
+     * A private constructor to prevent initialization of the class.
+     */
+    private function __construct()
+    {
+    }
 
     /**
      * Instantiate (if needed) and retrieve Console\Adapter instance.

--- a/library/Zend/Console/Console.php
+++ b/library/Zend/Console/Console.php
@@ -28,7 +28,7 @@ class Console
     /**
      * A private constructor to prevent initialization of the class.
      */
-    private function __construct()
+    protected function __construct()
     {
     }
 

--- a/library/Zend/Console/Console.php
+++ b/library/Zend/Console/Console.php
@@ -13,7 +13,7 @@ namespace Zend\Console;
 use Zend\Console\Exception\InvalidArgumentException;
 
 /**
- * An static, utility class for interacting with Console environment.
+ * A static, utility class for interacting with Console environment.
  *
  * @category   Zend
  * @package    Zend_Console
@@ -26,7 +26,7 @@ class Console
     protected static $instance;
     
     /**
-     * A private constructor to prevent initialization of the class.
+     * A protected constructor to prevent initialization of the class.
      */
     protected function __construct()
     {


### PR DESCRIPTION
Removed the abstract keyword since the class is not abstract but a singleton. A protected constructor will ensure the same effect in a more correct way.

As a side note I think that this class should not be a singleton at all.
