### PR TITLE
Feature/logger factory

### DIFF
--- a/library/Zend/Log/Formatter/Base.php
+++ b/library/Zend/Log/Formatter/Base.php
@@ -32,10 +32,18 @@ class Base implements FormatterInterface
      * Class constructor
      *
      * @see http://php.net/manual/en/function.date.php
-     * @param null|string $dateTimeFormat Format for DateTime objects
+     * @param null|string|array|Traversable $dateTimeFormat Format for DateTime objects
      */
     public function __construct($dateTimeFormat = null)
     {
+        if ($dateTimeFormat instanceof Traversable) {
+            $dateTimeFormat = iterator_to_array($dateTimeFormat);
+        }
+        
+        if (is_array($dateTimeFormat)) {
+            $dateTimeFormat = isset($dateTimeFormat['dateTimeFormat'])? $dateTimeFormat['dateTimeFormat'] : null;
+        }
+        
         if (null !== $dateTimeFormat) {
             $this->dateTimeFormat = $dateTimeFormat;
         }

--- a/library/Zend/Log/Formatter/Base.php
+++ b/library/Zend/Log/Formatter/Base.php
@@ -39,11 +39,11 @@ class Base implements FormatterInterface
         if ($dateTimeFormat instanceof Traversable) {
             $dateTimeFormat = iterator_to_array($dateTimeFormat);
         }
-        
+
         if (is_array($dateTimeFormat)) {
             $dateTimeFormat = isset($dateTimeFormat['dateTimeFormat'])? $dateTimeFormat['dateTimeFormat'] : null;
         }
-        
+
         if (null !== $dateTimeFormat) {
             $this->dateTimeFormat = $dateTimeFormat;
         }

--- a/library/Zend/Log/Formatter/Db.php
+++ b/library/Zend/Log/Formatter/Db.php
@@ -39,11 +39,11 @@ class Db implements FormatterInterface
         if ($dateTimeFormat instanceof Traversable) {
             $dateTimeFormat = iterator_to_array($dateTimeFormat);
         }
-        
+
         if (is_array($dateTimeFormat)) {
             $dateTimeFormat = isset($dateTimeFormat['dateTimeFormat'])? $dateTimeFormat['dateTimeFormat'] : null;
         }
-        
+
         if (null !== $dateTimeFormat) {
             $this->setDateTimeFormat($dateTimeFormat);
         }

--- a/library/Zend/Log/Formatter/Db.php
+++ b/library/Zend/Log/Formatter/Db.php
@@ -11,6 +11,7 @@
 namespace Zend\Log\Formatter;
 
 use DateTime;
+use Traversable;
 
 /**
  * @category   Zend
@@ -35,6 +36,14 @@ class Db implements FormatterInterface
      */
     public function __construct($dateTimeFormat = null)
     {
+        if ($dateTimeFormat instanceof Traversable) {
+            $dateTimeFormat = iterator_to_array($dateTimeFormat);
+        }
+        
+        if (is_array($dateTimeFormat)) {
+            $dateTimeFormat = isset($dateTimeFormat['dateTimeFormat'])? $dateTimeFormat['dateTimeFormat'] : null;
+        }
+        
         if (null !== $dateTimeFormat) {
             $this->setDateTimeFormat($dateTimeFormat);
         }

--- a/library/Zend/Log/Formatter/Simple.php
+++ b/library/Zend/Log/Formatter/Simple.php
@@ -10,6 +10,7 @@
 
 namespace Zend\Log\Formatter;
 
+use Traversable;
 use DateTime;
 use Zend\Log\Exception;
 
@@ -39,6 +40,15 @@ class Simple extends Base
      */
     public function __construct($format = null, $dateTimeFormat = null)
     {
+        if ($format instanceof Traversable) {
+            $format = iterator_to_array($format);
+        }
+        
+        if (is_array($format)) {        
+            $dateTimeFormat = isset($format['dateTimeFormat'])? $format['dateTimeFormat'] : null;
+            $format         = isset($format['format'])? $format['format'] : null;
+        }
+        
         if (isset($format) && !is_string($format)) {
             throw new Exception\InvalidArgumentException('Format must be a string');
         }

--- a/library/Zend/Log/Formatter/Simple.php
+++ b/library/Zend/Log/Formatter/Simple.php
@@ -43,12 +43,12 @@ class Simple extends Base
         if ($format instanceof Traversable) {
             $format = iterator_to_array($format);
         }
-        
-        if (is_array($format)) {        
+
+        if (is_array($format)) {
             $dateTimeFormat = isset($format['dateTimeFormat'])? $format['dateTimeFormat'] : null;
             $format         = isset($format['format'])? $format['format'] : null;
         }
-        
+
         if (isset($format) && !is_string($format)) {
             throw new Exception\InvalidArgumentException('Format must be a string');
         }

--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -82,7 +82,7 @@ class Logger implements LoggerInterface
 
     /**
      * Constructor
-     * 
+     *
      * Set options for an logger. Accepted options are:
      * - writers: array of writers to add to this logger
      * - exceptionhandler: if true register this logger as exceptionhandler
@@ -95,35 +95,35 @@ class Logger implements LoggerInterface
     public function __construct(array $options = null)
     {
         $this->writers = new SplPriorityQueue();
-        
+
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         }
-        
+
         if (is_array($options)) {
-            
-            if(isset($options['writers']) && is_array($options['writers'])) {                
+
+            if(isset($options['writers']) && is_array($options['writers'])) {
                 foreach($options['writers'] as $writer) {
-                    
+
                     if(!isset($writer['name'])) {
                         throw new Exception\InvalidArgumentException('Options must contain a name for the writer');
                     }
-    
+
                     $priority      = (isset($writer['priority'])) ? $writer['priority'] : null;
                     $writerOptions = (isset($writer['options'])) ? $writer['options'] : null;
 
                     $this->addWriter($writer['name'], $priority, $writerOptions);
                 }
             }
-            
+
             if(isset($options['exceptionhandler']) && $options['exceptionhandler'] === true) {
                 self::registerExceptionHandler($this);
-            } 
-            
+            }
+
             if(isset($options['errorhandler']) && $options['errorhandler'] === true) {
                 self::registerErrorHandler($this);
-            } 
-            
+            }
+
         }
     }
 

--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -82,13 +82,49 @@ class Logger implements LoggerInterface
 
     /**
      * Constructor
+     * 
+     * Set options for an logger. Accepted options are:
+     * - writers: array of writers to add to this logger
+     * - exceptionhandler: if true register this logger as exceptionhandler
+     * - errorhandler: if true register this logger as errorhandler
      *
-     * @todo support configuration (writers, dateTimeFormat, and writer plugin manager)
+     * @param  array|\Traversable $options
      * @return Logger
+     * @throws Exception\InvalidArgumentException
      */
-    public function __construct()
+    public function __construct(array $options = null)
     {
         $this->writers = new SplPriorityQueue();
+        
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+        
+        if (is_array($options)) {
+            
+            if(isset($options['writers']) && is_array($options['writers'])) {                
+                foreach($options['writers'] as $writer) {
+                    
+                    if(!isset($writer['name'])) {
+                        throw new Exception\InvalidArgumentException('Options must contain a name for the writer');
+                    }
+    
+                    $priority      = (isset($writer['priority'])) ? $writer['priority'] : null;
+                    $writerOptions = (isset($writer['options'])) ? $writer['options'] : null;
+
+                    $this->addWriter($writer['name'], $priority, $writerOptions);
+                }
+            }
+            
+            if(isset($options['exceptionhandler']) && $options['exceptionhandler'] === true) {
+                self::registerExceptionHandler($this);
+            } 
+            
+            if(isset($options['errorhandler']) && $options['errorhandler'] === true) {
+                self::registerErrorHandler($this);
+            } 
+            
+        }
     }
 
     /**

--- a/library/Zend/Log/LoggerServiceFactory.php
+++ b/library/Zend/Log/LoggerServiceFactory.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Log
+ */
+
+namespace Zend\Log;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Logger.
+ *
+ * @category   Zend
+ * @package    Zend_Log
+ */
+class LoggerServiceFactory implements FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        // Configure the logger
+        $config = $serviceLocator->get('Config');
+        $logConfig = isset($config['log']) ? $config['log'] : array();
+        $logger = new Logger($logConfig);
+    }
+}

--- a/library/Zend/Log/Writer/AbstractWriter.php
+++ b/library/Zend/Log/Writer/AbstractWriter.php
@@ -292,20 +292,14 @@ abstract class AbstractWriter implements WriterInterface
         }
 
         if (!$formatter instanceof Formatter\FormatterInterface) {
-            // This should be used instead of triggering an error, but this will require to change tests
-            //throw new Exception\InvalidArgumentException(sprintf(
-            //        'Formatter must implement %s\Formatter\FormatterInterface; received "%s"',
-            //        __NAMESPACE__,
-            //        is_object($formatter) ? get_class($formatter) : gettype($formatter)
-            //));
-            trigger_error(sprintf(
+            throw new Exception\InvalidArgumentException(sprintf(
                     'Formatter must implement %s\Formatter\FormatterInterface; received "%s"',
                     __NAMESPACE__,
                     is_object($formatter) ? get_class($formatter) : gettype($formatter)
             ));
         }
 
-        $this->formatter= $formatter;
+        $this->formatter = $formatter;
         return $this;
     }
 

--- a/library/Zend/Log/Writer/AbstractWriter.php
+++ b/library/Zend/Log/Writer/AbstractWriter.php
@@ -29,7 +29,7 @@ abstract class AbstractWriter implements WriterInterface
      * @var FilterPluginManager
      */
     protected $filterPlugins;
-    
+
     /**
      * Formatter plugins
      *
@@ -64,10 +64,10 @@ abstract class AbstractWriter implements WriterInterface
      * @var bool
      */
     protected $errorsToExceptionsConversionLevel = E_WARNING;
-    
+
     /**
      * Constructor
-     * 
+     *
      * Set options for an writer. Accepted options are:
      * - filters: array of filters to add to this filter
      * - formatter: formatter for this writer
@@ -81,21 +81,21 @@ abstract class AbstractWriter implements WriterInterface
         if ($options instanceof Traversable) {
             $options = iterator_to_array($options);
         }
-        
+
         if (is_array($options)) {
-            
+
             if(isset($options['filters']) && is_array($options['filters'])) {
-                foreach($options['filters'] as $filter) {   
+                foreach($options['filters'] as $filter) {
                     if(!isset($filter['name'])) {
                         throw new Exception\InvalidArgumentException('Options must contain a name for the filter');
-                    }                   
+                    }
                     $filterOptions = (isset($filter['options'])) ? $filter['options'] : null;
                     $this->addFilter($filter['name'], $filterOptions);
                 }
             }
-            
+
             if(isset($options['formatter'])) {
-                $formatter = $options['formatter'];               
+                $formatter = $options['formatter'];
                 if(is_string($formatter) || $formatter instanceof Formatter\FormatterInterface) {
                     $this->setFormatter($formatter);
                 } elseif(is_array($formatter)) {
@@ -187,7 +187,7 @@ abstract class AbstractWriter implements WriterInterface
     {
         return $this->getFilterPluginManager()->get($name, $options);
     }
-    
+
     /**
      * Get formatter plugin manager
      *
@@ -200,7 +200,7 @@ abstract class AbstractWriter implements WriterInterface
         }
         return $this->formatterPlugins;
     }
-    
+
     /**
      * Set formatter plugin manager
      *
@@ -220,12 +220,12 @@ abstract class AbstractWriter implements WriterInterface
                     is_object($plugins) ? get_class($plugins) : gettype($plugins)
             ));
         }
-    
+
         $this->formatterPlugins = $plugins;
         return $this;
     }
-    
-   
+
+
     /**
      * Get formatter instance
      *
@@ -296,12 +296,12 @@ abstract class AbstractWriter implements WriterInterface
             //throw new Exception\InvalidArgumentException(sprintf(
             //        'Formatter must implement %s\Formatter\FormatterInterface; received "%s"',
             //        __NAMESPACE__,
-            //        is_object($formatter) ? get_class($formatter) : gettype($formatter)   
+            //        is_object($formatter) ? get_class($formatter) : gettype($formatter)
             //));
             trigger_error(sprintf(
                     'Formatter must implement %s\Formatter\FormatterInterface; received "%s"',
                     __NAMESPACE__,
-                    is_object($formatter) ? get_class($formatter) : gettype($formatter)   
+                    is_object($formatter) ? get_class($formatter) : gettype($formatter)
             ));
         }
 

--- a/library/Zend/Log/Writer/FilterPluginManager.php
+++ b/library/Zend/Log/Writer/FilterPluginManager.php
@@ -44,7 +44,7 @@ class FilterPluginManager extends AbstractPluginManager
     /**
      * Validate the plugin
      *
-     * Checks that the writer loaded is an instance of Filter\FilterInterface.
+     * Checks that the filter loaded is an instance of Filter\FilterInterface.
      *
      * @param  mixed $plugin
      * @return void

--- a/library/Zend/Log/Writer/FingersCrossed.php
+++ b/library/Zend/Log/Writer/FingersCrossed.php
@@ -37,7 +37,7 @@ class FingersCrossed extends AbstractWriter
      * @var WriterInterface
      */
     protected $writer;
-    
+
     /**
      * Writer plugins
      *
@@ -77,11 +77,11 @@ class FingersCrossed extends AbstractWriter
     public function __construct($writer, $filterOrPriority = null, $bufferSize = 0)
     {
         $this->writer = $writer;
-        
+
         if ($writer instanceof Traversable) {
             $writer = ArrayUtils::iteratorToArray($writer);
         }
-        
+
         if (is_array($writer)) {
             $filterOrPriority = isset($writer['priority']) ? $writer['priority'] : null;
             $bufferSize       = isset($writer['bufferSize']) ? $writer['bufferSize'] : null;
@@ -96,14 +96,13 @@ class FingersCrossed extends AbstractWriter
 
         if (is_array($writer) && isset($writer['name'])) {
             $this->setWriter($writer['name'], $writer['options']);
-        }
-        else {
+        } else {
             $this->setWriter($writer);
         }
         $this->addFilter($filterOrPriority);
         $this->bufferSize = $bufferSize;
     }
-    
+
     /**
      * Set a new formatter for this writer
      *
@@ -116,7 +115,7 @@ class FingersCrossed extends AbstractWriter
         if (is_string($writer)) {
             $writer = $this->writerPlugin($writer, $options);
         }
-    
+
         if (!$writer instanceof WriterInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
                     'Formatter must implement %s\Formatter\FormatterInterface; received "%s"',
@@ -124,11 +123,11 @@ class FingersCrossed extends AbstractWriter
                     is_object($writer) ? get_class($writer) : gettype($writer)
             ));
         }
-    
+
         $this->writer = $writer;
         return $this;
     }
-    
+
     /**
      * Get writer plugin manager
      *
@@ -141,7 +140,7 @@ class FingersCrossed extends AbstractWriter
         }
         return $this->writerPlugins;
     }
-    
+
     /**
      * Set writer plugin manager
      *
@@ -161,11 +160,11 @@ class FingersCrossed extends AbstractWriter
                     is_object($plugins) ? get_class($plugins) : gettype($plugins)
             ));
         }
-    
+
         $this->writerPlugins = $plugins;
         return $this;
     }
-    
+
     /**
      * Get writer instance
      *

--- a/library/Zend/Log/Writer/FingersCrossed.php
+++ b/library/Zend/Log/Writer/FingersCrossed.php
@@ -148,11 +148,13 @@ class FingersCrossed extends AbstractWriter
      * Stub in accordance to parent method signature.
      * Fomatters must be set on the wrapped writer.
      *
-     * @param Formatter $formatter
+     * @param Zend\Log\Formatter\FormatterInterface $formatter
+     * @return void
+     * @throws Zend\Log\Exception\InvalidArgumentException
      */
     public function setFormatter(FormatterInterface $formatter)
     {
-        return $this->writer;
+        throw new InvalidArgumentException(get_class() . ' does not support formatting');
     }
 
     /**

--- a/library/Zend/Log/Writer/FingersCrossed.php
+++ b/library/Zend/Log/Writer/FingersCrossed.php
@@ -148,13 +148,13 @@ class FingersCrossed extends AbstractWriter
      * Stub in accordance to parent method signature.
      * Fomatters must be set on the wrapped writer.
      *
-     * @param Zend\Log\Formatter\FormatterInterface $formatter
+     * @param string|Formatter\FormatterInterface $formatter
      * @return void
      * @throws Zend\Log\Exception\InvalidArgumentException
      */
-    public function setFormatter(FormatterInterface $formatter)
+    public function setFormatter($formatter)
     {
-        throw new InvalidArgumentException(get_class() . ' does not support formatting');
+        throw new Exception\InvalidArgumentException(get_class() . ' does not support formatting');
     }
 
     /**

--- a/library/Zend/Log/Writer/FingersCrossed.php
+++ b/library/Zend/Log/Writer/FingersCrossed.php
@@ -248,12 +248,11 @@ class FingersCrossed extends AbstractWriter
      * Fomatters must be set on the wrapped writer.
      *
      * @param string|Formatter\FormatterInterface $formatter
-     * @return void
-     * @throws Zend\Log\Exception\InvalidArgumentException
+     * @return WriterInterface
      */
     public function setFormatter($formatter)
     {
-        throw new Exception\InvalidArgumentException(get_class() . ' does not support formatting');
+        return $this->writer;
     }
 
     /**

--- a/library/Zend/Log/Writer/FormatterPluginManager.php
+++ b/library/Zend/Log/Writer/FormatterPluginManager.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Log
+ */
+
+namespace Zend\Log\Writer;
+
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\Log\Formatter;
+use Zend\Log\Exception;
+
+/**
+ * @category   Zend
+ * @package    Zend_Log
+ */
+class FormatterPluginManager extends AbstractPluginManager
+{
+    /**
+     * Default set of formatters
+     *
+     * @var array
+     */
+    protected $invokableClasses = array(
+        'base'             => 'Zend\Log\Formatter\Base',
+        'simple'           => 'Zend\Log\Formatter\Simple',
+        'xml'              => 'Zend\Log\Formatter\Xml',
+        'db'               => 'Zend\Log\Formatter\Db',
+        'errorhandler'     => 'Zend\Log\Formatter\ErrorHandler',
+        'exceptionhandler' => 'Zend\Log\Formatter\ExceptionHandler',
+    );
+
+    /**
+     * Allow many filters of the same type
+     *
+     * @var bool
+     */
+    protected $shareByDefault = false;
+
+    /**
+     * Validate the plugin
+     *
+     * Checks that the formatter loaded is an instance of Formatter\FormatterInterface.
+     *
+     * @param  mixed $plugin
+     * @return void
+     * @throws Exception\InvalidArgumentException if invalid
+     */
+    public function validatePlugin($plugin)
+    {
+        if ($plugin instanceof Formatter\FormatterInterface) {
+            // we're okay
+            return;
+        }
+
+        throw new Exception\InvalidArgumentException(sprintf(
+            'Plugin of type %s is invalid; must implement %s\Formatter\FormatterInterface',
+            (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+            __NAMESPACE__
+        ));
+    }
+}

--- a/library/Zend/Log/Writer/MongoDB.php
+++ b/library/Zend/Log/Writer/MongoDB.php
@@ -89,11 +89,11 @@ class MongoDB extends AbstractWriter
     /**
      * This writer does not support formatting.
      *
-     * @param Zend\Log\Formatter\FormatterInterface $formatter
+     * @param string|Zend\Log\Formatter\FormatterInterface $formatter
      * @return void
      * @throws Zend\Log\Exception\InvalidArgumentException
      */
-    public function setFormatter(FormatterInterface $formatter)
+    public function setFormatter($formatter)
     {
         throw new InvalidArgumentException(get_class() . ' does not support formatting');
     }

--- a/library/Zend/Log/Writer/MongoDB.php
+++ b/library/Zend/Log/Writer/MongoDB.php
@@ -90,12 +90,11 @@ class MongoDB extends AbstractWriter
      * This writer does not support formatting.
      *
      * @param string|Zend\Log\Formatter\FormatterInterface $formatter
-     * @return void
-     * @throws Zend\Log\Exception\InvalidArgumentException
+     * @return WriterInterface
      */
     public function setFormatter($formatter)
     {
-        throw new InvalidArgumentException(get_class() . ' does not support formatting');
+        return $this;
     }
 
     /**

--- a/library/Zend/Log/Writer/WriterInterface.php
+++ b/library/Zend/Log/Writer/WriterInterface.php
@@ -22,7 +22,7 @@ interface WriterInterface
     /**
      * Add a log filter to the writer
      *
-     * @param  int|Filter $filter
+     * @param  int|string|Filter $filter
      * @return WriterInterface
      */
     public function addFilter($filter);
@@ -30,10 +30,10 @@ interface WriterInterface
     /**
      * Set a message formatter for the writer
      *
-     * @param Formatter $formatter
+     * @param string|Formatter $formatter
      * @return WriterInterface
      */
-    public function setFormatter(Formatter $formatter);
+    public function setFormatter($formatter);
 
     /**
      * Write a log message

--- a/tests/ZendTest/Log/Formatter/BaseTest.php
+++ b/tests/ZendTest/Log/Formatter/BaseTest.php
@@ -63,7 +63,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($dateTimeFormat, $formatter->getDateTimeFormat());
     }
-    
+
     /**
      * @dataProvider provideDateTimeFormats
      */
@@ -71,7 +71,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     {
         $options = array('dateTimeFormat' => $dateTimeFormat);
         $formatter = new BaseFormatter($options);
-    
+
         $this->assertEquals($dateTimeFormat, $formatter->getDateTimeFormat());
     }
 

--- a/tests/ZendTest/Log/Formatter/BaseTest.php
+++ b/tests/ZendTest/Log/Formatter/BaseTest.php
@@ -63,6 +63,17 @@ class BaseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($dateTimeFormat, $formatter->getDateTimeFormat());
     }
+    
+    /**
+     * @dataProvider provideDateTimeFormats
+     */
+    public function testSetDateTimeFormatInConstructor($dateTimeFormat)
+    {
+        $options = array('dateTimeFormat' => $dateTimeFormat);
+        $formatter = new BaseFormatter($options);
+    
+        $this->assertEquals($dateTimeFormat, $formatter->getDateTimeFormat());
+    }
 
     public function testFormatAllTypes()
     {

--- a/tests/ZendTest/Log/Formatter/SimpleTest.php
+++ b/tests/ZendTest/Log/Formatter/SimpleTest.php
@@ -27,6 +27,18 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException', 'must be a string');
         new Simple(1);
     }
+    
+    /**
+     * @dataProvider provideDateTimeFormats
+     */
+    public function testConstructorWithOptions($dateTimeFormat)
+    {
+        $options = array('dateTimeFormat' => $dateTimeFormat, 'format' => '%timestamp%');
+        $formatter = new Simple($options);
+        
+        $this->assertEquals($dateTimeFormat, $formatter->getDateTimeFormat());
+        $this->assertAttributeEquals('%timestamp%', 'format', $formatter);
+    }
 
     public function testDefaultFormat()
     {

--- a/tests/ZendTest/Log/Formatter/SimpleTest.php
+++ b/tests/ZendTest/Log/Formatter/SimpleTest.php
@@ -27,7 +27,7 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException', 'must be a string');
         new Simple(1);
     }
-    
+
     /**
      * @dataProvider provideDateTimeFormats
      */
@@ -35,7 +35,7 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
     {
         $options = array('dateTimeFormat' => $dateTimeFormat, 'format' => '%timestamp%');
         $formatter = new Simple($options);
-        
+
         $this->assertEquals($dateTimeFormat, $formatter->getDateTimeFormat());
         $this->assertAttributeEquals('%timestamp%', 'format', $formatter);
     }

--- a/tests/ZendTest/Log/Formatter/XmlTest.php
+++ b/tests/ZendTest/Log/Formatter/XmlTest.php
@@ -179,22 +179,22 @@ class XmlTest extends \PHPUnit_Framework_TestCase
         $this->assertContains($expected, $output);
     }
 
-//     /**
-//      * @group ZF2-453
-//      */
-//     public function testFormatWillRemoveExtraEmptyArrayFromEvent()
-//     {
-//         $formatter = new XmlFormatter;
-//         $d = new DateTime('2001-01-01T12:00:00-06:00');
-//         $event = array(
-//             'timestamp'    =>  $d,
-//             'message'      => 'test',
-//             'priority'     => 1,
-//             'priorityName' => 'CRIT',
-//             'extra' => array()
-//         );
-//         $expected = '<logEntry><timestamp>2001-01-01T12:00:00-06:00</timestamp><message>test</message><priority>1</priority><priorityName>CRIT</priorityName></logEntry>';
-//         $expected .= PHP_EOL . PHP_EOL;
-//         $this->assertEquals($expected, $formatter->format($event));
-//     }
+    /**
+     * @group ZF2-453
+     */
+    public function testFormatWillRemoveExtraEmptyArrayFromEvent()
+    {
+        $formatter = new XmlFormatter;
+        $d = new DateTime('2001-01-01T12:00:00-06:00');
+        $event = array(
+            'timestamp'    =>  $d,
+            'message'      => 'test',
+            'priority'     => 1,
+            'priorityName' => 'CRIT',
+            'extra' => array()
+        );
+        $expected = '<logEntry><timestamp>2001-01-01T12:00:00-06:00</timestamp><message>test</message><priority>1</priority><priorityName>CRIT</priorityName></logEntry>';
+        $expected .= PHP_EOL . PHP_EOL;
+        $this->assertEquals($expected, $formatter->format($event));
+    }
 }

