### PR TITLE
Add support for prev and next link relationships

### DIFF
--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -112,7 +112,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      */
     public function __call($method, $args)
     {
-        if (preg_match('/^(?P<action>set|(ap|pre)pend|offsetSet)(?P<type>Stylesheet|Alternate)$/', $method, $matches)) {
+        if (preg_match('/^(?P<action>set|(ap|pre)pend|offsetSet)(?P<type>Stylesheet|Alternate|Prev|Next)$/', $method, $matches)) {
             $argc   = count($args);
             $action = $matches['action'];
             $type   = $matches['type'];
@@ -422,4 +422,35 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         $attributes = compact('rel', 'href', 'type', 'title', 'extras');
         return $this->createData($attributes);
     }
+
+    /**
+     * Create item for a prev relationship (mainly used for pagination)
+     *
+     * @param array $args
+     * @return stdClass
+     */
+    public function createDataPrev(array $args)
+    {
+        $rel  = 'prev';
+        $href = (string) array_shift($args);
+
+        $attributes = compact('rel', 'href');
+        return $this->createData($attributes);
+    }
+
+    /**
+     * Create item for a prev relationship (mainly used for pagination)
+     *
+     * @param array $args
+     * @return stdClass
+     */
+    public function createDataNext(array $args)
+    {
+        $rel  = 'next';
+        $href = (string) array_shift($args);
+
+        $attributes = compact('rel', 'href');
+        return $this->createData($attributes);
+    }
 }
+

--- a/tests/ZendTest/View/Helper/HeadLinkTest.php
+++ b/tests/ZendTest/View/Helper/HeadLinkTest.php
@@ -381,6 +381,22 @@ class HeadLinkTest extends \PHPUnit_Framework_TestCase
         $this->assertContains(' media="screen,print"', $test);
     }
 
+    public function testSetPrevRelationship()
+    {
+        $this->helper->appendPrev('/foo/bar');
+        $test = $this->helper->toString();
+        $this->assertContains('href="/foo/bar"', $test);
+        $this->assertContains('rel="prev"', $test);
+    }
+
+    public function testSetNextRelationship()
+    {
+        $this->helper->appendNext('/foo/bar');
+        $test = $this->helper->toString();
+        $this->assertContains('href="/foo/bar"', $test);
+        $this->assertContains('rel="next"', $test);
+    }
+
     /**
      * @issue ZF-5435
      */


### PR DESCRIPTION
This PR adds native support for next and prev relationships in HeadLink helper. This is mainly used to provide some hints to search engines for pagination (http://googlewebmastercentral.blogspot.fr/2011/09/pagination-with-relnext-and-relprev.html).
