### PR TITLE
Chain authentication storage

### DIFF
--- a/library/Zend/Authentication/Storage/Chain.php
+++ b/library/Zend/Authentication/Storage/Chain.php
@@ -24,11 +24,11 @@ class Chain implements StorageInterface
      * Contains all storage that this authentication method uses. A storage
      * placed in the priority queue with a higher priority is always used
      * before using a storage with a lower priority.
-     * 
+     *
      * @var PriorityQueue
      */
     protected $storageChain;
-    
+
     /**
      * Initializes the priority queue.
      */
@@ -36,54 +36,53 @@ class Chain implements StorageInterface
     {
         $this->storageChain = new PriorityQueue();
     }
-    
+
     /**
      * @param StorageInterface $storage
-     * @param integer $priority
+     * @param integer          $priority
      */
     public function add( StorageInterface $storage, $priority = 1 )
     {
         $this->storageChain->insert($storage, $priority);
     }
-    
+
     /**
-     * Loop over the queue of storage until a storage is found that is non-empty. If such 
-     * storage is not found, then this chain storage itself is empty. 
-     * 
-     * In case a non-empty storage is found then this chain storage is also non-empty. Report 
-     * that, but also make sure that all storage with higher priorty that are empty 
+     * Loop over the queue of storage until a storage is found that is non-empty. If such
+     * storage is not found, then this chain storage itself is empty.
+     *
+     * In case a non-empty storage is found then this chain storage is also non-empty. Report
+     * that, but also make sure that all storage with higher priorty that are empty
      * are filled.
-     * 
+     *
      * @see StorageInterface::isEmpty()
      */
     public function isEmpty()
-    { 
+    {
         $storageWithHigherPriority = array();
 
-        // Loop invariant: $storageWithHigherPriority contains all storage with higher priorty  
+        // Loop invariant: $storageWithHigherPriority contains all storage with higher priorty
         // than the current one.
-        foreach( $this->storageChain as $storage )
-        {
-            if( $storage->isEmpty() )
-            {
+        foreach ($this->storageChain as $storage) {
+            if ( $storage->isEmpty() ) {
                 $storageWithHigherPriority[] = $storage;
                 continue;
             }
-             
+
             $storageValue = $storage->read();
-            foreach( $storageWithHigherPriority as $higherPriorityStorage )
+            foreach ($storageWithHigherPriority as $higherPriorityStorage) {
                 $higherPriorityStorage->write($storageValue);
-                
+            }
+
             return false;
         }
-        
+
         return true;
     }
 
     /**
-     * If the chain is non-empty then the storage with the top priority is guaranteed to be 
-     * filled. Return its value. 
-     * 
+     * If the chain is non-empty then the storage with the top priority is guaranteed to be
+     * filled. Return its value.
+     *
      * @see StorageInterface::read()
      */
     public function read()
@@ -93,23 +92,25 @@ class Chain implements StorageInterface
 
     /**
      * Write the new $contents to all storage in the chain.
-     * 
+     *
      * @see StorageInterface::write()
      */
     public function write( $contents )
     {
-        foreach( $this->storageChain as $storage )
+        foreach ($this->storageChain as $storage) {
             $storage->write($contents);
+        }
     }
 
     /**
      * Clear all storage in the chain.
-     * 
+     *
      * @see StorageInterface::clear()
      */
     public function clear()
     {
-        foreach( $this->storageChain as $storage )
+        foreach ($this->storageChain as $storage) {
             $storage->clear();
+        }
     }
 }

--- a/library/Zend/Authentication/Storage/Chain.php
+++ b/library/Zend/Authentication/Storage/Chain.php
@@ -67,15 +67,14 @@ class Chain implements StorageInterface
             if( $storage->isEmpty() )
             {
                 $storageWithHigherPriority[] = $storage;
+                continue;
             }
-            else
-            { 
-                $storageValue = $storage->read();
-                foreach( $storageWithHigherPriority as $higherPriorityStorage )
-                    $higherPriorityStorage->write($storageValue);
-                    
-                return false;
-            }
+             
+            $storageValue = $storage->read();
+            foreach( $storageWithHigherPriority as $higherPriorityStorage )
+                $higherPriorityStorage->write($storageValue);
+                
+            return false;
         }
         
         return true;

--- a/library/Zend/Authentication/Storage/Chain.php
+++ b/library/Zend/Authentication/Storage/Chain.php
@@ -46,14 +46,14 @@ class Chain implements StorageInterface
         $this->storages->insert($storage, $priority);
     }
     
