### PR TITLE
Selected Checkbox

### DIFF
--- a/library/Zend/Form/Element/Checkbox.php
+++ b/library/Zend/Form/Element/Checkbox.php
@@ -228,12 +228,8 @@ class Checkbox extends Element implements InputProviderInterface
     {
         if (is_bool($value)) {
             $this->value = $value;
-        } elseif ($value === $this->getCheckedValue()) {
-            $this->value = true;
-        } elseif (is_object($value) && method_exists('__toString', $value)) {
-            $this->value = $value->__toString() == $this->getCheckedValue();
         } else {
-            $this->value = false;
+            $this->value = $value === $this->getCheckedValue();
         }
         return $this;
     }

--- a/library/Zend/Form/Element/Checkbox.php
+++ b/library/Zend/Form/Element/Checkbox.php
@@ -195,4 +195,46 @@ class Checkbox extends Element implements InputProviderInterface
 
         return $spec;
     }
+
+    /**
+     * Checks if this checkbox is checked.
+     *
+     * @return bool
+     */
+    public function isChecked()
+    {
+        return (bool)$this->value;
+    }
+
+    /**
+     * Checks or unchecks the checkbox.
+     *
+     * @param bool $value The flag to set.
+     * @return Checkbox
+     */
+    public function setChecked($value)
+    {
+        $this->value = (bool)$value;
+        return $this;
+    }
+
+    /**
+     * Checks or unchecks the checkbox.
+     *
+     * @param mixed $value A boolean flag or string that is checked against the "checked value".
+     * @return Element
+     */
+    public function setValue($value)
+    {
+        if (is_bool($value)) {
+            $this->value = $value;
+        } elseif ($value === $this->getCheckedValue()) {
+            $this->value = true;
+        } elseif (is_object($value) && method_exists('__toString', $value)) {
+            $this->value = $value->__toString() == $this->getCheckedValue();
+        } else {
+            $this->value = false;
+        }
+        return $this;
+    }
 }

--- a/library/Zend/Form/Element/MultiCheckbox.php
+++ b/library/Zend/Form/Element/MultiCheckbox.php
@@ -69,4 +69,16 @@ class MultiCheckbox extends Checkbox
         }
         return $values;
     }
+
+    /**
+     * Sets the value that should be selected.
+     *
+     * @param mixed $value The value to set.
+     * @return Element
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+        return $this;
+    }
 }

--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -12,6 +12,7 @@ namespace Zend\Form\View\Helper;
 
 use Traversable;
 use Zend\Form\ElementInterface;
+use Zend\Form\Element\Checkbox;
 use Zend\Form\Exception;
 
 /**
@@ -43,10 +44,32 @@ class FormCheckbox extends FormInput
         $attributes['type']    = $this->getInputType();
         $closingBracket        = $this->getInlineClosingBracket();
 
-        if ($element->isChecked()) {
-            $attributes['checked'] = 'checked';
+        if ($element instanceof Checkbox) {
+            if ($element->isChecked()) {
+                $attributes['checked'] = 'checked';
+            }
+            $attributes['value'] = $element->getCheckedValue();
+            $useHiddenElement    = $element->useHiddenElement();
+            $unCheckedValue      = $element->getUncheckedValue();
         }
-        $attributes['value'] = $element->getCheckedValue();
+        if (!$element instanceof Checkbox) {
+            $value = (bool) $element->getValue();
+            if ($value) {
+                $attributes['checked'] = 'checked';
+            }
+            $attributes['value'] = $element->getOption('checked_value');
+            if (null === $attributes['value']) {
+                $attributes['value'] = '1';
+            }
+            $useHiddenElement    = $element->getOption('use_hidden_element');
+            if (null === $useHiddenElement) {
+                $useHiddenElement = true;
+            }
+            $unCheckedValue = $element->getOption('unchecked_value');
+            if (null === $unCheckedValue) {
+                $unCheckedValue = '0';
+            }
+        }
 
         $rendered = sprintf(
             '<input %s%s',
@@ -54,12 +77,10 @@ class FormCheckbox extends FormInput
             $closingBracket
         );
 
-        $useHiddenElement = $element->useHiddenElement();
-
         if ($useHiddenElement) {
             $hiddenAttributes = array(
                 'name'  => $attributes['name'],
-                'value' => $element->getUncheckedValue()
+                'value' => $unCheckedValue,
             );
 
             $rendered = sprintf(

--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -12,7 +12,6 @@ namespace Zend\Form\View\Helper;
 
 use Traversable;
 use Zend\Form\ElementInterface;
-use Zend\Form\Element\Checkbox as CheckboxElement;
 use Zend\Form\Exception;
 
 /**
@@ -31,13 +30,6 @@ class FormCheckbox extends FormInput
      */
     public function render(ElementInterface $element)
     {
-        if (! $element instanceof CheckboxElement) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s requires that the element is of type Zend\Form\Element\Checkbox',
-                __METHOD__
-            ));
-        }
-
         $name = $element->getName();
         if (empty($name) && $name !== 0) {
             throw new Exception\DomainException(sprintf(
@@ -46,10 +38,6 @@ class FormCheckbox extends FormInput
             ));
         }
 
