### PR TITLE
If a service locator is set, it should be preferred over the pluginmanag...

### DIFF
--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -66,7 +66,11 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
         $self = $this;
         $this->addInitializer(function ($instance) use ($self) {
             if ($instance instanceof ServiceLocatorAwareInterface) {
-                $instance->setServiceLocator($self);
+                $locator = $self->getServiceLocator();
+                if (!$locator) {
+                    $locator = $self;
+                }
+                $instance->setServiceLocator($locator);
             }
             if ($instance instanceof ServiceManagerAwareInterface) {
                 $instance->setServiceManager($self);


### PR DESCRIPTION
...er instance

I might be a little confused on this one, but shouldn't the existing serviceLocator instance be preferred if it exists? (looks like this was changed zen-92)
