### PR TITLE
Added test for ZF2-569 string with trailing 0's i.e. '10.0'

### DIFF
--- a/tests/ZendTest/I18n/Validator/FloatTest.php
+++ b/tests/ZendTest/I18n/Validator/FloatTest.php
@@ -58,6 +58,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
             array(1.00,   true),
             array(0.01,   true),
             array(-0.1,   true),
+            array('10.0', true),
             array('10.1', true),
             array(1,      true),
             array('10.1not a float', false),


### PR DESCRIPTION
This is not yet a hotfix, because I have no idea what would be the best way to approach this. Problem is described in http://framework.zend.com/issues/browse/ZF2-569

When submitting a string like '10.50' to the float validator it fails because the parsing gets rid of the trailing zeros and the string comparision at the end fails.

Maybe someone has an easy idea how to handle this? run the valueFiltered through the numberformatter gives errors, converting a string to float fails as well.
