### PR TITLE
Patch+Test for PR-2122: Fix extra values extraction from ContentType header (Zend\Mail)

### DIFF
--- a/library/Zend/Mail/Header/ContentType.php
+++ b/library/Zend/Mail/Header/ContentType.php
@@ -48,7 +48,7 @@ class ContentType implements HeaderInterface
 
         if (count($values)) {
             foreach ($values as $keyValuePair) {
-                list($key, $value) = explode('=', $keyValuePair);
+                list($key, $value) = explode('=', $keyValuePair, 2);
                 $value = trim($value, "'\" \t\n\r\0\x0B");
                 $header->addParameter($key, $value);
             }

--- a/tests/ZendTest/Mail/Header/ContentTypeTest.php
+++ b/tests/ZendTest/Mail/Header/ContentTypeTest.php
@@ -59,5 +59,14 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertContains(";\r\n charset=\"us-ascii\"", $string);
     }
 
+    public function testExtractsExtraInformationFromContentType()
+    {
+        $contentTypeHeader = ContentType::fromString(
+            'Content-Type: multipart/alternative; boundary="Apple-Mail=_1B852F10-F9C6-463D-AADD-CD503A5428DD"'
+        );
+        $params = $contentTypeHeader->getParameters();
+        $this->assertEquals($params,array('boundary' => 'Apple-Mail=_1B852F10-F9C6-463D-AADD-CD503A5428DD'));
+    }
+
 }
 


### PR DESCRIPTION
This is the same as PR #2122 but includes a valid test case.
