### PR TITLE
fixing extract behavior of Zend\Form\Element\Collection and added ability to use own fieldset helper within FormCollection-helper

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -480,6 +480,7 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
             if ($this->hydrator) {
                 $values[$key] = $this->hydrator->extract($value);
             } elseif ($value instanceof $this->targetElement->object) {
+                // @see https://github.com/zendframework/zf2/pull/2848
                 $targetElement = clone $this->targetElement;
                 $targetElement->object = $value;
                 $values[$key] = $targetElement->extract();

--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -480,8 +480,9 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
             if ($this->hydrator) {
                 $values[$key] = $this->hydrator->extract($value);
             } elseif ($value instanceof $this->targetElement->object) {
-                $this->targetElement->object = $value;
-                $values[$key] = $this->targetElement->extract();
+                $targetElement = clone $this->targetElement;
+                $targetElement->object = $value;
+                $values[$key] = $targetElement->extract();
             }
         }
 

--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -467,6 +467,7 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
      */
     public function extract()
     {
+
         if ($this->object instanceof Traversable) {
             $this->object = ArrayUtils::iteratorToArray($this->object);
         }
@@ -476,10 +477,12 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
         }
 
         $values = array();
+
         foreach ($this->object as $key => $value) {
             if ($this->hydrator) {
                 $values[$key] = $this->hydrator->extract($value);
             } elseif ($value instanceof $this->targetElement->object) {
+                // @see https://github.com/zendframework/zf2/pull/2848
                 $targetElement = clone $this->targetElement;
                 $targetElement->object = $value;
                 $values[$key] = $targetElement->extract();

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -46,11 +46,11 @@ class FormCollection extends AbstractHelper
     protected $elementHelper;
 
     /**
-	 * The view helper used to render sub fieldsets.
-	 *
-	 * @var AbstractHelper
-	 */
-	protected $fieldsetHelper;
+     * The view helper used to render sub fieldsets.
+     *
+     * @var AbstractHelper
+     */
+    protected $fieldsetHelper;
 
     /**
      * Render a collection by iterating through all fieldsets and elements
@@ -239,7 +239,8 @@ class FormCollection extends AbstractHelper
      * @param AbstractHelper $fieldsetHelper The fieldset helper to use.
      * @return FormCollection
      */
-    public function setFieldsetHelper(AbstractHelper $fieldsetHelper){
+    public function setFieldsetHelper(AbstractHelper $fieldsetHelper)
+    {
         $this->fieldsetHelper = $fieldsetHelper;
         return $this;
     }

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -46,6 +46,13 @@ class FormCollection extends AbstractHelper
     protected $elementHelper;
 
     /**
+	 * The view helper used to render sub fieldsets.
+	 *
+	 * @var AbstractHelper
+	 */
+	protected $fieldsetHelper;
+
+    /**
      * Render a collection by iterating through all fieldsets and elements
      *
      * @param  ElementInterface $element
@@ -63,12 +70,13 @@ class FormCollection extends AbstractHelper
         $templateMarkup = '';
         $escapeHtmlHelper = $this->getEscapeHtmlHelper();
         $elementHelper = $this->getElementHelper();
+        $fieldsetHelper = $this->getFieldsetHelper();
 
         if ($element instanceof CollectionElement && $element->shouldCreateTemplate()) {
             $elementOrFieldset = $element->getTemplateElement();
 
             if ($elementOrFieldset instanceof FieldsetInterface) {
-                $templateMarkup .= $this->render($elementOrFieldset);
+                $templateMarkup .= $fieldsetHelper($elementOrFieldset);
             } elseif ($elementOrFieldset instanceof ElementInterface) {
                 $templateMarkup .= $elementHelper($elementOrFieldset);
             }
@@ -76,7 +84,7 @@ class FormCollection extends AbstractHelper
 
         foreach ($element->getIterator() as $elementOrFieldset) {
             if ($elementOrFieldset instanceof FieldsetInterface) {
-                $markup .= $this->render($elementOrFieldset);
+                $markup .= $fieldsetHelper($elementOrFieldset);
             } elseif ($elementOrFieldset instanceof ElementInterface) {
                 $markup .= $elementHelper($elementOrFieldset);
             }
@@ -207,6 +215,32 @@ class FormCollection extends AbstractHelper
     public function setElementHelper(AbstractHelper $elementHelper)
     {
         $this->elementHelper = $elementHelper;
+        return $this;
+    }
+
+    /**
+     * Retrieve the fieldset helper.
+     *
+     * @return AbstractHelper
+     */
+    protected function getFieldsetHelper()
+    {
+        if ($this->fieldsetHelper) {
+            return $this->fieldsetHelper;
+        }
+
+        //if no special fieldset helper was set fall back to FormCollection helper
+        return $this;
+    }
+
+    /**
+     * Sets the fieldset helper that should be used by this collection.
+     *
+     * @param AbstractHelper $fieldsetHelper The fieldset helper to use.
+     * @return FormCollection
+     */
+    public function setFieldsetHelper(AbstractHelper $fieldsetHelper){
+        $this->fieldsetHelper = $fieldsetHelper;
         return $this;
     }
 }

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -13,15 +13,16 @@ namespace ZendTest\Form\Element;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element;
 use Zend\Form\Element\Collection as Collection;
-
+use ZendTest\Form\TestAsset\Entity\Product;
 class CollectionTest extends TestCase
 {
     protected $form;
+    protected $productFieldset;
 
     public function setUp()
     {
         $this->form = new \ZendTest\Form\TestAsset\FormCollection();
-
+        $this->productFieldset = new \ZendTest\Form\TestAsset\ProductFieldset();
         parent::setUp();
     }
 
@@ -231,5 +232,42 @@ class CollectionTest extends TestCase
         $this->assertInstanceOf('Zend\Form\Element', $collection->getTargetElement());
     }
 
+    public function testExtractFromObjectDoesntTouchOriginalObject()
+    {
+        $form = new \Zend\Form\Form();
+        $form->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
+        $this->productFieldset->setUseAsBaseFieldset(true);
+        $form->add($this->productFieldset);
 
+        $originalObjectHash = spl_object_hash($this->productFieldset->get("categories")->getTargetElement()->getObject());
+
+        $product = new Product();
+        $product->setName("foo");
+        $product->setPrice(42);
+        $cat1 = new \ZendTest\Form\TestAsset\Entity\Category();
+        $cat1->setName("bar");
+        $cat2 = new \ZendTest\Form\TestAsset\Entity\Category();
+        $cat2->setName("bar2");
+
+        $product->setCategories(array($cat1,$cat2));
+
+        $form->bind($product);
+
+        $form->setData(
+            array("product"=>
+                array(
+                    "name" => "franz",
+                    "price" => 13,
+                    "categories" => array(
+                        array("name" => "sepp"),
+                        array("name" => "herbert")
+                    )
+                )
+            )
+        );
+
+        $objectAfterExtractHash = spl_object_hash($this->productFieldset->get("categories")->getTargetElement()->getObject());
+
+        $this->assertSame($originalObjectHash,$objectAfterExtractHash);
+    }
 }

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -13,14 +13,17 @@ namespace ZendTest\Form\Element;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element;
 use Zend\Form\Element\Collection as Collection;
+use ZendTest\Form\TestAsset\Entity\Product;
 
 class CollectionTest extends TestCase
 {
     protected $form;
+    protected $productFieldset;
 
     public function setUp()
     {
         $this->form = new \ZendTest\Form\TestAsset\FormCollection();
+        $this->productFieldset = new \ZendTest\Form\TestAsset\ProductFieldset();
 
         parent::setUp();
     }
@@ -231,5 +234,42 @@ class CollectionTest extends TestCase
         $this->assertInstanceOf('Zend\Form\Element', $collection->getTargetElement());
     }
 
+    public function testExtractFromObjectDoesntTouchOriginalObject()
+    {
+        $form = new \Zend\Form\Form();
+        $form->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
+        $this->productFieldset->setUseAsBaseFieldset(true);
+        $form->add($this->productFieldset);
 
+        $originalObjectHash = spl_object_hash($this->productFieldset->get("categories")->getTargetElement()->getObject());
+
+        $product = new Product();
+        $product->setName("foo");
+        $product->setPrice(42);
+        $cat1 = new \ZendTest\Form\TestAsset\Entity\Category();
+        $cat1->setName("bar");
+        $cat2 = new \ZendTest\Form\TestAsset\Entity\Category();
+        $cat2->setName("bar2");
+
+        $product->setCategories(array($cat1,$cat2));
+
+        $form->bind($product);
+
+        $form->setData(
+            array("product"=>
+                array(
+                    "name" => "franz",
+                    "price" => 13,
+                    "categories" => array(
+                        array("name" => "sepp"),
+                        array("name" => "herbert")
+                    )
+                )
+            )
+        );
+
+        $objectAfterExtractHash = spl_object_hash($this->productFieldset->get("categories")->getTargetElement()->getObject());
+
+        $this->assertSame($originalObjectHash,$objectAfterExtractHash);
+    }
 }

