### PR TITLE
FormRow translate label fix (#ZF2-516)

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -78,6 +78,13 @@ class FormRow extends AbstractHelper
         $inputErrorClass = $this->getInputErrorClass();
         $elementErrors   = $elementErrorsHelper->render($element);
 
+        // Translate the label
+        if (null !== ($translator = $this->getTranslator())) {
+            $label = $translator->translate(
+                $label, $this->getTranslatorTextDomain()
+            );
+        }
+
         // Does this element have errors ?
         if (!empty($elementErrors) && !empty($inputErrorClass)) {
             $classAttributes = ($element->hasAttribute('class') ? $element->getAttribute('class') . ' ' : '');
@@ -279,6 +286,13 @@ class FormRow extends AbstractHelper
 
         if (!$this->labelHelper instanceof FormLabel) {
             $this->labelHelper = new FormLabel();
+        }
+
+        if ($this->hasTranslator()) {
+            $this->labelHelper->setTranslator(
+                $this->getTranslator(),
+                $this->getTranslatorTextDomain()
+            );
         }
 
         return $this->labelHelper;

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -78,13 +78,6 @@ class FormRow extends AbstractHelper
         $inputErrorClass = $this->getInputErrorClass();
         $elementErrors   = $elementErrorsHelper->render($element);
 
-        // Translate the label
-        if (null !== ($translator = $this->getTranslator())) {
-            $label = $translator->translate(
-                $label, $this->getTranslatorTextDomain()
-            );
-        }
-
         // Does this element have errors ?
         if (!empty($elementErrors) && !empty($inputErrorClass)) {
             $classAttributes = ($element->hasAttribute('class') ? $element->getAttribute('class') . ' ' : '');
@@ -95,7 +88,14 @@ class FormRow extends AbstractHelper
 
         $elementString = $elementHelper->render($element);
 
-        if (!empty($label)) {
+        if (isset($label) && '' !== $label) {
+            // Translate the label
+            if (null !== ($translator = $this->getTranslator())) {
+                $label = $translator->translate(
+                        $label, $this->getTranslatorTextDomain()
+                );
+            }
+
             $label = $escapeHtmlHelper($label);
             $labelAttributes = $element->getLabelAttributes();
 

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -166,7 +166,7 @@ class FormRowTest extends TestCase
         $element->setLabel('The value for foo:');
 
         $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
-        $mockTranslator->expects($this->exactly(1))
+        $mockTranslator->expects($this->any())
             ->method('translate')
             ->will($this->returnValue('translated content'));
 
@@ -177,7 +177,16 @@ class FormRowTest extends TestCase
         $this->assertContains('>translated content<', $markup);
         $this->assertContains('<label', $markup);
         $this->assertContains('</label>', $markup);
+
+        // Additional coverage when element's id is set
+        $element->setAttribute('id', 'foo');
+        $markup = $this->helper->__invoke($element);
+        $this->assertContains('>translated content<', $markup);
+        $this->assertContains('<label', $markup);
+        $this->assertContains('</label>', $markup);
     }
+
+
 
     public function testTranslatorMethods()
     {

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -159,4 +159,37 @@ class FormRowTest extends TestCase
     {
         $this->assertSame($this->helper, $this->helper->__invoke());
     }
+
+    public function testLabelWillBeTranslated()
+    {
+        $element = new Element('foo');
+        $element->setLabel('The value for foo:');
+
+        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+        $mockTranslator->expects($this->exactly(1))
+            ->method('translate')
+            ->will($this->returnValue('translated content'));
+
+        $this->helper->setTranslator($mockTranslator);
+        $this->assertTrue($this->helper->hasTranslator());
+
+        $markup = $this->helper->__invoke($element);
+        $this->assertContains('>translated content<', $markup);
+        $this->assertContains('<label', $markup);
+        $this->assertContains('</label>', $markup);
+    }
+
+    public function testTranslatorMethods()
+    {
+        $translatorMock = $this->getMock('Zend\I18n\Translator\Translator');
+        $this->helper->setTranslator($translatorMock, 'foo');
+
+        $this->assertEquals($translatorMock, $this->helper->getTranslator());
+        $this->assertEquals('foo', $this->helper->getTranslatorTextDomain());
+        $this->assertTrue($this->helper->hasTranslator());
+        $this->assertTrue($this->helper->isTranslatorEnabled());
+
+        $this->helper->setTranslatorEnabled(false);
+        $this->assertFalse($this->helper->isTranslatorEnabled());
+    }
 }


### PR DESCRIPTION
Fixed FormRow so it will translate labels, from this bug report: 
http://framework.zend.com/issues/browse/ZF2-516
