### PR TITLE
Inject controller in controller plugin every time a plugin is retrieved

### DIFF
--- a/library/Zend/Mvc/Controller/PluginManager.php
+++ b/library/Zend/Mvc/Controller/PluginManager.php
@@ -71,6 +71,27 @@ class PluginManager extends AbstractPluginManager
     }
 
     /**
+     * Retrieve a registered instance
+     *
+     * After the plugin is retrieved from the service locator, inject the
+     * controller in the plugin every time it is requested. This is required
+     * because a controller can use a plugin and another controller can be
+     * dispatched afterwards. If this second controller uses the same plugin
+     * as the first controller, the reference to the controller inside the
+     * plugin is lost.
+     *
+     * @param  string $cName
+     * @param  array $params
+     * @return mixed
+     */
+    public function get($name, $usePeeringServiceManagers = true)
+    {
+        $plugin = parent::get($name, $usePeeringServiceManagers);
+        $this->injectController($plugin);
+        return $plugin;
+    }
+
+    /**
      * Set controller
      *
      * @param  DispatchableInterface $controller

--- a/tests/Zend/Mvc/Controller/Plugin/TestAsset/SamplePlugin.php
+++ b/tests/Zend/Mvc/Controller/Plugin/TestAsset/SamplePlugin.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc\Controller\Plugin\TestAsset;
+
+use Zend\Mvc\Controller\Plugin\AbstractPlugin;
+
+class SamplePlugin extends AbstractPlugin
+{
+}

--- a/tests/Zend/Mvc/Controller/PluginManagerTest.php
+++ b/tests/Zend/Mvc/Controller/PluginManagerTest.php
@@ -17,6 +17,16 @@ use Zend\Mvc\Controller\PluginManager;
 
 class PluginManagerTest extends TestCase
 {
+    public function testPluginManagerThrowsExceptionForMissingPluginInterface()
+    {
+        $this->setExpectedException('Zend\Mvc\Exception\InvalidPluginException');
+
+        $pluginManager = new PluginManager;
+        $pluginManager->setInvokableClass('samplePlugin', 'stdClass');
+
+        $plugin = $pluginManager->get('samplePlugin');
+    }
+
     public function testPluginManagerInjectsControllerInPlugin()
     {
         $controller    = new SampleController;

--- a/tests/Zend/Mvc/Controller/PluginManagerTest.php
+++ b/tests/Zend/Mvc/Controller/PluginManagerTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc\Controller;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZendTest\Mvc\Controller\TestAsset\SampleController;
+use ZendTest\Mvc\Controller\Plugin\TestAsset\SamplePlugin;
+use Zend\Mvc\Controller\PluginManager;
+
+class PluginManagerTest extends TestCase
+{
+    public function testPluginManagerInjectsControllerInPlugin()
+    {
+        $controller    = new SampleController;
+        $pluginManager = new PluginManager;
+        $pluginManager->setInvokableClass('samplePlugin', 'ZendTest\Mvc\Controller\Plugin\TestAsset\SamplePlugin');
+        $pluginManager->setController($controller);
+
+        $plugin = $pluginManager->get('samplePlugin');
+        $this->assertEquals($controller, $plugin->getController());
+    }
+
+    public function testPluginManagerInjectsControllerForExistingPlugin()
+    {
+        $controller1   = new SampleController;
+        $pluginManager = new PluginManager;
+        $pluginManager->setInvokableClass('samplePlugin', 'ZendTest\Mvc\Controller\Plugin\TestAsset\SamplePlugin');
+        $pluginManager->setController($controller1);
+
+        // Plugin manager registers now instance of SamplePlugin
+        $pluginManager->get('samplePlugin');
+
+        $controller2   = new SampleController;
+        $pluginManager->setController($controller2);
+
+        $plugin = $pluginManager->get('samplePlugin');
+        $this->assertEquals($controller2, $plugin->getController());
+    }
+}


### PR DESCRIPTION
This fixes [ZF2-433](http://framework.zend.com/issues/browse/ZF2-433).

The following bug is solved with this PR:

```
class FooController
{
  public function indexAction()
  {
    $id = $this->params('id'); // Eg, this is "123"

    return $this->forward()->dispatch('BarController', array('action' => 'index', 'id' => '456'));
  }
}

class BarController
{
  public function indexAction()
  {
    $id = $this->params('id'); // This is now "123" and NOT "456"

    $id = $this->getEvent()->getRouteMatch()->getParam('id'); // This is now "456"
  }
}
```

Tests are attached to ensure behaviour is now correctly. A third test is attached to test validation of plugins, not really something of this PR, but makes the plugin manager a bit more tested (as nothing existed yet).

[![Build Status](https://secure.travis-ci.org/juriansluiman/zf2.png?branch=hotfix/controller-plugin)](http://travis-ci.org/#!/juriansluiman/zf2/builds/1993367)
