### PR TITLE
fixing ZF2-480 by falling back to '/' if no script basename is set

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -474,9 +474,12 @@ class Request extends HttpRequest
             // Backtrack up the SCRIPT_FILENAME to find the portion
             // matching PHP_SELF.
 
+            $baseUrl  = '/';
             $basename = basename($filename);
-            $path     = ($phpSelf ? trim($phpSelf, '/') : '');
-            $baseUrl  = '/'. substr($path, 0, strpos($path, $basename)) . $basename;
+            if ($basename) {
+                $path     = ($phpSelf ? trim($phpSelf, '/') : '');
+                $baseUrl .= substr($path, 0, strpos($path, $basename)) . $basename;
+            }
         }
 
         // Does the base URL have anything in common with the request URI?


### PR DESCRIPTION
This is a fix for http://framework.zend.com/issues/browse/ZF2-480, hopefully
