### PR TITLE
[ZF2-434] TranslatorServiceFactory error on empty 'translator' config key

### DIFF
--- a/library/Zend/I18n/Translator/TranslatorServiceFactory.php
+++ b/library/Zend/I18n/Translator/TranslatorServiceFactory.php
@@ -26,7 +26,8 @@ class TranslatorServiceFactory implements FactoryInterface
     {
         // Configure the translator
         $config = $serviceLocator->get('Configuration');
-        $translator = Translator::factory($config['translator']);
+        $trConfig = isset($config['translator']) ? $config['translator'] : array();
+        $translator = Translator::factory($trConfig);
         return $translator;
     }
 }

--- a/tests/Zend/I18n/Translator/TranslatorServiceFactoryTest.php
+++ b/tests/Zend/I18n/Translator/TranslatorServiceFactoryTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_I18n
+ */
+
+namespace ZendTest\I18n\Translator;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\I18n\Translator\TranslatorServiceFactory;
+
+class TranslatorServiceFactoryTest extends TestCase
+{
+    public function testCreateServiceWithNoTranslatorKeyDefined()
+    {
+        $slContents = array(array('Configuration', array()));
+        $serviceLocator = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $serviceLocator->expects($this->once())
+                       ->method('get')
+                       ->will($this->returnValueMap($slContents));
+
+        $factory = new TranslatorServiceFactory();
+        $translator = $factory->createService($serviceLocator);
+        $this->assertInstanceOf('Zend\I18n\Translator\Translator', $translator);
+    }
+}


### PR DESCRIPTION
Fixes [ZF2-434](http://framework.zend.com/issues/browse/ZF2-434)
