### PR TITLE
Prevent space before end of tag with HTML5 doctype

### DIFF
--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -261,27 +261,27 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
     public function itemToString(stdClass $item)
     {
         $attributes = (array) $item;
-        $link       = '<link ';
+        $link       = '<link';
 
         foreach ($this->itemKeys as $itemKey) {
             if (isset($attributes[$itemKey])) {
                 if (is_array($attributes[$itemKey])) {
                     foreach ($attributes[$itemKey] as $key => $value) {
-                        $link .= sprintf('%s="%s" ', $key, ($this->autoEscape) ? $this->escape($value) : $value);
+                        $link .= sprintf(' %s="%s"', $key, ($this->autoEscape) ? $this->escape($value) : $value);
                     }
                 } else {
-                    $link .= sprintf('%s="%s" ', $itemKey, ($this->autoEscape) ? $this->escape($attributes[$itemKey]) : $attributes[$itemKey]);
+                    $link .= sprintf(' %s="%s"', $itemKey, ($this->autoEscape) ? $this->escape($attributes[$itemKey]) : $attributes[$itemKey]);
                 }
             }
         }
 
         if (method_exists($this->view, 'plugin')) {
-            $link .= ($this->view->plugin('doctype')->isXhtml()) ? '/>' : '>';
+            $link .= ($this->view->plugin('doctype')->isXhtml()) ? ' />' : '>';
         } else {
-            $link .= '/>';
+            $link .= ' />';
         }
 
-        if (($link == '<link />') || ($link == '<link >')) {
+        if (($link == '<link />') || ($link == '<link>')) {
             return '';
         }
 

--- a/library/Zend/View/Helper/HeadMeta.php
+++ b/library/Zend/View/Helper/HeadMeta.php
@@ -337,6 +337,12 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
             $modifiersString .= $key . '="' . $this->escape($value) . '" ';
         }
 
+        $modifiersString = rtrim($modifiersString);
+
+        if ('' != $modifiersString) {
+            $modifiersString = ' ' . $modifiersString;
+        }
+
         if (method_exists($this->view, 'plugin')) {
             if ($this->view->plugin('doctype')->isHtml5()
                 && $type == 'charset'
@@ -345,12 +351,12 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
                     ? '<meta %s="%s"/>'
                     : '<meta %s="%s">';
             } elseif ($this->view->plugin('doctype')->isXhtml()) {
-                $tpl = '<meta %s="%s" content="%s" %s/>';
+                $tpl = '<meta %s="%s" content="%s"%s />';
             } else {
-                $tpl = '<meta %s="%s" content="%s" %s>';
+                $tpl = '<meta %s="%s" content="%s"%s>';
             }
         } else {
-            $tpl = '<meta %s="%s" content="%s" %s/>';
+            $tpl = '<meta %s="%s" content="%s"%s />';
         }
 
         $meta = sprintf(

--- a/tests/ZendTest/View/Helper/HeadLinkTest.php
+++ b/tests/ZendTest/View/Helper/HeadLinkTest.php
@@ -393,10 +393,10 @@ class HeadLinkTest extends \PHPUnit_Framework_TestCase
 
         $test = $this->helper->toString();
 
-        $expected = '<link href="/test1.css" media="screen" rel="stylesheet" type="text/css" >' . PHP_EOL
-                  . '<link href="/test4.css" media="screen" rel="stylesheet" type="text/css" >' . PHP_EOL
-                  . '<link href="/test2.css" media="screen" rel="stylesheet" type="text/css" >' . PHP_EOL
-                  . '<link href="/test3.css" media="screen" rel="stylesheet" type="text/css" >';
+        $expected = '<link href="/test1.css" media="screen" rel="stylesheet" type="text/css">' . PHP_EOL
+                  . '<link href="/test4.css" media="screen" rel="stylesheet" type="text/css">' . PHP_EOL
+                  . '<link href="/test2.css" media="screen" rel="stylesheet" type="text/css">' . PHP_EOL
+                  . '<link href="/test3.css" media="screen" rel="stylesheet" type="text/css">';
 
         $this->assertEquals($expected, $test);
     }


### PR DESCRIPTION
Currently, when using the `HeadMeta` and `HeadLink` view helpers, output like this is rendered:

``` html
<meta name="author" content="Localheinz" >
<link href="/css/styles.css" media="screen" rel="stylesheet" type="text/css" >
```

Please note the space before `>`.

This patch fixes it.
