### PR TITLE
Hotfix for BC DateTime in Log namespace

### DIFF
--- a/library/Zend/Log/Formatter/Db.php
+++ b/library/Zend/Log/Formatter/Db.php
@@ -49,9 +49,12 @@ class Db implements FormatterInterface
      */
     public function format($event)
     {
-        if (isset($event['timestamp']) && $event['timestamp'] instanceof DateTime) {
-            $event['timestamp'] = $event['timestamp']->format($this->getDateTimeFormat());
-        }
+        $format = $this->getDateTimeFormat();
+        array_walk_recursive($event, function (&$value) use ($format) {
+            if ($value instanceof DateTime) {
+                $value = $value->format($format);
+            }
+        });
 
         return $event;
     }

--- a/library/Zend/Log/Formatter/Db.php
+++ b/library/Zend/Log/Formatter/Db.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Log
+ */
+
+namespace Zend\Log\Formatter;
+
+use DateTime;
+use Zend\Log\Exception;
+
+/**
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage Formatter
+ */
+class Db implements FormatterInterface
+{
+    /**
+     * Format specifier for DateTime objects in event data (default: ISO 8601)
+     *
+     * @see http://php.net/manual/en/function.date.php
+     * @var string
+     */
+    protected $dateTimeFormat = self::DEFAULT_DATETIME_FORMAT;
+
+    /**
+     * Class constructor
+     *
+     * @see http://php.net/manual/en/function.date.php
+     * @param null|string $dateTimeFormat Format specifier for DateTime objects in event data
+     */
+    public function __construct($dateTimeFormat = null)
+    {
+        if (null !== $dateTimeFormat) {
+            $this->setDateTimeFormat($dateTimeFormat);
+        }
+    }
+
+    /**
+     * Formats data to be written by the writer.
+     *
+     * @param array $event event data
+     * @return array
+     */
+    public function format($event)
+    {
+        if (isset($event['timestamp']) && $event['timestamp'] instanceof DateTime) {
+            $event['timestamp'] = $event['timestamp']->format($this->getDateTimeFormat());
+        }
+
+        return $event;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDateTimeFormat()
+    {
+        return $this->dateTimeFormat;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setDateTimeFormat($dateTimeFormat)
+    {
+        $this->dateTimeFormat = (string) $dateTimeFormat;
+        return $this;
+    }
+}

--- a/library/Zend/Log/Writer/Db.php
+++ b/library/Zend/Log/Writer/Db.php
@@ -14,6 +14,7 @@ use Traversable;
 use Zend\Db\Adapter\Adapter;
 use Zend\Log\Exception;
 use Zend\Log\Formatter;
+use Zend\Log\Formatter\Db as DbFormatter;
 
 /**
  * @category   Zend
@@ -91,18 +92,8 @@ class Db extends AbstractWriter
         if (!empty($separator)) {
             $this->separator = $separator;
         }
-    }
 
-    /**
-     * Formatting is not possible on this writer
-     *
-     * @param Formatter\FormatterInterface $formatter
-     * @return void
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setFormatter(Formatter\FormatterInterface $formatter)
-    {
-        throw new Exception\InvalidArgumentException(get_class() . ' does not support formatting');
+        $this->setFormatter(new DbFormatter());
     }
 
     /**
@@ -127,6 +118,8 @@ class Db extends AbstractWriter
         if (null === $this->db) {
             throw new Exception\RuntimeException('Database adapter is null');
         }
+
+        $event = $this->formatter->format($event);
 
         // Transform the event array into fields
         if (null === $this->columnMap) {

--- a/tests/ZendTest/Log/Formatter/DbTest.php
+++ b/tests/ZendTest/Log/Formatter/DbTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Log
+ */
+
+namespace ZendTest\Log\Formatter;
+
+use DateTime;
+use ZendTest\Log\TestAsset\StringObject;
+use Zend\Log\Formatter\Db as DbFormatter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage UnitTests
+ * @group      Zend_Log
+ */
+class DbTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultDateTimeFormat()
+    {
+        $formatter = new DbFormatter();
+        $this->assertEquals(DbFormatter::DEFAULT_DATETIME_FORMAT, $formatter->getDateTimeFormat());
+    }
+
+    /**
+     * @dataProvider provideDateTimeFormats
+     */
+    public function testSetDateTimeFormat($dateTimeFormat)
+    {
+        $formatter = new DbFormatter();
+        $formatter->setDateTimeFormat($dateTimeFormat);
+
+        $this->assertEquals($dateTimeFormat, $formatter->getDateTimeFormat());
+    }
+
+    /**
+     * @return array
+     */
+    public function provideDateTimeFormats()
+    {
+        return array(
+            array('r'),
+            array('U'),
+            array(DateTime::RSS),
+        );
+    }
+
+    /**
+     * @dataProvider provideDateTimeFormats
+     */
+    public function testAllowsSpecifyingDateTimeFormatAsConstructorArgument($dateTimeFormat)
+    {
+        $formatter = new DbFormatter($dateTimeFormat);
+
+        $this->assertEquals($dateTimeFormat, $formatter->getDateTimeFormat());
+    }
+
+    public function testFormatDateTimeInEvent()
+    {
+        $datetime = new DateTime();
+        $event = array('timestamp' => $datetime);
+        $formatter = new DbFormatter();
+
+        $format = DbFormatter::DEFAULT_DATETIME_FORMAT;
+        $this->assertContains($datetime->format($format), $formatter->format($event));
+    }
+}

--- a/tests/ZendTest/Log/Writer/DbTest.php
+++ b/tests/ZendTest/Log/Writer/DbTest.php
@@ -207,7 +207,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $this->writer->setFormatter(new \StdClass());
     }
 
