### PR TITLE
PHPDoc params in AbstractTableGateway.php

### DIFF
--- a/library/Zend/Db/TableGateway/AbstractTableGateway.php
+++ b/library/Zend/Db/TableGateway/AbstractTableGateway.php
@@ -178,7 +178,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
     /**
      * Select
      *
-     * @param string|array|\Closure $where
+     * @param Where|\Closure|string|array $where
      * @return ResultSet
      */
     public function select($where = null)
@@ -362,7 +362,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
     /**
      * Delete
      *
-     * @param  \Closure $where
+     * @param  Where|\Closure|string|array $where
      * @return int
      */
     public function delete($where)


### PR DESCRIPTION
$table->methodName($where) must allow same parameter types as wrapped methods
