### PR TITLE
Don't use $ldap->getResource() if ErrorHandler is already started

### DIFF
--- a/library/Zend/Ldap/Collection/DefaultIterator.php
+++ b/library/Zend/Ldap/Collection/DefaultIterator.php
@@ -75,8 +75,9 @@ class DefaultIterator implements \Iterator, \Countable
         $this->ldap      = $ldap;
         $this->resultId  = $resultId;
 
+        $resource = $ldap->getResource();
         ErrorHandler::start();
-        $this->itemCount = ldap_count_entries($ldap->getResource(), $resultId);
+        $this->itemCount = ldap_count_entries($resource, $resultId);
         ErrorHandler::stop();
         if ($this->itemCount === false) {
             throw new Exception\LdapException($this->ldap, 'counting entries');
@@ -199,16 +200,17 @@ class DefaultIterator implements \Iterator, \Countable
         $entry          = array('dn' => $this->key());
         $ber_identifier = null;
 
+        $resource = $this->ldap->getResource();
         ErrorHandler::start();
         $name = ldap_first_attribute(
-            $this->ldap->getResource(), $this->current,
+            $resource, $this->current,
             $ber_identifier
         );
         ErrorHandler::stop();
 
         while ($name) {
             ErrorHandler::start();
-            $data = ldap_get_values_len($this->ldap->getResource(), $this->current, $name);
+            $data = ldap_get_values_len($resource, $this->current, $name);
             ErrorHandler::stop();
 
             if (!$data) {
@@ -237,7 +239,7 @@ class DefaultIterator implements \Iterator, \Countable
 
             ErrorHandler::start();
             $name = ldap_next_attribute(
-                $this->ldap->getResource(), $this->current,
+                $resource, $this->current,
                 $ber_identifier
             );
             ErrorHandler::stop();
@@ -259,8 +261,9 @@ class DefaultIterator implements \Iterator, \Countable
             $this->rewind();
         }
         if (is_resource($this->current)) {
+            $resource = $this->ldap->getResource();
             ErrorHandler::start();
-            $currentDn = ldap_get_dn($this->ldap->getResource(), $this->current);
+            $currentDn = ldap_get_dn($resource, $this->current);
             ErrorHandler::stop();
 
             if ($currentDn === false) {
@@ -285,8 +288,9 @@ class DefaultIterator implements \Iterator, \Countable
         $code = 0;
 
         if (is_resource($this->current) && $this->itemCount > 0) {
+            $resource = $this->ldap->getResource();
             ErrorHandler::start();
-            $this->current = ldap_next_entry($this->ldap->getResource(), $this->current);
+            $this->current = ldap_next_entry($resource, $this->current);
             ErrorHandler::stop();
             if ($this->current === false) {
                 $msg = $this->ldap->getLastError($code);
@@ -312,8 +316,9 @@ class DefaultIterator implements \Iterator, \Countable
     public function rewind()
     {
         if (is_resource($this->resultId)) {
+            $resource = $this->ldap->getResource();
             ErrorHandler::start();
-            $this->current = ldap_first_entry($this->ldap->getResource(), $this->resultId);
+            $this->current = ldap_first_entry($resource, $this->resultId);
             ErrorHandler::stop();
             if ($this->current === false
                 && $this->ldap->getLastErrorCode() > Exception\LdapException::LDAP_SUCCESS

--- a/library/Zend/Ldap/Ldap.php
+++ b/library/Zend/Ldap/Ldap.php
@@ -927,7 +927,7 @@ class Ldap
         }
         if ($sort !== null && is_string($sort)) {
             ErrorHandler::start(E_WARNING);
-            $isSorted = ldap_sort($this->getResource(), $search, $sort);
+            $isSorted = ldap_sort($resource, $search, $sort);
             ErrorHandler::stop();
             if ($isSorted === false) {
                 throw new Exception\LdapException($this, 'sorting: ' . $sort);
@@ -1173,8 +1173,9 @@ class Ldap
             }
         }
 
+        $resource = $this->getResource();
         ErrorHandler::start(E_WARNING);
-        $isAdded = ldap_add($this->getResource(), $dn->toString(), $entry);
+        $isAdded = ldap_add($resource, $dn->toString(), $entry);
         ErrorHandler::stop();
         if ($isAdded === false) {
             throw new Exception\LdapException($this, 'adding: ' . $dn->toString());
@@ -1214,8 +1215,9 @@ class Ldap
         }
 
         if (count($entry) > 0) {
+            $resource = $this->getResource();
             ErrorHandler::start(E_WARNING);
-            $isModified = ldap_modify($this->getResource(), $dn->toString(), $entry);
+            $isModified = ldap_modify($resource, $dn->toString(), $entry);
             ErrorHandler::stop();
             if ($isModified === false) {
                 throw new Exception\LdapException($this, 'updating: ' . $dn->toString());
@@ -1271,8 +1273,10 @@ class Ldap
                 }
             }
         }
+
+        $resource = $this->getResource();
         ErrorHandler::start(E_WARNING);
-        $isDeleted = ldap_delete($this->getResource(), $dn);
+        $isDeleted = ldap_delete($resource, $dn);
         ErrorHandler::stop();
         if ($isDeleted === false) {
             throw new Exception\LdapException($this, 'deleting: ' . $dn);
@@ -1298,14 +1302,15 @@ class Ldap
         }
         $children = array();
 
+        $resource = $this->getResource();
         ErrorHandler::start(E_WARNING);
-        $search = ldap_list($this->getResource(), $parentDn, '(objectClass=*)', array('dn'));
+        $search = ldap_list($resource, $parentDn, '(objectClass=*)', array('dn'));
         for (
-            $entry = ldap_first_entry($this->getResource(), $search);
+            $entry = ldap_first_entry($resource, $search);
             $entry !== false;
-            $entry = ldap_next_entry($this->getResource(), $entry)
+            $entry = ldap_next_entry($resource, $entry)
         ) {
-            $childDn = ldap_get_dn($this->getResource(), $entry);
+            $childDn = ldap_get_dn($resource, $entry);
             if ($childDn === false) {
                 ErrorHandler::stop();
                 throw new Exception\LdapException($this, 'getting dn');
@@ -1400,8 +1405,9 @@ class Ldap
             $newRdn    = Dn::implodeRdn(array_shift($newDnParts));
             $newParent = Dn::implodeDn($newDnParts);
 
+            $resource = $this->getResource();
             ErrorHandler::start(E_WARNING);
-            $isOK = ldap_rename($this->getResource(), $from, $newRdn, $newParent, true);
+            $isOK = ldap_rename($resource, $from, $newRdn, $newParent, true);
             ErrorHandler::stop();
             if ($isOK === false) {
                 throw new Exception\LdapException($this, 'renaming ' . $from . ' to ' . $to);


### PR DESCRIPTION
$ldap->getResource() is often called in ldap_\* function. Those are surronded by the ErrorHandler. But getResource() try to start the ErrorHandler. A Exception\LogicException is throwed.

Moving $ldap->getResource() outside the ErrorHandler::start/stop avoid this behaviour.

Related to bc9c0cc94d4818a669d3aaa82c0483d6cbdf9e94, 07a63c621c021f0e367fc1247d080e3a40fe8afd, 76e059222e5dd833ea386891b6d39009bb11391f
