### PR TITLE
Fix extra values extraction from ContentType header

### DIFF
--- a/library/Zend/Mail/Header/ContentType.php
+++ b/library/Zend/Mail/Header/ContentType.php
@@ -48,7 +48,7 @@ class ContentType implements HeaderInterface
 
         if (count($values)) {
             foreach ($values as $keyValuePair) {
-                list($key, $value) = explode('=', $keyValuePair);
+                list($key, $value) = explode('=', $keyValuePair, 2);
                 $value = trim($value, "'\" \t\n\r\0\x0B");
                 $header->addParameter($key, $value);
             }


### PR DESCRIPTION
Problem comes when value contains equal char. Ex :

```
Content-Type: multipart/alternative; boundary="Apple-Mail=_1B852F10-F9C6-463D-AADD-CD503A5428DD"
```

With Apple Mail client, content type boundary contains equal char
