### PR TITLE
Feature/adding getOpeningTag to abstractHtmlElement

### DIFF
--- a/library/Zend/View/Helper/AbstractHtmlElement.php
+++ b/library/Zend/View/Helper/AbstractHtmlElement.php
@@ -41,14 +41,16 @@ abstract class AbstractHtmlElement extends AbstractHelper
      * Note, no closing bracket is added
      *
      * @param string $element the tag name, such as table, ul, div etc
-     * @param array $attribs From this array, each key-value pair is
-     * converted to an attribute name and value.
+     * @param array  $attribs From this array, each key-value pair is
+     *                        converted to an attribute name and value.
      *
      * @return string
      */
     public function getOpeningTag($element, array $attribs = null)
     {
-        $str =  '<' . $element;
+        $escaper = $this->view->plugin('escapehtml');
+
+        $str = '<' . $escaper($element);
 
         if ($attribs) {
             $attribs = $this->htmlAttribs($attribs);
@@ -94,13 +96,13 @@ abstract class AbstractHtmlElement extends AbstractHelper
      * @access public
      *
      * @param array $attribs From this array, each key-value pair is
-     * converted to an attribute name and value.
+     *                       converted to an attribute name and value.
      *
      * @return string The XHTML for the attributes.
      */
     protected function htmlAttribs($attribs)
     {
-        $xhtml   = '';
+        $xhtml = '';
         $escaper = $this->view->plugin('escapehtml');
         foreach ((array) $attribs as $key => $val) {
             $key = $escaper($key);
@@ -141,6 +143,7 @@ abstract class AbstractHtmlElement extends AbstractHelper
      * Normalize an ID
      *
      * @param  string $value
+     *
      * @return string
      */
     protected function normalizeId($value)

--- a/library/Zend/View/Helper/AbstractHtmlElement.php
+++ b/library/Zend/View/Helper/AbstractHtmlElement.php
@@ -30,6 +30,36 @@ abstract class AbstractHtmlElement extends AbstractHelper
     protected $closingBracket = null;
 
     /**
+     * The opening tag html
+     *
+     * @var string
+     */
+    protected $openingTag = null;
+
+    /**
+     * Build the opening tag for an element, e.g. <foo class="bar" id="zar"
+     * Note, no closing bracket is added
+     *
+     * @param string $element the tag name, such as table, ul, div etc
+     * @param array $attribs From this array, each key-value pair is
+     * converted to an attribute name and value.
+     *
+     * @return string
+     */
+    public function getOpeningTag($element, array $attribs = null)
+    {
+        $str =  '<' . $element;
+
+        if ($attribs) {
+            $attribs = $this->htmlAttribs($attribs);
+            $str .= $attribs;
+        }
+
+        $this->openingTag = $str;
+        return $this->openingTag;
+    }
+
+    /**
      * Get the tag closing bracket
      *
      * @return string

--- a/tests/ZendTest/View/Helper/HtmlElementTest.php
+++ b/tests/ZendTest/View/Helper/HtmlElementTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_View
+ */
+
+namespace ZendTest\View\Helper;
+
+use Zend\View\Renderer\PhpRenderer as View;
+use ZendTest\View\Helper\TestAsset\OpeningTagHelper;
+
+/**
+ * @category   Zend
+ * @package    Zend_View
+ * @subpackage UnitTests
+ * @group      Zend_View
+ * @group      Zend_View_Helper
+ */
+class HtmlElementTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Zend_View_Helper_HtmlPage
+     */
+    public $helper;
+
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     * This method is called before a test is executed.
+     *
+     * @access protected
+     */
+    protected function setUp()
+    {
+        $this->view   = new View();
+        $this->helper = new OpeningTagHelper();
+        $this->helper->setView($this->view);
+    }
+
+    public function tearDown()
+    {
+        unset($this->helper);
+    }
+
+    public function testOpeningTag()
+    {
+        $output = $this->helper->__invoke();
+        $this->assertSame($output, '<div');
+    }
+
+    public function testOpeningTagWithAttributes(){
+        $attr = array(
+            'class' => array('alpha', 'bravo'),
+            'id' => 'some-id'
+        );
+        $output = $this->helper->__invoke($attr);
+        $this->assertSame($output, '<div class="alpha bravo" id="some-id"');
+    }
+}

--- a/tests/ZendTest/View/Helper/TestAsset/OpeningTagHelper.php
+++ b/tests/ZendTest/View/Helper/TestAsset/OpeningTagHelper.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Validator
+ */
+
+namespace ZendTest\View\Helper\TestAsset;
+
+use Zend\View\Helper\AbstractHtmlElement;
+
+class OpeningTagHelper extends AbstractHtmlElement
+{
+    public function __invoke($attribs = array())
+    {
+        return $this->getOpeningTag('div', $attribs);
+    }
+}


### PR DESCRIPTION
This replaces PR 2186 with a neater commit history! 
- Adding method to create an opening html tag sans closing bracket: <foo class="bar" id="zar" 
- Removing addition of '>' from the opening tag method (in 2186) for support of single tags in need of '/>'
- BONUS! 3 very minor cs changes!
- unit tests added

-- TODO validate element value for valid html tag name
