### PR TITLE
Optimize autoload prefix in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     },
     "autoload": {
         "psr-0": {
-            "Zend": "library/",
-            "ZendTest": "tests/"
+            "Zend\\": "library/",
+            "ZendTest\\": "tests/"
         }
     },
     "config": {


### PR DESCRIPTION
By having more specific autoload prefixes it is possible to reduce the number of stat calls made.
