### PR TITLE
Fixing the Cache Storage Factory Adapter Factory

### DIFF
--- a/library/Zend/Cache/StorageFactory.php
+++ b/library/Zend/Cache/StorageFactory.php
@@ -135,12 +135,15 @@ class StorageFactory
         if ($adapterName instanceof Storage\StorageInterface) {
             // $adapterName is already an adapter object
             $adapter = $adapterName;
+            if ($options) {
+                $adapter->setOptions($options);
+            }
         } else {
-            $adapter = static::getAdapterPluginManager()->get($adapterName);
-        }
-
-        if ($options) {
-            $adapter->setOptions($options);
+            if ($options) {
+                $adapter = static::getAdapterPluginManager()->get($adapterName, $options);
+            } else {
+                $adapter = static::getAdapterPluginManager()->get($adapterName);
+            }
         }
 
         return $adapter;


### PR DESCRIPTION
@marc-mabe

If $options is set, it should be passed to the plugin manager get function or else adapters like Memcached will not properly set servers. Memcached adapter only sets servers in the constructor so they cannot be added after.
