### PR TITLE
Allowing dependencies to be fetched through service manager

### DIFF
--- a/library/Zend/Mvc/Service/DiStrictAbstractServiceFactory.php
+++ b/library/Zend/Mvc/Service/DiStrictAbstractServiceFactory.php
@@ -12,6 +12,7 @@ namespace Zend\Mvc\Service;
 
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\Exception;
 use Zend\Di\Di;
 use Zend\Di\Exception\ClassNotFoundException;
@@ -87,7 +88,13 @@ class DiStrictAbstractServiceFactory extends Di implements AbstractFactoryInterf
             throw new Exception\InvalidServiceNameException('Service "' . $requestedName . '" is not whitelisted');
         }
 
-        $this->serviceLocator = $serviceLocator;
+
+        if ($serviceLocator instanceof AbstractPluginManager) {
+            /* @var $serviceLocator AbstractPluginManager */
+            $this->serviceLocator = $serviceLocator->getServiceLocator();
+        } else {
+            $this->serviceLocator = $serviceLocator;
+        }
 
         return parent::get($requestedName);
     }

--- a/tests/Zend/Mvc/Service/TestAsset/ControllerWithDependencies.php
+++ b/tests/Zend/Mvc/Service/TestAsset/ControllerWithDependencies.php
@@ -1,7 +1,11 @@
 <?php
 namespace ZendTest\Mvc\Service\TestAsset;
 
-class ControllerWithDependencies
+use Zend\Stdlib\DispatchableInterface;
+use Zend\Stdlib\RequestInterface;
+use Zend\Stdlib\ResponseInterface;
+
+class ControllerWithDependencies implements DispatchableInterface
 {
     /**
      * @var \stdClass
@@ -14,5 +18,9 @@ class ControllerWithDependencies
     public function setInjectedValue(\stdClass $injected)
     {
         $this->injectedValue = $injected;
+    }
+
+    public function dispatch(RequestInterface $request, ResponseInterface $response = null)
+    {
     }
 }


### PR DESCRIPTION
In zendframework/zf2#2005, I re-introduced fetching controllers from `Zend\Di`. This anyway is flawed since the DiC instance comes from the main `ServiceManager` instance, and the dependencies in that DiC too. That is broken, as the Di abstract factory instance (or well, the user who configured it) expects dependencies to be fetched from that particular `ServiceManager` instance.

This PR simply achieves what we currently do within the `ControllerLoader` factories by doing `$sm->getServiceLocator()->get('something')`, but implicitly and within the strict abstract Di factory.
