### PR TITLE
[WIP] Hotfix/composer phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require-dev": {
         "doctrine/common": ">=2.1",
-        "phpunit/phpunit": "3.7.*"
+        "EHER/PHPUnit": ">=1.2"
     },
     "suggest": {
         "doctrine/common": "Doctrine\\Common >=2.1 for annotation features",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "doctrine/common": ">=2.1"
+        "doctrine/common": ">=2.1",
+        "phpunit/phpunit": "3.7.*"
     },
     "suggest": {
         "doctrine/common": "Doctrine\\Common >=2.1 for annotation features",
@@ -27,9 +28,9 @@
             "ZendTest\\": "tests/"
         }
     },
-    "config": {
-        "bin-dir": "bin"
-    },
+    "bin": [
+        "bin/classmap_generator.php"
+    ],
     "replace": {
         "zendframework/zend-acl": "self.version",
         "zendframework/zend-authentication": "self.version",

--- a/tests/run-tests.php
+++ b/tests/run-tests.php
@@ -31,7 +31,7 @@
 // PHPUnit doesn't understand relative paths well when they are in the config file.
 chdir(__DIR__);
 
-$phpunit_bin      = 'phpunit';
+$phpunit_bin      = __DIR__ . '/../vendor/bin/phpunit';
 $phpunit_conf     = (file_exists('phpunit.xml') ? 'phpunit.xml' : 'phpunit.xml.dist');
 $phpunit_opts     = "-c $phpunit_conf";
 $phpunit_coverage = '';


### PR DESCRIPTION
This PR suggests using PHPUnit via composer. This would help us pin PHPUnit on specific versions both in terms of usage with Travis-CI as well as for individual collaborators.

Currently, there are reported issues with using PHPUnit via composer due to autoloader conflicts: 
- https://github.com/sebastianbergmann/phpunit/issues/660

As a result, this PR uses `EHER/PHPUnit`, which is from the following repository:
- https://github.com/EHER/phpunit-all-in-one

It provides the latest 3.6 series of PHPUnit, which is what we're currently using in ZF2 anyways. Once the autoloading issues have been straightened out and we can use the official PHPUnit packages, we can update the composer.json.

Usage is:
- php composer.phar install --dev
- in tests: ../vendor/bin/phpunit ZendTest/SomeComponent
- in tests: php run-tests.php

(I altered run-tests.php to use the vendor PHPUnit by default.)
