### PR TITLE
[#2679] Bitwise op instead of comparison

### DIFF
--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -380,7 +380,7 @@ class Logger implements LoggerInterface
         set_error_handler(function($errno, $errstr, $errfile, $errline, $errcontext) use ($errorHandlerMap, $logger) {
             $errorLevel = error_reporting();
 
-            if ($errorLevel && $errno) {
+            if ($errorLevel & $errno) {
                 if (isset($errorHandlerMap[$errno])) {
                     $priority = $errorHandlerMap[$errno];
                 } else {


### PR DESCRIPTION
- Unable to write a test for this, because when running the test suite,
  the condition will always evaluate true due to the fact that
  error_reporting is always dialed to the maximum.

Resolves #2679
