### PR TITLE
Fix for broken caching of translations

### DIFF
--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -446,7 +446,7 @@ class Translator
         if (null !== ($cache = $this->getCache())) {
             $cacheId = 'Zend_I18n_Translator_Messages_' . md5($textDomain . $locale);
 
-            if (false !== ($result = $cache->getItem($cacheId))) {
+            if (null !== ($result = $cache->getItem($cacheId))) {
                 $this->messages[$textDomain][$locale] = $result;
                 return;
             }

--- a/tests/ZendTest/I18n/Translator/TranslatorTest.php
+++ b/tests/ZendTest/I18n/Translator/TranslatorTest.php
@@ -112,6 +112,20 @@ class TranslatorTest extends TestCase
         $this->assertEquals('bar', $this->translator->translate('foo'));
     }
 
+
+    public function testTranslateWithCache()
+    {
+        $cache = \Zend\Cache\StorageFactory::factory(array('adapter' => 'memory'));
+        $this->translator->setCache($cache);
+
+        $loader = new TestLoader();
+        $loader->textDomain = new TextDomain(array('foo' => 'bar'));
+        $this->translator->getPluginManager()->setService('test', $loader);
+        $this->translator->addTranslationFile('test', null);
+
+        $this->assertEquals('bar', $this->translator->translate('foo'));
+    }
+
     public function testTranslatePlurals()
     {
         $this->translator->setLocale('en_EN');


### PR DESCRIPTION
Setting a cache object on the translator caused translation to break due to an incorrect return value check (false rather than null).  This PR resolves the issue and includes a new unit test to verify it.
