### PR TITLE
Mail\Message::getSubject() should return value the way it was set

### DIFF
--- a/library/Zend/Mail/Message.php
+++ b/library/Zend/Mail/Message.php
@@ -354,7 +354,7 @@ class Message
             return null;
         }
         $header = $headers->get('subject');
-        return $header->getFieldValue(Header\HeaderInterface::FORMAT_ENCODED);
+        return $header->getFieldValue();
     }
 
     /**

--- a/library/Zend/Mail/Transport/Sendmail.php
+++ b/library/Zend/Mail/Transport/Sendmail.php
@@ -179,7 +179,12 @@ class Sendmail implements TransportInterface
      */
     protected function prepareSubject(Mail\Message $message)
     {
-        return $message->getSubject();
+        $headers = $message->getHeaders();
+        if (!$headers->has('subject')) {
+            return null;
+        }
+        $header = $headers->get('subject');
+        return $header->getFieldValue(HeaderInterface::FORMAT_ENCODED);
     }
 
     /**

--- a/tests/ZendTest/Mail/MessageTest.php
+++ b/tests/ZendTest/Mail/MessageTest.php
@@ -602,6 +602,13 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('UTF-8', $this->message->getEncoding());
     }
 
+    public function testMessageReturnsNonEncodedSubject()
+    {
+        $this->message->setSubject('This is a subject');
+        $this->message->setEncoding('UTF-8');
+        $this->assertEquals('This is a subject', $this->message->getSubject());
+    }
+
     public function testSettingNonAsciiEncodingForcesMimeEncodingOfSomeHeaders()
     {
         $this->message->addTo('zf-devteam@zend.com', 'ZF DevTeam');

--- a/tests/ZendTest/Mail/Transport/SendmailTest.php
+++ b/tests/ZendTest/Mail/Transport/SendmailTest.php
@@ -124,4 +124,12 @@ class SendmailTest extends \PHPUnit_Framework_TestCase
         $this->transport->send($message);
         $this->assertContains("line.\n.. This", trim($this->message));
     }
+
+    public function testAssertSubjectEncoded()
+    {
+        $message = $this->getMessage();
+        $message->setEncoding('UTF-8');
+        $this->transport->send($message);
+        $this->assertEquals('=?UTF-8?Q?Testing=20Zend\Mail\Transport\Sendmail?=', $this->subject);
+    }
 }


### PR DESCRIPTION
Message return subject in encoded form which is quite unexpected behaviour for end user

``` php
$message->setSubject('Subject');
$message->setEncoding('UTF-8');
$message->getSubject(); // Subject
//before this PR:
$message->getSubject(); // =?UTF-8?Q?Subject?=
```

Transport should retrieve encoded Subject header value from headers and not directly from message object.
