### PR TITLE
Sessions: SessionConfig does not allow setting non-directory save path

### DIFF
--- a/library/Zend/Session/Config/SessionConfig.php
+++ b/library/Zend/Session/Config/SessionConfig.php
@@ -148,6 +148,24 @@ class SessionConfig extends StandardConfig
     }
 
     /**
+     * Set session.save_path
+     *
+     * @param  string $savePath
+     * @return StandardConfig
+     * @throws Exception\InvalidArgumentException on invalid path
+     */
+    public function setSavePath($savePath)
+    {
+        if ($this->getOption('save_handler') == 'files') {
+            parent::setSavePath($savePath);
+        }
+        $this->savePath = $savePath;
+        $this->setOption('save_path', $savePath);
+        return $this;
+    }
+
+
+    /**
      * Set session.serialize_handler
      *
      * @param  string $serializeHandler

--- a/library/Zend/Session/Config/SessionConfig.php
+++ b/library/Zend/Session/Config/SessionConfig.php
@@ -151,7 +151,7 @@ class SessionConfig extends StandardConfig
      * Set session.save_path
      *
      * @param  string $savePath
-     * @return StandardConfig
+     * @return SessionConfig
      * @throws Exception\InvalidArgumentException on invalid path
      */
     public function setSavePath($savePath)

--- a/tests/ZendTest/Session/Config/SessionConfigTest.php
+++ b/tests/ZendTest/Session/Config/SessionConfigTest.php
@@ -56,6 +56,12 @@ class SessionConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(__DIR__, ini_get('session.save_path'));
     }
 
+    public function testSavePathCanBeNonDirectoryWhenSaveHandlerNotFiles()
+    {
+        $this->config->setPhpSaveHandler('sqlite');
+        $this->config->setSavePath('/tmp/sessions.db');
+    }
+
     // session.name
 
     public function testNameDefaultsToIniSettings()


### PR DESCRIPTION
The StandardConfig defines that the only way to specify a savePath is to utilize a directory.  The SessionConfig then requires the savePath to be a directory since it inherits from the StandardConfig.

This pull request is to check in SessionConfig to see if the save_handler option is "files" and issue the set to the parent otherwise to skip checking.

This means it will allow the following use cases:
files => /path/to/directory
sqlite => /path/to/my.db
memcached => sess1:11211, sess2:11211
redis => tcp://0.0.0.0:6379
