### PR TITLE
ViewModel::setVariables() should not overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ recommend testing your production applications against it.
    composed objects. The HydratorInterface remains unchanged, but the
    shipped hydrators now all implement both that and the new
    StrategyEnabledInterface.
+ - Zend\View\Model\ViewModel::setVariables() no longer overwrites the
+   internal variables container by default. If you wish to do so, it
+   does provide an optional $overwrite argument; passing a boolean true
+   will cause the method to overwrite the container.
 
 Almost *XXX* pull requests for a variety of features and bugfixes were handled
 since beta5!

--- a/library/Zend/View/Model/ViewModel.php
+++ b/library/Zend/View/Model/ViewModel.php
@@ -84,7 +84,9 @@ class ViewModel implements ModelInterface
         if (null === $variables) {
             $variables = new ViewVariables();
         }
-        $this->setVariables($variables);
+
+        // Not using setter here, as it's initializing the variables container
+        $this->variables = $variables;
 
         if (null !== $options) {
             $this->setOptions($options);
@@ -250,25 +252,18 @@ class ViewModel implements ModelInterface
      */
     public function setVariables($variables)
     {
-        // Assumption is that renderers can handle arrays or ArrayAccess objects
-        if ($variables instanceof ArrayAccess && $variables instanceof Traversable) {
-            $this->variables = $variables;
-            return $this;
-        }
-
-        if ($variables instanceof Traversable) {
-            $variables = ArrayUtils::iteratorToArray($variables);
-        }
-
-        if (!is_array($variables)) {
+        if (!is_array($variables) && !$variables instanceof Traversable) {
             throw new Exception\InvalidArgumentException(sprintf(
-                '%s: expects an array, or Traversable ArrayAccess argument; received "%s"',
+                '%s: expects an array, or Traversable argument; received "%s"',
                 __METHOD__,
                 (is_object($variables) ? get_class($variables) : gettype($variables))
             ));
         }
 
-        $this->variables = $variables;
+        foreach ($variables as $key => $value) {
+            $this->setVariable($key, $value);
+        }
+
         return $this;
     }
 

--- a/library/Zend/View/Model/ViewModel.php
+++ b/library/Zend/View/Model/ViewModel.php
@@ -85,8 +85,8 @@ class ViewModel implements ModelInterface
             $variables = new ViewVariables();
         }
 
-        // Not using setter here, as it's initializing the variables container
-        $this->variables = $variables;
+        // Initializing the variables container
+        $this->setVariables($variables, true);
 
         if (null !== $options) {
             $this->setOptions($options);
@@ -248,9 +248,10 @@ class ViewModel implements ModelInterface
      * Can be an array or a Traversable + ArrayAccess object.
      *
      * @param  array|ArrayAccess&Traversable $variables
+     * @param  bool $overwrite Whether or not to overwrite the internal container with $variables
      * @return ViewModel
      */
-    public function setVariables($variables)
+    public function setVariables($variables, $overwrite = false)
     {
         if (!is_array($variables) && !$variables instanceof Traversable) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -258,6 +259,14 @@ class ViewModel implements ModelInterface
                 __METHOD__,
                 (is_object($variables) ? get_class($variables) : gettype($variables))
             ));
+        }
+
+        if ($overwrite) {
+            if (!is_object($variables) && !$variables instanceof ArrayAccess) {
+                $variables = ArrayUtils::iteratorToArray($variables);
+            }
+            $this->variables = $variables;
+            return $this;
         }
 
         foreach ($variables as $key => $value) {

--- a/tests/Zend/View/Model/ViewModelTest.php
+++ b/tests/Zend/View/Model/ViewModelTest.php
@@ -67,11 +67,11 @@ class ViewModelTest extends TestCase
         $this->assertEquals(array('foo' => 'baz'), $model->getVariables());
     }
 
-    public function testSetVariablesOverwritesAllPreviouslyStored()
+    public function testSetVariablesMergesWithPreviouslyStoredVariables()
     {
         $model = new ViewModel(array('foo' => 'bar', 'bar' => 'baz'));
         $model->setVariables(array('bar' => 'BAZBAT'));
-        $this->assertEquals(array('bar' => 'BAZBAT'), $model->getVariables());
+        $this->assertEquals(array('foo' => 'bar', 'bar' => 'BAZBAT'), $model->getVariables());
     }
 
     public function testCanSetOptionsSingly()
@@ -212,11 +212,10 @@ class ViewModelTest extends TestCase
         $this->assertEquals('foo', $child->captureTo());
     }
 
-    public function testAllowsPassingViewVariablesContainerAsVariables()
+    public function testAllowsPassingViewVariablesContainerAsVariablesToConstructor()
     {
         $variables = new ViewVariables();
-        $model     = new ViewModel();
-        $model->setVariables($variables);
+        $model     = new ViewModel($variables);
         $this->assertSame($variables, $model->getVariables());
     }
 
@@ -243,7 +242,7 @@ class ViewModelTest extends TestCase
         $this->assertTrue(isset($model->bar));
         $this->assertEquals('baz', $model->bar);
         $variables = $model->getVariables();
-        $this->assertArrayHasKey('bar', $variables);
+        $this->assertTrue(isset($variables['bar']));
         $this->assertEquals('baz', $variables['bar']);
     }
 }

--- a/tests/Zend/View/Model/ViewModelTest.php
+++ b/tests/Zend/View/Model/ViewModelTest.php
@@ -219,6 +219,15 @@ class ViewModelTest extends TestCase
         $this->assertSame($variables, $model->getVariables());
     }
 
+    public function testPassingOverwriteFlagWhenSettingVariablesOverwritesContainer()
+    {
+        $variables = new ViewVariables(array('foo' => 'bar'));
+        $model     = new ViewModel($variables);
+        $overwrite = new ViewVariables(array('foo' => 'baz'));
+        $model->setVariables($overwrite, true);
+        $this->assertSame($overwrite, $model->getVariables());
+    }
+
     public function testPropertyOverloadingGivesAccessToProperties()
     {
         $model      = new ViewModel();

--- a/tests/Zend/View/ViewTest.php
+++ b/tests/Zend/View/ViewTest.php
@@ -57,7 +57,10 @@ class ViewTest extends TestCase
         $this->model->setVariables($variables);
         $this->view->render($this->model);
 
-        $this->assertEquals(var_export($variables, true), $this->result->content);
+        foreach ($variables as $key => $value) {
+            $expect = sprintf("'%s' => '%s',", $key, $value);
+            $this->assertContains($expect, $this->result->content);
+        }
     }
 
     public function testRendersViewModelWithChildren()


### PR DESCRIPTION
- Modified logic internally to simply iterate and call setVariable()
- Passing variables to the constructor will initialize the internal
  property

This is per a discussion with Gary Hockin (@spabby), and posts to the ML.
