### PR TITLE
Load navigation container in helper from root service locator

### DIFF
--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -208,7 +208,11 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
                 ));
             }
 
-            $container = $this->getServiceLocator()->get($container);
+            $sl = $this->getServiceLocator();
+            if ($sl instanceof View\HelperPluginManager) {
+                $sl = $sl->getServiceLocator();
+            }
+            $container = $sl->get($container);
             return;
         }
 

--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -208,6 +208,13 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
                 ));
             }
 
+            /**
+             * Load the navigation container from the root service locator
+             *
+             * The navigation container is probably located in Zend\ServiceManager\ServiceManager
+             * and not in the Zend\View\HelperPluginManager. If the set service locator is a
+             * HelperPluginManager, access the navigation container via the main service locator.
+             */
             $sl = $this->getServiceLocator();
             if ($sl instanceof View\HelperPluginManager) {
                 $sl = $sl->getServiceLocator();

--- a/tests/Zend/View/Helper/Navigation/NavigationTest.php
+++ b/tests/Zend/View/Helper/Navigation/NavigationTest.php
@@ -141,11 +141,8 @@ class NavigationTest extends AbstractTest
                        ->with('navigation')
                        ->will($this->returnValue($container));
 
-        $pluginManager  = $this->getMock('Zend\View\HelperPluginManager', array('getServiceLocator'));
+        $pluginManager  = new View\HelperPluginManager;
         $pluginManager->setServiceLocator($serviceManager);
-        $pluginManager->expects($this->any())
-                      ->method('getServiceLocator')
-                      ->will($this->returnValue($serviceManager));
 
         $this->_helper->setServiceLocator($pluginManager);
         $this->_helper->setContainer('navigation');
@@ -153,7 +150,6 @@ class NavigationTest extends AbstractTest
         $expected = $this->_helper->getContainer();
         $actual   = $container;
         $this->assertEquals($expected, $actual);
-
     }
 
     public function testInjectingAcl()

--- a/tests/Zend/View/Helper/Navigation/NavigationTest.php
+++ b/tests/Zend/View/Helper/Navigation/NavigationTest.php
@@ -135,12 +135,8 @@ class NavigationTest extends AbstractTest
     public function testServiceManagerIsUsedToRetrieveContainer()
     {
         $container      = new Container;
-
-        $serviceManager = $this->getMock('Zend\ServiceManager\ServiceManager', array('get'));
-        $serviceManager->expects($this->any())
-                       ->method('get')
-                       ->with('navigation')
-                       ->will($this->returnValue($container));
+        $serviceManager = new ServiceManager;
+        $serviceManager->setService('navigation', $container);
 
         $pluginManager  = new View\HelperPluginManager;
         $pluginManager->setServiceLocator($serviceManager);

--- a/tests/Zend/View/Helper/Navigation/NavigationTest.php
+++ b/tests/Zend/View/Helper/Navigation/NavigationTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\View\Helper\Navigation;
 
+use Zend\Navigation\Navigation as Container;
 use Zend\Permissions\Acl;
 use Zend\Permissions\Acl\Role;
 use Zend\View;
@@ -128,6 +129,31 @@ class NavigationTest extends AbstractTest
         );
 
         $this->assertEquals($expected, $actual);
+    }
+
+    public function testServiceManagerIsUsedToRetrieveContainer()
+    {
+        $container      = new Container;
+
+        $serviceManager = $this->getMock('Zend\ServiceManager\ServiceManager', array('get'));
+        $serviceManager->expects($this->any())
+                       ->method('get')
+                       ->with('navigation')
+                       ->will($this->returnValue($container));
+
+        $pluginManager  = $this->getMock('Zend\View\HelperPluginManager', array('getServiceLocator'));
+        $pluginManager->setServiceLocator($serviceManager);
+        $pluginManager->expects($this->any())
+                      ->method('getServiceLocator')
+                      ->will($this->returnValue($serviceManager));
+
+        $this->_helper->setServiceLocator($pluginManager);
+        $this->_helper->setContainer('navigation');
+
+        $expected = $this->_helper->getContainer();
+        $actual   = $container;
+        $this->assertEquals($expected, $actual);
+
     }
 
     public function testInjectingAcl()

--- a/tests/Zend/View/Helper/Navigation/NavigationTest.php
+++ b/tests/Zend/View/Helper/Navigation/NavigationTest.php
@@ -13,6 +13,7 @@ namespace ZendTest\View\Helper\Navigation;
 use Zend\Navigation\Navigation as Container;
 use Zend\Permissions\Acl;
 use Zend\Permissions\Acl\Role;
+use Zend\ServiceManager\ServiceManager;
 use Zend\View;
 use Zend\View\Helper\Navigation;
 


### PR DESCRIPTION
Similar to PR #2033, this PR ensures the navigation _view helper_ loads the navigation _container_ from a different service manager. For an explanation why this PR is required I refer to [my comment on #2033](https://github.com/zendframework/zf2/pull/2033#issuecomment-7335546).

[![Build Status](https://secure.travis-ci.org/juriansluiman/zf2.png?branch=feature/navigation-servicelocator)](http://travis-ci.org/#!/juriansluiman/zf2/builds/1979042)
