### PR TITLE
hotfix : formRow() element error multi-checkbox and radio renderError not shown

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -134,10 +134,10 @@ class FormRow extends AbstractHelper
                         $markup = $labelOpen . $elementString . $label . $labelClose;
                         break;
                 }
+            }
 
-                if ($this->renderErrors) {
-                    $markup .= $elementErrors;
-                }
+            if ($this->renderErrors) {
+                $markup .= $elementErrors;
             }
         } else {
             if ($this->renderErrors) {

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -273,4 +273,21 @@ class FormRowTest extends TestCase
         $this->assertNotContains('<span', $markup);
         $this->assertNotContains('</span>', $markup);
     }
+    
+    public function testShowErrorInMultiCheckbox()
+    {
+        $element = new Element\MultiCheckbox('hobby');
+        $element->setLabel("Hobby");
+        $element->setValueOptions(array(
+            '0'=>'working',
+            '1'=>'coding'
+        ));
+        $element->setValue(3);
+        $element->setMessages(array(
+            'Error message'
+        ));
+        
+        $markup = $this->helper->__invoke($element);
+        $this->assertContains('<ul><li>Error message</li></ul>', $markup);
+    }
 }

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -282,7 +282,22 @@ class FormRowTest extends TestCase
             '0'=>'working',
             '1'=>'coding'
         ));
-        $element->setValue(3);
+        $element->setMessages(array(
+            'Error message'
+        ));
+        
+        $markup = $this->helper->__invoke($element);
+        $this->assertContains('<ul><li>Error message</li></ul>', $markup);
+    }
+    
+    public function testShowErrorInRadio()
+    {
+        $element = new Element\Radio('direction');
+        $element->setLabel("Direction");
+        $element->setValueOptions(array(
+            '0'=>'programming',
+            '1'=>'design'
+        ));
         $element->setMessages(array(
             'Error message'
         ));


### PR DESCRIPTION
Fix error element not shown by formRow() helper in multi-checkbox and radio element.
