### PR TITLE
fixing parse method to set a path of at least /

### DIFF
--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -253,9 +253,6 @@ class Socket implements HttpAdapter, StreamInterface
 
         // Build request headers
         $path = $uri->getPath();
-        if (strlen($path) === 0){
-            $path = '/';
-        }
         if ($uri->getQuery()) $path .= '?' . $uri->getQuery();
         $request = "{$method} {$path} HTTP/{$http_ver}\r\n";
         foreach ($headers as $k => $v) {

--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -253,6 +253,9 @@ class Socket implements HttpAdapter, StreamInterface
 
         // Build request headers
         $path = $uri->getPath();
+        if (strlen($path) === 0){
+            $path = '/';
+        }
         if ($uri->getQuery()) $path .= '?' . $uri->getQuery();
         $request = "{$method} {$path} HTTP/{$http_ver}\r\n";
         foreach ($headers as $k => $v) {

--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -178,4 +178,19 @@ class Http extends Uri
         }
         return $this->port;
     }
+
+    /**
+     * Parse a URI string
+     *
+     * @param  string $uri
+     * @return Uri
+     */
+    public function parse($uri)
+    {
+        parent::parse($uri);
+
+        if (empty($this->path)){
+            $this->path = '/';
+        }
+    }
 }

--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -192,5 +192,7 @@ class Http extends Uri
         if (empty($this->path)){
             $this->path = '/';
         }
+
+        return $this;
     }
 }

--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -183,7 +183,7 @@ class Http extends Uri
      * Parse a URI string
      *
      * @param  string $uri
-     * @return Uri
+     * @return Http
      */
     public function parse($uri)
     {

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -267,11 +267,12 @@ class Uri implements UriInterface
             $this->setHost($authority);
         }
 
+        if (!$uri) {
+            return $this;
+        }
+
         // Capture the path
         if (preg_match('|^[^\?#]*|', $uri, $match)) {
-            if (strlen($match[0]) === 0){
-                $match[0] = '/';
-            }
             $this->setPath($match[0]);
             $uri = substr($uri, strlen($match[0]));
         }

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -267,15 +267,15 @@ class Uri implements UriInterface
             $this->setHost($authority);
         }
 
-        if (!$uri) {
-            return $this;
-        }
-
         // Capture the path
         if (preg_match('|^[^\?#]*|', $uri, $match)) {
+            if (strlen($match[0]) === 0){
+                $match[0] = '/';
+            }
             $this->setPath($match[0]);
             $uri = substr($uri, strlen($match[0]));
         }
+
         if (!$uri) {
             return $this;
         }


### PR DESCRIPTION
if an uri of 'foobar.com' is passed to uri, a path of '/' is not inserted.

http://framework.zend.com/issues/browse/ZF2-444
