### PR TITLE
[WIP][RC4] SSL new options are not inherited in Socket subclasses

### DIFF
--- a/library/Zend/Http/Client/Adapter/Proxy.php
+++ b/library/Zend/Http/Client/Adapter/Proxy.php
@@ -34,16 +34,18 @@ class Proxy extends Socket
      * @var array
      */
     protected $config = array(
-        'ssltransport'  => 'ssl',
-        'sslcert'       => null,
-        'sslpassphrase' => null,
-        'sslusecontext' => false,
-        'proxy_host'    => '',
-        'proxy_port'    => 8080,
-        'proxy_user'    => '',
-        'proxy_pass'    => '',
-        'proxy_auth'    => Client::AUTH_BASIC,
-        'persistent'    => false
+        'ssltransport'       => 'ssl',
+        'sslcert'            => null,
+        'sslpassphrase'      => null,
+        'sslverifypeer'      => true,
+        'sslallowselfsigned' => false,
+        'sslusecontext'      => false,
+        'proxy_host'         => '',
+        'proxy_port'         => 8080,
+        'proxy_user'         => '',
+        'proxy_pass'         => '',
+        'proxy_auth'         => Client::AUTH_BASIC,
+        'persistent'         => false
     );
 
     /**

--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -184,7 +184,7 @@ class Socket implements HttpAdapter, StreamInterface
         if (! is_resource($this->socket) || ! $this->config['keepalive']) {
             $context = $this->getStreamContext();
             if ($secure || $this->config['sslusecontext']) {
-                if ($this->config['sslverifypeer'] !== null) {
+                if (isset($this->config['sslverifypeer']) && $this->config['sslverifypeer'] !== null) {
                     if (! stream_context_set_option($context, 'ssl', 'verify_peer',
                                                     $this->config['sslverifypeer'])) {
                         throw new AdapterException\RuntimeException('Unable to set sslverifypeer option');

--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -184,7 +184,7 @@ class Socket implements HttpAdapter, StreamInterface
         if (! is_resource($this->socket) || ! $this->config['keepalive']) {
             $context = $this->getStreamContext();
             if ($secure || $this->config['sslusecontext']) {
-                if (isset($this->config['sslverifypeer']) && $this->config['sslverifypeer'] !== null) {
+                if ($this->config['sslverifypeer'] !== null) {
                     if (! stream_context_set_option($context, 'ssl', 'verify_peer',
                                                     $this->config['sslverifypeer'])) {
                         throw new AdapterException\RuntimeException('Unable to set sslverifypeer option');

--- a/tests/ZendTest/Http/Client/ProxyAdapterTest.php
+++ b/tests/ZendTest/Http/Client/ProxyAdapterTest.php
@@ -87,8 +87,8 @@ class ProxyAdapterTest extends SocketTest
         ));
 
         $this->client->setUri($this->baseuri . 'testGetLastRequest.php');
-        $res = $this->client->request(Client::TRACE);
-        if ($res->getStatus() == 405 || $res->getStatus() == 501) {
+        $res = $this->client->setMethod(\Zend\Http\Request::METHOD_TRACE)->send();
+        if ($res->getStatusCode() == 405 || $res->getStatusCode() == 501) {
             $this->markTestSkipped('Server does not allow the TRACE method');
         }
 
@@ -102,5 +102,12 @@ class ProxyAdapterTest extends SocketTest
          * because the proxy server modifies the request which is sent back in
          * the TRACE response
          */
+    }
+
+    public function testDefaultConfig()
+    {
+        $config = $this->_adapter->getConfig();
+        $this->assertEquals(TRUE, $config['sslverifypeer']);
+        $this->assertEquals(FALSE, $config['sslallowselfsigned']);
     }
 }


### PR DESCRIPTION
Original title: "Do not try to set sslverifypeer if it's blank."
