### PR TITLE
Add empty option before empty check

### DIFF
--- a/library/Zend/Form/View/Helper/FormSelect.php
+++ b/library/Zend/Form/View/Helper/FormSelect.php
@@ -83,13 +83,6 @@ class FormSelect extends AbstractHelper
             $options = array('' => $emptyOption) + $options;
         }
 
-        if (empty($options)) {
-            throw new Exception\DomainException(sprintf(
-                '%s requires that the element has "value_options"; none found',
-                __METHOD__
-            ));
-        }
-
         $attributes = $element->getAttributes();
         $value      = $this->validateMultiValue($element->getValue(), $attributes);
 

--- a/library/Zend/Form/View/Helper/FormSelect.php
+++ b/library/Zend/Form/View/Helper/FormSelect.php
@@ -78,15 +78,16 @@ class FormSelect extends AbstractHelper
         }
 
         $options = $element->getValueOptions();
+
+        if (($emptyOption = $element->getEmptyOption()) !== null) {
+            $options = array('' => $emptyOption) + $options;
+        }
+
         if (empty($options)) {
             throw new Exception\DomainException(sprintf(
                 '%s requires that the element has "value_options"; none found',
                 __METHOD__
             ));
-        }
-
-        if (($emptyOption = $element->getEmptyOption()) !== null) {
-            $options = array('' => $emptyOption) + $options;
         }
 
         $attributes = $element->getAttributes();

--- a/tests/ZendTest/Form/View/Helper/FormSelectTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormSelectTest.php
@@ -337,11 +337,9 @@ class FormSelectTest extends CommonTestCase
         $this->helper->render($element);
     }
 
-    public function testRenderElementWithNoValueOptionsRaisesException()
+    public function testRenderElementWithNoValueOptionsDoesNotRaiseException()
     {
         $element = new SelectElement('foo');
-
-        $this->setExpectedException('Zend\Form\Exception\DomainException');
         $this->helper->render($element);
     }
 }

--- a/tests/ZendTest/Form/View/Helper/FormSelectTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormSelectTest.php
@@ -336,10 +336,4 @@ class FormSelectTest extends CommonTestCase
         $this->setExpectedException('Zend\Form\Exception\DomainException');
         $this->helper->render($element);
     }
-
-    public function testRenderElementWithNoValueOptionsDoesNotRaiseException()
-    {
-        $element = new SelectElement('foo');
-        $this->helper->render($element);
-    }
 }


### PR DESCRIPTION
Add empty option to options array before checking if is empty, to allow for an empty select in cases where a user may not have added options into database require to populate field.
