### PR TITLE
[2.1] ServiceManager tagging support

### DIFF
--- a/library/Zend/Mvc/Service/ServiceManagerConfig.php
+++ b/library/Zend/Mvc/Service/ServiceManagerConfig.php
@@ -60,6 +60,13 @@ class ServiceManagerConfig implements ConfigInterface
     );
 
     /**
+     * Tags
+     *
+     * @var array
+     */
+    protected $tags = array();
+
+    /**
      * Shared services
      *
      * Services are shared by default; this is primarily to indicate services
@@ -96,6 +103,10 @@ class ServiceManagerConfig implements ConfigInterface
             $this->aliases = array_merge($this->aliases, $configuration['aliases']);
         }
 
+        if (isset($configuration['tags'])) {
+            $this->tags = array_merge($this->tags, $configuration['tags']);
+        }
+
         if (isset($configuration['shared'])) {
             $this->shared = array_merge($this->shared, $configuration['shared']);
         }
@@ -129,6 +140,10 @@ class ServiceManagerConfig implements ConfigInterface
 
         foreach ($this->aliases as $name => $service) {
             $serviceManager->setAlias($name, $service);
+        }
+
+        foreach ($this->tags as $name => $services) {
+            $serviceManager->addTag($name, $services);
         }
 
         foreach ($this->shared as $name => $value) {

--- a/library/Zend/ServiceManager/Config.php
+++ b/library/Zend/ServiceManager/Config.php
@@ -49,6 +49,11 @@ class Config implements ConfigInterface
         return (isset($this->config['aliases'])) ? $this->config['aliases'] : array();
     }
 
+    public function getTags()
+    {
+        return (isset($this->config['tags'])) ? $this->config['tags'] : array();
+    }
+
     public function getInitializers()
     {
         return (isset($this->config['initializers'])) ? $this->config['initializers'] : array();
@@ -82,6 +87,10 @@ class Config implements ConfigInterface
 
         foreach ($this->getAliases() as $alias => $nameOrAlias) {
             $serviceManager->setAlias($alias, $nameOrAlias);
+        }
+
+        foreach ($this->getTags() as $tags => $namesOrAliases) {
+            $serviceManager->addTag($tags, $namesOrAliases);
         }
 
         foreach ($this->getInitializers() as $initializer) {

--- a/library/Zend/ServiceManager/Exception/TagNotFoundException.php
+++ b/library/Zend/ServiceManager/Exception/TagNotFoundException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_ServiceManager
+ */
+
+namespace Zend\ServiceManager\Exception;
+
+/**
+ * @category   Zend
+ * @package    Zend_ServiceManager
+ * @subpackage Exception
+ */
+class TagNotFoundException extends InvalidArgumentException
+{}

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -75,6 +75,11 @@ class ServiceManager implements ServiceLocatorInterface
     /**
      * @var array
      */
