### PR TITLE
Rely on log formatters for DateTime formatting

### DIFF
--- a/library/Zend/Log/Formatter/ErrorHandler.php
+++ b/library/Zend/Log/Formatter/ErrorHandler.php
@@ -10,6 +10,7 @@
 
 namespace Zend\Log\Formatter;
 
+use DateTime;
 use Zend\Log\Exception;
 
 /**
@@ -17,36 +18,9 @@ use Zend\Log\Exception;
  * @package    Zend_Log
  * @subpackage Formatter
  */
-class ErrorHandler implements FormatterInterface
+class ErrorHandler extends Simple
 {
     const DEFAULT_FORMAT = '%timestamp% %priorityName% (%priority%) %message% (errno %extra[errno]%) in %extra[file]% on line %extra[line]%';
-
-    /**
-     * Format
-     *
-     * @var string
-     */
-    protected $format;
-
-    /**
-     * Class constructor
-     *
-     * @param null|string $format Format specifier for log messages
-     * @return ErrorHandler
-     * @throws Exception\InvalidArgumentException
-     */
-    public function __construct($format = null)
-    {
-        if ($format === null) {
-            $format = self::DEFAULT_FORMAT;
-        }
-
-        if (!is_string($format)) {
-            throw new Exception\InvalidArgumentException('Format must be a string');
-        }
-
-        $this->format = $format;
-    }
 
     /**
      * This method formats the event for the PHP Error Handler.
@@ -57,6 +31,11 @@ class ErrorHandler implements FormatterInterface
     public function format($event)
     {
         $output = $this->format;
+
+        if (isset($event['timestamp']) && $event['timestamp'] instanceof DateTime) {
+            $event['timestamp'] = $event['timestamp']->format($this->dateTimeFormat);
+        }
+
         foreach ($event as $name => $value) {
             if (is_array($value)) {
                 foreach ($value as $sname => $svalue) {
@@ -66,6 +45,7 @@ class ErrorHandler implements FormatterInterface
                 $output = str_replace("%$name%", $value, $output);
             }
         }
+
         return $output;
     }
 }

--- a/library/Zend/Log/Formatter/ErrorHandler.php
+++ b/library/Zend/Log/Formatter/ErrorHandler.php
@@ -33,7 +33,7 @@ class ErrorHandler extends Simple
         $output = $this->format;
 
         if (isset($event['timestamp']) && $event['timestamp'] instanceof DateTime) {
-            $event['timestamp'] = $event['timestamp']->format($this->dateTimeFormat);
+            $event['timestamp'] = $event['timestamp']->format($this->getDateTimeFormat());
         }
 
         foreach ($event as $name => $value) {

--- a/library/Zend/Log/Formatter/ExceptionHandler.php
+++ b/library/Zend/Log/Formatter/ExceptionHandler.php
@@ -10,6 +10,8 @@
 
 namespace Zend\Log\Formatter;
 
+use DateTime;
+
 /**
  * @category   Zend
  * @package    Zend_Log
@@ -18,6 +20,14 @@ namespace Zend\Log\Formatter;
 class ExceptionHandler implements FormatterInterface
 {
     /**
+     * Format specifier for DateTime objects in event data
+     *
+     * @see http://php.net/manual/en/function.date.php
+     * @var string
+     */
+    protected $dateTimeFormat = self::DEFAULT_DATETIME_FORMAT;
+
+    /**
      * This method formats the event for the PHP Exception
      *
      * @param array $event
@@ -25,6 +35,10 @@ class ExceptionHandler implements FormatterInterface
      */
     public function format($event)
     {
+        if (isset($event['timestamp']) && $event['timestamp'] instanceof DateTime) {
+            $event['timestamp'] = $event['timestamp']->format($this->dateTimeFormat);
+        }
+
         $output = $event['timestamp'] . ' ' . $event['priorityName'] . ' ('
                 . $event['priority'] . ') ' . $event['message'] .' in '
                 . $event['extra']['file'] . ' on line ' . $event['extra']['line'];
@@ -43,6 +57,15 @@ class ExceptionHandler implements FormatterInterface
         }
 
         return $output;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setDateTimeFormat($dateTimeFormat)
+    {
+        $this->dateTimeFormat = (string) $dateTimeFormat;
+        return $this;
     }
 
     /**

--- a/library/Zend/Log/Formatter/ExceptionHandler.php
+++ b/library/Zend/Log/Formatter/ExceptionHandler.php
@@ -36,7 +36,7 @@ class ExceptionHandler implements FormatterInterface
     public function format($event)
     {
         if (isset($event['timestamp']) && $event['timestamp'] instanceof DateTime) {
-            $event['timestamp'] = $event['timestamp']->format($this->dateTimeFormat);
+            $event['timestamp'] = $event['timestamp']->format($this->getDateTimeFormat());
         }
 
         $output = $event['timestamp'] . ' ' . $event['priorityName'] . ' ('
@@ -57,6 +57,14 @@ class ExceptionHandler implements FormatterInterface
         }
 
         return $output;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDateTimeFormat()
+    {
+        return $this->dateTimeFormat;
     }
 
     /**

--- a/library/Zend/Log/Formatter/FirePhp.php
+++ b/library/Zend/Log/Formatter/FirePhp.php
@@ -31,6 +31,16 @@ class FirePhp implements FormatterInterface
     /**
      * This method is implemented for FormatterInterface but not used.
      *
+     * @return string
+     */
+    public function getDateTimeFormat()
+    {
+        return '';
+    }
+
+    /**
+     * This method is implemented for FormatterInterface but not used.
+     *
      * @param string $dateTimeFormat
      * @return FormatterInterface
      */

--- a/library/Zend/Log/Formatter/FirePhp.php
+++ b/library/Zend/Log/Formatter/FirePhp.php
@@ -18,7 +18,7 @@ namespace Zend\Log\Formatter;
 class FirePhp implements FormatterInterface
 {
     /**
-     * Formats the given evevnt data into a single line to be written by the writer.
+     * Formats the given event data into a single line to be written by the writer.
      *
      * @param array $event The event data which should be formatted.
      * @return string
@@ -26,5 +26,16 @@ class FirePhp implements FormatterInterface
     public function format($event)
     {
         return $event['message'];
+    }
+
+    /**
+     * This method is implemented for FormatterInterface but not used.
+     *
+     * @param string $dateTimeFormat
+     * @return FormatterInterface
+     */
+    public function setDateTimeFormat($dateTimeFormat)
+    {
+        return $this;
     }
 }

--- a/library/Zend/Log/Formatter/FormatterInterface.php
+++ b/library/Zend/Log/Formatter/FormatterInterface.php
@@ -32,7 +32,14 @@ interface FormatterInterface
     public function format($event);
 
     /**
-     * Formats data into a single line to be written by the writer.
+     * Get the format specifier for DateTime objects
+     *
+     * @return string
+     */
+    public function getDateTimeFormat();
+
+    /**
+     * Set the format specifier for DateTime objects
      *
      * @see http://php.net/manual/en/function.date.php
      * @param string $dateTimeFormat DateTime format

--- a/library/Zend/Log/Formatter/FormatterInterface.php
+++ b/library/Zend/Log/Formatter/FormatterInterface.php
@@ -17,10 +17,26 @@ namespace Zend\Log\Formatter;
 interface FormatterInterface
 {
     /**
+     * Default format specifier for DateTime objects is ISO 8601
+     *
+     * @see http://php.net/manual/en/function.date.php
+     */
+    const DEFAULT_DATETIME_FORMAT = 'c';
+
+    /**
      * Formats data into a single line to be written by the writer.
      *
      * @param array $event event data
      * @return string formatted line to write to the log
      */
     public function format($event);
+
+    /**
+     * Formats data into a single line to be written by the writer.
+     *
+     * @see http://php.net/manual/en/function.date.php
+     * @param string $dateTimeFormat DateTime format
+     * @return FormatterInterface
+     */
+    public function setDateTimeFormat($dateTimeFormat);
 }

