### PR TITLE
fixing warning that occurs if getenv('OS') returns false on an os

### DIFF
--- a/library/Zend/Console/Console.php
+++ b/library/Zend/Console/Console.php
@@ -108,8 +108,8 @@ abstract class Console
     {
         return
             ( defined('PHP_OS') && ( substr_compare(PHP_OS,'win',0,3,true) === 0) ) ||
-            substr_compare(getenv('OS'),'windows',0,7,true)
-        ;
+            (getenv('OS') != false && substr_compare(getenv('OS'),'windows',0,7,true))
+            ;
     }
 
     /**


### PR DESCRIPTION
when getenv('OS') is called to determine if on a windows system on a system that doesn't return a string, a warning is issued that the substring is trying to use an index that is greater than the string length.
