### PR TITLE
[Fix/Master] Form enctype fix when File elements are within a collection

### DIFF
--- a/library/Zend/Form/Element/File.php
+++ b/library/Zend/Form/Element/File.php
@@ -22,6 +22,8 @@
 namespace Zend\Form\Element;
 
 use Zend\Form\Element;
+use Zend\Form\ElementPrepareAwareInterface;
+use Zend\Form\Form;
 
 /**
  * @category   Zend
@@ -30,7 +32,7 @@ use Zend\Form\Element;
  * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class File extends Element
+class File extends Element implements ElementPrepareAwareInterface
 {
     /**
      * Seed attributes
@@ -40,4 +42,16 @@ class File extends Element
     protected $attributes = array(
         'type' => 'file',
     );
+
+    /**
+     * Prepare the form element (mostly used for rendering purposes)
+     *
+     * @param  Form $form
+     * @return mixed
+     */
+    public function prepareElement(Form $form)
+    {
+        // Ensure the form is using correct enctype
+        $form->setAttribute('enctype', 'multipart/form-data');
+    }
 }

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -137,12 +137,6 @@ class Form extends Fieldset implements FormInterface
             $elementOrFieldset = $factory->create($elementOrFieldset);
         }
 
-        // check if the element is a file and add enctype attribute if so
-        $type = $elementOrFieldset->getAttribute('type');
-        if (isset($type) && $type === 'file') {
-            $this->attributes['enctype'] = 'multipart/form-data';
-        }
-
         parent::add($elementOrFieldset, $flags);
 
         if ($elementOrFieldset instanceof Fieldset && $elementOrFieldset->useAsBaseFieldset()) {

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -305,13 +305,38 @@ class FormTest extends TestCase
      */
     public function testCanAddFileEnctypeAttribute()
     {
-        $this->form->add(array(
-            'name' => 'file_resource',
-            'attributes' => array(
-                'label' => 'This is a file',
-                'type' => 'file',
-            )));
+        $file = new Element\File('file_resource');
+        $file
+            ->setOptions(array())
+            ->setLabel('File');
+        $this->form->add($file);
 
+        $this->form->prepare();
+        $enctype = $this->form->getAttribute('enctype');
+        $this->assertNotEmpty($enctype);
+        $this->assertEquals($enctype, 'multipart/form-data');
+    }
+
+    /**
+     * @group ZF2-336
+     */
+    public function testCanAddFileEnctypeFromCollectionAttribute()
+    {
+        $file = new Element\File('file_resource');
+        $file
+            ->setOptions(array())
+            ->setLabel('File');
+
+        $fileCollection = new Element\Collection('collection');
+        $fileCollection->setOptions(array(
+             'count' => 2,
+             'allow_add' => false,
+             'allow_remove' => false,
+             'target_element' => $file,
+        ));
+        $this->form->add($fileCollection);
+
+        $this->form->prepare();
         $enctype = $this->form->getAttribute('enctype');
         $this->assertNotEmpty($enctype);
         $this->assertEquals($enctype, 'multipart/form-data');


### PR DESCRIPTION
Form enctype was not being set correctly if File elements were inside a collection. 
Fix against master, and should be applied to develop as well.
