### PR TITLE
[#ZF2-336] Zend\Form adds enctype attribute as multipart/form-data

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -137,6 +137,12 @@ class Form extends Fieldset implements FormInterface
             $elementOrFieldset = $factory->create($elementOrFieldset);
         }
 
+        // check if the element is a file and add enctype attribute if so
+        $type = $elementOrFieldset->getAttribute('type');
+        if (isset($type) && $type === 'file') {
+            $this->attributes['enctype'] = 'multipart/form-data';
+        }
+
         parent::add($elementOrFieldset, $flags);
 
         if ($elementOrFieldset instanceof Fieldset && $elementOrFieldset->useAsBaseFieldset()) {

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -286,6 +286,23 @@ class FormTest extends TestCase
         $this->assertInternalType('array', $data);
     }
 
+    /**
+     * @group ZF2-336
+     */
+    public function testCanAddFileEnctypeAttribute()
+    {
+        $this->form->add(array(
+            'name' => 'file_resource',
+            'attributes' => array(
+                'label' => 'This is a file',
+                'type' => 'file',
+            )));
+
+        $enctype = $this->form->getAttribute('enctype');
+        $this->assertNotEmpty($enctype);
+        $this->assertEquals($enctype, 'multipart/form-data');
+    }
+
     public function testCallingGetDataReturnsNormalizedDataByDefault()
     {
         $this->populateForm();


### PR DESCRIPTION
 when a file element is added to the form as specified in the W3C standard.
