### PR TITLE
Fix for ZF2-517: Zend\Mail\Header\GenericHeader fails to parse empty header

### DIFF
--- a/library/Zend/Mail/Header/GenericHeader.php
+++ b/library/Zend/Mail/Header/GenericHeader.php
@@ -41,7 +41,7 @@ class GenericHeader implements HeaderInterface, UnstructuredInterface
         if (count($parts) != 2) {
             throw new Exception\InvalidArgumentException('Header must match with the format "name: value"');
         }
-        $header = new static($parts[0], trim($parts[1]));
+        $header = new static($parts[0], ltrim($parts[1]));
         if ($decodedLine != $headerLine) {
             $header->setEncoding('UTF-8');
         }

--- a/library/Zend/Mail/Header/GenericHeader.php
+++ b/library/Zend/Mail/Header/GenericHeader.php
@@ -37,11 +37,11 @@ class GenericHeader implements HeaderInterface, UnstructuredInterface
     public static function fromString($headerLine)
     {
         $decodedLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-        $parts = explode(': ', $decodedLine, 2);
+        $parts = explode(':', $decodedLine, 2);
         if (count($parts) != 2) {
             throw new Exception\InvalidArgumentException('Header must match with the format "name: value"');
         }
-        $header = new static($parts[0], $parts[1]);
+        $header = new static($parts[0], trim($parts[1]));
         if ($decodedLine != $headerLine) {
             $header->setEncoding('UTF-8');
         }

--- a/tests/ZendTest/Mail/HeadersTest.php
+++ b/tests/ZendTest/Mail/HeadersTest.php
@@ -38,6 +38,17 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Fake', $header->getFieldName());
         $this->assertEquals('foo-bar', $header->getFieldValue());
     }
+    
+    public function testHeadersFromStringFactoryHandlesMissingWhitespace()
+    {
+        $headers = Mail\Headers::fromString("Fake:foo-bar");
+        $this->assertEquals(1, $headers->count());
+
+        $header = $headers->get('fake');
+        $this->assertInstanceOf('Zend\Mail\Header\GenericHeader', $header);
+        $this->assertEquals('Fake', $header->getFieldName());
+        $this->assertEquals('foo-bar', $header->getFieldValue());
+    }
 
     public function testHeadersFromStringFactoryCreatesSingleObjectWithContinuationLine()
     {


### PR DESCRIPTION
See http://framework.zend.com/issues/browse/ZF2-517
