### PR TITLE
Fixes failing DateStepTest on 31. after July

### DIFF
--- a/tests/Zend/Validator/DateStepTest.php
+++ b/tests/Zend/Validator/DateStepTest.php
@@ -65,7 +65,7 @@ class DateStepTest extends \PHPUnit_Framework_TestCase
             array('P2M',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-02-01T00:00:00Z', false),
             array('P2M',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1971-05-01T00:00:00Z', true ),
             array('P1M',  'Y-m',             '1970-01',              '1970-10',              true ),
-            array('P2M',  'Y-m',             '1970-01',              '1970-11',              true ),
+            array('P2M',  '!Y-m',            '1970-01',              '1970-11',              true ),
             array('P2M',  'Y-m',             '1970-01',              '1970-10',              false),
             // years
             array('P1Y',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true ),


### PR DESCRIPTION
This fixes a strange issue that occures in UnitTests for DateStepTests
on a 31st of a month.

The DataSet 32 of the stepTestsDataProvider contains a format-string for
the DateTime::createFromFormat. DateTime::createFromFormat() will
interpret the given date as January 1970. Due to the fact that the
formating string does not contain an exclamation mark all other values
will be inserted from the current datetime.

So on running the tests on the 6th of March the date will be set to '06'
instead of the expected '01'. THat does not make a difference. It does
make a difference though on the 31st of a month when the target month
for the comparison is September or November as these do not have 31
days. Therefore the created DateTime-Object references the first of the
following month. Therefore a diff now does not contain only a month, but
a month and one day. And therefore the test fails.

The test now uses an exclamation mark and therefore is "padded" with
"01"
