### PR TITLE
Fix for Email element validator when multiple is set and false

### DIFF
--- a/library/Zend/Form/Element/Email.php
+++ b/library/Zend/Form/Element/Email.php
@@ -51,7 +51,11 @@ class Email extends Element implements InputProviderInterface
     {
         if (null === $this->validator) {
             $emailValidator = $this->getEmailValidator();
-            if (!empty($this->attributes['multiple'])) {
+
+            $multiple = (isset($this->attributes['multiple']))
+                      ? $this->attributes['multiple'] : null;
+
+            if (true === $multiple || 'multiple' === $multiple) {
                 $this->validator = new ExplodeValidator(array(
                     'validator' => $emailValidator,
                 ));

--- a/tests/ZendTest/Form/Element/EmailTest.php
+++ b/tests/ZendTest/Form/Element/EmailTest.php
@@ -25,32 +25,39 @@ class EmailTest extends TestCase
         $this->assertArrayHasKey('validators', $inputSpec);
         $this->assertInternalType('array', $inputSpec['validators']);
 
-        $expectedClasses = array(
+        $expectedValidators = array(
             'Zend\Validator\Regex'
         );
-        foreach ($inputSpec['validators'] as $validator) {
+        foreach ($inputSpec['validators'] as $i => $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertEquals($expectedValidators[$i], $class);
         }
     }
 
-    public function testProvidesInputSpecificationThatIncludesValidatorsBasedOnAttributes()
+    public function emailAttributesDataProvider()
+    {
+        return array(
+                  // attributes               // expectedValidators
+            array(array('multiple' => true),  array('Zend\Validator\Explode')),
+            array(array('multiple' => false), array('Zend\Validator\Regex')),
+        );
+    }
+
+    /**
+     * @dataProvider emailAttributesDataProvider
+     */
+    public function testProvidesInputSpecificationBasedOnAttributes($attributes, $expectedValidators)
     {
         $element = new EmailElement();
-        $element->setAttributes(array(
-            'multiple' => true
-        ));
+        $element->setAttributes($attributes);
 
         $inputSpec = $element->getInputSpecification();
         $this->assertArrayHasKey('validators', $inputSpec);
         $this->assertInternalType('array', $inputSpec['validators']);
 
-        $expectedClasses = array(
-            'Zend\Validator\Explode'
-        );
-        foreach ($inputSpec['validators'] as $validator) {
+        foreach ($inputSpec['validators'] as $i => $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertEquals($expectedValidators[$i], $class);
             switch ($class) {
                 case 'Zend\Validator\Explode':
                     $this->assertInstanceOf('Zend\Validator\Regex', $validator->getValidator());


### PR DESCRIPTION
Fix for wrong default validators when Zend\Form\Element\Email had a "multiple" attribute set to false.
