### PR TITLE
Fixing Iban and Sepa validation

### DIFF
--- a/library/Zend/Validator/Iban.php
+++ b/library/Zend/Validator/Iban.php
@@ -23,9 +23,10 @@ use Zend\Validator\Exception;
  */
 class Iban extends AbstractValidator
 {
-    const NOTSUPPORTED = 'ibanNotSupported';
-    const FALSEFORMAT  = 'ibanFalseFormat';
-    const CHECKFAILED  = 'ibanCheckFailed';
+    const NOTSUPPORTED     = 'ibanNotSupported';
+    const SEPANOTSUPPORTED = 'ibanSepaNotSupported';
+    const FALSEFORMAT      = 'ibanFalseFormat';
+    const CHECKFAILED      = 'ibanCheckFailed';
 
     /**
      * Validation failure message template definitions
@@ -34,6 +35,7 @@ class Iban extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::NOTSUPPORTED => "Unknown country within the IBAN",
+        self::SEPANOTSUPPORTED => "Unknown country within the SEPA",
         self::FALSEFORMAT  => "The input has a false IBAN format",
         self::CHECKFAILED  => "The input has failed the IBAN check",
     );
@@ -46,50 +48,92 @@ class Iban extends AbstractValidator
     protected $countryCode;
 
     /**
+     * Optionally allow IBAN codes from non-SEPA countries. Defaults to true
+     * 
+     * @var bool
+     */
+    protected $allowNonSepa = true;
+    
+    /**
+     * The SEPA country codes
+     * 
+     * @var array<ISO 3166-1> 
+     */
+    protected static $sepaCountries = array(
+        'AT', 'BE', 'BG', 'CY', 'CZ', 'DK', 'FO', 'GL', 'EE', 'FI', 'FR', 'DE', 
+        'GI', 'GR', 'HU', 'IS', 'IE', 'IT', 'LV', 'LI', 'LT', 'LU', 'MT', 'MC', 
+        'NL', 'NO', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE', 'CH', 'GB'
+    );
+    
+    /**
      * IBAN regexes by country code
      *
      * @var array
      */
-    protected static $ibanRegex = array(
-        'AD' => '/^AD[0-9]{2}[0-9]{8}[A-Z0-9]{12}$/',
-        'AT' => '/^AT[0-9]{2}[0-9]{5}[0-9]{11}$/',
-        'BA' => '/^BA[0-9]{2}[0-9]{6}[0-9]{10}$/',
-        'BE' => '/^BE[0-9]{2}[0-9]{3}[0-9]{9}$/',
-        'BG' => '/^BG[0-9]{2}[A-Z]{4}[0-9]{4}[0-9]{2}[A-Z0-9]{8}$/',
-        'CH' => '/^CH[0-9]{2}[0-9]{5}[A-Z0-9]{12}$/',
-        'CS' => '/^CS[0-9]{2}[0-9]{3}[0-9]{15}$/',
-        'CY' => '/^CY[0-9]{2}[0-9]{8}[A-Z0-9]{16}$/',
-        'CZ' => '/^CZ[0-9]{2}[0-9]{4}[0-9]{16}$/',
-        'DE' => '/^DE[0-9]{2}[0-9]{8}[0-9]{10}$/',
-        'DK' => '/^DK[0-9]{2}[0-9]{4}[0-9]{10}$/',
-        'EE' => '/^EE[0-9]{2}[0-9]{4}[0-9]{12}$/',
-        'ES' => '/^ES[0-9]{2}[0-9]{8}[0-9]{12}$/',
-        'FR' => '/^FR[0-9]{2}[0-9]{10}[A-Z0-9]{13}$/',
-        'FI' => '/^FI[0-9]{2}[0-9]{6}[0-9]{8}$/',
-        'GB' => '/^GB[0-9]{2}[A-Z]{4}[0-9]{14}$/',
-        'GI' => '/^GI[0-9]{2}[A-Z]{4}[A-Z0-9]{15}$/',
-        'GR' => '/^GR[0-9]{2}[0-9]{7}[A-Z0-9]{16}$/',
-        'HR' => '/^HR[0-9]{2}[0-9]{7}[0-9]{10}$/',
-        'HU' => '/^HU[0-9]{2}[0-9]{7}[0-9]{1}[0-9]{15}[0-9]{1}$/',
-        'IE' => '/^IE[0-9]{2}[A-Z0-9]{4}[0-9]{6}[0-9]{8}$/',
-        'IS' => '/^IS[0-9]{2}[0-9]{4}[0-9]{18}$/',
-        'IT' => '/^IT[0-9]{2}[A-Z]{1}[0-9]{10}[A-Z0-9]{12}$/',
-        'LI' => '/^LI[0-9]{2}[0-9]{5}[A-Z0-9]{12}$/',
-        'LU' => '/^LU[0-9]{2}[0-9]{3}[A-Z0-9]{13}$/',
-        'LT' => '/^LT[0-9]{2}[0-9]{5}[0-9]{11}$/',
-        'LV' => '/^LV[0-9]{2}[A-Z]{4}[A-Z0-9]{13}$/',
-        'MK' => '/^MK[0-9]{2}[A-Z]{3}[A-Z0-9]{10}[0-9]{2}$/',
-        'MT' => '/^MT[0-9]{2}[A-Z]{4}[0-9]{5}[A-Z0-9]{18}$/',
-        'NL' => '/^NL[0-9]{2}[A-Z]{4}[0-9]{10}$/',
-        'NO' => '/^NO[0-9]{2}[0-9]{4}[0-9]{7}$/',
-        'PL' => '/^PL[0-9]{2}[0-9]{8}[0-9]{16}$/',
-        'PT' => '/^PT[0-9]{2}[0-9]{8}[0-9]{13}$/',
-        'RO' => '/^RO[0-9]{2}[A-Z]{4}[A-Z0-9]{16}$/',
-        'SE' => '/^SE[0-9]{2}[0-9]{3}[0-9]{17}$/',
-        'SI' => '/^SI[0-9]{2}[0-9]{5}[0-9]{8}[0-9]{2}$/',
-        'SK' => '/^SK[0-9]{2}[0-9]{4}[0-9]{16}$/',
-        'TN' => '/^TN[0-9]{2}[0-9]{5}[0-9]{15}$/',
-        'TR' => '/^TR[0-9]{2}[0-9]{5}[A-Z0-9]{17}$/'
+    protected static $ibanRegex = array(    
+        'AD' => 'AD[0-9]{2}[0-9]{4}[0-9]{4}[A-Z0-9]{12}',
+        'AE' => 'AE[0-9]{2}[0-9]{3}[0-9]{16}',
+        'AL' => 'AL[0-9]{2}[0-9]{8}[A-Z0-9]{16}',
+        'AT' => 'AT[0-9]{2}[0-9]{5}[0-9]{11}',
+        'AZ' => 'AZ[0-9]{2}[A-Z]{4}[A-Z0-9]{20}',
+        'BA' => 'BA[0-9]{2}[0-9]{3}[0-9]{3}[0-9]{8}[0-9]{2}',
+        'BE' => 'BE[0-9]{2}[0-9]{3}[0-9]{7}[0-9]{2}',
+        'BG' => 'BG[0-9]{2}[A-Z]{4}[0-9]{4}[0-9]{2}[A-Z0-9]{8}',
+        'BH' => 'BH[0-9]{2}[A-Z]{4}[A-Z0-9]{14}',
+        'CH' => 'CH[0-9]{2}[0-9]{5}[A-Z0-9]{12}',
+        'CR' => 'CR[0-9]{2}[0-9]{3}[0-9]{14}',
+        'CY' => 'CY[0-9]{2}[0-9]{3}[0-9]{5}[A-Z0-9]{16}',
+        'CZ' => 'CZ[0-9]{2}[0-9]{20}',
+        'DE' => 'DE[0-9]{2}[0-9]{8}[0-9]{10}',
+        'DO' => 'DO[0-9]{2}[A-Z0-9]{4}[0-9]{20}',
+        'DK' => 'DK[0-9]{2}[0-9]{14}',
+        'EE' => 'EE[0-9]{2}[0-9]{2}[0-9]{2}[0-9]{11}[0-9]{1}',
+        'ES' => 'ES[0-9]{2}[0-9]{4}[0-9]{4}[0-9]{1}[0-9]{1}[0-9]{10}',
+        'FI' => 'FI[0-9]{2}[0-9]{6}[0-9]{7}[0-9]{1}',
+        'FO' => 'FO[0-9]{2}[0-9]{4}[0-9]{9}[0-9]{1}',
+        'FR' => 'FR[0-9]{2}[0-9]{5}[0-9]{5}[A-Z0-9]{11}[0-9]{2}',
+        'GB' => 'GB[0-9]{2}[A-Z]{4}[0-9]{6}[0-9]{8}',
+        'GE' => 'GE[0-9]{2}[A-Z]{2}[0-9]{16}',
+        'GI' => 'GI[0-9]{2}[A-Z]{4}[A-Z0-9]{15}',
+        'GL' => 'GL[0-9]{2}[0-9]{4}[0-9]{9}[0-9]{1}',
+        'GR' => 'GR[0-9]{2}[0-9]{3}[0-9]{4}[A-Z0-9]{16}',
+        'GT' => 'GT[0-9]{2}[A-Z0-9]{4}[A-Z0-9]{20}',
+        'HR' => 'HR[0-9]{2}[0-9]{7}[0-9]{10}',
+        'HU' => 'HU[0-9]{2}[0-9]{3}[0-9]{4}[0-9]{1}[0-9]{15}[0-9]{1}',
+        'IE' => 'IE[0-9]{2}[A-Z]{4}[0-9]{6}[0-9]{8}',
+        'IL' => 'IL[0-9]{2}[0-9]{3}[0-9]{3}[0-9]{13}',
+        'IS' => 'IS[0-9]{2}[0-9]{4}[0-9]{2}[0-9]{6}[0-9]{10}',
+        'IT' => 'IT[0-9]{2}[A-Z]{1}[0-9]{5}[0-9]{5}[A-Z0-9]{12}',
+        'KW' => 'KW[0-9]{2}[A-Z]{4}[0-9]{22}',
+        'KZ' => 'KZ[0-9]{2}[0-9]{3}[A-Z0-9]{13}',
+        'LB' => 'LB[0-9]{2}[0-9]{4}[A-Z0-9]{20}',
+        'LI' => 'LI[0-9]{2}[0-9]{5}[A-Z0-9]{12}',
+        'LT' => 'LT[0-9]{2}[0-9]{5}[0-9]{11}',
+        'LU' => 'LU[0-9]{2}[0-9]{3}[A-Z0-9]{13}',
+        'LV' => 'LV[0-9]{2}[A-Z]{4}[A-Z0-9]{13}',
+        'MC' => 'MC[0-9]{2}[0-9]{5}[0-9]{5}[A-Z0-9]{11}[0-9]{2}',
+        'MD' => 'MD[0-9]{2}[A-Z0-9]{20}',
+        'ME' => 'ME[0-9]{2}[0-9]{3}[0-9]{13}[0-9]{2}',
+        'MK' => 'MK[0-9]{2}[0-9]{3}[A-Z0-9]{10}[0-9]{2}',
+        'MR' => 'MR13[0-9]{5}[0-9]{5}[0-9]{11}[0-9]{2}',
+        'MT' => 'MT[0-9]{2}[A-Z]{4}[0-9]{5}[A-Z0-9]{18}',
+        'MU' => 'MU[0-9]{2}[A-Z]{4}[0-9]{2}[0-9]{2}[0-9]{12}[0-9]{3}[A-Z]{3}',
+        'NL' => 'NL[0-9]{2}[A-Z]{4}[0-9]{10}',
+        'NO' => 'NO[0-9]{2}[0-9]{4}[0-9]{6}[0-9]{1}',
+        'PK' => 'PK[0-9]{2}[A-Z]{4}[A-Z0-9]{16}',
+        'PL' => 'PL[0-9]{2}[0-9]{8}[0-9]{16}',
+        'PS' => 'PS[0-9]{2}[A-Z]{4}[A-Z0-9]{21}',
+        'PT' => 'PT[0-9]{2}[0-9]{4}[0-9]{4}[0-9]{11}[0-9]{2}',
+        'RO' => 'RO[0-9]{2}[A-Z]{4}[A-Z0-9]{16}',
+        'RS' => 'RS[0-9]{2}[0-9]{3}[0-9]{13}[0-9]{2}',
+        'SA' => 'SA[0-9]{2}[0-9]{2}[A-Z0-9]{18}',
+        'SE' => 'SE[0-9]{2}[0-9]{3}[0-9]{16}[0-9]{1}',
+        'SI' => 'SI[0-9]{2}[0-9]{5}[0-9]{8}[0-9]{2}',
+        'SK' => 'SK[0-9]{2}[0-9]{4}[0-9]{6}[0-9]{10}',
+        'SM' => 'SM[0-9]{2}[A-Z]{1}[0-9]{5}[0-9]{5}[A-Z0-9]{12}',
+        'TN' => 'TN59[0-9]{2}[0-9]{3}[0-9]{13}[0-9]{2}',
+        'TR' => 'TR[0-9]{2}[0-9]{5}[A-Z0-9]{1}[A-Z0-9]{16}',
+        'VG' => 'VG[0-9]{2}[A-Z]{4}[0-9]{16}',
     );
 
     /**
@@ -107,6 +151,10 @@ class Iban extends AbstractValidator
             $this->setCountryCode($options['country_code']);
         }
 
+        if (array_key_exists('allow_non_sepa', $options)) {
+            $this->setAllowNonSepa($options['allow_non_sepa']);
+        }
+        
         parent::__construct($options);
     }
 
@@ -119,7 +167,7 @@ class Iban extends AbstractValidator
     {
         return $this->countryCode;
     }
-
+    
     /**
      * Sets an optional country code by ISO 3166-1
      *
@@ -140,6 +188,32 @@ class Iban extends AbstractValidator
         }
 
         $this->countryCode = $countryCode;
+        return $this;
+    }
+
+    /**
+     * Returns the optional allow non-sepa countries setting
+     * 
+     * @return bool
+     */
+    public function getAllowNonSepa()
+    {
+        return $this->allowNonSepa;
+    }
+    
+    /**
+     * Sets the optional allow non-sepa countries setting
+     * 
+     * @param type $allowNonSepa 
+     * @return Iban provides a fluent interface
+     */
+    public function setAllowNonSepa($allowNonSepa = null)
+    {
+        if ($allowNonSepa !== null) {
+            $allowNonSepa = (bool) $allowNonSepa;
+        }
+        
+        $this->allowNonSepa = $allowNonSepa;
         return $this;
     }
 
@@ -170,8 +244,14 @@ class Iban extends AbstractValidator
             return false;
         }
 
-        if (!preg_match(self::$ibanRegex[$countryCode], $value)) {
-            $this->error(self::FALSEFORMAT);
+        if (!$this->allowNonSepa && !in_array($countryCode, self::$sepaCountries)) {
+            $this->setValue($countryCode);
+            $this->error(self::SEPANOTSUPPORTED);
+            return false;
+        }
+        
+        if (!preg_match('/^' . self::$ibanRegex[$countryCode] . '$/', $value)) {
+            $this->error(self::FALSEFORMAT . $value . '<>' .  self::$ibanRegex[$countryCode]);
             return false;
         }
 

--- a/tests/Zend/Validator/IbanTest.php
+++ b/tests/Zend/Validator/IbanTest.php
@@ -27,6 +27,71 @@ class IbanTest extends \PHPUnit_Framework_TestCase
             array('AT611904300234573201',     true),
             array('AT61 1904 3002 3457 3201', false),
             array('AD1200012030200354100100', false),
+            
+            array('AL47212110090000000235698741', true),
+            array('AD1200012030200359100100', true),
+            array('AT611904300234573201', true),
+            array('AZ21NABZ00000000137010001944', true),
+            array('BH67BMAG00001299123456', true),
+            array('BE68539007547034', true),
+            array('BA391290079401028494', true),
+            array('BG80BNBG96611020345678', true),
+            array('CR0515202001026284066', true),
+            array('HR1210010051863000160', true),
+            array('CY17002001280000001200527600', true),
+            array('CZ6508000000192000145399', true),
+            array('DK5000400440116243', true),
+            array('DO28BAGR00000001212453611324', true),
+            array('EE382200221020145685', true),
+            array('FO6264600001631634', true),
+            array('FI2112345600000785', true),
+            array('FR1420041010050500013M02606', true),
+            array('GE29NB0000000101904917', true),
+            array('DE89370400440532013000', true),
+            array('GI75NWBK000000007099453', true),
+            array('GR1601101250000000012300695', true),
+            array('GL8964710001000206', true),
+            array('GT82TRAJ01020000001210029690', true),
+            array('HU42117730161111101800000000', true),
+            array('IS140159260076545510730339', true),
+            array('IE29AIBK93115212345678', true),
+            array('IL620108000000099999999', true),
+            array('IT60X0542811101000000123456', true),
+            array('KZ86125KZT5004100100', true),
+            array('KW81CBKU0000000000001234560101', true),
+            array('LV80BANK0000435195001', true),
+            array('LB62099900000001001901229114', true),
+            array('LI21088100002324013AA', true),
+            array('LT121000011101001000', true),
+            array('LU280019400644750000', true),
+            array('MK07250120000058984', true),
+            array('MT84MALT011000012345MTLCAST001S', true),
+            array('MR1300020001010000123456753', true),
+            array('MU17BOMM0101101030300200000MUR', true),
+            array('MD24AG000225100013104168', true),
+            array('MC5811222000010123456789030', true),
+            array('ME25505000012345678951', true),
+            array('NL91ABNA0417164300', true),
+            array('NO9386011117947', true),
+            array('PK36SCBL0000001123456702', true),
+            array('PL61109010140000071219812874', true),
+            array('PT50000201231234567890154', true),
+            array('RO49AAAA1B31007593840000', true),
+            array('SM86U0322509800000000270100', true),
+            array('SA0380000000608010167519', true),
+            array('RS35260005601001611379', true),
+            array('SK3112000000198742637541', true),
+            array('SI56191000000123438', true),
+            array('ES9121000418450200051332', true),
+            array('SE4550000000058398257466', true),
+            array('CH9300762011623852957', true),
+            array('TN5910006035183598478831', true),
+            array('TR330006100519786457841326', true),
+            array('AE070331234567890123456', true),
+            array('GB29NWBK60161331926819', true),
+            array('VG96VPVG0000012345678901', true),
+            
+            array('DO17552081023122561803924090', true),
         );
     }
 
