### PR TITLE
Decorator plugin manager was pointing to an inexistent class

### DIFF
--- a/library/Zend/Tag/Cloud/DecoratorPluginManager.php
+++ b/library/Zend/Tag/Cloud/DecoratorPluginManager.php
@@ -34,7 +34,7 @@ class DecoratorPluginManager extends AbstractPluginManager
     protected $invokableClasses = array(
         'htmlcloud' => 'Zend\Tag\Cloud\Decorator\HtmlCloud',
         'htmltag'   => 'Zend\Tag\Cloud\Decorator\HtmlTag',
-        'tag'       => 'Zend\Tag\Cloud\Decorator\Tag',
+        'tag'       => 'Zend\Tag\Cloud\Decorator\HtmlTag',
    );
 
     /**


### PR DESCRIPTION
Hello!

Found this little bug while updating the docs for Zend\Tag.
