### PR TITLE
Fix readChar() on Windows, fix NS import after recent refactor.

### DIFF
--- a/library/Zend/Console/Adapter/AbstractAdapter.php
+++ b/library/Zend/Console/Adapter/AbstractAdapter.php
@@ -14,6 +14,7 @@ use Zend\Console\AdapterInterface;
 use Zend\Console\ColorInterface;
 use Zend\Console\CharsetInterface;
 use Zend\Console\Exception\BadMethodCallException;
+use Zend\Console\Charset;
 use Zend\Console;
 
 /**
@@ -611,7 +612,7 @@ abstract class AbstractAdapter implements AdapterInterface
         $f = fopen('php://stdin','r');
         $line = stream_get_line($f,2048,"\n");
         fclose($f);
-        return $line;
+        return rtrim($line,"\n\r");
     }
 
     /**

--- a/library/Zend/Console/Adapter/Posix.php
+++ b/library/Zend/Console/Adapter/Posix.php
@@ -14,13 +14,14 @@ use Zend\Console\AdapterInterface;
 use Zend\Console\ColorInterface as Color;
 use Zend\Console\CharsetInterface;
 use Zend\Console\Exception\BadMethodCallException;
+use Zend\Console\Charset;
 use Zend\Console;
 
 /**
- * @link http://en.wikipedia.org/wiki/ANSI_escape_code
  * @category   Zend
  * @package    Zend_Console
  * @subpackage Adapter
+ * @link http://en.wikipedia.org/wiki/ANSI_escape_code
  */
 class Posix extends AbstractAdapter implements AdapterInterface
 {
@@ -337,7 +338,7 @@ class Posix extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-     * @return \Zend\Console\Charset
+     * @return \Zend\Console\CharsetInterface
      */
     public function getDefaultCharset()
     {

--- a/library/Zend/Console/Adapter/Virtual.php
+++ b/library/Zend/Console/Adapter/Virtual.php
@@ -13,6 +13,7 @@ namespace Zend\Console\Adapter;
 use Zend\Console\AdapterInterface;
 use Zend\Console\ColorInterface;
 use Zend\Console\CharsetInterface;
+use Zend\Console\Charset;
 use Zend\Console;
 
 /**

--- a/library/Zend/Console/Adapter/Windows.php
+++ b/library/Zend/Console/Adapter/Windows.php
@@ -14,6 +14,7 @@ use Zend\Console\AdapterInterface;
 use Zend\Console\ColorInterface;
 use Zend\Console\CharsetInterface;
 use Zend\Console\Exception\RuntimeException;
+use Zend\Console\Charset;
 use Zend\Console;
 
 /**

--- a/library/Zend/Console/Adapter/WindowsAnsicon.php
+++ b/library/Zend/Console/Adapter/WindowsAnsicon.php
@@ -14,6 +14,7 @@ use Zend\Console\AdapterInterface;
 use Zend\Console\ColorInterface;
 use Zend\Console\CharsetInterface;
 use Zend\Console\Exception\RuntimeException;
+use Zend\Console\Charset;
 use Zend\Console;
 
 /**

--- a/library/Zend/Console/Adapter/WindowsAnsicon.php
+++ b/library/Zend/Console/Adapter/WindowsAnsicon.php
@@ -191,6 +191,7 @@ class WindowsAnsicon extends Posix implements AdapterInterface
      * Read a single character from the console input
      *
      * @param string|null   $mask   A list of allowed chars
+     * @throws \Zend\Console\Exception\RuntimeException
      * @return string
      */
     public function readChar($mask = null)
@@ -198,11 +199,15 @@ class WindowsAnsicon extends Posix implements AdapterInterface
         /**
          * Decide if we can use `choice` tool
          */
-        $useChoice = $mask !== null && preg_match('/^[a-zA-Z0-9]$', $mask);
+        $useChoice = $mask !== null && preg_match('/^[a-zA-Z0-9]+$/D', $mask);
 
-        do {
-            if ($useChoice) {
-                system('choice /n /cs /c '.$mask,$return);
+        if ($useChoice) {
+            /**
+             * Use Windows 98+ "choice" command, which allows for reading a single character matching a mask,
+             * but is limited to lower ASCII range.
+             */
+            do {
+                system('choice /n /cs /c:'.$mask,$return);
                 if ($return == 255 || $return < 1 || $return > strlen($mask)) {
                     throw new RuntimeException('"choice" command failed to run. Are you using Windows XP or newer?');
                 } else {
@@ -211,10 +216,95 @@ class WindowsAnsicon extends Posix implements AdapterInterface
                      */
                     $char = substr($mask,$return-1,1);
                 }
-            } else {
-                $char = parent::readChar($mask);
+            } while (!$char || ($mask !== null && !stristr($mask, $char)));
+
+            return $char;
+        }
+
+        /**
+         * Try to use PowerShell, giving it console access. Because PowersShell interpreter can take a short while to
+         * load, we are emptying the whole keyboard buffer and picking the last key that has been pressed before or
+         * after PowerShell command has started. The ASCII code for that key is then converted to a character.
+         */
+        if ($mask === null) {
+            exec(
+                'powershell -NonInteractive -NoProfile -NoLogo -OutputFormat Text -Command "'.
+                'while ($Host.UI.RawUI.KeyAvailable) {$key = $Host.UI.RawUI.ReadKey(\'NoEcho,IncludeKeyDown\');}'.
+                'write $key.VirtualKeyCode;'.
+                '"',
+                $result,
+                $return
+            );
+
+            // Retrieve char from the result.
+            $char = !empty($result) ? implode('', $result) : null;
+
+            if(!empty($char) && !$return){
+                // We have obtained an ASCII code, convert back to a char ...
+                $char = chr($char);
+
+                // ... and return it...
+                return $char;
             }
+        } else {
+            /**
+             * Windows and DOS will return carriage-return char (ASCII 13) when the user presses [ENTER] key,
+             * but Console Adapter user might have provided a \n Newline (ASCII 10) in the mask, to allow [ENTER].
+             * We are going to replace all CR with NL to conform.
+             */
+            $mask = strtr($mask,"\n","\r");
+
+            /**
+             * Prepare a list of ASCII codes from mask chars
+             */
+            $asciiMask = array_map(function($char){
+                return ord($char);
+            },str_split($mask));
+            $asciiMask = array_unique($asciiMask);
+
+            /**
+             * Char mask filtering is now handled by the PowerShell itself, because it's a much faster method than
+             * invoking PS interpreter after each mismatch. The command should return ASCII code of a matching key.
+             */
+            $result = $return = null;
+            exec(
+                'powershell -NonInteractive -NoProfile -NoLogo -OutputFormat Text -Command "'.
+                '[int[]] $mask = '.join(',',$asciiMask).';'.
+                'do {'.
+                    '$key = $Host.UI.RawUI.ReadKey(\'NoEcho,IncludeKeyDown\').VirtualKeyCode;'.
+                '} while( !($mask -contains $key) );'.
+                'write $key;'.
+                '"',
+                $result,
+                $return
+            );
+
+            $char = !empty($result) ? trim(implode('',$result)) : null;
+
+            if(!$return && $char && ($mask === null || in_array($char,$asciiMask))){
+                // We have obtained an ASCII code, check if it is a carriage return and normalize it as needed
+                if ($char == 13) {
+                    $char = 10;
+                }
+                // Convert to a character
+                $char = chr($char);
+
+                // ... and return it...
+                return $char;
+            }
+        }
+
+        /**
+         * Fall back to standard input, which on Windows does not allow reading a single character. This is a
+         * limitation of Windows streams implementation (not PHP) and this behavior cannot be changed with a command
+         * like "stty", known to POSIX systems.
+         */
+        $stream = fopen('php://stdin','rb');
+        do {
+            $char = fgetc($stream);
+            $char = substr(trim($char), 0, 1);
         } while (!$char || ($mask !== null && !stristr($mask, $char)));
+        fclose($stream);
 
         return $char;
     }

--- a/library/Zend/Console/Prompt/AbstractPrompt.php
+++ b/library/Zend/Console/Prompt/AbstractPrompt.php
@@ -13,6 +13,7 @@ namespace Zend\Console\Prompt;
 use Zend\Console\PromptInterface;
 use Zend\Console\Console;
 use Zend\Console\AdapterInterface as ConsoleAdapter;
+use Zend\Console\Exception\BadMethodCallException;
 
 /**
  * @category   Zend
@@ -31,10 +32,7 @@ abstract class AbstractPrompt implements PromptInterface
      */
     protected $lastResponse;
 
-    public function show()
-    {
-
-    }
+    abstract public function show();
 
     /**
      * Return last answer to this prompt.
@@ -68,6 +66,28 @@ abstract class AbstractPrompt implements PromptInterface
     public function setConsole(ConsoleAdapter $adapter)
     {
         $this->console = $adapter;
+    }
+
+    /**
+     * Create an instance of this prompt, show it and return response.
+     * 
+     * This is a convenience method for creating statically creating prompts, i.e.:
+     *
+     *      $name = Zend\Console\Prompt\Line::prompt("Enter your name: ");
+     *
+     * @throws \Zend\Console\Exception\BadMethodCallException
+     * @return mixed
+     */
+    public static function prompt(){
+        if (get_called_class() === __CLASS__) {
+            throw new BadMethodCallException(
+                'Cannot call prompt() on AbstractPrompt class. Use one of Console\Prompt\ subclasses.'
+            );
+        }
+
+        $refl     = new \ReflectionClass(get_called_class());
+        $instance = $refl->newInstanceArgs(func_get_args());
+        return $instance->show();
     }
 
 }


### PR DESCRIPTION
### Fix NS import

One of recent refactors has made `Charset` subclasses undiscoverable, breaking `AdapterInterface::getDefaultCharset()` method.
### Workaround Windows limitation and allow for reading chars

Reading a single char, validated against a char mask now works on Windows. The adapter will attempt to use either "choice" command (known since Windows 95) or Windows PowerShell, to obtain a single keystroke from user and validate it against a mask of allowed characters. This method works with both low and high ASCII chars, which enables capturing keys such as cursors, tab, escape, backspace and enter.
### Add Prompt::prompt() convenience method

It is now possible to create prompts by calling static prompt() method, i.e. `$key = Prompt\Char::prompt("Press any key")`.
