### PR TITLE
travis: fix tests with PHP 5.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 
 before_install:
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
- - composer install --dev
+ - composer install --dev --prefer-source
  - wget http://cs.sensiolabs.org/get/php-cs-fixer.phar
 
 script:


### PR DESCRIPTION
adding `--prefer-source` to `composer install --dev` fixes the issue with travis-ci and PHP 5.3.3
