### PR TITLE
[ZF2-507] Ensure Date header is ASCII encoded

### DIFF
--- a/library/Zend/Mail/Message.php
+++ b/library/Zend/Mail/Message.php
@@ -103,7 +103,8 @@ class Message
     {
         if (null === $this->headers) {
             $this->setHeaders(new Headers());
-            $this->headers->addHeaderLine('Date', date('r'));
+            $date = Header\Date::fromString('Date: ' . date('r'));
+            $this->headers->addHeader($date);
         }
         return $this->headers;
     }

--- a/tests/ZendTest/Mail/MessageTest.php
+++ b/tests/ZendTest/Mail/MessageTest.php
@@ -632,4 +632,19 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $expected = 'Subject: =?UTF-8?Q?This=20is=20a=20subject?=';
         $this->assertContains($expected, $test);
     }
+
+    /**
+     * @group ZF2-507
+     */
+    public function testDefaultDateHeaderEncodingIsAlwaysAscii()
+    {
+        $this->message->setEncoding('utf-8');
+        $headers = $this->message->getHeaders();
+        $header  = $headers->get('date');
+        $date    = date('r');
+        $date    = substr($date, 0, 16);
+        $test    = $header->getFieldValue();
+        $test    = substr($test, 0, 16);
+        $this->assertEquals($date, $test);
+    }
 }


### PR DESCRIPTION
- Per ZF2-507, explicitly add a Date header object instance, which
  ensures encoding is ASCII, which is necessary to fulfill the RFC.
