### PR TITLE
[ZF2-478] Invalid session name generated for CSRF element

### DIFF
--- a/library/Zend/Validator/Csrf.php
+++ b/library/Zend/Validator/Csrf.php
@@ -235,7 +235,9 @@ class Csrf extends AbstractValidator
      */
     public function getSessionName()
     {
-        return str_replace('\\', '_', __CLASS__) . '_' . $this->getSalt() . '_' . $this->getName();
+        return str_replace('\\', '_', __CLASS__) . '_'
+            . $this->getSalt() . '_'
+            . strtr($this->getName(), array('[' => '_', ']' => ''));
     }
 
     /**

--- a/tests/Zend/Validator/CsrfTest.php
+++ b/tests/Zend/Validator/CsrfTest.php
@@ -132,6 +132,16 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->validator->getSessionName());
     }
 
+    public function testSessionNameRemainsValidForElementBelongingToFieldset()
+    {
+        $this->validator->setName('fieldset[csrf]');
+        $class = get_class($this->validator);
+        $class = str_replace('\\', '_', $class);
+        $name = strtr($this->validator->getName(), array('[' => '_', ']' => ''));
+        $expected = sprintf('%s_%s_%s', $class, $this->validator->getSalt(), $name);
+        $this->assertEquals($expected, $this->validator->getSessionName());
+    }
+
     public function testIsValidReturnsFalseWhenValueDoesNotMatchHash()
     {
         $this->assertFalse($this->validator->isValid('foo'));


### PR DESCRIPTION
Session name generated for CSRF element placed in fieldset contains `[` and `]` characters. Removing incorrect symbols solves the issue.
