### PR TITLE
add the support to register module paths over namespace

### DIFF
--- a/library/Zend/Loader/ModuleAutoloader.php
+++ b/library/Zend/Loader/ModuleAutoloader.php
@@ -330,7 +330,7 @@ class ModuleAutoloader implements SplAutoloader
             ));
         }
         if ($moduleName) {
-            if (in_array( substr($moduleName, -2 ), array('/*','/%') ) ) {
+            if (in_array( substr($moduleName, -2 ), array('\\*','\\%') ) ) {
                 $this->namespacedPaths[ substr($moduleName, 0, -2 ) ] = static::normalizePath($path);
             } else {
                 $this->explicitPaths[$moduleName] = static::normalizePath($path);

--- a/library/Zend/Loader/ModuleAutoloader.php
+++ b/library/Zend/Loader/ModuleAutoloader.php
@@ -30,6 +30,11 @@ class ModuleAutoloader implements SplAutoloader
     protected $explicitPaths = array();
 
     /**
+     * @var array An array of namespaceName => namespacePath
+     */
+    protected $namespacedPaths = array();
+
+    /**
      * @var array An array of supported phar extensions (filled on constructor)
      */
     protected $pharExtensions = array();
@@ -120,6 +125,28 @@ class ModuleAutoloader implements SplAutoloader
                 return $classLoaded;
             }
         }
+
+        if (count($this->namespacedPaths) >= 1 ) {
+        	foreach ( $this->namespacedPaths as $namespace=>$path ) {
+        		if ( false === strpos($moduleName,$namespace) ) {
+        			continue;
+        		}
+        		
+        		$moduleName_buffer = str_replace($namespace . "\\", "", $moduleName );
+        		$path .= DIRECTORY_SEPARATOR . $moduleName_buffer . DIRECTORY_SEPARATOR;
+        		
+        		$classLoaded = $this->loadModuleFromDir($path, $class);
+        		if ($classLoaded) {
+        			return $classLoaded;
+        		}
+        		
+        		$classLoaded = $this->loadModuleFromPhar($path, $class);
+        		if ($classLoaded) {
+        			return $classLoaded;
+        		}
+        	}
+        }
+        
 
         $moduleClassPath   = str_replace('\\', DIRECTORY_SEPARATOR, $moduleName);
 
@@ -277,7 +304,7 @@ class ModuleAutoloader implements SplAutoloader
 
         foreach ($paths as $module => $path) {
             if (is_string($module)) {
-                $this->registerPath($path, $module);
+            	$this->registerPath($path, $module);
             } else {
                 $this->registerPath($path);
             }
@@ -303,7 +330,11 @@ class ModuleAutoloader implements SplAutoloader
             ));
         }
         if ($moduleName) {
-            $this->explicitPaths[$moduleName] = static::normalizePath($path);
+        	if (in_array( substr($moduleName, -2 ), array('/*','/%') ) ) {
+        		$this->namespacedPaths[ substr($moduleName, 0, -2 ) ] = static::normalizePath($path);
+        	} else {
+        		$this->explicitPaths[$moduleName] = static::normalizePath($path);
+        	}
         } else {
             $this->paths[] = static::normalizePath($path);
         }

--- a/library/Zend/Loader/ModuleAutoloader.php
+++ b/library/Zend/Loader/ModuleAutoloader.php
@@ -127,24 +127,24 @@ class ModuleAutoloader implements SplAutoloader
         }
 
         if (count($this->namespacedPaths) >= 1 ) {
-        	foreach ( $this->namespacedPaths as $namespace=>$path ) {
-        		if ( false === strpos($moduleName,$namespace) ) {
-        			continue;
-        		}
-        		
-        		$moduleName_buffer = str_replace($namespace . "\\", "", $moduleName );
-        		$path .= DIRECTORY_SEPARATOR . $moduleName_buffer . DIRECTORY_SEPARATOR;
-        		
-        		$classLoaded = $this->loadModuleFromDir($path, $class);
-        		if ($classLoaded) {
-        			return $classLoaded;
-        		}
-        		
-        		$classLoaded = $this->loadModuleFromPhar($path, $class);
-        		if ($classLoaded) {
-        			return $classLoaded;
-        		}
-        	}
+            foreach ( $this->namespacedPaths as $namespace=>$path ) {
+                if ( false === strpos($moduleName,$namespace) ) {
+                    continue;
+            }
+            
+                $moduleName_buffer = str_replace($namespace . "\\", "", $moduleName );
+                $path .= DIRECTORY_SEPARATOR . $moduleName_buffer . DIRECTORY_SEPARATOR;
+                
+                $classLoaded = $this->loadModuleFromDir($path, $class);
+                if ($classLoaded) {
+                    return $classLoaded;
+                }
+                
+                $classLoaded = $this->loadModuleFromPhar($path, $class);
+                if ($classLoaded) {
+                    return $classLoaded;
+                }
+            }
         }
         
 
