### PR TITLE
Allow whitespace in Iban

### DIFF
--- a/library/Zend/Validator/Iban.php
+++ b/library/Zend/Validator/Iban.php
@@ -226,7 +226,7 @@ class Iban extends AbstractValidator
             return false;
         }
 
-        $value = strtoupper($value);
+        $value = str_replace(' ', '', strtoupper($value));
         $this->setValue($value);
 
         $countryCode = $this->getCountryCode();

--- a/tests/ZendTest/Validator/IbanTest.php
+++ b/tests/ZendTest/Validator/IbanTest.php
@@ -25,7 +25,7 @@ class IbanTest extends \PHPUnit_Framework_TestCase
         return array(
             array('AD1200012030200359100100', true),
             array('AT611904300234573201',     true),
-            array('AT61 1904 3002 3457 3201', false),
+            array('AT61 1904 3002 3457 3201', true),
             array('AD1200012030200354100100', false),
 
             array('AL47212110090000000235698741', true),


### PR DESCRIPTION
I'm not a bank expert, but I often see Iban numbers written with spaces between bank code, account number... I think it still should validate even if the code is written with spaces, shouldn't it ?