-    public function testWriteDateTime()
+    public function testWriteDateTimeAsTimestamp()
     {
         $date = new DateTime();
         $event = array('timestamp'=> $date);
@@ -218,6 +218,24 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array(array(
             'timestamp' => $date->format(FormatterInterface::DEFAULT_DATETIME_FORMAT)
+        )), $this->db->calls['execute'][0]);
+    }
+
+    public function testWriteDateTimeAsExtraValue()
+    {
+        $date = new DateTime();
+        $event = array(
+            'extra'=> array(
+                'request_time' => $date
+            )
+        );
+        $this->writer->write($event);
+
+        $this->assertContains('query', array_keys($this->db->calls));
+        $this->assertEquals(1, count($this->db->calls['query']));
+
+        $this->assertEquals(array(array(
+            'extra_request_time' => $date->format(FormatterInterface::DEFAULT_DATETIME_FORMAT)
         )), $this->db->calls['execute'][0]);
     }
 }

--- a/tests/ZendTest/Log/Writer/DbTest.php
+++ b/tests/ZendTest/Log/Writer/DbTest.php
@@ -10,11 +10,11 @@
 
 namespace ZendTest\Log\Writer;
 
+use DateTime;
 use ZendTest\Log\TestAsset\MockDbAdapter;
 use ZendTest\Log\TestAsset\MockDbDriver;
 use Zend\Log\Writer\Db as DbWriter;
-use Zend\Log\Logger;
-use Zend\Log\Formatter\Simple as SimpleFormatter;
+use Zend\Log\Formatter\FormatterInterface;
 
 /**
  * @category   Zend
@@ -30,12 +30,6 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
         $this->db     = new MockDbAdapter();
         $this->writer = new DbWriter($this->db, $this->tableName);
-    }
-
-    public function testFormattingIsNotSupported()
-    {
-        $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException', 'does not support formatting');
-        $this->writer->setFormatter(new SimpleFormatter);
     }
 
     public function testNotPassingTableNameToConstructorThrowsException()
@@ -211,5 +205,19 @@ class DbTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('PHPUnit_Framework_Error');
         $this->writer->setFormatter(new \StdClass());
+    }
+
+    public function testWriteDateTime()
+    {
+        $date = new DateTime();
+        $event = array('timestamp'=> $date);
+        $this->writer->write($event);
+
+        $this->assertContains('query', array_keys($this->db->calls));
+        $this->assertEquals(1, count($this->db->calls['query']));
+
+        $this->assertEquals(array(array(
+            'timestamp' => $date->format(FormatterInterface::DEFAULT_DATETIME_FORMAT)
+        )), $this->db->calls['execute'][0]);
     }
 }


### PR DESCRIPTION
Today, DbWriter for Logger is broken since we change string timestamp by an instance of DateTime for the MongoDbWriter.

More details on [PR 2179](https://github.com/zendframework/zf2/pull/2179) and [PR 2029](https://github.com/zendframework/zf2/pull/2029).

@weierophinney can you verify that ZendMonitorWriter in not broken since this recent BC?
