### PR TITLE
[Fix] Form Select InArray validation and MultiCheckbox/Radio inconsistency

### DIFF
--- a/library/Zend/Form/Element/MultiCheckbox.php
+++ b/library/Zend/Form/Element/MultiCheckbox.php
@@ -61,7 +61,7 @@ class MultiCheckbox extends Checkbox
         $values = array();
         $options = $this->getAttribute('options');
         foreach ($options as $key => $optionSpec) {
-            $value = (is_array($optionSpec)) ? $optionSpec['value'] : $optionSpec;
+            $value = (is_array($optionSpec)) ? $optionSpec['value'] : $key;
             $values[] = $value;
         }
         if ($this->useHiddenElement()) {

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -60,7 +60,7 @@ class Select extends Element implements InputProviderInterface
     {
         if (null === $this->validator) {
             $validator = new InArrayValidator(array(
-                'haystack' => (array) $this->getAttribute('options'),
+                'haystack' => $this->getOptionAttributeValues(),
                 'strict'   => false
             ));
 
@@ -97,5 +97,21 @@ class Select extends Element implements InputProviderInterface
         );
 
         return $spec;
+    }
+
+    /**
+     * Get only the values from the options attribute
+     *
+     * @return array
+     */
+    protected function getOptionAttributeValues()
+    {
+        $values = array();
+        $options = $this->getAttribute('options');
+        foreach ($options as $key => $optionSpec) {
+            $value = (is_array($optionSpec)) ? $optionSpec['value'] : $key;
+            $values[] = $value;
+        }
+        return $values;
     }
 }

--- a/library/Zend/Form/View/Helper/FormMultiCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormMultiCheckbox.php
@@ -269,8 +269,11 @@ class FormMultiCheckbox extends FormInput
             $inputAttributes = $attributes;
             $labelAttributes = $globalLabelAttributes;
 
-            if (is_string($optionSpec) || is_numeric($optionSpec) || is_bool($optionSpec)) {
-                $optionSpec = array('value' => (string) $optionSpec);
+            if (is_scalar($optionSpec)) {
+                $optionSpec = array(
+                    'label' => $optionSpec,
+                    'value' => $key
+                );
             }
 
             if (isset($optionSpec['value'])) {

--- a/tests/ZendTest/Form/Element/MultiCheckboxTest.php
+++ b/tests/ZendTest/Form/Element/MultiCheckboxTest.php
@@ -62,16 +62,46 @@ class MultiCheckboxTest extends TestCase
                 case 'Zend\Validator\Explode':
                     $inArrayValidator = $validator->getValidator();
                     $this->assertInstanceOf('Zend\Validator\InArray', $inArrayValidator);
-
-                    $values = array_values($options);
-                    if ($element->useHiddenElement()) {
-                        $values[] = $element->getUncheckedValue();
-                    }
-                    $this->assertEquals($values, $inArrayValidator->getHaystack());
                     break;
                 default:
                     break;
             }
         }
