### PR TITLE
Allow capath steam context option to be set

### DIFF
--- a/library/Zend/Http/Client/Adapter/Proxy.php
+++ b/library/Zend/Http/Client/Adapter/Proxy.php
@@ -38,6 +38,7 @@ class Proxy extends Socket
         'sslcert'            => null,
         'sslpassphrase'      => null,
         'sslverifypeer'      => true,
+        'sslcapath'          => null,
         'sslallowselfsigned' => false,
         'sslusecontext'      => false,
         'proxy_host'         => '',

--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -58,6 +58,7 @@ class Socket implements HttpAdapter, StreamInterface
         'sslcert'               => null,
         'sslpassphrase'         => null,
         'sslverifypeer'         => true,
+        'sslcapath'             => null,
         'sslallowselfsigned'    => false,
         'sslusecontext'         => false
     );
@@ -188,6 +189,10 @@ class Socket implements HttpAdapter, StreamInterface
                     if (! stream_context_set_option($context, 'ssl', 'verify_peer',
                                                     $this->config['sslverifypeer'])) {
                         throw new AdapterException\RuntimeException('Unable to set sslverifypeer option');
+                    }
+                    if (! stream_context_set_option($context, 'ssl', 'capath',
+                                                    $this->config['sslcapath'])) {
+                        throw new AdapterException\RuntimeException('Unable to set sslcapath option');
                     }
                     if ($this->config['sslallowselfsigned'] !== null) {
                         if (! stream_context_set_option($context, 'ssl', 'allow_self_signed',

--- a/tests/ZendTest/Http/Client/SocketTest.php
+++ b/tests/ZendTest/Http/Client/SocketTest.php
@@ -154,7 +154,8 @@ class SocketTest extends CommonHttpTests
                 'bindto' => '1.2.3.4:0'
             ),
             'ssl' => array(
-                'verify_peer' => true,
+                'capath'            => null,
+                'verify_peer'       => true,
                 'allow_self_signed' => false
             )
         );


### PR DESCRIPTION
The Socket adapter requires a capath option when verifypeer is set to
true (default value). As convenience, this path must be able to set
as option too, else people need to juggle with the stream context
function themselves.

As shown by [this thread](http://zend-framework-community.634137.n4.nabble.com/Re-Changes-to-Zend-Http-Client-Adapter-Socket-td4656215.html), the socket adapter broke with this change for various users because the capath was not set. Besides the required documentation, a convenience method to set the capath is required to make the adapter more usable. An example how this can be used shown [here](https://github.com/juriansluiman/SlmIdealPayment/blob/df10f36d4c6f58bd1d52943ab8cd3dc7f1cc5e09/config/module.config.php#L85-90) instead of the proposed:

``` php
$client = new Client();
$client->setAdapter('\Zend\Http\Client\Adapter\Socket');
$client->setMethod('GET');
$stream = $client->getAdapter()->getStreamContext();
if(!stream_context_set_option($stream, array('ssl'=>array('capath'=>'/etc/ssl/certs')))){
    echo "Error setting capath in Streamcontext"; die;
}
```
