### PR TITLE
Zend\Mvc\Router\Http\Regex erroneously turns + into <space> during match

### DIFF
--- a/library/Zend/Mvc/Router/Http/Regex.php
+++ b/library/Zend/Mvc/Router/Http/Regex.php
@@ -131,7 +131,7 @@ class Regex implements RouteInterface
             if (is_numeric($key) || is_int($key) || $value === '') {
                 unset($matches[$key]);
             } else {
-                $matches[$key] = urldecode($value);
+                $matches[$key] = rawurldecode($value);
             }
         }
 


### PR DESCRIPTION
A '+' character is valid in a path segment (see: http://tools.ietf.org/html/rfc3986#section-3.3 ) yet the use of urldecode on line 134 of the Regex router erroneously turns it into a space.

I believe rawurldecode should be in use to correctly decode all %XX encoded values while leaving spaces alone.

The '+' character only represents a space when it occurs in the value of a get param.
