### PR TITLE
Allow adding a custom NotEmpty validator to a required Input

### DIFF
--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -283,15 +283,13 @@ class Input implements InputInterface
         }
         $chain = $this->getValidatorChain();
 
-        // Check if NotEmpty validator is already in chain
+        // Check if NotEmpty validator is already first in chain
         $validators = $chain->getValidators();
-        foreach ($validators as $validatorInfo) {
-            if (isset($validatorInfo['instance'])
-                && $validatorInfo['instance'] instanceof NotEmpty
-            ) {
-                $this->notEmptyValidator = true;
-                return;
-            }
+        if (isset($validators[0]['instance'])
+            && $validators[0]['instance'] instanceof NotEmpty
+        ) {
+            $this->notEmptyValidator = true;
+            return;
         }
 
         $chain->prependByName('NotEmpty', array(), true);

--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -12,6 +12,7 @@ namespace Zend\InputFilter;
 
 use Zend\Filter\FilterChain;
 use Zend\Validator\ValidatorChain;
+use Zend\Validator\NotEmpty;
 
 /**
  * @category   Zend
@@ -19,14 +20,49 @@ use Zend\Validator\ValidatorChain;
  */
 class Input implements InputInterface
 {
+    /**
+     * @var boolean
+     */
     protected $allowEmpty = false;
+
+    /**
+     * @var boolean
+     */
     protected $breakOnFailure = false;
+
+    /**
+     * @var string|null
+     */
     protected $errorMessage;
+
+    /**
+     * @var FilterChain
+     */
     protected $filterChain;
+
+    /**
+     * @var string
+     */
     protected $name;
+
+    /**
+     * @var boolean
+     */
     protected $notEmptyValidator = false;
+
+    /**
+     * @var boolean
+     */
     protected $required = true;
+
+    /**
+     * @var ValidatorChain
+     */
     protected $validatorChain;
+
+    /**
+     * @var mixed
+     */
     protected $value;
 
     public function __construct($name = null)
@@ -34,18 +70,30 @@ class Input implements InputInterface
         $this->name = $name;
     }
 
+    /**
+     * @param  boolean $allowEmpty
+     * @return Input
+     */
     public function setAllowEmpty($allowEmpty)
     {
         $this->allowEmpty = (bool) $allowEmpty;
         return $this;
     }
 
+    /**
+     * @param  boolean $breakOnFailure
+     * @return Input
+     */
     public function setBreakOnFailure($breakOnFailure)
     {
         $this->breakOnFailure = (bool) $breakOnFailure;
         return $this;
     }
 
+    /**
+     * @param  string|null $errorMessage
+     * @return Input
+     */
     public function setErrorMessage($errorMessage)
     {
         $errorMessage = (null === $errorMessage) ? null : (string) $errorMessage;
@@ -53,51 +101,83 @@ class Input implements InputInterface
         return $this;
     }
 
+    /**
+     * @param  FilterChain $filterChain
+     * @return Input
+     */
     public function setFilterChain(FilterChain $filterChain)
     {
         $this->filterChain = $filterChain;
         return $this;
     }
 
+    /**
+     * @param  string $name
+     * @return Input
+     */
     public function setName($name)
     {
         $this->name = (string) $name;
         return $this;
     }
 
+    /**
+     * @param  boolean $required
+     * @return Input
+     */
     public function setRequired($required)
     {
         $this->required = (bool) $required;
         return $this;
     }
 
+    /**
+     * @param  ValidatorChain $validatorChain
+     * @return Input
+     */
     public function setValidatorChain(ValidatorChain $validatorChain)
     {
         $this->validatorChain = $validatorChain;
         return $this;
     }
 
+    /**
+     * @param  mixed $value
+     * @return Input
+     */
     public function setValue($value)
     {
         $this->value = $value;
         return $this;
     }
 
+    /**
+     * @return boolean
+     */
     public function allowEmpty()
     {
         return $this->allowEmpty;
     }
 
+    /**
+     * @return boolean
+     */
     public function breakOnFailure()
     {
         return $this->breakOnFailure;
     }
 
+    /**
+     * @return string|null
+     */
     public function getErrorMessage()
     {
         return $this->errorMessage;
     }
 
+    /**
+     * @return FilterChain
+     */
     public function getFilterChain()
     {
         if (!$this->filterChain) {
@@ -106,21 +186,33 @@ class Input implements InputInterface
         return $this->filterChain;
     }
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return $this->name;
     }
 
+    /**
+     * @return mixed
+     */
     public function getRawValue()
     {
         return $this->value;
     }
 
+    /**
+     * @return boolean
+     */
     public function isRequired()
     {
         return $this->required;
     }
 
+    /**
+     * @return ValidatorChain
+     */
     public function getValidatorChain()
     {
         if (!$this->validatorChain) {
@@ -129,12 +221,19 @@ class Input implements InputInterface
         return $this->validatorChain;
     }
 
+    /**
+     * @return mixed
+     */
     public function getValue()
     {
         $filter = $this->getFilterChain();
         return $filter->filter($this->value);
     }
 
+    /**
+     * @param  InputInterface $input
+     * @return Input
+     */
     public function merge(InputInterface $input)
     {
         $this->setAllowEmpty($input->allowEmpty());
@@ -149,8 +248,13 @@ class Input implements InputInterface
 
         $validatorChain = $input->getValidatorChain();
         $this->getValidatorChain()->merge($validatorChain);
+        return $this;
     }
 
+    /**
+     * @param  mixed $context Extra "context" to provide the validator
+     * @return boolean
+     */
     public function isValid($context = null)
     {
         $this->injectNotEmptyValidator();
@@ -159,6 +263,9 @@ class Input implements InputInterface
         return $validator->isValid($value, $context);
     }
 
+    /**
+     * @return array
+     */
     public function getMessages()
     {
         if (null !== $this->errorMessage) {
@@ -171,10 +278,22 @@ class Input implements InputInterface
 
     protected function injectNotEmptyValidator()
     {
-        if (!$this->isRequired() && $this->allowEmpty() && !$this->notEmptyValidator) {
+        if ((!$this->isRequired() && $this->allowEmpty()) || $this->notEmptyValidator) {
             return;
         }
         $chain = $this->getValidatorChain();
+
+        // Check if NotEmpty validator is already in chain
+        $validators = $chain->getValidators();
+        foreach ($validators as $validatorInfo) {
+            if (isset($validatorInfo['instance'])
+                && $validatorInfo['instance'] instanceof NotEmpty
+            ) {
+                $this->notEmptyValidator = true;
+                return;
+            }
+        }
+
         $chain->prependByName('NotEmpty', array(), true);
         $this->notEmptyValidator = true;
     }


### PR DESCRIPTION
Was trying to add custom validator messages to a NotEmpty validator on a required Input, but couldn't... 

This fix allows adding a custom NotEmpty validator to an Input. If the Input is required, it will first look through the existing validators and skip adding a default NotEmpty if one is found.

Example usage:

``` php
$myTextInput = new Input('mytext');
$chain = $myTextInput->getValidatorChain();
$chain->prependByName('NotEmpty', array('messages' => array('isEmpty' => 'CANT BE EMPTY')));
$myTextInput->setRequired(true);
```
