### PR TITLE
get root service locator instead of plugin manager sl

### DIFF
--- a/library/Zend/View/Helper/Navigation.php
+++ b/library/Zend/View/Helper/Navigation.php
@@ -121,7 +121,6 @@ class Navigation extends AbstractNavigationHelper
                 if ($sm->getServiceLocator()){
                     $sm = $sm->getServiceLocator();
                 }
-                //$helper->setServiceLocator($this->getServiceLocator()->getServiceLocator());
                 $helper->setServiceLocator($sm);
             }
             return call_user_func_array($helper, $arguments);

--- a/library/Zend/View/Helper/Navigation.php
+++ b/library/Zend/View/Helper/Navigation.php
@@ -83,7 +83,6 @@ class Navigation extends AbstractNavigationHelper
         if (null !== $container) {
             $this->setContainer($container);
         }
-
         return $this;
     }
 
@@ -118,7 +117,12 @@ class Navigation extends AbstractNavigationHelper
         $helper = $this->findHelper($method, false);
         if ($helper) {
             if ($helper instanceof ServiceLocatorAwareInterface && $this->getServiceLocator()) {
-                $helper->setServiceLocator($this->getServiceLocator());
+                $sm = $helper->getServiceLocator();
+                if ($sm->getServiceLocator()){
+                    $sm = $sm->getServiceLocator();
+                }
+                //$helper->setServiceLocator($this->getServiceLocator()->getServiceLocator());
+                $helper->setServiceLocator($sm);
             }
             return call_user_func_array($helper, $arguments);
         }

--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -213,7 +213,6 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
             if ($sm instanceof ServiceLocatorAwareInterface){
                 $sm = $sm->getServiceLocator();
             }
-            //$container = $this->getServiceLocator()->getServiceLocator()->get($container);
             $container = $sm->get($container);
             return;
         }

--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -208,7 +208,13 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
                 ));
             }
 
-            $container = $this->getServiceLocator()->get($container);
+            // get root service locator over plugin manager service locator
+            $sm = $this->getServiceLocator();
+            if ($sm instanceof ServiceLocatorAwareInterface){
+                $sm = $sm->getServiceLocator();
+            }
+            //$container = $this->getServiceLocator()->getServiceLocator()->get($container);
+            $container = $sm->get($container);
             return;
         }
 


### PR DESCRIPTION
When called from the view, the navigation helper is trying to create a Navigation object with the plugin manager service locator instead of the root service locator and failing miserably. i've added code to use the root service locator. a check has had to be inserted to determine if the sl is the "root" sl to allow the navigation output to be constructed elsewhere if necessary.

e.g. inside the controller this will (like without this patch) correctly output a nav

```
            // create Navigation instance from a factory
            $n = $this->getServiceLocator()->create('Navigation');

            // instantiate a new menu helper and set container and view
            $foo = new \Zend\View\Helper\Navigation\Menu();
            $foo->setContainer($n);
            $foo->setView(new \Zend\View\Renderer\PhpRenderer());
            $menu = $foo->render();
```

and with this patch, inside a view file this will now correctly output an html menu:

```
echo $this->navigation('Navigation')->menu();
```
