### PR TITLE
[Form] [Collection] Bug fix, adds missing check for count of elements

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -197,7 +197,7 @@ class Collection extends Fieldset
 
                 $this->add($elementOrFieldset);
             }
-        } else {
+        } elseif (!empty($data) && !$this->allowAdd) {
             throw new Exception\DomainException(sprintf(
                 'There are more elements than specified in the collection (%s). Either set the allow_add option ' .
                 'to true, or re-submit the form.',

--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -197,6 +197,13 @@ class Collection extends Fieldset
 
                 $this->add($elementOrFieldset);
             }
+        } else {
+            throw new Exception\DomainException(sprintf(
+                'There are more elements than specified in the collection (%s). Either set the allow_add option ' .
+                'to true, or re-submit the form.',
+                get_class($this)
+                )
+            );
         }
     }
 

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -505,16 +505,19 @@ class Form extends Fieldset implements FormInterface
             $fieldset = $formOrFieldset->byName[$key];
 
             if ($fieldset instanceof Collection) {
-                if (!isset($data[$key])) {
+                if (!isset($data[$key]) && $fieldset->getCount() == 0) {
                     unset ($validationGroup[$key]);
                     continue;
                 }
 
                 $values = array();
-                $count = count($data[$key]);
 
-                for ($i = 0 ; $i != $count ; ++$i) {
-                    $values[] = $value;
+                if (isset($data[$key])) {
+                    $count = count($data[$key]);
+
+                    for ($i = 0 ; $i != $count ; ++$i) {
+                        $values[] = $value;
+                    }
                 }
 
                 $value = $values;

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -44,9 +44,9 @@ class CollectionTest extends TestCase
         $collection->populateValues($data);
         $this->assertEquals(2, count($collection->getElements()));
 
+        $this->setExpectedException('Zend\Form\Exception\DomainException');
         $data[] = 'orange';
         $collection->populateValues($data);
-        $this->assertEquals(2, count($collection->getElements()));
     }
 
     public function testCanAddNewElementsIfAllowAddIsTrue()


### PR DESCRIPTION
In PR #2041 I introduced functionality to remove the collection from the validation group if a zero count was set, there wasn't a check however for the zero count which is introduced here correctly.

We also now correctly throw an Exception when more elements have been added to the collection than are allowed.
