### PR TITLE
Fixes: FormButton using wrong label; FormElement to use FormButton helper

### DIFF
--- a/library/Zend/Form/View/Helper/FormButton.php
+++ b/library/Zend/Form/View/Helper/FormButton.php
@@ -116,19 +116,22 @@ class FormButton extends FormInput
     public function render(ElementInterface $element, $buttonContent = null)
     {
         $openTag = $this->openTag($element);
-        $content = false;
+
         if (null === $buttonContent) {
-            $content = $element->getAttribute('label');
-            if (null === $content) {
+            $buttonContent = $element->getLabel();
+            if (null === $buttonContent) {
                 throw new Exception\DomainException(sprintf(
-                    '%s expects either button content as the second argument, or that the element provided has a label attribute; neither found',
+                    '%s expects either button content as the second argument, ' .
+                    'or that the element provided has a label value; neither found',
                     __METHOD__
                 ));
             }
-        }
 
-        if ($content && null === $buttonContent) {
-            $buttonContent = $content;
+            if (null !== ($translator = $this->getTranslator())) {
+                $buttonContent = $translator->translate(
+                    $buttonContent, $this->getTranslatorTextDomain()
+                );
+            }
         }
 
         $escape = $this->getEscapeHtmlHelper();

--- a/library/Zend/Form/View/Helper/FormElement.php
+++ b/library/Zend/Form/View/Helper/FormElement.php
@@ -38,6 +38,11 @@ class FormElement extends BaseAbstractHelper
             return '';
         }
 
+        if ($element instanceof Element\Button) {
+            $helper = $renderer->plugin('form_button');
+            return $helper($element);
+        }
+
         if ($element instanceof Element\Captcha) {
             $helper = $renderer->plugin('form_captcha');
             return $helper($element);

--- a/tests/ZendTest/Form/View/Helper/FormButtonTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormButtonTest.php
@@ -190,7 +190,7 @@ class FormButtonTest extends CommonTestCase
     public function testAllValidFormMarkupAttributesPresentInElementAreRendered($attribute, $assertion)
     {
         $element = $this->getCompleteElement();
-        $element->setAttribute('label', '{button_content}');
+        $element->setLabel('{button_content}');
         $markup  = $this->helper->render($element);
         switch ($attribute) {
             case 'value':
@@ -213,7 +213,7 @@ class FormButtonTest extends CommonTestCase
     public function testPassingElementToRenderGeneratesButtonMarkup()
     {
         $element = new Element('foo');
-        $element->setAttribute('label', '{button_content}');
+        $element->setLabel('{button_content}');
         $markup = $this->helper->render($element);
         $this->assertContains('>{button_content}<', $markup);
         $this->assertContains('name="foo"', $markup);

--- a/tests/ZendTest/Form/View/Helper/FormButtonTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormButtonTest.php
@@ -261,4 +261,35 @@ class FormButtonTest extends CommonTestCase
         $markup = $this->helper->__invoke($element, '{button_content}');
         $this->assertContains('name="0"', $markup);
     }
+
+    public function testCanTranslateContent()
+    {
+        $element = new Element('foo');
+        $element->setLabel('The value for foo:');
+
+        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+        $mockTranslator->expects($this->exactly(1))
+            ->method('translate')
+            ->will($this->returnValue('translated content'));
+
+        $this->helper->setTranslator($mockTranslator);
+        $this->assertTrue($this->helper->hasTranslator());
+
+        $markup = $this->helper->__invoke($element);
+        $this->assertContains('>translated content<', $markup);
+    }
+
+    public function testTranslatorMethods()
+    {
+        $translatorMock = $this->getMock('Zend\I18n\Translator\Translator');
+        $this->helper->setTranslator($translatorMock, 'foo');
+
+        $this->assertEquals($translatorMock, $this->helper->getTranslator());
+        $this->assertEquals('foo', $this->helper->getTranslatorTextDomain());
+        $this->assertTrue($this->helper->hasTranslator());
+        $this->assertTrue($this->helper->isTranslatorEnabled());
+
+        $this->helper->setTranslatorEnabled(false);
+        $this->assertFalse($this->helper->isTranslatorEnabled());
+    }
 }

--- a/tests/ZendTest/Form/View/Helper/FormElementTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormElementTest.php
@@ -171,6 +171,16 @@ class FormElementTest extends TestCase
         $this->assertContains('>Initial content<', $markup);
     }
 
+    public function testRendersButtonAsExpected()
+    {
+        $element = new Element\Button('foo');
+        $element->setLabel('My Button');
+        $markup  = $this->helper->render($element);
+
+        $this->assertContains('<button', $markup);
+        $this->assertContains('>My Button<', $markup);
+    }
+
     public function testInvokeWithNoElementChainsHelper()
     {
         $element = new Element('foo');


### PR DESCRIPTION
A while back the element labels changed from being in the "attributes" array to it's own property. It wasn't changed in the FormButton helper. Fixed.

Also, FormElement helper wasn't using the FormButton helper. Fixed.
