### PR TITLE
add Zend\EventManager to Zend\Code's composer.json

### DIFF
--- a/library/Zend/Code/composer.json
+++ b/library/Zend/Code/composer.json
@@ -13,7 +13,8 @@
     },
     "target-dir": "Zend/Code",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "zendframework/zend-eventmanager": "self.version"
     },
     "require-dev": {
         "doctrine/common": ">=2.1"


### PR DESCRIPTION
`Zend\Code` looks for `Zend\EventManager` in several places, so add it to `composer.json`. Using `Zend\Di` as a standalone component (which depends on `Zend\Code`), will fail without `Zend\EventManager`.
