### PR TITLE
[2.1] Load Messages from other than file

### DIFF
--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -127,7 +127,8 @@ class Translator
                     $pattern['type'],
                     $pattern['base_dir'],
                     $pattern['pattern'],
-                    isset($pattern['text_domain']) ? $pattern['text_domain'] : 'default'
+                    isset($pattern['text_domain']) ? $pattern['text_domain'] : 'default',
+                    isset($pattern['is_file']) ? $pattern['is_file'] : true
                 );
             }
         }
@@ -409,13 +410,15 @@ class Translator
      * @param  string $baseDir
      * @param  string $pattern
      * @param  string $textDomain
+     * @param  boolean $isFile
      * @return Translator
      */
     public function addTranslationPattern(
         $type,
         $baseDir,
         $pattern,
-        $textDomain = 'default'
+        $textDomain = 'default',
+        $isFile = true
     ) {
         if (!isset($this->patterns[$textDomain])) {
             $this->patterns[$textDomain] = array();
@@ -425,6 +428,7 @@ class Translator
             'type'    => $type,
             'baseDir' => rtrim($baseDir, '/'),
             'pattern' => $pattern,
+            'isFile' => $isFile,
         );
 
         return $this;
@@ -457,7 +461,7 @@ class Translator
             foreach ($this->patterns[$textDomain] as $pattern) {
                 $filename = $pattern['baseDir']
                           . '/' . sprintf($pattern['pattern'], $locale);
-                if (is_file($filename)) {
+                if ($pattern['isFile'] === false || is_file($filename)) {
                     $this->messages[$textDomain][$locale] = $this->getPluginManager()
                          ->get($pattern['type'])
                          ->load($filename, $locale);

--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -283,6 +283,11 @@ class Translator
         $locale      = ($locale ?: $this->getLocale());
         $translation = $this->getTranslatedMessage($message, $locale, $textDomain);
 
+        //allow use of translate if plurals are present
+        if(is_array($translation)) {
+            return $this->translatePlural($message, $message, 1, $textDomain, $locale);
+        }
+
         if ($translation !== null && $translation !== '') {
             return $translation;
         }

--- a/tests/ZendTest/I18n/Translator/TranslatorTest.php
+++ b/tests/ZendTest/I18n/Translator/TranslatorTest.php
@@ -161,12 +161,31 @@ class TranslatorTest extends TestCase
             'en_EN'
         );
 
-        $pl0 = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 1);
-        $pl1 = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 2);
-        $pl2 = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 10);
+        $pl0  = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 0);
+        $pl1  = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 1);
+        $pl2  = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 2);
+        $pl10 = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 10);
 
-        $this->assertEquals('Message 5 (en) Plural 0', $pl0);
-        $this->assertEquals('Message 5 (en) Plural 1', $pl1);
-        $this->assertEquals('Message 5 (en) Plural 2', $pl2);
+        $this->assertEquals('Message 5 (en) Plural 0 or not 10', $pl0);
+        $this->assertEquals('Message 5 (en) Plural 1 or Singular', $pl1);
+        $this->assertEquals('Message 5 (en) Plural 0 or not 10', $pl2);
+        $this->assertEquals('Message 5 (en) Plural 10', $pl10);
+    }
+
+    public function testTranslatePluralsAndSingular()
+    {
+        $this->translator->setLocale('en_EN');
+        $this->translator->addTranslationFile(
+            'phparray',
+            $this->testFilesDir . '/translation_en.php',
+            'default',
+            'en_EN'
+        );
+
+        $singular = $this->translator->translate('Message 5');
+        $plural   = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 1);
+
+        $this->assertEquals('Message 5 (en) Plural 1 or Singular', $singular);
+        $this->assertEquals('Message 5 (en) Plural 1 or Singular', $plural);
     }
 }

--- a/tests/ZendTest/I18n/Translator/TranslatorTest.php
+++ b/tests/ZendTest/I18n/Translator/TranslatorTest.php
@@ -52,7 +52,7 @@ class TranslatorTest extends TestCase
     {
         $translator = Translator::factory(array(
             'locale' => 'de_DE',
-            'patterns' => array(
+            'translation_patterns' => array(
                 array(
                     'type' => 'phparray',
                     'base_dir' => $this->testFilesDir . '/testarray',
@@ -75,7 +75,7 @@ class TranslatorTest extends TestCase
     {
         $translator = Translator::factory(array(
             'locale' => 'de_DE',
-            'patterns' => array(
+            'translation_patterns' => array(
                 array(
                     'type' => 'phparray',
                     'base_dir' => $this->testFilesDir . '/testarray',
@@ -110,6 +110,31 @@ class TranslatorTest extends TestCase
         $this->translator->addTranslationFile('test', null);
 
         $this->assertEquals('bar', $this->translator->translate('foo'));
+    }
+
+
+    public function testTranslateLoadFromOtherThanFile()
+    {
+        $translator = Translator::factory(array(
+            'locale' => 'es_ES',
+            'translation_patterns' => array(
+                array(
+                    'type' => 'test',
+                    'base_dir' => $this->testFilesDir . '/testarray',
+                    'pattern' => 'translation-%s.php',
+                    'is_file' => false
+                )
+            )
+        ));
+
+        $loader = $this->getMock('\Zend\I18N\Translator\Loader\LoaderInterface', array('load'));
+        $loader->expects($this->once())
+            ->method('load')
+            ->with($this->equalTo($this->testFilesDir . '/testarray/translation-es_ES.php'), $this->equalTo('es_ES'));
+
+        $translator->getPluginManager()->setService('test', $loader);
+
+        $this->assertEquals('foo', $translator->translate('foo'));
     }
 
 

--- a/tests/ZendTest/I18n/Translator/_files/translation_en.php
+++ b/tests/ZendTest/I18n/Translator/_files/translation_en.php
@@ -10,16 +10,16 @@
 
 return array(
     '' => array(
-        'plural_forms' => 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);'
+        'plural_forms' => 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n==0 || (n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20)) ? 1 : 2);'
     ),
     'Message 1' => 'Message 1 (en)',
     'Message 2' => 'Message 2 (en)',
     'Message 3' => 'Message 3 (en)',
     'Message 4' => 'Message 4 (en)',
     'Message 5' => array(
-        0 => 'Message 5 (en) Plural 0',
-        1 => 'Message 5 (en) Plural 1',
-        2 => 'Message 5 (en) Plural 2'
+        0 => 'Message 5 (en) Plural 1 or Singular',
+        1 => 'Message 5 (en) Plural 0 or not 10',
+        2 => 'Message 5 (en) Plural 10'
     ),
     'Cooking furniture' => 'Küchen Möbel (en)',
     'Küchen Möbel' => 'Cooking furniture (en)',


### PR DESCRIPTION
Added the possibility to load messages from other than files via configuration option. Default stays the same.

Introduced new option to translation_patterns => is_file (Default: true)
