### PR TITLE
Stop maintaining a separate name key for Inputs in InputFilter.

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -44,11 +44,10 @@ class BaseInputFilter implements InputFilterInterface
      * Add an input to the input filter
      *
      * @param  InputInterface|InputFilterInterface $input
-     * @param  null|string                         $name Name used to retrieve this input
      * @throws Exception\InvalidArgumentException
      * @return InputFilterInterface
      */
-    public function add($input, $name = null)
+    public function add($input)
     {
         if (!$input instanceof InputInterface && !$input instanceof InputFilterInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -60,9 +59,7 @@ class BaseInputFilter implements InputFilterInterface
             ));
         }
 
-        if (is_null($name) || $name === '') {
-            $name = $input->getName();
-        }
+        $name = $input->getName();
 
         if (isset($this->inputs[$name]) && $this->inputs[$name] instanceof InputInterface) {
             // The element already exists, so merge the config. Please note that the order is important (already existing


### PR DESCRIPTION
Stop maintaining a separate name key for Inputs in InputFilter because they already have names.

This is just a quick and dirty way to save having to specify the same name for inputs twice (once in the Input and once again in the InputFilter). I urge the maintainer to refactor this class so that add/has/get methods inspect each of the registered Inputs to retrieve their names. In this fashion, if the input name is updated, the InputFilter can use the new name immediately. Although there was a second parameter to the add() function, which would use the name of the Input if $name was null, this condition can never be reached using the Factory because even if array keys are not specified they will default to integers (array indexes).

One small additional note: InputFilter should be renamed InputGroup because it is in fact nothing more than a group of Inputs. InputFilter is an even larger misnomer particularly since it doesn't deal with filters.
