### PR TITLE
[#ZF2-498] added Translator to Form View Helpers

### DIFF
--- a/library/Zend/Form/View/Helper/AbstractHelper.php
+++ b/library/Zend/Form/View/Helper/AbstractHelper.php
@@ -47,8 +47,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
      * @var array
      */
     protected $translatableAttributes = array(
-        'placeholder' => true,
-        'value' => true
+        'placeholder' => true
     );
 
     /**

--- a/library/Zend/Form/View/Helper/AbstractHelper.php
+++ b/library/Zend/Form/View/Helper/AbstractHelper.php
@@ -42,6 +42,16 @@ abstract class AbstractHelper extends BaseAbstractHelper
     );
 
     /**
+     * Translatable attributes
+     *
+     * @var array
+     */
+    protected $translatableAttributes = array(
+        'placeholder' => true,
+        'value' => true
+    );
+
+    /**
      * @var Doctype
      */
     protected $doctypeHelper;
@@ -210,6 +220,16 @@ abstract class AbstractHelper extends BaseAbstractHelper
                     continue;
                 }
             }
+
+            //check if attribute is translatable
+            if (isset($this->translatableAttributes[$key]) && !empty($value)) {
+                if (($translator = $this->getTranslator()) !== null) {
+                    $value = $translator->translate(
+                            $value, $this->getTranslatorTextDomain()
+                    );
+                }
+            }
+
             //@TODO Escape event attributes like AbstractHtmlElement view helper does in htmlAttribs ??
             $strings[] = sprintf('%s="%s"', $escape($key), $escape($value));
         }

--- a/library/Zend/Form/View/Helper/FormReset.php
+++ b/library/Zend/Form/View/Helper/FormReset.php
@@ -33,6 +33,15 @@ class FormReset extends FormInput
         'type'           => true,
         'value'          => true,
     );
+    
+    /**
+     * Translatable attributes
+     * 
+     * @var array 
+     */
+    protected $translatableAttributes = array(
+        'value' => true
+    );
 
     /**
      * Determine input type to use
@@ -43,40 +52,5 @@ class FormReset extends FormInput
     protected function getType(ElementInterface $element)
     {
         return 'reset';
-    }
-
-    /**
-     * Render a form <input> element from the provided $element
-     *
-     * @param  ElementInterface $element
-     * @return string
-     */
-    public function render(ElementInterface $element)
-    {
-        $name = $element->getName();
-        if ($name === null || $name === '') {
-            throw new Exception\DomainException(sprintf(
-                '%s requires that the element has an assigned name; none discovered',
-                __METHOD__
-            ));
-        }
-
-        $resetValue = $element->getValue();
-        if (null !== ($translator = $this->getTranslator())) {
-            $resetValue = $translator->translate(
-                $resetValue, $this->getTranslatorTextDomain()
-            );
-        }
-
-        $attributes          = $element->getAttributes();
-        $attributes['name']  = $name;
-        $attributes['type']  = $this->getType($element);
-        $attributes['value'] = $resetValue;
-
-        return sprintf(
-            '<input %s%s',
-            $this->createAttributesString($attributes),
-            $this->getInlineClosingBracket()
-        );
     }
 }

