### PR TITLE
Allow not to render errors in FormRow

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -99,11 +99,11 @@ class FormRow extends AbstractHelper
 
                 switch ($this->labelPosition) {
                     case self::LABEL_PREPEND:
-                        $markup = $labelOpen . $label . $elementString . $labelClose;
+                        $markup = $labelOpen . '<span>' . $label . '</span>'. $elementString . $labelClose;
                         break;
                     case self::LABEL_APPEND:
                     default:
-                        $markup = $labelOpen . $elementString . $label . $labelClose;
+                        $markup = $labelOpen . $elementString . '<span>' . $label . '</span>' . $labelClose;
                         break;
                 }
 

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -30,6 +30,11 @@ class FormRow extends AbstractHelper
     protected $labelPosition = self::LABEL_PREPEND;
 
     /**
+     * @var bool
+     */
+    protected $renderErrors = true;
+
+    /**
      * @var array
      */
     protected $labelAttributes;
@@ -65,7 +70,6 @@ class FormRow extends AbstractHelper
         $elementErrorsHelper = $this->getElementErrorsHelper();
         $label               = $element->getLabel();
         $elementString       = $elementHelper->render($element);
-        $elementErrors       = $elementErrorsHelper->render($element);
 
         if (!empty($label)) {
             $label = $escapeHtmlHelper($label);
@@ -95,16 +99,24 @@ class FormRow extends AbstractHelper
 
                 switch ($this->labelPosition) {
                     case self::LABEL_PREPEND:
-                        $markup = $labelOpen . $label . $elementString . $labelClose . $elementErrors;
+                        $markup = $labelOpen . $label . $elementString . $labelClose;
                         break;
                     case self::LABEL_APPEND:
                     default:
-                        $markup = $labelOpen . $elementString . $label . $labelClose . $elementErrors;
+                        $markup = $labelOpen . $elementString . $label . $labelClose;
                         break;
+                }
+
+                if ($this->renderErrors) {
+                    $markup .= $elementErrorsHelper->render($element);
                 }
             }
         } else {
-            $markup = $elementString . $elementErrors;
+            if ($this->renderErrors) {
+                $markup = $elementString . $elementErrorsHelper->render($element);
+            } else {
+                $markup = $elementString;
+            }
         }
 
         return $markup;
@@ -116,10 +128,11 @@ class FormRow extends AbstractHelper
      * Proxies to {@link render()}.
      *
      * @param null|ElementInterface $element
-     * @param null|string $labelPosition
+     * @param null|string           $labelPosition
+     * @param bool                  $renderErrors
      * @return string|FormRow
      */
-    public function __invoke(ElementInterface $element = null, $labelPosition = null)
+    public function __invoke(ElementInterface $element = null, $labelPosition = null, $renderErrors = true)
     {
         if (!$element) {
             return $this;
@@ -128,6 +141,8 @@ class FormRow extends AbstractHelper
         if ($labelPosition !== null) {
             $this->setLabelPosition($labelPosition);
         }
+
+        $this->setRenderErrors($renderErrors);
 
         return $this->render($element);
     }
@@ -164,6 +179,26 @@ class FormRow extends AbstractHelper
     public function getLabelPosition()
     {
         return $this->labelPosition;
+    }
+
+    /**
+     * Are the errors rendered by this helper ?
+     *
+     * @param  bool $renderErrors
+     * @return FormRow
+     */
+    public function setRenderErrors($renderErrors)
+    {
+        $this->renderErrors = (bool) $renderErrors;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getRenderErrors()
+    {
+        return $this->renderErrors;
     }
 
     /**

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -54,7 +54,7 @@ class FormRowTest extends TestCase
         $element->setLabel('The value for foo:');
         $this->helper->setLabelPosition('prepend');
         $markup = $this->helper->render($element);
-        $this->assertContains('<label>The value for foo:<', $markup);
+        $this->assertContains('<label><span>The value for foo:</span><', $markup);
         $this->assertContains('</label>', $markup);
     }
 

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -119,6 +119,19 @@ class FormRowTest extends TestCase
         $this->assertRegexp('#<ul>\s*<li>First error message</li>\s*<li>Second error message</li>\s*<li>Third error message</li>\s*</ul>#s', $markup);
     }
 
+    public function testDoesNotRenderErrorsIfSetToFalse()
+    {
+        $element  = new Element('foo');
+        $element->setMessages(array(
+            'First error message',
+            'Second error message',
+            'Third error message',
+        ));
+
+        $markup = $this->helper->setRenderErrors(false)->render($element);
+        $this->assertRegexp('/<input name="foo" type="text"[^\/>]*\/?>/', $markup);
+    }
+
     public function testInvokeWithNoElementChainsHelper()
     {
         $this->assertSame($this->helper, $this->helper->__invoke());


### PR DESCRIPTION
Sometimes, you don't want to render errors in form inputs next to those inputs, while still being able to use the FormRow helper.

This PR allows you to set the renderErrors to false, and hence the label and element will still be rendered, but not the errors.

EDIT : this PR also slightly modify the markup generated by FormRow view helper (this is not a BC though).

Before :

<label>Text<input ...></label>

After :

<label><span>Text</span><input ...></label>

This is necessary to be able to style the text label (for instance to apply it a width, a margin...), otherwise without this, it's impossible to target it using CSS.
