### PR TITLE
[Crypt] Optimize Hmac::calc

### DIFF
--- a/library/Zend/Crypt/Hmac.php
+++ b/library/Zend/Crypt/Hmac.php
@@ -22,7 +22,7 @@ class Hmac
     const OUTPUT_BINARY = true;
 
     /**
-     * Last algorithm supported correctly
+     * Last algorithm supported
      *
      * @var string|null
      */
@@ -46,7 +46,7 @@ class Hmac
             throw new Exception\InvalidArgumentException('Provided key is null or empty');
         }
 
-        if ($hash !== static::$lastAlgorithmSupported && !static::isSupported($hash)) {
+        if (!$hash || ($hash !== static::$lastAlgorithmSupported && !static::isSupported($hash))) {
             throw new Exception\InvalidArgumentException(
                 "Hash algorithm is not supported on this PHP installation; provided '{$hash}'"
             );
@@ -95,5 +95,13 @@ class Hmac
         }
 
         return false;
+    }
+
+    /**
+     * Clear the cache of last algorithm supported
+     */
+    public static function clearLastAlgorithmCache()
+    {
+        static::$lastAlgorithmSupported = null;
     }
 }

--- a/library/Zend/Crypt/Hmac.php
+++ b/library/Zend/Crypt/Hmac.php
@@ -26,14 +26,7 @@ class Hmac
      *
      * @var string|null
      */
