### PR TITLE
Fix criteria for DB session garbage collection

### DIFF
--- a/library/Zend/Session/SaveHandler/DbTableGateway.php
+++ b/library/Zend/Session/SaveHandler/DbTableGateway.php
@@ -170,7 +170,7 @@ class DbTableGateway implements SaveHandlerInterface
     public function gc($maxlifetime)
     {
         $platform = $this->tableGateway->getAdapter()->getPlatform();
-        return (bool) $this->tableGateway->delete(sprintf('%s + %s > %d',
+        return (bool) $this->tableGateway->delete(sprintf('%s + %s < %d',
             $platform->quoteIdentifier($this->options->getModifiedColumn()),
             $platform->quoteIdentifier($this->options->getLifetimeColumn()),
             time()


### PR DESCRIPTION
Sessions are expired if their modified timestamp plus lifetime is less than, not greater than, the current time.
