### PR TITLE
Bug in Zend\Session that doesnt expire

### DIFF
--- a/library/Zend/Session/Container.php
+++ b/library/Zend/Session/Container.php
@@ -470,6 +470,7 @@ class Container extends ArrayObject
         }
 
         if (null === $vars) {
+            $this->expireKeys(); // first we need to expire global key, since it can already be expired
             $data = array('EXPIRE' => $ts);
         } elseif (is_array($vars)) {
             // Cannot pass "$this" to a lambda
@@ -518,6 +519,7 @@ class Container extends ArrayObject
         }
 
         if (null === $vars) {
+            $this->expireKeys(); // first we need to expire global key, since it can already be expired
             $data = array('EXPIRE_HOPS' => array('hops' => $hops, 'ts' => $ts));
         } elseif (is_array($vars)) {
             // Cannot pass "$this" to a lambda

--- a/tests/ZendTest/Session/ContainerTest.php
+++ b/tests/ZendTest/Session/ContainerTest.php
@@ -23,6 +23,16 @@ use Zend\Session;
  */
 class ContainerTest extends \PHPUnit_Framework_TestCase
 {
+
+    /**
+     * @var Manager
+     */
+    protected $manager;
+    /**
+     * @var Container
+     */
+    protected $container;
+
     public function setUp()
     {
         $this->forceAutoloader();
@@ -281,6 +291,15 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $storage->setMetadata('Default', array('EXPIRE_KEYS' => array('foo' => $_SERVER['REQUEST_TIME'] - 18600)));
         $this->assertFalse(isset($this->container->foo));
         $this->assertTrue(isset($this->container->bar));
+    }
+
+    public function testKeyExistsWithContainerExpirationInPastWithSetExpirationSecondsReturnsFalse()
+    {
+        $this->container->foo = 'bar';
+        $storage = $this->manager->getStorage();
+        $storage->setMetadata('Default', array('EXPIRE' => $_SERVER['REQUEST_TIME'] - 18600));
+        $this->container->setExpirationSeconds(1);
+        $this->assertFalse(isset($this->container->foo));
     }
 
     public function testSettingExpiredKeyOverwritesExpiryMetadataForThatKey()


### PR DESCRIPTION
Actually Zend\Session doesnt expire if you setExpirationSeconds before
use.
Added a TestCase that explains the problem.
