### PR TITLE
Hotfix/servicemanager duplicate services

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -889,8 +889,8 @@ class ServiceManager implements ServiceLocatorInterface
      * Called when $allowOverride is true and we detect that a service being
      * added to the instance already exists. This will remove the duplicate
      * entry, and also any shared flags previously registered.
-     * 
-     * @param  string $canonical 
+     *
+     * @param  string $canonical
      * @return void
      */
     protected function unregisterService($canonical)

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -212,15 +212,18 @@ class ServiceManager implements ServiceLocatorInterface
         $cName = $this->canonicalizeName($name);
         $rName = $name;
 
-        if ($this->allowOverride === false && $this->has(array($cName, $rName), false)) {
-            throw new Exception\InvalidServiceNameException(sprintf(
-                'A service by the name or alias "%s" already exists and cannot be overridden; please use an alternate name',
-                $cName
-            ));
+        if ($this->has(array($cName, $rName), false)) {
+            if ($this->allowOverride === false) {
+                throw new Exception\InvalidServiceNameException(sprintf(
+                    'A service by the name or alias "%s" already exists and cannot be overridden; please use an alternate name',
+                    $cName
+                ));
+            }
+            $this->unregisterService($cName);
         }
 
         $this->invokableClasses[$cName] = $invokableClass;
-        $this->shared[$cName]    = (bool) $shared;
+        $this->shared[$cName]           = (bool) $shared;
 
         return $this;
     }
@@ -243,11 +246,14 @@ class ServiceManager implements ServiceLocatorInterface
             );
         }
 
-        if ($this->allowOverride === false && $this->has(array($cName, $rName), false)) {
-            throw new Exception\InvalidServiceNameException(sprintf(
-                'A service by the name or alias "%s" already exists and cannot be overridden, please use an alternate name',
-                $cName
-            ));
+        if ($this->has(array($cName, $rName), false)) {
+            if ($this->allowOverride === false) {
+                throw new Exception\InvalidServiceNameException(sprintf(
+                    'A service by the name or alias "%s" already exists and cannot be overridden, please use an alternate name',
+                    $cName
+                ));
+            }
+            $this->unregisterService($cName);
         }
 
         $this->factories[$cName] = $factory;
@@ -328,17 +334,16 @@ class ServiceManager implements ServiceLocatorInterface
     {
         $cName = $this->canonicalizeName($name);
 
-        if ($this->allowOverride === false && $this->has($cName, false)) {
-            throw new Exception\InvalidServiceNameException(sprintf(
-                '%s: A service by the name "%s" or alias already exists and cannot be overridden, please use an alternate name.',
-                __METHOD__,
-                $name
-            ));
+        if ($this->has($cName, false)) {
+            if ($this->allowOverride === false) {
+                throw new Exception\InvalidServiceNameException(sprintf(
+                    '%s: A service by the name "%s" or alias already exists and cannot be overridden, please use an alternate name.',
+                    __METHOD__,
+                    $name
+                ));
+            }
+            $this->unregisterService($cName);
         }
-
-        /**
-         * @todo If a service is being overwritten, destroy all previous aliases
-         */
 
         $this->instances[$cName] = $service;
         $this->shared[$cName]    = (bool) $shared;
@@ -876,5 +881,34 @@ class ServiceManager implements ServiceLocatorInterface
         }
         $r = new ReflectionClass($className);
         return $r->implementsInterface($type);
+    }
+
+    /**
+     * Unregister a service
+     *
+     * Called when $allowOverride is true and we detect that a service being
+     * added to the instance already exists. This will remove the duplicate
+     * entry, and also any shared flags previously registered.
+     * 
+     * @param  string $canonical 
+     * @return void
+     */
+    protected function unregisterService($canonical)
+    {
+        $types = array('invokableClasses', 'factories', 'aliases');
+        foreach ($types as $type) {
+            if (isset($this->{$type}[$canonical])) {
+                unset($this->{$type}[$canonical]);
+                break;
+            }
+        }
+
+        if (isset($this->instances[$canonical])) {
+            unset($this->instances[$canonical]);
+        }
+
+        if (isset($this->shared[$canonical])) {
+            unset($this->shared[$canonical]);
+        }
     }
 }

