### PR TITLE
Add Zend\Db\Sql\Expression support to Zend\Db\Sql\Select::order().

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -676,7 +676,12 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         }
         $orders = array();
         foreach ($this->order as $k => $v) {
+            $quoteIdentifiers = true;
             if (is_int($k)) {
+                if ($v instanceof Expression) {
+                    $v = $this->processExpression($v, $platform, $adapter)->getSql();
+                    $quoteIdentifiers = false;  // expressions are already quoted
+                }
                 if (strpos($v, ' ') !== false) {
                     list($k, $v) = preg_split('# #', $v, 2);
                 } else {
@@ -684,10 +689,11 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                     $v = self::ORDER_ASCENDING;
                 }
             }
+            $k = $quoteIdentifiers ? $platform->quoteIdentifierInFragment($k) : $k;
             if (strtoupper($v) == self::ORDER_DESCENDING) {
-                $orders[] = array($platform->quoteIdentifierInFragment($k), self::ORDER_DESCENDING);
+                $orders[] = array($k, self::ORDER_DESCENDING);
             } else {
-                $orders[] = array($platform->quoteIdentifierInFragment($k), self::ORDER_ASCENDING);
+                $orders[] = array($k, self::ORDER_ASCENDING);
             }
         }
         return array($orders);

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -250,7 +250,18 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $select = new Select;
         $select->order(array('name ASC', 'age DESC'));
         $this->assertEquals(array('name ASC', 'age DESC'), $select->getRawState('order'));
+    }
 
+    /**
+     * @author Demian Katz
+     * @testdox unit test: Test order() supports Expressions
+     * @covers Zend\Db\Sql\Select::order
+     */
+    public function testOrderSupportsExpressions()
+    {
+        $select = new Select;
+        $select->order(array(new Expression('isnull(?) desc', array('name'), array(Expression::TYPE_IDENTIFIER)), 'name'));
+        $this->assertEquals('ORDER BY isnull("name") DESC, "name" ASC', $select->getSqlString());
     }
 
     /**


### PR DESCRIPTION
Sometimes it is useful to use complex expressions rather than simple field names for sorting database results.  This patch allows Zend\Db\Sql\Select to handle Zend\Db\Sql\Expression objects passed to the order() method.  It includes a unit test for the new functionality.
