### PR TITLE
Allow not to specify params when getting route params

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/Params.php
+++ b/library/Zend/Mvc/Controller/Plugin/Params.php
@@ -92,7 +92,7 @@ class Params extends AbstractPlugin
      * @return mixed
      * @throws RuntimeException
      */
-    public function fromRoute($param, $default = null)
+    public function fromRoute($param = null, $default = null)
     {
         $controller = $this->getController();
 

--- a/library/Zend/Mvc/Router/RouteMatch.php
+++ b/library/Zend/Mvc/Router/RouteMatch.php
@@ -98,7 +98,7 @@ class RouteMatch
         if ($name === null) {
             return $this->getParams();
         }
-        
+
         if (array_key_exists($name, $this->params)) {
             return $this->params[$name];
         }

--- a/library/Zend/Mvc/Router/RouteMatch.php
+++ b/library/Zend/Mvc/Router/RouteMatch.php
@@ -93,8 +93,12 @@ class RouteMatch
      * @param  mixed $default
      * @return mixed
      */
-    public function getParam($name, $default = null)
+    public function getParam($name = null, $default = null)
     {
+        if ($name === null) {
+            return $this->getParams();
+        }
+        
         if (array_key_exists($name, $this->params)) {
             return $this->params[$name];
         }


### PR DESCRIPTION
Not specifying will return all params, similar to how getPost, getQuery etc. in Http\Request.
This will allow to get all route params in a controller easily:
$this->params()->fromRoute();
instead of 
$this->getEvent()->getRouteMatch()->getParams();
