### PR TITLE
Bug in Zend\ModuleManager\Listener\LocatorRegistrationListener

### DIFF
--- a/library/Zend/ModuleManager/Listener/LocatorRegistrationListener.php
+++ b/library/Zend/ModuleManager/Listener/LocatorRegistrationListener.php
@@ -66,22 +66,26 @@ class LocatorRegistrationListener extends AbstractListener implements
         $moduleManager = $e->getTarget();
         $events        = $moduleManager->getEventManager()->getSharedManager();
 
-        // Shared instance for module manager
-        $events->attach('Zend\Mvc\Application', 'bootstrap', function ($e) use ($moduleManager) {
-            $moduleClassName = get_class($moduleManager);
-            $application     = $e->getApplication();
-            $services        = $application->getServiceManager();
-            if (!$services->has($moduleClassName)) {
-                $services->setService($moduleClassName, $moduleManager);
-            }
-        }, 1000);
+        if(false !== $events){
+            // Shared instance for module manager
+            $events->attach('Zend\Mvc\Application', 'bootstrap', function ($e) use ($moduleManager) {
+                $moduleClassName = get_class($moduleManager);
+                $application     = $e->getApplication();
+                $services        = $application->getServiceManager();
+                if (!$services->has($moduleClassName)) {
+                    $services->setService($moduleClassName, $moduleManager);
+                }
+            }, 1000);
+        }
 
         if (0 === count($this->modules)) {
             return;
         }
 
-        // Attach to the bootstrap event if there are modules we need to process
-        $events->attach('Zend\Mvc\Application', 'bootstrap', array($this, 'onBootstrap'), 1000);
+        if(false !== $events){
+            // Attach to the bootstrap event if there are modules we need to process
+            $events->attach('Zend\Mvc\Application', 'bootstrap', array($this, 'onBootstrap'), 1000);
+        }
     }
 
     /**

--- a/library/Zend/ModuleManager/Listener/LocatorRegistrationListener.php
+++ b/library/Zend/ModuleManager/Listener/LocatorRegistrationListener.php
@@ -66,26 +66,26 @@ class LocatorRegistrationListener extends AbstractListener implements
         $moduleManager = $e->getTarget();
         $events        = $moduleManager->getEventManager()->getSharedManager();
 
-        if(false !== $events){
-            // Shared instance for module manager
-            $events->attach('Zend\Mvc\Application', 'bootstrap', function ($e) use ($moduleManager) {
-                $moduleClassName = get_class($moduleManager);
-                $application     = $e->getApplication();
-                $services        = $application->getServiceManager();
-                if (!$services->has($moduleClassName)) {
-                    $services->setService($moduleClassName, $moduleManager);
-                }
-            }, 1000);
+        if(!$events){
+            return;
         }
+
+        // Shared instance for module manager
+        $events->attach('Zend\Mvc\Application', 'bootstrap', function ($e) use ($moduleManager) {
+            $moduleClassName = get_class($moduleManager);
+            $application     = $e->getApplication();
+            $services        = $application->getServiceManager();
+            if (!$services->has($moduleClassName)) {
+                $services->setService($moduleClassName, $moduleManager);
+            }
+        }, 1000);
 
         if (0 === count($this->modules)) {
             return;
         }
 
-        if(false !== $events){
-            // Attach to the bootstrap event if there are modules we need to process
-            $events->attach('Zend\Mvc\Application', 'bootstrap', array($this, 'onBootstrap'), 1000);
-        }
+        // Attach to the bootstrap event if there are modules we need to process
+        $events->attach('Zend\Mvc\Application', 'bootstrap', array($this, 'onBootstrap'), 1000);
     }
 
     /**


### PR DESCRIPTION
The shared event manager can be false sometimes and at lines 70 and 85 this wasn't checked so I caught some errors while running tests for a new module.

I'm not even sure if this is due to errors in my configuration, but considering that the shared event manager is not always returned we should check for it.
