### PR TITLE
Add functionality to call SessionContainer's method from Authentication\Storage\Session

### DIFF
--- a/library/Zend/Authentication/Storage/Session.php
+++ b/library/Zend/Authentication/Storage/Session.php
@@ -54,9 +54,9 @@ class Session implements StorageInterface
     /**
      * Sets session storage options and initializes session namespace object
      *
-     * @param  mixed $namespace
-     * @param  mixed $member
-     * @param  SessionManager $manager
+     * @param mixed          $namespace
+     * @param mixed          $member
+     * @param SessionManager $manager
      */
     public function __construct($namespace = null, $member = null, SessionManager $manager = null)
     {
@@ -128,5 +128,17 @@ class Session implements StorageInterface
     public function clear()
     {
         unset($this->session->{$this->member});
+    }
+
+    /**
+     * Call session's method
+     *
+     * @param  string $name      Name of the method we want to call.
+     * @param  array  $arguments List of parameters for the method.
+     * @return mixed  Returned results.
+     */
+    public function __call($name, $arguments)
+    {
+        return call_user_func_array(array($this->session, $name), $arguments);
     }
 }

--- a/library/Zend/Authentication/Storage/Session.php
+++ b/library/Zend/Authentication/Storage/Session.php
@@ -54,9 +54,9 @@ class Session implements StorageInterface
     /**
      * Sets session storage options and initializes session namespace object
      *
-     * @param mixed          $namespace
-     * @param mixed          $member
-     * @param SessionManager $manager
+     * @param  mixed          $namespace
+     * @param  mixed          $member
+     * @param  SessionManager $manager
      */
     public function __construct($namespace = null, $member = null, SessionManager $manager = null)
     {

--- a/tests/ZendTest/Authentication/Storage/SessionTest.php
+++ b/tests/ZendTest/Authentication/Storage/SessionTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Authentication
+ */
+
+namespace ZendTest\Authentication\Storage;
+
+use Zend\Authentication\Storage;
+
+/**
+ * @category   Zend
+ * @package    Zend_Auth
+ * @subpackage UnitTests
+ * @group      Zend_Auth
+ */
+class SessionTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->session = new Storage\Session('Session');
+    }
+
+    public function testCanCallMethod()
+    {
+        $this->assertEquals('Session', $this->session->getName());
+    }
+}


### PR DESCRIPTION
For example, with Authentication\Storage\Session can get the manager from SessionContainer directly.

```
 $storage  = new Authentication\Storage\Session();
 $storage->getManager()->rememberMe(1209600);
```
