### PR TITLE
Replace PHP internal fmod function because it gives false negatives

### DIFF
--- a/library/Zend/Validator/Step.php
+++ b/library/Zend/Validator/Step.php
@@ -127,11 +127,25 @@ class Step extends AbstractValidator
 
         $this->setValue($value);
 
-        if (fmod($value - $this->baseValue, $this->step) !== 0.0) {
+        if ($this->fmod($value - $this->baseValue, $this->step) !== 0.0) {
             $this->error(self::NOT_STEP);
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * replaces the internal fmod function which give wrong results on many cases
+     *
+     * @param float $x
+     * @param float $y
+     * @return float
+     */
+    protected function fmod($x, $y) {
+        if($y == 0.0) {
+            return 1.0;
+        }
+        return $x-$y*floor($x/$y);
     }
 }

--- a/library/Zend/Validator/Step.php
+++ b/library/Zend/Validator/Step.php
@@ -146,6 +146,6 @@ class Step extends AbstractValidator
         if($y == 0.0) {
             return 1.0;
         }
-        return $x-$y*floor($x/$y);
+        return $x - $y * floor($x / $y);
     }
 }

--- a/tests/ZendTest/Validator/StepTest.php
+++ b/tests/ZendTest/Validator/StepTest.php
@@ -96,6 +96,7 @@ class StepTest extends \PHPUnit_Framework_TestCase
             array(0.1, false),
             array(2.1, true),
             array(3.1, false),
+            array(10.5, true),
             array('2.1', true),
             array('1.1', false),
             array(1.11, false),


### PR DESCRIPTION
fmod is unsafe to use, because for floats that are internally represented differently it give results like 0.00099999997 or something. I used one of the replacement functions found on the PHP manual as a quick fix
