### PR TITLE
Disable external entity loading in Zend\Feed\Reader

### DIFF
--- a/library/Zend/Feed/Reader/Reader.php
+++ b/library/Zend/Feed/Reader/Reader.php
@@ -338,10 +338,10 @@ class Reader
         }
         $responseHtml = $response->getBody();
         $libxml_errflag = libxml_use_internal_errors(true);
-        //libxml_disable_entity_loader(true);
+        libxml_disable_entity_loader(true);
         $dom = new DOMDocument;
         $status = $dom->loadHTML($responseHtml);
-        //libxml_disable_entity_loader(false);
+        libxml_disable_entity_loader(false);
         libxml_use_internal_errors($libxml_errflag);
         if (!$status) {
             // Build error message
@@ -375,8 +375,10 @@ class Reader
         } elseif(is_string($feed) && !empty($feed)) {
             ErrorHandler::start(E_NOTICE|E_WARNING);
             ini_set('track_errors', 1);
+            libxml_disable_entity_loader(true);
             $dom = new DOMDocument;
             $status = $dom->loadXML($feed);
+            libxml_disable_entity_loader(false);
             ini_restore('track_errors');
             ErrorHandler::stop();
             if (!$status) {

--- a/library/Zend/Feed/Reader/Reader.php
+++ b/library/Zend/Feed/Reader/Reader.php
@@ -269,8 +269,10 @@ class Reader
     public static function importString($string)
     {
         $libxml_errflag = libxml_use_internal_errors(true);
+        libxml_disable_entity_loader(true);
         $dom = new DOMDocument;
         $status = $dom->loadXML($string);
+        libxml_disable_entity_loader(false);
         libxml_use_internal_errors($libxml_errflag);
 
         if (!$status) {
@@ -336,8 +338,10 @@ class Reader
         }
         $responseHtml = $response->getBody();
         $libxml_errflag = libxml_use_internal_errors(true);
+        //libxml_disable_entity_loader(true);
         $dom = new DOMDocument;
         $status = $dom->loadHTML($responseHtml);
+        //libxml_disable_entity_loader(false);
         libxml_use_internal_errors($libxml_errflag);
         if (!$status) {
             // Build error message

--- a/tests/Zend/Feed/Reader/ReaderTest.php
+++ b/tests/Zend/Feed/Reader/ReaderTest.php
@@ -261,6 +261,14 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Reader\Reader::isRegistered('JungleBooks'));
     }
 
+    public function testXxePreventionOnFeedParsing()
+    {
+        $string = file_get_contents($this->_feedSamplePath.'/Reader/xxe-atom10.xml');
+        $string = str_replace('XXE_URI', $this->_feedSamplePath.'/Reader/xxe-info.txt', $string);
+        $feed = Reader\Reader::importString($string);
+        $this->assertEquals('info:', $feed->getTitle());
+    }
+
     protected function _getTempDirectory()
     {
         $tmpdir = array();

--- a/tests/Zend/Feed/Reader/_files/Reader/xxe-atom10.xml
+++ b/tests/Zend/Feed/Reader/_files/Reader/xxe-atom10.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE results [ <!ENTITY discloseInfo SYSTEM "XXE_URI"> ]>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title type="text">info:&discloseInfo;</title>
+</feed>

--- a/tests/Zend/Feed/Reader/_files/Reader/xxe-info.txt
+++ b/tests/Zend/Feed/Reader/_files/Reader/xxe-info.txt
@@ -1,0 +1,1 @@
+xxe-information-disclosed


### PR DESCRIPTION
Refer to emailed report. Disabled for all DOMDocument instances used in Zend\Feed\Reader. Not required for Zend\Feed\Writer as those instances are not used for XML parsing of remote sources.
