### PR TITLE
[zen-92] cleanup ServiceManager vs ServiceLocator aware

### DIFF
--- a/library/Zend/Form/View/HelperConfig.php
+++ b/library/Zend/Form/View/HelperConfig.php
@@ -76,9 +76,7 @@ class HelperConfig implements ConfigInterface
      * Configure the provided service manager instance with the configuration
      * in this class.
      *
-     * In addition to using each of the internal properties to configure the
-     * service manager, also adds an initializer to inject ServiceManagerAware
-     * classes with the service manager.
+     * Adds the invokables defined in this class to the SM managing helpers.
      *
      * @param  ServiceManager $serviceManager
      * @return void

--- a/library/Zend/Mvc/Controller/ControllerManager.php
+++ b/library/Zend/Mvc/Controller/ControllerManager.php
@@ -48,7 +48,8 @@ class ControllerManager extends AbstractPluginManager
     public function __construct(ConfigurationInterface $configuration = null)
     {
         parent::__construct($configuration);
-        $this->addInitializer(array($this, 'injectControllerDependencies'));
+        // Pushing to bottom of stack to ensure this is done last
+        $this->addInitializer(array($this, 'injectControllerDependencies'), false);
     }
 
     /**

--- a/library/Zend/Mvc/Service/ServiceManagerConfig.php
+++ b/library/Zend/Mvc/Service/ServiceManagerConfig.php
@@ -13,6 +13,7 @@ namespace Zend\Mvc\Service;
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
 use Zend\ServiceManager\ConfigInterface;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\ServiceManagerAwareInterface;
 
@@ -107,7 +108,7 @@ class ServiceManagerConfig implements ConfigInterface
      *
      * In addition to using each of the internal properties to configure the
      * service manager, also adds an initializer to inject ServiceManagerAware
-     * classes with the service manager.
+     * and ServiceLocatorAware classes with the service manager.
      *
      * @param  ServiceManager $serviceManager
      * @return void
@@ -145,6 +146,12 @@ class ServiceManagerConfig implements ConfigInterface
         $serviceManager->addInitializer(function ($instance) use ($serviceManager) {
             if ($instance instanceof ServiceManagerAwareInterface) {
                 $instance->setServiceManager($serviceManager);
+            }
+        });
+
+        $serviceManager->addInitializer(function ($instance) use ($serviceManager) {
+            if ($instance instanceof ServiceLocatorAwareInterface) {
+                $instance->setServiceLocator($serviceManager);
             }
         });
 

--- a/library/Zend/Navigation/View/HelperConfig.php
+++ b/library/Zend/Navigation/View/HelperConfig.php
@@ -27,9 +27,8 @@ class HelperConfig implements ConfigInterface
      * Configure the provided service manager instance with the configuration
      * in this class.
      *
-     * In addition to using each of the internal properties to configure the
-     * service manager, also adds an initializer to inject ServiceManagerAware
-     * classes with the service manager.
+     * Simply adds a factory for the navigation helper, and has it inject the helper
+     * with the service locator instance.
      *
      * @param  ServiceManager $serviceManager
      * @return void

--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -65,21 +65,11 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
         parent::__construct($configuration);
         $self = $this;
         $this->addInitializer(function ($instance) use ($self) {
-            $locator = $self->getServiceLocator();
-            if (!$locator) {
-                $locator = $self;
-            }
             if ($instance instanceof ServiceLocatorAwareInterface) {
-                $instance->setServiceLocator($locator);
-            }
-        });
-        $this->addInitializer(function ($instance) use ($self) {
-            $locator = $self->getServiceLocator();
-            if (!$locator instanceof ServiceManager) {
-                $locator = $self;
+                $instance->setServiceLocator($self);
             }
             if ($instance instanceof ServiceManagerAwareInterface) {
-                $instance->setServiceManager($locator);
+                $instance->setServiceManager($self);
             }
         });
     }

--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -65,8 +65,21 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
         parent::__construct($configuration);
         $self = $this;
         $this->addInitializer(function ($instance) use ($self) {
+            $locator = $self->getServiceLocator();
+            if (!$locator) {
+                $locator = $self;
+            }
+            if ($instance instanceof ServiceLocatorAwareInterface) {
+                $instance->setServiceLocator($locator);
+            }
+        });
+        $this->addInitializer(function ($instance) use ($self) {
+            $locator = $self->getServiceLocator();
+            if (!$locator instanceof ServiceManager) {
+                $locator = $self;
+            }
             if ($instance instanceof ServiceManagerAwareInterface) {
-                $instance->setServiceManager($self);
+                $instance->setServiceManager($locator);
             }
         });
     }

--- a/tests/Zend/Mvc/ApplicationTest.php
+++ b/tests/Zend/Mvc/ApplicationTest.php
@@ -334,6 +334,9 @@ class ApplicationTest extends TestCase
         $this->assertContains('dispatch', $response->toString());
     }
 
+    /**
+     * @group zen-92
+     */
     public function testDispatchingInjectsLocatorInLocatorAwareControllers()
     {
         $this->setupActionController();


### PR DESCRIPTION
- Removed docblock verbiage about ServiceManagerAware from Navigation
  and Form view helper config classes; copy-and-paste problem only
- Updated Zend\Mvc\Service\ServiceManagerConfig to inject both
  ServiceManagerAware and ServiceLocatorAware classes with the SM
  instance.
