### PR TITLE
ZF-12462 Minimal search should always be UID only, ldap allows additional filters.

### DIFF
--- a/library/Zend/Ldap/Ldap.php
+++ b/library/Zend/Ldap/Ldap.php
@@ -464,7 +464,7 @@ class Ldap
             return sprintf("(&(objectClass=user)(sAMAccountName=%s))", $aname);
         }
 
-        return sprintf("(&(objectClass=posixAccount)(uid=%s))", $aname);
+        return sprintf("(&(uid=%s))", $aname);
     }
 
     /**


### PR DESCRIPTION
LDAP by default allows you to set filters. By setting the initial filter for posixAccount creates an issue on many enterpise LDAP applications that we currently work on. The lowest denominator should always be used by the search which is strictly (uid=username). Users have the ability to add filters in addition to the base filter which essentially renders this filter as a major bug on some LDAP servers where the posixAccount attribute does not exist. This requires the developers to patch the Zend\Ldap\Ldap.php during every release.

I will be happy to submit a merge request on github for zf2. However this affects the version 1.x release as well, and it's a single line that needs to be changed.

Pull request added as per Stefan Gehrig on http://framework.zend.com/issues/browse/ZF-12462
