### PR TITLE
AbstractPluginManager should not respond to...

### DIFF
--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -69,9 +69,6 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
             if ($instance instanceof ServiceLocatorAwareInterface) {
                 $instance->setServiceLocator($self);
             }
-            if ($instance instanceof ServiceManagerAwareInterface) {
-                $instance->setServiceManager($self);
-            }
         });
     }
 


### PR DESCRIPTION
...ServiceManagerAwareInterface; that is a more specific marker not intended for generic plugins.

(This is related to recent discussion on the zf-contributors mailing list).
