### PR TITLE
SharedEventManager Attach not returning a CallbackHandler

### DIFF
--- a/library/Zend/EventManager/SharedEventManager.php
+++ b/library/Zend/EventManager/SharedEventManager.php
@@ -59,7 +59,7 @@ class SharedEventManager implements SharedEventManagerInterface
      * @param  string $event
      * @param  callback $callback PHP Callback
      * @param  int $priority Priority at which listener should execute
-     * @return void
+     * @return CallbackHander|array Either CallbackHandler or array of CallbackHandlers
      */
     public function attach($id, $event, $callback, $priority = 1)
     {

--- a/library/Zend/EventManager/SharedEventManager.php
+++ b/library/Zend/EventManager/SharedEventManager.php
@@ -64,12 +64,17 @@ class SharedEventManager implements SharedEventManagerInterface
     public function attach($id, $event, $callback, $priority = 1)
     {
         $ids = (array) $id;
+        $listeners = array();
         foreach ($ids as $id) {
             if (!array_key_exists($id, $this->identifiers)) {
                 $this->identifiers[$id] = new EventManager();
             }
-            $this->identifiers[$id]->attach($event, $callback, $priority);
+            $listeners[] = $this->identifiers[$id]->attach($event, $callback, $priority);
         }
+        if (count($listeners) > 1){
+            return $listeners;
+        }
+        return $listeners[0];
     }
 
     /**

--- a/tests/ZendTest/EventManager/EventManagerTest.php
+++ b/tests/ZendTest/EventManager/EventManagerTest.php
@@ -612,9 +612,13 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($shared, StaticEventManager::getInstance());
     }
 
-    public function testSharedEventManagerAttachReturnsCallbackHander(){
+    public function testSharedEventManagerAttachReturnsCallbackHandler()
+    {
         $shared = new SharedEventManager;
-        $callbackHandler = $shared->attach('foo', 'bar', function($e){
+        $callbackHandler = $shared->attach(
+            'foo',
+            'bar',
+            function($e) {
                 return true;
             }
         );

--- a/tests/ZendTest/EventManager/EventManagerTest.php
+++ b/tests/ZendTest/EventManager/EventManagerTest.php
@@ -612,6 +612,15 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($shared, StaticEventManager::getInstance());
     }
 
+    public function testSharedEventManagerAttachReturnsCallbackHander(){
+        $shared = new SharedEventManager;
+        $callbackHandler = $shared->attach('foo', 'bar', function($e){
+                return true;
+            }
+        );
+        $this->assertTrue($callbackHandler instanceof CallbackHandler);
+    }
+
     public function testDoesNotCreateStaticInstanceIfNonePresent()
     {
         StaticEventManager::resetInstance();


### PR DESCRIPTION
In keeping with EventManager attach returning a Callback handler / array of, for detaching, the SharedEventManager should do so too.
