### PR TITLE
setCallbackOptions

### DIFF
--- a/library/Zend/Json/Server/Response.php
+++ b/library/Zend/Json/Server/Response.php
@@ -118,10 +118,10 @@ class Response
     /**
      * Set result error
      *
-     * @param  null|Error $error
+     * @param  Error $error
      * @return Response
      */
-    public function setError($error)
+    public function setError(Error $error = null)
     {
         $this->error = $error;
         return $this;

--- a/library/Zend/Json/Server/Response.php
+++ b/library/Zend/Json/Server/Response.php
@@ -118,10 +118,10 @@ class Response
     /**
      * Set result error
      *
-     * @param  Error $error
+     * @param  null|Error $error
      * @return Response
      */
-    public function setError(Error $error)
+    public function setError($error)
     {
         $this->error = $error;
         return $this;

--- a/library/Zend/Json/Server/Response.php
+++ b/library/Zend/Json/Server/Response.php
@@ -121,7 +121,7 @@ class Response
      * @param  null|Error $error
      * @return Response
      */
-    public function setError(Error $error)
+    public function setError($error)
     {
         $this->error = $error;
         return $this;

--- a/library/Zend/Json/Server/Response.php
+++ b/library/Zend/Json/Server/Response.php
@@ -121,7 +121,7 @@ class Response
      * @param  null|Error $error
      * @return Response
      */
-    public function setError($error)
+    public function setError(Error $error)
     {
         $this->error = $error;
         return $this;

--- a/library/Zend/Validator/Callback.php
+++ b/library/Zend/Validator/Callback.php
@@ -136,8 +136,8 @@ class Callback extends AbstractValidator
             $args = array_merge($args, $options);
         }
         if (!empty($options) && !empty($context)) {
-            $args[] = $context;
             $args   = array_merge($args, $options);
+            $args[] = $context;
         }
 
         try {

--- a/tests/ZendTest/Json/Server/ResponseTest.php
+++ b/tests/ZendTest/Json/Server/ResponseTest.php
@@ -66,6 +66,12 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->response->setError($error);
         $this->assertSame($error, $this->response->getError());
     }
+    
+    public function testErrorAccesorsShouldWorkWithNullInput()
+    {
+        $this->response->setError(null);
+        $this->assertNull($this->response->getError());
+    }
 
     public function testIdShouldBeNullByDefault()
     {

--- a/tests/ZendTest/Json/Server/ResponseTest.php
+++ b/tests/ZendTest/Json/Server/ResponseTest.php
@@ -71,6 +71,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     {
         $this->response->setError(null);
         $this->assertNull($this->response->getError());
+        $this->assertFalse($this->response->isError());
     }
 
     public function testIdShouldBeNullByDefault()

--- a/tests/ZendTest/Validator/CallbackTest.php
+++ b/tests/ZendTest/Validator/CallbackTest.php
@@ -97,8 +97,8 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $value     = 'bar';
         $context   = array('foo' => 'bar', 'bar' => 'baz');
         $options   = array('baz' => 'bat');
-        $validator = new Callback(function($v, $c, $baz) use ($value, $context, $options) {
-            return (($value == $v) && ($context == $c) && ($options['baz'] == $baz));
+        $validator = new Callback(function($v, $baz, $c) use ($value, $options, $context) {
+            return (($value == $v) && ($options['baz'] == $baz) && ($context == $c));
         });
         $validator->setCallbackOptions($options);
         $this->assertTrue($validator->isValid($value, $context));


### PR DESCRIPTION
http://framework.zend.com/manual/2.0/en/modules/zend.validator.set.html#adding-options

callbackOptions should be the 2nd param to pass to the callbackFunction not the last param (it could be the $context as optional)
