### PR TITLE
Correctly hydrate when using base fieldset

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -287,7 +287,14 @@ class Form extends Fieldset implements FormInterface
         }
 
         $data = $this->prepareBindData($data, $this->data);
-        $this->object = parent::bindValues($data);
+
+        // If there is a base fieldset, only hydrate beginning from the base fieldset
+        if ($this->baseFieldset !== null) {
+            $data = $data[$this->baseFieldset->getName()];
+            $this->object = $this->baseFieldset->bindValues($data);
+        } else {
+            $this->object = parent::bindValues($data);
+        }
     }
 
     /**

--- a/tests/ZendTest/Form/TestAsset/Entity/SimplePublicProperty.php
+++ b/tests/ZendTest/Form/TestAsset/Entity/SimplePublicProperty.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace ZendTest\Form\TestAsset\Entity;
+
+class SimplePublicProperty
+{
+    public $foo;
+}


### PR DESCRIPTION
This fix an odd bug that I discovered while writing my webinar code. I think nobody reported it because it only occurs when using base fieldset and ArraySerializable hydrator (most people use ClassMethods when the use case is more complex I suppose).

Basically, the problem is that even if a base fieldset was set, the form itself was hydrated. The logic was correctly done for extracting phase but not for hydrating phase.
