### PR TITLE
Allow Zend\Db\Sql\TableIdentifier in Zend\Db\Sql\Insert, Update & Delete

### DIFF
--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -41,7 +41,7 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
     );
 
     /**
-     * @var string
+     * @var string|TableIdentifier
      */
     protected $table = '';
 
@@ -63,7 +63,7 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
     /**
      * Constructor
      *
-     * @param  null|string $table
+     * @param  null|string|TableIdentifier $table
      */
     public function __construct($table = null)
     {
@@ -76,7 +76,7 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
     /**
      * Create from statement
      *
-     * @param  string $table
+     * @param  string|TableIdentifier $table
      * @return Delete
      */
     public function from($table)
@@ -169,7 +169,19 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $statementContainer->setParameterContainer($parameterContainer);
         }
 
-        $table = $platform->quoteIdentifier($this->table);
+        $table = $this->table;
+        $schema = null;
+
+        // create quoted table name to use in columns processing
+        if ($table instanceof TableIdentifier) {
+            list($table, $schema) = $table->getTableAndSchema();
+        }
+
+        $table = $platform->quoteIdentifier($table);
+
+        if ($schema) {
+            $table = $platform->quoteIdentifier($schema) . $platform->getIdentifierSeparator() . $table;
+        }
 
         $sql = sprintf($this->specifications[self::SPECIFICATION_DELETE], $table);
 

--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -172,7 +172,7 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
         $table = $this->table;
         $schema = null;
 
-        // create quoted table name to use in columns processing
+        // create quoted table name to use in delete processing
         if ($table instanceof TableIdentifier) {
             list($table, $schema) = $table->getTableAndSchema();
         }
@@ -205,11 +205,19 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
     public function getSqlString(PlatformInterface $adapterPlatform = null)
     {
         $adapterPlatform = ($adapterPlatform) ?: new Sql92;
-        $table = $adapterPlatform->quoteIdentifier($this->table);
+        $table = $this->table;
+        $schema = null;
 
-//        if ($this->schema != '') {
-//            $table = $platform->quoteIdentifier($this->schema) . $platform->getIdentifierSeparator() . $table;
-//        }
+        // create quoted table name to use in delete processing
+        if ($table instanceof TableIdentifier) {
+            list($table, $schema) = $table->getTableAndSchema();
+        }
+
+        $table = $adapterPlatform->quoteIdentifier($table);
+
+        if ($schema) {
+            $table = $adapterPlatform->quoteIdentifier($schema) . $adapterPlatform->getIdentifierSeparator() . $table;
+        }
 
         $sql = sprintf($this->specifications[self::SPECIFICATION_DELETE], $table);
 

--- a/library/Zend/Db/Sql/Insert.php
+++ b/library/Zend/Db/Sql/Insert.php
@@ -41,7 +41,7 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
     );
 
     /**
-     * @var string
+     * @var string|TableIdentifier
      */
     protected $table            = null;
     protected $columns          = array();
@@ -54,7 +54,7 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
     /**
      * Constructor
      *
-     * @param  null|string $table
+     * @param  null|string|TableIdentifier $table
      */
     public function __construct($table = null)
     {
@@ -66,7 +66,7 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
     /**
      * Crete INTO clause
      *
-     * @param  string $table
+     * @param  string|TableIdentifier $table
      * @return Insert
      */
     public function into($table)
@@ -152,7 +152,19 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $statementContainer->setParameterContainer($parameterContainer);
         }
 
-        $table = $platform->quoteIdentifier($this->table);
+        $table = $this->table;
+        $schema = null;
+
+        // create quoted table name to use in columns processing
+        if ($table instanceof TableIdentifier) {
+            list($table, $schema) = $table->getTableAndSchema();
+        }
+
+        $table = $platform->quoteIdentifier($table);
+
+        if ($schema) {
+            $table = $platform->quoteIdentifier($schema) . $platform->getIdentifierSeparator() . $table;
+        }
 
         $columns = array();
         $values  = array();

--- a/library/Zend/Db/Sql/Insert.php
+++ b/library/Zend/Db/Sql/Insert.php
@@ -155,7 +155,7 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
         $table = $this->table;
         $schema = null;
 
-        // create quoted table name to use in columns processing
+        // create quoted table name to use in insert processing
         if ($table instanceof TableIdentifier) {
             list($table, $schema) = $table->getTableAndSchema();
         }