--- a/tests/ZendTest/Form/TestAsset/CustomFieldsetHelper.php
+++ b/tests/ZendTest/Form/TestAsset/CustomFieldsetHelper.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Form\FieldsetInterface;
+use Zend\Form\View\Helper\AbstractHelper;
+use Zend\Form\View\Helper\FormCollection as FormCollectionHelper;
+
+class CustomFieldsetHelper extends AbstractHelper
+{
+    /**
+     * @var FormCollection
+     */
+    protected $fieldsetHelper;
+
+    public function __invoke(FieldsetInterface $fieldset)
+    {
+        $fieldsetHelper = $this->getFieldsetHelper();
+
+        $name = preg_replace('/[^a-z0-9_-]+/', '', $fieldset->getName());
+        echo get_class($fieldsetHelper);
+        $result = '<div id="customFieldset' . $name . '">' . $fieldsetHelper($fieldset) . '</div>';
+
+        return $result;
+    }
+
+    /**
+     * Retrieve the FormCollection helper
+     *
+     * @return FormCollection
+     */
+    protected function getFieldsetHelper()
+    {
+        if ($this->fieldsetHelper) {
+            return $this->fieldsetHelper;
+        }
+
+        if (method_exists($this->view, 'plugin')) {
+            $this->fieldsetHelper = $this->view->plugin('form_collection');
+        }
+
+        if (!$this->fieldsetHelper instanceof FormCollectionHelper) {
+            $this->fieldsetHelper = new FormCollectionHelper();
+        }
+
+        return $this->fieldsetHelper;
+    }
+}

