### PR TITLE
Allow to create empty option in Select

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ script:
  - output=$(php php-cs-fixer.phar fix -v --dry-run --level=psr2 .); if [[ $output ]]; then while read -r line; do echo -e "\e[00;31m$line\e[00m"; done <<< "$output"; false; fi;
 
 notifications:
-  irc: "irc.freenode.org#zftalk.2"
+  irc: "irc.freenode.org#zftalk.dev"
   email: false

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -573,7 +573,9 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                         $adapter,
                         $this->processInfo['paramPrefix'] . ((is_string($jKey)) ? $jKey : 'column')
                     );
-                    $parameterContainer->merge($jColumnParts->getParameterContainer());
+                    if ($parameterContainer) {
+                        $parameterContainer->merge($jColumnParts->getParameterContainer());
+                    }
                     $jColumns[] = $jColumnParts->getSql();
                 } else {
                     $name = (is_array($join['name'])) ? key($join['name']) : $name = $join['name'];

--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -77,8 +77,8 @@ class Number extends Element implements InputProviderInterface
             || 'any' !== $this->attributes['step']
         ) {
             $validators[] = new StepValidator(array(
-                'baseValue' => (isset($this->attributes['min']))  ?: 0,
-                'step'      => (isset($this->attributes['step'])) ?: 1,
+                'baseValue' => (isset($this->attributes['min']))  ? $this->attributes['min'] : 0,
+                'step'      => (isset($this->attributes['step'])) ? $this->attributes['step'] : 1,
             ));
         }
 

--- a/library/Zend/Form/Element/Range.php
+++ b/library/Zend/Form/Element/Range.php
@@ -53,12 +53,12 @@ class Range extends NumberElement
         }
 
         $validators[] = new GreaterThanValidator(array(
-            'min'       => (isset($this->attributes['min'])) ?: 0,
+            'min'       => (isset($this->attributes['min'])) ? $this->attributes['min'] : 0,
             'inclusive' => $inclusive
         ));
 
         $validators[] = new LessThanValidator(array(
-            'max'       => (isset($this->attributes['max'])) ?: 100,
+            'max'       => (isset($this->attributes['max'])) ? $this->attributes['max'] : 100,
             'inclusive' => $inclusive
         ));
 
@@ -67,8 +67,8 @@ class Range extends NumberElement
             || 'any' !== $this->attributes['step']
         ) {
             $validators[] = new StepValidator(array(
-                'baseValue' => (isset($this->attributes['min']))  ?: 0,
-                'step'      => (isset($this->attributes['step'])) ?: 1,
+                'baseValue' => (isset($this->attributes['min'])) ? $this->attributes['min'] : 0,
+                'step'      => (isset($this->attributes['step'])) ? $this->attributes['step'] : 1,
             ));
         }
 

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -86,7 +86,7 @@ class Select extends Element implements InputProviderInterface
      * - label: label to associate with the element
      * - label_attributes: attributes to use when the label is rendered
      * - value_options: list of values and labels for the select options
-     * _ create_empty_option: should an empty option be prepended to the options ?
+     * _ empty_option: should an empty option be prepended to the options ?
      *
      * @param  array|\Traversable $options
      * @return Select|ElementInterface
@@ -104,8 +104,8 @@ class Select extends Element implements InputProviderInterface
             $this->setValueOptions($this->options['options']);
         }
 
