### PR TITLE
Add class to inputs that have error

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -40,6 +40,11 @@ class FormRow extends AbstractHelper
     protected $labelAttributes;
 
     /**
+     * @var string
+     */
+    protected $inputErrorClass = 'input-error';
+
+    /**
      * @var FormLabel
      */
     protected $labelHelper;
@@ -68,8 +73,20 @@ class FormRow extends AbstractHelper
         $labelHelper         = $this->getLabelHelper();
         $elementHelper       = $this->getElementHelper();
         $elementErrorsHelper = $this->getElementErrorsHelper();
-        $label               = $element->getLabel();
-        $elementString       = $elementHelper->render($element);
+
+        $label           = $element->getLabel();
+        $inputErrorClass = $this->getInputErrorClass();
+        $elementErrors   = $elementErrorsHelper->render($element);
+
+        // Does this element have errors ?
+        if (!empty($elementErrors) && !empty($inputErrorClass)) {
+            $classAttributes = ($element->hasAttribute('class') ? $element->getAttribute('class') . ' ' : '');
+            $classAttributes = $classAttributes . $inputErrorClass;
+
+            $element->setAttribute('class', $classAttributes);
+        }
+
+        $elementString = $elementHelper->render($element);
 
         if (!empty($label)) {
             $label = $escapeHtmlHelper($label);
@@ -108,12 +125,12 @@ class FormRow extends AbstractHelper
                 }
 
                 if ($this->renderErrors) {
-                    $markup .= $elementErrorsHelper->render($element);
+                    $markup .= $elementErrors;
                 }
             }
         } else {
             if ($this->renderErrors) {
-                $markup = $elementString . $elementErrorsHelper->render($element);
+                $markup = $elementString . $elementErrors;
             } else {
                 $markup = $elementString;
             }
@@ -221,6 +238,28 @@ class FormRow extends AbstractHelper
     public function getLabelAttributes()
     {
         return $this->labelAttributes;
+    }
+
+    /**
+     * Set the class that is added to element that have errors
+     *
+     * @param  string $inputErrorClass
+     * @return FormRow
+     */
+    public function setInputErrorClass($inputErrorClass)
+    {
+        $this->inputErrorClass = $inputErrorClass;
+        return $this;
+    }
+
+    /**
+     * Get the class that is added to element that have errors
+     *
+     * @return string
+     */
+    public function getInputErrorClass()
+    {
+        return $this->inputErrorClass;
     }
 
     /**

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -119,7 +119,7 @@ class FormRowTest extends TestCase
         $this->assertRegexp('#<ul>\s*<li>First error message</li>\s*<li>Second error message</li>\s*<li>Third error message</li>\s*</ul>#s', $markup);
     }
 
-    public function testDoesNotRenderErrorsIfSetToFalse()
+    public function testDoesNotRenderErrorsListIfSetToFalse()
     {
         $element  = new Element('foo');
         $element->setMessages(array(
@@ -129,7 +129,30 @@ class FormRowTest extends TestCase
         ));
 
         $markup = $this->helper->setRenderErrors(false)->render($element);
-        $this->assertRegexp('/<input name="foo" type="text"[^\/>]*\/?>/', $markup);
+        $this->assertRegexp('/<input name="foo" class="input-error" type="text" [^\/>]*\/?>/', $markup);
+    }
+
+    public function testCanModifyDefaultErrorClass()
+    {
+        $element  = new Element('foo');
+        $element->setMessages(array(
+            'Error message'
+        ));
+
+        $markup = $this->helper->setInputErrorClass('custom-error-class')->render($element);
+        $this->assertRegexp('/<input name="foo" class="custom-error-class" type="text" [^\/>]*\/?>/', $markup);
+    }
+
+    public function testDoesNotOverrideClassesIfAlreadyPresentWhenThereAreErrors()
+    {
+        $element  = new Element('foo');
+        $element->setMessages(array(
+            'Error message'
+        ));
+        $element->setAttribute('class', 'foo bar');
+
+        $markup = $this->helper->setInputErrorClass('custom-error-class')->render($element);
+        $this->assertRegexp('/<input name="foo" class="foo bar custom-error-class" type="text" [^\/>]*\/?>/', $markup);
     }
 
     public function testInvokeWithNoElementChainsHelper()


### PR DESCRIPTION
Although the FormRow helper is very convenient, it was very hard (in fact, impossible) to style input that have errors (mostly because CSS does not have parent selector).

This PR allows to automatically add a class to every input that have errors (the default class being "input-error"). In order to avoid name clashes, this class can be changed in a helper basis, using the function setInputErrorClass.

I don't think it is necessary to allow to remove this class, as it would add another option and complicates the code for nothing..
