### PR TITLE
Patch for Issue #2971

### DIFF
--- a/library/Zend/Http/Cookies.php
+++ b/library/Zend/Http/Cookies.php
@@ -64,7 +64,6 @@ class Cookies extends Headers
     public function __construct(Headers $headers)
     {
         $this->headers = $headers;
-        parent::__construct();
     }
 
     /**

--- a/library/Zend/Http/Cookies.php
+++ b/library/Zend/Http/Cookies.php
@@ -61,7 +61,7 @@ class Cookies extends Headers
         );
     }
 
-    public function __construct(Headers $headers, $context = self::CONTEXT_REQUEST)
+    public function __construct(Headers $headers)
     {
         $this->headers = $headers;
         parent::__construct();


### PR DESCRIPTION
I remove the self::CONTEXT_REQUEST from the constructor arguments as it was unused.