@@ -200,7 +200,19 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
     public function getSqlString(PlatformInterface $adapterPlatform = null)
     {
         $adapterPlatform = ($adapterPlatform) ?: new Sql92;
-        $table = $adapterPlatform->quoteIdentifier($this->table);
+        $table = $this->table;
+        $schema = null;
+
+        // create quoted table name to use in insert processing
+        if ($table instanceof TableIdentifier) {
+            list($table, $schema) = $table->getTableAndSchema();
+        }
+
+        $table = $adapterPlatform->quoteIdentifier($table);
+
+        if ($schema) {
+            $table = $adapterPlatform->quoteIdentifier($schema) . $adapterPlatform->getIdentifierSeparator() . $table;
+        }
 
         $columns = array_map(array($adapterPlatform, 'quoteIdentifier'), $this->columns);
         $columns = implode(', ', $columns);

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -41,7 +41,7 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
     );
 
     /**
-     * @var string
+     * @var string|TableIdentifier
      */
     protected $table = '';
 
@@ -63,7 +63,7 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
     /**
      * Constructor
      *
-     * @param  null|string $table
+     * @param  null|string|TableIdentifier $table
      */
     public function __construct($table = null)
     {
@@ -76,7 +76,7 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
     /**
      * Specify table for statement
      *
-     * @param  string $table
+     * @param  string|TableIdentifier $table
      * @return Update
      */
     public function table($table)
@@ -202,7 +202,19 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $statementContainer->setParameterContainer($parameterContainer);
         }
 
