### PR TITLE
Fix expressionParamIndex for AbstractSql

### DIFF
--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -27,6 +27,11 @@ abstract class AbstractSql
      */
     protected $processInfo = array('paramPrefix' => '', 'subselectCount' => 0);
 
+    /**
+     * @var array
+     */
+    protected $instanceParameterIndex = array();
+
     protected function processExpression(ExpressionInterface $expression, PlatformInterface $platform, Adapter $adapter = null, $namedParameterPrefix = null)
     {
         // static counter for the number of times this method was invoked across the PHP runtime
@@ -42,7 +47,12 @@ abstract class AbstractSql
 
         // initialize variables
         $parts = $expression->getExpressionData();
-        $expressionParamIndex = 1;
+
+        if(!isset($this->instanceParameterIndex[$namedParameterPrefix])) {
+            $this->instanceParameterIndex[$namedParameterPrefix] = 1;
+        }
+
+        $expressionParamIndex = &$this->instanceParameterIndex[$namedParameterPrefix];
 
         foreach ($parts as $part) {
 


### PR DESCRIPTION
I experience some problems with creating joins in combination with Predicates. The predicate is build as identifier = value. When preparing this statement the prepared statement has three times joins1. The expected result is join1, join2, join3. 

The fix is really simple. For a given AbstractSql instance keep track of the last index for the provided $namedParameterPrefix. When it does not exists add it with index=1, otherwise use the given index.

The fix will be general. So every namedParameterPrefix will be tracked and corrected if needed.
##### Code for reproducing

```
$predicateA = new \Zend\Db\Sql\Predicate\Predicate();
$predicateA->equalTo('id', 1);

$predicateB = new \Zend\Db\Sql\Predicate\Predicate();
$predicateB->equalTo('id', 2);

$predicateC = new \Zend\Db\Sql\Predicate\Predicate();
$predicateC->equalTo('id', 3);

$sql = new \Zend\Db\Sql\Sql($this->getServiceLocator()->get('Zend\Db\Adapter\Adapter'));

$select = new \Zend\Db\Sql\Select();
$select->from('main')
    ->join('tableA', $predicateA)
    ->join('tableB', $predicateB)
    ->join('tableC', $predicateC);

$stmt = $sql->prepareStatementForSqlObject($select);
echo $stmt->getSql();
```
##### The result

```
SELECT `main`.*, `tableA`.*, `tableB`.*, `tableC`.* FROM `main` INNER JOIN `tableA` ON `id` = :join1 INNER JOIN `tableB` ON `id` = :join1 INNER JOIN `tableC` ON `id` = :join1
```
##### Expected Result

```
SELECT `main`.*, `tableA`.*, `tableB`.*, `tableC`.* FROM `main` INNER JOIN `tableA` ON `id` = :join1 INNER JOIN `tableB` ON `id` = :join2 INNER JOIN `tableC` ON `id` = :join3
```
