### PR TITLE
renamed serviceManager -> serviceLocator and removed duplication

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractActionController.php
+++ b/library/Zend/Mvc/Controller/AbstractActionController.php
@@ -10,11 +10,8 @@
 
 namespace Zend\Mvc\Controller;
 
-use Zend\Http\PhpEnvironment\Response as HttpResponse;
 use Zend\Mvc\Exception;
 use Zend\Mvc\MvcEvent;
-use Zend\Stdlib\RequestInterface as Request;
-use Zend\Stdlib\ResponseInterface as Response;
 use Zend\View\Model\ViewModel;
 
 /**
@@ -60,38 +57,6 @@ abstract class AbstractActionController extends AbstractController
         return new ViewModel(array(
             'content' => 'Page not found'
         ));
-    }
-
-    /**
-     * Dispatch a request
-     *
-     * @events dispatch.pre, dispatch.post
-     * @param  Request $request
-     * @param  null|Response $response
-     * @return Response|mixed
-     */
-    public function dispatch(Request $request, Response $response = null)
-    {
-        $this->request = $request;
-        if (!$response) {
-            $response = new HttpResponse();
-        }
-        $this->response = $response;
-
-        $e = $this->getEvent();
-        $e->setRequest($request)
-          ->setResponse($response)
-          ->setTarget($this);
-
-        $result = $this->getEventManager()->trigger(MvcEvent::EVENT_DISPATCH, $e, function($test) {
-            return ($test instanceof Response);
-        });
-
-        if ($result->stopped()) {
-            return $result->last();
-        }
-
-        return $e->getResult();
     }
 
     /**

--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -81,6 +81,39 @@ abstract class AbstractController implements
      */
     abstract public function onDispatch(MvcEvent $e);
 
+
+    /**
+     * Dispatch a request
+     *
+     * @events dispatch.pre, dispatch.post
+     * @param  Request $request
+     * @param  null|Response $response
+     * @return Response|mixed
+     */
+    public function dispatch(Request $request, Response $response = null)
+    {
+        $this->request = $request;
+        if (!$response) {
+            $response = new HttpResponse();
+        }
+        $this->response = $response;
+
+        $e = $this->getEvent();
+        $e->setRequest($request)
+          ->setResponse($response)
+          ->setTarget($this);
+
+        $result = $this->getEventManager()->trigger(MvcEvent::EVENT_DISPATCH, $e, function($test) {
+            return ($test instanceof Response);
+        });
+
+        if ($result->stopped()) {
+            return $result->last();
+        }
+
+        return $e->getResult();
+    }
+
     /**
      * Get request object
      *

--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -66,7 +66,7 @@ abstract class AbstractController implements
     /**
      * @var ServiceLocatorInterface
      */
-    protected $serviceManager;
+    protected $serviceLocator;
 
     /**
      * @var string
@@ -184,12 +184,12 @@ abstract class AbstractController implements
     /**
      * Set serviceManager instance
      *
-     * @param  ServiceLocatorInterface $serviceManager
+     * @param  ServiceLocatorInterface $serviceLocator
      * @return void
      */
-    public function setServiceLocator(ServiceLocatorInterface $serviceManager)
+    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
     {
-        $this->serviceManager = $serviceManager;
+        $this->serviceLocator = $serviceLocator;
     }
 
     /**
@@ -199,7 +199,7 @@ abstract class AbstractController implements
      */
     public function getServiceLocator()
     {
-        return $this->serviceManager;
+        return $this->serviceLocator;
     }
 
     /**

--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -101,25 +101,8 @@ abstract class AbstractRestfulController extends AbstractController
         if (!$request instanceof HttpRequest) {
             throw new Exception\InvalidArgumentException('Expected an HTTP request');
         }
-        $this->request = $request;
-        if (!$response) {
-            $response = new HttpResponse();
-        }
-        $this->response = $response;
 
-        $e = $this->getEvent();
-        $e->setRequest($request)
-          ->setResponse($response)
-          ->setTarget($this);
-
-        $result = $this->getEventManager()->trigger(MvcEvent::EVENT_DISPATCH, $e, function($test) {
-            return ($test instanceof Response);
-        });
-        if ($result->stopped()) {
-            return $result->last();
-        }
-
-        return $e->getResult();
+        return parent::dispatch($request, $response);
     }
 
     /**


### PR DESCRIPTION
- Moved dispatch functionality from AbstractActionController to AbstractController so AbstractController has default dispatch functions and removed duplication in AbstractRestfullController
- Renamed serviceManager to serviceLocator as suggested by Thinkscape in #2134 ([Comment](https://github.com/zendframework/zf2/pull/2134#issuecomment-7590560)) for consistency in the use of serviceLocator inside the controller
