### PR TITLE
Enhancements to Csrf Element and Validator

### DIFF
--- a/library/Zend/Form/Element/Csrf.php
+++ b/library/Zend/Form/Element/Csrf.php
@@ -33,21 +33,56 @@ class Csrf extends Element implements InputProviderInterface, ElementPrepareAwar
     );
 
     /**
+     * @var array
+     */
+    protected $csrfValidatorOptions = array();
+
+    /**
      * @var CsrfValidator
      */
-    protected $validator;
+    protected $csrfValidator;
+
+    /**
+     * @return array
+     */
+    public function getCsrfValidatorOptions()
+    {
+        return $this->csrfValidatorOptions;
+    }
+
+    /**
+     * @param  array $options
+     * @return Csrf
+     */
+    public function setCsrfValidatorOptions(array $options)
+    {
+        $this->csrfValidatorOptions = $options;
+        return $this;
+    }
 
     /**
      * Get CSRF validator
      *
      * @return CsrfValidator
      */
-    protected function getValidator()
+    public function getCsrfValidator()
     {
-        if (null === $this->validator) {
-            $this->validator = new CsrfValidator(array('name' => $this->getName()));
+        if (null === $this->csrfValidator) {
+            $csrfOptions = $this->getCsrfValidatorOptions();
+            $csrfOptions = array_merge($csrfOptions, array('name' => $this->getName()));
+            $this->csrfValidator = new CsrfValidator($csrfOptions);
         }
-        return $this->validator;
+        return $this->csrfValidator;
+    }
+
+    /**
+     * @param  \Zend\Validator\Csrf $validator
+     * @return Csrf
+     */
+    public function setCsrfValidator(CsrfValidator $validator)
+    {
+        $this->csrfValidator = $validator;
+        return $this;
     }
 
     /**
@@ -59,7 +94,7 @@ class Csrf extends Element implements InputProviderInterface, ElementPrepareAwar
      */
     public function getValue()
     {
-        $validator = $this->getValidator();
+        $validator = $this->getCsrfValidator();
         return $validator->getHash();
     }
 
@@ -73,7 +108,7 @@ class Csrf extends Element implements InputProviderInterface, ElementPrepareAwar
     public function getAttributes()
     {
         $attributes = parent::getAttributes();
-        $validator  = $this->getValidator();
+        $validator  = $this->getCsrfValidator();
         $attributes['value'] = $validator->getHash();
         return $attributes;
     }
@@ -94,7 +129,7 @@ class Csrf extends Element implements InputProviderInterface, ElementPrepareAwar
                 array('name' => 'Zend\Filter\StringTrim'),
             ),
             'validators' => array(
-                $this->getValidator(),
+                $this->getCsrfValidator(),
             ),
         );
     }
@@ -104,6 +139,6 @@ class Csrf extends Element implements InputProviderInterface, ElementPrepareAwar
      */
     public function prepareElement(Form $form)
     {
-        $this->getValidator()->getHash(true);
+        $this->getCsrfValidator()->getHash(true);
     }
 }

--- a/library/Zend/Validator/Csrf.php
+++ b/library/Zend/Validator/Csrf.php
@@ -65,7 +65,7 @@ class Csrf extends AbstractValidator
 
     /**
      * TTL for CSRF token
-     * @var int
+     * @var int|null
      */
     protected $timeout = 300;
 
@@ -243,12 +243,12 @@ class Csrf extends AbstractValidator
     /**
      * Set timeout for CSRF session token
      *
-     * @param  int $ttl
+     * @param  int|null $ttl
      * @return Csrf
      */
     public function setTimeout($ttl)
     {
-        $this->timeout = (int) $ttl;
+        $this->timeout = ($ttl !== null) ? (int)$ttl : null;
         return $this;
     }
 
@@ -271,7 +271,10 @@ class Csrf extends AbstractValidator
     {
         $session = $this->getSession();
         //$session->setExpirationHops(1, null, true);
-        $session->setExpirationSeconds($this->getTimeout());
+        $timeout = $this->getTimeout();
+        if (null !== $timeout) {
+            $session->setExpirationSeconds($timeout);
+        }
         $session->hash = $this->getHash();
     }
 

--- a/tests/ZendTest/Form/Element/CsrfTest.php
+++ b/tests/ZendTest/Form/Element/CsrfTest.php
@@ -40,4 +40,21 @@ class CsrfTest extends TestCase
             }
         }
     }
+
+    public function testAllowSettingCustomCsrfValidator()
+    {
+        $element = new CsrfElement('foo');
+        $validatorMock = $this->getMock('Zend\Validator\Csrf');
+        $element->setCsrfValidator($validatorMock);
+        $this->assertEquals($validatorMock, $element->getCsrfValidator());
+    }
+
+    public function testAllowSettingCsrfValidatorOptions()
+    {
+        $element = new CsrfElement('foo');
+        $element->setCsrfValidatorOptions(array('timeout' => 777));
+        $validator = $element->getCsrfValidator();
+        $this->assertEquals('foo', $validator->getName());
+        $this->assertEquals(777, $validator->getTimeout());
+    }
 }

--- a/tests/ZendTest/Validator/CsrfTest.php
+++ b/tests/ZendTest/Validator/CsrfTest.php
@@ -90,10 +90,24 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(300, $this->validator->getTimeout());
     }
 
-    public function testTimeoutIsMutable()
+    public function timeoutValuesDataProvider()
     {
-        $this->validator->setTimeout(600);
-        $this->assertEquals(600, $this->validator->getTimeout());
+        return array(
+            //    timeout  expected
+            array(600,     600),
+            array(null,    null),
+            array("0",     0),
+            array("100",   100),
+        );
+    }
+
+    /**
+     * @dataProvider timeoutValuesDataProvider
+     */
+    public function testTimeoutIsMutable($timeout, $expected)
+    {
+        $this->validator->setTimeout($timeout);
+        $this->assertEquals($expected, $this->validator->getTimeout());
     }
 
     public function testAllOptionsMayBeSetViaConstructor()


### PR DESCRIPTION
Zend\Element\Csrf:
- Allow changing the Csrf Validator that is returned from getInputSpecification().
- Allow setting the Csrf validator options (ie. setting the timeout).

Zend\Validator\Csrf:
- Allow setting the timeout to `null` so that the token can expire with the global session.
