### PR TITLE
quoteIdentifier() & quoteIdentifierChain() bug

### DIFF
--- a/library/Zend/Db/Adapter/Platform/Mysql.php
+++ b/library/Zend/Db/Adapter/Platform/Mysql.php
@@ -46,7 +46,7 @@ class Mysql implements PlatformInterface
      */
     public function quoteIdentifier($identifier)
     {
-        return '`' . str_replace('`', '\\' . '`', $identifier) . '`';
+        return '`' . str_replace('`', '``', $identifier) . '`';
     }
 
     /**
@@ -57,7 +57,7 @@ class Mysql implements PlatformInterface
      */
     public function quoteIdentifierChain($identifierChain)
     {
-        $identifierChain = str_replace('`', '\\`', $identifierChain);
+        $identifierChain = str_replace('`', '``', $identifierChain);
         if (is_array($identifierChain)) {
             $identifierChain = implode('`.`', $identifierChain);
         }

--- a/library/Zend/Db/Adapter/Platform/Mysql.php
+++ b/library/Zend/Db/Adapter/Platform/Mysql.php
@@ -134,7 +134,7 @@ class Mysql implements PlatformInterface
                 case 'as':
                     break;
                 default:
-                    $parts[$i] = '`' . str_replace('`', '\\' . '`', $part) . '`';
+                    $parts[$i] = '`' . str_replace('`', '``', $part) . '`';
             }
         }
         return implode('', $parts);

--- a/tests/ZendTest/Db/Adapter/Platform/MysqlTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/MysqlTest.php
@@ -50,8 +50,9 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
     public function testQuoteIdentifier()
     {
         $this->assertEquals('`identifier`', $this->platform->quoteIdentifier('identifier'));
+        $this->assertEquals('`ident``ifier`', $this->platform->quoteIdentifier('ident`ifier'));
     }
-
+     
     /**
      * @covers Zend\Db\Adapter\Platform\Mysql::quoteIdentifierChain
      */
@@ -60,6 +61,10 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('`identifier`', $this->platform->quoteIdentifierChain('identifier'));
         $this->assertEquals('`identifier`', $this->platform->quoteIdentifierChain(array('identifier')));
         $this->assertEquals('`schema`.`identifier`', $this->platform->quoteIdentifierChain(array('schema','identifier')));
+    
+        $this->assertEquals('`ident``ifier`', $this->platform->quoteIdentifierChain('ident`ifier'));
+        $this->assertEquals('`ident``ifier`', $this->platform->quoteIdentifierChain(array('ident`ifier')));
+        $this->assertEquals('`schema`.`ident``ifier`', $this->platform->quoteIdentifierChain(array('schema','ident`ifier')));  
     }
 
     /**


### PR DESCRIPTION
Identifier escaping is done means of doubling the delimiter character, and not using a backslash.
