### PR TITLE
Allow form collection to have any helper

### DIFF
--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -15,6 +15,7 @@ use Zend\Form\Element;
 use Zend\Form\ElementInterface;
 use Zend\Form\Element\Collection as CollectionElement;
 use Zend\Form\FieldsetInterface;
+use Zend\View\Helper\AbstractHelper as BaseAbstractHelper;
 
 /**
  * @category   Zend
@@ -189,7 +190,7 @@ class FormCollection extends AbstractHelper
             $this->elementHelper = $this->view->plugin($this->getDefaultElementHelper());
         }
 
-        if (!$this->elementHelper instanceof AbstractHelper) {
+        if (!$this->elementHelper instanceof BaseAbstractHelper) {
             // @todo Ideally the helper should implement an interface.
             throw new RuntimeException('Invalid element helper set in FormCollection. The helper must be an instance of AbstractHelper.');
         }


### PR DESCRIPTION
The Form Collection helper made the check against Zend\Form\View\Helper\AbstractHelper, while some other helpers in Form view helpers inherits from the base view helper (Zend\View\Helper\AbstractHelper), like the FormElement helper, and hence could not be used.

I don't know if it's better to either change every form helper to inherit from  Zend\Form\View\Helper\AbstractHelper, though (but it does not make a lot of sense for the Element helper).
