### PR TITLE
Hotfix: Allow items from Abstract Factories to have setShared() called

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -385,7 +385,11 @@ class ServiceManager implements ServiceLocatorInterface
     {
         $cName = $this->canonicalizeName($name);
 
-        if (!isset($this->invokableClasses[$cName]) && !isset($this->factories[$cName])) {
+        if (
+            !isset($this->invokableClasses[$cName])
+            && !isset($this->factories[$cName])
+            && !$this->canCreateFromAbstractFactory($cName, $name)
+        ) {
             throw new Exception\ServiceNotFoundException(sprintf(
                 '%s: A service by the name "%s" was not found and could not be marked as shared',
                 __METHOD__,

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -141,7 +141,6 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $this->serviceManager->addInitializer(5);
     }
 
-
     /**
      * @covers Zend\ServiceManager\ServiceManager::setService
      */
@@ -160,7 +159,7 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $ret = $this->serviceManager->setShared('foo', true);
         $this->assertSame($this->serviceManager, $ret);
     }
-    
+
     /**
      * @covers Zend\ServiceManager\ServiceManager::setShared
      */
@@ -206,7 +205,6 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotFoundException');
         $this->assertEquals('bar', $this->serviceManager->get('foo'));
     }
-
 
     /**
      * @covers Zend\ServiceManager\ServiceManager::get
@@ -546,6 +544,7 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
     public function duplicateService()
     {
         $self = $this;
+
         return array(
             array(
                 'setFactory',

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -160,6 +160,16 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $ret = $this->serviceManager->setShared('foo', true);
         $this->assertSame($this->serviceManager, $ret);
     }
+    
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::setShared
+     */
+    public function testSetSharedAbstractFactory()
+    {
+        $this->serviceManager->addAbstractFactory('ZendTest\ServiceManager\TestAsset\FooAbstractFactory');
+        $ret = $this->serviceManager->setShared('foo', false);
+        $this->assertSame($this->serviceManager, $ret);
+    }
 
     /**
      * @covers Zend\ServiceManager\ServiceManager::setShared


### PR DESCRIPTION
Some items that are created from Abstract Factories, we may want to
re-create each time - rather than having a shared object.  This allows
checks whether the requested object is able to be created via an
Abstract Factory.  The rest of the code is already in place to allow
this not to be added to $sm->instances;
