### PR TITLE
Translate element label in view helper formRow()

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -89,6 +89,12 @@ class FormRow extends AbstractHelper
         $elementString = $elementHelper->render($element);
 
         if (!empty($label)) {
+            if (null !== ($translator = $this->getTranslator())) {
+                $label = $translator->translate(
+                    $label, $this->getTranslatorTextDomain()
+                );
+            }
+
             $label = $escapeHtmlHelper($label);
             $labelAttributes = $element->getLabelAttributes();
 


### PR DESCRIPTION
When calling the view helper formRow() the label of a form element is now translated
