### PR TITLE
Unchecked Zend\Form\View\Helper\FormMultiCheckbox

### DIFF
--- a/library/Zend/Form/View/Helper/FormMultiCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormMultiCheckbox.php
@@ -297,7 +297,7 @@ class FormMultiCheckbox extends FormInput
                 $inputAttributes = array_merge($inputAttributes, $optionSpec['attributes']);
             }
 
-            if (in_array($value, $selectedOptions, true)) {
+            if (in_array($value, $selectedOptions)) {
                 $selected = true;
             }
 


### PR DESCRIPTION
Checkbox is unchecked when option and value have various data types. I think that this behavior is wrong, because i usually get value from request as string and options are usually defined as int.

e.g.
$options = array(1 => 'test 1', 2 => 'test 2');
$request = array('1');
For this example, checkbox is unchecked.
