### PR TITLE
Hotfix/db sql nested expressions

### DIFF
--- a/library/Zend/Db/Sql/Expression.php
+++ b/library/Zend/Db/Sql/Expression.php
@@ -79,8 +79,8 @@ class Expression implements ExpressionInterface
      */
     public function setParameters($parameters)
     {
-        if (!is_string($parameters) && !is_array($parameters)) {
-            throw new Exception\InvalidArgumentException('Expression parameters must be a string or array.');
+        if (!is_scalar($parameters) && !is_array($parameters)) {
+            throw new Exception\InvalidArgumentException('Expression parameters must be a scalar or array.');
         }
         $this->parameters = $parameters;
         return $this;
@@ -118,7 +118,7 @@ class Expression implements ExpressionInterface
      */
     public function getExpressionData()
     {
-        $parameters = (is_string($this->parameters)) ? array($this->parameters) : $this->parameters;
+        $parameters = (is_scalar($this->parameters)) ? array($this->parameters) : $this->parameters;
 
         $types = array();
         for ($i = 0; $i < count($parameters); $i++) {

--- a/library/Zend/Db/Sql/ExpressionInterface.php
+++ b/library/Zend/Db/Sql/ExpressionInterface.php
@@ -15,6 +15,10 @@ interface ExpressionInterface
     const TYPE_IDENTIFIER = 'identifier';
     const TYPE_VALUE = 'value';
     const TYPE_LITERAL = 'literal';
+
+    /**
+     * @deprecated This will go away in 2.1
+     */
     const TYPE_SELECT = 'select';
 
     /**

--- a/library/Zend/Db/Sql/Predicate/In.php
+++ b/library/Zend/Db/Sql/Predicate/In.php
@@ -94,7 +94,7 @@ class In implements PredicateInterface
         $values = $this->getValueSet();
         if ($values instanceof Select) {
             $specification = '%s IN %s';
-            $types = array(self::TYPE_SELECT);
+            $types = array(self::TYPE_VALUE);
             $values = array($values);
         } else {
             $specification = '%s IN (' . implode(', ', array_fill(0, count($values), '%s')) . ')';

--- a/tests/ZendTest/Db/Sql/AbstractSqlTest.php
+++ b/tests/ZendTest/Db/Sql/AbstractSqlTest.php
@@ -115,6 +115,17 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $sqlAndParams->getParameterContainer()->count());
     }
 
+    public function testProcessExpressionWorksWithExpressionContainingExpressionObject()
+    {
+        $expression = new Predicate\Operator(
+            'release_date',
+            '=',
+            new Expression('FROM_UNIXTIME(?)', 100000000)
+        );
+
+        $sqlAndParams = $this->invokeProcessExpressionMethod($expression);
+        $this->assertEquals('"release_date" = FROM_UNIXTIME(\'100000000\')', $sqlAndParams->getSql());
+    }
 
     /**
      * @param \Zend\Db\Sql\ExpressionInterface $expression

--- a/tests/ZendTest/Db/Sql/ExpressionTest.php
+++ b/tests/ZendTest/Db/Sql/ExpressionTest.php
@@ -70,7 +70,7 @@ class ExpressionTest extends \PHPUnit_Framework_TestCase
     {
         $expression = new Expression('','foo');
 
-        $this->setExpectedException('Zend\Db\Sql\Exception\InvalidArgumentException', 'Expression parameters must be a string or array.');
+        $this->setExpectedException('Zend\Db\Sql\Exception\InvalidArgumentException', 'Expression parameters must be a scalar or array.');
         $return = $expression->setParameters(null);
     }
 

--- a/tests/ZendTest/Db/Sql/Predicate/InTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/InTest.php
@@ -65,7 +65,7 @@ class InTest extends TestCase
         $expected = array(array(
             '%s IN %s',
             array('foo', $select),
-            array($in::TYPE_IDENTIFIER, $in::TYPE_SELECT)
+            array($in::TYPE_IDENTIFIER, $in::TYPE_VALUE)
         ));
         $this->assertEquals($expected, $in->getExpressionData());
     }


### PR DESCRIPTION
Fix for #2521.
- This now allows expressions within expressions:

``` php
$expression = new Predicate\Operator('release_date', '=', new Expression('FROM_UNIXTIME(?)', 100000000));
```
- Previous internal demarcation of the type being TYPE_SELECT is deprecated in favor of TYPE_VALUE. (This is an undocumented and internal only API change).
- Expression objects now accept scalar|array instead of string|array
