### PR TITLE
Fix 2567

### DIFF
--- a/tests/ZendTest/Uri/UriTest.php
+++ b/tests/ZendTest/Uri/UriTest.php
@@ -1286,6 +1286,11 @@ class UriTest extends \PHPUnit_Framework_TestCase
 
             //  RFC 3986 Capitalizing letters in escape sequences.
             array('http://www.example.com/a%c2%b1b', 'http://www.example.com/a%C2%B1b'),
+        		
+        	// RFC 3986 decode only unreserved characters
+        	array('http://www.example.com/%41%2d%5a%2e%c3%b6', 'http://www.example.com/A-Z.%C3%B6'),
+        	
+        	
 
             // This should be left unchanged, at least for the generic Uri class
             array('http://example.com:80/file?query=bar', 'http://example.com:80/file?query=bar'),

--- a/tests/ZendTest/Uri/UriTest.php
+++ b/tests/ZendTest/Uri/UriTest.php
@@ -1286,11 +1286,11 @@ class UriTest extends \PHPUnit_Framework_TestCase
 
             //  RFC 3986 Capitalizing letters in escape sequences.
             array('http://www.example.com/a%c2%b1b', 'http://www.example.com/a%C2%B1b'),
-        		
-        	// RFC 3986 decode only unreserved characters
-        	array('http://www.example.com/%41%2d%5a%2e%c3%b6', 'http://www.example.com/A-Z.%C3%B6'),
-        	
-        	
+
+            // RFC 3986 decode only unreserved characters
+            array('http://www.example.com/%41%2d%5a%2e%c3%b6', 'http://www.example.com/A-Z.%C3%B6'),
+
+
 
             // This should be left unchanged, at least for the generic Uri class
             array('http://example.com:80/file?query=bar', 'http://example.com:80/file?query=bar'),


### PR DESCRIPTION
This PR should fix issue 2567.

The issue is caused by a regular expression that will produce different results depending on whether a multibyte-aware regex-library is useb by the PHP-executable or not.

This regex has been changed to resemble the requirements of RFC 3986
