### PR TITLE
Add fluidity to the prepare() function for a form

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -159,7 +159,7 @@ class Form extends Fieldset implements FormInterface
      * available, and prepares any elements and/or fieldsets that require
      * preparation.
      *
-     * @return void
+     * @return \Zend\Form\Form
      */
     public function prepare()
     {
@@ -179,6 +179,8 @@ class Form extends Fieldset implements FormInterface
 
             $this->isPrepared = true;
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
When dealing with some of the code, I found that there was some fluidity missing ... I've added this.
