### PR TITLE
Hotfix/incorrect exception arg in AbstractArrayNotation

### DIFF
--- a/library/Zend/Form/Annotation/AnnotationBuilder.php
+++ b/library/Zend/Form/Annotation/AnnotationBuilder.php
@@ -337,6 +337,11 @@ class AnnotationBuilder implements EventManagerAwareInterface
         } else {
             if (!isset($formSpec['elements'])) {
                 $formSpec['elements'] = array();
+
+                // add required attribute to form element
+                if ($inputSpec['required']){
+                    $elementSpec['spec']['attributes']['required'] = 'required';
+                }
             }
             $formSpec['elements'][] = $elementSpec;
         }

--- a/tests/Zend/Form/Annotation/AnnotationBuilderTest.php
+++ b/tests/Zend/Form/Annotation/AnnotationBuilderTest.php
@@ -37,6 +37,8 @@ class AnnotationBuilderTest extends TestCase
 
         $username = $form->get('username');
         $this->assertInstanceOf('Zend\Form\Element', $username);
+        $attribute = $username->getAttribute('required');
+        $this->assertEquals('required', $attribute);
         $password = $form->get('password');
         $this->assertInstanceOf('Zend\Form\Element', $password);
         $attributes = $password->getAttributes();


### PR DESCRIPTION
exception will try to gettype of data['value'], even when the problem could be that it's not set.
