### PR TITLE
Hotfix BC for extra in Log\Formatter\Simple

### DIFF
--- a/library/Zend/Log/Formatter/Base.php
+++ b/library/Zend/Log/Formatter/Base.php
@@ -51,7 +51,12 @@ class Base implements FormatterInterface
     public function format($event)
     {
         foreach ($event as $key => $value) {
-            $event[$key] = $this->normalize($value);
+            // Keep extra as an array
+            if ('extra' === $key) {
+                $event[$key] = self::format($value);
+            } else {
+                $event[$key] = $this->normalize($value);
+            }
         }
 
         return $event;
@@ -65,13 +70,16 @@ class Base implements FormatterInterface
      */
     protected function normalize($value)
     {
-        if (is_scalar($value)) {
+        if (is_scalar($value) || null === $value) {
             return $value;
         }
 
         if ($value instanceof DateTime) {
             $value = $value->format($this->getDateTimeFormat());
         } elseif (is_array($value) || $value instanceof Traversable) {
+            if ($value instanceof Traversable) {
+                $value = iterator_to_array($value);
+            }
             foreach ($value as $key => $subvalue) {
                 $value[$key] = $this->normalize($subvalue);
             }

--- a/library/Zend/Log/Formatter/Base.php
+++ b/library/Zend/Log/Formatter/Base.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Log
+ */
+
+namespace Zend\Log\Formatter;
+
+use DateTime;
+use Traversable;
+use Zend\Log\Exception;
+
+/**
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage Formatter
+ */
+class Base implements FormatterInterface
+{
+    /**
+     * Format specifier for DateTime objects in event data (default: ISO 8601)
+     *
+     * @see http://php.net/manual/en/function.date.php
+     * @var string
+     */
+    protected $dateTimeFormat = self::DEFAULT_DATETIME_FORMAT;
+
+    /**
+     * Class constructor
+     *
+     * @see http://php.net/manual/en/function.date.php
+     * @param null|string $dateTimeFormat Format for DateTime objects
+     */
+    public function __construct($dateTimeFormat = null)
+    {
+        if (null !== $dateTimeFormat) {
+            $this->dateTimeFormat = $dateTimeFormat;
+        }
+    }
+
+    /**
+     * Formats data to be written by the writer.
+     *
+     * @param array $event event data
+     * @return array
+     */
+    public function format($event)
+    {
+        foreach ($event as $key => $value) {
+            $event[$key] = $this->normalize($value);
+        }
+
+        return $event;
+    }
+
+    /**
+     * Normalize all non-scalar data types (except null) in a string value
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    protected function normalize($value)
+    {
+        if (is_scalar($value)) {
+            return $value;
+        }
+
+        if ($value instanceof DateTime) {
+            $value = $value->format($this->getDateTimeFormat());
+        } elseif (is_array($value) || $value instanceof Traversable) {
+            foreach ($value as $key => $subvalue) {
+                $value[$key] = $this->normalize($subvalue);
+            }
+            $value = json_encode($value);
+        } elseif (is_object($value) && !method_exists($value,'__toString')) {
+            $value = sprintf('object(%s) %s', get_class($value), json_encode($value));
+        } elseif (is_resource($value)) {
+            $value = sprintf('resource(%s)', get_resource_type($value));
+        } elseif (!is_object($value)) {
+            $value = gettype($value);
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDateTimeFormat()
+    {
+        return $this->dateTimeFormat;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setDateTimeFormat($dateTimeFormat)
+    {
+        $this->dateTimeFormat = (string) $dateTimeFormat;
+        return $this;
+    }
+}

--- a/library/Zend/Log/Formatter/Simple.php
+++ b/library/Zend/Log/Formatter/Simple.php
@@ -59,13 +59,21 @@ class Simple extends Base
         $output = $this->format;
 
         $event = parent::format($event);
-        if (array_key_exists('extra', $event)) {
-            $event['extra'] = $this->normalize($event['extra']);
-        }
         foreach ($event as $name => $value) {
+            if ('extra' == $name && count($value)) {
+                $value = $this->normalize($value);
+            } elseif ('extra' == $name) {
+                // Don't print an empty array
+                $value = '';
+            }
             $output = str_replace("%$name%", $value, $output);
         }
 
+        if (isset($event['extra']) && empty($event['extra'])
+            && false !== strpos($this->format, '%extra%')
+        ) {
+            $output = rtrim($output, ' ');
+        }
         return $output;
     }
 }

--- a/library/Zend/Log/Formatter/Simple.php
+++ b/library/Zend/Log/Formatter/Simple.php
@@ -30,14 +30,6 @@ class Simple extends Base
     protected $format;
 
     /**
-     * Format specifier for DateTime objects in event data (default: ISO 8601)
-     *
-     * @see http://php.net/manual/en/function.date.php
-     * @var string
-     */
-    protected $dateTimeFormat = self::DEFAULT_DATETIME_FORMAT;
-
-    /**
      * Class constructor
      *
      * @see http://php.net/manual/en/function.date.php
@@ -53,9 +45,7 @@ class Simple extends Base
 
         $this->format = isset($format) ? $format : static::DEFAULT_FORMAT;
 
-        if (isset($dateTimeFormat)) {
-            $this->dateTimeFormat = $dateTimeFormat;
-        }
+        parent::__construct($dateTimeFormat);
     }
 
     /**
@@ -77,22 +67,5 @@ class Simple extends Base
         }
 
         return $output;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getDateTimeFormat()
-    {
-        return $this->dateTimeFormat;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function setDateTimeFormat($dateTimeFormat)
-    {
-        $this->dateTimeFormat = (string) $dateTimeFormat;
-        return $this;
     }
 }

--- a/library/Zend/Log/Formatter/Simple.php
+++ b/library/Zend/Log/Formatter/Simple.php
@@ -69,6 +69,9 @@ class Simple extends Base
         $output = $this->format;
 
         $event = parent::format($event);
+        if (array_key_exists('extra', $event)) {
+            $event['extra'] = $this->normalize($event['extra']);
+        }
         foreach ($event as $name => $value) {
             $output = str_replace("%$name%", $value, $output);
         }

--- a/library/Zend/Log/Formatter/Simple.php
+++ b/library/Zend/Log/Formatter/Simple.php
@@ -18,9 +18,9 @@ use Zend\Log\Exception;
  * @package    Zend_Log
  * @subpackage Formatter
  */
-class Simple implements FormatterInterface
+class Simple extends Base
 {
-    const DEFAULT_FORMAT = '%timestamp% %priorityName% (%priority%): %message% %info%';
+    const DEFAULT_FORMAT = '%timestamp% %priorityName% (%priority%): %message% %extra%';
 
     /**
      * Format specifier for log messages
@@ -68,21 +68,8 @@ class Simple implements FormatterInterface
     {
         $output = $this->format;
 
-        if (!isset($event['info'])) {
-            $event['info'] = '';
-        }
-
-        if (isset($event['timestamp']) && $event['timestamp'] instanceof DateTime) {
-            $event['timestamp'] = $event['timestamp']->format($this->getDateTimeFormat());
-        }
-
+        $event = parent::format($event);
         foreach ($event as $name => $value) {
-            if ((is_object($value) && !method_exists($value,'__toString'))
-                || is_array($value)
-            ) {
-                $value = gettype($value);
-            }
-
             $output = str_replace("%$name%", $value, $output);
         }
 

--- a/tests/ZendTest/Log/Formatter/BaseTest.php
+++ b/tests/ZendTest/Log/Formatter/BaseTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Log
+ */
+
+namespace ZendTest\Log\Formatter;
+
+use DateTime;
+use stdClass;
+use EmptyIterator;
+use ArrayIterator;
+use ZendTest\Log\TestAsset\StringObject;
+use Zend\Log\Formatter\Base as BaseFormatter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage UnitTests
+ * @group      Zend_Log
+ */
+class BaseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultDateTimeFormat()
+    {
+        $formatter = new BaseFormatter();
+        $this->assertEquals(BaseFormatter::DEFAULT_DATETIME_FORMAT, $formatter->getDateTimeFormat());
+    }
+
+    /**
+     * @dataProvider provideDateTimeFormats
+     */
+    public function testAllowsSpecifyingDateTimeFormatAsConstructorArgument($dateTimeFormat)
+    {
+        $formatter = new BaseFormatter($dateTimeFormat);
+
+        $this->assertEquals($dateTimeFormat, $formatter->getDateTimeFormat());
+    }
+
+    /**
+     * @return array
+     */
+    public function provideDateTimeFormats()
+    {
+        return array(
+            array('r'),
+            array('U'),
+            array(DateTime::RSS),
+        );
+    }
+
+    /**
+     * @dataProvider provideDateTimeFormats
+     */
+    public function testSetDateTimeFormat($dateTimeFormat)
+    {
+        $formatter = new BaseFormatter();
+        $formatter->setDateTimeFormat($dateTimeFormat);
+
+        $this->assertEquals($dateTimeFormat, $formatter->getDateTimeFormat());
+    }
+
+    public function testFormatAllTypes()
+    {
+        $datetime = new DateTime();
+        $object = new stdClass();
+        $object->foo = 'bar';
+        $formatter = new BaseFormatter();
+
+        $event = array(
+            'timestamp' => $datetime,
+            'priority' => 1,
+            'message' => 'tottakai',
+            'extra' => array(
+                'float' => 0.2,
+                'boolean' => false,
+                'array_empty' => array(),
+                'array' => range(0, 4),
+                'traversable_empty' => new EmptyIterator(),
+                'traversable' => new ArrayIterator(array('id', 42)),
+                'null' => null,
+                'object_empty' => new stdClass(),
+                'object' => $object,
+                'string object' => new StringObject(),
+                'resource' => fopen('php://stdout', 'w'),
+            ),
+        );
+        $outputExpected = array(
+            'timestamp' => $datetime->format($formatter->getDateTimeFormat()),
+            'priority' => 1,
+            'message' => 'tottakai',
+            'extra' => array(
+                'boolean' => false,
+                'float' => 0.2,
+                'array_empty' => '[]',
+                'array' => '[0,1,2,3,4]',
+                'traversable_empty' => '[]',
+                'traversable' => '["id",42]',
+                'null' => null,
+                'object_empty' => 'object(stdClass) {}',
+                'object' => 'object(stdClass) {"foo":"bar"}',
+                'string object' => 'Hello World',
+                'resource' => 'resource(stream)',
+            ),
+        );
+
+        $this->assertEquals($outputExpected, $formatter->format($event));
+    }
+}

--- a/tests/ZendTest/Log/Formatter/SimpleTest.php
+++ b/tests/ZendTest/Log/Formatter/SimpleTest.php
@@ -37,7 +37,8 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
             'timestamp'    => $date,
             'message'      => 'foo',
             'priority'     => 42,
-            'priorityName' => 'bar'
+            'priorityName' => 'bar',
+            'extra'        => array()
         );
 
         $f = new Simple();
@@ -54,7 +55,8 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
         $fields = array(
             'timestamp'    => new DateTime(),
             'priority'     => 42,
-            'priorityName' => 'bar'
+            'priorityName' => 'bar',
+            'extra'        => array()
         );
 
         $f = new Simple();
@@ -77,12 +79,12 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
 
         $fields['message'] = fopen('php://stdout', 'w');
         $line = $f->format($fields);
-        $this->assertContains('Resource id ', $line);
+        $this->assertContains('resource(stream)', $line);
         fclose($fields['message']);
 
         $fields['message'] = range(1, 10);
         $line = $f->format($fields);
-        $this->assertContains('array', $line);
+        $this->assertContains('[1,2,3,4,5,6,7,8,9,10]', $line);
 
         $fields['message'] = new StringObject();
         $line = $f->format($fields);
@@ -139,7 +141,7 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
             'message'      => 'Application error',
             'priority'     => 2,
             'priorityName' => 'CRIT',
-            'info'         => $exception,
+            'extra'        => array($exception),
         );
 
         $formatter = new Simple();

--- a/tests/ZendTest/Log/Formatter/SimpleTest.php
+++ b/tests/ZendTest/Log/Formatter/SimpleTest.php
@@ -137,4 +137,11 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains($message, $output);
     }
+
+    public function testAllowsSpecifyingFormatAsConstructorArgument()
+    {
+        $format = '[%timestamp%] %message%';
+        $formatter = new Simple($format);
+        $this->assertEquals($format, $formatter->format(array()));
+    }
 }

--- a/tests/ZendTest/Log/Formatter/SimpleTest.php
+++ b/tests/ZendTest/Log/Formatter/SimpleTest.php
@@ -50,7 +50,10 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
         $this->assertContains((string) $fields['priority'], $line);
     }
 
