### PR TITLE
[Fix][I18n] Fix to default text domain for Translate/TranslatePlural view helpers

### DIFF
--- a/library/Zend/I18n/View/Helper/Translate.php
+++ b/library/Zend/I18n/View/Helper/Translate.php
@@ -30,11 +30,14 @@ class Translate extends AbstractTranslatorHelper
      * @return string
      * @throws Exception\RuntimeException
      */
-    public function __invoke($message, $textDomain = 'default', $locale = null)
+    public function __invoke($message, $textDomain = null, $locale = null)
     {
         $translator = $this->getTranslator();
         if (null === $translator) {
             throw new Exception\RuntimeException('Translator has not been set');
+        }
+        if (null === $textDomain) {
+            $textDomain = $this->getTranslatorTextDomain();
         }
         return $translator->translate($message, $textDomain, $locale);
     }

--- a/library/Zend/I18n/View/Helper/TranslatePlural.php
+++ b/library/Zend/I18n/View/Helper/TranslatePlural.php
@@ -36,13 +36,16 @@ class TranslatePlural extends AbstractTranslatorHelper
         $singular,
         $plural,
         $number,
-        $textDomain = 'default',
+        $textDomain = null,
         $locale = null
     )
     {
         $translator = $this->getTranslator();
         if (null === $translator) {
             throw new Exception\RuntimeException('Translator has not been set');
+        }
+        if (null === $textDomain) {
+            $textDomain = $this->getTranslatorTextDomain();
         }
         return $translator->translatePlural($singular, $plural, $number, $textDomain, $locale);
     }

--- a/tests/Zend/I18n/View/Helper/TranslatePluralTest.php
+++ b/tests/Zend/I18n/View/Helper/TranslatePluralTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_I18n
+ */
+
+namespace ZendTest\I18n\View\Helper;
+
+use Zend\I18n\View\Helper\TranslatePlural as TranslatePluralHelper;
+
+/**
+ * @category   Zend
+ * @package    Zend_View
+ * @subpackage UnitTests
+ * @group      Zend_View
+ * @group      Zend_View_Helper
+ */
+class TranslatePluralTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TranslatePluralHelper
+     */
+    public $helper;
+
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     * This method is called before a test is executed.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->helper = new TranslatePluralHelper();
+    }
+
+    /**
+     * Tears down the fixture, for example, close a network connection.
+     * This method is called after a test is executed.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->helper);
+    }
+
+    public function testInvokingWithoutTranslatorWillRaiseException()
+    {
+        $this->setExpectedException('Zend\I18n\Exception\RuntimeException');
+        $this->helper->__invoke('singular', 'plural', 1);
+    }
+
+    public function testDefaultInvokeArguments()
+    {
+        $singularInput = 'singular';
+        $pluralInput   = 'plural';
+        $numberInput   = 1;
+        $expected      = 'translated';
+
+        $translatorMock = $this->getMock('Zend\I18n\Translator\Translator');
+        $translatorMock->expects($this->once())
+                       ->method('translatePlural')
+                       ->with(
+                           $this->equalTo($singularInput),
+                           $this->equalTo($pluralInput),
+                           $this->equalTo($numberInput),
+                           $this->equalTo('default'),
+                           $this->equalTo(null)
+                       )
+                       ->will($this->returnValue($expected));
+
+        $this->helper->setTranslator($translatorMock);
+
+        $this->assertEquals($expected, $this->helper->__invoke($singularInput, $pluralInput, $numberInput));
+    }
+
+    public function testCustomInvokeArguments()
+    {
+        $singularInput = 'singular';
+        $pluralInput   = 'plural';
+        $numberInput   = 1;
+        $expected      = 'translated';
+        $textDomain    = 'textDomain';
+        $locale        = 'en_US';
+
+        $translatorMock = $this->getMock('Zend\I18n\Translator\Translator');
+        $translatorMock->expects($this->once())
+                       ->method('translatePlural')
+                       ->with(
+                           $this->equalTo($singularInput),
+                           $this->equalTo($pluralInput),
+                           $this->equalTo($numberInput),
+                           $this->equalTo($textDomain),
+                           $this->equalTo($locale)
+                       )
+                       ->will($this->returnValue($expected));
+
+        $this->helper->setTranslator($translatorMock);
+
+        $this->assertEquals($expected, $this->helper->__invoke(
+            $singularInput, $pluralInput, $numberInput, $textDomain, $locale
+        ));
+    }
+}

--- a/tests/Zend/I18n/View/Helper/TranslateTest.php
+++ b/tests/Zend/I18n/View/Helper/TranslateTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_I18n
+ */
+
+namespace ZendTest\I18n\View\Helper;
+
+use Zend\I18n\View\Helper\Translate as TranslateHelper;
+
+/**
+ * @category   Zend
+ * @package    Zend_View
+ * @subpackage UnitTests
+ * @group      Zend_View
+ * @group      Zend_View_Helper
+ */
+class TranslateTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TranslateHelper
+     */
+    public $helper;
+
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     * This method is called before a test is executed.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->helper = new TranslateHelper();
+    }
+
+    /**
+     * Tears down the fixture, for example, close a network connection.
+     * This method is called after a test is executed.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->helper);
+    }
+
+    public function testInvokingWithoutTranslatorWillRaiseException()
+    {
+        $this->setExpectedException('Zend\I18n\Exception\RuntimeException');
+        $this->helper->__invoke('message');
+    }
+
+    public function testDefaultInvokeArguments()
+    {
+        $input    = 'input';
+        $expected = 'translated';
+
+        $translatorMock = $this->getMock('Zend\I18n\Translator\Translator');
+        $translatorMock->expects($this->once())
+                       ->method('translate')
+                       ->with($this->equalTo($input), $this->equalTo('default'), $this->equalTo(null))
+                       ->will($this->returnValue($expected));
+
+        $this->helper->setTranslator($translatorMock);
+
+        $this->assertEquals($expected, $this->helper->__invoke($input));
+    }
+
+    public function testCustomInvokeArguments()
+    {
+        $input      = 'input';
+        $expected   = 'translated';
+        $textDomain = 'textDomain';
+        $locale     = 'en_US';
+
+        $translatorMock = $this->getMock('Zend\I18n\Translator\Translator');
+        $translatorMock->expects($this->once())
+                       ->method('translate')
+                       ->with($this->equalTo($input), $this->equalTo($textDomain), $this->equalTo($locale))
+                       ->will($this->returnValue($expected));
+
+        $this->helper->setTranslator($translatorMock);
+
+        $this->assertEquals($expected, $this->helper->__invoke($input, $textDomain, $locale));
+    }
+}


### PR DESCRIPTION
Changed the Translate/TranslatePlural view helper's __invoke $textDomain default value to instead pull from it's protected property (inherited from AbstractTranslatorHelper), so that you can set the text domain to a different default prior to use.

Also added missing unit tests.
