### PR TITLE
More dynamic FormCollection helper.

### DIFF
--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -10,6 +10,7 @@
 
 namespace Zend\Form\View\Helper;
 
+use RuntimeException;
 use Zend\Form\Element;
 use Zend\Form\ElementInterface;
 use Zend\Form\Element\Collection as CollectionElement;
@@ -187,8 +188,9 @@ class FormCollection extends AbstractHelper
             $this->elementHelper = $this->view->plugin($this->defaultSubHelper);
         }
 
-        if (!$this->elementHelper instanceof FormRow) {
-            $this->elementHelper = new FormRow();
+        if (!$this->elementHelper instanceof AbstractHelper) {
+            // @todo Ideally the helper should implement an interface.
+            throw new RuntimeException('Invalid element helper set in FormCollection. The helper must be an instance of AbstractHelper.');
         }
 
         return $this->elementHelper;
@@ -200,7 +202,7 @@ class FormCollection extends AbstractHelper
      * @param FormRow $rowHelper The row helper to use.
      * @return FormCollection
      */
-    public function setElementHelper(FormRow $elementHelper)
+    public function setElementHelper(AbstractHelper $elementHelper)
     {
         $this->elementHelper = $elementHelper;
         return $this;

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -28,6 +28,13 @@ class FormCollection extends AbstractHelper
      * @var boolean
      */
     protected $shouldWrap = true;
+    
+    /**
+     * The default view helper that is used to render sub elements.
+     * 
+     * @var string
+     */
+    protected $defaultSubHelper = 'form_row';
 
     /**
      * @var FormRow
@@ -154,7 +161,7 @@ class FormCollection extends AbstractHelper
         }
 
         if (method_exists($this->view, 'plugin')) {
-            $this->rowHelper = $this->view->plugin('form_row');
+            $this->rowHelper = $this->view->plugin($this->defaultSubHelper);
         }
 
         if (!$this->rowHelper instanceof FormRow) {

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -192,4 +192,16 @@ class FormCollection extends AbstractHelper
 
         return $this->rowHelper;
     }
+    
+    /**
+     * Sets the row helper that should be used by this collection.
+     * 
+     * @param FormRow $rowHelper The row helper to use.
+     * @return FormCollection
+     */
+    public function setRowHelper(FormRow $rowHelper)
+    {
+        $this->rowHelper = $rowHelper;
+        return $this;
+    }
 }

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -59,7 +59,7 @@ class FormCollection extends AbstractHelper
         $markup = '';
         $templateMarkup = '';
         $escapeHtmlHelper = $this->getEscapeHtmlHelper();
-        $rowHelper = $this->getRowHelper();
+        $elementHelper = $this->getElementHelper();
 
         if ($element instanceof CollectionElement && $element->shouldCreateTemplate()) {
             $elementOrFieldset = $element->getTemplateElement();
@@ -67,7 +67,7 @@ class FormCollection extends AbstractHelper
             if ($elementOrFieldset instanceof FieldsetInterface) {
                 $templateMarkup .= $this->render($elementOrFieldset);
             } elseif ($elementOrFieldset instanceof ElementInterface) {
-                $templateMarkup .= $rowHelper($elementOrFieldset);
+                $templateMarkup .= $elementHelper($elementOrFieldset);
             }
         }
 
@@ -75,7 +75,7 @@ class FormCollection extends AbstractHelper
             if ($elementOrFieldset instanceof FieldsetInterface) {
                 $markup .= $this->render($elementOrFieldset);
             } elseif ($elementOrFieldset instanceof ElementInterface) {
-                $markup .= $rowHelper($elementOrFieldset);
+                $markup .= $elementHelper($elementOrFieldset);
             }
         }
 
@@ -176,7 +176,7 @@ class FormCollection extends AbstractHelper
      *
      * @return FormRow
      */