-    public function testComplexValues()
+    /**
+     * @dataProvider provideMessages
+     */
+    public function testComplexMessages($message, $printExpected)
     {
         $fields = array(
             'timestamp'    => new DateTime(),
@@ -59,40 +62,25 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
             'extra'        => array()
         );
 
-        $f = new Simple();
+        $formatter = new Simple();
 
-        $fields['message'] = 'Foo';
-        $line = $f->format($fields);
-        $this->assertContains($fields['message'], $line);
+        $fields['message'] = $message;
+        $line = $formatter->format($fields);
+        $this->assertContains($printExpected, $line);
+    }
 
-        $fields['message'] = 10;
-        $line = $f->format($fields);
-        $this->assertContains((string) $fields['message'], $line);
-
-        $fields['message'] = 10.5;
-        $line = $f->format($fields);
-        $this->assertContains((string) $fields['message'], $line);
-
-        $fields['message'] = true;
-        $line = $f->format($fields);
-        $this->assertContains('1', $line);
-
-        $fields['message'] = fopen('php://stdout', 'w');
-        $line = $f->format($fields);
-        $this->assertContains('resource(stream)', $line);
-        fclose($fields['message']);
-
-        $fields['message'] = range(1, 10);
-        $line = $f->format($fields);
-        $this->assertContains('[1,2,3,4,5,6,7,8,9,10]', $line);
-
-        $fields['message'] = new StringObject();
-        $line = $f->format($fields);
-        $this->assertContains($fields['message']->__toString(), $line);
-
-        $fields['message'] = new stdClass();
-        $line = $f->format($fields);
-        $this->assertContains('object', $line);
+    public function provideMessages()
+    {
+        return array(
+            array('Foo', 'Foo'),
+            array(10, '10'),
+            array(10.5, '10.5'),
+            array(true, '1'),
+            array(fopen('php://stdout', 'w'), 'resource(stream)'),
+            array(range(1, 10), '[1,2,3,4,5,6,7,8,9,10]'),
+            array(new StringObject(), 'Hello World'),
+            array(new stdClass(), 'object'),
+        );
     }
 
     /**

--- a/tests/ZendTest/Log/Formatter/SimpleTest.php
+++ b/tests/ZendTest/Log/Formatter/SimpleTest.php
@@ -32,7 +32,7 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultFormat()
     {
-        $date = new DateTime();
+        $date = new DateTime('2012-08-28T18:15:00Z');
         $fields = array(
             'timestamp'    => $date,
             'message'      => 'foo',
@@ -41,13 +41,10 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
             'extra'        => array()
         );
 
-        $f = new Simple();
-        $line = $f->format($fields);
+        $outputExpected = '2012-08-28T18:15:00+00:00 bar (42): foo';
+        $formatter = new Simple();
 
-        $this->assertContains($date->format('c'), $line, 'Default date format is ISO 8601');
-        $this->assertContains($fields['message'], $line);
-        $this->assertContains($fields['priorityName'], $line);
-        $this->assertContains((string) $fields['priority'], $line);
+        $this->assertEquals($outputExpected, $formatter->format($fields));
     }
 
     /**

--- a/tests/ZendTest/Log/Formatter/SimpleTest.php
+++ b/tests/ZendTest/Log/Formatter/SimpleTest.php
@@ -13,6 +13,8 @@ namespace ZendTest\Log\Formatter;
 use DateTime;
 use ZendTest\Log\TestAsset\StringObject;
 use Zend\Log\Formatter\Simple;
+use stdClass;
+use RuntimeException;
 
 /**
  * @category   Zend
@@ -31,10 +33,12 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
     public function testDefaultFormat()
     {
         $date = new DateTime();
-        $fields = array('timestamp'    => $date,
-                        'message'      => 'foo',
-                        'priority'     => 42,
-                        'priorityName' => 'bar');
+        $fields = array(
+            'timestamp'    => $date,
+            'message'      => 'foo',
+            'priority'     => 42,
+            'priorityName' => 'bar'
+        );
 
         $f = new Simple();
         $line = $f->format($fields);
@@ -42,14 +46,16 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
         $this->assertContains($date->format('c'), $line, 'Default date format is ISO 8601');
         $this->assertContains($fields['message'], $line);
         $this->assertContains($fields['priorityName'], $line);
-        $this->assertContains((string)$fields['priority'], $line);
+        $this->assertContains((string) $fields['priority'], $line);
     }
 
     public function testComplexValues()
     {
-        $fields = array('timestamp'    => new DateTime(),
-                        'priority'     => 42,
-                        'priorityName' => 'bar');
+        $fields = array(
+            'timestamp'    => new DateTime(),
+            'priority'     => 42,
+            'priorityName' => 'bar'
+        );
 
         $f = new Simple();
 
@@ -59,11 +65,11 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
 
         $fields['message'] = 10;
         $line = $f->format($fields);
-        $this->assertContains((string)$fields['message'], $line);
+        $this->assertContains((string) $fields['message'], $line);
 
         $fields['message'] = 10.5;
         $line = $f->format($fields);
-        $this->assertContains((string)$fields['message'], $line);
+        $this->assertContains((string) $fields['message'], $line);
 
         $fields['message'] = true;
         $line = $f->format($fields);
@@ -74,7 +80,7 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Resource id ', $line);
         fclose($fields['message']);
 
-        $fields['message'] = range(1,10);
+        $fields['message'] = range(1, 10);
         $line = $f->format($fields);
         $this->assertContains('array', $line);
 
@@ -82,7 +88,7 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
         $line = $f->format($fields);
         $this->assertContains($fields['message']->__toString(), $line);
 
-        $fields['message'] = new \stdClass();
+        $fields['message'] = new stdClass();
         $line = $f->format($fields);
         $this->assertContains('object', $line);
     }
@@ -127,7 +133,7 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
     public function testDefaultFormatShouldDisplayExtraInformations()
     {
         $message = 'custom message';
-        $exception = new \RuntimeException($message);
+        $exception = new RuntimeException($message);
         $event = array(
             'timestamp'    => new DateTime(),
             'message'      => 'Application error',

--- a/tests/ZendTest/Log/Formatter/SimpleTest.php
+++ b/tests/ZendTest/Log/Formatter/SimpleTest.php
@@ -48,39 +48,6 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider provideMessages
-     */
-    public function testComplexMessages($message, $printExpected)
-    {
-        $fields = array(
-            'timestamp'    => new DateTime(),
-            'priority'     => 42,
-            'priorityName' => 'bar',
-            'extra'        => array()
-        );
-
-        $formatter = new Simple();
-
-        $fields['message'] = $message;
-        $line = $formatter->format($fields);
-        $this->assertContains($printExpected, $line);
-    }
-
-    public function provideMessages()
-    {
-        return array(
-            array('Foo', 'Foo'),
-            array(10, '10'),
-            array(10.5, '10.5'),
-            array(true, '1'),
-            array(fopen('php://stdout', 'w'), 'resource(stream)'),
-            array(range(1, 10), '[1,2,3,4,5,6,7,8,9,10]'),
-            array(new StringObject(), 'Hello World'),
-            array(new stdClass(), 'object'),
-        );
-    }
-
-    /**
      * @dataProvider provideDateTimeFormats
      */
     public function testCustomDateTimeFormat($dateTimeFormat)


### PR DESCRIPTION
Hello folks :smiley:

ZF2 key is [**extra**](https://github.com/zendframework/zf2/blob/master/library/Zend/Log/Logger.php#L257), Simple Formatter uses the legacy (ZF1) key (= [**info**](https://github.com/zendframework/zf2/blob/master/library/Zend/Log/Formatter/Simple.php#L23)). It is not functional with Logger class.

The refactor introduces a **base formatter** in order to normalize in string value all non-scalar data in **extra** array.
I made the choice to use the json_encode instead of var_export for arrays, and objects. I think we should keep consistency for the [message in Logger](https://github.com/zendframework/zf2/blob/master/library/Zend/Log/Logger.php#L247-L249) when it's an array.

We can update others formatters to avoid the errors of a backend with a variable type (like an instance of DateTime, a resource, etc).

Greetings.
