### PR TITLE
Add AbstractController::getServiceManager() method

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -203,6 +203,16 @@ abstract class AbstractController implements
     }
 
     /**
+     * Retrieve serviceManager instance
+     *
+     * @return ServiceLocatorInterface
+     */
+    public function getServiceManager()
+    {
+        return $this->serviceManager;
+    }
+
+    /**
      * Get plugin manager
      *
      * @return PluginManager
@@ -220,7 +230,7 @@ abstract class AbstractController implements
      * Set plugin manager
      *
      * @param  string|PluginManager $plugins
-     * @return RestfulController
+     * @return AbstractController
      * @throws Exception\InvalidArgumentException
      */
     public function setPluginManager(PluginManager $plugins)


### PR DESCRIPTION
## Rationale

Throughout the whole framework and [official docs](zf2.readthedocs.org) we use the term `ServiceManager`, universally referring to the primary implementation which is (by default) an instance of `Zend\ServiceManager\ServiceManager`. 

It is obvious to me that inside an action controller, calling `$this->getServiceManager()` retrieves its instance. 
## The new

Before this PR the only way to retrieve `ServiceManager` was to call

``` php
$sm = $this->getServiceLocator();
```

After this PR it is also possible to use:

``` php
$sm = $this->getServiceManager();
```

This behavior is analogical to:
- `$this->getEventManager()` - returns `EventManagerInterface`
- `$this->getEvent()` - returns `MvcEvent`
- `$this->getPluginManager()` - returns specialized `ServiceLocatorInterface`
- `$this->getRequest()` - returns `RequestInterface`
- `$this->getResponse()` - returns `ResponseInterface`
## BC breaks

None. It's just an alias for `getServiceLocator()` that makes more sense.
