### PR TITLE
[Crypt][#2771] Optimize Pbkdf2

### DIFF
--- a/library/Zend/Crypt/Key/Derivation/Pbkdf2.php
+++ b/library/Zend/Crypt/Key/Derivation/Pbkdf2.php
@@ -33,16 +33,17 @@ class Pbkdf2
      */
     public static function calc($hash, $password, $salt, $iterations, $length)
     {
-        if (!in_array($hash, Hmac::getSupportedAlgorithms())) {
-            throw new Exception\InvalidArgumentException("The hash algorihtm $hash is not supported by " . __CLASS__);
+        if (!Hmac::isSupported($hash)) {
+            throw new Exception\InvalidArgumentException("The hash algorithm $hash is not supported by " . __CLASS__);
         }
+
         $num    = ceil($length / Hmac::getOutputSize($hash, Hmac::OUTPUT_BINARY));
         $result = '';
         for ($block = 1; $block <= $num; $block++) {
-            $hmac = Hmac::compute($password, $hash, $salt . pack('N', $block), Hmac::OUTPUT_BINARY);
+            $hmac = hash_hmac($hash, $salt . pack('N', $block), $password, Hmac::OUTPUT_BINARY);
             $mix  = $hmac;
             for ($i = 1; $i < $iterations; $i++) {
-                $hmac = Hmac::compute($password, $hash, $hmac, Hmac::OUTPUT_BINARY);
+                $hmac = hash_hmac($hash, $hmac, $password, Hmac::OUTPUT_BINARY);
                 $mix ^= $hmac;
             }
             $result .= $mix;

--- a/tests/ZendTest/Crypt/Key/Derivation/Pbkdf2Test.php
+++ b/tests/ZendTest/Crypt/Key/Derivation/Pbkdf2Test.php
@@ -38,7 +38,7 @@ class Pbkdf2Test extends \PHPUnit_Framework_TestCase
     public function testCalcWithWrongHash()
     {
         $this->setExpectedException('Zend\Crypt\Key\Derivation\Exception\InvalidArgumentException',
-                                    'The hash algorihtm wrong is not supported by Zend\Crypt\Key\Derivation\Pbkdf2');
+                                    'The hash algorithm wrong is not supported by Zend\Crypt\Key\Derivation\Pbkdf2');
         $password = Pbkdf2::calc('wrong', 'test', $this->salt, 5000, 32);
     }
 


### PR DESCRIPTION
Invoke directly hash_hmac core function instead of Hmac::compute

This change speed up the algorithm up to ~50%

Related issue #2771
