### PR TITLE
Hotfix/zf2-423: Zend\Navigation\Page\Mvc::isActive() bugfix

### DIFF
--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -106,21 +106,7 @@ class Mvc extends AbstractPage
     public function isActive($recursive = false)
     {
         if (!$this->active) {
-            $reqParams = array();
-            if ($this->routeMatch instanceof RouteMatch) {
-                $reqParams = $this->routeMatch->getParams();
-
-                if (null !== $this->getRoute()
-                    && $this->routeMatch->getMatchedRouteName() === $this->getRoute()
-                ) {
-                    $this->active = true;
-                    return true;
-                }
-            }
-
-
             $myParams = $this->params;
-
             if (null !== $this->controller) {
                 $myParams['controller'] = $this->controller;
             } else {
@@ -129,21 +115,30 @@ class Mvc extends AbstractPage
                  */
                 $myParams['controller'] = 'index';
             }
-
             if (null !== $this->action) {
                 $myParams['action'] = $this->action;
             } else {
                 /**
                  * @todo In ZF1, this was configurable and pulled from the front controller
                  */
-                $myParams['action'] = 'action';
+                $myParams['action'] = 'index';
             }
 
-            if (count(array_intersect_assoc($reqParams, $myParams)) ==
-                count($myParams)
-            ) {
-                $this->active = true;
-                return true;
+            if ($this->routeMatch instanceof RouteMatch) {
+                $reqParams = $this->routeMatch->getParams();
+                if($this->getRoute() !== null) {
+                    $routeName  = $this->getRoute();
+                } else {
+                    $routeName  = $this->routeMatch->getMatchedRouteName();
+                }
+
+                if ($this->routeMatch->getMatchedRouteName() === $routeName
+                    && (count($reqParams) == count($myParams))
+                    && (count(array_intersect_assoc($reqParams, $myParams)) == count($myParams))
+                ) {
+                    $this->active = true;
+                    return true;
+                }
             }
         }
 

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -105,7 +105,7 @@ class Mvc extends AbstractPage
      */
     public function isActive($recursive = false)
     {
-        if (!$this->active) {
+        if (!$this->active && $this->routeMatch instanceof RouteMatch) {
             $myParams = $this->params;
             if (null !== $this->controller) {
                 $myParams['controller'] = $this->controller;
@@ -124,24 +124,21 @@ class Mvc extends AbstractPage
                 $myParams['action'] = 'index';
             }
 
-            if ($this->routeMatch instanceof RouteMatch) {
-                $reqParams = $this->routeMatch->getParams();
-                if($this->getRoute() !== null) {
-                    $routeName  = $this->getRoute();
-                } else {
-                    $routeName  = $this->routeMatch->getMatchedRouteName();
-                }
+            $reqParams = $this->routeMatch->getParams();
+            if($this->getRoute() !== null) {
+                $routeName  = $this->getRoute();
+            } else {
+                $routeName  = $this->routeMatch->getMatchedRouteName();
+            }
 
-                if ($this->routeMatch->getMatchedRouteName() === $routeName
-                    && (count($reqParams) == count($myParams))
-                    && (count(array_intersect_assoc($reqParams, $myParams)) == count($myParams))
-                ) {
-                    $this->active = true;
-                    return true;
-                }
+            if ($this->routeMatch->getMatchedRouteName() === $routeName
+                && (count($reqParams) == count($myParams))
+                && (count(array_intersect_assoc($reqParams, $myParams)) == count($myParams))
+            ) {
+                $this->active = true;
+                return true;
             }
         }
-
         return parent::isActive($recursive);
     }
 

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -105,8 +105,30 @@ class Mvc extends AbstractPage
      */
     public function isActive($recursive = false)
     {
-        if (!$this->active && $this->routeMatch instanceof RouteMatch) {
+        if (!$this->active) {
+            $reqParams = array();
+            if ($this->routeMatch instanceof RouteMatch) {
+                $reqParams  = $this->routeMatch->getParams();
+
+                $myParams   = $this->params;
+                if (null !== $this->controller) {
+                    $myParams['controller'] = $this->controller;
+                }
+                if (null !== $this->action) {
+                    $myParams['action'] = $this->action;
+                }
+
+                if (null !== $this->getRoute()
+                    && $this->routeMatch->getMatchedRouteName() === $this->getRoute()
+                    && (count(array_intersect_assoc($reqParams, $myParams)) == count($myParams))
+                ) {
+                    $this->active = true;
+                    return true;
+                }
+            }
+
             $myParams = $this->params;
+
             if (null !== $this->controller) {
                 $myParams['controller'] = $this->controller;
             } else {
@@ -115,6 +137,7 @@ class Mvc extends AbstractPage
                  */
                 $myParams['controller'] = 'index';
             }
+
             if (null !== $this->action) {
                 $myParams['action'] = $this->action;
             } else {
@@ -124,21 +147,12 @@ class Mvc extends AbstractPage
                 $myParams['action'] = 'index';
             }
 
-            $reqParams = $this->routeMatch->getParams();
-            if($this->getRoute() !== null) {
-                $routeName  = $this->getRoute();
-            } else {
-                $routeName  = $this->routeMatch->getMatchedRouteName();
-            }
-
-            if ($this->routeMatch->getMatchedRouteName() === $routeName
-                && (count($reqParams) == count($myParams))
-                && (count(array_intersect_assoc($reqParams, $myParams)) == count($myParams))
-            ) {
+            if (count(array_intersect_assoc($reqParams, $myParams)) == count($myParams)) {
                 $this->active = true;
                 return true;
             }
         }
+
         return parent::isActive($recursive);
     }
 

--- a/tests/Zend/Navigation/Page/MvcTest.php
+++ b/tests/Zend/Navigation/Page/MvcTest.php
@@ -122,6 +122,21 @@ class MvcTest extends TestCase
         $this->assertEquals(true, $page->isActive());
     }
 
+    public function testIsActiveReturnsFalseWhenMatchingRouteButNonMatchingParams()
+    {
+        $page       = new Page\Mvc(array(
+                                   'label'     => 'foo',
+                                   'route'     => 'bar',
+                                   'action'    => 'baz',
+                               ));
+        $routeMatch = new RouteMatch(array());
+        $routeMatch->setMatchedRouteName('bar');
+        $routeMatch->setParam('action', 'qux');
+        $page->setRouteMatch($routeMatch);
+
+        $this->assertFalse($page->isActive());
+    }
+
     public function testIsActiveReturnsFalseWhenNoRouteAndNoMatchedRouteNameIsSet()
     {
         $page = new Page\Mvc();


### PR DESCRIPTION
## Zend\Navigation\Page\Mvc::isActive() bugfix

A hotfix for ZF2-423 (and possibly also for ZF2-126).
- Removed bug: Route name match alone was sufficient to mark an MVC page as active (the eventual route parameters were not taken into account).
- Change: Default action name changed from 'action' to 'index'.
