### PR TITLE
Typo in property name in Zend/Db/Metadata/Object/AbstractTableObject.php

### DIFF
--- a/library/Zend/Db/Metadata/Object/AbstractTableObject.php
+++ b/library/Zend/Db/Metadata/Object/AbstractTableObject.php
@@ -96,7 +96,7 @@ abstract class AbstractTableObject
      */
     public function getConstraints()
     {
-        return $this->columns;
+        return $this->constraints;
     }
 
     /**


### PR DESCRIPTION
Typo
