### PR TITLE
Update library/Zend/View/Helper/Navigation/Menu.php

### DIFF
--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -30,7 +30,7 @@ class Menu extends AbstractHelper
      *
      * @var string
      */
-    protected $ulClass = 'navigation';
+    protected $ulClass = 'nav';
 
     /**
      * Whether only active branch should be rendered


### PR DESCRIPTION
<del>edit $ulClass to nav for support class nav in bootstrap.js</del> in ZendSkeletonApplication templete and can use <?php echo $this->navigation('Navigation'); ?> in layout.phtml to use active page.

First: add this code in /module/Haban/config/module.config.php
'service_manager' => array(
   'factories' => array(
       'Navigation' => 'Zend\Navigation\Service\DefaultNavigationFactory'
   ),
),

Second: create pages.global.php in path /config/autoload/pages.global.php
<?php
return array(
  'navigation' => array(
    'default' => array(
      'home' => array(
        'label' => 'Home',
        'module' => 'Application',
        'controller' => 'index',
        'action'  => 'index',
        'route' => 'home',
        'active'  => true,
        'order' => -100,
      ),
      'rent' => array(
        'label' => 'Rent',
        'module' => 'Application',
        'controller' => 'rent',
        'action'  => 'index',
        'route' => 'rent',
      ),
      'advertise' => array(
        'label' => 'Advertise',
        'module' => 'Application',
        'controller' => 'index',
        'action'  => 'advertise',
        'route' => 'home/advertise',
      ),
      'contact' => array(
        'label' => 'Contact',
        'module' => 'Application',
        'controller' => 'index',
        'action'  => 'contact',
        'route' => 'home/contact',
      ),
    ),
  ),
);

Third: paste this code in /module/Application/view/layout/layout.phtml after line
<div class="nav-collapse collapse">
<?php echo $this->navigation('Navigation')->menu(); ?>

source: http://adam.lundrigan.ca/2012/07/quick-and-dirty-zf2-zend-navigation/
