### PR TITLE
Hotfix/zf2 440

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -160,8 +160,8 @@ class BaseInputFilter implements InputFilterInterface
         foreach ($inputs as $name) {
             $input = $this->inputs[$name];
             if (!array_key_exists($name, $this->data)
-                || (is_string($this->data[$name]) && strlen($this->data[$name]) === 0)
                 || (null === $this->data[$name])
+                || (is_string($this->data[$name]) && strlen($this->data[$name]) === 0)
             ) {
                 if($input instanceof InputInterface) {
                     // - test if input is required

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -157,10 +157,12 @@ class BaseInputFilter implements InputFilterInterface
         $valid               = true;
 
         $inputs = $this->validationGroup ?: array_keys($this->inputs);
-        //var_dump($inputs);
         foreach ($inputs as $name) {
             $input = $this->inputs[$name];
-            if (!array_key_exists($name, $this->data) || (is_string($this->data[$name]) && strlen($this->data[$name]) === 0)) {
+            if (!array_key_exists($name, $this->data) 
+                || (is_string($this->data[$name]) && strlen($this->data[$name]) === 0)
+                || (null === $this->data[$name])
+            ) {
                 if($input instanceof InputInterface) {
                     // - test if input is required
                     if (!$input->isRequired()) {

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -159,7 +159,7 @@ class BaseInputFilter implements InputFilterInterface
         $inputs = $this->validationGroup ?: array_keys($this->inputs);
         foreach ($inputs as $name) {
             $input = $this->inputs[$name];
-            if (!array_key_exists($name, $this->data) 
+            if (!array_key_exists($name, $this->data)
                 || (is_string($this->data[$name]) && strlen($this->data[$name]) === 0)
                 || (null === $this->data[$name])
             ) {

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -992,8 +992,8 @@ class FormTest extends TestCase
         $this->assertEquals('AAA', $entities[0]->getField2());
         $this->assertEquals('CCC', $entities[1]->getField2());
     }
-	
-	public function testSetDataWithNullValues()
+
+    public function testSetDataWithNullValues()
     {
         $this->populateForm();
 

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -992,4 +992,20 @@ class FormTest extends TestCase
         $this->assertEquals('AAA', $entities[0]->getField2());
         $this->assertEquals('CCC', $entities[1]->getField2());
     }
+	
+	public function testSetDataWithNullValues()
+    {
+        $this->populateForm();
+
+        $set = array(
+            'foo' => null,
+            'bar' => 'always valid',
+            'foobar' => array(
+                'foo' => 'abcde',
+                'bar' => 'always valid',
+            ),
+        );
+        $this->form->setData($set);
+        $this->assertTrue($this->form->isValid());
+    }
 }


### PR DESCRIPTION
Fixes (ZF2-440)[http://framework.zend.com/issues/browse/ZF2-440] -- as proven by #2095 -- whereby passing a null value to a non-required input previously failed validation; this patch makes such validation pass (as it should).
