### PR TITLE
Adding code to allow EventManager trigger listeners using wildcard identifier

### DIFF
--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -498,6 +498,10 @@ class EventManager implements EventManagerInterface
         }
 
         $identifiers     = $this->getIdentifiers();
+        //Add wildcard id to the search if not already added
+        if (!in_array('*', $identifiers)) {
+            $identifiers[] = '*';
+        }
         $sharedListeners = array();
 
         foreach ($identifiers as $id) {

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -498,7 +498,7 @@ class EventManager implements EventManagerInterface
         }
 
         $identifiers     = $this->getIdentifiers();
-        //Add wildcard id to the search if not already added
+        //Add wildcard id to the search, if not already added
         if (!in_array('*', $identifiers)) {
             $identifiers[] = '*';
         }

--- a/library/Zend/EventManager/SharedEventManager.php
+++ b/library/Zend/EventManager/SharedEventManager.php
@@ -101,6 +101,10 @@ class SharedEventManager implements SharedEventManagerInterface
     public function getEvents($id)
     {
         if (!array_key_exists($id, $this->identifiers)) {
+            //Check if there are any id wildcards listeners
+            if ('*' != $id && array_key_exists('*', $this->identifiers)) {
+                return $this->identifiers['*']->getEvents();
+            }
             return false;
         }
         return $this->identifiers[$id]->getEvents();
@@ -116,6 +120,10 @@ class SharedEventManager implements SharedEventManagerInterface
     public function getListeners($id, $event)
     {
         if (!array_key_exists($id, $this->identifiers)) {
+            //Check if there are any id wildcards listeners
+            if ('*' != $id && array_key_exists('*', $this->identifiers)) {
+                return $this->identifiers['*']->getListeners($event);
+            }
             return false;
         }
         return $this->identifiers[$id]->getListeners($event);

--- a/library/Zend/EventManager/SharedEventManager.php
+++ b/library/Zend/EventManager/SharedEventManager.php
@@ -120,10 +120,6 @@ class SharedEventManager implements SharedEventManagerInterface
     public function getListeners($id, $event)
     {
         if (!array_key_exists($id, $this->identifiers)) {
-            //Check if there are any id wildcards listeners
-            if ('*' != $id && array_key_exists('*', $this->identifiers)) {
-                return $this->identifiers['*']->getListeners($event);
-            }
             return false;
         }
         return $this->identifiers[$id]->getListeners($event);

--- a/tests/ZendTest/EventManager/StaticEventManagerTest.php
+++ b/tests/ZendTest/EventManager/StaticEventManagerTest.php
@@ -254,6 +254,26 @@ class StaticEventManagerTest extends TestCase
         $this->assertEquals(2, $test->triggered);
     }
 
+    public function testListenersAttachedToWildcardsWillBeTriggered()
+    {
+        $identifiers = array('foo', 'bar');
+        $events  = StaticEventManager::getInstance();
+        $manager = new EventManager($identifiers);
+        $manager->setSharedManager($events);
+
+        $test = new \stdClass;
+        $test->triggered = 0;
+        $events->attach('*', 'bar', function($e) use ($test) {
+            $test->triggered++;
+        });
+        //Tests one can have multiple wildcards attached
+        $events->attach('*', 'bar', function($e) use ($test) {
+            $test->triggered++;
+        });
+        $manager->trigger('bar', $this, array());
+        $this->assertEquals(2, $test->triggered);
+    }
+
     public function testListenersAttachedToAnyIdentifierProvidedToEventManagerOrWildcardsWillBeTriggered()
     {
         $identifiers = array('foo', 'bar');

--- a/tests/ZendTest/EventManager/StaticEventManagerTest.php
+++ b/tests/ZendTest/EventManager/StaticEventManagerTest.php
@@ -195,11 +195,19 @@ class StaticEventManagerTest extends TestCase
         $this->assertEquals(1, count($listeners));
     }
 
-    public function testCanGetListenersByWildcardAndEvent()
+    public function testCanNotGetListenersByResourceAndEventWithWildcard()
     {
         $events = StaticEventManager::getInstance();
         $events->attach('*', 'bar', array($this, __FUNCTION__));
         $listeners = $events->getListeners('foo', 'bar');
+        $this->assertFalse($listeners);
+    }
+
+    public function testCanGetListenersByWildcardAndEvent()
+    {
+        $events = StaticEventManager::getInstance();
+        $events->attach('*', 'bar', array($this, __FUNCTION__));
+        $listeners = $events->getListeners('*', 'bar');
         $this->assertInstanceOf('Zend\Stdlib\PriorityQueue', $listeners);
         $this->assertEquals(1, count($listeners));
     }


### PR DESCRIPTION
As in https://github.com/zendframework/zf2/pull/2626, the current EventManager does not trigger using identifier wildcards, just event ones.

Example:
This works as expected:

``` php
$sharedEventManager->attach('foo', '*', function($e){};
$eventManager->trigger('bar',$this,array());
```

This does not:

``` php
$sharedEventManager->attach('*', 'bar', function($e){};
$eventManager->trigger('bar',$this,array());
```

As stated by Matthew, the line https://github.com/zendframework/zf2/blob/master/library/Zend/EventManager/EventManager.php#L446
just handles event wildcards.

This PR tries to solve this.
