### PR TITLE
Handle postgres sequences

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pgsql/Feature/SequenceHelper.php
+++ b/library/Zend/Db/Adapter/Driver/Pgsql/Feature/SequenceHelper.php
@@ -12,6 +12,7 @@ namespace Zend\Db\Adapter\Driver\Pgsql\Feature;
 
 use Zend\Db\TableGateway\Feature\AbstractFeature;
 use Zend\Db\Metadata\Metadata;
+use Zend\Db\Adapter\Exception\RuntimeException;
 
 class SequenceHelper extends AbstractFeature
 {
@@ -26,11 +27,15 @@ class SequenceHelper extends AbstractFeature
         // Try to get primary key from the Metadata feature
         $metadata = $this->tableGateway->featureSet->getFeatureByClassName('Zend\Db\TableGateway\Feature\MetadataFeature');
         if ($metadata === false || !isset($metadata->sharedData['metadata'])) {
-            throw new Exception\RuntimeException('The MetadataFeature could not be consulted to find the Primary Key');
+            throw new RuntimeException('The MetadataFeature could not be consulted to find the Primary Key');
+        }
+
+        if (is_null($metadata->sharedData['metadata']['primaryKey'])) {
+            throw new RuntimeException('Can not build the sequence name without a PK column');
         }
 
         if (is_array($metadata->sharedData['metadata']['primaryKey'])) {
-            throw new Exception\RuntimeException('Can not build the sequence name with a multi-columns PK');
+            throw new RuntimeException('Can not build the sequence name with a multi-columns PK');
         }
 
         $primaryKey = $metadata->sharedData['metadata']['primaryKey'];

--- a/library/Zend/Db/Adapter/Driver/Pgsql/Feature/SequenceHelper.php
+++ b/library/Zend/Db/Adapter/Driver/Pgsql/Feature/SequenceHelper.php
@@ -7,3 +7,36 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  * @package   Zend_Db
  */
+
+namespace Zend\Db\Adapter\Driver\Pgsql\Feature;
+
+use Zend\Db\TableGateway\Feature\AbstractFeature;
+use Zend\Db\Metadata\Metadata;
+
+class SequenceHelper extends AbstractFeature
+{
+    public function postInitialize()
+    {
+
+        if ($this->tableGateway->adapter->getPlatform()->getName() != 'PostgreSQL') {
+            // Only postgres require a sequence name
+            return;
+        }
+
+        // Try to get primary key from the Metadata feature
+        $metadata = $this->tableGateway->featureSet->getFeatureByClassName('Zend\Db\TableGateway\Feature\MetadataFeature');
+        if ($metadata === false || !isset($metadata->sharedData['metadata'])) {
+            throw new Exception\RuntimeException('The MetadataFeature could not be consulted to find the Primary Key');
+        }
+
+        if (is_array($metadata->sharedData['metadata']['primaryKey'])) {
+            throw new Exception\RuntimeException('Can not build the sequence name with a multi-columns PK');
+        }
+
+        $primaryKey = $metadata->sharedData['metadata']['primaryKey'];
+
+        // build the sequence name {table}_{primary_key}_seq
+        $sequence = $this->tableGateway->getTable() . '_' . $primaryKey . '_seq';
+        $this->tableGateway->setSequence($sequence);
+    }
+}

--- a/library/Zend/Db/TableGateway/AbstractTableGateway.php
+++ b/library/Zend/Db/TableGateway/AbstractTableGateway.php
@@ -74,6 +74,13 @@ abstract class AbstractTableGateway implements TableGatewayInterface
     protected $lastInsertValue = null;
 
     /**
+     * sequence
+     *
+     * @var string
+     */
+    protected $sequence = null;
+
+    /**
      * @return bool
      */
     public function isInitialized()
@@ -292,7 +299,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
 
         $statement = $this->sql->prepareStatementForSqlObject($insert);
         $result = $statement->execute();
-        $this->lastInsertValue = $this->adapter->getDriver()->getConnection()->getLastGeneratedValue();
+        $this->lastInsertValue = $this->adapter->getDriver()->getConnection()->getLastGeneratedValue($this->sequence);
 
         // apply postInsert features
         $this->featureSet->apply('postInsert', array($statement, $result));
@@ -423,6 +430,28 @@ abstract class AbstractTableGateway implements TableGatewayInterface
     public function getLastInsertValue()
     {
         return $this->lastInsertValue;
+    }
+
+    /**
+     * Set the sequence name
+     *
+     * @return string
+     */
+    public function setSequence($sequence)
+    {
+        $this->sequence = $sequence;
+        return $this;
+    }
+
+    /**
+     * Get the sequence name
+     *
+     * @access public
+     * @return string
+     */
+    public function getSequence()
+    {
+        return $this->sequence;
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Driver/Pgsql/Feature/SequenceHelperTest.php
+++ b/tests/ZendTest/Db/Adapter/Driver/Pgsql/Feature/SequenceHelperTest.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace ZendText\Db\Adapter\Driver\Pgsql\Feature;
+
+use PHPUnit_Framework_TestCase;
+use Zend\Db\Adapter\Driver\Pgsql\Feature\SequenceHelper;
+
+class SequenceHelperTest extends PHPUnit_Framework_TestCase
+{
+    protected $mockDriver;
+    protected $mockPlatform;
+    protected $mockAdapter;
+
+    protected function setUp()
+    {
+        $this->mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+
+        $this->mockPlatform = $this->getMock('Zend\Db\Adapter\Platform\PlatformInterface');
+        $this->mockPlatform->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('PostgreSQL'));
+
+        $this->mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($this->mockDriver, $this->mockPlatform));
+    }
+
+    public function testPostInitChecksPlatformName()
+    {
+        $mockPlatform = $this->getMock('Zend\Db\Adapter\Platform\PlatformInterface');
+        $mockPlatform->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('Foo'));
+
+        $mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($this->mockDriver, $mockPlatform));
+
+        $tableGatewayMock = $this->getMockForAbstractClass('Zend\Db\TableGateway\AbstractTableGateway');
+        $tgReflection = new \ReflectionClass('Zend\Db\TableGateway\AbstractTableGateway');
+        foreach ($tgReflection->getProperties() as $tgPropReflection) {
+            $tgPropReflection->setAccessible(true);
+            if ('adapter' == $tgPropReflection->getName()) {
+                $tgPropReflection->setValue($tableGatewayMock, $mockAdapter);
+            }
+        }
+
+        $feature = new SequenceHelper();
+        $feature->setTableGateway($tableGatewayMock);
+        $feature->postInitialize();
+
+        $this->assertEquals(null, $tableGatewayMock->getSequence());
+    }
+
+    public function testPostInitWithoutMetadataFeature()
+    {
+        $featureSetMock = $this->getMock('Zend\Db\TableGateway\Feature\FeatureSet');
+        $featureSetMock->expects($this->any())
+            ->method('getFeatureByClassName')
+            ->with($this->equalTo('Zend\Db\TableGateway\Feature\MetadataFeature'))
+            ->will($this->returnValue('false'));
+
+        $tableGatewayMock = $this->getMockForAbstractClass('Zend\Db\TableGateway\AbstractTableGateway');
+        $tgReflection = new \ReflectionClass('Zend\Db\TableGateway\AbstractTableGateway');
+        foreach ($tgReflection->getProperties() as $tgPropReflection) {
+            $tgPropReflection->setAccessible(true);
+            switch ($tgPropReflection->getName()) {
+                case 'adapter':
+                    $tgPropReflection->setValue($tableGatewayMock, $this->mockAdapter);
+                    break;
+                case 'featureSet':
+                    $tgPropReflection->setValue($tableGatewayMock, $featureSetMock);
+                    break;
+            }
+        }
+
+        $feature = new SequenceHelper();
+        $feature->setTableGateway($tableGatewayMock);
+
+        $exThrow = false;
+        try {
+            $feature->postInitialize();
+        } catch(\Zend\Db\Adapter\Exception\RuntimeException $e) {
+            $exThrow = true;
+        }
+
+        if (!$exThrow) {
+            $this->fail('No exception thrown while metadata feature was not registered');
+        }
+
+        $this->assertEquals(null, $tableGatewayMock->getSequence());
+    }
+
+    public function testPostInitWithoutPk()
+    {
+        $metadataFeatureMock = $this->getMock('Zend\Db\TableGateway\Feature\MetadataFeature');
+
+        $featureSetMock = $this->getMock('Zend\Db\TableGateway\Feature\FeatureSet');
+        $featureSetMock->expects($this->any())
+            ->method('getFeatureByClassName')
+            ->with($this->equalTo('Zend\Db\TableGateway\Feature\MetadataFeature'))
+            ->will($this->returnValue($metadataFeatureMock));
+
+        $tableGatewayMock = $this->getMockForAbstractClass('Zend\Db\TableGateway\AbstractTableGateway');
+        $tgReflection = new \ReflectionClass('Zend\Db\TableGateway\AbstractTableGateway');
+        foreach ($tgReflection->getProperties() as $tgPropReflection) {
+            $tgPropReflection->setAccessible(true);
+            switch ($tgPropReflection->getName()) {
+                case 'adapter':
+                    $tgPropReflection->setValue($tableGatewayMock, $this->mockAdapter);
+                    break;
+                case 'featureSet':
+                    $tgPropReflection->setValue($tableGatewayMock, $featureSetMock);
+                    break;
+            }
+        }
+
+        $feature = new SequenceHelper();
+        $feature->setTableGateway($tableGatewayMock);
+
+        $exThrow = false;
+        try {
+            $feature->postInitialize();
+        } catch(\Zend\Db\Adapter\Exception\RuntimeException $e) {
+            $exThrow = true;
+        }
+
+        if (!$exThrow) {
+            $this->fail('No exception thrown while metadata feature was not registered');
+        }
+
+        $this->assertEquals(null, $tableGatewayMock->getSequence());
+    }
+
+    public function testPostInitWithComplexPk()
+    {
+        $metadataFeatureMock = $this->getMock('Zend\Db\TableGateway\Feature\MetadataFeature');
+        $r = new \ReflectionClass('Zend\Db\TableGateway\Feature\MetadataFeature');
+        foreach($r->getProperties() as $prop) {
+            $prop->setAccessible(true);
+            if ($prop->getName() == 'sharedData') {
+                $prop->setValue($metadataFeatureMock, array('metadata' => array('primaryKey' => array('foo', 'bar'))));
+            }
+        }
+
+        $featureSetMock = $this->getMock('Zend\Db\TableGateway\Feature\FeatureSet');
+        $featureSetMock->expects($this->any())
+            ->method('getFeatureByClassName')
+            ->with($this->equalTo('Zend\Db\TableGateway\Feature\MetadataFeature'))
+            ->will($this->returnValue($metadataFeatureMock));
+
+        $tableGatewayMock = $this->getMockForAbstractClass('Zend\Db\TableGateway\AbstractTableGateway');
+        $tgReflection = new \ReflectionClass('Zend\Db\TableGateway\AbstractTableGateway');
+        foreach ($tgReflection->getProperties() as $tgPropReflection) {
+            $tgPropReflection->setAccessible(true);
+            switch ($tgPropReflection->getName()) {
+                case 'adapter':
+                    $tgPropReflection->setValue($tableGatewayMock, $this->mockAdapter);
+                    break;
+                case 'featureSet':
+                    $tgPropReflection->setValue($tableGatewayMock, $featureSetMock);
+                    break;
+            }
+        }
+
+        $feature = new SequenceHelper();
+        $feature->setTableGateway($tableGatewayMock);
+
+        $exThrow = false;
+        try {
+            $feature->postInitialize();
+        } catch(\Zend\Db\Adapter\Exception\RuntimeException $e) {
+            $exThrow = true;
+        }
+
+        if (!$exThrow) {
+            $this->fail('No exception thrown while metadata feature was not registered');
+        }
+
+        $this->assertEquals(null, $tableGatewayMock->getSequence());
+    }
+
+    public function testPostInitSetsSequence()
+    {
+        $metadataFeatureMock = $this->getMock('Zend\Db\TableGateway\Feature\MetadataFeature');
+        $r = new \ReflectionClass('Zend\Db\TableGateway\Feature\MetadataFeature');
+        foreach($r->getProperties() as $prop) {
+            $prop->setAccessible(true);
+            if ($prop->getName() == 'sharedData') {
+                $prop->setValue($metadataFeatureMock, array('metadata' => array('primaryKey' => 'bar')));
+            }
+        }
+
+        $featureSetMock = $this->getMock('Zend\Db\TableGateway\Feature\FeatureSet');
+        $featureSetMock->expects($this->any())
+            ->method('getFeatureByClassName')
+            ->with($this->equalTo('Zend\Db\TableGateway\Feature\MetadataFeature'))
+            ->will($this->returnValue($metadataFeatureMock));
+
+        $tableGatewayMock = $this->getMockForAbstractClass('Zend\Db\TableGateway\AbstractTableGateway');
+        $tgReflection = new \ReflectionClass('Zend\Db\TableGateway\AbstractTableGateway');
+        foreach ($tgReflection->getProperties() as $tgPropReflection) {
+            $tgPropReflection->setAccessible(true);
+            switch ($tgPropReflection->getName()) {
+                case 'table':
+                    $tgPropReflection->setValue($tableGatewayMock, 'foo');
+                    break;
+                case 'adapter':
+                    $tgPropReflection->setValue($tableGatewayMock, $this->mockAdapter);
+                    break;
+                case 'featureSet':
+                    $tgPropReflection->setValue($tableGatewayMock, $featureSetMock);
+                    break;
+            }
+        }
+
+        $feature = new SequenceHelper();
+        $feature->setTableGateway($tableGatewayMock);
+        $feature->postInitialize();
+
+        $this->assertEquals('foo_bar_seq', $tableGatewayMock->getSequence());
+    }
+}


### PR DESCRIPTION
Hi,

I added the code in the existing, but empty, file Zend/Db/Adapter/Driver/Pgsql/Feature/SequenceHelper.php + unit tests.

You can find usage examples there https://github.com/geelweb/zf2-db-tests, I tested 3 use cases : 
- sets the sequence name to getLastGeneratedValue()
- sets the sequence name to the tableGateway with setSequence()
- use the features MetadataFeature + SequenceHelper to find the sequence name
