### PR TITLE
Remove usage of "application" EM context

### DIFF
--- a/library/Zend/ModuleManager/Listener/LocatorRegistrationListener.php
+++ b/library/Zend/ModuleManager/Listener/LocatorRegistrationListener.php
@@ -67,7 +67,7 @@ class LocatorRegistrationListener extends AbstractListener implements
         $events        = $moduleManager->getEventManager()->getSharedManager();
 
         // Shared instance for module manager
-        $events->attach('application', 'bootstrap', function ($e) use ($moduleManager) {
+        $events->attach('Zend\Mvc\Application', 'bootstrap', function ($e) use ($moduleManager) {
             $moduleClassName = get_class($moduleManager);
             $application     = $e->getApplication();
             $services        = $application->getServiceManager();
@@ -81,7 +81,7 @@ class LocatorRegistrationListener extends AbstractListener implements
         }
 
         // Attach to the bootstrap event if there are modules we need to process
-        $events->attach('application', 'bootstrap', array($this, 'onBootstrap'), 1000);
+        $events->attach('Zend\Mvc\Application', 'bootstrap', array($this, 'onBootstrap'), 1000);
     }
 
     /**

--- a/library/Zend/ModuleManager/Listener/OnBootstrapListener.php
+++ b/library/Zend/ModuleManager/Listener/OnBootstrapListener.php
@@ -39,6 +39,6 @@ class OnBootstrapListener extends AbstractListener
         $moduleManager = $e->getTarget();
         $events        = $moduleManager->getEventManager();
         $sharedEvents  = $events->getSharedManager();
-        $sharedEvents->attach('application', 'bootstrap', array($module, 'onBootstrap'));
+        $sharedEvents->attach('Zend\Mvc\Application', 'bootstrap', array($module, 'onBootstrap'));
     }
 }


### PR DESCRIPTION
- Per #2235 the "application" context was removed from
  Zend\Mvc\Application::setEventManager(). However, two listeners in the
  ModuleManager were using it.
- This supercedes #2237 as it also includes the LocatorRegistrationListener