-	/**
-	 * Loop over the queue of storages until a storage is found that is non-empty. If such 
-	 * storage is not found, then this chain storage itself is empty. 
-	 * 
-	 * In case a non-empty storage is found then this chain storage is also non-empty. Report 
-	 * that, but also make sure that all the storages with a higher priorty that are empty 
-	 * are filled.
-	 * 
+    /**
+     * Loop over the queue of storages until a storage is found that is non-empty. If such 
+     * storage is not found, then this chain storage itself is empty. 
+     * 
+     * In case a non-empty storage is found then this chain storage is also non-empty. Report 
+     * that, but also make sure that all the storages with a higher priorty that are empty 
+     * are filled.
+     * 
      * @see StorageInterface::isEmpty()
      */
     public function isEmpty()
@@ -81,10 +81,10 @@ class Chain implements StorageInterface
         return true;
     }
 
-	/**
-	 * If the chain is non-empty then the storage with the top priority is guaranteed to be 
-	 * filled. Return its value. 
-	 * 
+    /**
+     * If the chain is non-empty then the storage with the top priority is guaranteed to be 
+     * filled. Return its value. 
+     * 
      * @see StorageInterface::read()
      */
     public function read()
@@ -92,9 +92,9 @@ class Chain implements StorageInterface
         return $this->storages->top()->read();
     }
 
-	/**
-	 * Write the new $contents to all storages in the chain.
-	 * 
+    /**
+     * Write the new $contents to all storages in the chain.
+     * 
      * @see StorageInterface::write()
      */
     public function write( $contents )
@@ -103,10 +103,10 @@ class Chain implements StorageInterface
             $storage->write($contents);
     }
 
