### PR TITLE
Change format of Form element DateTime and DateTimeLocal

### DIFF
--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -26,6 +26,8 @@ use Zend\Validator\LessThan as LessThanValidator;
  */
 class DateTime extends Element implements InputProviderInterface
 {
+    const DATETIME_FORMAT = 'Y-m-d\TH:iP';
+
     /**
      * Seed attributes
      *
@@ -36,12 +38,13 @@ class DateTime extends Element implements InputProviderInterface
     );
 
     /**
-     * Date format to use for DateTime values. By default, this is RFC-3339,
-     * which is what HTML5 dictates.
+     *
+     * Opera and mobile browsers support datetime input, and display a datepicker control
+     * But the submitted value does not include seconds.
      *
      * @var string
      */
-    protected $format = PhpDateTime::RFC3339;
+    protected $format = self::DATETIME_FORMAT;
 
     /**
      * @var array
@@ -136,7 +139,7 @@ class DateTime extends Element implements InputProviderInterface
      */
     protected function getDateValidator()
     {
-        return new DateValidator(array('format' => PhpDateTime::ISO8601));
+        return new DateValidator(array('format' => $this->format));
     }
 
     /**
@@ -147,13 +150,13 @@ class DateTime extends Element implements InputProviderInterface
     protected function getStepValidator()
     {
         $stepValue = (isset($this->attributes['step']))
-                     ? $this->attributes['step'] : 1; // Minutes
+            ? $this->attributes['step'] : 1; // Minutes
 
         $baseValue = (isset($this->attributes['min']))
-                     ? $this->attributes['min'] : '1970-01-01T00:00:00Z';
+            ? $this->attributes['min'] : '1970-01-01T00:00Z';
 
         return new DateStepValidator(array(
-            'format'    => PhpDateTime::ISO8601,
+            'format'    => $this->format,
             'baseValue' => $baseValue,
             'step'      => new DateInterval("PT{$stepValue}M"),
         ));

--- a/library/Zend/Form/Element/DateTimeLocal.php
+++ b/library/Zend/Form/Element/DateTimeLocal.php
@@ -21,6 +21,8 @@ use Zend\Validator\ValidatorInterface;
  */
 class DateTimeLocal extends DateTime
 {
+    const DATETIME_LOCAL_FORMAT = 'Y-m-d\TH:i';
+
     /**
      * Seed attributes
      *
@@ -29,6 +31,15 @@ class DateTimeLocal extends DateTime
     protected $attributes = array(
         'type' => 'datetime-local',
     );
+
+    /**
+     *
+     * Opera and mobile browsers support datetime input, and display a datepicker control
+     * But the submitted value does not include seconds.
+     *
+     * @var string
+     */
+    protected $format = self::DATETIME_LOCAL_FORMAT;
 
     /**
      * Retrieves a DateStepValidator configured for a Date Input type
@@ -41,10 +52,10 @@ class DateTimeLocal extends DateTime
                      ? $this->attributes['step'] : 1; // Minutes
 
         $baseValue = (isset($this->attributes['min']))
-                     ? $this->attributes['min'] : '1970-01-01T00:00:00';
+                     ? $this->attributes['min'] : '1970-01-01T00:00';
 
         return new DateStepValidator(array(
-            'format'    => \DateTime::ISO8601,
+            'format'    => $this->format,
             'baseValue' => $baseValue,
             'step'      => new \DateInterval("PT{$stepValue}M"),
         ));

--- a/tests/ZendTest/Form/Element/DateTimeLocalTest.php
+++ b/tests/ZendTest/Form/Element/DateTimeLocalTest.php
@@ -20,8 +20,8 @@ class DateTimeLocalTest extends TestCase
         $element = new DateTimeLocalElement('foo');
         $element->setAttributes(array(
             'inclusive' => true,
-            'min'       => '2000-01-01T00:00:00Z',
-            'max'       => '2001-01-01T00:00:00Z',
+            'min'       => '2000-01-01T00:00Z',
+            'max'       => '2001-01-01T00:00Z',
             'step'      => '1',
         ));
 
@@ -41,11 +41,11 @@ class DateTimeLocalTest extends TestCase
             switch ($class) {
                 case 'Zend\Validator\GreaterThan':
                     $this->assertTrue($validator->getInclusive());
-                    $this->assertEquals('2000-01-01T00:00:00Z', $validator->getMin());
+                    $this->assertEquals('2000-01-01T00:00Z', $validator->getMin());
                     break;
                 case 'Zend\Validator\LessThan':
                     $this->assertTrue($validator->getInclusive());
-                    $this->assertEquals('2001-01-01T00:00:00Z', $validator->getMax());
+                    $this->assertEquals('2001-01-01T00:00Z', $validator->getMax());
                     break;
                 case 'Zend\Validator\DateStep':
                     $dateInterval = new \DateInterval('PT1M');

--- a/tests/ZendTest/Form/Element/DateTimeTest.php
+++ b/tests/ZendTest/Form/Element/DateTimeTest.php
@@ -21,8 +21,8 @@ class DateTimeTest extends TestCase
         $element = new DateTimeElement('foo');
         $element->setAttributes(array(
             'inclusive' => true,
-            'min'       => '2000-01-01T00:00:00Z',
-            'max'       => '2001-01-01T00:00:00Z',
+            'min'       => '2000-01-01T00:00Z',
+            'max'       => '2001-01-01T00:00Z',
             'step'      => '1',
         ));
 
@@ -42,11 +42,11 @@ class DateTimeTest extends TestCase
             switch ($class) {
                 case 'Zend\Validator\GreaterThan':
                     $this->assertTrue($validator->getInclusive());
-                    $this->assertEquals('2000-01-01T00:00:00Z', $validator->getMin());
+                    $this->assertEquals('2000-01-01T00:00Z', $validator->getMin());
                     break;
                 case 'Zend\Validator\LessThan':
                     $this->assertTrue($validator->getInclusive());
-                    $this->assertEquals('2001-01-01T00:00:00Z', $validator->getMax());
+                    $this->assertEquals('2001-01-01T00:00Z', $validator->getMax());
                     break;
                 case 'Zend\Validator\DateStep':
                     $dateInterval = new \DateInterval('PT1M');
@@ -58,18 +58,26 @@ class DateTimeTest extends TestCase
         }
     }
 
-    public function testUsesRfc3339FormatByDefault()
+    public function testUsesBrowserFormatByDefault()
     {
         $element = new DateTimeElement('foo');
-        $this->assertEquals(DateTime::RFC3339, $element->getFormat());
+        $this->assertEquals(DateTimeElement::DATETIME_FORMAT, $element->getFormat());
     }
 
-    public function testSpecifyingADateTimeValueWillReturnRfc3339FormattedStringByDefault()
+//    public function testSpecifyingADateTimeValueWillReturnRfc3339FormattedStringByDefault()
+//    {
+//        $date = new DateTime();
+//        $element = new DateTimeElement('foo');
+//        $element->setValue($date);
+//        $this->assertEquals($date->format($date::RFC3339), $element->getValue());
+//    }
+
+    public function testSpecifyingADateTimeValueWillReturnBrowserFormattedStringByDefault()
     {
         $date = new DateTime();
         $element = new DateTimeElement('foo');
         $element->setValue($date);
-        $this->assertEquals($date->format($date::RFC3339), $element->getValue());
+        $this->assertEquals($date->format(DateTimeElement::DATETIME_FORMAT), $element->getValue());
     }
 
     public function testValueIsFormattedAccordingToFormatInElement()


### PR DESCRIPTION
https://github.com/zendframework/zf2/issues/2897

See http://wufoo.com/html5/types/4-date.html

Currently, all browsers that supports input type datetime AND datetimelocal (opera, safari, ios, ICS android) , drop the second part.

If you want to display seconds, we should use Element Text.
