### PR TITLE
fix for setJsonpCallback not called when recieved JsonModel + test

### DIFF
--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -84,26 +84,23 @@ class JsonStrategy implements ListenerAggregateInterface
     {
         $model = $e->getModel();
 
-        if ($model instanceof Model\JsonModel) {
-            // JsonModel found
-            return $this->renderer;
-        }
+        $earlyReturn = $model instanceof Model\JsonModel ? $this->renderer : null;
 
         $request = $e->getRequest();
         if (!$request instanceof HttpRequest) {
             // Not an HTTP request; cannot autodetermine
-            return;
+            return $earlyReturn;
         }
 
         $headers = $request->getHeaders();
         if (!$headers->has('accept')) {
-            return;
+            return $earlyReturn;
         }
 
 
         $accept  = $headers->get('Accept');
         if (($match = $accept->match('application/json, application/javascript')) == false) {
-            return;
+            return $earlyReturn;
         }
 
         if ($match->getTypeString() == 'application/json') {

--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -84,23 +84,20 @@ class JsonStrategy implements ListenerAggregateInterface
     {
         $model = $e->getModel();
 
-        $earlyReturn = $model instanceof Model\JsonModel ? $this->renderer : null;
-
         $request = $e->getRequest();
         if (!$request instanceof HttpRequest) {
             // Not an HTTP request; cannot autodetermine
-            return $earlyReturn;
+            return ($model instanceof Model\JsonModel) ? $this->renderer : null;
         }
 
         $headers = $request->getHeaders();
         if (!$headers->has('accept')) {
-            return $earlyReturn;
+            return ($model instanceof Model\JsonModel) ? $this->renderer : null;
         }
-
 
         $accept  = $headers->get('Accept');
         if (($match = $accept->match('application/json, application/javascript')) == false) {
-            return $earlyReturn;
+            return ($model instanceof Model\JsonModel) ? $this->renderer : null;
         }
 
         if ($match->getTypeString() == 'application/json') {

--- a/tests/ZendTest/View/Strategy/JsonStrategyTest.php
+++ b/tests/ZendTest/View/Strategy/JsonStrategyTest.php
@@ -63,6 +63,18 @@ class JsonStrategyTest extends TestCase
         $this->assertFalse($result->hasJsonpCallback());
     }
 
+    public function testJsonModelJavascriptAcceptHeaderSetsJsonpCallback()
+    {
+        $this->event->setModel(new JsonModel());
+        $request = new HttpRequest();
+        $request->getHeaders()->addHeaderLine('Accept', 'application/javascript');
+        $request->setQuery(new Parameters(array('callback' => 'foo')));
+        $this->event->setRequest($request);
+        $result = $this->strategy->selectRenderer($this->event);
+        $this->assertSame($this->renderer, $result);
+        $this->assertTrue($result->hasJsonpCallback());
+    }
+
     public function testJavascriptAcceptHeaderSelectsJsonStrategyAndSetsJsonpCallback()
     {
         $request = new HttpRequest();


### PR DESCRIPTION
**resubmitted cleanly  without all the git cruft woot!**

When JsonStrategy::selectRenderer is called with an instanceof JsonModel in the event, the renderer would not be configured.

This is only an issue with accept header 'application/javascript' AND $request->getQuery()->get('callback') is available.

Reason is that it would return a renderer early based on the instance type at https://github.com/zendframework/zf2/blob/master/library/Zend/View/Strategy/JsonStrategy.php#L87
