### PR TITLE
Set the right count when object is bound

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -157,6 +157,8 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
         }
 
         $this->object = $object;
+        $this->count  = count($object);
+        
         return $this;
     }
 


### PR DESCRIPTION
When an object is bound and the data extracted, we need to change the actual count, otherwise it considers that there are as many objects as initially set in the "count" option. However, this number can be higher/lower.

I think we have some problems in the Collection element. I'd like to add some kind of validation like min_count / max_count, but I'm not sure if this is possible...
