### PR TITLE
Hotfix/zf2 427

### DIFF
--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -205,7 +205,7 @@ class Factory
         }
 
         $class = 'Zend\InputFilter\InputFilter';
-        if (isset($inputFilterSpecification['type'])) {
+        if (isset($inputFilterSpecification['type']) && is_string($inputFilterSpecification['type'])) {
             $class = $inputFilterSpecification['type'];
             if (!class_exists($class)) {
                 throw new Exception\RuntimeException(sprintf(

--- a/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
+++ b/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
@@ -186,4 +186,15 @@ class AnnotationBuilderTest extends TestCase
         $this->assertEquals('Username:', $username->getLabel());
         $this->assertEquals(array('class' => 'label'), $username->getLabelAttributes());
     }
+
+    public function testAllowTypeAsElementNameInInputFilter()
+    {
+        $entity  = new TestAsset\Annotation\EntityWithTypeAsElementName();
+        $builder = new Annotation\AnnotationBuilder();
+        $form    = $builder->createForm($entity);
+
+        $this->assertInstanceOf('Zend\Form\Form', $form);
+        $element = $form->get('type');
+        $this->assertInstanceOf('Zend\Form\Element', $element);
+    }
 }

--- a/tests/ZendTest/Form/TestAsset/Annotation/EntityWithTypeAsElementName.php
+++ b/tests/ZendTest/Form/TestAsset/Annotation/EntityWithTypeAsElementName.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace ZendTest\Form\TestAsset\Annotation;
+
+use ZendTest\Form\Annotation;
+
+class EntityWithTypeAsElementName
+{
+    /**
+      * @Annotation\Required(true)
+      * @Annotation\Filter({"name":"StringTrim"})
+      * @Annotation\Name("type")
+      */
+    public $type;
+}


### PR DESCRIPTION
This fixes the issue reported in ZF2-427, and verified with #2093. Basically, if you had an element you wanted to name "type" via the Name annotation, the input filter factory would try and use the value from that as the classname of the input being created. A check for is_string($value) now ensures we can add the input successfully, thus allowing elements named "type" from annotations.
