### PR TITLE
fix undeclared static property: Zend\Version\Version::$_latestVersion in VERSION_SERVICE_ZEND

### DIFF
--- a/library/Zend/Version/Version.php
+++ b/library/Zend/Version/Version.php
@@ -80,7 +80,7 @@ final class Version
     public static function getLatest($service = self::VERSION_SERVICE_GITHUB)
     {
         if (null === self::$latestVersion) {
-            self::$latestVersion = 'not available';
+            static::$latestVersion = 'not available';
             if ($service == self::VERSION_SERVICE_GITHUB) {
                 $url  = 'https://api.github.com/repos/zendframework/zf2/git/refs/tags/release-';
 
@@ -92,19 +92,19 @@ final class Version
                 }, $apiResponse);
 
                 // Fetch the latest version number from the array
-                self::$latestVersion = array_reduce($tags, function($a, $b) {
+                static::$latestVersion = array_reduce($tags, function($a, $b) {
                     return version_compare($a, $b, '>') ? $a : $b;
                 });
             } elseif($service == self::VERSION_SERVICE_ZEND) {
                 $handle = fopen('http://framework.zend.com/api/zf-version?v=2', 'r');
                 if (false !== $handle) {
-                    self::$_latestVersion = stream_get_contents($handle);
+                    static::$latestVersion = stream_get_contents($handle);
                     fclose($handle);
                 }
             }
         }
 
-        return self::$latestVersion;
+        return static::$latestVersion;
     }
 
     /**

--- a/tests/ZendTest/Version/VersionTest.php
+++ b/tests/ZendTest/Version/VersionTest.php
@@ -71,7 +71,14 @@ class Zend_VersionTest extends \PHPUnit_Framework_TestCase
 
     public function testFetchLatestZENDVersion()
     {
+        if (!constant('TESTS_ZEND_VERSION_ONLINE_ENABLED')) {
+            $this->markTestSkipped('Version online tests are not enabled');
+        }
+        if (!extension_loaded('openssl')) {
+            $this->markTestSkipped('This test requires openssl extension to be enabled in PHP');
+        }
         $actual = Version::getLatest('ZEND');
+
         $this->assertRegExp('/^[1-2](\.[0-9]+){2}/', $actual);
     }
 }

--- a/tests/ZendTest/Version/VersionTest.php
+++ b/tests/ZendTest/Version/VersionTest.php
@@ -68,7 +68,7 @@ class Zend_VersionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertRegExp('/^[1-2](\.[0-9]+){2}/', $actual);
     }
-    
+
     public function testFetchLatestZENDVersion()
     {
         $actual = Version::getLatest('ZEND');

--- a/tests/ZendTest/Version/VersionTest.php
+++ b/tests/ZendTest/Version/VersionTest.php
@@ -68,4 +68,10 @@ class Zend_VersionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertRegExp('/^[1-2](\.[0-9]+){2}/', $actual);
     }
+    
+    public function testFetchLatestZENDVersion()
+    {
+        $actual = Version::getLatest('ZEND');
+        $this->assertRegExp('/^[1-2](\.[0-9]+){2}/', $actual);
+    }
 }


### PR DESCRIPTION
remove underscore in $_latestVersion, should be $latestVersion, and <i>self::</i> should be <i>static::</i>
