### PR TITLE
Optimize autoload prefix in composer.json

### DIFF
--- a/library/Zend/Authentication/composer.json
+++ b/library/Zend/Authentication/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Authentication": ""
+            "Zend\\Authentication\\": ""
         }
     },
     "target-dir": "Zend/Authentication",

--- a/library/Zend/Barcode/composer.json
+++ b/library/Zend/Barcode/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Barcode": ""
+            "Zend\\Barcode\\": ""
         }
     },
     "target-dir": "Zend/Barcode",

--- a/library/Zend/Cache/composer.json
+++ b/library/Zend/Cache/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Cache": ""
+            "Zend\\Cache\\": ""
         }
     },
     "target-dir": "Zend/Cache",

--- a/library/Zend/Captcha/composer.json
+++ b/library/Zend/Captcha/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Captcha": ""
+            "Zend\\Captcha\\": ""
         }
     },
     "target-dir": "Zend/Captcha",

--- a/library/Zend/Code/composer.json
+++ b/library/Zend/Code/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Code": ""
+            "Zend\\Code\\": ""
         }
     },
     "target-dir": "Zend/Code",

--- a/library/Zend/Config/composer.json
+++ b/library/Zend/Config/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Config": ""
+            "Zend\\Config\\": ""
         }
     },
     "target-dir": "Zend/Config",

--- a/library/Zend/Console/composer.json
+++ b/library/Zend/Console/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Console": ""
+            "Zend\\Console\\": ""
         }
     },
     "target-dir": "Zend/Console",

--- a/library/Zend/Crypt/composer.json
+++ b/library/Zend/Crypt/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Crypt": ""
+            "Zend\\Crypt\\": ""
         }
     },
     "target-dir": "Zend/Crypt",

--- a/library/Zend/Db/composer.json
+++ b/library/Zend/Db/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Db": ""
+            "Zend\\Db\\": ""
         }
     },
     "target-dir": "Zend/Db",

--- a/library/Zend/Debug/composer.json
+++ b/library/Zend/Debug/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Debug": ""
+            "Zend\\Debug\\": ""
         }
     },
     "target-dir": "Zend/Debug",

--- a/library/Zend/Di/composer.json
+++ b/library/Zend/Di/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Di": ""
+            "Zend\\Di\\": ""
         }
     },
     "target-dir": "Zend/Di",

--- a/library/Zend/Dom/composer.json
+++ b/library/Zend/Dom/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Dom": ""
+            "Zend\\Dom\\": ""
         }
     },
     "target-dir": "Zend/Dom",

--- a/library/Zend/Escaper/composer.json
+++ b/library/Zend/Escaper/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Escaper": ""
+            "Zend\\Escaper\\": ""
         }
     },
     "target-dir": "Zend/Escaper",

--- a/library/Zend/EventManager/composer.json
+++ b/library/Zend/EventManager/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\EventManager": ""
+            "Zend\\EventManager\\": ""
         }
     },
     "target-dir": "Zend/EventManager",

--- a/library/Zend/Feed/composer.json
+++ b/library/Zend/Feed/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Feed": ""
+            "Zend\\Feed\\": ""
         }
     },
     "target-dir": "Zend/Feed",

--- a/library/Zend/File/composer.json
+++ b/library/Zend/File/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\File": ""
+            "Zend\\File\\": ""
         }
     },
     "target-dir": "Zend/File",

--- a/library/Zend/Filter/composer.json
+++ b/library/Zend/Filter/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Filter": ""
+            "Zend\\Filter\\": ""
         }
     },
     "target-dir": "Zend/Filter",

--- a/library/Zend/Form/composer.json
+++ b/library/Zend/Form/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Form": ""
+            "Zend\\Form\\": ""
         }
     },
     "target-dir": "Zend/Form",

--- a/library/Zend/Http/composer.json
+++ b/library/Zend/Http/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Http": ""
+            "Zend\\Http\\": ""
         }
     },
     "target-dir": "Zend/Http",

--- a/library/Zend/I18n/composer.json
+++ b/library/Zend/I18n/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\I18n": ""
+            "Zend\\I18n\\": ""
         }
     },
     "target-dir": "Zend/I18n",

--- a/library/Zend/InputFilter/composer.json
+++ b/library/Zend/InputFilter/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\InputFilter": ""
+            "Zend\\InputFilter\\": ""
         }
     },
     "target-dir": "Zend/InputFilter",

--- a/library/Zend/Json/composer.json
+++ b/library/Zend/Json/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Json": ""
+            "Zend\\Json\\": ""
         }
     },
     "target-dir": "Zend/Json",

--- a/library/Zend/Ldap/composer.json
+++ b/library/Zend/Ldap/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Ldap": ""
+            "Zend\\Ldap\\": ""
         }
     },
     "target-dir": "Zend/Ldap",

--- a/library/Zend/Loader/composer.json
+++ b/library/Zend/Loader/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Loader": ""
+            "Zend\\Loader\\": ""
         }
     },
     "target-dir": "Zend/Loader",

--- a/library/Zend/Log/composer.json
+++ b/library/Zend/Log/composer.json
@@ -9,7 +9,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Log": ""
+            "Zend\\Log\\": ""
         }
     },
     "target-dir": "Zend/Log",

