### PR TITLE
ZF2-543: removed linked but not implemented cache adapters

### DIFF
--- a/library/Zend/Cache/Storage/AdapterPluginManager.php
+++ b/library/Zend/Cache/Storage/AdapterPluginManager.php
@@ -36,12 +36,8 @@ class AdapterPluginManager extends AbstractPluginManager
         'filesystem'     => 'Zend\Cache\Storage\Adapter\Filesystem',
         'memcached'      => 'Zend\Cache\Storage\Adapter\Memcached',
         'memory'         => 'Zend\Cache\Storage\Adapter\Memory',
-        'sysvshm'        => 'Zend\Cache\Storage\Adapter\SystemVShm',
-        'systemvshm'     => 'Zend\Cache\Storage\Adapter\SystemVShm',
-        'sqlite'         => 'Zend\Cache\Storage\Adapter\Sqlite',
         'dba'            => 'Zend\Cache\Storage\Adapter\Dba',
         'wincache'       => 'Zend\Cache\Storage\Adapter\WinCache',
-        'xcache'         => 'Zend\Cache\Storage\Adapter\XCache',
         'zendserverdisk' => 'Zend\Cache\Storage\Adapter\ZendServerDisk',
         'zendservershm'  => 'Zend\Cache\Storage\Adapter\ZendServerShm',
     );


### PR DESCRIPTION
Removed not implemented cache adapters linked in AbstractPluginManager
