### PR TITLE
Change docblock to allow array in InputFilter

### DIFF
--- a/library/Zend/InputFilter/InputFilterInterface.php
+++ b/library/Zend/InputFilter/InputFilterInterface.php
@@ -23,7 +23,7 @@ interface InputFilterInterface extends Countable
     /**
      * Add an input to the input filter
      *
-     * @param  InputInterface|InputFilterInterface $input
+     * @param  InputInterface|InputFilterInterface|array $input
      * @param  null|string $name Name used to retrieve this input
      * @return InputFilterInterface
      */


### PR DESCRIPTION
Added array in the interface docblock, otherwise IDE are complaining when using an array specification to add new input filter.