@@ -304,7 +304,7 @@ class ModuleAutoloader implements SplAutoloader
 
         foreach ($paths as $module => $path) {
             if (is_string($module)) {
-            	$this->registerPath($path, $module);
+                $this->registerPath($path, $module);
             } else {
                 $this->registerPath($path);
             }
@@ -330,11 +330,11 @@ class ModuleAutoloader implements SplAutoloader
             ));
         }
         if ($moduleName) {
-        	if (in_array( substr($moduleName, -2 ), array('/*','/%') ) ) {
-        		$this->namespacedPaths[ substr($moduleName, 0, -2 ) ] = static::normalizePath($path);
-        	} else {
-        		$this->explicitPaths[$moduleName] = static::normalizePath($path);
-        	}
+            if (in_array( substr($moduleName, -2 ), array('/*','/%') ) ) {
+                $this->namespacedPaths[ substr($moduleName, 0, -2 ) ] = static::normalizePath($path);
+            } else {
+                $this->explicitPaths[$moduleName] = static::normalizePath($path);
+            }
         } else {
             $this->paths[] = static::normalizePath($path);
         }

--- a/library/Zend/Loader/ModuleAutoloader.php
+++ b/library/Zend/Loader/ModuleAutoloader.php
@@ -130,16 +130,16 @@ class ModuleAutoloader implements SplAutoloader
             foreach ( $this->namespacedPaths as $namespace=>$path ) {
                 if ( false === strpos($moduleName,$namespace) ) {
                     continue;
-            }
-            
+                }
+
                 $moduleName_buffer = str_replace($namespace . "\\", "", $moduleName );
                 $path .= DIRECTORY_SEPARATOR . $moduleName_buffer . DIRECTORY_SEPARATOR;
-                
+
                 $classLoaded = $this->loadModuleFromDir($path, $class);
                 if ($classLoaded) {
                     return $classLoaded;
                 }
-                
+
                 $classLoaded = $this->loadModuleFromPhar($path, $class);
                 if ($classLoaded) {
                     return $classLoaded;

--- a/tests/ZendTest/Loader/ModuleAutoloaderTest.php
+++ b/tests/ZendTest/Loader/ModuleAutoloaderTest.php
@@ -200,7 +200,7 @@ class ManagerTest extends TestCase
     public function testCanLoadModulesFromNamespace()
     {
         $loader = new ModuleAutoloader(array(
-            'FooModule/*' => __DIR__ . '/_files/FooModule',
+            'FooModule\*' => __DIR__ . '/_files/FooModule',
             'FooModule' => __DIR__ . '/_files/FooModule',
         ));
         $loader->register();

--- a/tests/ZendTest/Loader/ModuleAutoloaderTest.php
+++ b/tests/ZendTest/Loader/ModuleAutoloaderTest.php
@@ -197,4 +197,16 @@ class ManagerTest extends TestCase
         $this->assertTrue(class_exists('PharModuleExplicit\Module'));
     }
 
+    public function testCanLoadModulesFromNamespace()
+    {
+        $loader = new ModuleAutoloader(array(
+            'FooModule/*' => __DIR__ . '/_files/FooModule',
+            'FooModule' => __DIR__ . '/_files/FooModule',
+        ));
+        $loader->register();
+        $this->assertTrue(class_exists('FooModule\BarModule\Module'));
+        $this->assertTrue(class_exists('FooModule\SubModule\Module'));
+        $this->assertTrue(class_exists('FooModule\Module'));
+    }
+
 }

--- a/tests/ZendTest/Loader/_files/FooModule/BarModule/Module.php
+++ b/tests/ZendTest/Loader/_files/FooModule/BarModule/Module.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Loader
+ */
+
+namespace FooModule\BarModule;
+
+class Module
+{
+}


### PR DESCRIPTION
so you can define one path for all included Modules

like:

<pre>
return array(
    'modules' => array(
        'Namespace\ModuleA',
        'Namespace\ModuleB',
    ),
    'module_listener_options' => array(
        'config_glob_paths'    => array(
            'config/autoload/{,*.}{global,local}.php',
        ),
        'module_paths' => array(
            'Namespace\*'=>'./vendor/projektX/module_share/',
        ),
    ),
);
</pre>


The namespace map, runs after the explicitPaths. This allows you still defined a explicitPath for some modules.
