### PR TITLE
Remove module route listener params in url helper.

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/Url.php
+++ b/library/Zend/Mvc/Controller/Plugin/Url.php
@@ -79,6 +79,11 @@ class Url extends AbstractPlugin
 
             if (isset($routeMatchParams[ModuleRouteListener::ORIGINAL_CONTROLLER])) {
                 $routeMatchParams['controller'] = $routeMatchParams[ModuleRouteListener::ORIGINAL_CONTROLLER];
+                unset($routeMatchParams[ModuleRouteListener::ORIGINAL_CONTROLLER]);
+            }
+
+            if (isset($routeMatchParams[ModuleRouteListener::MODULE_NAMESPACE])) {
+                unset($routeMatchParams[ModuleRouteListener::MODULE_NAMESPACE]);
             }
 
             $params = array_merge($routeMatchParams, $params);

--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -102,6 +102,8 @@ class Url extends AbstractHelper
 
             if (isset($routeMatchParams[ModuleRouteListener::ORIGINAL_CONTROLLER])) {
                 $routeMatchParams['controller'] = $routeMatchParams[ModuleRouteListener::ORIGINAL_CONTROLLER];
+                unset($routeMatchParams[ModuleRouteListener::MODULE_NAMESPACE]);
+                unset($routeMatchParams[ModuleRouteListener::ORIGINAL_CONTROLLER]);
             }
 
             $params = array_merge($routeMatchParams, $params);

--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -102,8 +102,11 @@ class Url extends AbstractHelper
 
             if (isset($routeMatchParams[ModuleRouteListener::ORIGINAL_CONTROLLER])) {
                 $routeMatchParams['controller'] = $routeMatchParams[ModuleRouteListener::ORIGINAL_CONTROLLER];
-                unset($routeMatchParams[ModuleRouteListener::MODULE_NAMESPACE]);
                 unset($routeMatchParams[ModuleRouteListener::ORIGINAL_CONTROLLER]);
+            }
+
+            if (isset($routeMatchParams[ModuleRouteListener::MODULE_NAMESPACE])) {
+                unset($routeMatchParams[ModuleRouteListener::MODULE_NAMESPACE]);
             }
 
             $params = array_merge($routeMatchParams, $params);


### PR DESCRIPTION
The module route listener params probably shouldn't show up when using routes like Wildcard and Query
