### PR TITLE
[Server][Hotfix] sync svn r23315 - ZF-10365: report Unknown[] for parameters type-hinted

### DIFF
--- a/library/Zend/Server/Reflection/AbstractFunction.php
+++ b/library/Zend/Server/Reflection/AbstractFunction.php
@@ -276,6 +276,16 @@ abstract class AbstractFunction
         } else {
             $helpText = $function->getName();
             $return   = 'void';
+
+            // Try and auto-determine type, based on reflection
+            $paramTypesTmp = array();
+            foreach ($parameters as $i => $param) {
+                $paramType = 'mixed';
+                if ($param->isArray()) {
+                    $paramType = 'array';
+                }
+                $paramTypesTmp[$i] = $paramType;
+            }
         }
 
         // Set method description


### PR DESCRIPTION
[r23315](http://framework.zend.com/code/revision.php?repname=Zend+Framework&path=%2Ftrunk&rev=23315) 2010-11-10T16:36:46.060138Z / matthew

<pre>ZF-10365: report Unknown[] for parameters type-hinted as arrays
- Auto-detect array typehints during reflection
- In the Introspector, if a parameter is given an "array" typehint, return it as
"Unknown[]"
</pre>

- [library/Zend/Server/Reflection/Function/Abstract.php](http://framework.zend.com/code/diff.php?repname=Zend+Framework&path=%2Ftrunk%2Flibrary%2FZend%2FServer%2FReflection%2FFunction%2FAbstract.php&rev=23315)
