### PR TITLE
Updated zendframework/zend-i18n deps

### DIFF
--- a/library/Zend/I18n/composer.json
+++ b/library/Zend/I18n/composer.json
@@ -15,6 +15,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-intl": "*",
-        "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-stdlib": "self.version",
+        "zendframework/zend-filter": "self.version"
     }
 }

--- a/library/Zend/Validator/composer.json
+++ b/library/Zend/Validator/composer.json
@@ -16,6 +16,7 @@
         "php": ">=5.3.3",
         "zendframework/zend-i18n": "self.version",
         "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-servicemanager": "self.version"
     },
     "require-dev": {
         "zendframework/zend-math": "self.version"

--- a/library/Zend/Validator/composer.json
+++ b/library/Zend/Validator/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.3.3",
         "zendframework/zend-i18n": "self.version",
-        "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-stdlib": "self.version",
         "zendframework/zend-servicemanager": "self.version"
     },
     "require-dev": {


### PR DESCRIPTION
Missed dependency in https://github.com/zendframework/zf2/blob/master/library/Zend/Validator/ValidatorPluginManager.php#L14
and https://github.com/zendframework/zf2/blob/master/library/Zend/I18n/Filter/AbstractLocale.php#L14

This should fix `PHP Fatal error:  Class 'Zend\Filter\AbstractFilter' not found in Zend/I18n/Filter/AbstractLocale.php on line 21`
