### PR TITLE
Enable view sub-directories when using ModuleRouteListener

### DIFF
--- a/tests/ZendTest/Mvc/View/InjectTemplateListenerTest.php
+++ b/tests/ZendTest/Mvc/View/InjectTemplateListenerTest.php
@@ -103,7 +103,7 @@ class InjectTemplateListenerTest extends TestCase
         $this->assertEquals('custom', $model->getTemplate());
     }
 
-    public function testMapsSubNamespaceToSubDirectory()
+    public function testMapsSubNamespaceToSubDirectoryWithControllerFromRouteMatch()
     {
         $this->routeMatch->setParam(ModuleRouteListener::MODULE_NAMESPACE, 'Aj\Controller\SweetAppleAcres\Reports');
         $this->routeMatch->setParam('controller', 'CiderSales');
@@ -114,6 +114,21 @@ class InjectTemplateListenerTest extends TestCase
         $this->listener->injectTemplate($this->event);
 
         $this->assertEquals('sweet-apple-acres/reports/cider-sales/pinkie-pie-revenue', $model->getTemplate());
+    }
+
+    public function testMapsSubNamespaceToSubDirectoryWithControllerFromEventTarget()
+    {
+        $this->routeMatch->setParam(ModuleRouteListener::MODULE_NAMESPACE, 'ZendTest\Mvc\Controller\TestAsset');
+        $this->routeMatch->setParam('action', 'test');
+
+        $myViewModel  = new ViewModel();
+        $myController = new \ZendTest\Mvc\Controller\TestAsset\SampleController();
+
+        $this->event->setTarget($myController);
+        $this->event->setResult($myViewModel);
+        $this->listener->injectTemplate($this->event);
+
+        $this->assertEquals('zend-test/controller/test-asset/sample/test', $myViewModel->getTemplate());
     }
 
     public function testAttachesListenerAtExpectedPriority()

--- a/tests/ZendTest/Mvc/View/InjectTemplateListenerTest.php
+++ b/tests/ZendTest/Mvc/View/InjectTemplateListenerTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Mvc\View;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\EventManager\EventManager;
+use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\View\Http\InjectTemplateListener;
@@ -100,6 +101,19 @@ class InjectTemplateListenerTest extends TestCase
         $this->listener->injectTemplate($this->event);
 
         $this->assertEquals('custom', $model->getTemplate());
+    }
+
+    public function testMapsSubNamespaceToSubDirectory()
+    {
+        $this->routeMatch->setParam(ModuleRouteListener::MODULE_NAMESPACE, 'Aj\Controller\SweetAppleAcres\Reports');
+        $this->routeMatch->setParam('controller', 'CiderSales');
+        $this->routeMatch->setParam('action', 'PinkiePieRevenue');
+
+        $model = new ViewModel();
+        $this->event->setResult($model);
+        $this->listener->injectTemplate($this->event);
+
+        $this->assertEquals('sweet-apple-acres/reports/cider-sales/pinkie-pie-revenue', $model->getTemplate());
     }
 
     public function testAttachesListenerAtExpectedPriority()


### PR DESCRIPTION
This feature enables the InjectTemplateListener to specify view sub-directories when the ModuleRouteListener is being used.

For example: It allows a controller such as Foo\Controller\SubNamespace\BarController to map to "foo/sub-namespace/bar/(action)"
