### PR TITLE
Make Zend\Form\Element\Select implement InputProviderInterface

### DIFF
--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -34,7 +34,7 @@ use Zend\Validator\ValidatorInterface;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Select extends Element
+class Select extends Element implements InputProviderInterface
 {
     /**
      * Seed attributes


### PR DESCRIPTION
`Zend\Form\Element\Select` needs to implement `Zend\InputFilter\InputProviderInterface` in order for `Zend\Form` to pick up its default validators.

I think this was simply missed when the validation code was added in d5e9dac7ac07717be2958f2060957a3629110ad9. Other elements like `Csrf`, `Checkbox`, etc are declared correctly.
