### PR TITLE
Allow null value for route name in PRG plugin

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
@@ -23,10 +23,14 @@ use Zend\Session\Container;
  */
 class PostRedirectGet extends AbstractPlugin
 {
-    public function __invoke($redirect, $redirectToUrl = false)
+    public function __invoke($redirect = null, $redirectToUrl = false)
     {
         $controller = $this->getController();
-        $request = $controller->getRequest();
+        $request    = $controller->getRequest();
+
+        if (null === $redirect) {
+            $redirect = $controller->getEvent()->getRouteMatch()->getMatchedRouteName();
+        }
 
         $container = new Container('prg_post1');
 

--- a/tests/ZendTest/Mvc/Controller/Plugin/PostRedirectGetTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/PostRedirectGetTest.php
@@ -116,4 +116,23 @@ class PostRedirectGetTest extends TestCase
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->controller->prg('some/route');
     }
+
+    public function testNullRouteUsesMatchedRouteName()
+    {
+        $this->controller->getEvent()->getRouteMatch()->setMatchedRouteName('home');
+
+        $this->request->setMethod('POST');
+        $this->request->setPost(new Parameters(array(
+            'postval1' => 'value1'
+        )));
+
+
+        $result         = $this->controller->dispatch($this->request, $this->response);
+        $prgResultRoute = $this->controller->prg();
+
+        $this->assertInstanceOf('Zend\Http\Response', $prgResultRoute);
+        $this->assertTrue($prgResultRoute->getHeaders()->has('Location'));
+        $this->assertEquals('/', $prgResultRoute->getHeaders()->get('Location')->getUri());
+        $this->assertEquals(303, $prgResultRoute->getStatusCode());
+    }
 }


### PR DESCRIPTION
In a lot of PRG patterns the POST request happens to the same url as the GET request. This PR keeps the flexibility to set the route name but it also defaults to the currently matched route name.

Previously I did:

``` php
$route = $this->getEvent()->getRouteMatch()->getMatchedRouteName();

if (($result = $this->prg($route)) instanceof Response) {
    return $result;
}  elseif (false !== $result) {
    // Do stuff
}
```

Where now you're able to:

``` php
if (($result = $this->prg()) instanceof Response) {
    return $result;
}  elseif (false !== $result) {
    // Do stuff
}
```

Test is made to assert the behaviour.
