### PR TITLE
Reset the Order part when resetting Select

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -408,6 +408,9 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             case self::OFFSET:
                 $this->offset = null;
                 break;
+            case self::ORDER:
+                $this->order = null;
+                break;
         }
         return $this;
     }

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -371,6 +371,11 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $select->reset(Select::OFFSET);
         $this->assertNull($select->getRawState(Select::OFFSET));
 
+        // order
+        $select->order('foo asc');
+        $this->assertEquals(array('foo asc'), $select->getRawState(Select::ORDER));
+        $select->reset(Select::ORDER);
+        $this->assertNull($select->getRawState(Select::ORDER));
     }
 
     /**


### PR DESCRIPTION
The Order part of the Select object was not getting reset.
Test added.

Fixes #2730
