### PR TITLE
[BC] Remove need of setter in ClassMethods hydrator

### DIFF
--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -63,7 +63,7 @@ class ClassMethods extends AbstractHydrator
             if (!preg_match('/^(get|has|is)[A-Z]\w*/', $method)) {
                 continue;
             }
-            
+
             $attribute = $method;
             if (preg_match('/^get/', $method)) {
                 $attribute = substr($method, 3);

--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -63,12 +63,13 @@ class ClassMethods extends AbstractHydrator
             if (!preg_match('/^(get|has|is)[A-Z]\w*/', $method)) {
                 continue;
             }
+            
+            $attribute = $method;
             if (preg_match('/^get/', $method)) {
                 $attribute = substr($method, 3);
                 $attribute = lcfirst($attribute);
-            } else {
-                $attribute = $method;
             }
+
             if ($this->underscoreSeparatedKeys) {
                 $attribute = preg_replace_callback('/([A-Z])/', $transform, $attribute);
             }

--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -64,17 +64,10 @@ class ClassMethods extends AbstractHydrator
                 continue;
             }
             if (preg_match('/^get/', $method)) {
-                // setter verification
-                $setter = preg_replace('/^get/', 'set', $method);
                 $attribute = substr($method, 3);
                 $attribute = lcfirst($attribute);
             } else {
-                // setter verification
-                $setter = 'set' . ucfirst($method);
                 $attribute = $method;
-            }
-            if (!in_array($setter, $methods)) {
-                continue;
             }
             if ($this->underscoreSeparatedKeys) {
                 $attribute = preg_replace_callback('/([A-Z])/', $transform, $attribute);

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -123,20 +123,6 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($test->hasBar(), false);
     }
 
-    public function testHydratorClassMethodsCamelCaseWithSetterMissing()
-    {
-        $hydrator = new ClassMethods(false);
-        $datas = $hydrator->extract($this->classMethodsCamelCaseMissing);
-        $this->assertTrue(isset($datas['fooBar']));
-        $this->assertEquals($datas['fooBar'], '1');
-        $this->assertFalse(isset($datas['fooBarBaz']));
-        $this->assertFalse(isset($datas['foo_bar']));
-        $test = $hydrator->hydrate(array('fooBar' => 'foo'), $this->classMethodsCamelCaseMissing);
-        $this->assertSame($this->classMethodsCamelCaseMissing, $test);
-        $this->assertEquals($test->getFooBar(), 'foo');
-        $this->assertEquals($test->getFooBarBaz(), '2');
-    }
-
     public function testHydratorClassMethodsUnderscore()
     {
         $hydrator = new ClassMethods(true);

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -188,4 +188,19 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($test->getFooBar(), 'foo');
         $this->assertEquals($test->getFooBarBaz(), 'bar');
     }
+
+    public function testHydratorClassMethodsCamelCaseWithSetterMissing()
+    {
+        $hydrator = new ClassMethods(false);
+
+        $datas = $hydrator->extract($this->classMethodsCamelCaseMissing);
+        $this->assertTrue(isset($datas['fooBar']));
+        $this->assertEquals($datas['fooBar'], '1');
+        $this->assertTrue(isset($datas['fooBarBaz']));
+        $this->assertFalse(isset($datas['foo_bar']));
+        $test = $hydrator->hydrate(array('fooBar' => 'foo', 'fooBarBaz' => 1), $this->classMethodsCamelCaseMissing);
+        $this->assertSame($this->classMethodsCamelCaseMissing, $test);
+        $this->assertEquals($test->getFooBar(), 'foo');
+        $this->assertEquals($test->getFooBarBaz(), '2');
+    }
 }


### PR DESCRIPTION
This PR breaks compatibility, and I may be wrong, but the code of extracting was strange. If a getter was here but no setter, the current implementation skip the value and does not extract the value (because it wants both the getter and setter, which I can't understand and is not logical from an extraction point of view).

So I remove the need for that, but some tests break, that I remove. I can't honestly understand the use case and in some cases we only have getter (for instance for ID in entities, when you don't want to expose a setter, but still want be able to read the identifier in the form).

If someone can explain me the use case behind this, I can close this PR, but for now I think the current implementation is buggy and does not behave as expected.
