### PR TITLE
fixed http request if query contains full url

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -439,7 +439,7 @@ class Request extends HttpRequest
         }
 
         if ($requestUri !== null) {
-            return preg_replace('#^[^:]+://[^/]+#', '', $requestUri);
+            return preg_replace('#^[^/:]+://[^/]+#', '', $requestUri);
         }
 
         // IIS 5.0, PHP as CGI.

--- a/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
@@ -204,6 +204,17 @@ class RequestTest extends TestCase
                 '/html/index.php',
                 '/html'
             ),
+
+            //Test when url quert contains a full http url
+            array(
+                array(
+                    'REQUEST_URI' => '/html/index.php?url=http://test.example.com/path/&foo=bar',
+                    'PHP_SELF' => '/html/index.php',
+                    'SCRIPT_FILENAME' => '/var/web/html/index.php',
+                ),
+                '/html/index.php',
+                '/html'
+            ),
         );
     }
 
@@ -357,6 +368,18 @@ class RequestTest extends TestCase
                 '443',
                 '/news',
             ),
+
+            //Test when url quert contains a full http url
+            array(
+                array(
+                    'SERVER_NAME' => 'test.example.com',
+                    'REQUEST_URI' => '/html/index.php?url=http://test.example.com/path/&foo=bar',
+                ),
+                'test.example.com',
+                '80',
+                '/html/index.php?url=http://test.example.com/path/&foo=bar',
+            ),
+
         );
     }
 


### PR DESCRIPTION
Fixed http request detect issue.

When url query contains any url,  the requestUri part is not correct.

For example, 

```
 $_SERVER['REQUEST_URI'] = '/html/index.php?url=http://test.example.com/path/&foo=bar';
 $request = new \Zend\Http\PhpEnvironment\Request();
 echo $request->getRequestUri();
```

Output is:

```
 /path/&foo=bar
```

Correct should be

```
/html/index.php?url=http://test.example.com/path/&foo=bar
```
