### PR TITLE
Fixed proxy adapter keys being incorrectly set due Zend\Http\Client

### DIFF
--- a/library/Zend/Http/Client/Adapter/Proxy.php
+++ b/library/Zend/Http/Client/Adapter/Proxy.php
@@ -59,6 +59,24 @@ class Proxy extends Socket
     protected $negotiated = false;
 
     /**
+     * Set the configuration array for the adapter
+     *
+     * @param array $options
+     */
+    public function setOptions($options = array())
+    {
+        //enforcing that the proxy keys are set in the form proxy_*
+        foreach ($options as $k => $v) {
+            if (preg_match("/^proxy[a-z]+/", $k)) {
+                $options['proxy_' . substr($k, 5, strlen($k))] = $v;
+                unset($options[$k]);
+            }
+        }
+
+        parent::setOptions($options);
+    }
+
+    /**
      * Connect to the remote server
      *
      * Will try to connect to the proxy server. If no proxy was set, will

--- a/tests/ZendTest/Http/Client/ProxyAdapterTest.php
+++ b/tests/ZendTest/Http/Client/ProxyAdapterTest.php
@@ -28,6 +28,11 @@ use Zend\Http\Client;
  */
 class ProxyAdapterTest extends SocketTest
 {
+
+
+    protected $host;
+    protected $port;
+
     /**
      * Configuration array
      *
@@ -43,6 +48,8 @@ class ProxyAdapterTest extends SocketTest
             if (! $host)
                 $this->markTestSkipped('No valid proxy host name or address specified.');
 
+            $this->host = $host;
+
             $port = (int) $port;
             if ($port == 0) {
                 $port = 8080;
@@ -50,6 +57,8 @@ class ProxyAdapterTest extends SocketTest
                 if (($port < 1 || $port > 65535))
                     $this->markTestSkipped("$port is not a valid proxy port number. Should be between 1 and 65535.");
             }
+
+            $this->port = $port;
 
             $user = '';
             $pass = '';
@@ -110,4 +119,18 @@ class ProxyAdapterTest extends SocketTest
         $this->assertEquals(TRUE, $config['sslverifypeer']);
         $this->assertEquals(FALSE, $config['sslallowselfsigned']);
     }
+
+    /**
+     * Test that the proxy keys normalised by the client are correctly converted to what the proxy adapter expects.
+     */
+    public function testProxyKeysCorrectlySetInProxyAdapter()
+    {
+        $adapterConfig = $this->_adapter->getConfig();
+        $adapterHost = $adapterConfig['proxy_host'];
+        $adapterPort = $adapterConfig['proxy_port'];
+
+        $this->assertSame($this->host, $adapterHost);
+        $this->assertSame($this->port, $adapterPort);
+    }
+
 }


### PR DESCRIPTION
repo: git://github.com/bgallagher/zf2.git 
branch: ProxyClientAdapterBugFix

Zend\Http\Client::setOptions normalises the option keys, removing underscores among other things. However Zend\Http\Client\Adapter\Proxy expects keys proxy_host & proxy_port set including the underscores. This patch adds the method Zend\Http\Client\Adapter\Proxy::setOptions which correctly sets the keys.
