### PR TITLE
Inject options from constructor into parent

### DIFF
--- a/library/Zend/Validator/GreaterThan.php
+++ b/library/Zend/Validator/GreaterThan.php
@@ -89,7 +89,7 @@ class GreaterThan extends AbstractValidator
         $this->setMin($options['min'])
              ->setInclusive($options['inclusive']);
 
-        parent::__construct();
+        parent::__construct($options);
     }
 
     /**

--- a/library/Zend/Validator/LessThan.php
+++ b/library/Zend/Validator/LessThan.php
@@ -91,7 +91,7 @@ class LessThan extends AbstractValidator
         $this->setMax($options['max'])
              ->setInclusive($options['inclusive']);
 
-        parent::__construct();
+        parent::__construct($options);
     }
 
     /**


### PR DESCRIPTION
Like every other validator, the GreaterThan and LessThan validators should push their options into the parent constructor too. This change allows for example to set validation messages for both validators.

[![Build Status](https://secure.travis-ci.org/juriansluiman/zf2.png?branch=hotfix/validator-constructor-options)](http://travis-ci.org/#!/juriansluiman/zf2/builds/1976106)
