### PR TITLE
[#2925] Fix

### DIFF
--- a/library/Zend/Navigation/AbstractContainer.php
+++ b/library/Zend/Navigation/AbstractContainer.php
@@ -258,12 +258,23 @@ abstract class AbstractContainer implements Countable, RecursiveIterator
 
     /**
      * Returns true if container contains any pages
-     *
+     * 
+     * @param  bool $onlyVisible whether to check only visible pages
      * @return bool  whether container has any pages
      */
-    public function hasPages()
+    public function hasPages($onlyVisible = false)
     {
-        return count($this->index) > 0;
+        if($onlyVisible) {
+            foreach($this->pages as $page) {
+                if($page->isVisible()) {
+                    return true;
+                }
+            }
+            // no visible pages found
+            return false;
+        } else {
+            return count($this->index) > 0;
+        }
     }
 
     /**

--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -335,10 +335,10 @@ class Menu extends AbstractHelper
 
         // special case if active page is one below minDepth
         if ($active['depth'] < $minDepth) {
-            if (!$active['page']->hasPages()) {
+            if (!$active['page']->hasPages(!$this->renderInvisible)) {
                 return '';
             }
-        } elseif (!$active['page']->hasPages()) {
+        } elseif (!$active['page']->hasPages(!$this->renderInvisible)) {
             // found pages has no children; render siblings
             $active['page'] = $active['page']->getParent();
         } elseif (is_int($maxDepth) && $active['depth'] +1 > $maxDepth) {
@@ -419,7 +419,7 @@ class Menu extends AbstractHelper
                         $accept = true;
                     } elseif ($foundPage->getParent()->hasPage($page)) {
                         // page is a sibling of the active page...
-                        if (!$foundPage->hasPages() ||
+                        if (!$foundPage->hasPages(!$this->renderInvisible) ||
                             is_int($maxDepth) && $foundDepth + 1 > $maxDepth) {
                             // accept if active page has no children, or the
                             // children are too deep to be rendered


### PR DESCRIPTION
Zend\View\Helper\Navigation\Menu renders empty sub menus, if Zend\Navigation\AbstractContainer only contains invisible pages and renderInvisible is set to false.
