### PR TITLE
Validator::isValid with $context

### DIFF
--- a/library/Zend/I18n/Validator/Alnum.php
+++ b/library/Zend/I18n/Validator/Alnum.php
@@ -94,7 +94,7 @@ class Alnum extends AbstractValidator
      * @param  string $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value) && !is_int($value) && !is_float($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/I18n/Validator/Alpha.php
+++ b/library/Zend/I18n/Validator/Alpha.php
@@ -56,7 +56,7 @@ class Alpha extends Alnum
      * @param  string $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -93,7 +93,7 @@ class Float extends AbstractValidator
      * @return boolean
      * @throws Exception\InvalidArgumentException
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value) && !is_int($value) && !is_float($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/I18n/Validator/Int.php
+++ b/library/Zend/I18n/Validator/Int.php
@@ -90,7 +90,7 @@ class Int extends AbstractValidator
      * @return boolean
      * @throws Exception\InvalidArgumentException
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value) && !is_int($value) && !is_float($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/I18n/Validator/PostCode.php
+++ b/library/Zend/I18n/Validator/PostCode.php
@@ -327,7 +327,7 @@ class PostCode extends AbstractValidator
      * @return boolean
      * @throws Exception\InvalidArgumentException
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value) && !is_int($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/Barcode.php
+++ b/library/Zend/Validator/Barcode.php
@@ -137,7 +137,7 @@ class Barcode extends AbstractValidator
      * @param  string $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/Between.php
+++ b/library/Zend/Validator/Between.php
@@ -161,7 +161,7 @@ class Between extends AbstractValidator
      * @param  mixed $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         $this->setValue($value);
 

--- a/library/Zend/Validator/CreditCard.php
+++ b/library/Zend/Validator/CreditCard.php
@@ -249,7 +249,7 @@ class CreditCard extends AbstractValidator
      * @param  string $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         $this->setValue($value);
 

--- a/library/Zend/Validator/Date.php
+++ b/library/Zend/Validator/Date.php
@@ -100,7 +100,7 @@ class Date extends AbstractValidator
      * @param  string|array|int|DateTime $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value)
             && !is_array($value)

--- a/library/Zend/Validator/DateStep.php
+++ b/library/Zend/Validator/DateStep.php
@@ -213,9 +213,9 @@ class DateStep extends Date
      * @return bool
      * @throws Exception\InvalidArgumentException
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
-        parent::isValid($value);
+        parent::isValid($value, $context);
 
         $this->setValue($value);
 

