### PR TITLE
Fix for ZF2-512

### DIFF
--- a/library/Zend/Filter/FilterChain.php
+++ b/library/Zend/Filter/FilterChain.php
@@ -224,7 +224,7 @@ class FilterChain extends AbstractFilter implements Countable
 
         return $valueFiltered;
     }
-    
+
     /**
      * Prepare filter chain for serialization
      *

--- a/library/Zend/Filter/FilterChain.php
+++ b/library/Zend/Filter/FilterChain.php
@@ -228,9 +228,10 @@ class FilterChain extends AbstractFilter implements Countable
     /**
      * Prepare filter chain for serialization
      *
-     * FilterPluginManager cannot be serialized, as it contains Traits. For
-     * this reason property 'plugins' is excluded and thus serialized
-     * filter chain is not necessarily equal to current chain.
+     * Plugin manager (property 'plugins') cannot
+     * be serialized. On wakeup the property remains unset
+     * and next invokation to getPluginManager() sets
+     * the default plugin manager instance (FilterPluginManager).
      *
      * @return array
      */

--- a/library/Zend/Filter/FilterChain.php
+++ b/library/Zend/Filter/FilterChain.php
@@ -224,4 +224,18 @@ class FilterChain extends AbstractFilter implements Countable
 
         return $valueFiltered;
     }
+    
+    /**
+     * Prepare filter chain for serialization
+     *
+     * FilterPluginManager cannot be serialized, as it contains Traits. For
+     * this reason property 'plugins' is excluded and thus serialized
+     * filter chain is not necessarily equal to current chain.
+     *
+     * @return array
+     */
+    public function __sleep()
+    {
+        return array('filters');
+    }
 }

--- a/library/Zend/Validator/ValidatorChain.php
+++ b/library/Zend/Validator/ValidatorChain.php
@@ -230,4 +230,18 @@ class ValidatorChain implements
     {
         return $this->isValid($value);
     }
+    
+    /**
+     * Prepare validator chain for serialization
+     *
+     * ValidatorPluginManager cannot be serialized, as it contains Traits. For
+     * this reason property 'plugins' is excluded and thus serialized
+     * filter chain is not necessarily equal to current chain.
+     *
+     * @return array
+     */
+    public function __sleep()
+    {
+        return array('validators', 'messages');
+    }
 }

--- a/library/Zend/Validator/ValidatorChain.php
+++ b/library/Zend/Validator/ValidatorChain.php
@@ -230,7 +230,7 @@ class ValidatorChain implements
     {
         return $this->isValid($value);
     }
-    
+
     /**
      * Prepare validator chain for serialization
      *
@@ -243,6 +243,6 @@ class ValidatorChain implements
      */
     public function __sleep()
     {
-        return array('validators', 'messages');
+        return array('validators','messages');
     }
 }

--- a/library/Zend/Validator/ValidatorChain.php
+++ b/library/Zend/Validator/ValidatorChain.php
@@ -234,9 +234,10 @@ class ValidatorChain implements
     /**
      * Prepare validator chain for serialization
      *
-     * ValidatorPluginManager cannot be serialized, as it contains Traits. For
-     * this reason property 'plugins' is excluded and thus serialized
-     * filter chain is not necessarily equal to current chain.
+     * Plugin manager (property 'plugins') cannot
+     * be serialized. On wakeup the property remains unset
+     * and next invokation to getPluginManager() sets
+     * the default plugin manager instance (ValidatorPluginManager).
      *
      * @return array
      */


### PR DESCRIPTION
The fix is dead simple: prepare objects for serialization using magic __sleep. Only downside to this fix is that it actually loses information, as the references to plugins are lost. I think that this is acceptable, but should  probably be informed in reference documentation.

One might also consider removing those Traits from ServiceManager...
