### PR TITLE
Hotfix for AbstractDb and Csrf Validators

### DIFF
--- a/library/Zend/Validator/Csrf.php
+++ b/library/Zend/Validator/Csrf.php
@@ -76,7 +76,7 @@ class Csrf extends AbstractValidator
      */
     public function __construct($options = array())
     {
-        parent::__construct();
+        parent::__construct($options);
 
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);

--- a/library/Zend/Validator/Db/AbstractDb.php
+++ b/library/Zend/Validator/Db/AbstractDb.php
@@ -94,7 +94,7 @@ abstract class AbstractDb extends AbstractValidator
      */
     public function __construct($options = null)
     {
-        parent::__construct();
+        parent::__construct($options);
 
         if ($options instanceof DbSelect) {
             $this->setSelect($options);


### PR DESCRIPTION
These validators were not passing the `$options` constructor parameter up to their parent's constructor. This caused (among other things) custom validator messages to be ignored.
