### PR TITLE
Update library/Zend/Http/Header/SetCookie.php

### DIFF
--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -487,7 +487,7 @@ class SetCookie implements MultipleHeaderInterface
 
     public function isValidForRequest($requestDomain, $path, $isSecure = false)
     {
-        if ($this->getDomain() && (strrpos($requestDomain, $this->getDomain()) !== false)) {
+        if ($this->getDomain() && (strrpos($requestDomain, $this->getDomain()) === false)) {
             return false;
         }
 

--- a/tests/ZendTest/Http/Header/SetCookieTest.php
+++ b/tests/ZendTest/Http/Header/SetCookieTest.php
@@ -153,7 +153,19 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($target, $headerLine);
     }
 
-    /** Implmentation specific tests here */
+    public function testIsValidForRequestSubdomainMatch()
+    {
+        $setCookieHeader = new SetCookie(
+            'myname', 'myvalue', 'Wed, 13-Jan-2021 22:23:01 GMT',
+            '/accounts', '.foo.com', true, true, 99, 9
+        );
+        $this->assertTrue($setCookieHeader->isValidForRequest('bar.foo.com', '/accounts', true));
+        $this->assertFalse($setCookieHeader->isValidForRequest('bar.foooo.com', '/accounts', true)); // false because of domain
+        $this->assertFalse($setCookieHeader->isValidForRequest('bar.foo.com', '/accounts', false)); // false because of isSecure
+        $this->assertFalse($setCookieHeader->isValidForRequest('bar.foo.com', '/somethingelse', true)); // false because of path
+    }
+
+    /** Implementation specific tests here */
 
     /**
      * @group ZF2-169


### PR DESCRIPTION
Cookies were not handled correctly. If you had a cookie for .sub.domain.de from the last response and then fired a new request to www.sub.domain.de, the old cookie was not added to the request (because .sub.domain.de is a substring of www.sub.domain.de, it should be added, the method should return true which was not the case).
