### PR TITLE
[Paginator] Enable @group disable test

### DIFF
--- a/tests/ZendTest/Paginator/PaginatorTest.php
+++ b/tests/ZendTest/Paginator/PaginatorTest.php
@@ -198,10 +198,6 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @todo Why is this one causing a segfault?
-     * @group disable
-     */
     public function testRendersWithoutPartial()
     {
         $this->paginator->setView(new View\Renderer\PhpRenderer());


### PR DESCRIPTION
I can't reproduce this with Zend Server CE 5.6.0 running in a Mac OS X