-        $table = $platform->quoteIdentifier($this->table);
+        $table = $this->table;
+        $schema = null;
+
+        // create quoted table name to use in columns processing
+        if ($table instanceof TableIdentifier) {
+            list($table, $schema) = $table->getTableAndSchema();
+        }
+
+        $table = $platform->quoteIdentifier($table);
+
+        if ($schema) {
+            $table = $platform->quoteIdentifier($schema) . $platform->getIdentifierSeparator() . $table;
+        }
 
         $set = $this->set;
         if (is_array($set)) {

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -205,7 +205,7 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
         $table = $this->table;
         $schema = null;
 
-        // create quoted table name to use in columns processing
+        // create quoted table name to use in update processing
         if ($table instanceof TableIdentifier) {
             list($table, $schema) = $table->getTableAndSchema();
         }
@@ -252,7 +252,19 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
     public function getSqlString(PlatformInterface $adapterPlatform = null)
     {
         $adapterPlatform = ($adapterPlatform) ?: new Sql92;
-        $table = $adapterPlatform->quoteIdentifier($this->table);
+        $table = $this->table;
+        $schema = null;
+
+        // create quoted table name to use in update processing
+        if ($table instanceof TableIdentifier) {
+            list($table, $schema) = $table->getTableAndSchema();
+        }
+
+        $table = $adapterPlatform->quoteIdentifier($table);
+
+        if ($schema) {
+            $table = $adapterPlatform->quoteIdentifier($schema) . $adapterPlatform->getIdentifierSeparator() . $table;
+        }
 
         $set = $this->set;
         if (is_array($set)) {

--- a/tests/ZendTest/Db/Sql/DeleteTest.php
+++ b/tests/ZendTest/Db/Sql/DeleteTest.php
@@ -10,6 +10,8 @@
 
 namespace Zend\Db\Sql;
 
+use Zend\Db\Sql\TableIdentifier;
+
 class DeleteTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -41,6 +43,10 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
     {
         $this->delete->from('foo', 'bar');
         $this->assertEquals('foo', $this->readAttribute($this->delete, 'table'));
+
+        $tableIdentifier = new TableIdentifier('foo', 'bar');
+        $this->delete->from($tableIdentifier);
+        $this->assertEquals($tableIdentifier, $this->readAttribute($this->delete, 'table'));
     }
 
     /**
@@ -113,6 +119,20 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
             ->where('x = y');
 
         $this->delete->prepareStatement($mockAdapter, $mockStatement);
+
+        // with TableIdentifier
+        $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver));
+
+        $mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $mockStatement->expects($this->at(2))
+            ->method('setSql')
+            ->with($this->equalTo('DELETE FROM "sch"."foo" WHERE x = y'));
+
+        $this->delete->from(new TableIdentifier('foo', 'sch'))
+            ->where('x = y');
+
+        $this->delete->prepareStatement($mockAdapter, $mockStatement);
     }
 
     /**
@@ -124,6 +144,10 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
             ->where('x = y');
         $this->assertEquals('DELETE FROM "foo" WHERE x = y', $this->delete->getSqlString());
 
+        // with TableIdentifier
+        $this->delete->from(new TableIdentifier('foo', 'sch'))
+            ->where('x = y');
+        $this->assertEquals('DELETE FROM "sch"."foo" WHERE x = y', $this->delete->getSqlString());
     }
 
 }

--- a/tests/ZendTest/Db/Sql/DeleteTest.php
+++ b/tests/ZendTest/Db/Sql/DeleteTest.php
@@ -121,6 +121,7 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
         $this->delete->prepareStatement($mockAdapter, $mockStatement);
 
         // with TableIdentifier
+        $this->delete = new Delete;
         $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
         $mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver));
 
@@ -145,6 +146,7 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('DELETE FROM "foo" WHERE x = y', $this->delete->getSqlString());
 
         // with TableIdentifier
+        $this->delete = new Delete;
         $this->delete->from(new TableIdentifier('foo', 'sch'))
             ->where('x = y');
         $this->assertEquals('DELETE FROM "sch"."foo" WHERE x = y', $this->delete->getSqlString());

--- a/tests/ZendTest/Db/Sql/InsertTest.php
+++ b/tests/ZendTest/Db/Sql/InsertTest.php
@@ -86,6 +86,7 @@ class InsertTest extends \PHPUnit_Framework_TestCase
         $this->insert->prepareStatement($mockAdapter, $mockStatement);
 
         // with TableIdentifier
+        $this->insert = new Insert;
         $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
         $mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue('positional'));
         $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
@@ -96,7 +97,7 @@ class InsertTest extends \PHPUnit_Framework_TestCase
         $mockStatement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($pContainer));
         $mockStatement->expects($this->at(1))
             ->method('setSql')
-            ->with($this->equalTo('INSERT INTO "sch."foo" ("bar", "boo") VALUES (?, NOW())'));
+            ->with($this->equalTo('INSERT INTO "sch"."foo" ("bar", "boo") VALUES (?, NOW())'));
 
         $this->insert->into(new TableIdentifier('foo', 'sch'))
             ->values(array('bar' => 'baz', 'boo' => new Expression('NOW()')));
@@ -115,6 +116,7 @@ class InsertTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('INSERT INTO "foo" ("bar", "boo", "bam") VALUES (\'baz\', NOW(), NULL)', $this->insert->getSqlString());
 
         // with TableIdentifier
+        $this->insert = new Insert;
         $this->insert->into(new TableIdentifier('foo', 'sch'))
             ->values(array('bar' => 'baz', 'boo' => new Expression('NOW()'), 'bam' => null));
 

--- a/tests/ZendTest/Db/Sql/InsertTest.php
+++ b/tests/ZendTest/Db/Sql/InsertTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Db\Sql;
 
 use Zend\Db\Sql\Insert;
 use Zend\Db\Sql\Expression;
+use Zend\Db\Sql\TableIdentifier;
 
 class InsertTest extends \PHPUnit_Framework_TestCase
 {
@@ -36,6 +37,10 @@ class InsertTest extends \PHPUnit_Framework_TestCase
     {
         $this->insert->into('table', 'schema');
         $this->assertEquals('table', $this->readAttribute($this->insert, 'table'));
+
+        $tableIdentifier = new TableIdentifier('table', 'schema');
+        $this->insert->into($tableIdentifier);
+        $this->assertEquals($tableIdentifier, $this->readAttribute($this->insert, 'table'));
     }
 
     /**
@@ -79,6 +84,24 @@ class InsertTest extends \PHPUnit_Framework_TestCase
             ->values(array('bar' => 'baz', 'boo' => new Expression('NOW()')));
 
         $this->insert->prepareStatement($mockAdapter, $mockStatement);
+
+        // with TableIdentifier
+        $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue('positional'));
+        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
+        $mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver));
+
+        $mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $pContainer = new \Zend\Db\Adapter\ParameterContainer(array());
+        $mockStatement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($pContainer));
+        $mockStatement->expects($this->at(1))
+            ->method('setSql')
+            ->with($this->equalTo('INSERT INTO "sch."foo" ("bar", "boo") VALUES (?, NOW())'));
+
+        $this->insert->into(new TableIdentifier('foo', 'sch'))
+            ->values(array('bar' => 'baz', 'boo' => new Expression('NOW()')));
+
+        $this->insert->prepareStatement($mockAdapter, $mockStatement);
     }
 
     /**
@@ -90,6 +113,12 @@ class InsertTest extends \PHPUnit_Framework_TestCase
             ->values(array('bar' => 'baz', 'boo' => new Expression('NOW()'), 'bam' => null));
 
         $this->assertEquals('INSERT INTO "foo" ("bar", "boo", "bam") VALUES (\'baz\', NOW(), NULL)', $this->insert->getSqlString());
+
+        // with TableIdentifier
+        $this->insert->into(new TableIdentifier('foo', 'sch'))
+            ->values(array('bar' => 'baz', 'boo' => new Expression('NOW()'), 'bam' => null));
+
+        $this->assertEquals('INSERT INTO "sch"."foo" ("bar", "boo", "bam") VALUES (\'baz\', NOW(), NULL)', $this->insert->getSqlString());
     }
 
     /**

--- a/tests/ZendTest/Db/Sql/UpdateTest.php
+++ b/tests/ZendTest/Db/Sql/UpdateTest.php
@@ -173,6 +173,7 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
         $this->update->prepareStatement($mockAdapter, $mockStatement);
 
         // with TableIdentifier
+        $this->update = new Update;
         $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
         $mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue('positional'));
         $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
@@ -205,6 +206,7 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('UPDATE "foo" SET "bar" = \'baz\', "boo" = NOW(), "bam" = NULL WHERE x = y', $this->update->getSqlString());
 
         // with TableIdentifier
+        $this->update = new Update;
         $this->update->table(new TableIdentifier('foo', 'sch'))
             ->set(array('bar' => 'baz', 'boo' => new Expression('NOW()'), 'bam' => null))
             ->where('x = y');

--- a/tests/ZendTest/Db/Sql/UpdateTest.php
+++ b/tests/ZendTest/Db/Sql/UpdateTest.php
@@ -13,6 +13,7 @@ namespace ZendTest\Db\Sql;
 use Zend\Db\Sql\Update;
 use Zend\Db\Sql\Where;
 use Zend\Db\Sql\Expression;
+use Zend\Db\Sql\TableIdentifier;
 
 class UpdateTest extends \PHPUnit_Framework_TestCase
 {
@@ -45,6 +46,10 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
     {
         $this->update->table('foo', 'bar');
         $this->assertEquals('foo', $this->readAttribute($this->update, 'table'));
+
+        $tableIdentifier = new TableIdentifier('foo', 'bar');
+        $this->update->table($tableIdentifier);
+        $this->assertEquals($tableIdentifier, $this->readAttribute($this->update, 'table'));
     }
 
     /**
@@ -166,6 +171,26 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
             ->where('x = y');
 
         $this->update->prepareStatement($mockAdapter, $mockStatement);
+
+        // with TableIdentifier
+        $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue('positional'));
+        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
+        $mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver));
+
+        $mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $pContainer = new \Zend\Db\Adapter\ParameterContainer(array());
+        $mockStatement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($pContainer));
+
+        $mockStatement->expects($this->at(1))
+            ->method('setSql')
+            ->with($this->equalTo('UPDATE "sch"."foo" SET "bar" = ?, "boo" = NOW() WHERE x = y'));
+
+        $this->update->table(new TableIdentifier('foo', 'sch'))
+            ->set(array('bar' => 'baz', 'boo' => new Expression('NOW()')))
+            ->where('x = y');
+
+        $this->update->prepareStatement($mockAdapter, $mockStatement);
     }
 
     /**
@@ -178,6 +203,13 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
             ->where('x = y');
 
         $this->assertEquals('UPDATE "foo" SET "bar" = \'baz\', "boo" = NOW(), "bam" = NULL WHERE x = y', $this->update->getSqlString());
+
+        // with TableIdentifier
+        $this->update->table(new TableIdentifier('foo', 'sch'))
+            ->set(array('bar' => 'baz', 'boo' => new Expression('NOW()'), 'bam' => null))
+            ->where('x = y');
+
+        $this->assertEquals('UPDATE "sch"."foo" SET "bar" = \'baz\', "boo" = NOW(), "bam" = NULL WHERE x = y', $this->update->getSqlString());
     }
 
     /**


### PR DESCRIPTION
With this patch Zend\Db\Sql\TableIdentifier is allowed in
- `Zend\Db\Sql\Insert::__construct()`
- `Zend\Db\Sql\Insert::into()`
- `Zend\Db\Sql\Update::__construct()`
- `Zend\Db\Sql\Update::table()`
- `Zend\Db\Sql\Delete::__construct()`
- `Zend\Db\Sql\Delete::from()`

Previously it was already accepted by
- `Zend\Db\Sql\Sql::__construct()`
- `Zend\Db\Sql\Select::__construct()`
- `Zend\Db\Sql\Select::from()`

Before, while this code worked:

```
$sql = new Sql($tableIdentifier);
$sql->select();
...
```

These failed:

```
$sql = new Sql($tableIdentifier);
$sql->insert();
...
$sql->update();
...
$sql->delete();
...
```

This patch would be essential to those, who works with multiple schemas simultaneously.