--- a/library/Zend/Form/View/Helper/FormSubmit.php
+++ b/library/Zend/Form/View/Helper/FormSubmit.php
@@ -40,6 +40,15 @@ class FormSubmit extends FormInput
     );
 
     /**
+     * Translatable attributes
+     * 
+     * @var array 
+     */
+    protected $translatableAttributes = array(
+        'value' => true
+    );
+    
+    /**
      * Determine input type to use
      *
      * @param  ElementInterface $element
@@ -48,40 +57,5 @@ class FormSubmit extends FormInput
     protected function getType(ElementInterface $element)
     {
         return 'submit';
-    }
-
-    /**
-     * Render a form <input> element from the provided $element
-     *
-     * @param  ElementInterface $element
-     * @return string
-     */
-    public function render(ElementInterface $element)
-    {
-        $name = $element->getName();
-        if ($name === null || $name === '') {
-            throw new Exception\DomainException(sprintf(
-                '%s requires that the element has an assigned name; none discovered',
-                __METHOD__
-            ));
-        }
-
-        $submitValue = $element->getValue();
-        if (null !== ($translator = $this->getTranslator())) {
-            $submitValue = $translator->translate(
-                $submitValue, $this->getTranslatorTextDomain()
-            );
-        }
-
-        $attributes          = $element->getAttributes();
-        $attributes['name']  = $name;
-        $attributes['type']  = $this->getType($element);
-        $attributes['value'] = $submitValue;
-
-        return sprintf(
-            '<input %s%s',
-            $this->createAttributesString($attributes),
-            $this->getInlineClosingBracket()
-        );
     }
 }

--- a/tests/ZendTest/Form/View/Helper/FormInputTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormInputTest.php
@@ -449,12 +449,14 @@ class FormInputTest extends CommonTestCase
         $this->assertSame($this->helper, $this->helper->__invoke());
     }
 
-    /*
-     * To avoid repeating code on ZF2-489 tests. Creates a mock of the
-     * translator.
+    /**
+     * @group ZF2-489
      */
-    private function mockTranslator()
+    public function testCanTranslatePlaceholder()
     {
+        $element = new Element('test');
+        $element->setAttribute('placeholder', 'test');
+
         $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
 
         $mockTranslator->expects($this->exactly(1))
@@ -464,32 +466,6 @@ class FormInputTest extends CommonTestCase
         $this->helper->setTranslator($mockTranslator);
 
         $this->assertTrue($this->helper->hasTranslator());
-    }
-
-    /**
-     * @group ZF2-489
-     */
-    public function testcanTranslateValue()
-    {
-        $element = new Element('test');
-        $element->setValue('placeholder');
-
-        $this->mockTranslator();
-
-        $markup = $this->helper->__invoke($element);
-
-        $this->assertContains('value="translated string"', $markup);
-    }
-
-    /**
-     * @group ZF2-489
-     */
-    public function testCanTranslatePlaceholder()
-    {
-        $element = new Element('test');
-        $element->setAttribute('placeholder', 'test');
-
-        $this->mockTranslator();
 
         $markup = $this->helper->__invoke($element);
 

--- a/tests/ZendTest/Form/View/Helper/FormInputTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormInputTest.php
@@ -448,4 +448,51 @@ class FormInputTest extends CommonTestCase
         $element = new Element('foo');
         $this->assertSame($this->helper, $this->helper->__invoke());
     }
+
+    /*
+     * To avoid repeating code on ZF2-489 tests. Creates a mock of the
+     * translator.
+     */
+    private function mockTranslator()
+    {
+        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+
+        $mockTranslator->expects($this->exactly(1))
+                ->method('translate')
+                ->will($this->returnValue('translated string'));
+
+        $this->helper->setTranslator($mockTranslator);
+
+        $this->assertTrue($this->helper->hasTranslator());
+    }
+
+    /**
+     * @group ZF2-489
+     */
+    public function testcanTranslateValue()
+    {
+        $element = new Element('test');
+        $element->setValue('placeholder');
+
+        $this->mockTranslator();
+
+        $markup = $this->helper->__invoke($element);
+
+        $this->assertContains('value="translated string"', $markup);
+    }
+
+    /**
+     * @group ZF2-489
+     */
+    public function testCanTranslatePlaceholder()
+    {
+        $element = new Element('test');
+        $element->setAttribute('placeholder', 'test');
+
+        $this->mockTranslator();
+
+        $markup = $this->helper->__invoke($element);
+
+        $this->assertContains('placeholder="translated string"', $markup);
+    }
 }


### PR DESCRIPTION
allows the translation of the value and placeholder attributes. It can be configured for more attributes.
