### PR TITLE
[Form] Remove Collection from validationGroup when no data posted

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -477,13 +477,14 @@ class Form extends Fieldset implements FormInterface
                 continue;
             }
 
-            if (!isset($data[$key])) {
-                continue;
-            }
-
             $fieldset = $formOrFieldset->byName[$key];
 
             if ($fieldset instanceof Collection) {
+                if (!isset($data[$key])) {
+                    unset ($validationGroup[$key]);
+                    continue;
+                }
+
                 $values = array();
                 $count = count($data[$key]);
 
@@ -493,7 +494,9 @@ class Form extends Fieldset implements FormInterface
 
                 $value = $values;
             } else {
-                $this->prepareValidationGroup($fieldset, $data[$key], $validationGroup[$key]);
+                if (isset($data[$key])) {
+                    $this->prepareValidationGroup($fieldset, $data[$key], $validationGroup[$key]);
+                }
             }
         }
     }

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -892,13 +892,13 @@ class FormTest extends TestCase
         $this->assertObjectNotHasAttribute('foo', $data);
         $this->assertObjectHasAttribute('bar', $data);
     }
-	public function testRemoveCollectionFromValidationGroupWhenZeroCountAndNoData()
-	{
-		$dataWithoutCollection = array(
+    public function testRemoveCollectionFromValidationGroupWhenZeroCountAndNoData()
+    {
+        $dataWithoutCollection = array(
             'foo' => 'bar'
         );
-		$this->populateForm();
-		$this->form->add(array(
+        $this->populateForm();
+        $this->form->add(array(
             'type' => 'Zend\Form\Element\Collection',
             'name' => 'categories',
             'options' => array(
@@ -909,12 +909,12 @@ class FormTest extends TestCase
             )
         ));
         $this->form->setValidationGroup(array(
-			'foo',
+            'foo',
             'categories' => array(
                 'name'
             )
         ));
-		$this->form->setData($dataWithoutCollection);
-		$this->assertTrue($this->form->isValid());
-	}
+        $this->form->setData($dataWithoutCollection);
+        $this->assertTrue($this->form->isValid());
+    }
 }

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -892,4 +892,29 @@ class FormTest extends TestCase
         $this->assertObjectNotHasAttribute('foo', $data);
         $this->assertObjectHasAttribute('bar', $data);
     }
+	public function testRemoveCollectionFromValidationGroupWhenZeroCountAndNoData()
+	{
+		$dataWithoutCollection = array(
+            'foo' => 'bar'
+        );
+		$this->populateForm();
+		$this->form->add(array(
+            'type' => 'Zend\Form\Element\Collection',
+            'name' => 'categories',
+            'options' => array(
+                'count' => 0,
+                'target_element' => array(
+                    'type' => 'ZendTest\Form\TestAsset\CategoryFieldset'
+                )
+            )
+        ));
+        $this->form->setValidationGroup(array(
+			'foo',
+            'categories' => array(
+                'name'
+            )
+        ));
+		$this->form->setData($dataWithoutCollection);
+		$this->assertTrue($this->form->isValid());
+	}
 }


### PR DESCRIPTION
This solves the problem whereby a validation group fails because no collection elements exist (i.e. default count is set to 0 and none are posted)