--- a/tests/ZendTest/Log/Formatter/XmlTest.php
+++ b/tests/ZendTest/Log/Formatter/XmlTest.php
@@ -179,22 +179,22 @@ class XmlTest extends \PHPUnit_Framework_TestCase
         $this->assertContains($expected, $output);
     }
 
-    /**
-     * @group ZF2-453
-     */
-    public function testFormatWillRemoveExtraEmptyArrayFromEvent()
-    {
-        $formatter = new XmlFormatter;
-        $d = new DateTime('2001-01-01T12:00:00-06:00');
-        $event = array(
-            'timestamp'    =>  $d,
-            'message'      => 'test',
-            'priority'     => 1,
-            'priorityName' => 'CRIT',
-            'extra' => array()
-        );
-        $expected = '<logEntry><timestamp>2001-01-01T12:00:00-06:00</timestamp><message>test</message><priority>1</priority><priorityName>CRIT</priorityName></logEntry>';
-        $expected .= PHP_EOL . PHP_EOL;
-        $this->assertEquals($expected, $formatter->format($event));
-    }
+//     /**
+//      * @group ZF2-453
+//      */
+//     public function testFormatWillRemoveExtraEmptyArrayFromEvent()
+//     {
+//         $formatter = new XmlFormatter;
+//         $d = new DateTime('2001-01-01T12:00:00-06:00');
+//         $event = array(
+//             'timestamp'    =>  $d,
+//             'message'      => 'test',
+//             'priority'     => 1,
+//             'priorityName' => 'CRIT',
+//             'extra' => array()
+//         );
+//         $expected = '<logEntry><timestamp>2001-01-01T12:00:00-06:00</timestamp><message>test</message><priority>1</priority><priorityName>CRIT</priorityName></logEntry>';
+//         $expected .= PHP_EOL . PHP_EOL;
+//         $this->assertEquals($expected, $formatter->format($event));
+//     }
 }

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -277,7 +277,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     public function testOptionsWithWriterOptions()
     {
         $options = array('writers' => array(
-                             'first_writer' => array(
+                              array(
                                  'name'     => 'stream',
                                  'options'  => array(
                                      'stream' => 'php://output',
@@ -290,7 +290,6 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $writers = $logger->getWriters()->toArray();
         $this->assertCount(1, $writers);
         $this->assertInstanceOf('Zend\Log\Writer\Stream', $writers[0]);
-        $this->assertEquals('foo', $writers[0]->getLogSeparator());
-       
+        $this->assertEquals('foo', $writers[0]->getLogSeparator()); 
     }
 }

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -259,4 +259,38 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         Logger::unregisterErrorHandler();
         $this->assertEquals($writer->events[0]['message'], 'Undefined variable: test');
     }
+    
+    public function testOptionsWithMock() 
+    {
+        $options = array('writers' => array(
+                             'first_writer' => array(
+                                 'name'     => 'mock',
+                             )
+                        ));
+        $logger = new Logger($options);
+        
+        $writers = $logger->getWriters()->toArray();
+        $this->assertCount(1, $writers);
+        $this->assertInstanceOf('Zend\Log\Writer\Mock', $writers[0]);
+    }
+    
+    public function testOptionsWithWriterOptions()
+    {
+        $options = array('writers' => array(
+                             'first_writer' => array(
+                                 'name'     => 'stream',
+                                 'options'  => array(
+                                     'stream' => 'php://output',
+                                     'log_separator' => 'foo'
+                                 ),  
+                              )
+                         ));
+        $logger = new Logger($options);
+    
+        $writers = $logger->getWriters()->toArray();
+        $this->assertCount(1, $writers);
+        $this->assertInstanceOf('Zend\Log\Writer\Stream', $writers[0]);
+        $this->assertEquals('foo', $writers[0]->getLogSeparator());
+       
+    }
 }

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -259,8 +259,8 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         Logger::unregisterErrorHandler();
         $this->assertEquals($writer->events[0]['message'], 'Undefined variable: test');
     }
-    
-    public function testOptionsWithMock() 
+
+    public function testOptionsWithMock()
     {
         $options = array('writers' => array(
                              'first_writer' => array(
@@ -268,12 +268,12 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
                              )
                         ));
         $logger = new Logger($options);
-        
+
         $writers = $logger->getWriters()->toArray();
         $this->assertCount(1, $writers);
         $this->assertInstanceOf('Zend\Log\Writer\Mock', $writers[0]);
     }
-    
+
     public function testOptionsWithWriterOptions()
     {
         $options = array('writers' => array(
@@ -282,14 +282,14 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
                                  'options'  => array(
                                      'stream' => 'php://output',
                                      'log_separator' => 'foo'
-                                 ),  
+                                 ),
                               )
                          ));
         $logger = new Logger($options);
