### PR TITLE
Convert abstract classes that are only offering static methods

### DIFF
--- a/library/Zend/Barcode/Barcode.php
+++ b/library/Zend/Barcode/Barcode.php
@@ -20,7 +20,7 @@ use Zend\Stdlib\ArrayUtils;
  * @category   Zend
  * @package    Zend_Barcode
  */
-class Barcode
+abstract class Barcode
 {
     const OBJECT   = 'OBJECT';
     const RENDERER = 'RENDERER';

--- a/library/Zend/Cache/PatternFactory.php
+++ b/library/Zend/Cache/PatternFactory.php
@@ -17,7 +17,7 @@ use Zend\Stdlib\ArrayUtils;
  * @category   Zend
  * @package    Zend_Cache
  */
-class PatternFactory
+abstract class PatternFactory
 {
     /**
      * The pattern manager

--- a/library/Zend/Cache/StorageFactory.php
+++ b/library/Zend/Cache/StorageFactory.php
@@ -18,7 +18,7 @@ use Zend\Stdlib\ArrayUtils;
  * @package    Zend_Cache
  * @subpackage Storage
  */
-class StorageFactory
+abstract class StorageFactory
 {
     /**
      * Plugin manager for loading adapters

--- a/library/Zend/Math/BigInteger/BigInteger.php
+++ b/library/Zend/Math/BigInteger/BigInteger.php
@@ -15,7 +15,7 @@ namespace Zend\Math\BigInteger;
  * @package    Zend_Math
  * @subpackage BigInteger
  */
-class BigInteger
+abstract class BigInteger
 {
     /**
      * Plugin manager for loading adapters

--- a/library/Zend/Serializer/Serializer.php
+++ b/library/Zend/Serializer/Serializer.php
@@ -16,7 +16,7 @@ use Zend\Serializer\Adapter\AdapterInterface as Adapter;
  * @category   Zend
  * @package    Zend_Serializer
  */
-class Serializer
+abstract class Serializer
 {
     /**
      * Plugin manager for loading adapters


### PR DESCRIPTION
To respect recommanation :

"For classes that are only offering static methods, we typically
recommend making them abstract."
