### PR TITLE
Added EmailAddress validator tests for setting messages via options array

### DIFF
--- a/tests/ZendTest/Validator/EmailAddressTest.php
+++ b/tests/ZendTest/Validator/EmailAddressTest.php
@@ -519,6 +519,20 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('TestMessage', $messages[EmailAddress::INVALID]);
     }
 
+    public function testSetSingleMessageViaOptions()
+    {
+        $validator = new EmailAddress(array('message' => 'TestMessage'));
+        $messages = $validator->getMessageTemplates();
+        $this->assertEquals('TestMessage', $messages[EmailAddress::INVALID]);
+    }
+
+    public function testSetMultipleMessageViaOptions()
+    {
+        $validator = new EmailAddress(array('messages' => array(EmailAddress::INVALID => 'TestMessage')));
+        $messages = $validator->getMessageTemplates();
+        $this->assertEquals('TestMessage', $messages[EmailAddress::INVALID]);
+    }
+
     /**
      * Testing getValidateMx
      */


### PR DESCRIPTION
These tests will fail with `PHP Fatal error:  Call to a member function setMessage() on a non-object in /usr/local/share/php/zf2/library/Zend/Validator/EmailAddress.php on line 125`. Unfortunately I don't understand why this fails and therefore cannot fix it myself.

I propose pulling these tests and then merging a fix.