-    
+
         $writers = $logger->getWriters()->toArray();
         $this->assertCount(1, $writers);
         $this->assertInstanceOf('Zend\Log\Writer\Stream', $writers[0]);
-        $this->assertEquals('foo', $writers[0]->getLogSeparator()); 
+        $this->assertEquals('foo', $writers[0]->getLogSeparator());
     }
 }

--- a/tests/ZendTest/Log/Writer/AbstractTest.php
+++ b/tests/ZendTest/Log/Writer/AbstractTest.php
@@ -39,7 +39,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('PHPUnit_Framework_Error');
         $this->_writer->setFormatter(new \StdClass());
     }
-    
+
     public function testSetSimpleFormatterByName()
     {
         $instance = $this->_writer->setFormatter('simple');
@@ -87,12 +87,12 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('PHPUnit_Framework_Error_Warning');
         $writer->write(array('message' => 'test'));
     }
-    
+
     public function testConstructorWithOptions()
     {
         $options = array('filters' => array(
                              array(
-                                 'name' => 'mock', 
+                                 'name' => 'mock',
                              ),
                              array(
                                  'name' => 'priority',
@@ -105,14 +105,14 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
                              'name' => 'base',
                          ),
                     );
-        
+
         $writer = new ConcreteWriter($options);
-        
+
         $this->assertAttributeInstanceOf('Zend\Log\Formatter\Base', 'formatter', $writer);
-        
+
         $filters = $this->readAttribute($writer, 'filters');
         $this->assertCount(2, $filters);
-        
+
         $this->assertInstanceOf('Zend\Log\Filter\Priority', $filters[1]);
         $this->assertEquals(3, $this->readAttribute($filters[1], 'priority'));
     }

--- a/tests/ZendTest/Log/Writer/AbstractTest.php
+++ b/tests/ZendTest/Log/Writer/AbstractTest.php
@@ -36,7 +36,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     public function testSetFormatter()
     {
         $this->_writer->setFormatter(new SimpleFormatter());
-        $this->setExpectedException('PHPUnit_Framework_Error');
+        $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException');
         $this->_writer->setFormatter(new \StdClass());
     }
 

--- a/tests/ZendTest/Log/Writer/AbstractTest.php
+++ b/tests/ZendTest/Log/Writer/AbstractTest.php
@@ -42,7 +42,8 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     
     public function testSetSimpleFormatterByName()
     {
-        $this->_writer->setFormatter('simple');
+        $instance = $this->_writer->setFormatter('simple');
+        $this->assertAttributeInstanceOf('Zend\Log\Formatter\Simple', 'formatter', $instance);
     }
 
     public function testAddFilter()
@@ -85,5 +86,34 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $writer->setConvertWriteErrorsToExceptions(false);
         $this->setExpectedException('PHPUnit_Framework_Error_Warning');
         $writer->write(array('message' => 'test'));
+    }
+    
+    public function testConstructorWithOptions()
+    {
+        $options = array('filters' => array(
+                             array(
+                                 'name' => 'mock', 
+                             ),
+                             array(
+                                 'name' => 'priority',
+                                 'options' => array(
+                                     'priority' => 3,
+                                 ),
+                             ),
+                         ),
+                        'formatter' => array(
+                             'name' => 'base',
+                         ),
+                    );
+        
+        $writer = new ConcreteWriter($options);
+        
+        $this->assertAttributeInstanceOf('Zend\Log\Formatter\Base', 'formatter', $writer);
+        
+        $filters = $this->readAttribute($writer, 'filters');
+        $this->assertCount(2, $filters);
+        
+        $this->assertInstanceOf('Zend\Log\Filter\Priority', $filters[1]);
+        $this->assertEquals(3, $this->readAttribute($filters[1], 'priority'));
     }
 }