-        if (isset($this->options['create_empty_option'])) {
-            $this->setShouldCreateEmptyOption($this->options['create_empty_option']);
+        if (isset($this->options['empty_option'])) {
+            $this->setEmptyOption($this->options['empty_option']);
         }
 
         return $this;

--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -180,7 +180,7 @@ class Response extends AbstractMessage implements ResponseInterface
 
         $response = new static();
 
-        $regex   = '/^HTTP\/(?P<version>1\.[01]) (?P<status>\d{3})(?:[ ]+(?P<reason>.+))?$/';
+        $regex   = '/^HTTP\/(?P<version>1\.[01]) (?P<status>\d{3})(?:[ ]+(?P<reason>.*))?$/';
         $matches = array();
         if (!preg_match($regex, $firstLine, $matches)) {
             throw new Exception\InvalidArgumentException(

--- a/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
@@ -27,9 +27,13 @@ class PostRedirectGet extends AbstractPlugin
     {
         $controller = $this->getController();
         $request    = $controller->getRequest();
+        $params     = array();
 
         if (null === $redirect) {
-            $redirect = $controller->getEvent()->getRouteMatch()->getMatchedRouteName();
+            $routeMatch = $controller->getEvent()->getRouteMatch();
+
+            $redirect = $routeMatch->getMatchedRouteName();
+            $params   = $routeMatch->getParams();
         }
 
         $container = new Container('prg_post1');
@@ -42,9 +46,8 @@ class PostRedirectGet extends AbstractPlugin
                 // get the redirect plugin from the plugin manager
                 $redirector = $controller->getPluginManager()->get('Redirect');
             } else {
-
                 /*
-                 * if the user wants to redirect to a route, the redirector has to come
+                 * If the user wants to redirect to a route, the redirector has to come
                  * from the plugin manager -- otherwise no router will be injected
                  */
                 if ($redirectToUrl === false) {
@@ -55,13 +58,14 @@ class PostRedirectGet extends AbstractPlugin
             }
 
             if ($redirectToUrl === false) {
-                $response = $redirector->toRoute($redirect);
+                $response = $redirector->toRoute($redirect, $params);
                 $response->setStatusCode(303);
                 return $response;
             }
 
             $response = $redirector->toUrl($redirect);
             $response->setStatusCode(303);
+
             return $response;
         } else {
             if ($container->post !== null) {

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -746,14 +746,15 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             'processOrder'  => array(array(array('isnull("name") DESC'), array('"name"', Select::ORDER_ASCENDING)))
         );
 
-        // join with expression in COLUMNS part (ZF2-514)
+        // join with Expression object in COLUMNS part (ZF2-514)
+        // @co-author Koen Pieters (kpieters)
         $select35 = new Select;
-        $select35->from('foo')->join('zac', 'm = n', array('bar' => new Expression("IF(foo.id = 1, NULL, foo.bar)")));
+        $select35->from('foo')->columns(array())->join('bar', 'm = n', array('thecount' => new Expression("COUNT(*)")));
         $sqlPrep35 = // same
-        $sqlStr35 = 'SELECT "foo".*, IF(foo.id = 1, NULL, foo.bar) AS "bar" FROM "foo" INNER JOIN "zac" ON "m" = "n"';
+        $sqlStr35 = 'SELECT COUNT(*) AS "thecount" FROM "foo" INNER JOIN "bar" ON "m" = "n"';
         $internalTests35 = array(
-            'processSelect' => array(array(array('"foo".*'), array('IF(foo.id = 1, NULL, foo.bar)', '"bar"')), '"foo"'),
-            'processJoins'   => array(array(array('INNER', '"zac"', '"m" = "n"')))
+            'processSelect' => array(array(array('COUNT(*)', '"thecount"')), '"foo"'),
+            'processJoins'   => array(array(array('INNER', '"bar"', '"m" = "n"')))
         );
 
         /**

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -253,7 +253,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @testdox unit test: Test join() returns same Select object (is chainable)
+     * @testdox unit test: Test having() returns same Select object (is chainable)
      * @covers Zend\Db\Sql\Select::having
      */
     public function testHaving()
@@ -275,7 +275,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @testdox unit test: Test join() returns same Select object (is chainable)
+     * @testdox unit test: Test group() returns same Select object (is chainable)
      * @covers Zend\Db\Sql\Select::group
      */
     public function testGroup()
@@ -746,6 +746,16 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             'processOrder'  => array(array(array('isnull("name") DESC'), array('"name"', Select::ORDER_ASCENDING)))
         );
 
+        // join with expression in COLUMNS part (ZF2-514)
+        $select35 = new Select;
+        $select35->from('foo')->join('zac', 'm = n', array('bar' => new Expression("IF(foo.id = 1, NULL, foo.bar)")));
+        $sqlPrep35 = // same
+        $sqlStr35 = 'SELECT "foo".*, IF(foo.id = 1, NULL, foo.bar) AS "bar" FROM "foo" INNER JOIN "zac" ON "m" = "n"';
+        $internalTests35 = array(
+            'processSelect' => array(array(array('"foo".*'), array('IF(foo.id = 1, NULL, foo.bar)', '"bar"')), '"foo"'),
+            'processJoins'   => array(array(array('INNER', '"zac"', '"m" = "n"')))
+        );
+
         /**
          * $select = the select object
          * $sqlPrep = the sql as a result of preparation
@@ -790,6 +800,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             array($select32, $sqlPrep32, array(),    $sqlStr32, $internalTests32),
             array($select33, $sqlPrep33, array(),    $sqlStr33, $internalTests33),
             array($select34, $sqlPrep34, array(),    $sqlStr34, $internalTests34),
+            array($select35, $sqlPrep35, array(),    $sqlStr35, $internalTests35),
         );
     }
 

--- a/tests/ZendTest/Http/ResponseTest.php
+++ b/tests/ZendTest/Http/ResponseTest.php
@@ -73,6 +73,21 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Foo Bar', $response->getContent());
     }
 
+    public function testResponseHasZeroLengthReasonPhrase()
+    {
+        // Space after status code is mandatory,
+        // though, reason phrase can be empty.
+        // @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1
+        $string = 'HTTP/1.0 200 ' . "\r\n\r\n" . 'Foo Bar';
+
+        $response = Response::fromString($string);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Foo Bar', $response->getContent());
+
+        // Reason phrase would fallback to default reason phrase.
+        $this->assertEquals('OK', $response->getReasonPhrase());
+    }
+
     public function testGzipResponse ()
     {
         $response_text = file_get_contents(__DIR__ . '/_files/response_gzip');


### PR DESCRIPTION
DOES NOT break BC.

This PR adds an option to every Select element in order to automatically prepend an empty option to a select element. This is useful either in a user experience point of view, but most often because a lot of JavaScript libraries need an empty option to render, for instance, a placeholder value.

EDIT : it now instead allows to specify a string for the empty option. This string will be used as the label for the empty option, but without any value. This is by far more flexible as it allows to set either an empty string or a kind of placeholder.
