### PR TITLE
Create a default Input (InputFilter) for Form Elements without one

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -622,15 +622,19 @@ class Form extends Fieldset implements FormInterface
         $formFactory  = $this->getFormFactory();
         $inputFactory = $formFactory->getInputFilterFactory();
         foreach ($fieldset->getElements() as $element) {
-            if (!$element instanceof InputProviderInterface) {
-                // only interested in the element if it provides input information
-                continue;
-            }
-
             $name = $element->getName();
 
-            // Create an input based on the specification returned from the element
-            $spec  = $element->getInputSpecification();
+            if (!$element instanceof InputProviderInterface) {
+                if ($inputFilter->has($name)) {
+                    continue;
+                }
+                // Create a new empty default input for this element
+                $spec = array('name' => $name, 'required' => false);
+            } else {
+                // Create an input based on the specification returned from the element
+                $spec  = $element->getInputSpecification();
+            }
+
             $input = $inputFactory->createInput($spec);
             $inputFilter->add($input, $name);
         }

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -159,6 +159,14 @@ class FormTest extends TestCase
         $this->assertSame($filter, $this->form->getInputFilter());
     }
 
+    public function testDefaultNonRequiredInputFilterIsSet()
+    {
+        $this->form->add(new Element('foo'));
+        $inputFilter = $this->form->getInputFilter();
+        $fooInput = $inputFilter->get('foo');
+        $this->assertFalse($fooInput->isRequired());
+    }
+
     public function testCallingIsValidRaisesExceptionIfNoDataSet()
     {
         $this->setExpectedException('Zend\Form\Exception\DomainException');


### PR DESCRIPTION
With similar reasoning to #2252, this PR will add a default Input to the Form's InputFilter for Elements that are missing an Input. This was in response to some reported confusion for new users who forget to add an Input, and expect to see form values returned.

**No BC Breaks**
