### PR TITLE
Fix #2811

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -439,7 +439,7 @@ class Request extends HttpRequest
         }
 
         if ($requestUri !== null) {
-            return preg_replace('#^[^:]+://[^/]+#', '', $requestUri);
+            return preg_replace('#^(http|https){1}://[^/]+#', '', $requestUri);
         }
 
         // IIS 5.0, PHP as CGI.

--- a/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
@@ -204,6 +204,16 @@ class RequestTest extends TestCase
                 '/html/index.php',
                 '/html'
             ),
+            // https://github.com/zendframework/zf2/issues/2811
+            array(
+                array(
+                    'REQUEST_URI'     => '/index.php?redirect=http://www.example.com/bar/baz',
+                    'PHP_SELF'        => '/index.php',
+                    'SCRIPT_FILENAME' => '/var/web/html/index.php',
+                ),
+                '/index.php',
+                '',
+            ),
         );
     }
 


### PR DESCRIPTION
I believe the regex is trying to remove everything before the path portion of the URL, however when attempting to pass a URL as a parameter, it was being to greedy.

I'm not sure why it is necessary to apply this regex when coming from $_SERVER['REQUEST_URI'], but since we are in an HTTP Request class, I have adjusted the regex to be more specific about matching http or https only at the beginning of the string.

FYI - I chatted with @shevron on IRC and he confirmed that a URL as a parameter doesn't need characters encoded and that the bug was in the Request object.
