### PR TITLE
Allow HTML5 doctype to use metaproperty

### DIFF
--- a/library/Zend/View/Helper/Doctype.php
+++ b/library/Zend/View/Helper/Doctype.php
@@ -214,7 +214,7 @@ class Doctype extends AbstractHelper
      */
     public function isRdfa()
     {
-        return (stristr($this->getDoctype(), 'rdfa') ? true : false);
+        return ($this->isHtml5() || stristr($this->getDoctype(), 'rdfa') ? true : false);
     }
 
     /**

--- a/tests/Zend/View/Helper/DoctypeTest.php
+++ b/tests/Zend/View/Helper/DoctypeTest.php
@@ -141,6 +141,8 @@ class DoctypeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($this->helper->__invoke(Helper\Doctype::XHTML1_RDFA)->isRdfa());
         $this->assertTrue($this->helper->__invoke(Helper\Doctype::XHTML1_RDFA11)->isRdfa());
+        $this->assertTrue($this->helper->__invoke(Helper\Doctype::XHTML5)->isRdfa());
+        $this->assertTrue($this->helper->__invoke(Helper\Doctype::HTML5)->isRdfa());
 
         // build-in doctypes
         $doctypes = array(
@@ -149,11 +151,9 @@ class DoctypeTest extends \PHPUnit_Framework_TestCase
             Helper\Doctype::XHTML1_TRANSITIONAL,
             Helper\Doctype::XHTML1_FRAMESET,
             Helper\Doctype::XHTML_BASIC1,
-            Helper\Doctype::XHTML5,
             Helper\Doctype::HTML4_STRICT,
             Helper\Doctype::HTML4_LOOSE,
-            Helper\Doctype::HTML4_FRAMESET,
-            Helper\Doctype::HTML5,
+            Helper\Doctype::HTML4_FRAMESET
         );
 
         foreach ($doctypes as $type) {


### PR DESCRIPTION
It was not possible to use the "appendProperty/prependProperty" (used for Facebook open graph for instance) because <meta property was only allowed for doctype implementing RDFa. However, it looks like HTML5 doctype implicitely allow this usage (http://www.w3.org/TR/rdfa-in-html/)
