### PR TITLE
Allow forms that have been added as fieldsets to bind values to bound ob...

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -270,7 +270,12 @@ class Form extends Fieldset implements FormInterface
         if (!is_object($this->object)) {
             return;
         }
-        if (!$this->isValid) {
+        if (!$this->hasValidated() && !empty($values)) {
+            $this->setData($values);
+            if (!$this->isValid()) {
+                return;
+            }
+        } else if (!$this->isValid) {
             return;
         }
 
@@ -434,6 +439,8 @@ class Form extends Fieldset implements FormInterface
         }
 
         $this->isValid = $result = $filter->isValid();
+        $this->hasValidated = true;
+
         if ($result && $this->bindOnValidate()) {
             $this->bindValues();
         }
@@ -442,7 +449,6 @@ class Form extends Fieldset implements FormInterface
             $this->setMessages($filter->getMessages());
         }
 
-        $this->hasValidated = true;
         return $result;
     }
 

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -710,6 +710,35 @@ class FormTest extends TestCase
         $this->assertEquals('my.form.fieldset', $fieldset->getAttribute('data-js-type'));
     }
 
+    public function testFormAsFieldsetWillBindValuesToObject()
+    {
+        $parentForm        = new Form('parent');
+        $parentFormObject  = new \ArrayObject(array('parentId' => null));
+        $parentFormElement = new Element('parentId');
+        $parentForm->setObject($parentFormObject);
+        $parentForm->add($parentFormElement);
+
+        $childForm        = new Form('child');
+        $childFormObject  = new \ArrayObject(array('childId' => null));
+        $childFormElement = new Element('childId');
+        $childForm->setObject($childFormObject);
+        $childForm->add($childFormElement);
+
+        $parentForm->add($childForm);
+
+        $data = array(
+            'parentId' => 'mpinkston was here',
+            'child' => array(
+                'childId' => 'testing 123'
+            )
+        );
+
+        $parentForm->setData($data);
+        $this->assertTrue($parentForm->isValid());
+        $this->assertEquals($data['parentId'], $parentFormObject['parentId']);
+        $this->assertEquals($data['child']['childId'], $childFormObject['childId']);
+    }
+
     public function testWillUseInputSpecificationFromElementInInputFilterIfNoMatchingInputFound()
     {
         $element = new TestAsset\ElementWithFilter('foo');


### PR DESCRIPTION
...jects.

Currently, forms that are added as fieldsets to other forms will not bind values to bound objects because they never get a chance to validate. This checks to see if the form has not been validated and if values are being passed. If so, it sets the data, validates, and continues binding the values to the bound object.