-	/**
-	 * Clear all storages in the chain.
-	 * 
-	 * @see StorageInterface::clear()
+    /**
+     * Clear all storages in the chain.
+     * 
+     * @see StorageInterface::clear()
      */
     public function clear()
     {

--- a/library/Zend/Authentication/Storage/Chain.php
+++ b/library/Zend/Authentication/Storage/Chain.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Authentication
+ */
+
+namespace Zend\Authentication\Storage;
+
+use Zend\Stdlib\PriorityQueue;
+use Zend\Authentication\Storage\StorageInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Authentication
+ * @subpackage Storage
+ */
+class Chain implements StorageInterface
+{
+    /**
+     * Contains all storages that this authentication method uses. A storage
+     * placed in the priority queue with a higher priority is always used
+     * before using a storage with a lower priority.
+     * 
+     * @var PriorityQueue
+     */
+    protected $storages;
+    
+    /**
+     * Initializes the priority queue that contains storages.
+     */
+    public function __construct()
+    {
+        $this->storages = new PriorityQueue();
+    }
+    
+    /**
+     * @param StorageInterface $storage
+     * @param integer $priority
+     */
+    public function add( StorageInterface $storage, $priority = 1 )
+    {
+        $this->storages->insert($storage, $priority);
+    }
+    
+	/**
+	 * Loop over the queue of storages until a storage is found that is non-empty. If such 
+	 * storage is not found, then this chain storage itself is empty. 
+	 * 
+	 * In case a non-empty storage is found then this chain storage is also non-empty. Report 
+	 * that, but also make sure that all the storages with a higher priorty that are empty 
+	 * are filled.
+	 * 
+     * @see StorageInterface::isEmpty()
+     */
+    public function isEmpty()
+    { 
+        $storagesWithHigherPriority = array();
+
+        // Loop invariant: $storagesWithHigherPriority contains all storages with a higher priorty  
+        // than the current one.
+        foreach( $this->storages as $storage )
+        {
+            if( $storage->isEmpty() )
+            {
+                $storagesWithHigherPriority[] = $storage;
+            }
+            else
+            { 
+                $storageValue = $storage->read();
+                foreach( $storagesWithHigherPriority as $higherPriorityStorage )
+                    $higherPriorityStorage->write($storageValue);
+                    
+                return false;
+            }
+        }
+        
+        return true;
+    }
+
+	/**
+	 * If the chain is non-empty then the storage with the top priority is guaranteed to be 
+	 * filled. Return its value. 
+	 * 
+     * @see StorageInterface::read()
+     */
+    public function read()
+    {
+        return $this->storages->top()->read();
+    }
+
+	/**
+	 * Write the new $contents to all storages in the chain.
+	 * 
+     * @see StorageInterface::write()
+     */
+    public function write( $contents )
+    {
+        foreach( $this->storages as $storage )
+            $storage->write($contents);
+    }
+
+	/**
+	 * Clear all storages in the chain.
+	 * 
+	 * @see StorageInterface::clear()
+     */
+    public function clear()
+    {
+        foreach( $this->storages as $storage )
+            $storage->clear();
+    }
+}

--- a/library/Zend/Authentication/Storage/Chain.php
+++ b/library/Zend/Authentication/Storage/Chain.php
@@ -21,20 +21,20 @@ use Zend\Authentication\Storage\StorageInterface;
 class Chain implements StorageInterface
 {
     /**
-     * Contains all storages that this authentication method uses. A storage
+     * Contains all storage that this authentication method uses. A storage
      * placed in the priority queue with a higher priority is always used
      * before using a storage with a lower priority.
      * 
      * @var PriorityQueue
      */
-    protected $storages;
+    protected $storageQueue;
     
     /**
-     * Initializes the priority queue that contains storages.
+     * Initializes the priority queue.
      */
     public function __construct()
     {
-        $this->storages = new PriorityQueue();
+        $this->storageQueue = new PriorityQueue();
     }
     
     /**
@@ -43,35 +43,35 @@ class Chain implements StorageInterface
      */
     public function add( StorageInterface $storage, $priority = 1 )
     {
-        $this->storages->insert($storage, $priority);
+        $this->storageQueue->insert($storage, $priority);
     }
     
     /**
-     * Loop over the queue of storages until a storage is found that is non-empty. If such 
+     * Loop over the queue of storage until a storage is found that is non-empty. If such 
      * storage is not found, then this chain storage itself is empty. 
      * 
      * In case a non-empty storage is found then this chain storage is also non-empty. Report 
-     * that, but also make sure that all the storages with a higher priorty that are empty 
+     * that, but also make sure that all storage with higher priorty that are empty 
      * are filled.
      * 
      * @see StorageInterface::isEmpty()
      */
     public function isEmpty()
     { 
-        $storagesWithHigherPriority = array();
+        $storageWithHigherPriority = array();
 
-        // Loop invariant: $storagesWithHigherPriority contains all storages with a higher priorty  
+        // Loop invariant: $storageWithHigherPriority contains all storage with higher priorty  
         // than the current one.
-        foreach( $this->storages as $storage )
+        foreach( $this->storageQueue as $storage )
         {
             if( $storage->isEmpty() )
             {
-                $storagesWithHigherPriority[] = $storage;
+                $storageWithHigherPriority[] = $storage;
             }
             else
             { 
                 $storageValue = $storage->read();
-                foreach( $storagesWithHigherPriority as $higherPriorityStorage )
+                foreach( $storageWithHigherPriority as $higherPriorityStorage )
                     $higherPriorityStorage->write($storageValue);
                     
                 return false;
@@ -89,28 +89,28 @@ class Chain implements StorageInterface
      */
     public function read()
     {
-        return $this->storages->top()->read();
+        return $this->storageQueue->top()->read();
     }
 
     /**
-     * Write the new $contents to all storages in the chain.
+     * Write the new $contents to all storage in the chain.
      * 
      * @see StorageInterface::write()
      */
     public function write( $contents )
     {
-        foreach( $this->storages as $storage )
+        foreach( $this->storageQueue as $storage )
             $storage->write($contents);
     }
 
     /**
-     * Clear all storages in the chain.
+     * Clear all storage in the chain.
      * 
      * @see StorageInterface::clear()
      */
     public function clear()
     {
-        foreach( $this->storages as $storage )
+        foreach( $this->storageQueue as $storage )
             $storage->clear();
     }
 }

--- a/library/Zend/Authentication/Storage/Chain.php
+++ b/library/Zend/Authentication/Storage/Chain.php
@@ -27,14 +27,14 @@ class Chain implements StorageInterface
      * 
      * @var PriorityQueue
      */
-    protected $storageQueue;
+    protected $storageChain;
     
     /**
      * Initializes the priority queue.
      */
     public function __construct()
     {
-        $this->storageQueue = new PriorityQueue();
+        $this->storageChain = new PriorityQueue();
     }
     
     /**
@@ -43,7 +43,7 @@ class Chain implements StorageInterface
      */
     public function add( StorageInterface $storage, $priority = 1 )
     {
-        $this->storageQueue->insert($storage, $priority);
+        $this->storageChain->insert($storage, $priority);
     }
     
     /**
@@ -62,7 +62,7 @@ class Chain implements StorageInterface
 
         // Loop invariant: $storageWithHigherPriority contains all storage with higher priorty  
         // than the current one.
-        foreach( $this->storageQueue as $storage )
+        foreach( $this->storageChain as $storage )
         {
             if( $storage->isEmpty() )
             {
@@ -88,7 +88,7 @@ class Chain implements StorageInterface
      */
     public function read()
     {
-        return $this->storageQueue->top()->read();
+        return $this->storageChain->top()->read();
     }
 
     /**
@@ -98,7 +98,7 @@ class Chain implements StorageInterface
      */
     public function write( $contents )
     {
-        foreach( $this->storageQueue as $storage )
+        foreach( $this->storageChain as $storage )
             $storage->write($contents);
     }
 
@@ -109,7 +109,7 @@ class Chain implements StorageInterface
      */
     public function clear()
     {
-        foreach( $this->storageQueue as $storage )
+        foreach( $this->storageChain as $storage )
             $storage->clear();
     }
 }

--- a/tests/ZendTest/Authentication/Storage/ChainTest.php
+++ b/tests/ZendTest/Authentication/Storage/ChainTest.php
@@ -25,28 +25,28 @@ use PHPUnit_Framework_TestCase as TestCase;
 class ChainTest extends TestCase
 {
     const ID = 1337;
-    
+
     /**
      * Ensure chain without storage behavious as empty storage.
      */
     public function testEmptyChain()
     {
         $chain = new Chain;
-        
+
         $this->assertTrue($chain->isEmpty());
     }
-    
+
     /**
-     * Ensure chain with single empty storage behavious as expected. 
+     * Ensure chain with single empty storage behavious as expected.
      */
     public function testSingularChainEmpty()
     {
         $chain = new Chain;
         $chain->add($this->storageFactory());
-    
+
         $this->assertTrue($chain->isEmpty());
     }
-    
+
     /**
      * Ensure chain with single non-empty storage behavious as expected.
      */
@@ -54,11 +54,11 @@ class ChainTest extends TestCase
     {
         $chain = new Chain;
         $chain->add($this->storageFactory(self::ID));
-        
+
         $this->assertFalse($chain->isEmpty());
         $this->assertEquals(self::ID, $chain->read());
     }
-    
+
     /**
      * Ensure the priority of storage engines is correctly used.
      */
@@ -66,17 +66,17 @@ class ChainTest extends TestCase
     {
         $storageA = $this->storageFactory();
         $storageB = $this->storageFactory(self::ID);
-        
+
         $chain = new Chain;
         $chain->add($storageA); // Defaults to 1
         $chain->add($storageB, 10);
         $chain->isEmpty();
-        
+
         // Storage B has higher priority AND is non-empty. Thus
         // storage A should been used at all and remain empty.
         $this->assertTrue($storageA->isEmpty());
     }
-    
+
     /**
      * Ensure that a chain with empty storages is considered empty and
      * won't populated any of its underlying storages.
@@ -85,23 +85,23 @@ class ChainTest extends TestCase
     {
         $emptyStorageA = $this->storageFactory();
         $emptyStorageB = $this->storageFactory();
-        
+
         $chain = new Chain;
         $chain->add($emptyStorageA);
         $chain->add($emptyStorageB);
-        
+
         $this->assertTrue($chain->isEmpty());
-        
+
         // Storage A and B remain empty
         $this->assertTrue($emptyStorageA->isEmpty());
         $this->assertTrue($emptyStorageB->isEmpty());
     }
-    
+
     /**
      * Ensure that chain will yield non-empty if one of its underlying storage
      * engines is non-empty.
-     * 
-     * Make sure that storage engines with higher priority then the first non-empty 
+     *
+     * Make sure that storage engines with higher priority then the first non-empty
      * storage engine get populated with that same content.
      */
     public function testSuccessfullReadWillPopulateStoragesWithHigherPriority()
@@ -110,40 +110,41 @@ class ChainTest extends TestCase
         $emptyStorageB = $this->storageFactory();
         $storageC = $this->storageFactory(self::ID);
         $emptyStorageD = $this->storageFactory();
-        
+
         $chain = new Chain;
         $chain->add($emptyStorageA);
         $chain->add($emptyStorageB);
         $chain->add($storageC);
         $chain->add($emptyStorageD);
-        
+
         // Chain is non empty
         $this->assertFalse($chain->isEmpty());
         $this->assertEquals(self::ID, $chain->read());
-        
+
         // Storage A and B are filled
         $this->assertFalse($emptyStorageA->isEmpty());
         $this->assertEquals(self::ID, $emptyStorageA->read());
         $this->assertFalse($emptyStorageA->isEmpty());
         $this->assertEquals(self::ID, $emptyStorageB->read());
-        
+
         // Storage C and D remain identical
         $this->assertFalse($storageC->isEmpty());
         $this->assertEquals(self::ID, $storageC->read());
         $this->assertTrue($emptyStorageD->isEmpty());
     }
-    
+
     /**
-     * @param mixed $identity
+     * @param  mixed            $identity
      * @return StorageInterface
      */
     protected function storageFactory( $identity = null )
     {
         $storage = new NonPersistent();
-        
-        if( $identity !== null )
+
+        if ($identity !== null) {
             $storage->write($identity);
-        
+        }
+
         return $storage;
     }
 }

--- a/tests/ZendTest/Authentication/Storage/ChainTest.php
+++ b/tests/ZendTest/Authentication/Storage/ChainTest.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Uri
+ */
+
+namespace ZendTest\Authentication\Storage;
+
+use Zend\Authentication\Storage\Chain,
+    Zend\Authentication\Storage\StorageInterface,
+    Zend\Authentication\Storage\NonPersistent;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * @category   Zend
+ * @package    Zend_Auth
+ * @subpackage UnitTests
+  * @group      Zend_Auth
+ */
+class ChainTest extends TestCase
+{
+    const ID = 1337;
+    
+    /**
+     * Ensure chain without storage behavious as empty storage.
+     */
+    public function testEmptyChain()
+    {
+        $chain = new Chain;
+        
+        $this->assertTrue($chain->isEmpty());
+    }
+    
+    /**
+     * Ensure chain with single empty storage behavious as expected. 
+     */
+    public function testSingularChainEmpty()
+    {
+        $chain = new Chain;
+        $chain->add($this->storageFactory());
+    
+        $this->assertTrue($chain->isEmpty());
+    }
+    
+    /**
+     * Ensure chain with single non-empty storage behavious as expected.
+     */
+    public function testSingularChainNonEmpty()
+    {
+        $chain = new Chain;
+        $chain->add($this->storageFactory(self::ID));
+        
+        $this->assertFalse($chain->isEmpty());
+        $this->assertEquals(self::ID, $chain->read());
+    }
+    
+    /**
+     * Ensure the priority of storage engines is correctly used.
+     */
+    public function testChainPriority()
+    {
+        $storageA = $this->storageFactory();
+        $storageB = $this->storageFactory(self::ID);
+        
+        $chain = new Chain;
+        $chain->add($storageA); // Defaults to 1
+        $chain->add($storageB, 10);
+        $chain->isEmpty();
+        
+        // Storage B has higher priority AND is non-empty. Thus
+        // storage A should been used at all and remain empty.
+        $this->assertTrue($storageA->isEmpty());
+    }
+    
+    /**
+     * Ensure that a chain with empty storages is considered empty and
+     * won't populated any of its underlying storages.
+     */
+    public function testEmptyChainIsEmpty()
+    {
+        $emptyStorageA = $this->storageFactory();
+        $emptyStorageB = $this->storageFactory();
+        
+        $chain = new Chain;
+        $chain->add($emptyStorageA);
+        $chain->add($emptyStorageB);
+        
+        $this->assertTrue($chain->isEmpty());
+        
+        // Storage A and B remain empty
+        $this->assertTrue($emptyStorageA->isEmpty());
+        $this->assertTrue($emptyStorageB->isEmpty());
+    }
+    
+    /**
+     * Ensure that chain will yield non-empty if one of its underlying storage
+     * engines is non-empty.
+     * 
+     * Make sure that storage engines with higher priority then the first non-empty 
+     * storage engine get populated with that same content.
+     */
+    public function testSuccessfullReadWillPopulateStoragesWithHigherPriority()
+    {
+        $emptyStorageA = $this->storageFactory();
+        $emptyStorageB = $this->storageFactory();
+        $storageC = $this->storageFactory(self::ID);
+        $emptyStorageD = $this->storageFactory();
+        
+        $chain = new Chain;
+        $chain->add($emptyStorageA);
+        $chain->add($emptyStorageB);
+        $chain->add($storageC);
+        $chain->add($emptyStorageD);
+        
+        // Chain is non empty
+        $this->assertFalse($chain->isEmpty());
+        $this->assertEquals(self::ID, $chain->read());
+        
+        // Storage A and B are filled
+        $this->assertFalse($emptyStorageA->isEmpty());
+        $this->assertEquals(self::ID, $emptyStorageA->read());
+        $this->assertFalse($emptyStorageA->isEmpty());
+        $this->assertEquals(self::ID, $emptyStorageB->read());
+        
+        // Storage C and D remain identical
+        $this->assertFalse($storageC->isEmpty());
+        $this->assertEquals(self::ID, $storageC->read());
+        $this->assertTrue($emptyStorageD->isEmpty());
+    }
+    
+    /**
+     * @param mixed $identity
+     * @return StorageInterface
+     */
+    protected function storageFactory( $identity = null )
+    {
+        $storage = new NonPersistent();
+        
+        if( $identity !== null )
+            $storage->write($identity);
+        
+        return $storage;
+    }
+}


### PR DESCRIPTION
This component can be usefull if you want to store the identity in multiple places. For example once in the database and once in  `$_SESSION`. If either one of the storages is non-empty then the chain should also be non-empty. 

On top of that the order in which the storages are accessed is important. A use case that is often used: the identity is stored in the database and can be obtained using a cookie on the client. However one wants to retrieve this data from the database only on the first request of a browser session and therefore the identity is stored in `$_SESSION`.

Such configuration might look like:

``` php
$chain = new ChainStorage;
$chain->add(new SessionStorage, 2);
$chain->add(new DatabaseStorage, 1);
```

I developed the component for a website I am developing, but though it might be of use to other people.
