### PR TITLE
Form\Element\MultiCheckbox Set multi_checkbox as default attribute type

### DIFF
--- a/library/Zend/Form/Element/MultiCheckbox.php
+++ b/library/Zend/Form/Element/MultiCheckbox.php
@@ -22,6 +22,15 @@ use Zend\Validator\ValidatorInterface;
 class MultiCheckbox extends Checkbox
 {
     /**
+     * Seed attributes
+     *
+     * @var array
+     */
+    protected $attributes = array(
+        'type' => 'multi_checkbox',
+    );
+
+    /**
      * @var bool
      */
     protected $useHiddenElement = false;

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -82,7 +82,7 @@ class FormRow extends AbstractHelper
             // Multicheckbox elements have to be handled differently as the HTML standard does not allow nested
             // labels. The semantic way is to group them inside a fieldset
             $type = $element->getAttribute('type');
-            if ($type === 'multi_checkbox' || $type === 'multicheckbox' || $type === 'radio') {
+            if ($type === 'multi_checkbox' || $type === 'radio') {
                 $markup = sprintf(
                     '<fieldset><legend>%s</legend>%s</fieldset>',
                     $label,

--- a/tests/ZendTest/Form/Element/MultiCheckboxTest.php
+++ b/tests/ZendTest/Form/Element/MultiCheckboxTest.php
@@ -104,4 +104,13 @@ class MultiCheckboxTest extends TestCase
         $this->assertInstanceOf('Zend\Validator\Explode', $explodeValidator);
         $this->assertTrue($explodeValidator->isValid($valueTests));
     }
+
+    public function testAttributeType()
+    {
+        $element = new MultiCheckboxElement();
+        $attributes = $element->getAttributes();
+
+        $this->assertArrayHasKey('type', $attributes);
+        $this->assertEquals('multi_checkbox', $attributes['type']);
+    }
 }


### PR DESCRIPTION
 Removed 'multicheckbox' as a type. 
 Added unit test. 

It's also possible to also use 'multicheckbox', then it also need to be added to Form/View/Helper/FormElement.php so that the right plugin is used
