### PR TITLE
Added fluent inteface to prepend and set method. Zend\View\Container\AbstractContainer

### DIFF
--- a/library/Zend/View/Helper/Placeholder/Container/AbstractContainer.php
+++ b/library/Zend/View/Helper/Placeholder/Container/AbstractContainer.php
@@ -98,6 +98,7 @@ abstract class AbstractContainer extends \ArrayObject
     public function set($value)
     {
         $this->exchangeArray(array($value));
+        return $this;
     }
 
     /**
@@ -111,6 +112,7 @@ abstract class AbstractContainer extends \ArrayObject
         $values = $this->getArrayCopy();
         array_unshift($values, $value);
         $this->exchangeArray($values);
+        return $this;
     }
 
     /**

--- a/tests/ZendTest/View/Helper/Placeholder/ContainerTest.php
+++ b/tests/ZendTest/View/Helper/Placeholder/ContainerTest.php
@@ -126,6 +126,26 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     /**
      * @return void
      */
+
+    public function testPrependImplementsFluentInterface()
+    {
+        $result = $this->container->prepend( 'test' );
+        $this->assertSame($this->container, $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetImplementsFluentInterface()
+    {
+        $result = $this->container->set( 'test' );
+        $this->assertSame($this->container, $result);
+    }
+
+
+    /**
+     * @return void
+     */
     public function testSeparatorAccesorsWork()
     {
         $this->assertEquals('', $this->container->getSeparator());


### PR DESCRIPTION
I ran into an issue doing the following.

`$this->headTitle()->prepend( 'stuff' )->setSeparator( ':::' );`

The prepend method wasn't returning `$this`. I added that and also added it to the set method right above it.
