### PR TITLE
Allow Accept-Encoding header to be set explicitly by http request

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1040,7 +1040,7 @@ class Client implements Stdlib\DispatchableInterface
 
         // Set the Accept-encoding header if not set - depending on whether
         // zlib is available or not.
-        if (! isset($this->headers['accept-encoding'])) {
+        if (!$this->getRequest()->getHeaders()->has('Accept-Encoding')) {
             if (function_exists('gzinflate')) {
                 $headers['Accept-encoding'] = 'gzip, deflate';
             } else {

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1042,9 +1042,9 @@ class Client implements Stdlib\DispatchableInterface
         // zlib is available or not.
         if (!$this->getRequest()->getHeaders()->has('Accept-Encoding')) {
             if (function_exists('gzinflate')) {
-                $headers['Accept-encoding'] = 'gzip, deflate';
+                $headers['Accept-Encoding'] = 'gzip, deflate';
             } else {
-                $headers['Accept-encoding'] = 'identity';
+                $headers['Accept-Encoding'] = 'identity';
             }
         }
 

--- a/tests/ZendTest/Http/ClientTest.php
+++ b/tests/ZendTest/Http/ClientTest.php
@@ -11,8 +11,8 @@
 namespace ZendTest\Http;
 
 use Zend\Http\Client;
-use Zend\Http\Exception;
-use Zend\Http\Header\SetCookie;
+
+use Zend\Http\Header\AcceptEncoding;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
@@ -78,5 +78,27 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $cookies = $client->getCookies();
         $this->assertEquals(2, count($cookies));
+    }
+
+    public function testClientUsesAcceptEncodingHeaderFromRequestObject()
+    {
+        $client = new Client();
+
+        $client->setAdapter('Zend\Http\Client\Adapter\Test');
+
+        $request = $client->getRequest();
+
+        $acceptEncodingHeader = new AcceptEncoding();
+        $acceptEncodingHeader->addEncoding('foo', 1);
+        $request->getHeaders()->addHeader($acceptEncodingHeader);
+
+        $client->send();
+
+        $rawRequest = $client->getLastRawRequest();
+
+        $this->assertNotContains('Accept-Encoding: gzip, deflate', $rawRequest, null, true);
+        $this->assertNotContains('Accept-Encoding: identity', $rawRequest, null, true);
+
+        $this->assertContains('Accept-Encoding: foo', $rawRequest);
     }
 }


### PR DESCRIPTION
Currently it does not seem possible to override the Accept-Encoding header, I think because of some code in Zend\Http\Client::prepareHeaders that uses an undefined $headers member variable while it should check if the header is already explicitly set in the request.
