### PR TITLE
Select::where should accept PredicateInterface

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -231,7 +231,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     /**
      * Create where clause
      *
-     * @param  Where|\Closure|string|array $predicate
+     * @param  Where|\Closure|string|array|Predicate\PredicateInterface $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
      * @return Select
      */
@@ -239,6 +239,10 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     {
         if ($predicate instanceof Where) {
             $this->where = $predicate;
+        } elseif ($pvalue instanceof Predicate\PredicateInterface) {
+            // if a predicate is sent "as-is" just accept it
+            // instead of requiring that array($predicate) be passed
+            $this->where->addPredicate($predicate, $combination);
         } elseif ($predicate instanceof \Closure) {
             $predicate($this->where);
         } else {


### PR DESCRIPTION
PredicateInterface can just be accepted "as-is" instead of requiring a single-key array...
