### PR TITLE
Updated Params controller to match Request controller

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/Params.php
+++ b/library/Zend/Mvc/Controller/Plugin/Params.php
@@ -28,7 +28,7 @@ class Params extends AbstractPlugin
      * @param mixed $default
      * @return mixed
      */
-    public function __invoke($param = NULL, $default = null)
+    public function __invoke($param = null, $default = null)
     {
         if ($param === NULL) {
             return $this;
@@ -43,7 +43,7 @@ class Params extends AbstractPlugin
      * @param  mixed $default
      * @return array|\ArrayAccess|null
      */
-    public function fromFiles($name, $default = null)
+    public function fromFiles($name = null, $default = null)
     {
         return $this->getController()->getRequest()->getFiles($name, $default);
     }
@@ -55,7 +55,7 @@ class Params extends AbstractPlugin
      * @param  mixed $default
      * @return null|\Zend\Http\Header\HeaderInterface
      */
-    public function fromHeader($header, $default = null)
+    public function fromHeader($header = null, $default = null)
     {
         return $this->getController()->getRequest()->getHeaders($header, $default);
     }
@@ -67,7 +67,7 @@ class Params extends AbstractPlugin
      * @param mixed $default
      * @return mixed
      */
-    public function fromPost($param, $default = null)
+    public function fromPost($param = null, $default = null)
     {
         return $this->getController()->getRequest()->getPost($param, $default);
     }
@@ -79,7 +79,7 @@ class Params extends AbstractPlugin
      * @param mixed $default
      * @return mixed
      */
-    public function fromQuery($param, $default = null)
+    public function fromQuery($param = null, $default = null)
     {
         return $this->getController()->getRequest()->getQuery($param, $default);
     }

--- a/library/Zend/Mvc/Controller/Plugin/Params.php
+++ b/library/Zend/Mvc/Controller/Plugin/Params.php
@@ -37,7 +37,7 @@ class Params extends AbstractPlugin
     }
 
     /**
-     * Return all filesor a single file.
+     * Return all files or a single file.
      *
      * @param  string $name File name to retrieve, or null to get all.
      * @param  mixed $default Default value to use when the file is missing.

--- a/library/Zend/Mvc/Controller/Plugin/Params.php
+++ b/library/Zend/Mvc/Controller/Plugin/Params.php
@@ -30,69 +30,85 @@ class Params extends AbstractPlugin
      */
     public function __invoke($param = null, $default = null)
     {
-        if ($param === NULL) {
+        if ($param === null) {
             return $this;
         }
         return $this->fromRoute($param, $default);
     }
 
     /**
-     * Retrieve a named $_FILES value
+     * Return all filesor a single file.
      *
-     * @param  string $name
-     * @param  mixed $default
+     * @param  string $name File name to retrieve, or null to get all.
+     * @param  mixed $default Default value to use when the file is missing.
      * @return array|\ArrayAccess|null
      */
     public function fromFiles($name = null, $default = null)
     {
-        return $this->getController()->getRequest()->getFiles($name, $default);
+        if ($name === null) {
+            return $this->getController()->getRequest()->getFiles($name, $default)->toArray();
+        } else {
+            return $this->getController()->getRequest()->getFiles($name, $default);
+        }
     }
 
     /**
-     * Get a header
+     * Return all header parameters or a single header parameter.
      *
-     * @param  string $header
-     * @param  mixed $default
+     * @param  string $header Header name to retrieve, or null to get all.
+     * @param  mixed $default Default value to use when the requested header is missing.
      * @return null|\Zend\Http\Header\HeaderInterface
      */
     public function fromHeader($header = null, $default = null)
     {
-        return $this->getController()->getRequest()->getHeaders($header, $default);
+        if ($header === null) {
+            return $this->getController()->getRequest()->getHeaders($header, $default)->toArray();
+        } else {
+            return $this->getController()->getRequest()->getHeaders($header, $default);
+        }
     }
 
     /**
-     * Get a param from POST.
+     * Return all post parameters or a single post parameter.
      *
-     * @param string $param
-     * @param mixed $default
+     * @param string $param Parameter name to retrieve, or null to get all.
+     * @param mixed $default Default value to use when the parameter is missing.
      * @return mixed
      */
     public function fromPost($param = null, $default = null)
     {
-        return $this->getController()->getRequest()->getPost($param, $default);
+        if ($param === null) {
+            return $this->getController()->getRequest()->getPost($param, $default)->toArray();
+        } else {
+            return $this->getController()->getRequest()->getPost($param, $default);
+        }
     }
 
     /**
-     * Get a param from QUERY.
+     * Return all query parameters or a single query parameter.
      *
-     * @param string $param
-     * @param mixed $default
+     * @param string $param Parameter name to retrieve, or null to get all.
+     * @param mixed $default Default value to use when the parameter is missing.
      * @return mixed
      */
     public function fromQuery($param = null, $default = null)
     {
-        return $this->getController()->getRequest()->getQuery($param, $default);
+        if ($param === null) {
+            return $this->getController()->getRequest()->getQuery($param, $default)->toArray();
+        } else {
+            return $this->getController()->getRequest()->getQuery($param, $default);
+        }
     }
 
     /**
-     * Get a param from the route match.
+     * Return all route parameters or a single route parameter.
      *
-     * @param string $param
-     * @param mixed $default
+     * @param string $param Parameter name to retrieve, or null to get all.
+     * @param mixed $default Default value to use when the parameter is missing.
      * @return mixed
      * @throws RuntimeException
      */
-    public function fromRoute($param, $default = null)
+    public function fromRoute($param = null, $default = null)
     {
         $controller = $this->getController();
 
@@ -102,6 +118,10 @@ class Params extends AbstractPlugin
             );
         }
 
-        return $controller->getEvent()->getRouteMatch()->getParam($param, $default);
+        if ($param === null) {
+            return $controller->getEvent()->getRouteMatch()->getParams();
+        } else {
+            return $controller->getEvent()->getRouteMatch()->getParam($param, $default);
+        }
     }
 }

