### PR TITLE
JsonStrategy security fix

### DIFF
--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -88,36 +88,6 @@ class JsonStrategy implements ListenerAggregateInterface
             // JsonModel found
             return $this->renderer;
         }
-
-        $request = $e->getRequest();
-        if (!$request instanceof HttpRequest) {
-            // Not an HTTP request; cannot autodetermine
-            return;
-        }
-
-        $headers = $request->getHeaders();
-        if (!$headers->has('accept')) {
-            return;
-        }
-
-
-        $accept  = $headers->get('Accept');
-        if (($match = $accept->match('application/json, application/javascript')) == false) {
-            return;
-        }
-
-        if ($match->getTypeString() == 'application/json') {
-            // application/json Accept header found
-            return $this->renderer;
-        }
-
-        if ($match->getTypeString() == 'application/javascript') {
-            // application/javascript Accept header found
-            if (false != ($callback = $request->getQuery()->get('callback'))) {
-                $this->renderer->setJsonpCallback($callback);
-            }
-            return $this->renderer;
-        }
     }
 
     /**


### PR DESCRIPTION
Automatically switching to JSON output based on the Accept header is a massive security risk. I can crawl an entire ZF2 site with JsonStrategy enabled and get it to dump all the ViewModel variables for every page by simply adding "application/json" to the Accept header. This includes any information which the developer passed to the view but did not anticipate ever being rendered on a page and may include sensitive information.

The default use case should NOT automatically output JSON based on a user-defined request header. A better solution would be to make this a configuration option but this is beyond my knowledge of ZF2 and beyond my current availability to implement so I can only offer to remove the offending code for now.
