### PR TITLE
TimeStamp in Logger needs to be formatted, otherwise Db\Writer might issue fatal error

### DIFF
--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -79,6 +79,14 @@ class Logger implements LoggerInterface
      * @var boolean
      */
     protected static $registeredExceptionHandler = false;
+    
+    /**
+    * The format of the date used for a log entry (ISO 8601 date)
+    * @see http://www.php.net/manual/en/function.date.php
+    * 
+    * @var string
+    */
+    protected $dateTimeFormat = 'c';
 
     /**
      * Constructor
@@ -141,7 +149,29 @@ class Logger implements LoggerInterface
         $this->writerPlugins = $plugins;
         return $this;
     }
+    
+    /**    
+    * Return the format of DateTime
+    * 
+    * @return string
+    */    
+    public function getDateTimeFormat()
+    {
+        return $this->dateTimeFormat;
+    }
 
+    /**
+     *  Set the format of DateTime
+     *  
+     *  @see    http://nl3.php.net/manual/en/function.date.php
+     *  @return Logger
+     *  */
+    public function setDateTimeFormat($format)
+    {
+        $this->dateTimeFormat = (string) $format;
+        return $this;
+    }
+    		
     /**
      * Get writer instance
      *
@@ -243,7 +273,8 @@ class Logger implements LoggerInterface
             throw new Exception\RuntimeException('No log writer specified');
         }
 
-        $timestamp = new DateTime();
+        $date = new DateTime();
+        $timestamp = $date->format($this->getDateTimeFormat());
 
         if (is_array($message)) {
             $message = var_export($message, true);


### PR DESCRIPTION
Putting a DateTime object in the timestamp does not make sense. DateTime has to be formated (ISO 8601).

If left simple DateTime, PDO will issue a fatal error, (Object of class DateTime could not be converted to string in... )
