### PR TITLE
Use input name as filter name when filter name is an integer

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -44,10 +44,11 @@ class BaseInputFilter implements InputFilterInterface
      * Add an input to the input filter
      *
      * @param  InputInterface|InputFilterInterface $input
+     * @param  null|string                         $name Name used to retrieve this input
      * @throws Exception\InvalidArgumentException
      * @return InputFilterInterface
      */
-    public function add($input)
+    public function add($input, $name = null)
     {
         if (!$input instanceof InputInterface && !$input instanceof InputFilterInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -59,7 +60,9 @@ class BaseInputFilter implements InputFilterInterface
             ));
         }
 
-        $name = $input->getName();
+        if (is_null($name) || $name === '') {
+            $name = $input->getName();
+        }
 
         if (isset($this->inputs[$name]) && $this->inputs[$name] instanceof InputInterface) {
             // The element already exists, so merge the config. Please note that the order is important (already existing

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -60,7 +60,7 @@ class BaseInputFilter implements InputFilterInterface
             ));
         }
 
-        if (empty($name) || is_int($name)) {
+        if ($input instanceof InputInterface && (empty($name) || is_int($name))) {
             $name = $input->getName();
         }
 

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -60,7 +60,7 @@ class BaseInputFilter implements InputFilterInterface
             ));
         }
 
-        if (is_null($name) || $name === '') {
+        if (empty($name) || is_int($name)) {
             $name = $input->getName();
         }
 

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -44,11 +44,10 @@ class BaseInputFilter implements InputFilterInterface
      * Add an input to the input filter
      *
      * @param  InputInterface|InputFilterInterface $input
-     * @param  null|string                         $name Name used to retrieve this input
      * @throws Exception\InvalidArgumentException
      * @return InputFilterInterface
      */
-    public function add($input, $name = null)
+    public function add($input)
     {
         if (!$input instanceof InputInterface && !$input instanceof InputFilterInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -60,9 +59,7 @@ class BaseInputFilter implements InputFilterInterface
             ));
         }
 
-        if (is_null($name) || $name === '') {
-            $name = $input->getName();
-        }
+        $name = $input->getName();
 
         if (isset($this->inputs[$name]) && $this->inputs[$name] instanceof InputInterface) {
             // The element already exists, so merge the config. Please note that the order is important (already existing

--- a/tests/ZendTest/InputFilter/FactoryTest.php
+++ b/tests/ZendTest/InputFilter/FactoryTest.php
@@ -349,7 +349,8 @@ class FactoryTest extends TestCase
         }
     }
 
-    public function testFactoryWillCreateInputFilterMatchingInputNameWhenNotSpecified() {
+    public function testFactoryWillCreateInputFilterMatchingInputNameWhenNotSpecified()
+    {
         $factory     = new Factory();
         $inputFilter = $factory->createInputFilter(array(
             array('name' => 'foo')

--- a/tests/ZendTest/InputFilter/FactoryTest.php
+++ b/tests/ZendTest/InputFilter/FactoryTest.php
@@ -348,4 +348,14 @@ class FactoryTest extends TestCase
             }
         }
     }
+
+    public function testFactoryWillCreateInputFilterMatchingInputNameWhenNotSpecified() {
+        $factory     = new Factory();
+        $inputFilter = $factory->createInputFilter(array(
+            array('name' => 'foo')
+        ));
+
+        $this->assertTrue($inputFilter->has('foo'));
+        $this->assertInstanceOf('Zend\InputFilter\Input', $inputFilter->get('foo'));
+    }
 }


### PR DESCRIPTION
This relaxes the requirement to specify the same name for an InputFilter as its Inputs when using InputFilter\Factory. The implicit integers of an indexed array are assumed to be the absence of setting the name for the InputFilter.