+    }
+
+    public function multiCheckboxOptionsDataProvider()
+    {
+        return array(
+            array(
+                array('foo', 'bar'),
+                array(
+                    'foo' => 'My Foo Label',
+                    'bar' => 'My Bar Label',
+                )
+            ),
+            array(
+                array('foo', 'bar'),
+                array(
+                    0 => array('label' => 'My Foo Label', 'value' => 'foo'),
+                    1 => array('label' => 'My Bar Label', 'value' => 'bar'),
+                )
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider multiCheckboxOptionsDataProvider
+     */
+    public function testInArrayValidationOfOptions($valueTests, $options)
+    {
+        $element = new MultiCheckboxElement('my-checkbox');
+        $element->setAttributes(array(
+            'options' => $options,
+        ));
+        $inputSpec = $element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $explodeValidator = $inputSpec['validators'][0];
+        $this->assertInstanceOf('Zend\Validator\Explode', $explodeValidator);
+        $this->assertTrue($explodeValidator->isValid($valueTests));
     }
 }

--- a/tests/ZendTest/Form/Element/RadioTest.php
+++ b/tests/ZendTest/Form/Element/RadioTest.php
@@ -58,17 +58,44 @@ class RadioTest extends TestCase
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
             $this->assertTrue(in_array($class, $expectedClasses), $class);
-            switch ($class) {
-                case 'Zend\Validator\InArray':
-                    $values = array_values($options);
-                    if ($element->useHiddenElement()) {
-                        $values[] = $element->getUncheckedValue();
-                    }
-                    $this->assertEquals($values, $validator->getHaystack());
-                    break;
-                default:
-                    break;
-            }
+        }
+    }
+
+    public function radioOptionsDataProvider()
+    {
+        return array(
+            array(
+                array('foo', 'bar'),
+                array(
+                    'foo' => 'My Foo Label',
+                    'bar' => 'My Bar Label',
+                )
+            ),
+            array(
+                array('foo', 'bar'),
+                array(
+                    0 => array('label' => 'My Foo Label', 'value' => 'foo'),
+                    1 => array('label' => 'My Bar Label', 'value' => 'bar'),
+                )
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider radioOptionsDataProvider
+     */
+    public function testInArrayValidationOfOptions($valueTests, $options)
+    {
+        $element = new RadioElement('my-radio');
+        $element->setAttributes(array(
+            'options' => $options,
+        ));
+        $inputSpec = $element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $inArrayValidator = $inputSpec['validators'][0];
+        $this->assertInstanceOf('Zend\Validator\InArray', $inArrayValidator);
+        foreach ($valueTests as $valueToTest) {
+            $this->assertTrue($inArrayValidator->isValid($valueToTest));
         }
     }
 }

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -46,13 +46,6 @@ class SelectTest extends TestCase
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
             $this->assertTrue(in_array($class, $expectedClasses), $class);
-            switch ($class) {
-                case 'Zend\Validator\InArray':
-                    $this->assertEquals($element->getAttribute('options'), $validator->getHaystack());
-                    break;
-                default:
-                    break;
-            }
         }
     }
 
@@ -85,6 +78,44 @@ class SelectTest extends TestCase
                 default:
                     break;
             }
