### PR TITLE
Fix for insertion of rows with multi-part keys

### DIFF
--- a/library/Zend/Db/RowGateway/AbstractRowGateway.php
+++ b/library/Zend/Db/RowGateway/AbstractRowGateway.php
@@ -163,6 +163,8 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
             $result = $statement->execute();
             if (($primaryKeyValue = $result->getGeneratedValue()) && count($this->primaryKeyColumn) == 1) {
                 $this->primaryKeyData = array($this->primaryKeyColumn[0] => $primaryKeyValue);
+            } else {
+                $this->processPrimaryKeyData();
             }
             $rowsAffected = $result->getAffectedRows();
             unset($statement, $result); // cleanup


### PR DESCRIPTION
$this->primaryKeyData was not getting correctly initialized after insertion for multi-part keys, which was causing a fatal error.  By calling $this->processPrimaryKeyData() immediately after row insertion, we can either populate the property from user-provided data fields or else throw an exception if expected values are missing.

Unfortunately, I couldn't figure out how to write a unit test for this situation -- the bug is easily detected because null values get sent to the where() method of the Select object, but since the existing tests use a concrete rather than mock \Zend\Db\Sql\Sql object, there didn't seem to be a simple way to catch this.
