### PR TITLE
Hotfix/composer phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require-dev": {
         "doctrine/common": ">=2.1",
-        "phpunit/phpunit": "3.7.*"
+        "EHER/PHPUnit": ">=1.2"
     },
     "suggest": {
         "doctrine/common": "Doctrine\\Common >=2.1 for annotation features",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require-dev": {
         "doctrine/common": ">=2.1",
-        "EHER/PHPUnit": ">=1.2"
+        "phpunit/PHPUnit": "3.7.*"
     },
     "suggest": {
         "doctrine/common": "Doctrine\\Common >=2.1 for annotation features",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "doctrine/common": ">=2.1"
+        "doctrine/common": ">=2.1",
+        "phpunit/phpunit": "3.7.*"
     },
     "suggest": {
         "doctrine/common": "Doctrine\\Common >=2.1 for annotation features",
@@ -27,9 +28,9 @@
             "ZendTest\\": "tests/"
         }
     },
-    "config": {
-        "bin-dir": "bin"
-    },
+    "bin": [
+        "bin/classmap_generator.php"
+    ],
     "replace": {
         "zendframework/zend-acl": "self.version",
         "zendframework/zend-authentication": "self.version",

--- a/tests/run-tests.php
+++ b/tests/run-tests.php
@@ -31,7 +31,7 @@
 // PHPUnit doesn't understand relative paths well when they are in the config file.
 chdir(__DIR__);
 
-$phpunit_bin      = 'phpunit';
+$phpunit_bin      = __DIR__ . '/../vendor/bin/phpunit';
 $phpunit_conf     = (file_exists('phpunit.xml') ? 'phpunit.xml' : 'phpunit.xml.dist');
 $phpunit_opts     = "-c $phpunit_conf";
 $phpunit_coverage = '';

--- a/tests/run-tests.php
+++ b/tests/run-tests.php
@@ -32,6 +32,7 @@
 chdir(__DIR__);
 
 $phpunit_bin      = __DIR__ . '/../vendor/bin/phpunit';
+$phpunit_bin      = file_exists($phpunit_bin) ? $phpunit_bin : 'phpunit';
 $phpunit_conf     = (file_exists('phpunit.xml') ? 'phpunit.xml' : 'phpunit.xml.dist');
 $phpunit_opts     = "-c $phpunit_conf";
 $phpunit_coverage = '';


### PR DESCRIPTION
This PR adds PHPUnit as a composer development dependency. This allows us to pin the PHPUnit version, and install PHPUnit locally for the specific framework version.

Usage is as follows:

```
php /path/to/composer.phar install --dev
cd tests
../vendor/bin/phpunit ZendTest/SomeComponent
php run-tests.php
```
