### PR TITLE
Various Zend\Mvc\Router\Http routers turn + into a space in path segments

### DIFF
--- a/library/Zend/Mvc/Router/Http/Regex.php
+++ b/library/Zend/Mvc/Router/Http/Regex.php
@@ -156,7 +156,7 @@ class Regex implements RouteInterface
             $spec = '%' . $key . '%';
 
             if (strpos($url, $spec) !== false) {
-                $url = str_replace($spec, urlencode($value), $url);
+                $url = str_replace($spec, rawurlencode($value), $url);
 
                 $this->assembledParams[] = $key;
             }

--- a/library/Zend/Mvc/Router/Http/Regex.php
+++ b/library/Zend/Mvc/Router/Http/Regex.php
@@ -131,7 +131,7 @@ class Regex implements RouteInterface
             if (is_numeric($key) || is_int($key) || $value === '') {
                 unset($matches[$key]);
             } else {
-                $matches[$key] = urldecode($value);
+                $matches[$key] = rawurldecode($value);
             }
         }
 

--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -44,15 +44,15 @@ class Segment implements RouteInterface
         '%28' => "(", // sub-delims
         '%29' => ")", // sub-delims
         '%2A' => "*", // sub-delims
-//      '%2B' => "+", // sub-delims - special value for php/urlencode
+        '%2B' => "+", // sub-delims
         '%2C' => ",", // sub-delims
-//      '%2D' => "-", // unreserved - not touched by urlencode
-//      '%2E' => ".", // unreserved - not touched by urlencode
+//      '%2D' => "-", // unreserved - not touched by rawurlencode
+//      '%2E' => ".", // unreserved - not touched by rawurlencode
         '%3A' => ":", // pchar
         '%3B' => ";", // sub-delims
         '%3D' => "=", // sub-delims
         '%40' => "@", // pchar
-//      '%5F' => "_", // unreserved - not touched by urlencode
+//      '%5F' => "_", // unreserved - not touched by rawurlencode
         '%7E' => "~", // unreserved
     );
 
@@ -408,7 +408,7 @@ class Segment implements RouteInterface
      */
     private function encode($value)
     {
-        $encoded = urlencode($value);
+        $encoded = rawurlencode($value);
         $encoded = strtr($encoded, self::$urlencodeCorrectionMap);
         return $encoded;
     }
@@ -421,6 +421,6 @@ class Segment implements RouteInterface
      */
     private function decode($value)
     {
-        return urldecode($value);
+        return rawurldecode($value);
     }
 }

--- a/library/Zend/Mvc/Router/Http/Wildcard.php
+++ b/library/Zend/Mvc/Router/Http/Wildcard.php
@@ -134,7 +134,7 @@ class Wildcard implements RouteInterface
 
             for ($i = 1; $i < $count; $i += 2) {
                 if (isset($params[$i + 1])) {
-                    $matches[urldecode($params[$i])] = urldecode($params[$i + 1]);
+                    $matches[rawurldecode($params[$i])] = rawurldecode($params[$i + 1]);
                 }
             }
         } else {
@@ -144,7 +144,7 @@ class Wildcard implements RouteInterface
                 $param = explode($this->keyValueDelimiter, $param, 2);
 
                 if (isset($param[1])) {
-                    $matches[urldecode($param[0])] = urldecode($param[1]);
+                    $matches[rawurldecode($param[0])] = rawurldecode($param[1]);
                 }
             }
         }
@@ -168,7 +168,7 @@ class Wildcard implements RouteInterface
 
         if ($mergedParams) {
             foreach ($mergedParams as $key => $value) {
-                $elements[] = urlencode($key) . $this->keyValueDelimiter . urlencode($value);
+                $elements[] = rawurlencode($key) . $this->keyValueDelimiter . rawurlencode($value);
 
                 $this->assembledParams[] = $key;
             }

--- a/tests/ZendTest/Mvc/Router/Http/RegexTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/RegexTest.php
@@ -53,7 +53,7 @@ class RegexTest extends TestCase
             ),
             'url-encoded-parameters-are-decoded' => array(
                 new Regex('/(?<foo>[^/]+)', '/%foo%'),
-                '/foo+bar',
+                '/foo%20bar',
                 null,
                 array('foo' => 'foo bar')
             ),
@@ -147,5 +147,31 @@ class RegexTest extends TestCase
                 'spec'  => '/foo'
             )
         );
+    }
+
+    public function testRawDecode()
+    {
+        // verify all characters which don't absolutely require encoding pass through match unchanged
+        // this includes every character other than #, %, / and ?
+        $raw = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`-=[]\\;\',.~!@$^&*()_+{}|:"<>';
+        $request = new Request();
+        $request->setUri('http://example.com/' . $raw);
+        $route   = new Regex('/(?<foo>[^/]+)', '/%foo%');
+        $match   = $route->match($request);
+
+        $this->assertSame($raw, $match->getParam('foo'));
+    }
+
+    public function testEncodedDecode()
+    {
+        // every character
+        $in  = '%61%62%63%64%65%66%67%68%69%6a%6b%6c%6d%6e%6f%70%71%72%73%74%75%76%77%78%79%7a%41%42%43%44%45%46%47%48%49%4a%4b%4c%4d%4e%4f%50%51%52%53%54%55%56%57%58%59%5a%30%31%32%33%34%35%36%37%38%39%60%2d%3d%5b%5d%5c%3b%27%2c%2e%2f%7e%21%40%23%24%25%5e%26%2a%28%29%5f%2b%7b%7d%7c%3a%22%3c%3e%3f';
+        $out = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`-=[]\\;\',./~!@#$%^&*()_+{}|:"<>?';
+        $request = new Request();
+        $request->setUri('http://example.com/' . $in);
+        $route   = new Regex('/(?<foo>[^/]+)', '/%foo%');
+        $match   = $route->match($request);
+
+        $this->assertSame($out, $match->getParam('foo'));
     }
 }

