### PR TITLE
ZF2-539 Input type of image should not have attribute value

### DIFF
--- a/library/Zend/Form/View/Helper/FormImage.php
+++ b/library/Zend/Form/View/Helper/FormImage.php
@@ -39,7 +39,6 @@ class FormImage extends FormInput
         'height'         => true,
         'src'            => true,
         'type'           => true,
-        'value'          => true,
         'width'          => true,
     );
 

--- a/tests/ZendTest/Form/View/Helper/FormImageTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormImageTest.php
@@ -92,7 +92,7 @@ class FormImageTest extends CommonTestCase
             array('size', 'assertNotContains'),
             array('src', 'assertContains'),
             array('step', 'assertNotContains'),
-            array('value', 'assertContains'),
+            array('value', 'assertNotContains'),
             array('width', 'assertContains'),
         );
     }


### PR DESCRIPTION
class Zend\Form\View\Helper\FormImage should not have "value" in validTagAttributes
