### PR TITLE
[2.1] [WIP] Event driven view layer

### DIFF
--- a/library/Zend/View/ViewEvent.php
+++ b/library/Zend/View/ViewEvent.php
@@ -27,6 +27,7 @@ class ViewEvent extends Event
      * View events triggered by eventmanager
      */
     const EVENT_RENDERER = 'renderer';
+    const EVENT_RENDER   = 'render';
     const EVENT_RESPONSE = 'response';
     /**#@-*/
 


### PR DESCRIPTION
tl;dr: **Not a BC break** (yet) - Feel free to add suggestions, I will ping for review (close and re-open if dirty) once this is ready

This PR will introduce event driven view model rendering: It should now be possible to attach event listeners to the event manager in `Zend\View\View`, thus allowing to prepend and append content to the output generated when rendering a view model by listening to `Zend\View\ViewEvent::EVENT_RENDER` **(already working)**

**TODOs:**
1.  Testing
2.  Move the default render listener to its own class (probably a `Zend\EventManager\ListenerAggregateInterface`)
3.  Attach the default listener via `Zend\Mvc\Service\*` (factories, etc)
4.  Provide accessory methods to set the current produced output in the `Zend\View\ViewEvent`
5.  Avoid registering the `Zend\View\ViewEvent` within the `Zend\View\View` object itself (problematic when having multiple concurring events being triggered).
