### PR TITLE
Form Elements refactor: move "options" out of attributes (Select, Radio, etc.)

### DIFF
--- a/library/Zend/Form/Element/MultiCheckbox.php
+++ b/library/Zend/Form/Element/MultiCheckbox.php
@@ -32,6 +32,72 @@ class MultiCheckbox extends Checkbox
     protected $uncheckedValue = '';
 
     /**
+     * @var array
+     */
+    protected $valueOptions = array();
+
+    /**
+     * @return array
+     */
+    public function getValueOptions()
+    {
+        return $this->valueOptions;
+    }
+
+    /**
+     * @param  array $options
+     * @return MultiCheckbox
+     */
+    public function setValueOptions(array $options)
+    {
+        $this->valueOptions = $options;
+        return $this;
+    }
+
+    /**
+     * Set options for an element. Accepted options are:
+     * - label: label to associate with the element
+     * - label_attributes: attributes to use when the label is rendered
+     * - value_options: list of values and labels for the select options
+     *
+     * @param  array|\Traversable $options
+     * @return MultiCheckbox|ElementInterface
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setOptions($options)
+    {
+        parent::setOptions($options);
+
+        if (isset($this->options['value_options'])) {
+            $this->setValueOptions($this->options['value_options']);
+        }
+        // Alias for 'value_options'
+        if (isset($this->options['options'])) {
+            $this->setValueOptions($this->options['options']);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set a single element attribute
+     *
+     * @param  string $key
+     * @param  mixed  $value
+     * @return MultiCheckbox|ElementInterface
+     */
+    public function setAttribute($key, $value)
+    {
+        // Do not include the options in the list of attributes
+        // TODO: Deprecate this
+        if ($key === 'options') {
+            $this->setValueOptions($value);
+            return $this;
+        }
+        return parent::setAttribute($key, $value);
+    }
+
+    /**
      * Get validator
      *
      * @return ValidatorInterface
@@ -40,7 +106,7 @@ class MultiCheckbox extends Checkbox
     {
         if (null === $this->validator) {
             $inArrayValidator = new InArrayValidator(array(
-                'haystack'  => $this->getOptionAttributeValues(),
+                'haystack'  => $this->getValueOptionsValues(),
                 'strict'    => false,
             ));
             $this->validator = new ExplodeValidator(array(
@@ -56,10 +122,10 @@ class MultiCheckbox extends Checkbox
      *
      * @return array
      */
