### PR TITLE
preserve matched route name within route match instance while forwarding...

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/Forward.php
+++ b/library/Zend/Mvc/Controller/Plugin/Forward.php
@@ -135,10 +135,14 @@ class Forward extends AbstractPlugin
             }
         }
 
-        // Allow passing parameters to seed the RouteMatch with
+
+        // Allow passing parameters to seed the RouteMatch with & copy matched route name
         if ($params !== null) {
-            $event->setRouteMatch(new RouteMatch($params));
+            $routeMatch = new RouteMatch($params);
+            $routeMatch->setMatchedRouteName($event->getRouteMatch()->getMatchedRouteName());
+            $event->setRouteMatch($routeMatch);
         }
+
 
         if ($this->numNestedForwards > $this->maxNestedForwards) {
             throw new Exception\DomainException("Circular forwarding detected: greater than $this->maxNestedForwards nested forwards");

--- a/tests/ZendTest/Mvc/Controller/Plugin/ForwardTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/ForwardTest.php
@@ -41,7 +41,10 @@ class ForwardTest extends TestCase
         $event->setApplication($mockApplication);
         $event->setRequest(new Request());
         $event->setResponse(new Response());
-        $event->setRouteMatch(new RouteMatch(array('action' => 'test')));
+
+        $routeMatch = new RouteMatch(array('action' => 'test'));
+        $routeMatch->setMatchedRouteName('some-route');
+        $event->setRouteMatch($routeMatch);
 
         $locator = new Locator;
         $locator->add('forward', function() {
@@ -129,17 +132,20 @@ class ForwardTest extends TestCase
 
     public function testRouteMatchObjectRemainsSameFollowingForwardDispatch()
     {
-        $routeMatch  = $this->controller->getEvent()->getRouteMatch();
-        $matchParams = $routeMatch->getParams();
+        $routeMatch            = $this->controller->getEvent()->getRouteMatch();
+        $matchParams           = $routeMatch->getParams();
+        $matchMatchedRouteName = $routeMatch->getMatchedRouteName();
         $result = $this->plugin->dispatch('forward', array(
             'action' => 'test-matches',
             'param1' => 'foobar',
         ));
-        $test       = $this->controller->getEvent()->getRouteMatch();
-        $testParams = $test->getParams();
+        $testMatch            = $this->controller->getEvent()->getRouteMatch();
+        $testParams           = $testMatch->getParams();
+        $testMatchedRouteName = $testMatch->getMatchedRouteName();
 
-        $this->assertSame($routeMatch, $test);
+        $this->assertSame($routeMatch, $testMatch);
         $this->assertEquals($matchParams, $testParams);
+        $this->assertEquals($matchMatchedRouteName, $testMatchedRouteName);
     }
 
     public function testAllowsPassingEmptyArrayOfRouteParams()


### PR DESCRIPTION
... from controller

While forwarding a request within a controller with the forward plugin the matched route name wasn't forwarded to the next action when the param parameter was passed as an argument to the dispatch method.

this would affect (for one) the redirect->refresh() controller plugin (would work with directly called (matched) action, but not if used within a forwarded action method.

up for review
