### PR TITLE
Input fallback value option

### DIFF
--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -158,6 +158,9 @@ class Factory
                         $input->setRequired(!$value);
                     }
                     break;
+                case 'fallback_value':
+                    $input->setFallbackValue($value);
+                    break;
                 case 'filters':
                     if ($value instanceof FilterChain) {
                         $input->setFilterChain($value);

--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -65,6 +65,11 @@ class Input implements InputInterface
      */
     protected $value;
 
+    /**
+     * @var mixed
+     */
+    protected $fallbackValue;
+
     public function __construct($name = null)
     {
         $this->name = $name;
@@ -152,6 +157,16 @@ class Input implements InputInterface
     }
 
     /**
+     * @param  mixed $value
+     * @return Input
+     */
+    public function setFallbackValue($value)
+    {
+        $this->fallbackValue = $value;
+        return $this;
+    }
+
+    /**
      * @return boolean
      */
     public function allowEmpty()
@@ -231,6 +246,14 @@ class Input implements InputInterface
     }
 
     /**
+     * @return mixed
+     */
+    public function getFallbackValue()
+    {
+        return $this->fallbackValue;
+    }
+
+    /**
      * @param  InputInterface $input
      * @return Input
      */
@@ -260,7 +283,13 @@ class Input implements InputInterface
         $this->injectNotEmptyValidator();
         $validator = $this->getValidatorChain();
         $value     = $this->getValue();
-        return $validator->isValid($value, $context);
+        $result    = $validator->isValid($value, $context);
+        if (!$result && $fallbackValue = $this->getFallbackValue()) {
+            $this->setValue($fallbackValue);
+            $result = true;
+        }
+
+        return $result;
     }
 
     /**
@@ -270,6 +299,10 @@ class Input implements InputInterface
     {
         if (null !== $this->errorMessage) {
             return (array) $this->errorMessage;
+        }
+
+        if ($this->getFallbackValue()) {
+            return array();
         }
 
         $validator = $this->getValidatorChain();


### PR DESCRIPTION
This adds a support for additional Input option: fallback_value

When validation fails for an input then this fallback values is used. No validation messages is returned.

(Note I'm novice with GIT forking and branching so please excuse if my merge request is somehow crippled. Not sure if it's standard that after test\Zend was rename this pull request shows more then 3K changed files. Only '077943e' commit is importatnt.)
