### PR TITLE
Removed comment about non existent Zend_Tool

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,8 +6,6 @@ and add the library directory to your PHP `include_path`. To use
 components in the extras library, add the `extras/library` directory to
 your PHP `include_path` as well.
 
-If you would like to use Zend_Tool, simply add `bin/zf.bat` (for Windows)
-or `bin/zf.sh` (for anything else) to your system executable path.
 
 ## SYSTEM REQUIREMENTS
 -------------------


### PR DESCRIPTION
The comment about how to use Zend_Tool by adding bin/zf.bat or bin/zf.sh to your executable path is confusing in INSTALL.md as there is no bin/zf.bat or bin/zf.sh file at this time.

Removed the comment in INSTALL.md