--- a/library/Zend/Log/Formatter/Simple.php
+++ b/library/Zend/Log/Formatter/Simple.php
@@ -10,6 +10,7 @@
 
 namespace Zend\Log\Formatter;
 
+use DateTime;
 use Zend\Log\Exception;
 
 /**
@@ -19,31 +20,42 @@ use Zend\Log\Exception;
  */
 class Simple implements FormatterInterface
 {
+    const DEFAULT_FORMAT = '%timestamp% %priorityName% (%priority%): %message% %info%';
+
     /**
+     * Format specifier for log messages
+     *
      * @var string
      */
     protected $format;
 
-    const DEFAULT_FORMAT = '%timestamp% %priorityName% (%priority%): %message% %info%';
+    /**
+     * Format specifier for DateTime objects in event data (default: ISO 8601)
+     *
+     * @see http://php.net/manual/en/function.date.php
+     * @var string
+     */
+    protected $dateTimeFormat = self::DEFAULT_DATETIME_FORMAT;
 
     /**
      * Class constructor
      *
+     * @see http://php.net/manual/en/function.date.php
      * @param null|string $format Format specifier for log messages
-     * @return Simple
+     * @param null|string $dateTimeFormat Format specifier for DateTime objects in event data
      * @throws Exception\InvalidArgumentException
      */
-    public function __construct($format = null)
+    public function __construct($format = null, $dateTimeFormat = null)
     {
-        if ($format === null) {
-            $format = self::DEFAULT_FORMAT . PHP_EOL;
-        }
-
-        if (!is_string($format)) {
+        if (isset($format) && !is_string($format)) {
             throw new Exception\InvalidArgumentException('Format must be a string');
         }
 
-        $this->format = $format;
+        $this->format = isset($format) ? $format : static::DEFAULT_FORMAT;
+
+        if (isset($dateTimeFormat)) {
+            $this->dateTimeFormat = $dateTimeFormat;
+        }
     }
 
     /**
@@ -59,6 +71,11 @@ class Simple implements FormatterInterface
         if (!isset($event['info'])) {
             $event['info'] = '';
         }
+
+        if (isset($event['timestamp']) && $event['timestamp'] instanceof DateTime) {
+            $event['timestamp'] = $event['timestamp']->format($this->dateTimeFormat);
+        }
+
         foreach ($event as $name => $value) {
             if ((is_object($value) && !method_exists($value,'__toString'))
                 || is_array($value)
@@ -70,5 +87,14 @@ class Simple implements FormatterInterface
         }
 
         return $output;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setDateTimeFormat($dateTimeFormat)
+    {
+        $this->dateTimeFormat = (string) $dateTimeFormat;
+        return $this;
     }
 }

--- a/library/Zend/Log/Formatter/Simple.php
+++ b/library/Zend/Log/Formatter/Simple.php
@@ -73,7 +73,7 @@ class Simple implements FormatterInterface
         }
 
         if (isset($event['timestamp']) && $event['timestamp'] instanceof DateTime) {
-            $event['timestamp'] = $event['timestamp']->format($this->dateTimeFormat);
+            $event['timestamp'] = $event['timestamp']->format($this->getDateTimeFormat());
         }
 
         foreach ($event as $name => $value) {
@@ -87,6 +87,14 @@ class Simple implements FormatterInterface
         }
 
         return $output;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDateTimeFormat()
+    {
+        return $this->dateTimeFormat;
     }
 
     /**

--- a/library/Zend/Log/Formatter/Xml.php
+++ b/library/Zend/Log/Formatter/Xml.php
@@ -130,7 +130,7 @@ class Xml implements FormatterInterface
     public function format($event)
     {
         if (isset($event['timestamp']) && $event['timestamp'] instanceof DateTime) {
-            $event['timestamp'] = $event['timestamp']->format($this->dateTimeFormat);
+            $event['timestamp'] = $event['timestamp']->format($this->getDateTimeFormat());
         }
 
         if ($this->elementMap === null) {
@@ -162,6 +162,14 @@ class Xml implements FormatterInterface
         $xml = preg_replace('/<\?xml version="1.0"( encoding="[^\"]*")?\?>\n/u', '', $xml);
 
         return $xml . PHP_EOL;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDateTimeFormat()
+    {
+        return $this->dateTimeFormat;
     }
 
     /**

--- a/library/Zend/Log/Formatter/Xml.php
+++ b/library/Zend/Log/Formatter/Xml.php
@@ -10,6 +10,7 @@
 
 namespace Zend\Log\Formatter;
 
+use DateTime;
 use DOMDocument;
 use DOMElement;
 use Traversable;
@@ -38,6 +39,14 @@ class Xml implements FormatterInterface
     protected $encoding;
 
     /**
+     * Format specifier for DateTime objects in event data (default: ISO 8601)
+     *
+     * @see http://php.net/manual/en/function.date.php
+     * @var string
+     */
+    protected $dateTimeFormat = self::DEFAULT_DATETIME_FORMAT;
+
+    /**
      * Class constructor
      * (the default encoding is UTF-8)
      *
@@ -64,6 +73,10 @@ class Xml implements FormatterInterface
             if (count($args)) {
                 $options['encoding'] = array_shift($args);
             }
+
+            if (count($args)) {
+                $options['dateTimeFormat'] = array_shift($args);
+            }
         }
 
         if (!array_key_exists('rootElement', $options)) {
@@ -79,6 +92,10 @@ class Xml implements FormatterInterface
 
         if (array_key_exists('elementMap', $options)) {
             $this->elementMap  = $options['elementMap'];
+        }
+
+        if (array_key_exists('dateTimeFormat', $options)) {
+            $this->setDateTimeFormat($options['dateTimeFormat']);
         }
     }
 
@@ -112,6 +129,10 @@ class Xml implements FormatterInterface
      */
     public function format($event)
     {
+        if (isset($event['timestamp']) && $event['timestamp'] instanceof DateTime) {
+            $event['timestamp'] = $event['timestamp']->format($this->dateTimeFormat);
+        }
+
         if ($this->elementMap === null) {
             $dataToInsert = $event;
         } else {
@@ -141,5 +162,14 @@ class Xml implements FormatterInterface
         $xml = preg_replace('/<\?xml version="1.0"( encoding="[^\"]*")?\?>\n/u', '', $xml);
 
         return $xml . PHP_EOL;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setDateTimeFormat($dateTimeFormat)
+    {
+        $this->dateTimeFormat = (string) $dateTimeFormat;
+        return $this;
     }
 }

--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -37,14 +37,6 @@ class Logger implements LoggerInterface
     const DEBUG  = 7;
 
     /**
-     * The format of the date used for a log entry (ISO 8601 date)
-     *
-     * @see http://nl3.php.net/manual/en/function.date.php
-     * @var string
-     */
-    protected $dateTimeFormat = 'c';
-
-    /**
      * List of priority code => priority (short) name
      *
      * @var array
@@ -111,29 +103,6 @@ class Logger implements LoggerInterface
                 $writer->shutdown();
             } catch (\Exception $e) {}
         }
-    }
-
-    /**
-     * Return the format of DateTime
-     *
-     * @return string
-     */
-    public function getDateTimeFormat()
-    {
-        return $this->dateTimeFormat;
-    }
-
-    /**
-     * Set the format of DateTime
-     *
-     * @see    http://nl3.php.net/manual/en/function.date.php
-     * @param  string $format
-     * @return Logger
-     */
-    public function setDateTimeFormat($format)
-    {
-        $this->dateTimeFormat = (string) $format;
-        return $this;
     }
 
     /**
@@ -274,8 +243,7 @@ class Logger implements LoggerInterface
             throw new Exception\RuntimeException('No log writer specified');
         }
 
-        $date = new DateTime();
-        $timestamp = $date->format($this->getDateTimeFormat());
+        $timestamp = new DateTime();
 
         if (is_array($message)) {
             $message = var_export($message, true);

--- a/library/Zend/Log/Writer/Mail.php
+++ b/library/Zend/Log/Writer/Mail.php
@@ -181,7 +181,7 @@ class Mail extends AbstractWriter
         }
 
         // Always provide events to mail as plaintext.
-        $this->mail->setBody(implode('', $this->eventsToMail));
+        $this->mail->setBody(implode(PHP_EOL, $this->eventsToMail));
 
         // Finally, send the mail.  If an exception occurs, convert it into a
         // warning-level message so we can avoid an exception thrown without a

--- a/library/Zend/Log/Writer/MongoDB.php
+++ b/library/Zend/Log/Writer/MongoDB.php
@@ -11,7 +11,9 @@
 
 namespace Zend\Log\Writer;
 
+use DateTime;
 use Mongo;
+use MongoDate;
 use Traversable;
 use Zend\Log\Exception\InvalidArgumentException;
 use Zend\Log\Exception\RuntimeException;
@@ -107,6 +109,10 @@ class MongoDB extends AbstractWriter
     {
         if (null === $this->mongoCollection) {
             throw new RuntimeException('MongoCollection must be defined');
+        }
+
+        if (isset($event['timestamp']) && $event['timestamp'] instanceof DateTime) {
+            $event['timestamp'] = new MongoDate($event['timestamp']->getTimestamp());
         }
 
         $this->mongoCollection->save($event, $this->saveOptions);

--- a/library/Zend/Log/Writer/Stream.php
+++ b/library/Zend/Log/Writer/Stream.php
@@ -92,7 +92,7 @@ class Stream extends AbstractWriter
      */
     protected function doWrite(array $event)
     {
-        $line = $this->formatter->format($event);
+        $line = $this->formatter->format($event) . PHP_EOL;
 
         ErrorHandler::start(E_WARNING);
         $result = fwrite($this->stream, $line);

--- a/tests/Zend/Log/Formatter/ErrorHandlerTest.php
+++ b/tests/Zend/Log/Formatter/ErrorHandlerTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\Log\Formatter;
 
+use DateTime;
 use Zend\Log\Formatter\ErrorHandler;
 
 /**
@@ -22,7 +23,8 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 {
     public function testFormat()
     {
-        $date = date('c');
+        $date = new DateTime();
+
         $event = array(
             'timestamp'    => $date,
             'message'      => 'test',
@@ -37,6 +39,6 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
         $formatter = new ErrorHandler();
         $output = $formatter->format($event);
 
-        $this->assertEquals($date . ' CRIT (1) test (errno 1) in test.php on line 1', $output);
+        $this->assertEquals($date->format('c') . ' CRIT (1) test (errno 1) in test.php on line 1', $output);
     }
 }

--- a/tests/Zend/Log/Formatter/ErrorHandlerTest.php
+++ b/tests/Zend/Log/Formatter/ErrorHandlerTest.php
@@ -41,4 +41,13 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($date->format('c') . ' CRIT (1) test (errno 1) in test.php on line 1', $output);
     }
+
+    public function testSetDateTimeFormat()
+    {
+        $formatter = new ErrorHandler();
+
+        $this->assertEquals('c', $formatter->getDateTimeFormat());
+        $this->assertSame($formatter, $formatter->setDateTimeFormat('r'));
+        $this->assertEquals('r', $formatter->getDateTimeFormat());
+    }
 }

--- a/tests/Zend/Log/Formatter/ExceptionHandlerTest.php
+++ b/tests/Zend/Log/Formatter/ExceptionHandlerTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\Log\Formatter;
 
+use DateTime;
 use Zend\Log\Formatter\ExceptionHandler;
 
 /**
@@ -22,12 +23,14 @@ class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
 {
     public function testFormat()
     {
+        $date = new DateTime();
+
         $event = array(
-            'timestamp'    => '2012-06-12T09:00:00+02:00',
+            'timestamp'    => $date,
             'message'      => 'test',
             'priority'     => 1,
             'priorityName' => 'CRIT',
-            'extra' => array (
+            'extra' => array(
                 'file'  => 'test.php',
                 'line'  => 1,
                 'trace' => array(
@@ -53,7 +56,7 @@ class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
 
         // The formatter ends with unix style line endings so make sure we expect that
         // output as well:
-        $expected = "2012-06-12T09:00:00+02:00 CRIT (1) test in test.php on line 1\n";
+        $expected = $date->format('c') . " CRIT (1) test in test.php on line 1\n";
         $expected .= "[Trace]\n";
         $expected .= "File  : test.php\n";
         $expected .= "Line  : 1\n";
@@ -78,5 +81,39 @@ class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
         $output = $formatter->format($event);
 
         $this->assertEquals($expected, $output);
+    }
+
+    /**
+     * @dataProvider provideDateTimeFormats
+     */
+    public function testSetDateTimeFormat($dateTimeFormat)
+    {
+        $date = new DateTime();
+
+        $event = array(
+            'timestamp'    => $date,
+            'message'      => 'test',
+            'priority'     => 1,
+            'priorityName' => 'CRIT',
+            'extra' => array(
+                'file'  => 'test.php',
+                'line'  => 1,
+            ),
+        );
+
+        $expected = $date->format($dateTimeFormat) . ' CRIT (1) test in test.php on line 1';
+
+        $formatter = new ExceptionHandler();
+
+        $this->assertSame($formatter, $formatter->setDateTimeFormat($dateTimeFormat));
+        $this->assertEquals($expected, $formatter->format($event));
+    }
+
+    public function provideDateTimeFormats()
+    {
+        return array(
+            array('r'),
+            array('U'),
+        );
     }
 }

--- a/tests/Zend/Log/Formatter/ExceptionHandlerTest.php
+++ b/tests/Zend/Log/Formatter/ExceptionHandlerTest.php
@@ -106,6 +106,7 @@ class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
         $formatter = new ExceptionHandler();
 
         $this->assertSame($formatter, $formatter->setDateTimeFormat($dateTimeFormat));
+        $this->assertEquals($dateTimeFormat, $formatter->getDateTimeFormat());
         $this->assertEquals($expected, $formatter->format($event));
     }
 

--- a/tests/Zend/Log/Formatter/FirePhpTest.php
+++ b/tests/Zend/Log/Formatter/FirePhpTest.php
@@ -42,4 +42,13 @@ class FirePhpTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains($fields['message'], $line);
     }
+
+    public function testSetDateTimeFormatDoesNothing()
+    {
+        $formatter = new FirePhp();
+
+        $this->assertEquals('', $formatter->getDateTimeFormat());
+        $this->assertSame($formatter, $formatter->setDateTimeFormat('r'));
+        $this->assertEquals('', $formatter->getDateTimeFormat());
+    }
 }

