### PR TITLE
zend-inputfilter already requires 

### DIFF
--- a/library/Zend/Form/composer.json
+++ b/library/Zend/Form/composer.json
@@ -13,7 +13,8 @@
     },
     "target-dir": "Zend/Form",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "zendframework/zend-inputfilter": "self.version"
     },
     "require-dev": {
         "zendframework/zendservice-recaptcha": "*"


### PR DESCRIPTION
zend-filter , validator and stdlib. So not adding others.
