### PR TITLE
Fix issue when PREG_BAD_UTF8_OFFSET_ERROR is defined but Unicode support is not enabled on PCRE

### DIFF
--- a/library/Zend/Filter/AbstractFilter.php
+++ b/library/Zend/Filter/AbstractFilter.php
@@ -41,7 +41,7 @@ abstract class AbstractFilter implements FilterInterface
         if (static::$hasPcreUnicodeSupport === null) {
             static::$hasPcreUnicodeSupport = false;
             ErrorHandler::start();
-            if (defined('PREG_BAD_UTF8_OFFSET_ERROR') || preg_match('/\pL/u', 'a') == 1) {
+            if (defined('PREG_BAD_UTF8_OFFSET_ERROR') && preg_match('/\pL/u', 'a') == 1) {
                 static::$hasPcreUnicodeSupport = true;
             }
             ErrorHandler::stop();


### PR DESCRIPTION
Fixed issue when PREG_BAD_UTF8_OFFSET_ERROR is defined but Unicode support is not enabled on PCRE.
Zend/Filter/AbstractFilter.php
