### PR TITLE
<span>$label</span> only when filled

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -121,13 +121,17 @@ class FormRow extends AbstractHelper
                     $labelClose = $labelHelper->closeTag();
                 }
 
+                if (!empty($label)) {
+                    $label = '<span>' . $label . '</span>';
+                }
+
                 switch ($this->labelPosition) {
                     case self::LABEL_PREPEND:
-                        $markup = $labelOpen . '<span>' . $label . '</span>' . $elementString . $labelClose;
+                        $markup = $labelOpen . $label . $elementString . $labelClose;
                         break;
                     case self::LABEL_APPEND:
                     default:
-                        $markup = $labelOpen . $elementString . '<span>' . $label . '</span>' . $labelClose;
+                        $markup = $labelOpen . $elementString . $label . $labelClose;
                         break;
                 }
 

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -121,7 +121,7 @@ class FormRow extends AbstractHelper
                     $labelClose = $labelHelper->closeTag();
                 }
 
-                if (!empty($label)) {
+                if ($label !== '') {
                     $label = '<span>' . $label . '</span>';
                 }
 

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -257,4 +257,20 @@ class FormRowTest extends TestCase
         $this->helper->setLabelAttributes(array('foo', 'bar'));
         $this->assertEquals(array(0 => 'foo', 1 => 'bar'), $this->helper->getLabelAttributes());
     }
+
+    public function testWhenUsingIdAndLabelIsEmptyRemoveSpan()
+    {
+        $element = new Element('foo');
+        $element->setLabel('The value for foo:');
+
+        $markup = $this->helper->__invoke($element);
+        $this->assertContains('<span', $markup);
+        $this->assertContains('</span>', $markup);
+
+        $element->setAttribute('id', 'foo');
+
+        $markup = $this->helper->__invoke($element);
+        $this->assertNotContains('<span', $markup);
+        $this->assertNotContains('</span>', $markup);
+    }
 }

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -258,7 +258,7 @@ class FormRowTest extends TestCase
         $this->assertEquals(array(0 => 'foo', 1 => 'bar'), $this->helper->getLabelAttributes());
     }
 
-    public function testWhenUsingIdAndLabelIsEmptyRemoveSpan()
+    public function testWhenUsingIdAndLabelBecomesEmptyRemoveSpan()
     {
         $element = new Element('foo');
         $element->setLabel('The value for foo:');


### PR DESCRIPTION
When using 'id' attribute (very useful), $label is set to empty.

This PR deletes the <span> tags when this happens.
