### PR TITLE
Redirect to any scheme

### DIFF
--- a/library/Zend/Http/Header/AbstractLocation.php
+++ b/library/Zend/Http/Header/AbstractLocation.php
@@ -12,7 +12,6 @@ namespace Zend\Http\Header;
 
 use Zend\Uri\Exception as UriException;
 use Zend\Uri\UriInterface;
-use Zend\Uri\Http as HttpUri;
 use Zend\Uri\UriFactory;
 use Zend\Uri\Uri;
 
@@ -36,7 +35,7 @@ abstract class AbstractLocation implements HeaderInterface
     /**
      * URI for this header
      *
-     * @var HttpUri
+     * @var UriInterface
      */
     protected $uri = null;
 
@@ -69,7 +68,7 @@ abstract class AbstractLocation implements HeaderInterface
     /**
      * Set the URI/URL for this header, this can be a string or an instance of Zend\Uri\Http
      *
-     * @param string|HttpUri $uri
+     * @param string|UriInterface $uri
      * @return AbstractLocation
      * @throws Exception\InvalidArgumentException
      */
@@ -109,7 +108,7 @@ abstract class AbstractLocation implements HeaderInterface
     /**
      * Return the URI for this header as an instance of Zend\Uri\Http
      *
-     * @return HttpUri
+     * @return UriInterface
      */
     public function uri()
     {

--- a/library/Zend/Http/Header/AbstractLocation.php
+++ b/library/Zend/Http/Header/AbstractLocation.php
@@ -11,7 +11,11 @@
 namespace Zend\Http\Header;
 
 use Zend\Uri\Exception as UriException;
+use Zend\Uri\UriInterface;
 use Zend\Uri\Http as HttpUri;
+use Zend\Uri\UriFactory;
+use Zend\Uri\Uri;
+
 
 /**
  * Abstract Location Header
@@ -73,7 +77,7 @@ abstract class AbstractLocation implements HeaderInterface
     {
         if (is_string($uri)) {
             try {
-                $uri = new HttpUri($uri);
+                $uri = UriFactory::factory($uri);
             } catch (UriException\InvalidUriPartException $e) {
                 throw new Exception\InvalidArgumentException(
                         sprintf('Invalid URI passed as string (%s)', (string) $uri),
@@ -81,7 +85,7 @@ abstract class AbstractLocation implements HeaderInterface
                         $e
                 );
             }
-        } elseif (!($uri instanceof HttpUri)) {
+        } elseif (!($uri instanceof UriInterface)) {
             throw new Exception\InvalidArgumentException('URI must be an instance of Zend\Uri\Http or a string');
         }
         $this->uri = $uri;
@@ -96,7 +100,7 @@ abstract class AbstractLocation implements HeaderInterface
      */
     public function getUri()
     {
-        if ($this->uri instanceof HttpUri) {
+        if ($this->uri instanceof UriInterface) {
             return $this->uri->toString();
         }
         return $this->uri;
@@ -110,7 +114,7 @@ abstract class AbstractLocation implements HeaderInterface
     public function uri()
     {
         if ($this->uri === null || is_string($this->uri)) {
-            $this->uri = new HttpUri($this->uri);
+            $this->uri = UriFactory::factory($this->uri);
         }
         return $this->uri;
     }

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -18,7 +18,7 @@ use Zend\Validator;
  * @category  Zend
  * @package   Zend_Uri
  */
-class Uri
+class Uri implements UriInterface
 {
     /**
      * Character classes defined in RFC-3986
@@ -135,7 +135,7 @@ class Uri
     {
         if (is_string($uri)) {
             $this->parse($uri);
-        } elseif ($uri instanceof Uri) {
+        } elseif ($uri instanceof UriInterface) {
             // Copy constructor
             $this->setScheme($uri->getScheme());
             $this->setUserInfo($uri->getUserInfo());
@@ -387,6 +387,7 @@ class Uri
         }
 
         // If path is empty (and we have a host), path should be '/'
+        // Isn't this valid ONLY for HTTP-URI?
         if ($this->host && empty($this->path)) {
             $this->path = '/';
         }

--- a/library/Zend/Uri/UriFactory.php
+++ b/library/Zend/Uri/UriFactory.php
@@ -87,18 +87,24 @@ abstract class UriFactory
             $scheme = $defaultScheme;
         }
 
-        if ($scheme && isset(static::$schemeClasses[$scheme])) {
-            $class = static::$schemeClasses[$scheme];
-            $uri = new $class($uri);
-            if (! $uri instanceof Uri) {
-                throw new Exception\InvalidArgumentException(sprintf(
-                    'class "%s" registered for scheme "%s" is not a subclass of Zend\Uri\Uri',
-                    $class,
-                    $scheme
-                ));
-            }
+        if ($scheme && ! isset(static::$schemeClasses[$scheme])) {
+        	throw new Exception\InvalidArgumentException(sprintf(
+        			'no class registered for scheme "%s"',
+        			$scheme
+        		));
         }
-
+        if ($scheme && isset(static::$schemeClasses[$scheme])) {
+	        $class = static::$schemeClasses[$scheme];
+	        $uri = new $class($uri);
+	        if (! $uri instanceof UriInterface) {
+	            throw new Exception\InvalidArgumentException(sprintf(
+	                'class "%s" registered for scheme "%s" does not implement Zend\Uri\UriInterface',
+	                $class,
+	                $scheme
+	            ));
+	        }
+        }
+        
         return $uri;
     }
 }

--- a/library/Zend/Uri/UriFactory.php
+++ b/library/Zend/Uri/UriFactory.php
@@ -52,6 +52,19 @@ abstract class UriFactory
     }
 
     /**
+     * Unregister a scheme
+     *
+     * @param string $scheme
+     */
+    public static function unregisterScheme($scheme)
+    {
+        $scheme = strtolower($scheme);
+        if (isset(static::$schemeClasses[$scheme])) {
+        	unset(static::$schemeClasses[$scheme]);
+        }
+    }
+
+    /**
      * Create a URI from a string
      *
      * @param  string $uriString

--- a/library/Zend/Uri/UriFactory.php
+++ b/library/Zend/Uri/UriFactory.php
@@ -37,6 +37,8 @@ abstract class UriFactory
         'https'  => 'Zend\Uri\Http',
         'mailto' => 'Zend\Uri\Mailto',
         'file'   => 'Zend\Uri\File',
+        'urn'    => 'Zend\Uri\Uri',
+        'tag'    => 'Zend\Uri\Uri',
     );
 
     /**

--- a/library/Zend/Uri/UriInterface.php
+++ b/library/Zend/Uri/UriInterface.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Uri
+ */
+
+namespace Zend\Uri;
+
+/**
+ * Interface defining an URI
+ *
+ * @category  Zend
+ * @package   Zend_Uri
+ */
+interface UriInterface
+{
+
+    /**
+     * Create a new URI object
+     *
+     * @param  Uri|string|null $uri
+     * @throws Exception\InvalidArgumentException
+     */
+    public function __construct($uri = null);
+
+    /**
+     * Check if the URI is valid
+     *
+     * Note that a relative URI may still be valid
+     *
+     * @return boolean
+     */
+    public function isValid();
+
+    /**
+     * Check if the URI is a valid relative URI
+     *
+     * @return boolean
+     */
+    public function isValidRelative();
+
+    /**
+     * Check if the URI is an absolute or relative URI
+     *
+     * @return boolean
+     */
+    public function isAbsolute();
+
+    /**
+     * Parse a URI string
+     *
+     * @param  string $uri
+     * @return Uri
+     */
+    public function parse($uri);
+
+    /**
+     * Compose the URI into a string
+     *
+     * @return string
+     * @throws Exception\InvalidUriException
+     */
+    public function toString();
+
+    /**
+     * Normalize the URI
+     *
+     * Normalizing a URI includes removing any redundant parent directory or
+     * current directory references from the path (e.g. foo/bar/../baz becomes
+     * foo/baz), normalizing the scheme case, decoding any over-encoded
+     * characters etc.
+     *
+     * Eventually, two normalized URLs pointing to the same resource should be
+     * equal even if they were originally represented by two different strings
+     *
+     * @return Uri
+     */
+    public function normalize();
+
+
+
+    /**
+     * Convert the link to a relative link by substracting a base URI
+     *
+     *  This is the opposite of resolving a relative link - i.e. creating a
+     *  relative reference link from an original URI and a base URI.
+     *
+     *  If the two URIs do not intersect (e.g. the original URI is not in any
+     *  way related to the base URI) the URI will not be modified.
+     *
+     * @param  Uri|string $baseUri
+     * @return Uri
+     */
+    public function makeRelative($baseUri);
+
+    /**
+     * Get the scheme part of the URI
+     *
+     * @return string|null
+     */
+    public function getScheme();
+
+    /**
+     * Get the User-info (usually user:password) part
+     *
+     * @return string|null
+     */
+    public function getUserInfo();
+
+    /**
+     * Get the URI host
+     *
+     * @return string|null
+     */
+    public function getHost();
+
+    /**
+     * Get the URI port
+     *
+     * @return integer|null
+     */
+    public function getPort();
+
+    /**
+     * Get the URI path
+     *
+     * @return string|null
+     */
+    public function getPath();
+
+    /**
+     * Get the URI query
+     *
+     * @return string|null
+     */
+    public function getQuery();
+
+    /**
+     * Return the query string as an associative array of key => value pairs
+     *
+     * This is an extension to RFC-3986 but is quite useful when working with
+     * most common URI types
+     *
+     * @return array
+     */
+    public function getQueryAsArray();
+
+    /**
+     * Get the URI fragment
+     *
+     * @return string|null
+     */
+    public function getFragment();
+
+    /**
+     * Set the URI scheme
+     *
+     * If the scheme is not valid according to the generic scheme syntax or
+     * is not acceptable by the specific URI class (e.g. 'http' or 'https' are
+     * the only acceptable schemes for the Zend\Uri\Http class) an exception
+     * will be thrown.
+     *
+     * You can check if a scheme is valid before setting it using the
+     * validateScheme() method.
+     *
+     * @param  string $scheme
+     * @throws Exception\InvalidUriPartException
+     * @return Uri
+     */
+    public function setScheme($scheme);
+
+    /**
+     * Set the URI User-info part (usually user:password)
+     *
+     * @param  string $userInfo
+     * @return Uri
+     * @throws Exception\InvalidUriPartException If the schema definition
+     * does not have this part
+     */
+    public function setUserInfo($userInfo);
+
+    /**
+     * Set the URI host
+     *
+     * Note that the generic syntax for URIs allows using host names which
+     * are not necessarily IPv4 addresses or valid DNS host names. For example,
+     * IPv6 addresses are allowed as well, and also an abstract "registered name"
+     * which may be any name composed of a valid set of characters, including,
+     * for example, tilda (~) and underscore (_) which are not allowed in DNS
+     * names.
+     *
+     * Subclasses of Uri may impose more strict validation of host names - for
+     * example the HTTP RFC clearly states that only IPv4 and valid DNS names
+     * are allowed in HTTP URIs.
+     *
+     * @param  string $host
+     * @throws Exception\InvalidUriPartException
+     * @return Uri
+     */
+    public function setHost($host);
+
+    /**
+     * Set the port part of the URI
+     *
+     * @param  integer $port
+     * @return Uri
+     */
+    public function setPort($port);
+
+    /**
+     * Set the path
+     *
+     * @param  string $path
+     * @return Uri
+     */
+    public function setPath($path);
+
+    /**
+     * Set the query string
+     *
+     * If an array is provided, will encode this array of parameters into a
+     * query string. Array values will be represented in the query string using
+     * PHP's common square bracket notation.
+     *
+     * @param  string|array $query
+     * @return Uri
+     */
+    public function setQuery($query);
+
+    /**
+     * Set the URI fragment part
+     *
+     * @param  string $fragment
+     * @return Uri
+     * @throws Exception\InvalidUriPartException If the schema definition
+     * does not have this part
+     */
+    public function setFragment($fragment);
+
+    /**
+     * Magic method to convert the URI to a string
+     *
+     * @return string
+     */
+    public function __toString();
+}

--- a/tests/Zend/Http/Header/ContentLocationTest.php
+++ b/tests/Zend/Http/Header/ContentLocationTest.php
@@ -47,7 +47,7 @@ class ContentLocationTest extends \PHPUnit_Framework_TestCase
     {
         $contentLocationHeader = ContentLocation::fromString('Content-Location: http://www.example.com/path');
         $uri = $contentLocationHeader->uri();
-        $this->assertInstanceOf('Zend\Uri\Http', $uri);
+        $this->assertInstanceOf('Zend\Uri\UriInterface', $uri);
         $this->assertTrue($uri->isAbsolute());
         $this->assertEquals('http://www.example.com/path', $contentLocationHeader->getUri());
     }
@@ -56,7 +56,7 @@ class ContentLocationTest extends \PHPUnit_Framework_TestCase
     {
         $contentLocationHeader = ContentLocation::fromString('Content-Location: /path/to');
         $uri = $contentLocationHeader->uri();
-        $this->assertInstanceOf('Zend\Uri\Http', $uri);
+        $this->assertInstanceOf('Zend\Uri\UriInterface', $uri);
         $this->assertFalse($uri->isAbsolute());
         $this->assertEquals('/path/to', $contentLocationHeader->getUri());
     }

--- a/tests/Zend/Http/Header/LocationTest.php
+++ b/tests/Zend/Http/Header/LocationTest.php
@@ -16,11 +16,72 @@ use Zend\Uri\Http as HttpUri;
 class LocationTest extends \PHPUnit_Framework_TestCase
 {
 
-    public function testLocationFromStringCreatesValidLocationHeader()
+	/**
+	 * @paramstring $uri The URL to redirect to
+	 * @dataProvider locationFromStringCreatesValidLocationHeaderProvider
+	 */
+    public function testLocationFromStringCreatesValidLocationHeader($uri)
     {
-        $locationHeader = Location::fromString('Location: http://www.example.com/');
+        $locationHeader = Location::fromString('Location: ' . $uri);
         $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $locationHeader);
         $this->assertInstanceOf('Zend\Http\Header\Location', $locationHeader);
+    }
+    
+    public function locationFromStringCreatesValidLocationHeaderProvider()
+    {
+    	return array(
+    		array('http://www.example.com'),
+    		array('https://www.example.com'),
+    		array('mailto://www.example.com'),
+    		array('file://www.example.com'),
+    	);
+    }
+    
+    /**
+     * Test that we can set a redirect to different URI-Schemes
+     * 
+     * @param string $uri
+     * @param string $expectedClass
+     * 
+     * @dataProvider locationCanSetDifferentSchemeUrisProvider
+     */
+    public function testLocationCanSetDifferentSchemeUris($uri, $expectedClass)
+    {
+    	$locationHeader = new Location;
+    	$locationHeader->setUri($uri);
+    	$this->assertAttributeInstanceof($expectedClass, 'uri', $locationHeader);
+    }
+    
+    /**
+     * Test that we can set a redirect to different URI-schemes via a class
+     * 
+     * @param string $uri
+     * @param string $expectedClass
+     * 
+     * @dataProvider locationCanSetDifferentSchemeUrisProvider
+     */
+    public function testLocationCanSetDifferentSchemeUriObjects($uri, $expectedClass)
+    {
+	    	$uri = \Zend\Uri\UriFactory::factory($uri);
+    	$locationHeader = new Location;
+    	$locationHeader->setUri($uri);
+    	$this->assertAttributeInstanceof($expectedClass, 'uri', $locationHeader);
+    	
+    }
+    
+    /**
+     * Provide data to the locationCanSetDifferentSchemeUris-test
+     * 
+     * @return array
+     */
+    public function locationCanSetDifferentSchemeUrisProvider()
+    {
+    	return array(
+    		array('http://www.example.com', '\Zend\Uri\Http'),
+    		array('https://www.example.com', '\Zend\Uri\Http'),
+    		array('mailto://www.example.com', '\Zend\Uri\Mailto'),
+    		array('file://www.example.com', '\Zend\Uri\File'),
+    	);
     }
 
     public function testLocationGetFieldValueReturnsProperValue()
@@ -56,7 +117,7 @@ class LocationTest extends \PHPUnit_Framework_TestCase
     {
         $locationHeader = Location::fromString('Location: /path/to');
         $uri = $locationHeader->uri();
-        $this->assertInstanceOf('Zend\Uri\Http', $uri);
+        $this->assertInstanceOf('Zend\Uri\Uri', $uri);
         $this->assertFalse($uri->isAbsolute());
         $this->assertEquals('/path/to', $locationHeader->getUri());
     }

--- a/tests/Zend/Http/Header/RefererTest.php
+++ b/tests/Zend/Http/Header/RefererTest.php
@@ -56,7 +56,7 @@ class RefererTest extends \PHPUnit_Framework_TestCase
     {
         $refererHeader = Referer::fromString('Referer: /path/to');
         $uri = $refererHeader->uri();
-        $this->assertInstanceOf('Zend\Uri\Http', $uri);
+        $this->assertInstanceOf('Zend\Uri\Uri', $uri);
         $this->assertFalse($uri->isAbsolute());
         $this->assertEquals('/path/to', $refererHeader->getUri());
     }

--- a/tests/Zend/Uri/UriFactoryTest.php
+++ b/tests/Zend/Uri/UriFactoryTest.php
@@ -36,6 +36,9 @@ class UriFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeNotContains($class, 'schemeClasses', '\Zend\Uri\UriFactory');
         UriFactory::registerScheme($scheme, $class);
         $this->assertAttributeContains($class, 'schemeClasses', '\Zend\Uri\UriFactory');
+        UriFactory::unregisterScheme($scheme);
+        $this->assertAttributeNotContains($class, 'schemeClasses', '\Zend\Uri\UriFactory');
+       
     }
     
     /**

--- a/tests/Zend/Uri/UriFactoryTest.php
+++ b/tests/Zend/Uri/UriFactoryTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Uri
+ */
+
+namespace ZendTest\Uri;
+
+use Zend\Uri\UriFactory;
+
+/**
+ * @category   Zend
+ * @package    Zend_Uri
+ * @subpackage UnitTests
+ * @group      Zend_Uri
+ */
+class UriFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * General composing / parsing tests
+     */
+
+    /**
+     * Test registering a new Scheme
+     *
+     * @param        string $scheme
+     * @param        string $class
+     * @dataProvider registeringNewSchemeProvider
+     */
+    public function testRegisteringNewScheme($scheme, $class)
+    {
+        $this->assertAttributeNotContains($class, 'schemeClasses', '\Zend\Uri\UriFactory');
+        UriFactory::registerScheme($scheme, $class);
+        $this->assertAttributeContains($class, 'schemeClasses', '\Zend\Uri\UriFactory');
+    }
+    
+    /**
+     * Provide the data for the RegisterNewScheme-test
+     */
+    public function registeringNewSchemeProvider()
+    {
+    	return array(
+    		array('ssh', 'Foo\Bar\Class'),
+    		array('ntp', 'No real class at all!!!'),
+    	);
+    }
+    
+    /**
+     * Test creation of new URI with an existing scheme-classd
+     *
+     * @param string $uri           THe URI to create
+     * @param string $expectedClass The class expected
+     * 
+     * @dataProvider createUriWithFactoryProvider
+     */
+    public function testCreateUriWithFactory($uri, $expectedClass)
+    {
+    	$class = UriFactory::factory($uri);
+    	$this->assertInstanceof($expectedClass, $class);
+    }
+    
+    /**
+     * Providethe data for the CreateUriWithFactory-test
+     * 
+     * @return array
+     */
+    public function createUriWithFactoryProvider()
+    {
+    	return array(
+    		array('http://example.com', 'Zend\Uri\Http'),
+    		array('https://example.com', 'Zend\Uri\Http'),
+    		array('mailto://example.com', 'Zend\Uri\Mailto'),
+    		array('file://example.com', 'Zend\Uri\File'),
+    	);
+    }
+    
+    /**
+     * Test, that unknown Schemes will result in an exception
+     * 
+     * @param string $uri an uri with an unknown scheme
+     * @expectedException InvalidArgumentException
+     * @dataProvider unknownSchemeThrowsExceptionProvider
+     */
+    public function testUnknownSchemeThrowsException($uri)
+    {
+    	$url = UriFactory::factory($uri);	
+    }
+
+    /**
+     * Provide data to the unknownSchemeThrowsException-TEst
+     * 
+     * @return array
+     */
+    public function unknownSchemeThrowsExceptionProvider()
+    {
+    	return array(
+    		array('foo://bar'),
+    		array('ssh://bar'),
+    	);
+    }
+}

--- a/tests/Zend/Uri/UriFactoryTest.php
+++ b/tests/Zend/Uri/UriFactoryTest.php
@@ -85,7 +85,7 @@ class UriFactoryTest extends \PHPUnit_Framework_TestCase
      * Test, that unknown Schemes will result in an exception
      * 
      * @param string $uri an uri with an unknown scheme
-     * @expectedException InvalidArgumentException
+     * @expectedException Zend\Uri\Exception\InvalidArgumentException
      * @dataProvider unknownSchemeThrowsExceptionProvider
      */
     public function testUnknownSchemeThrowsException($uri)


### PR DESCRIPTION
The AbstractLocation now checks for an instance of UriInterface instead of Http-Uri to create a redirect-header. Therefore redirects to non-HTTP-URIs are possible now.

This adds an UriInterface that any 3rd-party URI-class has to implement to be recognised as URI.

Also the UriFactory is now used to create Uri-Objects from URI-strings

CAVEAT: This commit changes the ContentLocationTest and the AbstractLocationTest because they both asserted an instance of \Zend\Uri\Http when giving a relative URI which can no longer be true. This might break some behaviour!
