### PR TITLE
Fix console routes not being loaded, usage info styling.

### DIFF
--- a/library/Zend/Mvc/Service/RouterFactory.php
+++ b/library/Zend/Mvc/Service/RouterFactory.php
@@ -41,7 +41,7 @@ class RouterFactory implements FactoryInterface
 
         if(
             $rName === 'ConsoleRouter' ||                   // force console router
-            ($rName === null && Console::isConsole())       // auto detect console
+            ($cName === 'router' && Console::isConsole())       // auto detect console
         ){
             // We are in a console, use console router.
             if(isset($config['console']) && isset($config['console']['router'])){

--- a/library/Zend/Mvc/View/Console/InjectNamedConsoleParamsListener.php
+++ b/library/Zend/Mvc/View/Console/InjectNamedConsoleParamsListener.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace Zend\Mvc\View\Console;
+
+use Zend\EventManager\EventManagerInterface as Events;
+use Zend\EventManager\ListenerAggregateInterface;
+use Zend\Mvc\MvcEvent;
+use Zend\Console\Request as ConsoleRequest;
+
+class InjectNamedConsoleParamsListener implements ListenerAggregateInterface
+{
+    /**
+     * Listeners we've registered
+     *
+     * @var array
+     */
+    protected $listeners = array();
+
+    /**
+     * Attach listeners
+     *
+     * @param  Events $events
+     * @return void
+     */
+    public function attach(Events $events)
+    {
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'injectNamedParams'), -80);
+    }
+
+    /**
+     * Detach listeners
+     *
+     * @param  Events $events
+     * @return void
+     */
+    public function detach(Events $events)
+    {
+        foreach ($this->listeners as $index => $listener) {
+            if ($events->detach($listener)) {
+                unset($this->listeners[$index]);
+            }
+        }
+    }
+
+
+    /**
+     * Inspect the result, and cast it to a ViewModel if a string is detected
+     *
+     * @param MvcEvent $e
+     * @return void
+    */
+    public function injectNamedParams(MvcEvent $e)
+    {
+        if (!$routeMatch = $e->getRouteMatch()) {
+            return; // cannot work without route match
+        }
+
+        $request = $e->getRequest();
+        if (!$request instanceof ConsoleRequest) {
+            return; // will not inject non-console requests
+        }
+
+        // Inject route match params into request
+        $params = array_merge(
+            $request->getParams()->toArray(),
+            $routeMatch->getParams()
+        );
+        $request->getParams()->fromArray($params);
+    }
+
+}

--- a/library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php
@@ -275,6 +275,9 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
                             // render last table
                             $result .= $this->renderTable($table, $tableCols,$console->getWidth());
                             $table = false;
+
+                             // add extra newline for clarity
+                            $result .= "\n";
                         }
 
                         $tableCols = 2;
@@ -288,6 +291,9 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
                             // render last table
                             $result .= $this->renderTable($table, $tableCols, $console->getWidth());
                             $table = false;
+
+                             // add extra newline for clarity
+                            $result .= "\n";
                         }
 
                         $tableCols = count($b);

--- a/library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php
@@ -259,6 +259,7 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
         $result = '';
         $table = false;
         $tableCols = 0;
+        $tableType = 0;
         foreach($usageInfo as $moduleName => $usage){
             if(is_string($usage)){
                 // It's a plain string - output as is
@@ -270,25 +271,27 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
                         /**
                          *    'ivocation method' => 'explanation'
                          */
-                        if($tableCols !== 2 && $table !== false){
+                        if(($tableCols !== 2 || $tableType != 1) && $table !== false){
                             // render last table
                             $result .= $this->renderTable($table, $tableCols,$console->getWidth());
                             $table = false;
                         }
 
                         $tableCols = 2;
+                        $tableType = 1;
                         $table[] = array($scriptName . ' ' . $a, $b);
                     }elseif(is_array($b)){
                         /**
                          *  array( '--param', '--explanation' )
                          */
-                        if(count($b) != $tableCols && $table !== false){
+                        if((count($b) != $tableCols || $tableType != 2) && $table !== false){
                             // render last table
-                            $result .= $this->renderTable($table, $tableCols,$console->getWidth());
+                            $result .= $this->renderTable($table, $tableCols, $console->getWidth());
                             $table = false;
                         }
 
                         $tableCols = count($b);
+                        $tableType = 2;
                         $table[] = $b;
                     }else{
                         /**
@@ -296,12 +299,14 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
                          */
                         if($table !== false){
                             // render last table
-                            $result .= $this->renderTable($table, $tableCols,$console->getWidth());
+                            $result .= $this->renderTable($table, $tableCols, $console->getWidth());
                             $table = false;
 
                             // add extra newline for clarity
                             $result .= "\n";
                         }
+
+                        $tableType = 0;
                         $result .= $b."\n";
                     }
                 }

--- a/library/Zend/Mvc/View/Console/ViewManager.php
+++ b/library/Zend/Mvc/View/Console/ViewManager.php
@@ -61,6 +61,7 @@ class ViewManager extends BaseViewManager
         $createViewModelListener = new CreateViewModelListener();
         $injectViewModelListener = new InjectViewModelListener();
         $sendResponseListener    = new SendResponseListener();
+        $injectParamsListener    = new InjectNamedConsoleParamsListener();
 
         $this->registerMvcRenderingStrategies($events);
         $this->registerViewStrategies();
@@ -71,6 +72,7 @@ class ViewManager extends BaseViewManager
         $events->attach($mvcRenderingStrategy);
         $events->attach($sendResponseListener);
 
+        $sharedEvents->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, array($injectParamsListener,  'injectNamedParams'), 1000);
         $sharedEvents->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, array($createViewModelListener, 'createViewModelFromArray'), -80);
         $sharedEvents->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, array($createViewModelListener, 'createViewModelFromString'), -80);
         $sharedEvents->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, array($createViewModelListener, 'createViewModelFromNull'), -80);

