### PR TITLE
Allow setting CsrfValidatorOptions in constructor

### DIFF
--- a/library/Zend/Form/Element/Csrf.php
+++ b/library/Zend/Form/Element/Csrf.php
@@ -41,6 +41,24 @@ class Csrf extends Element implements InputProviderInterface, ElementPrepareAwar
      * @var CsrfValidator
      */
     protected $csrfValidator;
+    
+    /**
+     * Accepted options for Csrf:
+     * - csrf_options: an array used in the Csrf
+     *
+     * @param array|\Traversable $options
+     * @return Csrf
+     */
+    public function setOptions($options)
+    {
+        parent::setOptions($options);
+
+        if (isset($options['csrf_options'])) {
+            $this->setCsrfValidatorOptions($options['csrf_options']);
+        }
+
+        return $this;
+    }
 
     /**
      * @return array

--- a/tests/ZendTest/Form/Element/CsrfTest.php
+++ b/tests/ZendTest/Form/Element/CsrfTest.php
@@ -37,6 +37,7 @@ class CsrfTest extends TestCase
                     break;
                 default:
                     break;
+                
             }
         }
     }
@@ -56,5 +57,18 @@ class CsrfTest extends TestCase
         $validator = $element->getCsrfValidator();
         $this->assertEquals('foo', $validator->getName());
         $this->assertEquals(777, $validator->getTimeout());
+    }
+    
+    public function testAllowSettingCsrfOptions() {
+        $element = new CsrfElement('foo');
+        $element->setOptions(array(
+            'csrf_options' => array(
+                'timeout' => 777,
+                'salt' => 'MySalt')
+            ));
+        $validator = $element->getCsrfValidator();
+        $this->assertEquals('foo', $validator->getName());
+        $this->assertEquals(777, $validator->getTimeOut());
+        $this->assertEquals('MySalt', $validator->getSalt());
     }
 }


### PR DESCRIPTION
This PR adds the option to set CSRF validator options directly when constructing the CSRF element
