### PR TITLE
allowing uriHandler to be specified as class name and thus lazy-loaded

### DIFF
--- a/library/Zend/Validator/Uri.php
+++ b/library/Zend/Validator/Uri.php
@@ -13,6 +13,7 @@ namespace Zend\Validator;
 use Traversable;
 use Zend\Uri\Exception\ExceptionInterface as UriException;
 use Zend\Uri\Uri as UriHandler;
+use Zend\Validator\Exception\InvalidArgumentException;
 
 /**
  * @category   Zend
@@ -89,7 +90,15 @@ class Uri extends AbstractValidator
         if (null === $this->uriHandler) {
             // Lazy load the base Uri handler
             $this->uriHandler = new UriHandler();
+
+        } elseif (is_string($this->uriHandler)) {
+            $this->uriHandler = new $this->uriHandler;
         }
+
+        if (! $this->uriHandler instanceof UriHandler) {
+            throw new InvalidArgumentException('URI handler is expected to be a Zend\Uri\Uri object');
+        }
+
         return $this->uriHandler;
     }
 
@@ -99,6 +108,10 @@ class Uri extends AbstractValidator
      */
     public function setUriHandler($uriHandler)
     {
+        if (! is_subclass_of($uriHandler, 'Zend\Uri\Uri')) {
+            throw new InvalidArgumentException('Expecting a subclass name or instance of Zend\Uri\Uri as $uriHandler');
+        }
+
         $this->uriHandler = $uriHandler;
         return $this;
     }

--- a/tests/ZendTest/Validator/UriTest.php
+++ b/tests/ZendTest/Validator/UriTest.php
@@ -134,4 +134,26 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertObjectHasAttribute('messageTemplates', $validator);
         $this->assertAttributeEquals($validator->getOption('messageTemplates'), 'messageTemplates', $validator);
     }
+
+    public function testUriHandlerCanBeSpecifiedAsString()
+    {
+        $this->validator->setUriHandler('Zend\Uri\Http');
+        $this->assertInstanceOf('Zend\Uri\Http', $this->validator->getUriHandler());
+    }
+
+    /**
+     * @expectedException Zend\Validator\Exception\InvalidArgumentException
+     */
+    public function testUriHandlerStringInvalidClassThrowsException()
+    {
+        $this->validator->setUriHandler('stdClass');
+    }
+
+    /**
+     * @expectedException Zend\Validator\Exception\InvalidArgumentException
+     */
+    public function testUriHandlerInvalidTypeThrowsException()
+    {
+        $this->validator->setUriHandler(new \stdClass());
+    }
 }


### PR DESCRIPTION
This is a small change to the Uri validator, allowing the URI handler to be specified as a class name rather than an instance of Zend\Uri\Uri. It allows lazy instantiation of the Uri object, thus making things a little bit more efficient when working for example in Zend\Form context (as validation is not always going to happen). 

It also includes a few additional tests.