-    protected function getOptionAttributeValues()
+    protected function getValueOptionsValues()
     {
         $values = array();
-        $options = $this->getAttribute('options');
+        $options = $this->getValueOptions();
         foreach ($options as $key => $optionSpec) {
             $value = (is_array($optionSpec)) ? $optionSpec['value'] : $key;
             $values[] = $value;

--- a/library/Zend/Form/Element/Radio.php
+++ b/library/Zend/Form/Element/Radio.php
@@ -38,7 +38,7 @@ class Radio extends MultiCheckbox
     {
         if (null === $this->validator) {
             $this->validator = new InArrayValidator(array(
-                'haystack'  => $this->getOptionAttributeValues(),
+                'haystack'  => $this->getValueOptionsValues(),
                 'strict'    => false,
             ));
         }

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -43,25 +43,90 @@ class Select extends Element implements InputProviderInterface
      * @var array
      */
     protected $attributes = array(
-        'type'    => 'select',
-        'options' => array(),
+        'type' => 'select',
     );
 
     /**
-    * @var ValidatorInterface
-    */
+     * @var ValidatorInterface
+     */
     protected $validator;
 
     /**
-    * Get validator
-    *
-    * @return ValidatorInterface
-    */
+     * @var array
+     */
+    protected $valueOptions = array();
+
+    /**
+     * @return array
+     */
+    public function getValueOptions()
+    {
+        return $this->valueOptions;
+    }
+
+    /**
+     * @param  array $options
+     * @return Select
+     */
+    public function setValueOptions(array $options)
+    {
+        $this->valueOptions = $options;
+        return $this;
+    }
+
+    /**
+     * Set options for an element. Accepted options are:
+     * - label: label to associate with the element
+     * - label_attributes: attributes to use when the label is rendered
+     * - value_options: list of values and labels for the select options
+     *
+     * @param  array|\Traversable $options
+     * @return Select|ElementInterface
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setOptions($options)
+    {
+        parent::setOptions($options);
+
+        if (isset($this->options['value_options'])) {
+            $this->setValueOptions($this->options['value_options']);
+        }
+        // Alias for 'value_options'
+        if (isset($this->options['options'])) {
+            $this->setValueOptions($this->options['options']);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set a single element attribute
+     *
+     * @param  string $key
+     * @param  mixed  $value
+     * @return Select|ElementInterface
+     */
+    public function setAttribute($key, $value)
+    {
+        // Do not include the options in the list of attributes
+        // TODO: Deprecate this
+        if ($key === 'options') {
+            $this->setValueOptions($value);
+            return $this;
+        }
+        return parent::setAttribute($key, $value);
+    }
+
+    /**
+     * Get validator
+     *
+     * @return ValidatorInterface
+     */
     protected function getValidator()
     {
         if (null === $this->validator) {
             $validator = new InArrayValidator(array(
-                'haystack' => $this->getOptionAttributeValues(),
+                'haystack' => $this->getValueOptionsValues(),
                 'strict'   => false
             ));
 
@@ -105,10 +170,10 @@ class Select extends Element implements InputProviderInterface
      *
      * @return array
      */
-    protected function getOptionAttributeValues()
+    protected function getValueOptionsValues()
     {
         $values = array();
-        $options = $this->getAttribute('options');
+        $options = $this->getValueOptions();
         foreach ($options as $key => $optionSpec) {
             $value = (is_array($optionSpec)) ? $optionSpec['value'] : $key;
             $values[] = $value;

--- a/library/Zend/Form/View/Helper/FormElement.php
+++ b/library/Zend/Form/View/Helper/FormElement.php
@@ -58,8 +58,7 @@ class FormElement extends BaseAbstractHelper
             return $helper($element);
         }
 
-        $type    = $element->getAttribute('type');
-        $options = $element->getAttribute('options');
+        $type = $element->getAttribute('type');
 
         if ('checkbox' == $type) {
             $helper = $renderer->plugin('form_checkbox');
@@ -111,7 +110,7 @@ class FormElement extends BaseAbstractHelper
             return $helper($element);
         }
 
-        if ('multi_checkbox' == $type && is_array($options)) {
+        if ('multi_checkbox' == $type) {
             $helper = $renderer->plugin('form_multi_checkbox');
             return $helper($element);
         }
@@ -126,7 +125,7 @@ class FormElement extends BaseAbstractHelper
             return $helper($element);
         }
 
-        if ('radio' == $type && is_array($options)) {
+        if ('radio' == $type) {
             $helper = $renderer->plugin('form_radio');
             return $helper($element);
         }
@@ -146,7 +145,7 @@ class FormElement extends BaseAbstractHelper
             return $helper($element);
         }
 
-        if ('select' == $type && is_array($options)) {
+        if ('select' == $type) {
             $helper = $renderer->plugin('form_select');
             return $helper($element);
         }

--- a/library/Zend/Form/View/Helper/FormMultiCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormMultiCheckbox.php
@@ -12,6 +12,7 @@ namespace Zend\Form\View\Helper;
 
 use Traversable;
 use Zend\Form\ElementInterface;
+use Zend\Form\Element\MultiCheckbox as MultiCheckboxElement;
 use Zend\Form\Exception;
 
 /**
@@ -190,6 +191,13 @@ class FormMultiCheckbox extends FormInput
      */
     public function render(ElementInterface $element)
     {
+        if (!$element instanceof MultiCheckboxElement) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s requires that the element is of type Zend\Form\Element\MultiCheckbox',
+                __METHOD__
+            ));
+        }
+
         $name = static::getName($element);
         if ($name === null || $name === '') {
             throw new Exception\DomainException(sprintf(
@@ -198,20 +206,15 @@ class FormMultiCheckbox extends FormInput
             ));
         }
 
-        $attributes = $element->getAttributes();
-
-        if (!isset($attributes['options'])
-            || (!is_array($attributes['options']) && !$attributes['options'] instanceof Traversable)
-        ) {
+        $options = $element->getValueOptions();
+        if (empty($options)) {
             throw new Exception\DomainException(sprintf(
-                '%s requires that the element has an array or Traversable "options" attribute; none found',
+                '%s requires that the element has "value_options"; none found',
                 __METHOD__
             ));
         }
 
-        $options = $attributes['options'];
-        unset($attributes['options']);
-
+        $attributes         = $element->getAttributes();
         $attributes['name'] = $name;
         $attributes['type'] = $this->getInputType();
         $selectedOptions    = (array) $element->getValue();
@@ -233,13 +236,13 @@ class FormMultiCheckbox extends FormInput
     /**
      * Render options
      *
-     * @param ElementInterface $element
-     * @param array            $options
-     * @param array            $selectedOptions
-     * @param array            $attributes
+     * @param MultiCheckboxElement $element
+     * @param array                $options
+     * @param array                $selectedOptions
+     * @param array                $attributes
      * @return string
      */
-    protected function renderOptions(ElementInterface $element, array $options, array $selectedOptions,
+    protected function renderOptions(MultiCheckboxElement $element, array $options, array $selectedOptions,
                                      array $attributes)
     {
         $escapeHtmlHelper = $this->getEscapeHtmlHelper();
@@ -263,7 +266,7 @@ class FormMultiCheckbox extends FormInput
             }
 
             $value           = '';
-            $label           = $key;
+            $label           = '';
             $selected        = false;
             $disabled        = false;
             $inputAttributes = $attributes;
@@ -339,11 +342,11 @@ class FormMultiCheckbox extends FormInput
     /**
      * Render a hidden element for empty/unchecked value
      *
-     * @param  ElementInterface $element
-     * @param  array $attributes
+     * @param  MultiCheckboxElement $element
+     * @param  array                $attributes
      * @return string
      */
-    protected function renderHiddenElement(ElementInterface $element, array $attributes)
+    protected function renderHiddenElement(MultiCheckboxElement $element, array $attributes)
     {
         $closingBracket = $this->getInlineClosingBracket();
 

--- a/library/Zend/Form/View/Helper/FormSelect.php
+++ b/library/Zend/Form/View/Helper/FormSelect.php
@@ -12,6 +12,7 @@ namespace Zend\Form\View\Helper;
 
 use Traversable;
 use Zend\Form\ElementInterface;
+use Zend\Form\Element\Select as SelectElement;
 use Zend\Form\Exception;
 
 /**
@@ -60,6 +61,13 @@ class FormSelect extends AbstractHelper
      */
     public function render(ElementInterface $element)
     {
+        if (!$element instanceof SelectElement) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s requires that the element is of type Zend\Form\Element\Select',
+                __METHOD__
+            ));
+        }
+
         $name   = $element->getName();
         if (empty($name) && $name !== 0) {
             throw new Exception\DomainException(sprintf(
@@ -68,21 +76,17 @@ class FormSelect extends AbstractHelper
             ));
         }
 
-        $attributes = $element->getAttributes();
 
-        if (!isset($attributes['options'])
-            || (!is_array($attributes['options']) && !$attributes['options'] instanceof Traversable)
-        ) {
+        $options = $element->getValueOptions();
+        if (empty($options)) {
             throw new Exception\DomainException(sprintf(
-                '%s requires that the element has an array or Traversable "options" attribute; none found',
+                '%s requires that the element has "value_options"; none found',
                 __METHOD__
             ));
         }
 
-        $options = (array) $attributes['options'];
-        unset($attributes['options']);
-
-        $value = $this->validateMultiValue($element->getValue(), $attributes);
+        $attributes = $element->getAttributes();
+        $value      = $this->validateMultiValue($element->getValue(), $attributes);
 
         $attributes['name'] = $name;
         if (array_key_exists('multiple', $attributes) && $attributes['multiple']) {

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -30,7 +30,7 @@ class SelectTest extends TestCase
     public function testProvidesInputSpecificationForSingleSelect()
     {
         $element = new SelectElement();
-        $element->setAttribute('options', array(
+        $element->setValueOptions(array(
             'Option 1' => 'option1',
             'Option 2' => 'option2',
             'Option 3' => 'option3',
@@ -54,11 +54,11 @@ class SelectTest extends TestCase
         $element = new SelectElement();
         $element->setAttributes(array(
             'multiple' => true,
-            'options'  => array(
-                'Option 1' => 'option1',
-                'Option 2' => 'option2',
-                'Option 3' => 'option3',
-            ),
+        ));
+        $element->setValueOptions(array(
+            'Option 1' => 'option1',
+            'Option 2' => 'option2',
+            'Option 3' => 'option3',
         ));
 
         $inputSpec = $element->getInputSpecification();
@@ -107,9 +107,7 @@ class SelectTest extends TestCase
     public function testInArrayValidationOfOptions($valueTests, $options)
     {
         $element = new SelectElement('my-select');
-        $element->setAttributes(array(
-            'options' => $options,
-        ));
+        $element->setValueOptions($options);
         $inputSpec = $element->getInputSpecification();
         $this->assertArrayHasKey('validators', $inputSpec);
         $inArrayValidator = $inputSpec['validators'][0];
@@ -122,6 +120,21 @@ class SelectTest extends TestCase
     public function testOptionsHasArrayOnConstruct()
     {
         $element = new SelectElement();
-        $this->assertTrue(is_array($element->getAttribute('options')));
+        $this->assertTrue(is_array($element->getValueOptions()));
+    }
+
+    public function testDeprecateOptionsInAttributes()
+    {
+        $element = new SelectElement();
+        $valueOptions = array(
+            'Option 1' => 'option1',
+            'Option 2' => 'option2',
+            'Option 3' => 'option3',
+        );
+        $element->setAttributes(array(
+            'multiple' => true,
+            'options'  => $valueOptions,
+        ));
+        $this->assertEquals($valueOptions, $element->getValueOptions());
     }
 }

--- a/tests/ZendTest/Form/View/Helper/FormElementTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormElementTest.php
@@ -80,6 +80,8 @@ class FormElementTest extends TestCase
             $element = new Element\Radio('foo');
         } elseif ($type === 'checkbox') {
             $element = new Element\Checkbox('foo');
+        } elseif ($type === 'select') {
+            $element = new Element\Select('foo');
         } else {
             $element = new Element('foo');
         }
@@ -108,9 +110,17 @@ class FormElementTest extends TestCase
      */
     public function testRendersMultiElementsAsExpected($type, $inputType, $additionalMarkup)
     {
-        $element = new Element\MultiCheckbox('foo');
+        if ($type === 'radio') {
+            $element = new Element\Radio('foo');
+        } elseif ($type === 'multi_checkbox') {
+            $element = new Element\MultiCheckbox('foo');
+        } elseif ($type === 'select') {
+            $element = new Element\Select('foo');
+        } else {
+            $element = new Element('foo');
+        }
         $element->setAttribute('type', $type);
-        $element->setAttribute('options', array(
+        $element->setValueOptions(array(
             'value1' => 'option',
             'value2' => 'label',
             'value3' => 'last',

--- a/tests/ZendTest/Form/View/Helper/FormMultiCheckboxTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormMultiCheckboxTest.php
@@ -35,7 +35,7 @@ class FormMultiCheckboxTest extends CommonTestCase
             'value2' => 'This is the second label',
             'value3' => 'This is the third label',
         );
-        $element->setAttribute('options', $options);
+        $element->setValueOptions($options);
         return $element;
     }
 
@@ -53,14 +53,14 @@ class FormMultiCheckboxTest extends CommonTestCase
             ),
             'value3' => 'This is the third label',
         );
-        $element->setAttribute('options', $options);
+        $element->setValueOptions($options);
         return $element;
     }
 
     public function testUsesOptionsAttributeToGenerateCheckBoxes()
     {
         $element = $this->getElement();
-        $options = $element->getAttribute('options');
+        $options = $element->getValueOptions();
         $markup  = $this->helper->render($element);
 
         $this->assertEquals(3, substr_count($markup, 'name="foo'));
@@ -77,7 +77,7 @@ class FormMultiCheckboxTest extends CommonTestCase
     public function testUsesOptionsAttributeWithOptionSpecToGenerateCheckBoxes()
     {
         $element = $this->getElementWithOptionSpec();
-        $options = $element->getAttribute('options');
+        $options = $element->getValueOptions();
         $markup  = $this->helper->render($element);
 
         $this->assertEquals(3, substr_count($markup, 'name="foo'));
@@ -109,7 +109,7 @@ class FormMultiCheckboxTest extends CommonTestCase
         $element = $this->getElement();
         $element->setUseHiddenElement(true);
         $element->setUncheckedValue('none');
-        $options = $element->getAttribute('options');
+        $options = $element->getValueOptions();
         $markup  = $this->helper->render($element);
 
         $this->assertEquals(4, substr_count($markup, 'name="foo'));
@@ -147,7 +147,7 @@ class FormMultiCheckboxTest extends CommonTestCase
     public function testAllowsSpecifyingLabelPosition()
     {
         $element = $this->getElement();
-        $options = $element->getAttribute('options');
+        $options = $element->getValueOptions();
         $this->helper->setLabelPosition(FormMultiCheckboxHelper::LABEL_PREPEND);
         $markup  = $this->helper->render($element);
 
@@ -212,17 +212,17 @@ class FormMultiCheckboxTest extends CommonTestCase
 
     public function testEnsureUseHiddenElementMethodExists()
     {
-        $element = new Element();
+        $element = new MultiCheckboxElement();
         $element->setName('codeType');
         $element->setOptions(array('label' => 'Code Type'));
         $element->setAttributes(array(
             'type' => 'radio',
-            'options' => array(
-                'Markdown' => 'markdown',
-                'HTML'     => 'html',
-                'Wiki'     => 'wiki',
-            ),
             'value' => array('markdown'),
+        ));
+        $element->setValueOptions(array(
+            'Markdown' => 'markdown',
+            'HTML'     => 'html',
+            'Wiki'     => 'wiki',
         ));
 
         $markup = $this->helper->render($element);
@@ -232,8 +232,8 @@ class FormMultiCheckboxTest extends CommonTestCase
 
     public function testCanTranslateContent()
     {
-        $element = new Element('foo');
-        $element->setAttribute('options', array(
+        $element = new MultiCheckboxElement('foo');
+        $element->setValueOptions(array(
             array(
                 'label' => 'label1',
                 'value' => 'value1',

--- a/tests/ZendTest/Form/View/Helper/FormRadioTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRadioTest.php
@@ -34,7 +34,7 @@ class FormRadioTest extends CommonTestCase
             'value2' => 'This is the second label',
             'value3' => 'This is the third label',
         );
-        $element->setAttribute('options', $options);
+        $element->setValueOptions($options);
         return $element;
     }
 
@@ -52,14 +52,14 @@ class FormRadioTest extends CommonTestCase
             ),
             'value3' => 'This is the third label',
         );
-        $element->setAttribute('options', $options);
+        $element->setValueOptions($options);
         return $element;
     }
 
     public function testUsesOptionsAttributeToGenerateRadioOptions()
     {
         $element = $this->getElement();
-        $options = $element->getAttribute('options');
+        $options = $element->getValueOptions();
         $markup  = $this->helper->render($element);
 
         $this->assertEquals(3, substr_count($markup, 'name="foo"'));
@@ -76,7 +76,7 @@ class FormRadioTest extends CommonTestCase
     public function testUsesOptionsAttributeWithOptionSpecToGenerateRadioOptions()
     {
         $element = $this->getElementWithOptionSpec();
-        $options = $element->getAttribute('options');
+        $options = $element->getValueOptions();
         $markup  = $this->helper->render($element);
 
         $this->assertEquals(3, substr_count($markup, 'name="foo'));
@@ -108,7 +108,7 @@ class FormRadioTest extends CommonTestCase
         $element = $this->getElement();
         $element->setUseHiddenElement(true);
         $element->setUncheckedValue('none');
-        $options = $element->getAttribute('options');
+        $options = $element->getValueOptions();
         $markup  = $this->helper->render($element);
 
         $this->assertEquals(4, substr_count($markup, 'name="foo'));
@@ -146,7 +146,7 @@ class FormRadioTest extends CommonTestCase
     public function testAllowsSpecifyingLabelPosition()
     {
         $element = $this->getElement();
-        $options = $element->getAttribute('options');
+        $options = $element->getValueOptions();
         $this->helper->setLabelPosition(FormRadioHelper::LABEL_PREPEND);
         $markup  = $this->helper->render($element);
 
@@ -163,7 +163,7 @@ class FormRadioTest extends CommonTestCase
     public function testDoesNotRenderCheckedAttributeIfNotPassed()
     {
         $element = $this->getElement();
-        $options = $element->getAttribute('options');
+        $options = $element->getValueOptions();
         $markup  = $this->helper->render($element);
 
         $this->assertNotContains('checked', $markup);
@@ -216,7 +216,7 @@ class FormRadioTest extends CommonTestCase
     public function testCanTranslateContent()
     {
         $element = new RadioElement('foo');
-        $element->setAttribute('options', array(
+        $element->setValueOptions(array(
             array(
                 'label' => 'label1',
                 'value' => 'value1',

--- a/tests/ZendTest/Form/View/Helper/FormSelectTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormSelectTest.php
@@ -11,7 +11,7 @@
 namespace ZendTest\Form\View\Helper;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\Form\Element;
+use Zend\Form\Element\Select as SelectElement;
 use Zend\Form\View\Helper\FormSelect as FormSelectHelper;
 
 class FormSelectTest extends CommonTestCase
@@ -24,7 +24,7 @@ class FormSelectTest extends CommonTestCase
 
     public function getElement()
     {
-        $element = new Element('foo');
+        $element = new SelectElement('foo');
         $options = array(
             array(
                 'label' => 'This is the first label',
@@ -39,7 +39,7 @@ class FormSelectTest extends CommonTestCase
                 'value' => 'value3',
             ),
         );
-        $element->setAttribute('options', $options);
+        $element->setValueOptions($options);
         return $element;
     }
 
@@ -96,9 +96,9 @@ class FormSelectTest extends CommonTestCase
     public function testCanMarkOptionsAsDisabled()
     {
         $element = $this->getElement();
-        $options = $element->getAttribute('options');
+        $options = $element->getValueOptions('options');
         $options[1]['disabled'] = true;
-        $element->setAttribute('options', $options);
+        $element->setValueOptions($options);
 
         $markup = $this->helper->render($element);
         $this->assertRegexp('#option .*?value="value2" .*?disabled="disabled"#', $markup);
@@ -107,14 +107,14 @@ class FormSelectTest extends CommonTestCase
     public function testOptgroupsAreCreatedWhenAnOptionHasAnOptionsKey()
     {
         $element = $this->getElement();
-        $options = $element->getAttribute('options');
+        $options = $element->getValueOptions('options');
         $options[1]['options'] = array(
             array(
                 'label' => 'foo',
                 'value' => 'bar',
             )
         );
-        $element->setAttribute('options', $options);
+        $element->setValueOptions($options);
 
         $markup = $this->helper->render($element);
         $this->assertRegexp('#optgroup[^>]*?label="This is the second label"[^>]*>\s*<option[^>]*?value="bar"[^>]*?>foo.*?</optgroup>#s', $markup);
@@ -123,7 +123,7 @@ class FormSelectTest extends CommonTestCase
     public function testCanDisableAnOptgroup()
     {
         $element = $this->getElement();
-        $options = $element->getAttribute('options');
+        $options = $element->getValueOptions('options');
         $options[1]['disabled'] = true;
         $options[1]['options']  = array(
             array(
@@ -131,7 +131,7 @@ class FormSelectTest extends CommonTestCase
                 'value' => 'bar',
             )
         );
-        $element->setAttribute('options', $options);
+        $element->setValueOptions($options);
 
         $markup = $this->helper->render($element);
         $this->assertRegexp('#optgroup .*?label="This is the second label"[^>]*?disabled="disabled"[^>]*?>\s*<option[^>]*?value="bar"[^>]*?>foo.*?</optgroup>#', $markup);
@@ -192,8 +192,8 @@ class FormSelectTest extends CommonTestCase
      */
     public function testScalarOptionValues($options)
     {
-        $element = new Element('foo');
-        $element->setAttribute('options', $options);
+        $element = new SelectElement('foo');
+        $element->setValueOptions($options);
         $markup = $this->helper->render($element);
         list($value, $label) = each($options);
         $this->assertRegexp(sprintf('#option .*?value="%s"#', (string)$value), $markup);
@@ -207,8 +207,8 @@ class FormSelectTest extends CommonTestCase
 
     public function testCanTranslateContent()
     {
-        $element = new Element('foo');
-        $element->setAttribute('options', array(
+        $element = new SelectElement('foo');
+        $element->setValueOptions(array(
             array(
                 'label' => 'label1',
                 'value' => 'value1',


### PR DESCRIPTION
Refactor to clean up the Element attributes, and move out value options into it's own property.

Affects Select, Radio, and MultiCheckbox elements and view helpers.
