### PR TITLE
Form: lazy assign an InputFilter if one does not exist

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -577,6 +577,10 @@ class Form extends Fieldset implements FormInterface
             }
         }
 
+        if (null === $this->filter) {
+            $this->filter = new InputFilter();
+        }
+
         if ($this->filter instanceof InputFilterInterface && $this->useInputFilterDefaults()) {
             $this->attachInputFilterDefaults($this->filter, $this);
         }

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -147,9 +147,9 @@ class FormTest extends TestCase
         $this->form->setInputFilter($inputFilter);
     }
 
-    public function testNoInputFilterPresentByDefault()
+    public function testInputFilterPresentByDefault()
     {
-        $this->assertNull($this->form->getInputFilter());
+        $this->assertNotNull($this->form->getInputFilter());
     }
 
     public function testCanComposeAnInputFilter()


### PR DESCRIPTION
Forgetting to set the Form's input filter is tripping some people up. 

Here, it will set one in the getInputFilter() method if it does not exist.
