### PR TITLE
Improved error message when ServiceManager does not find an invokable class

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -815,7 +815,7 @@ class ServiceManager implements ServiceLocatorInterface
                 __METHOD__,
                 $canonicalName,
                 ($requestedName ? '(alias: ' . $requestedName . ')' : ''),
-                $canonicalName
+                $invokable
             ));
         }
         $instance = new $invokable;


### PR DESCRIPTION
Example of improved error message:
Fatal error: Uncaught exception 'Zend\ServiceManager\Exception\ServiceNotFoundException' with message 'Zend\ServiceManager\ServiceManager::createFromInvokable: failed retrieving "log(alias: log)" via invokable class "**Zend\Log\Writer\FirePhp2**"; class does not exist' in /Users/bartmcleod/git/CuddleFish3/vendor/ZF2/library/Zend/ServiceManager/ServiceManager.php on line 813

This used to be:
Fatal error: Uncaught exception 'Zend\ServiceManager\Exception\ServiceNotFoundException' with message 'Zend\ServiceManager\ServiceManager::createFromInvokable: failed retrieving "log(alias: log)" via invokable class "**log**"; class does not exist' in /Users/bartmcleod/git/CuddleFish3/vendor/ZF2/library/Zend/ServiceManager/ServiceManager.php on line 813
