### PR TITLE
prepareNotFoundViewModel listner -  eventResult as ViewModel if set

### DIFF
--- a/library/Zend/Mvc/View/Http/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/Http/RouteNotFoundStrategy.php
@@ -204,9 +204,21 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
             // Only handle 404 responses
             return;
         }
-
-        $model = new ViewModel();
-        $model->setVariable('message', 'Page not found.');
+        
+        if (!$vars instanceof ViewModel) {
+            $model = new ViewModel();
+            if (is_string($vars)) {
+                $model->setVariable('message', $vars);
+            } else {
+                $model->setVariable('message', 'Page not found.');
+            }
+        } else {
+            $model = $vars;
+            if ($model->getVariable('message') === null) {
+                $model->setVariable('message', 'Page not found.');
+            }
+        }
+        
         $model->setTemplate($this->getNotFoundTemplate());
 
         // If displaying reasons, inject the reason

--- a/library/Zend/Mvc/View/Http/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/Http/RouteNotFoundStrategy.php
@@ -204,7 +204,7 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
             // Only handle 404 responses
             return;
         }
-        
+
         if (!$vars instanceof ViewModel) {
             $model = new ViewModel();
             if (is_string($vars)) {
@@ -218,7 +218,7 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
                 $model->setVariable('message', 'Page not found.');
             }
         }
-        
+
         $model->setTemplate($this->getNotFoundTemplate());
 
         // If displaying reasons, inject the reason

--- a/tests/ZendTest/Mvc/View/RouteNotFoundStrategyTest.php
+++ b/tests/ZendTest/Mvc/View/RouteNotFoundStrategyTest.php
@@ -31,6 +31,44 @@ class RouteNotFoundStrategyTest extends TestCase
         $this->strategy = new RouteNotFoundStrategy();
     }
 
+    public function testMessageParamsInViewModel()
+    {
+        $response = new Response();
+        $event    = new MvcEvent();
+        $event->setResponse($response);
+        $response->setStatusCode(404);
+        
+        $event->setResult(null);
+        
+        $testCase = array(
+            'assertEquals' => array (
+                'bar',
+                new ViewModel(array('message' => 'bar')),
+            ),
+            'assertTrue' => array (
+                null,
+                new ViewModel(),
+            )
+        );
+        foreach ($testCase as $type => $results) {
+            foreach ($results as $resultEvent) {
+                $event->setResult($resultEvent);
+                $this->strategy->prepareNotFoundViewModel($event);
+                $viewModel = $event->getResult();
+                $this->assertInstanceOf('Zend\View\Model\ModelInterface', $viewModel);
+                $variables = $viewModel->getVariables();
+                switch ($type) {
+                    case 'assertEquals':
+                        $this->assertEquals('bar', $variables['message']);
+                        break;
+                    case 'assertTrue':
+                        $this->assertTrue(isset($variables['message']));
+                        break;
+                }
+            }
+        }
+    }
+
     public function test404ErrorsInject404ResponseStatusCode()
     {
         $response = new Response();
@@ -63,6 +101,7 @@ class RouteNotFoundStrategyTest extends TestCase
             $this->strategy->setDisplayNotFoundReason($allow);
             foreach ($errors as $key => $error) {
                 $response->setStatusCode(200);
+                $event->setResult(null);
                 $event->setError($error);
                 $this->strategy->detectNotFoundError($event);
                 $this->strategy->prepareNotFoundViewModel($event);
@@ -151,6 +190,7 @@ class RouteNotFoundStrategyTest extends TestCase
         foreach (array(true, false) as $allow) {
             $this->strategy->setDisplayNotFoundReason($allow);
             $response->setStatusCode(404);
+            $event->setResult(null);
             $event->setResponse($response);
             $this->strategy->prepareNotFoundViewModel($event);
             $model = $event->getResult();
@@ -175,6 +215,7 @@ class RouteNotFoundStrategyTest extends TestCase
         foreach (array(true, false) as $allow) {
             $this->strategy->setDisplayExceptions($allow);
             $response->setStatusCode(404);
+            $event->setResult(null);
             $event->setResponse($response);
             $this->strategy->prepareNotFoundViewModel($event);
             $model = $event->getResult();
@@ -202,6 +243,7 @@ class RouteNotFoundStrategyTest extends TestCase
             foreach (array(true, false) as $allow) {
                 $this->strategy->$method($allow);
                 $response->setStatusCode(404);
+                $event->setResult(null);
                 $event->setResponse($response);
                 $this->strategy->prepareNotFoundViewModel($event);
                 $model = $event->getResult();

--- a/tests/ZendTest/Mvc/View/RouteNotFoundStrategyTest.php
+++ b/tests/ZendTest/Mvc/View/RouteNotFoundStrategyTest.php
@@ -37,9 +37,9 @@ class RouteNotFoundStrategyTest extends TestCase
         $event    = new MvcEvent();
         $event->setResponse($response);
         $response->setStatusCode(404);
-        
+
         $event->setResult(null);
-        
+
         $testCase = array(
             'assertEquals' => array (
                 'bar',


### PR DESCRIPTION
use case:

public function indexAction() {
  $this->getResponse()->setStatusCode(404);
  $viewModel->setVariable('message', 'not found article');
  return $viewModel;
}

or simple:
  $this->getResponse()->setStatusCode(404);
  return 'not found article';
