### PR TITLE
Improved previous fix for ZF2-558.  

### DIFF
--- a/library/Zend/Form/Element/MultiCheckbox.php
+++ b/library/Zend/Form/Element/MultiCheckbox.php
@@ -63,8 +63,8 @@ class MultiCheckbox extends Checkbox
     {
         $this->valueOptions = $options;
 
-        // Update InArray validator haystack
-        if (!is_null($this->validator) && $this->validator instanceof ExplodeValidator) {
+        // Update Explode validator haystack
+        if ($this->validator instanceof ExplodeValidator) {
             $validator = $this->validator->getValidator();
             $validator->setHaystack($this->getValueOptionsValues());
         }

--- a/library/Zend/Form/Element/MultiCheckbox.php
+++ b/library/Zend/Form/Element/MultiCheckbox.php
@@ -64,7 +64,7 @@ class MultiCheckbox extends Checkbox
         $this->valueOptions = $options;
 
         // Update InArray validator haystack
-        if (!is_null($this->validator)) {
+        if (!is_null($this->validator) && $this->validator instanceof ExplodeValidator) {
             $validator = $this->validator->getValidator();
             $validator->setHaystack($this->getValueOptionsValues());
         }

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -83,8 +83,15 @@ class Select extends Element implements InputProviderInterface
 
         // Update InArrayValidator validator haystack
         if (!is_null($this->validator)) {
-            $validator = $this->validator instanceof InArrayValidator ? $this->validator : $this->validator->getValidator();
-            $validator->setHaystack($this->getValueOptionsValues());
+            if ($this->validator instanceof InArrayValidator){
+                $validator = $this->validator;
+            }
+            if ($this->validator instanceof ExplodeValidator){
+                $validator = $this->validator->getValidator();
+            }
+            if (!empty($validator)){
+                $validator->setHaystack($this->getValueOptionsValues());
+            }
         }
 
         return $this;

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -86,7 +86,9 @@ class Select extends Element implements InputProviderInterface
             if ($this->validator instanceof InArrayValidator){
                 $validator = $this->validator;
             }
-            if ($this->validator instanceof ExplodeValidator){
+            if ($this->validator instanceof ExplodeValidator 
+                && $this->validator->getValidator instanceof InArrayValidator
+            ){
                 $validator = $this->validator->getValidator();
             }
             if (!empty($validator)){

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -87,7 +87,7 @@ class Select extends Element implements InputProviderInterface
                 $validator = $this->validator;
             }
             if ($this->validator instanceof ExplodeValidator 
-                && $this->validator->getValidator instanceof InArrayValidator
+                && $this->validator->getValidator() instanceof InArrayValidator
             ){
                 $validator = $this->validator->getValidator();
             }


### PR DESCRIPTION
Previous fix made implicit assumptions that could cause issues in subclasses of Element[Select|MultiCheckbox].  This fix dispenses with those assumptions so subclasses that override getValidator() and attach validators that are neither InArray or Explode won't break.  For instance, [DoctrineORMModule\Form\Element\DoctrineEntity](https://github.com/doctrine/DoctrineORMModule/blob/master/src/DoctrineORMModule/Form/Element/DoctrineEntity.php) was broken by the original fix (294a7d18a832ce5eb297b43832c2b67db77fb425)
