### PR TITLE
Update library/Zend/Db/Adapter/Driver/Mysqli/Connection.php

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
@@ -207,6 +207,10 @@ class Connection implements ConnectionInterface
      */
     public function beginTransaction()
     {
+        if (!$this->isConnected()) {
+            $this->connect();
+        }
+
         $this->resource->autocommit(false);
         $this->inTransaction = true;
     }


### PR DESCRIPTION
Resolves PHP Fatal error: Call to a member function autocommit() on a non-object. Was missing $this->connect(); in beginTransaction
