### PR TITLE
Fix potential issue with Sitemap test

### DIFF
--- a/tests/ZendTest/View/Helper/Navigation/SitemapTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/SitemapTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\View\Helper\Navigation;
 
+use DOMDocument;
 use Zend\View;
 
 /**
@@ -198,7 +199,13 @@ class SitemapTest extends AbstractTest
         $this->_helper->setUseSitemapValidators(false);
 
         $expected = $this->_getExpected('sitemap/invalid.xml');
-        $this->assertEquals(trim($expected), $this->_helper->render($nav));
+
+        // using assertEqualXMLStructure to prevent differences in libxml from invalidating test
+        $expectedDom = new DOMDocument();
+        $receivedDom = new DOMDocument();
+        $expectedDom->loadXML($expected);
+        $receivedDom->loadXML($this->_helper->render($nav));
+        $this->assertEqualXMLStructure($expectedDom->documentElement, $receivedDom->documentElement);
     }
 
     public function testSetServerUrlRequiresValidUri()


### PR DESCRIPTION
- Gabriel403 reported that some PHP and PHPUnit combinations made the
  testDisablingValidators() test fail. Based on the reported failure, it appears
  that different versions of libxml may result in differences in how empty tags
  are created (e.g., "<lastmod></lastmod>" vs "<lastmod/>"). Using the
  assertEqualXMLStructure() assertion should correct this.
