### PR TITLE
Make case insensitive ssl config option to be more consistent with Mail\...

### DIFF
--- a/library/Zend/Mail/Protocol/Imap.php
+++ b/library/Zend/Mail/Protocol/Imap.php
@@ -70,6 +70,10 @@ class Imap
      */
     public function connect($host, $port = null, $ssl = false)
     {
+        if ($ssl !== false) {
+            $ssl = strtoupper( $ssl );
+        }
+
         if ($ssl == 'SSL') {
             $host = 'ssl://' . $host;
         }

--- a/library/Zend/Mail/Protocol/Imap.php
+++ b/library/Zend/Mail/Protocol/Imap.php
@@ -70,16 +70,25 @@ class Imap
      */
     public function connect($host, $port = null, $ssl = false)
     {
-        if ($ssl !== false) {
-            $ssl = strtoupper( $ssl );
+        $isTls = false;
+
+        if ( $ssl !== false ) {
+            $ssl = strtolower($ssl);
         }
 
-        if ($ssl == 'SSL') {
-            $host = 'ssl://' . $host;
-        }
-
-        if ($port === null) {
-            $port = $ssl === 'SSL' ? 993 : 143;
+        switch ($ssl) {
+            case 'ssl':
+                $host = 'ssl://' . $host;
+                if (!$port) {
+                    $port = 993;
+                }
+                break;
+            case 'tls':
+                $isTls = true;
+            default:
+                if ( !$port ) {
+                    $port = 143;
+                }
         }
 
         ErrorHandler::start();
@@ -87,7 +96,7 @@ class Imap
         $error = ErrorHandler::stop();
         if (!$this->socket) {
             throw new Exception\RuntimeException(sprintf(
-                'cannot connect to host%s',
+                'cannot connect to host %s',
                 ($error ? sprintf('; error = %s (errno = %d )', $error->getMessage(), $error->getCode()) : '')
             ), 0, $error);
         }
@@ -96,7 +105,7 @@ class Imap
             throw new Exception\RuntimeException('host doesn\'t allow connection');
         }
 
-        if ($ssl === 'TLS') {
+        if ($isTls) {
             $result = $this->requestAndResponse('STARTTLS');
             $result = $result && stream_socket_enable_crypto($this->socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
             if (!$result) {

--- a/library/Zend/Mail/Protocol/Pop3.php
+++ b/library/Zend/Mail/Protocol/Pop3.php
@@ -78,16 +78,25 @@ class Pop3
      */
     public function connect($host, $port = null, $ssl = false)
     {
+        $isTls = false;
+
         if ($ssl !== false) {
-            $ssl = strtoupper($ssl);
+            $ssl = strtolower($ssl);
         }
 
-        if ($ssl == 'SSL') {
-            $host = 'ssl://' . $host;
-        }
-
-        if ($port === null) {
-            $port = $ssl == 'SSL' ? 995 : 110;
+        switch( $ssl ) {
+            case 'ssl':
+                $host = 'ssl://' . $host;
+                if ( !$port ) {
+                    $port = 995;
+                }
+                break;
+            case 'tls':
+                $isTls = true;
+            default:
+                if ( !$port ) {
+                    $port = 110;
+                }
         }
 
         ErrorHandler::start();
@@ -95,7 +104,7 @@ class Pop3
         $error = ErrorHandler::stop();
         if (!$this->socket) {
             throw new Exception\RuntimeException(sprintf(
-                'cannot connect to host%s',
+                'cannot connect to host %s',
                 ($error ? sprintf('; error = %s (errno = %d )', $error->getMessage(), $error->getCode()) : '')
             ), 0, $error);
         }
@@ -110,7 +119,7 @@ class Pop3
             $this->timestamp = '<' . $this->timestamp . '>';
         }
 
-        if ($ssl === 'TLS') {
+        if ($isTls === true) {
             $this->request('STLS');
             $result = stream_socket_enable_crypto($this->socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
             if (!$result) {

--- a/library/Zend/Mail/Protocol/Pop3.php
+++ b/library/Zend/Mail/Protocol/Pop3.php
@@ -78,6 +78,10 @@ class Pop3
      */
     public function connect($host, $port = null, $ssl = false)
     {
+        if ($ssl !== false) {
+            $ssl = strtoupper($ssl);
+        }
+
         if ($ssl == 'SSL') {
             $host = 'ssl://' . $host;
         }


### PR DESCRIPTION
...Transport\SmtpOptions

php -r 'print ("ssl" === "SSL" ? "OK\n" : "Nein\n");'

This way it doesn't matter how you write it, you'll have the same result for the config.
