### PR TITLE
Beadcrumb navigation viewhelper fix

### DIFF
--- a/library/Zend/View/Helper/Navigation.php
+++ b/library/Zend/View/Helper/Navigation.php
@@ -45,6 +45,13 @@ class Navigation extends AbstractNavigationHelper
     protected $defaultProxy = 'menu';
 
     /**
+     * Indicates whether or not a given helper has been injected
+     *
+     * @var array
+     */
+    protected $injected = array();
+
+    /**
      * Whether container should be injected when proxying
      *
      * @var bool
@@ -183,7 +190,11 @@ class Navigation extends AbstractNavigationHelper
         $helper = $plugins->get($proxy);
         $class  = get_class($helper);
 
-        $this->inject($helper);
+        if (!isset($this->injected[$class])) {
+            $this->inject($helper);
+            $this->injected[$class] = true;
+        }
+
         return $helper;
     }
 
@@ -196,16 +207,20 @@ class Navigation extends AbstractNavigationHelper
      */
     protected function inject(NavigationHelper $helper)
     {
-        if ($this->getInjectContainer()) {
+        if ($this->getInjectContainer() && !$helper->hasContainer()) {
             $helper->setContainer($this->getContainer());
         }
 
         if ($this->getInjectAcl()) {
-            $helper->setAcl($this->getAcl());
-            $helper->setRole($this->getRole());
+            if (!$helper->hasAcl()) {
+                $helper->setAcl($this->getAcl());
+            }
+            if (!$helper->hasRole()) {
+                $helper->setRole($this->getRole());
+            }
         }
 
-        if ($this->getInjectTranslator()) {
+        if ($this->getInjectTranslator() && !$helper->hasTranslator()) {
             $helper->setTranslator(
                 $this->getTranslator(), $this->getTranslatorTextDomain()
             );

--- a/library/Zend/View/Helper/Navigation.php
+++ b/library/Zend/View/Helper/Navigation.php
@@ -45,13 +45,6 @@ class Navigation extends AbstractNavigationHelper
     protected $defaultProxy = 'menu';
 
     /**
-     * Indicates whether or not a given helper has been injected
-     *
-     * @var array
-     */
-    protected $injected = array();
-
-    /**
      * Whether container should be injected when proxying
      *
      * @var bool
@@ -190,11 +183,7 @@ class Navigation extends AbstractNavigationHelper
         $helper = $plugins->get($proxy);
         $class  = get_class($helper);
 
-        if (!isset($this->injected[$class])) {
-            $this->inject($helper);
-            $this->injected[$class] = true;
-        }
-
+        $this->inject($helper);
         return $helper;
     }
 
@@ -207,20 +196,16 @@ class Navigation extends AbstractNavigationHelper
      */
     protected function inject(NavigationHelper $helper)
     {
-        if ($this->getInjectContainer() && !$helper->hasContainer()) {
+        if ($this->getInjectContainer()) {
             $helper->setContainer($this->getContainer());
         }
 
         if ($this->getInjectAcl()) {
-            if (!$helper->hasAcl()) {
-                $helper->setAcl($this->getAcl());
-            }
-            if (!$helper->hasRole()) {
-                $helper->setRole($this->getRole());
-            }
+            $helper->setAcl($this->getAcl());
+            $helper->setRole($this->getRole());
         }
 
-        if ($this->getInjectTranslator() && !$helper->hasTranslator()) {
+        if ($this->getInjectTranslator()) {
             $helper->setTranslator(
                 $this->getTranslator(), $this->getTranslatorTextDomain()
             );

--- a/library/Zend/View/Helper/Navigation/Breadcrumbs.php
+++ b/library/Zend/View/Helper/Navigation/Breadcrumbs.php
@@ -60,9 +60,6 @@ class Breadcrumbs extends AbstractHelper
      */
     public function __invoke($container = null)
     {
-        if (is_string($container)) {
-            $container = $this->getServiceLocator()->get($container);
-        }
         if (null !== $container) {
             $this->setContainer($container);
         }

--- a/tests/ZendTest/View/Helper/Navigation/AbstractTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/AbstractTest.php
@@ -133,6 +133,9 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
         $sm->get('Application')->bootstrap();
         $sm->setFactory('Navigation', 'Zend\Navigation\Service\DefaultNavigationFactory');
 
+        $sm->setService('nav1', $this->_nav1);
+        $sm->setService('nav2', $this->_nav2);
+        
         $app = $this->serviceManager->get('Application');
         $app->getMvcEvent()->setRouteMatch(new RouteMatch(array(
             'controller' => 'post',

--- a/tests/ZendTest/View/Helper/Navigation/BreadcrumbsTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/BreadcrumbsTest.php
@@ -69,6 +69,17 @@ class BreadcrumbsTest extends AbstractTest
         $this->assertEquals($this->_nav2, $returned->getContainer());
     }
 
+    public function testHelperEntryPointWithContainerStringParam()
+    {
+        $pm = new \Zend\View\HelperPluginManager;
+        $pm->setServiceLocator($this->serviceManager);
+        $this->_helper->setServiceLocator($pm);
+        
+        $returned = $this->_helper->__invoke('nav1');
+        $this->assertEquals($this->_helper, $returned);
+        $this->assertEquals($this->_nav1, $returned->getContainer());
+    }
+
     public function testNullOutContainer()
     {
         $old = $this->_helper->getContainer();


### PR DESCRIPTION
When passing a string to the breadcrumb navigation viewhelper the invoke method tried to fetch the service itsself instead of letting parseContainer() do the work properly.
