### PR TITLE
ZF2-417 Form Annotation Hydrator options support

### DIFF
--- a/library/Zend/Form/Annotation/AbstractArrayOrStringAnnotation.php
+++ b/library/Zend/Form/Annotation/AbstractArrayOrStringAnnotation.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace Zend\Form\Annotation;
+
+use Zend\Form\Exception;
+
+/**
+ * @package    Zend_Form
+ * @subpackage Annotation
+ */
+abstract class AbstractArrayOrStringAnnotation
+{
+    /**
+     * @var array|string
+     */
+    protected $value;
+
+    /**
+     * Receive and process the contents of an annotation
+     *
+     * @param  array $data
+     * @throws Exception\DomainException if a 'value' key is missing, or its value is not an array or string
+     */
+    public function __construct(array $data)
+    {
+        if (!isset($data['value']) || (!is_array($data['value']) && !is_string($data['value']))) {
+            throw new Exception\DomainException(sprintf(
+                '%s expects the annotation to define an array or string; received "%s"',
+                get_class($this),
+                isset($data['value']) ? gettype($data['value']) : 'null'
+            ));
+        }
+        $this->value = $data['value'];
+    }
+}

--- a/library/Zend/Form/Annotation/Hydrator.php
+++ b/library/Zend/Form/Annotation/Hydrator.php
@@ -21,12 +21,12 @@ namespace Zend\Form\Annotation;
  * @package    Zend_Form
  * @subpackage Annotation
  */
-class Hydrator extends AbstractStringAnnotation
+class Hydrator extends AbstractArrayOrStringAnnotation
 {
     /**
      * Retrieve the hydrator class
      *
-     * @return null|string
+     * @return null|string|array
      */
     public function getHydrator()
     {

--- a/library/Zend/Stdlib/Hydrator/AbstractHydrator.php
+++ b/library/Zend/Stdlib/Hydrator/AbstractHydrator.php
@@ -56,7 +56,7 @@ abstract class AbstractHydrator implements HydratorInterface, StrategyEnabledInt
                 $name
             ));
         }
-        
+
         return $this->strategies['*'];
     }
 

--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -17,22 +17,61 @@ use Zend\Stdlib\Exception;
  * @package    Zend_Stdlib
  * @subpackage Hydrator
  */
