### PR TITLE
[Fix] Cleanup unnecessary method override in FormCheckbox view helper

### DIFF
--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -75,23 +75,6 @@ class FormCheckbox extends FormInput
     }
 
     /**
-     * Invoke helper as functor
-     *
-     * Proxies to {@link render()}.
-     *
-     * @param  ElementInterface $element
-     * @return string|FormCheckbox
-     */
-    public function __invoke(ElementInterface $element = null)
-    {
-        if (!$element) {
-            return $this;
-        }
-
-        return $this->render($element);
-    }
-
-    /**
      * Return input type
      *
      * @return string


### PR DESCRIPTION
Removed a method in FormCheckbox that was the same as it's parent class: https://github.com/zendframework/zf2/blob/master/library/Zend/Form/View/Helper/FormInput.php#L129