--- a/tests/Zend/Mvc/Router/Console/SimpleTest.php
+++ b/tests/Zend/Mvc/Router/Console/SimpleTest.php
@@ -373,9 +373,34 @@ class SimpleTestTest extends TestCase
                     'c' => true,
                 ),
             ),
+            'optional-value-param-1' => array(
+                'a b [<c>]',
+                array('a','b','bar'),
+                array(
+                    'a'   => true,
+                    'b'   => true,
+                    'c'   => 'bar',
+                    'bar' => null,
+                ),
+            ),
+            'optional-value-param-2' => array(
+                'a b [<c>]',
+                array('a','b'),
+                array(
+                    'a'   => true,
+                    'b'   => true,
+                    'c'   => null,
+                    'bar' => null,
+                ),
+            ),
+            'optional-value-param-3' => array(
+                'a b [<c>]',
+                array('a','b','--c'),
+                null
+            ),
 
             // -- combinations
-            'mandatory-long-short-alternative1' => array(
+            'mandatory-long-short-alternative-1' => array(
                 ' ( --foo | -f )',
                 array('--foo'),
                 array(
@@ -384,7 +409,7 @@ class SimpleTestTest extends TestCase
                     'baz' => null,
                 )
             ),
-            'mandatory-long-short-alternative2' => array(
+            'mandatory-long-short-alternative-2' => array(
                 ' ( --foo | -f )',
                 array('-f'),
                 array(
@@ -393,6 +418,70 @@ class SimpleTestTest extends TestCase
                     'baz' => null,
                 )
             ),
+            'optional-long-short-alternative-1' => array(
+                'a <b> [ --foo | -f ]',
+                array('a','bar'),
+                array(
+                    'a'   => true,
+                    'b'   => 'bar',
+                    'foo' => false,
+                    'f'   => false,
+                    'baz' => null,
+                )
+            ),
+            'optional-long-short-alternative-2' => array(
+                'a <b> [ --foo | -f ]',
+                array('a','bar', '-f'),
+                array(
+                    'a'   => true,
+                    'b'   => 'bar',
+                    'foo' => false,
+                    'f'   => true,
+                    'baz' => null,
+                )
+            ),
+            'optional-long-short-alternative-3' => array(
+                'a <b> [ --foo | -f ]',
+                array('a','--foo', 'bar'),
+                array(
+                    'a'   => true,
+                    'b'   => 'bar',
+                    'foo' => true,
+                    'f'   => false,
+                    'baz' => null,
+                )
+            ),
+
+
+            'mandatory-and-optional-value-params-with-flags-1' => array(
+                'a b <c> [<d>] [--eee|-e] [--fff|-f]',
+                array('a','b','foo','bar'),
+                array(
+                    'a'   => true,
+                    'b'   => true,
+                    'c'   => 'foo',
+                    'd'   => 'bar',
+                    'e'   => false,
+                    'eee' => false,
+                    'fff' => false,
+                    'f'   => false,
+                ),
+            ),
+            'mandatory-and-optional-value-params-with-flags-2' => array(
+                'a b <c> [<d>] [--eee|-e] [--fff|-f]',
+                array('a','b','--eee', 'foo','bar'),
+                array(
+                    'a'   => true,
+                    'b'   => true,
+                    'c'   => 'foo',
+                    'd'   => 'bar',
+                    'e'   => false,
+                    'eee' => true,
+                    'fff' => false,
+                    'f'   => false,
+                ),
+            ),
+
 
             // -- overflows
             'too-many-arguments1' => array(


### PR DESCRIPTION
#### Routes not being loaded

One of previous commits added ability to fetch console or http router on demand from `Mvc\Service\RouterFactory`, but this has broken the default behavior - automatic console detection and instantiating of console routes.
#### Change rendering of usage info:

In case there are arguments array('-arg', 'description') directly followed by usage lines array('some usage <param>' => 'help') the resulting info was rendered in a single table, which for long usage lines would be hard to read. After this fix, in such case there would be 2 separate tables (with separate columns) holding arguments and usage lines.
