### PR TITLE
Allow to render template separately

### DIFF
--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -64,13 +64,7 @@ class FormCollection extends AbstractHelper
         $elementHelper = $this->getElementHelper();
 
         if ($element instanceof CollectionElement && $element->shouldCreateTemplate()) {
-            $elementOrFieldset = $element->getTemplateElement();
-
-            if ($elementOrFieldset instanceof FieldsetInterface) {
-                $templateMarkup .= $this->render($elementOrFieldset);
-            } elseif ($elementOrFieldset instanceof ElementInterface) {
-                $templateMarkup .= $elementHelper($elementOrFieldset);
-            }
+            $templateMarkup = $this->renderTemplate($element);
         }
 
         foreach ($element->getIterator() as $elementOrFieldset) {
@@ -83,12 +77,7 @@ class FormCollection extends AbstractHelper
 
         // If $templateMarkup is not empty, use it for simplify adding new element in JavaScript
         if (!empty($templateMarkup)) {
-            $escapeHtmlAttribHelper = $this->getEscapeHtmlAttrHelper();
-
-            $markup .= sprintf(
-                '<span data-template="%s"></span>',
-                $escapeHtmlAttribHelper($templateMarkup)
-            );
+            $markup .= $templateMarkup;
         }
 
         // Every collection is wrapped by a fieldset if needed
@@ -107,6 +96,32 @@ class FormCollection extends AbstractHelper
         }
 
         return $markup;
+    }
+
+    /**
+     * Only render a template
+     *
+     * @param  CollectionElement            $collection
+     * @return string
+     */
+    public function renderTemplate(CollectionElement $collection)
+    {
+        $elementHelper          = $this->getElementHelper();
+        $escapeHtmlAttribHelper = $this->getEscapeHtmlAttrHelper();
+        $templateMarkup         = '';
+
+        $elementOrFieldset = $collection->getTemplateElement();
+
+        if ($elementOrFieldset instanceof FieldsetInterface) {
+            $templateMarkup .= $this->render($elementOrFieldset);
+        } elseif ($elementOrFieldset instanceof ElementInterface) {
+            $templateMarkup .= $elementHelper($elementOrFieldset);
+        }
+
+        return sprintf(
+            '<span data-template="%s"></span>',
+            $escapeHtmlAttribHelper($templateMarkup)
+        );
     }
 
     /**

--- a/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
@@ -139,5 +139,14 @@ class FormCollectionTest extends TestCase
         $this->assertSame('foo', $defaultElement);
     }
 
+    public function testCanRenderTemplateAlone()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setShouldCreateTemplate(true);
 
+        $markup = $this->helper->renderTemplate($collection);
+        $this->assertContains('<span data-template', $markup);
+        $this->assertContains($collection->getTemplatePlaceholder(), $markup);
+    }
 }


### PR DESCRIPTION
When dealing with complex form structures, calling view helpers directly does not offer enough flexibility. However, it is still useful to be able to have some template in Collections.

Therefore, this PR simply allows the Collection view helper to render only a template for JavaScript purposes.