--- a/library/Zend/Validator/Db/NoRecordExists.php
+++ b/library/Zend/Validator/Db/NoRecordExists.php
@@ -20,7 +20,7 @@ use Zend\Validator\Exception;
  */
 class NoRecordExists extends AbstractDb
 {
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         /*
          * Check for an adapter being defined. If not, throw an exception.

--- a/library/Zend/Validator/Db/RecordExists.php
+++ b/library/Zend/Validator/Db/RecordExists.php
@@ -20,7 +20,7 @@ use Zend\Validator\Exception;
  */
 class RecordExists extends AbstractDb
 {
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         /*
          * Check for an adapter being defined. If not, throw an exception.

--- a/library/Zend/Validator/Digits.php
+++ b/library/Zend/Validator/Digits.php
@@ -46,7 +46,7 @@ class Digits extends AbstractValidator
      * @param  string $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value) && !is_int($value) && !is_float($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/EmailAddress.php
+++ b/library/Zend/Validator/EmailAddress.php
@@ -496,7 +496,7 @@ class EmailAddress extends AbstractValidator
      * @param  string $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/Explode.php
+++ b/library/Zend/Validator/Explode.php
@@ -120,7 +120,7 @@ class Explode extends AbstractValidator
      * @return boolean
      * @throws Exception\RuntimeException
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value) && !is_array($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/GreaterThan.php
+++ b/library/Zend/Validator/GreaterThan.php
@@ -142,7 +142,7 @@ class GreaterThan extends AbstractValidator
      * @param  mixed $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         $this->setValue($value);
 

--- a/library/Zend/Validator/Hex.php
+++ b/library/Zend/Validator/Hex.php
@@ -35,7 +35,7 @@ class Hex extends AbstractValidator
      * @param  string $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value) && !is_int($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/Hostname.php
+++ b/library/Zend/Validator/Hostname.php
@@ -443,7 +443,7 @@ class Hostname extends AbstractValidator
      * @param  string $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value)) {
             $this->error(self::INVALID);
@@ -453,7 +453,7 @@ class Hostname extends AbstractValidator
         $this->setValue($value);
         // Check input against IP address schema
         if (preg_match('/^[0-9a-f:.]*$/i', $value) &&
-            $this->getIpValidator()->setTranslator($this->getTranslator())->isValid($value)) {
+            $this->getIpValidator()->setTranslator($this->getTranslator())->isValid($value, $context)) {
             if (!($this->getAllow() & self::ALLOW_IP)) {
                 $this->error(self::IP_ADDRESS_NOT_ALLOWED);
                 return false;
@@ -478,7 +478,7 @@ class Hostname extends AbstractValidator
 
         // Prevent partial IP V4 addresses (ending '.')
         if ((count($domainParts) == 4) && preg_match('/^[0-9.a-e:.]*$/i', $value) &&
-            $this->getIpValidator()->setTranslator($this->getTranslator())->isValid($value)) {
+            $this->getIpValidator()->setTranslator($this->getTranslator())->isValid($value, $context)) {
             $this->error(self::INVALID_LOCAL_NAME);
         }
 

--- a/library/Zend/Validator/Iban.php
+++ b/library/Zend/Validator/Iban.php
@@ -219,7 +219,7 @@ class Iban extends AbstractValidator
      * @param  string $value
      * @return bool
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value)) {
             $this->error(self::FALSEFORMAT);

--- a/library/Zend/Validator/InArray.php
+++ b/library/Zend/Validator/InArray.php
@@ -169,7 +169,7 @@ class InArray extends AbstractValidator
      * See {@link http://php.net/manual/function.in-array.php#104501}
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         // we create a copy of the haystack in case we need to modify it
         $haystack = $this->getHaystack();

--- a/library/Zend/Validator/Ip.php
+++ b/library/Zend/Validator/Ip.php
@@ -65,7 +65,7 @@ class Ip extends AbstractValidator
      * @param  mixed $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/Isbn.php
+++ b/library/Zend/Validator/Isbn.php
@@ -94,7 +94,7 @@ class Isbn extends AbstractValidator
      * @param  string $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value) && !is_int($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/LessThan.php
+++ b/library/Zend/Validator/LessThan.php
@@ -145,7 +145,7 @@ class LessThan extends AbstractValidator
      * @param  mixed $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         $this->setValue($value);
 

--- a/library/Zend/Validator/NotEmpty.php
+++ b/library/Zend/Validator/NotEmpty.php
@@ -158,7 +158,7 @@ class NotEmpty extends AbstractValidator
      * @param  string $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if ($value !== null && !is_string($value) && !is_int($value) && !is_float($value) &&
             !is_bool($value) && !is_array($value) && !is_object($value)

--- a/library/Zend/Validator/Regex.php
+++ b/library/Zend/Validator/Regex.php
@@ -115,7 +115,7 @@ class Regex extends AbstractValidator
      * @param  string $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value) && !is_int($value) && !is_float($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/Sitemap/Changefreq.php
+++ b/library/Zend/Validator/Sitemap/Changefreq.php
@@ -58,7 +58,7 @@ class Changefreq extends AbstractValidator
      * @param  string  $value  value to validate
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/Sitemap/Lastmod.php
+++ b/library/Zend/Validator/Sitemap/Lastmod.php
@@ -55,7 +55,7 @@ class Lastmod extends AbstractValidator
      * @param  string  $value  value to validate
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/Sitemap/Loc.php
+++ b/library/Zend/Validator/Sitemap/Loc.php
@@ -50,7 +50,7 @@ class Loc extends AbstractValidator
      * @param  string  $value  value to validate
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/Sitemap/Priority.php
+++ b/library/Zend/Validator/Sitemap/Priority.php
@@ -48,7 +48,7 @@ class Priority extends AbstractValidator
      * @param  string  $value  value to validate
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_numeric($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/Step.php
+++ b/library/Zend/Validator/Step.php
@@ -118,7 +118,7 @@ class Step extends AbstractValidator
      * @param mixed $value
      * @return bool
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_numeric($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/StringLength.php
+++ b/library/Zend/Validator/StringLength.php
@@ -166,7 +166,7 @@ class StringLength extends AbstractValidator
      * @param  string $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/Uri.php
+++ b/library/Zend/Validator/Uri.php
@@ -168,7 +168,7 @@ class Uri extends AbstractValidator
      * @param  string $value
      * @return boolean
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         if (!is_string($value)) {
             $this->error(self::INVALID);

--- a/library/Zend/Validator/ValidatorInterface.php
+++ b/library/Zend/Validator/ValidatorInterface.php
@@ -27,7 +27,7 @@ interface ValidatorInterface
      * @return boolean
      * @throws Exception\RuntimeException If validation of $value is impossible
      */
-    public function isValid($value);
+    public function isValid($value, $context = null);
 
     /**
      * Returns an array of messages that explain why the most recent isValid()

--- a/tests/ZendTest/Captcha/TestAsset/MockCaptcha.php
+++ b/tests/ZendTest/Captcha/TestAsset/MockCaptcha.php
@@ -46,7 +46,7 @@ class MockCaptcha implements AdapterInterface
         return 'doctype';
     }
 
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         return true;
     }

--- a/tests/ZendTest/Form/TestAsset/Annotation/UrlValidator.php
+++ b/tests/ZendTest/Form/TestAsset/Annotation/UrlValidator.php
@@ -14,7 +14,7 @@ use Zend\Validator\ValidatorInterface;
 
 class UrlValidator implements ValidatorInterface
 {
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
     }
 

--- a/tests/ZendTest/Validator/TestAsset/ConcreteValidator.php
+++ b/tests/ZendTest/Validator/TestAsset/ConcreteValidator.php
@@ -20,7 +20,7 @@ class ConcreteValidator extends AbstractValidator
         'fooMessage' => '%value% was passed',
     );
 
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         $this->setValue($value);
         $this->error(self::FOO_MESSAGE);


### PR DESCRIPTION
So, a little recap:

https://github.com/zendframework/zf2/blob/release-2.0.3/library/Zend/InputFilter/BaseInputFilter.php#L195
ok, it passes the $context
https://github.com/zendframework/zf2/blob/release-2.0.3/library/Zend/InputFilter/Input.php#L286
ok, it passes the $context
https://github.com/zendframework/zf2/blob/release-2.0.3/library/Zend/Validator/ValidatorChain.php#L175
ok, it passes the $context

But

https://github.com/zendframework/zf2/blob/release-2.0.3/library/Zend/Validator/ValidatorInterface.php#L30 deny the ability to have the $context, so no validator can see the $context, really important for example for a PasswordConfirm validator.

For those who don't want to wait, you can use `func_get_args()` and it receives the second argument.