-class ClassMethods extends AbstractHydrator
+class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
 {
     /**
      * Flag defining whether array keys are underscore-separated (true) or camel case (false)
      * @var boolean
      */
-    protected $underscoreSeparatedKeys;
+    protected $underscoreSeparatedKeys = true;
 
     /**
      * Define if extract values will use camel case or name with underscore
-     * @param boolean $underscoreSeparatedKeys
+     * @param boolean|array $underscoreSeparatedKeys
      */
     public function __construct($underscoreSeparatedKeys = true)
     {
         parent::__construct();
+        $this->setUnderscoreSeparatedKeys($underscoreSeparatedKeys);
+    }
+
+    /**
+     * @param  array|\Traversable $options
+     * @return ClassMethods
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setOptions($options)
+    {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        } elseif (!is_array($options)) {
+            throw new Exception\InvalidArgumentException(
+                'The options parameter must be an array or a Traversable'
+            );
+        }
+        if (isset($options['underscoreSeparatedKeys'])) {
+            $this->setUnderscoreSeparatedKeys($options['underscoreSeparatedKeys']);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param  boolean $underscoreSeparatedKeys
+     * @return ClassMethods
+     */
+    public function setUnderscoreSeparatedKeys($underscoreSeparatedKeys)
+    {
         $this->underscoreSeparatedKeys = $underscoreSeparatedKeys;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getUnderscoreSeparatedKeys()
+    {
+        return $this->underscoreSeparatedKeys;
     }
 
     /**

--- a/library/Zend/Stdlib/Hydrator/HydratorOptionsInterface.php
+++ b/library/Zend/Stdlib/Hydrator/HydratorOptionsInterface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+
+namespace Zend\Stdlib\Hydrator;
+
+/**
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage Hydrator
+ */
+interface HydratorOptionsInterface
+{
+    /**
+     * @param  array|\Traversable $options
+     * @return HydratorOptionsInterface
+     */
+    public function setOptions($options);
+}

--- a/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
+++ b/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
@@ -187,6 +187,17 @@ class AnnotationBuilderTest extends TestCase
         $this->assertEquals(array('class' => 'label'), $username->getLabelAttributes());
     }
 
+    public function testCanHandleHydratorArrayAnnotation()
+    {
+        $entity  = new TestAsset\Annotation\EntityWithHydratorArray();
+        $builder = new Annotation\AnnotationBuilder();
+        $form    = $builder->createForm($entity);
+
+        $hydrator = $form->getHydrator();
+        $this->assertInstanceOf('Zend\Stdlib\Hydrator\ClassMethods', $hydrator);
+        $this->assertFalse($hydrator->getUnderscoreSeparatedKeys());
+    }
+
     public function testAllowTypeAsElementNameInInputFilter()
     {
         $entity  = new TestAsset\Annotation\EntityWithTypeAsElementName();

--- a/tests/ZendTest/Form/FactoryTest.php
+++ b/tests/ZendTest/Form/FactoryTest.php
@@ -317,6 +317,22 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('Zend\Stdlib\Hydrator\ObjectProperty', $hydrator);
     }
 
+    public function testCanCreateHydratorFromArray()
+    {
+        $form = $this->factory->createForm(array(
+            'name' => 'foo',
+            'hydrator' => array(
+                'type' => 'Zend\Stdlib\Hydrator\ClassMethods',
+                'options' => array('underscoreSeparatedKeys' => false),
+            ),
+        ));
+
+        $this->assertInstanceOf('Zend\Form\FormInterface', $form);
+        $hydrator = $form->getHydrator();
+        $this->assertInstanceOf('Zend\Stdlib\Hydrator\ClassMethods', $hydrator);
+        $this->assertFalse($hydrator->getUnderscoreSeparatedKeys());
+    }
+
     public function testCanCreateHydratorFromConcreteClass()
     {
         $form = $this->factory->createForm(array(

--- a/tests/ZendTest/Form/TestAsset/Annotation/EntityWithHydratorArray.php
+++ b/tests/ZendTest/Form/TestAsset/Annotation/EntityWithHydratorArray.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace ZendTest\Form\TestAsset\Annotation;
+
+use Zend\Form\Annotation;
+
+/**
+ * @Annotation\Name("user")
+ * @Annotation\Attributes({"legend":"Register"})
+ * @Annotation\Hydrator({"type":"Zend\Stdlib\Hydrator\ClassMethods", "options": {"underscoreSeparatedKeys": false}})
+ */
+class EntityWithHydratorArray
+{
+    /**
+     * @Annotation\Options({"label":"Username:", "label_attributes": {"class": "label"}})
+     */
+    public $username;
+}

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -179,6 +179,16 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($test->hasBar(), false);
     }
 
+    public function testHydratorClassMethodsOptions()
+    {
+        $hydrator = new ClassMethods();
+        $this->assertTrue($hydrator->getUnderscoreSeparatedKeys());
+        $hydrator->setOptions(array('underscoreSeparatedKeys' => false));
+        $this->assertFalse($hydrator->getUnderscoreSeparatedKeys());
+        $hydrator->setUnderscoreSeparatedKeys(true);
+        $this->assertTrue($hydrator->getUnderscoreSeparatedKeys());
+    }
+
     public function testHydratorClassMethodsIgnoresInvalidValues()
     {
         $hydrator = new ClassMethods(true);


### PR DESCRIPTION
Backwards compatible to support both string and array annotations:

`@Annotation\Hydrator("Zend\Stdlib\Hydrator\ObjectProperty")`
or
`@Annotation\Hydrator({"type":"Zend\Stdlib\Hydrator\ClassMethods", "options": {"underscoreSeparatedKeys": false}})`

Some API additions, so this PR is targeted against the develop branch.
