### PR TITLE
small speed-up of Zend\EventManager\EventManager::triggerListeners()

### DIFF
--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -447,19 +447,15 @@ class EventManager implements EventManagerInterface
         $wildcardListeners       = $this->getListeners('*');
         if (count($sharedListeners) || count($sharedWildcardListeners) || count($wildcardListeners)) {
             $listeners = clone $listeners;
-        }
 
-        // Shared listeners on this specific event
-        $this->insertListeners($listeners, $sharedListeners);
+            // Shared listeners on this specific event
+            $this->insertListeners($listeners, $sharedListeners);
 
-        // Shared wildcard listeners
-        $this->insertListeners($listeners, $sharedWildcardListeners);
+            // Shared wildcard listeners
+            $this->insertListeners($listeners, $sharedWildcardListeners);
 
-        // Add wildcard listeners
-        $this->insertListeners($listeners, $wildcardListeners);
-
-        if ($listeners->isEmpty()) {
-            return $responses;
+            // Add wildcard listeners
+            $this->insertListeners($listeners, $wildcardListeners);
         }
 
         foreach ($listeners as $listener) {
@@ -535,10 +531,6 @@ class EventManager implements EventManagerInterface
      */
     protected function insertListeners($masterListeners, $listeners)
     {
-        if (!count($listeners)) {
-            return;
-        }
-
         foreach ($listeners as $listener) {
             $priority = $listener->getMetadatum('priority');
             if (null === $priority) {


### PR DESCRIPTION
This small changes speeds up the calls of `triggerListeners` 20% (~0.20s before and ~0.16s after)
- call `insertListeners` only if the listeners to insert are not empty (already checked above)
- don't check emptiness to not ran into a loop - the loop itself checks emptiness

my bench: https://gist.github.com/4045274
