### PR TITLE
[Zend\Db] ZF2-464: Fixed Pdo Connection to not unset class property, use null instead.

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -263,7 +263,7 @@ class Connection implements ConnectionInterface
     public function disconnect()
     {
         if ($this->isConnected()) {
-            unset($this->resource);
+            $this->resource = null;
         }
         return $this;
     }


### PR DESCRIPTION
see: http://framework.zend.com/issues/browse/ZF2-464
