### PR TITLE
fixed a lot of phpDoc comments

### DIFF
--- a/library/Zend/Authentication/Storage/NonPersistent.php
+++ b/library/Zend/Authentication/Storage/NonPersistent.php
@@ -31,7 +31,6 @@ class NonPersistent implements StorageInterface
     /**
      * Returns true if and only if storage is empty
      *
-     * @throws Zend\Authentication\Storage\Exception If it is impossible to determine whether storage is empty
      * @return boolean
      */
     public function isEmpty()

--- a/library/Zend/Barcode/Object/AbstractObject.php
+++ b/library/Zend/Barcode/Object/AbstractObject.php
@@ -201,7 +201,6 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Constructor
      * @param array|Traversable $options
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Barcode/Object/AbstractObject.php
+++ b/library/Zend/Barcode/Object/AbstractObject.php
@@ -403,7 +403,7 @@ abstract class AbstractObject implements ObjectInterface
 
     /**
      * Retrieve color of the barcode and text
-     * @return unknown
+     * @return integer
      */
     public function getForeColor()
     {
@@ -462,7 +462,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Activate/deactivate drawing of the quiet zones
      * @param boolean $value
-     * @return Zend\Barcode\AbstractObject
+     * @return AbstractObject
      */
     public function setWithQuietZones($value)
     {
@@ -944,6 +944,7 @@ abstract class AbstractObject implements ObjectInterface
 
     /**
      * Get height of the result object
+     * @param bool $recalculate
      * @return integer
      */
     public function getHeight($recalculate = false)
@@ -958,6 +959,7 @@ abstract class AbstractObject implements ObjectInterface
 
     /**
      * Get width of the result object
+     * @param bool $recalculate
      * @return integer
      */
     public function getWidth($recalculate = false)

--- a/library/Zend/Barcode/Object/Error.php
+++ b/library/Zend/Barcode/Object/Error.php
@@ -39,6 +39,7 @@ class Error extends AbstractObject
 
     /**
      * Width is forced
+     * @param bool $recalculate
      * @return integer
      */
     public function getWidth($recalculate = false)

--- a/library/Zend/Barcode/Object/ObjectInterface.php
+++ b/library/Zend/Barcode/Object/ObjectInterface.php
@@ -22,7 +22,6 @@ interface ObjectInterface
     /**
      * Constructor
      * @param array|\Traversable $options
-     * @return void
      */
     public function __construct($options = null);
 

--- a/library/Zend/Barcode/Object/ObjectInterface.php
+++ b/library/Zend/Barcode/Object/ObjectInterface.php
@@ -29,7 +29,7 @@ interface ObjectInterface
     /**
      * Set barcode state from options array
      * @param  array $options
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setOptions($options);
 
@@ -37,7 +37,7 @@ interface ObjectInterface
      * Set barcode namespace for autoloading
      *
      * @param string $namespace
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setBarcodeNamespace($namespace);
 
@@ -57,7 +57,7 @@ interface ObjectInterface
     /**
      * Set height of the barcode bar
      * @param integer $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setBarHeight($value);
 
@@ -70,7 +70,7 @@ interface ObjectInterface
     /**
      * Set thickness of thin bar
      * @param integer $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setBarThinWidth($value);
 
@@ -83,7 +83,7 @@ interface ObjectInterface
     /**
      * Set thickness of thick bar
      * @param integer $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setBarThickWidth($value);
 
@@ -97,7 +97,7 @@ interface ObjectInterface
      * Set factor applying to
      * thinBarWidth - thickBarWidth - barHeight - fontSize
      * @param integer $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setFactor($value);
 
@@ -111,20 +111,20 @@ interface ObjectInterface
     /**
      * Set color of the barcode and text
      * @param string $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setForeColor($value);
 
     /**
      * Retrieve color of the barcode and text
-     * @return unknown
+     * @return integer
      */
     public function getForeColor();
 
     /**
      * Set the color of the background
      * @param integer $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setBackgroundColor($value);
 
@@ -137,7 +137,7 @@ interface ObjectInterface
     /**
      * Activate/deactivate drawing of the bar
      * @param boolean $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setWithBorder($value);
 
@@ -149,14 +149,14 @@ interface ObjectInterface
 
     /**
      * Allow fast inversion of font/bars color and background color
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setReverseColor();
 
     /**
      * Set orientation of barcode and text
      * @param float $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setOrientation($value);
 
@@ -169,7 +169,7 @@ interface ObjectInterface
     /**
      * Set text to encode
      * @param string $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setText($value);
 
@@ -194,7 +194,7 @@ interface ObjectInterface
     /**
      * Activate/deactivate drawing of text to encode
      * @param boolean $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setDrawText($value);
 
@@ -208,7 +208,7 @@ interface ObjectInterface
      * Activate/deactivate the adjustment of the position
      * of the characters to the position of the bars
      * @param boolean $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setStretchText($value);
 
@@ -224,7 +224,7 @@ interface ObjectInterface
      * of the checksum character
      * added to the barcode text
      * @param boolean $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setWithChecksum($value);
 
@@ -240,7 +240,7 @@ interface ObjectInterface
      * of the checksum character
      * added to the barcode text
      * @param boolean $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setWithChecksumInText($value);
 
@@ -256,7 +256,7 @@ interface ObjectInterface
      *  - if integer between 1 and 5, use gd built-in fonts
      *  - if string, $value is assumed to be the path to a TTF font
      * @param integer|string $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setFont($value);
 
@@ -269,7 +269,7 @@ interface ObjectInterface
     /**
      * Set the size of the font in case of TTF
      * @param float $value
-     * @return Object\ObjectInterface
+     * @return ObjectInterface
      */
     public function setFontSize($value);
 
@@ -300,12 +300,14 @@ interface ObjectInterface
 
     /**
      * Get height of the result object
+     * @param boolean $recalculate
      * @return integer
      */
     public function getHeight($recalculate = false);
 
     /**
      * Get width of the result object
+     * @param boolean $recalculate
      * @return integer
      */
     public function getWidth($recalculate = false);

--- a/library/Zend/Barcode/Renderer/AbstractRenderer.php
+++ b/library/Zend/Barcode/Renderer/AbstractRenderer.php
@@ -86,7 +86,6 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Constructor
      * @param array|Traversable $options
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Barcode/Renderer/RendererInterface.php
+++ b/library/Zend/Barcode/Renderer/RendererInterface.php
@@ -24,7 +24,6 @@ interface RendererInterface
     /**
      * Constructor
      * @param array|\Traversable $options
-     * @return void
      */
     public function __construct($options = null);
 

--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -77,7 +77,6 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      *
      * @param  null|array|Traversable|AdapterOptions $options
      * @throws Exception\ExceptionInterface
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Cache/Storage/Adapter/Apc.php
+++ b/library/Zend/Cache/Storage/Adapter/Apc.php
@@ -48,7 +48,6 @@ class Apc extends AbstractAdapter implements
      *
      * @param  null|array|Traversable|ApcOptions $options
      * @throws Exception\ExceptionInterface
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Cache/Storage/Adapter/ApcIterator.php
+++ b/library/Zend/Cache/Storage/Adapter/ApcIterator.php
@@ -55,7 +55,6 @@ class ApcIterator implements IteratorInterface
      * @param Apc             $storage
      * @param BaseApcIterator $baseIterator
      * @param string          $prefix
-     * @return void
      */
     public function __construct(Apc $storage, BaseApcIterator $baseIterator, $prefix)
     {

--- a/library/Zend/Cache/Storage/Adapter/Dba.php
+++ b/library/Zend/Cache/Storage/Adapter/Dba.php
@@ -50,7 +50,6 @@ class Dba extends AbstractAdapter implements
      *
      * @param  null|array|Traversable|DbaOptions $options
      * @throws Exception\ExceptionInterface
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Cache/Storage/Adapter/DbaIterator.php
+++ b/library/Zend/Cache/Storage/Adapter/DbaIterator.php
@@ -61,7 +61,6 @@ class DbaIterator implements IteratorInterface
      * @param Dba      $storage
      * @param resource $handle
      * @param string   $prefix
-     * @return void
      */
     public function __construct(Dba $storage, $handle, $prefix)
     {

--- a/library/Zend/Cache/Storage/Adapter/FilesystemIterator.php
+++ b/library/Zend/Cache/Storage/Adapter/FilesystemIterator.php
@@ -62,7 +62,6 @@ class FilesystemIterator implements IteratorInterface
      * @param Filesystem  $storage
      * @param string      $path
      * @param string      $prefix
-     * @return void
      */
     public function __construct(Filesystem $storage, $path, $prefix)
     {

--- a/library/Zend/Cache/Storage/Adapter/KeyListIterator.php
+++ b/library/Zend/Cache/Storage/Adapter/KeyListIterator.php
@@ -62,7 +62,6 @@ class KeyListIterator implements IteratorInterface, Countable
      *
      * @param StorageInterface $storage
      * @param array            $keys
-     * @return void
      */
     public function __construct(StorageInterface $storage, array $keys)
     {

--- a/library/Zend/Cache/Storage/Adapter/Memcached.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcached.php
@@ -52,7 +52,6 @@ class Memcached extends AbstractAdapter implements
      *
      * @param  null|array|Traversable|MemcachedOptions $options
      * @throws Exception\ExceptionInterface
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Cache/Storage/Adapter/WinCache.php
+++ b/library/Zend/Cache/Storage/Adapter/WinCache.php
@@ -34,7 +34,6 @@ class WinCache extends AbstractAdapter implements
      *
      * @param  array|Traversable|WinCacheOptions $options
      * @throws Exception\ExceptionInterface
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Cache/Storage/Adapter/ZendServerDisk.php
+++ b/library/Zend/Cache/Storage/Adapter/ZendServerDisk.php
@@ -42,7 +42,6 @@ class ZendServerDisk extends AbstractZendServer implements
      *
      * @param  null|array|\Traversable|AdapterOptions $options
      * @throws Exception\ExceptionInterface
-     * @return void
      */
     public function __construct($options = array())
     {

--- a/library/Zend/Cache/Storage/Adapter/ZendServerShm.php
+++ b/library/Zend/Cache/Storage/Adapter/ZendServerShm.php
@@ -32,7 +32,6 @@ class ZendServerShm extends AbstractZendServer implements
      *
      * @param  null|array|\Traversable|AdapterOptions $options
      * @throws Exception\ExceptionInterface
-     * @return void
      */
     public function __construct($options = array())
     {

--- a/library/Zend/Cache/Storage/Event.php
+++ b/library/Zend/Cache/Storage/Event.php
@@ -28,7 +28,6 @@ class Event extends BaseEvent
      * @param  string           $name Event name
      * @param  StorageInterface $storage
      * @param  ArrayObject      $params
-     * @return void
      */
     public function __construct($name, StorageInterface $storage, ArrayObject $params)
     {

--- a/library/Zend/Cache/Storage/ExceptionEvent.php
+++ b/library/Zend/Cache/Storage/ExceptionEvent.php
@@ -44,7 +44,6 @@ class ExceptionEvent extends PostEvent
      * @param  ArrayObject $params
      * @param  mixed       $result
      * @param  Exception   $exception
-     * @return void
      */
     public function __construct($name, StorageInterface $storage, ArrayObject $params, & $result, Exception $exception)
     {

--- a/library/Zend/Cache/Storage/Plugin/IgnoreUserAbort.php
+++ b/library/Zend/Cache/Storage/Plugin/IgnoreUserAbort.php
@@ -31,7 +31,7 @@ class IgnoreUserAbort extends AbstractPlugin
     /**
      * The storage who activated ignore_user_abort.
      *
-     * @var null|Zend\Cache\Storage\StorageInterface
+     * @var null|\Zend\Cache\Storage\StorageInterface
      */
     protected $activatedTarget = null;
 

--- a/library/Zend/Cache/Storage/Plugin/PluginInterface.php
+++ b/library/Zend/Cache/Storage/Plugin/PluginInterface.php
@@ -22,8 +22,8 @@ interface PluginInterface extends ListenerAggregateInterface
     /**
      * Set options
      *
-     * @param  Plugin\PluginOptions $options
-     * @return Plugin
+     * @param  PluginOptions $options
+     * @return PluginInterface
      */
     public function setOptions(PluginOptions $options);
 

--- a/library/Zend/Cache/Storage/PostEvent.php
+++ b/library/Zend/Cache/Storage/PostEvent.php
@@ -35,7 +35,6 @@ class PostEvent extends Event
      * @param  StorageInterface $storage
      * @param  ArrayObject      $params
      * @param  mixed            $result
-     * @return void
      */
     public function __construct($name, StorageInterface $storage, ArrayObject $params, & $result)
     {

--- a/library/Zend/Cache/StorageFactory.php
+++ b/library/Zend/Cache/StorageFactory.php
@@ -183,9 +183,9 @@ class StorageFactory
     /**
      * Instantiate a storage plugin
      *
-     * @param string|Storage\Plugin                          $pluginName
+     * @param string|Storage\Plugin\PluginInterface     $pluginName
      * @param array|Traversable|Storage\Plugin\PluginOptions $options
-     * @return Storage\Plugin
+     * @return Storage\Plugin\PluginInterface
      * @throws Exception\RuntimeException
      */
     public static function pluginFactory($pluginName, $options = array())

--- a/library/Zend/Captcha/Figlet.php
+++ b/library/Zend/Captcha/Figlet.php
@@ -34,7 +34,6 @@ class Figlet extends AbstractWord
      * Constructor
      *
      * @param  null|string|array|\Traversable $options
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Captcha/Image.php
+++ b/library/Zend/Captcha/Image.php
@@ -123,7 +123,6 @@ class Image extends AbstractWord
      * Constructor
      *
      * @param  array|\Traversable $options
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Captcha/ReCaptcha.php
+++ b/library/Zend/Captcha/ReCaptcha.php
@@ -122,7 +122,6 @@ class ReCaptcha extends AbstractAdapter
      * Constructor
      *
      * @param  null|array|Traversable $options
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Console/Exception/RuntimeException.php
+++ b/library/Zend/Console/Exception/RuntimeException.php
@@ -29,7 +29,6 @@ class RuntimeException extends \RuntimeException implements ExceptionInterface
      *
      * @param string $message
      * @param string $usage
-     * @return void
      */
     public function __construct($message, $usage = '')
     {

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -212,7 +212,6 @@ class Getopt
      * @param  array $rules
      * @param  array $argv
      * @param  array $getoptConfig
-     * @return void
      */
     public function __construct($rules, $argv = null, $getoptConfig = array())
     {

--- a/library/Zend/Db/Metadata/Metadata.php
+++ b/library/Zend/Db/Metadata/Metadata.php
@@ -47,7 +47,7 @@ class Metadata implements MetadataInterface
      * Create source from adapter
      *
      * @param  Adapter $adapter
-     * @return Source\InformationSchemaMetadata
+     * @return Source\AbstractSource
      */
     protected function createSourceFromAdapter(Adapter $adapter)
     {

--- a/library/Zend/Db/Metadata/Source/AbstractSource.php
+++ b/library/Zend/Db/Metadata/Source/AbstractSource.php
@@ -375,8 +375,7 @@ abstract class AbstractSource implements MetadataInterface
      * @param  string $constraint
      * @param  string $table
      * @param  string $schema
-     * @param  string $database
-     * @return Object\ConstraintKeyObject
+     * @return array
      */
     public function getConstraintKeys($constraint, $table, $schema = null)
     {

--- a/library/Zend/Db/ResultSet/HydratingResultSet.php
+++ b/library/Zend/Db/ResultSet/HydratingResultSet.php
@@ -36,7 +36,6 @@ class HydratingResultSet extends AbstractResultSet
      *
      * @param  null|HydratorInterface $hydrator
      * @param  null|object $objectPrototype
-     * @return void
      */
     public function __construct(HydratorInterface $hydrator = null, $objectPrototype = null)
     {

--- a/library/Zend/Db/ResultSet/ResultSet.php
+++ b/library/Zend/Db/ResultSet/ResultSet.php
@@ -48,7 +48,6 @@ class ResultSet extends AbstractResultSet
      * Constructor
      *
      * @param  null|ArrayObject $arrayObjectPrototype
-     * @return void
      */
     public function __construct($returnType = self::TYPE_ARRAYOBJECT, $arrayObjectPrototype = null)
     {

--- a/library/Zend/Db/RowGateway/RowGateway.php
+++ b/library/Zend/Db/RowGateway/RowGateway.php
@@ -11,8 +11,6 @@
 namespace Zend\Db\RowGateway;
 
 use Zend\Db\Adapter\Adapter;
-use Zend\Db\ResultSet\Row;
-use Zend\Db\ResultSet\RowObjectInterface;
 use Zend\Db\Sql\Sql;
 
 /**
@@ -26,10 +24,9 @@ class RowGateway extends AbstractRowGateway
     /**
      * Constructor
      *
-     * @param string $tableGateway
+     * @param string $primaryKeyColumn
      * @param string|\Zend\Db\Sql\TableIdentifier $table
-     * @param Adapter $adapter
-     * @param Sql\Sql $sql
+     * @param Adapter|Sql $adapterOrSql
      */
     public function __construct($primaryKeyColumn, $table, $adapterOrSql = null)
     {

--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -65,7 +65,6 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
      *
      * @param  null|string $table
      * @param  null|string $schema
-     * @return void
      */
     public function __construct($table = null)
     {

--- a/library/Zend/Db/Sql/Insert.php
+++ b/library/Zend/Db/Sql/Insert.php
@@ -56,7 +56,6 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
      *
      * @param  null|string $table
      * @param  null|string $schema
-     * @return void
      */
     public function __construct($table = null)
     {

--- a/library/Zend/Db/Sql/Platform/AbstractPlatform.php
+++ b/library/Zend/Db/Sql/Platform/AbstractPlatform.php
@@ -15,6 +15,7 @@ use Zend\Db\Adapter\Driver\StatementInterface;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Sql\PreparableSqlInterface;
 use Zend\Db\Sql\SqlInterface;
+use Zend\Db\Sql\Exception;
 
 class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInterface, SqlInterface
 {
@@ -55,7 +56,7 @@ class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInter
 
     /**
      * @param Adapter $adapter
-     * @return StatementInterface
+     * @param StatementInterface $statement
      */
     public function prepareStatement(Adapter $adapter, StatementInterface $statement)
     {

--- a/library/Zend/Db/Sql/Predicate/Between.php
+++ b/library/Zend/Db/Sql/Predicate/Between.php
@@ -28,7 +28,6 @@ class Between implements PredicateInterface
      * @param  string $identifier
      * @param  string $minValue
      * @param  string $maxValue
-     * @return void
      */
     public function __construct($identifier = null, $minValue = null, $maxValue = null)
     {

--- a/library/Zend/Db/Sql/Predicate/Expression.php
+++ b/library/Zend/Db/Sql/Predicate/Expression.php
@@ -25,7 +25,6 @@ class Expression extends BaseExpression implements PredicateInterface
      *
      * @param string $expression
      * @param mixed $valueParameter
-     * @return void
      */
     public function __construct($expression = null, $valueParameter = null /*[, $valueParameter, ... ]*/)
     {

--- a/library/Zend/Db/Sql/Predicate/In.php
+++ b/library/Zend/Db/Sql/Predicate/In.php
@@ -25,7 +25,6 @@ class In implements PredicateInterface
      *
      * @param  null|string $identifier
      * @param  array $valueSet
-     * @return void
      */
     public function __construct($identifier = null, array $valueSet = array())
     {

--- a/library/Zend/Db/Sql/Predicate/IsNull.php
+++ b/library/Zend/Db/Sql/Predicate/IsNull.php
@@ -32,7 +32,6 @@ class IsNull implements PredicateInterface
      * Constructor
      *
      * @param  string $identifier
-     * @return void
      */
     public function __construct($identifier = null)
     {

--- a/library/Zend/Db/Sql/Predicate/Operator.php
+++ b/library/Zend/Db/Sql/Predicate/Operator.php
@@ -54,7 +54,6 @@ class Operator implements PredicateInterface
      * @param  mixed $right
      * @param  TYPE_IDENTIFIER|TYPE_VALUE $leftType
      * @param  TYPE_IDENTIFIER|TYPE_VALUE $rightType
-     * @return void
      */
     public function __construct($left = null, $operator = self::OPERATOR_EQUAL_TO, $right = null, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {

--- a/library/Zend/Db/Sql/Predicate/PredicateSet.php
+++ b/library/Zend/Db/Sql/Predicate/PredicateSet.php
@@ -33,7 +33,6 @@ class PredicateSet implements PredicateInterface, Countable
      *
      * @param  null|array $predicates
      * @param  string $defaultCombination
-     * @return void
      */
     public function __construct(array $predicates = null, $defaultCombination = self::COMBINED_BY_AND)
     {

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -136,7 +136,6 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
      * Constructor
      *
      * @param  null|string $table
-     * @return void
      */
     public function __construct($table = null)
     {

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -65,7 +65,6 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
      *
      * @param  null|string $table
      * @param  null|string $schema
-     * @return void
      */
     public function __construct($table = null)
     {

--- a/library/Zend/Db/TableGateway/AbstractTableGateway.php
+++ b/library/Zend/Db/TableGateway/AbstractTableGateway.php
@@ -63,7 +63,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
     protected $resultSetPrototype = null;
 
     /**
-     * @var Sql\Sql
+     * @var Sql
      */
     protected $sql = null;
 
@@ -198,7 +198,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
     }
 
     /**
-     * @param Sql\Select $select
+     * @param Select $select
      * @return null|ResultSetInterface
      * @throws \RuntimeException
      */

--- a/library/Zend/Dom/Query.php
+++ b/library/Zend/Dom/Query.php
@@ -68,7 +68,6 @@ class Query
      * Constructor
      *
      * @param  null|string $document
-     * @return void
      */
     public function __construct($document = null, $encoding = null)
     {

--- a/library/Zend/EventManager/Event.php
+++ b/library/Zend/EventManager/Event.php
@@ -51,7 +51,6 @@ class Event implements EventInterface
      * @param  string $name Event name
      * @param  string|object $target
      * @param  array|ArrayAccess $params
-     * @return void
      */
     public function __construct($name = null, $target = null, $params = null)
     {

--- a/library/Zend/Feed/Reader/AbstractEntry.php
+++ b/library/Zend/Feed/Reader/AbstractEntry.php
@@ -68,7 +68,6 @@ abstract class AbstractEntry
      * @param  DOMElement $entry
      * @param  int $entryKey
      * @param  null|string $type
-     * @return void
      */
     public function __construct(DOMElement $entry, $entryKey, $type = null)
     {

--- a/library/Zend/Feed/Reader/AbstractEntry.php
+++ b/library/Zend/Feed/Reader/AbstractEntry.php
@@ -37,7 +37,7 @@ abstract class AbstractEntry
     /**
      * Entry instance
      *
-     * @var Zend\Feed\Entry
+     * @var DOMElement
      */
     protected $entry = null;
 
@@ -67,7 +67,7 @@ abstract class AbstractEntry
      *
      * @param  DOMElement $entry
      * @param  int $entryKey
-     * @param  string $type
+     * @param  null|string $type
      * @return void
      */
     public function __construct(DOMElement $entry, $entryKey, $type = null)
@@ -78,7 +78,7 @@ abstract class AbstractEntry
         if ($type !== null) {
             $this->data['type'] = $type;
         } else {
-            $this->data['type'] = Reader::detectType($feed);
+            $this->data['type'] = Reader::detectType($entry);
         }
         $this->_loadExtensions();
     }
@@ -157,7 +157,7 @@ abstract class AbstractEntry
      * Set the XPath query
      *
      * @param  DOMXPath $xpath
-     * @return Zend\Feed\Reader\AbstractEntry
+     * @return \Zend\Feed\Reader\AbstractEntry
      */
     public function setXpath(DOMXPath $xpath)
     {

--- a/library/Zend/Feed/Reader/AbstractFeed.php
+++ b/library/Zend/Feed/Reader/AbstractFeed.php
@@ -127,7 +127,7 @@ abstract class AbstractFeed implements Feed\FeedInterface
     /**
      * Return the current entry
      *
-     * @return \Zend\Feed\Reader\Entry
+     * @return \Zend\Feed\Reader\AbstractEntry
      */
     public function current()
     {

--- a/library/Zend/Feed/Reader/Entry/AbstractEntry.php
+++ b/library/Zend/Feed/Reader/Entry/AbstractEntry.php
@@ -70,7 +70,6 @@ abstract class AbstractEntry
      * @param  DOMElement $entry
      * @param  int $entryKey
      * @param  string $type
-     * @return void
      */
     public function __construct(DOMElement $entry, $entryKey, $type = null)
     {

--- a/library/Zend/Feed/Reader/Entry/Atom.php
+++ b/library/Zend/Feed/Reader/Entry/Atom.php
@@ -33,7 +33,6 @@ class Atom extends AbstractEntry implements EntryInterface
      * @param  DOMElement $entry
      * @param  int $entryKey
      * @param  string $type
-     * @return void
      */
     public function __construct(DOMElement $entry, $entryKey, $type = null)
     {

--- a/library/Zend/Feed/Reader/Entry/Rss.php
+++ b/library/Zend/Feed/Reader/Entry/Rss.php
@@ -43,7 +43,6 @@ class Rss extends AbstractEntry implements EntryInterface
      * @param  DOMElement $entry
      * @param  string $entryKey
      * @param  string $type
-     * @return void
      */
     public function __construct(DOMElement $entry, $entryKey, $type = null)
     {

--- a/library/Zend/Feed/Reader/Extension/AbstractEntry.php
+++ b/library/Zend/Feed/Reader/Extension/AbstractEntry.php
@@ -175,7 +175,7 @@ abstract class AbstractEntry
      * Set the XPath query
      *
      * @param  DOMXPath $xpath
-     * @return Reader\Reader_Extension_EntryAbstract
+     * @return AbstractEntry
      */
     public function setXpath(DOMXPath $xpath)
     {
@@ -221,7 +221,7 @@ abstract class AbstractEntry
      * Set the XPath prefix
      *
      * @param  string $prefix
-     * @return Reader\Reader_Extension_EntryAbstract
+     * @return AbstractEntry
      */
     public function setXpathPrefix($prefix)
     {

--- a/library/Zend/Feed/Reader/Extension/AbstractFeed.php
+++ b/library/Zend/Feed/Reader/Extension/AbstractFeed.php
@@ -125,7 +125,7 @@ abstract class AbstractFeed
      * Set the XPath query
      *
      * @param  DOMXPath $xpath
-     * @return Reader\Reader_Extension_EntryAbstract
+     * @return AbstractEntry
      */
     public function setXpath(DOMXPath $xpath = null)
     {

--- a/library/Zend/Feed/Reader/Extension/Atom/Entry.php
+++ b/library/Zend/Feed/Reader/Extension/Atom/Entry.php
@@ -521,7 +521,7 @@ class Entry extends Extension\AbstractEntry
     /**
      * Get source feed metadata from the entry
      *
-     * @return Reader\Reader_Feed_Atom_Source|null
+     * @return Reader\Feed\Atom\Source|null
      */
     public function getSource()
     {

--- a/library/Zend/Feed/Writer/AbstractFeed.php
+++ b/library/Zend/Feed/Writer/AbstractFeed.php
@@ -44,7 +44,6 @@ class AbstractFeed
      * Constructor: Primarily triggers the registration of core extensions and
      * loads those appropriate to this data container.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/Feed/Writer/Entry.php
+++ b/library/Zend/Feed/Writer/Entry.php
@@ -47,7 +47,6 @@ class Entry
      * Constructor: Primarily triggers the registration of core extensions and
      * loads those appropriate to this data container.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/Feed/Writer/Renderer/AbstractRenderer.php
+++ b/library/Zend/Feed/Writer/Renderer/AbstractRenderer.php
@@ -70,7 +70,6 @@ class AbstractRenderer
      * Constructor
      *
      * @param  mixed $container
-     * @return void
      */
     public function __construct($container)
     {

--- a/library/Zend/Feed/Writer/Renderer/Entry/Atom/Deleted.php
+++ b/library/Zend/Feed/Writer/Renderer/Entry/Atom/Deleted.php
@@ -26,7 +26,6 @@ class Deleted
      * Constructor
      *
      * @param  \Zend\Feed\Writer\Deleted $container
-     * @return void
      */
     public function __construct (\Zend\Feed\Writer\Deleted $container)
     {

--- a/library/Zend/Feed/Writer/Renderer/Entry/AtomDeleted.php
+++ b/library/Zend/Feed/Writer/Renderer/Entry/AtomDeleted.php
@@ -26,7 +26,6 @@ class AtomDeleted extends Renderer\AbstractRenderer implements Renderer\Renderer
      * Constructor
      *
      * @param  Writer\Deleted $container
-     * @return void
      */
     public function __construct (Writer\Deleted $container)
     {

--- a/library/Zend/Feed/Writer/Renderer/Entry/Rss.php
+++ b/library/Zend/Feed/Writer/Renderer/Entry/Rss.php
@@ -27,7 +27,6 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
      * Constructor
      *
      * @param  Writer\Entry $container
-     * @return void
      */
     public function __construct (Writer\Entry $container)
     {

--- a/library/Zend/Feed/Writer/Renderer/Feed/AbstractAtom.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/AbstractAtom.php
@@ -27,7 +27,6 @@ class AbstractAtom extends Renderer\AbstractRenderer
      * Constructor
      *
      * @param  Zend_Feed_Writer_Feed $container
-     * @return void
      */
     public function __construct ($container)
     {

--- a/library/Zend/Feed/Writer/Renderer/Feed/Atom.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/Atom.php
@@ -24,7 +24,6 @@ class Atom extends AbstractAtom implements Renderer\RendererInterface
      * Constructor
      *
      * @param  Writer\Feed $container
-     * @return void
      */
     public function __construct (Writer\Feed $container)
     {

--- a/library/Zend/Feed/Writer/Renderer/Feed/Atom/AbstractAtom.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/Atom/AbstractAtom.php
@@ -26,7 +26,6 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
      * Constructor
      *
      * @param  \Zend\Feed\Writer\Feed $container
-     * @return void
      */
     public function __construct ($container)
     {

--- a/library/Zend/Feed/Writer/Renderer/Feed/Atom/Source.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/Atom/Source.php
@@ -24,7 +24,6 @@ class Source extends AbstractAtom implements \Zend\Feed\Writer\Renderer\Renderer
      * Constructor
      *
      * @param  \Zend\Feed\Writer\Source $container
-     * @return void
      */
     public function __construct (\Zend\Feed\Writer\Source $container)
     {

--- a/library/Zend/Feed/Writer/Renderer/Feed/AtomSource.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/AtomSource.php
@@ -26,7 +26,6 @@ class AtomSource extends AbstractAtom implements Renderer\RendererInterface
      * Constructor
      *
      * @param  Zend_Feed_Writer_Feed_Source $container
-     * @return void
      */
     public function __construct (Writer\Source $container)
     {

--- a/library/Zend/Feed/Writer/Renderer/Feed/Rss.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/Rss.php
@@ -28,7 +28,6 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
      * Constructor
      *
      * @param  Zend_Feed_Writer_Feed $container
-     * @return void
      */
     public function __construct (Writer\Feed $container)
     {

--- a/library/Zend/Filter/Compress/Lzf.php
+++ b/library/Zend/Filter/Compress/Lzf.php
@@ -24,7 +24,6 @@ class Lzf implements CompressionAlgorithmInterface
      * Class constructor
      *
      * @param  null $options
-     * @return void
      * @throws Exception\ExtensionNotLoadedException if lzf extension missing
      */
     public function __construct($options = null)

--- a/library/Zend/Filter/Compress/Zip.php
+++ b/library/Zend/Filter/Compress/Zip.php
@@ -40,7 +40,6 @@ class Zip extends AbstractCompressionAlgorithm
      * Class constructor
      *
      * @param  null|array|\Traversable $options (Optional) Options to set
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Filter/PregReplace.php
+++ b/library/Zend/Filter/PregReplace.php
@@ -31,7 +31,6 @@ class PregReplace extends AbstractFilter
      *     'replacement' => replace with this
      *
      * @param  array|Traversable|string|null $options
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Form/Annotation/AbstractArrayAnnotation.php
+++ b/library/Zend/Form/Annotation/AbstractArrayAnnotation.php
@@ -27,7 +27,6 @@ abstract class AbstractArrayAnnotation
      * Receive and process the contents of an annotation
      *
      * @param  array $data
-     * @return void
      * @throws Exception\DomainException if a 'value' key is missing, or its value is not an array
      */
     public function __construct(array $data)

--- a/library/Zend/Form/Annotation/AbstractStringAnnotation.php
+++ b/library/Zend/Form/Annotation/AbstractStringAnnotation.php
@@ -27,7 +27,6 @@ abstract class AbstractStringAnnotation
      * Receive and process the contents of an annotation
      *
      * @param  array $data
-     * @return void
      * @throws Exception\DomainException if a 'value' key is missing, or its value is not a string
      */
     public function __construct(array $data)

--- a/library/Zend/Form/Annotation/Required.php
+++ b/library/Zend/Form/Annotation/Required.php
@@ -35,7 +35,6 @@ class Required
      * Receive and process the contents of an annotation
      *
      * @param  array $data
-     * @return void
      */
     public function __construct(array $data)
     {

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1254,8 +1254,8 @@ class Client implements Stdlib\DispatchableInterface
      * the interaction with the adapter
      *
      * @param Http $uri
-     * @param string $secure
      * @param string $method
+     * @param boolean $secure
      * @param array $headers
      * @param string $body
      * @return string the raw response

--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -74,7 +74,6 @@ class Curl implements HttpAdapter, StreamInterface
      *
      * Config is set using setOptions()
      *
-     * @return void
      * @throws AdapterException\InitializationException
      */
     public function __construct()

--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -75,7 +75,7 @@ class SetCookie implements MultipleHeaderInterface
     protected $secure = null;
 
     /**
-     * @var true
+     * @var boolean|null
      */
     protected $httponly = null;
 
@@ -432,7 +432,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param \Zend\Http\Header\true $httponly
+     * @param boolean $httponly
      */
     public function setHttponly($httponly)
     {
@@ -440,7 +440,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return \Zend\Http\Header\true
+     * @return boolean
      */
     public function isHttponly()
     {

--- a/library/Zend/I18n/Translator/Plural/Parser.php
+++ b/library/Zend/I18n/Translator/Plural/Parser.php
@@ -55,7 +55,6 @@ class Parser
     /**
      * Create a new plural parser.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/I18n/Translator/Plural/Symbol.php
+++ b/library/Zend/I18n/Translator/Plural/Symbol.php
@@ -96,7 +96,6 @@ class Symbol
      * @param  Parser  $parser
      * @param  string  $id
      * @param  integer $leftBindingPower
-     * @return void
      */
     public function __construct(Parser $parser, $id, $leftBindingPower)
     {

--- a/library/Zend/Json/Expr.php
+++ b/library/Zend/Json/Expr.php
@@ -49,7 +49,6 @@ class Expr
      * Constructor
      *
      * @param  string $expression the expression to hold.
-     * @return void
      */
     public function __construct($expression)
     {

--- a/library/Zend/Json/Server/Error.php
+++ b/library/Zend/Json/Server/Error.php
@@ -60,7 +60,6 @@ class Error
      * @param  string $message
      * @param  int $code
      * @param  mixed $data
-     * @return void
      */
     public function __construct($message = null, $code = -32000, $data = null)
     {

--- a/library/Zend/Json/Server/Request/Http.php
+++ b/library/Zend/Json/Server/Request/Http.php
@@ -29,7 +29,6 @@ class Http extends JsonRequest
      *
      * Pull JSON request from raw POST body and use to populate request.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/Json/Server/Response.php
+++ b/library/Zend/Json/Server/Response.php
@@ -39,7 +39,7 @@ class Response
 
     /**
      * Service map
-     * @var Smd\Smd
+     * @var Smd
      */
     protected $serviceMap;
 
@@ -248,7 +248,7 @@ class Response
     /**
      * Set service map object
      *
-     * @param  Smd\Smd $serviceMap
+     * @param  Smd $serviceMap
      * @return Response
      */
     public function setServiceMap($serviceMap)
@@ -260,7 +260,7 @@ class Response
     /**
      * Retrieve service map
      *
-     * @return Smd\Smd|null
+     * @return Smd|null
      */
     public function getServiceMap()
     {

--- a/library/Zend/Json/Server/Smd.php
+++ b/library/Zend/Json/Server/Smd.php
@@ -97,7 +97,7 @@ class Smd
      * Set object state via options
      *
      * @param  array $options
-     * @return Zend\Json\Server\Smd
+     * @return Smd
      */
     public function setOptions(array $options)
     {
@@ -114,7 +114,7 @@ class Smd
      * Set transport
      *
      * @param  string $transport
-     * @return Zend\Json\Server\Smd
+     * @return \Zend\Json\Server\Smd
      */
     public function setTransport($transport)
     {
@@ -139,7 +139,7 @@ class Smd
      * Set envelope
      *
      * @param  string $envelopeType
-     * @return Zend\Json\Server\Smd
+     * @return Smd
      */
     public function setEnvelope($envelopeType)
     {
@@ -165,7 +165,7 @@ class Smd
      * Set content type
      *
      * @param  string $type
-     * @return Zend\Json\Server\Smd
+     * @return \Zend\Json\Server\Smd
      */
     public function setContentType($type)
     {
@@ -190,7 +190,7 @@ class Smd
      * Set service target
      *
      * @param  string $target
-     * @return Zend\Json\Server\Smd
+     * @return Smd
      */
     public function setTarget($target)
     {
@@ -212,7 +212,7 @@ class Smd
      * Set service ID
      *
      * @param  string $Id
-     * @return Zend\Json\Server\Smd
+     * @return Smd
      */
     public function setId($id)
     {
@@ -234,7 +234,7 @@ class Smd
      * Set service description
      *
      * @param  string $description
-     * @return Zend\Json\Server\Smd
+     * @return Smd
      */
     public function setDescription($description)
     {
@@ -256,7 +256,7 @@ class Smd
      * Indicate whether or not to generate Dojo-compatible SMD
      *
      * @param  bool $flag
-     * @return Zend\Json\Server\Smd
+     * @return Smd
      */
     public function setDojoCompatible($flag)
     {
@@ -277,8 +277,8 @@ class Smd
     /**
      * Add Service
      *
-     * @param Zend\Json\Server\Smd\Service|array $service
-     * @return void
+     * @param Smd\Service|array $service
+     * @return Smd
      */
     public function addService($service)
     {
@@ -302,7 +302,7 @@ class Smd
      * Add many services
      *
      * @param  array $services
-     * @return Zend\Json\Server\Smd
+     * @return Smd
      */
     public function addServices(array $services)
     {
@@ -316,7 +316,7 @@ class Smd
      * Overwrite existing services with new ones
      *
      * @param  array $services
-     * @return Zend\Json\Server\Smd
+     * @return Smd
      */
     public function setServices(array $services)
     {
@@ -328,7 +328,7 @@ class Smd
      * Get service object
      *
      * @param  string $name
-     * @return false|Zend\Json\Server\Smd\Service
+     * @return boolean|Smd\Service
      */
     public function getService($name)
     {

--- a/library/Zend/Json/Server/Smd/Service.php
+++ b/library/Zend/Json/Server/Smd/Service.php
@@ -107,7 +107,6 @@ class Service
      * Constructor
      *
      * @param  string|array $spec
-     * @return void
      * @throws Zend\Json\Server\Exception\InvalidArgumentException if no name provided
      */
     public function __construct($spec)

--- a/library/Zend/Json/Server/Smd/Service.php
+++ b/library/Zend/Json/Server/Smd/Service.php
@@ -428,9 +428,10 @@ class Service
     /**
      * Validate parameter type
      *
-     * @param  string $type
-     * @return true
-     * @throws Zend\Json\Server\Exception
+     * @param string  $type
+     * @param boolean $isReturn
+     * @return string
+     * @throws InvalidArgumentException
      */
     protected function _validateParamType($type, $isReturn = false)
     {

--- a/library/Zend/Loader/ModuleAutoloader.php
+++ b/library/Zend/Loader/ModuleAutoloader.php
@@ -45,7 +45,6 @@ class ModuleAutoloader implements SplAutoloader
      * Allow configuration of the autoloader via the constructor.
      *
      * @param  null|array|Traversable $options
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Loader/PluginClassLoader.php
+++ b/library/Zend/Loader/PluginClassLoader.php
@@ -38,7 +38,6 @@ class PluginClassLoader implements PluginClassLocator
      * Constructor
      *
      * @param  null|array|Traversable $map If provided, seeds the loader with a map
-     * @return void
      */
     public function __construct($map = null)
     {

--- a/library/Zend/Loader/StandardAutoloader.php
+++ b/library/Zend/Loader/StandardAutoloader.php
@@ -50,7 +50,6 @@ class StandardAutoloader implements SplAutoloader
      * Constructor
      *
      * @param  null|array|\Traversable $options
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Log/Writer/MongoDB.php
+++ b/library/Zend/Log/Writer/MongoDB.php
@@ -47,10 +47,10 @@ class MongoDB extends AbstractWriter
      * Constructor
      *
      * @param Mongo|array|Traversable $mongo
-     * @param string $database
+     * @param string|MongoDB $database
      * @param string $collection
-     * @param array  $saveOptions
-     * @return Zend\Log\Writer\MongoDB
+     * @param array $saveOptions
+     * @return void
      */
     public function __construct($mongo, $database, $collection, array $saveOptions = array())
     {

--- a/library/Zend/Log/Writer/MongoDB.php
+++ b/library/Zend/Log/Writer/MongoDB.php
@@ -50,7 +50,6 @@ class MongoDB extends AbstractWriter
      * @param string|MongoDB $database
      * @param string $collection
      * @param array $saveOptions
-     * @return void
      */
     public function __construct($mongo, $database, $collection, array $saveOptions = array())
     {

--- a/library/Zend/Memory/MemoryManager.php
+++ b/library/Zend/Memory/MemoryManager.php
@@ -129,7 +129,6 @@ class MemoryManager
      * If cache is not specified, then memory objects are never swapped
      *
      * @param  CacheStorage $cache
-     * @return void
      */
     public function __construct(CacheStorage $cache = null)
     {

--- a/library/Zend/Memory/MemoryManager.php
+++ b/library/Zend/Memory/MemoryManager.php
@@ -224,8 +224,8 @@ class MemoryManager
      * Create new Zend_Memory value container
      *
      * @param string $value
-     * @return \Zend\Memory\Container
-     * @throws \Zend\Memory\Exception
+     * @return Container\ContainerInterface
+     * @throws Exception\ExceptionInterface
      */
     public function create($value = '')
     {
@@ -237,8 +237,8 @@ class MemoryManager
      * locked in memory
      *
      * @param string $value
-     * @return \Zend\Memory\Container
-     * @throws \Zend\Memory\Exception
+     * @return Container\ContainerInterface
+     * @throws Exception\ExceptionInterface
      */
     public function createLocked($value = '')
     {
@@ -250,8 +250,8 @@ class MemoryManager
      *
      * @param string $value
      * @param boolean $locked
-     * @return \Zend\Memory\Container
-     * @throws \Zend\Memory\Exception
+     * @return \Zend\Memory\Container\ContainerInterface
+     * @throws \Zend\Memory\Exception\ExceptionInterface
      */
     private function _create($value, $locked)
     {
@@ -280,8 +280,9 @@ class MemoryManager
      * Used by Memory container destroy() method
      *
      * @internal
+     * @param Container\Movable $container
      * @param integer $id
-     * @return \Zend\Memory\Container\AbstractContainer
+     * @return null
      */
     public function unlink(Container\Movable $container, $id)
     {

--- a/library/Zend/Mime/Mime.php
+++ b/library/Zend/Mime/Mime.php
@@ -280,7 +280,6 @@ class Mime
      *
      * @param null|string $boundary
      * @access public
-     * @return void
      */
     public function __construct($boundary = null)
     {

--- a/library/Zend/ModuleManager/ModuleManager.php
+++ b/library/Zend/ModuleManager/ModuleManager.php
@@ -61,7 +61,6 @@ class ModuleManager implements ModuleManagerInterface
      *
      * @param  array|Traversable $modules
      * @param  EventManagerInterface $eventManager
-     * @return void
      */
     public function __construct($modules, EventManagerInterface $eventManager = null)
     {

--- a/library/Zend/ProgressBar/Adapter/AbstractAdapter.php
+++ b/library/Zend/ProgressBar/Adapter/AbstractAdapter.php
@@ -53,7 +53,7 @@ abstract class AbstractAdapter
      * Set options via an array
      *
      * @param  array $options
-     * @return \Zend\ProgressBar\Adapter\Adapter
+     * @return AbstractAdapter
      */
     public function setOptions(array $options)
     {

--- a/library/Zend/ProgressBar/Adapter/Console.php
+++ b/library/Zend/ProgressBar/Adapter/Console.php
@@ -239,7 +239,7 @@ class Console extends AbstractAdapter
      * Set the elements to display with the progressbar
      *
      * @param  array $elements
-     * @throws \Zend\ProgressBar\Adapter\Exception When an invalid element is found in the array
+     * @throws \Zend\ProgressBar\Adapter\Exception\InvalidArgumentException When an invalid element is found in the array
      * @return \Zend\ProgressBar\Adapter\Console
      */
     public function setElements(array $elements)
@@ -264,7 +264,7 @@ class Console extends AbstractAdapter
      * Set the left-hand character for the bar
      *
      * @param  string $char
-     * @throws \Zend\ProgressBar\Adapter\Exception When character is empty
+     * @throws \Zend\ProgressBar\Adapter\Exception\InvalidArgumentException When character is empty
      * @return \Zend\ProgressBar\Adapter\Console
      */
     public function setBarLeftChar($char)
@@ -282,7 +282,7 @@ class Console extends AbstractAdapter
      * Set the right-hand character for the bar
      *
      * @param  string $char
-     * @throws \Zend\ProgressBar\Adapter\Exception When character is empty
+     * @throws \Zend\ProgressBar\Adapter\Exception\InvalidArgumentException When character is empty
      * @return \Zend\ProgressBar\Adapter\Console
      */
     public function setBarRightChar($char)
@@ -338,7 +338,7 @@ class Console extends AbstractAdapter
      * Set the finish action
      *
      * @param  string $action
-     * @throws \Zend\ProgressBar\Adapter\Exception When an invalid action is specified
+     * @throws \Zend\ProgressBar\Adapter\Exception\InvalidArgumentException When an invalid action is specified
      * @return \Zend\ProgressBar\Adapter\Console
      */
     public function setFinishAction($action)

--- a/library/Zend/ProgressBar/ProgressBar.php
+++ b/library/Zend/ProgressBar/ProgressBar.php
@@ -59,7 +59,7 @@ class ProgressBar
     /**
      * Adapter for the output
      *
-     * @var \Zend\ProgressBar\Adapter\Adapter
+     * @var \Zend\ProgressBar\Adapter\AbstractAdapter
      */
     protected $adapter;
 
@@ -74,9 +74,9 @@ class ProgressBar
      * Create a new progressbar backend.
      *
      * @param  Adapter\AbstractAdapter $adapter
-     * @param  float                    $min
-     * @param  float                    $max
-     * @param  string                   $persistenceNamespace
+     * @param  float|int               $min
+     * @param  float|int               $max
+     * @param  string|null             $persistenceNamespace
      * @throws Exception\OutOfRangeException When $min is greater than $max
      */
     public function __construct(Adapter\AbstractAdapter $adapter, $min = 0, $max = 100, $persistenceNamespace = null)

--- a/library/Zend/Server/AbstractServer.php
+++ b/library/Zend/Server/AbstractServer.php
@@ -35,7 +35,6 @@ abstract class AbstractServer implements Server
      *
      * Setup server description
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/Server/Definition.php
+++ b/library/Zend/Server/Definition.php
@@ -32,7 +32,6 @@ class Definition implements \Countable, \Iterator
      * Constructor
      *
      * @param  null|array $methods
-     * @return void
      */
     public function __construct($methods = null)
     {

--- a/library/Zend/Server/Definition.php
+++ b/library/Zend/Server/Definition.php
@@ -59,7 +59,7 @@ class Definition implements \Countable, \Iterator
      * @param  array|\Zend\Server\Method\Definition $method
      * @param  null|string $name
      * @return \Zend\Server\Definition
-     * @throws \Zend\Server\Exception if duplicate or invalid method provided
+     * @throws \Zend\Server\Exception\ExceptionInterface if duplicate or invalid method provided
      */
     public function addMethod($method, $name = null)
     {

--- a/library/Zend/Server/Method/Callback.php
+++ b/library/Zend/Server/Method/Callback.php
@@ -150,8 +150,8 @@ class Callback
      * Set callback type
      *
      * @param  string $type
-     * @return \Zend\Server\Method\Callback
-     * @throws \Zend\Server\Exception
+     * @return Callback
+     * @throws Server\Exception\InvalidArgumentException
      */
     public function setType($type)
     {

--- a/library/Zend/Server/Method/Callback.php
+++ b/library/Zend/Server/Method/Callback.php
@@ -50,7 +50,6 @@ class Callback
      * Constructor
      *
      * @param  null|array $options
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Server/Method/Definition.php
+++ b/library/Zend/Server/Method/Definition.php
@@ -55,7 +55,6 @@ class Definition
      * Constructor
      *
      * @param  null|array $options
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Server/Method/Parameter.php
+++ b/library/Zend/Server/Method/Parameter.php
@@ -48,7 +48,6 @@ class Parameter
      * Constructor
      *
      * @param  null|array $options
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Server/Method/Prototype.php
+++ b/library/Zend/Server/Method/Prototype.php
@@ -38,7 +38,6 @@ class Prototype
      * Constructor
      *
      * @param  null|array $options
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Server/Reflection.php
+++ b/library/Zend/Server/Reflection.php
@@ -31,12 +31,12 @@ class Reflection
      * be provided as an array to $argv.
      *
      * @param string|object $class Class name or object
-     * @param null|array $argv Optional arguments to be used during the method call
+     * @param boolean|array $argv Optional arguments to be used during the method call
      * @param string $namespace Optional namespace with which to prefix the
      * method name (used for the signature key). Primarily to avoid collisions,
      * also for XmlRpc namespacing
-     * @return \Zend\Server\Reflection\ClassReflection
-     * @throws \Zend\Server\Reflection\Exception
+     * @return \Zend\Server\Reflection\ReflectionClass
+     * @throws \Zend\Server\Reflection\Exception\ExceptionInterface
      */
     public static function reflectClass($class, $argv = false, $namespace = '')
     {
@@ -65,12 +65,12 @@ class Reflection
      * may be provided as an array to $argv.
      *
      * @param string $function Function name
-     * @param null|array $argv Optional arguments to be used during the method call
+     * @param boolean|array $argv Optional arguments to be used during the method call
      * @param string $namespace Optional namespace with which to prefix the
      * function name (used for the signature key). Primarily to avoid
      * collisions, also for XmlRpc namespacing
-     * @return \Zend\Server\Reflection\FunctionReflection
-     * @throws \Zend\Server\Reflection\Exception
+     * @return \Zend\Server\Reflection\ReflectionFunction
+     * @throws \Zend\Server\Reflection\Exception\ExceptionInterface
      */
     public static function reflectFunction($function, $argv = false, $namespace = '')
     {

--- a/library/Zend/Server/Reflection/Prototype.php
+++ b/library/Zend/Server/Reflection/Prototype.php
@@ -26,7 +26,6 @@ class Prototype
      *
      * @param ReflectionReturnValue $return
      * @param array $params
-     * @return void
      */
     public function __construct(ReflectionReturnValue $return, $params = null)
     {

--- a/library/Zend/Server/Reflection/Prototype.php
+++ b/library/Zend/Server/Reflection/Prototype.php
@@ -24,7 +24,7 @@ class Prototype
     /**
      * Constructor
      *
-     * @param Zend\Server\Reflection\ReflectionReturnValue $return
+     * @param ReflectionReturnValue $return
      * @param array $params
      * @return void
      */
@@ -61,7 +61,7 @@ class Prototype
      * Retrieve the return value object
      *
      * @access public
-     * @return Zend\Server\Reflection\ReflectionReturnValue
+     * @return \Zend\Server\Reflection\ReflectionReturnValue
      */
     public function getReturnValue()
     {

--- a/library/Zend/Server/Reflection/ReflectionClass.php
+++ b/library/Zend/Server/Reflection/ReflectionClass.php
@@ -56,7 +56,6 @@ class ReflectionClass
      * @param ReflectionClass $reflection
      * @param string $namespace
      * @param mixed $argv
-     * @return void
      */
     public function __construct(\ReflectionClass $reflection, $namespace = null, $argv = false)
     {

--- a/library/Zend/Server/Reflection/ReflectionMethod.php
+++ b/library/Zend/Server/Reflection/ReflectionMethod.php
@@ -38,7 +38,6 @@ class ReflectionMethod extends AbstractFunction
      * @param \ReflectionMethod $r
      * @param string $namespace
      * @param array $argv
-     * @return void
      */
     public function __construct(ReflectionClass $class, \ReflectionMethod $r, $namespace = null, $argv = array())
     {

--- a/library/Zend/Server/Reflection/ReflectionMethod.php
+++ b/library/Zend/Server/Reflection/ReflectionMethod.php
@@ -27,15 +27,15 @@ class ReflectionMethod extends AbstractFunction
 
     /**
      * Parent class reflection
-     * @var Zend\Server\Reflection\ReflectionClass
+     * @var ReflectionClass
      */
     protected $classReflection;
 
     /**
      * Constructor
      *
-     * @param \Zend\Server\Reflection\ReflectionClass $class
-     * @param ReflectionMethod $r
+     * @param ReflectionClass $class
+     * @param \ReflectionMethod $r
      * @param string $namespace
      * @param array $argv
      * @return void

--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -58,7 +58,6 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
      * creation.
      *
      * @param  null|ConfigInterface $configuration
-     * @return void
      */
     public function __construct(ConfigInterface $configuration = null)
     {

--- a/library/Zend/Soap/Client.php
+++ b/library/Zend/Soap/Client.php
@@ -15,7 +15,7 @@ use Zend\Server\Client as ServerClient;
 use Zend\Stdlib\ArrayUtils;
 
 /**
- * \Zend\Soap\Client\Client
+ * \Zend\Soap\Client
  *
  * @category   Zend
  * @package    Zend_Soap
@@ -69,7 +69,7 @@ class Client implements ServerClient
 
     /**
      * WSDL used to access server
-     * It also defines \Zend\Soap\Client\Client working mode (WSDL vs non-WSDL)
+     * It also defines \Zend\Soap\Client working mode (WSDL vs non-WSDL)
      *
      * @var string
      */
@@ -141,7 +141,7 @@ class Client implements ServerClient
      * Set wsdl
      *
      * @param string $wsdl
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function setWSDL($wsdl)
     {
@@ -167,7 +167,7 @@ class Client implements ServerClient
      * Allows setting options as an associative array of option => value pairs.
      *
      * @param  array|Traversable $options
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      * @throws Exception\InvalidArgumentException
      */
     public function setOptions($options)
@@ -315,8 +315,8 @@ class Client implements ServerClient
      * Set SOAP version
      *
      * @param  int $version One of the SOAP_1_1 or SOAP_1_2 constants
-     * @return \Zend\Soap\Client\Client
-     * @throws \Zend\Soap\Client\Exception with invalid soap version argument
+     * @return \Zend\Soap\Client
+     * @throws \Zend\Soap\Exception\ExceptionInterface with invalid soap version argument
      */
     public function setSoapVersion($version)
     {
@@ -344,8 +344,8 @@ class Client implements ServerClient
      * Set classmap
      *
      * @param  array $classmap
-     * @return \Zend\Soap\Client\Client
-     * @throws \Zend\Soap\Client\Exception for any invalid class in the class map
+     * @return \Zend\Soap\Client
+     * @throws \Zend\Soap\Exception\ExceptionInterface for any invalid class in the class map
      */
     public function setClassmap(array $classmap)
     {
@@ -376,8 +376,8 @@ class Client implements ServerClient
      * Set encoding
      *
      * @param  string $encoding
-     * @return \Zend\Soap\Client\Client
-     * @throws \Zend\Soap\Client\Exception with invalid encoding argument
+     * @return \Zend\Soap\Client
+     * @throws \Zend\Soap\Exception\ExceptionInterface with invalid encoding argument
      */
     public function setEncoding($encoding)
     {
@@ -406,8 +406,8 @@ class Client implements ServerClient
      * Check for valid URN
      *
      * @param  string $urn
-     * @return true
-     * @throws \Zend\Soap\Client\Exception on invalid URN
+     * @return boolean
+     * @throws \Zend\Soap\Exception\ExceptionInterface on invalid URN
      */
     public function validateUrn($urn)
     {
@@ -426,8 +426,8 @@ class Client implements ServerClient
      * URI in Web Service the target namespace
      *
      * @param  string $uri
-     * @return \Zend\Soap\Client\Client
-     * @throws \Zend\Soap\Client\Exception with invalid uri argument
+     * @return \Zend\Soap\Client
+     * @throws \Zend\Soap\Exception\ExceptionInterface with invalid uri argument
      */
     public function setUri($uri)
     {
@@ -455,8 +455,8 @@ class Client implements ServerClient
      * URI in Web Service the target namespace
      *
      * @param  string $location
-     * @return \Zend\Soap\Client\Client
-     * @throws \Zend\Soap\Client\Exception with invalid uri argument
+     * @return \Zend\Soap\Client
+     * @throws \Zend\Soap\Exception\ExceptionInterface with invalid uri argument
      */
     public function setLocation($location)
     {
@@ -482,8 +482,8 @@ class Client implements ServerClient
      * Set request style
      *
      * @param  int $style One of the SOAP_RPC or SOAP_DOCUMENT constants
-     * @return \Zend\Soap\Client\Client
-     * @throws \Zend\Soap\Client\Exception with invalid style argument
+     * @return \Zend\Soap\Client
+     * @throws \Zend\Soap\Exception\ExceptionInterface with invalid style argument
      */
     public function setStyle($style)
     {
@@ -512,8 +512,8 @@ class Client implements ServerClient
      * Set message encoding method
      *
      * @param  int $use One of the SOAP_ENCODED or SOAP_LITERAL constants
-     * @return \Zend\Soap\Client\Client
-     * @throws \Zend\Soap\Client\Exception with invalid message encoding method argument
+     * @return \Zend\Soap\Client
+     * @throws \Zend\Soap\Exception\ExceptionInterface with invalid message encoding method argument
      */
     public function setEncodingMethod($use)
     {
@@ -542,7 +542,7 @@ class Client implements ServerClient
      * Set HTTP login
      *
      * @param  string $login
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function setHttpLogin($login)
     {
@@ -567,7 +567,7 @@ class Client implements ServerClient
      * Set HTTP password
      *
      * @param  string $password
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function setHttpPassword($password)
     {
@@ -592,7 +592,7 @@ class Client implements ServerClient
      * Set proxy host
      *
      * @param  string $proxyHost
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function setProxyHost($proxyHost)
     {
@@ -617,7 +617,7 @@ class Client implements ServerClient
      * Set proxy port
      *
      * @param  int $proxyPort
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function setProxyPort($proxyPort)
     {
@@ -642,7 +642,7 @@ class Client implements ServerClient
      * Set proxy login
      *
      * @param  string $proxyLogin
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function setProxyLogin($proxyLogin)
     {
@@ -667,7 +667,7 @@ class Client implements ServerClient
      * Set proxy password
      *
      * @param  string $proxyLogin
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function setProxyPassword($proxyPassword)
     {
@@ -682,8 +682,8 @@ class Client implements ServerClient
      * Set HTTPS client certificate path
      *
      * @param  string $localCert local certificate path
-     * @return \Zend\Soap\Client\Client
-     * @throws \Zend\Soap\Client\Exception with invalid local certificate path argument
+     * @return \Zend\Soap\Client
+     * @throws \Zend\Soap\Exception\ExceptionInterface with invalid local certificate path argument
      */
     public function setHttpsCertificate($localCert)
     {
@@ -712,7 +712,7 @@ class Client implements ServerClient
      * Set HTTPS client certificate passphrase
      *
      * @param  string $passphrase
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function setHttpsCertPassphrase($passphrase)
     {
@@ -737,7 +737,7 @@ class Client implements ServerClient
      * Set compression options
      *
      * @param  int|null $compressionOptions
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function setCompressionOptions($compressionOptions)
     {
@@ -774,7 +774,7 @@ class Client implements ServerClient
     /**
      * Set Stream Context
      *
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function setStreamContext($context)
     {
@@ -800,7 +800,7 @@ class Client implements ServerClient
      * Set the SOAP Feature options.
      *
      * @param  string|int $feature
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function setSoapFeatures($feature)
     {
@@ -824,7 +824,7 @@ class Client implements ServerClient
      * Set the SOAP WSDL Caching Options
      *
      * @param string|int|boolean|null $caching
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function setWSDLCache($caching)
     {
@@ -850,7 +850,7 @@ class Client implements ServerClient
      * Set the string to use in User-Agent header
      *
      * @param  string|null $userAgent
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function setUserAgent($userAgent)
     {
@@ -964,7 +964,7 @@ class Client implements ServerClient
     /**
      * Initialize SOAP Client object
      *
-     * @throws \Zend\Soap\Client\Exception
+     * @throws \Zend\Soap\Exception\ExceptionInterface
      */
     protected function _initSoapClientObject()
     {
@@ -1023,7 +1023,7 @@ class Client implements ServerClient
      *
      * @param SoapHeader $header
      * @param boolean $permanent
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function addSoapInputHeader(\SoapHeader $header, $permanent = false)
     {
@@ -1039,7 +1039,7 @@ class Client implements ServerClient
     /**
      * Reset SOAP input headers
      *
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function resetSoapInputHeaders()
     {
@@ -1101,7 +1101,7 @@ class Client implements ServerClient
      * Return a list of available functions
      *
      * @return array
-     * @throws \Zend\Soap\Client\Exception
+     * @throws \Zend\Soap\Exception\ExceptionInterface
      */
     public function getFunctions()
     {
@@ -1124,7 +1124,7 @@ class Client implements ServerClient
      * Return a list of SOAP types
      *
      * @return array
-     * @throws \Zend\Soap\Client\Exception
+     * @throws \Zend\Soap\Exception\ExceptionInterface
      */
     public function getTypes()
     {
@@ -1139,7 +1139,7 @@ class Client implements ServerClient
 
     /**
      * @param SoapClient $soapClient
-     * @return \Zend\Soap\Client\Client
+     * @return \Zend\Soap\Client
      */
     public function setSoapClient(\SoapClient $soapClient)
     {
@@ -1148,7 +1148,7 @@ class Client implements ServerClient
     }
 
     /**
-     * @return SoapClient
+     * @return \SoapClient
      */
     public function getSoapClient()
     {
@@ -1159,9 +1159,9 @@ class Client implements ServerClient
     }
 
     /**
-     * @param string $name
-     * @param string $value
-     * @return \Zend\Soap\Client\Client
+     * @param string $cookieName
+     * @param string $cookieValue
+     * @return \Zend\Soap\Client
      */
     public function setCookie($cookieName, $cookieValue=null)
     {

--- a/library/Zend/Soap/Client/DotNet.php
+++ b/library/Zend/Soap/Client/DotNet.php
@@ -49,7 +49,8 @@ class DotNet extends SOAPClient
      * My be overridden in descendant classes
      *
      * @param array $arguments
-     * @throws \Zend\Soap\ClientException
+     * @throws Exception\RuntimeException
+     * @return array
      */
     protected function _preProcessArguments($arguments)
     {
@@ -68,7 +69,7 @@ class DotNet extends SOAPClient
      *
      * My be overridden in descendant classes
      *
-     * @param array $arguments
+     * @param object $result
      */
     protected function _preProcessResult($result)
     {

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -144,7 +144,6 @@ class Server implements \Zend\Server\Server
      *
      * @param string $wsdl
      * @param array $options
-     * @return void
      * @throws Exception\ExtensionNotLoadedException
      */
     public function __construct($wsdl = null, array $options = null)

--- a/library/Zend/Soap/Wsdl.php
+++ b/library/Zend/Soap/Wsdl.php
@@ -122,7 +122,7 @@ class Wsdl
      * Set a new uri for this WSDL
      *
      * @param  string|Uri $uri
-     * @return \Zend\Server\Wsdl
+     * @return \Zend\Soap\Wsdl
      */
     public function setUri($uri)
     {

--- a/library/Zend/Stdlib/CallbackHandler.php
+++ b/library/Zend/Stdlib/CallbackHandler.php
@@ -55,7 +55,6 @@ class CallbackHandler
      * @param  string                       $event    Event to which slot is subscribed
      * @param  string|array|object|callable $callback PHP callback
      * @param  array                        $options  Options used by the callback handler (e.g., priority)
-     * @return void
      */
     public function __construct($callback, array $metadata = array())
     {

--- a/library/Zend/Stdlib/Parameters.php
+++ b/library/Zend/Stdlib/Parameters.php
@@ -21,7 +21,6 @@ class Parameters extends ArrayObject implements ParametersInterface
      * elements.
      *
      * @param  array $values
-     * @return void
      */
     public function __construct(array $values = null)
     {

--- a/library/Zend/Tag/Cloud/Decorator/DecoratorInterface.php
+++ b/library/Zend/Tag/Cloud/Decorator/DecoratorInterface.php
@@ -25,7 +25,6 @@ interface DecoratorInterface
      * Allow passing options to the constructor.
      *
      * @param  mixed $options
-     * @return void
      */
     public function __construct($options = null);
 

--- a/library/Zend/Tag/Item.php
+++ b/library/Zend/Tag/Item.php
@@ -57,7 +57,6 @@ class Item implements TaggableInterface
      * @throws \Zend\Tag\Exception\InvalidArgumentException When invalid options are provided
      * @throws \Zend\Tag\Exception\InvalidArgumentException When title was not set
      * @throws \Zend\Tag\Exception\InvalidArgumentException When weight was not set
-     * @return void
      */
     public function __construct($options)
     {

--- a/library/Zend/Validator/ValidatorPluginManager.php
+++ b/library/Zend/Validator/ValidatorPluginManager.php
@@ -121,7 +121,6 @@ class ValidatorPluginManager extends AbstractPluginManager
      * attached translator, if any, to the currently requested helper.
      *
      * @param  null|ConfigInterface $configuration
-     * @return void
      */
     public function __construct(ConfigInterface $configuration = null)
     {

--- a/library/Zend/View/Helper/Gravatar.php
+++ b/library/Zend/View/Helper/Gravatar.php
@@ -86,7 +86,7 @@ class Gravatar extends AbstractHtmlElement
      * @param  string|null $email Email address.
      * @param  null|array $options Options
      * @param  array $attribs Attributes for image tag (title, alt etc.)
-     * @return Zend\View\Helper\Gravatar
+     * @return Gravatar
      */
     public function __invoke($email = "", $options = array(), $attribs = array())
     {

--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -39,7 +39,6 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      *
      * Use PHP_EOL as separator
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/View/Helper/HeadMeta.php
+++ b/library/Zend/View/Helper/HeadMeta.php
@@ -40,7 +40,6 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      *
      * Set separator to PHP_EOL
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -77,7 +77,6 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      *
      * Set separator to PHP_EOL.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/View/Helper/HeadStyle.php
+++ b/library/Zend/View/Helper/HeadStyle.php
@@ -65,7 +65,6 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      *
      * Set separator to PHP_EOL.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/View/Helper/Navigation.php
+++ b/library/Zend/View/Helper/Navigation.php
@@ -149,7 +149,7 @@ class Navigation extends AbstractNavigationHelper
      * Lazy-loads an instance of Navigation\HelperLoader if none currently
      * registered.
      *
-     * @return ShortNameLocator
+     * @return Navigation\PluginManager
      */
     public function getPluginManager()
     {
@@ -170,7 +170,7 @@ class Navigation extends AbstractNavigationHelper
      *                                             exceptions should be
      *                                             thrown if something goes
      *                                             wrong. Default is true.
-     * @return \Zend\View\Helper\Navigation\Helper\HelperInterface  helper instance
+     * @return \Zend\View\Helper\Navigation\HelperInterface  helper instance
      * @throws \Zend\Loader\PluginLoader\Exception  if $strict is true and
      *         helper cannot be found
      * @throws Exception\InvalidArgumentException if $strict is true and

--- a/library/Zend/View/Helper/Navigation/HelperInterface.php
+++ b/library/Zend/View/Helper/Navigation/HelperInterface.php
@@ -64,7 +64,7 @@ interface HelperInterface extends BaseHelperInterface
      * @param  mixed $role [optional] role to set.  Expects a string, an
      *                     instance of type {@link Acl\Role}, or null. Default
      *                     is null.
-     * @throws \Zend\View\Exception if $role is invalid
+     * @throws \Zend\View\Exception\ExceptionInterface if $role is invalid
      * @return HelperInterface fluent interface, returns
      *                                             self
      */
@@ -73,7 +73,7 @@ interface HelperInterface extends BaseHelperInterface
     /**
      * Returns ACL role to use when iterating pages, or null if it isn't set
      *
-     * @return string|Acl\Role|null  role or null
+     * @return string|Acl\Role\RoleInterface|null  role or null
      */
     public function getRole();
 

--- a/library/Zend/View/Helper/Navigation/Links.php
+++ b/library/Zend/View/Helper/Navigation/Links.php
@@ -100,7 +100,7 @@ class Links extends AbstractHelper
      * Helper entry point
      *
      * @param  string|AbstractContainer $container container to operate on
-     * @return Navigation
+     * @return Links
      */
     public function __invoke($container = null)
     {
@@ -124,7 +124,7 @@ class Links extends AbstractHelper
      *
      * @param  string $method             method name
      * @param  array  $arguments          method arguments
-     * @throws Navigation\Exception\ExceptionInterface  if method does not exist in container
+     * @throws Exception\ExceptionInterface  if method does not exist in container
      */
     public function __call($method, array $arguments = array())
     {

--- a/library/Zend/View/Helper/Placeholder.php
+++ b/library/Zend/View/Helper/Placeholder.php
@@ -39,7 +39,6 @@ class Placeholder extends AbstractHelper
      *
      * Retrieve container registry from Placeholder\Registry, or create new one and register it.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/View/Helper/Placeholder/Container/AbstractContainer.php
+++ b/library/Zend/View/Helper/Placeholder/Container/AbstractContainer.php
@@ -83,7 +83,6 @@ abstract class AbstractContainer extends \ArrayObject
     /**
      * Constructor - This is needed so that we can attach a class member as the ArrayObject container
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/View/Helper/Placeholder/Container/AbstractStandalone.php
+++ b/library/Zend/View/Helper/Placeholder/Container/AbstractStandalone.php
@@ -49,7 +49,6 @@ abstract class AbstractStandalone
     /**
      * Constructor
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/View/Helper/ServerUrl.php
+++ b/library/Zend/View/Helper/ServerUrl.php
@@ -36,7 +36,6 @@ class ServerUrl extends AbstractHelper
     /**
      * Constructor
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/View/HelperPluginManager.php
+++ b/library/Zend/View/HelperPluginManager.php
@@ -82,7 +82,6 @@ class HelperPluginManager extends AbstractPluginManager
      * attached renderer and translator, if any, to the currently requested helper.
      *
      * @param  null|ConfigInterface $configuration
-     * @return void
      */
     public function __construct(ConfigInterface $configuration = null)
     {

--- a/library/Zend/View/Model/ViewModel.php
+++ b/library/Zend/View/Model/ViewModel.php
@@ -77,7 +77,6 @@ class ViewModel implements ModelInterface
      *
      * @param  null|array|Traversable $variables
      * @param  array|Traversable $options
-     * @return void
      */
     public function __construct($variables = null, $options = null)
     {

--- a/library/Zend/View/Renderer/ConsoleRenderer.php
+++ b/library/Zend/View/Renderer/ConsoleRenderer.php
@@ -25,9 +25,7 @@ namespace Zend\View\Renderer;
 
 use ArrayAccess;
 use Zend\Filter\FilterChain;
-use Zend\Loader\Pluggable;
 use Zend\View\Exception;
-use Zend\View\HelperBroker;
 use Zend\View\Model;
 use Zend\View\Renderer;
 use Zend\View\Resolver;
@@ -98,7 +96,7 @@ class ConsoleRenderer implements Renderer, TreeRendererInterface
      * Set filter chain
      *
      * @param  FilterChain $filters
-     * @return Zend\View\PhpRenderer
+     * @return ConsoleRenderer
      */
     public function setFilterChain(FilterChain $filters)
     {

--- a/library/Zend/View/Resolver/AggregateResolver.php
+++ b/library/Zend/View/Resolver/AggregateResolver.php
@@ -48,7 +48,6 @@ class AggregateResolver implements Countable, IteratorAggregate, ResolverInterfa
      *
      * Instantiate the internal priority queue
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/View/Resolver/TemplateMapResolver.php
+++ b/library/Zend/View/Resolver/TemplateMapResolver.php
@@ -35,7 +35,6 @@ class TemplateMapResolver implements IteratorAggregate, ResolverInterface
      * Instantiate and optionally populate template map.
      *
      * @param  array|Traversable $map
-     * @return void
      */
     public function __construct($map = array())
     {

--- a/library/Zend/View/Resolver/TemplatePathStack.php
+++ b/library/Zend/View/Resolver/TemplatePathStack.php
@@ -66,7 +66,6 @@ class TemplatePathStack implements ResolverInterface
      * Constructor
      *
      * @param  null|array|Traversable $options
-     * @return void
      */
     public function __construct($options = null)
     {

--- a/library/Zend/View/Resolver/TemplatePathStack.php
+++ b/library/Zend/View/Resolver/TemplatePathStack.php
@@ -233,7 +233,7 @@ class TemplatePathStack implements ResolverInterface
      * Set LFI protection flag
      *
      * @param  bool $flag
-     * @return \Zend\View\TemplatePathStack
+     * @return TemplatePathStack
      */
     public function setLfiProtection($flag)
     {
@@ -255,7 +255,7 @@ class TemplatePathStack implements ResolverInterface
      * Set flag indicating if stream wrapper should be used if short_open_tag is off
      *
      * @param  bool $flag
-     * @return \Zend\View\View
+     * @return TemplatePathStack
      */
     public function setUseStreamWrapper($flag)
     {

--- a/library/Zend/View/Strategy/FeedStrategy.php
+++ b/library/Zend/View/Strategy/FeedStrategy.php
@@ -40,7 +40,6 @@ class FeedStrategy implements ListenerAggregateInterface
      * Constructor
      *
      * @param  FeedRenderer $renderer
-     * @return void
      */
     public function __construct(FeedRenderer $renderer)
     {

--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -39,7 +39,6 @@ class JsonStrategy implements ListenerAggregateInterface
      * Constructor
      *
      * @param  JsonRenderer $renderer
-     * @return void
      */
     public function __construct(JsonRenderer $renderer)
     {

--- a/library/Zend/View/Strategy/PhpRendererStrategy.php
+++ b/library/Zend/View/Strategy/PhpRendererStrategy.php
@@ -45,7 +45,6 @@ class PhpRendererStrategy implements ListenerAggregateInterface
      * Constructor
      *
      * @param  PhpRenderer $renderer
-     * @return void
      */
     public function __construct(PhpRenderer $renderer)
     {

--- a/library/Zend/View/Variables.php
+++ b/library/Zend/View/Variables.php
@@ -36,7 +36,6 @@ class Variables extends ArrayObject
      *
      * @param  array $variables
      * @param  array $options
-     * @return void
      */
     public function __construct(array $variables = array(), array $options = array())
     {

--- a/library/Zend/XmlRpc/AbstractValue.php
+++ b/library/Zend/XmlRpc/AbstractValue.php
@@ -47,7 +47,7 @@ abstract class AbstractValue
     protected $xml;
 
     /**
-     * @var Zend\XmlRpc\Generator\GeneratorAbstract
+     * @var \Zend\XmlRpc\Generator\GeneratorInterface
      */
     protected static $generator;
 
@@ -323,10 +323,10 @@ abstract class AbstractValue
     /**
      * Transform an XML string into a XML-RPC native value
      *
-     * @param string|SimpleXMLElement $xml A SimpleXMLElement object represent the XML string
+     * @param string|\SimpleXMLElement $xml A SimpleXMLElement object represent the XML string
      * It can be also a valid XML string for conversion
      *
-     * @return Zend\XmlRpc\Value\AbstractValue
+     * @return \Zend\XmlRpc\AbstractValue
      * @static
      */
     protected static function _xmlStringToNativeXmlRpc($xml)
@@ -431,7 +431,7 @@ abstract class AbstractValue
     /**
      * Extract XML/RPC type and value from SimpleXMLElement object
      *
-     * @param SimpleXMLElement $xml
+     * @param \SimpleXMLElement $xml
      * @param string &$type Type bind variable
      * @param string &$value Value bind variable
      * @return void

--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -32,25 +32,25 @@ class Client implements ServerClient
 
     /**
      * HTTP Client to use for requests
-     * @var Zend\Http\Client
+     * @var \Zend\Http\Client
      */
     protected $httpClient = null;
 
     /**
      * Introspection object
-     * @var Zend\Http\Client\ServerIntrospection
+     * @var \Zend\XmlRpc\Client\ServerIntrospection
      */
     protected $introspector = null;
 
     /**
      * Request of the last method call
-     * @var Zend\XmlRpc\Request
+     * @var \Zend\XmlRpc\Request
      */
     protected $lastRequest = null;
 
     /**
      * Response received from the last method call
-     * @var Zend\XmlRpc\Response
+     * @var \Zend\XmlRpc\Response
      */
     protected $lastResponse = null;
 
@@ -90,8 +90,8 @@ class Client implements ServerClient
     /**
      * Sets the HTTP client object to use for connecting the XML-RPC server.
      *
-     * @param  Zend\Http\Client $httpClient
-     * @return Zend\Http\Client
+     * @param  \Zend\Http\Client $httpClient
+     * @return \Zend\Http\Client
      */
     public function setHttpClient(Http\Client $httpClient)
     {
@@ -102,7 +102,7 @@ class Client implements ServerClient
     /**
      * Gets the HTTP client object.
      *
-     * @return Zend\Http\Client
+     * @return \Zend\Http\Client
      */
     public function getHttpClient()
     {
@@ -113,8 +113,8 @@ class Client implements ServerClient
     /**
      * Sets the object used to introspect remote servers
      *
-     * @param  Zend\XmlRpc\Client\ServerIntrospection
-     * @return Zend\XmlRpc\Client\ServerIntrospection
+     * @param  \Zend\XmlRpc\Client\ServerIntrospection
+     * @return \Zend\XmlRpc\Client\ServerIntrospection
      */
     public function setIntrospector(Client\ServerIntrospection $introspector)
     {
@@ -125,7 +125,7 @@ class Client implements ServerClient
     /**
      * Gets the introspection object.
      *
-     * @return Zend\XmlRpc\Client\ServerIntrospection
+     * @return \Zend\XmlRpc\Client\ServerIntrospection
      */
     public function getIntrospector()
     {
@@ -136,7 +136,7 @@ class Client implements ServerClient
    /**
      * The request of the last method call
      *
-     * @return Zend\XmlRpc\Request
+     * @return \Zend\XmlRpc\Request
      */
     public function getLastRequest()
     {
@@ -147,7 +147,7 @@ class Client implements ServerClient
     /**
      * The response received from the last method call
      *
-     * @return Zend\XmlRpc\Response
+     * @return \Zend\XmlRpc\Response
      */
     public function getLastResponse()
     {
@@ -158,8 +158,8 @@ class Client implements ServerClient
     /**
      * Returns a proxy object for more convenient method calls
      *
-     * @param $namespace  Namespace to proxy or empty string for none
-     * @return Zend\XmlRpc\Client\ServerProxy
+     * @param string $namespace  Namespace to proxy or empty string for none
+     * @return \Zend\XmlRpc\Client\ServerProxy
      */
     public function getProxy($namespace = '')
     {
@@ -174,7 +174,7 @@ class Client implements ServerClient
      * Set skip system lookup flag
      *
      * @param  bool $flag
-     * @return Zend\XmlRpc\Client
+     * @return \Zend\XmlRpc\Client
      */
     public function setSkipSystemLookup($flag = true)
     {
@@ -195,10 +195,10 @@ class Client implements ServerClient
     /**
      * Perform an XML-RPC request and return a response.
      *
-     * @param Zend\XmlRpc\Request $request
-     * @param null|Zend\XmlRpc\Response $response
+     * @param \Zend\XmlRpc\Request $request
+     * @param null|\Zend\XmlRpc\Response $response
      * @return void
-     * @throws Zend\XmlRpc\Client\HttpException
+     * @throws \Zend\XmlRpc\Client\Exception\HttpException
      */
     public function doRequest($request, $response = null)
     {
@@ -252,7 +252,7 @@ class Client implements ServerClient
      * @param  string $method Name of the method we want to call
      * @param  array $params Array of parameters for the method
      * @return mixed
-     * @throws Zend\XmlRpc\Client\FaultException
+     * @throws \Zend\XmlRpc\Client\Exception\FaultException
      */
     public function call($method, $params=array())
     {
@@ -335,7 +335,9 @@ class Client implements ServerClient
     /**
      * Create request object
      *
-     * @return Zend\XmlRpc\Request
+     * @param string $method
+     * @param array $params
+     * @return \Zend\XmlRpc\Request
      */
     protected function _createRequest($method, $params)
     {

--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -72,7 +72,6 @@ class Client implements ServerClient
      * @param  string $server      Full address of the XML-RPC service
      *                             (e.g. http://time.xmlrpc.com/RPC2)
      * @param  \Zend\Http\Client $httpClient HTTP Client to use for requests
-     * @return void
      */
     public function __construct($server, Http\Client $httpClient = null)
     {

--- a/library/Zend/XmlRpc/Client/ServerIntrospection.php
+++ b/library/Zend/XmlRpc/Client/ServerIntrospection.php
@@ -28,7 +28,7 @@ class ServerIntrospection
 
 
     /**
-     * @param Zend\XmlRpc\Client $client
+     * @param \Zend\XmlRpc\Client $client
      */
     public function __construct(XMLRPCClient $client)
     {

--- a/library/Zend/XmlRpc/Fault.php
+++ b/library/Zend/XmlRpc/Fault.php
@@ -84,7 +84,6 @@ class Fault
     /**
      * Constructor
      *
-     * @return void
      */
     public function __construct($code = 404, $message = '')
     {

--- a/library/Zend/XmlRpc/Request.php
+++ b/library/Zend/XmlRpc/Request.php
@@ -52,7 +52,7 @@ class Request
 
     /**
      * Fault object, if any
-     * @var Zend\XmlRpc\Fault
+     * @var \Zend\XmlRpc\Fault
      */
     protected $fault = null;
 
@@ -90,7 +90,7 @@ class Request
      * Set encoding to use in request
      *
      * @param string $encoding
-     * @return Zend\XmlRpc\Request
+     * @return \Zend\XmlRpc\Request
      */
     public function setEncoding($encoding)
     {
@@ -350,7 +350,7 @@ class Request
     /**
      * Retrieve the fault response, if any
      *
-     * @return null|Zend\XmlRpc\Fault
+     * @return null|\Zend\XmlRpc\Fault
      */
     public function getFault()
     {

--- a/library/Zend/XmlRpc/Request/Http.php
+++ b/library/Zend/XmlRpc/Request/Http.php
@@ -44,7 +44,6 @@ class Http extends XmlRpcRequest
      * occurs in doing so, or if the XML is invalid, the request is declared a
      * fault.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/XmlRpc/Request/Stdin.php
+++ b/library/Zend/XmlRpc/Request/Stdin.php
@@ -38,7 +38,6 @@ class Stdin extends XmlRpcRequest
      * occurs in doing so, or if the XML is invalid, the request is declared a
      * fault.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/XmlRpc/Response.php
+++ b/library/Zend/XmlRpc/Response.php
@@ -52,7 +52,6 @@ class Response
      *
      * @param mixed $return
      * @param string $type
-     * @return void
      */
     public function __construct($return = null, $type = null)
     {

--- a/library/Zend/XmlRpc/Response.php
+++ b/library/Zend/XmlRpc/Response.php
@@ -40,7 +40,7 @@ class Response
 
     /**
      * Fault, if response is a fault response
-     * @var null|Zend\XmlRpc\Fault
+     * @var null|\Zend\XmlRpc\Fault
      */
     protected $fault = null;
 
@@ -63,7 +63,7 @@ class Response
      * Set encoding to use in response
      *
      * @param string $encoding
-     * @return Zend\XmlRpc\Response
+     * @return \Zend\XmlRpc\Response
      */
     public function setEncoding($encoding)
     {
@@ -110,7 +110,7 @@ class Response
     /**
      * Retrieve the XMLRPC value for the return value
      *
-     * @return Zend\XmlRpc\Value
+     * @return \Zend\XmlRpc\AbstractValue
      */
     protected function _getXmlRpcReturn()
     {
@@ -130,7 +130,7 @@ class Response
     /**
      * Returns the fault, if any.
      *
-     * @return null|Zend\XmlRpc\Fault
+     * @return null|\Zend\XmlRpc\Fault
      */
     public function getFault()
     {

--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -149,7 +149,7 @@ class Server extends AbstractServer
      * @param  string $method
      * @param  array $params
      * @return mixed
-     * @throws Zend\XmlRpc\Server\Exception
+     * @throws Server\Exception\BadMethodCallException
      */
     public function __call($method, $params)
     {
@@ -174,7 +174,7 @@ class Server extends AbstractServer
      * @param string|array|callable $function  Valid callback
      * @param string                $namespace Optional namespace prefix
      * @return void
-     * @throws Zend\XmlRpc\Server\Exception
+     * @throws \Zend\XmlRpc\Exception\InvalidArgumentException
      */
     public function addFunction($function, $namespace = '')
     {
@@ -213,7 +213,7 @@ class Server extends AbstractServer
      * @param string $namespace Optional
      * @param mixed $argv Optional arguments to pass to methods
      * @return void
-     * @throws Zend\XmlRpc\Server\Exception on invalid input
+     * @throws Server\Exception\InvalidArgumentException on invalid input
      */
     public function setClass($class, $namespace = '', $argv = null)
     {
@@ -235,9 +235,9 @@ class Server extends AbstractServer
     /**
      * Raise an xmlrpc server fault
      *
-     * @param string|Exception $fault
+     * @param string|\Exception $fault
      * @param int $code
-     * @return Zend\XmlRpc\Server\Fault
+     * @return Server\Fault
      */
     public function fault($fault = null, $code = 404)
     {
@@ -327,7 +327,7 @@ class Server extends AbstractServer
      *
      * @param  array|Definition $definition
      * @return void
-     * @throws Server\Exception on invalid input
+     * @throws Server\Exception\InvalidArgumentException on invalid input
      */
     public function loadFunctions($definition)
     {
@@ -393,7 +393,7 @@ class Server extends AbstractServer
      *
      * @param  string|Request $request
      * @return Server
-     * @throws Server\Exception on invalid request class or object
+     * @throws Server\Exception\InvalidArgumentException on invalid request class or object
      */
     public function setRequest($request)
     {
@@ -527,7 +527,7 @@ class Server extends AbstractServer
      *
      * @param  Request $request
      * @return Response
-     * @throws Server\Exception|Exception
+     * @throws Server\Exception\RuntimeException
      * Zend\XmlRpc\Server\Exceptions are thrown for internal errors; otherwise,
      * any other exception may be thrown by the callback
      */

--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -135,7 +135,6 @@ class Server extends AbstractServer
      *
      * Creates system.* methods.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/library/Zend/XmlRpc/Server/System.php
+++ b/library/Zend/XmlRpc/Server/System.php
@@ -28,7 +28,6 @@ class System
      * Constructor
      *
      * @param \Zend\XmlRpc\Server $server
-     * @return void
      */
     public function __construct(\Zend\XmlRpc\Server $server)
     {

--- a/library/Zend/XmlRpc/Server/System.php
+++ b/library/Zend/XmlRpc/Server/System.php
@@ -27,7 +27,7 @@ class System
     /**
      * Constructor
      *
-     * @param  \Zend\XmlRpc\Server\Server $server
+     * @param \Zend\XmlRpc\Server $server
      * @return void
      */
     public function __construct(\Zend\XmlRpc\Server $server)

--- a/tests/ZendTest/Feed/Reader/Entry/_files/Common/atom.xml
+++ b/tests/ZendTest/Feed/Reader/Entry/_files/Common/atom.xml
@@ -525,7 +525,6 @@ class Wp_Amf_Gateway
      *
      * @param array $dbConfig
      * @param string $prefix
-     * @return void
      */
     public function __construct(array $dbConfig, $prefix)
     {

--- a/tests/ZendTest/Feed/Reader/Entry/_files/Common/atom_noencodingdefined.xml
+++ b/tests/ZendTest/Feed/Reader/Entry/_files/Common/atom_noencodingdefined.xml
@@ -525,7 +525,6 @@ class Wp_Amf_Gateway
      *
      * @param array $dbConfig
      * @param string $prefix
-     * @return void
      */
     public function __construct(array $dbConfig, $prefix)
     {

--- a/tests/ZendTest/Feed/Reader/Entry/_files/Common/rss.xml
+++ b/tests/ZendTest/Feed/Reader/Entry/_files/Common/rss.xml
@@ -504,7 +504,6 @@ class Wp_Amf_Gateway
      *
      * @param array $dbConfig
      * @param string $prefix
-     * @return void
      */
     public function __construct(array $dbConfig, $prefix)
     {

--- a/tests/ZendTest/Feed/Reader/Feed/_files/Common/atom.xml
+++ b/tests/ZendTest/Feed/Reader/Feed/_files/Common/atom.xml
@@ -525,7 +525,6 @@ class Wp_Amf_Gateway
      *
      * @param array $dbConfig
      * @param string $prefix
-     * @return void
      */
     public function __construct(array $dbConfig, $prefix)
     {

--- a/tests/ZendTest/Feed/Reader/Feed/_files/Common/atom_noencodingdefined.xml
+++ b/tests/ZendTest/Feed/Reader/Feed/_files/Common/atom_noencodingdefined.xml
@@ -525,7 +525,6 @@ class Wp_Amf_Gateway
      *
      * @param array $dbConfig
      * @param string $prefix
-     * @return void
      */
     public function __construct(array $dbConfig, $prefix)
     {

--- a/tests/ZendTest/Feed/Reader/Feed/_files/Common/atom_rewrittenbydom.xml
+++ b/tests/ZendTest/Feed/Reader/Feed/_files/Common/atom_rewrittenbydom.xml
@@ -521,7 +521,6 @@ class Wp_Amf_Gateway
      *
      * @param array $dbConfig
      * @param string $prefix
-     * @return void
      */
     public function __construct(array $dbConfig, $prefix)
     {

--- a/tests/ZendTest/Feed/Reader/Feed/_files/Common/rss.xml
+++ b/tests/ZendTest/Feed/Reader/Feed/_files/Common/rss.xml
@@ -504,7 +504,6 @@ class Wp_Amf_Gateway
      *
      * @param array $dbConfig
      * @param string $prefix
-     * @return void
      */
     public function __construct(array $dbConfig, $prefix)
     {

--- a/tests/ZendTest/Feed/Reader/Integration/_files/wordpress-atom10.xml
+++ b/tests/ZendTest/Feed/Reader/Integration/_files/wordpress-atom10.xml
@@ -525,7 +525,6 @@ class Wp_Amf_Gateway
      *
      * @param array $dbConfig
      * @param string $prefix
-     * @return void
      */
     public function __construct(array $dbConfig, $prefix)
     {

--- a/tests/ZendTest/Feed/Reader/Integration/_files/wordpress-rss2-dc-atom.xml
+++ b/tests/ZendTest/Feed/Reader/Integration/_files/wordpress-rss2-dc-atom.xml
@@ -504,7 +504,6 @@ class Wp_Amf_Gateway
      *
      * @param array $dbConfig
      * @param string $prefix
-     * @return void
      */
     public function __construct(array $dbConfig, $prefix)
     {

--- a/tests/ZendTest/Mvc/Router/FactoryTester.php
+++ b/tests/ZendTest/Mvc/Router/FactoryTester.php
@@ -29,7 +29,6 @@ class FactoryTester
      * Create a new factory tester.
      *
      * @param  TestCase $testCase
-     * @return void
      */
     public function __construct(TestCase $testCase)
     {

--- a/tests/ZendTest/Server/ReflectionTest.php
+++ b/tests/ZendTest/Server/ReflectionTest.php
@@ -110,7 +110,6 @@ class ReflectionTestClass
      * This shouldn't be reflected
      *
      * @param mixed $arg
-     * @return void
      */
     public function __construct($arg = null)
     {

--- a/tests/ZendTest/XmlRpc/ServerTest.php
+++ b/tests/ZendTest/XmlRpc/ServerTest.php
@@ -699,7 +699,6 @@ class TestClass
     /**
      * Constructor
      *
-     * @return void
      */
     public function __construct($value1 = null, $value2 = null)
     {


### PR DESCRIPTION
There were and still are a lot of wrong classnames in phpdoc comments. I found them very easily with PHPStorm and the "undefined namespace" inspection.
