### PR TITLE
Removed underscores from protected Zend\View properties and methods...

### DIFF
--- a/library/Zend/Form/View/Helper/AbstractHelper.php
+++ b/library/Zend/Form/View/Helper/AbstractHelper.php
@@ -210,7 +210,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
                     continue;
                 }
             }
-            //@TODO Escape event attributes like AbstractHtmlElement view helper does in _htmlAttribs ??
+            //@TODO Escape event attributes like AbstractHtmlElement view helper does in htmlAttribs ??
             $strings[] = sprintf('%s="%s"', $escape($key), $escape($value));
         }
         return implode(' ', $strings);

--- a/library/Zend/View/Helper/AbstractHtmlElement.php
+++ b/library/Zend/View/Helper/AbstractHtmlElement.php
@@ -27,7 +27,7 @@ abstract class AbstractHtmlElement extends AbstractHelper
      *
      * @var string
      */
-    protected $_closingBracket = null;
+    protected $closingBracket = null;
 
     /**
      * Get the tag closing bracket
@@ -36,15 +36,15 @@ abstract class AbstractHtmlElement extends AbstractHelper
      */
     public function getClosingBracket()
     {
-        if (!$this->_closingBracket) {
-            if ($this->_isXhtml()) {
-                $this->_closingBracket = ' />';
+        if (!$this->closingBracket) {
+            if ($this->isXhtml()) {
+                $this->closingBracket = ' />';
             } else {
-                $this->_closingBracket = '>';
+                $this->closingBracket = '>';
             }
         }
 
-        return $this->_closingBracket;
+        return $this->closingBracket;
     }
 
     /**
@@ -52,7 +52,7 @@ abstract class AbstractHtmlElement extends AbstractHelper
      *
      * @return boolean
      */
-    protected function _isXhtml()
+    protected function isXhtml()
     {
         $doctype = $this->view->plugin('doctype');
         return $doctype->isXhtml();
@@ -68,7 +68,7 @@ abstract class AbstractHtmlElement extends AbstractHelper
      *
      * @return string The XHTML for the attributes.
      */
-    protected function _htmlAttribs($attribs)
+    protected function htmlAttribs($attribs)
     {
         $xhtml   = '';
         $escaper = $this->view->plugin('escapehtml');
@@ -94,7 +94,7 @@ abstract class AbstractHtmlElement extends AbstractHelper
             }
 
             if ('id' == $key) {
-                $val = $this->_normalizeId($val);
+                $val = $this->normalizeId($val);
             }
 
             if (strpos($val, '"') !== false) {
@@ -113,7 +113,7 @@ abstract class AbstractHtmlElement extends AbstractHelper
      * @param  string $value
      * @return string
      */
-    protected function _normalizeId($value)
+    protected function normalizeId($value)
     {
         if (strstr($value, '[')) {
             if ('[]' == substr($value, -2)) {

--- a/library/Zend/View/Helper/Cycle.php
+++ b/library/Zend/View/Helper/Cycle.php
@@ -30,21 +30,21 @@ class Cycle extends AbstractHelper implements \Iterator
      *
      * @var array
      */
-    protected $_pointers = array(self::DEFAULT_NAME =>-1) ;
+    protected $pointers = array(self::DEFAULT_NAME =>-1) ;
 
     /**
      * Array of values
      *
      * @var array
      */
-    protected $_data = array(self::DEFAULT_NAME=>array());
+    protected $data = array(self::DEFAULT_NAME=>array());
 
     /**
      * Actual name of cycle
      *
      * @var string
      */
-    protected $_name = self::DEFAULT_NAME;
+    protected $name = self::DEFAULT_NAME;
 
     /**
      * Add elements to alternate
@@ -56,7 +56,7 @@ class Cycle extends AbstractHelper implements \Iterator
     public function __invoke(array $data = array(), $name = self::DEFAULT_NAME)
     {
         if(!empty($data))
-           $this->_data[$name] = $data;
+           $this->data[$name] = $data;
 
         $this->setName($name);
         return $this;
@@ -72,7 +72,7 @@ class Cycle extends AbstractHelper implements \Iterator
     public function assign(Array $data , $name = self::DEFAULT_NAME)
     {
         $this->setName($name);
-        $this->_data[$name] = $data;
+        $this->data[$name] = $data;
         $this->rewind();
         return $this;
     }
@@ -85,12 +85,12 @@ class Cycle extends AbstractHelper implements \Iterator
      */
     public function setName($name = self::DEFAULT_NAME)
     {
-       $this->_name = $name;
+       $this->name = $name;
 
-       if(!isset($this->_data[$this->_name]))
-         $this->_data[$this->_name] = array();
+       if(!isset($this->data[$this->name]))
+         $this->data[$this->name] = array();
 
-       if(!isset($this->_pointers[$this->_name]))
+       if(!isset($this->pointers[$this->name]))
          $this->rewind();
 
        return $this;
@@ -104,7 +104,7 @@ class Cycle extends AbstractHelper implements \Iterator
      */
     public function getName()
     {
-        return $this->_name;
+        return $this->name;
     }
 
 
@@ -115,7 +115,7 @@ class Cycle extends AbstractHelper implements \Iterator
      */
     public function getAll()
     {
-        return $this->_data[$this->_name];
+        return $this->data[$this->name];
     }
 
     /**
@@ -125,7 +125,7 @@ class Cycle extends AbstractHelper implements \Iterator
      */
     public function toString()
     {
-        return (string) $this->_data[$this->_name][$this->key()];
+        return (string) $this->data[$this->name][$this->key()];
     }
 
     /**
@@ -145,11 +145,11 @@ class Cycle extends AbstractHelper implements \Iterator
      */
     public function next()
     {
-        $count = count($this->_data[$this->_name]);
-        if ($this->_pointers[$this->_name] == ($count - 1))
-            $this->_pointers[$this->_name] = 0;
+        $count = count($this->data[$this->name]);
+        if ($this->pointers[$this->name] == ($count - 1))
+            $this->pointers[$this->name] = 0;
         else
-            $this->_pointers[$this->_name] = ++$this->_pointers[$this->_name];
+            $this->pointers[$this->name] = ++$this->pointers[$this->name];
         return $this;
     }
 
@@ -160,11 +160,11 @@ class Cycle extends AbstractHelper implements \Iterator
      */
     public function prev()
     {
-        $count = count($this->_data[$this->_name]);
-        if ($this->_pointers[$this->_name] <= 0)
-            $this->_pointers[$this->_name] = $count - 1;
+        $count = count($this->data[$this->name]);
+        if ($this->pointers[$this->name] <= 0)
+            $this->pointers[$this->name] = $count - 1;
         else
-            $this->_pointers[$this->_name] = --$this->_pointers[$this->_name];
+            $this->pointers[$this->name] = --$this->pointers[$this->name];
         return $this;
     }
 
@@ -175,10 +175,10 @@ class Cycle extends AbstractHelper implements \Iterator
      */
     public function key()
     {
-        if ($this->_pointers[$this->_name] < 0)
+        if ($this->pointers[$this->name] < 0)
             return 0;
         else
-            return $this->_pointers[$this->_name];
+            return $this->pointers[$this->name];
     }
 
     /**
@@ -188,7 +188,7 @@ class Cycle extends AbstractHelper implements \Iterator
      */
     public function rewind()
     {
-        $this->_pointers[$this->_name] = -1;
+        $this->pointers[$this->name] = -1;
         return $this;
     }
 
@@ -199,7 +199,7 @@ class Cycle extends AbstractHelper implements \Iterator
      */
     public function valid()
     {
-        return isset($this->_data[$this->_name][$this->key()]);
+        return isset($this->data[$this->name][$this->key()]);
     }
 
     /**
@@ -209,6 +209,6 @@ class Cycle extends AbstractHelper implements \Iterator
      */
     public function current()
     {
-        return $this->_data[$this->_name][$this->key()];
+        return $this->data[$this->name][$this->key()];
     }
 }

--- a/library/Zend/View/Helper/DeclareVars.php
+++ b/library/Zend/View/Helper/DeclareVars.php
@@ -55,10 +55,10 @@ class DeclareVars extends AbstractHelper
         foreach($args as $key) {
             if (is_array($key)) {
                 foreach ($key as $name => $value) {
-                    $this->_declareVar($name, $value);
+                    $this->declareVar($name, $value);
                 }
             } elseif (!isset($view->vars()->$key)) {
-                $this->_declareVar($key);
+                $this->declareVar($key);
             }
         }
     }
@@ -72,7 +72,7 @@ class DeclareVars extends AbstractHelper
      * @param  string $value Defaults to an empty string
      * @return void
      */
-    protected function _declareVar($key, $value = '')
+    protected function declareVar($key, $value = '')
     {
         $view = $this->getView();
         $vars = $view->vars();

--- a/library/Zend/View/Helper/Gravatar.php
+++ b/library/Zend/View/Helper/Gravatar.php
@@ -332,7 +332,7 @@ class Gravatar extends AbstractHtmlElement
     {
         $this->setSrcAttribForImg();
         $html = '<img'
-              . $this->_htmlAttribs($this->getAttribs())
+              . $this->htmlAttribs($this->getAttribs())
               . $this->getClosingBracket();
 
         return $html;

--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -27,12 +27,12 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      *
      * @var array
      */
-    protected $_itemKeys = array('charset', 'href', 'hreflang', 'id', 'media', 'rel', 'rev', 'type', 'title', 'extras');
+    protected $itemKeys = array('charset', 'href', 'hreflang', 'id', 'media', 'rel', 'rev', 'type', 'title', 'extras');
 
     /**
      * @var string registry key
      */
-    protected $_regKey = 'Zend_View_Helper_HeadLink';
+    protected $regKey = 'Zend_View_Helper_HeadLink';
 
     /**
      * Constructor
@@ -160,7 +160,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      * @param  mixed $value
      * @return boolean
      */
-    protected function _isValid($value)
+    protected function isValid($value)
     {
         if (!$value instanceof \stdClass) {
             return false;
@@ -168,7 +168,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
 
         $vars         = get_object_vars($value);
         $keys         = array_keys($vars);
-        $intersection = array_intersect($this->_itemKeys, $keys);
+        $intersection = array_intersect($this->itemKeys, $keys);
         if (empty($intersection)) {
             return false;
         }
@@ -185,7 +185,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      */
     public function append($value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException(
                 'append() expects a data token; please use one of the custom append*() methods'
             );
@@ -204,7 +204,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      */
     public function offsetSet($index, $value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException(
                 'offsetSet() expects a data token; please use one of the custom offsetSet*() methods'
             );
@@ -222,7 +222,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      */
     public function prepend($value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException(
                 'prepend() expects a data token; please use one of the custom prepend*() methods'
             );
@@ -240,7 +240,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      */
     public function set($value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException(
                 'set() expects a data token; please use one of the custom set*() methods'
             );
@@ -261,14 +261,14 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         $attributes = (array) $item;
         $link       = '<link ';
 
-        foreach ($this->_itemKeys as $itemKey) {
+        foreach ($this->itemKeys as $itemKey) {
             if (isset($attributes[$itemKey])) {
                 if(is_array($attributes[$itemKey])) {
                     foreach($attributes[$itemKey] as $key => $value) {
-                        $link .= sprintf('%s="%s" ', $key, ($this->_autoEscape) ? $this->_escape($value) : $value);
+                        $link .= sprintf('%s="%s" ', $key, ($this->autoEscape) ? $this->escape($value) : $value);
                     }
                 } else {
-                    $link .= sprintf('%s="%s" ', $itemKey, ($this->_autoEscape) ? $this->_escape($attributes[$itemKey]) : $attributes[$itemKey]);
+                    $link .= sprintf('%s="%s" ', $itemKey, ($this->autoEscape) ? $this->escape($attributes[$itemKey]) : $attributes[$itemKey]);
                 }
             }
         }
@@ -311,7 +311,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
             $items[] = $this->itemToString($item);
         }
 
-        return $indent . implode($this->_escape($this->getSeparator()) . $indent, $items);
+        return $indent . implode($this->escape($this->getSeparator()) . $indent, $items);
     }
 
     /**
@@ -340,7 +340,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         $conditionalStylesheet = false;
         $href                  = array_shift($args);
 
-        if ($this->_isDuplicateStylesheet($href)) {
+        if ($this->isDuplicateStylesheet($href)) {
             return false;
         }
 
@@ -376,7 +376,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      * @param  string $uri
      * @return bool
      */
-    protected function _isDuplicateStylesheet($uri)
+    protected function isDuplicateStylesheet($uri)
     {
         foreach ($this->getContainer() as $item) {
             if (($item->rel == 'stylesheet') && ($item->href == $uri)) {

--- a/library/Zend/View/Helper/HeadMeta.php
+++ b/library/Zend/View/Helper/HeadMeta.php
@@ -26,14 +26,14 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      * Types of attributes
      * @var array
      */
-    protected $_typeKeys     = array('name', 'http-equiv', 'charset', 'property');
-    protected $_requiredKeys = array('content');
-    protected $_modifierKeys = array('lang', 'scheme');
+    protected $typeKeys     = array('name', 'http-equiv', 'charset', 'property');
+    protected $requiredKeys = array('content');
+    protected $modifierKeys = array('lang', 'scheme');
 
     /**
      * @var string registry key
      */
-    protected $_regKey = 'Zend_View_Helper_HeadMeta';
+    protected $regKey = 'Zend_View_Helper_HeadMeta';
 
     /**
      * Constructor
@@ -85,7 +85,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      * @return string
      * @throws Exception\DomainException
      */
-    protected function _normalizeType($type)
+    protected function normalizeType($type)
     {
         switch ($type) {
             case 'Name':
@@ -96,7 +96,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
                 return 'property';
             default:
                 throw new Exception\DomainException(sprintf(
-                    'Invalid type "%s" passed to _normalizeType',
+                    'Invalid type "%s" passed to normalizeType',
                     $type
                 ));
         }
@@ -128,7 +128,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
     {
         if (preg_match('/^(?P<action>set|(pre|ap)pend|offsetSet)(?P<type>Name|HttpEquiv|Property)$/', $method, $matches)) {
             $action = $matches['action'];
-            $type   = $this->_normalizeType($matches['type']);
+            $type   = $this->normalizeType($matches['type']);
             $argc   = count($args);
             $index  = null;
 
@@ -187,7 +187,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      * @param  mixed $item
      * @return boolean
      */
-    protected function _isValid($item)
+    protected function isValid($item)
     {
         if ((!$item instanceof \stdClass)
             || !isset($item->type)
@@ -220,7 +220,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      */
     public function append($value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException(
                 'Invalid value passed to append; please use appendMeta()'
             );
@@ -239,7 +239,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      */
     public function offsetSet($index, $value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw  new Exception\InvalidArgumentException(
                 'Invalid value passed to offsetSet; please use offsetSetName() or offsetSetHttpEquiv()'
             );
@@ -273,7 +273,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      */
     public function prepend($value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException(
                 'Invalid value passed to prepend; please use prependMeta()'
             );
@@ -291,7 +291,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      */
     public function set($value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException('Invalid value passed to set; please use setMeta()');
         }
 
@@ -317,7 +317,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      */
     public function itemToString(\stdClass $item)
     {
-        if (!in_array($item->type, $this->_typeKeys)) {
+        if (!in_array($item->type, $this->typeKeys)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Invalid type "%s" provided for meta',
                 $item->type
@@ -334,10 +334,10 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
                     'Invalid modifier "scheme" provided; not supported by HTML5'
                 );
             }
-            if (!in_array($key, $this->_modifierKeys)) {
+            if (!in_array($key, $this->modifierKeys)) {
                 continue;
             }
-            $modifiersString .= $key . '="' . $this->_escape($value) . '" ';
+            $modifiersString .= $key . '="' . $this->escape($value) . '" ';
         }
 
         if (method_exists($this->view, 'plugin')) {
@@ -359,8 +359,8 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
         $meta = sprintf(
             $tpl,
             $type,
-            $this->_escape($item->$type),
-            $this->_escape($item->content),
+            $this->escape($item->$type),
+            $this->escape($item->content),
             $modifiersString
         );
 
@@ -368,7 +368,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
             && !empty($item->modifiers['conditional'])
             && is_string($item->modifiers['conditional']))
         {
-            $meta = '<!--[if ' . $this->_escape($item->modifiers['conditional']) . ']>' . $meta . '<![endif]-->';
+            $meta = '<!--[if ' . $this->escape($item->modifiers['conditional']) . ']>' . $meta . '<![endif]-->';
         }
 
         return $meta;
@@ -396,7 +396,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
             trigger_error($e->getMessage(), E_USER_WARNING);
             return '';
         }
-        return $indent . implode($this->_escape($this->getSeparator()) . $indent, $items);
+        return $indent . implode($this->escape($this->getSeparator()) . $indent, $items);
     }
 
     /**

--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -33,29 +33,29 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * Registry key for placeholder
      * @var string
      */
-    protected $_regKey = 'Zend_View_Helper_HeadScript';
+    protected $regKey = 'Zend_View_Helper_HeadScript';
 
     /**
      * Are arbitrary attributes allowed?
      * @var bool
      */
-    protected $_arbitraryAttributes = false;
+    protected $arbitraryAttributes = false;
 
     /**#@+
      * Capture type and/or attributes (used for hinting during capture)
      * @var string
      */
-    protected $_captureLock;
-    protected $_captureScriptType  = null;
-    protected $_captureScriptAttrs = null;
-    protected $_captureType;
+    protected $captureLock;
+    protected $captureScriptType  = null;
+    protected $captureScriptAttrs = null;
+    protected $captureType;
     /**#@-*/
 
     /**
      * Optional allowed attributes for script tag
      * @var array
      */
-    protected $_optionalAttributes = array(
+    protected $optionalAttributes = array(
         'charset', 'defer', 'language', 'src'
     );
 
@@ -63,7 +63,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * Required attributes for script tag
      * @var string
      */
-    protected $_requiredAttributes = array('type');
+    protected $requiredAttributes = array('type');
 
     /**
      * Whether or not to format scripts using CDATA; used only if doctype
@@ -130,14 +130,14 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      */
     public function captureStart($captureType = Placeholder\Container\AbstractContainer::APPEND, $type = 'text/javascript', $attrs = array())
     {
-        if ($this->_captureLock) {
+        if ($this->captureLock) {
             throw new Exception\RuntimeException('Cannot nest headScript captures');
         }
 
-        $this->_captureLock        = true;
-        $this->_captureType        = $captureType;
-        $this->_captureScriptType  = $type;
-        $this->_captureScriptAttrs = $attrs;
+        $this->captureLock        = true;
+        $this->captureType        = $captureType;
+        $this->captureScriptType  = $type;
+        $this->captureScriptAttrs = $attrs;
         ob_start();
     }
 
@@ -149,17 +149,17 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
     public function captureEnd()
     {
         $content                   = ob_get_clean();
-        $type                      = $this->_captureScriptType;
-        $attrs                     = $this->_captureScriptAttrs;
-        $this->_captureScriptType  = null;
-        $this->_captureScriptAttrs = null;
-        $this->_captureLock        = false;
+        $type                      = $this->captureScriptType;
+        $attrs                     = $this->captureScriptAttrs;
+        $this->captureScriptType  = null;
+        $this->captureScriptAttrs = null;
+        $this->captureLock        = false;
 
-        switch ($this->_captureType) {
+        switch ($this->captureType) {
             case Placeholder\Container\AbstractContainer::SET:
             case Placeholder\Container\AbstractContainer::PREPEND:
             case Placeholder\Container\AbstractContainer::APPEND:
-                $action = strtolower($this->_captureType) . 'Script';
+                $action = strtolower($this->captureType) . 'Script';
                 break;
             default:
                 $action = 'appendScript';
@@ -231,7 +231,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
                     break;
                 case 'file':
                 default:
-                    if (!$this->_isDuplicate($content)) {
+                    if (!$this->isDuplicate($content)) {
                         $attrs['src'] = $content;
                         $item = $this->createData($type, $attrs);
                         if ('offsetSet' == $action) {
@@ -255,7 +255,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * @param  string $file Name of file to check
      * @return bool
      */
-    protected function _isDuplicate($file)
+    protected function isDuplicate($file)
     {
         foreach ($this->getContainer() as $item) {
             if (($item->source === null)
@@ -274,7 +274,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * @param  mixed  $value  Is the given script valid?
      * @return bool
      */
-    protected function _isValid($value)
+    protected function isValid($value)
     {
         if ((!$value instanceof \stdClass)
             || !isset($value->type)
@@ -295,7 +295,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      */
     public function append($value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException(
                 'Invalid argument passed to append(); please use one of the helper methods, appendScript() or appendFile()'
             );
@@ -313,7 +313,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      */
     public function prepend($value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException(
                 'Invalid argument passed to prepend(); please use one of the helper methods, prependScript() or prependFile()'
             );
@@ -331,7 +331,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      */
     public function set($value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException(
                 'Invalid argument passed to set(); please use one of the helper methods, setScript() or setFile()'
             );
@@ -350,7 +350,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      */
     public function offsetSet($index, $value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException(
                 'Invalid argument passed to offsetSet(); please use one of the helper methods, offsetSetScript() or offsetSetFile()'
             );
@@ -367,7 +367,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      */
     public function setAllowArbitraryAttributes($flag)
     {
-        $this->_arbitraryAttributes = (bool) $flag;
+        $this->arbitraryAttributes = (bool) $flag;
         return $this;
     }
 
@@ -378,7 +378,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      */
     public function arbitraryAttributesAllowed()
     {
-        return $this->_arbitraryAttributes;
+        return $this->arbitraryAttributes;
     }
 
     /**
@@ -395,7 +395,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
         $attrString = '';
         if (!empty($item->attributes)) {
             foreach ($item->attributes as $key => $value) {
-                if ((!$this->arbitraryAttributesAllowed() && !in_array($key, $this->_optionalAttributes))
+                if ((!$this->arbitraryAttributesAllowed() && !in_array($key, $this->optionalAttributes))
                     || in_array($key, array('conditional', 'noescape')))
                 {
                     continue;
@@ -403,14 +403,14 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
                 if ('defer' == $key) {
                     $value = 'defer';
                 }
-                $attrString .= sprintf(' %s="%s"', $key, ($this->_autoEscape) ? $this->_escape($value) : $value);
+                $attrString .= sprintf(' %s="%s"', $key, ($this->autoEscape) ? $this->escape($value) : $value);
             }
         }
 
 
         $addScriptEscape = !(isset($item->attributes['noescape']) && filter_var($item->attributes['noescape'], FILTER_VALIDATE_BOOLEAN));
 
-        $type = ($this->_autoEscape) ? $this->_escape($item->type) : $item->type;
+        $type = ($this->autoEscape) ? $this->escape($item->type) : $item->type;
         $html  = '<script type="' . $type . '"' . $attrString . '>';
         if (!empty($item->source)) {
             $html .= PHP_EOL ;
@@ -465,7 +465,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
         $items = array();
         $this->getContainer()->ksort();
         foreach ($this as $item) {
-            if (!$this->_isValid($item)) {
+            if (!$this->isValid($item)) {
                 continue;
             }
 

--- a/library/Zend/View/Helper/HeadStyle.php
+++ b/library/Zend/View/Helper/HeadStyle.php
@@ -25,19 +25,19 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      * Registry key for placeholder
      * @var string
      */
-    protected $_regKey = 'Zend_View_Helper_HeadStyle';
+    protected $regKey = 'Zend_View_Helper_HeadStyle';
 
     /**
      * Allowed optional attributes
      * @var array
      */
-    protected $_optionalAttributes = array('lang', 'title', 'media', 'dir');
+    protected $optionalAttributes = array('lang', 'title', 'media', 'dir');
 
     /**
      * Allowed media types
      * @var array
      */
-    protected $_mediaTypes = array(
+    protected $mediaTypes = array(
         'all', 'aural', 'braille', 'handheld', 'print',
         'projection', 'screen', 'tty', 'tv'
     );
@@ -46,19 +46,19 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      * Capture type and/or attributes (used for hinting during capture)
      * @var string
      */
-    protected $_captureAttrs = null;
+    protected $captureAttrs = null;
 
     /**
      * Capture lock
      * @var bool
      */
-    protected $_captureLock;
+    protected $captureLock;
 
     /**
      * Capture type (append, prepend, set)
      * @var string
      */
-    protected $_captureType;
+    protected $captureType;
 
     /**
      * Constructor
@@ -166,7 +166,7 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      * @param  string $method
      * @return boolean
      */
-    protected function _isValid($value)
+    protected function isValid($value)
     {
         if ((!$value instanceof \stdClass)
             || !isset($value->content)
@@ -187,7 +187,7 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      */
     public function append($value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException(
                 'Invalid value passed to append; please use appendStyle()'
             );
@@ -206,7 +206,7 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      */
     public function offsetSet($index, $value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException(
                 'Invalid value passed to offsetSet; please use offsetSetStyle()'
             );
@@ -224,7 +224,7 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      */
     public function prepend($value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException(
                 'Invalid value passed to prepend; please use prependStyle()'
             );
@@ -242,7 +242,7 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      */
     public function set($value)
     {
-        if (!$this->_isValid($value)) {
+        if (!$this->isValid($value)) {
             throw new Exception\InvalidArgumentException('Invalid value passed to set; please use setStyle()');
         }
 
@@ -259,13 +259,13 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      */
     public function captureStart($type = Placeholder\Container\AbstractContainer::APPEND, $attrs = null)
     {
-        if ($this->_captureLock) {
+        if ($this->captureLock) {
             throw new Exception\RuntimeException('Cannot nest headStyle captures');
         }
 
-        $this->_captureLock        = true;
-        $this->_captureAttrs       = $attrs;
-        $this->_captureType        = $type;
+        $this->captureLock        = true;
+        $this->captureAttrs       = $attrs;
+        $this->captureType        = $type;
         ob_start();
     }
 
@@ -277,11 +277,11 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
     public function captureEnd()
     {
         $content             = ob_get_clean();
-        $attrs               = $this->_captureAttrs;
-        $this->_captureAttrs = null;
-        $this->_captureLock  = false;
+        $attrs               = $this->captureAttrs;
+        $this->captureAttrs = null;
+        $this->captureLock  = false;
 
-        switch ($this->_captureType) {
+        switch ($this->captureType) {
             case Placeholder\Container\AbstractContainer::SET:
                 $this->setStyle($content, $attrs);
                 break;
@@ -313,12 +313,12 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
                 $enc = $this->view->getEncoding();
             }
             foreach ($item->attributes as $key => $value) {
-                if (!in_array($key, $this->_optionalAttributes)) {
+                if (!in_array($key, $this->optionalAttributes)) {
                     continue;
                 }
                 if ('media' == $key) {
                     if(false === strpos($value, ',')) {
-                        if (!in_array($value, $this->_mediaTypes)) {
+                        if (!in_array($value, $this->mediaTypes)) {
                             continue;
                         }
                     } else {
@@ -326,7 +326,7 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
                         $value = '';
                         foreach($media_types as $type) {
                             $type = trim($type);
-                            if (!in_array($type, $this->_mediaTypes)) {
+                            if (!in_array($type, $this->mediaTypes)) {
                                 continue;
                             }
                             $value .= $type .',';
@@ -374,7 +374,7 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
         $items = array();
         $this->getContainer()->ksort();
         foreach ($this as $item) {
-            if (!$this->_isValid($item)) {
+            if (!$this->isValid($item)) {
                 continue;
             }
             $items[] = $this->itemToString($item, $indent);

--- a/library/Zend/View/Helper/HeadTitle.php
+++ b/library/Zend/View/Helper/HeadTitle.php
@@ -27,14 +27,14 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
      * Registry key for placeholder
      * @var string
      */
-    protected $_regKey = 'Zend_View_Helper_HeadTitle';
+    protected $regKey = 'Zend_View_Helper_HeadTitle';
 
     /**
      * Default title rendering order (i.e. order in which each title attached)
      *
      * @var string
      */
-    protected $_defaultAttachOrder = null;
+    protected $defaultAttachOrder = null;
 
     /**
      * Translator (optional)
@@ -104,7 +104,7 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
                 "You must use a valid attach order: 'PREPEND', 'APPEND' or 'SET'"
             );
         }
-        $this->_defaultAttachOrder = $setType;
+        $this->defaultAttachOrder = $setType;
 
         return $this;
     }
@@ -116,7 +116,7 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
      */
     public function getDefaultAttachOrder()
     {
-        return $this->_defaultAttachOrder;
+        return $this->defaultAttachOrder;
     }
 
     /**
@@ -160,7 +160,7 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
             $output .= $postfix;
         }
 
-        $output = ($this->_autoEscape) ? $this->_escape($output) : $output;
+        $output = ($this->autoEscape) ? $this->escape($output) : $output;
 
         return $indent . '<title>' . $output . '</title>';
     }

--- a/library/Zend/View/Helper/HtmlList.php
+++ b/library/Zend/View/Helper/HtmlList.php
@@ -50,7 +50,7 @@ class HtmlList extends AbstractHtmlElement
         }
 
         if ($attribs) {
-            $attribs = $this->_htmlAttribs($attribs);
+            $attribs = $this->htmlAttribs($attribs);
         } else {
             $attribs = '';
         }

--- a/library/Zend/View/Helper/HtmlObject.php
+++ b/library/Zend/View/Helper/HtmlObject.php
@@ -51,7 +51,7 @@ class HtmlObject extends AbstractHtmlElement
 
             $options = array_merge(array('name' => $param), $options);
 
-            $paramHtml[] = '<param' . $this->_htmlAttribs($options) . $closingBracket;
+            $paramHtml[] = '<param' . $this->htmlAttribs($options) . $closingBracket;
         }
 
         // Content
@@ -60,7 +60,7 @@ class HtmlObject extends AbstractHtmlElement
         }
 
         // Object header
-        $xhtml = '<object' . $this->_htmlAttribs($attribs) . '>' . self::EOL
+        $xhtml = '<object' . $this->htmlAttribs($attribs) . '>' . self::EOL
                  . implode(self::EOL, $paramHtml) . self::EOL
                  . ($content ? $content . self::EOL : '')
                  . '</object>';

--- a/library/Zend/View/Helper/HtmlPage.php
+++ b/library/Zend/View/Helper/HtmlPage.php
@@ -34,7 +34,7 @@ class HtmlPage extends AbstractHtmlElement
      *
      * @var array
      */
-    protected $_attribs = array('classid' => self::ATTRIB_CLASSID);
+    protected $attribs = array('classid' => self::ATTRIB_CLASSID);
 
     /**
      * Output a html object tag
@@ -48,7 +48,7 @@ class HtmlPage extends AbstractHtmlElement
     public function __invoke($data, array $attribs = array(), array $params = array(), $content = null)
     {
         // Attrs
-        $attribs = array_merge($this->_attribs, $attribs);
+        $attribs = array_merge($this->attribs, $attribs);
 
         // Params
         $params = array_merge(array('data' => $data), $params);

--- a/library/Zend/View/Helper/HtmlQuicktime.php
+++ b/library/Zend/View/Helper/HtmlQuicktime.php
@@ -40,7 +40,7 @@ class HtmlQuicktime extends AbstractHtmlElement
      *
      * @var array
      */
-    protected $_attribs = array('classid'  => self::ATTRIB_CLASSID,
+    protected $attribs = array('classid'  => self::ATTRIB_CLASSID,
                                 'codebase' => self::ATTRIB_CODEBASE);
 
     /**
@@ -55,7 +55,7 @@ class HtmlQuicktime extends AbstractHtmlElement
     public function __invoke($data, array $attribs = array(), array $params = array(), $content = null)
     {
         // Attrs
-        $attribs = array_merge($this->_attribs, $attribs);
+        $attribs = array_merge($this->attribs, $attribs);
 
         // Params
         $params = array_merge(array('src' => $data), $params);

--- a/library/Zend/View/Helper/InlineScript.php
+++ b/library/Zend/View/Helper/InlineScript.php
@@ -23,7 +23,7 @@ class InlineScript extends HeadScript
      * Registry key for placeholder
      * @var string
      */
-    protected $_regKey = 'Zend_View_Helper_InlineScript';
+    protected $regKey = 'Zend_View_Helper_InlineScript';
 
     /**
      * Return InlineScript object

--- a/library/Zend/View/Helper/Navigation.php
+++ b/library/Zend/View/Helper/Navigation.php
@@ -193,7 +193,7 @@ class Navigation extends AbstractNavigationHelper
         $class  = get_class($helper);
 
         if (!isset($this->injected[$class])) {
-            $this->_inject($helper);
+            $this->inject($helper);
             $this->injected[$class] = true;
         }
 
@@ -207,7 +207,7 @@ class Navigation extends AbstractNavigationHelper
      * @param  NavigationHelper $helper  helper instance
      * @return void
      */
-    protected function _inject(NavigationHelper $helper)
+    protected function inject(NavigationHelper $helper)
     {
         if ($this->getInjectContainer() && !$helper->hasContainer()) {
             $helper->setContainer($this->getContainer());

--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -604,7 +604,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
 
         $escaper = $this->view->plugin('escapeHtml');
 
-        return '<a' . $this->_htmlAttribs($attribs) . '>'
+        return '<a' . $this->htmlAttribs($attribs) . '>'
              . $escaper($label)
              . '</a>';
     }
@@ -794,13 +794,13 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     /**
      * Converts an associative array to a string of tag attributes.
      *
-     * Overloads {@link View\Helper\AbstractHtmlElement::_htmlAttribs()}.
+     * Overloads {@link View\Helper\AbstractHtmlElement::htmlAttribs()}.
      *
      * @param  array $attribs  an array where each key-value pair is converted
      *                         to an attribute name and value
      * @return string          an attribute string
      */
-    protected function _htmlAttribs($attribs)
+    protected function htmlAttribs($attribs)
     {
         // filter out null values and empty string values
         foreach ($attribs as $key => $value) {
@@ -809,18 +809,18 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
             }
         }
 
-        return parent::_htmlAttribs($attribs);
+        return parent::htmlAttribs($attribs);
     }
 
     /**
      * Normalize an ID
      *
-     * Overrides {@link View\Helper\AbstractHtmlElement::_normalizeId()}.
+     * Overrides {@link View\Helper\AbstractHtmlElement::normalizeId()}.
      *
      * @param  string $value
      * @return string
      */
-    protected function _normalizeId($value)
+    protected function normalizeId($value)
     {
         $prefix = get_class($this);
         $prefix = strtolower(trim(substr($prefix, strrpos($prefix, '\\')), '\\'));

--- a/library/Zend/View/Helper/Navigation/Links.php
+++ b/library/Zend/View/Helper/Navigation/Links.php
@@ -716,7 +716,7 @@ class Links extends AbstractHelper
         );
 
         return '<link' .
-               $this->_htmlAttribs($attribs) .
+               $this->htmlAttribs($attribs) .
                $this->getClosingBracket();
     }
 

--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -222,7 +222,7 @@ class Menu extends AbstractHelper
         }
 
         $escaper = $this->view->plugin('escapeHtml');
-        return '<' . $element . $this->_htmlAttribs($attribs) . '>'
+        return '<' . $element . $this->htmlAttribs($attribs) . '>'
              . $escaper($label)
              . '</' . $element . '>';
     }
@@ -344,7 +344,7 @@ class Menu extends AbstractHelper
      * @param  bool                      $onlyActive  render only active branch?
      * @return string
      */
-    protected function _renderMenu(AbstractContainer $container,
+    protected function renderNormalMenu(AbstractContainer $container,
                                    $ulClass,
                                    $indent,
                                    $minDepth,
@@ -480,7 +480,7 @@ class Menu extends AbstractHelper
                                               $options['minDepth'],
                                               $options['maxDepth']);
         } else {
-            $html = $this->_renderMenu($container,
+            $html = $this->renderNormalMenu($container,
                                        $options['ulClass'],
                                        $options['indent'],
                                        $options['minDepth'],
@@ -496,7 +496,7 @@ class Menu extends AbstractHelper
      *
      * This is a convenience method which is equivalent to the following call:
      * <code>
-     * _renderMenu($container, array(
+     * renderMenu($container, array(
      *     'indent'           => $indent,
      *     'ulClass'          => $ulClass,
      *     'minDepth'         => null,

--- a/library/Zend/View/Helper/Partial.php
+++ b/library/Zend/View/Helper/Partial.php
@@ -24,7 +24,7 @@ class Partial extends AbstractHelper
      * Variable to which object will be assigned
      * @var string
      */
-    protected $_objectKey;
+    protected $objectKey;
 
     /**
      * Renders a template fragment within a variable scope distinct from the
@@ -94,9 +94,9 @@ class Partial extends AbstractHelper
     public function setObjectKey($key)
     {
         if (null === $key) {
-            $this->_objectKey = null;
+            $this->objectKey = null;
         } else {
-            $this->_objectKey = (string) $key;
+            $this->objectKey = (string) $key;
         }
 
         return $this;
@@ -112,6 +112,6 @@ class Partial extends AbstractHelper
      */
     public function getObjectKey()
     {
-        return $this->_objectKey;
+        return $this->objectKey;
     }
 }

--- a/library/Zend/View/Helper/Placeholder.php
+++ b/library/Zend/View/Helper/Placeholder.php
@@ -27,23 +27,23 @@ class Placeholder extends AbstractHelper
      * Placeholder items
      * @var array
      */
-    protected $_items = array();
+    protected $items = array();
 
     /**
      * @var \Zend\View\Helper\Placeholder\Registry
      */
-    protected $_registry;
+    protected $registry;
 
     /**
      * Constructor
      *
-     * Retrieve container registry from Zend_Registry, or create new one and register it.
+     * Retrieve container registry from Placeholder\Registry, or create new one and register it.
      *
      * @return void
      */
     public function __construct()
     {
-        $this->_registry = Placeholder\Registry::getRegistry();
+        $this->registry = Placeholder\Registry::getRegistry();
     }
 
     /**
@@ -60,7 +60,7 @@ class Placeholder extends AbstractHelper
         }
 
         $name = (string) $name;
-        return $this->_registry->getContainer($name);
+        return $this->registry->getContainer($name);
     }
 
     /**
@@ -70,6 +70,6 @@ class Placeholder extends AbstractHelper
      */
     public function getRegistry()
     {
-        return $this->_registry;
+        return $this->registry;
     }
 }

--- a/library/Zend/View/Helper/Placeholder/Container/AbstractContainer.php
+++ b/library/Zend/View/Helper/Placeholder/Container/AbstractContainer.php
@@ -42,43 +42,43 @@ abstract class AbstractContainer extends \ArrayObject
      * What text to prefix the placeholder with when rendering
      * @var string
      */
-    protected $_prefix    = '';
+    protected $prefix    = '';
 
     /**
      * What text to append the placeholder with when rendering
      * @var string
      */
-    protected $_postfix   = '';
+    protected $postfix   = '';
 
     /**
      * What string to use between individual items in the placeholder when rendering
      * @var string
      */
-    protected $_separator = '';
+    protected $separator = '';
 
     /**
      * What string to use as the indentation of output, this will typically be spaces. Eg: '    '
      * @var string
      */
-    protected $_indent = '';
+    protected $indent = '';
 
     /**
      * Whether or not we're already capturing for this given container
      * @var bool
      */
-    protected $_captureLock = false;
+    protected $captureLock = false;
 
     /**
      * What type of capture (overwrite (set), append, prepend) to use
      * @var string
      */
-    protected $_captureType;
+    protected $captureType;
 
     /**
      * Key to which to capture content
      * @var string
      */
-    protected $_captureKey;
+    protected $captureKey;
 
     /**
      * Constructor - This is needed so that we can attach a class member as the ArrayObject container
@@ -141,7 +141,7 @@ abstract class AbstractContainer extends \ArrayObject
      */
     public function setPrefix($prefix)
     {
-        $this->_prefix = (string) $prefix;
+        $this->prefix = (string) $prefix;
         return $this;
     }
 
@@ -152,7 +152,7 @@ abstract class AbstractContainer extends \ArrayObject
      */
     public function getPrefix()
     {
-        return $this->_prefix;
+        return $this->prefix;
     }
 
     /**
@@ -163,7 +163,7 @@ abstract class AbstractContainer extends \ArrayObject
      */
     public function setPostfix($postfix)
     {
-        $this->_postfix = (string) $postfix;
+        $this->postfix = (string) $postfix;
         return $this;
     }
 
@@ -174,7 +174,7 @@ abstract class AbstractContainer extends \ArrayObject
      */
     public function getPostfix()
     {
-        return $this->_postfix;
+        return $this->postfix;
     }
 
     /**
@@ -187,7 +187,7 @@ abstract class AbstractContainer extends \ArrayObject
      */
     public function setSeparator($separator)
     {
-        $this->_separator = (string) $separator;
+        $this->separator = (string) $separator;
         return $this;
     }
 
@@ -198,7 +198,7 @@ abstract class AbstractContainer extends \ArrayObject
      */
     public function getSeparator()
     {
-        return $this->_separator;
+        return $this->separator;
     }
 
     /**
@@ -210,7 +210,7 @@ abstract class AbstractContainer extends \ArrayObject
      */
     public function setIndent($indent)
     {
-        $this->_indent = $this->getWhitespace($indent);
+        $this->indent = $this->getWhitespace($indent);
         return $this;
     }
 
@@ -221,7 +221,7 @@ abstract class AbstractContainer extends \ArrayObject
      */
     public function getIndent()
     {
-        return $this->_indent;
+        return $this->indent;
     }
 
     /**
@@ -248,16 +248,16 @@ abstract class AbstractContainer extends \ArrayObject
      */
     public function captureStart($type = AbstractContainer::APPEND, $key = null)
     {
-        if ($this->_captureLock) {
+        if ($this->captureLock) {
             throw new Exception\RuntimeException(
                 'Cannot nest placeholder captures for the same placeholder'
             );
         }
 
-        $this->_captureLock = true;
-        $this->_captureType = $type;
+        $this->captureLock = true;
+        $this->captureType = $type;
         if ((null !== $key) && is_scalar($key)) {
-            $this->_captureKey = (string) $key;
+            $this->captureKey = (string) $key;
         }
         ob_start();
     }
@@ -271,11 +271,11 @@ abstract class AbstractContainer extends \ArrayObject
     {
         $data               = ob_get_clean();
         $key                = null;
-        $this->_captureLock = false;
-        if (null !== $this->_captureKey) {
-            $key = $this->_captureKey;
+        $this->captureLock = false;
+        if (null !== $this->captureKey) {
+            $key = $this->captureKey;
         }
-        switch ($this->_captureType) {
+        switch ($this->captureType) {
             case self::SET:
                 if (null !== $key) {
                     $this[$key] = $data;

--- a/library/Zend/View/Helper/Placeholder/Container/AbstractStandalone.php
+++ b/library/Zend/View/Helper/Placeholder/Container/AbstractStandalone.php
@@ -26,25 +26,25 @@ abstract class AbstractStandalone
     /**
      * @var \Zend\View\Helper\Placeholder\Container\AbstractContainer
      */
-    protected $_container;
+    protected $container;
 
     /**
      * @var \Zend\View\Helper\Placeholder\Registry
      */
-    protected $_registry;
+    protected $registry;
 
     /**
      * Registry key under which container registers itself
      * @var string
      */
-    protected $_regKey;
+    protected $regKey;
 
     /**
      * Flag wheter to automatically escape output, must also be
      * enforced in the child class if __toString/toString is overriden
      * @var book
      */
-    protected $_autoEscape = true;
+    protected $autoEscape = true;
 
     /**
      * Constructor
@@ -54,7 +54,7 @@ abstract class AbstractStandalone
     public function __construct()
     {
         $this->setRegistry(Registry::getRegistry());
-        $this->setContainer($this->getRegistry()->getContainer($this->_regKey));
+        $this->setContainer($this->getRegistry()->getContainer($this->regKey));
     }
 
     /**
@@ -64,7 +64,7 @@ abstract class AbstractStandalone
      */
     public function getRegistry()
     {
-        return $this->_registry;
+        return $this->registry;
     }
 
     /**
@@ -75,7 +75,7 @@ abstract class AbstractStandalone
      */
     public function setRegistry(Registry $registry)
     {
-        $this->_registry = $registry;
+        $this->registry = $registry;
         return $this;
     }
 
@@ -87,7 +87,7 @@ abstract class AbstractStandalone
      */
     public function setAutoEscape($autoEscape = true)
     {
-        $this->_autoEscape = ($autoEscape) ? true : false;
+        $this->autoEscape = ($autoEscape) ? true : false;
         return $this;
     }
 
@@ -98,7 +98,7 @@ abstract class AbstractStandalone
      */
     public function getAutoEscape()
     {
-        return $this->_autoEscape;
+        return $this->autoEscape;
     }
 
     /**
@@ -107,7 +107,7 @@ abstract class AbstractStandalone
      * @param  string $string
      * @return string
      */
-    protected function _escape($string)
+    protected function escape($string)
     {
         $enc = 'UTF-8';
         if ($this->view instanceof \Zend\View\Renderer\RendererInterface
@@ -136,7 +136,7 @@ abstract class AbstractStandalone
      */
     public function setContainer(AbstractContainer $container)
     {
-        $this->_container = $container;
+        $this->container = $container;
         return $this;
     }
 
@@ -147,7 +147,7 @@ abstract class AbstractStandalone
      */
     public function getContainer()
     {
-        return $this->_container;
+        return $this->container;
     }
 
     /**

--- a/library/Zend/View/Helper/Placeholder/Registry.php
+++ b/library/Zend/View/Helper/Placeholder/Registry.php
@@ -29,13 +29,13 @@ class Registry
      * Default container class
      * @var string
      */
-    protected $_containerClass = 'Zend\View\Helper\Placeholder\Container';
+    protected $containerClass = 'Zend\View\Helper\Placeholder\Container';
 
     /**
      * Placeholder containers
      * @var array
      */
-    protected $_items = array();
+    protected $items = array();
 
     /**
      * Retrieve or create registry instance
@@ -74,8 +74,8 @@ class Registry
     {
         $key = (string) $key;
 
-        $this->_items[$key] = new $this->_containerClass($value);
-        return $this->_items[$key];
+        $this->items[$key] = new $this->containerClass($value);
+        return $this->items[$key];
     }
 
     /**
@@ -87,8 +87,8 @@ class Registry
     public function getContainer($key)
     {
         $key = (string) $key;
-        if (isset($this->_items[$key])) {
-            return $this->_items[$key];
+        if (isset($this->items[$key])) {
+            return $this->items[$key];
         }
 
         $container = $this->createContainer($key);
@@ -105,7 +105,7 @@ class Registry
     public function containerExists($key)
     {
         $key = (string) $key;
-        $return =  array_key_exists($key, $this->_items);
+        $return =  array_key_exists($key, $this->items);
         return $return;
     }
 
@@ -119,7 +119,7 @@ class Registry
     public function setContainer($key, Container\AbstractContainer $container)
     {
         $key = (string) $key;
-        $this->_items[$key] = $container;
+        $this->items[$key] = $container;
         return $this;
     }
 
@@ -132,8 +132,8 @@ class Registry
     public function deleteContainer($key)
     {
         $key = (string) $key;
-        if (isset($this->_items[$key])) {
-            unset($this->_items[$key]);
+        if (isset($this->items[$key])) {
+            unset($this->items[$key]);
             return true;
         }
 
@@ -162,7 +162,7 @@ class Registry
             throw new Exception\InvalidArgumentException('Invalid Container class specified');
         }
 
-        $this->_containerClass = $name;
+        $this->containerClass = $name;
         return $this;
     }
 
@@ -173,6 +173,6 @@ class Registry
      */
     public function getContainerClass()
     {
-        return $this->_containerClass;
+        return $this->containerClass;
     }
 }

--- a/library/Zend/View/Helper/ServerUrl.php
+++ b/library/Zend/View/Helper/ServerUrl.php
@@ -24,14 +24,14 @@ class ServerUrl extends AbstractHelper
      *
      * @var string
      */
-    protected $_scheme;
+    protected $scheme;
 
     /**
      * Host (including port)
      *
      * @var string
      */
-    protected $_host;
+    protected $host;
 
     /**
      * Constructor
@@ -97,7 +97,7 @@ class ServerUrl extends AbstractHelper
      */
     public function getHost()
     {
-        return $this->_host;
+        return $this->host;
     }
 
     /**
@@ -108,7 +108,7 @@ class ServerUrl extends AbstractHelper
      */
     public function setHost($host)
     {
-        $this->_host = $host;
+        $this->host = $host;
         return $this;
     }
 
@@ -119,7 +119,7 @@ class ServerUrl extends AbstractHelper
      */
     public function getScheme()
     {
-        return $this->_scheme;
+        return $this->scheme;
     }
 
     /**
@@ -130,7 +130,7 @@ class ServerUrl extends AbstractHelper
      */
     public function setScheme($scheme)
     {
-        $this->_scheme = $scheme;
+        $this->scheme = $scheme;
         return $this;
     }
 }

--- a/library/Zend/View/Stream.php
+++ b/library/Zend/View/Stream.php
@@ -33,21 +33,21 @@ class Stream
      *
      * @var int
      */
-    protected $_pos = 0;
+    protected $pos = 0;
 
     /**
      * Data for streaming.
      *
      * @var string
      */
-    protected $_data;
+    protected $data;
 
     /**
      * Stream stats.
      *
      * @var array
      */
-    protected $_stat;
+    protected $stat;
 
     /**
      * Opens the script file and converts markup.
@@ -56,14 +56,14 @@ class Stream
     {
         // get the view script source
         $path        = str_replace('zend.view://', '', $path);
-        $this->_data = file_get_contents($path);
+        $this->data = file_get_contents($path);
 
         /**
          * If reading the file failed, update our local stat store
          * to reflect the real stat of the file, then return on failure
          */
-        if ($this->_data === false) {
-            $this->_stat = stat($path);
+        if ($this->data === false) {
+            $this->stat = stat($path);
             return false;
         }
 
@@ -71,15 +71,15 @@ class Stream
          * Convert <?= ?> to long-form <?php echo ?> and <?php ?> to <?php ?>
          *
          */
-        $this->_data = preg_replace('/\<\?\=/',          "<?php echo ",  $this->_data);
-        $this->_data = preg_replace('/<\?(?!xml|php)/s', '<?php ',       $this->_data);
+        $this->data = preg_replace('/\<\?\=/',          "<?php echo ",  $this->data);
+        $this->data = preg_replace('/<\?(?!xml|php)/s', '<?php ',       $this->data);
 
         /**
          * file_get_contents() won't update PHP's stat cache, so we grab a stat
          * of the file to prevent additional reads should the script be
          * requested again, which will make include() happy.
          */
-        $this->_stat = stat($path);
+        $this->stat = stat($path);
 
         return true;
     }
@@ -91,7 +91,7 @@ class Stream
      */
     public function url_stat()
     {
-        return $this->_stat;
+        return $this->stat;
     }
 
     /**
@@ -99,8 +99,8 @@ class Stream
      */
     public function stream_read($count)
     {
-        $ret = substr($this->_data, $this->_pos, $count);
-        $this->_pos += strlen($ret);
+        $ret = substr($this->data, $this->pos, $count);
+        $this->pos += strlen($ret);
         return $ret;
     }
 
@@ -110,7 +110,7 @@ class Stream
      */
     public function stream_tell()
     {
-        return $this->_pos;
+        return $this->pos;
     }
 
 
@@ -119,7 +119,7 @@ class Stream
      */
     public function stream_eof()
     {
-        return $this->_pos >= strlen($this->_data);
+        return $this->pos >= strlen($this->data);
     }
 
 
@@ -128,7 +128,7 @@ class Stream
      */
     public function stream_stat()
     {
-        return $this->_stat;
+        return $this->stat;
     }
 
 
@@ -139,8 +139,8 @@ class Stream
     {
         switch ($whence) {
             case SEEK_SET:
-                if ($offset < strlen($this->_data) && $offset >= 0) {
-                $this->_pos = $offset;
+                if ($offset < strlen($this->data) && $offset >= 0) {
+                $this->pos = $offset;
                     return true;
                 } else {
                     return false;
@@ -149,7 +149,7 @@ class Stream
 
             case SEEK_CUR:
                 if ($offset >= 0) {
-                    $this->_pos += $offset;
+                    $this->pos += $offset;
                     return true;
                 } else {
                     return false;
@@ -157,8 +157,8 @@ class Stream
                 break;
 
             case SEEK_END:
-                if (strlen($this->_data) + $offset >= 0) {
-                    $this->_pos = strlen($this->_data) + $offset;
+                if (strlen($this->data) + $offset >= 0) {
+                    $this->pos = strlen($this->data) + $offset;
                     return true;
                 } else {
                     return false;


### PR DESCRIPTION
This required renaming _renderMenu to _renderNormalMenu in Helper\Navigation\Menu to avoid conflicts.

I've confirmed that I haven't broken any unit tests by doing the refactoring (and, of course, I tried to be very careful); however, I haven't tested all of these changes in an actual web app.  If I broke anything, it's a sign that more test coverage is needed.
