### PR TITLE
[Code] Add support for @throws, multiple types and typed arrays

### DIFF
--- a/library/Zend/Code/Reflection/DocBlock/Tag/MethodTag.php
+++ b/library/Zend/Code/Reflection/DocBlock/Tag/MethodTag.php
@@ -14,14 +14,14 @@ namespace Zend\Code\Reflection\DocBlock\Tag;
  * @category   Zend
  * @package    Zend_Reflection
  */
-class MethodTag implements TagInterface
+class MethodTag implements TagInterface, PhpDocTypedTagInterface
 {
     /**
      * Return value type
      *
-     * @var string
+     * @var array
      */
-    protected $returnType = null;
+    protected $types = array();
 
     /**
      * Method name
@@ -67,7 +67,7 @@ class MethodTag implements TagInterface
             }
 
             if ($match[2] !== '') {
-                $this->returnType = rtrim($match[2]);
+                $this->types = explode('|', rtrim($match[2]));
             }
 
             $this->methodName = $match[3];
@@ -81,11 +81,21 @@ class MethodTag implements TagInterface
     /**
      * Get return value type
      *
-     * @return string
+     * @return null|string
+     * @deprecated 2.0.4 use getTypes instead
      */
     public function getReturnType()
     {
-        return $this->returnType;
+        if (empty($this->types)) {
+            return null;
+        }
+
+        return $this->types[0];
+    }
+
+    public function getTypes()
+    {
+        return $this->types;
     }
 
     /**

--- a/library/Zend/Code/Reflection/DocBlock/Tag/PhpDocTypedTagInterface.php
+++ b/library/Zend/Code/Reflection/DocBlock/Tag/PhpDocTypedTagInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Code
+ */
+
+namespace Zend\Code\Reflection\DocBlock\Tag;
+
+interface PhpDocTypedTagInterface
+{
+    /**
+     * Return all types supported by the tag definition
+     *
+     * @return string[]
+     */
+    public function getTypes();
+}

--- a/library/Zend/Code/Reflection/DocBlock/Tag/PropertyTag.php
+++ b/library/Zend/Code/Reflection/DocBlock/Tag/PropertyTag.php
@@ -14,12 +14,12 @@ namespace Zend\Code\Reflection\DocBlock\Tag;
  * @category   Zend
  * @package    Zend_Reflection
  */
-class PropertyTag implements TagInterface
+class PropertyTag implements TagInterface, PhpDocTypedTagInterface
 {
     /**
-     * @var string
+     * @var array
      */
-    protected $type = null;
+    protected $types = array();
 
     /**
      * @var string
@@ -48,7 +48,7 @@ class PropertyTag implements TagInterface
     {
         if (preg_match('#^(.+)?(\$[\S]+)[\s]*(.*)$#m', $tagDocblockLine, $match)) {
             if ($match[1] !== '') {
-                $this->type = rtrim($match[1]);
+                $this->types = explode('|', rtrim($match[1]));
             }
 
             if ($match[2] !== '') {
@@ -65,10 +65,20 @@ class PropertyTag implements TagInterface
      * Get property variable type
      *
      * @return null|string
+     * @deprecated 2.0.4 use getTypes instead
      */
     public function getType()
     {
-        return $this->type;
+        if (empty($this->types)) {
+            return null;
+        }
+
+        return $this->types[0];
+    }
+
+    public function getTypes()
+    {
+        return $this->types;
     }
 
     /**

--- a/library/Zend/Code/Reflection/DocBlock/Tag/ReturnTag.php
+++ b/library/Zend/Code/Reflection/DocBlock/Tag/ReturnTag.php
@@ -14,12 +14,12 @@ namespace Zend\Code\Reflection\DocBlock\Tag;
  * @category   Zend
  * @package    Zend_Reflection
  */
-class ReturnTag implements TagInterface
+class ReturnTag implements TagInterface, PhpDocTypedTagInterface
 {
     /**
-     * @var string
+     * @var array
      */
-    protected $type = null;
+    protected $types = array();
 
     /**
      * @var string
@@ -41,12 +41,12 @@ class ReturnTag implements TagInterface
     public function initialize($tagDocBlockLine)
     {
         $matches = array();
-        preg_match('#([\w|\\\]+)(?:\s+(.*))?#', $tagDocBlockLine, $matches);
+        preg_match('#((?:[\w|\\\]+(?:\[\])*\|?)+)(?:\s+(.*))?#s', $tagDocBlockLine, $matches);
 
-        $this->type = $matches[1];
+        $this->types = explode('|', $matches[1]);
 
         if (isset($matches[2])) {
-            $this->description = $matches[2];
+            $this->description = trim(preg_replace('#\s+#', ' ', $matches[2]));
         }
     }
 
@@ -54,10 +54,20 @@ class ReturnTag implements TagInterface
      * Get return variable type
      *
      * @return string
+     * @deprecated 2.0.4 use getTypes instead
      */
     public function getType()
     {
-        return $this->type;
+        if (empty($this->types)) {
+            return '';
+        }
+
+        return $this->types[0];
+    }
+
+    public function getTypes()
+    {
+        return $this->types;
     }
 
     public function getDescription()

--- a/library/Zend/Code/Reflection/DocBlock/Tag/ThrowsTag.php
+++ b/library/Zend/Code/Reflection/DocBlock/Tag/ThrowsTag.php
@@ -14,17 +14,12 @@ namespace Zend\Code\Reflection\DocBlock\Tag;
  * @category   Zend
  * @package    Zend_Reflection
  */
-class ParamTag implements TagInterface, PhpDocTypedTagInterface
+class ThrowsTag implements TagInterface, PhpDocTypedTagInterface
 {
-    /**
-     * @var array
-     */
-    protected $types = array();
-
     /**
      * @var string
      */
-    protected $variableName = null;
+    protected $type = null;
 
     /**
      * @var string
@@ -36,58 +31,39 @@ class ParamTag implements TagInterface, PhpDocTypedTagInterface
      */
     public function getName()
     {
-        return 'param';
+        return 'throws';
     }
 
     /**
-     * Initializer
-     *
-     * @param string $tagDocBlockLine
+     * @param  string $tagDocBlockLine
+     * @return void
      */
     public function initialize($tagDocBlockLine)
     {
         $matches = array();
-        preg_match('#((?:[\w|\\\]+(?:\[\])*\|?)+)(?:\s+(\$\S+))?(?:\s+(.*))?#s', $tagDocBlockLine, $matches);
+        preg_match('#([\w|\\\]+)(?:\s+(.*))?#', $tagDocBlockLine, $matches);
 
-        $this->types = explode('|', $matches[1]);
+        $this->type = $matches[1];
 
         if (isset($matches[2])) {
-            $this->variableName = $matches[2];
-        }
-
-        if (isset($matches[3])) {
-            $this->description = trim(preg_replace('#\s+#', ' ', $matches[3]));
+            $this->description = $matches[2];
         }
     }
 
     /**
-     * Get parameter variable type
+     * Get return variable type
      *
      * @return string
      * @deprecated 2.0.4 use getTypes instead
      */
     public function getType()
     {
-        if (empty($this->types)) {
-            return '';
-        }
-
-        return $this->types[0];
+        return $this->type;
     }
 
     public function getTypes()
     {
-        return $this->types;
-    }
-
-    /**
-     * Get parameter name
-     *
-     * @return string
-     */
-    public function getVariableName()
-    {
-        return $this->variableName;
+        return array($this->type);
     }
 
     public function getDescription()

--- a/library/Zend/Code/Reflection/DocBlock/TagManager.php
+++ b/library/Zend/Code/Reflection/DocBlock/TagManager.php
@@ -37,6 +37,7 @@ class TagManager
         $this->addTagPrototype(new Tag\ReturnTag());
         $this->addTagPrototype(new Tag\MethodTag());
         $this->addTagPrototype(new Tag\PropertyTag());
+        $this->addTagPrototype(new Tag\ThrowsTag());
         $this->addTagPrototype(new Tag\GenericTag());
     }
 

--- a/tests/ZendTest/Code/Reflection/DocBlock/Tag/MethodTagTest.php
+++ b/tests/ZendTest/Code/Reflection/DocBlock/Tag/MethodTagTest.php
@@ -35,11 +35,12 @@ class MethodTagTest extends \PHPUnit_Framework_TestCase
     public function testParseNameAndType()
     {
         $tag = new MethodTag();
-        $tag->initialize('string test()');
+        $tag->initialize('string|null test()');
         $this->assertEquals('method', $tag->getName());
         $this->assertEquals('test()', $tag->getMethodName());
         $this->assertFalse($tag->isStatic());
         $this->assertEquals('string', $tag->getReturnType());
+        $this->assertEquals(array('string', 'null'), $tag->getTypes());
         $this->assertNull($tag->getDescription());
     }
 

--- a/tests/ZendTest/Code/Reflection/DocBlock/Tag/PropertyTagTest.php
+++ b/tests/ZendTest/Code/Reflection/DocBlock/Tag/PropertyTagTest.php
@@ -34,10 +34,11 @@ class PropertyTagTest extends \PHPUnit_Framework_TestCase
     public function testParseTypeAndName()
     {
         $tag = new PropertyTag();
-        $tag->initialize('string $test');
+        $tag->initialize('string|null $test');
         $this->assertEquals('$test', $tag->getPropertyName());
         $this->assertNull($tag->getDescription());
         $this->assertEquals('string', $tag->getType());
+        $this->assertEquals(array('string', 'null'), $tag->getTypes());
     }
 
     public function testParseNameAndDescription()

--- a/tests/ZendTest/Code/Reflection/DocBlockReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/DocBlockReflectionTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Code\Reflection;
 
 use Zend\Code\Reflection\ClassReflection;
+use Zend\Code\Reflection\DocBlockReflection;
 
 /**
  * @category   Zend
@@ -119,5 +120,53 @@ EOS;
                         . '}' . PHP_EOL;
 
         $this->assertEquals($expectedString, (string)$classDocBlock);
+    }
+
+    public function testFunctionDocBlockTags()
+    {
+        $docblock = '
+    /**
+     * Method ShortDescription
+     *
+     * @param int $one Description for one
+     * @param int[] Description for two
+     * @param string|null $three Description for three
+     *                      which spans multiple lines
+     * @return int[]|null Description
+     * @throws Exception
+     */
+';
+
+        $docblockReflection = new DocBlockReflection($docblock);
+
+        $paramTags = $docblockReflection->getTags('param');
+
+        $this->assertEquals(5, count($docblockReflection->getTags()));
+        $this->assertEquals(3, count($paramTags));
+        $this->assertEquals(1, count($docblockReflection->getTags('return')));
+        $this->assertEquals(1, count($docblockReflection->getTags('throws')));
+
+        $returnTag = $docblockReflection->getTag('return');
+        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\ReturnTag', $returnTag);
+        $this->assertEquals('int[]', $returnTag->getType());
+        $this->assertEquals(array('int[]', 'null'), $returnTag->getTypes());
+        $this->assertEquals('Description', $returnTag->getDescription());
+
+        $throwsTag = $docblockReflection->getTag('throws');
+        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\ThrowsTag', $throwsTag);
+        $this->assertEquals('Exception', $throwsTag->getType());
+
+        $paramTag = $paramTags[0];
+        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\ParamTag', $paramTag);
+        $this->assertEquals('int', $paramTag->getType());
+
+        $paramTag = $paramTags[1];
+        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\ParamTag', $paramTag);
+        $this->assertEquals('int[]', $paramTag->getType());
+
+        $paramTag = $paramTags[2];
+        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\ParamTag', $paramTag);
+        $this->assertEquals('string', $paramTag->getType());
+        $this->assertEquals(array('string', 'null'), $paramTag->getTypes());
     }
 }


### PR DESCRIPTION
Declare as deprecated `getType():string` in favor of `getTypes():array`
