### PR TITLE
Zend\Http\Response should accept status line with zero length reason phrase.

### DIFF
--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -180,7 +180,7 @@ class Response extends AbstractMessage implements ResponseInterface
 
         $response = new static();
 
-        $regex   = '/^HTTP\/(?P<version>1\.[01]) (?P<status>\d{3})(?:[ ]+(?P<reason>.+))?$/';
+        $regex   = '/^HTTP\/(?P<version>1\.[01]) (?P<status>\d{3})(?:[ ]+(?P<reason>.*))?$/';
         $matches = array();
         if (!preg_match($regex, $firstLine, $matches)) {
             throw new Exception\InvalidArgumentException(

--- a/tests/ZendTest/Http/ResponseTest.php
+++ b/tests/ZendTest/Http/ResponseTest.php
@@ -73,6 +73,21 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Foo Bar', $response->getContent());
     }
 
+    public function testResponseHasZeroLengthReasonPhrase()
+    {
+        // Space after status code is mandatory,
+        // though, reason phrase can be empty.
+        // @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1
+        $string = 'HTTP/1.0 200 ' . "\r\n\r\n" . 'Foo Bar';
+
+        $response = Response::fromString($string);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Foo Bar', $response->getContent());
+
+        // Reason phrase would fallback to default reason phrase.
+        $this->assertEquals('OK', $response->getReasonPhrase());
+    }
+
     public function testGzipResponse ()
     {
         $response_text = file_get_contents(__DIR__ . '/_files/response_gzip');


### PR DESCRIPTION
I had encountered such a server that returns status line with zero length reason phrase like below:

```
// underscores denote spaces here, for readability.
HTTP/1.0_200_\r\n\r\n
```

However, Zend\Http\Response::fromString() method throws Exception with such status lines.

As with RFC2616 specification (http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1),
HTTP status line should be this form:

```
Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF
```

Althougn `SP` between Status-Code and Reason-Phrase is mandatory,
Reason-Phrase can be empty as specified as below.

```
Reason-Phrase  = *<TEXT, excluding CR, LF>
```

With this specification, status lines such as below should be accepted.

```
HTTP/1.0_200_\r\n\r\n
```

Code changes would be really tiny as I wrote in this pull request.
I would appreciate if this request were accepted.

Thank you.
