### PR TITLE
[2.1] Feature/uri normalize filter

### DIFF
--- a/library/Zend/Filter/FilterPluginManager.php
+++ b/library/Zend/Filter/FilterPluginManager.php
@@ -68,6 +68,7 @@ class FilterPluginManager extends AbstractPluginManager
         'stringtrim'                => 'Zend\Filter\StringTrim',
         'stripnewlines'             => 'Zend\Filter\StripNewlines',
         'striptags'                 => 'Zend\Filter\StripTags',
+        'urinormalize'              => 'Zend\Filter\UriNormalize',
         'wordcamelcasetodash'       => 'Zend\Filter\Word\CamelCaseToDash',
         'wordcamelcasetoseparator'  => 'Zend\Filter\Word\CamelCaseToSeparator',
         'wordcamelcasetounderscore' => 'Zend\Filter\Word\CamelCaseToUnderscore',

--- a/library/Zend/Filter/UriNormalize.php
+++ b/library/Zend/Filter/UriNormalize.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Zend\Filter;
+
+use Zend\Filter\AbstractFilter,
+    Zend\Filter\Exception\InvalidArgumentException,
+    Zend\Uri\UriFactory,
+    Zend\Uri\Uri,
+    Zend\Uri\Exception\ExceptionInterface as UriException;
+
+class UriNormalize extends AbstractFilter
+{
+    /**
+     * The default scheme to use when parsing scheme-less URIs
+     *
+     * @var string
+     */
+    protected $defaultScheme = null;
+
+    /**
+     * Enforced scheme for scheme-less URIs. See setEnforcedScheme docs for info
+     *
+     * @var string
+     */
+    protected $enforcedScheme = null;
+
+    /**
+     * Sets filter options
+     *
+     * @param  string|array|\Zend\Config\Config $options
+     * @return void
+     */
+    public function __construct($options = null)
+    {
+        if ($options) $this->setOptions($options);
+    }
+
+    /**
+     * Set the default scheme to use when parsing scheme-less URIs
+     *
+     * The scheme used when parsing URIs may affect the specific object used to
+     * normalize the URI and thus may affect the resulting normalize URI.
+     *
+     * @param  string $defaultScheme
+     * @return \Zend\Filter\UriNormalize
+     */
+    public function setDefaultScheme($defaultScheme)
+    {
+        $this->defaultScheme = $defaultScheme;
+        return $this;
+    }
+
+    /**
+     * Set a URI scheme to enforce on schemeless URIs
+     *
+     * This allows forcing input values such as 'www.example.com/foo' into
+     * 'http://www.example.com/foo'.
+     *
+     * This should be used with caution, as a standard-compliant URI parser
+     * would regard 'www.example.com' in the above input URI to be the path and
+     * not host part of the URI. While this option can assist in solving
+     * real-world user mishaps, it may yield unexpected results at times.
+     *
+     * @param  string $enforcedScheme
+     * @return \Zend\Filter\UriNormalize
+     */
+    public function setEnforcedScheme($enforcedScheme)
+    {
+        $this->enforcedScheme = $enforcedScheme;
+        return $this;
+    }
+
+    /**
+     * Filter the URL by normalizing it and applying a default scheme if set
+     *
+     * @param  string $value
+     * @return string
+     */
+    public function filter($value)
+    {
+        $defaultScheme = $this->defaultScheme ?: $this->enforcedScheme;
+
+        // Reset default scheme if it is not a known scheme
+        if (! UriFactory::getRegisteredSchemeClass($defaultScheme)) {
+            $defaultScheme = null;
+        }
+
+        try {
+            $uri = UriFactory::factory($value, $defaultScheme);
+            if ($this->enforcedScheme && (! $uri->getScheme())) {
+                $this->enforceScheme($uri);
+            }
+
+        } catch (UriException $ex) {
+            // We are unable to parse / enfore scheme with the given config and input
+            return $value;
+        }
+
+        $uri->normalize();
+
+        if (! $uri->isValid()) {
+            return $value;
+        }
+
+        return $uri->toString();
+    }
+
+    /**
+     * Enforce the defined scheme on the URI
+     *
+     * This will also adjust the host and path parts of the URI as expected in
+     * the case of scheme-less network URIs
+     *
+     * @param Uri $uri
+     */
+    protected function enforceScheme(Uri $uri)
+    {
+        $path = $uri->getPath();
+        if (strpos($path, '/') !== false) {
+            list($host, $path) = explode('/', $path, 2);
+            $path = '/' . $path;
+        } else {
+            $host = $path;
+            $path = '';
+        }
+
+        // We have nothing to do if we have no host
+        if (! $host) return;
+
+        $uri->setScheme($this->enforcedScheme)
+            ->setHost($host)
+            ->setPath($path);
+    }
+}

