### PR TITLE
StringTrim fixes (see details)

### DIFF
--- a/library/Zend/Filter/StringTrim.php
+++ b/library/Zend/Filter/StringTrim.php
@@ -102,12 +102,12 @@ class StringTrim extends AbstractFilter
     protected function unicodeTrim($value, $charlist = '\\\\s')
     {
         $chars = preg_replace(
-            array('/[\^\-\]\\\]/S', '/\\\{4}/S', '/\//'),
+            array('/[\^\-\]\\\]/S', '/\\\{4}/', '/\//'),
             array('\\\\\\0', '\\', '\/'),
             $charlist
         );
 
-        $pattern = '/^[' . $chars . ']*|[' . $chars . ']*$/sSD';
+        $pattern = '/^[' . $chars . ']+|[' . $chars . ']+$/usD';
 
         return preg_replace($pattern, '', $value);
     }

--- a/tests/ZendTest/Filter/StringTrimTest.php
+++ b/tests/ZendTest/Filter/StringTrimTest.php
@@ -55,6 +55,16 @@ class StringTrimTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Ensures that the filter follows expected behavior
+     *
+     * @return void
+     */
+    public function testUtf8()
+    {
+        $this->assertEquals('a', $this->_filter(utf8_encode("\xa0a\xa0")));
+    }
+
+    /**
      * Ensures that getCharList() returns expected default value
      *
      * @return void


### PR DESCRIPTION
- Enabled UTF-8 modifier (u) since the function claims to be a Unicode trim. This also expands the meaning of \s to include a more complete whitespace character list.
- Ensured pattern matches at least one char before attempting removal (\* -> +)
- Removed study modifier (S) from patterns that do not benefit from it.
