### PR TITLE
Allow (int)0 in coomments count in entry feed

### DIFF
--- a/library/Zend/Feed/Writer/Entry.php
+++ b/library/Zend/Feed/Writer/Entry.php
@@ -250,7 +250,7 @@ class Entry
      */
     public function setCommentCount($count)
     {
-        if (empty($count) || !is_numeric($count) || (int) $count < 0) {
+        if (!is_numeric($count) || (int) $count < 0) {
             throw new Exception\InvalidArgumentException('Invalid parameter: "count" must be a non-empty integer number');
         }
         $this->data['commentCount'] = (int) $count;

--- a/library/Zend/Feed/Writer/Entry.php
+++ b/library/Zend/Feed/Writer/Entry.php
@@ -250,8 +250,8 @@ class Entry
      */
     public function setCommentCount($count)
     {
-        if (!is_numeric($count) || (int) $count < 0) {
-            throw new Exception\InvalidArgumentException('Invalid parameter: "count" must be a non-empty integer number');
+        if (!is_numeric($count) || (int)$count != $count || (int) $count < 0) {
+            throw new Exception\InvalidArgumentException('Invalid parameter: "count" must be a positive integer number or zero');
         }
         $this->data['commentCount'] = (int) $count;
     }

--- a/tests/ZendTest/Feed/Writer/EntryTest.php
+++ b/tests/ZendTest/Feed/Writer/EntryTest.php
@@ -521,6 +521,13 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $entry->getCommentCount());
     }
 
+    public function testSetsCommentCount0()
+    {
+        $entry = new Writer\Entry;
+        $entry->setCommentCount(0);
+        $this->assertEquals(0, $entry->getCommentCount());
+    }
+
     public function testSetCommentCountThrowsExceptionOnInvalidEmptyParameter()
     {
         $entry = new Writer\Entry;

--- a/tests/ZendTest/Feed/Writer/EntryTest.php
+++ b/tests/ZendTest/Feed/Writer/EntryTest.php
@@ -528,6 +528,27 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $entry->getCommentCount());
     }
 
+    public function testSetsCommentCountAllowed()
+    {
+        $entry = new Writer\Entry;
+        foreach (array(0, 0.0, 1, PHP_INT_MAX) as $testCase) {
+            $entry->setCommentCount($testCase);
+            $this->assertEquals((int)$testCase, $entry->getCommentCount());
+        }
+    }
+
+    public function testSetsCommentCountDisallowed()
+    {
+        $entry = new Writer\Entry;
+        foreach (array(1.1, -1, -PHP_INT_MAX, array(), '', false, true, new \stdClass, null) as $testCase) {
+            try {
+                $entry->setCommentCount($testCase);
+                $this->fail();
+            } catch (Writer\Exception\ExceptionInterface $e) {
+            }
+        }
+    }
+
     public function testSetCommentCountThrowsExceptionOnInvalidEmptyParameter()
     {
         $entry = new Writer\Entry;


### PR DESCRIPTION
I think empty() is not required. And with it the value of (int)0 is not allowed
