### PR TITLE
Set SSL Context in HTTP Client's Socket adapter to use verify_peer===TRUE by default

### DIFF
--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -53,11 +53,13 @@ class Socket implements HttpAdapter, StreamInterface
      * @var array
      */
     protected $config = array(
-        'persistent'    => false,
-        'ssltransport'  => 'ssl',
-        'sslcert'       => null,
-        'sslpassphrase' => null,
-        'sslusecontext' => false
+        'persistent'            => false,
+        'ssltransport'          => 'ssl',
+        'sslcert'               => null,
+        'sslpassphrase'         => null,
+        'sslverifypeer'         => true,
+        'sslallowselfsigned'    => false,
+        'sslusecontext'         => false
     );
 
     /**
@@ -182,6 +184,18 @@ class Socket implements HttpAdapter, StreamInterface
         if (! is_resource($this->socket) || ! $this->config['keepalive']) {
             $context = $this->getStreamContext();
             if ($secure || $this->config['sslusecontext']) {
+                if ($this->config['sslverifypeer'] !== null) {
+                    if (! stream_context_set_option($context, 'ssl', 'verify_peer',
+                                                    $this->config['sslverifypeer'])) {
+                        throw new AdapterException\RuntimeException('Unable to set sslverifypeer option');
+                    }
+                    if ($this->config['sslallowselfsigned'] !== null) {
+                        if (! stream_context_set_option($context, 'ssl', 'allow_self_signed',
+                                                        $this->config['sslallowselfsigned'])) {
+                            throw new AdapterException\RuntimeException('Unable to set sslallowselfsigned option');
+                        }
+                    }
+                }
                 if ($this->config['sslcert'] !== null) {
                     if (! stream_context_set_option($context, 'ssl', 'local_cert',
                                                     $this->config['sslcert'])) {

--- a/tests/Zend/Http/Client/SocketTest.php
+++ b/tests/Zend/Http/Client/SocketTest.php
@@ -65,6 +65,29 @@ class SocketTest extends CommonHttpTests
         }
     }
 
+    public function testDefaultConfig()
+    {
+        $config = $this->_adapter->getConfig();
+        $this->assertEquals(TRUE, $config['sslverifypeer']);
+        $this->assertEquals(FALSE, $config['sslallowselfsigned']);
+    }
+
+    public function testConnectingViaSslEnforcesDefaultSslOptionsOnContext()
+    {
+        $config = array('timeout' => 30);
+        $this->_adapter->setOptions($config);
+        try {
+            $this->_adapter->connect('localhost', 443, true);
+        } catch (\Zend\Http\Client\Adapter\Exception\RuntimeException $e) {
+            // Test is designed to allow connect failure because we're interested
+            // only in the stream context state created within that method.
+        }
+        $context = $this->_adapter->getStreamContext();
+        $options = stream_context_get_options($context);
+        $this->assertTrue($options['ssl']['verify_peer']);
+        $this->assertFalse($options['ssl']['allow_self_signed']);
+    }
+
     /**
      * Test that a Zend_Config object can be used to set configuration
      *


### PR DESCRIPTION
Not performing SSL server verification leaves the adapter vulnerable to Man-In-The-Middle attacks by default. Curl adapter is not impacted as it enables peer verification by default and it must be deliberately disable for that adapter.
