### PR TITLE
access protected should be public for getValue() func

### DIFF
--- a/library/Zend/Validator/AbstractValidator.php
+++ b/library/Zend/Validator/AbstractValidator.php
@@ -357,7 +357,7 @@ abstract class AbstractValidator implements
      *
      * @return mixed Value to be validated
      */
-    protected function getValue()
+    public function getValue()
     {
         return $this->value;
     }

--- a/tests/ZendTest/Validator/StringLengthTest.php
+++ b/tests/ZendTest/Validator/StringLengthTest.php
@@ -162,4 +162,12 @@ class StringLengthTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($validator->getOption('messageVariables'),
                                      'messageVariables', $validator);
     }
+    
+    public function testValueofVariablePasstoValidator()
+    {
+        $validator = $this->validator;
+        $validator->isValid('word');
+        
+        $this->assertEquals('word', $validator->getValue());
+    }
 }


### PR DESCRIPTION
for public access, i can call :

```
$validator = new Zend\Validator\StringLength(array('min' => 8, 'max' => 12));
if (!validator->isValid('word')) {
    echo 'Word failed: '
        . $validator->getValue()
        . '; its length is not between '
        . $validator->min
        . ' and '
        . $validator->max
        . "\n";
}
```

as follow http://zf2.readthedocs.org/en/latest/modules/zend.validator.html docs ( with currently doc, not working because it call "$validator" with "validator" without "$" and $validator->value should be $validator->getValue() in public mode
