### PR TITLE
[ZF2-550]   Removed type check so that string("5.00") is recognized as equal to int(5) to validate it is a float

### DIFF
--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -123,7 +123,7 @@ class Float extends AbstractValidator
         $valueFiltered = str_replace($groupingSep, '', $value);
         $valueFiltered = str_replace($decimalSep, '.', $valueFiltered);
 
-        if (strval($parsedFloat) !== $valueFiltered) {
+        if (strval($parsedFloat) != $valueFiltered) {
             $this->error(self::NOT_FLOAT);
             return false;
         }

--- a/tests/ZendTest/I18n/Validator/FloatTest.php
+++ b/tests/ZendTest/I18n/Validator/FloatTest.php
@@ -59,6 +59,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
             array(0.01,   true),
             array(-0.1,   true),
             array('10.1', true),
+            array('5.00', true),
             array(1,      true),
             array('10.1not a float', false),
         );


### PR DESCRIPTION
When validating floats the last part of the international float validator runs a type/ value check to see if string("5.00") is equal to it's parsed value, int(5), returning false.

Removed the type check to determine whether the valueFiltered and the parsedFloat were equal as the valueFiltered ("5.00") may not be the same as the parsedFloat ("5") despite being equal to it (as mentioned above).
