### PR TITLE
Fix Zend\Code\Scanner\TokenArrayScanner

### DIFF
--- a/library/Zend/Code/Scanner/TokenArrayScanner.php
+++ b/library/Zend/Code/Scanner/TokenArrayScanner.php
@@ -584,10 +584,6 @@ class TokenArrayScanner implements ScannerInterface
             }
         }
 
-        if (!$namespaces) {
-            return array();
-        }
-
         if ($namespace === null) {
             $namespace = array_shift($namespaces);
         } elseif (!is_string($namespace)) {

--- a/tests/ZendTest/Code/Scanner/TokenArrayScannerTest.php
+++ b/tests/ZendTest/Code/Scanner/TokenArrayScannerTest.php
@@ -24,6 +24,18 @@ class TokenArrayScannerTest extends TestCase
         $this->assertContains('ZendTest\Code\TestAsset', $namespaces);
     }
 
+    public function testScannerReturnsNamespacesInNotNamespacedClasses()
+    {
+        $tokenScanner = new TokenArrayScanner(token_get_all(file_get_contents((__DIR__ . '/../TestAsset/FooBarClass.php'))));
+        $uses = $tokenScanner->getUses();
+        $this->assertInternalType('array', $uses);
+        $foundUses = array();
+        foreach ($uses as $use) {
+            $foundUses[] = $use['use'];
+        }
+        $this->assertContains('ArrayObject', $foundUses);
+    }
+
     public function testScannerReturnsClassNames()
     {
         $tokenScanner = new TokenArrayScanner(token_get_all(file_get_contents((__DIR__ . '/../TestAsset/FooClass.php'))));

--- a/tests/ZendTest/Code/TestAsset/FooBarClass.php
+++ b/tests/ZendTest/Code/TestAsset/FooBarClass.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Code
+ */
+
+use ArrayObject;
+
+/**
+ * This is a test class, declaring no namespace at all.
+ * It is used to test, if the token scanner can find use
+ * statements in classes with no namespace defined.
+ */
+class ZendTest_Code_TestAsset_FooBar extends ArrayObject
+{
+}


### PR DESCRIPTION
In PHP 5.3 it's possible to declare use statements even without declaring a namespace. This is very usefull, if you have non-namespaced PHP code (for example a ZF1 application), that uses a namespaced library (for example Doctrine 2).
