### PR TITLE
Fix onBootstrap(): use Zend\Mvc\Application as shared EM identifier

### DIFF
--- a/library/Zend/ModuleManager/Listener/OnBootstrapListener.php
+++ b/library/Zend/ModuleManager/Listener/OnBootstrapListener.php
@@ -39,6 +39,6 @@ class OnBootstrapListener extends AbstractListener
         $moduleManager = $e->getTarget();
         $events        = $moduleManager->getEventManager();
         $sharedEvents  = $events->getSharedManager();
-        $sharedEvents->attach('application', 'bootstrap', array($module, 'onBootstrap'));
+        $sharedEvents->attach('Zend\Mvc\Application', 'bootstrap', array($module, 'onBootstrap'));
     }
 }


### PR DESCRIPTION
The `Zend/ModuleManager/Listener/OnBootstrapListener` is broken because of 7eea0c7. This uses the correct identifier so in every module the onBootstrap is triggered again.
