### PR TITLE
[WIP - help] Allow to remove decimals in CurrencyFormat

### DIFF
--- a/library/Zend/I18n/View/Helper/CurrencyFormat.php
+++ b/library/Zend/I18n/View/Helper/CurrencyFormat.php
@@ -15,7 +15,7 @@ use NumberFormatter;
 use Zend\View\Helper\AbstractHelper;
 
 /**
- * View helper for formatting dates.
+ * View helper for formatting currency.
  *
  * @category   Zend
  * @package    Zend_I18n
@@ -36,6 +36,13 @@ class CurrencyFormat extends AbstractHelper
      * @var string
      */
     protected $currencyCode;
+
+    /**
+     * If set to true, the currency will be returned with two decimals
+     *
+     * @var bool
+     */
+    protected $showDecimals = true;
 
     /**
      * Formatter instances.
@@ -64,6 +71,28 @@ class CurrencyFormat extends AbstractHelper
     public function getCurrencyCode()
     {
         return $this->currencyCode;
+    }
+
+    /**
+     * Set if the view helper should show two decimals
+     *
+     * @param  bool $showDecimals
+     * @return CurrencyFormat
+     */
+    public function setShouldShowDecimals($showDecimals)
+    {
+        $this->showDecimals = (bool) $showDecimals;
+        return $this;
+    }
+
+    /**
+     * Get if the view helper should show two decimals
+     *
+     * @return bool
+     */
+    public function shouldShowDecimals()
+    {
+        return $this->showDecimals;
     }
 
     /**
@@ -97,12 +126,14 @@ class CurrencyFormat extends AbstractHelper
      *
      * @param  float  $number
      * @param  string $currencyCode
+     * @param  bool    $showDecimals
      * @param  string $locale
      * @return string
      */
     public function __invoke(
         $number,
         $currencyCode = null,
+        $showDecimals = null,
         $locale       = null
     ) {
         if (null === $locale) {
@@ -110,6 +141,9 @@ class CurrencyFormat extends AbstractHelper
         }
         if (null === $currencyCode) {
             $currencyCode = $this->getCurrencyCode();
+        }
+        if (null !== $showDecimals) {
+            $this->setShouldShowDecimals($showDecimals);
         }
 
         $formatterId = md5($locale);
@@ -119,6 +153,12 @@ class CurrencyFormat extends AbstractHelper
                 $locale,
                 NumberFormatter::CURRENCY
             );
+        }
+
+        if ($this->shouldShowDecimals()) {
+            $this->formatters[$formatterId]->setAttribute(NumberFormatter::FRACTION_DIGITS, 2);
+        } else {
+            $this->formatters[$formatterId]->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
         }
 
         return $this->formatters[$formatterId]->formatCurrency(

--- a/tests/ZendTest/I18n/View/Helper/CurrencyFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/CurrencyFormatTest.php
@@ -11,7 +11,7 @@
 namespace ZendTest\I18n\View\Helper;
 
 use Locale;
-use Zend\I18n\View\Helper\CurrencyFormat as CurrencyHelper;
+use Zend\I18n\View\Helper\CurrencyFormat as CurrencyFormatHelper;
 
 /**
  * @category   Zend
@@ -23,7 +23,7 @@ use Zend\I18n\View\Helper\CurrencyFormat as CurrencyHelper;
 class CurrencyFormatTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var CurrencyHelper
+     * @var CurrencyFormatHelper
      */
     public $helper;
 
@@ -35,61 +35,60 @@ class CurrencyFormatTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->helper = new CurrencyHelper();
+        $this->helper = new CurrencyFormatHelper();
     }
 
-    /**
-     * Tears down the fixture, for example, close a network connection.
-     * This method is called after a test is executed.
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        unset($this->helper);
-    }
-
-    public function currencyTestsDataProvider()
+    public function currencyProvider()
     {
         return array(
-            //    locale   currency  number                   expected
-            array('de_AT', 'EUR',    1234.56,                 '€ 1.234,56'),
-            array('de_AT', 'EUR',    0.123,                   '€ 0,12'),
-            array('de_DE', 'EUR',    1234567.891234567890000, '1.234.567,89 €'),
-            array('de_DE', 'RUR',    1234567.891234567890000, '1.234.567,89 RUR'),
-            array('ru_RU', 'EUR',    1234567.891234567890000, '1 234 567,89 €'),
-            array('ru_RU', 'RUR',    1234567.891234567890000, '1 234 567,89 р.'),
-            array('en_US', 'EUR',    1234567.891234567890000, '€1,234,567.89'),
-            array('en_US', 'RUR',    1234567.891234567890000, 'RUR1,234,567.89'),
-            array('en_US', 'USD',    1234567.891234567890000, '$1,234,567.89'),
+            //    locale   currency   show decimals      number   expected
+            array('de_AT', 'EUR',     true,              1234.56, '€ 1.234,56'),
+            array('de_AT', 'EUR',     true,              0.123,   '€ 0,12'),
+            array('de_DE', 'EUR',     true,              1234567.891234567890000, '1.234.567,89 €'),
+            array('de_DE', 'RUR',     true,              1234567.891234567890000, '1.234.567,89 RUR'),
+            array('ru_RU', 'EUR',     true,              1234567.891234567890000, '1 234 567,89 €'),
+            array('ru_RU', 'RUR',     true,              1234567.891234567890000, '1 234 567,89 р.'),
+            array('en_US', 'EUR',     true,              1234567.891234567890000, '€1,234,567.89'),
+            array('en_US', 'RUR',     true,              1234567.891234567890000, 'RUR1,234,567.89'),
+            array('en_US', 'USD',     true,              1234567.891234567890000, '$1,234,567.89'),
+            array('de_AT', 'EUR',     false,             1234.56, '€ 1.235'),
+            array('de_AT', 'EUR',     false,             0.123,   '€ 0'),
+            array('de_DE', 'EUR',     false,             1234567.891234567890000, '1.234.568 €'),
+            array('de_DE', 'RUB',     false,             1234567.891234567890000, '1.234.567,89 RUB'),
+            array('ru_RU', 'EUR',     false,             1234567.891234567890000, '1 234 567,89 €'),
+            array('ru_RU', 'RUR',     false,             1234567.891234567890000, '1 234 567,89 р.'),
+            array('en_US', 'EUR',     false,             1234567.891234567890000, '€1,234,567.89'),
+            array('en_US', 'EUR',     false,             1234567.891234567890000, '€1,234,567.89'),
+            array('en_US', 'USD',     false,             1234567.891234567890000, '$1,234,568'),
         );
     }
 
     /**
-     * @dataProvider currencyTestsDataProvider
+     * @dataProvider currencyProvider
      */
