### PR TITLE
fix formRow() element error multi-checkbox and radio renderError not shown

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -135,7 +135,7 @@ class FormRow extends AbstractHelper
                         break;
                 }
             }
-            
+
             if ($this->renderErrors) {
                 $markup .= $elementErrors;
             }

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -134,10 +134,10 @@ class FormRow extends AbstractHelper
                         $markup = $labelOpen . $elementString . $label . $labelClose;
                         break;
                 }
-
-                if ($this->renderErrors) {
-                    $markup .= $elementErrors;
-                }
+            }
+            
+            if ($this->renderErrors) {
+                $markup .= $elementErrors;
             }
         } else {
             if ($this->renderErrors) {


### PR DESCRIPTION
Fix error element not shown by formRow() helper in multi-checkbox and radio element.
