### PR TITLE
Session\Storage: always preserve _REQUEST_ACCESS_TIME

### DIFF
--- a/library/Zend/Session/Storage/ArrayStorage.php
+++ b/library/Zend/Session/Storage/ArrayStorage.php
@@ -47,13 +47,25 @@ class ArrayStorage extends ArrayObject implements StorageInterface
         $iteratorClass = '\\ArrayIterator'
     ) {
         parent::__construct($input, $flags, $iteratorClass);
-        $this->setMetadata('_REQUEST_ACCESS_TIME', microtime(true));
+        $this->setRequestAccessTime(microtime(true));
+    }
+
+    /**
+     * Set the request access time
+     *
+     * @param  float $time
+     * @return ArrayStorage
+     */
+    protected function setRequestAccessTime($time)
+    {
+        $this->setMetadata('_REQUEST_ACCESS_TIME', $time);
+        return $this;
     }
 
     /**
      * Retrieve the request access time
      *
-     * @return int
+     * @return float
      */
     public function getRequestAccessTime()
     {
@@ -289,7 +301,7 @@ class ArrayStorage extends ArrayObject implements StorageInterface
             throw new Exception\RuntimeException('Cannot clear storage as it is marked immutable');
         }
         if (null === $key) {
-            $this->exchangeArray(array());
+            $this->fromArray(array());
             return $this;
         }
 
@@ -317,7 +329,9 @@ class ArrayStorage extends ArrayObject implements StorageInterface
      */
     public function fromArray(array $array)
     {
+        $ts = $this->getRequestAccessTime();
         $this->exchangeArray($array);
+        $this->setRequestAccessTime($ts);
         return $this;
     }
 

--- a/library/Zend/Session/Storage/SessionStorage.php
+++ b/library/Zend/Session/Storage/SessionStorage.php
@@ -76,7 +76,7 @@ class SessionStorage extends ArrayStorage
      */
     public function fromArray(array $array)
     {
-        $this->exchangeArray($array);
+        parent::fromArray($array);
         if ($_SESSION !== $this) {
             $_SESSION = $this;
         }

--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -311,7 +311,7 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
         $storage = $this->manager->getStorage();
         $storage['foo'] = 'bar';
         $this->manager->destroy(array('clear_storage' => true));
-        $this->assertSame(array(), (array) $storage);
+        $this->assertFalse(isset($storage['foo']));
     }
 
     /**

--- a/tests/ZendTest/Session/StorageTest.php
+++ b/tests/ZendTest/Session/StorageTest.php
@@ -220,4 +220,11 @@ class StorageTest extends \PHPUnit_Framework_TestCase
                                     'Cannot clear storage as it is marked immutable');
         $this->storage->clear();
     }
+
+    public function testRequestAccessTimeIsPreservedEvenInFactoryMethod()
+    {
+        $this->assertNotEmpty($this->storage->getRequestAccessTime());
+        $this->storage->fromArray(array());
+        $this->assertNotEmpty($this->storage->getRequestAccessTime());
+    }
 }


### PR DESCRIPTION
`SessionManager::start()` is called by default with `$preserveStorage = false` (and that' ok), but doing so the special metadata `_REQUEST_ACCESS_TIME` is lost due to https://github.com/zendframework/zf2/blob/master/library/Zend/Session/SessionManager.php#L95-97 always-called overwriting method.

This is a bug that deny the `Session\Container::expireByHops()` functionality.
