### PR TITLE
Fix to Adapter Mysqli Connection to support prepared / parameter SQL queries

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
@@ -281,6 +281,20 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * @param string $sql
+     * @return Statement
+     */
+    public function prepare($sql)
+    {
+        if (!$this->isConnected()) {
+            $this->connect();
+        }
+
+        $statement = $this->driver->createStatement($sql);
+        return $statement;
+    }
+
+    /**
      * Get last generated id
      *
      * @param  null $name Ignored


### PR DESCRIPTION
MySQLi adapter missing method prepare() to handle prepared statements. Copied prepare() method from PDO. Tested as working in my own project. Affects 2.0.2 and 2.0.3.
