### PR TITLE
fix for setFeedType not called when recieved FeedModel + test

### DIFF
--- a/library/Zend/View/Strategy/FeedStrategy.php
+++ b/library/Zend/View/Strategy/FeedStrategy.php
@@ -85,25 +85,20 @@ class FeedStrategy implements ListenerAggregateInterface
     {
         $model = $e->getModel();
 
-        if ($model instanceof Model\FeedModel) {
-            // FeedModel found
-            return $this->renderer;
-        }
-
         $request = $e->getRequest();
         if (!$request instanceof HttpRequest) {
             // Not an HTTP request; cannot autodetermine
-            return;
+            return ($model instanceof Model\FeedModel) ? $this->renderer : null;
         }
 
         $headers = $request->getHeaders();
         if (!$headers->has('accept')) {
-            return;
+            return ($model instanceof Model\FeedModel) ? $this->renderer : null;
         }
 
         $accept  = $headers->get('accept');
         if (($match = $accept->match('application/rss+xml, application/atom+xml')) == false) {
-            return;
+            return ($model instanceof Model\FeedModel) ? $this->renderer : null;
         }
 
         if ($match->getTypeString() == 'application/rss+xml') {
@@ -116,6 +111,7 @@ class FeedStrategy implements ListenerAggregateInterface
             return $this->renderer;
         }
 
+        return ($model instanceof Model\FeedModel) ? $this->renderer : null;
     }
 
     /**

--- a/tests/ZendTest/View/Strategy/FeedStrategyTest.php
+++ b/tests/ZendTest/View/Strategy/FeedStrategyTest.php
@@ -62,6 +62,27 @@ class FeedStrategyTest extends TestCase
         $this->assertSame($this->renderer, $result);
     }
 
+    public function testViewModelMatchedAcceptHeaderMatchSelectsFeedStrategy()
+    {
+        $this->event->setModel(new FeedModel());
+        $request = new HttpRequest();
+        $request->getHeaders()->addHeaderLine('Accept', '*/*');
+        $this->event->setRequest($request);
+        $result = $this->strategy->selectRenderer($this->event);
+        $this->assertSame($this->renderer, $result);
+    }
+
+    public function testViewModelAcceptHeaderSelectsFeedStrategyAndSetsFeedtype()
+    {
+        $this->event->setModel(new FeedModel());
+        $request = new HttpRequest();
+        $request->getHeaders()->addHeaderLine('Accept', 'application/atom+xml');
+        $this->event->setRequest($request);
+        $result = $this->strategy->selectRenderer($this->event);
+        $this->assertSame($this->renderer, $result);
+        $this->assertSame('atom', $result->getFeedType());
+    }
+
     public function testLackOfFeedModelOrAcceptHeaderDoesNotSelectFeedStrategy()
     {
         $result = $this->strategy->selectRenderer($this->event);


### PR DESCRIPTION
Ensures FeedRenderer is correctly configured and not returned early when a FeedModel is supplied.

Complements json specific pr https://github.com/zendframework/zf2/pull/2643 & https://github.com/zendframework/zf2/pull/2660