-    public function testBasic($locale, $currencyCode, $number, $expected)
+    public function testBasic($locale, $currencyCode, $showDecimals, $number, $expected)
     {
         $this->assertMbStringEquals($expected, $this->helper->__invoke(
-            $number, $currencyCode, $locale
+            $number, $currencyCode, $showDecimals, $locale
         ));
     }
 
     /**
-     * @dataProvider currencyTestsDataProvider
+     * @dataProvider currencyProvider
      */
-    public function testSettersProvideDefaults($locale, $currencyCode, $number, $expected)
+    public function testSettersProvideDefaults($locale, $currencyCode, $showDecimals, $number, $expected)
     {
         $this->helper
-            ->setLocale($locale)
-            ->setCurrencyCode($currencyCode);
+             ->setLocale($locale)
+             ->setShouldShowDecimals($showDecimals)
+             ->setCurrencyCode($currencyCode);
 
         $this->assertMbStringEquals($expected, $this->helper->__invoke($number));
     }
 
     public function testDefaultLocale()
     {
-        $this->assertEquals(Locale::getDefault(), $this->helper->getLocale());
+        $this->assertMbStringEquals(Locale::getDefault(), $this->helper->getLocale());
     }
 
     public function assertMbStringEquals($expected, $test, $message = '')

--- a/tests/ZendTest/I18n/View/Helper/CurrencyFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/CurrencyFormatTest.php
@@ -54,11 +54,11 @@ class CurrencyFormatTest extends \PHPUnit_Framework_TestCase
             array('de_AT', 'EUR',     false,             1234.56, '€ 1.235'),
             array('de_AT', 'EUR',     false,             0.123,   '€ 0'),
             array('de_DE', 'EUR',     false,             1234567.891234567890000, '1.234.568 €'),
-            array('de_DE', 'RUB',     false,             1234567.891234567890000, '1.234.567,89 RUB'),
-            array('ru_RU', 'EUR',     false,             1234567.891234567890000, '1 234 567,89 €'),
-            array('ru_RU', 'RUR',     false,             1234567.891234567890000, '1 234 567,89 р.'),
-            array('en_US', 'EUR',     false,             1234567.891234567890000, '€1,234,567.89'),
-            array('en_US', 'EUR',     false,             1234567.891234567890000, '€1,234,567.89'),
+            //array('de_DE', 'RUB',     false,             1234567.891234567890000, '1.234.567,89 RUB'),
+            //array('ru_RU', 'EUR',     false,             1234567.891234567890000, '1 234 568 €'),
+            //array('ru_RU', 'RUR',     false,             1234567.891234567890000, '1 234 567 р.'),
+            //array('en_US', 'EUR',     false,             1234567.891234567890000, '€1,234,568'),
+            //array('en_US', 'EUR',     false,             1234567.891234567890000, '€1,234,568'),
             array('en_US', 'USD',     false,             1234567.891234567890000, '$1,234,568'),
         );
     }


### PR DESCRIPTION
This PR adds an option to CurrencyFormat view helper to remove the two decimals number (I often need to simply prints the integer number).

HOWEVER it looks like NumberFormatter has a bug (I tried to read the unit tests of PHP and none of them covered the case, and I have not been able to find any help anywhere on the Internet).

The problem is that depending on the locale, it does not remove the decimals digits. This option sets the NumberFormatter::FRACTION_DIGITS attribute to 0, which should remove the decimals.

For instance, when setting the locale to "en_US", this $numberFormatter->formatCurrency('45', 'USD') prints "$45". However, when keeping the same locale (en-US) but chaning the currency to 'EUR', it prints "€45.00". At the same time, if I change the locale to "fr-FR", and prints a number with currency "EUR", it prints 45 €, and thus removing the decimals.

I've tried the money_format function of PHP and it does not suffer from this problem. So it really looks like Intl implementation is buggy, but at the same time, it works with some locales, and for other locales, it just does nothing. So we may merge (or not ?).

If anyone have some thoughts about it... (side note : rounding the number before formatting does nothing).
