### PR TITLE
Http\PhpEnv: By default response the same HTTP version as the request was

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Response.php
+++ b/library/Zend/Http/PhpEnvironment/Response.php
@@ -32,6 +32,22 @@ class Response extends HttpResponse
     protected $contentSent = false;
 
     /**
+     * Construct
+     * Instantiates response.
+     */
+    public function __construct()
+    {
+        // autodetect default HTTP version
+        if (isset($_SERVER['SERVER_PROTOCOL'])) {
+            if ($_SERVER['SERVER_PROTOCOL'] == 'HTTP/1.0') {
+                $this->setVersion(self::VERSION_10);
+            } elseif ($_SERVER['SERVER_PROTOCOL'] == 'HTTP/1.1') {
+                $this->setVersion(self::VERSION_11);
+            }
+        }
+    }
+
+    /**
      * @return bool
      */
     public function headersSent()

--- a/library/Zend/Http/PhpEnvironment/Response.php
+++ b/library/Zend/Http/PhpEnvironment/Response.php
@@ -22,6 +22,14 @@ use Zend\Http\Response as HttpResponse;
 class Response extends HttpResponse
 {
     /**
+     * The current used version
+     * (The value will be detected on getVersion)
+     *
+     * @var null|string
+     */
+    protected $version;
+
+    /**
      * @var bool
      */
     protected $headersSent = false;
@@ -32,19 +40,34 @@ class Response extends HttpResponse
     protected $contentSent = false;
 
     /**
-     * Construct
-     * Instantiates response.
+     * Return the HTTP version for this response
+     *
+     * @return string
+     * @see \Zend\Http\AbstractMessage::getVersion()
      */
-    public function __construct()
+    public function getVersion()
     {
-        // autodetect default HTTP version
+        if (!$this->version) {
+            $this->version = $this->detectVersion();
+        }
+        return $this->version;
+    }
+
+    /**
+     * Detect the current used protocol version.
+     * If detection failed it falls back to version 1.0.
+     *
+     * @return string
+     */
+    protected function detectVersion()
+    {
         if (isset($_SERVER['SERVER_PROTOCOL'])) {
-            if ($_SERVER['SERVER_PROTOCOL'] == 'HTTP/1.0') {
-                $this->setVersion(self::VERSION_10);
-            } elseif ($_SERVER['SERVER_PROTOCOL'] == 'HTTP/1.1') {
-                $this->setVersion(self::VERSION_11);
+            if ($_SERVER['SERVER_PROTOCOL'] == 'HTTP/1.1') {
+                return self::VERSION_11;
             }
         }
+
+        return self::VERSION_10;
     }
 
     /**

--- a/tests/ZendTest/Http/PhpEnvironment/ResponseTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/ResponseTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
+
+namespace ZendTest\Http\PhpEnvironment;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Http\PhpEnvironment\Response;
+
+class ResposneTest extends TestCase
+{
+    /**
+     * Original environemnt
+     *
+     * @var array
+     */
+    protected $originalEnvironment;
+
+    /**
+     * Save the original environment and set up a clean one.
+     */
+    public function setUp()
+    {
+        $this->originalEnvironment = array(
+            'post'   => $_POST,
+            'get'    => $_GET,
+            'cookie' => $_COOKIE,
+            'server' => $_SERVER,
+            'env'    => $_ENV,
+            'files'  => $_FILES,
+        );
+
+        $_POST   = array();
+        $_GET    = array();
+        $_COOKIE = array();
+        $_SERVER = array();
+        $_ENV    = array();
+        $_FILES  = array();
+    }
+
+    /**
+     * Restore the original environment
+     */
+    public function tearDown()
+    {
+        $_POST   = $this->originalEnvironment['post'];
+        $_GET    = $this->originalEnvironment['get'];
+        $_COOKIE = $this->originalEnvironment['cookie'];
+        $_SERVER = $this->originalEnvironment['server'];
+        $_ENV    = $this->originalEnvironment['env'];
+        $_FILES  = $this->originalEnvironment['files'];
+    }
+
+    public function testHttpVersion()
+    {
+        // 'HTTP/1.0
+        $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.0';
+        $response = new Response();
+        $this->assertSame(Response::VERSION_10, $response->getVersion());
+
+        // 'HTTP/1.1
+        $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
+        $response = new Response();
+        $this->assertSame(Response::VERSION_11, $response->getVersion());
+
+        // unknown protocol or version
+        $_SERVER['SERVER_PROTOCOL'] = 'zf/2.0';
+        $response = new Response();
+        $this->assertSame(Response::VERSION_11, $response->getVersion());
+
+        // undefined
+        unset($_SERVER['SERVER_PROTOCOL']);
+        $response = new Response();
+        $this->assertSame(Response::VERSION_11, $response->getVersion());
+    }
+}

--- a/tests/ZendTest/Http/PhpEnvironment/ResponseTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/ResponseTest.php
@@ -13,7 +13,7 @@ namespace ZendTest\Http\PhpEnvironment;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Http\PhpEnvironment\Response;
 
-class ResposneTest extends TestCase
+class ResponseTest extends TestCase
 {
     /**
      * Original environemnt

--- a/tests/ZendTest/Http/PhpEnvironment/ResponseTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/ResponseTest.php
@@ -69,14 +69,14 @@ class ResponseTest extends TestCase
         $response = new Response();
         $this->assertSame(Response::VERSION_11, $response->getVersion());
 
-        // unknown protocol or version
+        // unknown protocol or version -> fallback to HTTP/1.0
         $_SERVER['SERVER_PROTOCOL'] = 'zf/2.0';
         $response = new Response();
-        $this->assertSame(Response::VERSION_11, $response->getVersion());
+        $this->assertSame(Response::VERSION_10, $response->getVersion());
 
-        // undefined
+        // undefined -> fallback to HTTP/1.0
         unset($_SERVER['SERVER_PROTOCOL']);
         $response = new Response();
-        $this->assertSame(Response::VERSION_11, $response->getVersion());
+        $this->assertSame(Response::VERSION_10, $response->getVersion());
     }
 }


### PR DESCRIPTION
This fixes the issue with `ApacheBenchmark` discussed in ML "Performance Oddity"