--- a/tests/ZendTest/Mvc/Controller/Plugin/ParamsTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/ParamsTest.php
@@ -27,7 +27,10 @@ class ParamsTest extends TestCase
 
         $event->setRequest($this->request);
         $event->setResponse(new Response());
-        $event->setRouteMatch(new RouteMatch(array('value' => 'rm:1234')));
+        $event->setRouteMatch(new RouteMatch(array(
+            'value' => 'rm:1234',
+            'other' => '1234:rm',
+        )));
 
         $this->controller = new SampleController();
         $this->controller->setEvent($event);
@@ -53,6 +56,18 @@ class ParamsTest extends TestCase
         $this->assertEquals($value, 'rm:1234');
     }
 
+    public function testFromRouteNotReturnsExpectedValueWithDefault()
+    {
+        $value = $this->plugin->fromRoute('value', 'default');
+        $this->assertEquals($value, 'rm:1234');
+    }
+
+    public function testFromRouteReturnsAllIfEmpty()
+    {
+        $value = $this->plugin->fromRoute();
+        $this->assertEquals($value, array('value' => 'rm:1234', 'other' => '1234:rm'));
+    }
+
     public function testFromQueryReturnsDefaultIfSet()
     {
         $this->setQuery();
@@ -67,6 +82,22 @@ class ParamsTest extends TestCase
 
         $value = $this->plugin->fromQuery('value');
         $this->assertEquals($value, 'query:1234');
+    }
+
+    public function testFromQueryReturnsExpectedValueWithDefault()
+    {
+        $this->setQuery();
+
+        $value = $this->plugin->fromQuery('value', 'default');
+        $this->assertEquals($value, 'query:1234');
+    }
+
+    public function testFromQueryReturnsAllIfEmpty()
+    {
+        $this->setQuery();
+
+        $value = $this->plugin->fromQuery();
+        $this->assertEquals($value, array('value' => 'query:1234', 'other' => '1234:other'));
     }
 
     public function testFromPostReturnsDefaultIfSet()
@@ -85,6 +116,22 @@ class ParamsTest extends TestCase
         $this->assertEquals($value, 'post:1234');
     }
 