--- a/library/Zend/Mail/composer.json
+++ b/library/Zend/Mail/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Mail": ""
+            "Zend\\Mail\\": ""
         }
     },
     "target-dir": "Zend/Mail",

--- a/library/Zend/Math/composer.json
+++ b/library/Zend/Math/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Math": ""
+            "Zend\\Math\\": ""
         }
     },
     "target-dir": "Zend/Math",

--- a/library/Zend/Memory/composer.json
+++ b/library/Zend/Memory/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Memory": ""
+            "Zend\\Memory\\": ""
         }
     },
     "target-dir": "Zend/Memory",

--- a/library/Zend/Mime/composer.json
+++ b/library/Zend/Mime/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Mime": ""
+            "Zend\\Mime\\": ""
         }
     },
     "target-dir": "Zend/Mime",

--- a/library/Zend/ModuleManager/composer.json
+++ b/library/Zend/ModuleManager/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\ModuleManager": ""
+            "Zend\\ModuleManager\\": ""
         }
     },
     "target-dir": "Zend/ModuleManager",

--- a/library/Zend/Mvc/composer.json
+++ b/library/Zend/Mvc/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Mvc": ""
+            "Zend\\Mvc\\": ""
         }
     },
     "target-dir": "Zend/Mvc",

--- a/library/Zend/Navigation/composer.json
+++ b/library/Zend/Navigation/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Navigation": ""
+            "Zend\\Navigation\\": ""
         }
     },
     "target-dir": "Zend/Navigation",

--- a/library/Zend/Paginator/composer.json
+++ b/library/Zend/Paginator/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Paginator": ""
+            "Zend\\Paginator\\": ""
         }
     },
     "target-dir": "Zend/Paginator",

--- a/library/Zend/Permissions/Acl/composer.json
+++ b/library/Zend/Permissions/Acl/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Permissions\\Acl": ""
+            "Zend\\Permissions\\Acl\\": ""
         }
     },
     "target-dir": "Zend/Permissions/Acl",

--- a/library/Zend/ProgressBar/composer.json
+++ b/library/Zend/ProgressBar/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\ProgressBar": ""
+            "Zend\\ProgressBar\\": ""
         }
     },
     "target-dir": "Zend/ProgressBar",

--- a/library/Zend/Serializer/composer.json
+++ b/library/Zend/Serializer/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Serializer": ""
+            "Zend\\Serializer\\": ""
         }
     },
     "target-dir": "Zend/Serializer",

--- a/library/Zend/Server/composer.json
+++ b/library/Zend/Server/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Server": ""
+            "Zend\\Server\\": ""
         }
     },
     "target-dir": "Zend/Server",

--- a/library/Zend/ServiceManager/composer.json
+++ b/library/Zend/ServiceManager/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\ServiceManager": ""
+            "Zend\\ServiceManager\\": ""
         }
     },
     "target-dir": "Zend/ServiceManager",

--- a/library/Zend/Session/composer.json
+++ b/library/Zend/Session/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Session": ""
+            "Zend\\Session\\": ""
         }
     },
     "target-dir": "Zend/Session",

--- a/library/Zend/Soap/composer.json
+++ b/library/Zend/Soap/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Soap": ""
+            "Zend\\Soap\\": ""
         }
     },
     "target-dir": "Zend/Soap",

--- a/library/Zend/Stdlib/composer.json
+++ b/library/Zend/Stdlib/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Stdlib": ""
+            "Zend\\Stdlib\\": ""
         }
     },
     "target-dir": "Zend/Stdlib",

--- a/library/Zend/Tag/composer.json
+++ b/library/Zend/Tag/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Tag": ""
+            "Zend\\Tag\\": ""
         }
     },
     "target-dir": "Zend/Tag",

--- a/library/Zend/Text/composer.json
+++ b/library/Zend/Text/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Text": ""
+            "Zend\\Text\\": ""
         }
     },
     "target-dir": "Zend/Text",

--- a/library/Zend/Uri/composer.json
+++ b/library/Zend/Uri/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Uri": ""
+            "Zend\\Uri\\": ""
         }
     },
     "target-dir": "Zend/Uri",

--- a/library/Zend/Validator/composer.json
+++ b/library/Zend/Validator/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Validator": ""
+            "Zend\\Validator\\": ""
         }
     },
     "target-dir": "Zend/Validator",

--- a/library/Zend/Version/composer.json
+++ b/library/Zend/Version/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\Version": ""
+            "Zend\\Version\\": ""
         }
     },
     "target-dir": "Zend/Version",

--- a/library/Zend/View/composer.json
+++ b/library/Zend/View/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\View": ""
+            "Zend\\View\\": ""
         }
     },
     "target-dir": "Zend/View",

--- a/library/Zend/XmlRpc/composer.json
+++ b/library/Zend/XmlRpc/composer.json
@@ -8,7 +8,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Zend\\XmlRpc": ""
+            "Zend\\XmlRpc\\": ""
         }
     },
     "target-dir": "Zend/XmlRpc",


### PR DESCRIPTION
By having more specific autoload prefixes it is possible to reduce the number of stat calls made.

Ref: https://github.com/zendframework/zf2/commit/e58c6cdbf50dd06b71e76a413fb870c95ab22bf5
