### PR TITLE
Hotfix/mvc dependency cleanup

### DIFF
--- a/library/Zend/Mvc/Service/RequestFactory.php
+++ b/library/Zend/Mvc/Service/RequestFactory.php
@@ -31,7 +31,7 @@ class RequestFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        if (class_exists("Zend\Console\Console") && Console::isConsole()) {
+        if (Console::isConsole()) {
             return new ConsoleRequest();
         }
 

--- a/library/Zend/Mvc/Service/RequestFactory.php
+++ b/library/Zend/Mvc/Service/RequestFactory.php
@@ -31,7 +31,7 @@ class RequestFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        if (Console::isConsole()) {
+        if (class_exists("Zend\Console\Console") && Console::isConsole()) {
             return new ConsoleRequest();
         }
 

--- a/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
+++ b/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
@@ -51,17 +51,17 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
         foreach ($this->defaultHelperMapClasses as $configClass) {
             if (is_string($configClass) && class_exists($configClass)) {
                 $config = new $configClass;
-            }
 
-            if (!$config instanceof ConfigInterface) {
-                throw new Exception\RuntimeException(sprintf(
-                    'Invalid service manager configuration class provided; received "%s", expected class implementing %s',
-                    $configClass,
-                    'Zend\ServiceManager\ConfigInterface'
-                ));
+	            if (!$config instanceof ConfigInterface) {
+	                throw new Exception\RuntimeException(sprintf(
+	                    'Invalid service manager configuration class provided; received "%s", expected class implementing %s',
+	                    $configClass,
+	                    'Zend\ServiceManager\ConfigInterface'
+	                ));
+	            }
+	
+	            $config->configureServiceManager($plugins);
             }
-
-            $config->configureServiceManager($plugins);
         }
 
         // Configure URL view helper with router

--- a/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
+++ b/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
@@ -52,15 +52,15 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
             if (is_string($configClass) && class_exists($configClass)) {
                 $config = new $configClass;
 
-	            if (!$config instanceof ConfigInterface) {
-	                throw new Exception\RuntimeException(sprintf(
-	                    'Invalid service manager configuration class provided; received "%s", expected class implementing %s',
-	                    $configClass,
-	                    'Zend\ServiceManager\ConfigInterface'
-	                ));
-	            }
-	
-	            $config->configureServiceManager($plugins);
+                if (!$config instanceof ConfigInterface) {
+                    throw new Exception\RuntimeException(sprintf(
+                        'Invalid service manager configuration class provided; received "%s", expected class implementing %s',
+                        $configClass,
+                        'Zend\ServiceManager\ConfigInterface'
+                    ));
+                }
+
+                $config->configureServiceManager($plugins);
             }
         }
 

--- a/library/Zend/Mvc/composer.json
+++ b/library/Zend/Mvc/composer.json
@@ -14,6 +14,7 @@
     "target-dir": "Zend/Mvc",
     "require": {
         "php": ">=5.3.3",
+        "zendframework/zend-console": "self.version",
         "zendframework/zend-di": "self.version",
         "zendframework/zend-eventmanager": "self.version",
         "zendframework/zend-modulemanager": "self.version",


### PR DESCRIPTION
Update Mvc dependencies.

Some Mvc services depend on Zend\Console*.
Zend\Mvc\Service\ViewHelperManagerFactory threw exceptions if Zend\Form, Zend\I18n and/or Zend\Navigation was not present.
These defaultHelperMapClasses are optional now.