--- a/library/Zend/Filter/UriNormalize.php
+++ b/library/Zend/Filter/UriNormalize.php
@@ -1,13 +1,25 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Filter
+ */
 
 namespace Zend\Filter;
 
-use Zend\Filter\AbstractFilter,
-    Zend\Filter\Exception\InvalidArgumentException,
-    Zend\Uri\UriFactory,
-    Zend\Uri\Uri,
-    Zend\Uri\Exception\ExceptionInterface as UriException;
+use Zend\Filter\AbstractFilter;
+use Zend\Filter\Exception\InvalidArgumentException;
+use Zend\Uri\UriFactory;
+use Zend\Uri\Uri;
+use Zend\Uri\Exception\ExceptionInterface as UriException;
 
+/**
+ * @category   Zend
+ * @package    Zend_Filter
+ */
 class UriNormalize extends AbstractFilter
 {
     /**
@@ -32,7 +44,9 @@ class UriNormalize extends AbstractFilter
      */
     public function __construct($options = null)
     {
-        if ($options) $this->setOptions($options);
+        if ($options) {
+            $this->setOptions($options);
+        }
     }
 
     /**
@@ -81,13 +95,13 @@ class UriNormalize extends AbstractFilter
         $defaultScheme = $this->defaultScheme ?: $this->enforcedScheme;
 
         // Reset default scheme if it is not a known scheme
-        if (! UriFactory::getRegisteredSchemeClass($defaultScheme)) {
+        if (!UriFactory::getRegisteredSchemeClass($defaultScheme)) {
             $defaultScheme = null;
         }
 
         try {
             $uri = UriFactory::factory($value, $defaultScheme);
-            if ($this->enforcedScheme && (! $uri->getScheme())) {
+            if ($this->enforcedScheme && (!$uri->getScheme())) {
                 $this->enforceScheme($uri);
             }
 
@@ -98,7 +112,7 @@ class UriNormalize extends AbstractFilter
 
         $uri->normalize();
 
-        if (! $uri->isValid()) {
+        if (!$uri->isValid()) {
             return $value;
         }
 
@@ -125,7 +139,9 @@ class UriNormalize extends AbstractFilter
         }
 
         // We have nothing to do if we have no host
-        if (! $host) return;
+        if (!$host) {
+            return;
+        }
 
         $uri->setScheme($this->enforcedScheme)
             ->setHost($host)

--- a/library/Zend/Uri/UriFactory.php
+++ b/library/Zend/Uri/UriFactory.php
@@ -67,6 +67,23 @@ abstract class UriFactory
     }
 
     /**
+     * Get the class name for a registered scheme
+     *
+     * If provided scheme is not registered, will return NULL
+     *
+     * @param  string $scheme
+     * @return string|null
+     */
+    public static function getRegisteredSchemeClass($scheme)
+    {
+        if (isset(static::$schemeClasses[$scheme])) {
+            return static::$schemeClasses[$scheme];
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * Create a URI from a string
      *
      * @param  string $uriString

--- a/tests/ZendTest/Filter/UriNormalizeTest.php
+++ b/tests/ZendTest/Filter/UriNormalizeTest.php
@@ -1,9 +1,23 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Filter
+ */
 
 namespace ZendTest\Filter;
 
 use Zend\Filter\UriNormalize;
 
+/**
+ * @category   Zend
+ * @package    Zend_Filter
+ * @subpackage UnitTests
+ * @group      Zend_Filter
+ */
 class UriNormalizeTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -31,7 +45,7 @@ class UriNormalizeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
     }
 
-    static public function abnormalUriProvider()
+    public static function abnormalUriProvider()
     {
         return array(
             array('http://www.example.com', 'http://www.example.com/'),
@@ -43,7 +57,7 @@ class UriNormalizeTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    static public function enforcedSchemeTestcaseProvider()
+    public static function enforcedSchemeTestcaseProvider()
     {
         return array(
             array('ftp', 'http://www.example.com', 'http://www.example.com/'), // no effect - this one has a scheme


### PR DESCRIPTION
This adds a Zend\Filter that allows URI normalization. In addition to normalizing URIs based on their given scheme, it will also allow enforcing a scheme on scheme-less URIs (e.g. converting strings such as 'www.example.com' to 'http://www.example.com/'). 
