### PR TITLE
Controller action HttpResponse is not used by SendResponseListener

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -299,6 +299,7 @@ class Application implements
         $response = $result->last();
         if ($response instanceof ResponseInterface) {
             $event->setTarget($this);
+            $event->setResponse($response);
             $events->trigger(MvcEvent::EVENT_FINISH, $event);
             return $response;
         }


### PR DESCRIPTION
SendResponseListener is getting the response from the event via the getResponse, whereas the actual HttpResponse returned by the controller action is stored as the result for that event.

```
public function indexAction()
{
    //return new ViewModel();
    $response = new \Zend\Http\PhpEnvironment\Response();
    $response->setContent('OK');

    return $response;
}
```

This is a little confusing given that the AbstractController will stop dispatching when the returned value is a Response instance.

```
    $result = $this->getEventManager()->trigger(MvcEvent::EVENT_DISPATCH, $e, function($test) {
        return ($test instanceof Response);
    });
```

And then the SendResponseLister is pulling from getResponse()

```
public function sendResponse(MvcEvent $e)
{
    $response = $e->getResponse();
    var_dump($response, $e->getResult()); //these instances differ
```

It seems like the Mvc\Application should set the result Response as the event response?

```
    $response = $result->last();
    if ($response instanceof ResponseInterface) {
        $event->setTarget($this);
        $event->setResponse($response); //set response for SendResponseListener
```
