### PR TITLE
when strategy is fed a JsonModel and basic requirements are met the json...

### DIFF
--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -112,6 +112,8 @@ class JsonStrategy implements ListenerAggregateInterface
             }
             return $this->renderer;
         }
+        
+        return ($model instanceof Model\JsonModel) ? $this->renderer : null;
     }
 
     /**

--- a/tests/ZendTest/View/Strategy/JsonStrategyTest.php
+++ b/tests/ZendTest/View/Strategy/JsonStrategyTest.php
@@ -63,6 +63,16 @@ class JsonStrategyTest extends TestCase
         $this->assertFalse($result->hasJsonpCallback());
     }
 
+    public function testJsonModelMatchedAcceptHeaderMatchSelectsJsonStrategy()
+    {
+        $this->event->setModel(new JsonModel());
+        $request = new HttpRequest();
+        $request->getHeaders()->addHeaderLine('Accept', '*/*');
+        $this->event->setRequest($request);
+        $result = $this->strategy->selectRenderer($this->event);
+        $this->assertSame($this->renderer, $result);
+    }
+
     public function testJsonModelJavascriptAcceptHeaderSetsJsonpCallback()
     {
         $this->event->setModel(new JsonModel());


### PR DESCRIPTION
... renderer should be selected.

return new JsonModel() must select JsonRenderer

it did not
