### PR TITLE
[Form][Bug] Instantiate Select with empty array of options

### DIFF
--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -43,7 +43,8 @@ class Select extends Element implements InputProviderInterface
      * @var array
      */
     protected $attributes = array(
-        'type' => 'select',
+        'type'    => 'select',
+        'options' => array(),
     );
 
     /**

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -122,6 +122,6 @@ class SelectTest extends TestCase
     public function testOptionsHasArrayOnConstruct()
     {
         $element = new SelectElement();
-        $this->assertTrue(is_array($this->getAttribute('options')));
+        $this->assertTrue(is_array($element->getAttribute('options')));
     }
 }

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -118,4 +118,10 @@ class SelectTest extends TestCase
             $this->assertTrue($inArrayValidator->isValid($valueToTest));
         }
     }
+
+    public function testOptionsHasArrayOnConstruct()
+    {
+        $element = new SelectElement();
+        $this->assertTrue(is_array($this->getAttribute('options')));
+    }
 }


### PR DESCRIPTION
After #2187, if you don't specify any options (i.e. you dynamically populate after form creation), you get the following error;

```
Warning: Invalid argument supplied for foreach() in zendframework/zendframework/library/Zend/Form/Element/Select.php on line 111
```

As no options were set.
