### PR TITLE
Hotfix/zf2 412

### DIFF
--- a/library/Zend/Filter/FilterChain.php
+++ b/library/Zend/Filter/FilterChain.php
@@ -11,7 +11,7 @@
 namespace Zend\Filter;
 
 use Countable;
-use Zend\Stdlib\SplPriorityQueue;
+use Zend\Stdlib\PriorityQueue;
 
 /**
  * @category   Zend
@@ -32,7 +32,7 @@ class FilterChain extends AbstractFilter implements Countable
     /**
      * Filter chain
      *
-     * @var SplPriorityQueue
+     * @var PriorityQueue
      */
     protected $filters;
 
@@ -42,7 +42,7 @@ class FilterChain extends AbstractFilter implements Countable
      */
     public function __construct($options = null)
     {
-        $this->filters = new SplPriorityQueue();
+        $this->filters = new PriorityQueue();
 
         if (null !== $options) {
             $this->setOptions($options);
@@ -198,7 +198,7 @@ class FilterChain extends AbstractFilter implements Countable
     /**
      * Get all the filters
      *
-     * @return SplPriorityQueue
+     * @return PriorityQueue
      */
     public function getFilters()
     {

--- a/library/Zend/Filter/FilterPluginManager.php
+++ b/library/Zend/Filter/FilterPluginManager.php
@@ -83,6 +83,13 @@ class FilterPluginManager extends AbstractPluginManager
     );
 
     /**
+     * Whether or not to share by default; default to false
+     *
+     * @var bool
+     */
+    protected $shareByDefault = false;
+
+    /**
      * Validate the plugin
      *
      * Checks that the filter loaded is either a valid callback or an instance

--- a/library/Zend/Validator/ValidatorChain.php
+++ b/library/Zend/Validator/ValidatorChain.php
@@ -177,7 +177,7 @@ class ValidatorChain implements
             }
             $result         = false;
             $messages       = $validator->getMessages();
-            $this->messages = array_merge($this->messages, $messages);
+            $this->messages = array_replace_recursive($this->messages, $messages);
             if ($element['breakChainOnFailure']) {
                 break;
             }

--- a/library/Zend/Validator/ValidatorPluginManager.php
+++ b/library/Zend/Validator/ValidatorPluginManager.php
@@ -107,6 +107,14 @@ class ValidatorPluginManager extends AbstractPluginManager
         'step'                     => 'Zend\Validator\Step',
     );
 
+
+    /**
+     * Whether or not to share by default; default to false
+     *
+     * @var bool
+     */
+    protected $shareByDefault = false;
+
     /**
      * Constructor
      *

--- a/library/Zend/Validator/ValidatorPluginManager.php
+++ b/library/Zend/Validator/ValidatorPluginManager.php
@@ -107,7 +107,6 @@ class ValidatorPluginManager extends AbstractPluginManager
         'step'                     => 'Zend\Validator\Step',
     );
 
-
     /**
      * Whether or not to share by default; default to false
      *

--- a/tests/Zend/Filter/FilterChainTest.php
+++ b/tests/Zend/Filter/FilterChainTest.php
@@ -132,6 +132,32 @@ class FilterChainTest extends \PHPUnit_Framework_TestCase
     {
         return strtoupper($value);
     }
+
+    /**
+     * @group ZF-412
+     */
+    public function testCanAttachMultipleFiltersOfTheSameTypeAsDiscreteInstances()
+    {
+        $chain = new FilterChain();
+        $chain->attachByName('PregReplace', array(
+            'pattern'     => '/Foo/',
+            'replacement' => 'Bar',
+        ));
+        $chain->attachByName('PregReplace', array(
+            'pattern'     => '/Bar/',
+            'replacement' => 'PARTY',
+        ));
+
+        $this->assertEquals(2, count($chain));
+        $filters = $chain->getFilters();
+        $compare = null;
+        foreach ($filters as $filter) {
+            $this->assertNotSame($compare, $filter);
+            $compare = $filter;
+        }
+
+        $this->assertEquals('Tu et PARTY', $chain->filter('Tu et Foo'));
+    }
 }
 
 


### PR DESCRIPTION
Fixes bad behavior in the ValidatorChain and FilterChain whereby they did not allow multiple instances of validators/filters of the same type. Additionally, FilterChain was using Stdlib\SplPriorityQueue internally, which did not allow for multiple iterations of the chain; I changed this to use Stdlib\PriorityQueue instead.

Resolves http://framework.zend.com/issues/browse/ZF2-412
