### PR TITLE
Refactores UriFactory

### DIFF
--- a/library/Zend/Uri/UriFactory.php
+++ b/library/Zend/Uri/UriFactory.php
@@ -68,13 +68,13 @@ abstract class UriFactory
 
     /**
      * Create a URI from a string
-     * 
-     * When a relative URI without a scheme is given, this will return an 
-     * URI-object of scheme <var>$defaultScheme</var> 
+     *
+     * When a relative URI without a scheme is given, this will return an
+     * URI-object of scheme <var>$defaultScheme</var>
      *
      * @param  string $uriString     The URI to create an object for
      * @param  string $defaultScheme What scheme to use for relative URIs
-     * 
+     *
      * @throws Exception\InvalidArgumentException
      * @return \Zend\Uri\UriInterface
      */
@@ -93,9 +93,9 @@ abstract class UriFactory
         if (!$scheme && $defaultScheme) {
             $scheme = $defaultScheme;
         }
-        
+
         if (!$scheme) {
-        	throw new Exception\InvalidArgumentException('no scheme has been given');
+            throw new Exception\InvalidArgumentException('no scheme has been given');
         }
 
         if (! isset(static::$schemeClasses[$scheme])) {
@@ -113,7 +113,7 @@ abstract class UriFactory
                 $scheme
             ));
         }
-        
+
         return $uri;
     }
 }

--- a/library/Zend/Uri/UriFactory.php
+++ b/library/Zend/Uri/UriFactory.php
@@ -68,13 +68,17 @@ abstract class UriFactory
 
     /**
      * Create a URI from a string
+     * 
+     * When a relative URI without a scheme is given, this will return an 
+     * URI-object of scheme <var>$defaultScheme</var> 
      *
-     * @param  string $uriString
-     * @param  string $defaultScheme
+     * @param  string $uriString     The URI to create an object for
+     * @param  string $defaultScheme What scheme to use for relative URIs
+     * 
      * @throws Exception\InvalidArgumentException
-     * @return \Zend\Uri\Uri
+     * @return \Zend\Uri\UriInterface
      */
-    public static function factory($uriString, $defaultScheme = null)
+    public static function factory($uriString, $defaultScheme = 'http')
     {
         if (!is_string($uriString)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -83,30 +87,33 @@ abstract class UriFactory
             ));
         }
 
-        $uri    = new Uri($uriString);
-        $scheme = strtolower($uri->getScheme());
+        $colon  = strpos($uriString, ':');
+        $scheme = substr($uriString, 0, $colon);
+        $scheme = strtolower($scheme);
         if (!$scheme && $defaultScheme) {
             $scheme = $defaultScheme;
         }
+        
+        if (!$scheme) {
+        	throw new Exception\InvalidArgumentException('no scheme has been given');
+        }
 
-        if ($scheme && ! isset(static::$schemeClasses[$scheme])) {
+        if (! isset(static::$schemeClasses[$scheme])) {
             throw new Exception\InvalidArgumentException(sprintf(
-                    'no class registered for scheme "%s"',
-                    $scheme
-                ));
+                'no class registered for scheme "%s"',
+                $scheme
+            ));
         }
-        if ($scheme && isset(static::$schemeClasses[$scheme])) {
-            $class = static::$schemeClasses[$scheme];
-            $uri = new $class($uri);
-            if (! $uri instanceof UriInterface) {
-                throw new Exception\InvalidArgumentException(sprintf(
-                    'class "%s" registered for scheme "%s" does not implement Zend\Uri\UriInterface',
-                    $class,
-                    $scheme
-                ));
-            }
+        $class = static::$schemeClasses[$scheme];
+        $uri = new $class($uriString);
+        if (! $uri instanceof UriInterface) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'class "%s" registered for scheme "%s" does not implement Zend\Uri\UriInterface',
+                $class,
+                $scheme
+            ));
         }
-
+        
         return $uri;
     }
 }

--- a/tests/Zend/Uri/UriFactoryTest.php
+++ b/tests/Zend/Uri/UriFactoryTest.php
@@ -62,11 +62,11 @@ class UriFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateUriWithFactory($uri, $expectedClass, $defaultScheme = null)
     {
-    	if ($defaultScheme) {
-    		$class = UriFactory::factory($uri, $defaultScheme);
-    	} else {
-	        $class = UriFactory::factory($uri);
-    	}
+        if ($defaultScheme) {
+            $class = UriFactory::factory($uri, $defaultScheme);
+        } else {
+            $class = UriFactory::factory($uri);
+        }
         $this->assertInstanceof($expectedClass, $class);
     }
 
@@ -82,8 +82,8 @@ class UriFactoryTest extends \PHPUnit_Framework_TestCase
             array('https://example.com', 'Zend\Uri\Http'),
             array('mailto://example.com', 'Zend\Uri\Mailto'),
             array('file://example.com', 'Zend\Uri\File'),
-        	array('https:', 'Zend\Uri\Http'),
-        	array('/foo/bar/?test', 'Zend\Uri\File', 'file'),
+            array('https:', 'Zend\Uri\Http'),
+            array('/foo/bar/?test', 'Zend\Uri\File', 'file'),
         );
     }
 

--- a/tests/Zend/Uri/UriFactoryTest.php
+++ b/tests/Zend/Uri/UriFactoryTest.php
@@ -60,9 +60,13 @@ class UriFactoryTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider createUriWithFactoryProvider
      */
-    public function testCreateUriWithFactory($uri, $expectedClass)
+    public function testCreateUriWithFactory($uri, $expectedClass, $defaultScheme = null)
     {
-        $class = UriFactory::factory($uri);
+    	if ($defaultScheme) {
+    		$class = UriFactory::factory($uri, $defaultScheme);
+    	} else {
+	        $class = UriFactory::factory($uri);
+    	}
         $this->assertInstanceof($expectedClass, $class);
     }
 
@@ -78,6 +82,8 @@ class UriFactoryTest extends \PHPUnit_Framework_TestCase
             array('https://example.com', 'Zend\Uri\Http'),
             array('mailto://example.com', 'Zend\Uri\Mailto'),
             array('file://example.com', 'Zend\Uri\File'),
+        	array('https:', 'Zend\Uri\Http'),
+        	array('/foo/bar/?test', 'Zend\Uri\File', 'file'),
         );
     }
 


### PR DESCRIPTION
UriFactory::factory now creates an URI without instantiating an Uri-Object to retrieve the scheme.

If no scheme is found in the URI-string (for instance when passing a relative URI) a defaultScheme can be given, that will force creation of an URI object for the given scheme.

This will only be used when no scheme can be detected in the URI-string!
