### PR TITLE
Added loadModule.post event to loadModule().

### DIFF
--- a/library/Zend/ModuleManager/ModuleEvent.php
+++ b/library/Zend/ModuleManager/ModuleEvent.php
@@ -28,6 +28,7 @@ class ModuleEvent extends Event
     CONST EVENT_LOAD_MODULE_RESOLVE = 'loadModule.resolve';
     CONST EVENT_LOAD_MODULE         = 'loadModule';
     CONST EVENT_LOAD_MODULES_POST   = 'loadModules.post';
+    CONST EVENT_LOAD_MODULE_POST    = 'loadModule.post';
 
     /**
      * @var mixed

--- a/library/Zend/ModuleManager/ModuleEvent.php
+++ b/library/Zend/ModuleManager/ModuleEvent.php
@@ -58,7 +58,7 @@ class ModuleEvent extends Event
     /**
      * Set the name of a given module
      *
-     * @param  string $moduleName
+     * @param  string                             $moduleName
      * @throws Exception\InvalidArgumentException
      * @return ModuleEvent
      */
@@ -89,7 +89,7 @@ class ModuleEvent extends Event
     /**
      * Set module object to compose in this event
      *
-     * @param  object $module
+     * @param  object                             $module
      * @throws Exception\InvalidArgumentException
      * @return ModuleEvent
      */

--- a/library/Zend/ModuleManager/ModuleManager.php
+++ b/library/Zend/ModuleManager/ModuleManager.php
@@ -152,6 +152,7 @@ class ModuleManager implements ModuleManagerInterface
         $this->loadedModules[$moduleName] = $module;
 
         $this->loadFinished = true;
+        $this->getEventManager()->trigger(ModuleEvent::EVENT_LOAD_MODULE_POST, $this, $event);
 
         return $module;
     }

--- a/library/Zend/ModuleManager/ModuleManager.php
+++ b/library/Zend/ModuleManager/ModuleManager.php
@@ -59,8 +59,8 @@ class ModuleManager implements ModuleManagerInterface
     /**
      * Constructor
      *
-     * @param  array|Traversable $modules
-     * @param  EventManagerInterface $eventManager
+     * @param array|Traversable     $modules
+     * @param EventManagerInterface $eventManager
      */
     public function __construct($modules, EventManagerInterface $eventManager = null)
     {
@@ -93,7 +93,7 @@ class ModuleManager implements ModuleManagerInterface
      *
      * @triggers loadModules
      * @triggers loadModules.post
-     * @return   ModuleManager
+     * @return ModuleManager
      */
     public function loadModules()
     {
@@ -117,11 +117,11 @@ class ModuleManager implements ModuleManagerInterface
     /**
      * Load a specific module by name.
      *
-     * @param    string $moduleName
-     * @throws   Exception\RuntimeException
+     * @param  string                     $moduleName
+     * @throws Exception\RuntimeException
      * @triggers loadModule.resolve
      * @triggers loadModule
-     * @return   mixed Module's Module class
+     * @return mixed Module's Module class
      */
     public function loadModule($moduleName)
     {
@@ -160,7 +160,7 @@ class ModuleManager implements ModuleManagerInterface
     /**
      * Get an array of the loaded modules.
      *
-     * @param  bool $loadModules If true, load modules if they're not already
+     * @param  bool  $loadModules If true, load modules if they're not already
      * @return array An array of Module objects, keyed by module name
      */
     public function getLoadedModules($loadModules = false)
@@ -168,6 +168,7 @@ class ModuleManager implements ModuleManagerInterface
         if (true === $loadModules) {
             $this->loadModules();
         }
+
         return $this->loadedModules;
     }
 
@@ -182,6 +183,7 @@ class ModuleManager implements ModuleManagerInterface
         if (!isset($this->loadedModules[$moduleName])) {
             return null;
         }
+
         return $this->loadedModules[$moduleName];
     }
 
@@ -198,7 +200,7 @@ class ModuleManager implements ModuleManagerInterface
     /**
      * Set an array or Traversable of module names that this module manager should load.
      *
-     * @param  mixed $modules array or Traversable of module names
+     * @param  mixed                              $modules array or Traversable of module names
      * @throws Exception\InvalidArgumentException
      * @return ModuleManager
      */
@@ -212,6 +214,7 @@ class ModuleManager implements ModuleManagerInterface
                 __CLASS__, __METHOD__
             ));
         }
+
         return $this;
     }
 
@@ -225,18 +228,20 @@ class ModuleManager implements ModuleManagerInterface
         if (!$this->event instanceof ModuleEvent) {
             $this->setEvent(new ModuleEvent);
         }
+
         return $this->event;
     }
 
     /**
      * Set the module event
      *
-     * @param  ModuleEvent $event
+     * @param  ModuleEvent   $event
      * @return ModuleManager
      */
     public function setEvent(ModuleEvent $event)
     {
         $this->event = $event;
+
         return $this;
     }
 
@@ -255,6 +260,7 @@ class ModuleManager implements ModuleManagerInterface
         ));
         $this->events = $events;
         $this->attachDefaultListeners();
+
         return $this;
     }
 
@@ -270,6 +276,7 @@ class ModuleManager implements ModuleManagerInterface
         if (!$this->events instanceof EventManagerInterface) {
             $this->setEventManager(new EventManager());
         }
