### PR TITLE
Update library/Zend/Feed/Writer/AbstractFeed.php

### DIFF
--- a/library/Zend/Feed/Writer/AbstractFeed.php
+++ b/library/Zend/Feed/Writer/AbstractFeed.php
@@ -36,7 +36,7 @@ class AbstractFeed
     protected $type = null;
 
     /**
-     * @var $_extensions
+     * @var $extensions
      */
     protected $extensions;
 


### PR DESCRIPTION
Changed docblock:
@var $_extensions to @var $extensions

I didn't found the property in the code, maybe it's not needed anymore?
