### PR TITLE
[Form] Hotfix - Apply object's InputFilter to baseFieldset key

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -547,7 +547,15 @@ class Form extends Fieldset implements FormInterface
     public function getInputFilter()
     {
         if ($this->object instanceof InputFilterAwareInterface) {
-            $this->filter = $this->object->getInputFilter();
+            $filter = $this->object->getInputFilter();
+
+            if (null !== $this->baseFieldset) {
+                $name = $this->baseFieldset->getName();
+                $filter = new InputFilter();
+                $filter->add($this->object->getInputFilter(), $name);
+            }
+
+            $this->filter = $filter;
         }
 
         if ($this->filter instanceof InputFilterInterface && $this->useInputFilterDefaults()) {

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -547,15 +547,16 @@ class Form extends Fieldset implements FormInterface
     public function getInputFilter()
     {
         if ($this->object instanceof InputFilterAwareInterface) {
-            $filter = $this->object->getInputFilter();
-
-            if (null !== $this->baseFieldset) {
+            if (null == $this->baseFieldset) {
+                $this->filter = $this->object->getInputFilter();
+            } else {
                 $name = $this->baseFieldset->getName();
-                $filter = new InputFilter();
-                $filter->add($this->object->getInputFilter(), $name);
+                if (!$this->filter instanceof InputFilterInterface || !$this->filter->has($name)) {
+                    $filter = new InputFilter();
+                    $filter->add($this->object->getInputFilter(), $name);
+                    $this->filter = $filter;
+                }
             }
-
-            $this->filter = $filter;
         }
 
         if ($this->filter instanceof InputFilterInterface && $this->useInputFilterDefaults()) {

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -892,6 +892,7 @@ class FormTest extends TestCase
         $this->assertObjectNotHasAttribute('foo', $data);
         $this->assertObjectHasAttribute('bar', $data);
     }
+
     public function testRemoveCollectionFromValidationGroupWhenZeroCountAndNoData()
     {
         $dataWithoutCollection = array(
@@ -915,6 +916,41 @@ class FormTest extends TestCase
             )
         ));
         $this->form->setData($dataWithoutCollection);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testApplyObjectInputFilterToBaseFieldsetAndApplyValidationGroup()
+    {
+        $fieldset = new Fieldset('foobar');
+        $fieldset->add(new Element('foo'));
+        $fieldset->setUseAsBaseFieldset(true);
+        $this->form->add($fieldset);
+        $this->form->setValidationGroup(array(
+            'foobar'=> array(
+                'foo',
+            )
+        ));
+
+        $inputFilterFactory = new InputFilterFactory();
+        $inputFilter = $inputFilterFactory->createInputFilter(array(
+            'foo' => array(
+                'name'       => 'foo',
+                'required'   => true,
+            ),
+        ));
+        $model = new TestAsset\ValidatingModel();
+        $model->setInputFilter($inputFilter);
+        $this->form->bind($model);
+
+        $this->form->setData(array());
+        $this->assertFalse($this->form->isValid());
+
+        $validSet = array(
+            'foobar' => array(
+                'foo' => 'abcde',
+            )
+        );
+        $this->form->setData($validSet);
         $this->assertTrue($this->form->isValid());
     }
 }


### PR DESCRIPTION
This resolves a bug where the objects inputfilter was applied to the root of the form, not the basefieldset when one exists
