### PR TITLE
Hotfix/console 404 reporting

### DIFF
--- a/library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php
@@ -208,8 +208,9 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
             );
             $result .= sprintf("\nReason for failure: %s\n", $reasons[$reason]);
 
-            if ($exception instanceof \Exception) {
-                $result .= sprintf("Exception: %s\nTrace:\n%s\n", $exception->getMessage(), $exception->getTraceAsString());
+            while ($exception instanceof \Exception) {
+                $result   .= sprintf("Exception: %s\nTrace:\n%s\n", $exception->getMessage(), $exception->getTraceAsString());
+                $exception = $exception->getPrevious();
             }
         }
         $model->setResult($result);

--- a/library/Zend/Mvc/View/Console/ViewManager.php
+++ b/library/Zend/Mvc/View/Console/ViewManager.php
@@ -146,6 +146,13 @@ class ViewManager extends BaseViewManager
 
         $this->routeNotFoundStrategy = new RouteNotFoundStrategy();
 
+        $displayNotFoundReason = true;
+
+        if (array_key_exists('display_not_found_reason', $this->config)) {
+            $displayNotFoundReason = $this->config['display_not_found_reason'];
+        }
+        $this->routeNotFoundStrategy->setDisplayNotFoundReason($displayNotFoundReason);
+
         $this->services->setService('RouteNotFoundStrategy', $this->routeNotFoundStrategy);
         $this->services->setAlias('Zend\Mvc\View\RouteNotFoundStrategy', 'RouteNotFoundStrategy');
         $this->services->setAlias('Zend\Mvc\View\Console\RouteNotFoundStrategy', 'RouteNotFoundStrategy');


### PR DESCRIPTION
Adds error reporting capabilities to the Console RouteNotFoundStrategy.

If the view_manager "display_not_found_reason" flag is enabled, this will display the reason for the "404" condition, as well as any exceptions, if any, present in the event (looping through all previous exceptions).
