### PR TITLE
Synced url plugin and helper usage

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/Url.php
+++ b/library/Zend/Mvc/Controller/Plugin/Url.php
@@ -13,6 +13,7 @@ namespace Zend\Mvc\Controller\Plugin;
 use Zend\EventManager\EventInterface;
 use Zend\Mvc\Exception;
 use Zend\Mvc\InjectApplicationEventInterface;
+use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteStackInterface;
 
@@ -28,27 +29,58 @@ class Url extends AbstractPlugin
      *
      * @param  string $route RouteInterface name
      * @param  array $params Parameters to use in url generation, if any
-     * @param  array $options RouteInterface-specific options to use in url generation, if any
+     * @param  array|bool $options RouteInterface-specific options to use in url generation, if any. If boolean, and no fourth argument, used as $reuseMatchedParams
+     * @param  boolean $reuseMatchedParams Whether to reuse matched parameters
      * @return string
      * @throws Exception\DomainException if composed controller does not implement InjectApplicationEventInterface, or
      *         router cannot be found in controller event
      */
-    public function fromRoute($route, array $params = array(), array $options = array())
+    public function fromRoute($route = null, array $params = array(), $options = array(), $reuseMatchedParams = false)
     {
         $controller = $this->getController();
         if (!$controller instanceof InjectApplicationEventInterface) {
             throw new Exception\DomainException('Url plugin requires a controller that implements InjectApplicationEventInterface');
         }
 
-        $event  = $controller->getEvent();
-        $router = null;
+        $event   = $controller->getEvent();
+        $router  = null;
+        $matches =null;
         if ($event instanceof MvcEvent) {
-            $router = $event->getRouter();
+            $router  = $event->getRouter();
+            $matches = $event->getRouteMatch();
         } elseif ($event instanceof EventInterface) {
-            $router = $event->getParam('router', false);
+            $router  = $event->getParam('router', false);
+            $matches = $event->getParam('route-match', false);
         }
         if (!$router instanceof RouteStackInterface) {
             throw new Exception\DomainException('Url plugin requires that controller event compose a router; none found');
+        }
+
+        if (3 == func_num_args() && is_bool($options)) {
+            $reuseMatchedParams = $options;
+            $options = array();
+        }
+
+        if ($route === null) {
+            if (!$matches) {
+                throw new Exception\RuntimeException('No RouteMatch instance present');
+            }
+
+            $route = $matches->getMatchedRouteName();
+
+            if ($route === null) {
+                throw new Exception\RuntimeException('RouteMatch does not contain a matched route name');
+            }
+        }
+
+        if ($reuseMatchedParams && $matches) {
+            $routeMatchParams = $matches->getParams();
+
+            if (isset($routeMatchParams[ModuleRouteListener::ORIGINAL_CONTROLLER])) {
+                $routeMatchParams['controller'] = $routeMatchParams[ModuleRouteListener::ORIGINAL_CONTROLLER];
+            }
+
+            $params = array_merge($routeMatchParams, $params);
         }
 
         $options['name'] = $route;

--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -74,10 +74,15 @@ class Url extends AbstractHelper
      * @throws Exception\RuntimeException  If no RouteMatch was provided
      * @throws Exception\RuntimeException  If RouteMatch didn't contain a matched route name
      */
-    public function __invoke($name = null, array $params = array(), array $options = array(), $reuseMatchedParams = false)
+    public function __invoke($name = null, array $params = array(), $options = array(), $reuseMatchedParams = false)
     {
         if (null === $this->router) {
             throw new Exception\RuntimeException('No RouteStackInterface instance provided');
+        }
+
+        if (3 == func_num_args() && is_bool($options)) {
+            $reuseMatchedParams = $options;
+            $options = array();
         }
 
         if ($name === null) {


### PR DESCRIPTION
As reported by Ralf Eggert on the mailing list, the signatures for the url controller plugin and view helper differ. Additionally, the "reuseMatchedParameters" flag, being a final optional flag, is hard to set. This PR addresses these issues.
- Both now allow using route match parameters
- Both now allow empty invocation (defaulting to current matched route)
- Both now allow passing the $reuseMatchedParams flag as the third
  parameter if no options are being passed
- Unit tests were added for both classes