--- a/tests/Zend/Log/Formatter/SimpleTest.php
+++ b/tests/Zend/Log/Formatter/SimpleTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\Log\Formatter;
 
+use DateTime;
 use ZendTest\Log\TestAsset\StringObject;
 use Zend\Log\Formatter\Simple;
 
@@ -29,7 +30,8 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultFormat()
     {
-        $fields = array('timestamp'    => 0,
+        $date = new DateTime();
+        $fields = array('timestamp'    => $date,
                         'message'      => 'foo',
                         'priority'     => 42,
                         'priorityName' => 'bar');
@@ -37,7 +39,7 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
         $f = new Simple();
         $line = $f->format($fields);
 
-        $this->assertContains((string)$fields['timestamp'], $line);
+        $this->assertContains($date->format('c'), $line, 'Default date format is ISO 8601');
         $this->assertContains($fields['message'], $line);
         $this->assertContains($fields['priorityName'], $line);
         $this->assertContains((string)$fields['priority'], $line);
@@ -45,7 +47,7 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
 
     public function testComplexValues()
     {
-        $fields = array('timestamp'    => 0,
+        $fields = array('timestamp'    => new DateTime(),
                         'priority'     => 42,
                         'priorityName' => 'bar');
 
@@ -57,11 +59,11 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
 
         $fields['message'] = 10;
         $line = $f->format($fields);
-        $this->assertContains($fields['message'], $line);
+        $this->assertContains((string)$fields['message'], $line);
 
         $fields['message'] = 10.5;
         $line = $f->format($fields);
-        $this->assertContains($fields['message'], $line);
+        $this->assertContains((string)$fields['message'], $line);
 
         $fields['message'] = true;
         $line = $f->format($fields);
@@ -86,6 +88,39 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider provideDateTimeFormats
+     */
+    public function testCustomDateTimeFormat($dateTimeFormat)
+    {
+        $date = new DateTime();
+        $event = array('timestamp' => $date);
+        $formatter = new Simple('%timestamp%', $dateTimeFormat);
+
+        $this->assertEquals($date->format($dateTimeFormat), $formatter->format($event));
+    }
+
+    /**
+     * @dataProvider provideDateTimeFormats
+     */
+    public function testSetDateTimeFormat($dateTimeFormat)
+    {
+        $date = new DateTime();
+        $event = array('timestamp' => $date);
+        $formatter = new Simple('%timestamp%');
+
+        $this->assertSame($formatter, $formatter->setDateTimeFormat($dateTimeFormat));
+        $this->assertEquals($date->format($dateTimeFormat), $formatter->format($event));
+    }
+
+    public function provideDateTimeFormats()
+    {
+        return array(
+            array('r'),
+            array('U'),
+        );
+    }
+
+    /**
      * @group ZF-10427
      */
     public function testDefaultFormatShouldDisplayExtraInformations()
@@ -93,7 +128,7 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
         $message = 'custom message';
         $exception = new \RuntimeException($message);
         $event = array(
-            'timestamp'    => date('c'),
+            'timestamp'    => new DateTime(),
             'message'      => 'Application error',
             'priority'     => 2,
             'priorityName' => 'CRIT',

--- a/tests/Zend/Log/Formatter/SimpleTest.php
+++ b/tests/Zend/Log/Formatter/SimpleTest.php
@@ -109,6 +109,7 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
         $formatter = new Simple('%timestamp%');
 
         $this->assertSame($formatter, $formatter->setDateTimeFormat($dateTimeFormat));
+        $this->assertEquals($dateTimeFormat, $formatter->getDateTimeFormat());
         $this->assertEquals($date->format($dateTimeFormat), $formatter->format($event));
     }
 

--- a/tests/Zend/Log/Formatter/XmlTest.php
+++ b/tests/Zend/Log/Formatter/XmlTest.php
@@ -58,6 +58,7 @@ class XmlTest extends \PHPUnit_Framework_TestCase
         $date = new DateTime();
         $f = new XmlFormatter();
         $this->assertSame($f, $f->setDateTimeFormat($dateTimeFormat));
+        $this->assertContains($dateTimeFormat, $f->getDateTimeFormat());
         $this->assertContains($date->format($dateTimeFormat), $f->format(array('timestamp' => $date)));
     }
 

--- a/tests/Zend/Log/Formatter/XmlTest.php
+++ b/tests/Zend/Log/Formatter/XmlTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\Log\Formatter;
 
+use DateTime;
 use ZendTest\Log\TestAsset\SerializableObject;
 use Zend\Log\Formatter\Xml as XmlFormatter;
 
@@ -23,9 +24,11 @@ class XmlTest extends \PHPUnit_Framework_TestCase
 {
     public function testDefaultFormat()
     {
+        $date = new DateTime();
         $f = new XmlFormatter();
-        $line = $f->format(array('message' => 'foo', 'priority' => 42));
+        $line = $f->format(array('timestamp' => $date, 'message' => 'foo', 'priority' => 42));
 
+        $this->assertContains($date->format('c'), $line);
         $this->assertContains('foo', $line);
         $this->assertContains((string)42, $line);
     }
@@ -35,6 +38,35 @@ class XmlTest extends \PHPUnit_Framework_TestCase
         $f = new XmlFormatter('log', array('foo' => 'bar'));
         $line = $f->format(array('bar' => 'baz'));
         $this->assertContains('<log><foo>baz</foo></log>', $line);
+    }
+
+    /**
+     * @dataProvider provideDateTimeFormats
+     */
+    public function testConfiguringDateTimeFormat($dateTimeFormat)
+    {
+        $date = new DateTime();
+        $f = new XmlFormatter('log', null, 'UTF-8', $dateTimeFormat);
+        $this->assertContains($date->format($dateTimeFormat), $f->format(array('timestamp' => $date)));
+    }
+
+    /**
+     * @dataProvider provideDateTimeFormats
+     */
+    public function testSetDateTimeFormat($dateTimeFormat)
+    {
+        $date = new DateTime();
+        $f = new XmlFormatter();
+        $this->assertSame($f, $f->setDateTimeFormat($dateTimeFormat));
+        $this->assertContains($date->format($dateTimeFormat), $f->format(array('timestamp' => $date)));
+    }
+
+    public function provideDateTimeFormats()
+    {
+        return array(
+            array('r'),
+            array('U'),
+        );
     }
 
     public function testXmlDeclarationIsStripped()
@@ -81,18 +113,22 @@ class XmlTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorWithArray()
     {
+        $date = new DateTime();
         $options = array(
             'rootElement' => 'log',
             'elementMap' => array(
+                'date' => 'timestamp',
                 'word' => 'message',
                 'priority' => 'priority'
-            )
+            ),
+            'dateTimeFormat' => 'r',
         );
         $event = array(
+            'timestamp' => $date,
             'message' => 'tottakai',
             'priority' => 4
         );
-        $expected = '<log><word>tottakai</word><priority>4</priority></log>';
+        $expected = sprintf('<log><date>%s</date><word>tottakai</word><priority>4</priority></log>', $date->format('r'));
 
         $formatter = new XmlFormatter($options);
         $output = $formatter->format($event);

--- a/tests/Zend/Log/LoggerTest.php
+++ b/tests/Zend/Log/LoggerTest.php
@@ -29,17 +29,6 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $this->logger = new Logger;
     }
 
-    public function testUsesDateFormatIso8601ByDefault()
-    {
-        $this->assertEquals('c', $this->logger->getDateTimeFormat());
-    }
-
-    public function testPassingStringToSetDateTimeFormat()
-    {
-        $this->logger->setDateTimeFormat('U');
-        $this->assertEquals('U', $this->logger->getDateTimeFormat());
-    }
-
     public function testUsesWriterPluginManagerByDefault()
     {
         $this->assertInstanceOf('Zend\Log\WriterPluginManager', $this->logger->getWriterPluginManager());

--- a/tests/Zend/Log/Writer/MongoDBTest.php
+++ b/tests/Zend/Log/Writer/MongoDBTest.php
@@ -11,6 +11,8 @@
 
 namespace ZendTest\Log\Writer;
 
+use DateTime;
+use MongoDate;
 use Zend\Log\Logger;
 use Zend\Log\Writer\MongoDB as MongoDBWriter;
 
@@ -80,6 +82,20 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase
             ->with($event, $saveOptions);
 
         $writer = new MongoDBWriter($this->mongo, $this->database, $this->collection, $saveOptions);
+
+        $writer->write($event);
+    }
+
+    public function testWriteConvertsDateTimeToMongoDate()
+    {
+        $date = new DateTime();
+        $event = array('timestamp'=> $date);
+
+        $this->mongoCollection->expects($this->once())
+            ->method('save')
+            ->with($this->contains(new MongoDate($date->getTimestamp()), false));
+
+        $writer = new MongoDBWriter($this->mongo, $this->database, $this->collection);
 
         $writer->write($event);
     }


### PR DESCRIPTION
See: [this thread on fw-core](http://zend-framework-community.634137.n4.nabble.com/fw-core-Relocating-Logger-log-date-formatting-to-formatters-td4655676.html) for context.

This shifts date formatting responsibilities to the log formatter classes. The basic logic I used was to check whether the `timestamp` field in event data is a DateTime, and invoke it's `format()` method if so. Writers that do not support a formatter, or those that work with event data outside of `FormatterInterface::format()`, will be responsible for handling the DateTime object on their own.

Here is the state of the existing writers:
- **Db**: This writer doesn't support a formatter. I assume the `timestamp` field in event data is currently inserted into a string column. Ideally, I think we'd want to store this as a native date type, but I'm not familiar enough with the DB layer to determine how to accomplish this.
- **FirePhp**: This only references the `message` and `priority` fields in event data. In its formatter class, I implemented the `setDateTimeFormat()` method (to adhere to the interface change) but it does nothing.
- **Mail** and **Stream**: These writers construct a vanilla SimpleFormatter internally, which means the default date format (ISO 8601) will be used unless the user changes the formatter with the writer's `setFormatter()` method. I suppose this is OK.
- **MongoDB**: If the `timestamp` field in event data is a DateTime instance, it is converted to MongoDate.
- **Syslog**: Formatters are optional. Without a formatter, only the `message` field in event data is used. I don't think anything needs to be done here.
- **ZendMonitor**: I also unfamiliar with this writer and I found little documentation on the `zend_monitor_custom_event()` and `monitor_custom_event()` functions. Would this writer require conversion of the DateTime object, or is it reasonable to store that directly?
