### PR TITLE
Added the Base64 decode on RSA verify and decrypt

### DIFF
--- a/library/Zend/Crypt/PublicKey/Rsa.php
+++ b/library/Zend/Crypt/PublicKey/Rsa.php
@@ -251,7 +251,7 @@ class Rsa
             throw new Exception\InvalidArgumentException('No key specified for the decryption');
         }
 
-        // check if date is encoded in Base64
+        // check if data is encoded in Base64
         $output = base64_decode($data, true);
         if (false !== $output) {
             $data = $output;

--- a/library/Zend/Crypt/PublicKey/Rsa.php
+++ b/library/Zend/Crypt/PublicKey/Rsa.php
@@ -184,7 +184,13 @@ class Rsa
         if (null === $publicKey) {
             $publicKey = $this->options->getPublicKey();
         }
-
+        
+        // check if signature is encoded in Base64
+        $output = base64_decode($signature, true);
+        if (false !== $output) {
+            $signature = $output;
+        }       
+        
         $result = openssl_verify(
             $data,
             $signature,
@@ -245,6 +251,12 @@ class Rsa
             throw new Exception\InvalidArgumentException('No key specified for the decryption');
         }
 
+        // check if date is encoded in Base64
+        $output = base64_decode($data, true);
+        if (false !== $output) {
+            $data = $output;
+        } 
+        
         return $key->decrypt($data);
     }
 

--- a/tests/Zend/Crypt/PublicKey/RsaTest.php
+++ b/tests/Zend/Crypt/PublicKey/RsaTest.php
@@ -261,7 +261,7 @@ CERT;
     public function testVerifyVerifiesBase64Signatures()
     {
         $signature = $this->rsaBase64Out->sign('1234567890');
-        $result    = $this->rsaBase64Out->verify('1234567890', base64_decode($signature));
+        $result    = $this->rsaBase64Out->verify('1234567890', $signature);
 
         $this->assertSame(true, $result);
     }
@@ -308,7 +308,7 @@ CERT;
         $this->assertEquals(
             '1234567890',
             $this->rsaBase64Out->decrypt(
-                base64_decode($encrypted),
+                $encrypted,
                 $this->rsaBase64Out->getOptions()->getPrivateKey()
             )
         );


### PR DESCRIPTION
I added the automatic decode of Base64 in verify() and decrypt() of RSA if the $signature or $data are encoded in Base64. With this PR developers don't need to remember if the signature or the message to decrypt have been encoded in Base64.
