### PR TITLE
Fix validate data contains arrays as values

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -169,6 +169,7 @@ class BaseInputFilter implements InputFilterInterface
                 || (is_array($this->data[$name])
                     && isset($this->data[$name]['error']) && $this->data[$name]['error'] === UPLOAD_ERR_NO_FILE)
                 || (is_array($this->data[$name]) && count($this->data[$name]) === 1
+                    && is_array($this->data[$name][0])
                     && isset($this->data[$name][0]['error']) && $this->data[$name][0]['error'] === UPLOAD_ERR_NO_FILE)
             ) {
                 if ($input instanceof InputInterface) {

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -169,7 +169,7 @@ class BaseInputFilter implements InputFilterInterface
                 || (is_array($this->data[$name])
                     && isset($this->data[$name]['error']) && $this->data[$name]['error'] === UPLOAD_ERR_NO_FILE)
                 || (is_array($this->data[$name]) && count($this->data[$name]) === 1
-                    && is_array($this->data[$name][0])
+                    && isset($this->data[$name][0]) && is_array($this->data[$name][0])
                     && isset($this->data[$name][0]['error']) && $this->data[$name][0]['error'] === UPLOAD_ERR_NO_FILE)
             ) {
                 if ($input instanceof InputInterface) {

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -569,4 +569,36 @@ class BaseInputFilterTest extends TestCase
         $this->assertArrayHasKey('foo', $messages);
         $this->assertNotEmpty($messages['foo']);
     }
+
+    public function testValidateUseExplode()
+    {
+        $filter = new InputFilter();
+
+        $input = new Input();
+        $input->setRequired(true);
+
+        $input->getValidatorChain()->addValidator(
+            new \Zend\Validator\Explode(
+                array(
+                    'validator' => new \Zend\Validator\IsInstanceOf(
+                        array(
+                            'className' => 'Zend\InputFilter\Input'
+                        )
+                    )
+                )
+            )
+        );
+
+        $filter->add($input, 'example');
+
+        $data = array(
+            'example' => array(
+                $input
+            )
+        );
+
+        $filter->setData($data);
+        $this->assertTrue($filter->isValid());
+
+    }
 }


### PR DESCRIPTION
This patch does not solve the problem at all, I think this code should not be here.

```
(is_array($this->data[$name]) 
 && isset($this->data[$name]['error']) 
 && $this->data[$name]['error'] === UPLOAD_ERR_NO_FILE
)
|| (is_array($this->data[$name]) 
 && count($this->data[$name]) === 1
 && is_array($this->data[$name][0])
 && isset($this->data[$name][0]['error']) 
 && $this->data[$name][0]['error'] === UPLOAD_ERR_NO_FILE)
```