-    protected static $lastAlgorithmSupported = null;
-
-    /**
-     * List of hash algorithms supported
-     *
-     * @var array
-     */
-    protected static $supportedAlgorithms = array();
+    protected static $lastAlgorithmSupported;
 
     /**
      * Performs a HMAC computation given relevant details such as Key, Hashing
@@ -81,11 +74,7 @@ class Hmac
      */
     public static function getSupportedAlgorithms()
     {
-        if (empty(static::$supportedAlgorithms)) {
-            static::$supportedAlgorithms = hash_algos();
-        }
-
-        return static::$supportedAlgorithms;
+        return hash_algos();
     }
 
     /**

--- a/library/Zend/Crypt/Hmac.php
+++ b/library/Zend/Crypt/Hmac.php
@@ -18,8 +18,15 @@ namespace Zend\Crypt;
  */
 class Hmac
 {
-    const OUTPUT_STRING = 'string';
-    const OUTPUT_BINARY = 'binary';
+    const OUTPUT_STRING = false;
+    const OUTPUT_BINARY = true;
+
+    /**
+     * Last algorithm supported correctly
+     *
+     * @var string|null
+     */
+    protected static $lastAlgorithmSupported = null;
 
     /**
      * List of hash algorithms supported
@@ -33,40 +40,38 @@ class Hmac
      * algorithm, the data to compute MAC of, and an output format of String,
      * or Binary.
      *
-     * @param  string $key
-     * @param  string $hash
-     * @param  string $data
-     * @param  string $output
+     * @param  string  $key
+     * @param  string  $hash
+     * @param  string  $data
+     * @param  boolean $output
      * @throws Exception\InvalidArgumentException
      * @return string
      */
     public static function compute($key, $hash, $data, $output = self::OUTPUT_STRING)
     {
-        if (!isset($key) || empty($key)) {
+        if (empty($key)) {
             throw new Exception\InvalidArgumentException('Provided key is null or empty');
         }
 
-        $hash = strtolower($hash);
-        if (!self::isSupported($hash)) {
+        if ($hash !== static::$lastAlgorithmSupported && !static::isSupported($hash)) {
             throw new Exception\InvalidArgumentException(
                 "Hash algorithm is not supported on this PHP installation; provided '{$hash}'"
             );
         }
 
-        $output = ($output === self::OUTPUT_BINARY);
         return hash_hmac($hash, $data, $key, $output);
     }
 
     /**
      * Get the output size according to the hash algorithm and the output format
      *
-     * @param  string $hash
-     * @param  string $output
+     * @param  string  $hash
+     * @param  boolean $output
      * @return integer
      */
     public static function getOutputSize($hash, $output = self::OUTPUT_STRING)
     {
-        return strlen(self::compute('key', $hash, 'data', $output));
+        return strlen(static::compute('key', $hash, 'data', $output));
     }
 
     /**
@@ -76,20 +81,30 @@ class Hmac
      */
     public static function getSupportedAlgorithms()
     {
-        if (empty(self::$supportedAlgorithms)) {
-            self::$supportedAlgorithms = hash_algos();
+        if (empty(static::$supportedAlgorithms)) {
+            static::$supportedAlgorithms = hash_algos();
         }
-        return self::$supportedAlgorithms;
+
+        return static::$supportedAlgorithms;
     }
 
     /**
      * Is the hash algorithm supported?
      *
-     * @param  string $algo
+     * @param  string $algorithm
      * @return boolean
      */
-    public static function isSupported($algo)
+    public static function isSupported($algorithm)
     {
-        return in_array($algo, self::getSupportedAlgorithms());
+        if ($algorithm === static::$lastAlgorithmSupported) {
+            return true;
+        }
+
+        if (in_array(strtolower($algorithm), hash_algos(), true)) {
+            static::$lastAlgorithmSupported = $algorithm;
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/ZendTest/Crypt/HmacTest.php
+++ b/tests/ZendTest/Crypt/HmacTest.php
@@ -10,7 +10,7 @@
 
 namespace ZendTest\Crypt;
 
-use Zend\Crypt\Hmac as HMAC;
+use Zend\Crypt\Hmac;
 
 /**
  * Outside the Internal Function tests, tests do not distinguish between hash and mhash
@@ -25,198 +25,141 @@ use Zend\Crypt\Hmac as HMAC;
  */
 class HmacTest extends \PHPUnit_Framework_TestCase
 {
+    public function testIsSupportedAndCache()
+    {
+        Hmac::clearLastAlgorithmCache();
+        $this->assertAttributeEquals(null, 'lastAlgorithmSupported', 'Zend\Crypt\Hmac');
+
+        $algorithm = 'sha512';
+
+        // cache value must be exactly equal to the original input
+        $this->assertTrue(Hmac::isSupported($algorithm));
+        $this->assertAttributeEquals($algorithm, 'lastAlgorithmSupported', 'Zend\Crypt\Hmac');
+        $this->assertAttributeNotEquals('sHa512', 'lastAlgorithmSupported', 'Zend\Crypt\Hmac');
+
+        // cache value must be exactly equal to the first input (cache hit)
+        Hmac::isSupported('sha512');
+        $this->assertAttributeEquals($algorithm, 'lastAlgorithmSupported', 'Zend\Crypt\Hmac');
+
+        // cache changes with a new algorithm
+        $this->assertTrue(Hmac::isSupported('MD5'));
+        $this->assertAttributeEquals('MD5', 'lastAlgorithmSupported', 'Zend\Crypt\Hmac');
+
+        // cache don't change due wrong algorithm
+        $this->assertFalse(Hmac::isSupported('wrong'));
+        $this->assertAttributeEquals('MD5', 'lastAlgorithmSupported', 'Zend\Crypt\Hmac');
+
+        Hmac::clearLastAlgorithmCache();
+        $this->assertAttributeEquals(null, 'lastAlgorithmSupported', 'Zend\Crypt\Hmac');
+    }
 
     // MD5 tests taken from RFC 2202
-
-    public function testHmacMD5_1()
+    public function provideMd5Data()
     {
-        $data = 'Hi There';
-        $key  = str_repeat("\x0b", 16);
-        $hmac = HMAC::compute($key, 'MD5', $data);
-        $this->assertEquals('9294727a3638bb1c13f48ef8158bfc9d', $hmac);
+        return array(
+            array('Hi There', str_repeat("\x0b", 16), '9294727a3638bb1c13f48ef8158bfc9d'),
+            array('what do ya want for nothing?', 'Jefe', '750c783e6ab0b503eaa86e310a5db738'),
+            array(str_repeat("\xdd", 50), str_repeat("\xaa", 16), '56be34521d144c88dbb8c733f0e8b3f6'),
+            array(str_repeat("\xcd", 50),
+                  "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19",
+                  '697eaf0aca3a3aea3a75164746ffaa79'),
+            array('Test With Truncation', str_repeat("\x0c", 16), '56461ef2342edc00f9bab995690efd4c'),
+            array('Test Using Larger Than Block-Size Key - Hash Key First', str_repeat("\xaa", 80),
+                  '6b1ab7fe4bd7bf8f0b62e6ce61b9d0cd'),
+            array('Test Using Larger Than Block-Size Key and Larger Than One Block-Size Data',
+                  str_repeat("\xaa", 80), '6f630fad67cda0ee1fb1f562db3aa53e'),
+        );
     }
 
-    public function testHmacMD5_2()
+    /**
+     * @dataProvider provideMd5Data
+     */
+    public function testMd5($data, $key, $output)
     {
-        $data = 'what do ya want for nothing?';
-        $key  = 'Jefe';
-        $hmac = HMAC::compute($key, 'MD5', $data);
-        $this->assertEquals('750c783e6ab0b503eaa86e310a5db738', $hmac);
+        $hash = Hmac::compute($key, 'MD5', $data);
+        $this->assertEquals($output, $hash);
     }
 
-    public function testHmacMD5_3()
-    {
-        $data = str_repeat("\xdd", 50);
-        $key  = str_repeat("\xaa", 16);
-        $hmac = HMAC::compute($key, 'MD5', $data);
-        $this->assertEquals('56be34521d144c88dbb8c733f0e8b3f6', $hmac);
-    }
-
-    public function testHmacMD5_4()
-    {
-        $data = str_repeat("\xcd", 50);
-        $key  = "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19";
-        $hmac = HMAC::compute($key, 'MD5', $data);
-        $this->assertEquals('697eaf0aca3a3aea3a75164746ffaa79', $hmac);
-    }
-
-    public function testHmacMD5_5()
-    {
-        $data = 'Test With Truncation';
-        $key  = str_repeat("\x0c", 16);
-        $hmac = HMAC::compute($key, 'MD5', $data);
-        $this->assertEquals('56461ef2342edc00f9bab995690efd4c', $hmac);
-    }
-
-    public function testHmacMD5_6()
-    {
-        $data = 'Test Using Larger Than Block-Size Key - Hash Key First';
-        $key  = str_repeat("\xaa", 80);
-        $hmac = HMAC::compute($key, 'MD5', $data);
-        $this->assertEquals('6b1ab7fe4bd7bf8f0b62e6ce61b9d0cd', $hmac);
-    }
-
-    public function testHmacMD5_7()
-    {
-        $data = 'Test Using Larger Than Block-Size Key and Larger Than One Block-Size Data';
-        $key  = str_repeat("\xaa", 80);
-        $hmac = HMAC::compute($key, 'MD5', $data);
-        $this->assertEquals('6f630fad67cda0ee1fb1f562db3aa53e', $hmac);
-    }
 
     // SHA1 tests taken from RFC 2202
-
-    public function testHmacSHA1_1()
+    public function provideSha1Data()
     {
-        $data = 'Hi There';
-        $key  = str_repeat("\x0b", 20);
-        $hmac = HMAC::compute($key, 'SHA1', $data);
-        $this->assertEquals('b617318655057264e28bc0b6fb378c8ef146be00', $hmac);
+        return array(
+            array('Hi There', str_repeat("\x0b", 20), 'b617318655057264e28bc0b6fb378c8ef146be00'),
+            array('what do ya want for nothing?', 'Jefe', 'effcdf6ae5eb2fa2d27416d5f184df9c259a7c79'),
+            array(str_repeat("\xdd", 50), str_repeat("\xaa", 20), '125d7342b9ac11cd91a39af48aa17b4f63f175d3'),
+            array(str_repeat("\xcd", 50),
+                  "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19",
+                  '4c9007f4026250c6bc8414f9bf50c86c2d7235da'),
+            array('Test With Truncation', str_repeat("\x0c", 20), '4c1a03424b55e07fe7f27be1d58bb9324a9a5a04'),
+            array('Test Using Larger Than Block-Size Key - Hash Key First', str_repeat("\xaa", 80),
+                  'aa4ae5e15272d00e95705637ce8a3b55ed402112'),
+            array('Test Using Larger Than Block-Size Key and Larger Than One Block-Size Data',
+                  str_repeat("\xaa", 80), 'e8e99d0f45237d786d6bbaa7965c7808bbff1a91'),
+        );
     }
 
-    public function testHmacSHA1_2()
+    /**
+     * @dataProvider provideSha1Data
+     */
+    public function testSha1($data, $key, $output)
     {
-        $data = 'what do ya want for nothing?';
-        $key  = 'Jefe';
-        $hmac = HMAC::compute($key, 'SHA1', $data);
-        $this->assertEquals('effcdf6ae5eb2fa2d27416d5f184df9c259a7c79', $hmac);
-    }
-
-    public function testHmacSHA1_3()
-    {
-        $data = str_repeat("\xdd", 50);
-        $key  = str_repeat("\xaa", 20);
-        $hmac = HMAC::compute($key, 'SHA1', $data);
-        $this->assertEquals('125d7342b9ac11cd91a39af48aa17b4f63f175d3', $hmac);
-    }
-
-    public function testHmacSHA1_4()
-    {
-        $data = str_repeat("\xcd", 50);
-        $key  = "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19";
-        $hmac = HMAC::compute($key, 'SHA1', $data);
-        $this->assertEquals('4c9007f4026250c6bc8414f9bf50c86c2d7235da', $hmac);
-    }
-
-    public function testHmacSHA1_5()
-    {
-        $data = 'Test With Truncation';
-        $key  = str_repeat("\x0c", 20);
-        $hmac = HMAC::compute($key, 'SHA1', $data);
-        $this->assertEquals('4c1a03424b55e07fe7f27be1d58bb9324a9a5a04', $hmac);
-    }
-
-    public function testHmacSHA1_6()
-    {
-        $data = 'Test Using Larger Than Block-Size Key - Hash Key First';
-        $key  = str_repeat("\xaa", 80);
-        $hmac = HMAC::compute($key, 'SHA1', $data);
-        $this->assertEquals('aa4ae5e15272d00e95705637ce8a3b55ed402112', $hmac);
-    }
-
-    public function testHmacSHA1_7()
-    {
-        $data = 'Test Using Larger Than Block-Size Key and Larger Than One Block-Size Data';
-        $key  = str_repeat("\xaa", 80);
-        $hmac = HMAC::compute($key, 'SHA1', $data);
-        $this->assertEquals('e8e99d0f45237d786d6bbaa7965c7808bbff1a91', $hmac);
+        $hash = Hmac::compute($key, 'SHA1', $data);
+        $this->assertEquals($output, $hash);
     }
 
     // RIPEMD160 tests taken from RFC 2286
-
-    public function testHmacRIPEMD160_1()
+    public function provideRipemd160Data()
     {
-        $data = 'Hi There';
-        $key  = str_repeat("\x0b", 20);
-        $hmac = HMAC::compute($key, 'RIPEMD160', $data);
-        $this->assertEquals('24cb4bd67d20fc1a5d2ed7732dcc39377f0a5668', $hmac);
+        return array(
+            array('Hi There', str_repeat("\x0b", 20), '24cb4bd67d20fc1a5d2ed7732dcc39377f0a5668'),
+            array('what do ya want for nothing?', 'Jefe', 'dda6c0213a485a9e24f4742064a7f033b43c4069'),
+            array(str_repeat("\xdd", 50), str_repeat("\xaa", 20), 'b0b105360de759960ab4f35298e116e295d8e7c1'),
+            array(str_repeat("\xcd", 50),
+                  "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19",
+                  'd5ca862f4d21d5e610e18b4cf1beb97a4365ecf4'),
+            array('Test With Truncation', str_repeat("\x0c", 20), '7619693978f91d90539ae786500ff3d8e0518e39'),
+            array('Test Using Larger Than Block-Size Key - Hash Key First', str_repeat("\xaa", 80),
+                  '6466ca07ac5eac29e1bd523e5ada7605b791fd8b'),
+            array('Test Using Larger Than Block-Size Key and Larger Than One Block-Size Data',
+                  str_repeat("\xaa", 80), '69ea60798d71616cce5fd0871e23754cd75d5a0a'),
+        );
     }
 
-    public function testHmacRIPEMD160_2()
+    /**
+     * @dataProvider provideRipemd160Data
+     */
+    public function testRipemd160($data, $key, $output)
     {
-        $data = 'what do ya want for nothing?';
-        $key  = 'Jefe';
-        $hmac = HMAC::compute($key, 'RIPEMD160', $data);
-        $this->assertEquals('dda6c0213a485a9e24f4742064a7f033b43c4069', $hmac);
-    }
-
-    public function testHmacRIPEMD160_3()
-    {
-        $data = str_repeat("\xdd", 50);
-        $key  = str_repeat("\xaa", 20);
-        $hmac = HMAC::compute($key, 'RIPEMD160', $data);
-        $this->assertEquals('b0b105360de759960ab4f35298e116e295d8e7c1', $hmac);
-    }
-
-    public function testHmacRIPEMD160_4()
-    {
-        $data = str_repeat("\xcd", 50);
-        $key  = "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19";
-        $hmac = HMAC::compute($key, 'RIPEMD160', $data);
-        $this->assertEquals('d5ca862f4d21d5e610e18b4cf1beb97a4365ecf4', $hmac);
-    }
-
-    public function testHmacRIPEMD160_5()
-    {
-        $data = 'Test With Truncation';
-        $key  = str_repeat("\x0c", 20);
-        $hmac = HMAC::compute($key, 'RIPEMD160', $data);
-        $this->assertEquals('7619693978f91d90539ae786500ff3d8e0518e39', $hmac);
-    }
-
-    public function testHmacRIPEMD160_6()
-    {
-        $data = 'Test Using Larger Than Block-Size Key - Hash Key First';
-        $key  = str_repeat("\xaa", 80);
-        $hmac = HMAC::compute($key, 'RIPEMD160', $data);
-        $this->assertEquals('6466ca07ac5eac29e1bd523e5ada7605b791fd8b', $hmac);
-    }
-
-    public function testHmacRIPEMD160_7()
-    {
-        $data = 'Test Using Larger Than Block-Size Key and Larger Than One Block-Size Data';
-        $key  = str_repeat("\xaa", 80);
-        $hmac = HMAC::compute($key, 'RIPEMD160', $data);
-        $this->assertEquals('69ea60798d71616cce5fd0871e23754cd75d5a0a', $hmac);
+        $hash = Hmac::compute($key, 'RIPEMD160', $data);
+        $this->assertEquals($output, $hash);
     }
 
     public function testEmptyKey()
     {
+        Hmac::clearLastAlgorithmCache();
         $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
                                     'Provided key is null or empty');
-        $hash = HMAC::compute(null, 'md5', 'test');
+        Hmac::compute(null, 'md5', 'test');
+    }
+
+    public function testNullHashAlgorithm()
+    {
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    'Hash algorithm is not supported on this PHP installation');
+        Hmac::compute('key', null, 'test');
     }
 
     public function testWrongHashAlgorithm()
     {
         $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
                                     'Hash algorithm is not supported on this PHP installation');
-        $hash = HMAC::compute('key', 'wrong', 'test');
+        Hmac::compute('key', 'wrong', 'test');
     }
 
     public function testBinaryOutput()
     {
-        $data = HMAC::compute('key', 'sha256', 'test', HMAC::OUTPUT_BINARY);
+        $data = Hmac::compute('key', 'sha256', 'test', Hmac::OUTPUT_BINARY);
         $this->assertEquals('Aq+1YwSQLGVvy3N83QPeYgW7bUAdooEu/ZstNqCK8Vk=', base64_encode($data));
     }
 }


### PR DESCRIPTION
Cached the last algorithm supported for speed up the calc() preconditions

This version speed up the code ~30%

Change related with the discussion [#2771]
