### PR TITLE
added an option to skip escaping labels

### DIFF
--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -132,18 +132,10 @@ class Menu extends AbstractHelper
      * @param bool $flag [optional] escape labels. Default is true.
      * @return Menu  fluent interface, returns self
      */
-    public function setEscapeLabels($flag = true)
+    public function escapeLabels($flag = true)
     {
         $this->escapeLabels = $flag;
         return $this;
-    }
-
-    /**
-     * @return bool whether or not to escape labels
-     */
-    public function getEscapeLabels()
-    {
-        return $this->escapeLabels;
     }
 
     /**
@@ -306,7 +298,7 @@ class Menu extends AbstractHelper
         }
 
         if (!isset($options['escapeLabels'])) {
-            $options['escapeLabels'] = $this->getEscapeLabels();
+            $options['escapeLabels'] = $this->escapeLabels;
         }
 
         if (!isset($options['renderParents'])) {

--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -134,7 +134,7 @@ class Menu extends AbstractHelper
      */
     public function escapeLabels($flag = true)
     {
-        $this->escapeLabels = $flag;
+        $this->escapeLabels = (bool) $flag;
         return $this;
     }
 

--- a/tests/Zend/View/Helper/Navigation/MenuTest.php
+++ b/tests/Zend/View/Helper/Navigation/MenuTest.php
@@ -174,6 +174,24 @@ class MenuTest extends AbstractTest
         $this->assertEquals($expected, $this->_helper->render($this->_nav2));
     }
 
+    public function testOptionEscapeLabelsAsFalse()
+    {
+        $options = array(
+            'escapeLabels' => false
+        );
+
+        $container = new \Zend\Navigation\Navigation($this->_nav2->toArray());
+        $container->addPage(array(
+            'label' => 'Badges <span class="badge">1</span>',
+            'uri' => 'badges'
+        ));
+
+        $expected = $this->_getExpected('menu/escapelabels_as_false.html');
+        $actual = $this->_helper->renderMenu($container, $options);
+
+        $this->assertEquals($expected, $actual);
+    }
+
     public function testTranslationUsingZendTranslate()
     {
         $translator = $this->_getTranslator();

--- a/tests/Zend/View/Helper/Navigation/MenuTest.php
+++ b/tests/Zend/View/Helper/Navigation/MenuTest.php
@@ -174,6 +174,24 @@ class MenuTest extends AbstractTest
         $this->assertEquals($expected, $this->_helper->render($this->_nav2));
     }
 
+    public function testOptionEscapeLabelsAsTrue()
+    {
+        $options = array(
+            'escapeLabels' => true
+        );
+
+        $container = new \Zend\Navigation\Navigation($this->_nav2->toArray());
+        $container->addPage(array(
+            'label' => 'Badges <span class="badge">1</span>',
+            'uri' => 'badges'
+        ));
+
+        $expected = $this->_getExpected('menu/escapelabels_as_true.html');
+        $actual = $this->_helper->renderMenu($container, $options);
+
+        $this->assertEquals($expected, $actual);
+    }
+
     public function testOptionEscapeLabelsAsFalse()
     {
         $options = array(

--- a/tests/Zend/View/Helper/Navigation/_files/expected/menu/escapelabels_as_false.html
+++ b/tests/Zend/View/Helper/Navigation/_files/expected/menu/escapelabels_as_false.html
@@ -1,0 +1,14 @@
+<ul class="navigation">
+    <li>
+        <a href="site1">Site 1</a>
+    </li>
+    <li class="active">
+        <a href="site2">Site 2</a>
+    </li>
+    <li>
+        <a href="site3">Site 3</a>
+    </li>
+    <li>
+        <a href="badges">Badges <span class="badge">1</span></a>
+    </li>
+</ul>

--- a/tests/Zend/View/Helper/Navigation/_files/expected/menu/escapelabels_as_true.html
+++ b/tests/Zend/View/Helper/Navigation/_files/expected/menu/escapelabels_as_true.html
@@ -1,0 +1,14 @@
+<ul class="navigation">
+    <li>
+        <a href="site1">Site 1</a>
+    </li>
+    <li class="active">
+        <a href="site2">Site 2</a>
+    </li>
+    <li>
+        <a href="site3">Site 3</a>
+    </li>
+    <li>
+        <a href="badges">Badges &lt;span class=&quot;badge&quot;&gt;1&lt;/span&gt;</a>
+    </li>
+</ul>


### PR DESCRIPTION
If possible, I'd like an option to skip escaping html labels in the menu helper. This is so I can do things like add badges to menu items without having to resort to partials or overriding any existing classes. 