+    protected $tags = array();
+
+    /**
+     * @var array
+     */
     protected $initializers = array();
 
     /**
@@ -373,6 +378,93 @@ class ServiceManager implements ServiceLocatorInterface
 
         $this->shared[$cName] = (bool) $isShared;
         return $this;
+    }
+
+
+    /**
+     * Adds a tag.
+     *
+     * A tag can contain one or more services/aliases.
+     *
+     * @param  string       $name
+     * @param  string|array $serviceNames
+     * @return ServiceManager
+     * @throws Exception\InvalidArgumentException
+     */
+    public function addTag($name, $serviceNames)
+    {
+        $cName = $this->canonicalizeName($name);
+        $rName = $name;
+
+        if (!isset($this->tags[$cName])) {
+            $this->tags[$cName] = array();
+        }
+
+        if (is_string($serviceNames)) {
+            $this->tags[$cName] = array_merge($this->tags[$cName], array($serviceNames));
+        } elseif (is_array($serviceNames)) {
+            $this->tags[$cName] = array_merge($this->tags[$cName], $serviceNames);
+        } else {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Unable to add tag for %s. The second argument must be an array or string, %s given.',
+                $rName,
+                gettype($serviceNames)
+            ));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Checks if a tag exists.
+     *
+     * @param  string $name
+     * @return bool
+     */
+    public function hasTag($name)
+    {
+        $cName = $this->canonicalizeName($name);
+
+        return isset($this->tags[$cName]);
+    }
+
+    /**
+     * Returns the all services associated with that tag.
+     *
+     * If $instantiate is set to true, the key will be the service name and the
+     * value will be an instance of that service, otherwise it will return a
+     * list containing the service names/aliases.
+     *
+     * @param  string $name
+     * @param  bool   $instantiate
+     * @param  bool   $usePeeringServiceManagers
+     * @return array
+     * @throws Exception\InvalidArgumentException
+     */
+    public function getTag($name, $instantiate = true, $usePeeringServiceManagers = true)
+    {
+        $cName = $this->canonicalizeName($name);
+        $rName = $name;
+
+        if (!isset($this->tags[$cName])) {
+            throw new Exception\ServiceNotFoundException(sprintf(
+                '%s was unable to fetch a tag named %s.',
+                __METHOD__,
+                $rName
+            ));
+        }
+
+        if ($instantiate === true) {
+            $tag = array();
+
+            foreach ($this->tags[$cName] as $service) {
+                $tag[$service] = $this->get($service, $usePeeringServiceManagers);
+            }
+
+            return $tag;
+        }
+
+        return $this->tags[$cName];
     }
 
     /**
@@ -719,6 +811,7 @@ class ServiceManager implements ServiceLocatorInterface
             'factories' => array_keys($this->factories),
             'aliases' => array_keys($this->aliases),
             'instances' => array_keys($this->instances),
+            'tags' => $this->tags,
         );
     }
 

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -439,7 +439,7 @@ class ServiceManager implements ServiceLocatorInterface
      * @param  bool   $instantiate
      * @param  bool   $usePeeringServiceManagers
      * @return array
-     * @throws Exception\InvalidArgumentException
+     * @throws Exception\TagNotFoundException
      */
     public function getTag($name, $instantiate = true, $usePeeringServiceManagers = true)
     {
@@ -447,7 +447,7 @@ class ServiceManager implements ServiceLocatorInterface
         $rName = $name;
 
         if (!isset($this->tags[$cName])) {
-            throw new Exception\ServiceNotFoundException(sprintf(
+            throw new Exception\TagNotFoundException(sprintf(
                 '%s was unable to fetch a tag named %s.',
                 __METHOD__,
                 $rName

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -566,4 +566,118 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $this->serviceManager->{$method}('response', $service);
         $this->{$assertion}($expected, $this->serviceManager->get('response'));
     }
+
+    public function testRegisteredServicesContainsTags()
+    {
+        $serviceManager = new ServiceManager();
+        $serviceManager->addTag('Zend\Test', 'ItsOver9000');
+
+        $this->assertArrayHasKey('tags', $serviceManager->getRegisteredServices());
+    }
+
+    /**
+     * @depends testRegisteredServicesContainsTags
+     */
+    public function testCanAddTagWithStringServiceName()
+    {
+        $serviceManager = new ServiceManager();
+        $serviceManager->addTag('Zend\Test', 'AllYourBase');
+
+        $services = $serviceManager->getRegisteredServices();
+        $tags     = $services['tags'];
+
+        $this->assertArrayHasKey('zendtest', $tags);
+        $this->assertTrue(in_array('AllYourBase', $tags['zendtest']));
+    }
+
+    /**
+     * @expectedException Zend\ServiceManager\Exception\InvalidArgumentException
+     */
+    public function testCannotAddTagWithInvalidServiceName()
+    {
+        $serviceManager = new ServiceManager();
+        $serviceManager->addTag('Zend\Test', null);
+    }
+
+    /**
+     * @depends testRegisteredServicesContainsTags
+     */
+    public function testCanAddTagWithStringDoesNotOverride()
+    {
+        $serviceManager = new ServiceManager();
+        $serviceManager->addTag('Zend\Test', 'AllYourBase');
+        $serviceManager->addTag('Zend\Test', 'BelongsToUs');
+
+        $services = $serviceManager->getRegisteredServices();
+        $tags     = $services['tags'];
+
+        $this->assertArrayHasKey('zendtest', $tags);
+        $this->assertTrue(in_array('BelongsToUs', $tags['zendtest']));
+    }
+
+    /**
+     * @depends testRegisteredServicesContainsTags
+     */
+    public function testCanAddTagWithArrayServiceNames()
+    {
+        $serviceManager = new ServiceManager();
+        $serviceManager->addTag('Zend\Test', array('For', 'Great', 'Justice'));
+
+        $services = $serviceManager->getRegisteredServices();
+        $tags     = $services['tags'];
+
+        $this->assertArrayHasKey('zendtest', $tags);
+        $this->assertTrue(in_array('For', $tags['zendtest']));
+        $this->assertTrue(in_array('Great', $tags['zendtest']));
+        $this->assertTrue(in_array('Justice', $tags['zendtest']));
+    }
+
+    /**
+     * @depends testRegisteredServicesContainsTags
+     */
+    public function testCanAddTagWithArrayDoesNotOverride()
+    {
+        $serviceManager = new ServiceManager();
+        $serviceManager->addTag('Zend\Test', array('For', 'Great', 'Justice'));
+        $serviceManager->addTag('Zend\Test', array('Flux', 'Capacitor'));
+
+        $services = $serviceManager->getRegisteredServices();
+        $tags     = $services['tags'];
+
+        $this->assertArrayHasKey('zendtest', $tags);
+        $this->assertTrue(in_array('For', $tags['zendtest']));
+        $this->assertTrue(in_array('Great', $tags['zendtest']));
+        $this->assertTrue(in_array('Justice', $tags['zendtest']));
+        $this->assertTrue(in_array('Flux', $tags['zendtest']));
+        $this->assertTrue(in_array('Capacitor', $tags['zendtest']));
+    }
+
+    public function testHasTag()
+    {
+        $serviceManager = new ServiceManager();
+        $serviceManager->addTag('Zend\Test', 'CowBell');
+
+        $this->assertTrue($serviceManager->hasTag('Zend\Test'));
+        $this->assertFalse($serviceManager->hasTag('MoarCowBell'));
+    }
+
+    public function testGetTagWithoutInstantiating()
+    {
+        $serviceManager = new ServiceManager();
+        $serviceManager->addTag('Zend\Test', 'CowBell');
+
+        $this->assertTrue(in_array('CowBell', $serviceManager->getTag('Zend\Test', false)));
+    }
+
+    public function testGetTagAndInstantiating()
+    {
+        $testStdClass   = new \stdClass();
+        $serviceManager = new ServiceManager();
+        $serviceManager->setService('UnitTesto', $testStdClass);
+        $serviceManager->addTag('Zend\Test', 'UnitTesto');
+
+        $tag = $serviceManager->getTag('Zend\Test');
+
+        $this->assertSame(spl_object_hash($testStdClass), spl_object_hash($tag['UnitTesto']));
+    }
 }

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -661,6 +661,15 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($serviceManager->hasTag('MoarCowBell'));
     }
 
+    /**
+     * @expectedException Zend\ServiceManager\Exception\TagNotFoundException
+     */
+    public function testTagNotFound()
+    {
+        $serviceManager = new ServiceManager();
+        $serviceManager->getTag('Zend\Test\DoesNotExists');
+    }
+
     public function testGetTagWithoutInstantiating()
     {
         $serviceManager = new ServiceManager();


### PR DESCRIPTION
The current `ServiceManager` implementation allows only N names (aliases) for 1 service. This PR adds the ability to add 1 name (tag) for N services or aliases. It is basicly a bag of services. 

The current implementation won't check if a service or an alias exists before inserting it into the tag bag nor does it ensure that a service is unique in the bag, because that would require a more complex implementation which would decrease the performance of the `ServiceManager`.

**Example:**

```
$serviceManager->addTag('Example', 'Zend\Example\One');
$serviceManager->addTag('Example', array('Zend\Example\Two', 'Zend\Example\Three'));

// array('Zend\Example\One', 'Zend\Example\Two', 'Zend\Example\Three')
$services = $serviceManager->getTag('Example', false);

// array(
//     'Zend\Example\One' => objectInstance,
//     'Zend\Example\Two' => objectInstance, 
//     'Zend\Example\Three' => objectInstance,
// )
$services = $serviceManager->getTag('Example');
```
