### PR TITLE
Correcting event attachment to post module load.

### DIFF
--- a/library/Zend/ModuleManager/Listener/LocatorRegistrationListener.php
+++ b/library/Zend/ModuleManager/Listener/LocatorRegistrationListener.php
@@ -117,7 +117,7 @@ class LocatorRegistrationListener extends AbstractListener implements
     public function attach(EventManagerInterface $events)
     {
         $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, array($this, 'onLoadModule'));
-        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULES, array($this, 'onLoadModulesPost'), -1000);
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULES_POST, array($this, 'onLoadModulesPost'), -1000);
         return $this;
     }
 


### PR DESCRIPTION
I'm actually not sure if this is a bug or not but the code seems to indicate that the wrong event is being attached to.

I think this still works because it's attached with a -1000 and the POST event is called right after anyway.

I tried a simple hello world and got no errors. 