@@ -39,7 +104,7 @@ class IbanTest extends \PHPUnit_Framework_TestCase
     public function testBasic($iban, $expected)
     {
         $validator = new IbanValidator();
-        $this->assertEquals($expected, $validator->isValid($iban));
+        $this->assertEquals($expected, $validator->isValid($iban), implode("\n", array_merge($validator->getMessages())));
     }
 
     public function testSettingAndGettingCountryCode()
@@ -60,6 +125,16 @@ class IbanTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException('Zend\Validator\Exception\InvalidArgumentException', 'ISO 3166-1');
         $validator = new IbanValidator(array('country_code' => 'BAR'));
+    }
+
+    public function testSepaNotSupportedCountryCode()
+    {
+        $validator = new IbanValidator();
+        $this->assertTrue($validator->isValid('DO17552081023122561803924090'));
+        $validator->setAllowNonSepa(false);
+        $this->assertFalse($validator->isValid('DO17552081023122561803924090'));
+        $validator->setAllowNonSepa(true);
+        $this->assertTrue($validator->isValid('DO17552081023122561803924090'));
     }
 
     public function testIbanNotSupportedCountryCode()


### PR DESCRIPTION
The ValidatorIban class was missing quite some countries. Also the unit test was only covering a small part of the written code.

I added all IBAN countries and the option to disallow non-SEPA countries. In the unit test there is now at least one IBAN that will be tested against per country. A test for non-SEPA has also been added,