--- a/tests/ZendTest/Mvc/Router/Http/SegmentTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/SegmentTest.php
@@ -149,15 +149,15 @@ class SegmentTest extends TestCase
             ),
             'url-encoded-parameters-are-decoded' => array(
                 new Segment('/:foo'),
-                '/foo+bar',
+                '/foo%20bar',
                 null,
                 array('foo' => 'foo bar')
             ),
             'urlencode-flaws-corrected' => array(
                 new Segment('/:foo'),
-                "/!$&'()*,-.:;=@_~",
+                "/!$&'()*,-.:;=@_~+",
                 null,
-                array('foo' => "!$&'()*,-.:;=@_~")
+                array('foo' => "!$&'()*,-.:;=@_~+")
             ),
             'empty-matches-are-replaced-with-defaults' => array(
                 new Segment('/foo[/:bar]/baz-:baz', array(), array('bar' => 'bar')),
@@ -310,5 +310,31 @@ class SegmentTest extends TestCase
                 'constraints' => array('foo' => 'bar')
             )
         );
+    }
+
+    public function testRawDecode()
+    {
+        // verify all characters which don't absolutely require encoding pass through match unchanged
+        // this includes every character other than #, %, / and ?
+        $raw = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`-=[]\\;\',.~!@$^&*()_+{}|:"<>';
+        $request = new Request();
+        $request->setUri('http://example.com/' . $raw);
+        $route   = new Segment('/:foo');
+        $match   = $route->match($request);
+
+        $this->assertSame($raw, $match->getParam('foo'));
+    }
+
+    public function testEncodedDecode()
+    {
+        // every character
+        $in  = '%61%62%63%64%65%66%67%68%69%6a%6b%6c%6d%6e%6f%70%71%72%73%74%75%76%77%78%79%7a%41%42%43%44%45%46%47%48%49%4a%4b%4c%4d%4e%4f%50%51%52%53%54%55%56%57%58%59%5a%30%31%32%33%34%35%36%37%38%39%60%2d%3d%5b%5d%5c%3b%27%2c%2e%2f%7e%21%40%23%24%25%5e%26%2a%28%29%5f%2b%7b%7d%7c%3a%22%3c%3e%3f';
+        $out = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`-=[]\\;\',./~!@#$%^&*()_+{}|:"<>?';
+        $request = new Request();
+        $request->setUri('http://example.com/' . $in);
+        $route   = new Segment('/:foo');
+        $match   = $route->match($request);
+
+        $this->assertSame($out, $match->getParam('foo'));
     }
 }

--- a/tests/ZendTest/Mvc/Router/Http/WildcardTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/WildcardTest.php
@@ -78,7 +78,7 @@ class WildcardTest extends TestCase
             ),
             'url-encoded-parameters-are-decoded' => array(
                 new Wildcard(),
-                '/foo/foo+bar',
+                '/foo/foo%20bar',
                 null,
                 array('foo' => 'foo bar')
             ),
@@ -161,5 +161,31 @@ class WildcardTest extends TestCase
             array(),
             array()
         );
+    }
+
+    public function testRawDecode()
+    {
+        // verify all characters which don't absolutely require encoding pass through match unchanged
+        // this includes every character other than #, %, / and ?
+        $raw = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`-=[]\\;\',.~!@$^&*()_+{}|:"<>';
+        $request = new Request();
+        $request->setUri('http://example.com/foo/' . $raw);
+        $route   = new Wildcard();
+        $match   = $route->match($request);
+
+        $this->assertSame($raw, $match->getParam('foo'));
+    }
+
+    public function testEncodedDecode()
+    {
+        // every character
+        $in  = '%61%62%63%64%65%66%67%68%69%6a%6b%6c%6d%6e%6f%70%71%72%73%74%75%76%77%78%79%7a%41%42%43%44%45%46%47%48%49%4a%4b%4c%4d%4e%4f%50%51%52%53%54%55%56%57%58%59%5a%30%31%32%33%34%35%36%37%38%39%60%2d%3d%5b%5d%5c%3b%27%2c%2e%2f%7e%21%40%23%24%25%5e%26%2a%28%29%5f%2b%7b%7d%7c%3a%22%3c%3e%3f';
+        $out = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`-=[]\\;\',./~!@#$%^&*()_+{}|:"<>?';
+        $request = new Request();
+        $request->setUri('http://example.com/foo/' . $in);
+        $route   = new Wildcard();
+        $match   = $route->match($request);
+
+        $this->assertSame($out, $match->getParam('foo'));
     }
 }


### PR DESCRIPTION
A plus located in a path segment should be treated as a literal +.

Updating all http routers to use rawurlencode/rawurldecode to ensure this is the case.

Added tests to verify all characters are properly handled (including space) when present in either their raw or encoded forms.
