### PR TITLE
Update library/Zend/Db/Adapter/Platform/Mysql.php

### DIFF
--- a/library/Zend/Db/Adapter/Platform/Mysql.php
+++ b/library/Zend/Db/Adapter/Platform/Mysql.php
@@ -82,6 +82,10 @@ class Mysql implements PlatformInterface
      */
     public function quoteValue($value)
     {
+        if(is_numeric($value)) {
+        	return $value;
+    	}
+        
         return '\'' . str_replace('\'', '\\' . '\'', $value) . '\'';
     }
 


### PR DESCRIPTION
For future versions of mysql you dont need to quote numbers.

The issue was when i use db->limit(10), in Select::processOffset 
the limit and offset is quoted with quoteValue.