+
         return $this->events;
     }
 

--- a/tests/ZendTest/ModuleManager/ModuleManagerTest.php
+++ b/tests/ZendTest/ModuleManager/ModuleManagerTest.php
@@ -150,14 +150,15 @@ class ModuleManagerTest extends TestCase
         $moduleManager->getEventManager()->attachAggregate($this->defaultListeners);
         
         $callback = false;
+        $self = $this; // PHP 5.3 doesn't support $this in closure context
         $moduleManager->getEventManager()
-                ->attach(ModuleEvent::EVENT_LOAD_MODULE_POST, function( \Zend\ModuleManager\ModuleEvent $e ) use(&$callback) { 
+                ->attach(ModuleEvent::EVENT_LOAD_MODULE_POST, function( \Zend\ModuleManager\ModuleEvent $e ) use(&$callback, $self) { 
                         $callback = true;
                         
                         /* Post Event must identify BarModule as being loaded; failure could result in inifinite loops. */
                         $modules = $e->getTarget()->getLoadedModules(true);
-                        $this->assertArrayHasKey('BarModule', $modules);
-                        $this->assertInstanceOf('BarModule\Module', $modules['BarModule']);
+                        $self->assertArrayHasKey('BarModule', $modules);
+                        $self->assertInstanceOf('BarModule\Module', $modules['BarModule']);
                     });
                     
         $moduleManager->loadModule('BarModule');

--- a/tests/ZendTest/ModuleManager/ModuleManagerTest.php
+++ b/tests/ZendTest/ModuleManager/ModuleManagerTest.php
@@ -144,7 +144,7 @@ class ModuleManagerTest extends TestCase
         $this->assertSame('oh, yeah baby!', $config['loaded']);
     }
 
-    public function testLoadModulePostEvent() 
+    public function testLoadModulePostEvent()
     {
         $moduleManager  = new ModuleManager(array());
         $moduleManager->getEventManager()->attachAggregate($this->defaultListeners);
@@ -152,7 +152,7 @@ class ModuleManagerTest extends TestCase
         $callback = false;
         $self = $this; // PHP 5.3 doesn't support $this in closure context
         $moduleManager->getEventManager()
-                ->attach(ModuleEvent::EVENT_LOAD_MODULE_POST, function( \Zend\ModuleManager\ModuleEvent $e ) use(&$callback, $self) { 
+                ->attach(ModuleEvent::EVENT_LOAD_MODULE_POST, function( \Zend\ModuleManager\ModuleEvent $e ) use (&$callback, $self) {
                         $callback = true;
 
                         /* Post Event must identify BarModule as being loaded; failure could result in inifinite loops. */

--- a/tests/ZendTest/ModuleManager/ModuleManagerTest.php
+++ b/tests/ZendTest/ModuleManager/ModuleManagerTest.php
@@ -148,7 +148,7 @@ class ModuleManagerTest extends TestCase
     {
         $moduleManager  = new ModuleManager(array());
         $moduleManager->getEventManager()->attachAggregate($this->defaultListeners);
-        
+
         $callback = false;
         $self = $this; // PHP 5.3 doesn't support $this in closure context
         $moduleManager->getEventManager()
@@ -160,9 +160,9 @@ class ModuleManagerTest extends TestCase
                         $self->assertArrayHasKey('BarModule', $modules);
                         $self->assertInstanceOf('BarModule\Module', $modules['BarModule']);
                     });
-                    
+
         $moduleManager->loadModule('BarModule');
-        
+
         $this->assertTrue($callback);
     }
 }

--- a/tests/ZendTest/ModuleManager/ModuleManagerTest.php
+++ b/tests/ZendTest/ModuleManager/ModuleManagerTest.php
@@ -143,7 +143,7 @@ class ModuleManagerTest extends TestCase
         $this->assertTrue(isset($config['loaded']));
         $this->assertSame('oh, yeah baby!', $config['loaded']);
     }
-    
+
     public function testLoadModulePostEvent() 
     {
         $moduleManager  = new ModuleManager(array());
@@ -154,7 +154,7 @@ class ModuleManagerTest extends TestCase
         $moduleManager->getEventManager()
                 ->attach(ModuleEvent::EVENT_LOAD_MODULE_POST, function( \Zend\ModuleManager\ModuleEvent $e ) use(&$callback, $self) { 
                         $callback = true;
-                        
+
                         /* Post Event must identify BarModule as being loaded; failure could result in inifinite loops. */
                         $modules = $e->getTarget()->getLoadedModules(true);
                         $self->assertArrayHasKey('BarModule', $modules);


### PR DESCRIPTION
I added a loadModule.post event that is trigged at the end of loadModule() within Zend\ModuleManager\ModuleManager. 

While I found loadModules.post useful, there was no way to do the same when loading just one module manually. loadModule.post event is triggered right after loadFinished is set to true.

I required a post event due to loading module dependencies: a module would dynamically load, and after it loads, the post even will read its dependencies, and load those modules. loadModule event was called before a module officially "loads", so when a dependent, of a dependent, recursively called a module that was suppose to be loaded, "loadModule" event did not see the module loaded, and went through an infinite loop. "loadModule.post" will now recognize a module was already loaded, and bail-out before attempting to call itself again.
