### PR TITLE
[#2964] Retrieve application events before triggering

### DIFF
--- a/library/Zend/Mvc/View/Http/DefaultRenderingStrategy.php
+++ b/library/Zend/Mvc/View/Http/DefaultRenderingStrategy.php
@@ -130,10 +130,11 @@ class DefaultRenderingStrategy implements ListenerAggregateInterface
         try {
             $view->render($viewModel);
         } catch(\Exception $ex) {
+            $application = $e->getApplication();
+            $events      = $application->getEventManager();
             $e->setError(Application::ERROR_EXCEPTION)
               ->setParam('exception', $ex);
-            $e->trigger(MvcEvent::EVENT_RENDER_ERROR, $e);
-            $e->trigger(MvcEvent::EVENT_RENDER, $e);
+            $events->trigger(MvcEvent::EVENT_RENDER_ERROR, $e);
         }
 
         return $response;

--- a/tests/ZendTest/Mvc/View/_files/exception.phtml
+++ b/tests/ZendTest/Mvc/View/_files/exception.phtml
@@ -1,0 +1,2 @@
+<?php
+throw new \Exception('thrown from view script');


### PR DESCRIPTION
- The block that handled exceptions in DefaultRenderingStrategy was
  calling trigger() on the event object -- clearly a problem. Code has
  been modified to retrieve the event manager from the application
  object composed in the event, and trigger from there.
- Additionally, a potential infinite loop was removed (the render event
  was getting triggered a second time from within the catch clause)
- Tests added to ensure that the render.error event is now properly
  triggered.
