### PR TITLE
Micro (Really micro) optimization for canonicalizeName in ServiceManager

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -99,6 +99,11 @@ class ServiceManager implements ServiceLocatorInterface
     protected $throwExceptionInCreate = true;
 
     /**
+     * @var array map of characters to be replaced through strtr
+     */
+    protected $canonicalNamesReplacements = array('-' => '', '_' => '', ' ' => '', '\\' => '', '/' => '');
+
+    /**
      * @param ConfigInterface $config
      */
     public function __construct(ConfigInterface $config = null)
@@ -651,10 +656,12 @@ class ServiceManager implements ServiceLocatorInterface
      */
     protected function canonicalizeName($name)
     {
-        if (!isset($this->canonicalNames[$name])) {
-            $this->canonicalNames[$name] = strtolower(str_replace(array('-', '_', ' ', '\\', '/'), '', $name));
+        if (isset($this->canonicalNames[$name])) {
+            return $this->canonicalNames[$name];
         }
-        return $this->canonicalNames[$name];
+
+        // this is just for performance instead of using str_replace
+        return $this->canonicalNames[$name] = strtolower(strtr($name, $this->canonicalNamesReplacements));
     }
 
     /**


### PR DESCRIPTION
### Here the performance tests with output

 (this is really just experimenting how far you can go with micro-optimization)

``` php
<?php

$string = 'Some\Weird-Service_Name/here';
$translations = array('-', '_', ' ', '\\', '/');
$iterations = 1000000;

$start = microtime(true);
for ($i = 0; $i < $iterations; $i++) {
    $result = strtolower(str_replace(array('-', '_', ' ', '\\', '/'), '', $string));
}
echo 'strtolower(str_replace(array(\'-\', \'_\', \' \', \'\\\\\', \'/\'), \'\', $string))';
var_dump(microtime(true) - $start);

$start = microtime(true);
for ($i = 0; $i < $iterations; $i++) {
    $result = strtolower(str_replace($translations, '', $string));
}
echo 'strtolower(str_replace($translations, \'\', $string))';
var_dump(microtime(true) - $start);

$translations = array('-' => '', '_' => '', ' ' => '', '\\' => '', '/' => '');
$start = microtime(true);
for ($i = 0; $i < $iterations; $i++) {
    $result = strtolower(strtr($string, $translations));
}
echo 'strtolower(strtr($string, $translations))';
var_dump(microtime(true) - $start);

$start = microtime(true);
for ($i = 0; $i < $iterations; $i++) {
    $result = strtolower(strtr($string, array('-' => '', '_' => '', ' ' => '', '\\' => '', '/' => '')));
}
echo 'strtolower(strtr($string, array(\'-\' => \'\', \'_\' => \'\', \' \' => \'\', \'\\\\\' => \'\', \'/\' => \'\')))';
var_dump(microtime(true) - $start);

$start = microtime(true);
for ($i = 0; $i < $iterations; $i++) {
    $result = strtolower(strtr($string, '-_\\/ ', "\x00\x00\x00\x00\x00"));
}
echo 'strtolower(strtr($string, \'-_\\\\/ \', "\x00\x00\x00\x00\x00"))';
var_dump(microtime(true) - $start);
```
### Here the results

```
ocramius@ocra-g74:~/Desktop$ php strtr.php 
strtolower(str_replace(array('-', '_', ' ', '\\', '/'), '', $string)) float(3.2611382007599)
strtolower(str_replace($translations, '', $string)) float(3.3164780139923)
strtolower(strtr($string, $translations)) float(2.6864230632782)
strtolower(strtr($string, array('-' => '', '_' => '', ' ' => '', '\\' => '', '/' => ''))) float(3.4354269504547)
strtolower(strtr($string, '-_\\/', "\x00\x00\x00\x00\x00")) float(2.0616290569305)
```

Last applied method resulted as invalid
