### PR TITLE
Fix for issue ZF2-503

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -703,12 +703,10 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $sql = $driver->formatParameterName('limit');
             $parameterContainer->offsetSet('limit', $this->limit, ParameterContainer::TYPE_INTEGER);
         } else {
-			if (is_int($this->limit)) {
-				$sql = $this->limit;
-			}
-			else {
-				throw new Exception\InvalidArgumentException('LIMIT should be given as INTEGER');
-			}
+            if (!is_int($this->limit)) {
+                throw new Exception\InvalidArgumentException('LIMIT should be given as INTEGER');
+            }
+            $sql = $this->limit;
         }
         return array($sql);
     }
@@ -722,12 +720,10 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $parameterContainer->offsetSet('offset', $this->offset, ParameterContainer::TYPE_INTEGER);
             return array($adapter->getDriver()->formatParameterName('offset'));
         } else {
-			if (is_int($this->offset)) {
-				return array($this->offset);
-			}
-			else {
-				throw new Exception\InvalidArgumentException('OFFSET should be given as INTEGER');
-			}
+            if (!is_int($this->offset)) {
+                throw new Exception\InvalidArgumentException('OFFSET should be given as INTEGER');							
+            }	
+            return array($this->offset);
         }
     }
 

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -703,9 +703,13 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $sql = $driver->formatParameterName('limit');
             $parameterContainer->offsetSet('limit', $this->limit, ParameterContainer::TYPE_INTEGER);
         } else {
-            $sql = $platform->quoteValue($this->limit);
+			if (is_int($this->limit)) {
+				$sql = $this->limit;
+			}
+			else {
+				throw new Exception\InvalidArgumentException('LIMIT should be given as INTEGER');
+			}
         }
-
         return array($sql);
     }
 
@@ -718,7 +722,12 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $parameterContainer->offsetSet('offset', $this->offset, ParameterContainer::TYPE_INTEGER);
             return array($adapter->getDriver()->formatParameterName('offset'));
         } else {
-            return array($platform->quoteValue($this->offset));
+			if (is_int($this->offset)) {
+				return array($this->offset);
+			}
+			else {
+				throw new Exception\InvalidArgumentException('OFFSET should be given as INTEGER');
+			}
         }
     }
 

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -721,8 +721,8 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             return array($adapter->getDriver()->formatParameterName('offset'));
         } else {
             if (!is_int($this->offset)) {
-                throw new Exception\InvalidArgumentException('OFFSET should be given as INTEGER');							
-            }	
+                throw new Exception\InvalidArgumentException('OFFSET should be given as INTEGER');
+            }
             return array($this->offset);
         }
     }

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -653,7 +653,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $select26 = new Select;
         $select26->from('foo')->limit(5);
         $sqlPrep26 = 'SELECT "foo".* FROM "foo" LIMIT ?';
-        $sqlStr26 = 'SELECT "foo".* FROM "foo" LIMIT \'5\'';
+        $sqlStr26 = 'SELECT "foo".* FROM "foo" LIMIT 5';
         $params26 = array('limit' => 5);
         $internalTests26 = array(
             'processSelect' => array(array(array('"foo".*')), '"foo"'),
@@ -664,7 +664,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $select27 = new Select;
         $select27->from('foo')->limit(5)->offset(10);
         $sqlPrep27 = 'SELECT "foo".* FROM "foo" LIMIT ? OFFSET ?';
-        $sqlStr27 = 'SELECT "foo".* FROM "foo" LIMIT \'5\' OFFSET \'10\'';
+        $sqlStr27 = 'SELECT "foo".* FROM "foo" LIMIT 5 OFFSET 10';
         $params27 = array('limit' => 5, 'offset' => 10);
         $internalTests27 = array(
             'processSelect' => array(array(array('"foo".*')), '"foo"'),


### PR DESCRIPTION
Fixed invalid quoting of LIMIT and OFFSET clauses in getSqlStringForSqlObject() as described in http://framework.zend.com/issues/browse/ZF2-503.

The solution works and I believe it does the same thing that was intended with quoteValue() (stopping injections), but it now returns a valid SQL statement. However I'm unsure if throwing an exception like that is expected behaviour so let me know if it's no good.
