### PR TITLE
Don't add separator if not prefixing columns

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -533,7 +533,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $fromTable = ($this->prefixColumnsWithTable) ? $table : '';
         }
 
-        $fromTable .= $platform->getIdentifierSeparator();
+        $fromTable .= ($this->prefixColumnsWithTable) ? $platform->getIdentifierSeparator() : '';
 
         // process table columns
         $columns = array();

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -470,6 +470,20 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @autor robertbasic
+     * @group issue2599
+     * @testdox unit test: Not prefixing columns with table will create a valid query
+     */
+    public function testNotPrefixingColumnsWithTableNameCreatesValidQuery()
+    {
+        $select = new Select;
+        $select->from('foo')
+                ->columns(array('bar'), false);
+
+        $this->assertEquals('SELECT "bar" AS "bar" FROM "foo"', $select->getSqlString());
+    }
+
     public function providerData()
     {
         // basic table


### PR DESCRIPTION
When not prefixing columns with the table name
don't add the platform's identifier separator.

Fixes #2599
