### PR TITLE
add isset checks around timeout and maxredirects

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -204,11 +204,15 @@ class Curl implements HttpAdapter, StreamInterface
             curl_setopt($this->curl, CURLOPT_PORT, intval($port));
         }
 
-        // Set timeout
-        curl_setopt($this->curl, CURLOPT_CONNECTTIMEOUT, $this->config['timeout']);
+        if (isset($this->config['timeout'])) {
+            // Set timeout
+            curl_setopt($this->curl, CURLOPT_CONNECTTIMEOUT, $this->config['timeout']);
+        }
 
-        // Set Max redirects
-        curl_setopt($this->curl, CURLOPT_MAXREDIRS, $this->config['maxredirects']);
+        if (isset($this->config['maxredirects'])) {
+            // Set Max redirects
+            curl_setopt($this->curl, CURLOPT_MAXREDIRS, $this->config['maxredirects']);
+        }
 
         if (!$this->curl) {
             $this->close();


### PR DESCRIPTION
timeout and maxredirect config items are not required for a curl request. These items weren't checked if they are specified or not. 

If the config items are not set, then it wouldn't set these curl options.

This will fix the check and the code will not throw any notices anymore about this issue.
