### PR TITLE
fixing error in abstractarrayannotation arg

### DIFF
--- a/library/Zend/Form/Annotation/AbstractArrayAnnotation.php
+++ b/library/Zend/Form/Annotation/AbstractArrayAnnotation.php
@@ -36,7 +36,7 @@ abstract class AbstractArrayAnnotation
             throw new Exception\DomainException(sprintf(
                 '%s expects the annotation to define an array; received "%s"',
                 get_class($this),
-                gettype($data['value'])
+                isset($data['value']) ? gettype($data['value']) : 'null',
             ));
         }
         $this->value = $data['value'];

--- a/library/Zend/Form/Annotation/AbstractArrayAnnotation.php
+++ b/library/Zend/Form/Annotation/AbstractArrayAnnotation.php
@@ -36,7 +36,7 @@ abstract class AbstractArrayAnnotation
             throw new Exception\DomainException(sprintf(
                 '%s expects the annotation to define an array; received "%s"',
                 get_class($this),
-                isset($data['value']) ? gettype($data['value']) : 'null',
+                isset($data['value']) ? gettype($data['value']) : 'null'
             ));
         }
         $this->value = $data['value'];


### PR DESCRIPTION
gettype was called on the value key, even though the arg may not be set
