### PR TITLE
Trying to solve issue ZF2-558 

### DIFF
--- a/library/Zend/Form/Element/MultiCheckbox.php
+++ b/library/Zend/Form/Element/MultiCheckbox.php
@@ -62,6 +62,13 @@ class MultiCheckbox extends Checkbox
     public function setValueOptions(array $options)
     {
         $this->valueOptions = $options;
+        
+        // Update InArray validator haystack
+        if (!is_null($this->validator)) {
+        	$validator = $this->validator->getValidator();
+        	$validator->setHaystack($this->getValueOptionsValues());
+        }
+        
         return $this;
     }
 

--- a/library/Zend/Form/Element/MultiCheckbox.php
+++ b/library/Zend/Form/Element/MultiCheckbox.php
@@ -65,8 +65,8 @@ class MultiCheckbox extends Checkbox
         
         // Update InArray validator haystack
         if (!is_null($this->validator)) {
-        	$validator = $this->validator->getValidator();
-        	$validator->setHaystack($this->getValueOptionsValues());
+            $validator = $this->validator->getValidator();
+            $validator->setHaystack($this->getValueOptionsValues());
         }
         
         return $this;

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -80,6 +80,13 @@ class Select extends Element implements InputProviderInterface
     public function setValueOptions(array $options)
     {
         $this->valueOptions = $options;
+        
+        // Update InArray validator haystack
+        if (!is_null($this->validator)) {
+            $validator = $this->validator instanceof InArray ? $this->validator : $this->validator->getValidator();
+            $validator->setHaystack($this->getValueOptionsValues());          
+        }
+        
         return $this;
     }
 

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -81,9 +81,9 @@ class Select extends Element implements InputProviderInterface
     {
         $this->valueOptions = $options;
         
-        // Update InArray validator haystack
+        // Update InArrayValidator validator haystack
         if (!is_null($this->validator)) {
-            $validator = $this->validator instanceof InArray ? $this->validator : $this->validator->getValidator();
+            $validator = $this->validator instanceof InArrayValidator ? $this->validator : $this->validator->getValidator();
             $validator->setHaystack($this->getValueOptionsValues());          
         }
         

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -86,7 +86,7 @@ class Select extends Element implements InputProviderInterface
             $validator = $this->validator instanceof InArrayValidator ? $this->validator : $this->validator->getValidator();
             $validator->setHaystack($this->getValueOptionsValues());          
         }
-        
+                
         return $this;
     }
 

