### PR TITLE
[ZF2-479] Zend\Db\Sql : Handling of null value on query mode Execute

### DIFF
--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -118,7 +118,15 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
                     if (is_string($pkey) && strpos($pkey, '?') !== false) {
                         $predicate = new Predicate\Expression($pkey, $pvalue);
                     } elseif (is_string($pkey)) {
-                        $predicate = new Predicate\Operator($pkey, Predicate\Operator::OP_EQ, $pvalue);
+                        if (is_null($pvalue)) {
+                            $predicate = new Predicate\IsNull($pkey, $pvalue);
+                        } else if (is_array($pvalue)) {
+                            $predicate = new Predicate\In($pkey, $pvalue);
+                        } else {
+                            $predicate = new Predicate\Operator($pkey, Predicate\Operator::OP_EQ, $pvalue);
+                        }
+                    } else if ($pvalue instanceof Predicate\PredicateInterface) {
+                        $predicate = $pvalue;
                     } else {
                         $predicate = new Predicate\Expression($pvalue);
                     }

--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -120,12 +120,12 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
                     } elseif (is_string($pkey)) {
                         if (is_null($pvalue)) {
                             $predicate = new Predicate\IsNull($pkey, $pvalue);
-                        } else if (is_array($pvalue)) {
+                        } elseif (is_array($pvalue)) {
                             $predicate = new Predicate\In($pkey, $pvalue);
                         } else {
                             $predicate = new Predicate\Operator($pkey, Predicate\Operator::OP_EQ, $pvalue);
                         }
-                    } else if ($pvalue instanceof Predicate\PredicateInterface) {
+                    } elseif ($pvalue instanceof Predicate\PredicateInterface) {
                         $predicate = $pvalue;
                     } else {
                         $predicate = new Predicate\Expression($pvalue);

--- a/library/Zend/Db/Sql/Insert.php
+++ b/library/Zend/Db/Sql/Insert.php
@@ -193,7 +193,7 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
             if ($value instanceof Expression) {
                 $exprData = $this->processExpression($value, $adapterPlatform);
                 $values[] = $exprData->getSql();
-            } else if (is_null($value)) {
+            } elseif (is_null($value)) {
                 $values[] = 'NULL';
             } else {
                 $values[] = $adapterPlatform->quoteValue($value);

--- a/library/Zend/Db/Sql/Insert.php
+++ b/library/Zend/Db/Sql/Insert.php
@@ -193,6 +193,8 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
             if ($value instanceof Expression) {
                 $exprData = $this->processExpression($value, $adapterPlatform);
                 $values[] = $exprData->getSql();
+            } else if (is_null($value)) {
+                $values[] = 'NULL';
             } else {
                 $values[] = $adapterPlatform->quoteValue($value);
             }

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -249,12 +249,12 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                     } elseif (is_string($pkey)) {
                         if (is_null($pvalue)) {
                             $predicate = new Predicate\IsNull($pkey, $pvalue);
-                        } else if (is_array($pvalue)) {
+                        } elseif (is_array($pvalue)) {
                             $predicate = new Predicate\In($pkey, $pvalue);
                         } else {
                             $predicate = new Predicate\Operator($pkey, Predicate\Operator::OP_EQ, $pvalue);
                         }
-                    } else if ($pvalue instanceof Predicate\PredicateInterface) {
+                    } elseif ($pvalue instanceof Predicate\PredicateInterface) {
                         $predicate = $pvalue;
                     } else {
                         $predicate = new Predicate\Expression($pvalue);

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -247,7 +247,15 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                     if (is_string($pkey) && strpos($pkey, '?') !== false) {
                         $predicate = new Predicate\Expression($pkey, $pvalue);
                     } elseif (is_string($pkey)) {
-                        $predicate = new Predicate\Operator($pkey, Predicate\Operator::OP_EQ, $pvalue);
+                        if (is_null($pvalue)) {
+                            $predicate = new Predicate\IsNull($pkey, $pvalue);
+                        } else if (is_array($pvalue)) {
+                            $predicate = new Predicate\In($pkey, $pvalue);
+                        } else {
+                            $predicate = new Predicate\Operator($pkey, Predicate\Operator::OP_EQ, $pvalue);
+                        }
+                    } else if ($pvalue instanceof Predicate\PredicateInterface) {
+                        $predicate = $pvalue;
                     } else {
                         $predicate = new Predicate\Expression($pvalue);
                     }

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -140,12 +140,12 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
                     } elseif (is_string($pkey)) {
                         if (is_null($pvalue)) {
                             $predicate = new Predicate\IsNull($pkey, $pvalue);
-                        } else if (is_array($pvalue)) {
+                        } elseif (is_array($pvalue)) {
                             $predicate = new Predicate\In($pkey, $pvalue);
                         } else {
                             $predicate = new Predicate\Operator($pkey, Predicate\Operator::OP_EQ, $pvalue);
                         }
-                    } else if ($pvalue instanceof Predicate\PredicateInterface) {
+                    } elseif ($pvalue instanceof Predicate\PredicateInterface) {
                         $predicate = $pvalue;
                     } else {
                         $predicate = new Predicate\Expression($pvalue);
@@ -233,7 +233,7 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 if ($value instanceof Expression) {
                     $exprData = $this->processExpression($value, $adapterPlatform);
                     $setSql[] = $adapterPlatform->quoteIdentifier($column) . ' = ' . $exprData->getSql();
-                } else if (is_null($value)) {
+                } elseif (is_null($value)) {
                     $setSql[] = $adapterPlatform->quoteIdentifier($column) . ' = NULL';
                 } else {
                     $setSql[] = $adapterPlatform->quoteIdentifier($column) . ' = ' . $adapterPlatform->quoteValue($value);

--- a/tests/ZendTest/Db/Sql/DeleteTest.php
+++ b/tests/ZendTest/Db/Sql/DeleteTest.php
@@ -122,4 +122,51 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
         ));
         $this->assertCount(2, $this->delete->getRawState('where'));
     }
