### PR TITLE
Removed abstract method AbstractPrompt::show() (Issue #2899)

### DIFF
--- a/library/Zend/Console/Prompt/AbstractPrompt.php
+++ b/library/Zend/Console/Prompt/AbstractPrompt.php
@@ -33,13 +33,6 @@ abstract class AbstractPrompt implements PromptInterface
     protected $lastResponse;
 
     /**
-     * Show a prompt
-     *
-     * @return void
-     */
-    abstract public function show();
-
-    /**
      * Return last answer to this prompt.
      *
      * @return mixed


### PR DESCRIPTION
Fix Fatal Error in PHP 5.3.2, see https://github.com/zendframework/zf2/issues/2899.
