### PR TITLE
fix redundance errors "The input does not appear to be a valid date" show twice

### DIFF
--- a/library/Zend/Validator/Date.php
+++ b/library/Zend/Validator/Date.php
@@ -128,7 +128,7 @@ class Date extends AbstractValidator
             // and still return a DateTime object
             $errors = DateTime::getLastErrors();
 
-            if (false === $date || $errors['warning_count'] > 0) {
+            if ($errors['warning_count'] > 0) {
                 $this->error(self::INVALID_DATE);
                 return false;
             }

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -305,4 +305,18 @@ class FormRowTest extends TestCase
         $markup = $this->helper->__invoke($element);
         $this->assertContains('<ul><li>Error message</li></ul>', $markup);
     }
+    
+    public function testErrorShowTwice()
+    {
+        $element = new  Element\Date('birth');
+        $element->setFormat('Y-m-d');
+        $element->setValue('2010-13-13');
+        
+        $validator = new \Zend\Validator\Date();
+        $validator->isValid($element->getValue());
+        $element->setMessages($validator->getMessages());
+        
+        $markup = $this->helper->__invoke($element);
+        $this->assertEquals(2,  count(explode("<ul><li>The input does not appear to be a valid date</li></ul>", $markup)));
+    }
 }


### PR DESCRIPTION
Fix The input does not appear to be a valid date that show twice.