+    
+    
+    
+     
+    /**
+     * @covers Zend\Db\Sql\Delete::where
+     * @group ZF2-479
+     */
+    public function testWhereArrayEnhanced()
+    {
+        $this->delete->from('table');
+        $this->delete->where(array(
+            'c1' => null,
+            'c2' => array(1, 2, 3),
+            new \Zend\Db\Sql\Predicate\IsNotNull('c3')
+        ));
+        $this->assertEquals('DELETE FROM "table" WHERE "c1" IS NULL AND "c2" IN (\'1\', \'2\', \'3\') AND "c3" IS NOT NULL', $this->delete->getSqlString());
+    }
+
+    /**
+     * @covers Zend\Db\Sql\Delete::prepareStatement
+     * @group ZF2-479
+     */
+    public function testPrepareStatementEnhanced()
+    {
+        $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue('positional'));
+        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
+        $mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver));
+
+        $mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $pContainer = new \Zend\Db\Adapter\ParameterContainer(array());
+        $mockStatement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($pContainer));
+
+        $mockStatement->expects($this->at(1))
+                ->method('setSql')
+                ->with($this->equalTo('DELETE FROM "table" WHERE "c1" IS NULL AND "c2" IN (?, ?, ?) AND "c3" IS NOT NULL'));
+
+        $this->delete->from('table');
+        $this->delete->where(array(
+            'c1' => null,
+            'c2' => array(1, 2, 3),
+            new \Zend\Db\Sql\Predicate\IsNotNull('c3')
+        ));
+
+        $this->delete->prepareStatement($mockAdapter, $mockStatement);
+    }
 }

--- a/tests/ZendTest/Db/Sql/DeleteTest.php
+++ b/tests/ZendTest/Db/Sql/DeleteTest.php
@@ -122,10 +122,9 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
         ));
         $this->assertCount(2, $this->delete->getRawState('where'));
     }
-    
-    
-    
-     
+
+
+
     /**
      * @covers Zend\Db\Sql\Delete::where
      * @group ZF2-479

--- a/tests/ZendTest/Db/Sql/InsertTest.php
+++ b/tests/ZendTest/Db/Sql/InsertTest.php
@@ -136,4 +136,17 @@ class InsertTest extends \PHPUnit_Framework_TestCase
         $this->insert->foo = 'bar';
         $this->assertEquals('bar', $this->insert->foo);
     }
+    
+        
+    /**
+     * @covers Zend\Db\Sql\Insert::getSqlString
+     * @group ZF2-479
+     */
+    public function testGetSqlStringNull()
+    {
+        $this->insert->into('foo')
+            ->values(array('bar' => 'baz', 'boo' => null));
+
+        $this->assertEquals('INSERT INTO "foo" ("bar", "boo") VALUES (\'baz\', NULL)', $this->insert->getSqlString());
+    }
 }

--- a/tests/ZendTest/Db/Sql/InsertTest.php
+++ b/tests/ZendTest/Db/Sql/InsertTest.php
@@ -136,8 +136,8 @@ class InsertTest extends \PHPUnit_Framework_TestCase
         $this->insert->foo = 'bar';
         $this->assertEquals('bar', $this->insert->foo);
     }
-    
-        
+
+
     /**
      * @covers Zend\Db\Sql\Insert::getSqlString
      * @group ZF2-479

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -768,10 +768,10 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    
-    
 
-     
+
+
+
     /**
      * @covers Zend\Db\Sql\Select::where
      * @group ZF2-479

--- a/tests/ZendTest/Db/Sql/UpdateTest.php
+++ b/tests/ZendTest/Db/Sql/UpdateTest.php
@@ -162,10 +162,9 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
             ));
         $this->assertEquals('UPDATE "foo" SET "bar" = \'baz\' WHERE id = \'1\'', $update2->getSqlString());
     }
-    
-    
-    
-    
+
+
+
     /**
      * @covers Zend\Db\Sql\Update::getSqlString
      * @group ZF2-479
@@ -178,8 +177,8 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('UPDATE "foo" SET "bar" = \'baz\', "boo" = NULL WHERE x = y', $this->update->getSqlString());
     }
-    
-    
+
+
     /**
      * @covers Zend\Db\Sql\Update::where
      * @group ZF2-479
@@ -195,7 +194,7 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
          ));
         $this->assertEquals('UPDATE "table" SET "foo" = \'bar\' WHERE "c1" IS NULL AND "c2" IN (\'1\', \'2\', \'3\') AND "c3" IS NOT NULL', $this->update->getSqlString());
     }
-    
+
     /**
      * @covers Zend\Db\Sql\Update::prepareStatement
      * @group ZF2-479


### PR DESCRIPTION
_The old pull request was from master, moved to a new branch_

See : http://framework.zend.com/issues/browse/ZF2-479
There is no issue with prepared statement.

It also enhance the where method of Select, Update and Delete when using an array parameter.

```
$select->where(array(
    'c1' => null,
    'c2' => array(1, 2, 3),
    new \Zend\Db\Sql\Predicate\IsNotNull('c3')
));
```

If the value is : 
- null, then It will convert it to Predicate/IsNull, 
- an array, it will convert it to Predicate/In
- instanceof Predicate/PredicateInterface, no conversion

Be careful if you use prepared statement, the prepared string will be something like

```
SELECT "table".* FROM "table" WHERE "c1" IS NULL AND "c2" IN (?, ?, ?) AND "c3" IS NOT NULL
```

There will be no placeholder for c1, and c2 must need a fixed number of values.
