### PR TITLE
Fix for Zend\Form\Element\Select validators for multiple select

### DIFF
--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -24,6 +24,7 @@ namespace Zend\Form\Element;
 use Traversable;
 use Zend\Form\Element;
 use Zend\InputFilter\InputProviderInterface;
+use Zend\Validator\Explode as ExplodeValidator;
 use Zend\Validator\InArray as InArrayValidator;
 use Zend\Validator\ValidatorInterface;
 
@@ -58,10 +59,22 @@ class Select extends Element
     protected function getValidator()
     {
         if (null === $this->validator) {
-            $this->validator = new InArrayValidator(array(
+            $validator = new InArrayValidator(array(
                 'haystack' => (array) $this->getAttribute('options'),
                 'strict'   => false
             ));
+
+            $multiple = (isset($this->attributes['multiple']))
+                      ? $this->attributes['multiple'] : null;
+
+            if (true === $multiple || 'multiple' === $multiple) {
+                $validator = new ExplodeValidator(array(
+                    'validator'      => $validator,
+                    'valueDelimiter' => null, // skip explode if only one value
+                ));
+            }
+
+            $this->validator = $validator;
         }
         return $this->validator;
     }

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -27,7 +27,7 @@ use Zend\Form\Factory;
 
 class SelectTest extends TestCase
 {
-    public function testProvidesInputSpecificationThatIncludesValidatorsBasedOnAttributes()
+    public function testProvidesInputSpecificationForSingleSelect()
     {
         $element = new SelectElement();
         $element->setAttribute('options', array(
@@ -49,6 +49,38 @@ class SelectTest extends TestCase
             switch ($class) {
                 case 'Zend\Validator\InArray':
                     $this->assertEquals($element->getAttribute('options'), $validator->getHaystack());
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    public function testProvidesInputSpecificationForMultipleSelect()
+    {
+        $element = new SelectElement();
+        $element->setAttributes(array(
+            'multiple' => true,
+            'options'  => array(
+                'Option 1' => 'option1',
+                'Option 2' => 'option2',
+                'Option 3' => 'option3',
+            ),
+        ));
+
+        $inputSpec = $element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $this->assertInternalType('array', $inputSpec['validators']);
+
+        $expectedClasses = array(
+            'Zend\Validator\Explode'
+        );
+        foreach ($inputSpec['validators'] as $validator) {
+            $class = get_class($validator);
+            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            switch ($class) {
+                case 'Zend\Validator\Explode':
+                    $this->assertInstanceOf('Zend\Validator\InArray', $validator->getValidator());
                     break;
                 default:
                     break;


### PR DESCRIPTION
Check if "multiple" is true and add the Explode and InArray validators, similar to MultiCheckbox.

Related to: http://framework.zend.com/issues/browse/ZF2-413
