### PR TITLE
[WIP] Zend\Paginator\Adapter\DbSelect

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -352,7 +352,9 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             'columns' => $this->columns,
             'table' => $this->table,
             'joins' => $this->joins,
+            'having' => $this->having,
             'where' => $this->where,
+            'group' => $this->group,
             'order' => $this->order,
             'limit' => $this->limit,
             'offset' => $this->offset

--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -116,7 +116,9 @@ class DbSelect implements AdapterInterface
 
         $sql        = new Sql\Sql($this->options->dbAdapter);
         $statement  = $sql->prepareStatementForSqlObject($select);
-        return $statement->execute();
+        $result     = $statement->execute();
+        $resultset  = $this->options->getResultSetPrototype()->initialize($result);
+        return $resultset->toArray();
     }
 
     /**

--- a/library/Zend/Paginator/Adapter/DbSelectOptions.php
+++ b/library/Zend/Paginator/Adapter/DbSelectOptions.php
@@ -26,10 +26,19 @@ use Zend\Db\ResultSet\ResultSet;
  */
 class DbSelectOptions extends AbstractOptions
 {
+    /**
+     * @var DbAdapter
+     */
     protected $db_adapter;
 
+    /**
+     * @var SqlSelect
+     */
     protected $select_query;
 
+    /**
+     * @var ResultSet
+     */
     protected $result_set_prototype;
 
     public function setDbAdapter(DbAdapter $adapter)

--- a/library/Zend/Paginator/Adapter/DbSelectOptions.php
+++ b/library/Zend/Paginator/Adapter/DbSelectOptions.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Cache
+ */
+
+namespace Zend\Paginator\Adapter;
+
+use ArrayObject;
+use Zend\Stdlib\AbstractOptions;
+use Zend\Db\Adapter\Adapter as DbAdapter;
+use Zend\Db\Sql\Select as SqlSelect;
+
+/**
+ * Options provider for Zend\Paginator\Adapter\DbSelect
+ *
+ * @category   Zend
+ * @package    Zend_Paginator
+ * @subpackage Adapter
+ */
+class DbSelectOptions extends AbstractOptions
+{
+    protected $db_adapter;
+
+    protected $select_query;
+
+    public function setDbAdapter(DbAdapter $adapter)
+    {
+        $this->db_adapter = $adapter;
+        return $this;
+    }
+
+    public function getDbAdapter()
+    {
+        return $this->db_adapter;
+    }
+
+    public function setSelectQuery(SqlSelect $select)
+    {
+        $this->select_query = $select;
+        return $this;
+    }
+
+    public function getSelectQuery()
+    {
+        return $this->select_query;
+    }
+}

--- a/library/Zend/Paginator/Adapter/DbSelectOptions.php
+++ b/library/Zend/Paginator/Adapter/DbSelectOptions.php
@@ -14,6 +14,8 @@ use ArrayObject;
 use Zend\Stdlib\AbstractOptions;
 use Zend\Db\Adapter\Adapter as DbAdapter;
 use Zend\Db\Sql\Select as SqlSelect;
+use Zend\Db\ResultSet\ResultSetInterface;
+use Zend\Db\ResultSet\ResultSet;
 
 /**
  * Options provider for Zend\Paginator\Adapter\DbSelect
@@ -27,6 +29,8 @@ class DbSelectOptions extends AbstractOptions
     protected $db_adapter;
 
     protected $select_query;
+
+    protected $result_set_prototype;
 
     public function setDbAdapter(DbAdapter $adapter)
     {
@@ -49,4 +53,19 @@ class DbSelectOptions extends AbstractOptions
     {
         return $this->select_query;
     }
+
+    public function setResultSetPrototype($prototype)
+    {
+        $this->result_set_prototype = $prototype;
+        return $this;
+    }
+
+    public function getResultSetPrototype()
+    {
+        if (is_null($this->result_set_prototype)) {
+            $this->result_set_prototype = new ResultSet();
+        }
+        return $this->result_set_prototype;
+    }
+
 }

--- a/library/Zend/Paginator/Adapter/DbSelectOptions.php
+++ b/library/Zend/Paginator/Adapter/DbSelectOptions.php
@@ -54,7 +54,7 @@ class DbSelectOptions extends AbstractOptions
         return $this->select_query;
     }
 
-    public function setResultSetPrototype($prototype)
+    public function setResultSetPrototype(ResultSetInterface $prototype)
     {
         $this->result_set_prototype = $prototype;
         return $this;

--- a/tests/ZendTest/Paginator/Adapter/DbSelectTest.php
+++ b/tests/ZendTest/Paginator/Adapter/DbSelectTest.php
@@ -28,27 +28,27 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
     /**
      * @var DbSelect
      */
-    protected $_adapter;
+    protected $adapter;
 
     /**
      * @var Adapter\Adapter
      */
-    protected $_db;
+    protected $db;
 
     /**
      * @var Sql\Sql
      */
-    protected $_sql;
+    protected $sql;
 
     /**
      * @var Sql\Select
      */
-    protected $_query;
+    protected $query;
 
     /**
      * @var \Zend\Db\TableGateway\TableGateway
      */
-    protected $_table;
+    protected $table;
 
     /**
      * Prepares the environment before running a test.
@@ -61,23 +61,23 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
 
         parent::setUp();
 
-        $this->_db = new DbAdapter\Adapter(array(
+        $this->db = new DbAdapter\Adapter(array(
             'driver'   => 'Pdo_Sqlite',
             'database' =>  __DIR__ . '/../_files/test.sqlite',
         ));
 
-        $this->_table = new \ZendTest\Paginator\TestAsset\TestTable('test', $this->_db);
+        $this->table = new \ZendTest\Paginator\TestAsset\TestTable('test', $this->db);
 
-        $this->_query = new Sql\Select;
-        $this->_query->from('test')
+        $this->query = new Sql\Select;
+        $this->query->from('test')
                      ->order('number ASC'); // ZF-3740
                      //->limit(1000, 0); // ZF-3727
 
-        $this->_sql = new Sql\Sql($this->_db);
+        $this->sql = new Sql\Sql($this->db);
 
-        $this->_adapter = new Adapter\DbSelect(array(
-            'select_query' => $this->_query,
-            'db_adapter'   => $this->_db,
+        $this->adapter = new Adapter\DbSelect(array(
+            'select_query' => $this->query,
+            'db_adapter'   => $this->db,
         ), 'dbquery');
     }
     /**
@@ -85,13 +85,13 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
      */
     protected function tearDown()
     {
-        $this->_adapter = null;
+        $this->adapter = null;
         parent::tearDown();
     }
 
     public function testGetsItemsAtOffsetZero()
     {
-        $actual = $this->_adapter->getItems(0, 10);
+        $actual = $this->adapter->getItems(0, 10);
 
         $i = 1;
         foreach ($actual as $item) {
@@ -102,7 +102,7 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
 
     public function testGetsItemsAtOffsetTen()
     {
-        $actual = $this->_adapter->getItems(10, 10);
+        $actual = $this->adapter->getItems(10, 10);
 
         $i = 11;
         foreach ($actual as $item) {
@@ -113,52 +113,52 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
 
     public function testAcceptsIntegerValueForRowCount()
     {
-        $this->_adapter->setRowCount(101);
-        $this->assertEquals(101, $this->_adapter->count());
+        $this->adapter->setRowCount(101);
+        $this->assertEquals(101, $this->adapter->count());
     }
 
     public function testThrowsExceptionIfInvalidQuerySuppliedForRowCount()
     {
         $this->setExpectedException('Zend\Paginator\Adapter\Exception\InvalidArgumentException', 'Row count column not found');
-        $select = $this->_sql->select();
+        $select = $this->sql->select();
         $select->from('test');
-        $this->_adapter->setRowCount($select);
+        $this->adapter->setRowCount($select);
     }
 
     public function testThrowsExceptionIfInvalidQuerySuppliedForRowCount2()
     {
-        $wrongcolumn = $this->_db->getPlatform()->quoteIdentifier('wrongcolumn');
+        $wrongcolumn = $this->db->getPlatform()->quoteIdentifier('wrongcolumn');
         $expr = new Sql\Expression("COUNT(*) AS $wrongcolumn");
         $query = new Sql\Select;
         $query->from('test');
 
         $this->setExpectedException('Zend\Paginator\Adapter\Exception\InvalidArgumentException', 'Row count column not found');
-        $this->_adapter->setRowCount($query);
+        $this->adapter->setRowCount($query);
     }
 
     public function testAcceptsQueryForRowCount()
     {
-        $row_count_column = $this->_db->getPlatform()->quoteIdentifier(Adapter\DbSelect::ROW_COUNT_COLUMN);
+        $row_count_column = $this->db->getPlatform()->quoteIdentifier(Adapter\DbSelect::ROW_COUNT_COLUMN);
         $expression = new Sql\Expression("COUNT(*) AS $row_count_column");
 
-        $rowCount = clone $this->_query;
+        $rowCount = clone $this->query;
         $rowCount->columns(array($expression));
 
-        $this->_adapter->setRowCount($rowCount);
+        $this->adapter->setRowCount($rowCount);
 
-        $this->assertEquals(500, $this->_adapter->count());
+        $this->assertEquals(500, $this->adapter->count());
     }
 
     public function testThrowsExceptionIfInvalidRowCountValueSupplied()
     {
         $this->setExpectedException('Zend\Paginator\Adapter\Exception\InvalidArgumentException', 'Invalid row count');
-        $this->_adapter->setRowCount('invalid');
+        $this->adapter->setRowCount('invalid');
     }
 
     public function testReturnsCorrectCountWithAutogeneratedQuery()
     {
         $expected = 500;
-        $actual = $this->_adapter->count();
+        $actual = $this->adapter->count();
 
         $this->assertEquals($expected, $actual);
     }
@@ -166,8 +166,8 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
     public function testDbTableSelectDoesNotThrowException()
     {
         $adapter = new Adapter\DbSelect(array(
-            'db_adapter'   => $this->_db,
-            'select_query' => $this->_table->getSql()->select(),
+            'db_adapter'   => $this->db,
+            'select_query' => $this->table->getSql()->select(),
         ), 'dbselect');
         $count = $adapter->count();
         $this->assertEquals(500, $count);
@@ -185,7 +185,7 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
                ->group('number');
 
         $adapter = new Adapter\DbSelect(array(
-            'db_adapter'   => $this->_db,
+            'db_adapter'   => $this->db,
             'select_query' => $query,
         ), 'dbselect');
 
@@ -207,7 +207,7 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
               ->order('number ASC')
               ->limit(1000, 0);
         $adapter = new Adapter\DbSelect(array(
-            'db_adapter'   => $this->_db,
+            'db_adapter'   => $this->db,
             'select_query' => $query,
         ), 'dbselect');
 
@@ -225,7 +225,7 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
               ->limit(1000, 0)
               ->group('testgroup');
         $adapter = new Adapter\DbSelect(array(
-            'db_adapter'   => $this->_db,
+            'db_adapter'   => $this->db,
             'select_query' => $query,
         ), 'dbselect');
 
@@ -238,13 +238,15 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
      */
     public function testDistinctColumnQueryReturnsCorrectResult()
     {
+        $this->markTestSkipped('Distinct not fully implemented (ZF2-424)');
+
         $query = new Sql\Select;
         $query->from('test')
-//              ->distinct()
+              ->distinct()
               ->order('number ASC')
               ->limit(1000, 0);
         $adapter = new Adapter\DbSelect(array(
-            'db_adapter'   => $this->_db,
+            'db_adapter'   => $this->db,
             'select_query' => $query,
         ), 'dbselect');
 
@@ -256,11 +258,11 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
      */
     public function testSelectSpecificColumns()
     {
-        $number = $this->_db->getPlatform()->quoteIdentifier('number');
-        $query = $this->_sql->select()->from('test', array('testgroup', 'number'))
+        $number = $this->db->getPlatform()->quoteIdentifier('number');
+        $query = $this->sql->select()->from('test', array('testgroup', 'number'))
                                      ->where("$number >= ?", '1');
         $adapter = new Adapter\DbSelect(array(
-            'db_adapter'   => $this->_db,
+            'db_adapter'   => $this->db,
             'select_query' => $query,
         ), 'dbselect');
 
@@ -273,10 +275,12 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
      */
     public function testSelectDistinctAllUsesRegularCountAll()
     {
-        $query = $this->_sql->select()->from('test');
-                                     //->distinct();
+        $this->markTestSkipped('Distinct not fully implemented (ZF2-424)');
+
+        $query = $this->sql->select()->from('test')
+                                     ->distinct();
         $adapter = new Adapter\DbSelect(array(
-            'db_adapter'   => $this->_db,
+            'db_adapter'   => $this->db,
             'select_query' => $query,
         ), 'dbselect');
 
@@ -289,7 +293,7 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
      */
     public function testSelectHasAliasedColumns()
     {
-        $db = $this->_db;
+        $db = $this->db;
 
         $db->query('DROP TABLE IF EXISTS `sandboxTransaction`');
         $db->query('DROP TABLE IF EXISTS `sandboxForeign`');
@@ -343,7 +347,7 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
                               ->distinct(true);
 
         $adapter = new Adapter\DbSelect(array(
-            'db_adapter'   => $this->_db,
+            'db_adapter'   => $this->db,
             'select_query' => $query,
         ), 'dbselect');
 
@@ -355,11 +359,15 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
      */
     public function testMultipleDistinctColumns()
     {
-        $select = $this->_sql->select()->from('test', array('testgroup', 'number'));
-//                                      ->distinct(true);
+        $this->markTestSkipped('Distinct not fully implemented (ZF2-424)');
+
+        $expr = new Sql\Expression("DISTINCT testgroup ");
+        $select = new Sql\Select;
+        $select->from('test')
+            ->columns(array($expr, 'testgroup', 'number'));
 
         $adapter = new Adapter\DbSelect(array(
-            'db_adapter'   => $this->_db,
+            'db_adapter'   => $this->db,
             'select_query' => $select,
         ), 'dbselect');
 
@@ -375,10 +383,12 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
      */
     public function testSingleDistinctColumn()
     {
-        $select = $this->_sql->select()->from('test', 'testgroup');
+        $this->markTestSkipped('Distinct not fully implemented (ZF2-424)');
+        $select = $this->sql->select()->from('test')
+            ->columns(array('testgroup'));
 
         $adapter = new Adapter\DbSelect(array(
-            'db_adapter'   => $this->_db,
+            'db_adapter'   => $this->db,
             'select_query' => $select,
         ), 'dbselect');
 
@@ -394,11 +404,13 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
      */
     public function testGroupByMultipleColumns()
     {
-        $select = $this->_sql->select()->from('test', 'testgroup')
-                                      ->group(array('number', 'testgroup'));
+        $select = $this->sql->select();
+        $select->from('test')
+               ->columns(array('testgroup'))
+               ->group(array('number', 'testgroup'));
 
         $adapter = new Adapter\DbSelect(array(
-            'db_adapter'   => $this->_db,
+            'db_adapter'   => $this->db,
             'select_query' => $select,
         ), 'dbselect');
 
@@ -414,11 +426,13 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
      */
     public function testGroupBySingleColumn()
     {
-        $select = $this->_sql->select()->from('test', 'testgroup')
-                                      ->group('test.testgroup');
+        $select = $this->sql->select();
+        $select->from('test')
+               ->columns(array('testgroup'))
+               ->group('test.testgroup');
 
         $adapter = new Adapter\DbSelect(array(
-            'db_adapter'   => $this->_db,
+            'db_adapter'   => $this->db,
             'select_query' => $select,
         ), 'dbselect');
 
@@ -434,12 +448,12 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
      */
     public function testSelectWithHaving()
     {
-        $select = $this->_sql->select()->from('test')
+        $select = $this->sql->select()->from('test')
                                       ->group('number')
                                       ->having('number > 250');
 
         $adapter = new Adapter\DbSelect(array(
-            'db_adapter'   => $this->_db,
+            'db_adapter'   => $this->db,
             'select_query' => $select,
         ), 'dbselect');
 
@@ -455,13 +469,13 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
      */
     public function testMultipleGroupSelect()
     {
-        $select = $this->_sql->select()->from('test')
+        $select = $this->sql->select()->from('test')
                                       ->group('testgroup')
                                       ->group('number')
                                       ->where('number > 250');
 
         $adapter = new Adapter\DbSelect(array(
-            'db_adapter'   => $this->_db,
+            'db_adapter'   => $this->db,
             'select_query' => $select,
         ), 'dbselect');
 


### PR DESCRIPTION
Opening a PR with progress towards rewriting the DbSelect adapter to work with Zend\Db 2.0 to get early feedback. 

Issue Tracker entries:  [ZF2-246](http://framework.zend.com/issues/browse/ZF2-246) [ZF2-416](http://framework.zend.com/issues/browse/ZF2-416)

**Complete/Working**
- Works for basic SQL queries
- Integrates Zend\Db\ResultSet to (optionally) hydrate query results

**Incomplete**
- Edge cases supported in the ZF1 adapter (ie: special handling for DISTINCT and UNION queries)
- Unit test updates (syntax update complete, but need to review coverage / fix failing tests)

**Usage**
1. Standard Usage

```
$paginator = \Zend\Paginator\Paginator::factory(array(
    'db_adapter'       => $dbAdapter,  // Instance of Zend\Db\Adapter\Adapter
    'select_query'     => $select,     // Instance of Zend\Db\Sql\Select
), 'dbselect');
```
1. Extended usage - specifying the ResultSet implementation

```
$paginator = \Zend\Paginator\Paginator::factory(array(
    'db_adapter'           => $dbAdapter,  // Instance of Zend\Db\Adapter\Adapter
    'select_query'         => $select,     // Instance of Zend\Db\Sql\Select
    'result_set_prototype' => $prototype,  // Concrete implementation of Zend\Db\ResultSet\ResultSetInterface
), 'dbselect');
```
