### PR TITLE
Fix for ZF2-499

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -261,13 +261,18 @@ class Request extends HttpRequest
         $port = null;
         if (isset($this->serverParams['SERVER_NAME'])) {
             $host = $this->serverParams['SERVER_NAME'];
+            if (isset($this->serverParams['SERVER_PORT'])) {
+                $port = (int) $this->serverParams['SERVER_PORT'];
+            }
             // Check for missinterpreted IPv6-Address
             // Reported at least for Safari on Windows
             if (isset($this->serverParams['SERVER_ADDR']) && preg_match('/^\[[0-9a-fA-F\:]+\]$/', $host)) {
             	$host = '[' . $this->serverParams['SERVER_ADDR'] . ']';
-            }
-            if (isset($this->serverParams['SERVER_PORT'])) {
-                $port = (int) $this->serverParams['SERVER_PORT'];
+            	if ($port . ']' == substr($host, strrpos($host, ':')+1)) {
+            		// The last digit of the IPv6-Address has been taken as port
+            		// Unset the port so the default port can be used
+            		$port = null;
+            	}
             }
         } elseif ($this->getHeaders()->get('host')) {
             $host = $this->getHeaders()->get('host')->getFieldValue();

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -267,12 +267,12 @@ class Request extends HttpRequest
             // Check for missinterpreted IPv6-Address
             // Reported at least for Safari on Windows
             if (isset($this->serverParams['SERVER_ADDR']) && preg_match('/^\[[0-9a-fA-F\:]+\]$/', $host)) {
-            	$host = '[' . $this->serverParams['SERVER_ADDR'] . ']';
-            	if ($port . ']' == substr($host, strrpos($host, ':')+1)) {
-            		// The last digit of the IPv6-Address has been taken as port
-            		// Unset the port so the default port can be used
-            		$port = null;
-            	}
+                $host = '[' . $this->serverParams['SERVER_ADDR'] . ']';
+                if ($port . ']' == substr($host, strrpos($host, ':')+1)) {
+                    // The last digit of the IPv6-Address has been taken as port
+                    // Unset the port so the default port can be used
+                    $port = null;
+                }
             }
         } elseif ($this->getHeaders()->get('host')) {
             $host = $this->getHeaders()->get('host')->getFieldValue();

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -261,6 +261,11 @@ class Request extends HttpRequest
         $port = null;
         if (isset($this->serverParams['SERVER_NAME'])) {
             $host = $this->serverParams['SERVER_NAME'];
+            // Check for missinterpreted IPv6-Address
+            // Reported at least for Safari on Windows
+            if (isset($this->serverParams['SERVER_ADDR']) && preg_match('/^\[[0-9a-fA-F\:]+\]$/', $host)) {
+            	$host = '[' . $this->serverParams['SERVER_ADDR'] . ']';
+            }
             if (isset($this->serverParams['SERVER_PORT'])) {
                 $port = (int) $this->serverParams['SERVER_PORT'];
             }

--- a/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
@@ -313,6 +313,27 @@ class RequestTest extends TestCase
             ),
             array(
                 array(
+                    'SERVER_NAME' => '[1:2:3:4:5:6::6]',
+                    'SERVER_ADDR' => '1:2:3:4:5:6::6',
+                	'SERVER_PORT' => '80',
+                	'REQUEST_URI' => 'http://[1:2:3:4:5:6::6]/news',
+                ),
+                '[1:2:3:4:5:6::6]',
+                '/news',
+            ),
+       		// Test for broken $_SERVER implementation from Windows-Safari 
+            array(
+                array(
+                    'SERVER_NAME' => '[1:2:3:4:5:6:]',
+                    'SERVER_ADDR' => '1:2:3:4:5:6::6',
+                	'SERVER_PORT' => '80',
+                	'REQUEST_URI' => 'http://[1:2:3:4:5:6::6]/news',
+                ),
+                '[1:2:3:4:5:6::6]',
+                '/news',
+            ),
+            array(
+                array(
                     'SERVER_NAME' => 'test.example.com',
                     'SERVER_PORT' => '8080',
                     'REQUEST_URI' => 'http://test.example.com/news',

--- a/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
@@ -301,7 +301,7 @@ class RequestTest extends TestCase
                     'REQUEST_URI' => 'http://test.example.com/news',
                 ),
                 'test.example.com',
-            	'80',
+                '80',
                 '/news',
             ),
             array(
@@ -310,30 +310,30 @@ class RequestTest extends TestCase
                     'REQUEST_URI' => 'http://test.example.com/news',
                 ),
                 'test.example.com',
-            	'80',
+                '80',
                 '/news',
             ),
             array(
                 array(
                     'SERVER_NAME' => '[1:2:3:4:5:6::6]',
                     'SERVER_ADDR' => '1:2:3:4:5:6::6',
-                	'SERVER_PORT' => '80',
-                	'REQUEST_URI' => 'http://[1:2:3:4:5:6::6]/news',
+                    'SERVER_PORT' => '80',
+                    'REQUEST_URI' => 'http://[1:2:3:4:5:6::6]/news',
                 ),
                 '[1:2:3:4:5:6::6]',
-            	'80',
+                '80',
                 '/news',
             ),
