### PR TITLE
[Tests] Use Zend_Autoloader when Composer's autoloader is not present.

### DIFF
--- a/tests/_autoload.php
+++ b/tests/_autoload.php
@@ -3,19 +3,17 @@
  * Setup autoloading
  */
 
-// Setup autoloading for ZendTest assets
-require_once __DIR__ . '/../library/Zend/Loader/StandardAutoloader.php';
-$loader = new Zend\Loader\StandardAutoloader(
-    array(
-            Zend\Loader\StandardAutoloader::LOAD_NS => array(
-                'ZendTest' => __DIR__ . '/ZendTest',
-            ),
-    ));
-$loader->register();
-
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     include_once __DIR__ . '/../vendor/autoload.php';
 } else {
     // if composer autoloader is missing, explicitly add the ZF library path
-    $loader->registerNamespace('Zend', __DIR__ . '/../library/Zend');
+    require_once __DIR__ . '/../library/Zend/Loader/StandardAutoloader.php';
+    $loader = new Zend\Loader\StandardAutoloader(
+        array(
+             Zend\Loader\StandardAutoloader::LOAD_NS => array(
+                 'Zend'     => __DIR__ . '/../library/Zend',
+                 'ZendTest' => __DIR__ . '/ZendTest',
+             ),
+        ));
+    $loader->register();
 }


### PR DESCRIPTION
Note: If your tests are failing after this patch probably you need to do "php composer.phar update" to update Composer's autoloader with the new lists of namespaces