--- a/tests/ZendTest/Form/Element/MultiCheckboxTest.php
+++ b/tests/ZendTest/Form/Element/MultiCheckboxTest.php
@@ -113,15 +113,15 @@ class MultiCheckboxTest extends TestCase
      */
     public function testInArrayValidatorHaystakIsUpdated($valueTests, $options)
     {
-    	$element = new MultiCheckboxElement('my-checkbox');
-    	$inputSpec = $element->getInputSpecification();    	
-    	$inArrayValidator=$inputSpec['validators'][0]->getValidator();
+        $element = new MultiCheckboxElement('my-checkbox');
+        $inputSpec = $element->getInputSpecification();    	
+        $inArrayValidator=$inputSpec['validators'][0]->getValidator();
 
-    	$element->setAttributes(array(
-    			'options' => $options,
+        $element->setAttributes(array(
+    	    'options' => $options,
     	));
-    	$haystack=$inArrayValidator->getHaystack();
-    	$this->assertCount(count($options), $haystack);
+        $haystack=$inArrayValidator->getHaystack();
+        $this->assertCount(count($options), $haystack);
     }
     
     

--- a/tests/ZendTest/Form/Element/MultiCheckboxTest.php
+++ b/tests/ZendTest/Form/Element/MultiCheckboxTest.php
@@ -105,6 +105,26 @@ class MultiCheckboxTest extends TestCase
         $this->assertTrue($explodeValidator->isValid($valueTests));
     }
 
+    /**
+     * Testing that InArray Validator Haystack is Updated if the Options
+     * are added after the validator is attached
+     *
+     * @dataProvider multiCheckboxOptionsDataProvider
+     */
+    public function testInArrayValidatorHaystakIsUpdated($valueTests, $options)
+    {
+    	$element = new MultiCheckboxElement('my-checkbox');
+    	$inputSpec = $element->getInputSpecification();    	
+    	$inArrayValidator=$inputSpec['validators'][0]->getValidator();
+
+    	$element->setAttributes(array(
+    			'options' => $options,
+    	));
+    	$haystack=$inArrayValidator->getHaystack();
+    	$this->assertCount(count($options), $haystack);
+    }
+    
+    
     public function testAttributeType()
     {
         $element = new MultiCheckboxElement();

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -160,17 +160,15 @@ class SelectTest extends TestCase
      */
     public function testInArrayValidatorHaystakIsUpdated($valueTests, $options)
     {
-    	$element = new SelectElement('my-select');
-    	$inputSpec = $element->getInputSpecification();
+        $element = new SelectElement('my-select');
+        $inputSpec = $element->getInputSpecification();
     	 
-    	$inArrayValidator = $inputSpec['validators'][0];
-    	$this->assertInstanceOf('Zend\Validator\InArray', $inArrayValidator);
+        $inArrayValidator = $inputSpec['validators'][0];
+        $this->assertInstanceOf('Zend\Validator\InArray', $inArrayValidator);
     	 
-    	$element->setAttributes(array(
-    			'options' => $options,
-    	));
-    	$haystack=$inArrayValidator->getHaystack();
-    	$this->assertCount(count($options), $haystack);
+        $element->setValueOptions($options);
+        $haystack=$inArrayValidator->getHaystack();
+        $this->assertCount(count($options), $haystack);
     }
     
 

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -151,6 +151,28 @@ class SelectTest extends TestCase
             $this->assertTrue($inArrayValidator->isValid($valueToTest));
         }
     }
+    
+    /**
+     * Testing that InArray Validator Haystack is Updated if the Options
+     * are added after the validator is attached
+     *
+     * @dataProvider selectOptionsDataProvider
+     */
+    public function testInArrayValidatorHaystakIsUpdated($valueTests, $options)
+    {
+    	$element = new SelectElement('my-select');
+    	$inputSpec = $element->getInputSpecification();
+    	 
+    	$explodeValidator = $inputSpec['validators'][0];
+    	$this->assertInstanceOf('Zend\Validator\InArray', $explodeValidator);
+    	 
+    	$element->setAttributes(array(
+    			'options' => $options,
+    	));
+    	$haystack=$explodeValidator->getHaystack();
+    	$this->assertCount(count($options), $haystack);
+    }
+    
 
     public function testOptionsHasArrayOnConstruct()
     {

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -163,8 +163,8 @@ class SelectTest extends TestCase
     	$element = new SelectElement('my-select');
     	$inputSpec = $element->getInputSpecification();
     	 
-    	$explodeValidator = $inputSpec['validators'][0];
-    	$this->assertInstanceOf('Zend\Validator\InArray', $explodeValidator);
+    	$inArrayValidator = $inputSpec['validators'][0];
+    	$this->assertInstanceOf('Zend\Validator\InArray', $inArrayValidator);
     	 
     	$element->setAttributes(array(
     			'options' => $options,

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -169,7 +169,7 @@ class SelectTest extends TestCase
     	$element->setAttributes(array(
     			'options' => $options,
     	));
-    	$haystack=$explodeValidator->getHaystack();
+    	$haystack=$inArrayValidator->getHaystack();
     	$this->assertCount(count($options), $haystack);
     }
     


### PR DESCRIPTION
The setValueOptions method of Zend/Form/Element/Select and Zend/Form/Element/Select were updating the options of the Element but were not updating the InArray Validator Haystack if the options were added after that the validator were attached.
