### PR TITLE
Fixed Zend\Di\Di::get() to use 'shared' config. setting as advertised

### DIFF
--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -150,7 +150,8 @@ class Di implements DependencyInjectionInterface
                 return $im->getSharedInstance($name, $params);
             }
         }
-        $instance = $this->newInstance($name, $params);
+        $config = $im->getConfig($name);
+        $instance = $this->newInstance($name, $params, $config['shared']);
         array_pop($this->instanceContext);
 
         return $instance;

--- a/tests/ZendTest/Di/DiTest.php
+++ b/tests/ZendTest/Di/DiTest.php
@@ -65,12 +65,36 @@ class DiTest extends \PHPUnit_Framework_TestCase
 
     public function testGetRetrievesSameInstanceOnSubsequentCalls()
     {
-        $di = new Di();
+        $config = new Config(array(
+            'instance' => array(
+                'ZendTest\Di\TestAsset\BasicClass' => array(
+                    'shared' => true,
+                    ),
+                ),
+        ));
+        $di = new Di(null, null, $config);
         $obj1 = $di->get('ZendTest\Di\TestAsset\BasicClass');
         $obj2 = $di->get('ZendTest\Di\TestAsset\BasicClass');
         $this->assertInstanceOf('ZendTest\Di\TestAsset\BasicClass', $obj1);
         $this->assertInstanceOf('ZendTest\Di\TestAsset\BasicClass', $obj2);
         $this->assertSame($obj1, $obj2);
+    }
+
+    public function testGetRetrievesDifferentInstanceOnSubsequentCallsIfSharingDisabled()
+    {
+        $config = new Config(array(
+            'instance' => array(
+                'ZendTest\Di\TestAsset\BasicClass' => array(
+                    'shared' => false,
+                    ),
+                ),
+        ));
+        $di = new Di(null, null, $config);
+        $obj1 = $di->get('ZendTest\Di\TestAsset\BasicClass');
+        $obj2 = $di->get('ZendTest\Di\TestAsset\BasicClass');
+        $this->assertInstanceOf('ZendTest\Di\TestAsset\BasicClass', $obj1);
+        $this->assertInstanceOf('ZendTest\Di\TestAsset\BasicClass', $obj2);
+        $this->assertNotSame($obj1, $obj2);
     }
 
     public function testGetThrowsExceptionWhenUnknownClassIsUsed()


### PR DESCRIPTION
Fixed Zend\Di\Di::get() to use 'shared' config. setting as advertised, per email to fw-general@ today:

I've been using the ZF2 Di component for quite a while and have just recently come across a need to _not_ share instances of a certain class managed by the container.  Though Di\Config.php properly parses out the 'shared' instance config. parameter and calls setShared() on the instance manager, in Di.php the get() method doesn't actually look for that config. setting and pass it along when it calls newInstance(), even though its comment documentation says it will honor that -- "Attempts to load the class (or service alias) provided. If it has been loaded before, the previous instance will be returned (unless the service definition indicates shared instances should not be used)."

The patch includes the fix and a new unit test to verify it works.