-    protected function getRowHelper()
+    protected function getElementHelper()
     {
         if ($this->rowHelper) {
             return $this->rowHelper;
@@ -199,7 +199,7 @@ class FormCollection extends AbstractHelper
      * @param FormRow $rowHelper The row helper to use.
      * @return FormCollection
      */
-    public function setRowHelper(FormRow $rowHelper)
+    public function setElementHelper(FormRow $rowHelper)
     {
         $this->rowHelper = $rowHelper;
         return $this;

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -35,7 +35,7 @@ class FormCollection extends AbstractHelper
      * 
      * @var string
      */
-    protected $defaultElementHelper = 'form_row';
+    protected $defaultElementHelper = 'formrow';
 
     /**
      * The view helper used to render sub elements.

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -35,7 +35,7 @@ class FormCollection extends AbstractHelper
      * 
      * @var string
      */
-    protected $defaultSubHelper = 'form_row';
+    protected $defaultElementHelper = 'form_row';
 
     /**
      * The view helper used to render sub elements.
@@ -156,9 +156,9 @@ class FormCollection extends AbstractHelper
      * 
      * @return string
      */
-    public function getDefaultSubHelper()
+    public function getDefaultElementHelper()
     {
-        return $this->defaultSubHelper;
+        return $this->defaultElementHelper;
     }
     
     /**
@@ -167,9 +167,9 @@ class FormCollection extends AbstractHelper
      * @param string $defaultSubHelper The name of the view helper to set.
      * @return FormCollection
      */
-    public function setDefaultSubHelper($defaultSubHelper)
+    public function setDefaultElementHelper($defaultSubHelper)
     {
-        $this->defaultSubHelper = $defaultSubHelper;
+        $this->defaultElementHelper = $defaultSubHelper;
         return $this;
     }
 
@@ -185,7 +185,7 @@ class FormCollection extends AbstractHelper
         }
 
         if (method_exists($this->view, 'plugin')) {
-            $this->elementHelper = $this->view->plugin($this->defaultSubHelper);
+            $this->elementHelper = $this->view->plugin($this->getDefaultElementHelper());
         }
 
         if (!$this->elementHelper instanceof AbstractHelper) {

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -30,17 +30,18 @@ class FormCollection extends AbstractHelper
     protected $shouldWrap = true;
     
     /**
-     * The default view helper that is used to render sub elements.
+     * The name of the default view helper that is used to render sub elements.
      * 
      * @var string
      */
     protected $defaultSubHelper = 'form_row';
 
     /**
-     * @var FormRow
+     * The view helper used to render sub elements.
+     * 
+     * @var AbstractHelper
      */
-    protected $rowHelper;
-
+    protected $elementHelper;
 
     /**
      * Render a collection by iterating through all fieldsets and elements
@@ -178,19 +179,19 @@ class FormCollection extends AbstractHelper
      */
     protected function getElementHelper()
     {
-        if ($this->rowHelper) {
-            return $this->rowHelper;
+        if ($this->elementHelper) {
+            return $this->elementHelper;
         }
 
         if (method_exists($this->view, 'plugin')) {
-            $this->rowHelper = $this->view->plugin($this->defaultSubHelper);
+            $this->elementHelper = $this->view->plugin($this->defaultSubHelper);
         }
 
-        if (!$this->rowHelper instanceof FormRow) {
-            $this->rowHelper = new FormRow();
+        if (!$this->elementHelper instanceof FormRow) {
+            $this->elementHelper = new FormRow();
         }
 
-        return $this->rowHelper;
+        return $this->elementHelper;
     }
     
     /**
@@ -199,9 +200,9 @@ class FormCollection extends AbstractHelper
      * @param FormRow $rowHelper The row helper to use.
      * @return FormCollection
      */
-    public function setElementHelper(FormRow $rowHelper)
+    public function setElementHelper(FormRow $elementHelper)
     {
-        $this->rowHelper = $rowHelper;
+        $this->elementHelper = $elementHelper;
         return $this;
     }
 }

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -148,6 +148,28 @@ class FormCollection extends AbstractHelper
     {
         return $this->shouldWrap();
     }
+    
+    /**
+     * Gets the name of the view helper that should be used to render sub elements.
+     * 
+     * @return string
+     */
+    public function getDefaultSubHelper()
+    {
+        return $this->defaultSubHelper;
+    }
+    
+    /**
+     * Sets the name of the view helper that should be used to render sub elements.
+     * 
+     * @param string $defaultSubHelper The name of the view helper to set.
+     * @return FormCollection
+     */
+    public function setDefaultSubHelper($defaultSubHelper)
+    {
+        $this->defaultSubHelper = $defaultSubHelper;
+        return $this;
+    }
 
     /**
      * Retrieve the FormRow helper

--- a/tests/Zend/Form/TestAsset/CustomViewHelper.php
+++ b/tests/Zend/Form/TestAsset/CustomViewHelper.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Form\ElementInterface;
+use Zend\Form\View\Helper\AbstractHelper;
+use Zend\Form\View\Helper\FormElement;
+
+class CustomViewHelper extends AbstractHelper
+{
+    /**
+     * @var FormElement
+     */
+    protected $elementHelper;
+    
+    public function __invoke(ElementInterface $element)
+    {
+        $elementHelper = $this->getElementHelper();
+        
+        $name = preg_replace('/[^a-z0-9_-]+/', '', $element->getName());
+        
+        $result = '<div id="custom' . $name . '">' . $elementHelper($element) . '</div>';
+        
+        return $result;
+    }
+
+    /**
+     * Retrieve the FormElement helper
+     *
+     * @return FormElement
+     */
+    protected function getElementHelper()
+    {
+        if ($this->elementHelper) {
+            return $this->elementHelper;
+        }
+
+        if (method_exists($this->view, 'plugin')) {
+            $this->elementHelper = $this->view->plugin('form_element');
+        }
+
+        if (!$this->elementHelper instanceof FormElement) {
+            $this->elementHelper = new FormElement();
+        }
+
+        return $this->elementHelper;
+    }
+}

--- a/tests/Zend/Form/View/Helper/FormCollectionTest.php
+++ b/tests/Zend/Form/View/Helper/FormCollectionTest.php
@@ -17,6 +17,7 @@ use Zend\Form\View\Helper\FormCollection as FormCollectionHelper;
 use Zend\View\Helper\Doctype;
 use Zend\View\Renderer\PhpRenderer;
 use ZendTest\Form\TestAsset\FormCollection;
+use ZendTest\Form\TestAsset\CustomViewHelper;
 
 /**
  * @category   Zend
@@ -96,5 +97,21 @@ class FormCollectionTest extends TestCase
         $this->assertContains('fieldsets[0][field]', $markup);
         $this->assertContains('fieldsets[1][field]', $markup);
         $this->assertContains('fieldsets[1][nested_fieldset][anotherField]', $markup);
+    }
+
+    public function testRenderWithDefaultHelper()
+    {
+        $form = $this->getForm();
+        
+        $collection = $form->get('colors');
+        $collection->setShouldCreateTemplate(false);
+
+        $elementHelper = new CustomViewHelper();
+        $elementHelper->setView($this->renderer);
+        
+        $markup = $this->helper->setElementHelper($elementHelper)->render($collection);
+        
+        $this->assertContains('id="customcolors0"', $markup);
+        $this->assertContains('id="customcolors1"', $markup);
     }
 }


### PR DESCRIPTION
The FormCollection helper forced the usage of the FormRow helper for sub elements. This PR changes that.

You can now do this:

``` php```
'view_helpers' => array(
    'invokables' => array(
        'MyCustomHelper' => 'Zend\Form\View\Helper\FormRow',
    ),
),
```

``` php```
echo $this->formCollection()->setDefaultElementHelper('MyCustomHelper')->render($form->get('ElementName'));
```
