### PR TITLE
Replace Router with Http router in url view helper

### DIFF
--- a/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
+++ b/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
@@ -67,7 +67,7 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
         // Configure URL view helper with router
         $plugins->setFactory('url', function($sm) use($serviceLocator) {
             $helper = new ViewHelper\Url;
-            $helper->setRouter($serviceLocator->get('Router'));
+            $helper->setRouter($serviceLocator->get('HttpRouter'));
 
             $match = $serviceLocator->get('application')
                         ->getMvcEvent()


### PR DESCRIPTION
The url helper assembles urls solely for an http environment. When
the current request is a CLI request, the injected router is a CLI
router. This causes troubles when in a CLI environment html templates
will be assembled with URLs, which can't be assembled because the
router is a CLI router (and has no awareness of any URLs).

Tests run (locally) still fine, so only this file is modified.
