### PR TITLE
ClassMethods hydrator to support getters prefixed with "is"

### DIFF
--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -71,6 +71,17 @@ class ClassMethods extends AbstractHydrator
                     $attribute = preg_replace_callback('/([A-Z])/', $transform, $attribute);
                 }
                 $attributes[$attribute] = $this->extractValue($attribute, $object->$method());
+            } elseif (preg_match('/^is[A-Z]\w*/', $method)) {
+                // setter verification
+                $setter = 'set' . ucfirst($method);
+                if (!in_array($setter, $methods)) {
+                    continue;
+                }
+                $attribute = $method;
+                if ($this->underscoreSeparatedKeys) {
+                    $attribute = preg_replace_callback('/([A-Z])/', $transform, $attribute);
+                }
+                $attributes[$attribute] = $this->extractValue($attribute, $object->$method());
             }
         }
 

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -58,8 +58,12 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals($this->classMethodsCamelCase->getFooBar(), '1');
         $this->assertEquals($this->classMethodsCamelCase->getFooBarBaz(), '2');
+        $this->assertEquals($this->classMethodsCamelCase->getIsFoo(), true);
+        $this->assertEquals($this->classMethodsCamelCase->isBar(), true);
         $this->assertEquals($this->classMethodsUnderscore->getFooBar(), '1');
         $this->assertEquals($this->classMethodsUnderscore->getFooBarBaz(), '2');
+        $this->assertEquals($this->classMethodsUnderscore->getIsFoo(), true);
+        $this->assertEquals($this->classMethodsUnderscore->isBar(), true);
     }
 
     public function testHydratorReflection()
@@ -87,10 +91,24 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($datas['fooBar'], '1');
         $this->assertTrue(isset($datas['fooBarBaz']));
         $this->assertFalse(isset($datas['foo_bar']));
-        $test = $hydrator->hydrate(array('fooBar' => 'foo', 'fooBarBaz' => 'bar'), $this->classMethodsCamelCase);
+        $this->assertTrue(isset($datas['isFoo']));
+        $this->assertEquals($datas['isFoo'], true);
+        $this->assertTrue(isset($datas['isBar']));
+        $this->assertEquals($datas['isBar'], true);
+        $test = $hydrator->hydrate(
+            array(
+                'fooBar' => 'foo',
+                'fooBarBaz' => 'bar',
+                'isFoo' => false,
+                'isBar' => false,
+            ),
+            $this->classMethodsCamelCase
+        );
         $this->assertSame($this->classMethodsCamelCase, $test);
         $this->assertEquals($test->getFooBar(), 'foo');
         $this->assertEquals($test->getFooBarBaz(), 'bar');
+        $this->assertEquals($test->getIsFoo(), false);
+        $this->assertEquals($test->isBar(), false);
     }
 
     public function testHydratorClassMethodsCamelCaseWithSetterMissing()
@@ -115,10 +133,26 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($datas['foo_bar'], '1');
         $this->assertTrue(isset($datas['foo_bar_baz']));
         $this->assertFalse(isset($datas['fooBar']));
-        $test = $hydrator->hydrate(array('foo_bar' => 'foo', 'foo_bar_baz' => 'bar'), $this->classMethodsUnderscore);
+        $this->assertTrue(isset($datas['is_foo']));
+        $this->assertFalse(isset($datas['isFoo']));
+        $this->assertEquals($datas['is_foo'], true);
+        $this->assertTrue(isset($datas['is_bar']));
+        $this->assertFalse(isset($datas['isBar']));
+        $this->assertEquals($datas['is_bar'], true);
+        $test = $hydrator->hydrate(
+            array(
+                'foo_bar' => 'foo',
+                'foo_bar_baz' => 'bar',
+                'is_foo' => false,
+                'is_bar' => false,
+            ),
+            $this->classMethodsUnderscore
+        );
         $this->assertSame($this->classMethodsUnderscore, $test);
         $this->assertEquals($test->getFooBar(), 'foo');
         $this->assertEquals($test->getFooBarBaz(), 'bar');
+        $this->assertEquals($test->getIsFoo(), false);
+        $this->assertEquals($test->isBar(), false);
     }
 
     public function testHydratorClassMethodsIgnoresInvalidValues()

--- a/tests/ZendTest/Stdlib/TestAsset/ClassMethodsCamelCase.php
+++ b/tests/ZendTest/Stdlib/TestAsset/ClassMethodsCamelCase.php
@@ -16,6 +16,10 @@ class ClassMethodsCamelCase
 
     protected $fooBarBaz = '2';
 
+    protected $isFoo = true;
+
+    protected $isBar = true;
+
     public function getFooBar()
     {
         return $this->fooBar;
@@ -35,6 +39,28 @@ class ClassMethodsCamelCase
     public function setFooBarBaz($value)
     {
         $this->fooBarBaz = $value;
+        return $this;
+    }
+
+    public function getIsFoo()
+    {
+        return $this->isFoo;
+    }
+
+    public function setIsFoo($value)
+    {
+        $this->isFoo = $value;
+        return $this;
+    }
+
+    public function isBar()
+    {
+        return $this->isBar;
+    }
+
+    public function setIsBar($value)
+    {
+        $this->isBar = $value;
         return $this;
     }
 }

--- a/tests/ZendTest/Stdlib/TestAsset/ClassMethodsUnderscore.php
+++ b/tests/ZendTest/Stdlib/TestAsset/ClassMethodsUnderscore.php
@@ -16,6 +16,10 @@ class ClassMethodsUnderscore
 
     protected $foo_bar_baz = '2';
 
+    protected $is_foo = true;
+
+    protected $is_bar = true;
+
     public function getFooBar()
     {
         return $this->foo_bar;
@@ -35,6 +39,28 @@ class ClassMethodsUnderscore
     public function setFooBarBaz($value)
     {
         $this->foo_bar_baz = $value;
+        return $this;
+    }
+
+    public function getIsFoo()
+    {
+        return $this->is_foo;
+    }
+
+    public function setIsFoo($value)
+    {
+        $this->is_foo = $value;
+        return $this;
+    }
+
+    public function isBar()
+    {
+        return $this->is_bar;
+    }
+
+    public function setIsBar($value)
+    {
+        $this->is_bar = $value;
         return $this;
     }
 }


### PR DESCRIPTION
Prefer using `isFoo()` rather than `getIsFoo()`. The latter is required for the ClassMethods hydration to work. 

Changed ClassMethods hydrator to support both `isFoo()` and `getIsFoo()`.