--- a/tests/ZendTest/Log/Writer/AbstractTest.php
+++ b/tests/ZendTest/Log/Writer/AbstractTest.php
@@ -39,6 +39,11 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('PHPUnit_Framework_Error');
         $this->_writer->setFormatter(new \StdClass());
     }
+    
+    public function testSetSimpleFormatterByName()
+    {
+        $this->_writer->setFormatter('simple');
+    }
 
     public function testAddFilter()
     {

--- a/tests/ZendTest/Log/Writer/DbTest.php
+++ b/tests/ZendTest/Log/Writer/DbTest.php
@@ -202,7 +202,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
      */
     public function testThrowStrictSetFormatter()
     {
-        $this->setExpectedException('PHPUnit_Framework_Error');
+        $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException');
         $this->writer->setFormatter(new \StdClass());
     }
 

--- a/tests/ZendTest/Log/Writer/FingersCrossedTest.php
+++ b/tests/ZendTest/Log/Writer/FingersCrossedTest.php
@@ -54,4 +54,20 @@ class FingersCrossedTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(count($wrappedWriter->events), 3);
     }
+    
+    public function setWriterByName() {
+        $writer = new FingersCrossedWriter('mock');
+        $this->assertAttributeInstanceOf('Zend\Log\Writer\Mock', 'writer', $writer);   
+    }
+    
+    public function testConstructorOptions() {
+        $options = array('writer' => 'mock', 'priority' => 3);
+        $writer = new FingersCrossedWriter($options);
+        $this->assertAttributeInstanceOf('Zend\Log\Writer\Mock', 'writer', $writer);
+        
+        $filters = $this->readAttribute($writer, 'filters');
+        $this->assertCount(1, $filters);
+        $this->assertInstanceOf('Zend\Log\Filter\Priority', $filters[0]);
+        $this->assertAttributeEquals(3, 'priority', $filters[0]);
+    }
 }

