### PR TITLE
Revert PR #2943 for 5.3.3 fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
 
 before_install:
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
- - composer self-update
  - composer install --dev
  - wget http://cs.sensiolabs.org/get/php-cs-fixer.phar
 


### PR DESCRIPTION
This PR reverts https://github.com/zendframework/zf2/pull/2943 .

I'm going to rebase this branch periodically, and as soon as Travis will update composer with the fix for php 5.3.3, the tests eventually pass.

Do not merge until that moment.
