### PR TITLE
Fix $underscoreSeparatedKeys handling on strategies

### DIFF
--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -103,10 +103,10 @@ class ClassMethods extends AbstractHydrator
         };
 
         foreach ($data as $property => $value) {
-            if ($this->underscoreSeparatedKeys) {
-                $property = preg_replace_callback('/(_[a-z])/', $transform, $property);
-            }
             $method = 'set' . ucfirst($property);
+            if ($this->underscoreSeparatedKeys) {
+                $method = preg_replace_callback('/(_[a-z])/', $transform, $method);
+            }
             if (method_exists($object, $method)) {
                 $value = $this->hydrateValue($property, $value);
 

--- a/tests/ZendTest/Stdlib/HydratorStrategyTest.php
+++ b/tests/ZendTest/Stdlib/HydratorStrategyTest.php
@@ -103,4 +103,45 @@ class HydratorStrategyTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(3, $entities);
     }
+
+    /**
+     * @dataProvider underscoreHandlingDataProvider
+     */
+    public function testWhenUsingUnderscoreSeparatedKeysHydratorStrategyIsAlwaysConsideredUnderscoreSeparatedToo($underscoreSeparatedKeys, $formFieldKey)
+    {
+        $hydrator = new ClassMethods($underscoreSeparatedKeys);
+
+        $strategy = $this->getMock('Zend\Stdlib\Hydrator\Strategy\StrategyInterface');
+
+        $entity = new TestAsset\ClassMethodsUnderscore();
+        $value = $entity->getFooBar();
+
+        $hydrator->addStrategy($formFieldKey, $strategy);
+
+        $strategy
+            ->expects($this->once())
+            ->method('extract')
+            ->with($this->identicalTo($value))
+            ->will($this->returnValue($value))
+        ;
+
+        $attributes = $hydrator->extract($entity);
+
+        $strategy
+            ->expects($this->once())
+            ->method('hydrate')
+            ->with($this->identicalTo($value))
+            ->will($this->returnValue($value))
+        ;
+
+        $hydrator->hydrate($attributes, $entity);
+    }
+
+    public function underscoreHandlingDataProvider()
+    {
+        return array(
+            array(true, 'foo_bar'),
+            array(false, 'fooBar'),
+        );
+    }
 }


### PR DESCRIPTION
The strategy name is always referred to the form field name, so it has not to be transformed in camel case, unlike setter method, during hydration.
