### PR TITLE
Add wildcard event identifier

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -151,6 +151,7 @@ abstract class AbstractController implements
     public function setEventManager(EventManagerInterface $events)
     {
         $events->setIdentifiers(array(
+            '*',
             'Zend\Stdlib\DispatchableInterface',
             __CLASS__,
             get_called_class(),


### PR DESCRIPTION
By adding a wildcard identifier, it is possible to attach listeners to all named instances in the shared event manager with just one line of code.

Example:

``` php
$sharedEventManager->attach('*', \Your\Controller::EVENT_INIT, function($e){

    /* @var $e \Zend\EventManager\Event */

    $event = $e->getName();
    $context = get_class($e->getTarget());
    $params = serialize($e->getParams());

    error_log(sprintf(
            'Shared event manager: %s called on %s, using params %s',
            $event,
            $context,
            $params
    ));
});
```

You can even combine it with a wildcard event to listen to all events.

Example with double wildcard:

``` php
$sharedEventManager->attach('*', '*', function($e){

    /* @var $e \Zend\EventManager\Event */

    $event = $e->getName();
    $context = get_class($e->getTarget());
    $params = serialize($e->getParams());

    error_log(sprintf(
            'Shared event manager: %s called on %s, using params %s',
            $event,
            $context,
            $params
    ));
});
```

Very easy to use and yet very powerful, so I thought it might be interesting for others too...

Change-Id: I17580674a217a80939cc908b754fa9edd734f870
