### PR TITLE
fix captcha helper test.

### DIFF
--- a/tests/ZendTest/Form/View/Helper/Captcha/ImageTest.php
+++ b/tests/ZendTest/Form/View/Helper/Captcha/ImageTest.php
@@ -62,7 +62,7 @@ class ImageTest extends CommonTestCase
     public function tearDown()
     {
         // remove captcha images
-        foreach (new DirectoryIterator($this->tmpDir) as $file) {
+        foreach (new DirectoryIterator($this->testDir) as $file) {
             if (!$file->isDot() && !$file->isDir()) {
                 unlink($file->getPathname());
             }


### PR DESCRIPTION
Remove only captcha images from test temp directory.
Without this script trying remove all files from /tmp dir on production server
