### PR TITLE
Hotfix/db adapter pdo result set not returning int count

### DIFF
--- a/library/Zend/Console/Console.php
+++ b/library/Zend/Console/Console.php
@@ -108,7 +108,7 @@ abstract class Console
     {
         return
             ( defined('PHP_OS') && ( substr_compare(PHP_OS,'win',0,3,true) === 0) ) ||
-            substr_compare(getenv('OS'),'windows',0,7,true)
+            (getenv('OS') != false && substr_compare(getenv('OS'),'windows',0,7,true))
         ;
     }
 

--- a/library/Zend/Db/Adapter/Driver/Pdo/Result.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Result.php
@@ -176,9 +176,9 @@ class Result implements Iterator, ResultInterface
             return $this->rowCount;
         }
         if ($this->rowCount instanceof \Closure) {
-            $this->rowCount = call_user_func($this->rowCount);
+            $this->rowCount = (int)call_user_func($this->rowCount);
         } else {
-            $this->rowCount = $this->resource->rowCount();
+            $this->rowCount = (int)$this->resource->rowCount();
         }
         return $this->rowCount;
     }


### PR DESCRIPTION
it's possible that pdo result count can return a string row count instead of an int
