### PR TITLE
Return proper server host name when behind a proxy

### DIFF
--- a/library/Zend/View/Helper/ServerUrl.php
+++ b/library/Zend/View/Helper/ServerUrl.php
@@ -50,7 +50,14 @@ class ServerUrl extends AbstractHelper
         }
         $this->setScheme($scheme);
 
-        if (isset($_SERVER['HTTP_HOST']) && !empty($_SERVER['HTTP_HOST'])) {
+        if (isset($_SERVER['HTTP_X_FORWARDED_HOST']) && !empty($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+            $host = $_SERVER['HTTP_X_FORWARDED_HOST'];
+            if (strpos($host, ',') !== false) {
+                $hosts = explode(',', $host);
+                $host = trim(array_pop($hosts));
+            }
+            $this->setHost($host);
+        } elseif (isset($_SERVER['HTTP_HOST']) && !empty($_SERVER['HTTP_HOST'])) {
             $this->setHost($_SERVER['HTTP_HOST']);
         } elseif (isset($_SERVER['SERVER_NAME'], $_SERVER['SERVER_PORT'])) {
             $name = $_SERVER['SERVER_NAME'];

--- a/tests/ZendTest/View/Helper/ServerUrlTest.php
+++ b/tests/ZendTest/View/Helper/ServerUrlTest.php
@@ -161,4 +161,26 @@ class ServerUrlTest extends \PHPUnit_Framework_TestCase
         $url = new Helper\ServerUrl();
         $this->assertEquals('https://example.com', $url->__invoke());
     }
+
+    /**
+     * @group ZF2-508
+     */
+    public function testServerUrlWithProxy()
+    {
+        $_SERVER['HTTP_HOST'] = 'proxyserver.com';
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'www.firsthost.org';
+        $url = new Helper\ServerUrl();
+        $this->assertEquals('http://www.firsthost.org', $url->__invoke());
+    }
+
+    /**
+     * @group ZF2-508
+     */
+    public function testServerUrlWithMultipleProxies()
+    {
+        $_SERVER['HTTP_HOST'] = 'proxyserver.com';
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'www.firsthost.org, www.secondhost.org';
+        $url = new Helper\ServerUrl();
+        $this->assertEquals('http://www.secondhost.org', $url->__invoke());
+    }
 }


### PR DESCRIPTION
Fix for: http://framework.zend.com/issues/browse/ZF2-508

Automated Tests also created.