+        }
+    }
+
+    public function selectOptionsDataProvider()
+    {
+        return array(
+            array(
+                array('foo', 'bar'),
+                array(
+                    'foo' => 'My Foo Label',
+                    'bar' => 'My Bar Label',
+                )
+            ),
+            array(
+                array('foo', 'bar'),
+                array(
+                    0 => array('label' => 'My Foo Label', 'value' => 'foo'),
+                    1 => array('label' => 'My Bar Label', 'value' => 'bar'),
+                )
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider selectOptionsDataProvider
+     */
+    public function testInArrayValidationOfOptions($valueTests, $options)
+    {
+        $element = new SelectElement('my-select');
+        $element->setAttributes(array(
+            'options' => $options,
+        ));
+        $inputSpec = $element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $inArrayValidator = $inputSpec['validators'][0];
+        $this->assertInstanceOf('Zend\Validator\InArray', $inArrayValidator);
+        foreach ($valueTests as $valueToTest) {
+            $this->assertTrue($inArrayValidator->isValid($valueToTest));
         }
     }
 }

--- a/tests/ZendTest/Form/View/Helper/FormMultiCheckboxTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormMultiCheckboxTest.php
@@ -31,9 +31,9 @@ class FormMultiCheckboxTest extends CommonTestCase
     {
         $element = new MultiCheckboxElement('foo');
         $options = array(
-            'This is the first label' => 'value1',
-            'This is the second label' => 'value2',
-            'This is the third label' => 'value3',
+            'value1' => 'This is the first label',
+            'value2' => 'This is the second label',
+            'value3' => 'This is the third label',
         );
         $element->setAttribute('options', $options);
         return $element;
@@ -43,15 +43,15 @@ class FormMultiCheckboxTest extends CommonTestCase
     {
         $element = new MultiCheckboxElement('foo');
         $options = array(
-            'This is the first label' => 'value1',
-            'This is the second label' => array(
+            'value1' => 'This is the first label',
+            1 => array(
                 'value'           => 'value2',
                 'label'           => 'This is the second label (overridden)',
                 'disabled'        => false,
                 'label_attributes' => array('class' => 'label-class'),
                 'attributes'      => array('class' => 'input-class'),
             ),
-            'This is the third label' => 'value3',
+            'value3' => 'This is the third label',
         );
         $element->setAttribute('options', $options);
         return $element;
@@ -68,7 +68,7 @@ class FormMultiCheckboxTest extends CommonTestCase
         $this->assertEquals(3, substr_count($markup, '<input'));
         $this->assertEquals(3, substr_count($markup, '<label'));
 
-        foreach ($options as $label => $value) {
+        foreach ($options as $value => $label) {
             $this->assertContains(sprintf('>%s</label>', $label), $markup);
             $this->assertContains(sprintf('value="%s"', $value), $markup);
         }
@@ -119,7 +119,7 @@ class FormMultiCheckboxTest extends CommonTestCase
         $this->assertEquals(4, substr_count($markup, '<input'));
         $this->assertEquals(3, substr_count($markup, '<label'));
 
-        foreach ($options as $label => $value) {
+        foreach ($options as $value => $label) {
             $this->assertContains(sprintf('>%s</label>', $label), $markup);
             $this->assertContains(sprintf('value="%s"', $value), $markup);
         }
@@ -156,7 +156,7 @@ class FormMultiCheckboxTest extends CommonTestCase
         $this->assertEquals(3, substr_count($markup, '<input'));
         $this->assertEquals(3, substr_count($markup, '<label'));
 
-        foreach ($options as $label => $value) {
+        foreach ($options as $value => $label) {
             $this->assertContains(sprintf('<label>%s<', $label), $markup);
         }
     }

--- a/tests/ZendTest/Form/View/Helper/FormRadioTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRadioTest.php
@@ -30,9 +30,9 @@ class FormRadioTest extends CommonTestCase
     {
         $element = new RadioElement('foo');
         $options = array(
-            'This is the first label' => 'value1',
-            'This is the second label' => 'value2',
-            'This is the third label' => 'value3',
+            'value1' => 'This is the first label',
+            'value2' => 'This is the second label',
+            'value3' => 'This is the third label',
         );
         $element->setAttribute('options', $options);
         return $element;
@@ -42,15 +42,15 @@ class FormRadioTest extends CommonTestCase
     {
         $element = new RadioElement('foo');
         $options = array(
-            'This is the first label' => 'value1',
-            'This is the second label' => array(
+            'value1' => 'This is the first label',
+            1 => array(
                 'value'           => 'value2',
                 'label'           => 'This is the second label (overridden)',
                 'disabled'        => false,
                 'label_attributes' => array('class' => 'label-class'),
                 'attributes'      => array('class' => 'input-class'),
             ),
-            'This is the third label' => 'value3',
+            'value3' => 'This is the third label',
         );
         $element->setAttribute('options', $options);
         return $element;
@@ -67,7 +67,7 @@ class FormRadioTest extends CommonTestCase
         $this->assertEquals(3, substr_count($markup, '<input'));
         $this->assertEquals(3, substr_count($markup, '<label'));
 
-        foreach ($options as $label => $value) {
+        foreach ($options as $value => $label) {
             $this->assertContains(sprintf('>%s</label>', $label), $markup);
             $this->assertContains(sprintf('value="%s"', $value), $markup);
         }
@@ -118,7 +118,7 @@ class FormRadioTest extends CommonTestCase
         $this->assertEquals(4, substr_count($markup, '<input'));
         $this->assertEquals(3, substr_count($markup, '<label'));
 
-        foreach ($options as $label => $value) {
+        foreach ($options as $value => $label) {
             $this->assertContains(sprintf('>%s</label>', $label), $markup);
             $this->assertContains(sprintf('value="%s"', $value), $markup);
         }
@@ -155,7 +155,7 @@ class FormRadioTest extends CommonTestCase
         $this->assertEquals(3, substr_count($markup, '<input'));
         $this->assertEquals(3, substr_count($markup, '<label'));
 
-        foreach ($options as $label => $value) {
+        foreach ($options as $value => $label) {
             $this->assertContains(sprintf('<label>%s<', $label), $markup);
         }
     }


### PR DESCRIPTION
This fixes the Select validation (InArray was using incorrect options haystack), and an inconsistency between the Select options and the format in MultiCheckbox/Radio.

NOTE: This causes breaking changes to the MultiCheckbox and Radio element options, to match that of Select.

This replaces PR #2183