+    public function testFromPostReturnsExpectedValueWithDefault()
+    {
+        $this->setPost();
+
+        $value = $this->plugin->fromPost('value', 'default');
+        $this->assertEquals($value, 'post:1234');
+    }
+
+    public function testFromPostReturnsAllIfEmpty()
+    {
+        $this->setPost();
+
+        $value = $this->plugin->fromPost();
+        $this->assertEquals($value, array('value' => 'post:1234', 'other' => '2345:other'));
+    }
+
     public function testFromFilesReturnsExpectedValue()
     {
         $file = array(
@@ -98,7 +145,32 @@ class ParamsTest extends TestCase
         $this->controller->dispatch($this->request);
 
         $value = $this->plugin->fromFiles('test');
-        $this->assertEquals($file, $value);
+        $this->assertEquals($value, $file);
+    }
+
+    public function testFromFilesReturnsAllIfEmpty()
+    {
+        $file = array(
+            'name'     => 'test.txt',
+            'type'     => 'text/plain',
+            'size'     => 0,
+            'tmp_name' => '/tmp/' . uniqid(),
+            'error'    => UPLOAD_ERR_OK,
+        );
+		
+        $file2 = array(
+            'name'     => 'file2.txt',
+            'type'     => 'text/plain',
+            'size'     => 1,
+            'tmp_name' => '/tmp/' . uniqid(),
+            'error'    => UPLOAD_ERR_OK,
+        );
+        $this->request->getFiles()->set('file', $file);
+        $this->request->getFiles()->set('file2', $file2);
+        $this->controller->dispatch($this->request);
+
+        $value = $this->plugin->fromFiles();
+        $this->assertEquals($value, array('file' => $file, 'file2' => $file2));
     }
 
     public function testFromHeaderReturnsExpectedValue()
@@ -108,7 +180,21 @@ class ParamsTest extends TestCase
         $this->controller->dispatch($this->request);
 
         $value = $this->plugin->fromHeader('X-TEST');
-        $this->assertSame($header, $value);
+        $this->assertSame($value, $header);
+    }
+
+    public function testFromHeaderReturnsAllIfEmpty()
+    {
+        $header = new GenericHeader('X-TEST', 'test');
+        $header2 = new GenericHeader('OTHER-TEST', 'value:12345');
+		
+        $this->request->getHeaders()->addHeader($header);
+        $this->request->getHeaders()->addHeader($header2);
+		
+        $this->controller->dispatch($this->request);
+
+        $value = $this->plugin->fromHeader();
+        $this->assertSame($value, array('X-TEST' => 'test', 'OTHER-TEST' => 'value:12345'));
     }
 
     public function testInvokeWithNoArgumentsReturnsInstance()
@@ -120,6 +206,7 @@ class ParamsTest extends TestCase
     {
         $this->request->setMethod(Request::METHOD_GET);
         $this->request->getQuery()->set('value', 'query:1234');
+        $this->request->getQuery()->set('other', '1234:other');
 
         $this->controller->dispatch($this->request);
     }
@@ -128,6 +215,7 @@ class ParamsTest extends TestCase
     {
         $this->request->setMethod(Request::METHOD_POST);
         $this->request->getPost()->set('value', 'post:1234');
+        $this->request->getPost()->set('other', '2345:other');
 
         $this->controller->dispatch($this->request);
     }

--- a/tests/ZendTest/Mvc/Controller/Plugin/ParamsTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/ParamsTest.php
@@ -157,7 +157,7 @@ class ParamsTest extends TestCase
             'tmp_name' => '/tmp/' . uniqid(),
             'error'    => UPLOAD_ERR_OK,
         );
-		
+
         $file2 = array(
             'name'     => 'file2.txt',
             'type'     => 'text/plain',

--- a/tests/ZendTest/Mvc/Controller/Plugin/ParamsTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/ParamsTest.php
@@ -187,10 +187,10 @@ class ParamsTest extends TestCase
     {
         $header = new GenericHeader('X-TEST', 'test');
         $header2 = new GenericHeader('OTHER-TEST', 'value:12345');
-		
+
         $this->request->getHeaders()->addHeader($header);
         $this->request->getHeaders()->addHeader($header2);
-		
+
         $this->controller->dispatch($this->request);
 
         $value = $this->plugin->fromHeader();


### PR DESCRIPTION
Method signature of 
$this->getController()->getRequest()->getQuery($param, $default);
is public function getQuery($name = null, $default = null)
so it should be possible calling the Params plugin controller without specifying any parameters (currently you have to pass in null values).
