### PR TITLE
force to check className parameters 

### DIFF
--- a/library/Zend/Di/Definition/ClassDefinition.php
+++ b/library/Zend/Di/Definition/ClassDefinition.php
@@ -136,6 +136,9 @@ class ClassDefinition implements DefinitionInterface, PartialMarker
      */
     public function getClassSupertypes($class)
     {
+        if ($this->class !== $class) {
+            return array();
+        }
         return $this->supertypes;
     }
 
@@ -144,6 +147,9 @@ class ClassDefinition implements DefinitionInterface, PartialMarker
      */
     public function getInstantiator($class)
     {
+        if ($this->class !== $class) {
+            return null;
+        }
         return $this->instantiator;
     }
 
@@ -160,6 +166,9 @@ class ClassDefinition implements DefinitionInterface, PartialMarker
      */
     public function getMethods($class)
     {
+        if ($this->class !== $class) {
+            return array();
+        }
         return $this->methods;
     }
 
@@ -168,6 +177,10 @@ class ClassDefinition implements DefinitionInterface, PartialMarker
      */
     public function hasMethod($class, $method)
     {
+        if ($this->class !== $class) {
+            return null;
+        }
+
         if (is_array($this->methods)) {
             return array_key_exists($method, $this->methods);
         } else {
@@ -180,6 +193,9 @@ class ClassDefinition implements DefinitionInterface, PartialMarker
      */
     public function hasMethodParameters($class, $method)
     {
+        if ($this->class !== $class) {
+            return false;
+        }
         return (array_key_exists($method, $this->methodParameters));
     }
 
@@ -188,6 +204,10 @@ class ClassDefinition implements DefinitionInterface, PartialMarker
      */
     public function getMethodParameters($class, $method)
     {
+        if ($this->class !== $class) {
+            return null;
+        }
+
         if (array_key_exists($method, $this->methodParameters)) {
             return $this->methodParameters[$method];
         }

--- a/tests/ZendTest/Di/Definition/ClassDefinitionTest.php
+++ b/tests/ZendTest/Di/Definition/ClassDefinitionTest.php
@@ -27,4 +27,52 @@ class ClassDefinitionTest extends TestCase
         $definition->addMethod('doBar');
         $this->assertTrue($definition->hasMethods('Foo'));
     }
+
+    public function testGetClassSupertypes()
+    {
+        $definition = new ClassDefinition('Foo');
+        $definition->setSupertypes(array('superFoo'));
+        $this->assertEquals(array(), $definition->getClassSupertypes('Bar'));
+        $this->assertEquals(array('superFoo'), $definition->getClassSupertypes('Foo'));
+    }
+
+    public function testGetInstantiator()
+    {
+        $definition = new ClassDefinition('Foo');
+        $definition->setInstantiator('__construct');
+        $this->assertNull($definition->getInstantiator('Bar'));
+        $this->assertEquals('__construct', $definition->getInstantiator('Foo'));
+    }
+
+    public function testGetMethods()
+    {
+        $definition = new ClassDefinition('Foo');
+        $definition->addMethod("setVar", true);
+        $this->assertEquals(array(), $definition->getMethods('Bar'));
+        $this->assertEquals(array('setVar' => true), $definition->getMethods('Foo'));
+    }
+
+    public function testHasMethod()
+    {
+        $definition = new ClassDefinition('Foo');
+        $definition->addMethod("setVar", true);
+        $this->assertNull($definition->hasMethod('Bar', "setVar"));
+        $this->assertTrue($definition->hasMethod('Foo', "setVar"));
+    }
+
+    public function testHasMethodParameters()
+    {
+        $definition = new ClassDefinition('Foo');
+        $definition->addMethodParameter("setVar", "var", array(null, true));
+        $this->assertFalse($definition->hasMethodParameters("Bar", "setVar"));
+        $this->assertTrue($definition->hasMethodParameters("Foo", "setVar"));
+    }
+
+    public function testGetMethodParameters()
+    {
+        $definition = new ClassDefinition('Foo');
+        $definition->addMethodParameter("setVar", "var", array('type' => null, 'required' => true));
+        $this->assertNull($definition->getMethodParameters("Bar", "setVar"));
+        $this->assertEquals(array('Foo::setVar:var' => array("var", null, true)), $definition->getMethodParameters("Foo", "setVar"));
+    }
 }

--- a/tests/ZendTest/Di/DefinitionListTest.php
+++ b/tests/ZendTest/Di/DefinitionListTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+* Zend Framework (http://framework.zend.com/)
+*
+* @link http://github.com/zendframework/zf2 for the canonical source repository
+* @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+* @license http://framework.zend.com/license/new-bsd New BSD License
+* @package Zend_Di
+*/
+
+namespace ZendTest\Di;
+
+use Zend\Di\DefinitionList;
+use Zend\Di\Definition\ClassDefinition;
+use Zend\Di\Definition\RuntimeDefinition;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+class DefinitionListTest extends TestCase
+{
+    public function testGetClassSupertypes()
+    {
+        $definitionClassA = new ClassDefinition("A");
+        $superTypesA = array("superA");
+        $definitionClassA->setSupertypes($superTypesA);
+
+        $definitionClassB = new ClassDefinition("B");
+        $definitionClassB->setSupertypes(array("superB"));
+
+        $definitionList = new DefinitionList(array($definitionClassA, $definitionClassB));
+
+        $this->assertEquals($superTypesA, $definitionList->getClassSupertypes("A"));
+
+    }
+}


### PR DESCRIPTION
(relative to http://framework.zend.com/issues/browse/ZF2-509)
Zend\Di\DefinitionList::getClassSupertypes returns wrong supertypes.
add ClassDefinitionTest
add DefinitionListTest
modify ClassDefinition to check the parameter.