--- a/tests/ZendTest/Barcode/FactoryTest.php
+++ b/tests/ZendTest/Barcode/FactoryTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\Barcode;
 
+use ReflectionClass;
 use Zend\Barcode;
 use Zend\Barcode\Renderer;
 use Zend\Barcode\Object;
@@ -38,19 +39,21 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         // Set timezone to avoid "It is not safe to rely on the system's timezone settings."
         // message if timezone is not set within php.ini
         date_default_timezone_set('GMT');
+
+        // Reset plugin managers
+        $r = new ReflectionClass('Zend\Barcode\Barcode');
+
+        $rObjectPlugins = $r->getProperty('objectPlugins');
+        $rObjectPlugins->setAccessible(true);
+        $rObjectPlugins->setValue(null);
+
+        $rRendererPlugins = $r->getProperty('rendererPlugins');
+        $rRendererPlugins->setAccessible(true);
+        $rRendererPlugins->setValue(null);
     }
 
     public function tearDown()
     {
-        $objectPlugins = Barcode\Barcode::getObjectPluginManager();
-        $objectPlugins->setService('code25', null);
-        $objectPlugins->setService('code39', null);
-        $objectPlugins->setService('error', null);
-
-        $rendererPlugins = Barcode\Barcode::getRendererPluginManager();
-        $rendererPlugins->setService('image', null);
-        $rendererPlugins->setService('pdf', null);
-
         date_default_timezone_set($this->originaltimezone);
     }
 
@@ -62,6 +65,9 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($renderer->getBarcode() instanceof Object\Code39);
     }
 
+    /**
+     * @group fml
+     */
     public function testMinimalFactoryWithRenderer()
     {
         $renderer = Barcode\Barcode::factory('code39', 'pdf');

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -527,7 +527,7 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         return array(
             array(
-                'setFactory', 
+                'setFactory',
                 function ($services) use ($self) {
                     return $self;
                 },
@@ -535,13 +535,13 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
                 'assertSame',
             ),
             array(
-                'setInvokableClass', 
+                'setInvokableClass',
                 'stdClass',
                 'stdClass',
                 'assertInstanceOf',
             ),
             array(
-                'setService', 
+                'setService',
                 $self,
                 $self,
                 'assertSame',

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -521,4 +521,49 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\ServiceManager\Exception\InvalidArgumentException');
         $result = $this->serviceManager->addInitializer(get_class($this));
     }
+
+    public function duplicateService()
+    {
+        $self = $this;
+        return array(
+            array(
+                'setFactory', 
+                function ($services) use ($self) {
+                    return $self;
+                },
+                $self,
+                'assertSame',
+            ),
+            array(
+                'setInvokableClass', 
+                'stdClass',
+                'stdClass',
+                'assertInstanceOf',
+            ),
+            array(
+                'setService', 
+                $self,
+                $self,
+                'assertSame',
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider duplicateService
+     */
+    public function testWithAllowOverrideOnRegisteringAServiceDuplicatingAnExistingAliasShouldInvalidateTheAlias($method, $service, $expected, $assertion = 'assertSame')
+    {
+        $this->serviceManager->setAllowOverride(true);
+        $sm = $this->serviceManager;
+        $this->serviceManager->setFactory('http.response', function ($services) use ($sm) {
+            return $sm;
+        });
+        $this->serviceManager->setAlias('response', 'http.response');
+        $this->assertSame($sm, $this->serviceManager->get('response'));
+
+        $self = $this;
+        $this->serviceManager->{$method}('response', $service);
+        $this->{$assertion}($expected, $this->serviceManager->get('response'));
+    }
 }


### PR DESCRIPTION
This PR solves the following problem:
- You have marked your service manager to allowOverride == true (such as in the plugin managers)
- You have defined a service using, for example, the name "foo"
- You have aliased this service to "bar"
- You then create a service named "bar"

Previously, if you then retrieved "bar", you'd still get "foo". This PR makes it so that you'll now get the service you created last.

This will work properly now when you call setInvokableClass(), setFactory(), or setService().
