### PR TITLE
Added the ability for FirePhp to understand 'extras' passed to \Zend\Log

### DIFF
--- a/library/Zend/Log/Formatter/FirePhp.php
+++ b/library/Zend/Log/Formatter/FirePhp.php
@@ -21,11 +21,19 @@ class FirePhp implements FormatterInterface
      * Formats the given event data into a single line to be written by the writer.
      *
      * @param array $event The event data which should be formatted.
-     * @return string
+     * @return array  line message and optionally label if 'extra' data exists.
      */
     public function format($event)
     {
-        return $event['message'];
+        $label = null;
+        if ( !empty($event['extra']) ) {
+            $line  = $event['extra'];
+            $label = $event['message'];
+        } else {
+            $line = $event['message'];
+        }
+
+        return array($line, $label);
     }
 
     /**

--- a/library/Zend/Log/Formatter/FirePhp.php
+++ b/library/Zend/Log/Formatter/FirePhp.php
@@ -20,8 +20,8 @@ class FirePhp implements FormatterInterface
     /**
      * Formats the given event data into a single line to be written by the writer.
      *
-     * @param array $event The event data which should be formatted.
-     * @return array  line message and optionally label if 'extra' data exists.
+     * @param  array $event The event data which should be formatted.
+     * @return array line message and optionally label if 'extra' data exists.
      */
     public function format($event)
     {
@@ -49,7 +49,7 @@ class FirePhp implements FormatterInterface
     /**
      * This method is implemented for FormatterInterface but not used.
      *
-     * @param string $dateTimeFormat
+     * @param  string             $dateTimeFormat
      * @return FormatterInterface
      */
     public function setDateTimeFormat($dateTimeFormat)

--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -55,15 +55,8 @@ class FirePhp extends AbstractWriter
             return;
         }
 
-        $label = null;
+        list($line, $label) = $this->formatter->format($event);
         
-        if ( !empty($event['extra']) ) {
-            $line  = $event['extra'];
-            $label = $this->formatter->format($event);
-        } else {
-            $line = $this->formatter->format($event);
-        }
-
         switch ($event['priority']) {
             case Logger::EMERG:
             case Logger::ALERT:

--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -44,7 +44,7 @@ class FirePhp extends AbstractWriter
     /**
      * Write a message to the log.
      *
-     * @param array $event event data
+     * @param  array $event event data
      * @return void
      */
     protected function doWrite(array $event)
@@ -117,6 +117,7 @@ class FirePhp extends AbstractWriter
     public function setFirePhp(FirePhp\FirePhpInterface $instance)
     {
         $this->firephp = $instance;
+
         return $this;
     }
 }

--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -55,27 +55,34 @@ class FirePhp extends AbstractWriter
             return;
         }
 
-        $line = $this->formatter->format($event);
+        $label = null;
+        
+        if ( !empty($event['extra']) ) {
+            $line  = $event['extra'];
+            $label = $this->formatter->format($event);
+        } else {
+            $line = $this->formatter->format($event);
+        }
 
         switch ($event['priority']) {
             case Logger::EMERG:
             case Logger::ALERT:
             case Logger::CRIT:
             case Logger::ERR:
-                $firephp->error($line);
+                $firephp->error($line, $label);
                 break;
             case Logger::WARN:
-                $firephp->warn($line);
+                $firephp->warn($line, $label);
                 break;
             case Logger::NOTICE:
             case Logger::INFO:
-                $firephp->info($line);
+                $firephp->info($line, $label);
                 break;
             case Logger::DEBUG:
                 $firephp->trace($line);
                 break;
             default:
-                $firephp->log($line);
+                $firephp->log($line, $label);
                 break;
         }
     }

--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -56,7 +56,7 @@ class FirePhp extends AbstractWriter
         }
 
         list($line, $label) = $this->formatter->format($event);
-        
+
         switch ($event['priority']) {
             case Logger::EMERG:
             case Logger::ALERT:

--- a/tests/ZendTest/Log/Formatter/FirePhpTest.php
+++ b/tests/ZendTest/Log/Formatter/FirePhpTest.php
@@ -33,14 +33,39 @@ use Zend\Log\Formatter\FirePhp;
  */
 class FirePhpTest extends \PHPUnit_Framework_TestCase
 {
-    public function testFormat()
+    public function testFormatWithExtraData()
+    {
+        $fields = array( 'message' => 'foo',
+                'extra' => new \stdClass() );
+
+        $f = new FirePhp();
+        list($line, $label) = $f->format($fields);
+
+        $this->assertContains($fields['message'], $label);
+        $this->assertEquals($fields['extra'], $line);
+    }
+    
+    public function testFormatWithoutExtra() 
     {
         $fields = array( 'message' => 'foo' );
 
         $f = new FirePhp();
-        $line = $f->format($fields);
+        list($line, $label) = $f->format($fields);
 
         $this->assertContains($fields['message'], $line);
+        $this->assertNull($label);
+    }
+    
+    public function testFormatWithEmptyExtra() 
+    {
+        $fields = array( 'message' => 'foo',
+                'extra' => array() );
+
+        $f = new FirePhp();
+        list($line, $label) = $f->format($fields);
+
+        $this->assertContains($fields['message'], $line);
+        $this->assertEmpty($label);
     }
 
     public function testSetDateTimeFormatDoesNothing()

--- a/tests/ZendTest/Log/Formatter/FirePhpTest.php
+++ b/tests/ZendTest/Log/Formatter/FirePhpTest.php
@@ -44,8 +44,8 @@ class FirePhpTest extends \PHPUnit_Framework_TestCase
         $this->assertContains($fields['message'], $label);
         $this->assertEquals($fields['extra'], $line);
     }
-    
-    public function testFormatWithoutExtra() 
+
+    public function testFormatWithoutExtra()
     {
         $fields = array( 'message' => 'foo' );
 
@@ -55,8 +55,8 @@ class FirePhpTest extends \PHPUnit_Framework_TestCase
         $this->assertContains($fields['message'], $line);
         $this->assertNull($label);
     }
-    
-    public function testFormatWithEmptyExtra() 
+
+    public function testFormatWithEmptyExtra()
     {
         $fields = array( 'message' => 'foo',
                 'extra' => array() );
@@ -65,7 +65,7 @@ class FirePhpTest extends \PHPUnit_Framework_TestCase
         list($line, $label) = $f->format($fields);
 
         $this->assertContains($fields['message'], $line);
-        $this->assertEmpty($label);
+        $this->assertNull($label);
     }
 
     public function testSetDateTimeFormatDoesNothing()


### PR DESCRIPTION
FirePhp never understood the 'extra' data that gets passed in. When using the error handler options, this became necessary: "Invalid argument supplied for foreach()" is impossible to debug without knowing where it came from; this data was supplied in the 'extra' data.

This update uses the built-in FirePhp function of line, and label, to add the 'extra' data (basic dump) to the $line, and moving $event['message'] into the $label field.

In the event there are no extras, $event['message'] remains in the $line (pure aesthetics reason: so message isn't "message:" [with the colon]).

$label was not added to DEBUG due to its "trace" usage which already uses $extra['message'] as a label.