--- a/tests/ZendTest/Form/TestAsset/CustomFieldsetHelper.php
+++ b/tests/ZendTest/Form/TestAsset/CustomFieldsetHelper.php
@@ -26,7 +26,6 @@ class CustomFieldsetHelper extends AbstractHelper
         $fieldsetHelper = $this->getFieldsetHelper();
 
         $name = preg_replace('/[^a-z0-9_-]+/', '', $fieldset->getName());
-        echo get_class($fieldsetHelper);
         $result = '<div id="customFieldset' . $name . '">' . $fieldsetHelper($fieldset) . '</div>';
 
         return $result;

--- a/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
@@ -17,6 +17,7 @@ use Zend\View\Helper\Doctype;
 use Zend\View\Renderer\PhpRenderer;
 use ZendTest\Form\TestAsset\FormCollection;
 use ZendTest\Form\TestAsset\CustomViewHelper;
+use ZendTest\Form\TestAsset\CustomFieldsetHelper;
 
 /**
  * @category   Zend
@@ -112,6 +113,19 @@ class FormCollectionTest extends TestCase
 
         $this->assertContains('id="customcolors0"', $markup);
         $this->assertContains('id="customcolors1"', $markup);
+    }
+
+    public function testRenderWithCustomFieldsetHelper()
+    {
+        $form = $this->getForm();
+
+        $fieldsetHelper = new CustomFieldsetHelper();
+        $fieldsetHelper->setView($this->renderer);
+
+        $markup = $this->helper->setFieldsetHelper($fieldsetHelper)->render($form);
+
+        $this->assertContains('id="customFieldsetcolors"', $markup);
+        $this->assertContains('id="customFieldsetfieldsets"', $markup);
     }
 
     public function testShouldWrapReturnsDefaultTrue()


### PR DESCRIPTION
## fixing extract behavior of Zend\Form\Element\Collection

If the initial target element object gets overwritten with the current one for extracting the values, the original object gets corrupted and the last one extracted stays in. This means that maybe for later hydrating a completely new object (think of the allowAdd option) the values from the last extracted one get transferred to the new one. In case of active record objects with object states (e.g. isNew) this could lead to unwanted and hard to debug behavior.
Therefore cloning the target element and work on the cloned one for extracting is the more appropriate approach imo. The original targetElements objects stays intact this way.
## added ability to use own fieldset helper within FormCollection-helper

Now one can use an own helper for fieldsets and for elements and still benefit from the FormCollection-helpers useful features. If you would solve this problem with simply extending the FormCollection Helper you would have to copy the whole render() method which is not very nice imo.
