### PR TITLE
Expose formally protected method in ConfigListener

### DIFF
--- a/library/Zend/ModuleManager/Listener/ConfigListener.php
+++ b/library/Zend/ModuleManager/Listener/ConfigListener.php
@@ -278,6 +278,21 @@ class ConfigListener extends AbstractListener implements
     }
 
     /**
+     * Whether the config is already cached
+     *
+     * @return bool
+     */
+    public function hasCachedConfig()
+    {
+        if (($this->getOptions()->getConfigCacheEnabled())
+            && (file_exists($this->getOptions()->getConfigCacheFile()))
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Add an array of paths of config files to merge after loading modules
      *
      * @param  Traversable|array $paths
@@ -371,19 +386,6 @@ class ConfigListener extends AbstractListener implements
         }
 
         return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function hasCachedConfig()
-    {
-        if (($this->getOptions()->getConfigCacheEnabled())
-            && (file_exists($this->getOptions()->getConfigCacheFile()))
-        ) {
-            return true;
-        }
-        return false;
     }
 
     /**

--- a/library/Zend/ModuleManager/Listener/ConfigMergerInterface.php
+++ b/library/Zend/ModuleManager/Listener/ConfigMergerInterface.php
@@ -34,4 +34,11 @@ interface ConfigMergerInterface
      * @return ConfigMergerInterface
      */
     public function setMergedConfig(array $config);
+
+    /**
+     * Whether the config is already cached
+     *
+     * @return bool
+     */
+    public function hasCachedConfig();
 }


### PR DESCRIPTION
I made the "hasCachedConfig()" method public and added it to ConfigMergerInterface.
The reason for this is, sometimes it's useful to know, whether or not the config object is already merged and cached or not.
F.e. when I allow a method like: "getPHPUnitPaths()" in a module with an PHPUnitProviderInterface, and the return value should get merged into the config file this would lead to bugs, because the order of the modules is not correctly applied any more. Therefore I need to know, whether the work is already done and therefore I know, I can skip at this point. Otherwise I can merge together a part of config file from "getConfig()" with the return value of a custom provider method.