-        $checkedValue     = $element->getCheckedValue();
-        $uncheckedValue   = $element->getUncheckedValue();
-        $useHiddenElement = $element->useHiddenElement();
-
         $attributes            = $element->getAttributes();
         $attributes['name']    = $name;
         $attributes['checked'] = '';
@@ -57,10 +45,10 @@ class FormCheckbox extends FormInput
         $closingBracket        = $this->getInlineClosingBracket();
 
         $value = $element->getValue();
-        if ($value === $checkedValue) {
+        if ($value == $element->getCheckedValue()) {
             $attributes['checked'] = 'checked';
         }
-        $attributes['value'] = $checkedValue;
+        $attributes['value'] = $element->getCheckedValue();
 
         $rendered = sprintf(
             '<input %s%s',
@@ -68,10 +56,12 @@ class FormCheckbox extends FormInput
             $closingBracket
         );
 
+        $useHiddenElement = $element->useHiddenElement();
+
         if ($useHiddenElement) {
             $hiddenAttributes = array(
                 'name'  => $attributes['name'],
-                'value' => $uncheckedValue
+                'value' => $element->getUncheckedValue()
             );
 
             $rendered = sprintf(

--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -31,6 +31,13 @@ class FormCheckbox extends FormInput
      */
     public function render(ElementInterface $element)
     {
+        if (!$element instanceof CheckboxElement) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s requires that the element is of type Zend\Form\Element\Checkbox',
+                __METHOD__
+            ));
+        }
+
         $name = $element->getName();
         if (empty($name) && $name !== 0) {
             throw new Exception\DomainException(sprintf(

--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -12,7 +12,7 @@ namespace Zend\Form\View\Helper;
 
 use Traversable;
 use Zend\Form\ElementInterface;
-use Zend\Form\Element\Checkbox;
+use Zend\Form\Element\Checkbox as CheckboxElement;
 use Zend\Form\Exception;
 
 /**
@@ -49,34 +49,15 @@ class FormCheckbox extends FormInput
         $attributes            = $element->getAttributes();
         $attributes['name']    = $name;
         $attributes['type']    = $this->getInputType();
+        $attributes['value']   = $element->getCheckedValue();
         $closingBracket        = $this->getInlineClosingBracket();
 
-        if ($element instanceof Checkbox) {
-            if ($element->isChecked()) {
-                $attributes['checked'] = 'checked';
-            }
-            $attributes['value'] = $element->getCheckedValue();
-            $useHiddenElement    = $element->useHiddenElement();
-            $unCheckedValue      = $element->getUncheckedValue();
+        if ($element->isChecked()) {
+            $attributes['checked'] = 'checked';
         }
-        if (!$element instanceof Checkbox) {
-            $value = (bool) $element->getValue();
-            if ($value) {
-                $attributes['checked'] = 'checked';
-            }
-            $attributes['value'] = $element->getOption('checked_value');
-            if (null === $attributes['value']) {
-                $attributes['value'] = '1';
-            }
-            $useHiddenElement    = $element->getOption('use_hidden_element');
-            if (null === $useHiddenElement) {
-                $useHiddenElement = true;
-            }
-            $unCheckedValue = $element->getOption('unchecked_value');
-            if (null === $unCheckedValue) {
-                $unCheckedValue = '0';
-            }
-        }
+
+        $useHiddenElement    = $element->useHiddenElement();
+        $unCheckedValue      = $element->getUncheckedValue();
 
         $rendered = sprintf(
             '<input %s%s',

--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -40,12 +40,10 @@ class FormCheckbox extends FormInput
 
         $attributes            = $element->getAttributes();
         $attributes['name']    = $name;
-        $attributes['checked'] = '';
         $attributes['type']    = $this->getInputType();
         $closingBracket        = $this->getInlineClosingBracket();
 
-        $value = $element->getValue();
-        if ($value == $element->getCheckedValue()) {
+        if ($element->isChecked()) {
             $attributes['checked'] = 'checked';
         }
         $attributes['value'] = $element->getCheckedValue();

--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -55,20 +55,17 @@ class FormCheckbox extends FormInput
         if ($element->isChecked()) {
             $attributes['checked'] = 'checked';
         }
-
-        $useHiddenElement    = $element->useHiddenElement();
-        $unCheckedValue      = $element->getUncheckedValue();
-
+        
         $rendered = sprintf(
             '<input %s%s',
             $this->createAttributesString($attributes),
             $closingBracket
         );
 
-        if ($useHiddenElement) {
+        if ($element->useHiddenElement()) {
             $hiddenAttributes = array(
                 'name'  => $attributes['name'],
-                'value' => $unCheckedValue,
+                'value' => $element->getUncheckedValue(),
             );
 
             $rendered = sprintf(

--- a/tests/ZendTest/Form/Element/CheckboxTest.php
+++ b/tests/ZendTest/Form/Element/CheckboxTest.php
@@ -57,4 +57,45 @@ class CheckboxTest extends TestCase
             }
         }
     }
+
+    public function testIsChecked()
+    {
+        $element = new CheckboxElement();
+        $this->assertEquals(false, $element->isChecked());
+    }
+
+    public function testSetAttributeValue()
+    {
+        $element = new CheckboxElement();
+        $this->assertEquals(false, $element->isChecked());
+
+        $element->setAttribute('value', 123);
+        $this->assertEquals(false, $element->isChecked());
+
+        $element->setAttribute('value', true);
+        $this->assertEquals(true, $element->isChecked());
+    }
+
+    public function testIntegerCheckedValue()
+    {
+        $element = new CheckboxElement();
+        $element->setCheckedValue(123);
+
+        $this->assertEquals(false, $element->isChecked());
+
+        $element->setAttribute('value', 123);
+        $this->assertEquals(true, $element->isChecked());
+    }
+
+    public function testSetChecked()
+    {
+        $element = new CheckboxElement();
+        $this->assertEquals(false, $element->isChecked());
+
+        $element->setChecked(true);
+        $this->assertEquals(true, $element->isChecked());
+
+        $element->setChecked(false);
+        $this->assertEquals(false, $element->isChecked());
+    }
 }

--- a/tests/ZendTest/Form/Element/CheckboxTest.php
+++ b/tests/ZendTest/Form/Element/CheckboxTest.php
@@ -23,7 +23,6 @@ namespace ZendTest\Form\Element;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element\Checkbox as CheckboxElement;
-use Zend\Form\Factory;
 
 class CheckboxTest extends TestCase
 {

--- a/tests/ZendTest/Form/Element/CheckboxTest.php
+++ b/tests/ZendTest/Form/Element/CheckboxTest.php
@@ -98,4 +98,13 @@ class CheckboxTest extends TestCase
         $element->setChecked(false);
         $this->assertEquals(false, $element->isChecked());
     }
+
+    public function testCheckWithCheckedValue()
+    {
+        $element = new CheckboxElement();
+        $this->assertEquals(false, $element->isChecked());
+
+        $element->setValue($element->getCheckedValue());
+        $this->assertEquals(true, $element->isChecked());
+    }
 }

--- a/tests/ZendTest/Form/View/Helper/FormCheckboxTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCheckboxTest.php
@@ -54,8 +54,8 @@ class FormCheckboxTest extends CommonTestCase
         $element->setValue('checked');
         $markup  = $this->helper->render($element);
 
-        $this->assertRegexp('#checked="checked"\s+value="checked"#', $markup);
-        $this->assertNotRegexp('#checked="checked"\s+value="unchecked"#', $markup);
+        $this->assertRegexp('#value="checked"\s+checked="checked"#', $markup);
+        $this->assertNotRegexp('#value="unchecked"\s+checked="checked"#', $markup);
     }
 
     public function testNoOptionsAttributeCreatesDefaultCheckedAndUncheckedValues()


### PR DESCRIPTION
This is needed because the value could be populated from a hydrator for example. Setting the value to the boolean value "true" would fail because "true is not identical to 1" where 1 is the default checked value. The equal operator does the job in such cases.

An alternative to this PR would be to introduce methods to enable or disable a checkbox:
setChecked(bool);
bool isChecked();

and than overload the setValue function in order to always pass a boolean to setChecked.
