### PR TITLE
Zend\I18n\View\Helper\DateFormat - Fallback to date.timezone instead of system timezone.

### DIFF
--- a/library/Zend/I18n/View/Helper/DateFormat.php
+++ b/library/Zend/I18n/View/Helper/DateFormat.php
@@ -69,6 +69,10 @@ class DateFormat extends AbstractHelper
      */
     public function getTimezone()
     {
+        if(!$this->timezone) {
+            return date_default_timezone_get();
+        }
+        
         return $this->timezone;
     }
 

--- a/library/Zend/I18n/View/Helper/DateFormat.php
+++ b/library/Zend/I18n/View/Helper/DateFormat.php
@@ -72,7 +72,7 @@ class DateFormat extends AbstractHelper
         if(!$this->timezone) {
             return date_default_timezone_get();
         }
-        
+
         return $this->timezone;
     }
 

--- a/library/Zend/I18n/View/Helper/DateFormat.php
+++ b/library/Zend/I18n/View/Helper/DateFormat.php
@@ -69,7 +69,7 @@ class DateFormat extends AbstractHelper
      */
     public function getTimezone()
     {
-        if(!$this->timezone) {
+        if (!$this->timezone) {
             return date_default_timezone_get();
         }
 


### PR DESCRIPTION
Fallback to date.timezone instead of system timezone.

If we do not explicitly set timezone on DateFormat, it passes null value as timezone to IntlDateFormatter, that should fallback to date.timezone but doesn't. So we better do it ourselves.

Here's a test to demonstrate the bug:

``` php
//set timezone to UTC
ini_set('date.timezone', 'UTC');

$now = new \DateTime;
$now->setTimezone(new \DateTimeZone('UTC'));
$expected = $now->format('g:i A');

//format
$helper = $this->getLocator()->get('Zend\I18n\View\Helper\DateFormat');
$formatted = $helper->__invoke(
    $now,
    \IntlDateFormatter::NONE,
    \IntlDateFormatter::SHORT,
    'en_US'
);

$this->assertEquals($expected, $formatted);
```
