### PR TITLE
Zend\Db: Subselect support in Zend\Db\Sql*

### DIFF
--- a/library/Zend/Db/Adapter/ParameterContainer.php
+++ b/library/Zend/Db/Adapter/ParameterContainer.php
@@ -15,7 +15,7 @@ namespace Zend\Db\Adapter;
  * @package    Zend_Db
  * @subpackage Adapter
  */
-class ParameterContainer implements \Iterator, \ArrayAccess
+class ParameterContainer implements \Iterator, \ArrayAccess, \Countable
 {
 
     const TYPE_AUTO    = 'auto';
@@ -288,9 +288,21 @@ class ParameterContainer implements \Iterator, \ArrayAccess
      * @param array $array
      * @return ParameterContainer
      */
-    public function merge(array $array)
+    public function merge($parameters)
     {
-        foreach ($array as $key => $value) {
+        if (!is_array($parameters) && !$parameters instanceof ParameterContainer) {
+            throw new Exception\InvalidArgumentException('$parameters must be an array or an instance of ParameterContainer');
+        }
+
+        if (count($parameters) == 0) {
+            return;
+        }
+
+        if ($parameters instanceof ParameterContainer) {
+            $parameters = $parameters->getNamedArray();
+        }
+
+        foreach ($parameters as $key => $value) {
             if (is_int($key)) {
                 $key = null;
             }

--- a/library/Zend/Db/Adapter/StatementContainer.php
+++ b/library/Zend/Db/Adapter/StatementContainer.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Db
+ */
+
+namespace Zend\Db\Adapter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Db
+ * @subpackage Adapter
+ */
+class StatementContainer implements StatementContainerInterface
+{
+
+    /**
+     * @var string
+     */
+    protected $sql = '';
+
+    /**
+     * @var ParameterContainer
+     */
+    protected $parameterContainer = null;
+
+    /**
+     * @param string|null $sql
+     * @param ParameterContainer|null $parameterContainer
+     */
+    public function __construct($sql = null, ParameterContainer $parameterContainer = null)
+    {
+        if ($sql) {
+            $this->setSql($sql);
+        }
+        $this->parameterContainer = ($parameterContainer) ?: new ParameterContainer;
+    }
+
+    /**
+     * @param $sql
+     * @return StatementContainer
+     */
+    public function setSql($sql)
+    {
+        $this->sql = $sql;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSql()
+    {
+        return $this->sql;
+    }
+
+    public function setParameterContainer(ParameterContainer $parameterContainer)
+    {
+        $this->parameterContainer = $parameterContainer;
+        return $this;
+    }
+
+    /**
+     * @return null|ParameterContainer
+     */
+    public function getParameterContainer()
+    {
+        return $this->parameterContainer;
+    }
+}

--- a/library/Zend/Db/Adapter/StatementContainerInterface.php
+++ b/library/Zend/Db/Adapter/StatementContainerInterface.php
@@ -8,41 +8,37 @@
  * @package   Zend_Db
  */
 
-namespace Zend\Db\Adapter\Driver;
-
-use Zend\Db\Adapter\StatementContainerInterface;
-use Zend\Db\Adapter\ParameterContainer;
+namespace Zend\Db\Adapter;
 
 /**
  * @category   Zend
  * @package    Zend_Db
  * @subpackage Adapter
  */
-interface StatementInterface extends StatementContainerInterface
+interface StatementContainerInterface
 {
-
     /**
-     * @return resource
+     * @abstract
+     * @param $sql
+     * @return mixed
      */
-    public function getResource();
+    public function setSql($sql);
 
     /**
      * @abstract
-     * @param string $sql
+     * @return mixed
      */
-    public function prepare($sql = null);
+    public function getSql();
 
     /**
      * @abstract
-     * @return bool
+     * @return mixed
      */
-    public function isPrepared();
+    public function setParameterContainer(ParameterContainer $parameterContainer);
 
     /**
      * @abstract
-     * @param null $parameters
-     * @return ResultInterface
+     * @return mixed
      */
-    public function execute($parameters = null);
-
+    public function getParameterContainer();
 }

--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -10,26 +10,35 @@
 
 namespace Zend\Db\Sql;
 
-use Zend\Db\Adapter\Driver\DriverInterface;
+use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\StatementContainer;
+use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 
 abstract class AbstractSql
 {
+    /**
+     * @var array
+     */
     protected $specifications = array();
 
-    protected function processExpression(ExpressionInterface $expression, PlatformInterface $platform, DriverInterface $driver = null, $namedParameterPrefix = null)
+    /**
+     * @var string
+     */
+    protected $processInfo = array('paramPrefix' => '', 'subselectCount' => 0);
+
+    protected function processExpression(ExpressionInterface $expression, PlatformInterface $platform, Adapter $adapter = null, $namedParameterPrefix = null)
     {
         // static counter for the number of times this method was invoked across the PHP runtime
         static $runtimeExpressionPrefix = 0;
 
-        if ($driver && ((!is_string($namedParameterPrefix) || $namedParameterPrefix == ''))) {
+        if ($adapter && ((!is_string($namedParameterPrefix) || $namedParameterPrefix == ''))) {
             $namedParameterPrefix = sprintf('expr%04dParam', ++$runtimeExpressionPrefix);
         }
 
-        $return = array(
-            'sql' => '',
-            'parameters' => array()
-        );
+        $sql = '';
+        $statementContainer = new StatementContainer;
+        $parameterContainer = $statementContainer->getParameterContainer();
 
         // initialize variables
         $parts = $expression->getExpressionData();
@@ -39,7 +48,7 @@ abstract class AbstractSql
 
             // if it is a string, simply tack it onto the return sql "specification" string
             if (is_string($part)) {
-                $return['sql'] .= $part;
+                $sql .= $part;
                 continue;
             }
 
@@ -57,10 +66,10 @@ abstract class AbstractSql
 
                     // if prepareType is set, it means that this particular value must be
                     // passed back to the statement in a way it can be used as a placeholder value
-                    if ($driver) {
+                    if ($adapter) {
                         $name = $namedParameterPrefix . $expressionParamIndex++;
-                        $return['parameters'][$name] = $value;
-                        $values[$vIndex] = $driver->formatParameterName($name);
+                        $parameterContainer->offsetSet($name, $value);
+                        $values[$vIndex] = $adapter->getDriver()->formatParameterName($name);
                         continue;
                     }
 
@@ -68,14 +77,22 @@ abstract class AbstractSql
                     $values[$vIndex] = $platform->quoteValue($value);
                 } elseif (isset($types[$vIndex]) && $types[$vIndex] == ExpressionInterface::TYPE_LITERAL) {
                     $values[$vIndex] = $value;
+                } elseif (isset($types[$vIndex]) && $types[$vIndex] == ExpressionInterface::TYPE_SELECT) {
+                    // process sub-select
+                    if ($adapter) {
+                        $values[$vIndex] = '(' . $this->processSubSelect($value, $platform, $adapter, $statementContainer->getParameterContainer()) . ')';
+                    } else {
+                        $values[$vIndex] = '(' . $this->processSubSelect($value, $platform) . ')';
+                    }
                 }
             }
 
             // after looping the values, interpolate them into the sql string (they might be placeholder names, or values)
-            $return['sql'] .= vsprintf($part[0], $values);
+            $sql .= vsprintf($part[0], $values);
         }
 
-        return $return;
+        $statementContainer->setSql($sql);
+        return $statementContainer;
     }
 
     /**
@@ -116,6 +133,30 @@ abstract class AbstractSql
             }
         }
         return vsprintf($topSpec, $topParameters);
+    }
+
+    protected function processSubSelect(Select $subselect, PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null)
+    {
+        if ($adapter) {
+            $stmtContainer = new \Zend\Db\Adapter\StatementContainer;
+
+            // Track subselect prefix and count for parameters
+            $this->processInfo['subselectCount']++;
+            $subselect->processInfo['subselectCount'] = $this->processInfo['subselectCount'];
+            $subselect->processInfo['paramPrefix'] = 'subselect' . $subselect->processInfo['subselectCount'];
+
+            // call subselect
+            $subselect->prepareStatement($adapter, $stmtContainer);
+
+            // copy count
+            $this->processInfo['subselectCount'] = $subselect->processInfo['subselectCount'];
+
+            $parameterContainer->merge($stmtContainer->getParameterContainer()->getNamedArray());
+            $sql = $stmtContainer->getSql();
+        } else {
+            $sql = $subselect->getSqlString($platform);
+        }
+        return $sql;
     }
 
 }

--- a/library/Zend/Db/Sql/ExpressionInterface.php
+++ b/library/Zend/Db/Sql/ExpressionInterface.php
@@ -15,6 +15,7 @@ interface ExpressionInterface
     const TYPE_IDENTIFIER = 'identifier';
     const TYPE_VALUE = 'value';
     const TYPE_LITERAL = 'literal';
+    const TYPE_SELECT = 'select';
 
     /**
      * @abstract

--- a/library/Zend/Db/Sql/Insert.php
+++ b/library/Zend/Db/Sql/Insert.php
@@ -11,7 +11,7 @@
 namespace Zend\Db\Sql;
 
 use Zend\Db\Adapter\Adapter;
-use Zend\Db\Adapter\Driver\StatementInterface;
+use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Adapter\Platform\Sql92;
@@ -135,18 +135,18 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
      * Prepare statement
      *
      * @param  Adapter $adapter
-     * @param  StatementInterface $statement
+     * @param  StatementContainerInterface $statementContainer
      * @return void
      */
-    public function prepareStatement(Adapter $adapter, StatementInterface $statement)
+    public function prepareStatement(Adapter $adapter, StatementContainerInterface $statementContainer)
     {
         $driver   = $adapter->getDriver();
         $platform = $adapter->getPlatform();
-        $parameterContainer = $statement->getParameterContainer();
+        $parameterContainer = $statementContainer->getParameterContainer();
 
         if (!$parameterContainer instanceof ParameterContainer) {
             $parameterContainer = new ParameterContainer();
-            $statement->setParameterContainer($parameterContainer);
+            $statementContainer->setParameterContainer($parameterContainer);
         }
 
         $table = $platform->quoteIdentifier($this->table);
@@ -157,11 +157,9 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
         foreach ($this->columns as $cIndex => $column) {
             $columns[$cIndex] = $platform->quoteIdentifier($column);
             if ($this->values[$cIndex] instanceof Expression) {
-                $exprData = $this->processExpression($this->values[$cIndex], $platform, $driver);
-                $values[$cIndex] = $exprData['sql'];
-                if (count($exprData['parameters']) > 0) {
-                    $parameterContainer->merge($exprData['parameters']);
-                }
+                $exprData = $this->processExpression($this->values[$cIndex], $platform, $adapter);
+                $values[$cIndex] = $exprData->getSql();
+                $parameterContainer->merge($exprData->getParameterContainer());
             } else {
                 $values[$cIndex] = $driver->formatParameterName($column);
                 $parameterContainer->offsetSet($column, $this->values[$cIndex]);
@@ -175,7 +173,7 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
             implode(', ', $values)
         );
 
-        $statement->setSql($sql);
+        $statementContainer->setSql($sql);
     }
 
     /**
@@ -196,7 +194,7 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
         foreach ($this->values as $value) {
             if ($value instanceof Expression) {
                 $exprData = $this->processExpression($value, $adapterPlatform);
-                $values[] = $exprData['sql'];
+                $values[] = $exprData->getSql();
             } else {
                 $values[] = $adapterPlatform->quoteValue($value);
             }

--- a/library/Zend/Db/Sql/Platform/AbstractPlatform.php
+++ b/library/Zend/Db/Sql/Platform/AbstractPlatform.php
@@ -11,7 +11,7 @@
 namespace Zend\Db\Sql\Platform;
 
 use Zend\Db\Adapter\Adapter;
-use Zend\Db\Adapter\Driver\StatementInterface;
+use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Sql\PreparableSqlInterface;
 use Zend\Db\Sql\SqlInterface;
@@ -59,7 +59,7 @@ class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInter
      * @param StatementInterface $statement
      * @return void
      */
-    public function prepareStatement(Adapter $adapter, StatementInterface $statement)
+    public function prepareStatement(Adapter $adapter, StatementContainerInterface $statementContainer)
     {
         if (!$this->subject instanceof PreparableSqlInterface) {
             throw new Exception\RuntimeException('The subject does not appear to implement Zend\Db\Sql\PreparableSqlInterface, thus calling prepareStatement() has no effect');
@@ -75,9 +75,9 @@ class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInter
         }
         if ($decoratorForType) {
             $decoratorForType->setSubject($this->subject);
-            $decoratorForType->prepareStatement($adapter, $statement);
+            $decoratorForType->prepareStatement($adapter, $statementContainer);
         } else {
-            $this->subject->prepareStatement($adapter, $statement);
+            $this->subject->prepareStatement($adapter, $statementContainer);
         }
     }
 

--- a/library/Zend/Db/Sql/Platform/AbstractPlatform.php
+++ b/library/Zend/Db/Sql/Platform/AbstractPlatform.php
@@ -56,7 +56,7 @@ class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInter
 
     /**
      * @param Adapter $adapter
-     * @param StatementInterface $statement
+     * @param StatementContainerInterface $statement
      * @return void
      */
     public function prepareStatement(Adapter $adapter, StatementContainerInterface $statementContainer)

--- a/library/Zend/Db/Sql/Platform/SqlServer/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/SqlServer/SelectDecorator.php
@@ -11,7 +11,7 @@
 namespace Zend\Db\Sql\Platform\SqlServer;
 
 use Zend\Db\Adapter\Adapter;
-use Zend\Db\Adapter\Driver\StatementInterface;
+use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
@@ -34,9 +34,9 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
 
     /**
      * @param Adapter $adapter
-     * @param StatementInterface $statement
+     * @param StatementContainerInterface $statementContainer
      */
-    public function prepareStatement(Adapter $adapter, StatementInterface $statement)
+    public function prepareStatement(Adapter $adapter, StatementContainerInterface $statementContainer)
     {
         // localize variables
         foreach (get_object_vars($this->select) as $name => $value) {
@@ -48,7 +48,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         unset($this->specifications[self::SPECIFICATION_OFFSET]);
 
         $this->specifications['LIMITOFFSET'] = null;
-        parent::prepareStatement($adapter, $statement);
+        parent::prepareStatement($adapter, $statementContainer);
     }
 
     /**

--- a/library/Zend/Db/Sql/Predicate/In.php
+++ b/library/Zend/Db/Sql/Predicate/In.php
@@ -10,6 +10,9 @@
 
 namespace Zend\Db\Sql\Predicate;
 
+use Zend\Db\Sql\Select;
+use Zend\Db\Sql\Exception;
+
 /**
  * @category   Zend
  * @package    Zend_Db
@@ -26,12 +29,12 @@ class In implements PredicateInterface
      * @param  null|string $identifier
      * @param  array $valueSet
      */
-    public function __construct($identifier = null, array $valueSet = array())
+    public function __construct($identifier = null, $valueSet = null)
     {
         if ($identifier) {
             $this->setIdentifier($identifier);
         }
-        if (!empty($valueSet)) {
+        if ($valueSet) {
             $this->setValueSet($valueSet);
         }
     }
@@ -64,8 +67,13 @@ class In implements PredicateInterface
      * @param  array $valueSet
      * @return In
      */
-    public function setValueSet(array $valueSet)
+    public function setValueSet($valueSet)
     {
+        if (!is_array($valueSet) && !$valueSet instanceof Select) {
+            throw new Exception\InvalidArgumentException(
+                '$valueSet must be either an array or a Zend\Db\Sql\Select object, ' . gettype($valueSet) . ' given'
+            );
+        }
         $this->valueSet = $valueSet;
         return $this;
     }
@@ -83,8 +91,14 @@ class In implements PredicateInterface
     public function getExpressionData()
     {
         $values = $this->getValueSet();
-        $specification = '%s IN (' . implode(', ', array_fill(0, count($values), '%s')) . ')';
-        $types  = array_fill(0, count($values), self::TYPE_VALUE);
+        if ($values instanceof Select) {
+            $specification = '%s IN %s';
+            $types = array(self::TYPE_SELECT);
+            $values = array($values);
+        } else {
+            $specification = '%s IN (' . implode(', ', array_fill(0, count($values), '%s')) . ')';
+            $types = array_fill(0, count($values), self::TYPE_VALUE);
+        }
 
         $identifier = $this->getIdentifier();
         array_unshift($values, $identifier);

--- a/library/Zend/Db/Sql/Predicate/Predicate.php
+++ b/library/Zend/Db/Sql/Predicate/Predicate.php
@@ -283,10 +283,10 @@ class Predicate extends PredicateSet
      * Utilizes In predicate
      *
      * @param  string $identifier
-     * @param  array $valueSet
+     * @param  array|Select $valueSet
      * @return Predicate
      */
-    public function in($identifier, array $valueSet = array())
+    public function in($identifier, $valueSet = null)
     {
         $this->addPredicate(
             new In($identifier, $valueSet),

--- a/library/Zend/Db/Sql/PreparableSqlInterface.php
+++ b/library/Zend/Db/Sql/PreparableSqlInterface.php
@@ -11,7 +11,7 @@
 namespace Zend\Db\Sql;
 
 use Zend\Db\Adapter\Adapter;
-use Zend\Db\Adapter\Driver\StatementInterface;
+use Zend\Db\Adapter\StatementContainerInterface;
 
 /**
  * @category   Zend
@@ -24,7 +24,7 @@ interface PreparableSqlInterface
     /**
      * @abstract
      * @param Adapter $adapter
-     * @return StatementInterface
+     * @return StatementContainerInterface
      */
-    public function prepareStatement(Adapter $adapter, StatementInterface $statement);
+    public function prepareStatement(Adapter $adapter, StatementContainerInterface $statementContainer);
 }

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -349,12 +349,14 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     {
         $rawState = array(
             'columns' => $this->columns,
-            'table' => $this->table,
-            'joins' => $this->joins,
-            'where' => $this->where,
-            'order' => $this->order,
-            'limit' => $this->limit,
-            'offset' => $this->offset
+            'table'   => $this->table,
+            'joins'   => $this->joins,
+            'where'   => $this->where,
+            'order'   => $this->order,
+            'group'   => $this->group,
+            'having'  => $this->having,
+            'limit'   => $this->limit,
+            'offset'  => $this->offset
         );
         return (isset($key) && array_key_exists($key, $rawState)) ? $rawState[$key] : $rawState;
     }

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -11,7 +11,7 @@
 namespace Zend\Db\Sql;
 
 use Zend\Db\Adapter\Adapter;
-use Zend\Db\Adapter\Driver\StatementInterface;
+use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Adapter\Platform\Sql92 as AdapterSql92Platform;
@@ -363,16 +363,16 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
      * Prepare statement
      *
      * @param \Zend\Db\Adapter\Adapter $adapter
-     * @param \Zend\Db\Adapter\Driver\StatementInterface $statement
+     * @param \Zend\Db\Adapter\Driver\StatementInterface $statementContainer
      * @return void
      */
-    public function prepareStatement(Adapter $adapter, StatementInterface $statement)
+    public function prepareStatement(Adapter $adapter, StatementContainerInterface $statementContainer)
     {
         // ensure statement has a ParameterContainer
-        $parameterContainer = $statement->getParameterContainer();
+        $parameterContainer = $statementContainer->getParameterContainer();
         if (!$parameterContainer instanceof ParameterContainer) {
             $parameterContainer = new ParameterContainer();
-            $statement->setParameterContainer($parameterContainer);
+            $statementContainer->setParameterContainer($parameterContainer);
         }
 
         $sqls = array();
@@ -380,15 +380,15 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         $platform = $adapter->getPlatform();
 
         foreach ($this->specifications as $name => $specification) {
-             $parameters[$name] = $this->{'process' . $name}($platform, $adapter, $parameterContainer, $sqls, $parameters);
-             if ($specification && is_array($parameters[$name])) {
-                 $sqls[$name] = $this->createSqlFromSpecificationAndParameters($specification, $parameters[$name]);
-             }
+            $parameters[$name] = $this->{'process' . $name}($platform, $adapter, $parameterContainer, $sqls, $parameters);
+            if ($specification && is_array($parameters[$name])) {
+                $sqls[$name] = $this->createSqlFromSpecificationAndParameters($specification, $parameters[$name]);
+            }
         }
 
         $sql = implode(' ', $sqls);
 
-        $statement->setSql($sql);
+        $statementContainer->setSql($sql);
         return;
     }
 
@@ -407,10 +407,10 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         $parameters = array();
 
         foreach ($this->specifications as $name => $specification) {
-             $parameters[$name] = $this->{'process' . $name}($adapterPlatform, null, null, $sqls, $parameters);
-             if ($specification && is_array($parameters[$name])) {
-                 $sqls[$name] = $this->createSqlFromSpecificationAndParameters($specification, $parameters[$name]);
-             }
+            $parameters[$name] = $this->{'process' . $name}($adapterPlatform, null, null, $sqls, $parameters);
+            if ($specification && is_array($parameters[$name])) {
+                $sqls[$name] = $this->createSqlFromSpecificationAndParameters($specification, $parameters[$name]);
+            }
         }
 
         $sql = implode(' ', $sqls);
@@ -438,7 +438,12 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             list($table, $schema) = $table->getTableAndSchema();
         }
 
-        $table = $platform->quoteIdentifier($table);
+        if ($table instanceof Select) {
+            $table = '(' . $this->processSubselect($table, $platform, $adapter, $parameterContainer) . ')';
+        } else {
+            $table = $platform->quoteIdentifier($table);
+        }
+
         if ($schema) {
             $table = $platform->quoteIdentifier($schema) . $platform->getIdentifierSeparator() . $table;
         }
@@ -466,13 +471,13 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 $columnParts = $this->processExpression(
                     $column,
                     $platform,
-                    ($adapter) ? $adapter->getDriver() : null,
-                    (is_string($columnIndexOrAs)) ? $columnIndexOrAs : 'column'
+                    $adapter,
+                    $this->processInfo['paramPrefix'] . ((is_string($columnIndexOrAs)) ? $columnIndexOrAs : 'column')
                 );
-                if (count($columnParts['parameters']) > 0) {
-                    $parameterContainer->merge($columnParts['parameters']);
+                if ($parameterContainer) {
+                    $parameterContainer->merge($columnParts->getParameterContainer());
                 }
-                $columnName .= $columnParts['sql'];
+                $columnName .= $columnParts->getSql();
             } else {
                 $columnName .= $fromTable . $platform->quoteIdentifier($column);
             }
@@ -492,8 +497,19 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         foreach ($this->joins as $join) {
             foreach ($join['columns'] as $jKey => $jColumn) {
                 $jColumns = array();
-                $name = (is_array($join['name'])) ? key($join['name']) : $name = $join['name'];
-                $jColumns[] = $platform->quoteIdentifier($name) . $separator . $platform->quoteIdentifierInFragment($jColumn);
+                if ($jColumn instanceof ExpressionInterface) {
+                    $jColumnParts = $this->processExpression(
+                        $jColumn,
+                        $platform,
+                        $adapter,
+                        $this->processInfo['paramPrefix'] . ((is_string($jKey)) ? $jKey : 'column')
+                    );
+                    $parameterContainer->merge($jColumnParts->getParameterContainer());
+                    $jColumns[] = $jColumnParts->getSql();
+                } else {
+                    $name = (is_array($join['name'])) ? key($join['name']) : $name = $join['name'];
+                    $jColumns[] = $platform->quoteIdentifier($name) . $separator . $platform->quoteIdentifierInFragment($jColumn);
+                }
                 if (is_string($jKey)) {
                     $jColumns[] = $platform->quoteIdentifier($jKey);
                 } elseif ($jColumn !== self::SQL_STAR) {
@@ -524,13 +540,13 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 : $platform->quoteIdentifier($join['name']);
             // on expression
             $joinSpecArgArray[$j][] = ($join['on'] instanceof ExpressionInterface)
-                ? $this->processExpression($join['on'], $platform, ($adapter) ? $adapter->getDriver() : null, 'join')
+                ? $this->processExpression($join['on'], $platform, $adapter, $this->processInfo['paramPrefix'] . 'join')
                 : $platform->quoteIdentifierInFragment($join['on'], array('=', 'AND', 'OR', '(', ')', 'BETWEEN')); // on
-            if (is_array($joinSpecArgArray[$j][2])) {
-                if (count($joinSpecArgArray[$j][2]['parameters']) > 0) {
-                    $parameterContainer->merge($joinSpecArgArray[$j][2]['parameters']);
+            if ($joinSpecArgArray[$j][2] instanceof StatementContainerInterface) {
+                if ($parameterContainer) {
+                    $parameterContainer->merge($joinSpecArgArray[$j][2]->getParameterContainer());
                 }
-                $joinSpecArgArray[$j][2] = $joinSpecArgArray[$j][2]['sql'];
+                $joinSpecArgArray[$j][2] = $joinSpecArgArray[$j][2]->getSql();
             }
         }
 
@@ -542,11 +558,11 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         if ($this->where->count() == 0) {
             return null;
         }
-        $whereParts = $this->processExpression($this->where, $platform, ($adapter) ? $adapter->getDriver() : null, 'where');
-        if (count($whereParts['parameters']) > 0) {
-            $parameterContainer->merge($whereParts['parameters']);
+        $whereParts = $this->processExpression($this->where, $platform, $adapter, $this->processInfo['paramPrefix'] . 'where');
+        if ($parameterContainer) {
+            $parameterContainer->merge($whereParts->getParameterContainer());
         }
-        return array($whereParts['sql']);
+        return array($whereParts->getSql());
     }
 
     protected function processGroup(PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null)
@@ -559,11 +575,11 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         foreach ($this->group as $column) {
             $columnSql = '';
             if ($column instanceof Expression) {
-                $columnParts = $this->processExpression($column, $platform, ($adapter) ? $adapter->getDriver() : null, 'group');
-                if (count($columnParts['parameters']) > 0) {
-                    $parameterContainer->merge($columnParts['parameters']);
+                $columnParts = $this->processExpression($column, $platform, $adapter, $this->processInfo['paramPrefix'] . 'group');
+                if ($parameterContainer) {
+                    $parameterContainer->merge($columnParts->getParameterContainer());
                 }
-                $columnSql .= $columnParts['sql'];
+                $columnSql .= $columnParts->getSql();
             } else {
                 $columnSql .= $platform->quoteIdentifierInFragment($column);
             }
@@ -577,11 +593,11 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         if ($this->having->count() == 0) {
             return null;
         }
-        $whereParts = $this->processExpression($this->having, $platform, ($adapter) ? $adapter->getDriver() : null, 'having');
-        if (count($whereParts['parameters']) > 0) {
-            $parameterContainer->merge($whereParts['parameters']);
+        $whereParts = $this->processExpression($this->having, $platform, $adapter, $this->processInfo['paramPrefix'] . 'having');
+        if ($parameterContainer) {
+            $parameterContainer->merge($whereParts->getParameterContainer());
         }
-        return array($whereParts['sql']);
+        return array($whereParts->getSql());
     }
 
     protected function processOrder(PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null)

--- a/tests/ZendTest/Db/Sql/AbstractSqlTest.php
+++ b/tests/ZendTest/Db/Sql/AbstractSqlTest.php
@@ -37,9 +37,9 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
         $expression = new Expression('? > ? AND y < ?', array('x', 5, 10), array(Expression::TYPE_IDENTIFIER));
         $sqlAndParams = $this->invokeProcessExpressionMethod($expression);
 
-        $this->assertEquals("\"x\" > '5' AND y < '10'", $sqlAndParams['sql']);
-        $this->assertInternalType('array', $sqlAndParams['parameters']);
-        $this->assertEmpty($sqlAndParams['parameters']);
+        $this->assertEquals("\"x\" > '5' AND y < '10'", $sqlAndParams->getSql());
+        $this->assertInstanceOf('Zend\Db\Adapter\ParameterContainer', $sqlAndParams->getParameterContainer());
+        $this->assertEquals(0, $sqlAndParams->getParameterContainer()->count());
     }
 
     /**
@@ -72,26 +72,33 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
         $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnCallback(function ($x) {
             return ':' . $x;
         }));
+        $mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver));
 
         $expression = new Expression('? > ? AND y < ?', array('x', 5, 10), array(Expression::TYPE_IDENTIFIER));
-        $sqlAndParams = $this->invokeProcessExpressionMethod($expression, $mockDriver);
+        $sqlAndParams = $this->invokeProcessExpressionMethod($expression, $mockAdapter);
 
-        $this->assertRegExp('#"x" > :expr\d\d\d\dParam1 AND y < :expr\d\d\d\dParam2#', $sqlAndParams['sql']);
-        $this->assertInternalType('array', $sqlAndParams['parameters']);
+        $parameterContainer = $sqlAndParams->getParameterContainer();
+        $parameters = $parameterContainer->getNamedArray();
+
+        $this->assertRegExp('#"x" > :expr\d\d\d\dParam1 AND y < :expr\d\d\d\dParam2#', $sqlAndParams->getSql());
 
         // test keys and values
-        preg_match('#expr(\d\d\d\d)Param1#', key($sqlAndParams['parameters']), $matches);
+        preg_match('#expr(\d\d\d\d)Param1#', key($parameters), $matches);
         $expressionNumber = $matches[1];
 
-        $this->assertRegExp('#expr\d\d\d\dParam1#', key($sqlAndParams['parameters']));
-        $this->assertEquals(5, current($sqlAndParams['parameters']));
-        next($sqlAndParams['parameters']);
-        $this->assertRegExp('#expr\d\d\d\dParam2#', key($sqlAndParams['parameters']));
-        $this->assertEquals(10, current($sqlAndParams['parameters']));
+        $this->assertRegExp('#expr\d\d\d\dParam1#', key($parameters));
+        $this->assertEquals(5, current($parameters));
+        next($parameters);
+        $this->assertRegExp('#expr\d\d\d\dParam2#', key($parameters));
+        $this->assertEquals(10, current($parameters));
 
         // ensure next invocation increases number by 1
-        $sqlAndParamsNext = $this->invokeProcessExpressionMethod($expression, $mockDriver);
-        preg_match('#expr(\d\d\d\d)Param1#', key($sqlAndParamsNext['parameters']), $matches);
+        $sqlAndParamsNext = $this->invokeProcessExpressionMethod($expression, $mockAdapter);
+
+        $parameterContainer = $sqlAndParamsNext->getParameterContainer();
+        $parameters = $parameterContainer->getNamedArray();
+
+        preg_match('#expr(\d\d\d\d)Param1#', key($parameters), $matches);
         $expressionNumberNext = $matches[1];
 
         $this->assertEquals(1, (int) $expressionNumberNext - (int) $expressionNumber);
@@ -107,16 +114,15 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
         $predicateSet = new Predicate\PredicateSet(array(new Predicate\PredicateSet(array($expression))));
         $sqlAndParams = $this->invokeProcessExpressionMethod($predicateSet);
 
-        $this->assertEquals("(x = '5')", $sqlAndParams['sql']);
-        $this->assertInternalType('array', $sqlAndParams['parameters']);
-        $this->assertEmpty($sqlAndParams['parameters']);
+        $this->assertEquals("(x = '5')", $sqlAndParams->getSql());
+        $this->assertEquals(0, $sqlAndParams->getParameterContainer()->count());
     }
 
-    protected function invokeProcessExpressionMethod(ExpressionInterface $expression, DriverInterface $driver = null)
+    protected function invokeProcessExpressionMethod(ExpressionInterface $expression, $adapter = null)
     {
         $method = new \ReflectionMethod($this->abstractSql, 'processExpression');
         $method->setAccessible(true);
-        return $method->invoke($this->abstractSql, $expression, new Sql92, $driver);
+        return $method->invoke($this->abstractSql, $expression, new Sql92, $adapter);
     }
 
 }

--- a/tests/ZendTest/Db/Sql/Predicate/InTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/InTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Db\Sql\Predicate;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Db\Sql\Select;
 use Zend\Db\Sql\Predicate\In;
 
 class InTest extends TestCase
@@ -54,6 +55,17 @@ class InTest extends TestCase
             '%s IN (%s, %s, %s)',
             array('foo.bar', 1, 2, 3),
             array(In::TYPE_IDENTIFIER, In::TYPE_VALUE, In::TYPE_VALUE, In::TYPE_VALUE),
+        ));
+        $this->assertEquals($expected, $in->getExpressionData());
+    }
+
+    public function testGetExpressionDataWithSubselect()
+    {
+        $in = new In('foo', $select = new Select);
+        $expected = array(array(
+            '%s IN %s',
+            array('foo', $select),
+            array($in::TYPE_IDENTIFIER, $in::TYPE_SELECT)
         ));
         $this->assertEquals($expected, $in->getExpressionData());
     }


### PR DESCRIPTION
Subselect support is important to make Pagination work in 2.0.0.  It currently applies to Select::from and the In predicate; though foundational support is not built in for it to be expanded to other areas easily.

The public API for this feature is 100% backwards compatible.
The protected API has changed for Zend\Db\Sql\AbstractSql only, which at this point should affect no one.
