### PR TITLE
Issue 2781

### DIFF
--- a/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
+++ b/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
@@ -86,7 +86,7 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
             $config = $serviceLocator->get('Config');
             $basePathHelper = new ViewHelper\BasePath;
             if (isset($config['view_manager']) && isset($config['view_manager']['base_path'])) {
-                $basePath = $config['base_path'];
+                $basePath = $config['view_manager']['base_path'];
             } else {
                 $basePath = $serviceLocator->get('Request')->getBasePath();
             }


### PR DESCRIPTION
Commit a4cb964 broke view_path parameter. 
Class Zend\Mvc\Service\ViewHelperManagerFactory line 89 instead of

`$basePath = $config['base_path'];`
put
`$basePath = $config['view_manager']['base_path'];`
