### PR TITLE
Remove "application" identifier

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -199,7 +199,6 @@ class Application implements
         $eventManager->setIdentifiers(array(
             __CLASS__,
             get_called_class(),
-            'application',
         ));
         $this->events = $eventManager;
         return $this;

--- a/tests/ZendTest/Mvc/ApplicationTest.php
+++ b/tests/ZendTest/Mvc/ApplicationTest.php
@@ -135,7 +135,7 @@ class ApplicationTest extends TestCase
     {
         $events      = $this->application->getEventManager();
         $identifiers = $events->getIdentifiers();
-        $expected    = array('Zend\Mvc\Application', 'application');
+        $expected    = array('Zend\Mvc\Application');
         $this->assertEquals($expected, array_values($identifiers));
     }
 


### PR DESCRIPTION
- Removed the "application" identifier from the Zend\Mvc\Application
  EventManager instance. This currently can lead to confusion when you have an
  Application module, as both the identifiers "application" and "Application"
  can be in play; unless you know the difference for the casing, you may not
  know which one to attach to. Additionally, the convention we've established
  within the framework is to only use the FQCN and interface names as
  identifiers; this helps reduce collisions, as well as provide good semantics
  for those attaching listeners. (The one exception is that our controllers, by
  default, also attach the top-level namespace of the extending class, which is
  usually the module namespace; this is a good practice as it makes having
  module-specific listeners trivial.)