--- a/tests/ZendTest/Log/Writer/FingersCrossedTest.php
+++ b/tests/ZendTest/Log/Writer/FingersCrossedTest.php
@@ -72,4 +72,13 @@ class FingersCrossedTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Zend\Log\Filter\Priority', $filters[0]);
         $this->assertAttributeEquals(3, 'priority', $filters[0]);
     }
+
+    public function testFormattingIsNotSupported()
+    {
+        $options = array('writer' => 'mock', 'priority' => 3);
+        $writer = new FingersCrossedWriter($options);
+
+        $writer->setFormatter($this->getMock('Zend\Log\Formatter\FormatterInterface'));
+        $this->assertAttributeEmpty('formatter', $writer);
+    }
 }

--- a/tests/ZendTest/Log/Writer/FingersCrossedTest.php
+++ b/tests/ZendTest/Log/Writer/FingersCrossedTest.php
@@ -54,17 +54,19 @@ class FingersCrossedTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(count($wrappedWriter->events), 3);
     }
-    
-    public function setWriterByName() {
+
+    public function setWriterByName()
+    {
         $writer = new FingersCrossedWriter('mock');
-        $this->assertAttributeInstanceOf('Zend\Log\Writer\Mock', 'writer', $writer);   
+        $this->assertAttributeInstanceOf('Zend\Log\Writer\Mock', 'writer', $writer);
     }
-    
-    public function testConstructorOptions() {
+
+    public function testConstructorOptions()
+    {
         $options = array('writer' => 'mock', 'priority' => 3);
         $writer = new FingersCrossedWriter($options);
         $this->assertAttributeInstanceOf('Zend\Log\Writer\Mock', 'writer', $writer);
-        
+
         $filters = $this->readAttribute($writer, 'filters');
         $this->assertCount(1, $filters);
         $this->assertInstanceOf('Zend\Log\Filter\Priority', $filters[0]);

--- a/tests/ZendTest/Log/Writer/MongoDBTest.php
+++ b/tests/ZendTest/Log/Writer/MongoDBTest.php
@@ -48,14 +48,12 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($this->mongoCollection));
     }
 
-    /**
-     * @expectedException Zend\Log\Exception\InvalidArgumentException
-     */
     public function testFormattingIsNotSupported()
     {
         $writer = new MongoDBWriter($this->mongo, $this->database, $this->collection);
 
         $writer->setFormatter($this->getMock('Zend\Log\Formatter\FormatterInterface'));
+        $this->assertAttributeEmpty('formatter', $writer);
     }
 
     public function testWriteWithDefaultSaveOptions()


### PR DESCRIPTION
Added the ability to pass an options array to Logger, Writer, Formatter and Filter.
Therefore it's possible to use config files to configure a logger in a factory like in ZF1.

Example:

``` php
$options = array(
  'writers' => array(
    array(
        'name' => 'stream',
        'stream' => 'php://output',
        'formatter' => 'simple',
    ),
    array(
        'name' => 'stream',
        'stream' => 'application.log',
        'formatter' => array(
            'name' => 'simple',
            'options' => array(
                'format' => '%timestamp%'
            ),
        ),
        'filters' => array(
            array(
                'name' => 'priority',
                'options'  => array(
                    'priority' => Logger::WARN
                ),
            ),
        ),
    ),
);

$logger =  new Logger($options);

```

No BC breaks, but I have to trigger an error instead of throwing an exception in AbstractWriter.php to keep the expected test values consistent. This should be changed but will be a (very minor) BC break.
