### PR TITLE
[Form] Only bind values that were posted

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -262,7 +262,32 @@ class Form extends Fieldset implements FormInterface
                 break;
         }
 
+        $data = $this->prepareBindData($data, $this->data);
         $this->object = parent::bindValues($data);
+    }
+
+    /**
+     * Parse filtered values and return only posted fields for binding
+     * 
+     * @param array $values
+     * @param type $match
+     * @return array
+     */
+    protected function prepareBindData(array $values, $match)
+    {
+        $data = array();
+        foreach ($values as $name => $value) {
+            if (!array_key_exists($name, $match)) {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $data[$name] = $this->prepareBindData($value, $match[$name]);
+            } else {
+                $data[$name] = $value;
+            }
+        }
+        return $data;
     }
 
     /**

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -268,12 +268,12 @@ class Form extends Fieldset implements FormInterface
 
     /**
      * Parse filtered values and return only posted fields for binding
-     * 
+     *
      * @param array $values
-     * @param type $match
+     * @param array $match
      * @return array
      */
-    protected function prepareBindData(array $values, $match)
+    protected function prepareBindData(array $values, array $match)
     {
         $data = array();
         foreach ($values as $name => $value) {

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -873,20 +873,23 @@ class FormTest extends TestCase
         $this->assertEquals('foo[fieldsets][0][field]', $form->get('fieldsets')->get('0')->get('field')->getName());
     }
 
-    public function testEmptyValuesNotBound()
+    public function testUnsetValuesNotBound()
     {
-        $this->populateForm();
+        $model = new stdClass;
         $validSet = array(
-            'foo' => null,
-            'bar' => ' ALWAYS valid ',
+            'bar' => 'always valid',
             'foobar' => array(
                 'foo' => 'abcde',
-                'bar' => ' ALWAYS valid',
+                'bar' => 'always valid',
             ),
         );
+        $this->populateForm();
+        $this->form->setHydrator(new Hydrator\ObjectProperty());
+        $this->form->bind($model);
         $this->form->setData($validSet);
         $this->form->isValid();
-        $data = $this->form->getData(Form::VALUES_RAW);
-        $this->assertEmpty($data['foo']);
+        $data = $this->form->getData();
+        $this->assertClassNotHasAttribute('foo', $data);
+        $this->assertClassHasAttribute('bar', $data);
     }
 }


### PR DESCRIPTION
InputFilter currently returns all fields, even if no data was set, meaning values that weren't posted are getting bound as null against existing objects (causing data loss).

This PR resolves this behaviour by processing the bound data first.
