### PR TITLE
Form develop/allow date time

### DIFF
--- a/library/Zend/Form/Element/DateSelect.php
+++ b/library/Zend/Form/Element/DateSelect.php
@@ -91,7 +91,16 @@ class DateSelect extends MonthSelect
      */
     public function setValue($value)
     {
-        parent::setValue($value);
+        if ($value instanceof DateTime) {
+            $value = array(
+                'year'  => $value->format('Y'),
+                'month' => $value->format('m'),
+                'day'   => $value->format('d')
+            );
+        }
+
+        $this->yearElement->setValue($value['year']);
+        $this->monthElement->setValue($value['month']);
         $this->dayElement->setValue($value['day']);
     }
 

--- a/library/Zend/Form/Element/DateSelect.php
+++ b/library/Zend/Form/Element/DateSelect.php
@@ -163,5 +163,15 @@ class DateSelect extends MonthSelect
             )
         );
     }
+
+    /**
+     * Clone the element (this is needed by Collection element, as it needs different copies of the elements)
+     */
+    public function __clone()
+    {
+        $this->dayElement   = clone $this->dayElement;
+        $this->monthElement = clone $this->monthElement;
+        $this->yearElement  = clone $this->yearElement;
+    }
 }
 

--- a/library/Zend/Form/Element/MonthSelect.php
+++ b/library/Zend/Form/Element/MonthSelect.php
@@ -301,5 +301,14 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
             )
         );
     }
+
+    /**
+     * Clone the element (this is needed by Collection element, as it needs different copies of the elements)
+     */
+    public function __clone()
+    {
+        $this->monthElement = clone $this->monthElement;
+        $this->yearElement  = clone $this->yearElement;
+    }
 }
 

--- a/library/Zend/Form/Element/MonthSelect.php
+++ b/library/Zend/Form/Element/MonthSelect.php
@@ -10,6 +10,7 @@
 
 namespace Zend\Form\Element;
 
+use DateTime;
 use Zend\Form\Element;
 use Zend\Form\ElementPrepareAwareInterface;
 use Zend\Form\Form;
@@ -235,8 +236,15 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
      */
     public function setValue($value)
     {
-        $this->monthElement->setValue($value['month']);
+        if ($value instanceof DateTime) {
+            $value = array(
+                'year'  => $value->format('Y'),
+                'month' => $value->format('m')
+            );
+        }
+
         $this->yearElement->setValue($value['year']);
+        $this->monthElement->setValue($value['month']);
     }
 
     /**

--- a/tests/ZendTest/Form/Element/DateSelectTest.php
+++ b/tests/ZendTest/Form/Element/DateSelectTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\Form\Element;
 
+use DateTime;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element\DateSelect as DateSelectElement;
 use Zend\Form\Factory;
@@ -38,5 +39,15 @@ class DateSelectTest extends TestCase
                     break;
             }
         }
+    }
+
+    public function testCanSetDateFromDateTime()
+    {
+        $element  = new DateSelectElement();
+        $element->setValue(new DateTime('2012-09-24'));
+
+        $this->assertEquals('2012', $element->getYearElement()->getValue());
+        $this->assertEquals('09', $element->getMonthElement()->getValue());
+        $this->assertEquals('24', $element->getDayElement()->getValue());
     }
 }

--- a/tests/ZendTest/Form/Element/MonthSelectTest.php
+++ b/tests/ZendTest/Form/Element/MonthSelectTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\Form\Element;
 
+use DateTime;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element\MonthSelect as MonthSelectElement;
 use Zend\Form\Factory;
@@ -70,5 +71,14 @@ class MonthSelectTest extends TestCase
         $this->assertArrayHasKey('validators', $inputSpec);
         $monthValidator = $inputSpec['validators'][0];
         $this->assertEquals($expected, $monthValidator->isValid($value));
+    }
+
+    public function testCanSetMonthFromDateTime()
+    {
+        $element  = new MonthSelectElement();
+        $element->setValue(new DateTime('2012-09'));
+
+        $this->assertEquals('2012', $element->getYearElement()->getValue());
+        $this->assertEquals('09', $element->getMonthElement()->getValue());
     }
 }


### PR DESCRIPTION
The DateSelect and MonthSelect failed to extract values when an object was bound with a DateTime. This now works as expected.
