### PR TITLE
Fix #2902

### DIFF
--- a/library/Zend/Mvc/Router/Http/Part.php
+++ b/library/Zend/Mvc/Router/Http/Part.php
@@ -139,7 +139,7 @@ class Part extends TreeRouteStack implements RouteInterface
             $uri        = $request->getUri();
             $pathLength = strlen($uri->getPath());
 
-            if ($this->mayTerminate && $nextOffset === $pathLength) {
+            if ($this->mayTerminate && $nextOffset === $pathLength && trim($uri->getQuery()) == "") {
                 return $match;
             }
 

--- a/tests/ZendTest/Mvc/Router/Http/PartTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/PartTest.php
@@ -94,7 +94,38 @@ class PartTest extends TestCase
             )
         );
     }
-
+    public static function getRouteAlternative ()
+    {
+        $routePlugins = new RoutePluginManager();
+        $routePlugins->setInvokableClass('part', 'Zend\Mvc\Router\Http\Part');
+        return new Part(
+                array(
+                        'type' => 'Zend\Mvc\Router\Http\Segment',
+                        'options' => array(
+                                'route' => '/[:controller[/:action]]',
+                                'defaults' => array(
+                                        'controller' => 'fo-fo',
+                                        'action' => 'index'
+                                )
+                        )
+                ), true, $routePlugins,
+                array(
+                        'wildcard' => array(
+                                'type' => 'Zend\Mvc\Router\Http\Wildcard',
+                                'options' => array(
+                                        'key_value_delimiter' => '/',
+                                        'param_delimiter' => '/'
+                                )
+                        ),
+                        'query' => array(
+                                'type' => 'Zend\Mvc\Router\Http\Query',
+                                'options' => array(
+                                        'key_value_delimiter' => '=',
+                                        'param_delimiter' => '&'
+                                )
+                        )
+                ));
+    }
     public static function routeProvider()
     {
         return array(
@@ -122,14 +153,14 @@ class PartTest extends TestCase
             'offset-does-not-enable-partial-matching' => array(
                 self::getRoute(),
                 '/foo/foo',
-                0,
+                null,
                 null,
                 null
             ),
             'offset-does-not-enable-partial-matching-in-child' => array(
                 self::getRoute(),
                 '/foo/bar/baz',
-                0,
+                null,
                 null,
                 null
             ),
@@ -175,6 +206,37 @@ class PartTest extends TestCase
                 'bat/optional',
                 array('foo' => 'bar')
             ),
+            'simple-match' => array(
+                    self::getRouteAlternative(),
+                    '/',
+                    null,
+                    null,
+                    array(
+                            'controller' => 'fo-fo',
+                            'action' => 'index'
+                    )
+            ),
+            'match-wildcard' => array(
+                    self::getRouteAlternative(),
+                    '/fo-fo/index/param1/value1',
+                    null,
+                    'wildcard',
+                    array(
+                            'controller' => 'fo-fo',
+                            'action' => 'index',
+                            'param1' => 'value1'
+                    )
+            ),
+            'match-query' => array(
+                    self::getRouteAlternative(),
+                    '/fo-fo/index?param1=value1',
+                    0,
+                    'query',
+                    array(
+                            'controller' => 'fo-fo',
+                            'action' => 'index'
+                    )
+            )
         );
     }
 


### PR DESCRIPTION
When a route is defined with a query part, the router will only match the first part of the url and the route matched name would not contains the "query" part. This is not the case with a 'wildcard' subroute.
So this contribution fixed that.