-       		// Test for broken $_SERVER implementation from Windows-Safari 
+               // Test for broken $_SERVER implementation from Windows-Safari
             array(
                 array(
                     'SERVER_NAME' => '[1:2:3:4:5:6:]',
                     'SERVER_ADDR' => '1:2:3:4:5:6::6',
-                	'SERVER_PORT' => '6',
-                	'REQUEST_URI' => 'http://[1:2:3:4:5:6::6]/news',
+                    'SERVER_PORT' => '6',
+                    'REQUEST_URI' => 'http://[1:2:3:4:5:6::6]/news',
                 ),
                 '[1:2:3:4:5:6::6]',
-            	'80',
+                '80',
                 '/news',
             ),
             array(
@@ -373,7 +373,7 @@ class RequestTest extends TestCase
 
         $host = $request->getUri()->getHost();
         $this->assertEquals($expectedHost, $host);
-        
+
         $port = $request->getUri()->getPort();
         $this->assertEquals($expectedPort, $port);
 

--- a/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
@@ -301,6 +301,7 @@ class RequestTest extends TestCase
                     'REQUEST_URI' => 'http://test.example.com/news',
                 ),
                 'test.example.com',
+            	'80',
                 '/news',
             ),
             array(
@@ -309,6 +310,7 @@ class RequestTest extends TestCase
                     'REQUEST_URI' => 'http://test.example.com/news',
                 ),
                 'test.example.com',
+            	'80',
                 '/news',
             ),
             array(
@@ -319,6 +321,7 @@ class RequestTest extends TestCase
                 	'REQUEST_URI' => 'http://[1:2:3:4:5:6::6]/news',
                 ),
                 '[1:2:3:4:5:6::6]',
+            	'80',
                 '/news',
             ),
        		// Test for broken $_SERVER implementation from Windows-Safari 
@@ -326,10 +329,11 @@ class RequestTest extends TestCase
                 array(
                     'SERVER_NAME' => '[1:2:3:4:5:6:]',
                     'SERVER_ADDR' => '1:2:3:4:5:6::6',
-                	'SERVER_PORT' => '80',
+                	'SERVER_PORT' => '6',
                 	'REQUEST_URI' => 'http://[1:2:3:4:5:6::6]/news',
                 ),
                 '[1:2:3:4:5:6::6]',
+            	'80',
                 '/news',
             ),
             array(
@@ -339,6 +343,7 @@ class RequestTest extends TestCase
                     'REQUEST_URI' => 'http://test.example.com/news',
                 ),
                 'test.example.com',
+                '8080',
                 '/news',
             ),
             array(
@@ -349,6 +354,7 @@ class RequestTest extends TestCase
                     'REQUEST_URI' => 'https://test.example.com/news',
                 ),
                 'test.example.com',
+                '443',
                 '/news',
             ),
         );
@@ -360,13 +366,16 @@ class RequestTest extends TestCase
      * @param string $name
      * @param string $value
      */
-    public function testServerHostnameProvider(array $server, $expectedHost, $expectedRequestUri)
+    public function testServerHostnameProvider(array $server, $expectedHost, $expectedPort, $expectedRequestUri)
     {
         $_SERVER = $server;
         $request = new Request();
 
         $host = $request->getUri()->getHost();
         $this->assertEquals($expectedHost, $host);
+        
+        $port = $request->getUri()->getPort();
+        $this->assertEquals($expectedPort, $port);
 
         $requestUri = $request->getRequestUri();
         $this->assertEquals($expectedRequestUri, $requestUri);


### PR DESCRIPTION
This PR adds some lines to check for IPv6-Address in $_SERVER['SERVER_NAME'].

If SERVER_NAME starts and ends with a square bracket and only contains hexadecimals and colons this is assumed to be an IPv6-Address. The host is then set using the SERVER_ADDR as that is correct. 

If the SERVER_PORT matches the digits after the last colon of SERVER_ADDR the port has been scrambled and is removed so that the default port can be set. If the SERVER_PORT is different nothing will be changed.
