### PR TITLE
Fix problems with Validator\Identical when the form has Fieldsets

### DIFF
--- a/library/Zend/Validator/Identical.php
+++ b/library/Zend/Validator/Identical.php
@@ -131,7 +131,25 @@ class Identical extends AbstractValidator
     {
         $this->setValue($value);
 
-        if (($context !== null) && isset($context) && array_key_exists($this->getToken(), $context)) {
+        $regexMatches = array();
+        $token = null;
+        if (($context !== null) && isset($context) && (preg_match_all('/(.+?)(?:\[)*\b([a-zA-Z]+)/', $this->getToken(), $regexMatches))) { // regex match example: user[name]
+            $firstKey = $regexMatches[1][0];
+            if(array_key_exists($firstKey, $context))
+            {
+                $tmpContext = $context[$firstKey];
+                for($i = 0; $i < count($regexMatches[0]); $i++) {
+                    $secondKey = $regexMatches[2][$i];
+                    // doesnt exists, reset token
+                    if(!array_key_exists($secondKey, $tmpContext)) {
+                        $token = null;
+                        break;
+                    }
+                    else // token = tmpToken
+                        $token = $tmpContext[$secondKey];
+                }
+            }
+        } elseif(($context !== null) && isset($context) && array_key_exists($this->getToken(), $context)) {
             $token = $context[$this->getToken()];
         } else {
             $token = $this->getToken();


### PR DESCRIPTION
Today this validator can't check a identical field if it is in a
fieldset.
Now you can do that passing a token like: 'user[password]' like our
forms names.

An example of usage:

/\* In the FORM */

```
    $confirmaSenhaInput = new \Zend\InputFilter\Input('confirm_password');
    $confirmaSenhaInput->setRequired(true);
    $validatorChain = new \Zend\Validator\ValidatorChain();
    $validatorChain->addValidator(new \Zend\Validator\Identical("user[password]"));
    $confirmaSenhaInput->setValidatorChain($validatorChain);
```

/\* In the FIELDSET named: USER */

```
    $this->add(array(
        'name' => 'password',
        'options' => array(
            'label' => 'Password*:'
        ),
        'attributes' => array(
            'required' => 'required',
            'id' => 'password',
        )
    ));
```
