### PR TITLE
Run php-cs-fixer after phpunit on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ before_install:
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
  - curl -s https://getcomposer.org/installer | php -- --quiet
  - php composer.phar install --dev
+ - wget http://cs.sensiolabs.org/get/php-cs-fixer.phar
 
 script:
  - php ./tests/run-tests.php
+ - output=$(php php-cs-fixer.phar fix -v --fixers=elseif,trailing_spaces,linefeed,indentation --dry-run .); if [[ $output ]]; then echo -e "\e[00;31m$output\e[00m"; false; fi;
 
 notifications:
   irc: "irc.freenode.org#zftalk.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 
 script:
  - php ./tests/run-tests.php
- - output=$(php php-cs-fixer.phar fix -v --fixers=elseif,trailing_spaces,linefeed,indentation --dry-run .); if [[ $output ]]; then echo -e "\e[00;31m$output\e[00m"; false; fi;
+ - output=$(php php-cs-fixer.phar fix -v --fixers=elseif,trailing_spaces,linefeed,indentation --dry-run .); if [[ $output ]]; then while read -r line; do echo -e "\e[00;31m$line\e[00m"; done <<< "$output"; false; fi;
 
 notifications:
   irc: "irc.freenode.org#zftalk.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 
 script:
  - php ./tests/run-tests.php
- - output=$(php php-cs-fixer.phar fix -v --fixers=elseif,trailing_spaces,linefeed,indentation --dry-run .); if [[ $output ]]; then while read -r line; do echo -e "\e[00;31m$line\e[00m"; done <<< "$output"; false; fi;
+ - output=$(php php-cs-fixer.phar fix -v --dry-run --level=psr2 .); if [[ $output ]]; then while read -r line; do echo -e "\e[00;31m$line\e[00m"; done <<< "$output"; false; fi;
 
 notifications:
   irc: "irc.freenode.org#zftalk.2"


### PR DESCRIPTION
This PR makes travis run [php-cs-fixer](http://cs.sensiolabs.org/).
- It checks the entire code base against PSR2.
- If there are any CS violations, the build will fail, and it will output a list of the files which have issues in red.

This PR will intentionally fail to show the functionality. Merge [PR #2015](https://github.com/zendframework/zf2/pull/2015), then close and re-open this PR to see it pass.

For the record, I'm not sure if we should _actually_ do this... It's mostly a proof of concept, but if everyone likes it, we can move forward with it.
