### PR TITLE
SetCookie::getFieldValue() always uses urlencode() for cookie values, even in case they are already encoded

### DIFF
--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -230,7 +230,7 @@ class SetCookie implements MultipleHeaderInterface
         if (strpos($value, '"')!==false) {
             $value = '"'.urlencode(str_replace('"', '', $value)).'"';
         } else {
-            $value = urlencode($value);
+            $value = urlencode(urldecode($value));
         }
         $fieldValue = $this->getName() . '=' . $value;
 

--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -109,7 +109,7 @@ class SetCookie implements MultipleHeaderInterface
                     // First K=V pair is always the cookie name and value
                     if ($header->getName() === NULL) {
                         $header->setName($headerKey);
-                        $header->setValue($headerValue);
+                        $header->setValue(urldecode($headerValue));
                         continue;
                     }
 
@@ -230,7 +230,7 @@ class SetCookie implements MultipleHeaderInterface
         if (strpos($value, '"')!==false) {
             $value = '"'.urlencode(str_replace('"', '', $value)).'"';
         } else {
-            $value = urlencode(urldecode($value));
+            $value = urlencode($value);
         }
         $fieldValue = $this->getName() . '=' . $value;
 

--- a/tests/ZendTest/Http/Header/SetCookieTest.php
+++ b/tests/ZendTest/Http/Header/SetCookieTest.php
@@ -319,7 +319,7 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
                     'secure'  => true,
                     'httponly'=> false
                 ),
-                'PHPSESSID=123456789%2Babcd%252Cef; Expires=Tue, 21-Nov-2006 08:33:44 GMT; Domain=.localdomain; Path=/foo/baz; Secure'
+                'PHPSESSID=123456789+abcd%2Cef; Expires=Tue, 21-Nov-2006 08:33:44 GMT; Domain=.localdomain; Path=/foo/baz; Secure'
             ),
             array(
                 'Set-Cookie: myname=myvalue; Domain=docs.foo.com; Path=/accounts; Expires=Wed, 13-Jan-2021 22:23:01 GMT; Secure; HttpOnly',


### PR DESCRIPTION
https://github.com/zendframework/zf2/issues/2444
