### PR TITLE
[WIP] Add full stop at end of validator messages (fixes #2966)

### DIFF
--- a/library/Zend/Captcha/AbstractWord.php
+++ b/library/Zend/Captcha/AbstractWord.php
@@ -102,9 +102,9 @@ abstract class AbstractWord extends AbstractAdapter
      * @var array
      */
     protected $messageTemplates = array(
-        self::MISSING_VALUE => 'Empty captcha value',
-        self::MISSING_ID    => 'Captcha ID field is missing',
-        self::BAD_CAPTCHA   => 'Captcha value is wrong',
+        self::MISSING_VALUE => "Empty captcha value.",
+        self::MISSING_ID    => "Captcha ID field is missing.",
+        self::BAD_CAPTCHA   => "Captcha value is wrong.",
     );
 
     /**

--- a/library/Zend/Captcha/ReCaptcha.php
+++ b/library/Zend/Captcha/ReCaptcha.php
@@ -68,9 +68,9 @@ class ReCaptcha extends AbstractAdapter
      * @var array
      */
     protected $messageTemplates = array(
-        self::MISSING_VALUE => 'Missing captcha fields',
-        self::ERR_CAPTCHA   => 'Failed to validate captcha',
-        self::BAD_CAPTCHA   => 'Captcha value is wrong: %value%',
+        self::MISSING_VALUE => "Missing captcha fields.",
+        self::ERR_CAPTCHA   => "Failed to validate captcha.",
+        self::BAD_CAPTCHA   => "Captcha value is wrong: %value%.",
     );
 
     /**

--- a/library/Zend/I18n/Validator/Alnum.php
+++ b/library/Zend/I18n/Validator/Alnum.php
@@ -37,9 +37,9 @@ class Alnum extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID      => "Invalid type given. String, integer or float expected",
-        self::NOT_ALNUM    => "The input contains characters which are non alphabetic and no digits",
-        self::STRING_EMPTY => "The input is an empty string",
+        self::INVALID      => "Invalid type given. String, integer or float expected.",
+        self::NOT_ALNUM    => "The input contains characters which are non alphabetic and no digits.",
+        self::STRING_EMPTY => "The input is an empty string.",
     );
 
     /**

--- a/library/Zend/I18n/Validator/Alpha.php
+++ b/library/Zend/I18n/Validator/Alpha.php
@@ -36,9 +36,9 @@ class Alpha extends Alnum
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID      => "Invalid type given. String expected",
-        self::NOT_ALPHA    => "The input contains non alphabetic characters",
-        self::STRING_EMPTY => "The input is an empty string"
+        self::INVALID      => "Invalid type given. String expected.",
+        self::NOT_ALPHA    => "The input contains non alphabetic characters.",
+        self::STRING_EMPTY => "The input is an empty string.",
     );
 
     /**

--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -31,7 +31,7 @@ class Float extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID   => "Invalid type given. String, integer or float expected",
+        self::INVALID   => "Invalid type given. String, integer or float expected.",
         self::NOT_FLOAT => "The input does not appear to be a float",
     );
 

--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -32,7 +32,7 @@ class Float extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID   => "Invalid type given. String, integer or float expected.",
-        self::NOT_FLOAT => "The input does not appear to be a float",
+        self::NOT_FLOAT => "The input does not appear to be a float.",
     );
 
     /**

--- a/library/Zend/I18n/Validator/Int.php
+++ b/library/Zend/I18n/Validator/Int.php
@@ -31,8 +31,8 @@ class Int extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID => "Invalid type given. String or integer expected",
-        self::NOT_INT => "The input does not appear to be an integer",
+        self::INVALID => "Invalid type given. String or integer expected.",
+        self::NOT_INT => "The input does not appear to be an integer.",
     );
 
     /**

--- a/library/Zend/I18n/Validator/PostCode.php
+++ b/library/Zend/I18n/Validator/PostCode.php
@@ -34,9 +34,9 @@ class PostCode extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID        => "Invalid type given. String or integer expected.",
-        self::NO_MATCH       => "The input does not appear to be a postal code",
-        self::SERVICE        => "The input does not appear to be a postal code",
-        self::SERVICEFAILURE => "An exception has been raised while validating the input",
+        self::NO_MATCH       => "The input does not appear to be a postal code.",
+        self::SERVICE        => "The input does not appear to be a postal code.",
+        self::SERVICEFAILURE => "An exception has been raised while validating the input.",
     );
 
     /**

--- a/library/Zend/I18n/Validator/PostCode.php
+++ b/library/Zend/I18n/Validator/PostCode.php
@@ -33,7 +33,7 @@ class PostCode extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID        => "Invalid type given. String or integer expected",
+        self::INVALID        => "Invalid type given. String or integer expected.",
         self::NO_MATCH       => "The input does not appear to be a postal code",
         self::SERVICE        => "The input does not appear to be a postal code",
         self::SERVICEFAILURE => "An exception has been raised while validating the input",

--- a/library/Zend/Validator/Barcode.php
+++ b/library/Zend/Validator/Barcode.php
@@ -24,10 +24,10 @@ class Barcode extends AbstractValidator
     const INVALID_LENGTH = 'barcodeInvalidLength';
 
     protected $messageTemplates = array(
-        self::FAILED         => "The input failed checksum validation",
-        self::INVALID_CHARS  => "The input contains invalid characters",
-        self::INVALID_LENGTH => "The input should have a length of %length% characters",
-        self::INVALID        => "Invalid type given. String expected",
+        self::FAILED         => "The input failed checksum validation.",
+        self::INVALID_CHARS  => "The input contains invalid characters.",
+        self::INVALID_LENGTH => "The input should have a length of %length% characters.",
+        self::INVALID        => "Invalid type given. String expected.",
     );
 
     /**

--- a/library/Zend/Validator/Between.php
+++ b/library/Zend/Validator/Between.php
@@ -28,8 +28,8 @@ class Between extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_BETWEEN        => "The input is not between '%min%' and '%max%', inclusively",
-        self::NOT_BETWEEN_STRICT => "The input is not strictly between '%min%' and '%max%'"
+        self::NOT_BETWEEN        => "The input is not between '%min%' and '%max%', inclusively.",
+        self::NOT_BETWEEN_STRICT => "The input is not strictly between '%min%' and '%max%'.",
     );
 
     /**

--- a/library/Zend/Validator/Callback.php
+++ b/library/Zend/Validator/Callback.php
@@ -32,8 +32,8 @@ class Callback extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID_VALUE    => "The input is not valid",
-        self::INVALID_CALLBACK => "An exception has been raised within the callback",
+        self::INVALID_VALUE    => "The input is not valid.",
+        self::INVALID_CALLBACK => "An exception has been raised within the callback.",
     );
 
     /**

--- a/library/Zend/Validator/CreditCard.php
+++ b/library/Zend/Validator/CreditCard.php
@@ -51,13 +51,13 @@ class CreditCard extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::CHECKSUM       => "The input seems to contain an invalid checksum",
-        self::CONTENT        => "The input must contain only digits",
-        self::INVALID        => "Invalid type given. String expected",
-        self::LENGTH         => "The input contains an invalid amount of digits",
-        self::PREFIX         => "The input is not from an allowed institute",
-        self::SERVICE        => "The input seems to be an invalid creditcard number",
-        self::SERVICEFAILURE => "An exception has been raised while validating the input",
+        self::CHECKSUM       => "The input seems to contain an invalid checksum.",
+        self::CONTENT        => "The input must contain only digits.",
+        self::INVALID        => "Invalid type given. String expected.",
+        self::LENGTH         => "The input contains an invalid amount of digits.",
+        self::PREFIX         => "The input is not from an allowed institute.",
+        self::SERVICE        => "The input seems to be an invalid creditcard number.",
+        self::SERVICEFAILURE => "An exception has been raised while validating the input.",
     );
 
     /**

--- a/library/Zend/Validator/Csrf.php
+++ b/library/Zend/Validator/Csrf.php
@@ -28,7 +28,7 @@ class Csrf extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_SAME => "The form submitted did not originate from the expected site",
+        self::NOT_SAME => "The form submitted did not originate from the expected site.",
     );
 
     /**

--- a/library/Zend/Validator/Date.php
+++ b/library/Zend/Validator/Date.php
@@ -29,9 +29,9 @@ class Date extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID        => "Invalid type given. String, integer, array or DateTime expected",
-        self::INVALID_DATE   => "The input does not appear to be a valid date",
-        self::FALSEFORMAT    => "The input does not fit the date format '%format%'",
+        self::INVALID        => "Invalid type given. String, integer, array or DateTime expected.",
+        self::INVALID_DATE   => "The input does not appear to be a valid date.",
+        self::FALSEFORMAT    => "The input does not fit the date format '%format%'.",
     );
 
     /**

--- a/library/Zend/Validator/DateStep.php
+++ b/library/Zend/Validator/DateStep.php
@@ -29,7 +29,7 @@ class DateStep extends Date
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_STEP     => "The input is not a valid step"
+        self::NOT_STEP     => "The input is not a valid step.",
     );
 
     /**

--- a/library/Zend/Validator/Db/AbstractDb.php
+++ b/library/Zend/Validator/Db/AbstractDb.php
@@ -37,8 +37,8 @@ abstract class AbstractDb extends AbstractValidator
      * @var array Message templates
      */
     protected $messageTemplates = array(
-        self::ERROR_NO_RECORD_FOUND => "No record matching the input was found",
-        self::ERROR_RECORD_FOUND    => "A record matching the input was found",
+        self::ERROR_NO_RECORD_FOUND => "No record matching the input was found.",
+        self::ERROR_RECORD_FOUND    => "A record matching the input was found.",
     );
 
     /**

--- a/library/Zend/Validator/Digits.php
+++ b/library/Zend/Validator/Digits.php
@@ -35,9 +35,9 @@ class Digits extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_DIGITS   => "The input must contain only digits",
-        self::STRING_EMPTY => "The input is an empty string",
-        self::INVALID      => "Invalid type given. String, integer or float expected",
+        self::NOT_DIGITS   => "The input must contain only digits.",
+        self::STRING_EMPTY => "The input is an empty string.",
+        self::INVALID      => "Invalid type given. String, integer or float expected.",
     );
 
     /**

--- a/library/Zend/Validator/EmailAddress.php
+++ b/library/Zend/Validator/EmailAddress.php
@@ -30,15 +30,15 @@ class EmailAddress extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID            => "Invalid type given. String expected",
-        self::INVALID_FORMAT     => "The input is not a valid email address. Use the basic format local-part@hostname",
-        self::INVALID_HOSTNAME   => "'%hostname%' is not a valid hostname for the email address",
-        self::INVALID_MX_RECORD  => "'%hostname%' does not appear to have any valid MX or A records for the email address",
-        self::INVALID_SEGMENT    => "'%hostname%' is not in a routable network segment. The email address should not be resolved from public network",
-        self::DOT_ATOM           => "'%localPart%' can not be matched against dot-atom format",
-        self::QUOTED_STRING      => "'%localPart%' can not be matched against quoted-string format",
-        self::INVALID_LOCAL_PART => "'%localPart%' is not a valid local part for the email address",
-        self::LENGTH_EXCEEDED    => "The input exceeds the allowed length",
+        self::INVALID            => "Invalid type given. String expected.",
+        self::INVALID_FORMAT     => "The input is not a valid email address. Use the basic format local-part@hostname.",
+        self::INVALID_HOSTNAME   => "'%hostname%' is not a valid hostname for the email address.",
+        self::INVALID_MX_RECORD  => "'%hostname%' does not appear to have any valid MX or A records for the email address.",
+        self::INVALID_SEGMENT    => "'%hostname%' is not in a routable network segment. The email address should not be resolved from public network.",
+        self::DOT_ATOM           => "'%localPart%' can not be matched against dot-atom format.",
+        self::QUOTED_STRING      => "'%localPart%' can not be matched against quoted-string format.",
+        self::INVALID_LOCAL_PART => "'%localPart%' is not a valid local part for the email address.",
+        self::LENGTH_EXCEEDED    => "The input exceeds the allowed length.",
     );
 
     /**

--- a/library/Zend/Validator/Explode.php
+++ b/library/Zend/Validator/Explode.php
@@ -22,7 +22,7 @@ class Explode extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID => "Invalid type given. String expected",
+        self::INVALID => "Invalid type given. String expected.",
     );
 
     /**

--- a/library/Zend/Validator/File/Count.php
+++ b/library/Zend/Validator/File/Count.php
@@ -32,8 +32,8 @@ class Count extends AbstractValidator
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::TOO_MANY => "Too many files, maximum '%max%' are allowed but '%count%' are given",
-        self::TOO_FEW  => "Too few files, minimum '%min%' are expected but '%count%' are given",
+        self::TOO_MANY => "Too many files, maximum '%max%' are allowed but '%count%' are given.",
+        self::TOO_FEW  => "Too few files, minimum '%min%' are expected but '%count%' are given.",
     );
 
     /**

--- a/library/Zend/Validator/File/Crc32.php
+++ b/library/Zend/Validator/File/Crc32.php
@@ -29,9 +29,9 @@ class Crc32 extends Hash
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::DOES_NOT_MATCH => "File '%value%' does not match the given crc32 hashes",
-        self::NOT_DETECTED   => "A crc32 hash could not be evaluated for the given file",
-        self::NOT_FOUND      => "File '%value%' is not readable or does not exist",
+        self::DOES_NOT_MATCH => "File '%value%' does not match the given crc32 hashes.",
+        self::NOT_DETECTED   => "A crc32 hash could not be evaluated for the given file.",
+        self::NOT_FOUND      => "File '%value%' is not readable or does not exist.",
     );
 
     /**

--- a/library/Zend/Validator/File/ExcludeExtension.php
+++ b/library/Zend/Validator/File/ExcludeExtension.php
@@ -28,8 +28,8 @@ class ExcludeExtension extends Extension
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::FALSE_EXTENSION => "File '%value%' has a false extension",
-        self::NOT_FOUND       => "File '%value%' is not readable or does not exist",
+        self::FALSE_EXTENSION => "File '%value%' has a false extension.",
+        self::NOT_FOUND       => "File '%value%' is not readable or does not exist.",
     );
 
     /**

--- a/library/Zend/Validator/File/Exists.php
+++ b/library/Zend/Validator/File/Exists.php
@@ -30,7 +30,7 @@ class Exists extends AbstractValidator
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::DOES_NOT_EXIST => "File '%value%' does not exist",
+        self::DOES_NOT_EXIST => "File '%value%' does not exist.",
     );
 
     /**

--- a/library/Zend/Validator/File/Extension.php
+++ b/library/Zend/Validator/File/Extension.php
@@ -32,8 +32,8 @@ class Extension extends AbstractValidator
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::FALSE_EXTENSION => "File '%value%' has a false extension",
-        self::NOT_FOUND       => "File '%value%' is not readable or does not exist",
+        self::FALSE_EXTENSION => "File '%value%' has a false extension.",
+        self::NOT_FOUND       => "File '%value%' is not readable or does not exist.",
     );
 
     /**

--- a/library/Zend/Validator/File/FilesSize.php
+++ b/library/Zend/Validator/File/FilesSize.php
@@ -34,9 +34,9 @@ class FilesSize extends Size
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::TOO_BIG      => "All files in sum should have a maximum size of '%max%' but '%size%' were detected",
-        self::TOO_SMALL    => "All files in sum should have a minimum size of '%min%' but '%size%' were detected",
-        self::NOT_READABLE => "One or more files can not be read",
+        self::TOO_BIG      => "All files in sum should have a maximum size of '%max%' but '%size%' were detected.",
+        self::TOO_SMALL    => "All files in sum should have a minimum size of '%min%' but '%size%' were detected.",
+        self::NOT_READABLE => "One or more files can not be read.",
     );
 
     /**

--- a/library/Zend/Validator/File/Hash.php
+++ b/library/Zend/Validator/File/Hash.php
@@ -32,9 +32,9 @@ class Hash extends AbstractValidator
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::DOES_NOT_MATCH => "File '%value%' does not match the given hashes",
-        self::NOT_DETECTED   => "A hash could not be evaluated for the given file",
-        self::NOT_FOUND      => "File '%value%' is not readable or does not exist"
+        self::DOES_NOT_MATCH => "File '%value%' does not match the given hashes.",
+        self::NOT_DETECTED   => "A hash could not be evaluated for the given file.",
+        self::NOT_FOUND      => "File '%value%' is not readable or does not exist."
     );
 
     /**

--- a/library/Zend/Validator/File/Hash.php
+++ b/library/Zend/Validator/File/Hash.php
@@ -34,7 +34,7 @@ class Hash extends AbstractValidator
     protected $messageTemplates = array(
         self::DOES_NOT_MATCH => "File '%value%' does not match the given hashes.",
         self::NOT_DETECTED   => "A hash could not be evaluated for the given file.",
-        self::NOT_FOUND      => "File '%value%' is not readable or does not exist."
+        self::NOT_FOUND      => "File '%value%' is not readable or does not exist.",
     );
 
     /**

--- a/library/Zend/Validator/File/ImageSize.php
+++ b/library/Zend/Validator/File/ImageSize.php
@@ -36,12 +36,12 @@ class ImageSize extends AbstractValidator
      * @var array Error message template
      */
     protected $messageTemplates = array(
-        self::WIDTH_TOO_BIG    => "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected",
-        self::WIDTH_TOO_SMALL  => "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected",
-        self::HEIGHT_TOO_BIG   => "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected",
-        self::HEIGHT_TOO_SMALL => "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected",
-        self::NOT_DETECTED     => "The size of image '%value%' could not be detected",
-        self::NOT_READABLE     => "File '%value%' is not readable or does not exist",
+        self::WIDTH_TOO_BIG    => "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected.",
+        self::WIDTH_TOO_SMALL  => "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected.",
+        self::HEIGHT_TOO_BIG   => "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected.",
+        self::HEIGHT_TOO_SMALL => "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected.",
+        self::NOT_DETECTED     => "The size of image '%value%' could not be detected.",
+        self::NOT_READABLE     => "File '%value%' is not readable or does not exist.",
     );
 
     /**

--- a/library/Zend/Validator/File/IsCompressed.php
+++ b/library/Zend/Validator/File/IsCompressed.php
@@ -32,9 +32,9 @@ class IsCompressed extends MimeType
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::FALSE_TYPE   => "File '%value%' is not compressed, '%type%' detected",
-        self::NOT_DETECTED => "The mimetype of file '%value%' could not be detected",
-        self::NOT_READABLE => "File '%value%' is not readable or does not exist",
+        self::FALSE_TYPE   => "File '%value%' is not compressed, '%type%' detected.",
+        self::NOT_DETECTED => "The mimetype of file '%value%' could not be detected.",
+        self::NOT_READABLE => "File '%value%' is not readable or does not exist.",
     );
 
     /**

--- a/library/Zend/Validator/File/IsImage.php
+++ b/library/Zend/Validator/File/IsImage.php
@@ -32,9 +32,9 @@ class IsImage extends MimeType
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::FALSE_TYPE   => "File '%value%' is no image, '%type%' detected",
-        self::NOT_DETECTED => "The mimetype of file '%value%' could not be detected",
-        self::NOT_READABLE => "File '%value%' is not readable or does not exist",
+        self::FALSE_TYPE   => "File '%value%' is no image, '%type%' detected.",
+        self::NOT_DETECTED => "The mimetype of file '%value%' could not be detected.",
+        self::NOT_READABLE => "File '%value%' is not readable or does not exist.",
     );
 
     /**

--- a/library/Zend/Validator/File/Md5.php
+++ b/library/Zend/Validator/File/Md5.php
@@ -29,9 +29,9 @@ class Md5 extends Hash
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::DOES_NOT_MATCH => "File '%value%' does not match the given md5 hashes",
-        self::NOT_DETECTED   => "A md5 hash could not be evaluated for the given file",
-        self::NOT_FOUND      => "File '%value%' is not readable or does not exist",
+        self::DOES_NOT_MATCH => "File '%value%' does not match the given md5 hashes.",
+        self::NOT_DETECTED   => "A md5 hash could not be evaluated for the given file.",
+        self::NOT_FOUND      => "File '%value%' is not readable or does not exist.",
     );
 
     /**

--- a/library/Zend/Validator/File/MimeType.php
+++ b/library/Zend/Validator/File/MimeType.php
@@ -36,9 +36,9 @@ class MimeType extends AbstractValidator
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::FALSE_TYPE   => "File '%value%' has a false mimetype of '%type%'",
-        self::NOT_DETECTED => "The mimetype of file '%value%' could not be detected",
-        self::NOT_READABLE => "File '%value%' is not readable or does not exist",
+        self::FALSE_TYPE   => "File '%value%' has a false mimetype of '%type%'.",
+        self::NOT_DETECTED => "The mimetype of file '%value%' could not be detected.",
+        self::NOT_READABLE => "File '%value%' is not readable or does not exist.",
     );
 
     /**

--- a/library/Zend/Validator/File/NotExists.php
+++ b/library/Zend/Validator/File/NotExists.php
@@ -27,7 +27,7 @@ class NotExists extends Exists
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::DOES_EXIST => "File '%value%' exists",
+        self::DOES_EXIST => "File '%value%' exists.",
     );
 
     /**

--- a/library/Zend/Validator/File/Sha1.php
+++ b/library/Zend/Validator/File/Sha1.php
@@ -30,9 +30,9 @@ class Sha1 extends Hash
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::DOES_NOT_MATCH => "File '%value%' does not match the given sha1 hashes",
-        self::NOT_DETECTED   => "A sha1 hash could not be evaluated for the given file",
-        self::NOT_FOUND      => "File '%value%' is not readable or does not exist",
+        self::DOES_NOT_MATCH => "File '%value%' does not match the given sha1 hashes.",
+        self::NOT_DETECTED   => "A sha1 hash could not be evaluated for the given file.",
+        self::NOT_FOUND      => "File '%value%' is not readable or does not exist.",
     );
 
     /**

--- a/library/Zend/Validator/File/Size.php
+++ b/library/Zend/Validator/File/Size.php
@@ -33,9 +33,9 @@ class Size extends AbstractValidator
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::TOO_BIG   => "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected",
-        self::TOO_SMALL => "Minimum expected size for file '%value%' is '%min%' but '%size%' detected",
-        self::NOT_FOUND => "File '%value%' is not readable or does not exist",
+        self::TOO_BIG   => "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected.",
+        self::TOO_SMALL => "Minimum expected size for file '%value%' is '%min%' but '%size%' detected.",
+        self::NOT_FOUND => "File '%value%' is not readable or does not exist.",
     );
 
     /**

--- a/library/Zend/Validator/File/Upload.php
+++ b/library/Zend/Validator/File/Upload.php
@@ -39,16 +39,16 @@ class Upload extends AbstractValidator
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::INI_SIZE       => "File '%value%' exceeds the defined ini size",
-        self::FORM_SIZE      => "File '%value%' exceeds the defined form size",
-        self::PARTIAL        => "File '%value%' was only partially uploaded",
-        self::NO_FILE        => "File '%value%' was not uploaded",
-        self::NO_TMP_DIR     => "No temporary directory was found for file '%value%'",
-        self::CANT_WRITE     => "File '%value%' can't be written",
-        self::EXTENSION      => "A PHP extension returned an error while uploading the file '%value%'",
-        self::ATTACK         => "File '%value%' was illegally uploaded. This could be a possible attack",
-        self::FILE_NOT_FOUND => "File '%value%' was not found",
-        self::UNKNOWN        => "Unknown error while uploading file '%value%'"
+        self::INI_SIZE       => "File '%value%' exceeds the defined ini size.",
+        self::FORM_SIZE      => "File '%value%' exceeds the defined form size.",
+        self::PARTIAL        => "File '%value%' was only partially uploaded.",
+        self::NO_FILE        => "File '%value%' was not uploaded.",
+        self::NO_TMP_DIR     => "No temporary directory was found for file '%value%'.",
+        self::CANT_WRITE     => "File '%value%' can't be written.",
+        self::EXTENSION      => "A PHP extension returned an error while uploading the file '%value%'.",
+        self::ATTACK         => "File '%value%' was illegally uploaded. This could be a possible attack.",
+        self::FILE_NOT_FOUND => "File '%value%' was not found.",
+        self::UNKNOWN        => "Unknown error while uploading file '%value%'."
     );
 
     protected $options = array(

--- a/library/Zend/Validator/File/Upload.php
+++ b/library/Zend/Validator/File/Upload.php
@@ -48,7 +48,7 @@ class Upload extends AbstractValidator
         self::EXTENSION      => "A PHP extension returned an error while uploading the file '%value%'.",
         self::ATTACK         => "File '%value%' was illegally uploaded. This could be a possible attack.",
         self::FILE_NOT_FOUND => "File '%value%' was not found.",
-        self::UNKNOWN        => "Unknown error while uploading file '%value%'."
+        self::UNKNOWN        => "Unknown error while uploading file '%value%'.",
     );
 
     protected $options = array(

--- a/library/Zend/Validator/File/WordCount.php
+++ b/library/Zend/Validator/File/WordCount.php
@@ -29,9 +29,9 @@ class WordCount extends Count
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::TOO_MUCH => "Too much words, maximum '%max%' are allowed but '%count%' were counted",
-        self::TOO_LESS => "Too less words, minimum '%min%' are expected but '%count%' were counted",
-        self::NOT_FOUND => "File '%value%' is not readable or does not exist",
+        self::TOO_MUCH => "Too much words, maximum '%max%' are allowed but '%count%' were counted.",
+        self::TOO_LESS => "Too less words, minimum '%min%' are expected but '%count%' were counted.",
+        self::NOT_FOUND => "File '%value%' is not readable or does not exist.",
     );
 
     /**

--- a/library/Zend/Validator/GreaterThan.php
+++ b/library/Zend/Validator/GreaterThan.php
@@ -28,8 +28,8 @@ class GreaterThan extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_GREATER => "The input is not greater than '%min%'",
-        self::NOT_GREATER_INCLUSIVE => "The input is not greater or equal than '%min%'"
+        self::NOT_GREATER => "The input is not greater than '%min%'.",
+        self::NOT_GREATER_INCLUSIVE => "The input is not greater or equal than '%min%'.",
     );
 
     /**

--- a/library/Zend/Validator/Hex.php
+++ b/library/Zend/Validator/Hex.php
@@ -25,8 +25,8 @@ class Hex extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID => "Invalid type given. String expected",
-        self::NOT_HEX => "The input contains non-hexadecimal characters",
+        self::INVALID => "Invalid type given. String expected.",
+        self::NOT_HEX => "The input contains non-hexadecimal characters.",
     );
 
     /**

--- a/library/Zend/Validator/Hostname.php
+++ b/library/Zend/Validator/Hostname.php
@@ -43,17 +43,17 @@ class Hostname extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::CANNOT_DECODE_PUNYCODE  => "The input appears to be a DNS hostname but the given punycode notation cannot be decoded",
-        self::INVALID                 => "Invalid type given. String expected",
-        self::INVALID_DASH            => "The input appears to be a DNS hostname but contains a dash in an invalid position",
-        self::INVALID_HOSTNAME        => "The input does not match the expected structure for a DNS hostname",
-        self::INVALID_HOSTNAME_SCHEMA => "The input appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'",
-        self::INVALID_LOCAL_NAME      => "The input does not appear to be a valid local network name",
-        self::INVALID_URI             => "The input does not appear to be a valid URI hostname",
-        self::IP_ADDRESS_NOT_ALLOWED  => "The input appears to be an IP address, but IP addresses are not allowed",
-        self::LOCAL_NAME_NOT_ALLOWED  => "The input appears to be a local network name but local network names are not allowed",
-        self::UNDECIPHERABLE_TLD      => "The input appears to be a DNS hostname but cannot extract TLD part",
-        self::UNKNOWN_TLD             => "The input appears to be a DNS hostname but cannot match TLD against known list",
+        self::CANNOT_DECODE_PUNYCODE  => "The input appears to be a DNS hostname but the given punycode notation cannot be decoded.",
+        self::INVALID                 => "Invalid type given. String expected.",
+        self::INVALID_DASH            => "The input appears to be a DNS hostname but contains a dash in an invalid position.",
+        self::INVALID_HOSTNAME        => "The input does not match the expected structure for a DNS hostname.",
+        self::INVALID_HOSTNAME_SCHEMA => "The input appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'.",
+        self::INVALID_LOCAL_NAME      => "The input does not appear to be a valid local network name.",
+        self::INVALID_URI             => "The input does not appear to be a valid URI hostname.",
+        self::IP_ADDRESS_NOT_ALLOWED  => "The input appears to be an IP address, but IP addresses are not allowed.",
+        self::LOCAL_NAME_NOT_ALLOWED  => "The input appears to be a local network name but local network names are not allowed.",
+        self::UNDECIPHERABLE_TLD      => "The input appears to be a DNS hostname but cannot extract TLD part.",
+        self::UNKNOWN_TLD             => "The input appears to be a DNS hostname but cannot match TLD against known list.",
     );
 
     /**

--- a/library/Zend/Validator/Iban.php
+++ b/library/Zend/Validator/Iban.php
@@ -34,10 +34,10 @@ class Iban extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOTSUPPORTED     => "Unknown country within the IBAN",
-        self::SEPANOTSUPPORTED => "Countries outside the Single Euro Payments Area (SEPA) are not supported",
-        self::FALSEFORMAT      => "The input has a false IBAN format",
-        self::CHECKFAILED      => "The input has failed the IBAN check",
+        self::NOTSUPPORTED     => "Unknown country within the IBAN.",
+        self::SEPANOTSUPPORTED => "Countries outside the Single Euro Payments Area (SEPA) are not supported.",
+        self::FALSEFORMAT      => "The input has a false IBAN format.",
+        self::CHECKFAILED      => "The input has failed the IBAN check.",
     );
 
     /**

--- a/library/Zend/Validator/Identical.php
+++ b/library/Zend/Validator/Identical.php
@@ -31,8 +31,8 @@ class Identical extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_SAME      => "The two given tokens do not match",
-        self::MISSING_TOKEN => 'No token was provided to match against',
+        self::NOT_SAME      => "The two given tokens do not match.",
+        self::MISSING_TOKEN => "No token was provided to match against.",
     );
 
     /**

--- a/library/Zend/Validator/InArray.php
+++ b/library/Zend/Validator/InArray.php
@@ -45,7 +45,7 @@ class InArray extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_IN_ARRAY => 'The input was not found in the haystack',
+        self::NOT_IN_ARRAY => "The input was not found in the haystack.",
     );
 
     /**

--- a/library/Zend/Validator/Ip.php
+++ b/library/Zend/Validator/Ip.php
@@ -25,8 +25,8 @@ class Ip extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID        => 'Invalid type given. String expected',
-        self::NOT_IP_ADDRESS => "The input does not appear to be a valid IP address",
+        self::INVALID        => 'Invalid type given. String expected.',
+        self::NOT_IP_ADDRESS => 'The input does not appear to be a valid IP address.',
     );
 
     /**

--- a/library/Zend/Validator/Ip.php
+++ b/library/Zend/Validator/Ip.php
@@ -25,8 +25,8 @@ class Ip extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID        => 'Invalid type given. String expected.',
-        self::NOT_IP_ADDRESS => 'The input does not appear to be a valid IP address.',
+        self::INVALID        => "Invalid type given. String expected.",
+        self::NOT_IP_ADDRESS => "The input does not appear to be a valid IP address.",
     );
 
     /**

--- a/library/Zend/Validator/Isbn.php
+++ b/library/Zend/Validator/Isbn.php
@@ -28,8 +28,8 @@ class Isbn extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID => "Invalid type given. String or integer expected",
-        self::NO_ISBN => "The input is not a valid ISBN number",
+        self::INVALID => "Invalid type given. String or integer expected.",
+        self::NO_ISBN => "The input is not a valid ISBN number.",
     );
 
     protected $options = array(

--- a/library/Zend/Validator/LessThan.php
+++ b/library/Zend/Validator/LessThan.php
@@ -28,8 +28,8 @@ class LessThan extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_LESS           => "The input is not less than '%max%'",
-        self::NOT_LESS_INCLUSIVE => "The input is not less or equal than '%max%'"
+        self::NOT_LESS           => "The input is not less than '%max%'.",
+        self::NOT_LESS_INCLUSIVE => "The input is not less or equal than '%max%'.",
     );
 
     /**

--- a/library/Zend/Validator/NotEmpty.php
+++ b/library/Zend/Validator/NotEmpty.php
@@ -56,8 +56,8 @@ class NotEmpty extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::IS_EMPTY => "Value is required and can't be empty",
-        self::INVALID  => "Invalid type given. String, integer, float, boolean or array expected",
+        self::IS_EMPTY => "Value is required and can't be empty.",
+        self::INVALID  => "Invalid type given. String, integer, float, boolean or array expected.",
     );
 
     /**

--- a/library/Zend/Validator/Regex.php
+++ b/library/Zend/Validator/Regex.php
@@ -28,9 +28,9 @@ class Regex extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID   => "Invalid type given. String, integer or float expected",
-        self::NOT_MATCH => "The input does not match against pattern '%pattern%'",
-        self::ERROROUS  => "There was an internal error while using the pattern '%pattern%'",
+        self::INVALID   => "Invalid type given. String, integer or float expected.",
+        self::NOT_MATCH => "The input does not match against pattern '%pattern%'.",
+        self::ERROROUS  => "There was an internal error while using the pattern '%pattern%'.",
     );
 
     /**

--- a/library/Zend/Validator/Sitemap/Changefreq.php
+++ b/library/Zend/Validator/Sitemap/Changefreq.php
@@ -36,8 +36,8 @@ class Changefreq extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_VALID => "The input is not a valid sitemap changefreq",
-        self::INVALID   => "Invalid type given. String expected",
+        self::NOT_VALID => "The input is not a valid sitemap changefreq.",
+        self::INVALID   => "Invalid type given. String expected.",
     );
 
     /**

--- a/library/Zend/Validator/Sitemap/Lastmod.php
+++ b/library/Zend/Validator/Sitemap/Lastmod.php
@@ -43,8 +43,8 @@ class Lastmod extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_VALID => "The input is not a valid sitemap lastmod",
-        self::INVALID   => "Invalid type given. String expected",
+        self::NOT_VALID => "The input is not a valid sitemap lastmod.",
+        self::INVALID   => "Invalid type given. String expected.",
     );
 
     /**

--- a/library/Zend/Validator/Sitemap/Loc.php
+++ b/library/Zend/Validator/Sitemap/Loc.php
@@ -38,8 +38,8 @@ class Loc extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_VALID => "The input is not a valid sitemap location",
-        self::INVALID   => "Invalid type given. String expected",
+        self::NOT_VALID => "The input is not a valid sitemap location.",
+        self::INVALID   => "Invalid type given. String expected.",
     );
 
     /**

--- a/library/Zend/Validator/Sitemap/Priority.php
+++ b/library/Zend/Validator/Sitemap/Priority.php
@@ -36,8 +36,8 @@ class Priority extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_VALID => "The input is not a valid sitemap priority",
-        self::INVALID   => "Invalid type given. Numeric string, integer or float expected",
+        self::NOT_VALID => "The input is not a valid sitemap priority.",
+        self::INVALID   => "Invalid type given. Numeric string, integer or float expected.",
     );
 
     /**

--- a/library/Zend/Validator/Step.php
+++ b/library/Zend/Validator/Step.php
@@ -25,8 +25,8 @@ class Step extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID => "Invalid value given. Scalar expected",
-        self::NOT_STEP => "The input is not a valid step"
+        self::INVALID => "Invalid value given. Scalar expected.",
+        self::NOT_STEP => "The input is not a valid step.",
     );
 
     /**

--- a/library/Zend/Validator/StringLength.php
+++ b/library/Zend/Validator/StringLength.php
@@ -24,9 +24,9 @@ class StringLength extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID   => "Invalid type given. String expected",
-        self::TOO_SHORT => "The input is less than %min% characters long",
-        self::TOO_LONG  => "The input is more than %max% characters long",
+        self::INVALID   => "Invalid type given. String expected.",
+        self::TOO_SHORT => "The input is less than %min% characters long.",
+        self::TOO_LONG  => "The input is more than %max% characters long.",
     );
 
     /**

--- a/library/Zend/Validator/Uri.php
+++ b/library/Zend/Validator/Uri.php
@@ -28,8 +28,8 @@ class Uri extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID => "Invalid type given. String expected",
-        self::NOT_URI => "The input does not appear to be a valid Uri",
+        self::INVALID => "Invalid type given. String expected.",
+        self::NOT_URI => "The input does not appear to be a valid Uri.",
     );
 
     /**

--- a/resources/languages/ar/Zend_Captcha.php
+++ b/resources/languages/ar/Zend_Captcha.php
@@ -24,12 +24,12 @@
  */
 return array(
     // Zend_Captcha_ReCaptcha
-    "Missing captcha fields" => "كلمة التحقق مفقودة",
-    "Failed to validate captcha" => "فشل في التحقق من صحة كلمة التحقق",
-    "Captcha value is wrong: %value%" => "كلمة التحقق خاطئة: %value%",
+    "Missing captcha fields." => "كلمة التحقق مفقودة",
+    "Failed to validate captcha." => "فشل في التحقق من صحة كلمة التحقق",
+    "Captcha value is wrong: %value%." => "كلمة التحقق خاطئة: %value%",
 
     // Zend_Captcha_Word
-    "Empty captcha value" => "كلمة التحقق فارغة",
-    "Captcha ID field is missing" => "معرف (ID) لكلمة التحقق مفقود",
-    "Captcha value is wrong" => "كلمة التحقق خاطئة",
+    "Empty captcha value." => "كلمة التحقق فارغة",
+    "Captcha ID field is missing." => "معرف (ID) لكلمة التحقق مفقود",
+    "Captcha value is wrong." => "كلمة التحقق خاطئة",
 );

--- a/resources/languages/ar/Zend_Validate.php
+++ b/resources/languages/ar/Zend_Validate.php
@@ -24,242 +24,242 @@
  */
 return array(
     // Zend_Validate_Alnum
-    "Invalid type given. String, integer or float expected" => "خطأ في المدخلة. يجب ادخال أرقام أو حروف فقط",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' تحتوي على رموز ليست حروف أو أرقام",
-    "'%value%' is an empty string" => "'%value%' فارغ",
+    "Invalid type given. String, integer or float expected." => "خطأ في المدخلة. يجب ادخال أرقام أو حروف فقط",
+    "'%value%' contains characters which are non alphabetic and no digits." => "'%value%' تحتوي على رموز ليست حروف أو أرقام",
+    "'%value%' is an empty string." => "'%value%' فارغ",
 
     // Zend_Validate_Alpha
-    "Invalid type given. String expected" => "خطأ في المدخلة. يجب ادخال حروف فقط",
-    "'%value%' contains non alphabetic characters" => "'%value%' تحتوي على رموز ليست حروف",
-    "'%value%' is an empty string" => "'%value%' فارغ",
+    "Invalid type given. String expected." => "خطأ في المدخلة. يجب ادخال حروف فقط",
+    "'%value%' contains non alphabetic characters." => "'%value%' تحتوي على رموز ليست حروف",
+    "'%value%' is an empty string." => "'%value%' فارغ",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "'%value%' لم يجتز فحص الصحة",
     "'%value%' contains invalid characters" => "'%value%' يحتوي على رموز خاطئة",
     "'%value%' should have a length of %length% characters" => "طول '%value%' يجب أن يكون %length% حرف",
-    "Invalid type given. String expected" => "خطأ في المدخلة. يجب ادخال نص",
+    "Invalid type given. String expected." => "خطأ في المدخلة. يجب ادخال نص",
 
     // Zend_Validate_Between
     "'%value%' is not between '%min%' and '%max%', inclusively" => "قيمة '%value%' يجب أن تكون بين '%min%' و '%max%'",
     "'%value%' is not strictly between '%min%' and '%max%'" => "قيمة '%value%' ليست بين '%min%' و '%max%'",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "'%value%' خاطئ",
-    "An exception has been raised within the callback" => "حصل خطأ داخلي أثناء تنفيذ العملية",
+    "'%value%' is not valid." => "'%value%' خاطئ",
+    "An exception has been raised within the callback." => "حصل خطأ داخلي أثناء تنفيذ العملية",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' يجب أن تحتوي على ما بين 13 إلى 19 رقم",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "فشل اختبار Luhn algorithm (mod-10 checksum) على '%value%'",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' يجب أن تحتوي على ما بين 13 إلى 19 رقم",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "فشل اختبار Luhn algorithm (mod-10 checksum) على '%value%'",
 
     // Zend_Validate_CreditCard
-    "'%value%' seems to contain an invalid checksum" => "'%value%' لم يجتز فحص الصحة",
-    "'%value%' must contain only digits" => "'%value%' يجب أن تحتوي على أرقام فقط",
-    "Invalid type given. String expected" => "خطأ في المدخلة. يجب ادخال نص",
-    "'%value%' contains an invalid amount of digits" => "'%value%' تحتوي على عدد خاطئ من الأرقام",
-    "'%value%' is not from an allowed institute" => "قيمة '%value%' ليست من مؤسسة مسموحة أو مقبولة",
+    "'%value%' seems to contain an invalid checksum." => "'%value%' لم يجتز فحص الصحة",
+    "'%value%' must contain only digits." => "'%value%' يجب أن تحتوي على أرقام فقط",
+    "Invalid type given. String expected." => "خطأ في المدخلة. يجب ادخال نص",
+    "'%value%' contains an invalid amount of digits." => "'%value%' تحتوي على عدد خاطئ من الأرقام",
+    "'%value%' is not from an allowed institute." => "قيمة '%value%' ليست من مؤسسة مسموحة أو مقبولة",
     "'%value%' seems to be an invalid creditcard number" => "'%value%' ليس رقم بطاقة إئتمان",
-    "An exception has been raised while validating '%value%'" => "حصل خطأ أثناء التحقق من صحة '%value%'",
+    "An exception has been raised while validating '%value%'." => "حصل خطأ أثناء التحقق من صحة '%value%'",
 
     // Zend_Validate_Date
-    "Invalid type given. String, integer, array or Zend_Date expected" => "خطأ في المدخلة. يجب ادخال حروف، أرقام، متسلسلات، أو Zend_Date",
-    "'%value%' does not appear to be a valid date" => "'%value%' ليس تاريخ صحيح",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' لا يطابق شكل التاريخ '%format%'",
+    "Invalid type given. String, integer, array or Zend_Date expected." => "خطأ في المدخلة. يجب ادخال حروف، أرقام، متسلسلات، أو Zend_Date",
+    "'%value%' does not appear to be a valid date." => "'%value%' ليس تاريخ صحيح",
+    "'%value%' does not fit the date format '%format%'." => "'%value%' لا يطابق شكل التاريخ '%format%'",
 
     // Zend_Validate_Db_Abstract
-    "No record matching '%value%' was found" => "لم يتم العثور على سجل مطابق لـ '%value%'",
-    "A record matching '%value%' was found" => "السجل '%value%' موجود",
+    "No record matching '%value%' was found." => "لم يتم العثور على سجل مطابق لـ '%value%'",
+    "A record matching '%value%' was found." => "السجل '%value%' موجود",
 
     // Zend_Validate_Digits
-    "Invalid type given. String, integer or float expected" => "خطأ في المدخلة. يجب ادخال أرقام أو حروف فقط",
-    "'%value%' must contain only digits" => "'%value%' يجب أن يحتوي على أرقام فقط",
-    "'%value%' is an empty string" => "'%value%' فارغ",
+    "Invalid type given. String, integer or float expected." => "خطأ في المدخلة. يجب ادخال أرقام أو حروف فقط",
+    "'%value%' must contain only digits." => "'%value%' يجب أن يحتوي على أرقام فقط",
+    "'%value%' is an empty string." => "'%value%' فارغ",
 
     // Zend_Validate_EmailAddress
-    "Invalid type given. String expected" => "خطأ في المدخلة. يجب ادخال نص",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "قيمة '%value%' ليست بريد الكتروني صحيح يطابق نمط local-part@hostname",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "قيمة '%hostname%' للبريد الإلكتروني '%value%' ليس صحيح",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "لا يوجد مدخلة MX صحيحة لـ'%hostname%' للبريد الإلكتروني '%value%'",
-    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network" => "'%hostname%' غير موجود في مكان يمكن الوصول إليه. البريد الإلكتروني '%value%' لا يمكن الوصول إليه من شبكة عامة",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' لا يمكن مطابقته مع شكل dot-atom",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' لا يمكن مطابقته مع شكل quoted-string",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' ليس بريد الكتروني صحيح لقيمة '%value%'",
-    "'%value%' exceeds the allowed length" => "طول '%value%' تعدى الطول المسموح",
+    "Invalid type given. String expected." => "خطأ في المدخلة. يجب ادخال نص",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "قيمة '%value%' ليست بريد الكتروني صحيح يطابق نمط local-part@hostname",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "قيمة '%hostname%' للبريد الإلكتروني '%value%' ليس صحيح",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "لا يوجد مدخلة MX صحيحة لـ'%hostname%' للبريد الإلكتروني '%value%'",
+    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' غير موجود في مكان يمكن الوصول إليه. البريد الإلكتروني '%value%' لا يمكن الوصول إليه من شبكة عامة",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' لا يمكن مطابقته مع شكل dot-atom",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' لا يمكن مطابقته مع شكل quoted-string",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "'%localPart%' ليس بريد الكتروني صحيح لقيمة '%value%'",
+    "'%value%' exceeds the allowed length." => "طول '%value%' تعدى الطول المسموح",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "'%count%' ملف/ملفات هو عدد أكبر من العدد المسموح به وهو '%max%'",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "'%count%' ملف/ملفات هو عدد أقل من العدد المطلوب وهو '%min%'",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "'%count%' ملف/ملفات هو عدد أكبر من العدد المسموح به وهو '%max%'",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "'%count%' ملف/ملفات هو عدد أقل من العدد المطلوب وهو '%min%'",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "لم يطابق تشفير crc32 للملف '%value%' التشفير المعطى",
-    "A crc32 hash could not be evaluated for the given file" => "لا يمكن معرفة قيمة تشفير crc32 للملف",
-    "File '%value%' is not readable or does not exist" => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
+    "File '%value%' does not match the given crc32 hashes." => "لم يطابق تشفير crc32 للملف '%value%' التشفير المعطى",
+    "A crc32 hash could not be evaluated for the given file." => "لا يمكن معرفة قيمة تشفير crc32 للملف",
+    "File '%value%' is not readable or does not exist." => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "امتداد الملف '%value%' خاطئ",
-    "File '%value%' is not readable or does not exist" => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
+    "File '%value%' has a false extension." => "امتداد الملف '%value%' خاطئ",
+    "File '%value%' is not readable or does not exist." => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "الملف '%value%' له نوع خاطئ وهو '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "لم يتم التعرف على نوع الملف '%value%'",
-    "File '%value%' is not readable or does not exist" => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
+    "File '%value%' has a false mimetype of '%type%'." => "الملف '%value%' له نوع خاطئ وهو '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "لم يتم التعرف على نوع الملف '%value%'",
+    "File '%value%' is not readable or does not exist." => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "الملف '%value%' غير موجود",
+    "File '%value%' does not exist." => "الملف '%value%' غير موجود",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "صيغة الملف '%value%' خاطئة",
-    "File '%value%' is not readable or does not exist" => "'%value%' لا يمكن قراءة محتوى الملف أو أنه غير موجود",
+    "File '%value%' has a false extension." => "صيغة الملف '%value%' خاطئة",
+    "File '%value%' is not readable or does not exist." => "'%value%' لا يمكن قراءة محتوى الملف أو أنه غير موجود",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "'%size%' هو حجم أكبر من الحد الأقصى المسموح به للملفات وهو '%max%'",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "'%size%' هو حجم أصغر من الحد الأدنى المسموح به للملفات وهو '%min%'",
-    "One or more files can not be read" => "لا يمكن قراءة محتوى ملف أو أكثر",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "'%size%' هو حجم أكبر من الحد الأقصى المسموح به للملفات وهو '%max%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "'%size%' هو حجم أصغر من الحد الأدنى المسموح به للملفات وهو '%min%'",
+    "One or more files can not be read." => "لا يمكن قراءة محتوى ملف أو أكثر",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "لم يطابق تشفير الملف '%value%' التشفير المعطى",
-    "A hash could not be evaluated for the given file" => "لا يمكن معرفة قيمة التشفير للملف",
-    "File '%value%' is not readable or does not exist" => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
+    "File '%value%' does not match the given hashes." => "لم يطابق تشفير الملف '%value%' التشفير المعطى",
+    "A hash could not be evaluated for the given file." => "لا يمكن معرفة قيمة التشفير للملف",
+    "File '%value%' is not readable or does not exist." => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "أكبر عرض مسموح به للصورة '%value%' هو '%maxwidth%' ولكن العرض الحالي هو '%width%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "أقل عرض مسموح به للصورة '%value%' هو '%minwidth%' ولكن العرض الحالي هو '%width%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "أكبر ارتفاع مسموح به للصورة '%value%' هو '%maxheight%' ولكن الطول الحالي هو '%height%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "أقل ارتفاع مسموح به للصورة '%value%' should be '%minheight%' ولكن الطول الحالي هو '%height%'",
-    "The size of image '%value%' could not be detected" => "لا يمكن أبعاد الصورة '%value%'",
-    "File '%value%' is not readable or does not exist" => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "أكبر عرض مسموح به للصورة '%value%' هو '%maxwidth%' ولكن العرض الحالي هو '%width%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "أقل عرض مسموح به للصورة '%value%' هو '%minwidth%' ولكن العرض الحالي هو '%width%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "أكبر ارتفاع مسموح به للصورة '%value%' هو '%maxheight%' ولكن الطول الحالي هو '%height%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "أقل ارتفاع مسموح به للصورة '%value%' should be '%minheight%' ولكن الطول الحالي هو '%height%'",
+    "The size of image '%value%' could not be detected." => "لا يمكن أبعاد الصورة '%value%'",
+    "File '%value%' is not readable or does not exist." => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "الملف '%value%' ليس ملف مضغوط، بل هو ملف '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "لم يتم التعرف على نوع الملف '%value%'",
-    "File '%value%' is not readable or does not exist" => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
+    "File '%value%' is not compressed, '%type%' detected." => "الملف '%value%' ليس ملف مضغوط، بل هو ملف '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "لم يتم التعرف على نوع الملف '%value%'",
+    "File '%value%' is not readable or does not exist." => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "الملف '%value%' ليس صورة، بل هو ملف '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "لم يتم التعرف على نوع الملف '%value%'",
-    "File '%value%' is not readable or does not exist" => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
+    "File '%value%' is no image, '%type%' detected." => "الملف '%value%' ليس صورة، بل هو ملف '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "لم يتم التعرف على نوع الملف '%value%'",
+    "File '%value%' is not readable or does not exist." => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "لم يطابق تشفير md5 للملف '%value%' التشفير المعطى",
-    "A md5 hash could not be evaluated for the given file" => "لا يمكن معرفة قيمة تشفير md5 للملف",
-    "File '%value%' is not readable or does not exist" => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
+    "File '%value%' does not match the given md5 hashes." => "لم يطابق تشفير md5 للملف '%value%' التشفير المعطى",
+    "A md5 hash could not be evaluated for the given file." => "لا يمكن معرفة قيمة تشفير md5 للملف",
+    "File '%value%' is not readable or does not exist." => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "الملف '%value%' له نوع خاطئ وهو '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "لم يتم التعرف على نوع الملف '%value%'",
-    "File '%value%' is not readable or does not exist" => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
+    "File '%value%' has a false mimetype of '%type%'." => "الملف '%value%' له نوع خاطئ وهو '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "لم يتم التعرف على نوع الملف '%value%'",
+    "File '%value%' is not readable or does not exist." => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "الملف '%value%' موجود",
+    "File '%value%' exists." => "الملف '%value%' موجود",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "لم يطابق تشفير sha1 للملف '%value%' التشفير المعطى",
-    "A sha1 hash could not be evaluated for the given file" => "لا يمكن معرفة قيمة تشفير sha1 للملف",
-    "File '%value%' is not readable or does not exist" => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
+    "File '%value%' does not match the given sha1 hashes." => "لم يطابق تشفير sha1 للملف '%value%' التشفير المعطى",
+    "A sha1 hash could not be evaluated for the given file." => "لا يمكن معرفة قيمة تشفير sha1 للملف",
+    "File '%value%' is not readable or does not exist." => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "حجم الملف '%value%' هو '%size%' وهذا الحجم أكبر من الحد الأقصى المسموح به وهو '%max%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "حجم الملف '%value%' هو '%size%' وهذا الحجم أقل من الحد الأدنى المسموح به وهو '%min%'",
-    "File '%value%' is not readable or does not exist" => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "حجم الملف '%value%' هو '%size%' وهذا الحجم أكبر من الحد الأقصى المسموح به وهو '%max%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "حجم الملف '%value%' هو '%size%' وهذا الحجم أقل من الحد الأدنى المسموح به وهو '%min%'",
+    "File '%value%' is not readable or does not exist." => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "الملف '%value%' تعدى الحجم المسموح به حسب التعريف في ini",
-    "File '%value%' exceeds the defined form size" => "الملف '%value%' تعدى الحجم المسموح به حسب التعريف في النموذج",
-    "File '%value%' was only partially uploaded" => "الملف '%value%' تم تحميل جزء منه",
-    "File '%value%' was not uploaded" => "الملف '%value%' لم يتم تحميله",
-    "No temporary directory was found for file '%value%'" => "لم يتم العثور على مكان مؤقت للملف '%value%'",
-    "File '%value%' can't be written" => "الملف '%value%' لا يمكن كتابته وتخزينه",
-    "A PHP extension returned an error while uploading the file '%value%'" => "لقد حصل خطأ من إضافة PHP في عملية تحميل الملف '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "لقد تم تحميل الملف '%value%' بطريقة غير مشروعة. وهذا يمكن أن يكون محاولة هجوم",
-    "File '%value%' was not found" => "لم يتم العثور على الملف '%value%'",
-    "Unknown error while uploading file '%value%'" => "حصل خطأ غير معروف في عملية تحميل الملف '%value%'",
+    "File '%value%' exceeds the defined ini size." => "الملف '%value%' تعدى الحجم المسموح به حسب التعريف في ini",
+    "File '%value%' exceeds the defined form size." => "الملف '%value%' تعدى الحجم المسموح به حسب التعريف في النموذج",
+    "File '%value%' was only partially uploaded." => "الملف '%value%' تم تحميل جزء منه",
+    "File '%value%' was not uploaded." => "الملف '%value%' لم يتم تحميله",
+    "No temporary directory was found for file '%value%'." => "لم يتم العثور على مكان مؤقت للملف '%value%'",
+    "File '%value%' can't be written." => "الملف '%value%' لا يمكن كتابته وتخزينه",
+    "A PHP extension returned an error while uploading the file '%value%'." => "لقد حصل خطأ من إضافة PHP في عملية تحميل الملف '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "لقد تم تحميل الملف '%value%' بطريقة غير مشروعة. وهذا يمكن أن يكون محاولة هجوم",
+    "File '%value%' was not found." => "لم يتم العثور على الملف '%value%'",
+    "Unknown error while uploading file '%value%'." => "حصل خطأ غير معروف في عملية تحميل الملف '%value%'",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "'%count%' كلمات أكثر من العدد الأقصى المسموح به وهو '%max%' كلمات",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "'%count%' كلمات أقل من العدد الأدنى المسموح وهو '%min%' كلمات",
-    "File '%value%' is not readable or does not exist" => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "'%count%' كلمات أكثر من العدد الأقصى المسموح به وهو '%max%' كلمات",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "'%count%' كلمات أقل من العدد الأدنى المسموح وهو '%min%' كلمات",
+    "File '%value%' is not readable or does not exist." => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
 
     // Zend_Validate_Float
-    "Invalid type given. String, integer or float expected" => "خطأ في المدخلة. يجب ادخال أرقام أو حروف فقط",
-    "'%value%' does not appear to be a float" => "'%value%' ليس رقم",
+    "Invalid type given. String, integer or float expected." => "خطأ في المدخلة. يجب ادخال أرقام أو حروف فقط",
+    "'%value%' does not appear to be a float." => "'%value%' ليس رقم",
 
     // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' ليس أكبر من '%min%'",
+    "'%value%' is not greater than '%min%'." => "'%value%' ليس أكبر من '%min%'",
 
     // Zend_Validate_Hex
-    "Invalid type given. String expected" => "خطأ في المدخلة. يجب ادخال نص",
-    "'%value%' has not only hexadecimal digit characters" => "'%value%' يحتوي على حروف أو رموز ليست من النظام الست عشري (hexadecimal)",
+    "Invalid type given. String expected." => "خطأ في المدخلة. يجب ادخال نص",
+    "'%value%' has not only hexadecimal digit characters." => "'%value%' يحتوي على حروف أو رموز ليست من النظام الست عشري (hexadecimal)",
 
     // Zend_Validate_Hostname
-    "Invalid type given. String expected" => "خطأ في المدخلة. يجب ادخال نص",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "قيمة '%value%' تبدو أنها عنوان بروتوكول انترنت (IP) وهذا غير مسموح به",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' هو اسم نظام أسماء المجالات (DNS)، ولكن اسم المجال ذو المستوى العال (TLD) غير معروف",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' هو اسم نظام أسماء المجالات (DNS)، ولكنه يحتوي على (-) في مكان خاطئ",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' هو اسم نظام أسماء المجالات (DNS)، ولكن لا يمكن مطابقته مع اسم مخطط لاسم المجال ذو المستوى العال (TLD) '%tld%'",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' هو اسم نظام أسماء المجالات (DNS)، ولكن لا يمكن معرفة جزء اسم مجال ذو مستوى عال (TLD) منه",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' لا يطابق شكل نظام أسماء المجالات (DNS)",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' ليس اسم صحيح لشبكة محلية",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' هو اسم لشبكة محلية، والشبكة المحلية غير مسموح بها",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "'%value%' هو اسم نظام أسماء المجالات (DNS)،  ولكن الرموز في الاسم لا يمكن تفكيكها وتحويلها لصيغة أبسط",
-    "'%value%' does not appear to be a valid URI hostname" => "'%value%' ليس عنوان اسم صحيح لمضيف",
+    "Invalid type given. String expected." => "خطأ في المدخلة. يجب ادخال نص",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => "قيمة '%value%' تبدو أنها عنوان بروتوكول انترنت (IP) وهذا غير مسموح به",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => "'%value%' هو اسم نظام أسماء المجالات (DNS)، ولكن اسم المجال ذو المستوى العال (TLD) غير معروف",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => "'%value%' هو اسم نظام أسماء المجالات (DNS)، ولكنه يحتوي على (-) في مكان خاطئ",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => "'%value%' هو اسم نظام أسماء المجالات (DNS)، ولكن لا يمكن مطابقته مع اسم مخطط لاسم المجال ذو المستوى العال (TLD) '%tld%'",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => "'%value%' هو اسم نظام أسماء المجالات (DNS)، ولكن لا يمكن معرفة جزء اسم مجال ذو مستوى عال (TLD) منه",
+    "'%value%' does not match the expected structure for a DNS hostname." => "'%value%' لا يطابق شكل نظام أسماء المجالات (DNS)",
+    "'%value%' does not appear to be a valid local network name." => "'%value%' ليس اسم صحيح لشبكة محلية",
+    "'%value%' appears to be a local network name but local network names are not allowed." => "'%value%' هو اسم لشبكة محلية، والشبكة المحلية غير مسموح بها",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => "'%value%' هو اسم نظام أسماء المجالات (DNS)،  ولكن الرموز في الاسم لا يمكن تفكيكها وتحويلها لصيغة أبسط",
+    "'%value%' does not appear to be a valid URI hostname." => "'%value%' ليس عنوان اسم صحيح لمضيف",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "لم يتم التعرف على الدولة في الرقم الدولي للحساب البنكي (IBAN) '%value%'",
-    "'%value%' has a false IBAN format" => "'%value%' ليس صيفة صحيحة لالرقم الدولي للحساب البنكي (IBAN)",
-    "'%value%' has failed the IBAN check" => "'%value%' لم يجتز فحص الرقم الدولي للحساب البنكي (IBAN)",
+    "Unknown country within the IBAN '%value%'." => "لم يتم التعرف على الدولة في الرقم الدولي للحساب البنكي (IBAN) '%value%'",
+    "'%value%' has a false IBAN format." => "'%value%' ليس صيفة صحيحة لالرقم الدولي للحساب البنكي (IBAN)",
+    "'%value%' has failed the IBAN check." => "'%value%' لم يجتز فحص الرقم الدولي للحساب البنكي (IBAN)",
 
     // Zend_Validate_Identical
-    "The two given tokens do not match" => "الرمزان غير متطابقان",
-    "No token was provided to match against" => "لا يوجد رمز للمقارنة به",
+    "The two given tokens do not match." => "الرمزان غير متطابقان",
+    "No token was provided to match against." => "لا يوجد رمز للمقارنة به",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "لم يتم العثور على '%value%' في المتسلسلة",
+    "'%value%' was not found in the haystack." => "لم يتم العثور على '%value%' في المتسلسلة",
 
     // Zend_Validate_Int
-    "Invalid type given. String or integer expected" => "خطأ في المدخلة. يجب ادخال أرقام",
-    "'%value%' does not appear to be an integer" => "'%value%' ليس رقم",
+    "Invalid type given. String or integer expected." => "خطأ في المدخلة. يجب ادخال أرقام",
+    "'%value%' does not appear to be an integer." => "'%value%' ليس رقم",
 
     // Zend_Validate_Ip
-    "Invalid type given. String expected" => "خطأ في المدخلة. يجب ادخال نص",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' ليس عنوان بروتوكول انترنت (IP) صحيح",
+    "Invalid type given. String expected." => "خطأ في المدخلة. يجب ادخال نص",
+    "'%value%' does not appear to be a valid IP address." => "'%value%' ليس عنوان بروتوكول انترنت (IP) صحيح",
 
     // Zend_Validate_Isbn
-    "Invalid type given. String or integer expected" => "خطأ في المدخلة. يجب ادخال أرقام أو حروف",
-    "'%value%' is not a valid ISBN number" => "'%value%' ليس قيمة صحيحة لالرقم الدولي الموحد للكتاب (ISBN)",
+    "Invalid type given. String or integer expected." => "خطأ في المدخلة. يجب ادخال أرقام أو حروف",
+    "'%value%' is not a valid ISBN number." => "'%value%' ليس قيمة صحيحة لالرقم الدولي الموحد للكتاب (ISBN)",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' ليس أقل من '%max%'",
+    "'%value%' is not less than '%max%'." => "'%value%' ليس أقل من '%max%'",
 
     // Zend_Validate_NotEmpty
-    "Invalid type given. String, integer, float, boolean or array expected" => "خطأ في المدخلة. يجب ادخال أرقام، حروف، صح أو خطأ، أو متسلسلة",
-    "Value is required and can't be empty" => "لا يمكن ترك هذا الحقل فارغ",
+    "Invalid type given. String, integer, float, boolean or array expected." => "خطأ في المدخلة. يجب ادخال أرقام، حروف، صح أو خطأ، أو متسلسلة",
+    "Value is required and can't be empty." => "لا يمكن ترك هذا الحقل فارغ",
 
     // Zend_Validate_PostCode
-    "Invalid type given. String or integer expected" => "خطأ في المدخلة. يجب ادخال أرقام أو حروف",
-    "'%value%' does not appear to be a postal code" => "'%value%' ليس رمز بريدي صحيح",
+    "Invalid type given. String or integer expected." => "خطأ في المدخلة. يجب ادخال أرقام أو حروف",
+    "'%value%' does not appear to be a postal code." => "'%value%' ليس رمز بريدي صحيح",
 
     // Zend_Validate_Regex
-    "Invalid type given. String, integer or float expected" => "خطأ في المدخلة. يجب ادخال أرقام أو حروف فقط",
-    "'%value%' does not match against pattern '%pattern%'" => "'%value%' لا يطابق النمط '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "حصل خطأ داخلي أثناء استخدام النمط '%pattern%'",
+    "Invalid type given. String, integer or float expected." => "خطأ في المدخلة. يجب ادخال أرقام أو حروف فقط",
+    "'%value%' does not match against pattern '%pattern%'." => "'%value%' لا يطابق النمط '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "حصل خطأ داخلي أثناء استخدام النمط '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => "'%value%' ليست قيمة صحيحة لوتيرة التغيير لخريطة الموقع",
-    "Invalid type given. String expected" => "خطأ في المدخلة. يجب ادخال نص",
+    "'%value%' is not a valid sitemap changefreq." => "'%value%' ليست قيمة صحيحة لوتيرة التغيير لخريطة الموقع",
+    "Invalid type given. String expected." => "خطأ في المدخلة. يجب ادخال نص",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => "'%value%' ليست قيمة صحيحة لتاريخ آخر تعديل لخريطة الموقع",
-    "Invalid type given. String expected" => "خطأ في المدخلة. يجب ادخال نص",
+    "'%value%' is not a valid sitemap lastmod." => "'%value%' ليست قيمة صحيحة لتاريخ آخر تعديل لخريطة الموقع",
+    "Invalid type given. String expected." => "خطأ في المدخلة. يجب ادخال نص",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => "'%value%' ليس عنوان صحيح لخريطة الموقع",
-    "Invalid type given. String expected" => "خطأ في المدخلة. يجب ادخال نص",
+    "'%value%' is not a valid sitemap location." => "'%value%' ليس عنوان صحيح لخريطة الموقع",
+    "Invalid type given. String expected." => "خطأ في المدخلة. يجب ادخال نص",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => "'%value%' ليست أولوية صحيحة لعنوان خريطة الموقع",
-    "Invalid type given. Numeric string, integer or float expected" => "خطأ في المدخلة. يجب ادخال أرقام أو حروف فقط",
+    "'%value%' is not a valid sitemap priority." => "'%value%' ليست أولوية صحيحة لعنوان خريطة الموقع",
+    "Invalid type given. Numeric string, integer or float expected." => "خطأ في المدخلة. يجب ادخال أرقام أو حروف فقط",
 
     // Zend_Validate_StringLength
-    "Invalid type given. String expected" => "خطأ في المدخلة. يجب ادخال نص",
-    "'%value%' is less than %min% characters long" => "طول '%value%' يجب أن يكون %min% حرف على الأقل",
-    "'%value%' is more than %max% characters long" => "طول '%value%' يجب أن يكون %max% كحد أقصى",
+    "Invalid type given. String expected." => "خطأ في المدخلة. يجب ادخال نص",
+    "'%value%' is less than %min% characters long." => "طول '%value%' يجب أن يكون %min% حرف على الأقل",
+    "'%value%' is more than %max% characters long." => "طول '%value%' يجب أن يكون %max% كحد أقصى",
 );

--- a/resources/languages/bg/Zend_Captcha.php
+++ b/resources/languages/bg/Zend_Captcha.php
@@ -24,12 +24,12 @@
  */
 return array(
     // Zend_Captcha_ReCaptcha
-    "Missing captcha fields" => "Непопълнена стойност на капча",
-    "Failed to validate captcha" => "Не може да валидира капча",
-    "Captcha value is wrong: %value%" => "Стойността на капча е грешна: %value%",
+    "Missing captcha fields." => "Непопълнена стойност на капча",
+    "Failed to validate captcha." => "Не може да валидира капча",
+    "Captcha value is wrong: %value%." => "Стойността на капча е грешна: %value%",
 
     // Zend_Captcha_Word
-    "Empty captcha value" => "Непопълнена стойност на капча",
-    "Captcha ID field is missing" => "Липсващо капча ID поле",
-    "Captcha value is wrong" => "Стойността на капча е грешна",
+    "Empty captcha value." => "Непопълнена стойност на капча",
+    "Captcha ID field is missing." => "Липсващо капча ID поле",
+    "Captcha value is wrong." => "Стойността на капча е грешна",
 );

--- a/resources/languages/bg/Zend_Validate.php
+++ b/resources/languages/bg/Zend_Validate.php
@@ -35,7 +35,7 @@ return array(
 
     // Zend_I18n_Validator_Float
     "Invalid type given. String, integer or float expected." => "Зададен е невалиден тип данни. Очаква се цяло или реално число",
-    "The input does not appear to be a float" => "Не е въведено реално число",
+    "The input does not appear to be a float." => "Не е въведено реално число",
 
     // Zend_I18n_Validator_Int
     "Invalid type given. String or integer expected." => "Зададен е невалиден тип данни. Очаква се цяло число",
@@ -43,8 +43,8 @@ return array(
 
     // Zend_I18n_Validator_PostCode
     "Invalid type given. String or integer expected." => "Зададен е невалиден тип данни. Очаква се стринг или цяло число",
-    "The input does not appear to be a postal code" => "Не е въведен валиден пощенски код",
-    "An exception has been raised while validating the input" => "По време на валидацията беше върнато изключение",
+    "The input does not appear to be a postal code." => "Не е въведен валиден пощенски код",
+    "An exception has been raised while validating the input." => "По време на валидацията беше върнато изключение",
 
     // Zend_Validator_Barcode
     "The input failed checksum validation." => "Въведената стойност не успя на премине валидацията на контролната сума",
@@ -67,7 +67,7 @@ return array(
     "The input contains an invalid amount of digits" => "Въведената стойност съдържа невалиден брой цифри",
     "The input is not from an allowed institute" => "Въведената стойност не е разрешена организация",
     "The input seems to be an invalid creditcard number" => "Въведената стойност не е валиден номер на кредитна карта",
-    "An exception has been raised while validating the input" => "По време на валидацията беше върнато ново изключение",
+    "An exception has been raised while validating the input." => "По време на валидацията беше върнато ново изключение",
 
     // Zend_Validator_Csrf
     "The form submitted did not originate from the expected site" => "Формата не е изпратена от очаквания сайт",

--- a/resources/languages/bg/Zend_Validate.php
+++ b/resources/languages/bg/Zend_Validate.php
@@ -24,33 +24,33 @@
  */
 return array(
     // Zend_I18n_Validator_Alnum
-    "Invalid type given. String, integer or float expected" => "Зададен е невалиден тип данни. Очаква се стринг, цяло или реално число",
-    "The input contains characters which are non alphabetic and no digits" => "Въведени са символи, които не са букви или числа",
-    "The input is an empty string" => "Въведен е празен стринг",
+    "Invalid type given. String, integer or float expected." => "Зададен е невалиден тип данни. Очаква се стринг, цяло или реално число",
+    "The input contains characters which are non alphabetic and no digits." => "Въведени са символи, които не са букви или числа",
+    "The input is an empty string." => "Въведен е празен стринг",
 
     // Zend_I18n_Validator_Alpha
-    "Invalid type given. String expected" => "Зададен е невалиден тип данни. Очаква се стринг",
-    "The input contains non alphabetic characters" => "Въведени са символи, които не са букви",
-    "The input is an empty string" => "Въведен е празен стринг",
+    "Invalid type given. String expected." => "Зададен е невалиден тип данни. Очаква се стринг",
+    "The input contains non alphabetic characters." => "Въведени са символи, които не са букви",
+    "The input is an empty string." => "Въведен е празен стринг",
 
     // Zend_I18n_Validator_Float
-    "Invalid type given. String, integer or float expected" => "Зададен е невалиден тип данни. Очаква се цяло или реално число",
+    "Invalid type given. String, integer or float expected." => "Зададен е невалиден тип данни. Очаква се цяло или реално число",
     "The input does not appear to be a float" => "Не е въведено реално число",
 
     // Zend_I18n_Validator_Int
-    "Invalid type given. String or integer expected" => "Зададен е невалиден тип данни. Очаква се цяло число",
-    "The input does not appear to be an integer" => "Не е въведено цяло число",
+    "Invalid type given. String or integer expected." => "Зададен е невалиден тип данни. Очаква се цяло число",
+    "The input does not appear to be an integer." => "Не е въведено цяло число",
 
     // Zend_I18n_Validator_PostCode
-    "Invalid type given. String or integer expected" => "Зададен е невалиден тип данни. Очаква се стринг или цяло число",
+    "Invalid type given. String or integer expected." => "Зададен е невалиден тип данни. Очаква се стринг или цяло число",
     "The input does not appear to be a postal code" => "Не е въведен валиден пощенски код",
     "An exception has been raised while validating the input" => "По време на валидацията беше върнато изключение",
 
     // Zend_Validator_Barcode
-    "The input failed checksum validation" => "Въведената стойност не успя на премине валидацията на контролната сума",
+    "The input failed checksum validation." => "Въведената стойност не успя на премине валидацията на контролната сума",
     "The input contains invalid characters" => "Въведената стойност съдържа невалидни символи",
     "The input should have a length of %length% characters" => "Въведената стойност трябва да има дължина от %length% символа",
-    "Invalid type given. String expected" => "Зададен е невалиден тип данни. Очаква се стринг",
+    "Invalid type given. String expected." => "Зададен е невалиден тип данни. Очаква се стринг",
 
     // Zend_Validator_Between
     "The input is not between '%min%' and '%max%', inclusively" => "Въведената стойност не е между '%min%' и '%max%' включително",
@@ -58,12 +58,12 @@ return array(
 
     // Zend_Validator_Callback
     "The input is not valid" => "Въведена е невалидна стойност",
-    "An exception has been raised within the callback" => "По време на заявката беше върнато ново изключение",
+    "An exception has been raised within the callback." => "По време на заявката беше върнато ново изключение",
 
     // Zend_Validator_CreditCard
     "The input seems to contain an invalid checksum" => "Въведената стойност съдържа невалидна контролна сума",
     "The input must contain only digits" => "Въведената стойност трябва да съдържа само цифри",
-    "Invalid type given. String expected" => "Зададен е навалиден тип данни. Очаква се стринг",
+    "Invalid type given. String expected." => "Зададен е навалиден тип данни. Очаква се стринг",
     "The input contains an invalid amount of digits" => "Въведената стойност съдържа невалиден брой цифри",
     "The input is not from an allowed institute" => "Въведената стойност не е разрешена организация",
     "The input seems to be an invalid creditcard number" => "Въведената стойност не е валиден номер на кредитна карта",
@@ -88,122 +88,122 @@ return array(
 
     // Zend_Validator_Digits
     "The input must contain only digits" => "Въведената стойност трябва да съдържа само цифри",
-    "The input is an empty string" => "Въведената стойност е празен стринг",
-    "Invalid type given. String, integer or float expected" => "Зададен е невалиден тип данни. Очаква се стринг, цяло или реално число",
+    "The input is an empty string." => "Въведената стойност е празен стринг",
+    "Invalid type given. String, integer or float expected." => "Зададен е невалиден тип данни. Очаква се стринг, цяло или реално число",
 
     // Zend_Validator_EmailAddress
-    "Invalid type given. String expected" => "Зададен е навалиден тип данни. Очаква се стринг",
+    "Invalid type given. String expected." => "Зададен е навалиден тип данни. Очаква се стринг",
     "The input is not a valid email address. Use the basic format local-part@hostname" => "Въведената стойност не е валиден email адрес в базовия формат local-part@hostname",
     "'%hostname%' is not a valid hostname for the email address" => "'%hostname%' не е валидно име на хост за въведения email адрес",
     "'%hostname%' does not appear to have any valid MX or A records for the email address" => "'%hostname%' няма валиден MX запис за въведения email адрес",
     "'%hostname%' is not in a routable network segment. The email address should not be resolved from public network" => "'%hostname%' не е рутируем мрежов сегмент. Въведения email адрес не трябва да бъде достъпен от публични мрежи",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' не може да бъде сравнен с dot-atom формат",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' не може да бъде сравнен с quoted-string формат",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' не може да бъде сравнен с dot-atom формат",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' не може да бъде сравнен с quoted-string формат",
     "'%localPart%' is not a valid local part for the email address" => "'%localPart%' не е валидна локална част от въведения email адрес",
     "The input exceeds the allowed length" => "Въведената стойност надвишава разрешение размер",
 
     // Zend_Validator_Explode
-    "Invalid type given. String expected" => "Зададен е навалиден тип данни. Очаква се стринг",
+    "Invalid type given. String expected." => "Зададен е навалиден тип данни. Очаква се стринг",
 
     // Zend_Validator_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Твърде много файлове, максимум '%max%' са разрешени, но '%count%' са зададени",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Твърде малко файлове, минимум '%min%' са очаквани, но '%count%' са зададени",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Твърде много файлове, максимум '%max%' са разрешени, но '%count%' са зададени",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Твърде малко файлове, минимум '%min%' са очаквани, но '%count%' са зададени",
 
     // Zend_Validator_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Файлът '%value%' не съвпада с дадения crc32 хаш",
-    "A crc32 hash could not be evaluated for the given file" => "Този crc32 хаш не може да оцени зададения файл",
-    "File '%value%' is not readable or does not exist" => "Файлът '%value%' не може да бъде прочетен или не съществува",
+    "File '%value%' does not match the given crc32 hashes." => "Файлът '%value%' не съвпада с дадения crc32 хаш",
+    "A crc32 hash could not be evaluated for the given file." => "Този crc32 хаш не може да оцени зададения файл",
+    "File '%value%' is not readable or does not exist." => "Файлът '%value%' не може да бъде прочетен или не съществува",
 
     // Zend_Validator_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Файлът '%value%' има грешно разширение",
-    "File '%value%' is not readable or does not exist" => "Файлът '%value%' не може да бъде прочетен или не съществува",
+    "File '%value%' has a false extension." => "Файлът '%value%' има грешно разширение",
+    "File '%value%' is not readable or does not exist." => "Файлът '%value%' не може да бъде прочетен или не съществува",
 
     // Zend_Validator_File_Exists
-    "File '%value%' does not exist" => "Файлът '%value%' не съществува",
+    "File '%value%' does not exist." => "Файлът '%value%' не съществува",
 
     // Zend_Validator_File_Extension
-    "File '%value%' has a false extension" => "Файлът '%value%' е с грешно разширение",
-    "File '%value%' is not readable or does not exist" => "Файлът '%value%' е нечетим или не съществува",
+    "File '%value%' has a false extension." => "Файлът '%value%' е с грешно разширение",
+    "File '%value%' is not readable or does not exist." => "Файлът '%value%' е нечетим или не съществува",
 
     // Zend_Validator_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Файлове трябва да имат общ размер от максимум '%max%', но в момента той е '%size%'",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Файлове трябва да имат общ размер от минимум '%min%', но в момента той е '%size%'",
-    "One or more files can not be read" => "Един или повече файлове не могат да бъдат прочетени",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Файлове трябва да имат общ размер от максимум '%max%', но в момента той е '%size%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Файлове трябва да имат общ размер от минимум '%min%', но в момента той е '%size%'",
+    "One or more files can not be read." => "Един или повече файлове не могат да бъдат прочетени",
 
     // Zend_Validator_File_Hash
-    "File '%value%' does not match the given hashes" => "Файлът '%value%' не съвпада с зададения хаш",
-    "A hash could not be evaluated for the given file" => "Този хаш не може да оцени дадения файл",
-    "File '%value%' is not readable or does not exist" => "Файлът '%value%' не може да бъде прочетен или не съществува",
+    "File '%value%' does not match the given hashes." => "Файлът '%value%' не съвпада с зададения хаш",
+    "A hash could not be evaluated for the given file." => "Този хаш не може да оцени дадения файл",
+    "File '%value%' is not readable or does not exist." => "Файлът '%value%' не може да бъде прочетен или не съществува",
 
     // Zend_Validator_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Максималната ширина на изображението '%value%' трябва да бъде '%maxwidth%', но в момента е '%width%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Минималната ширина на изображението '%value%' трябва да бъде '%minwidth%', но в момента е '%width%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Максималната височина на изображението '%value%' трябва да бъде '%maxheight%', но в момента е '%height%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Минималната височина на изображението '%value%' трябва да бъде '%minheight%', но в момента е '%height%'",
-    "The size of image '%value%' could not be detected" => "Размера на изображението '%value%' не може да бъде открит",
-    "File '%value%' is not readable or does not exist" => "Файлът '%value%' не може да бъде прочетен или не съществува",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Максималната ширина на изображението '%value%' трябва да бъде '%maxwidth%', но в момента е '%width%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Минималната ширина на изображението '%value%' трябва да бъде '%minwidth%', но в момента е '%width%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Максималната височина на изображението '%value%' трябва да бъде '%maxheight%', но в момента е '%height%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Минималната височина на изображението '%value%' трябва да бъде '%minheight%', но в момента е '%height%'",
+    "The size of image '%value%' could not be detected." => "Размера на изображението '%value%' не може да бъде открит",
+    "File '%value%' is not readable or does not exist." => "Файлът '%value%' не може да бъде прочетен или не съществува",
 
     // Zend_Validator_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Файлът '%value%' не е компресиран, неговия формат е '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Не може да бъде открит маймтайп формата на '%value%'",
-    "File '%value%' is not readable or does not exist" => "Файлът '%value%' не може да бъде прочетен или не съществува",
+    "File '%value%' is not compressed, '%type%' detected." => "Файлът '%value%' не е компресиран, неговия формат е '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Не може да бъде открит маймтайп формата на '%value%'",
+    "File '%value%' is not readable or does not exist." => "Файлът '%value%' не може да бъде прочетен или не съществува",
 
     // Zend_Validator_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Файлът '%value%' не е изображение, неговия формат е '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Не може да бъде открит маймтайп формата на '%value%'",
-    "File '%value%' is not readable or does not exist" => "Файлът '%value%' не може да бъде прочетен или не съществува",
+    "File '%value%' is no image, '%type%' detected." => "Файлът '%value%' не е изображение, неговия формат е '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Не може да бъде открит маймтайп формата на '%value%'",
+    "File '%value%' is not readable or does not exist." => "Файлът '%value%' не може да бъде прочетен или не съществува",
 
     // Zend_Validator_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Файлът '%value%' не съвпада с дадения md5 хаш",
-    "A md5 hash could not be evaluated for the given file" => "Този md5 хаш не може да оцени дадения файл",
-    "File '%value%' is not readable or does not exist" => "Файлът '%value%' не може да бъде прочетен или не съществува",
+    "File '%value%' does not match the given md5 hashes." => "Файлът '%value%' не съвпада с дадения md5 хаш",
+    "A md5 hash could not be evaluated for the given file." => "Този md5 хаш не може да оцени дадения файл",
+    "File '%value%' is not readable or does not exist." => "Файлът '%value%' не може да бъде прочетен или не съществува",
 
     // Zend_Validator_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Файлът '%value%' има грешен маймтайп - '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Не може да бъде открит маймтайп формата на '%value%'",
-    "File '%value%' is not readable or does not exist" => "Файлът '%value%' не може да бъде прочетен или не съществува",
+    "File '%value%' has a false mimetype of '%type%'." => "Файлът '%value%' има грешен маймтайп - '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Не може да бъде открит маймтайп формата на '%value%'",
+    "File '%value%' is not readable or does not exist." => "Файлът '%value%' не може да бъде прочетен или не съществува",
 
     // Zend_Validator_File_NotExists
-    "File '%value%' exists" => "Файлът '%value%' съществува",
+    "File '%value%' exists." => "Файлът '%value%' съществува",
 
     // Zend_Validator_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Файлът '%value%' не съвпада с зададения sha1 хаш",
-    "A sha1 hash could not be evaluated for the given file" => "Този sha1 хаш не може да оцени дадения файл",
-    "File '%value%' is not readable or does not exist" => "Файлът '%value%' не може да бъде прочетен или не съществува",
+    "File '%value%' does not match the given sha1 hashes." => "Файлът '%value%' не съвпада с зададения sha1 хаш",
+    "A sha1 hash could not be evaluated for the given file." => "Този sha1 хаш не може да оцени дадения файл",
+    "File '%value%' is not readable or does not exist." => "Файлът '%value%' не може да бъде прочетен или не съществува",
 
     // Zend_Validator_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Максималния разрешен размер на файла '%value%' е '%max%', но в момента той е '%size%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Минималния разрешен размер на файла '%value%' е '%min%', но в момента той е '%size%'",
-    "File '%value%' is not readable or does not exist" => "Файлът '%value%' не може да бъде прочетен или не съществува",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Максималния разрешен размер на файла '%value%' е '%max%', но в момента той е '%size%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Минималния разрешен размер на файла '%value%' е '%min%', но в момента той е '%size%'",
+    "File '%value%' is not readable or does not exist." => "Файлът '%value%' не може да бъде прочетен или не съществува",
 
     // Zend_Validator_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Файлът '%value%' надвишава зададения размер в ini файла",
-    "File '%value%' exceeds the defined form size" => "Файлът '%value%' надвишава зададения във формата размер",
-    "File '%value%' was only partially uploaded" => "Файлът '%value%' беше качен само частично",
-    "File '%value%' was not uploaded" => "Файлът '%value%' не беше качен",
-    "No temporary directory was found for file '%value%'" => "Не беше открита временна директория за файла '%value%'",
-    "File '%value%' can't be written" => "Файлът '%value%' не може да бъде записан",
-    "A PHP extension returned an error while uploading the file '%value%'" => "PHP изключение беше върнато по време на качването на файла '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Файлът '%value%' беше качен без позволение. Това може да бъде потенциална атака",
-    "File '%value%' was not found" => "Файлът '%value%' не беше открит",
-    "Unknown error while uploading file '%value%'" => "Възникна грешка при качването на файла '%value%'",
+    "File '%value%' exceeds the defined ini size." => "Файлът '%value%' надвишава зададения размер в ini файла",
+    "File '%value%' exceeds the defined form size." => "Файлът '%value%' надвишава зададения във формата размер",
+    "File '%value%' was only partially uploaded." => "Файлът '%value%' беше качен само частично",
+    "File '%value%' was not uploaded." => "Файлът '%value%' не беше качен",
+    "No temporary directory was found for file '%value%'." => "Не беше открита временна директория за файла '%value%'",
+    "File '%value%' can't be written." => "Файлът '%value%' не може да бъде записан",
+    "A PHP extension returned an error while uploading the file '%value%'." => "PHP изключение беше върнато по време на качването на файла '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Файлът '%value%' беше качен без позволение. Това може да бъде потенциална атака",
+    "File '%value%' was not found." => "Файлът '%value%' не беше открит",
+    "Unknown error while uploading file '%value%'." => "Възникна грешка при качването на файла '%value%'",
 
     // Zend_Validator_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Твърде много думи, очакват се максимум '%max%', но '%count%' бяха открити",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Твърде малко думи, очакват се минимум '%min%' но само '%count%' бяха открити",
-    "File '%value%' is not readable or does not exist" => "Файлът '%value%' не може да бъде прочетен или не съществува",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Твърде много думи, очакват се максимум '%max%', но '%count%' бяха открити",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Твърде малко думи, очакват се минимум '%min%' но само '%count%' бяха открити",
+    "File '%value%' is not readable or does not exist." => "Файлът '%value%' не може да бъде прочетен или не съществува",
 
     // Zend_Validator_GreaterThan
     "The input is not greater than '%min%'" => "Въведената стойност не е по-голяма от '%min%'",
     "The input is not greater or equal than '%min%'" => "Въведената стойност не е по-голяма или равна на '%min%'",
 
     // Zend_Validator_Hex
-    "Invalid type given. String expected" => "Зададен е невалиден тип данни. Очаква се стринг",
+    "Invalid type given. String expected." => "Зададен е невалиден тип данни. Очаква се стринг",
     "The input contains non-hexadecimal characters" => "Въведената стойност не съдържа само шестнадесетични символи",
 
     // Zend_Validator_Hostname
     "The input appears to be a DNS hostname but the given punycode notation cannot be decoded" => "Въведената стойност е DNS хост име, но зададения пюникод не може да бъде декодиран",
-    "Invalid type given. String expected" => "Зададен е невалиден тип данни. Очаква се стринг",
+    "Invalid type given. String expected." => "Зададен е невалиден тип данни. Очаква се стринг",
     "The input appears to be a DNS hostname but contains a dash in an invalid position" => "Въведената стойност е DNS хост име, но съдържа тире на непозволено място",
     "The input does not match the expected structure for a DNS hostname" => "Въведената стойност не съвпада с очакваната структура за DNS хост име",
     "The input appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "Въведената стойност е DNS хост име, но не съвпада със схемата на TLD '%tld%'",
@@ -221,18 +221,18 @@ return array(
     "The input has failed the IBAN check" => "Въведен е невалиден IBAN",
 
     // Zend_Validator_Identical
-    "The two given tokens do not match" => "Двете зададени стойности не съвпадат",
-    "No token was provided to match against" => "Не е зададена стойност за сравнение",
+    "The two given tokens do not match." => "Двете зададени стойности не съвпадат",
+    "No token was provided to match against." => "Не е зададена стойност за сравнение",
 
     // Zend_Validator_InArray
     "The input was not found in the haystack" => "Въведената стойност не беше открита",
 
     // Zend_Validator_Ip
-    "Invalid type given. String expected" => "Зададен е невалиден тип данни. Очаква се стринг",
+    "Invalid type given. String expected." => "Зададен е невалиден тип данни. Очаква се стринг",
     "The input does not appear to be a valid IP address" => "Въведената стойност не е валиден IP адрес",
 
     // Zend_Validator_Isbn
-    "Invalid type given. String or integer expected" => "Зададен е невалиден тип данни. Очаква се стринг или цяло число",
+    "Invalid type given. String or integer expected." => "Зададен е невалиден тип данни. Очаква се стринг или цяло число",
     "The input is not a valid ISBN number" => "Въведената стойност не е валиден ISBN номер",
 
     // Zend_Validator_LessThan
@@ -240,40 +240,40 @@ return array(
     "The input is not less or equal than '%max%'" => "Въведената стойност не е по-малка или равна на '%max%'",
 
     // Zend_Validator_NotEmpty
-    "Value is required and can't be empty" => "Очакваната стойност не може да бъде празна",
-    "Invalid type given. String, integer, float, boolean or array expected" => "Зададен е невалиден тип данни. Очаква се стринг, цяло или реално число, булева стойност или масив",
+    "Value is required and can't be empty." => "Очакваната стойност не може да бъде празна",
+    "Invalid type given. String, integer, float, boolean or array expected." => "Зададен е невалиден тип данни. Очаква се стринг, цяло или реално число, булева стойност или масив",
 
     // Zend_Validator_Regex
-    "Invalid type given. String, integer or float expected" => "Зададен е невалиден тип данни. Очаква се стринг, цяло или реално число",
+    "Invalid type given. String, integer or float expected." => "Зададен е невалиден тип данни. Очаква се стринг, цяло или реално число",
     "The input does not match against pattern '%pattern%'" => "Въведената стойност не съвпада с шаблона '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "Получена е системна грешка докато се ползва шаблона '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "Получена е системна грешка докато се ползва шаблона '%pattern%'",
 
     // Zend_Validator_Sitemap_Changefreq
     "The input is not a valid sitemap changefreq" => "Въведена е невалидна стойност за changefreq",
-    "Invalid type given. String expected" => "Зададен е невалиден тип данни. Очаква се стринг",
+    "Invalid type given. String expected." => "Зададен е невалиден тип данни. Очаква се стринг",
 
     // Zend_Validator_Sitemap_Lastmod
     "The input is not a valid sitemap lastmod" => "Въведена е невалидна стойност за lastmod",
-    "Invalid type given. String expected" => "Зададен е невалиден тип данни. Очаква се стринг",
+    "Invalid type given. String expected." => "Зададен е невалиден тип данни. Очаква се стринг",
 
     // Zend_Validator_Sitemap_Loc
     "The input is not a valid sitemap location" => "Въведена е невалидна стойност за location",
-    "Invalid type given. String expected" => "Зададен е невалиден тип данни. Очаква се стринг",
+    "Invalid type given. String expected." => "Зададен е невалиден тип данни. Очаква се стринг",
 
     // Zend_Validator_Sitemap_Priority
     "The input is not a valid sitemap priority" => "Въведена е невалидна стойност за priority",
-    "Invalid type given. Numeric string, integer or float expected" => "Зададен е невалиден тип данни. Очаква се стринг, цяло или реално число",
+    "Invalid type given. Numeric string, integer or float expected." => "Зададен е невалиден тип данни. Очаква се стринг, цяло или реално число",
 
     // Zend_Validator_Step
     "Invalid value given. Scalar expected" => "Зададен е невалиден тип данни. Очаква се скаларен тип",
     "The input is not a valid step" => "Въведената стойност не е валидна стъпка",
 
     // Zend_Validator_StringLength
-    "Invalid type given. String expected" => "Зададен е невалиден тип данни. Очаква се стринг",
+    "Invalid type given. String expected." => "Зададен е невалиден тип данни. Очаква се стринг",
     "The input is less than %min% characters long" => "Въведената стойност е по-малкa от %min% символа",
     "The input is more than %max% characters long" => "Въведената стойност е по-голяма от %max% символа",
 
     // Zend_Validator_Uri
-    "Invalid type given. String expected" => "Зададен е невалиден тип данни. Очаква се стринг",
+    "Invalid type given. String expected." => "Зададен е невалиден тип данни. Очаква се стринг",
     "The input does not appear to be a valid Uri" => "Въведената стойност не е валиден URI",
 );

--- a/resources/languages/cs/Zend_Captcha.php
+++ b/resources/languages/cs/Zend_Captcha.php
@@ -24,12 +24,12 @@
  */
 return array(
     // Zend_Captcha_AbstractWord
-    "Empty captcha value" => "Hodnota captcha nebyla zadána",
-    "Captcha ID field is missing" => "Chybí pole captcha ID",
-    "Captcha value is wrong" => "Chybná hodnota catpcha",
+    "Empty captcha value." => "Hodnota captcha nebyla zadána",
+    "Captcha ID field is missing." => "Chybí pole captcha ID",
+    "Captcha value is wrong." => "Chybná hodnota catpcha",
 
     // Zend_Captcha_ReCaptcha
-    "Missing captcha fields" => "Chybí captcha pole",
-    "Failed to validate captcha" => "Captchu se nepodařilo ověřit",
-    "Captcha value is wrong: %value%" => "Hodnota captchy není správná: %value%",
+    "Missing captcha fields." => "Chybí captcha pole",
+    "Failed to validate captcha." => "Captchu se nepodařilo ověřit",
+    "Captcha value is wrong: %value%." => "Hodnota captchy není správná: %value%",
 );

--- a/resources/languages/cs/Zend_Validate.php
+++ b/resources/languages/cs/Zend_Validate.php
@@ -24,33 +24,33 @@
  */
 return array(
     // Zend_I18n_Validator_Alnum
-    "Invalid type given. String, integer or float expected" => "Chybný typ. Byl očekáván řetězec, celé nebo desetinné číslo",
-    "The input contains characters which are non alphabetic and no digits" => "Hodnota obsahuje i jiné znaky než písmena a číslice",
-    "The input is an empty string" => "Hodnota je prázdný řetězec",
+    "Invalid type given. String, integer or float expected." => "Chybný typ. Byl očekáván řetězec, celé nebo desetinné číslo",
+    "The input contains characters which are non alphabetic and no digits." => "Hodnota obsahuje i jiné znaky než písmena a číslice",
+    "The input is an empty string." => "Hodnota je prázdný řetězec",
 
     // Zend_I18n_Validator_Alpha
-    "Invalid type given. String expected" => "Chybný typ. Byl očekáván řetězec",
-    "The input contains non alphabetic characters" => "Hodnota obsahuje i jiné znaky než písmena",
-    "The input is an empty string" => "Hodnota je prázdný řetězec",
+    "Invalid type given. String expected." => "Chybný typ. Byl očekáván řetězec",
+    "The input contains non alphabetic characters." => "Hodnota obsahuje i jiné znaky než písmena",
+    "The input is an empty string." => "Hodnota je prázdný řetězec",
 
     // Zend_I18n_Validator_Float
-    "Invalid type given. String, integer or float expected" => "Chybný typ. Byl očekáván řetězec, celé nebo desetinné číslo",
+    "Invalid type given. String, integer or float expected." => "Chybný typ. Byl očekáván řetězec, celé nebo desetinné číslo",
     "The input does not appear to be a float" => "Hodnota nevypadá jako desetinné číslo",
 
     // Zend_I18n_Validator_Int
-    "Invalid type given. String or integer expected" => "Chybný typ. Byl očekáván řetězec nebo celé číslo",
-    "The input does not appear to be an integer" => "Hodnota nevypadá jako celé číslo",
+    "Invalid type given. String or integer expected." => "Chybný typ. Byl očekáván řetězec nebo celé číslo",
+    "The input does not appear to be an integer." => "Hodnota nevypadá jako celé číslo",
 
     // Zend_I18n_Validator_PostCode
-    "Invalid type given. String or integer expected" => "Chybný typ. Byl očekáván řetězec nebo celé číslo",
+    "Invalid type given. String or integer expected." => "Chybný typ. Byl očekáván řetězec nebo celé číslo",
     "The input does not appear to be a postal code" => "Hodnota nevypadá jako PSČ",
     "An exception has been raised while validating the input" => "Během volání byla vyvolána výjimka",
 
     // Zend_Validator_Barcode
-    "The input failed checksum validation" => "Hodnota má chybný kontrolní součet",
+    "The input failed checksum validation." => "Hodnota má chybný kontrolní součet",
     "The input contains invalid characters" => "Hodnota obsahuje neplatné znaky",
     "The input should have a length of %length% characters" => "Hodnota by měla mít délku %length% znaků",
-    "Invalid type given. String expected" => "Chybný typ. Byl očekáván řetězec",
+    "Invalid type given. String expected." => "Chybný typ. Byl očekáván řetězec",
 
     // Zend_Validator_Between
     "The input is not between '%min%' and '%max%', inclusively" => "Hodnota není mezi '%min%' a '%max%', včetně",
@@ -58,12 +58,12 @@ return array(
 
     // Zend_Validator_Callback
     "The input is not valid" => "Hodnota není platná",
-    "An exception has been raised within the callback" => "Během volání byla vyvolána výjimka",
+    "An exception has been raised within the callback." => "Během volání byla vyvolána výjimka",
 
     // Zend_Validator_CreditCard
     "The input seems to contain an invalid checksum" => "Hodnota obsahuje neplatný kontrolní součet",
     "The input must contain only digits" => "Hodnota musí obsahovat pouze číslice",
-    "Invalid type given. String expected" => "Chybný typ. Byl očekáván řetězec",
+    "Invalid type given. String expected." => "Chybný typ. Byl očekáván řetězec",
     "The input contains an invalid amount of digits" => "Hodnota obsahuje neplatný počet číslic",
     "The input is not from an allowed institute" => "Hodnota není od povolené společnosti",
     "The input seems to be an invalid creditcard number" => "Hodnota není platné číslo kreditní karty",
@@ -88,122 +88,122 @@ return array(
 
     // Zend_Validator_Digits
     "The input must contain only digits" => "Hodnota musí obsahovat pouze číslice",
-    "The input is an empty string" => "Hodnota je prázdný řetězec",
-    "Invalid type given. String, integer or float expected" => "Chybný typ. Byl očekáván řetězec, celé nebo desetinné číslo",
+    "The input is an empty string." => "Hodnota je prázdný řetězec",
+    "Invalid type given. String, integer or float expected." => "Chybný typ. Byl očekáván řetězec, celé nebo desetinné číslo",
 
     // Zend_Validator_EmailAddress
-    "Invalid type given. String expected" => "Chybný typ. Byl očekáván řetězec",
+    "Invalid type given. String expected." => "Chybný typ. Byl očekáván řetězec",
     "The input is not a valid email address. Use the basic format local-part@hostname" => "Hodnota není platná emailová adresa ve formátu local-part@hostname",
     "'%hostname%' is not a valid hostname for the email address" => "'%hostname%' není platné hostname pro emailovou adresu",
     "'%hostname%' does not appear to have any valid MX or A records for the email address" => "'%hostname%' neobsahuje platný MX záznam pro emailovou adresu",
     "'%hostname%' is not in a routable network segment. The email address should not be resolved from public network" => "'%hostname%' není v směrovatelném úseku sítě. Emailová adresa by neměla být požadována z veřejné sítě",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' nemůže být porovnán proti dot-atom formátu",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' nemůže být porovnán proti quoted-string formátu",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' nemůže být porovnán proti dot-atom formátu",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' nemůže být porovnán proti quoted-string formátu",
     "'%localPart%' is not a valid local part for the email address" => "'%localPart%' není platná 'local part' pro emailovou adresu",
     "The input exceeds the allowed length" => "Hodnota překročila povolenou délku",
 
     // Zend_Validator_Explode
-    "Invalid type given. String expected" => "Chybný typ. Byl očekáván řetězec",
+    "Invalid type given. String expected." => "Chybný typ. Byl očekáván řetězec",
 
     // Zend_Validator_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Příliš mnoho souborů. Maximum je '%max%', ale bylo zadáno '%count%'",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Příliš málo souborů. Minimum je '%min%', ale byl zadáno jen '%count%'",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Příliš mnoho souborů. Maximum je '%max%', ale bylo zadáno '%count%'",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Příliš málo souborů. Minimum je '%min%', ale byl zadáno jen '%count%'",
 
     // Zend_Validator_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Soubor '%value%' neodpovídá zadanému crc32 hashi",
-    "A crc32 hash could not be evaluated for the given file" => "Pro zadaný soubor nemohl být vypočítán crc32 hash",
-    "File '%value%' is not readable or does not exist" => "Soubor '%value%' buď není čitelný nebo neexistuje",
+    "File '%value%' does not match the given crc32 hashes." => "Soubor '%value%' neodpovídá zadanému crc32 hashi",
+    "A crc32 hash could not be evaluated for the given file." => "Pro zadaný soubor nemohl být vypočítán crc32 hash",
+    "File '%value%' is not readable or does not exist." => "Soubor '%value%' buď není čitelný nebo neexistuje",
 
     // Zend_Validator_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Soubor '%value%' má nesprávnou příponu",
-    "File '%value%' is not readable or does not exist" => "Soubor '%value%' buď není čitelný nebo neexistuje",
+    "File '%value%' has a false extension." => "Soubor '%value%' má nesprávnou příponu",
+    "File '%value%' is not readable or does not exist." => "Soubor '%value%' buď není čitelný nebo neexistuje",
 
     // Zend_Validator_File_Exists
-    "File '%value%' does not exist" => "Soubor '%value%' neexistuje",
+    "File '%value%' does not exist." => "Soubor '%value%' neexistuje",
 
     // Zend_Validator_File_Extension
-    "File '%value%' has a false extension" => "Soubor '%value%' má nesprávnou příponu",
-    "File '%value%' is not readable or does not exist" => "Soubor '%value%' není čitelný nebo neexistuje",
+    "File '%value%' has a false extension." => "Soubor '%value%' má nesprávnou příponu",
+    "File '%value%' is not readable or does not exist." => "Soubor '%value%' není čitelný nebo neexistuje",
 
     // Zend_Validator_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Součet velikostí všech souborů by měl být maximálně '%max%', ale je '%size%'",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Součet velikostí všech souborů by měl být nejméně '%min%', ale je '%size%'",
-    "One or more files can not be read" => "Jeden nebo více souborů není možné načíst",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Součet velikostí všech souborů by měl být maximálně '%max%', ale je '%size%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Součet velikostí všech souborů by měl být nejméně '%min%', ale je '%size%'",
+    "One or more files can not be read." => "Jeden nebo více souborů není možné načíst",
 
     // Zend_Validator_File_Hash
-    "File '%value%' does not match the given hashes" => "Soubor '%value%' neodpovídané danému hashi",
-    "A hash could not be evaluated for the given file" => "Hash nemohl být pro daný soubor vypočítán",
-    "File '%value%' is not readable or does not exist" => "Soubor '%value%' není čitelný nebo neexistuje",
+    "File '%value%' does not match the given hashes." => "Soubor '%value%' neodpovídané danému hashi",
+    "A hash could not be evaluated for the given file." => "Hash nemohl být pro daný soubor vypočítán",
+    "File '%value%' is not readable or does not exist." => "Soubor '%value%' není čitelný nebo neexistuje",
 
     // Zend_Validator_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Maximální šířka obrázku '%value%' by měla být '%maxwidth%', ale je '%width%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Minimální šířka obrázku '%value%' by měla být '%minwidth%', ale je '%width%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Maximální výška obrázku '%value%' by měla být '%maxheight%', ale je '%height%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Minimální výška obrázku '%value%' by měla být '%minheight%', ale je '%height%'",
-    "The size of image '%value%' could not be detected" => "Rozměry obrázku '%value%' nebylo možné zjistit",
-    "File '%value%' is not readable or does not exist" => "Soubor '%value%' není čitelný nebo neexistuje",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Maximální šířka obrázku '%value%' by měla být '%maxwidth%', ale je '%width%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Minimální šířka obrázku '%value%' by měla být '%minwidth%', ale je '%width%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Maximální výška obrázku '%value%' by měla být '%maxheight%', ale je '%height%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Minimální výška obrázku '%value%' by měla být '%minheight%', ale je '%height%'",
+    "The size of image '%value%' could not be detected." => "Rozměry obrázku '%value%' nebylo možné zjistit",
+    "File '%value%' is not readable or does not exist." => "Soubor '%value%' není čitelný nebo neexistuje",
 
     // Zend_Validator_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Soubor '%value%' není komprimovaný, ale '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Mimetyp souboru '%value%' nebylo možné zjistit",
-    "File '%value%' is not readable or does not exist" => "Soubor '%value%' není čitelný nebo neexistuje",
+    "File '%value%' is not compressed, '%type%' detected." => "Soubor '%value%' není komprimovaný, ale '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Mimetyp souboru '%value%' nebylo možné zjistit",
+    "File '%value%' is not readable or does not exist." => "Soubor '%value%' není čitelný nebo neexistuje",
 
     // Zend_Validator_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Soubor '%value%' není obrázek, ale '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Mimetyp souboru '%value%' nebylo možné zjistit",
-    "File '%value%' is not readable or does not exist" => "Soubor '%value%' není čitelný nebo neexistuje",
+    "File '%value%' is no image, '%type%' detected." => "Soubor '%value%' není obrázek, ale '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Mimetyp souboru '%value%' nebylo možné zjistit",
+    "File '%value%' is not readable or does not exist." => "Soubor '%value%' není čitelný nebo neexistuje",
 
     // Zend_Validator_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Soubor '%value%' neodpovídá danému md5 hashi",
-    "A md5 hash could not be evaluated for the given file" => "md5 hash nemohl být pro daný soubor vypočítán",
-    "File '%value%' is not readable or does not exist" => "Soubor '%value%' není čitelný nebo neexistuje",
+    "File '%value%' does not match the given md5 hashes." => "Soubor '%value%' neodpovídá danému md5 hashi",
+    "A md5 hash could not be evaluated for the given file." => "md5 hash nemohl být pro daný soubor vypočítán",
+    "File '%value%' is not readable or does not exist." => "Soubor '%value%' není čitelný nebo neexistuje",
 
     // Zend_Validator_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Soubor '%value%' má neplatný mimetyp '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Mimetyp souboru '%value%' nebylo možné zjistit",
-    "File '%value%' is not readable or does not exist" => "Soubor '%value%' není čitelný nebo neexistuje",
+    "File '%value%' has a false mimetype of '%type%'." => "Soubor '%value%' má neplatný mimetyp '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Mimetyp souboru '%value%' nebylo možné zjistit",
+    "File '%value%' is not readable or does not exist." => "Soubor '%value%' není čitelný nebo neexistuje",
 
     // Zend_Validator_File_NotExists
-    "File '%value%' exists" => "Soubor '%value%' již existuje",
+    "File '%value%' exists." => "Soubor '%value%' již existuje",
 
     // Zend_Validator_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Soubor '%value%' neodpovídá danému sha1 hashi",
-    "A sha1 hash could not be evaluated for the given file" => "sha1 hash nemohl být pro daný soubor vypočítán",
-    "File '%value%' is not readable or does not exist" => "Soubor '%value%' není čitelný nebo neexistuje",
+    "File '%value%' does not match the given sha1 hashes." => "Soubor '%value%' neodpovídá danému sha1 hashi",
+    "A sha1 hash could not be evaluated for the given file." => "sha1 hash nemohl být pro daný soubor vypočítán",
+    "File '%value%' is not readable or does not exist." => "Soubor '%value%' není čitelný nebo neexistuje",
 
     // Zend_Validator_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Maximální povolená velikost souboru je '%max%', ale '%value%' má '%size%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Minimální velikost souboru je '%min%', ale '%value%' má '%size%'",
-    "File '%value%' is not readable or does not exist" => "Soubor '%value%' buď není čitelný nebo neexistuje",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Maximální povolená velikost souboru je '%max%', ale '%value%' má '%size%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Minimální velikost souboru je '%min%', ale '%value%' má '%size%'",
+    "File '%value%' is not readable or does not exist." => "Soubor '%value%' buď není čitelný nebo neexistuje",
 
     // Zend_Validator_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Soubor '%value%' překročil velikost definovanou v ini souboru",
-    "File '%value%' exceeds the defined form size" => "Soubor '%value%' překročil velikost definovanou ve formuláři",
-    "File '%value%' was only partially uploaded" => "Soubor '%value%' byl nahrán jen částečně",
-    "File '%value%' was not uploaded" => "Soubor '%value%' nebyl nahrán",
-    "No temporary directory was found for file '%value%'" => "Pro soubor '%value%' nebyl nalezen žádný dočasný adresář",
-    "File '%value%' can't be written" => "Soubor '%value%' nemůže být zapsán",
-    "A PHP extension returned an error while uploading the file '%value%'" => "PHP rozšíření vrátilo chybu během nahrávání souboru '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Soubor '%value%' byl nedovoleně nahrán. Může se jednat o útok",
-    "File '%value%' was not found" => "Soubor '%value%' nebyl nalezen",
-    "Unknown error while uploading file '%value%'" => "Během nahrávání souboru '%value%' došlo k chybě",
+    "File '%value%' exceeds the defined ini size." => "Soubor '%value%' překročil velikost definovanou v ini souboru",
+    "File '%value%' exceeds the defined form size." => "Soubor '%value%' překročil velikost definovanou ve formuláři",
+    "File '%value%' was only partially uploaded." => "Soubor '%value%' byl nahrán jen částečně",
+    "File '%value%' was not uploaded." => "Soubor '%value%' nebyl nahrán",
+    "No temporary directory was found for file '%value%'." => "Pro soubor '%value%' nebyl nalezen žádný dočasný adresář",
+    "File '%value%' can't be written." => "Soubor '%value%' nemůže být zapsán",
+    "A PHP extension returned an error while uploading the file '%value%'." => "PHP rozšíření vrátilo chybu během nahrávání souboru '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Soubor '%value%' byl nedovoleně nahrán. Může se jednat o útok",
+    "File '%value%' was not found." => "Soubor '%value%' nebyl nalezen",
+    "Unknown error while uploading file '%value%'." => "Během nahrávání souboru '%value%' došlo k chybě",
 
     // Zend_Validator_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Příliš mnoho slov. Je jich dovoleno maximálně '%max%', ale bylo zadáno '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Příliš málo slov. Musí jich být alespoň '%min%', ale bylo zadáno jen '%count%'",
-    "File '%value%' is not readable or does not exist" => "Soubor '%value%' není čitelný nebo neexistuje",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Příliš mnoho slov. Je jich dovoleno maximálně '%max%', ale bylo zadáno '%count%'",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Příliš málo slov. Musí jich být alespoň '%min%', ale bylo zadáno jen '%count%'",
+    "File '%value%' is not readable or does not exist." => "Soubor '%value%' není čitelný nebo neexistuje",
 
     // Zend_Validator_GreaterThan
     "The input is not greater than '%min%'" => "Hodnota není větší než '%min%'",
     "The input is not greater or equal than '%min%'" => "Hodnota není větší nebo rovna '%min%'",
 
     // Zend_Validator_Hex
-    "Invalid type given. String expected" => "Chybný typ. Byl očekáván řetězec",
+    "Invalid type given. String expected." => "Chybný typ. Byl očekáván řetězec",
     "The input contains non-hexadecimal characters" => "Hodnota neobsahuje jen znaky hexadecimálních čísel",
 
     // Zend_Validator_Hostname
     "The input appears to be a DNS hostname but the given punycode notation cannot be decoded" => "Hodnota vypadá jako DNS hostname ale zadanou punycode notaci není možné dekódovat",
-    "Invalid type given. String expected" => "Chybný typ. Byl očekáván řetězec",
+    "Invalid type given. String expected." => "Chybný typ. Byl očekáván řetězec",
     "The input appears to be a DNS hostname but contains a dash in an invalid position" => "Hodnota vypadá jako hostname, ale obsahuje pomlčku na nedovoleném místě",
     "The input does not match the expected structure for a DNS hostname" => "Hodnota neodpovídá očekáváné struktuře hostname",
     "The input appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "Hodnota vypadá jako hostname, ale neodpovídá formátu hostname pro '%tld%'",
@@ -215,24 +215,24 @@ return array(
     "The input appears to be a DNS hostname but cannot match TLD against known list" => "Hodnota vypadá jako hostname, ale nemohl být ověřen proti známým TLD",
 
     // Zend_Validator_Iban
-    "Unknown country within the IBAN '%value%'" => "Neznámý stát v IBAN '%value%'",
+    "Unknown country within the IBAN '%value%'." => "Neznámý stát v IBAN '%value%'",
     "Countries outside the Single Euro Payments Area (SEPA) are not supported" => "Státy mimo jednotný evropský platební prostor nejsou podporovány",
     "The input has a false IBAN format" => "Hodnota není platný formát IBAN",
     "The input has failed the IBAN check" => "Hodnota neprošlo kontrolou IBAN",
 
     // Zend_Validator_Identical
-    "The two given tokens do not match" => "Zadané položky nejsou shodné",
-    "No token was provided to match against" => "Nebyla zadána položka pro porovnání",
+    "The two given tokens do not match." => "Zadané položky nejsou shodné",
+    "No token was provided to match against." => "Nebyla zadána položka pro porovnání",
 
     // Zend_Validator_InArray
     "The input was not found in the haystack" => "Hodnota nebyla nalezena v seznamu",
 
     // Zend_Validator_Ip
-    "Invalid type given. String expected" => "Chybný typ. Byl očekáván řetězec",
+    "Invalid type given. String expected." => "Chybný typ. Byl očekáván řetězec",
     "The input does not appear to be a valid IP address" => "Hodnota nevypadá jako platná IP adresa",
 
     // Zend_Validator_Isbn
-    "Invalid type given. String or integer expected" => "Chybný typ. Byl očekáván řetězec nebo celé číslo",
+    "Invalid type given. String or integer expected." => "Chybný typ. Byl očekáván řetězec nebo celé číslo",
     "The input is not a valid ISBN number" => "Hodnota není platné ISBN",
 
     // Zend_Validator_LessThan
@@ -240,36 +240,36 @@ return array(
     "The input is not less or equal than '%max%'" => "Hodnota není menší nebo rovna '%max%'",
 
     // Zend_Validator_NotEmpty
-    "Value is required and can't be empty" => "Položka je povinná a nesmí být prázdná",
-    "Invalid type given. String, integer, float, boolean or array expected" => "Chybný typ. Byl očekáván řetězec, celé nebo desetinné číslo, boolean nebo pole",
+    "Value is required and can't be empty." => "Položka je povinná a nesmí být prázdná",
+    "Invalid type given. String, integer, float, boolean or array expected." => "Chybný typ. Byl očekáván řetězec, celé nebo desetinné číslo, boolean nebo pole",
 
     // Zend_Validator_Regex
-    "Invalid type given. String, integer or float expected" => "Chybný typ. Byl očekáván řetězec, celé nebo desetinné číslo",
+    "Invalid type given. String, integer or float expected." => "Chybný typ. Byl očekáván řetězec, celé nebo desetinné číslo",
     "The input does not match against pattern '%pattern%'" => "Hodnota neodpovídá šabloně '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "Během zpracování šablony '%pattern%' došlo k interní chybě",
+    "There was an internal error while using the pattern '%pattern%'." => "Během zpracování šablony '%pattern%' došlo k interní chybě",
 
     // Zend_Validator_Sitemap_Changefreq
     "The input is not a valid sitemap changefreq" => "Hodnota není platné 'changefreq' pro sitemapu",
-    "Invalid type given. String expected" => "Chybný typ. Byl očekáván řetězec",
+    "Invalid type given. String expected." => "Chybný typ. Byl očekáván řetězec",
 
     // Zend_Validator_Sitemap_Lastmod
     "The input is not a valid sitemap lastmod" => "Hodnota není platné 'lastmod' pro sitemapu",
-    "Invalid type given. String expected" => "Chybný typ. Byl očekáván řetězec",
+    "Invalid type given. String expected." => "Chybný typ. Byl očekáván řetězec",
 
     // Zend_Validator_Sitemap_Loc
     "The input is not a valid sitemap location" => "Hodnota není platná 'location' pro sitemapu",
-    "Invalid type given. String expected" => "Chybný typ. Byl očekáván řetězec",
+    "Invalid type given. String expected." => "Chybný typ. Byl očekáván řetězec",
 
     // Zend_Validator_Sitemap_Priority
     "The input is not a valid sitemap priority" => "Hodnota není platná 'priority' pro sitemapu",
-    "Invalid type given. Numeric string, integer or float expected" => "Chybný typ. Byl očekáván číselný řetězec, celé nebo desetinné číslo",
+    "Invalid type given. Numeric string, integer or float expected." => "Chybný typ. Byl očekáván číselný řetězec, celé nebo desetinné číslo",
 
     // Zend_Validator_Step
     "Invalid type given. Scalar expected" => "Chybný typ. Byla očekávána skalární hodnota",
     "The input is not a valid step" => "Hodnota není platný krok",
 
     // Zend_Validator_StringLength
-    "Invalid type given. String expected" => "Chybný typ. Byla očekávána řetězec",
+    "Invalid type given. String expected." => "Chybný typ. Byla očekávána řetězec",
     "The input is less than %min% characters long" => "Hodnota je kratší než %min% znaků",
     "The input is more than %max% characters long" => "Hodnota je delší než %max% znaků",
 

--- a/resources/languages/cs/Zend_Validate.php
+++ b/resources/languages/cs/Zend_Validate.php
@@ -35,7 +35,7 @@ return array(
 
     // Zend_I18n_Validator_Float
     "Invalid type given. String, integer or float expected." => "Chybný typ. Byl očekáván řetězec, celé nebo desetinné číslo",
-    "The input does not appear to be a float" => "Hodnota nevypadá jako desetinné číslo",
+    "The input does not appear to be a float." => "Hodnota nevypadá jako desetinné číslo",
 
     // Zend_I18n_Validator_Int
     "Invalid type given. String or integer expected." => "Chybný typ. Byl očekáván řetězec nebo celé číslo",
@@ -43,8 +43,8 @@ return array(
 
     // Zend_I18n_Validator_PostCode
     "Invalid type given. String or integer expected." => "Chybný typ. Byl očekáván řetězec nebo celé číslo",
-    "The input does not appear to be a postal code" => "Hodnota nevypadá jako PSČ",
-    "An exception has been raised while validating the input" => "Během volání byla vyvolána výjimka",
+    "The input does not appear to be a postal code." => "Hodnota nevypadá jako PSČ",
+    "An exception has been raised while validating the input." => "Během volání byla vyvolána výjimka",
 
     // Zend_Validator_Barcode
     "The input failed checksum validation." => "Hodnota má chybný kontrolní součet",
@@ -67,7 +67,7 @@ return array(
     "The input contains an invalid amount of digits" => "Hodnota obsahuje neplatný počet číslic",
     "The input is not from an allowed institute" => "Hodnota není od povolené společnosti",
     "The input seems to be an invalid creditcard number" => "Hodnota není platné číslo kreditní karty",
-    "An exception has been raised while validating the input" => "Během validace byla vyvolána výjimka",
+    "An exception has been raised while validating the input." => "Během validace byla vyvolána výjimka",
 
     // Zend_Validator_Csrf
     "The form submitted did not originate from the expected site" => "Odeslaný formulář nepochází z předpokládané internetové stránky",

--- a/resources/languages/de/Zend_Captcha.php
+++ b/resources/languages/de/Zend_Captcha.php
@@ -24,12 +24,12 @@
  */
 return array(
     // Zend_Captcha_ReCaptcha
-    "Missing captcha fields"          => "Die Captcha-Felder fehlen",
-    "Failed to validate captcha"      => "Die Prüfung des Captchas ist fehlgeschlagen",
-    "Captcha value is wrong: %value%" => "Der Captcha-Wert %value% ist falsch",
+    "Missing captcha fields."          => "Die Captcha-Felder fehlen",
+    "Failed to validate captcha."      => "Die Prüfung des Captchas ist fehlgeschlagen",
+    "Captcha value is wrong: %value%." => "Der Captcha-Wert %value% ist falsch",
 
     // Zend_Captcha_Word
-    "Empty captcha value"             => "Der Captcha-Wert ist leer",
-    "Captcha ID field is missing"     => "Das Captcha-ID-Feld fehlt",
-    "Captcha value is wrong"          => "Der Captcha-Wert ist falsch",
+    "Empty captcha value."             => "Der Captcha-Wert ist leer",
+    "Captcha ID field is missing."     => "Das Captcha-ID-Feld fehlt",
+    "Captcha value is wrong."          => "Der Captcha-Wert ist falsch",
 );

--- a/resources/languages/de/Zend_Validate.php
+++ b/resources/languages/de/Zend_Validate.php
@@ -24,242 +24,242 @@
  */
 return array(
     // Zend_Validate_Alnum
-    "Invalid type given. String, integer or float expected" => "Ungültiger Typ angegeben. String, Integer oder Float erwartet",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' enthält Zeichen welche keine Buchstaben und keine Ziffern sind",
-    "'%value%' is an empty string" => "'%value%' ist ein leerer String",
+    "Invalid type given. String, integer or float expected." => "Ungültiger Typ angegeben. String, Integer oder Float erwartet",
+    "'%value%' contains characters which are non alphabetic and no digits." => "'%value%' enthält Zeichen welche keine Buchstaben und keine Ziffern sind",
+    "'%value%' is an empty string." => "'%value%' ist ein leerer String",
 
     // Zend_Validate_Alpha
-    "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
-    "'%value%' contains non alphabetic characters" => "'%value%' enthält Zeichen welche keine Buchstaben sind",
-    "'%value%' is an empty string" => "'%value%' ist ein leerer String",
+    "Invalid type given. String expected." => "Ungültiger Typ angegeben. String erwartet",
+    "'%value%' contains non alphabetic characters." => "'%value%' enthält Zeichen welche keine Buchstaben sind",
+    "'%value%' is an empty string." => "'%value%' ist ein leerer String",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "'%value%' hat die Prüfung der Checksumme nicht bestanden",
     "'%value%' contains invalid characters" => "'%value%' enthält ungültige Zeichen",
     "'%value%' should have a length of %length% characters" => "'%value%' sollte eine Länge von %length% Zeichen haben",
-    "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
+    "Invalid type given. String expected." => "Ungültiger Typ angegeben. String erwartet",
 
     // Zend_Validate_Between
     "'%value%' is not between '%min%' and '%max%', inclusively" => "'%value%' ist nicht zwischen '%min%' und '%max%', inklusive diesen Werten",
     "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' ist nicht strikt zwischen '%min%' und '%max%'",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "'%value%' ist nicht gültig",
-    "An exception has been raised within the callback" => "Eine Exception wurde im Callback geworfen",
+    "'%value%' is not valid." => "'%value%' ist nicht gültig",
+    "An exception has been raised within the callback." => "Eine Exception wurde im Callback geworfen",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' muss zwischen 13 und 19 Ziffern enthalten",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Der Luhn Algorithmus (Mod-10 Checksumme) ist auf '%value%' fehlgeschlagen",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' muss zwischen 13 und 19 Ziffern enthalten",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Der Luhn Algorithmus (Mod-10 Checksumme) ist auf '%value%' fehlgeschlagen",
 
     // Zend_Validate_CreditCard
-    "'%value%' seems to contain an invalid checksum" => "'%value%' scheint eine ungültige Prüfsumme zu enthalten",
-    "'%value%' must contain only digits" => "'%value%' darf nur Ziffern enthalten",
-    "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
-    "'%value%' contains an invalid amount of digits" => "'%value%' enthält eine ungültige Anzahl an Ziffern",
-    "'%value%' is not from an allowed institute" => "'%value%' ist nicht von einem der erlaubten Institute",
+    "'%value%' seems to contain an invalid checksum." => "'%value%' scheint eine ungültige Prüfsumme zu enthalten",
+    "'%value%' must contain only digits." => "'%value%' darf nur Ziffern enthalten",
+    "Invalid type given. String expected." => "Ungültiger Typ angegeben. String erwartet",
+    "'%value%' contains an invalid amount of digits." => "'%value%' enthält eine ungültige Anzahl an Ziffern",
+    "'%value%' is not from an allowed institute." => "'%value%' ist nicht von einem der erlaubten Institute",
     "'%value%' seems to be an invalid creditcard number" => "'%value%' scheint eine ungültige Kreditkarten-Nummer zu sein",
-    "An exception has been raised while validating '%value%'" => "Eine Exception wurde wärend der Prüfung von '%value%' geworfen",
+    "An exception has been raised while validating '%value%'." => "Eine Exception wurde wärend der Prüfung von '%value%' geworfen",
 
     // Zend_Validate_Date
-    "Invalid type given. String, integer, array or Zend_Date expected" => "Ungültiger Typ angegeben. String, Integer, Array oder Zend_Date erwartet",
-    "'%value%' does not appear to be a valid date" => "'%value%' scheint kein gültiges Datum zu sein",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' passt nicht in das angegebene Datumsformat '%format%'",
+    "Invalid type given. String, integer, array or Zend_Date expected." => "Ungültiger Typ angegeben. String, Integer, Array oder Zend_Date erwartet",
+    "'%value%' does not appear to be a valid date." => "'%value%' scheint kein gültiges Datum zu sein",
+    "'%value%' does not fit the date format '%format%'." => "'%value%' passt nicht in das angegebene Datumsformat '%format%'",
 
     // Zend_Validate_Db_Abstract
-    "No record matching '%value%' was found" => "Es wurde kein Eintrag gefunden der '%value%' entspricht",
-    "A record matching '%value%' was found" => "Ein Eintrag der '%value%' entspricht wurde gefunden",
+    "No record matching '%value%' was found." => "Es wurde kein Eintrag gefunden der '%value%' entspricht",
+    "A record matching '%value%' was found." => "Ein Eintrag der '%value%' entspricht wurde gefunden",
 
     // Zend_Validate_Digits
-    "Invalid type given. String, integer or float expected" => "Ungültiger Typ angegeben. String, Integer oder Float erwartet",
-    "'%value%' must contain only digits" => "'%value%' darf nur Ziffern enthalten",
-    "'%value%' is an empty string" => "'%value%' ist ein leerer String",
+    "Invalid type given. String, integer or float expected." => "Ungültiger Typ angegeben. String, Integer oder Float erwartet",
+    "'%value%' must contain only digits." => "'%value%' darf nur Ziffern enthalten",
+    "'%value%' is an empty string." => "'%value%' ist ein leerer String",
 
     // Zend_Validate_EmailAddress
-    "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' ist keine gültige Emailadresse im Basisformat local-part@hostname",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' ist kein gültiger Hostname für die Emailadresse '%value%'",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' scheint keinen gültigen MX Eintrag für die Emailadresse '%value%' zu haben",
-    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network" => "'%hostname%' ist in keinem routebaren Netzwerksegment. Die Emailadresse '%value%' sollte nicht vom öffentlichen Netz aus aufgelöst werden",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' passt nicht auf das dot-atom Format",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' passt nicht auf das quoted-string Format",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' ist kein gültiger lokaler Teil für die Emailadresse '%value%'",
-    "'%value%' exceeds the allowed length" => "'%value%' ist länger als erlaubt",
+    "Invalid type given. String expected." => "Ungültiger Typ angegeben. String erwartet",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "'%value%' ist keine gültige Emailadresse im Basisformat local-part@hostname",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "'%hostname%' ist kein gültiger Hostname für die Emailadresse '%value%'",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "'%hostname%' scheint keinen gültigen MX Eintrag für die Emailadresse '%value%' zu haben",
+    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' ist in keinem routebaren Netzwerksegment. Die Emailadresse '%value%' sollte nicht vom öffentlichen Netz aus aufgelöst werden",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' passt nicht auf das dot-atom Format",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' passt nicht auf das quoted-string Format",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "'%localPart%' ist kein gültiger lokaler Teil für die Emailadresse '%value%'",
+    "'%value%' exceeds the allowed length." => "'%value%' ist länger als erlaubt",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Zu viele Dateien. Maximal '%max%' sind erlaubt aber '%count%' wurden angegeben",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Zu wenige Dateien. Minimal '%min%' wurden erwartet aber nur '%count%' wurden angegeben",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Zu viele Dateien. Maximal '%max%' sind erlaubt aber '%count%' wurden angegeben",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Zu wenige Dateien. Minimal '%min%' wurden erwartet aber nur '%count%' wurden angegeben",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Die Datei '%value%' passt nicht auf die angegebenen Crc32 Hashes",
-    "A crc32 hash could not be evaluated for the given file" => "Für die angegebene Datei konnte kein Crc32 Hash evaluiert werden",
-    "File '%value%' is not readable or does not exist" => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
+    "File '%value%' does not match the given crc32 hashes." => "Die Datei '%value%' passt nicht auf die angegebenen Crc32 Hashes",
+    "A crc32 hash could not be evaluated for the given file." => "Für die angegebene Datei konnte kein Crc32 Hash evaluiert werden",
+    "File '%value%' is not readable or does not exist." => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Die Datei '%value%' hat eine falsche Erweiterung",
-    "File '%value%' is not readable or does not exist" => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
+    "File '%value%' has a false extension." => "Die Datei '%value%' hat eine falsche Erweiterung",
+    "File '%value%' is not readable or does not exist." => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Die Datei '%value%' hat einen falschen Mimetyp von '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Der Mimetyp der Datei '%value%' konnte nicht erkannt werden",
-    "File '%value%' is not readable or does not exist" => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
+    "File '%value%' has a false mimetype of '%type%'." => "Die Datei '%value%' hat einen falschen Mimetyp von '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Der Mimetyp der Datei '%value%' konnte nicht erkannt werden",
+    "File '%value%' is not readable or does not exist." => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "Die Datei '%value%' existiert nicht",
+    "File '%value%' does not exist." => "Die Datei '%value%' existiert nicht",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "Die Datei '%value%' hat eine falsche Erweiterung",
-    "File '%value%' is not readable or does not exist" => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
+    "File '%value%' has a false extension." => "Die Datei '%value%' hat eine falsche Erweiterung",
+    "File '%value%' is not readable or does not exist." => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Alle Dateien sollten in Summe eine maximale Größe von '%max%' haben, aber es wurde '%size%' erkannt",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Alle Dateien sollten in Summe eine minimale Größe von '%min%' haben, aber es wurde '%size%' erkannt",
-    "One or more files can not be read" => "Ein oder mehrere Dateien konnten nicht gelesen werden",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Alle Dateien sollten in Summe eine maximale Größe von '%max%' haben, aber es wurde '%size%' erkannt",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Alle Dateien sollten in Summe eine minimale Größe von '%min%' haben, aber es wurde '%size%' erkannt",
+    "One or more files can not be read." => "Ein oder mehrere Dateien konnten nicht gelesen werden",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "Die Datei '%value%' passt nicht auf die angegebenen Hashes",
-    "A hash could not be evaluated for the given file" => "Für die angegebene Datei konnte kein Hash evaluiert werden",
-    "File '%value%' is not readable or does not exist" => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
+    "File '%value%' does not match the given hashes." => "Die Datei '%value%' passt nicht auf die angegebenen Hashes",
+    "A hash could not be evaluated for the given file." => "Für die angegebene Datei konnte kein Hash evaluiert werden",
+    "File '%value%' is not readable or does not exist." => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Die maximal erlaubte Breite für das Bild '%value%' ist '%maxwidth%', aber es wurde '%width%' erkannt",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Die minimal erlaubte Breite für das Bild '%value%' ist '%minwidth%', aber es wurde '%width%' erkannt",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Die maximal erlaubte Höhe für das Bild '%value%' ist '%maxheight%', aber es wurde '%height%' erkannt",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Die minimal erlaubte Höhe für das Bild '%value%' ist '%minheight%', aber es wurde '%height%' erkannt",
-    "The size of image '%value%' could not be detected" => "Die Größe des Bildes '%value%' konnte nicht erkannt werden",
-    "File '%value%' is not readable or does not exist" => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Die maximal erlaubte Breite für das Bild '%value%' ist '%maxwidth%', aber es wurde '%width%' erkannt",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Die minimal erlaubte Breite für das Bild '%value%' ist '%minwidth%', aber es wurde '%width%' erkannt",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Die maximal erlaubte Höhe für das Bild '%value%' ist '%maxheight%', aber es wurde '%height%' erkannt",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Die minimal erlaubte Höhe für das Bild '%value%' ist '%minheight%', aber es wurde '%height%' erkannt",
+    "The size of image '%value%' could not be detected." => "Die Größe des Bildes '%value%' konnte nicht erkannt werden",
+    "File '%value%' is not readable or does not exist." => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Die Datei '%value%' ist nicht komprimiert. Es wurde '%type%' erkannt",
-    "The mimetype of file '%value%' could not be detected" => "Der Mimetyp der Datei '%value%' konnte nicht erkannt werden",
-    "File '%value%' is not readable or does not exist" => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
+    "File '%value%' is not compressed, '%type%' detected." => "Die Datei '%value%' ist nicht komprimiert. Es wurde '%type%' erkannt",
+    "The mimetype of file '%value%' could not be detected." => "Der Mimetyp der Datei '%value%' konnte nicht erkannt werden",
+    "File '%value%' is not readable or does not exist." => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Die Datei '%value%' ist kein Bild. Es wurde '%type%' erkannt",
-    "The mimetype of file '%value%' could not be detected" => "Der Mimetyp der Datei '%value%' konnte nicht erkannt werden",
-    "File '%value%' is not readable or does not exist" => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
+    "File '%value%' is no image, '%type%' detected." => "Die Datei '%value%' ist kein Bild. Es wurde '%type%' erkannt",
+    "The mimetype of file '%value%' could not be detected." => "Der Mimetyp der Datei '%value%' konnte nicht erkannt werden",
+    "File '%value%' is not readable or does not exist." => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Die Datei '%value%' passt nicht auf die angegebenen Md5 Hashes",
-    "A md5 hash could not be evaluated for the given file" => "Für die angegebene Datei konnte kein Md5 Hash evaluiert werden",
-    "File '%value%' is not readable or does not exist" => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
+    "File '%value%' does not match the given md5 hashes." => "Die Datei '%value%' passt nicht auf die angegebenen Md5 Hashes",
+    "A md5 hash could not be evaluated for the given file." => "Für die angegebene Datei konnte kein Md5 Hash evaluiert werden",
+    "File '%value%' is not readable or does not exist." => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Die Datei '%value%' hat einen falschen Mimetyp von '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Der Mimetyp der Datei '%value%' konnte nicht erkannt werden",
-    "File '%value%' is not readable or does not exist" => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
+    "File '%value%' has a false mimetype of '%type%'." => "Die Datei '%value%' hat einen falschen Mimetyp von '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Der Mimetyp der Datei '%value%' konnte nicht erkannt werden",
+    "File '%value%' is not readable or does not exist." => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "Die Datei '%value%' existiert bereits",
+    "File '%value%' exists." => "Die Datei '%value%' existiert bereits",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Die Datei '%value%' passt nicht auf die angegebenen Sha1 Hashes",
-    "A sha1 hash could not be evaluated for the given file" => "Für die angegebene Datei konnte kein Sha1 Hash evaluiert werden",
-    "File '%value%' is not readable or does not exist" => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
+    "File '%value%' does not match the given sha1 hashes." => "Die Datei '%value%' passt nicht auf die angegebenen Sha1 Hashes",
+    "A sha1 hash could not be evaluated for the given file." => "Für die angegebene Datei konnte kein Sha1 Hash evaluiert werden",
+    "File '%value%' is not readable or does not exist." => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Die maximal erlaubte Größe für die Datei '%value%' ist '%max%', aber es wurde '%size%' entdeckt",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Die mindestens erwartete Größe für die Datei '%value%' ist '%min%', aber es wurde '%size%' entdeckt",
-    "File '%value%' is not readable or does not exist" => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Die maximal erlaubte Größe für die Datei '%value%' ist '%max%', aber es wurde '%size%' entdeckt",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Die mindestens erwartete Größe für die Datei '%value%' ist '%min%', aber es wurde '%size%' entdeckt",
+    "File '%value%' is not readable or does not exist." => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Die Datei '%value%' übersteigt die definierte Größe in der Konfiguration",
-    "File '%value%' exceeds the defined form size" => "Die Datei '%value%' übersteigt die definierte Größe des Formulars",
-    "File '%value%' was only partially uploaded" => "Die Datei '%value%' wurde nur teilweise hochgeladen",
-    "File '%value%' was not uploaded" => "Die Datei '%value%' wurde nicht hochgeladen",
-    "No temporary directory was found for file '%value%'" => "Für die Datei '%value%' wurde kein temporäres Verzeichnis gefunden",
-    "File '%value%' can't be written" => "Die Datei '%value%' konnte nicht geschrieben werden",
-    "A PHP extension returned an error while uploading the file '%value%'" => "Eine PHP Erweiterung retournierte einen Fehler wärend die Datei '%value%' hochgeladen wurde",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Die Datei '%value%' wurde illegal hochgeladen. Dies könnte eine mögliche Attacke sein",
-    "File '%value%' was not found" => "Die Datei '%value%' wurde nicht gefunden",
-    "Unknown error while uploading file '%value%'" => "Ein unbekannter Fehler ist aufgetreten wärend die Datei '%value%' hochgeladen wurde",
+    "File '%value%' exceeds the defined ini size." => "Die Datei '%value%' übersteigt die definierte Größe in der Konfiguration",
+    "File '%value%' exceeds the defined form size." => "Die Datei '%value%' übersteigt die definierte Größe des Formulars",
+    "File '%value%' was only partially uploaded." => "Die Datei '%value%' wurde nur teilweise hochgeladen",
+    "File '%value%' was not uploaded." => "Die Datei '%value%' wurde nicht hochgeladen",
+    "No temporary directory was found for file '%value%'." => "Für die Datei '%value%' wurde kein temporäres Verzeichnis gefunden",
+    "File '%value%' can't be written." => "Die Datei '%value%' konnte nicht geschrieben werden",
+    "A PHP extension returned an error while uploading the file '%value%'." => "Eine PHP Erweiterung retournierte einen Fehler wärend die Datei '%value%' hochgeladen wurde",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Die Datei '%value%' wurde illegal hochgeladen. Dies könnte eine mögliche Attacke sein",
+    "File '%value%' was not found." => "Die Datei '%value%' wurde nicht gefunden",
+    "Unknown error while uploading file '%value%'." => "Ein unbekannter Fehler ist aufgetreten wärend die Datei '%value%' hochgeladen wurde",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Zu viele Wörter. Maximal '%max%' sind erlaubt, aber '%count%' wurden gezählt",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Zu wenige Wörter. Mindestens '%min%' wurden erwartet, aber '%count%' wurden gezählt",
-    "File '%value%' is not readable or does not exist" => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Zu viele Wörter. Maximal '%max%' sind erlaubt, aber '%count%' wurden gezählt",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Zu wenige Wörter. Mindestens '%min%' wurden erwartet, aber '%count%' wurden gezählt",
+    "File '%value%' is not readable or does not exist." => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
 
     // Zend_Validate_Float
-    "Invalid type given. String, integer or float expected" => "Ungültiger Typ angegeben. String, Integer oder Float erwartet",
-    "'%value%' does not appear to be a float" => "'%value%' scheint kein Float zu sein",
+    "Invalid type given. String, integer or float expected." => "Ungültiger Typ angegeben. String, Integer oder Float erwartet",
+    "'%value%' does not appear to be a float." => "'%value%' scheint kein Float zu sein",
 
     // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' ist nicht größer als '%min%'",
+    "'%value%' is not greater than '%min%'." => "'%value%' ist nicht größer als '%min%'",
 
     // Zend_Validate_Hex
-    "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
-    "'%value%' has not only hexadecimal digit characters" => "'%value%' enthält nicht nur hexadezimale Ziffern",
+    "Invalid type given. String expected." => "Ungültiger Typ angegeben. String erwartet",
+    "'%value%' has not only hexadecimal digit characters." => "'%value%' enthält nicht nur hexadezimale Ziffern",
 
     // Zend_Validate_Hostname
-    "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "'%value%' scheint eine IP Adresse zu sein, aber IP Adressen sind nicht erlaubt",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' scheint ein DNS Hostname zu sein, aber die TLD wurde in der bekannten Liste nicht gefunden",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' scheint ein DNS Hostname zu sein, enthält aber einen Bindestrich an einer ungültigen Position",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' scheint ein DNS Hostname zu sein, passt aber nicht in das Hostname Schema für die TLD '%tld%'",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' scheint ein DNS Hostname zu sein, aber der TLD Teil konnte nicht extrahiert werden",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' passt nicht in die erwartete Struktur für einen DNS Hostname",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' scheint kein gültiger lokaler Netzerkname zu sein",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' scheint ein lokaler Netzwerkname zu sein, aber lokale Netzwerknamen sind nicht erlaubt",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "'%value%' scheint ein DNS Hostname zu sein, aber die angegebene Punycode Schreibweise konnte nicht dekodiert werden",
-    "'%value%' does not appear to be a valid URI hostname" => "'%value%' scheint kein gültiger URI Hostname zu sein",
+    "Invalid type given. String expected." => "Ungültiger Typ angegeben. String erwartet",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => "'%value%' scheint eine IP Adresse zu sein, aber IP Adressen sind nicht erlaubt",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => "'%value%' scheint ein DNS Hostname zu sein, aber die TLD wurde in der bekannten Liste nicht gefunden",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => "'%value%' scheint ein DNS Hostname zu sein, enthält aber einen Bindestrich an einer ungültigen Position",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => "'%value%' scheint ein DNS Hostname zu sein, passt aber nicht in das Hostname Schema für die TLD '%tld%'",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => "'%value%' scheint ein DNS Hostname zu sein, aber der TLD Teil konnte nicht extrahiert werden",
+    "'%value%' does not match the expected structure for a DNS hostname." => "'%value%' passt nicht in die erwartete Struktur für einen DNS Hostname",
+    "'%value%' does not appear to be a valid local network name." => "'%value%' scheint kein gültiger lokaler Netzerkname zu sein",
+    "'%value%' appears to be a local network name but local network names are not allowed." => "'%value%' scheint ein lokaler Netzwerkname zu sein, aber lokale Netzwerknamen sind nicht erlaubt",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => "'%value%' scheint ein DNS Hostname zu sein, aber die angegebene Punycode Schreibweise konnte nicht dekodiert werden",
+    "'%value%' does not appear to be a valid URI hostname." => "'%value%' scheint kein gültiger URI Hostname zu sein",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "Unbekanntes Land in der IBAN '%value%'",
-    "'%value%' has a false IBAN format" => "'%value%' enthält ein falsches IBAN Format",
-    "'%value%' has failed the IBAN check" => "Die IBAN Prüfung ist für '%value%' fehlgeschlagen",
+    "Unknown country within the IBAN '%value%'." => "Unbekanntes Land in der IBAN '%value%'",
+    "'%value%' has a false IBAN format." => "'%value%' enthält ein falsches IBAN Format",
+    "'%value%' has failed the IBAN check." => "Die IBAN Prüfung ist für '%value%' fehlgeschlagen",
 
     // Zend_Validate_Identical
-    "The two given tokens do not match" => "Die zwei angegebenen Token stimmen nicht überein",
-    "No token was provided to match against" => "Es wurde kein Token angegeben gegen den geprüft werden kann",
+    "The two given tokens do not match." => "Die zwei angegebenen Token stimmen nicht überein",
+    "No token was provided to match against." => "Es wurde kein Token angegeben gegen den geprüft werden kann",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "'%value%' wurde im Haystack nicht gefunden",
+    "'%value%' was not found in the haystack." => "'%value%' wurde im Haystack nicht gefunden",
 
     // Zend_Validate_Int
-    "Invalid type given. String or integer expected" => "Ungültiger Typ angegeben. String oder Integer erwartet",
-    "'%value%' does not appear to be an integer" => "'%value%' scheint kein Integer zu sein",
+    "Invalid type given. String or integer expected." => "Ungültiger Typ angegeben. String oder Integer erwartet",
+    "'%value%' does not appear to be an integer." => "'%value%' scheint kein Integer zu sein",
 
     // Zend_Validate_Ip
-    "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' scheint keine gültige IP Adresse zu sein",
+    "Invalid type given. String expected." => "Ungültiger Typ angegeben. String erwartet",
+    "'%value%' does not appear to be a valid IP address." => "'%value%' scheint keine gültige IP Adresse zu sein",
 
     // Zend_Validate_Isbn
-    "Invalid type given. String or integer expected" => "Ungültiger Typ angegeben. String oder Integer erwartet",
-    "'%value%' is not a valid ISBN number" => "'%value%' ist keine gültige ISBN Nummer",
+    "Invalid type given. String or integer expected." => "Ungültiger Typ angegeben. String oder Integer erwartet",
+    "'%value%' is not a valid ISBN number." => "'%value%' ist keine gültige ISBN Nummer",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' ist nicht weniger als '%max%'",
+    "'%value%' is not less than '%max%'." => "'%value%' ist nicht weniger als '%max%'",
 
     // Zend_Validate_NotEmpty
-    "Invalid type given. String, integer, float, boolean or array expected" => "Ungültiger Typ angegeben. String, Integer, Float, Boolean oder Array erwartet",
-    "Value is required and can't be empty" => "Es wird ein Wert benötigt. Dieser darf nicht leer sein",
+    "Invalid type given. String, integer, float, boolean or array expected." => "Ungültiger Typ angegeben. String, Integer, Float, Boolean oder Array erwartet",
+    "Value is required and can't be empty." => "Es wird ein Wert benötigt. Dieser darf nicht leer sein",
 
     // Zend_Validate_PostCode
-    "Invalid type given. String or integer expected" => "Ungültiger Typ angegeben. String oder Integer erwartet",
-    "'%value%' does not appear to be a postal code" => "'%value%' scheint keine gültige Postleitzahl zu sein",
+    "Invalid type given. String or integer expected." => "Ungültiger Typ angegeben. String oder Integer erwartet",
+    "'%value%' does not appear to be a postal code." => "'%value%' scheint keine gültige Postleitzahl zu sein",
 
     // Zend_Validate_Regex
-    "Invalid type given. String, integer or float expected" => "Ungültiger Typ angegeben. String, Integer oder Float erwartet",
-    "'%value%' does not match against pattern '%pattern%'" => "'%value%' scheint nicht auf das Pattern '%pattern%' zu passen",
-    "There was an internal error while using the pattern '%pattern%'" => "Es gab einen internen Fehler bei der Verwendung des Patterns '%pattern%'",
+    "Invalid type given. String, integer or float expected." => "Ungültiger Typ angegeben. String, Integer oder Float erwartet",
+    "'%value%' does not match against pattern '%pattern%'." => "'%value%' scheint nicht auf das Pattern '%pattern%' zu passen",
+    "There was an internal error while using the pattern '%pattern%'." => "Es gab einen internen Fehler bei der Verwendung des Patterns '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => "'%value%' ist keine gültige Changefreq für Sitemap",
-    "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
+    "'%value%' is not a valid sitemap changefreq." => "'%value%' ist keine gültige Changefreq für Sitemap",
+    "Invalid type given. String expected." => "Ungültiger Typ angegeben. String erwartet",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => "'%value%' ist keine gültige Lastmod für Sitemap",
-    "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
+    "'%value%' is not a valid sitemap lastmod." => "'%value%' ist keine gültige Lastmod für Sitemap",
+    "Invalid type given. String expected." => "Ungültiger Typ angegeben. String erwartet",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => "'%value%' ist keine gültige Location für Sitemap",
-    "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
+    "'%value%' is not a valid sitemap location." => "'%value%' ist keine gültige Location für Sitemap",
+    "Invalid type given. String expected." => "Ungültiger Typ angegeben. String erwartet",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => "'%value%' ist keine gültige Priority für Sitemap",
-    "Invalid type given. Numeric string, integer or float expected" => "Ungültiger Typ angegeben. Nummerischer String, Integer oder Float erwartet",
+    "'%value%' is not a valid sitemap priority." => "'%value%' ist keine gültige Priority für Sitemap",
+    "Invalid type given. Numeric string, integer or float expected." => "Ungültiger Typ angegeben. Nummerischer String, Integer oder Float erwartet",
 
     // Zend_Validate_StringLength
-    "Invalid type given. String expected" => "Ungültiger Typ angegeben. String erwartet",
-    "'%value%' is less than %min% characters long" => "'%value%' ist weniger als %min% Zeichen lang",
-    "'%value%' is more than %max% characters long" => "'%value%' ist mehr als %max% Zeichen lang",
+    "Invalid type given. String expected." => "Ungültiger Typ angegeben. String erwartet",
+    "'%value%' is less than %min% characters long." => "'%value%' ist weniger als %min% Zeichen lang",
+    "'%value%' is more than %max% characters long." => "'%value%' ist mehr als %max% Zeichen lang",
 );

--- a/resources/languages/en/Zend_Captcha.php
+++ b/resources/languages/en/Zend_Captcha.php
@@ -24,12 +24,12 @@
  */
 return array(
     // Zend_Captcha_ReCaptcha
-    "Missing captcha fields" => "Missing captcha fields",
-    "Failed to validate captcha" => "Failed to validate captcha",
-    "Captcha value is wrong: %value%" => "Captcha value is wrong: %value%",
+    "Missing captcha fields." => "Missing captcha fields.",
+    "Failed to validate captcha." => "Failed to validate captcha.",
+    "Captcha value is wrong: %value%." => "Captcha value is wrong: %value%.",
 
     // Zend_Captcha_Word
-    "Empty captcha value" => "Empty captcha value",
-    "Captcha ID field is missing" => "Captcha ID field is missing",
-    "Captcha value is wrong" => "Captcha value is wrong",
+    "Empty captcha value." => "Empty captcha value.",
+    "Captcha ID field is missing." => "Captcha ID field is missing.",
+    "Captcha value is wrong." => "Captcha value is wrong.",
 );

--- a/resources/languages/en/Zend_Validate.php
+++ b/resources/languages/en/Zend_Validate.php
@@ -24,33 +24,33 @@
  */
 return array(
     // Zend_I18n_Validator_Alnum
-    "Invalid type given. String, integer or float expected" => "Invalid type given. String, integer or float expected",
-    "The input contains characters which are non alphabetic and no digits" => "The input contains characters which are non alphabetic and no digits",
-    "The input is an empty string" => "The input is an empty string",
+    "Invalid type given. String, integer or float expected." => "Invalid type given. String, integer or float expected.",
+    "The input contains characters which are non alphabetic and no digits." => "The input contains characters which are non alphabetic and no digits.",
+    "The input is an empty string." => "The input is an empty string.",
 
     // Zend_I18n_Validator_Alpha
-    "Invalid type given. String expected" => "Invalid type given. String expected",
-    "The input contains non alphabetic characters" => "The input contains non alphabetic characters",
-    "The input is an empty string" => "The input is an empty string",
+    "Invalid type given. String expected." => "Invalid type given. String expected.",
+    "The input contains non alphabetic characters." => "The input contains non alphabetic characters.",
+    "The input is an empty string." => "The input is an empty string.",
 
     // Zend_I18n_Validator_Float
-    "Invalid type given. String, integer or float expected" => "Invalid type given. String, integer or float expected",
+    "Invalid type given. String, integer or float expected." => "Invalid type given. String, integer or float expected.",
     "The input does not appear to be a float" => "The input does not appear to be a float",
 
     // Zend_I18n_Validator_Int
-    "Invalid type given. String or integer expected" => "Invalid type given. String or integer expected",
-    "The input does not appear to be an integer" => "The input does not appear to be an integer",
+    "Invalid type given. String or integer expected." => "Invalid type given. String or integer expected.",
+    "The input does not appear to be an integer." => "The input does not appear to be an integer.",
 
     // Zend_I18n_Validator_PostCode
-    "Invalid type given. String or integer expected" => "Invalid type given. String or integer expected",
+    "Invalid type given. String or integer expected." => "Invalid type given. String or integer expected.",
     "The input does not appear to be a postal code" => "The input does not appear to be a postal code",
     "An exception has been raised while validating the input" => "An exception has been raised while validating the input",
 
     // Zend_Validator_Barcode
-    "The input failed checksum validation" => "The input failed checksum validation",
+    "The input failed checksum validation." => "The input failed checksum validation.",
     "The input contains invalid characters" => "The input contains invalid characters",
     "The input should have a length of %length% characters" => "The input should have a length of %length% characters",
-    "Invalid type given. String expected" => "Invalid type given. String expected",
+    "Invalid type given. String expected." => "Invalid type given. String expected.",
 
     // Zend_Validator_Between
     "The input is not between '%min%' and '%max%', inclusively" => "The input is not between '%min%' and '%max%', inclusively",
@@ -58,12 +58,12 @@ return array(
 
     // Zend_Validator_Callback
     "The input is not valid" => "The input is not valid",
-    "An exception has been raised within the callback" => "An exception has been raised within the callback",
+    "An exception has been raised within the callback." => "An exception has been raised within the callback.",
 
     // Zend_Validator_CreditCard
     "The input seems to contain an invalid checksum" => "The input seems to contain an invalid checksum",
     "The input must contain only digits" => "The input must contain only digits",
-    "Invalid type given. String expected" => "Invalid type given. String expected",
+    "Invalid type given. String expected." => "Invalid type given. String expected.",
     "The input contains an invalid amount of digits" => "The input contains an invalid amount of digits",
     "The input is not from an allowed institute" => "The input is not from an allowed institute",
     "The input seems to be an invalid creditcard number" => "The input seems to be an invalid creditcard number",
@@ -88,122 +88,122 @@ return array(
 
     // Zend_Validator_Digits
     "The input must contain only digits" => "The input must contain only digits",
-    "The input is an empty string" => "The input is an empty string",
-    "Invalid type given. String, integer or float expected" => "Invalid type given. String, integer or float expected",
+    "The input is an empty string." => "The input is an empty string.",
+    "Invalid type given. String, integer or float expected." => "Invalid type given. String, integer or float expected.",
 
     // Zend_Validator_EmailAddress
-    "Invalid type given. String expected" => "Invalid type given. String expected",
+    "Invalid type given. String expected." => "Invalid type given. String expected.",
     "The input is not a valid email address. Use the basic format local-part@hostname" => "The input is not a valid email address. Use the basic format local-part@hostname",
     "'%hostname%' is not a valid hostname for the email address" => "'%hostname%' is not a valid hostname for the email address",
     "'%hostname%' does not appear to have any valid MX or A records for the email address" => "'%hostname%' does not appear to have any valid MX or A records for the email address",
     "'%hostname%' is not in a routable network segment. The email address should not be resolved from public network" => "'%hostname%' is not in a routable network segment. The email address should not be resolved from public network",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' can not be matched against dot-atom format",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' can not be matched against quoted-string format",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' can not be matched against dot-atom format.",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' can not be matched against quoted-string format.",
     "'%localPart%' is not a valid local part for the email address" => "'%localPart%' is not a valid local part for the email address",
     "The input exceeds the allowed length" => "The input exceeds the allowed length",
 
     // Zend_Validator_Explode
-    "Invalid type given. String expected" => "Invalid type given. String expected",
+    "Invalid type given. String expected." => "Invalid type given. String expected.",
 
     // Zend_Validator_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Too many files, maximum '%max%' are allowed but '%count%' are given",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Too few files, minimum '%min%' are expected but '%count%' are given",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Too many files, maximum '%max%' are allowed but '%count%' are given.",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Too few files, minimum '%min%' are expected but '%count%' are given.",
 
     // Zend_Validator_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "File '%value%' does not match the given crc32 hashes",
-    "A crc32 hash could not be evaluated for the given file" => "A crc32 hash could not be evaluated for the given file",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "File '%value%' does not match the given crc32 hashes." => "File '%value%' does not match the given crc32 hashes.",
+    "A crc32 hash could not be evaluated for the given file." => "A crc32 hash could not be evaluated for the given file.",
+    "File '%value%' is not readable or does not exist." => "File '%value%' is not readable or does not exist.",
 
     // Zend_Validator_File_ExcludeExtension
-    "File '%value%' has a false extension" => "File '%value%' has a false extension",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "File '%value%' has a false extension." => "File '%value%' has a false extension.",
+    "File '%value%' is not readable or does not exist." => "File '%value%' is not readable or does not exist.",
 
     // Zend_Validator_File_Exists
-    "File '%value%' does not exist" => "File '%value%' does not exist",
+    "File '%value%' does not exist." => "File '%value%' does not exist.",
 
     // Zend_Validator_File_Extension
-    "File '%value%' has a false extension" => "File '%value%' has a false extension",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "File '%value%' has a false extension." => "File '%value%' has a false extension.",
+    "File '%value%' is not readable or does not exist." => "File '%value%' is not readable or does not exist.",
 
     // Zend_Validator_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "All files in sum should have a maximum size of '%max%' but '%size%' were detected",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "All files in sum should have a minimum size of '%min%' but '%size%' were detected",
-    "One or more files can not be read" => "One or more files can not be read",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "All files in sum should have a maximum size of '%max%' but '%size%' were detected.",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "All files in sum should have a minimum size of '%min%' but '%size%' were detected.",
+    "One or more files can not be read." => "One or more files can not be read.",
 
     // Zend_Validator_File_Hash
-    "File '%value%' does not match the given hashes" => "File '%value%' does not match the given hashes",
-    "A hash could not be evaluated for the given file" => "A hash could not be evaluated for the given file",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "File '%value%' does not match the given hashes." => "File '%value%' does not match the given hashes.",
+    "A hash could not be evaluated for the given file." => "A hash could not be evaluated for the given file.",
+    "File '%value%' is not readable or does not exist." => "File '%value%' is not readable or does not exist.",
 
     // Zend_Validator_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected",
-    "The size of image '%value%' could not be detected" => "The size of image '%value%' could not be detected",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected.",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected.",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected.",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected.",
+    "The size of image '%value%' could not be detected." => "The size of image '%value%' could not be detected.",
+    "File '%value%' is not readable or does not exist." => "File '%value%' is not readable or does not exist.",
 
     // Zend_Validator_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "File '%value%' is not compressed, '%type%' detected",
-    "The mimetype of file '%value%' could not be detected" => "The mimetype of file '%value%' could not be detected",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "File '%value%' is not compressed, '%type%' detected." => "File '%value%' is not compressed, '%type%' detected.",
+    "The mimetype of file '%value%' could not be detected." => "The mimetype of file '%value%' could not be detected.",
+    "File '%value%' is not readable or does not exist." => "File '%value%' is not readable or does not exist.",
 
     // Zend_Validator_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "File '%value%' is no image, '%type%' detected",
-    "The mimetype of file '%value%' could not be detected" => "The mimetype of file '%value%' could not be detected",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "File '%value%' is no image, '%type%' detected." => "File '%value%' is no image, '%type%' detected.",
+    "The mimetype of file '%value%' could not be detected." => "The mimetype of file '%value%' could not be detected.",
+    "File '%value%' is not readable or does not exist." => "File '%value%' is not readable or does not exist.",
 
     // Zend_Validator_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "File '%value%' does not match the given md5 hashes",
-    "A md5 hash could not be evaluated for the given file" => "A md5 hash could not be evaluated for the given file",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "File '%value%' does not match the given md5 hashes." => "File '%value%' does not match the given md5 hashes.",
+    "A md5 hash could not be evaluated for the given file." => "A md5 hash could not be evaluated for the given file.",
+    "File '%value%' is not readable or does not exist." => "File '%value%' is not readable or does not exist.",
 
     // Zend_Validator_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "File '%value%' has a false mimetype of '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "The mimetype of file '%value%' could not be detected",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "File '%value%' has a false mimetype of '%type%'." => "File '%value%' has a false mimetype of '%type%'.",
+    "The mimetype of file '%value%' could not be detected." => "The mimetype of file '%value%' could not be detected.",
+    "File '%value%' is not readable or does not exist." => "File '%value%' is not readable or does not exist.",
 
     // Zend_Validator_File_NotExists
-    "File '%value%' exists" => "File '%value%' exists",
+    "File '%value%' exists." => "File '%value%' exists.",
 
     // Zend_Validator_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "File '%value%' does not match the given sha1 hashes",
-    "A sha1 hash could not be evaluated for the given file" => "A sha1 hash could not be evaluated for the given file",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "File '%value%' does not match the given sha1 hashes." => "File '%value%' does not match the given sha1 hashes.",
+    "A sha1 hash could not be evaluated for the given file." => "A sha1 hash could not be evaluated for the given file.",
+    "File '%value%' is not readable or does not exist." => "File '%value%' is not readable or does not exist.",
 
     // Zend_Validator_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Minimum expected size for file '%value%' is '%min%' but '%size%' detected",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected.",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Minimum expected size for file '%value%' is '%min%' but '%size%' detected.",
+    "File '%value%' is not readable or does not exist." => "File '%value%' is not readable or does not exist.",
 
     // Zend_Validator_File_Upload
-    "File '%value%' exceeds the defined ini size" => "File '%value%' exceeds the defined ini size",
-    "File '%value%' exceeds the defined form size" => "File '%value%' exceeds the defined form size",
-    "File '%value%' was only partially uploaded" => "File '%value%' was only partially uploaded",
-    "File '%value%' was not uploaded" => "File '%value%' was not uploaded",
-    "No temporary directory was found for file '%value%'" => "No temporary directory was found for file '%value%'",
-    "File '%value%' can't be written" => "File '%value%' can't be written",
-    "A PHP extension returned an error while uploading the file '%value%'" => "A PHP extension returned an error while uploading the file '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "File '%value%' was illegally uploaded. This could be a possible attack",
-    "File '%value%' was not found" => "File '%value%' was not found",
-    "Unknown error while uploading file '%value%'" => "Unknown error while uploading file '%value%'",
+    "File '%value%' exceeds the defined ini size." => "File '%value%' exceeds the defined ini size.",
+    "File '%value%' exceeds the defined form size." => "File '%value%' exceeds the defined form size.",
+    "File '%value%' was only partially uploaded." => "File '%value%' was only partially uploaded.",
+    "File '%value%' was not uploaded." => "File '%value%' was not uploaded.",
+    "No temporary directory was found for file '%value%'." => "No temporary directory was found for file '%value%'.",
+    "File '%value%' can't be written." => "File '%value%' can't be written.",
+    "A PHP extension returned an error while uploading the file '%value%'." => "A PHP extension returned an error while uploading the file '%value%'.",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "File '%value%' was illegally uploaded. This could be a possible attack.",
+    "File '%value%' was not found." => "File '%value%' was not found.",
+    "Unknown error while uploading file '%value%'." => "Unknown error while uploading file '%value%'.",
 
     // Zend_Validator_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Too much words, maximum '%max%' are allowed but '%count%' were counted",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Too less words, minimum '%min%' are expected but '%count%' were counted",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Too much words, maximum '%max%' are allowed but '%count%' were counted.",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Too less words, minimum '%min%' are expected but '%count%' were counted.",
+    "File '%value%' is not readable or does not exist." => "File '%value%' is not readable or does not exist.",
 
     // Zend_Validator_GreaterThan
     "The input is not greater than '%min%'" => "The input is not greater than '%min%'",
     "The input is not greater or equal than '%min%'" => "The input is not greater or equal than '%min%'",
 
     // Zend_Validator_Hex
-    "Invalid type given. String expected" => "Invalid type given. String expected",
+    "Invalid type given. String expected." => "Invalid type given. String expected.",
     "The input contains non-hexadecimal characters" => "The input contains non-hexadecimal characters",
 
     // Zend_Validator_Hostname
     "The input appears to be a DNS hostname but the given punycode notation cannot be decoded" => "The input appears to be a DNS hostname but the given punycode notation cannot be decoded",
-    "Invalid type given. String expected" => "Invalid type given. String expected",
+    "Invalid type given. String expected." => "Invalid type given. String expected.",
     "The input appears to be a DNS hostname but contains a dash in an invalid position" => "The input appears to be a DNS hostname but contains a dash in an invalid position",
     "The input does not match the expected structure for a DNS hostname" => "The input does not match the expected structure for a DNS hostname",
     "The input appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "The input appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'",
@@ -221,18 +221,18 @@ return array(
     "The input has failed the IBAN check" => "The input has failed the IBAN check",
 
     // Zend_Validator_Identical
-    "The two given tokens do not match" => "The two given tokens do not match",
-    "No token was provided to match against" => "No token was provided to match against",
+    "The two given tokens do not match." => "The two given tokens do not match.",
+    "No token was provided to match against." => "No token was provided to match against.",
 
     // Zend_Validator_InArray
     "The input was not found in the haystack" => "The input was not found in the haystack",
 
     // Zend_Validator_Ip
-    "Invalid type given. String expected" => "Invalid type given. String expected",
+    "Invalid type given. String expected." => "Invalid type given. String expected.",
     "The input does not appear to be a valid IP address" => "The input does not appear to be a valid IP address",
 
     // Zend_Validator_Isbn
-    "Invalid type given. String or integer expected" => "Invalid type given. String or integer expected",
+    "Invalid type given. String or integer expected." => "Invalid type given. String or integer expected.",
     "The input is not a valid ISBN number" => "The input is not a valid ISBN number",
 
     // Zend_Validator_LessThan
@@ -240,40 +240,40 @@ return array(
     "The input is not less or equal than '%max%'" => "The input is not less or equal than '%max%'",
 
     // Zend_Validator_NotEmpty
-    "Value is required and can't be empty" => "Value is required and can't be empty",
-    "Invalid type given. String, integer, float, boolean or array expected" => "Invalid type given. String, integer, float, boolean or array expected",
+    "Value is required and can't be empty." => "Value is required and can't be empty.",
+    "Invalid type given. String, integer, float, boolean or array expected." => "Invalid type given. String, integer, float, boolean or array expected.",
 
     // Zend_Validator_Regex
-    "Invalid type given. String, integer or float expected" => "Invalid type given. String, integer or float expected",
+    "Invalid type given. String, integer or float expected." => "Invalid type given. String, integer or float expected.",
     "The input does not match against pattern '%pattern%'" => "The input does not match against pattern '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "There was an internal error while using the pattern '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "There was an internal error while using the pattern '%pattern%'.",
 
     // Zend_Validator_Sitemap_Changefreq
     "The input is not a valid sitemap changefreq" => "The input is not a valid sitemap changefreq",
-    "Invalid type given. String expected" => "Invalid type given. String expected",
+    "Invalid type given. String expected." => "Invalid type given. String expected.",
 
     // Zend_Validator_Sitemap_Lastmod
     "The input is not a valid sitemap lastmod" => "The input is not a valid sitemap lastmod",
-    "Invalid type given. String expected" => "Invalid type given. String expected",
+    "Invalid type given. String expected." => "Invalid type given. String expected.",
 
     // Zend_Validator_Sitemap_Loc
     "The input is not a valid sitemap location" => "The input is not a valid sitemap location",
-    "Invalid type given. String expected" => "Invalid type given. String expected",
+    "Invalid type given. String expected." => "Invalid type given. String expected.",
 
     // Zend_Validator_Sitemap_Priority
     "The input is not a valid sitemap priority" => "The input is not a valid sitemap priority",
-    "Invalid type given. Numeric string, integer or float expected" => "Invalid type given. Numeric string, integer or float expected",
+    "Invalid type given. Numeric string, integer or float expected." => "Invalid type given. Numeric string, integer or float expected.",
 
     // Zend_Validator_Step
     "Invalid value given. Scalar expected" => "Invalid value given. Scalar expected",
     "The input is not a valid step" => "The input is not a valid step",
 
     // Zend_Validator_StringLength
-    "Invalid type given. String expected" => "Invalid type given. String expected",
+    "Invalid type given. String expected." => "Invalid type given. String expected.",
     "The input is less than %min% characters long" => "The input is less than %min% characters long",
     "The input is more than %max% characters long" => "The input is more than %max% characters long",
 
     // Zend_Validator_Uri
-    "Invalid type given. String expected" => "Invalid type given. String expected",
+    "Invalid type given. String expected." => "Invalid type given. String expected.",
     "The input does not appear to be a valid Uri" => "The input does not appear to be a valid Uri",
 );

--- a/resources/languages/en/Zend_Validate.php
+++ b/resources/languages/en/Zend_Validate.php
@@ -35,7 +35,7 @@ return array(
 
     // Zend_I18n_Validator_Float
     "Invalid type given. String, integer or float expected." => "Invalid type given. String, integer or float expected.",
-    "The input does not appear to be a float" => "The input does not appear to be a float",
+    "The input does not appear to be a float." => "The input does not appear to be a float.",
 
     // Zend_I18n_Validator_Int
     "Invalid type given. String or integer expected." => "Invalid type given. String or integer expected.",
@@ -43,8 +43,8 @@ return array(
 
     // Zend_I18n_Validator_PostCode
     "Invalid type given. String or integer expected." => "Invalid type given. String or integer expected.",
-    "The input does not appear to be a postal code" => "The input does not appear to be a postal code",
-    "An exception has been raised while validating the input" => "An exception has been raised while validating the input",
+    "The input does not appear to be a postal code." => "The input does not appear to be a postal code.",
+    "An exception has been raised while validating the input." => "An exception has been raised while validating the input.",
 
     // Zend_Validator_Barcode
     "The input failed checksum validation." => "The input failed checksum validation.",
@@ -67,7 +67,7 @@ return array(
     "The input contains an invalid amount of digits" => "The input contains an invalid amount of digits",
     "The input is not from an allowed institute" => "The input is not from an allowed institute",
     "The input seems to be an invalid creditcard number" => "The input seems to be an invalid creditcard number",
-    "An exception has been raised while validating the input" => "An exception has been raised while validating the input",
+    "An exception has been raised while validating the input." => "An exception has been raised while validating the input.",
 
     // Zend_Validator_Csrf
     "The form submitted did not originate from the expected site" => "The form submitted did not originate from the expected site",

--- a/resources/languages/es/Zend_Validate.php
+++ b/resources/languages/es/Zend_Validate.php
@@ -25,13 +25,13 @@
 return array(
     // Zend_Validate_Alnum
     "Invalid type given, value should be float, string, or integer" => "El tipo especificado no es válido, el valor debe ser de tipo float, una cadena de texto o entero",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' contiene caracteres que no son alfabéticos ni dígitos",
-    "'%value%' is an empty string" => "'%value%' es una cadena de texto vacia",
+    "'%value%' contains characters which are non alphabetic and no digits." => "'%value%' contiene caracteres que no son alfabéticos ni dígitos",
+    "'%value%' is an empty string." => "'%value%' es una cadena de texto vacia",
 
     // Zend_Validate_Alpha
     "Invalid type given, value should be a string" => "El tipo especificado no es válido, el valor debe ser una cadena de texto",
-    "'%value%' contains non alphabetic characters" => "'%value%' contiene caracteres no alfabéticos",
-    "'%value%' is an empty string" => "'%value%' es una cadena de texto vacia",
+    "'%value%' contains non alphabetic characters." => "'%value%' contiene caracteres no alfabéticos",
+    "'%value%' is an empty string." => "'%value%' es una cadena de texto vacia",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "'%value%' Fallo la validación de  checksum",
@@ -44,26 +44,26 @@ return array(
     "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' no está exactamente entre '%min%' y '%max%'",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "'%value%' no es válido",
+    "'%value%' is not valid." => "'%value%' no es válido",
     "Failure within the callback, exception returned" => "Falló dentro de la llamada de retorno, ha devuelto una excepción",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' debe contener entre 13 y 19 dígitos",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "El algoritmo de Luhn (checksum del módulo 10) fallo en '%value%'",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' debe contener entre 13 y 19 dígitos",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "El algoritmo de Luhn (checksum del módulo 10) fallo en '%value%'",
 
     // Zend_Validate_CreditCard
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "El algoritmo de Luhn (checksum del módulo 10) fallo en '%value%'",
-    "'%value%' must contain only digits" => "'%value%' debe contener solo dígitos",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "El algoritmo de Luhn (checksum del módulo 10) fallo en '%value%'",
+    "'%value%' must contain only digits." => "'%value%' debe contener solo dígitos",
     "Invalid type given, value should be a string" => "El tipo especificado no es válido, el valor debe ser una cadena de texto",
-    "'%value%' contains an invalid amount of digits" => "'%value%' contiene una cantidad inválida de dígitos",
-    "'%value%' is not from an allowed institute" => "'%value%' no es de una institución autorizada",
+    "'%value%' contains an invalid amount of digits." => "'%value%' contiene una cantidad inválida de dígitos",
+    "'%value%' is not from an allowed institute." => "'%value%' no es de una institución autorizada",
     "Validation of '%value%' has been failed by the service" => "La validación de '%value%' fallo por causa del servicio",
     "The service returned a failure while validating '%value%'" => "El servicio devolvió un fallo durante la validación de '%value%'",
 
     // Zend_Validate_Date
     "Invalid type given, value should be string, integer, array or Zend_Date" => "El tipo especificado no es válido, el valor debe ser una cadena de texto, entero, array o un objeto Zend_Date",
-    "'%value%' does not appear to be a valid date" => "'%value%' no parece ser una fecha válida",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' no se ajusta al formato de fecha '%format%'",
+    "'%value%' does not appear to be a valid date." => "'%value%' no parece ser una fecha válida",
+    "'%value%' does not fit the date format '%format%'." => "'%value%' no se ajusta al formato de fecha '%format%'",
 
     // Zend_Validate_Db_Abstract
     "No record matching %value% was found" => "No fue encontrado ningun registro que coincida con %value%",
@@ -72,193 +72,193 @@ return array(
     // Zend_Validate_Digits
     "Invalid type given, value should be string, integer or float" => "El tipo especificado no es válido, el valor debe ser una cadena de texto, entero o float",
     "'%value%' contains characters which are not digits; but only digits are allowed" => "'%value%' contiene caracteres que no son dígitos, solo se permiten dígitos",
-    "'%value%' is an empty string" => "'%value%' es una cadena vacía",
+    "'%value%' is an empty string." => "'%value%' es una cadena vacía",
 
     // Zend_Validate_EmailAddress
     "Invalid type given, value should be a string" => "El tipo especificado no es válido, el valor debe ser una cadena de texto",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' no es una dirección de correo electrónico válido en el formato local-part@hostname",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' no es un nombre de host válido para la dirección de correo electrónico '%value%'",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' no parece tener un registro MX válido para la dirección de correo electrónico '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "'%value%' no es una dirección de correo electrónico válido en el formato local-part@hostname",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "'%hostname%' no es un nombre de host válido para la dirección de correo electrónico '%value%'",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "'%hostname%' no parece tener un registro MX válido para la dirección de correo electrónico '%value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' no esta en un segmento de red ruteable. La dirección de correo electrónico '%value%' no se debe poder resolver desde una red pública.",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' no es igual al formato dot-atom",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' no es igual al formato quoted-string",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' no es una parte local válida para la dirección de correo electrónico '%value%'",
-    "'%value%' exceeds the allowed length" => "'%value%' excede la longitud permitida",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' no es igual al formato dot-atom",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' no es igual al formato quoted-string",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "'%localPart%' no es una parte local válida para la dirección de correo electrónico '%value%'",
+    "'%value%' exceeds the allowed length." => "'%value%' excede la longitud permitida",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Demasiados archivos, se permiten un máximo de '%max%' pero se han especificado '%count%'",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Muy pocos archivos, se esperaba un mí­nimo de '%min%' pero sólo se han especificado '%count%'",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Demasiados archivos, se permiten un máximo de '%max%' pero se han especificado '%count%'",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Muy pocos archivos, se esperaba un mí­nimo de '%min%' pero sólo se han especificado '%count%'",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "El CRC32 del archivo '%value%' es incorrecto",
-    "A crc32 hash could not be evaluated for the given file" => "No se ha podido calcular el CRC32 del archivo especificado",
+    "File '%value%' does not match the given crc32 hashes." => "El CRC32 del archivo '%value%' es incorrecto",
+    "A crc32 hash could not be evaluated for the given file." => "No se ha podido calcular el CRC32 del archivo especificado",
     "File '%value%' could not be found" => "No se ha podido encontrar el archivo '%value%'",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "El archivo '%value%' tiene una extensión incorrecta",
+    "File '%value%' has a false extension." => "El archivo '%value%' tiene una extensión incorrecta",
     "File '%value%' could not be found" => "No se ha podido encontrar el archivo '%value%'",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "El archivo '%value%' tiene un tipo MIME '%type%' incorrecto",
-    "The mimetype of file '%value%' could not be detected" => "No se ha podido determinar el tipo MIME del archivo '%value%'",
+    "File '%value%' has a false mimetype of '%type%'." => "El archivo '%value%' tiene un tipo MIME '%type%' incorrecto",
+    "The mimetype of file '%value%' could not be detected." => "No se ha podido determinar el tipo MIME del archivo '%value%'",
     "File '%value%' can not be read" => "El archivo '%value%' no se puede leer",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "El archivo '%value%' no existe",
+    "File '%value%' does not exist." => "El archivo '%value%' no existe",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "El archivo '%value%' tiene una extensión incorrecta",
+    "File '%value%' has a false extension." => "El archivo '%value%' tiene una extensión incorrecta",
     "File '%value%' could not be found" => "No se ha podido encontrar el archivo '%value%'",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Todos los archivos deberí­an tener un tamaño máximo de '%max%' pero tiene un tamaño de '%size%'",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Todos los archivos deberí­an tener un tamaño mí­nimo de '%min%' pero tiene un tamaño de '%size%'",
-    "One or more files can not be read" => "Uno o más archivos no se pueden leer",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Todos los archivos deberí­an tener un tamaño máximo de '%max%' pero tiene un tamaño de '%size%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Todos los archivos deberí­an tener un tamaño mí­nimo de '%min%' pero tiene un tamaño de '%size%'",
+    "One or more files can not be read." => "Uno o más archivos no se pueden leer",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "El archivo '%value%' no se corresponde con los códigos hash especificados",
-    "A hash could not be evaluated for the given file" => "No se ha podido evaluar ningún código hash para el archivo especificado",
+    "File '%value%' does not match the given hashes." => "El archivo '%value%' no se corresponde con los códigos hash especificados",
+    "A hash could not be evaluated for the given file." => "No se ha podido evaluar ningún código hash para el archivo especificado",
     "File '%value%' could not be found" => "No se ha podido encontrar el archivo '%value%'",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "El ancho máxima para la imagen '%value%' deberí­a ser '%maxwidth%' pero es de '%width%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "El ancho mí­nima para la imagen '%value%' deberí­a ser '%minwidth%' pero es de '%width%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "La altura máxima para la imagen '%value%' deberí­a ser '%maxheight%' pero es de '%height%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "La altura mí­nima para la imagen '%value%' deberí­a ser '%minheight%' pero es de '%height%'",
-    "The size of image '%value%' could not be detected" => "No se ha podido determinar el tamaño de la imagen '%value%'",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "El ancho máxima para la imagen '%value%' deberí­a ser '%maxwidth%' pero es de '%width%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "El ancho mí­nima para la imagen '%value%' deberí­a ser '%minwidth%' pero es de '%width%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "La altura máxima para la imagen '%value%' deberí­a ser '%maxheight%' pero es de '%height%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "La altura mí­nima para la imagen '%value%' deberí­a ser '%minheight%' pero es de '%height%'",
+    "The size of image '%value%' could not be detected." => "No se ha podido determinar el tamaño de la imagen '%value%'",
     "File '%value%' can not be read" => "El archivo '%value%' no se puede leer",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "El archivo '%value%' no está comprimido, '%type%' detectado",
-    "The mimetype of file '%value%' could not be detected" => "No se ha podido determinar el tipo MIME del archivo '%value%'",
+    "File '%value%' is not compressed, '%type%' detected." => "El archivo '%value%' no está comprimido, '%type%' detectado",
+    "The mimetype of file '%value%' could not be detected." => "No se ha podido determinar el tipo MIME del archivo '%value%'",
     "File '%value%' can not be read" => "El archivo '%value%' no se puede leer",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "El archivo '%value%' no es una imagen, '%type%' detectado",
-    "The mimetype of file '%value%' could not be detected" => "No se ha podido determinar el tipo MIME del archivo '%value%'",
+    "File '%value%' is no image, '%type%' detected." => "El archivo '%value%' no es una imagen, '%type%' detectado",
+    "The mimetype of file '%value%' could not be detected." => "No se ha podido determinar el tipo MIME del archivo '%value%'",
     "File '%value%' can not be read" => "El archivo '%value%' no se puede leer",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "El archivo '%value%' no se corresponde con el MD5 especificado",
-    "A md5 hash could not be evaluated for the given file" => "No se ha podido calcular el MD5 del archivo especificado",
+    "File '%value%' does not match the given md5 hashes." => "El archivo '%value%' no se corresponde con el MD5 especificado",
+    "A md5 hash could not be evaluated for the given file." => "No se ha podido calcular el MD5 del archivo especificado",
     "File '%value%' could not be found" => "No se ha podido encontrar el archivo '%value%'",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "El archivo '%value%' tiene un tipo MIME '%type%' falso",
-    "The mimetype of file '%value%' could not be detected" => "No se ha podido determinar el tipo MIME del archivo '%value%'",
+    "File '%value%' has a false mimetype of '%type%'." => "El archivo '%value%' tiene un tipo MIME '%type%' falso",
+    "The mimetype of file '%value%' could not be detected." => "No se ha podido determinar el tipo MIME del archivo '%value%'",
     "File '%value%' can not be read" => "El archivo '%value%' no se puede leer",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "El archivo '%value%' existe",
+    "File '%value%' exists." => "El archivo '%value%' existe",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "El archivo '%value%' no es igual al SHA1 especificado",
-    "A sha1 hash could not be evaluated for the given file" => "No se ha podido calcular el SHA1 del archivo especificado",
+    "File '%value%' does not match the given sha1 hashes." => "El archivo '%value%' no es igual al SHA1 especificado",
+    "A sha1 hash could not be evaluated for the given file." => "No se ha podido calcular el SHA1 del archivo especificado",
     "File '%value%' could not be found" => "No se ha podido encontrar el archivo '%value%'",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "El tamaño máximo permitido para el archivo '%value%' es '%max%' pero se ha detectado un tamaño de '%size%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "El tamaño mí­nimo permitido para el archivo '%value%' es '%min%' pero se ha detectado un tamaño de '%size%'",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "El tamaño máximo permitido para el archivo '%value%' es '%max%' pero se ha detectado un tamaño de '%size%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "El tamaño mí­nimo permitido para el archivo '%value%' es '%min%' pero se ha detectado un tamaño de '%size%'",
     "File '%value%' could not be found" => "No se ha podido encontrar el archivo '%value%'",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "El tamaño del archivo '%value%' excede el valor definido en el ini",
-    "File '%value%' exceeds the defined form size" => "El archivo '%value%' excede el tamaño definido en el formulario",
-    "File '%value%' was only partially uploaded" => "El archivo '%value%' ha sido sólo parcialmente subido",
-    "File '%value%' was not uploaded" => "El archivo '%value%' no ha sido subido",
-    "No temporary directory was found for file '%value%'" => "No se ha encontrado el directorio temporal para el archivo '%value%'",
-    "File '%value%' can't be written" => "No se puede escribir en el archivo '%value%'",
-    "A PHP extension returned an error while uploading the file '%value%'" => "Una extensión PHP devolvió un error mientras se subí­a el archivo '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "El archivo '%value%' ha sido subido ilegalmente, lo cual podrí­a ser un ataque",
-    "File '%value%' was not found" => "Archivo '%value%' no encontrado",
-    "Unknown error while uploading file '%value%'" => "error desconocido al intentar subir el archivo '%value%'",
+    "File '%value%' exceeds the defined ini size." => "El tamaño del archivo '%value%' excede el valor definido en el ini",
+    "File '%value%' exceeds the defined form size." => "El archivo '%value%' excede el tamaño definido en el formulario",
+    "File '%value%' was only partially uploaded." => "El archivo '%value%' ha sido sólo parcialmente subido",
+    "File '%value%' was not uploaded." => "El archivo '%value%' no ha sido subido",
+    "No temporary directory was found for file '%value%'." => "No se ha encontrado el directorio temporal para el archivo '%value%'",
+    "File '%value%' can't be written." => "No se puede escribir en el archivo '%value%'",
+    "A PHP extension returned an error while uploading the file '%value%'." => "Una extensión PHP devolvió un error mientras se subí­a el archivo '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "El archivo '%value%' ha sido subido ilegalmente, lo cual podrí­a ser un ataque",
+    "File '%value%' was not found." => "Archivo '%value%' no encontrado",
+    "Unknown error while uploading file '%value%'." => "error desconocido al intentar subir el archivo '%value%'",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Demasiadas palabras, sólo se permiten '%max%' pero se han contado '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Demasiado pocas palabras, se esperaban al menos '%min%' pero se han contado '%count%'",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Demasiadas palabras, sólo se permiten '%max%' pero se han contado '%count%'",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Demasiado pocas palabras, se esperaban al menos '%min%' pero se han contado '%count%'",
     "File '%value%' could not be found" => "No se ha podido encontrar el archivo '%value%'",
 
     // Zend_Validate_Float
     "Invalid type given, value should be float, string, or integer" => "El tipo especificado no es válido, el valor deberí­a ser de tipo float, una cadena de texto o un entero",
-    "'%value%' does not appear to be a float" => "'%value%' no parece ser un float",
+    "'%value%' does not appear to be a float." => "'%value%' no parece ser un float",
 
 // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' no es mayor que '%min%'",
+    "'%value%' is not greater than '%min%'." => "'%value%' no es mayor que '%min%'",
 
     // Zend_Validate_Hex
     "Invalid type given, value should be a string" => "El tipo especificado es incorrecto, el valor deberí­a ser una cadena de texto",
-    "'%value%' has not only hexadecimal digit characters" => "'%value%' no consta únicamente de dí­gitos y caracteres hexadecimales",
+    "'%value%' has not only hexadecimal digit characters." => "'%value%' no consta únicamente de dí­gitos y caracteres hexadecimales",
 
     // Zend_Validate_Hostname
     "Invalid type given, value should be a string" => "El tipo especificado es incorrecto, el valor deberí­a ser una cadena de texto",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "'%value%' parece una dirección IP, pero éstas no están permitidas",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' parece ser un nombre de dominio DNS pero el TLD no es válido",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' parece ser un nombre de dominio DNS pero contiene una barra en una posición inválida",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' parece ser un nombre de dominio DNS pero su formato no se corresponde con el correcto para el TLD '%tld%'",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' parece ser un nombre de dominio DNS pero no se puede extraer la parte del TLD",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' no se corresponde con la estructura esperada para un nombre de dominio DNS",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' no parece ser un nombre de área local válido",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' parece ser un nombre de área local pero no se permiten nombres de área local",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "'%value%' parece ser un nombre de dominio DNS pero no se puede decodificar la notación de punycode",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => "'%value%' parece una dirección IP, pero éstas no están permitidas",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => "'%value%' parece ser un nombre de dominio DNS pero el TLD no es válido",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => "'%value%' parece ser un nombre de dominio DNS pero contiene una barra en una posición inválida",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => "'%value%' parece ser un nombre de dominio DNS pero su formato no se corresponde con el correcto para el TLD '%tld%'",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => "'%value%' parece ser un nombre de dominio DNS pero no se puede extraer la parte del TLD",
+    "'%value%' does not match the expected structure for a DNS hostname." => "'%value%' no se corresponde con la estructura esperada para un nombre de dominio DNS",
+    "'%value%' does not appear to be a valid local network name." => "'%value%' no parece ser un nombre de área local válido",
+    "'%value%' appears to be a local network name but local network names are not allowed." => "'%value%' parece ser un nombre de área local pero no se permiten nombres de área local",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => "'%value%' parece ser un nombre de dominio DNS pero no se puede decodificar la notación de punycode",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "Paí­s desconocido dentro del IBAN '%value%'",
-    "'%value%' has a false IBAN format" => "'%value%' tiene un formato falso de IBAN",
-    "'%value%' has failed the IBAN check" => "La prueba de validación de IBAN de '%value%' ha fallado",
+    "Unknown country within the IBAN '%value%'." => "Paí­s desconocido dentro del IBAN '%value%'",
+    "'%value%' has a false IBAN format." => "'%value%' tiene un formato falso de IBAN",
+    "'%value%' has failed the IBAN check." => "La prueba de validación de IBAN de '%value%' ha fallado",
 
     // Zend_Validate_Identical
-    "The two given tokens do not match" => "Las dos muestras especificados no concuerdan",
-    "No token was provided to match against" => "No se ha especificado ninguna muestra a comprobar",
+    "The two given tokens do not match." => "Las dos muestras especificados no concuerdan",
+    "No token was provided to match against." => "No se ha especificado ninguna muestra a comprobar",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "No se ha encontrado '%value%' en el argumento especificado",
+    "'%value%' was not found in the haystack." => "No se ha encontrado '%value%' en el argumento especificado",
 
     // Zend_Validate_Int
     "Invalid type given, value should be string or integer" => "El tipo especificado es inválido, el valor deberí­a ser una cadena de texto o un entero",
-    "'%value%' does not appear to be an integer" => "'%value%' no parece ser un entero",
+    "'%value%' does not appear to be an integer." => "'%value%' no parece ser un entero",
 
     // Zend_Validate_Ip
     "Invalid type given, value should be a string" => "El tipo especificado es incorrecto, el valor deberí­a ser una cadena de texto",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' no parece ser una dirección IP válida",
+    "'%value%' does not appear to be a valid IP address." => "'%value%' no parece ser una dirección IP válida",
 
     // Zend_Validate_Isbn
     "Invalid type given, value should be string or integer" => "El tipo especificado es inválido, el valor deberí­a ser una cadena de texto o un entero",
-    "'%value%' is not a valid ISBN number" => "El número ISBN especificado ('%value%') no es válido",
+    "'%value%' is not a valid ISBN number." => "El número ISBN especificado ('%value%') no es válido",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' no es menor que '%max%'",
+    "'%value%' is not less than '%max%'." => "'%value%' no es menor que '%max%'",
 
     // Zend_Validate_NotEmpty
     "Invalid type given, value should be float, string, array, boolean or integer" => "El tipo especificado es inválido, el valor deberí­a ser un float, una cadena de texto, un array, un boolean o un entero",
-    "Value is required and can't be empty" => "Se requiere un valor y éste no puede estar vací­o",
+    "Value is required and can't be empty." => "Se requiere un valor y éste no puede estar vací­o",
 
     // Zend_Validate_PostCode
     "Invalid type given. The value should be a string or a integer" => "El tipo especificado es incorrecto, el valor deberí­a ser una cadena de texto",
-    "'%value%' does not appear to be a postal code" => "'%value%' no parece ser un código postal",
+    "'%value%' does not appear to be a postal code." => "'%value%' no parece ser un código postal",
 
     // Zend_Validate_Regex
     "Invalid type given, value should be string, integer or float" => "El tipo especificado es incorrecto, el valor deberí­a ser de tipo float, una cadena de texto o un entero",
-    "'%value%' does not match against pattern '%pattern%'" => "'%value%' no concuerda con el patrón '%pattern%' especificado",
-    "There was an internal error while using the pattern '%pattern%'" => "Se ha producido un error interno al usar el patrón '%pattern%' especificado",
+    "'%value%' does not match against pattern '%pattern%'." => "'%value%' no concuerda con el patrón '%pattern%' especificado",
+    "There was an internal error while using the pattern '%pattern%'." => "Se ha producido un error interno al usar el patrón '%pattern%' especificado",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => "'%value%' no es una especificación válida de frecuencia de cambio",
+    "'%value%' is not a valid sitemap changefreq." => "'%value%' no es una especificación válida de frecuencia de cambio",
     "Invalid type given, the value should be a string" => "El tipo especificado es inválido, el valor deberí­a ser una cadena de texto",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => "'%value%' no es un lastmod de mapa web válido",
+    "'%value%' is not a valid sitemap lastmod." => "'%value%' no es un lastmod de mapa web válido",
     "Invalid type given, the value should be a string" => "El tipo especificado es inválido, el valor deberí­a ser una cadena de texto",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => "'%value%' no es una ubicación de mapa web válida",
+    "'%value%' is not a valid sitemap location." => "'%value%' no es una ubicación de mapa web válida",
     "Invalid type given, the value should be a string" => "El tipo especificado es inválido, el valor deberí­a ser una cadena de texto",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => "'%value%' no es una prioridad de mapa web válida",
+    "'%value%' is not a valid sitemap priority." => "'%value%' no es una prioridad de mapa web válida",
     "Invalid type given, the value should be a integer, a float or a numeric string" => "El tipo especificado es inválido, el valor deberí­a ser un entero, un float o una cadena de texto numérica",
 
     // Zend_Validate_StringLength
     "Invalid type given, value should be a string" => "El tipo especificado es incorrecto, el valor deberí­a ser una cadena de texto",
-    "'%value%' is less than %min% characters long" => "'%value%' tiene menos de '%min%' caracteres",
-    "'%value%' is more than %max% characters long" => "'%value%' tiene más de '%max%' caracteres",
+    "'%value%' is less than %min% characters long." => "'%value%' tiene menos de '%min%' caracteres",
+    "'%value%' is more than %max% characters long." => "'%value%' tiene más de '%max%' caracteres",
 );

--- a/resources/languages/fi/Zend_Validate.php
+++ b/resources/languages/fi/Zend_Validate.php
@@ -24,241 +24,241 @@
  */
 return array(
     // Zend_Validate_Alnum
-    "Invalid type given. String, integer or float expected" => "Epäkelpo syöte. Pitäisi olla liukuluku, merkkijono tai kokonaisluku",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' on virheelinen, ainoastaan aakkoset ja numerot ovat sallittuja",
-    "'%value%' is an empty string" => "'%value%' on tyhjä merkkijono",
+    "Invalid type given. String, integer or float expected." => "Epäkelpo syöte. Pitäisi olla liukuluku, merkkijono tai kokonaisluku",
+    "'%value%' contains characters which are non alphabetic and no digits." => "'%value%' on virheelinen, ainoastaan aakkoset ja numerot ovat sallittuja",
+    "'%value%' is an empty string." => "'%value%' on tyhjä merkkijono",
 
     // Zend_Validate_Alpha
-    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
-    "'%value%' contains non alphabetic characters" => "'%value%' on virheellinen, ainoastaan aakkoset ovat sallittuja",
-    "'%value%' is an empty string" => "'%value%' on tyhjä merkkijono",
+    "Invalid type given. String expected." => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' contains non alphabetic characters." => "'%value%' on virheellinen, ainoastaan aakkoset ovat sallittuja",
+    "'%value%' is an empty string." => "'%value%' on tyhjä merkkijono",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "Syötteen '%value%' tarkistusluvun vahvistus epäonnistui",
     "'%value%' contains invalid characters" => "'%value%' sisältää epäkelpoja merkkejä",
     "'%value%' should have a length of %length% characters" => "'%value%' pitäisi olla %length% merkkiä pitkä",
-    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "Invalid type given. String expected." => "Epäkelpo syöte. Pitäisi olla merkkijono",
 
     // Zend_Validate_Between
     "'%value%' is not between '%min%' and '%max%', inclusively" => "'%value%' ei ole luku väliltä %min%-%max%",
     "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' ei ole luku väliltä %min%-%max%, poislukien ylä- ja alarajat",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "'%value%' on epäkelpo",
-    "An exception has been raised within the callback" => "Odottamaton virhe, callback-validaattori palautti poikkeuksen",
+    "'%value%' is not valid." => "'%value%' on epäkelpo",
+    "An exception has been raised within the callback." => "Odottamaton virhe, callback-validaattori palautti poikkeuksen",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' pitää olla luku väliltä 13-19",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Luhn-algoritmin (mod 10) suoritus syötteelle '%value%' epäonnistui",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' pitää olla luku väliltä 13-19",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Luhn-algoritmin (mod 10) suoritus syötteelle '%value%' epäonnistui",
 
     // Zend_Validate_CreditCard
-    "'%value%' seems to contain an invalid checksum" => "Syötteen '%value%' tarkistusluku on viallinen",
-    "'%value%' must contain only digits" => "'%value%' saa sisältää ainoastaan numeroita",
-    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
-    "'%value%' contains an invalid amount of digits" => "'%value%' sisältää väärän määrän numeroita",
-    "'%value%' is not from an allowed institute" => "'%value%' ei ole sallitun luottolaitoksen alkuosa",
+    "'%value%' seems to contain an invalid checksum." => "Syötteen '%value%' tarkistusluku on viallinen",
+    "'%value%' must contain only digits." => "'%value%' saa sisältää ainoastaan numeroita",
+    "Invalid type given. String expected." => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' contains an invalid amount of digits." => "'%value%' sisältää väärän määrän numeroita",
+    "'%value%' is not from an allowed institute." => "'%value%' ei ole sallitun luottolaitoksen alkuosa",
     "'%value%' seems to be an invalid creditcard number" => "Luottokortin numero '%value%' tulkittiin virheelliseksi",
-    "An exception has been raised while validating '%value%'" => "Kortin '%value%' varmennus epäonnistui, palvelu palautti virheen",
+    "An exception has been raised while validating '%value%'." => "Kortin '%value%' varmennus epäonnistui, palvelu palautti virheen",
 
     // Zend_Validate_Date
-    "Invalid type given. String, integer, array or Zend_Date expected" => "Epäkelpo syöte. Pitäisi olla merkkijono, kokonaisluku, taulukko tai Zend_Date",
-    "'%value%' does not appear to be a valid date" => "'%value%' ei ole kelvollinen päivä",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' ei ole muotoa '%format%'",
+    "Invalid type given. String, integer, array or Zend_Date expected." => "Epäkelpo syöte. Pitäisi olla merkkijono, kokonaisluku, taulukko tai Zend_Date",
+    "'%value%' does not appear to be a valid date." => "'%value%' ei ole kelvollinen päivä",
+    "'%value%' does not fit the date format '%format%'." => "'%value%' ei ole muotoa '%format%'",
 
     // Zend_Validate_Db_Abstract
-    "No record matching '%value%' was found" => "Rekisteristä ei löytynyt arvoa, joka vastaisi syötettä '%value%'",
-    "A record matching '%value%' was found" => "Rekisteristä löytyi syötettä '%value%' vastaava arvo",
+    "No record matching '%value%' was found." => "Rekisteristä ei löytynyt arvoa, joka vastaisi syötettä '%value%'",
+    "A record matching '%value%' was found." => "Rekisteristä löytyi syötettä '%value%' vastaava arvo",
 
     // Zend_Validate_Digits
-    "Invalid type given. String, integer or float expected" => "Epäkelpo syöte. Pitäisi olla merkkijono, kokonaisluku tai liukuluku",
-    "'%value%' must contain only digits" => "'%value%' on virheellinen, ainoastaan numerot ovat sallittuja",
-    "'%value%' is an empty string" => "'%value%' on tyhjä merkkijono",
+    "Invalid type given. String, integer or float expected." => "Epäkelpo syöte. Pitäisi olla merkkijono, kokonaisluku tai liukuluku",
+    "'%value%' must contain only digits." => "'%value%' on virheellinen, ainoastaan numerot ovat sallittuja",
+    "'%value%' is an empty string." => "'%value%' on tyhjä merkkijono",
 
     // Zend_Validate_EmailAddress
-    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' on virheellinen sähköpostiosoite, ei vastaa muotoa paikallisosa@alue",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' on virheellinen verkkotunnus osoitteelle '%value%'",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "Osoitteen '%value%' verkkotunnukselle '%hostname%' ei löydy MX-tietuetta",
-    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network" => "'%hostname%' ei ole reititettävän verkon osa. Sähköpostiosoitetta '%value%' ei pitäisi selvittää julkisesta verkosta.",
-    "'%localPart%' can not be matched against dot-atom format" => "Virheellinen paikallisosa, '%localPart%' ei ole verrattavissa dot-atom -muotoon",
-    "'%localPart%' can not be matched against quoted-string format" => "Virheellinen paikallisosa, '%localPart%' ei ole verrattavissa quoted-string -muotoon",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "Sähköpostiosoitteen '%value%' paikallisosa '%localPart%' on virheellinen",
-    "'%value%' exceeds the allowed length" => "Osoite '%value%' on liian pitkä",
+    "Invalid type given. String expected." => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "'%value%' on virheellinen sähköpostiosoite, ei vastaa muotoa paikallisosa@alue",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "'%hostname%' on virheellinen verkkotunnus osoitteelle '%value%'",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "Osoitteen '%value%' verkkotunnukselle '%hostname%' ei löydy MX-tietuetta",
+    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' ei ole reititettävän verkon osa. Sähköpostiosoitetta '%value%' ei pitäisi selvittää julkisesta verkosta.",
+    "'%localPart%' can not be matched against dot-atom format." => "Virheellinen paikallisosa, '%localPart%' ei ole verrattavissa dot-atom -muotoon",
+    "'%localPart%' can not be matched against quoted-string format." => "Virheellinen paikallisosa, '%localPart%' ei ole verrattavissa quoted-string -muotoon",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "Sähköpostiosoitteen '%value%' paikallisosa '%localPart%' on virheellinen",
+    "'%value%' exceeds the allowed length." => "Osoite '%value%' on liian pitkä",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Virheellinen määrä tiedostoja, maksimimäärä on '%max%', vastaanotettiin '%count%'",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Virheellinen määrä tiedostoja, minimimäärä on '%min%', vastaanotettiin '%count%'",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Virheellinen määrä tiedostoja, maksimimäärä on '%max%', vastaanotettiin '%count%'",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Virheellinen määrä tiedostoja, minimimäärä on '%min%', vastaanotettiin '%count%'",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Tiedoston '%value%' crc32-tarkistusluku ei vastaa annettua",
-    "A crc32 hash could not be evaluated for the given file" => "Tarkistuslukua crc32 ei pystytty määrittämään vastaanotetulle tiedostolle",
-    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+    "File '%value%' does not match the given crc32 hashes." => "Tiedoston '%value%' crc32-tarkistusluku ei vastaa annettua",
+    "A crc32 hash could not be evaluated for the given file." => "Tarkistuslukua crc32 ei pystytty määrittämään vastaanotetulle tiedostolle",
+    "File '%value%' is not readable or does not exist." => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Tiedostolla '%value%' on virheellinen pääte",
-    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+    "File '%value%' has a false extension." => "Tiedostolla '%value%' on virheellinen pääte",
+    "File '%value%' is not readable or does not exist." => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Tiedoston '%value%' MIME-tyyppi '%type%' on virheellinen",
-    "The mimetype of file '%value%' could not be detected" => "Tiedoston '%value%' MIME-tyyppiä ei pystytty todentamaan",
-    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+    "File '%value%' has a false mimetype of '%type%'." => "Tiedoston '%value%' MIME-tyyppi '%type%' on virheellinen",
+    "The mimetype of file '%value%' could not be detected." => "Tiedoston '%value%' MIME-tyyppiä ei pystytty todentamaan",
+    "File '%value%' is not readable or does not exist." => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "Tiedostoa '%value%' ei ole olemassa",
+    "File '%value%' does not exist." => "Tiedostoa '%value%' ei ole olemassa",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "Tiedostolla '%value%' on virheellinen pääte",
-    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+    "File '%value%' has a false extension." => "Tiedostolla '%value%' on virheellinen pääte",
+    "File '%value%' is not readable or does not exist." => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Kaikkien tiedostojen yhteenlaskettu koko saa olla maksimissaan '%max%', vastaanotettiin '%size%'",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Kaikkien tiedostojen yhteenlaskettu koko pitää olla vähintään '%min%', vastaanotettiin '%size%'",
-    "One or more files can not be read" => "Yhtä tai useampaa tiedostoa ei voida lukea",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Kaikkien tiedostojen yhteenlaskettu koko saa olla maksimissaan '%max%', vastaanotettiin '%size%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Kaikkien tiedostojen yhteenlaskettu koko pitää olla vähintään '%min%', vastaanotettiin '%size%'",
+    "One or more files can not be read." => "Yhtä tai useampaa tiedostoa ei voida lukea",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "Tiedoston '%value%' tarkastusluku ei vastaa annettua",
-    "A hash could not be evaluated for the given file" => "Tarkistuslukua ei pystytty määrittämään vastaanotetulle tiedostolle",
-    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+    "File '%value%' does not match the given hashes." => "Tiedoston '%value%' tarkastusluku ei vastaa annettua",
+    "A hash could not be evaluated for the given file." => "Tarkistuslukua ei pystytty määrittämään vastaanotetulle tiedostolle",
+    "File '%value%' is not readable or does not exist." => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Kuvan '%value%' maksimileveys on '%maxwidth%', annettu '%width%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Kuvan '%value%' minimileveys on '%minwidth%', annettu '%width%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Kuvan '%value%' maksimikorkeus on '%maxheight%', annettu '%height%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Kuvan '%value%' minimikorkeus on '%minheight%', annettu '%height%'",
-    "The size of image '%value%' could not be detected" => "Kuvan '%value%' kokoa ei voida todentaa",
-    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Kuvan '%value%' maksimileveys on '%maxwidth%', annettu '%width%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Kuvan '%value%' minimileveys on '%minwidth%', annettu '%width%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Kuvan '%value%' maksimikorkeus on '%maxheight%', annettu '%height%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Kuvan '%value%' minimikorkeus on '%minheight%', annettu '%height%'",
+    "The size of image '%value%' could not be detected." => "Kuvan '%value%' kokoa ei voida todentaa",
+    "File '%value%' is not readable or does not exist." => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Tiedosto '%value%' ei ole pakattu, vastaanotettiin tyyppiä '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Tiedoston '%value%' MIME-tyyppiä ei pystytty todentamaan",
-    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+    "File '%value%' is not compressed, '%type%' detected." => "Tiedosto '%value%' ei ole pakattu, vastaanotettiin tyyppiä '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Tiedoston '%value%' MIME-tyyppiä ei pystytty todentamaan",
+    "File '%value%' is not readable or does not exist." => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Tiedosto '%value%' ei ole kuvatiedosto, vastaanotettiin tyyppiä '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Tiedoston '%value%' MIME-tyyppiä ei pystytty todentamaan",
-    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+    "File '%value%' is no image, '%type%' detected." => "Tiedosto '%value%' ei ole kuvatiedosto, vastaanotettiin tyyppiä '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Tiedoston '%value%' MIME-tyyppiä ei pystytty todentamaan",
+    "File '%value%' is not readable or does not exist." => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Tiedoston '%value%' tarkistusluku ei vastaa annettua (md5)",
-    "A md5 hash could not be evaluated for the given file" => "Tiedostolle ei voitu määrittää md5-tarkistuslukua",
-    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+    "File '%value%' does not match the given md5 hashes." => "Tiedoston '%value%' tarkistusluku ei vastaa annettua (md5)",
+    "A md5 hash could not be evaluated for the given file." => "Tiedostolle ei voitu määrittää md5-tarkistuslukua",
+    "File '%value%' is not readable or does not exist." => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Tiedoston '%value%' MIME-tyyppi '%type%' on virheellinen",
-    "The mimetype of file '%value%' could not be detected" => "Tiedoston '%value%' MIME-tyyppiä ei pystytty todentamaan",
-    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+    "File '%value%' has a false mimetype of '%type%'." => "Tiedoston '%value%' MIME-tyyppi '%type%' on virheellinen",
+    "The mimetype of file '%value%' could not be detected." => "Tiedoston '%value%' MIME-tyyppiä ei pystytty todentamaan",
+    "File '%value%' is not readable or does not exist." => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "Tiedostoa '%value%' ei ole olemassa",
+    "File '%value%' exists." => "Tiedostoa '%value%' ei ole olemassa",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Tiedoston '%value%' tarkistusluku ei vastaa annettua (sha1)",
-    "A sha1 hash could not be evaluated for the given file" => "Tiedostolle ei voitu määrittää sha1-tarkistuslukua",
-    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+    "File '%value%' does not match the given sha1 hashes." => "Tiedoston '%value%' tarkistusluku ei vastaa annettua (sha1)",
+    "A sha1 hash could not be evaluated for the given file." => "Tiedostolle ei voitu määrittää sha1-tarkistuslukua",
+    "File '%value%' is not readable or does not exist." => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Tiedoston '%value%' maksimikoko on '%max%', vastaanotettu '%size%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Tiedoston '%value%' minimikoko on '%min%', vastaanotettu '%size%'",
-    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voidea lukea tai sitä ei ole",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Tiedoston '%value%' maksimikoko on '%max%', vastaanotettu '%size%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Tiedoston '%value%' minimikoko on '%min%', vastaanotettu '%size%'",
+    "File '%value%' is not readable or does not exist." => "Tiedostoa '%value%' ei voidea lukea tai sitä ei ole",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Tiedosto '%value%' ylittää ini-tiedostossa määritellyn tiedostokoon",
-    "File '%value%' exceeds the defined form size" => "Tiedosto '%value%' ylittää lomakkeessa määritellyn tiedostokoon",
-    "File '%value%' was only partially uploaded" => "Tiedosto '%value%' vastaanotettiin ainoastaan osittain",
-    "File '%value%' was not uploaded" => "Tiedostoa '%value%' ei lähetetty",
-    "No temporary directory was found for file '%value%'" => "Väliaikaishakemistoa ei löytynyt tiedostolle '%value%'",
-    "File '%value%' can't be written" => "Tiedostoon '%value%' ei voida kirjoittaa",
-    "A PHP extension returned an error while uploading the file '%value%'" => "PHP:n lisäosa palautti virheen kesken tiedoston '%value%' lähetyksen",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Tiedoston '%value%' lähetyksessä haivattu laittomuus, mahdollinen hyökkäys",
-    "File '%value%' was not found" => "Tiedostoa '%value%' ei löydy",
-    "Unknown error while uploading file '%value%'" => "Tiedoston '%value%' lähetyksessä tapahtui tunnistamaton virhe",
+    "File '%value%' exceeds the defined ini size." => "Tiedosto '%value%' ylittää ini-tiedostossa määritellyn tiedostokoon",
+    "File '%value%' exceeds the defined form size." => "Tiedosto '%value%' ylittää lomakkeessa määritellyn tiedostokoon",
+    "File '%value%' was only partially uploaded." => "Tiedosto '%value%' vastaanotettiin ainoastaan osittain",
+    "File '%value%' was not uploaded." => "Tiedostoa '%value%' ei lähetetty",
+    "No temporary directory was found for file '%value%'." => "Väliaikaishakemistoa ei löytynyt tiedostolle '%value%'",
+    "File '%value%' can't be written." => "Tiedostoon '%value%' ei voida kirjoittaa",
+    "A PHP extension returned an error while uploading the file '%value%'." => "PHP:n lisäosa palautti virheen kesken tiedoston '%value%' lähetyksen",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Tiedoston '%value%' lähetyksessä haivattu laittomuus, mahdollinen hyökkäys",
+    "File '%value%' was not found." => "Tiedostoa '%value%' ei löydy",
+    "Unknown error while uploading file '%value%'." => "Tiedoston '%value%' lähetyksessä tapahtui tunnistamaton virhe",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Virheellinen määrä sanoja, maksimäärä on '%max%', annettu '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Virheellinen määrä sanoja, minimimäärä on '%min%', annettu '%count%'",
-    "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Virheellinen määrä sanoja, maksimäärä on '%max%', annettu '%count%'",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Virheellinen määrä sanoja, minimimäärä on '%min%', annettu '%count%'",
+    "File '%value%' is not readable or does not exist." => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
 
     // Zend_Validate_Float
-    "Invalid type given. String, integer or float expected" => "Epäkelpo syöte. Pitäisi olla liukuluku, merkkijono tai kokonaisluku",
-    "'%value%' does not appear to be a float" => "'%value%' ei ole liukuluku",
+    "Invalid type given. String, integer or float expected." => "Epäkelpo syöte. Pitäisi olla liukuluku, merkkijono tai kokonaisluku",
+    "'%value%' does not appear to be a float." => "'%value%' ei ole liukuluku",
 
     // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' ei ole suurempi kuin '%min%'",
+    "'%value%' is not greater than '%min%'." => "'%value%' ei ole suurempi kuin '%min%'",
 
     // Zend_Validate_Hex
-    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
-    "'%value%' has not only hexadecimal digit characters" => "'%value%' voi sisältää ainoastaan heksadeslimaalin muotoisia merkkejä",
+    "Invalid type given. String expected." => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' has not only hexadecimal digit characters." => "'%value%' voi sisältää ainoastaan heksadeslimaalin muotoisia merkkejä",
 
     // Zend_Validate_Hostname
-    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "'%value%' näyttäisi olevan ip-osoite eikä verkkotunnus",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' verkkotunnuksen TLD-osa ei ole tunnettu",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' näyttäisi olevan käypä verkkotunnus, mutta sisältää viivan väärässä paikassa",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' näyttäisi olevan käypä verkkotunnus, mutta sen TLD-osa '%tld%' on virheellinen",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' verkkotunnuksen TLD-osaa ei pystytty erottamaan",
-    "'%value%' does not match the expected structure for a DNS hostname" => "Verkkotunnus '%value%' on jäsennykseltään virheellinen",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' on epäkelpo paikallisverkkon tunnus",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' tulkittiin paikallisverkon tunnukseksi, jotka eivät ole sallittuja",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "Verkkotunnuksen '%value%' punycode-koodauksen purku epäonnistui",
+    "Invalid type given. String expected." => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => "'%value%' näyttäisi olevan ip-osoite eikä verkkotunnus",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => "'%value%' verkkotunnuksen TLD-osa ei ole tunnettu",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => "'%value%' näyttäisi olevan käypä verkkotunnus, mutta sisältää viivan väärässä paikassa",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => "'%value%' näyttäisi olevan käypä verkkotunnus, mutta sen TLD-osa '%tld%' on virheellinen",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => "'%value%' verkkotunnuksen TLD-osaa ei pystytty erottamaan",
+    "'%value%' does not match the expected structure for a DNS hostname." => "Verkkotunnus '%value%' on jäsennykseltään virheellinen",
+    "'%value%' does not appear to be a valid local network name." => "'%value%' on epäkelpo paikallisverkkon tunnus",
+    "'%value%' appears to be a local network name but local network names are not allowed." => "'%value%' tulkittiin paikallisverkon tunnukseksi, jotka eivät ole sallittuja",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => "Verkkotunnuksen '%value%' punycode-koodauksen purku epäonnistui",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "Maata ei pystytty tunnistamaan IBAN-koodista '%value%'",
-    "'%value%' has a false IBAN format" => "'%value%' on väärän muotoinen IBAN-koodi",
-    "'%value%' has failed the IBAN check" => "'%value%' IBAN-koodin tarkastus epäonnistui",
+    "Unknown country within the IBAN '%value%'." => "Maata ei pystytty tunnistamaan IBAN-koodista '%value%'",
+    "'%value%' has a false IBAN format." => "'%value%' on väärän muotoinen IBAN-koodi",
+    "'%value%' has failed the IBAN check." => "'%value%' IBAN-koodin tarkastus epäonnistui",
 
     // Zend_Validate_Identical
-    "The two given tokens do not match" => "Annetut kaksi arvoa eivät täsmää",
-    "No token was provided to match against" => "Toinen arvoista puuttuu",
+    "The two given tokens do not match." => "Annetut kaksi arvoa eivät täsmää",
+    "No token was provided to match against." => "Toinen arvoista puuttuu",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "'%value%' ei löydy sallittujen syötteiden joukosta",
+    "'%value%' was not found in the haystack." => "'%value%' ei löydy sallittujen syötteiden joukosta",
 
     // Zend_Validate_Int
-    "Invalid type given. String or integer expected" => "Epäkelpo syöte. Pitäisi olla merkkijono tai kokonaisluku",
-    "'%value%' does not appear to be an integer" => "'%value%' ei ole kokonaisluku",
+    "Invalid type given. String or integer expected." => "Epäkelpo syöte. Pitäisi olla merkkijono tai kokonaisluku",
+    "'%value%' does not appear to be an integer." => "'%value%' ei ole kokonaisluku",
 
     // Zend_Validate_Ip
-    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' ei ole käypä IP-osoite",
+    "Invalid type given. String expected." => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' does not appear to be a valid IP address." => "'%value%' ei ole käypä IP-osoite",
 
     // Zend_Validate_Isbn
-    "Invalid type given. String or integer expected" => "Epäkelpo syöte. Pitäisi olla merkkijono tai kokonaisluku",
-    "'%value%' is not a valid ISBN number" => "'%value%' ei ole käypä ISBN-numero",
+    "Invalid type given. String or integer expected." => "Epäkelpo syöte. Pitäisi olla merkkijono tai kokonaisluku",
+    "'%value%' is not a valid ISBN number." => "'%value%' ei ole käypä ISBN-numero",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' ei ole pienempi kuin '%max%'",
+    "'%value%' is not less than '%max%'." => "'%value%' ei ole pienempi kuin '%max%'",
 
     // Zend_Validate_NotEmpty
-    "Invalid type given. String, integer, float, boolean or array expected" => "Epäkelpo syöte. Pitäisi olla kokonaisluku, liukuluku, boolean tai taulukko",
-    "Value is required and can't be empty" => "Kenttä ei voi olla tyhjä",
+    "Invalid type given. String, integer, float, boolean or array expected." => "Epäkelpo syöte. Pitäisi olla kokonaisluku, liukuluku, boolean tai taulukko",
+    "Value is required and can't be empty." => "Kenttä ei voi olla tyhjä",
 
     // Zend_Validate_PostCode
-    "Invalid type given. String or integer expected" => "Epäkelpo syöte. Pitäisi olla merkkijono tai kokonaisluku",
-    "'%value%' does not appear to be a postal code" => "'%value%' ei ole käypä postiosoite",
+    "Invalid type given. String or integer expected." => "Epäkelpo syöte. Pitäisi olla merkkijono tai kokonaisluku",
+    "'%value%' does not appear to be a postal code." => "'%value%' ei ole käypä postiosoite",
 
     // Zend_Validate_Regex
-    "Invalid type given. String, integer or float expected" => "Epäkelpo syöte. Pitäisi olla merkkijono, kokonaisluku tai liukuluku",
-    "'%value%' does not match against pattern '%pattern%'" => "'%value%' ei ole muotoa '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "Sisäinen virhe käytettäessa muotoa '%pattern%'",
+    "Invalid type given. String, integer or float expected." => "Epäkelpo syöte. Pitäisi olla merkkijono, kokonaisluku tai liukuluku",
+    "'%value%' does not match against pattern '%pattern%'." => "'%value%' ei ole muotoa '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "Sisäinen virhe käytettäessa muotoa '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => "'%value%' ei ole käypä sivukartan muutosnopeus",
-    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' is not a valid sitemap changefreq." => "'%value%' ei ole käypä sivukartan muutosnopeus",
+    "Invalid type given. String expected." => "Epäkelpo syöte. Pitäisi olla merkkijono",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => "'%value%' ei ole käypä arvo sivukartan viimeksimuokatuksi arvoksi",
-    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' is not a valid sitemap lastmod." => "'%value%' ei ole käypä arvo sivukartan viimeksimuokatuksi arvoksi",
+    "Invalid type given. String expected." => "Epäkelpo syöte. Pitäisi olla merkkijono",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => "'%value%' ei ole käypä sivukartan sijainti",
-    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' is not a valid sitemap location." => "'%value%' ei ole käypä sivukartan sijainti",
+    "Invalid type given. String expected." => "Epäkelpo syöte. Pitäisi olla merkkijono",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => "'%value%' ei ole käypä sivukartan prioriteetti",
-    "Invalid type given. Numeric string, integer or float expected" => "Epäkelpo syöte. Pitäisi olla kokonaisluku tai liukuluku",
+    "'%value%' is not a valid sitemap priority." => "'%value%' ei ole käypä sivukartan prioriteetti",
+    "Invalid type given. Numeric string, integer or float expected." => "Epäkelpo syöte. Pitäisi olla kokonaisluku tai liukuluku",
 
     // Zend_Validate_StringLength
-    "Invalid type given. String expected" => "Epäkelpo syöte. Pitäisi olla merkkijono",
-    "'%value%' is less than %min% characters long" => "'%value%' on lyhyempi kuin vaaditut %min% merkkiä",
-    "'%value%' is more than %max% characters long" => "'%value%' on pidempi kuin sallitut %max% merkkiä",
+    "Invalid type given. String expected." => "Epäkelpo syöte. Pitäisi olla merkkijono",
+    "'%value%' is less than %min% characters long." => "'%value%' on lyhyempi kuin vaaditut %min% merkkiä",
+    "'%value%' is more than %max% characters long." => "'%value%' on pidempi kuin sallitut %max% merkkiä",
 );

--- a/resources/languages/fr/Zend_Validate.php
+++ b/resources/languages/fr/Zend_Validate.php
@@ -36,7 +36,7 @@ return array(
 
     // Zend_I18n_Validator_Float
     "Invalid type given. String, integer or float expected." => "Type invalide. Chaîne, entier ou flottant attendu",
-    "The input does not appear to be a float" => "L'entrée n'est pas un nombre flottant",
+    "The input does not appear to be a float." => "L'entrée n'est pas un nombre flottant",
 
     // Zend_I18n_Validator_Int
     "Invalid type given. String or integer expected." => "Type invalide. Chaîne ou entier attendu",
@@ -44,8 +44,8 @@ return array(
 
     // Zend_I18n_Validator_PostCode
     "Invalid type given. String or integer expected." => "Type invalid. Chaîne ou entier attendu",
-    "The input does not appear to be a postal code" => "L'entrée ne semble pas être un code postal valide",
-    "An exception has been raised while validating the input" => "Une exception a été levée lors de la validation de l'entrée",
+    "The input does not appear to be a postal code." => "L'entrée ne semble pas être un code postal valide",
+    "An exception has been raised while validating the input." => "Une exception a été levée lors de la validation de l'entrée",
 
     // Zend_Validator_Barcode
     "The input failed checksum validation." => "L'entrée n'a pas passé la validation de la somme de contrôle",
@@ -68,7 +68,7 @@ return array(
     "The input contains an invalid amount of digits" => "L'entrée contient un nombre invalide de chiffres",
     "The input is not from an allowed institute" => "L'entrée ne provient pas d'une institution autorisée",
     "The input seems to be an invalid creditcard number" => "L'entrée semble être un numéro de carte bancaire invalide",
-    "An exception has been raised while validating the input" => "Une exception a été levée lors de la validation de l'entrée",
+    "An exception has been raised while validating the input." => "Une exception a été levée lors de la validation de l'entrée",
 
     // Zend_Validator_Csrf
     "The form submitted did not originate from the expected site" => "Le formulaire ne provient pas du site attendu",

--- a/resources/languages/fr/Zend_Validate.php
+++ b/resources/languages/fr/Zend_Validate.php
@@ -25,33 +25,33 @@
  */
 return array(
     // Zend_I18n_Validator_Alnum
-    "Invalid type given. String, integer or float expected" => "Type invalide. Chaîne, entier ou flottant attendu",
-    "The input contains characters which are non alphabetic and no digits" => "L'entrée contient des caractères non alphabétiques et non numériques",
-    "The input is an empty string" => "L'entrée est une chaîne vide",
+    "Invalid type given. String, integer or float expected." => "Type invalide. Chaîne, entier ou flottant attendu",
+    "The input contains characters which are non alphabetic and no digits." => "L'entrée contient des caractères non alphabétiques et non numériques",
+    "The input is an empty string." => "L'entrée est une chaîne vide",
 
     // Zend_I18n_Validator_Alpha
-    "Invalid type given. String expected" => "Type invalide. Chaîne attendue",
-    "The input contains non alphabetic characters" => "L'entrée contient des caractères non alphabétiques",
-    "The input is an empty string" => "L'entrée est une chaîne vide",
+    "Invalid type given. String expected." => "Type invalide. Chaîne attendue",
+    "The input contains non alphabetic characters." => "L'entrée contient des caractères non alphabétiques",
+    "The input is an empty string." => "L'entrée est une chaîne vide",
 
     // Zend_I18n_Validator_Float
-    "Invalid type given. String, integer or float expected" => "Type invalide. Chaîne, entier ou flottant attendu",
+    "Invalid type given. String, integer or float expected." => "Type invalide. Chaîne, entier ou flottant attendu",
     "The input does not appear to be a float" => "L'entrée n'est pas un nombre flottant",
 
     // Zend_I18n_Validator_Int
-    "Invalid type given. String or integer expected" => "Type invalide. Chaîne ou entier attendu",
-    "The input does not appear to be an integer" => "L'entrée n'est pas un entier",
+    "Invalid type given. String or integer expected." => "Type invalide. Chaîne ou entier attendu",
+    "The input does not appear to be an integer." => "L'entrée n'est pas un entier",
 
     // Zend_I18n_Validator_PostCode
-    "Invalid type given. String or integer expected" => "Type invalid. Chaîne ou entier attendu",
+    "Invalid type given. String or integer expected." => "Type invalid. Chaîne ou entier attendu",
     "The input does not appear to be a postal code" => "L'entrée ne semble pas être un code postal valide",
     "An exception has been raised while validating the input" => "Une exception a été levée lors de la validation de l'entrée",
 
     // Zend_Validator_Barcode
-    "The input failed checksum validation" => "L'entrée n'a pas passé la validation de la somme de contrôle",
+    "The input failed checksum validation." => "L'entrée n'a pas passé la validation de la somme de contrôle",
     "The input contains invalid characters" => "L'entrée contient des caractères invalides",
     "The input should have a length of %length% characters" => "L'entrée devrait contenir %length% caractères",
-    "Invalid type given. String expected" => "Type invalide. Chaîne attendue",
+    "Invalid type given. String expected." => "Type invalide. Chaîne attendue",
 
     // Zend_Validator_Between
     "The input is not between '%min%' and '%max%', inclusively" => "L'entrée n'est pas comprise entre '%min%' et '%max%', inclusivement",
@@ -59,12 +59,12 @@ return array(
 
     // Zend_Validator_Callback
     "The input is not valid" => "L'entrée n'est pas valide",
-    "An exception has been raised within the callback" => "Une exception a été levée dans la fonction de rappel",
+    "An exception has been raised within the callback." => "Une exception a été levée dans la fonction de rappel",
 
     // Zend_Validator_CreditCard
     "The input seems to contain an invalid checksum" => "L'entrée semble contenir une somme de contrôle invalide",
     "The input must contain only digits" => "L'entrée ne doit contenir que des chiffres",
-    "Invalid type given. String expected" => "Type invalide. Chaîne attendue",
+    "Invalid type given. String expected." => "Type invalide. Chaîne attendue",
     "The input contains an invalid amount of digits" => "L'entrée contient un nombre invalide de chiffres",
     "The input is not from an allowed institute" => "L'entrée ne provient pas d'une institution autorisée",
     "The input seems to be an invalid creditcard number" => "L'entrée semble être un numéro de carte bancaire invalide",
@@ -89,122 +89,122 @@ return array(
 
     // Zend_Validator_Digits
     "The input must contain only digits" => "L'entrée ne doit contenir que des chiffres",
-    "The input is an empty string" => "L'entrée est une chaîne vide",
-    "Invalid type given. String, integer or float expected" => "Type invalide. Chaîne, entier ou flottant attendu",
+    "The input is an empty string." => "L'entrée est une chaîne vide",
+    "Invalid type given. String, integer or float expected." => "Type invalide. Chaîne, entier ou flottant attendu",
 
     // Zend_Validator_EmailAddress
-    "Invalid type given. String expected" => "Type invalide. Chaîne attendue",
+    "Invalid type given. String expected." => "Type invalide. Chaîne attendue",
     "The input is not a valid email address. Use the basic format local-part@hostname" => "L'entrée n'est pas une adresse email valide. Utilisez le format local-part@hostname",
     "'%hostname%' is not a valid hostname for the email address" => "'%hostname%' n'est pas un nom d'hôte valide pour l'adresse email",
     "'%hostname%' does not appear to have any valid MX or A records for the email address" => "'%hostname%' ne semble pas avoir d'enregistrement MX valide pour l'adresse email",
     "'%hostname%' is not in a routable network segment. The email address should not be resolved from public network" => "'%hostname%' n'est pas dans un segment réseau routable. L'adresse email ne devrait pas être résolue depuis un réseau public.",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' ne correspond pas au format dot-atom",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' ne correspond pas à une chaîne entre quotes",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' ne correspond pas au format dot-atom",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' ne correspond pas à une chaîne entre quotes",
     "'%localPart%' is not a valid local part for the email address" => "'%localPart%' n'est pas une partie locale valide pour l'adresse email",
     "The input exceeds the allowed length" => "L'entrée dépasse la taille autorisée",
 
     // Zend_Validator_Explode
-    "Invalid type given. String expected" => "Type invalide. Chaîne attendue",
+    "Invalid type given. String expected." => "Type invalide. Chaîne attendue",
 
     // Zend_Validator_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Trop de fichiers. '%max%' sont autorisés au maximum, mais '%count%' reçu(s)",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Trop peu de fichiers. '%min%' sont attendus, mais '%count%' reçu(s)",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Trop de fichiers. '%max%' sont autorisés au maximum, mais '%count%' reçu(s)",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Trop peu de fichiers. '%min%' sont attendus, mais '%count%' reçu(s)",
 
     // Zend_Validator_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Le fichier '%value%' ne correspond pas aux sommes de contrôle CRC32 données",
-    "A crc32 hash could not be evaluated for the given file" => "Une somme de contrôle CRC32 n'a pas pu être calculée pour le fichier",
-    "File '%value%' is not readable or does not exist" => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
+    "File '%value%' does not match the given crc32 hashes." => "Le fichier '%value%' ne correspond pas aux sommes de contrôle CRC32 données",
+    "A crc32 hash could not be evaluated for the given file." => "Une somme de contrôle CRC32 n'a pas pu être calculée pour le fichier",
+    "File '%value%' is not readable or does not exist." => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
 
     // Zend_Validator_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Le fichier '%value%' a une mauvaise extension",
-    "File '%value%' is not readable or does not exist" => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
+    "File '%value%' has a false extension." => "Le fichier '%value%' a une mauvaise extension",
+    "File '%value%' is not readable or does not exist." => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
 
     // Zend_Validator_File_Exists
-    "File '%value%' does not exist" => "Le fichier '%value%' n'existe pas",
+    "File '%value%' does not exist." => "Le fichier '%value%' n'existe pas",
 
     // Zend_Validator_File_Extension
-    "File '%value%' has a false extension" => "Le fichier '%value%' a une mauvaise extension",
-    "File '%value%' is not readable or does not exist" => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
+    "File '%value%' has a false extension." => "Le fichier '%value%' a une mauvaise extension",
+    "File '%value%' is not readable or does not exist." => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
 
     // Zend_Validator_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Tous les fichiers devraient avoir une taille maximale de '%max%' mais une taille de '%size%' a été détectée",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Tous les fichiers devraient avoir une taille minimale de '%max%' mais une taille de '%size%' a été détectée",
-    "One or more files can not be read" => "Un ou plusieurs fichiers ne peut pas être lu",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Tous les fichiers devraient avoir une taille maximale de '%max%' mais une taille de '%size%' a été détectée",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Tous les fichiers devraient avoir une taille minimale de '%max%' mais une taille de '%size%' a été détectée",
+    "One or more files can not be read." => "Un ou plusieurs fichiers ne peut pas être lu",
 
     // Zend_Validator_File_Hash
-    "File '%value%' does not match the given hashes" => "Le fichier '%value%' ne correspond pas aux sommes de contrôle données",
-    "A hash could not be evaluated for the given file" => "Une somme de contrôle n'a pas pu être calculée pour le fichier",
-    "File '%value%' is not readable or does not exist" => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
+    "File '%value%' does not match the given hashes." => "Le fichier '%value%' ne correspond pas aux sommes de contrôle données",
+    "A hash could not be evaluated for the given file." => "Une somme de contrôle n'a pas pu être calculée pour le fichier",
+    "File '%value%' is not readable or does not exist." => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
 
     // Zend_Validator_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "La largeur maximale pour l'image '%value%' devrait être '%maxwidth%', mais '%width%' détecté",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "La largeur minimale pour l'image '%value%' devrait être '%minwidth%', mais '%width%' détecté",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "La hauteur maximale pour l'image '%value%' devrait être '%maxheight%', mais '%height%' détecté",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "La hauteur maximale pour l'image '%value%' devrait être '%minheight%', mais '%height%' détecté",
-    "The size of image '%value%' could not be detected" => "La taille de l'image '%value%' n'a pas pu être détectée",
-    "File '%value%' is not readable or does not exist" => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "La largeur maximale pour l'image '%value%' devrait être '%maxwidth%', mais '%width%' détecté",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "La largeur minimale pour l'image '%value%' devrait être '%minwidth%', mais '%width%' détecté",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "La hauteur maximale pour l'image '%value%' devrait être '%maxheight%', mais '%height%' détecté",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "La hauteur maximale pour l'image '%value%' devrait être '%minheight%', mais '%height%' détecté",
+    "The size of image '%value%' could not be detected." => "La taille de l'image '%value%' n'a pas pu être détectée",
+    "File '%value%' is not readable or does not exist." => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
 
     // Zend_Validator_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Le fichier '%value%' n'est pas compressé, '%type%' détecté",
-    "The mimetype of file '%value%' could not be detected" => "Le type MIME du fichier '%value%' n'a pas pu être détecté",
-    "File '%value%' is not readable or does not exist" => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
+    "File '%value%' is not compressed, '%type%' detected." => "Le fichier '%value%' n'est pas compressé, '%type%' détecté",
+    "The mimetype of file '%value%' could not be detected." => "Le type MIME du fichier '%value%' n'a pas pu être détecté",
+    "File '%value%' is not readable or does not exist." => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
 
     // Zend_Validator_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Le fichier '%value%' n'est pas une image, '%type%' détecté",
-    "The mimetype of file '%value%' could not be detected" => "Le type MIME du fichier '%value%' n'a pas pu être détecté",
-    "File '%value%' is not readable or does not exist" => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
+    "File '%value%' is no image, '%type%' detected." => "Le fichier '%value%' n'est pas une image, '%type%' détecté",
+    "The mimetype of file '%value%' could not be detected." => "Le type MIME du fichier '%value%' n'a pas pu être détecté",
+    "File '%value%' is not readable or does not exist." => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
 
     // Zend_Validator_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Le fichier '%value%' ne correspond pas aux sommes de contrôle MD5 données",
-    "A md5 hash could not be evaluated for the given file" => "Une somme de contrôle MD5 n'a pas pu être calculée pour le fichier",
-    "File '%value%' is not readable or does not exist" => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
+    "File '%value%' does not match the given md5 hashes." => "Le fichier '%value%' ne correspond pas aux sommes de contrôle MD5 données",
+    "A md5 hash could not be evaluated for the given file." => "Une somme de contrôle MD5 n'a pas pu être calculée pour le fichier",
+    "File '%value%' is not readable or does not exist." => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
 
     // Zend_Validator_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Le fichier '%value%' a un faux type MIME : '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Le type MIME du fichier '%value%' n'a pas pu être détecté",
-    "File '%value%' is not readable or does not exist" => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
+    "File '%value%' has a false mimetype of '%type%'." => "Le fichier '%value%' a un faux type MIME : '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Le type MIME du fichier '%value%' n'a pas pu être détecté",
+    "File '%value%' is not readable or does not exist." => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
 
     // Zend_Validator_File_NotExists
-    "File '%value%' exists" => "Le fichier '%value%' existe",
+    "File '%value%' exists." => "Le fichier '%value%' existe",
 
     // Zend_Validator_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Le fichier '%value%' ne correspond pas aux sommes de contrôle SHA1 données",
-    "A sha1 hash could not be evaluated for the given file" => "Une somme de contrôle SHA1 n'a pas pu être calculée pour le fichier",
-    "File '%value%' is not readable or does not exist" => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
+    "File '%value%' does not match the given sha1 hashes." => "Le fichier '%value%' ne correspond pas aux sommes de contrôle SHA1 données",
+    "A sha1 hash could not be evaluated for the given file." => "Une somme de contrôle SHA1 n'a pas pu être calculée pour le fichier",
+    "File '%value%' is not readable or does not exist." => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
 
     // Zend_Validator_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "La taille de fichier maximale pour '%value%' est '%max%', mais '%size%' détectée",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "La taille de fichier minimale pour '%value%' est '%min%', mais '%size%' détectée",
-    "File '%value%' is not readable or does not exist" => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "La taille de fichier maximale pour '%value%' est '%max%', mais '%size%' détectée",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "La taille de fichier minimale pour '%value%' est '%min%', mais '%size%' détectée",
+    "File '%value%' is not readable or does not exist." => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
 
     // Zend_Validator_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Le fichier '%value%' dépasse la taille définie dans le fichier INI",
-    "File '%value%' exceeds the defined form size" => "Le fichier '%value%' dépasse la taille définie dans le formulaire",
-    "File '%value%' was only partially uploaded" => "Le fichier '%value%' n'a été que partiellement envoyé",
-    "File '%value%' was not uploaded" => "Le fichier '%value%' n'a pas été envoyé",
-    "No temporary directory was found for file '%value%'" => "Le dossier temporaire n'a pas été trouvé pour le fichier '%value%'",
-    "File '%value%' can't be written" => "Impossible d'écrire dans le fichier '%value%'",
-    "A PHP extension returned an error while uploading the file '%value%'" => "Une extension PHP a retourné une erreur en envoyant le fichier '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Le fichier '%value%' a été envoyé illégalement. Il peut s'agir d'une attaque",
-    "File '%value%' was not found" => "Le fichier '%value%' n'a pas été trouvé",
-    "Unknown error while uploading file '%value%'" => "Erreur inconnue lors de l'envoi du fichier '%value%'",
+    "File '%value%' exceeds the defined ini size." => "Le fichier '%value%' dépasse la taille définie dans le fichier INI",
+    "File '%value%' exceeds the defined form size." => "Le fichier '%value%' dépasse la taille définie dans le formulaire",
+    "File '%value%' was only partially uploaded." => "Le fichier '%value%' n'a été que partiellement envoyé",
+    "File '%value%' was not uploaded." => "Le fichier '%value%' n'a pas été envoyé",
+    "No temporary directory was found for file '%value%'." => "Le dossier temporaire n'a pas été trouvé pour le fichier '%value%'",
+    "File '%value%' can't be written." => "Impossible d'écrire dans le fichier '%value%'",
+    "A PHP extension returned an error while uploading the file '%value%'." => "Une extension PHP a retourné une erreur en envoyant le fichier '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Le fichier '%value%' a été envoyé illégalement. Il peut s'agir d'une attaque",
+    "File '%value%' was not found." => "Le fichier '%value%' n'a pas été trouvé",
+    "Unknown error while uploading file '%value%'." => "Erreur inconnue lors de l'envoi du fichier '%value%'",
 
     // Zend_Validator_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Trop de mots. '%max%' sont autorisés, '%count%' comptés",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Pas assez de mots. '%min%' sont attendus, '%count%' comptés",
-    "File '%value%' is not readable or does not exist" => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Trop de mots. '%max%' sont autorisés, '%count%' comptés",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Pas assez de mots. '%min%' sont attendus, '%count%' comptés",
+    "File '%value%' is not readable or does not exist." => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
 
     // Zend_Validator_GreaterThan
     "The input is not greater than '%min%'" => "L'entrée n'est pas supérieure à '%min%'",
     "The input is not greater or equal than '%min%'" => "L'entrée n'est pas supérieure ou égale à '%min%'",
 
     // Zend_Validator_Hex
-    "Invalid type given. String expected" => "Type invalide. Chaîne attendue",
+    "Invalid type given. String expected." => "Type invalide. Chaîne attendue",
     "The input contains non-hexadecimal characters" => "L'entrée contient des caractères non-hexadécimaux",
 
     // Zend_Validator_Hostname
     "The input appears to be a DNS hostname but the given punycode notation cannot be decoded" => "L'entrée semble être un DNS valide mais le code n'a pu être décodé",
-    "Invalid type given. String expected" => "Type invalide. Chaîne attendue",
+    "Invalid type given. String expected." => "Type invalide. Chaîne attendue",
     "The input appears to be a DNS hostname but contains a dash in an invalid position" => "L'entrée semble être un nom d'hôte DNS mais il contient un tiret à une position invalide",
     "The input does not match the expected structure for a DNS hostname" => "L'entrée ne correspond pas à la structure attendue d'un nom d'hôte DNS",
     "The input appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "L'entrée semble être un nom d'hôte DNS valide mais ne correspond pas au schéma de l'extension TLD '%tld%'",
@@ -222,18 +222,18 @@ return array(
     "The input has failed the IBAN check" => "L'entrée n'a pas passé la validation IBAN",
 
     // Zend_Validator_Identical
-    "The two given tokens do not match" => "Les deux jetons passés ne correspondent pas",
-    "No token was provided to match against" => "Aucun jeton de correspondance n'a été donné",
+    "The two given tokens do not match." => "Les deux jetons passés ne correspondent pas",
+    "No token was provided to match against." => "Aucun jeton de correspondance n'a été donné",
 
     // Zend_Validator_InArray
     "The input was not found in the haystack" => "L'entrée ne fait pas partie des valeurs attendues",
 
     // Zend_Validator_Ip
-    "Invalid type given. String expected" => "Type invalide. Chaîne attendue",
+    "Invalid type given. String expected." => "Type invalide. Chaîne attendue",
     "The input does not appear to be a valid IP address" => "L'entrée ne semble pas être une adresse IP valide",
 
     // Zend_Validator_Isbn
-    "Invalid type given. String or integer expected" => "Type invalide. Chaîne ou entier attendu",
+    "Invalid type given. String or integer expected." => "Type invalide. Chaîne ou entier attendu",
     "The input is not a valid ISBN number" => "L'entrée n'est pas un nombre ISBN valide",
 
     // Zend_Validator_LessThan
@@ -241,40 +241,40 @@ return array(
     "The input is not less or equal than '%max%'" => "L'entrée n'est pas inférieure ou égale à '%max%'",
 
     // Zend_Validator_NotEmpty
-    "Value is required and can't be empty" => "Une valeur est requise et ne peut être vide",
-    "Invalid type given. String, integer, float, boolean or array expected" => "Type invalide. Chaîne, entier, flottant, booléen ou tableau attendu",
+    "Value is required and can't be empty." => "Une valeur est requise et ne peut être vide",
+    "Invalid type given. String, integer, float, boolean or array expected." => "Type invalide. Chaîne, entier, flottant, booléen ou tableau attendu",
 
     // Zend_Validator_Regex
-    "Invalid type given. String, integer or float expected" => "Type invalide. Chaîne, entier ou flottant attendu",
+    "Invalid type given. String, integer or float expected." => "Type invalide. Chaîne, entier ou flottant attendu",
     "The input does not match against pattern '%pattern%'" => "L'entrée n'est pas valide avec l'expression '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "Une erreur interne est survenue avec l'expression '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "Une erreur interne est survenue avec l'expression '%pattern%'",
 
     // Zend_Validator_Sitemap_Changefreq
     "The input is not a valid sitemap changefreq" => "L'entrée n'est pas une valeur de fréquence de changement de sitemap valide",
-    "Invalid type given. String expected" => "Type invalide. Chaîne attendue",
+    "Invalid type given. String expected." => "Type invalide. Chaîne attendue",
 
     // Zend_Validator_Sitemap_Lastmod
     "The input is not a valid sitemap lastmod" => "L'entrée n'est pas une date de dernière modification de sitemap valide",
-    "Invalid type given. String expected" => "Type invalide. Chaîne attendue",
+    "Invalid type given. String expected." => "Type invalide. Chaîne attendue",
 
     // Zend_Validator_Sitemap_Loc
     "The input is not a valid sitemap location" => "L'entrée n'est pas un emplacement de sitemap valide",
-    "Invalid type given. String expected" => "Type invalide. Chaîne attendue",
+    "Invalid type given. String expected." => "Type invalide. Chaîne attendue",
 
     // Zend_Validator_Sitemap_Priority
     "The input is not a valid sitemap priority" => "L'entrée n'est pas une priorité de sitemap valide",
-    "Invalid type given. Numeric string, integer or float expected" => "Type invalide. Chaîne numérique, entier ou flottant attendu",
+    "Invalid type given. Numeric string, integer or float expected." => "Type invalide. Chaîne numérique, entier ou flottant attendu",
 
     // Zend_Validator_Step
     "Invalid value given. Scalar expected" => "Type invalide. Scalaire attendu",
     "The input is not a valid step" => "L'entrée n'est pas un intervalle valide",
 
     // Zend_Validator_StringLength
-    "Invalid type given. String expected" => "Type invalide. Chaîne attendue",
+    "Invalid type given. String expected." => "Type invalide. Chaîne attendue",
     "The input is less than %min% characters long" => "L'entrée contient moins de %min% caractères",
     "The input is more than %max% characters long" => "L'entrée contient plus de %max% caractères",
 
     // Zend_Validator_Uri
-    "Invalid type given. String expected" => "Type invalide. Chaîne attendue",
+    "Invalid type given. String expected." => "Type invalide. Chaîne attendue",
     "The input does not appear to be a valid Uri" => "L'entrée ne semble pas être une URI valide",
 );

--- a/resources/languages/hr/Zend_Validate.php
+++ b/resources/languages/hr/Zend_Validate.php
@@ -25,13 +25,13 @@
 return array(
     // Zend_Validate_Alnum
     "Invalid type given, value should be float, string, or integer" => "Neispravan tip, vrijednost bi trebala biti niz slova, brojki ili realni broj",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' sadrži znakove koji nisu ni slova ni brojke",
-    "'%value%' is an empty string" => "'%value%' je prazan niz",
+    "'%value%' contains characters which are non alphabetic and no digits." => "'%value%' sadrži znakove koji nisu ni slova ni brojke",
+    "'%value%' is an empty string." => "'%value%' je prazan niz",
 
     // Zend_Validate_Alpha
     "Invalid type given, value should be a string" => "Neispravan tip, vrijednost mora biti niz slova",
-    "'%value%' contains non alphabetic characters" => "'%value%' sadrži znakove koji nisu slova",
-    "'%value%' is an empty string" => "'%value%' je prazan niz",
+    "'%value%' contains non alphabetic characters." => "'%value%' sadrži znakove koji nisu slova",
+    "'%value%' is an empty string." => "'%value%' je prazan niz",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "'%value%' nije prošao provjeru",
@@ -44,26 +44,26 @@ return array(
     "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' nije strogo između '%min%' i '%max%'",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "'%value%' nije ispravan",
+    "'%value%' is not valid." => "'%value%' nije ispravan",
     "Failure within the callback, exception returned" => "Pogreška sa povratnim pozivom, iznimka vraćena",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' mora sadržavati između 13 i 19 znamenki",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Luhn algoritam (mod-10 provjera) nije prošla na '%value%'",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' mora sadržavati između 13 i 19 znamenki",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Luhn algoritam (mod-10 provjera) nije prošla na '%value%'",
 
     // Zend_Validate_CreditCard
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Luhn algoritam (mod-10 provjera) nije prošla na '%value%'",
-    "'%value%' must contain only digits" => "'%value%' mora sadržavati samo znamenke",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Luhn algoritam (mod-10 provjera) nije prošla na '%value%'",
+    "'%value%' must contain only digits." => "'%value%' mora sadržavati samo znamenke",
     "Invalid type given, value should be a string" => "Neispravan tip, vrijednost mora biti niz znakova",
-    "'%value%' contains an invalid amount of digits" => "'%value%' sadrži neispravan broj znamenki",
-    "'%value%' is not from an allowed institute" => "'%value%' nije iz dozvoljene institucije",
+    "'%value%' contains an invalid amount of digits." => "'%value%' sadrži neispravan broj znamenki",
+    "'%value%' is not from an allowed institute." => "'%value%' nije iz dozvoljene institucije",
     "Validation of '%value%' has been failed by the service" => "Servis nije odobrio provjeru '%value%'",
     "The service returned a failure while validating '%value%'" => "Servis je vratio pogrešku provjeravajući '%value%'",
 
     // Zend_Validate_Date
     "Invalid type given, value should be string, integer, array or Zend_Date" => "Neispravan tip, vrijednost mora biti niz znakova, broj, polje ili Zend_Date",
-    "'%value%' does not appear to be a valid date" => "'%value%' ne izgleda kao ispravan datum",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' ne odgovara formatu datuma '%format%'",
+    "'%value%' does not appear to be a valid date." => "'%value%' ne izgleda kao ispravan datum",
+    "'%value%' does not fit the date format '%format%'." => "'%value%' ne odgovara formatu datuma '%format%'",
 
     // Zend_Validate_Db_Abstract
     "No record matching %value% was found" => "Nije pronađen zapis koji se podudara sa %value%",
@@ -72,193 +72,193 @@ return array(
     // Zend_Validate_Digits
     "Invalid type given, value should be string, integer or float" => "Neispravan tip, vrijednost bi trebala biti niz slova, brojki ili realni broj",
     "'%value%' contains characters which are not digits; but only digits are allowed" => "'%value%' sadrži znakove koji nisu znamenke; samo znamenke su dozvoljene",
-    "'%value%' is an empty string" => "'%value%' je prazan niz",
+    "'%value%' is an empty string." => "'%value%' je prazan niz",
 
     // Zend_Validate_EmailAddress
     "Invalid type given, value should be a string" => "Neispravan tip, vrijednost bi trebala biti niz",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' nije ispravna email adresa u osnovnom formatu lokalni-dio@ime-poslužitelja",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' nije ispravno ime poslužitelja za email adresu '%value%'",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' nema ispravan MX zapis za email adresu '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "'%value%' nije ispravna email adresa u osnovnom formatu lokalni-dio@ime-poslužitelja",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "'%hostname%' nije ispravno ime poslužitelja za email adresu '%value%'",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "'%hostname%' nema ispravan MX zapis za email adresu '%value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' nije u rutabilnom mrežnom segmentu. Email adresa '%value%' ne bi smjela biti razlučiva iz javne mreže.",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' se ne podudara s dot-atom formatom",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' se ne podudara s 'quoted-string' formatom",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' nije ispravan lokalni dio za email adresu '%value%'",
-    "'%value%' exceeds the allowed length" => "'%value%' je duža od dozvoljene dužine",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' se ne podudara s dot-atom formatom",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' se ne podudara s 'quoted-string' formatom",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "'%localPart%' nije ispravan lokalni dio za email adresu '%value%'",
+    "'%value%' exceeds the allowed length." => "'%value%' je duža od dozvoljene dužine",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Previše datoteka, maksimalno '%max%' je dozvoljeno, a '%count%' je zadano",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Premalo datoteka, minimalno '%min%' se očekuje a '%count%' je zadano",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Previše datoteka, maksimalno '%max%' je dozvoljeno, a '%count%' je zadano",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Premalo datoteka, minimalno '%min%' se očekuje a '%count%' je zadano",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Datoteka '%value%' se ne podudara sa zadanim crc32 hash-em",
-    "A crc32 hash could not be evaluated for the given file" => "crc32 hash se ne može izračunati za zadanu datoteku",
+    "File '%value%' does not match the given crc32 hashes." => "Datoteka '%value%' se ne podudara sa zadanim crc32 hash-em",
+    "A crc32 hash could not be evaluated for the given file." => "crc32 hash se ne može izračunati za zadanu datoteku",
     "File '%value%' could not be found" => "Datoteku '%value%' nije moguće pronaći",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Datoteka '%value%' ima neispravnu ekstenziju",
+    "File '%value%' has a false extension." => "Datoteka '%value%' ima neispravnu ekstenziju",
     "File '%value%' could not be found" => "Datoteku '%value%' nije moguće pronaći",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Datoteka '%value%' ima neispravan 'mime' tip '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "'Mime' tip datoteke '%value%' nije moguće detektirati",
+    "File '%value%' has a false mimetype of '%type%'." => "Datoteka '%value%' ima neispravan 'mime' tip '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "'Mime' tip datoteke '%value%' nije moguće detektirati",
     "File '%value%' can not be read" => "Datoteku '%value%' nije moguće pročitati",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "Datoteka '%value%' ne postoji",
+    "File '%value%' does not exist." => "Datoteka '%value%' ne postoji",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "Datoteka '%value%' ima neispravnu ekstenziju",
+    "File '%value%' has a false extension." => "Datoteka '%value%' ima neispravnu ekstenziju",
     "File '%value%' could not be found" => "Datoteku '%value%' nije moguće pronaći",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Sve datoteke zajedno mogu imati maksimalnu veličinu od '%max%', a imaju '%size%'",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Sve datoteke zajedno moraju imati minimalnu veličinu od '%min%', a imaju '%size%'",
-    "One or more files can not be read" => "Jednu ili više datoteka nije moguće pročitati",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Sve datoteke zajedno mogu imati maksimalnu veličinu od '%max%', a imaju '%size%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Sve datoteke zajedno moraju imati minimalnu veličinu od '%min%', a imaju '%size%'",
+    "One or more files can not be read." => "Jednu ili više datoteka nije moguće pročitati",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "Datoteka '%value%' ne odgovara danom 'hashu'",
-    "A hash could not be evaluated for the given file" => "'Hash' nije moguće izračunati za zadanu datoteku",
+    "File '%value%' does not match the given hashes." => "Datoteka '%value%' ne odgovara danom 'hashu'",
+    "A hash could not be evaluated for the given file." => "'Hash' nije moguće izračunati za zadanu datoteku",
     "File '%value%' could not be found" => "Datoteku '%value%' nije moguće pronaći",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Maksimalna dozvoljena širina slike '%value%' je '%maxwidth%', slika je široka '%width%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Minimalna očekivana širina slike '%value%' je '%minwidth%' slika je široka '%width%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Maksimalna dozvoljena visina slike '%value%' je '%maxheight%', slika je visoka '%height%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Minimalna očekivana visina slike '%value%' je '%minheight%', slika je visoka '%height%'",
-    "The size of image '%value%' could not be detected" => "Dimenzije slike '%value%' nije moguće otkriti",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Maksimalna dozvoljena širina slike '%value%' je '%maxwidth%', slika je široka '%width%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Minimalna očekivana širina slike '%value%' je '%minwidth%' slika je široka '%width%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Maksimalna dozvoljena visina slike '%value%' je '%maxheight%', slika je visoka '%height%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Minimalna očekivana visina slike '%value%' je '%minheight%', slika je visoka '%height%'",
+    "The size of image '%value%' could not be detected." => "Dimenzije slike '%value%' nije moguće otkriti",
     "File '%value%' can not be read" => "Datoteku '%value%' nije moguće pročitati",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Datoteka '%value%' nije kompresirana, datoteka je tipa '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "'Mime' tip datoteke '%value%' nije moguće detektirati",
+    "File '%value%' is not compressed, '%type%' detected." => "Datoteka '%value%' nije kompresirana, datoteka je tipa '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "'Mime' tip datoteke '%value%' nije moguće detektirati",
     "File '%value%' can not be read" => "Datoteku '%value%' nije moguće pročitati",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Datoteka '%value%' nije slika, datoteka je tipa '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "'Mime' tip datoteke '%value%' nijem moguće detektirati",
+    "File '%value%' is no image, '%type%' detected." => "Datoteka '%value%' nije slika, datoteka je tipa '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "'Mime' tip datoteke '%value%' nijem moguće detektirati",
     "File '%value%' can not be read" => "Datoteku '%value%' nije moguće pročitati",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Datoteka '%value%' ne odgovara zadanom md5 hash-u",
-    "A md5 hash could not be evaluated for the given file" => "Md5 hash nije moguće izračunati za zadanu datoteku",
+    "File '%value%' does not match the given md5 hashes." => "Datoteka '%value%' ne odgovara zadanom md5 hash-u",
+    "A md5 hash could not be evaluated for the given file." => "Md5 hash nije moguće izračunati za zadanu datoteku",
     "File '%value%' could not be found" => "Datoteku '%value%' nije moguće pronaći",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Datoteka '%value%' ima neispravan 'mime' tip '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "'Mime' tip datoteke '%value%' nije moguće detektirati",
+    "File '%value%' has a false mimetype of '%type%'." => "Datoteka '%value%' ima neispravan 'mime' tip '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "'Mime' tip datoteke '%value%' nije moguće detektirati",
     "File '%value%' can not be read" => "Datoteku '%value%' nije moguće pročitati",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "Datiteja '%value%' postoji",
+    "File '%value%' exists." => "Datiteja '%value%' postoji",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Datoteka '%value%' ne odgovara zadanom sha1 hash-u",
-    "A sha1 hash could not be evaluated for the given file" => "Sha1 hash se ne može izračunati za zadanu datoteku",
+    "File '%value%' does not match the given sha1 hashes." => "Datoteka '%value%' ne odgovara zadanom sha1 hash-u",
+    "A sha1 hash could not be evaluated for the given file." => "Sha1 hash se ne može izračunati za zadanu datoteku",
     "File '%value%' could not be found" => "Datoteku '%value%' nije moguće pronaći",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Maksimalna dozvoljena veličina datoteka '%value%' je '%max%', datoteka je velika '%size%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Minimalna dozvoljena veličina datoteke '%value%' je '%min%', datoteka je velika '%size%'",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Maksimalna dozvoljena veličina datoteka '%value%' je '%max%', datoteka je velika '%size%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Minimalna dozvoljena veličina datoteke '%value%' je '%min%', datoteka je velika '%size%'",
     "File '%value%' could not be found" => "Datoteku '%value%' nije moguće pronaći",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Datoteka '%value%' prelazi veličinu definiranu u ini datoteci",
-    "File '%value%' exceeds the defined form size" => "Datoteka '%value%' prelazi veličinu definiranu u formi",
-    "File '%value%' was only partially uploaded" => "Datoteka '%value%' je samo djelomično poslana",
-    "File '%value%' was not uploaded" => "Datoteka '%value%' nije poslana",
-    "No temporary directory was found for file '%value%'" => "Nije pronađen privremeni direktorij za datoteku '%value%'",
-    "File '%value%' can't be written" => "Datoteku '%value%' nije moguće zapisati",
-    "A PHP extension returned an error while uploading the file '%value%'" => "PHP ekstenzija je vratila pogrešku prilikom slanja datoteke '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Datoteka '%value%' je nelegalno poslana. Ovo bi mogao biti napad",
-    "File '%value%' was not found" => "Datoteka '%value%' nije pronađena",
-    "Unknown error while uploading file '%value%'" => "Nepoznata pogreška prilikom slanja datoteke '%value%'",
+    "File '%value%' exceeds the defined ini size." => "Datoteka '%value%' prelazi veličinu definiranu u ini datoteci",
+    "File '%value%' exceeds the defined form size." => "Datoteka '%value%' prelazi veličinu definiranu u formi",
+    "File '%value%' was only partially uploaded." => "Datoteka '%value%' je samo djelomično poslana",
+    "File '%value%' was not uploaded." => "Datoteka '%value%' nije poslana",
+    "No temporary directory was found for file '%value%'." => "Nije pronađen privremeni direktorij za datoteku '%value%'",
+    "File '%value%' can't be written." => "Datoteku '%value%' nije moguće zapisati",
+    "A PHP extension returned an error while uploading the file '%value%'." => "PHP ekstenzija je vratila pogrešku prilikom slanja datoteke '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Datoteka '%value%' je nelegalno poslana. Ovo bi mogao biti napad",
+    "File '%value%' was not found." => "Datoteka '%value%' nije pronađena",
+    "Unknown error while uploading file '%value%'." => "Nepoznata pogreška prilikom slanja datoteke '%value%'",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Previše riječi, maksimalno '%max%' riječi je dozvoljeno, a ima ih '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Premalo riječi, očekuje se minimalno '%min%' riječi, a ima ih '%count%' ",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Previše riječi, maksimalno '%max%' riječi je dozvoljeno, a ima ih '%count%'",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Premalo riječi, očekuje se minimalno '%min%' riječi, a ima ih '%count%' ",
     "File '%value%' could not be found" => "Datoteku '%value%' nije moguće pronaći",
 
     // Zend_Validate_Float
     "Invalid type given, value should be float, string, or integer" => "Neispravan tip, vrijednost bi trebala biti niz slova, brojki ili realni broj",
-    "'%value%' does not appear to be a float" => "'%value%' nije realni broj",
+    "'%value%' does not appear to be a float." => "'%value%' nije realni broj",
 
     // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' nije veće od '%min%'",
+    "'%value%' is not greater than '%min%'." => "'%value%' nije veće od '%min%'",
 
     // Zend_Validate_Hex
     "Invalid type given, value should be a string" => "Neispravan tip, vrijednost bi trebala biti niz",
-    "'%value%' has not only hexadecimal digit characters" => "'%value%' nema samo heksadekadske znamenke",
+    "'%value%' has not only hexadecimal digit characters." => "'%value%' nema samo heksadekadske znamenke",
 
     // Zend_Validate_Hostname
     "Invalid type given, value should be a string" => "Neispravan tup, vrijednost bi trebala biti niz",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "'%value%' izgleda kao IP adresa, IP adrese nisu dozvoljene",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' izgleda kao DNS ime poslužitelja, ali ne mogu pronaći vršnu domenu u listi poznatih",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' izgleda kao DNS ime poslužitelja, ali ima crtu ne neispravnoj poziciji",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' izgleda kao DNS ime poslužitelja ali se ne podudara sa shemom imena poslužitelja za vršnu domenu '%tld%'",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' izgleda kao DNS ime poslužitelja, ali ne mogu izvući dio koji označava vršnu domenu",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' se ne podudara sa očekivanom strukturom DNS imena poslužitelja",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' ne izgleda kao ispravno ime lokalne mreže",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' izgleda kao ime lokalne mreže, ali imena lokalnih mreža nisu dozvoljena",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "'%value%' izgleda kao DNS ime poslužitelja ali zadanu 'punycode' notaciju nije moguće dekodirati",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => "'%value%' izgleda kao IP adresa, IP adrese nisu dozvoljene",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => "'%value%' izgleda kao DNS ime poslužitelja, ali ne mogu pronaći vršnu domenu u listi poznatih",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => "'%value%' izgleda kao DNS ime poslužitelja, ali ima crtu ne neispravnoj poziciji",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => "'%value%' izgleda kao DNS ime poslužitelja ali se ne podudara sa shemom imena poslužitelja za vršnu domenu '%tld%'",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => "'%value%' izgleda kao DNS ime poslužitelja, ali ne mogu izvući dio koji označava vršnu domenu",
+    "'%value%' does not match the expected structure for a DNS hostname." => "'%value%' se ne podudara sa očekivanom strukturom DNS imena poslužitelja",
+    "'%value%' does not appear to be a valid local network name." => "'%value%' ne izgleda kao ispravno ime lokalne mreže",
+    "'%value%' appears to be a local network name but local network names are not allowed." => "'%value%' izgleda kao ime lokalne mreže, ali imena lokalnih mreža nisu dozvoljena",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => "'%value%' izgleda kao DNS ime poslužitelja ali zadanu 'punycode' notaciju nije moguće dekodirati",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "Nepoznata zemlja unutar IBAN-a '%value%'",
-    "'%value%' has a false IBAN format" => "'%value%' ima neispravan IBAN format",
-    "'%value%' has failed the IBAN check" => "'%value%' nije prošlo IBAN provjeru",
+    "Unknown country within the IBAN '%value%'." => "Nepoznata zemlja unutar IBAN-a '%value%'",
+    "'%value%' has a false IBAN format." => "'%value%' ima neispravan IBAN format",
+    "'%value%' has failed the IBAN check." => "'%value%' nije prošlo IBAN provjeru",
 
     // Zend_Validate_Identical
-    "The two given tokens do not match" => "Zadane vrijednosti se ne podudaraju",
-    "No token was provided to match against" => "Nije zadano vrijednost s kojom se treba usporediti",
+    "The two given tokens do not match." => "Zadane vrijednosti se ne podudaraju",
+    "No token was provided to match against." => "Nije zadano vrijednost s kojom se treba usporediti",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "Vrijednost '%value%' nije pronađena u polju",
+    "'%value%' was not found in the haystack." => "Vrijednost '%value%' nije pronađena u polju",
 
     // Zend_Validate_Int
     "Invalid type given, value should be string or integer" => "Neispravan tip, vrijednost bi trebala biti niz ili cijeli broj",
-    "'%value%' does not appear to be an integer" => "'%value%' ne izgleda kao cijeli broj",
+    "'%value%' does not appear to be an integer." => "'%value%' ne izgleda kao cijeli broj",
 
     // Zend_Validate_Ip
     "Invalid type given, value should be a string" => "Neispravan tip, vrijednost mora biti niz",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' ne izgleda kao ispravna IP adresa",
+    "'%value%' does not appear to be a valid IP address." => "'%value%' ne izgleda kao ispravna IP adresa",
 
     // Zend_Validate_Isbn
     "Invalid type given, value should be string or integer" => "Neispravan tip, vrijednost mora biti niz ili cijeli broj",
-    "'%value%' is not a valid ISBN number" => "'%value%' nije ispravan ISBN broj",
+    "'%value%' is not a valid ISBN number." => "'%value%' nije ispravan ISBN broj",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' nije manje od '%max%'",
+    "'%value%' is not less than '%max%'." => "'%value%' nije manje od '%max%'",
 
     // Zend_Validate_NotEmpty
     "Invalid type given, value should be float, string, array, boolean or integer" => "Neispravan tip, vrijednost mora biti realni broj, niz, polje, cijeli broj ili 'boolean'",
-    "Value is required and can't be empty" => "Vrijednost ne smije biti prazna",
+    "Value is required and can't be empty." => "Vrijednost ne smije biti prazna",
 
     // Zend_Validate_PostCode
     "Invalid type given. The value should be a string or a integer" => "Neispravan tip. Vrijednost mora biti niz ili cijeli broj",
-    "'%value%' does not appear to be a postal code" => "'%value%' ne izgleda kao poštanski kod",
+    "'%value%' does not appear to be a postal code." => "'%value%' ne izgleda kao poštanski kod",
 
     // Zend_Validate_Regex
     "Invalid type given, value should be string, integer or float" => "Neispravan tip, vrijednost mora biti niz, cijeli ili realni broj",
-    "'%value%' does not match against pattern '%pattern%'" => "'%value%' se ne podudara sa uzorkom '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "Došlo je do interne pogreške prilikom korištenja uzorka '%pattern%'",
+    "'%value%' does not match against pattern '%pattern%'." => "'%value%' se ne podudara sa uzorkom '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "Došlo je do interne pogreške prilikom korištenja uzorka '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => "'%value%' nije ispravna vrijednost za sitemap 'changefreq'",
+    "'%value%' is not a valid sitemap changefreq." => "'%value%' nije ispravna vrijednost za sitemap 'changefreq'",
     "Invalid type given, the value should be a string" => "Neispravan tip, vrijednost mora biti niz",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => "'%value%' nije ispravna vrijednost za sitemap 'lastmod'",
+    "'%value%' is not a valid sitemap lastmod." => "'%value%' nije ispravna vrijednost za sitemap 'lastmod'",
     "Invalid type given, the value should be a string" => "Neispravan tip, vrijednost mora biti niz",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => "'%value%' nije ispravna lokacija za 'sitemap'",
+    "'%value%' is not a valid sitemap location." => "'%value%' nije ispravna lokacija za 'sitemap'",
     "Invalid type given, the value should be a string" => "Neispravan tip, vrijednost mora biti niz",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => "'%value%' nije ispravna vrijednost za sitemap 'priority'",
+    "'%value%' is not a valid sitemap priority." => "'%value%' nije ispravna vrijednost za sitemap 'priority'",
     "Invalid type given, the value should be a integer, a float or a numeric string" => "Neispravan tip, vrijednost mora biti cijeli broj, realni broj ili niz znamenki",
 
     // Zend_Validate_StringLength
     "Invalid type given, value should be a string" => "Neispravan tip, vrijednost mora biti niz",
-    "'%value%' is less than %min% characters long" => "'%value%' ima manje od %min% znaka",
-    "'%value%' is more than %max% characters long" => "'%value%' ima više od %max% znakova",
+    "'%value%' is less than %min% characters long." => "'%value%' ima manje od %min% znaka",
+    "'%value%' is more than %max% characters long." => "'%value%' ima više od %max% znakova",
 );

--- a/resources/languages/it/Zend_Captcha.php
+++ b/resources/languages/it/Zend_Captcha.php
@@ -24,12 +24,12 @@
  */
 return array(
     // Zend_Captcha_ReCaptcha
-    "Missing captcha fields" => "Campi captcha mancanti",
-    "Failed to validate captcha" => "Validazione del captcha fallito",
-    "Captcha value is wrong: %value%" => "Il valore del Captcha è sbagliato: %value%",
+    "Missing captcha fields." => "Campi captcha mancanti",
+    "Failed to validate captcha." => "Validazione del captcha fallito",
+    "Captcha value is wrong: %value%." => "Il valore del Captcha è sbagliato: %value%",
 
     // Zend_Captcha_Word
-    "Empty captcha value" => "Valore del captcha vuoto",
-    "Captcha ID field is missing" => "Manca il campo Captcha ID",
-    "Captcha value is wrong" => "Il valore del Captcha è sbagliato",
+    "Empty captcha value." => "Valore del captcha vuoto",
+    "Captcha ID field is missing." => "Manca il campo Captcha ID",
+    "Captcha value is wrong." => "Il valore del Captcha è sbagliato",
 );

--- a/resources/languages/it/Zend_Validate.php
+++ b/resources/languages/it/Zend_Validate.php
@@ -24,33 +24,33 @@
  */
 return array(
     // Zend_I18n_Validator_Alnum
-    "Invalid type given. String, integer or float expected" => "Tipo di dato non valido. Era atteso un dato di tipo string, float o integer",
-    "The input contains characters which are non alphabetic and no digits" => "L'input contiene caratteri che non sono alfanumerici",
-    "The input is an empty string" => "L'input è una stringa vuota",
+    "Invalid type given. String, integer or float expected." => "Tipo di dato non valido. Era atteso un dato di tipo string, float o integer",
+    "The input contains characters which are non alphabetic and no digits." => "L'input contiene caratteri che non sono alfanumerici",
+    "The input is an empty string." => "L'input è una stringa vuota",
 
     // Zend_I18n_Validator_Alpha
-    "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
-    "The input contains non alphabetic characters" => "L'input contiene caratteri non alfabetici",
-    "The input is an empty string" => "L'input è una stringa vuota",
+    "Invalid type given. String expected." => "Tipo di dato non valido. Era attesto un dato di tipo string",
+    "The input contains non alphabetic characters." => "L'input contiene caratteri non alfabetici",
+    "The input is an empty string." => "L'input è una stringa vuota",
 
     // Zend_I18n_Validator_Float
-    "Invalid type given. String, integer or float expected" => "Tipo di dato non valido. Era atteso un dato di tipo string, float o integer",
+    "Invalid type given. String, integer or float expected." => "Tipo di dato non valido. Era atteso un dato di tipo string, float o integer",
     "The input does not appear to be a float" => "L'input non sembra essere un dato di tipo float",
 
     // Zend_I18n_Validator_Int
-    "Invalid type given. String or integer expected" => "Tipo di dato non valido. Era atteso un dato di tipo string o integer",
-    "The input does not appear to be an integer" => "L'input non sembra essere un intero",
+    "Invalid type given. String or integer expected." => "Tipo di dato non valido. Era atteso un dato di tipo string o integer",
+    "The input does not appear to be an integer." => "L'input non sembra essere un intero",
 
     // Zend_I18n_Validator_PostCode
-    "Invalid type given. String or integer expected" => "Tipo di dato non valido. Era atteso un dato di tipo string o integer",
+    "Invalid type given. String or integer expected." => "Tipo di dato non valido. Era atteso un dato di tipo string o integer",
     "The input does not appear to be a postal code" => "L'input non sembra essere un codice postale",
     "An exception has been raised while validating the input" => "Un'eccezione è stata sollevada durante la validazione dell'input",
 
     // Zend_Validator_Barcode
-    "The input failed checksum validation" => "L'input non ha un checksum valido",
+    "The input failed checksum validation." => "L'input non ha un checksum valido",
     "The input contains invalid characters" => "L'input contiene caratteri non permessi",
     "The input should have a length of %length% characters" => "L'input non ha la lunghezza corretta di %length% caratteri",
-    "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
+    "Invalid type given. String expected." => "Tipo di dato non valido. Era attesto un dato di tipo string",
 
     // Zend_Validator_Between
     "The input is not between '%min%' and '%max%', inclusively" => "L'input non è compreso tra '%min%' e '%max%', inclusi",
@@ -58,12 +58,12 @@ return array(
 
     // Zend_Validator_Callback
     "The input is not valid" => "L'input non è valido",
-    "An exception has been raised within the callback" => "Un'eccezione è stata sollevata all'interno della callback",
+    "An exception has been raised within the callback." => "Un'eccezione è stata sollevata all'interno della callback",
 
     // Zend_Validator_CreditCard
     "The input seems to contain an invalid checksum" => "L'input sembra avere un checksum non valido",
     "The input must contain only digits" => "L'input deve contenere solo cifre",
-    "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
+    "Invalid type given. String expected." => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input contains an invalid amount of digits" => "L'input contiene un numero non valido di cifre",
     "The input is not from an allowed institute" => "L'input proviene da un istituto non supportato",
     "The input seems to be an invalid creditcard number" => "L'input sembra essere un numero di carta di credito non valido",
@@ -88,122 +88,122 @@ return array(
 
     // Zend_Validator_Digits
     "The input must contain only digits" => "L'input deve contenere solo cifre",
-    "The input is an empty string" => "L'input è una stringa vuota",
-    "Invalid type given. String, integer or float expected" => "Tipo di dato non valido. Era atteso un dato di tipo string, float o integer",
+    "The input is an empty string." => "L'input è una stringa vuota",
+    "Invalid type given. String, integer or float expected." => "Tipo di dato non valido. Era atteso un dato di tipo string, float o integer",
 
     // Zend_Validator_EmailAddress
-    "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
+    "Invalid type given. String expected." => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input is not a valid email address. Use the basic format local-part@hostname" => "L'input non è un indirizzo email valido nel formato base local-part@hostname",
     "'%hostname%' is not a valid hostname for the email address" => "'%hostname%' non è un hostname valido nell'indirizzo email",
     "'%hostname%' does not appear to have any valid MX or A records for the email address" => "'%hostname%' non sembra avere un record MX o A valido nell'indirizzo email",
     "'%hostname%' is not in a routable network segment. The email address should not be resolved from public network" => "'%hostname%' non è in un segmento di rete instradabile. L'indirizzo email non può essere risolto nella rete pubblica.",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' non può essere validato nel formato dot-atom",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' non può essere validato nel formato quoted-string",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' non può essere validato nel formato dot-atom",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' non può essere validato nel formato quoted-string",
     "'%localPart%' is not a valid local part for the email address" => "'%localPart%' non è una local part valida nell'indirizzo email",
     "The input exceeds the allowed length" => "L'input supera la lunghezza consentita",
 
     // Zend_Validator_Explode
-    "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
+    "Invalid type given. String expected." => "Tipo di dato non valido. Era attesto un dato di tipo string",
 
     // Zend_Validator_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Troppi file, sono consentiti massimo '%max%' file ma ne sono stati passati '%count%'",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Troppi pochi file, sono attesi minimo '%min%' file ma ne sono stato passati solo '%count%'",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Troppi file, sono consentiti massimo '%max%' file ma ne sono stati passati '%count%'",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Troppi pochi file, sono attesi minimo '%min%' file ma ne sono stato passati solo '%count%'",
 
     // Zend_Validator_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Il file '%value%' non ha un hash crc32 tra quelli consentiti",
-    "A crc32 hash could not be evaluated for the given file" => "L'hash crc32 non può essere calcolato per il file dato",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "File '%value%' does not match the given crc32 hashes." => "Il file '%value%' non ha un hash crc32 tra quelli consentiti",
+    "A crc32 hash could not be evaluated for the given file." => "L'hash crc32 non può essere calcolato per il file dato",
+    "File '%value%' is not readable or does not exist." => "Il file '%value%' non è leggibile o non esiste",
 
     // Zend_Validator_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Il file '%value%' ha un'estensione invalida",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "File '%value%' has a false extension." => "Il file '%value%' ha un'estensione invalida",
+    "File '%value%' is not readable or does not exist." => "Il file '%value%' non è leggibile o non esiste",
 
     // Zend_Validator_File_Exists
-    "File '%value%' does not exist" => "Il file '%value%' non esiste",
+    "File '%value%' does not exist." => "Il file '%value%' non esiste",
 
     // Zend_Validator_File_Extension
-    "File '%value%' has a false extension" => "Il file '%value%' ha un'estensione invalida",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "File '%value%' has a false extension." => "Il file '%value%' ha un'estensione invalida",
+    "File '%value%' is not readable or does not exist." => "Il file '%value%' non è leggibile o non esiste",
 
     // Zend_Validator_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "I file devono avere in totale una dimensione massima di '%max%' ma è stata rilevata una dimensione di '%size%'",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "I file devono avere in totale una dimensione minima di '%min%' ma è stata rilevata una dimensione di '%size%'",
-    "One or more files can not be read" => "Uno o più file non possono essere letti",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "I file devono avere in totale una dimensione massima di '%max%' ma è stata rilevata una dimensione di '%size%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "I file devono avere in totale una dimensione minima di '%min%' ma è stata rilevata una dimensione di '%size%'",
+    "One or more files can not be read." => "Uno o più file non possono essere letti",
 
     // Zend_Validator_File_Hash
-    "File '%value%' does not match the given hashes" => "I file '%value%' non corrisponde agli hash dati",
-    "A hash could not be evaluated for the given file" => "Un hash non può essere valutato per il file dato",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "File '%value%' does not match the given hashes." => "I file '%value%' non corrisponde agli hash dati",
+    "A hash could not be evaluated for the given file." => "Un hash non può essere valutato per il file dato",
+    "File '%value%' is not readable or does not exist." => "Il file '%value%' non è leggibile o non esiste",
 
     // Zend_Validator_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "La larghezza massima consentita per l'immagine '%value%' è '%maxwidth%' ma è stata rilevata una larghezza di '%width%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "La larghezza minima consentita per l'immagine '%value%' è '%minwidth%' ma è stata rilevata una larghezza di '%width%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "L'altezza massima consentita per l'immagine '%value%' è '%maxheight%' ma è stata rilevata un'altezza di '%height%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "L'altezza minima consentita per l'immagine '%value%' è '%minheight%' ma è stata rilevata un'altezza di '%height%'",
-    "The size of image '%value%' could not be detected" => "Le dimensioni dell'immagine '%value%' non possono essere rilevate",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "La larghezza massima consentita per l'immagine '%value%' è '%maxwidth%' ma è stata rilevata una larghezza di '%width%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "La larghezza minima consentita per l'immagine '%value%' è '%minwidth%' ma è stata rilevata una larghezza di '%width%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "L'altezza massima consentita per l'immagine '%value%' è '%maxheight%' ma è stata rilevata un'altezza di '%height%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "L'altezza minima consentita per l'immagine '%value%' è '%minheight%' ma è stata rilevata un'altezza di '%height%'",
+    "The size of image '%value%' could not be detected." => "Le dimensioni dell'immagine '%value%' non possono essere rilevate",
+    "File '%value%' is not readable or does not exist." => "Il file '%value%' non è leggibile o non esiste",
 
     // Zend_Validator_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Il file '%value%' non è un file compresso, ma un file di tipo '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Il mimetype del file '%value%' non può essere rilevato",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "File '%value%' is not compressed, '%type%' detected." => "Il file '%value%' non è un file compresso, ma un file di tipo '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Il mimetype del file '%value%' non può essere rilevato",
+    "File '%value%' is not readable or does not exist." => "Il file '%value%' non è leggibile o non esiste",
 
     // Zend_Validator_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Il file '%value%' non è un'immagine, ma un file di tipo '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Il mimetype del file '%value%' non può essere rilevato",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "File '%value%' is no image, '%type%' detected." => "Il file '%value%' non è un'immagine, ma un file di tipo '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Il mimetype del file '%value%' non può essere rilevato",
+    "File '%value%' is not readable or does not exist." => "Il file '%value%' non è leggibile o non esiste",
 
     // Zend_Validator_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Il file '%value%' non corrisponde agli hash md5 dati",
-    "A md5 hash could not be evaluated for the given file" => "Un hash md5 non può essere valutato per il file dato",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "File '%value%' does not match the given md5 hashes." => "Il file '%value%' non corrisponde agli hash md5 dati",
+    "A md5 hash could not be evaluated for the given file." => "Un hash md5 non può essere valutato per il file dato",
+    "File '%value%' is not readable or does not exist." => "Il file '%value%' non è leggibile o non esiste",
 
     // Zend_Validator_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Il file '%value%' ha un mimetype invalido: '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Il mimetype del file '%value%' non può essere rilevato",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "File '%value%' has a false mimetype of '%type%'." => "Il file '%value%' ha un mimetype invalido: '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Il mimetype del file '%value%' non può essere rilevato",
+    "File '%value%' is not readable or does not exist." => "Il file '%value%' non è leggibile o non esiste",
 
     // Zend_Validator_File_NotExists
-    "File '%value%' exists" => "Il file '%value%' esiste già",
+    "File '%value%' exists." => "Il file '%value%' esiste già",
 
     // Zend_Validator_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Il file '%value%' non corrisponde agli hash sha1 dati",
-    "A sha1 hash could not be evaluated for the given file" => "Un hash sha1 non può essere valutato per il file dato",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "File '%value%' does not match the given sha1 hashes." => "Il file '%value%' non corrisponde agli hash sha1 dati",
+    "A sha1 hash could not be evaluated for the given file." => "Un hash sha1 non può essere valutato per il file dato",
+    "File '%value%' is not readable or does not exist." => "Il file '%value%' non è leggibile o non esiste",
 
     // Zend_Validator_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "La dimensione massima consentita per il file '%value%' è '%max%' ma è stata rilevata una dimensione di '%size%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "La dimensione minima consentita per il file '%value%' è '%min%' ma è stata rilevata una dimensione di '%size%'",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "La dimensione massima consentita per il file '%value%' è '%max%' ma è stata rilevata una dimensione di '%size%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "La dimensione minima consentita per il file '%value%' è '%min%' ma è stata rilevata una dimensione di '%size%'",
+    "File '%value%' is not readable or does not exist." => "Il file '%value%' non è leggibile o non esiste",
 
     // Zend_Validator_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Il file '%value%' eccede la dimensione definita nell'ini",
-    "File '%value%' exceeds the defined form size" => "Il file '%value%' eccede la dimensione definita nella form",
-    "File '%value%' was only partially uploaded" => "Il file '%value%' è stato caricato solo parzialmente",
-    "File '%value%' was not uploaded" => "Il file '%value%' non è stato caricato",
-    "No temporary directory was found for file '%value%'" => "Non è stata trovata una directory temporanea per il file '%value%'",
-    "File '%value%' can't be written" => "Il file '%value%' non può essere scritto",
-    "A PHP extension returned an error while uploading the file '%value%'" => "Un'estensione di PHP ha generato un errore durante il caricamento del file '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Il file '%value%' è stato caricato irregolarmente. Potrebbe trattarsi di un attacco",
-    "File '%value%' was not found" => "Il file '%value%' non è stato trovato",
-    "Unknown error while uploading file '%value%'" => "Errore sconosciuto durante il caricamento del file '%value%'",
+    "File '%value%' exceeds the defined ini size." => "Il file '%value%' eccede la dimensione definita nell'ini",
+    "File '%value%' exceeds the defined form size." => "Il file '%value%' eccede la dimensione definita nella form",
+    "File '%value%' was only partially uploaded." => "Il file '%value%' è stato caricato solo parzialmente",
+    "File '%value%' was not uploaded." => "Il file '%value%' non è stato caricato",
+    "No temporary directory was found for file '%value%'." => "Non è stata trovata una directory temporanea per il file '%value%'",
+    "File '%value%' can't be written." => "Il file '%value%' non può essere scritto",
+    "A PHP extension returned an error while uploading the file '%value%'." => "Un'estensione di PHP ha generato un errore durante il caricamento del file '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Il file '%value%' è stato caricato irregolarmente. Potrebbe trattarsi di un attacco",
+    "File '%value%' was not found." => "Il file '%value%' non è stato trovato",
+    "Unknown error while uploading file '%value%'." => "Errore sconosciuto durante il caricamento del file '%value%'",
 
     // Zend_Validator_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Il file contiene troppe parole, ne sono consentite massimo '%max%' ma ne sono state contate '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Il file contiene troppe poche parole, ne sono consentite minimo '%min%' ma ne sono state contate '%count%'",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Il file contiene troppe parole, ne sono consentite massimo '%max%' ma ne sono state contate '%count%'",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Il file contiene troppe poche parole, ne sono consentite minimo '%min%' ma ne sono state contate '%count%'",
+    "File '%value%' is not readable or does not exist." => "Il file '%value%' non è leggibile o non esiste",
 
     // Zend_Validator_GreaterThan
     "The input is not greater than '%min%'" => "L'input non è maggiore di '%min%'",
     "The input is not greater or equal than '%min%'" => "L'input non è maggiore o uguale a '%min%'",
 
     // Zend_Validator_Hex
-    "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
+    "Invalid type given. String expected." => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input contains non-hexadecimal characters" => "L'input non è composto solo da caratteri esadecimali",
 
     // Zend_Validator_Hostname
     "The input appears to be a DNS hostname but the given punycode notation cannot be decoded" => "L'input sembra essere un hostname DNS ma la notazione punycode data non può essere decodificata",
-    "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
+    "Invalid type given. String expected." => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input appears to be a DNS hostname but contains a dash in an invalid position" => "L'input sembra essere un hostname DNS ma contiene un trattino in una posizione non valida",
     "The input does not match the expected structure for a DNS hostname" => "L'input non sembra rispettare la struttura attesa per un hostname DNS",
     "The input appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "L'input sembra essere un hostname DNS ma non rispetta lo schema per il TLD '%tld%'",
@@ -221,18 +221,18 @@ return array(
     "The input has failed the IBAN check" => "L'input ha fallito il controllo IBAN",
 
     // Zend_Validator_Identical
-    "The two given tokens do not match" => "I due token dati non corrispondono",
-    "No token was provided to match against" => "Non è stato dato nessun token per il confronto",
+    "The two given tokens do not match." => "I due token dati non corrispondono",
+    "No token was provided to match against." => "Non è stato dato nessun token per il confronto",
 
     // Zend_Validator_InArray
     "The input was not found in the haystack" => "L'input non è stato trovato nell'array",
 
     // Zend_Validator_Ip
-    "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
+    "Invalid type given. String expected." => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input does not appear to be a valid IP address" => "L'input non sembra essere un indirizzo IP valido",
 
     // Zend_Validator_Isbn
-    "Invalid type given. String or integer expected" => "Tipo di dato non valido. Era atteso un dato di tipo string o integer",
+    "Invalid type given. String or integer expected." => "Tipo di dato non valido. Era atteso un dato di tipo string o integer",
     "The input is not a valid ISBN number" => "L'input non è un numero ISBN valido",
 
     // Zend_Validator_LessThan
@@ -240,40 +240,40 @@ return array(
     "The input is not less or equal than '%max%'" => "L'input non è minore o uguale a '%max%'",
 
     // Zend_Validator_NotEmpty
-    "Value is required and can't be empty" => "Il dato è richiesto e non può essere vuoto",
-    "Invalid type given. String, integer, float, boolean or array expected" => "Tipo di dato non valido. Era atteso un dato di tipo string, integer, float, boolean o array",
+    "Value is required and can't be empty." => "Il dato è richiesto e non può essere vuoto",
+    "Invalid type given. String, integer, float, boolean or array expected." => "Tipo di dato non valido. Era atteso un dato di tipo string, integer, float, boolean o array",
 
     // Zend_Validator_Regex
-    "Invalid type given. String, integer or float expected" => "Tipo di dato non valido. Era atteso un dato di tipo string, float o integer",
+    "Invalid type given. String, integer or float expected." => "Tipo di dato non valido. Era atteso un dato di tipo string, float o integer",
     "The input does not match against pattern '%pattern%'" => "L'input non corrisponde al pattern '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "Si è verificato un errore interno usando il pattern '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "Si è verificato un errore interno usando il pattern '%pattern%'",
 
     // Zend_Validator_Sitemap_Changefreq
     "The input is not a valid sitemap changefreq" => "L'input non è una sitemap changefreq valida",
-    "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
+    "Invalid type given. String expected." => "Tipo di dato non valido. Era attesto un dato di tipo string",
 
     // Zend_Validator_Sitemap_Lastmod
     "The input is not a valid sitemap lastmod" => "L'input non è un sitemap lastmod valido",
-    "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
+    "Invalid type given. String expected." => "Tipo di dato non valido. Era attesto un dato di tipo string",
 
     // Zend_Validator_Sitemap_Loc
     "The input is not a valid sitemap location" => "L'input non è una sitemap location valida",
-    "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
+    "Invalid type given. String expected." => "Tipo di dato non valido. Era attesto un dato di tipo string",
 
     // Zend_Validator_Sitemap_Priority
     "The input is not a valid sitemap priority" => "L'input non è una sitemap priority valida",
-    "Invalid type given. Numeric string, integer or float expected" => "Tipo di dato non valido. Era atteso un dato di tipo stringa numerica, float o integer",
+    "Invalid type given. Numeric string, integer or float expected." => "Tipo di dato non valido. Era atteso un dato di tipo stringa numerica, float o integer",
 
     // Zend_Validator_Step
     "Invalid value given. Scalar expected" => "Tipo di dato non valido. Era attesto un dato di tipo scalare",
     "The input is not a valid step" => "L'input non è uno step valido",
 
     // Zend_Validator_StringLength
-    "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
+    "Invalid type given. String expected." => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input is less than %min% characters long" => "L'input è meno lungo di %min% caratteri",
     "The input is more than %max% characters long" => "L'input è più lungo di %max% caratteri",
 
     // Zend_Validator_Uri
-    "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
+    "Invalid type given. String expected." => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input does not appear to be a valid Uri" => "L'input non sembra essere un indirizzo URI valido",
 );

--- a/resources/languages/it/Zend_Validate.php
+++ b/resources/languages/it/Zend_Validate.php
@@ -35,7 +35,7 @@ return array(
 
     // Zend_I18n_Validator_Float
     "Invalid type given. String, integer or float expected." => "Tipo di dato non valido. Era atteso un dato di tipo string, float o integer",
-    "The input does not appear to be a float" => "L'input non sembra essere un dato di tipo float",
+    "The input does not appear to be a float." => "L'input non sembra essere un dato di tipo float",
 
     // Zend_I18n_Validator_Int
     "Invalid type given. String or integer expected." => "Tipo di dato non valido. Era atteso un dato di tipo string o integer",
@@ -43,8 +43,8 @@ return array(
 
     // Zend_I18n_Validator_PostCode
     "Invalid type given. String or integer expected." => "Tipo di dato non valido. Era atteso un dato di tipo string o integer",
-    "The input does not appear to be a postal code" => "L'input non sembra essere un codice postale",
-    "An exception has been raised while validating the input" => "Un'eccezione è stata sollevada durante la validazione dell'input",
+    "The input does not appear to be a postal code." => "L'input non sembra essere un codice postale",
+    "An exception has been raised while validating the input." => "Un'eccezione è stata sollevada durante la validazione dell'input",
 
     // Zend_Validator_Barcode
     "The input failed checksum validation." => "L'input non ha un checksum valido",
@@ -67,7 +67,7 @@ return array(
     "The input contains an invalid amount of digits" => "L'input contiene un numero non valido di cifre",
     "The input is not from an allowed institute" => "L'input proviene da un istituto non supportato",
     "The input seems to be an invalid creditcard number" => "L'input sembra essere un numero di carta di credito non valido",
-    "An exception has been raised while validating the input" => "Un'eccezione è stata sollevada durante la validazione dell'input",
+    "An exception has been raised while validating the input." => "Un'eccezione è stata sollevada durante la validazione dell'input",
 
     // Zend_Validator_Csrf
     "The form submitted did not originate from the expected site" => "La form inviata non ha avuto origine dal luogo previsto",

--- a/resources/languages/ja/Zend_Validate.php
+++ b/resources/languages/ja/Zend_Validate.php
@@ -24,241 +24,241 @@
  */
 return array(
     // Zend_Validate_Alnum
-    "Invalid type given. String, integer or float expected" => "不正な形式です。文字列、整数もしくは小数が期待されています",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' にアルファベットと数字以外の文字が含まれています",
-    "'%value%' is an empty string" => "'%value%' は空の文字列です",
+    "Invalid type given. String, integer or float expected." => "不正な形式です。文字列、整数もしくは小数が期待されています",
+    "'%value%' contains characters which are non alphabetic and no digits." => "'%value%' にアルファベットと数字以外の文字が含まれています",
+    "'%value%' is an empty string." => "'%value%' は空の文字列です",
 
     // Zend_Validate_Alpha
-    "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
-    "'%value%' contains non alphabetic characters" => "'%value%' にアルファベット以外の文字が含まれています",
-    "'%value%' is an empty string" => "'%value%' は空の文字列です",
+    "Invalid type given. String expected." => "不正な形式です。文字列が期待されています",
+    "'%value%' contains non alphabetic characters." => "'%value%' にアルファベット以外の文字が含まれています",
+    "'%value%' is an empty string." => "'%value%' は空の文字列です",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "'%value%' はチェックサムが一致していません",
     "'%value%' contains invalid characters" => "'%value%' は不正な文字を含んでいます",
     "'%value%' should have a length of %length% characters" => "'%value%' は %length% 文字である必要があります",
-    "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
+    "Invalid type given. String expected." => "不正な形式です。文字列が期待されています",
 
     // Zend_Validate_Between
     "'%value%' is not between '%min%' and '%max%', inclusively" => "'%value%' は '%min%' 以上 '%max%' 以下ではありません",
     "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' は '%min%' 以下か '%max%' 以上です",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "'%value%' は正しくありません",
-    "An exception has been raised within the callback" => "コールバック内で例外が発生しました",
+    "'%value%' is not valid." => "'%value%' は正しくありません",
+    "An exception has been raised within the callback." => "コールバック内で例外が発生しました",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' は 13 桁から 19 桁の数字でなければなりません",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "'%value%' でルーンアルゴリズム(mod-10 チェックサム)に失敗しました",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' は 13 桁から 19 桁の数字でなければなりません",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "'%value%' でルーンアルゴリズム(mod-10 チェックサム)に失敗しました",
 
     // Zend_Validate_CreditCard
     "%value%' seems to contain an invalid checksum" => "'%value%' は不正なチェックサムを含んでいるようです",
-    "'%value%' must contain only digits" => "'%value%' は数値だけで構成される必要があります",
-    "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
-    "'%value%' contains an invalid amount of digits" => "'%value%' は不正な桁数です",
-    "'%value%' is not from an allowed institute" => "'%value%' は認可機関から許可されていません",
+    "'%value%' must contain only digits." => "'%value%' は数値だけで構成される必要があります",
+    "Invalid type given. String expected." => "不正な形式です。文字列が期待されています",
+    "'%value%' contains an invalid amount of digits." => "'%value%' は不正な桁数です",
+    "'%value%' is not from an allowed institute." => "'%value%' は認可機関から許可されていません",
     "%value%' seems to be an invalid creditcard number" => "'%value%' は不正なクレジットカード番号を含んでいるようです",
     "An exception has been raised while validating '%value%" => "'%value%' を検証中に例外が発生しました",
 
     // Zend_Validate_Date
     "Invalid type given, value should be string, integer, array or Zend_Date" => "不正な形式です。値は文字列、整数、配列もしくは Zend_Date 形式である必要があります",
-    "'%value%' does not appear to be a valid date" => "'%value%' は正しい日付ではないようです",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' は '%format%' フォーマットに一致していません",
+    "'%value%' does not appear to be a valid date." => "'%value%' は正しい日付ではないようです",
+    "'%value%' does not fit the date format '%format%'." => "'%value%' は '%format%' フォーマットに一致していません",
 
     // Zend_Validate_Db_Abstract
-    "No record matching '%value%' was found" => " '%value%' に一致するレコードは見つかりませんでした",
-    "A record matching '%value%' was found" => " '%value%' に一致するレコードが見つかりました",
+    "No record matching '%value%' was found." => " '%value%' に一致するレコードは見つかりませんでした",
+    "A record matching '%value%' was found." => " '%value%' に一致するレコードが見つかりました",
 
     // Zend_Validate_Digits
-    "Invalid type given. String, integer or float expected" => "不正な形式です。文字列、整数または小数が期待されています",
+    "Invalid type given. String, integer or float expected." => "不正な形式です。文字列、整数または小数が期待されています",
     "%value%' must contain only digits" => "'%value%' は数字のみである必要があります",
-    "'%value%' is an empty string" => "'%value%' は空の文字列です",
+    "'%value%' is an empty string." => "'%value%' は空の文字列です",
 
     // Zend_Validate_EmailAddress
-    "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' はメールアドレスの基本的な形式 local-part@hostname ではありません",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "メールアドレス '%value%' 内の '%hostname%' は有効なホスト名ではありません",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "メールアドレス '%value%' 内の '%hostname%' は有効な MX レコードではないようです",
-    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network" => "'%hostname%' はネットワークセグメントにありません。メールアドレス '%value%' はパブリックなネットワークから名前解決できませんでした",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' はドットアトム形式ではありません",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' は引用文字列形式ではありません",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "メールアドレス '%value%' 内の '%localPart%' は有効なローカルパートではありません",
-    "'%value%' exceeds the allowed length" => "'%value%' は許された長さを超えています",
+    "Invalid type given. String expected." => "不正な形式です。文字列が期待されています",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "'%value%' はメールアドレスの基本的な形式 local-part@hostname ではありません",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "メールアドレス '%value%' 内の '%hostname%' は有効なホスト名ではありません",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "メールアドレス '%value%' 内の '%hostname%' は有効な MX レコードではないようです",
+    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' はネットワークセグメントにありません。メールアドレス '%value%' はパブリックなネットワークから名前解決できませんでした",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' はドットアトム形式ではありません",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' は引用文字列形式ではありません",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "メールアドレス '%value%' 内の '%localPart%' は有効なローカルパートではありません",
+    "'%value%' exceeds the allowed length." => "'%value%' は許された長さを超えています",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "ファイル数が多すぎます。最大 '%max%' まで許されていますが、 '%count%' 個指定ました",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "ファイル数が少なすぎます。最小 '%min%' 以上の必要がありますが、 '%count%' 個指定されていません",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "ファイル数が多すぎます。最大 '%max%' まで許されていますが、 '%count%' 個指定ました",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "ファイル数が少なすぎます。最小 '%min%' 以上の必要がありますが、 '%count%' 個指定されていません",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "ファイル '%value%' は crc32 ハッシュ値と一致しませんでした",
-    "A crc32 hash could not be evaluated for the given file" => "ファイルに crc32 ハッシュ値が見つかりませんでした",
-    "File '%value%' is not readable or does not exist" => "ファイル '%value%' は読み込めないかもしくは存在しません",
+    "File '%value%' does not match the given crc32 hashes." => "ファイル '%value%' は crc32 ハッシュ値と一致しませんでした",
+    "A crc32 hash could not be evaluated for the given file." => "ファイルに crc32 ハッシュ値が見つかりませんでした",
+    "File '%value%' is not readable or does not exist." => "ファイル '%value%' は読み込めないかもしくは存在しません",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "ファイル '%value%' は誤った拡張子です",
-    "File '%value%' is not readable or does not exist" => "ファイル '%value%' は読み込めないかもしくは存在しません",
+    "File '%value%' has a false extension." => "ファイル '%value%' は誤った拡張子です",
+    "File '%value%' is not readable or does not exist." => "ファイル '%value%' は読み込めないかもしくは存在しません",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "ファイル '%value%' は誤った mimetype '%type%' です",
-    "The mimetype of file '%value%' could not be detected" => "ファイル '%value%' の mimetype が見つかりませんでした",
-    "File '%value%' is not readable or does not exist" => "ファイル '%value%' は読み込めないかもしくは存在しません",
+    "File '%value%' has a false mimetype of '%type%'." => "ファイル '%value%' は誤った mimetype '%type%' です",
+    "The mimetype of file '%value%' could not be detected." => "ファイル '%value%' の mimetype が見つかりませんでした",
+    "File '%value%' is not readable or does not exist." => "ファイル '%value%' は読み込めないかもしくは存在しません",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "ファイル '%value%' は存在しません",
+    "File '%value%' does not exist." => "ファイル '%value%' は存在しません",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "ファイル '%value%' は誤った拡張子です",
-    "File '%value%' is not readable or does not exist" => "ファイル '%value%' は読み込めないかもしくは存在しません",
+    "File '%value%' has a false extension." => "ファイル '%value%' は誤った拡張子です",
+    "File '%value%' is not readable or does not exist." => "ファイル '%value%' は読み込めないかもしくは存在しません",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "全てのファイルの合計は最大 '%max%' より小さい必要があります。しかしファイルサイズは '%size%' でした",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "全てのファイルの合計は最小 '%min%' より大きい必要があります。しかしファイルサイズは '%size%' でした",
-    "One or more files can not be read" => "ファイルを読み込めませんでした",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "全てのファイルの合計は最大 '%max%' より小さい必要があります。しかしファイルサイズは '%size%' でした",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "全てのファイルの合計は最小 '%min%' より大きい必要があります。しかしファイルサイズは '%size%' でした",
+    "One or more files can not be read." => "ファイルを読み込めませんでした",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "ファイル '%value%' は設定されたハッシュ値と一致しませんでした",
-    "A hash could not be evaluated for the given file" => "渡されたファイルのハッシュ値を評価できませんでした",
-    "File '%value%' is not readable or does not exist" => "ファイル '%value%' は読み込めないかもしくは存在しません",
+    "File '%value%' does not match the given hashes." => "ファイル '%value%' は設定されたハッシュ値と一致しませんでした",
+    "A hash could not be evaluated for the given file." => "渡されたファイルのハッシュ値を評価できませんでした",
+    "File '%value%' is not readable or does not exist." => "ファイル '%value%' は読み込めないかもしくは存在しません",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "画像 '%value%' の横幅は '%width%' でした。横幅は最大 '%maxwidth%' まで許されています",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "画像 '%value%' の横幅は '%width%' でした。横幅は最小 '%minwidth%' 以上である必要があります",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "画像 '%value%' の高さは '%height%' でした。高さは最大 '%maxheight%' まで許されています",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "画像 '%value%' の高さは '%height%' でした。高さは最小 '%minheight%' 以上である必要があります",
-    "The size of image '%value%' could not be detected" => "画像 '%value%' の大きさを取得できませんでした",
-    "File '%value%' is not readable or does not exist" => "ファイル '%value%' は読み込めないかもしくは存在しません",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "画像 '%value%' の横幅は '%width%' でした。横幅は最大 '%maxwidth%' まで許されています",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "画像 '%value%' の横幅は '%width%' でした。横幅は最小 '%minwidth%' 以上である必要があります",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "画像 '%value%' の高さは '%height%' でした。高さは最大 '%maxheight%' まで許されています",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "画像 '%value%' の高さは '%height%' でした。高さは最小 '%minheight%' 以上である必要があります",
+    "The size of image '%value%' could not be detected." => "画像 '%value%' の大きさを取得できませんでした",
+    "File '%value%' is not readable or does not exist." => "ファイル '%value%' は読み込めないかもしくは存在しません",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => " '%type%' が見つかりました。ファイル '%value%' は圧縮されていません",
-    "The mimetype of file '%value%' could not be detected" => "ファイル '%value%' の Mimetype は見つかりませんでした",
-    "File '%value%' is not readable or does not exist" => "ファイル '%value%' は読み込めないかもしくは存在しません",
+    "File '%value%' is not compressed, '%type%' detected." => " '%type%' が見つかりました。ファイル '%value%' は圧縮されていません",
+    "The mimetype of file '%value%' could not be detected." => "ファイル '%value%' の Mimetype は見つかりませんでした",
+    "File '%value%' is not readable or does not exist." => "ファイル '%value%' は読み込めないかもしくは存在しません",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "ファイル '%value%' は画像ではありません。 '%type%' です",
-    "The mimetype of file '%value%' could not be detected" => "ファイル '%value%' の Mimetype は見つかりませんでした",
-    "File '%value%' is not readable or does not exist" => "ファイル '%value%' は読み込めないかもしくは存在しません",
+    "File '%value%' is no image, '%type%' detected." => "ファイル '%value%' は画像ではありません。 '%type%' です",
+    "The mimetype of file '%value%' could not be detected." => "ファイル '%value%' の Mimetype は見つかりませんでした",
+    "File '%value%' is not readable or does not exist." => "ファイル '%value%' は読み込めないかもしくは存在しません",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "ファイル '%value%' は md5 ハッシュ値と一致していません",
-    "A md5 hash could not be evaluated for the given file" => "渡されたファイルの md5 ハッシュ値を評価できませんでした",
-    "File '%value%' is not readable or does not exist" => "ファイル '%value%' は読み込めないかもしくは存在しません",
+    "File '%value%' does not match the given md5 hashes." => "ファイル '%value%' は md5 ハッシュ値と一致していません",
+    "A md5 hash could not be evaluated for the given file." => "渡されたファイルの md5 ハッシュ値を評価できませんでした",
+    "File '%value%' is not readable or does not exist." => "ファイル '%value%' は読み込めないかもしくは存在しません",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "ファイル '%value%' は誤った MimeType '%type%' です",
-    "The mimetype of file '%value%' could not be detected" => "ファイル '%value%' の Mimetype は見つかりませんでした",
-    "File '%value%' is not readable or does not exist" => "ファイル '%value%' は読み込めないかもしくは存在しません",
+    "File '%value%' has a false mimetype of '%type%'." => "ファイル '%value%' は誤った MimeType '%type%' です",
+    "The mimetype of file '%value%' could not be detected." => "ファイル '%value%' の Mimetype は見つかりませんでした",
+    "File '%value%' is not readable or does not exist." => "ファイル '%value%' は読み込めないかもしくは存在しません",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "ファイル '%value%' は存在しています",
+    "File '%value%' exists." => "ファイル '%value%' は存在しています",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "ファイル '%value%' は sha1 ハッシュ値と一致していません",
-    "A sha1 hash could not be evaluated for the given file" => "渡されたファイルの sha1 ハッシュ値を評価できませんでした",
-    "File '%value%' is not readable or does not exist" => "ファイル '%value%' は読み込めないかもしくは存在しません",
+    "File '%value%' does not match the given sha1 hashes." => "ファイル '%value%' は sha1 ハッシュ値と一致していません",
+    "A sha1 hash could not be evaluated for the given file." => "渡されたファイルの sha1 ハッシュ値を評価できませんでした",
+    "File '%value%' is not readable or does not exist." => "ファイル '%value%' は読み込めないかもしくは存在しません",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "ファイルサイズは '%size%' です。ファイル '%value%' のサイズは最大 '%max%' まで許されています",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "ファイルサイズは '%size%' です。ファイル '%value%' のサイズは最小 '%min%' 以上必要です",
-    "File '%value%' is not readable or does not exist" => "ファイル '%value%' は読み込めないかもしくは存在しません",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "ファイルサイズは '%size%' です。ファイル '%value%' のサイズは最大 '%max%' まで許されています",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "ファイルサイズは '%size%' です。ファイル '%value%' のサイズは最小 '%min%' 以上必要です",
+    "File '%value%' is not readable or does not exist." => "ファイル '%value%' は読み込めないかもしくは存在しません",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "ファイル '%value%' は ini で定義されたサイズを超えています",
-    "File '%value%' exceeds the defined form size" => "ファイル '%value%' はフォームで定義されたサイズを超えています",
-    "File '%value%' was only partially uploaded" => "ファイル '%value%' は一部のみしかアップロードされていません",
-    "File '%value%' was not uploaded" => "ファイル '%value%' はアップロードされませんでした",
-    "No temporary directory was found for file '%value%'" => "ファイル '%value%' をアップロードする一時ディレクトリが見つかりませんでした",
-    "File '%value%' can't be written" => "ファイル '%value%' は書き込めませんでした",
-    "A PHP extension returned an error while uploading the file '%value%'" => "ファイル '%value%' をアップロード中に拡張モジュールがエラーを応答しました",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "ファイル '%value%' は不正なアップロードでした。攻撃の可能性があります",
-    "File '%value%' was not found" => "ファイル '%value%' は見つかりませんでした",
-    "Unknown error while uploading file '%value%'" => "ファイル '%value%' をアップロード中に未知のエラーが発生しました",
+    "File '%value%' exceeds the defined ini size." => "ファイル '%value%' は ini で定義されたサイズを超えています",
+    "File '%value%' exceeds the defined form size." => "ファイル '%value%' はフォームで定義されたサイズを超えています",
+    "File '%value%' was only partially uploaded." => "ファイル '%value%' は一部のみしかアップロードされていません",
+    "File '%value%' was not uploaded." => "ファイル '%value%' はアップロードされませんでした",
+    "No temporary directory was found for file '%value%'." => "ファイル '%value%' をアップロードする一時ディレクトリが見つかりませんでした",
+    "File '%value%' can't be written." => "ファイル '%value%' は書き込めませんでした",
+    "A PHP extension returned an error while uploading the file '%value%'." => "ファイル '%value%' をアップロード中に拡張モジュールがエラーを応答しました",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "ファイル '%value%' は不正なアップロードでした。攻撃の可能性があります",
+    "File '%value%' was not found." => "ファイル '%value%' は見つかりませんでした",
+    "Unknown error while uploading file '%value%'." => "ファイル '%value%' をアップロード中に未知のエラーが発生しました",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "単語数 '%count%' が多過ぎます。最大で '%max%' 個が許されます",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "単語数 '%count%' が少な過ぎます。少なくとも '%min%' 個必要です",
-    "File '%value%' is not readable or does not exist" => "ファイル '%value%' は読み込めないかもしくは存在しません",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "単語数 '%count%' が多過ぎます。最大で '%max%' 個が許されます",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "単語数 '%count%' が少な過ぎます。少なくとも '%min%' 個必要です",
+    "File '%value%' is not readable or does not exist." => "ファイル '%value%' は読み込めないかもしくは存在しません",
 
     // Zend_Validate_Float
-    "Invalid type given. String, integer or float expected" => "不正な形式です。文字列、整数もしくは小数が期待されています",
-    "'%value%' does not appear to be a float" => " '%value%' は小数ではないようです",
+    "Invalid type given. String, integer or float expected." => "不正な形式です。文字列、整数もしくは小数が期待されています",
+    "'%value%' does not appear to be a float." => " '%value%' は小数ではないようです",
 
     // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => " '%value%' は '%min%' より大きくありません",
+    "'%value%' is not greater than '%min%'." => " '%value%' は '%min%' より大きくありません",
 
     // Zend_Validate_Hex
-    "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
-    "'%value%' has not only hexadecimal digit characters" => " '%value%' は 16 進文字列以外を含んでいます",
+    "Invalid type given. String expected." => "不正な形式です。文字列が期待されています",
+    "'%value%' has not only hexadecimal digit characters." => " '%value%' は 16 進文字列以外を含んでいます",
 
     // Zend_Validate_Hostname
-    "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => " '%value%' は IP アドレスのようですが、 IP アドレスは許されていません",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => " '%value%' は DNS ホスト名のようですが、 TLD が一覧に見つかりません",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => " '%value%' は DNS ホスト名のようですが不正な位置にダッシュがあります",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => " '%value%' は DNS ホスト名のようですが TLD '%tld%' のホスト名スキーマと一致していません",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => " '%value%' は DNS ホスト名のようですが TLD 部を展開できません",
-    "'%value%' does not match the expected structure for a DNS hostname" => " '%value%' は DNS ホスト名の構造に一致していません",
-    "'%value%' does not appear to be a valid local network name" => " '%value%' は有効なローカルネットワーク名ではないようです",
-    "'%value%' appears to be a local network name but local network names are not allowed" => " '%value%' はローカルネットワーク名のようですがローカルネットワーク名は許されていません",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => " '%value%' は DNS ホスト名のようですが、 punycode 変換ができませんでした",
+    "Invalid type given. String expected." => "不正な形式です。文字列が期待されています",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => " '%value%' は IP アドレスのようですが、 IP アドレスは許されていません",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => " '%value%' は DNS ホスト名のようですが、 TLD が一覧に見つかりません",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => " '%value%' は DNS ホスト名のようですが不正な位置にダッシュがあります",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => " '%value%' は DNS ホスト名のようですが TLD '%tld%' のホスト名スキーマと一致していません",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => " '%value%' は DNS ホスト名のようですが TLD 部を展開できません",
+    "'%value%' does not match the expected structure for a DNS hostname." => " '%value%' は DNS ホスト名の構造に一致していません",
+    "'%value%' does not appear to be a valid local network name." => " '%value%' は有効なローカルネットワーク名ではないようです",
+    "'%value%' appears to be a local network name but local network names are not allowed." => " '%value%' はローカルネットワーク名のようですがローカルネットワーク名は許されていません",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => " '%value%' は DNS ホスト名のようですが、 punycode 変換ができませんでした",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "IBAN コード '%value%' に未知の国があります",
-    "'%value%' has a false IBAN format" => " '%value%' は誤った IBAN 書式です",
-    "'%value%' has failed the IBAN check" => " '%value%' は IBAN コードチェックに失敗しました",
+    "Unknown country within the IBAN '%value%'." => "IBAN コード '%value%' に未知の国があります",
+    "'%value%' has a false IBAN format." => " '%value%' は誤った IBAN 書式です",
+    "'%value%' has failed the IBAN check." => " '%value%' は IBAN コードチェックに失敗しました",
 
     // Zend_Validate_Identical
-    "The two given tokens do not match" => "2 つのトークンは一致しませんでした",
-    "No token was provided to match against" => "チェックを行うためのトークンがありませんでした",
+    "The two given tokens do not match." => "2 つのトークンは一致しませんでした",
+    "No token was provided to match against." => "チェックを行うためのトークンがありませんでした",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => " '%value%' が haystack の中に見つかりませんでした",
+    "'%value%' was not found in the haystack." => " '%value%' が haystack の中に見つかりませんでした",
 
     // Zend_Validate_Int
-    "Invalid type given. String or integer expected" => "不正な形式です。文字列または整数が期待されています",
-    "'%value%' does not appear to be an integer" => " '%value%' は整数ではないようです",
+    "Invalid type given. String or integer expected." => "不正な形式です。文字列または整数が期待されています",
+    "'%value%' does not appear to be an integer." => " '%value%' は整数ではないようです",
 
     // Zend_Validate_Ip
-    "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
-    "'%value%' does not appear to be a valid IP address" => " '%value%' は IP アドレスではないようです",
+    "Invalid type given. String expected." => "不正な形式です。文字列が期待されています",
+    "'%value%' does not appear to be a valid IP address." => " '%value%' は IP アドレスではないようです",
 
     // Zend_Validate_Isbn
-     "Invalid type given. String or integer expected" => "不正な形式です。文字列または整数が期待されています",
-    "'%value%' is not a valid ISBN number" => " '%value%' は ISBN 番号ではありません",
+     "Invalid type given. String or integer expected." => "不正な形式です。文字列または整数が期待されています",
+    "'%value%' is not a valid ISBN number." => " '%value%' は ISBN 番号ではありません",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => " '%value%' は '%max%' 未満ではありません",
+    "'%value%' is not less than '%max%'." => " '%value%' は '%max%' 未満ではありません",
 
     // Zend_Validate_NotEmpty
-    "Invalid type given. String, integer, float, boolean or array expected" => "不正な形式です。文字列、整数、小数、真偽値もしくは配列が期待されています",
-    "Value is required and can't be empty" => "値は必須です。空値は許可されていません",
+    "Invalid type given. String, integer, float, boolean or array expected." => "不正な形式です。文字列、整数、小数、真偽値もしくは配列が期待されています",
+    "Value is required and can't be empty." => "値は必須です。空値は許可されていません",
 
     // Zend_Validate_PostCode
-    "Invalid type given. String or integer expected" => "不正な形式です。文字列もしくは整数が期待されています",
-    "'%value%' does not appear to be a postal code" => " '%value%' は郵便番号でないようです",
+    "Invalid type given. String or integer expected." => "不正な形式です。文字列もしくは整数が期待されています",
+    "'%value%' does not appear to be a postal code." => " '%value%' は郵便番号でないようです",
 
     // Zend_Validate_Regex
-    "Invalid type given. String, integer or float expected" => "不正な形式です。文字列、整数、もしくは小数が期待されています",
-    "'%value%' does not match against pattern '%pattern%'" => " '%value%' はパターン '%pattern%' と一致していません",
-    "There was an internal error while using the pattern '%pattern%'" => "正規表現パターン '%pattern%' を使用中に内部エラーが発生しました。",
+    "Invalid type given. String, integer or float expected." => "不正な形式です。文字列、整数、もしくは小数が期待されています",
+    "'%value%' does not match against pattern '%pattern%'." => " '%value%' はパターン '%pattern%' と一致していません",
+    "There was an internal error while using the pattern '%pattern%'." => "正規表現パターン '%pattern%' を使用中に内部エラーが発生しました。",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => " '%value%' は正しいサイトマップの更新頻度ではありません",
-    "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
+    "'%value%' is not a valid sitemap changefreq." => " '%value%' は正しいサイトマップの更新頻度ではありません",
+    "Invalid type given. String expected." => "不正な形式です。文字列が期待されています",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => " '%value%' は正しいサイトマップの最終更新日ではありません",
-    "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
+    "'%value%' is not a valid sitemap lastmod." => " '%value%' は正しいサイトマップの最終更新日ではありません",
+    "Invalid type given. String expected." => "不正な形式です。文字列が期待されています",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => " '%value%' は正しいサイトマップの位置ではありません",
-    "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
+    "'%value%' is not a valid sitemap location." => " '%value%' は正しいサイトマップの位置ではありません",
+    "Invalid type given. String expected." => "不正な形式です。文字列が期待されています",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => " '%value%' は正しいサイトマップの優先度ではありません",
-    "Invalid type given. Numeric string, integer or float expected" => "不正な形式です。数字、整数もしくは小数が期待されています",
+    "'%value%' is not a valid sitemap priority." => " '%value%' は正しいサイトマップの優先度ではありません",
+    "Invalid type given. Numeric string, integer or float expected." => "不正な形式です。数字、整数もしくは小数が期待されています",
 
     // Zend_Validate_StringLength
-    "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",
-    "'%value%' is less than %min% characters long" => " '%value%' は %min% 文字より短いです",
-    "'%value%' is more than %max% characters long" => " '%value%' は %max% 文字より長いです",
+    "Invalid type given. String expected." => "不正な形式です。文字列が期待されています",
+    "'%value%' is less than %min% characters long." => " '%value%' は %min% 文字より短いです",
+    "'%value%' is more than %max% characters long." => " '%value%' は %max% 文字より長いです",
 );

--- a/resources/languages/nl/Zend_Validate.php
+++ b/resources/languages/nl/Zend_Validate.php
@@ -24,33 +24,33 @@
  */
 return array(
     // Zend_I18n_Validator_Alnum
-    "Invalid type given. String, integer or float expected" => "Ongeldig type opgegeven, waarde moet een float, string of integer zijn",
-    "The input contains characters which are non alphabetic and no digits" => "De input bevat tekens welke alfabetisch, noch numeriek zijn",
-    "The input is an empty string" => "De input is een lege string",
+    "Invalid type given. String, integer or float expected." => "Ongeldig type opgegeven, waarde moet een float, string of integer zijn",
+    "The input contains characters which are non alphabetic and no digits." => "De input bevat tekens welke alfabetisch, noch numeriek zijn",
+    "The input is an empty string." => "De input is een lege string",
 
     // Zend_I18n_Validator_Alpha
-    "Invalid type given. String expected" => "Ongeldig type opgegeven, waarde moet een string zijn",
-    "The input contains non alphabetic characters" => "De input bevat tekens welke niet alfabetisch zijn",
-    "The input is an empty string" => "De input is een lege string",
+    "Invalid type given. String expected." => "Ongeldig type opgegeven, waarde moet een string zijn",
+    "The input contains non alphabetic characters." => "De input bevat tekens welke niet alfabetisch zijn",
+    "The input is an empty string." => "De input is een lege string",
 
     // Zend_I18n_Validator_Float
-    "Invalid type given. String, integer or float expected" => "Invalid type given. String, integer or float expected",
+    "Invalid type given. String, integer or float expected." => "Invalid type given. String, integer or float expected.",
     "The input does not appear to be a float" => "The input does not appear to be a float",
 
     // Zend_I18n_Validator_Int
-    "Invalid type given. String or integer expected" => "Invalid type given. String or integer expected",
-    "The input does not appear to be an integer" => "The input does not appear to be an integer",
+    "Invalid type given. String or integer expected." => "Invalid type given. String or integer expected.",
+    "The input does not appear to be an integer." => "The input does not appear to be an integer.",
 
     // Zend_I18n_Validator_PostCode
-    "Invalid type given. String or integer expected" => "Ongeldig type opgegeven, waarde moet een string of integer zijn",
+    "Invalid type given. String or integer expected." => "Ongeldig type opgegeven, waarde moet een string of integer zijn",
     "The input does not appear to be a postal code" => "De input lijkt geen geldige postcode te zijn",
     "An exception has been raised while validating the input" => "Er is een interne fout opgetreden tijdens het valideren van de input",
 
     // Zend_Validator_Barcode
-    "The input failed checksum validation" => "De input slaagde niet in de checksum validatie",
+    "The input failed checksum validation." => "De input slaagde niet in de checksum validatie",
     "The input contains invalid characters" => "De input bevat ongeldige tekens",
     "The input should have a length of %length% characters" => "De input moet een lengte hebben van %length% tekens",
-    "Invalid type given. String expected" => "Ongeldig type opgegeven, waarde moet een string zijn",
+    "Invalid type given. String expected." => "Ongeldig type opgegeven, waarde moet een string zijn",
 
     // Zend_Validator_Between
     "The input is not between '%min%' and '%max%', inclusively" => "De input is niet tussen of gelijk aan '%min%' en '%max%'",
@@ -58,12 +58,12 @@ return array(
 
     // Zend_Validator_Callback
     "The input is not valid" => "De input is ongeldig",
-    "An exception has been raised within the callback" => "Fout opgetreden in de callback, exceptie teruggegeven",
+    "An exception has been raised within the callback." => "Fout opgetreden in de callback, exceptie teruggegeven",
 
     // Zend_Validator_CreditCard
     "The input seems to contain an invalid checksum" => "De input bevat een ongeldige checksum",
     "The input must contain only digits" => "De input kan alleen cijfers bevatten",
-    "Invalid type given. String expected" => "Ongeldig type opgegeven, waarde moet een string zijn",
+    "Invalid type given. String expected." => "Ongeldig type opgegeven, waarde moet een string zijn",
     "The input contains an invalid amount of digits" => "De input bevat een ongeldige hoeveelheid cijfers",
     "The input is not from an allowed institute" => "De input is niet afkomstig van een toegestaan instituut",
     "The input seems to be an invalid creditcard number" => "De input is een ongeldig creditcard nummer",
@@ -88,122 +88,122 @@ return array(
 
     // Zend_Validator_Digits
     "The input must contain only digits" => "De input bevat niet enkel numerieke karakters",
-    "The input is an empty string" => "De input is een lege string",
-    "Invalid type given. String, integer or float expected" => "Ongeldig type opgegeven, waarde moet een string, integer of float zijn",
+    "The input is an empty string." => "De input is een lege string",
+    "Invalid type given. String, integer or float expected." => "Ongeldig type opgegeven, waarde moet een string, integer of float zijn",
 
     // Zend_Validator_EmailAddress
-    "Invalid type given. String expected" => "Ongeldig type opgegeven, waarde moet een string zijn",
+    "Invalid type given. String expected." => "Ongeldig type opgegeven, waarde moet een string zijn",
     "The input is not a valid email address. Use the basic format local-part@hostname" => "De input is geen geldig e-mail adres in het basis formaat lokaal-gedeelte@hostname",
     "'%hostname%' is not a valid hostname for the email address" => "'%hostname%' is geen geldige hostnaam voor het e-mail adres",
     "'%hostname%' does not appear to have any valid MX or A records for the email address" => "'%hostname%' lijkt geen geldig MX of A record te hebben voor het e-mail adres",
     "'%hostname%' is not in a routable network segment. The email address should not be resolved from public network" => "'%hostname%' bevindt zich niet in een routeerbaar netwerk segment. Het e-mail adres zou niet naar mogen worden verwezen vanaf een publiek netwerk",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' kan niet worden gematched met het dot-atom formaat",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' kan niet worden gematched met het quoted-string formaat",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' kan niet worden gematched met het dot-atom formaat",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' kan niet worden gematched met het quoted-string formaat",
     "'%localPart%' is not a valid local part for the email address" => "'%localPart%' is geen geldig lokaal gedeelte voor het e-mail adres",
     "The input exceeds the allowed length" => "De input overschrijdt de toegestane lengte",
 
     // Zend_Validator_Explode
-    "Invalid type given. String expected" => "Ongeldig type opgegeven, waarde moet een string zijn",
+    "Invalid type given. String expected." => "Ongeldig type opgegeven, waarde moet een string zijn",
 
     // Zend_Validator_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Te veel bestanden, maximaal '%max%' zijn toegestaan, maar '%count%' werd opgegeven",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Te weinig bestanden, er worden er minimaal '%min%' verwacht, maar er waren er  '%count%' opgegeven",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Te veel bestanden, maximaal '%max%' zijn toegestaan, maar '%count%' werd opgegeven",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Te weinig bestanden, er worden er minimaal '%min%' verwacht, maar er waren er  '%count%' opgegeven",
 
     // Zend_Validator_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "File '%value%' matcht niet met de opgegeven crc32 hashes",
-    "A crc32 hash could not be evaluated for the given file" => "Fout tijdens het genereren van een crc32 hash van het opgegeven bestand",
-    "File '%value%' is not readable or does not exist" => "Het bestand '%value%' kon niet worden gevonden",
+    "File '%value%' does not match the given crc32 hashes." => "File '%value%' matcht niet met de opgegeven crc32 hashes",
+    "A crc32 hash could not be evaluated for the given file." => "Fout tijdens het genereren van een crc32 hash van het opgegeven bestand",
+    "File '%value%' is not readable or does not exist." => "Het bestand '%value%' kon niet worden gevonden",
 
     // Zend_Validator_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Het bestand '%value%' heeft een ongeldige extensie",
-    "File '%value%' is not readable or does not exist" => "Het bestand '%value%' kon niet worden gevonden",
+    "File '%value%' has a false extension." => "Het bestand '%value%' heeft een ongeldige extensie",
+    "File '%value%' is not readable or does not exist." => "Het bestand '%value%' kon niet worden gevonden",
 
     // Zend_Validator_File_Exists
-    "File '%value%' does not exist" => "Bestand '%value%' bestaat niet",
+    "File '%value%' does not exist." => "Bestand '%value%' bestaat niet",
 
     // Zend_Validator_File_Extension
-    "File '%value%' has a false extension" => "Het bestand '%value%' heeft een ongeldige extensie",
-    "File '%value%' is not readable or does not exist" => "Het bestand '%value%' kon niet worden gevonden",
+    "File '%value%' has a false extension." => "Het bestand '%value%' heeft een ongeldige extensie",
+    "File '%value%' is not readable or does not exist." => "Het bestand '%value%' kon niet worden gevonden",
 
     // Zend_Validator_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Alle bestanden tesamen hebben een maximale grootte van '%max%' maar '%size%' was gedetecteerd",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Alle bestanden tesamen hebben een minimum grotte van '%min%' maar '%size%' was gedetecteerd",
-    "One or more files can not be read" => "One or more files can not be read",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Alle bestanden tesamen hebben een maximale grootte van '%max%' maar '%size%' was gedetecteerd",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Alle bestanden tesamen hebben een minimum grotte van '%min%' maar '%size%' was gedetecteerd",
+    "One or more files can not be read." => "One or more files can not be read.",
 
     // Zend_Validator_File_Hash
-    "File '%value%' does not match the given hashes" => "Het bestand '%value%' matcht niet met de opgegeven hashes",
-    "A hash could not be evaluated for the given file" => "Een hash kon niet worden gegenereerd voor het opgegeven bestand",
-    "File '%value%' is not readable or does not exist" => "Het bestand '%value%' kon niet worden gevonden",
+    "File '%value%' does not match the given hashes." => "Het bestand '%value%' matcht niet met de opgegeven hashes",
+    "A hash could not be evaluated for the given file." => "Een hash kon niet worden gegenereerd voor het opgegeven bestand",
+    "File '%value%' is not readable or does not exist." => "Het bestand '%value%' kon niet worden gevonden",
 
     // Zend_Validator_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Maximum breedte voor afbeelding '%value%' is '%maxwidth%' maar '%width%' werd gedetecteerd",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Minimum breedte voor afbeelding '%value%' is '%minwidth%' maar '%width%' werd gedetecteerd",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Maximum hoogte voor afbeelding '%value%' is '%maxheight%' maar '%height%' werd gedetecteerd",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Minimum hoogte voor afbeelding '%value%' is '%minheight%' maar '%height%' werd gedetecteerd",
-    "The size of image '%value%' could not be detected" => "De grootte van afbeelding '%value%' kon niet worden gedetecteerd",
-    "File '%value%' is not readable or does not exist" => "Het bestand '%value%' kon niet worden gevonden",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Maximum breedte voor afbeelding '%value%' is '%maxwidth%' maar '%width%' werd gedetecteerd",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Minimum breedte voor afbeelding '%value%' is '%minwidth%' maar '%width%' werd gedetecteerd",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Maximum hoogte voor afbeelding '%value%' is '%maxheight%' maar '%height%' werd gedetecteerd",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Minimum hoogte voor afbeelding '%value%' is '%minheight%' maar '%height%' werd gedetecteerd",
+    "The size of image '%value%' could not be detected." => "De grootte van afbeelding '%value%' kon niet worden gedetecteerd",
+    "File '%value%' is not readable or does not exist." => "Het bestand '%value%' kon niet worden gevonden",
 
     // Zend_Validator_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Het bestand '%value%' is niet gecomprimeerd, '%type%' gedetecteerd",
-    "The mimetype of file '%value%' could not be detected" => "Het mimetype van bestand '%value%' kon niet worden gedetecteerd",
-    "File '%value%' is not readable or does not exist" => "Het bestand '%value%' kon niet worden gevonden",
+    "File '%value%' is not compressed, '%type%' detected." => "Het bestand '%value%' is niet gecomprimeerd, '%type%' gedetecteerd",
+    "The mimetype of file '%value%' could not be detected." => "Het mimetype van bestand '%value%' kon niet worden gedetecteerd",
+    "File '%value%' is not readable or does not exist." => "Het bestand '%value%' kon niet worden gevonden",
 
     // Zend_Validator_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Het bestand '%value%' is geen afbeelding, '%type%' gedetecteerd",
-    "The mimetype of file '%value%' could not be detected" => "Het mimetype van bestand '%value%' kon niet worden gedetecteerd",
-    "File '%value%' is not readable or does not exist" => "Het bestand '%value%' kon niet worden gevonden",
+    "File '%value%' is no image, '%type%' detected." => "Het bestand '%value%' is geen afbeelding, '%type%' gedetecteerd",
+    "The mimetype of file '%value%' could not be detected." => "Het mimetype van bestand '%value%' kon niet worden gedetecteerd",
+    "File '%value%' is not readable or does not exist." => "Het bestand '%value%' kon niet worden gevonden",
 
     // Zend_Validator_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Het bestand '%value%' matcht niet met de opgegeven md5-hashes",
-    "A md5 hash could not be evaluated for the given file" => "Een md5-hash kon niet gegenereerd worden voor het opgegeven bestand",
-    "File '%value%' is not readable or does not exist" => "Het bestand '%value%' kon niet worden gevonden",
+    "File '%value%' does not match the given md5 hashes." => "Het bestand '%value%' matcht niet met de opgegeven md5-hashes",
+    "A md5 hash could not be evaluated for the given file." => "Een md5-hash kon niet gegenereerd worden voor het opgegeven bestand",
+    "File '%value%' is not readable or does not exist." => "Het bestand '%value%' kon niet worden gevonden",
 
     // Zend_Validator_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Het bestand '%value%' heeft een ongeldig mimetype: '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Het mimetype van bestand '%value%' kon niet worden gedetecteerd",
-    "File '%value%' is not readable or does not exist" => "Het bestand '%value%' kon niet worden gevonden",
+    "File '%value%' has a false mimetype of '%type%'." => "Het bestand '%value%' heeft een ongeldig mimetype: '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Het mimetype van bestand '%value%' kon niet worden gedetecteerd",
+    "File '%value%' is not readable or does not exist." => "Het bestand '%value%' kon niet worden gevonden",
 
     // Zend_Validator_File_NotExists
-    "File '%value%' exists" => "Het bestand '%value%' bestaat",
+    "File '%value%' exists." => "Het bestand '%value%' bestaat",
 
     // Zend_Validator_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Het bestand '%value%' matcht niet met de opgegeven sha1-hashes",
-    "A sha1 hash could not be evaluated for the given file" => "Een sha1-hash kon niet worden gegenereerd voor het opgegeven bestand",
-    "File '%value%' is not readable or does not exist" => "Het bestand '%value%' kon niet worden gevonden",
+    "File '%value%' does not match the given sha1 hashes." => "Het bestand '%value%' matcht niet met de opgegeven sha1-hashes",
+    "A sha1 hash could not be evaluated for the given file." => "Een sha1-hash kon niet worden gegenereerd voor het opgegeven bestand",
+    "File '%value%' is not readable or does not exist." => "Het bestand '%value%' kon niet worden gevonden",
 
     // Zend_Validator_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Maximum grootte voor bestand '%value%' is '%max%' maar '%size%' werd gedetecteerd",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Minimum grootte voor bestand '%value%' is '%min%' maar '%size%' werd gedetecteerd",
-    "File '%value%' is not readable or does not exist" => "Het bestand '%value%' kon niet worden gevonden",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Maximum grootte voor bestand '%value%' is '%max%' maar '%size%' werd gedetecteerd",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Minimum grootte voor bestand '%value%' is '%min%' maar '%size%' werd gedetecteerd",
+    "File '%value%' is not readable or does not exist." => "Het bestand '%value%' kon niet worden gevonden",
 
     // Zend_Validator_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Het bestand '%value%' overschrijdt de ini grootte",
-    "File '%value%' exceeds the defined form size" => "Het bestand '%value%' overschrijdt de formulier grootte",
-    "File '%value%' was only partially uploaded" => "Het bestand '%value%' was slechts gedeeltelijk geüpload",
-    "File '%value%' was not uploaded" => "Het bestand '%value%' was niet geüpload",
-    "No temporary directory was found for file '%value%'" => "Geen tijdelijke map was gevonden voor bestand '%value%'",
-    "File '%value%' can't be written" => "Het bestand '%value%' kan niet worden geschreven",
-    "A PHP extension returned an error while uploading the file '%value%'" => "Een PHP-extensie gaf een foutmelding terug tijdens het uploaden van het bestand '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Het bestand '%value%' was illegaal geüpload. Dit kan een aanval zijn",
-    "File '%value%' was not found" => "Het bestand '%value%' kon niet worden gevonden",
-    "Unknown error while uploading file '%value%'" => "Er is een onbekende fout opgetreden tijdens het uploaden van '%value%'",
+    "File '%value%' exceeds the defined ini size." => "Het bestand '%value%' overschrijdt de ini grootte",
+    "File '%value%' exceeds the defined form size." => "Het bestand '%value%' overschrijdt de formulier grootte",
+    "File '%value%' was only partially uploaded." => "Het bestand '%value%' was slechts gedeeltelijk geüpload",
+    "File '%value%' was not uploaded." => "Het bestand '%value%' was niet geüpload",
+    "No temporary directory was found for file '%value%'." => "Geen tijdelijke map was gevonden voor bestand '%value%'",
+    "File '%value%' can't be written." => "Het bestand '%value%' kan niet worden geschreven",
+    "A PHP extension returned an error while uploading the file '%value%'." => "Een PHP-extensie gaf een foutmelding terug tijdens het uploaden van het bestand '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Het bestand '%value%' was illegaal geüpload. Dit kan een aanval zijn",
+    "File '%value%' was not found." => "Het bestand '%value%' kon niet worden gevonden",
+    "Unknown error while uploading file '%value%'." => "Er is een onbekende fout opgetreden tijdens het uploaden van '%value%'",
 
     // Zend_Validator_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Te veel woorden, er is een maximum van '%max%', maar er waren '%count%' geteld",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Te weinig worden, er is een minimum van '%min%' maar er waren '%count%' getelc",
-    "File '%value%' is not readable or does not exist" => "Het bestand '%value%' kon niet worden gevonden",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Te veel woorden, er is een maximum van '%max%', maar er waren '%count%' geteld",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Te weinig worden, er is een minimum van '%min%' maar er waren '%count%' getelc",
+    "File '%value%' is not readable or does not exist." => "Het bestand '%value%' kon niet worden gevonden",
 
     // Zend_Validator_GreaterThan
     "The input is not greater than '%min%'" => "De input is niet groter dan '%min%'",
     "The input is not greater or equal than '%min%'" => "De input is niet groter dan of gelijk aan '%min%'",
 
     // Zend_Validator_Hex
-    "Invalid type given. String expected" => "Ongeldig type gegeven, waarde moet een string zijn",
+    "Invalid type given. String expected." => "Ongeldig type gegeven, waarde moet een string zijn",
     "The input contains non-hexadecimal characters" => "De input bestaat niet enkel uit hexadecimale cijfers",
 
     // Zend_Validator_Hostname
     "The input appears to be a DNS hostname but the given punycode notation cannot be decoded" => "De input lijkt een geldige DNS hostnaam te zijn, maar de opgegeven punnycode notatie kan niet worden gedecodeerd",
-    "Invalid type given. String expected" => "Ongeldig type gegeven, waarde moet een string zijn",
+    "Invalid type given. String expected." => "Ongeldig type gegeven, waarde moet een string zijn",
     "The input appears to be a DNS hostname but contains a dash in an invalid position" => "De input lijkt een DNS hostnaam te zijn, maar bevat een streep op een ongeldige plek",
     "The input does not match the expected structure for a DNS hostname" => "De input matcht niet met de verwachte structuur voor een DNS hostnaam",
     "The input appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "De input lijkt een DNS hostnaam te zijn, maar past niet in het hostnaam-schema voor TLD '%tld%'",
@@ -221,18 +221,18 @@ return array(
     "The input has failed the IBAN check" => "De input is geen geldige IBAN",
 
     // Zend_Validator_Identical
-    "The two given tokens do not match" => "De twee tokens komen niet overeen",
-    "No token was provided to match against" => "Er is geen token opgegeven om mee te matchen",
+    "The two given tokens do not match." => "De twee tokens komen niet overeen",
+    "No token was provided to match against." => "Er is geen token opgegeven om mee te matchen",
 
     // Zend_Validator_InArray
     "The input was not found in the haystack" => "De input kon niet worden gevonden in lijst met beschikbare waardes",
 
     // Zend_Validator_Ip
-    "Invalid type given. String expected" => "Ongeldig type gegeven, waarde moet een string zijn",
+    "Invalid type given. String expected." => "Ongeldig type gegeven, waarde moet een string zijn",
     "The input does not appear to be a valid IP address" => "De input lijkt geen geldig IP adres te zijn",
 
     // Zend_Validator_Isbn
-    "Invalid type given. String or integer expected" => "Ongeldig type opgegeven, waarde moet een string of integer zijn",
+    "Invalid type given. String or integer expected." => "Ongeldig type opgegeven, waarde moet een string of integer zijn",
     "The input is not a valid ISBN number" => "De input is geen geldig ISBN nummer",
 
     // Zend_Validator_LessThan
@@ -240,40 +240,40 @@ return array(
     "The input is not less or equal than '%max%'" => "De input is niet minder dan of gelijk aan '%max%'",
 
     // Zend_Validator_NotEmpty
-    "Value is required and can't be empty" => "Waarde is vereist en kan niet leeg worden gelaten",
-    "Invalid type given. String, integer, float, boolean or array expected" => "Ongeldig type opgegeven, waarde dient een float, string, array, boolean of integer te zijn",
+    "Value is required and can't be empty." => "Waarde is vereist en kan niet leeg worden gelaten",
+    "Invalid type given. String, integer, float, boolean or array expected." => "Ongeldig type opgegeven, waarde dient een float, string, array, boolean of integer te zijn",
 
     // Zend_Validator_Regex
-    "Invalid type given. String, integer or float expected" => "Ongeldig type opgegeven, waarde dient een string, integer of float te zijn",
+    "Invalid type given. String, integer or float expected." => "Ongeldig type opgegeven, waarde dient een string, integer of float te zijn",
     "The input does not match against pattern '%pattern%'" => "De input matcht niet met het patroon '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "Er is een interne fout opgetreden tijdens het gebruik van het patroon '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "Er is een interne fout opgetreden tijdens het gebruik van het patroon '%pattern%'",
 
     // Zend_Validator_Sitemap_Changefreq
     "The input is not a valid sitemap changefreq" => "De input is geen geldige sitemap changefreq",
-    "Invalid type given. String expected" => "Ongeldig type opgegeven, waarde dient een string te zijn",
+    "Invalid type given. String expected." => "Ongeldig type opgegeven, waarde dient een string te zijn",
 
     // Zend_Validator_Sitemap_Lastmod
     "The input is not a valid sitemap lastmod" => "De input is geen geldige sitemap lastmod",
-    "Invalid type given. String expected" => "Ongeldig type opgegeven, waarde dient een string te zijn",
+    "Invalid type given. String expected." => "Ongeldig type opgegeven, waarde dient een string te zijn",
 
     // Zend_Validator_Sitemap_Loc
     "The input is not a valid sitemap location" => "De input is geen geldige sitemap locatie",
-    "Invalid type given. String expected" => "Ongeldig type opgegeven, waarde dient een string te zijn",
+    "Invalid type given. String expected." => "Ongeldig type opgegeven, waarde dient een string te zijn",
 
     // Zend_Validator_Sitemap_Priority
     "The input is not a valid sitemap priority" => "De input is geen geldige sitemap prioriteit",
-    "Invalid type given. Numeric string, integer or float expected" => "Ongeldig type opgegeven, waarde dient een numerieke string, integer of float te zijn",
+    "Invalid type given. Numeric string, integer or float expected." => "Ongeldig type opgegeven, waarde dient een numerieke string, integer of float te zijn",
 
     // Zend_Validator_Step
     "Invalid value given. Scalar expected" => "Ongeldige waarde opgegeven, waarde dient een scalar te zijn",
     "The input is not a valid step" => "De input is geen geldige stap",
 
     // Zend_Validator_StringLength
-    "Invalid type given. String expected" => "Ongeldig type opgegeven, waarde dient een string te zijn",
+    "Invalid type given. String expected." => "Ongeldig type opgegeven, waarde dient een string te zijn",
     "The input is less than %min% characters long" => "De input is minder dan %min% tekens lang",
     "The input is more than %max% characters long" => "De input is meer dan %max% tekens lang",
 
     // Zend_Validator_Uri
-    "Invalid type given. String expected" => "Ongeldig type opgegeven, waarde dient een string te zijn",
+    "Invalid type given. String expected." => "Ongeldig type opgegeven, waarde dient een string te zijn",
     "The input does not appear to be a valid Uri" => "De input blijkt geen geldige Uri te zijn",
 );

--- a/resources/languages/nl/Zend_Validate.php
+++ b/resources/languages/nl/Zend_Validate.php
@@ -35,7 +35,7 @@ return array(
 
     // Zend_I18n_Validator_Float
     "Invalid type given. String, integer or float expected." => "Invalid type given. String, integer or float expected.",
-    "The input does not appear to be a float" => "The input does not appear to be a float",
+    "The input does not appear to be a float." => "The input does not appear to be a float.",
 
     // Zend_I18n_Validator_Int
     "Invalid type given. String or integer expected." => "Invalid type given. String or integer expected.",
@@ -43,8 +43,8 @@ return array(
 
     // Zend_I18n_Validator_PostCode
     "Invalid type given. String or integer expected." => "Ongeldig type opgegeven, waarde moet een string of integer zijn",
-    "The input does not appear to be a postal code" => "De input lijkt geen geldige postcode te zijn",
-    "An exception has been raised while validating the input" => "Er is een interne fout opgetreden tijdens het valideren van de input",
+    "The input does not appear to be a postal code." => "De input lijkt geen geldige postcode te zijn",
+    "An exception has been raised while validating the input." => "Er is een interne fout opgetreden tijdens het valideren van de input",
 
     // Zend_Validator_Barcode
     "The input failed checksum validation." => "De input slaagde niet in de checksum validatie",
@@ -67,7 +67,7 @@ return array(
     "The input contains an invalid amount of digits" => "De input bevat een ongeldige hoeveelheid cijfers",
     "The input is not from an allowed institute" => "De input is niet afkomstig van een toegestaan instituut",
     "The input seems to be an invalid creditcard number" => "De input is een ongeldig creditcard nummer",
-    "An exception has been raised while validating the input" => "Er is een interne fout opgetreden tijdens het valideren van de input",
+    "An exception has been raised while validating the input." => "Er is een interne fout opgetreden tijdens het valideren van de input",
 
     // Zend_Validator_Csrf
     "The form submitted did not originate from the expected site" => "Het verzonden formulier kwam niet van de verwachte website",

--- a/resources/languages/no/Zend_Captcha.php
+++ b/resources/languages/no/Zend_Captcha.php
@@ -24,12 +24,12 @@
  */
 return array(
     // Zend_Captcha_ReCaptcha
-    "Missing captcha fields" => "Captcha-feltene mangler",
-    "Failed to validate captcha" => "Captcha-validering feilet",
-    "Captcha value is wrong: %value%" => "Captcha-verdien er feil: %value%",
+    "Missing captcha fields." => "Captcha-feltene mangler",
+    "Failed to validate captcha." => "Captcha-validering feilet",
+    "Captcha value is wrong: %value%." => "Captcha-verdien er feil: %value%",
 
     // Zend_Captcha_Word
-    "Empty captcha value" => "Mangler Captcha-verdi",
-    "Captcha ID field is missing" => "Captcha ID-feltet mangler",
-    "Captcha value is wrong" => "Captcha-verdien er feil",
+    "Empty captcha value." => "Mangler Captcha-verdi",
+    "Captcha ID field is missing." => "Captcha ID-feltet mangler",
+    "Captcha value is wrong." => "Captcha-verdien er feil",
 );

--- a/resources/languages/no/Zend_Validate.php
+++ b/resources/languages/no/Zend_Validate.php
@@ -24,242 +24,242 @@
  */
 return array(
     // Zend_Validate_Alnum
-    "Invalid type given. String, integer or float expected" => "Ugyldig type angitt. Forventet streng, heltall eller flyt-tall",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' inneholder tegn som ikke er alfabetiske eller sifre",
-    "'%value%' is an empty string" => "'%value%' er en tom streng",
+    "Invalid type given. String, integer or float expected." => "Ugyldig type angitt. Forventet streng, heltall eller flyt-tall",
+    "'%value%' contains characters which are non alphabetic and no digits." => "'%value%' inneholder tegn som ikke er alfabetiske eller sifre",
+    "'%value%' is an empty string." => "'%value%' er en tom streng",
 
     // Zend_Validate_Alpha
-    "Invalid type given. String expected" => "Ugyldig type angitt. Forventet streng",
-    "'%value%' contains non alphabetic characters" => "'%value%' inneholder ikke-alfabetiske tegn",
-    "'%value%' is an empty string" => "'%value%' er en tom streng",
+    "Invalid type given. String expected." => "Ugyldig type angitt. Forventet streng",
+    "'%value%' contains non alphabetic characters." => "'%value%' inneholder ikke-alfabetiske tegn",
+    "'%value%' is an empty string." => "'%value%' er en tom streng",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "'%value%' feilet kontrollsumvalidering",
     "'%value%' contains invalid characters" => "'%value%' inneholder ugyldige tegn",
     "'%value%' should have a length of %length% characters" => "'%value%' må ha en lengde på %length% tegn",
-    "Invalid type given. String expected" => "Ugyldig type er angitt. Forventet streng",
+    "Invalid type given. String expected." => "Ugyldig type er angitt. Forventet streng",
 
     // Zend_Validate_Between
     "'%value%' is not between '%min%' and '%max%', inclusively" => "'%value%' er ikke mellom eller lik '%min%' og '%max%'",
     "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' er ikke utelukkende mellom '%min%' og '%max%'",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "'%value%' er ugyldig",
-    "An exception has been raised within the callback" => "Et unntak ble reist i tilbakeringingen",
+    "'%value%' is not valid." => "'%value%' er ugyldig",
+    "An exception has been raised within the callback." => "Et unntak ble reist i tilbakeringingen",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' må være mellom 13 og 19 siffer",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Luhn-algoritmen (mod-10 sjekksum) feilet for '%value%'",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' må være mellom 13 og 19 siffer",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Luhn-algoritmen (mod-10 sjekksum) feilet for '%value%'",
 
     // Zend_Validate_CreditCard
-    "'%value%' seems to contain an invalid checksum" => "Det synes som at '%value%' har en ugyldig sjekksum",
-    "'%value%' must contain only digits" => "'%value%' kan kun inneholde siffer",
-    "Invalid type given. String expected" => "Ugyldig type angitt. Forventet streng",
-    "'%value%' contains an invalid amount of digits" => "'%value%' inneholder ugyldig antall sifre",
-    "'%value%' is not from an allowed institute" => "'%value%' er ikke fra et tillatt institutt",
+    "'%value%' seems to contain an invalid checksum." => "Det synes som at '%value%' har en ugyldig sjekksum",
+    "'%value%' must contain only digits." => "'%value%' kan kun inneholde siffer",
+    "Invalid type given. String expected." => "Ugyldig type angitt. Forventet streng",
+    "'%value%' contains an invalid amount of digits." => "'%value%' inneholder ugyldig antall sifre",
+    "'%value%' is not from an allowed institute." => "'%value%' er ikke fra et tillatt institutt",
     "'%value%' seems to be an invalid creditcard number" => "'%value%' synes å være et ugyldig kredittkortnummer",
-    "An exception has been raised while validating '%value%'" => "Et unntak ble reist ved validering av '%value%'",
+    "An exception has been raised while validating '%value%'." => "Et unntak ble reist ved validering av '%value%'",
 
     // Zend_Validate_Date
-    "Invalid type given. String, integer, array or Zend_Date expected" => "Ugyldig type angitt. Forventet streng, heltall, matrise eller Zend_Dat",
-    "'%value%' does not appear to be a valid date" => "'%value%' synes ikke å være en gyldig dato",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' passer ikke datoformatet '%format%'",
+    "Invalid type given. String, integer, array or Zend_Date expected." => "Ugyldig type angitt. Forventet streng, heltall, matrise eller Zend_Dat",
+    "'%value%' does not appear to be a valid date." => "'%value%' synes ikke å være en gyldig dato",
+    "'%value%' does not fit the date format '%format%'." => "'%value%' passer ikke datoformatet '%format%'",
 
     // Zend_Validate_Db_Abstract
-    "No record matching '%value%' was found" => "Ingen poster ble funnet for '%value%'",
-    "A record matching '%value%' was found" => "En post ble funnet for '%value%'",
+    "No record matching '%value%' was found." => "Ingen poster ble funnet for '%value%'",
+    "A record matching '%value%' was found." => "En post ble funnet for '%value%'",
 
     // Zend_Validate_Digits
-    "Invalid type given. String, integer or float expected" => "Ugyldig type angitt. Forventet streng, heltall eller flyt-tall",
-    "'%value%' must contain only digits" => "'%value%' kan bare inneholde sifre",
-    "'%value%' is an empty string" => "'%value%' er en tom streng",
+    "Invalid type given. String, integer or float expected." => "Ugyldig type angitt. Forventet streng, heltall eller flyt-tall",
+    "'%value%' must contain only digits." => "'%value%' kan bare inneholde sifre",
+    "'%value%' is an empty string." => "'%value%' er en tom streng",
 
     // Zend_Validate_EmailAddress
-    "Invalid type given. String expected" => "Ugyldig type angitt. Forventet streng",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' er ikke, i det grunnleggende formatet bruker@vertsnavn, en gyldig e-postadresse.",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' er ikke et gyldig vertsnavn for e-postadressen '%value%'",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' synes ikke å ha et gyldig MX oppslag for e-postadressen '%value%'",
-    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network" => "'%hostname%' er ikke i et rutbart nettverks segment. E-postadressen '%value%' kommer ikke fra et offentlig nett",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' stemmer ikke overens med dot-atom formatet",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' stemmer ikke overens med anførselstegn-streng formatet",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' er ikke gyldig som lokal del for e-postadressen '%value%'",
-    "'%value%' exceeds the allowed length" => "'%value%' overstiger tillatt lengde",
+    "Invalid type given. String expected." => "Ugyldig type angitt. Forventet streng",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "'%value%' er ikke, i det grunnleggende formatet bruker@vertsnavn, en gyldig e-postadresse.",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "'%hostname%' er ikke et gyldig vertsnavn for e-postadressen '%value%'",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "'%hostname%' synes ikke å ha et gyldig MX oppslag for e-postadressen '%value%'",
+    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' er ikke i et rutbart nettverks segment. E-postadressen '%value%' kommer ikke fra et offentlig nett",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' stemmer ikke overens med dot-atom formatet",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' stemmer ikke overens med anførselstegn-streng formatet",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "'%localPart%' er ikke gyldig som lokal del for e-postadressen '%value%'",
+    "'%value%' exceeds the allowed length." => "'%value%' overstiger tillatt lengde",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "For mange filer, maksimum '%max%' er tillatt, men '%count%' er angitt",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "for få filer, minimum '%min%' er forventet, men '%count%' er angitt",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "For mange filer, maksimum '%max%' er tillatt, men '%count%' er angitt",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "for få filer, minimum '%min%' er forventet, men '%count%' er angitt",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Filen '%value%' samsvarer ikke med gitte crc32 hasher",
-    "A crc32 hash could not be evaluated for the given file" => "En crc32 hash kunne ikke bli evaluert for den gitte filen",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' er ikke lesbar eller finnes ikke",
+    "File '%value%' does not match the given crc32 hashes." => "Filen '%value%' samsvarer ikke med gitte crc32 hasher",
+    "A crc32 hash could not be evaluated for the given file." => "En crc32 hash kunne ikke bli evaluert for den gitte filen",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' er ikke lesbar eller finnes ikke",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Feil filtype for filen '%value%'",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' er ikke lesbar eller finnes ikke",
+    "File '%value%' has a false extension." => "Feil filtype for filen '%value%'",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' er ikke lesbar eller finnes ikke",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Filen '%value%' har en feil mimetype av '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Mimetype for filen '%value%' ble ikke funnet",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' er ikke lesbar eller finnes ikke",
+    "File '%value%' has a false mimetype of '%type%'." => "Filen '%value%' har en feil mimetype av '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Mimetype for filen '%value%' ble ikke funnet",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' er ikke lesbar eller finnes ikke",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "Filen '%value%' finnes ikke",
+    "File '%value%' does not exist." => "Filen '%value%' finnes ikke",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "Feil filtype for filen '%value%'",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' er ikke lesbar eller finnes ikke",
+    "File '%value%' has a false extension." => "Feil filtype for filen '%value%'",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' er ikke lesbar eller finnes ikke",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Total filstørrelse skal ikke overstige '%max%'. Beregnet filstørrelse ('%size%') overstiger dette",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Total filstørrelse skal minimum overstige '%min%'. Beregnet sum er '%size%'",
-    "One or more files can not be read" => "En eller flere filer kan ikke leses",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Total filstørrelse skal ikke overstige '%max%'. Beregnet filstørrelse ('%size%') overstiger dette",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Total filstørrelse skal minimum overstige '%min%'. Beregnet sum er '%size%'",
+    "One or more files can not be read." => "En eller flere filer kan ikke leses",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "Filen '%value%' samsvarer ikke med de gitte hasher",
-    "A hash could not be evaluated for the given file" => "En hash kunne ikke bli evaulert for den gitte filen",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' er ikke lesbar eller finnes ikke",
+    "File '%value%' does not match the given hashes." => "Filen '%value%' samsvarer ikke med de gitte hasher",
+    "A hash could not be evaluated for the given file." => "En hash kunne ikke bli evaulert for den gitte filen",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' er ikke lesbar eller finnes ikke",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Maksimal tillatt bredde for bilde '%value%' skulle være '%maxwidth%', men '%width%' ble oppdaget",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Minimum forventet bredde for bilde '%value%' skulle være '%minwidth%', men '%width%' ble oppdaget",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Maksimal tillatt høyde for bilde '%value%' skulle være '%maxheight%', men '%height%' ble oppdaget",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Minimum forventet høyde for bilde '%value%' skulle være '%minheight%', men '%height%' ble oppdaget",
-    "The size of image '%value%' could not be detected" => "Størrelsen på bildet '%value%' kunne ikke bli oppdaget",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' er ikke lesbar eller finnes ikke",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Maksimal tillatt bredde for bilde '%value%' skulle være '%maxwidth%', men '%width%' ble oppdaget",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Minimum forventet bredde for bilde '%value%' skulle være '%minwidth%', men '%width%' ble oppdaget",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Maksimal tillatt høyde for bilde '%value%' skulle være '%maxheight%', men '%height%' ble oppdaget",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Minimum forventet høyde for bilde '%value%' skulle være '%minheight%', men '%height%' ble oppdaget",
+    "The size of image '%value%' could not be detected." => "Størrelsen på bildet '%value%' kunne ikke bli oppdaget",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' er ikke lesbar eller finnes ikke",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Filen '%value%' er ikke komprimert, filtype '%type%' ble funnet",
-    "The mimetype of file '%value%' could not be detected" => "Mimetype for filen '%value%' ble ikke oppdaget",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' er ikke lesbar eller finnes ikke",
+    "File '%value%' is not compressed, '%type%' detected." => "Filen '%value%' er ikke komprimert, filtype '%type%' ble funnet",
+    "The mimetype of file '%value%' could not be detected." => "Mimetype for filen '%value%' ble ikke oppdaget",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' er ikke lesbar eller finnes ikke",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Filen '%value%' er ikke et bilde, '%type%' ble funnet",
-    "The mimetype of file '%value%' could not be detected" => "Mimetype for filen '%value%' fle ikke funnet",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' er ikke lesbar eller finnes ikke",
+    "File '%value%' is no image, '%type%' detected." => "Filen '%value%' er ikke et bilde, '%type%' ble funnet",
+    "The mimetype of file '%value%' could not be detected." => "Mimetype for filen '%value%' fle ikke funnet",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' er ikke lesbar eller finnes ikke",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Filen '%value%' er ikke samsvarer med den angitte md5 hashen",
-    "A md5 hash could not be evaluated for the given file" => "En md5 hash kunne ikke bli evaluert for den gitte filen",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' er ikke lesbar eller finnes ikke",
+    "File '%value%' does not match the given md5 hashes." => "Filen '%value%' er ikke samsvarer med den angitte md5 hashen",
+    "A md5 hash could not be evaluated for the given file." => "En md5 hash kunne ikke bli evaluert for den gitte filen",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' er ikke lesbar eller finnes ikke",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Filen '%value%' har en feil mimetype for '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Mimetypen for filen '%value%' ble ikke funnet",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' er ikke lesbar eller finnes ikke",
+    "File '%value%' has a false mimetype of '%type%'." => "Filen '%value%' har en feil mimetype for '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Mimetypen for filen '%value%' ble ikke funnet",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' er ikke lesbar eller finnes ikke",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "Filen '%value%' finnes",
+    "File '%value%' exists." => "Filen '%value%' finnes",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Filen '%value%' samsvarer ikke med den angitte sha1 hashen",
-    "A sha1 hash could not be evaluated for the given file" => "En sha1 hash kunne ikke bli evaluert for den gitte filen",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' er ikke lesbar eller finnes ikke",
+    "File '%value%' does not match the given sha1 hashes." => "Filen '%value%' samsvarer ikke med den angitte sha1 hashen",
+    "A sha1 hash could not be evaluated for the given file." => "En sha1 hash kunne ikke bli evaluert for den gitte filen",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' er ikke lesbar eller finnes ikke",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Maksimal tillatt størrelse for filen '%value%' er '%max%', men '%size%' ble oppdaget",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Minimum forventet størrelse for filen '%value%' er '%min%', men '%size%' ble oppdaget",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' er ikke lesbar eller finnes ikke",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Maksimal tillatt størrelse for filen '%value%' er '%max%', men '%size%' ble oppdaget",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Minimum forventet størrelse for filen '%value%' er '%min%', men '%size%' ble oppdaget",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' er ikke lesbar eller finnes ikke",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Filen '%value%' overskrider definert ini størrelse",
-    "File '%value%' exceeds the defined form size" => "Filen '%value%' overskrider definert skjema størrelse",
-    "File '%value%' was only partially uploaded" => "Filen '%value%' ble bare delvis lastet opp",
-    "File '%value%' was not uploaded" => "Filen '%value%' ble ikke lastet opp",
-    "No temporary directory was found for file '%value%'" => "Ingen midlertidig mappe ble funnet for filen '%value%'",
-    "File '%value%' can't be written" => "Filen '%value%' kan ikke bli skrevet",
-    "A PHP extension returned an error while uploading the file '%value%'" => "En PHP utvidelse returnerte en feil under opplasting av filen '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Filen '%value%' ble ulovlig lastet opp. Dette kan være en mulig angrep",
-    "File '%value%' was not found" => "Filen '%value%' ble ikke funnet",
-    "Unknown error while uploading file '%value%'" => "Ukjent feil under opplasting av filen '%value%'",
+    "File '%value%' exceeds the defined ini size." => "Filen '%value%' overskrider definert ini størrelse",
+    "File '%value%' exceeds the defined form size." => "Filen '%value%' overskrider definert skjema størrelse",
+    "File '%value%' was only partially uploaded." => "Filen '%value%' ble bare delvis lastet opp",
+    "File '%value%' was not uploaded." => "Filen '%value%' ble ikke lastet opp",
+    "No temporary directory was found for file '%value%'." => "Ingen midlertidig mappe ble funnet for filen '%value%'",
+    "File '%value%' can't be written." => "Filen '%value%' kan ikke bli skrevet",
+    "A PHP extension returned an error while uploading the file '%value%'." => "En PHP utvidelse returnerte en feil under opplasting av filen '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Filen '%value%' ble ulovlig lastet opp. Dette kan være en mulig angrep",
+    "File '%value%' was not found." => "Filen '%value%' ble ikke funnet",
+    "Unknown error while uploading file '%value%'." => "Ukjent feil under opplasting av filen '%value%'",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "For mange ord, maksimum '%max%' er tillatt, men '%count%' ble telt",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "For få ord, minimum '%min%' er forventet, men '%count%' ble telt",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' er ikke lesbar eller finnes ikke",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "For mange ord, maksimum '%max%' er tillatt, men '%count%' ble telt",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "For få ord, minimum '%min%' er forventet, men '%count%' ble telt",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' er ikke lesbar eller finnes ikke",
 
     // Zend_Validate_Float
-    "Invalid type given. String, integer or float expected" => "Ugyldig type gitt. Forvente streng, heltall eller flyt-tall",
-    "'%value%' does not appear to be a float" => "'%value%' synes ikke å være flyt-tall",
+    "Invalid type given. String, integer or float expected." => "Ugyldig type gitt. Forvente streng, heltall eller flyt-tall",
+    "'%value%' does not appear to be a float." => "'%value%' synes ikke å være flyt-tall",
 
     // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' er ikke større enn '%min%'",
+    "'%value%' is not greater than '%min%'." => "'%value%' er ikke større enn '%min%'",
 
     // Zend_Validate_Hex
-    "Invalid type given. String expected" => "Ugyldig type angitt. Forventet streng",
-    "'%value%' has not only hexadecimal digit characters" => "'%value%' har ikke bare heksadesimale siffer tegn",
+    "Invalid type given. String expected." => "Ugyldig type angitt. Forventet streng",
+    "'%value%' has not only hexadecimal digit characters." => "'%value%' har ikke bare heksadesimale siffer tegn",
 
     // Zend_Validate_Hostname
-    "Invalid type given. String expected" => "Ugyldig type gitt. Forventet streng",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "'%value%' synes å være en IP-adresse, men IP-adresser er ikke tillatt",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' synes å være et DNS-vertsnavn, men kunne ikke matche TLD mot kjent liste",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' synes å være et DNS-vertsnavn, men inneholder en bindestrek i en ugyldig posisjon",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' synes å være et DNS-vertsnavn, men kunne ikke sammenligne mot vertsnavn skjema for TLD '%tld%'",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' synes å være et DNS-vertsnavn, men kan ikke trekke ut TLD del",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' samsvarer ikke med forventet struktur for et DNS vertsnavn",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' synes ikke å være et gyldig lokalt nettverksnavn",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' synes å være et lokalt nettverksnavn, men lokale nettverk er ikke tillatt",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "'%value%' synes å være et DNS-vertsnavn, men den gitte punycode notasjonen ikke kan dekodes",
-    "'%value%' does not appear to be a valid URI hostname" => "'%value%' synes ikke å være et gyldig URI vertsnavn",
+    "Invalid type given. String expected." => "Ugyldig type gitt. Forventet streng",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => "'%value%' synes å være en IP-adresse, men IP-adresser er ikke tillatt",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => "'%value%' synes å være et DNS-vertsnavn, men kunne ikke matche TLD mot kjent liste",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => "'%value%' synes å være et DNS-vertsnavn, men inneholder en bindestrek i en ugyldig posisjon",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => "'%value%' synes å være et DNS-vertsnavn, men kunne ikke sammenligne mot vertsnavn skjema for TLD '%tld%'",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => "'%value%' synes å være et DNS-vertsnavn, men kan ikke trekke ut TLD del",
+    "'%value%' does not match the expected structure for a DNS hostname." => "'%value%' samsvarer ikke med forventet struktur for et DNS vertsnavn",
+    "'%value%' does not appear to be a valid local network name." => "'%value%' synes ikke å være et gyldig lokalt nettverksnavn",
+    "'%value%' appears to be a local network name but local network names are not allowed." => "'%value%' synes å være et lokalt nettverksnavn, men lokale nettverk er ikke tillatt",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => "'%value%' synes å være et DNS-vertsnavn, men den gitte punycode notasjonen ikke kan dekodes",
+    "'%value%' does not appear to be a valid URI hostname." => "'%value%' synes ikke å være et gyldig URI vertsnavn",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "Ukjent land i IBAN '%value%'",
-    "'%value%' has a false IBAN format" => "'%value%' har feil IBAN-format",
-    "'%value%' has failed the IBAN check" => "'%value%' har feilet IBAN-sjekk",
+    "Unknown country within the IBAN '%value%'." => "Ukjent land i IBAN '%value%'",
+    "'%value%' has a false IBAN format." => "'%value%' har feil IBAN-format",
+    "'%value%' has failed the IBAN check." => "'%value%' har feilet IBAN-sjekk",
 
     // Zend_Validate_Identical
-    "The two given tokens do not match" => "De to angitte tokenene stemmer ikke overens",
-    "No token was provided to match against" => "Ingen token ble angitt for å matche mot",
+    "The two given tokens do not match." => "De to angitte tokenene stemmer ikke overens",
+    "No token was provided to match against." => "Ingen token ble angitt for å matche mot",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "'%value%' ble ikke funnet i høystakken",
+    "'%value%' was not found in the haystack." => "'%value%' ble ikke funnet i høystakken",
 
     // Zend_Validate_Int
-    "Invalid type given. String or integer expected" => "Ugyldig type gitt. Forventet streng eller heltall",
-    "'%value%' does not appear to be an integer" => "'%value%' synes ikke å være et heltall",
+    "Invalid type given. String or integer expected." => "Ugyldig type gitt. Forventet streng eller heltall",
+    "'%value%' does not appear to be an integer." => "'%value%' synes ikke å være et heltall",
 
     // Zend_Validate_Ip
-    "Invalid type given. String expected" => "Ugyldig type gitt. Forventet streng",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' synes ikke å være en gyldig IP-adresse",
+    "Invalid type given. String expected." => "Ugyldig type gitt. Forventet streng",
+    "'%value%' does not appear to be a valid IP address." => "'%value%' synes ikke å være en gyldig IP-adresse",
 
     // Zend_Validate_Isbn
-    "Invalid type given. String or integer expected" => "Ugyldig type gitt. Forventet streng eller heltall",
-    "'%value%' is not a valid ISBN number" => "'%value%' er ikke et gyldig ISBN-nummer",
+    "Invalid type given. String or integer expected." => "Ugyldig type gitt. Forventet streng eller heltall",
+    "'%value%' is not a valid ISBN number." => "'%value%' er ikke et gyldig ISBN-nummer",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' er ikke mindre enn '%max%'",
+    "'%value%' is not less than '%max%'." => "'%value%' er ikke mindre enn '%max%'",
 
     // Zend_Validate_NotEmpty
-    "Invalid type given. String, integer, float, boolean or array expected" => "Ugyldig type gitt. Forventet streng, heltall, flyt-tall, boolean eller matrise", 
-    "Value is required and can't be empty" => "Verdi er påkrevd, og kan ikke være tomt",
+    "Invalid type given. String, integer, float, boolean or array expected." => "Ugyldig type gitt. Forventet streng, heltall, flyt-tall, boolean eller matrise",
+    "Value is required and can't be empty." => "Verdi er påkrevd, og kan ikke være tomt",
 
     // Zend_Validate_PostCode
-    "Invalid type given. String or integer expected" => "Ugyldig type gitt. Forventet streng eller heltall",
-    "'%value%' does not appear to be a postal code" => "'%value%' synes ikke å være et gyldig postnummer",
+    "Invalid type given. String or integer expected." => "Ugyldig type gitt. Forventet streng eller heltall",
+    "'%value%' does not appear to be a postal code." => "'%value%' synes ikke å være et gyldig postnummer",
 
     // Zend_Validate_Regex
-    "Invalid type given. String, integer or float expected" => "Ugyldig type angitt. Forventet streng, heltall eller flyt-tall",
-    "'%value%' does not match against pattern '%pattern%'" => "'%value%' stemmer ikke mot mønsteret '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "En intern feil oppsto ved bruk av mønsteret '%pattern%'",
+    "Invalid type given. String, integer or float expected." => "Ugyldig type angitt. Forventet streng, heltall eller flyt-tall",
+    "'%value%' does not match against pattern '%pattern%'." => "'%value%' stemmer ikke mot mønsteret '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "En intern feil oppsto ved bruk av mønsteret '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => "'%value%' er ikke en gyldig changefreq-verdi for sitemap",
-    "Invalid type given. String expected" => "Ugyldig type gitt. Forventet streng",
+    "'%value%' is not a valid sitemap changefreq." => "'%value%' er ikke en gyldig changefreq-verdi for sitemap",
+    "Invalid type given. String expected." => "Ugyldig type gitt. Forventet streng",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => "'%value%' er ikke en gyldig lastmod-verdi for sitemap",
-    "Invalid type given. String expected" => "Ugyldig type gitt. Forventet streng",
+    "'%value%' is not a valid sitemap lastmod." => "'%value%' er ikke en gyldig lastmod-verdi for sitemap",
+    "Invalid type given. String expected." => "Ugyldig type gitt. Forventet streng",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => "'%value%' er ikke en gyldig sitemap sted",
-    "Invalid type given. String expected" => "Ugyldig type gitt. Forventet streng",
+    "'%value%' is not a valid sitemap location." => "'%value%' er ikke en gyldig sitemap sted",
+    "Invalid type given. String expected." => "Ugyldig type gitt. Forventet streng",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => "'%value%' er ikke en gyldig prioritet-verdi for sitemap",
-    "Invalid type given. Numeric string, integer or float expected" => "Ugyldig type angitt. Forventet numerisk streng, heltall eller flyt-tall",
+    "'%value%' is not a valid sitemap priority." => "'%value%' er ikke en gyldig prioritet-verdi for sitemap",
+    "Invalid type given. Numeric string, integer or float expected." => "Ugyldig type angitt. Forventet numerisk streng, heltall eller flyt-tall",
 
     // Zend_Validate_StringLength
-    "Invalid type given. String expected" => "Ugyldig type gitt. Forventet streng",
-    "'%value%' is less than %min% characters long" => "'%value%' er mindre enn %min% tegn",
-    "'%value%' is more than %max% characters long" => "'%value%' er mer enn %max% tegn",
+    "Invalid type given. String expected." => "Ugyldig type gitt. Forventet streng",
+    "'%value%' is less than %min% characters long." => "'%value%' er mindre enn %min% tegn",
+    "'%value%' is more than %max% characters long." => "'%value%' er mer enn %max% tegn",
 );

--- a/resources/languages/pl/Zend_Validate.php
+++ b/resources/languages/pl/Zend_Validate.php
@@ -24,241 +24,241 @@
  */
 return array(
     // Zend_Validate_Alnum
-    "Invalid type given. String, integer or float expected" => "Podana wartość powinna być ciągiem znaków, liczbą całkowitą lub liczbą zmiennoprzecinkową",
-    "'%value%' contains characters which are non alphabetic and no digits" => "Wartość '%value%' powinna zawierać znaki z alfabetu lub cyfry",
-    "'%value%' is an empty string" => "'%value%' jest pustym ciągiem znaków",
+    "Invalid type given. String, integer or float expected." => "Podana wartość powinna być ciągiem znaków, liczbą całkowitą lub liczbą zmiennoprzecinkową",
+    "'%value%' contains characters which are non alphabetic and no digits." => "Wartość '%value%' powinna zawierać znaki z alfabetu lub cyfry",
+    "'%value%' is an empty string." => "'%value%' jest pustym ciągiem znaków",
 
     // Zend_Validate_Alpha
-    "Invalid type given. String expected" => "Podana wartość nie jest ciągiem znaków",
-    "'%value%' contains non alphabetic characters" => "'%value%' zawiera znaki spoza alfabetu",
-    "'%value%' is an empty string" => "'%value%' jest pustym ciągiem znaków",
+    "Invalid type given. String expected." => "Podana wartość nie jest ciągiem znaków",
+    "'%value%' contains non alphabetic characters." => "'%value%' zawiera znaki spoza alfabetu",
+    "'%value%' is an empty string." => "'%value%' jest pustym ciągiem znaków",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "Błędna suma kontrolna dla wartości '%value%'",
     "'%value%' contains invalid characters" => "'%value%' zawiera niedozwolone znaki",
     "'%value%' should have a length of %length% characters" => "Wartość '%value%' powinna być długości %length% znaków",
-    "Invalid type given. String expected" => "Podana wartość nie jest ciągiem znaków",
+    "Invalid type given. String expected." => "Podana wartość nie jest ciągiem znaków",
 
     // Zend_Validate_Between
     "'%value%' is not between '%min%' and '%max%', inclusively" => "'%value%' nie zawiera się w przedziale od '%min%' do '%max%' włącznie",
     "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' nie zawiera się w przedziale od '%min%' do '%max%'",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "Wartość '%value%' jest nie poprawna",
-    "An exception has been raised within the callback" => "Wystąpił błąd podczas działania funkcji sprawdzającej",
+    "'%value%' is not valid." => "Wartość '%value%' jest nie poprawna",
+    "An exception has been raised within the callback." => "Wystąpił błąd podczas działania funkcji sprawdzającej",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' musi zawierać od 13 do 19 cyfr",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Błąd podczas wykonywania algorytmu Luhna (mod-10 checksum) dla wartości '%value%'",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' musi zawierać od 13 do 19 cyfr",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Błąd podczas wykonywania algorytmu Luhna (mod-10 checksum) dla wartości '%value%'",
 
     // Zend_Validate_CreditCard
-    "'%value%' seems to contain an invalid checksum" => "'%value%' zawiera niepoprawną sumę kontrolną",
-    "'%value%' must contain only digits" => "Numer karty może zawierać tylko cyfry",
-    "Invalid type given. String expected" => "Podana wartość nie jest ciągiem znaków",
-    "'%value%' contains an invalid amount of digits" => "Numer '%value%' zawiera niepoprawną liczbę cyfr",
-    "'%value%' is not from an allowed institute" => "Numer '%value%' nie jest z dozwolonej instytucji",
+    "'%value%' seems to contain an invalid checksum." => "'%value%' zawiera niepoprawną sumę kontrolną",
+    "'%value%' must contain only digits." => "Numer karty może zawierać tylko cyfry",
+    "Invalid type given. String expected." => "Podana wartość nie jest ciągiem znaków",
+    "'%value%' contains an invalid amount of digits." => "Numer '%value%' zawiera niepoprawną liczbę cyfr",
+    "'%value%' is not from an allowed institute." => "Numer '%value%' nie jest z dozwolonej instytucji",
     "'%value%' seems to be an invalid creditcard number" => "'%value%' jest niepoprawnym numerem karty",
-    "An exception has been raised while validating '%value%'" => "Wystąpił błąd podczas sprawdzania numeru karty '%value%'",
+    "An exception has been raised while validating '%value%'." => "Wystąpił błąd podczas sprawdzania numeru karty '%value%'",
 
     // Zend_Validate_Date
-    "Invalid type given. String, integer, array or Zend_Date expected" => "Podana wartość powinna być ciągiem znaków, liczbą, tablicą lub obiektem Zend_Date",
-    "'%value%' does not appear to be a valid date" => "'%value%' nie jest poprawną datą",
-    "'%value%' does not fit the date format '%format%'" => "Data '%value%' nie jest w formacie '%format%'",
+    "Invalid type given. String, integer, array or Zend_Date expected." => "Podana wartość powinna być ciągiem znaków, liczbą, tablicą lub obiektem Zend_Date",
+    "'%value%' does not appear to be a valid date." => "'%value%' nie jest poprawną datą",
+    "'%value%' does not fit the date format '%format%'." => "Data '%value%' nie jest w formacie '%format%'",
 
     // Zend_Validate_Db_Abstract
-    "No record matching '%value%' was found" => "Nie znaleziono rekordu dla '%value%'",
-    "A record matching '%value%' was found" => "Znaleziono rekord dla '%value%'",
+    "No record matching '%value%' was found." => "Nie znaleziono rekordu dla '%value%'",
+    "A record matching '%value%' was found." => "Znaleziono rekord dla '%value%'",
 
     // Zend_Validate_Digits
-    "Invalid type given. String, integer or float expected" => "Podana wartość powinna być ciągiem znaków, liczbą całkowitą lub liczbą zmiennoprzecinkową",
-    "'%value%' must contain only digits" => "'%value%' może zawierać tylko cyfry",
-    "'%value%' is an empty string" => "'%value%' jest pustym ciągiem znaków",
+    "Invalid type given. String, integer or float expected." => "Podana wartość powinna być ciągiem znaków, liczbą całkowitą lub liczbą zmiennoprzecinkową",
+    "'%value%' must contain only digits." => "'%value%' może zawierać tylko cyfry",
+    "'%value%' is an empty string." => "'%value%' jest pustym ciągiem znaków",
 
     // Zend_Validate_EmailAddress
-    "Invalid type given. String expected" => "Podana wartość nie jest ciągiem znaków",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' nie jest poprawnym adresem email w formacie nazwa@serwer",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "Email '%value%' zawiera niepoprawną nazwę serwera '%hostname%'",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "Serwer '%hostname%' nie posiada poprawnie zdefiniowanego rekordu MX dla adresu '%value%'",
-    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network" => "'%hostname%' nie rutowalnym segmentem sieci. Email '%value%' nie powinien być wykrywany z sieci publiczej",
-    "'%localPart%' can not be matched against dot-atom format" => "Nazwa '%localPart%' nie jest w formacie dot-atom",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' nie jest w formacie quoted-string",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' nie jest poprawną nazwą",
-    "'%value%' exceeds the allowed length" => "Wartość '%value%' przekroczyła dozwoloną długość",
+    "Invalid type given. String expected." => "Podana wartość nie jest ciągiem znaków",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "'%value%' nie jest poprawnym adresem email w formacie nazwa@serwer",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "Email '%value%' zawiera niepoprawną nazwę serwera '%hostname%'",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "Serwer '%hostname%' nie posiada poprawnie zdefiniowanego rekordu MX dla adresu '%value%'",
+    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' nie rutowalnym segmentem sieci. Email '%value%' nie powinien być wykrywany z sieci publiczej",
+    "'%localPart%' can not be matched against dot-atom format." => "Nazwa '%localPart%' nie jest w formacie dot-atom",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' nie jest w formacie quoted-string",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "'%localPart%' nie jest poprawną nazwą",
+    "'%value%' exceeds the allowed length." => "Wartość '%value%' przekroczyła dozwoloną długość",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Wybrano '%count%' plików. Dopuszczalna liczba plików to '%max%'",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Wybrano '%count%' plików. Minimalna liczba plików to '%min%'",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Wybrano '%count%' plików. Dopuszczalna liczba plików to '%max%'",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Wybrano '%count%' plików. Minimalna liczba plików to '%min%'",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Błędna suma kontrolna pliku '%value%'",
-    "A crc32 hash could not be evaluated for the given file" => "Nie można obliczyć sumy kontrolnej dla podanego pliku",
-    "File '%value%' is not readable or does not exist" => "Plik '%value%' nie istnieje lub nie można go odczytać",
+    "File '%value%' does not match the given crc32 hashes." => "Błędna suma kontrolna pliku '%value%'",
+    "A crc32 hash could not be evaluated for the given file." => "Nie można obliczyć sumy kontrolnej dla podanego pliku",
+    "File '%value%' is not readable or does not exist." => "Plik '%value%' nie istnieje lub nie można go odczytać",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Plik '%value%' ma niepoprawne rozszerzenie",
-    "File '%value%' is not readable or does not exist" => "Plik '%value%' nie istnieje lub nie można go odczytać",
+    "File '%value%' has a false extension." => "Plik '%value%' ma niepoprawne rozszerzenie",
+    "File '%value%' is not readable or does not exist." => "Plik '%value%' nie istnieje lub nie można go odczytać",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Plik '%value%' ma niepoprawny typ MIME '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Nie można wykryć typu MIME dla pliku '%value%'",
-    "File '%value%' is not readable or does not exist" => "Plik '%value%' nie istnieje lub nie można go odczytać",
+    "File '%value%' has a false mimetype of '%type%'." => "Plik '%value%' ma niepoprawny typ MIME '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Nie można wykryć typu MIME dla pliku '%value%'",
+    "File '%value%' is not readable or does not exist." => "Plik '%value%' nie istnieje lub nie można go odczytać",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "Plik '%value%' nie istnieje",
+    "File '%value%' does not exist." => "Plik '%value%' nie istnieje",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "Plik '%value%' ma niepoprawne rozszerzenie",
-    "File '%value%' is not readable or does not exist" => "Plik '%value%' nie istnieje lub nie można go odczytać",
+    "File '%value%' has a false extension." => "Plik '%value%' ma niepoprawne rozszerzenie",
+    "File '%value%' is not readable or does not exist." => "Plik '%value%' nie istnieje lub nie można go odczytać",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Wybrane pliki łącznie zajmują '%size%'. Maksymalny łączny rozmiar to '%max%'",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Wybrane pliki łącznie zajmują '%size%'. Minimalny łączny rozmiar to '%min%'",
-    "One or more files can not be read" => "Jeden lub więcej plików nie mogą zostać odczytane",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Wybrane pliki łącznie zajmują '%size%'. Maksymalny łączny rozmiar to '%max%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Wybrane pliki łącznie zajmują '%size%'. Minimalny łączny rozmiar to '%min%'",
+    "One or more files can not be read." => "Jeden lub więcej plików nie mogą zostać odczytane",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "Plik '%value%' ma niedopuszczalny hash",
-    "A hash could not be evaluated for the given file" => "Nie można obliczyć funkcji haszującej dla podanego pliku",
-    "File '%value%' is not readable or does not exist" => "Plik '%value%' nie istnieje lub nie można go odczytać",
+    "File '%value%' does not match the given hashes." => "Plik '%value%' ma niedopuszczalny hash",
+    "A hash could not be evaluated for the given file." => "Nie można obliczyć funkcji haszującej dla podanego pliku",
+    "File '%value%' is not readable or does not exist." => "Plik '%value%' nie istnieje lub nie można go odczytać",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Plik '%value%' ma szerokość '%width%'. Maksymalna szerokość to '%maxwidth%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Plik '%value%' ma szerokość '%width%'. Minimalna szerokość to '%maxwidth%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Plik '%value%' ma wysokość '%height%'. Maksymalna wysokość to '%maxheight%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Plik '%value%' ma wysokość '%height%'. Minimalna wysokość to '%minheight%'",
-    "The size of image '%value%' could not be detected" => "Nie można określić rozmiaru pliku '%value%'",
-    "File '%value%' is not readable or does not exist" => "Plik '%value%' nie istnieje lub nie można go odczytać",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Plik '%value%' ma szerokość '%width%'. Maksymalna szerokość to '%maxwidth%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Plik '%value%' ma szerokość '%width%'. Minimalna szerokość to '%maxwidth%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Plik '%value%' ma wysokość '%height%'. Maksymalna wysokość to '%maxheight%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Plik '%value%' ma wysokość '%height%'. Minimalna wysokość to '%minheight%'",
+    "The size of image '%value%' could not be detected." => "Nie można określić rozmiaru pliku '%value%'",
+    "File '%value%' is not readable or does not exist." => "Plik '%value%' nie istnieje lub nie można go odczytać",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Plik '%value%' typu '%type%' nie jest skompresowany",
-    "The mimetype of file '%value%' could not be detected" => "Nie można wykryć typu MIME dla pliku '%value%'",
-    "File '%value%' is not readable or does not exist" => "Plik '%value%' nie istnieje lub nie można go odczytać",
+    "File '%value%' is not compressed, '%type%' detected." => "Plik '%value%' typu '%type%' nie jest skompresowany",
+    "The mimetype of file '%value%' could not be detected." => "Nie można wykryć typu MIME dla pliku '%value%'",
+    "File '%value%' is not readable or does not exist." => "Plik '%value%' nie istnieje lub nie można go odczytać",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Plik '%value%' typu '%type%' nie jest obrazem",
-    "The mimetype of file '%value%' could not be detected" => "Nie można wykryć typu MIME dla pliku '%value%'",
-    "File '%value%' is not readable or does not exist" => "Plik '%value%' nie istnieje lub nie można go odczytać",
+    "File '%value%' is no image, '%type%' detected." => "Plik '%value%' typu '%type%' nie jest obrazem",
+    "The mimetype of file '%value%' could not be detected." => "Nie można wykryć typu MIME dla pliku '%value%'",
+    "File '%value%' is not readable or does not exist." => "Plik '%value%' nie istnieje lub nie można go odczytać",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Plik '%value%' ma niedopuszczalny hash md5",
-    "A md5 hash could not be evaluated for the given file" => "Nie można obliczyć funkcji haszującej md5 dla podanego pliku",
-    "File '%value%' is not readable or does not exist" => "Plik '%value%' nie istnieje lub nie można go odczytać",
+    "File '%value%' does not match the given md5 hashes." => "Plik '%value%' ma niedopuszczalny hash md5",
+    "A md5 hash could not be evaluated for the given file." => "Nie można obliczyć funkcji haszującej md5 dla podanego pliku",
+    "File '%value%' is not readable or does not exist." => "Plik '%value%' nie istnieje lub nie można go odczytać",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Plik '%value%' ma niepoprawny typ MIME '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Nie można wykryć typu MIME dla pliku '%value%'",
-    "File '%value%' is not readable or does not exist" => "Plik '%value%' nie istnieje lub nie można go odczytać",
+    "File '%value%' has a false mimetype of '%type%'." => "Plik '%value%' ma niepoprawny typ MIME '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Nie można wykryć typu MIME dla pliku '%value%'",
+    "File '%value%' is not readable or does not exist." => "Plik '%value%' nie istnieje lub nie można go odczytać",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "Plik '%value%' istnieje",
+    "File '%value%' exists." => "Plik '%value%' istnieje",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Plik '%value%' ma niedopuszczalny hash sha1",
-    "A sha1 hash could not be evaluated for the given file" => "Nie można obliczyć funkcji haszującej sha1 dla podanego pliku",
-    "File '%value%' is not readable or does not exist" => "Plik '%value%' nie istnieje lub nie można go odczytać",
+    "File '%value%' does not match the given sha1 hashes." => "Plik '%value%' ma niedopuszczalny hash sha1",
+    "A sha1 hash could not be evaluated for the given file." => "Nie można obliczyć funkcji haszującej sha1 dla podanego pliku",
+    "File '%value%' is not readable or does not exist." => "Plik '%value%' nie istnieje lub nie można go odczytać",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Podany plik ma rozmiar '%size%'. Maksymalny rozmiar pliku to '%max%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Podany plik ma rozmiar '%size%'. Minimalny rozmiar pliku to '%min%'",
-    "File '%value%' is not readable or does not exist" => "Plik '%value%' nie istnieje lub nie można go odczytać",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Podany plik ma rozmiar '%size%'. Maksymalny rozmiar pliku to '%max%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Podany plik ma rozmiar '%size%'. Minimalny rozmiar pliku to '%min%'",
+    "File '%value%' is not readable or does not exist." => "Plik '%value%' nie istnieje lub nie można go odczytać",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Rozmiar pliku '%value%' przekroczył zdefiniowaną wartość w ini",
-    "File '%value%' exceeds the defined form size" => "Rozmiar pliku '%value%' przekroczył zdefiniowaną wartość w formularzu",
-    "File '%value%' was only partially uploaded" => "Plik '%value%' nie został całkowicie wysłany",
-    "File '%value%' was not uploaded" => "Plik '%value%' nie został wysłany",
-    "No temporary directory was found for file '%value%'" => "Nie zdefiniowano tymczasowego katalogu",
-    "File '%value%' can't be written" => "Nie można zapisać pliku '%value%'",
-    "A PHP extension returned an error while uploading the file '%value%'" => "Rozszerzenie PHP zgłosiło wyjątek podczas wysyłania pliku '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Plik '%value%' został niepoprawnie wysłany. Istnieje możliwość wystąpienia ataku",
-    "File '%value%' was not found" => "Nie znaleziono pliku '%value%'",
-    "Unknown error while uploading file '%value%'" => "Nieznany błąd podczas wysyłania pliku '%value%'",
+    "File '%value%' exceeds the defined ini size." => "Rozmiar pliku '%value%' przekroczył zdefiniowaną wartość w ini",
+    "File '%value%' exceeds the defined form size." => "Rozmiar pliku '%value%' przekroczył zdefiniowaną wartość w formularzu",
+    "File '%value%' was only partially uploaded." => "Plik '%value%' nie został całkowicie wysłany",
+    "File '%value%' was not uploaded." => "Plik '%value%' nie został wysłany",
+    "No temporary directory was found for file '%value%'." => "Nie zdefiniowano tymczasowego katalogu",
+    "File '%value%' can't be written." => "Nie można zapisać pliku '%value%'",
+    "A PHP extension returned an error while uploading the file '%value%'." => "Rozszerzenie PHP zgłosiło wyjątek podczas wysyłania pliku '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Plik '%value%' został niepoprawnie wysłany. Istnieje możliwość wystąpienia ataku",
+    "File '%value%' was not found." => "Nie znaleziono pliku '%value%'",
+    "Unknown error while uploading file '%value%'." => "Nieznany błąd podczas wysyłania pliku '%value%'",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Podano '%count%' słów. Maksymalna liczba słów to '%max%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Podano '%count%' słów. Minimalna liczba słów to '%min%'",
-    "File '%value%' is not readable or does not exist" => "Plik '%value%' nie istnieje lub nie można go odczytać",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Podano '%count%' słów. Maksymalna liczba słów to '%max%'",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Podano '%count%' słów. Minimalna liczba słów to '%min%'",
+    "File '%value%' is not readable or does not exist." => "Plik '%value%' nie istnieje lub nie można go odczytać",
 
     // Zend_Validate_Float
-    "Invalid type given. String, integer or float expected" => "Podana wartość powinna być ciągiem znaków, liczbą całkowitą lub liczbą zmiennoprzecinkową",
-    "'%value%' does not appear to be a float" => "'%value%' nie jest liczbą zmiennoprzecinkową",
+    "Invalid type given. String, integer or float expected." => "Podana wartość powinna być ciągiem znaków, liczbą całkowitą lub liczbą zmiennoprzecinkową",
+    "'%value%' does not appear to be a float." => "'%value%' nie jest liczbą zmiennoprzecinkową",
 
     // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' nie jest większe niż '%min%'",
+    "'%value%' is not greater than '%min%'." => "'%value%' nie jest większe niż '%min%'",
 
     // Zend_Validate_Hex
-    "Invalid type given. String expected" => "Podana wartość nie jest ciągiem znaków",
-    "'%value%' has not only hexadecimal digit characters" => "'%value%' nie jest wartością heksadecymalną",
+    "Invalid type given. String expected." => "Podana wartość nie jest ciągiem znaków",
+    "'%value%' has not only hexadecimal digit characters." => "'%value%' nie jest wartością heksadecymalną",
 
     // Zend_Validate_Hostname
-    "Invalid type given. String expected" => "Podana wartość nie jest ciągiem znaków",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "Wartość '%value%' jest adresem IP a nie nazwą hosta",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' zawiera nieznane TLD",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "Nazwa hosta '%value%' zawiera znak '-' w złym miejscu",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "Nazwa hosta '%value%' jest niezgodna ze schematem dla TLD '%tld%'",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "Nie można rozpoznać TLD dla nazwy hosta '%value%'",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' nie jest poprawną nazwą hosta",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' nie jest poprawną nazwą sieci lokalnej",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' prawdopodobnie jest nazwą sieci lokalnej. Nazwy sieci lokalnych są niedozwolone",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "Nie można zdekodować punycode dla podanej nazwy hosta '%value%'",
+    "Invalid type given. String expected." => "Podana wartość nie jest ciągiem znaków",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => "Wartość '%value%' jest adresem IP a nie nazwą hosta",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => "'%value%' zawiera nieznane TLD",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => "Nazwa hosta '%value%' zawiera znak '-' w złym miejscu",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => "Nazwa hosta '%value%' jest niezgodna ze schematem dla TLD '%tld%'",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => "Nie można rozpoznać TLD dla nazwy hosta '%value%'",
+    "'%value%' does not match the expected structure for a DNS hostname." => "'%value%' nie jest poprawną nazwą hosta",
+    "'%value%' does not appear to be a valid local network name." => "'%value%' nie jest poprawną nazwą sieci lokalnej",
+    "'%value%' appears to be a local network name but local network names are not allowed." => "'%value%' prawdopodobnie jest nazwą sieci lokalnej. Nazwy sieci lokalnych są niedozwolone",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => "Nie można zdekodować punycode dla podanej nazwy hosta '%value%'",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "Niepoprawny kraj w IBAN '%value%'",
-    "'%value%' has a false IBAN format" => "Wartość '%value%' nie jest w formacie IBAN",
-    "'%value%' has failed the IBAN check" => "Wystąpił błąd podczas sprawdzania IBAN dla '%value%'",
+    "Unknown country within the IBAN '%value%'." => "Niepoprawny kraj w IBAN '%value%'",
+    "'%value%' has a false IBAN format." => "Wartość '%value%' nie jest w formacie IBAN",
+    "'%value%' has failed the IBAN check." => "Wystąpił błąd podczas sprawdzania IBAN dla '%value%'",
 
     // Zend_Validate_Identical
-    "The two given tokens do not match" => "Podane wartości nie są takie same",
-    "No token was provided to match against" => "Nie podano wartości do porównania",
+    "The two given tokens do not match." => "Podane wartości nie są takie same",
+    "No token was provided to match against." => "Nie podano wartości do porównania",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "Nie znaleziono wartości '%value%'",
+    "'%value%' was not found in the haystack." => "Nie znaleziono wartości '%value%'",
 
     // Zend_Validate_Int
-    "Invalid type given. String or integer expected" => "Podana wartość powinna być ciągiem znaków lub liczbą całkowitą",
-    "'%value%' does not appear to be an integer" => "'%value%' nie jest liczbą",
+    "Invalid type given. String or integer expected." => "Podana wartość powinna być ciągiem znaków lub liczbą całkowitą",
+    "'%value%' does not appear to be an integer." => "'%value%' nie jest liczbą",
 
     // Zend_Validate_Ip
-    "Invalid type given. String expected" => "Podana wartość nie jest ciągiem znaków",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' nie jest poprawnym adresem IP",
+    "Invalid type given. String expected." => "Podana wartość nie jest ciągiem znaków",
+    "'%value%' does not appear to be a valid IP address." => "'%value%' nie jest poprawnym adresem IP",
 
     // Zend_Validate_Isbn
-    "Invalid type given. String or integer expected" => "Podana wartość powinna być ciągiem znaków lub liczbą całkowitą",
-    "'%value%' is not a valid ISBN number"  => "'%value%' nie jest poprawnym ISBN",
+    "Invalid type given. String or integer expected." => "Podana wartość powinna być ciągiem znaków lub liczbą całkowitą",
+    "'%value%' is not a valid ISBN number."  => "'%value%' nie jest poprawnym ISBN",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' nie jest mniejsze niż '%max%'",
+    "'%value%' is not less than '%max%'." => "'%value%' nie jest mniejsze niż '%max%'",
 
     // Zend_Validate_NotEmpty
-    "Invalid type given. String, integer, float, boolean or array expected" => "Podana wartość powinna być ciągiem znaków, liczbą całkowitą, liczbą zmiennoprzecinkową, wartością logiczną lub tablicą",
-    "Value is required and can't be empty" => "To pole jest wymagane",
+    "Invalid type given. String, integer, float, boolean or array expected." => "Podana wartość powinna być ciągiem znaków, liczbą całkowitą, liczbą zmiennoprzecinkową, wartością logiczną lub tablicą",
+    "Value is required and can't be empty." => "To pole jest wymagane",
 
     // Zend_Validate_PostCode
-    "Invalid type given. String or integer expected" => "Podana wartość powinna być ciągiem znaków lub liczbą całkowitą",
-    "'%value%' does not appear to be a postal code" => "Wartość '%value%' nie jest poprawnym kodem pocztowym",
+    "Invalid type given. String or integer expected." => "Podana wartość powinna być ciągiem znaków lub liczbą całkowitą",
+    "'%value%' does not appear to be a postal code." => "Wartość '%value%' nie jest poprawnym kodem pocztowym",
 
     // Zend_Validate_Regex
-    "Invalid type given. String, integer or float expected" => "Podana wartość powinna być ciągiem znaków, liczbą całkowitą lub liczbą zmiennoprzecinkową",
-    "'%value%' does not match against pattern '%pattern%'" => "Wartość '%value%' nie pasuje do wzorca '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "Wystąpił błąd podczas dopasowania wyrażenia '%pattern%'",
+    "Invalid type given. String, integer or float expected." => "Podana wartość powinna być ciągiem znaków, liczbą całkowitą lub liczbą zmiennoprzecinkową",
+    "'%value%' does not match against pattern '%pattern%'." => "Wartość '%value%' nie pasuje do wzorca '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "Wystąpił błąd podczas dopasowania wyrażenia '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => "'%value%' nie jest poprawną wartością changefreq",
-    "Invalid type given. String expected" => "Podana wartość nie jest ciągiem znaków",
+    "'%value%' is not a valid sitemap changefreq." => "'%value%' nie jest poprawną wartością changefreq",
+    "Invalid type given. String expected." => "Podana wartość nie jest ciągiem znaków",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => "'%value%' nie jest poprawną wartością lastmod",
-    "Invalid type given. String expected" => "Podana wartość nie jest ciągiem znaków",
+    "'%value%' is not a valid sitemap lastmod." => "'%value%' nie jest poprawną wartością lastmod",
+    "Invalid type given. String expected." => "Podana wartość nie jest ciągiem znaków",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => "'%value%' nie jest poprawną lokalizacją mapy strony",
-    "Invalid type given. String expected" => "Podana wartość nie jest ciągiem znaków",
+    "'%value%' is not a valid sitemap location." => "'%value%' nie jest poprawną lokalizacją mapy strony",
+    "Invalid type given. String expected." => "Podana wartość nie jest ciągiem znaków",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => "'%value%' nie jest poprawną wartością priorytetu",
-    "Invalid type given. Numeric string, integer or float expected" => "Podana wartość powinna być ciągiem znaków, liczbą całkowitą lub liczbą zmiennoprzecinkową",
+    "'%value%' is not a valid sitemap priority." => "'%value%' nie jest poprawną wartością priorytetu",
+    "Invalid type given. Numeric string, integer or float expected." => "Podana wartość powinna być ciągiem znaków, liczbą całkowitą lub liczbą zmiennoprzecinkową",
 
     // Zend_Validate_StringLength
-    "Invalid type given. String expected" => "Podana wartość nie jest ciągiem znaków",
-    "'%value%' is less than %min% characters long" => "'%value%' zawiera mniej niż %min% znaków",
-    "'%value%' is more than %max% characters long" => "'%value%' zawiera więcej niż %max% znaków",
+    "Invalid type given. String expected." => "Podana wartość nie jest ciągiem znaków",
+    "'%value%' is less than %min% characters long." => "'%value%' zawiera mniej niż %min% znaków",
+    "'%value%' is more than %max% characters long." => "'%value%' zawiera więcej niż %max% znaków",
 );

--- a/resources/languages/pt_BR/Zend_Validate.php
+++ b/resources/languages/pt_BR/Zend_Validate.php
@@ -24,242 +24,242 @@
  */
 return array(
     // Zend_Validate_Alnum
-    "Invalid type given. String, integer or float expected" => "O tipo especificado é inválido, o valor deve ser float, string, ou inteiro",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' contém caracteres que não são alfabéticos e nem dígitos",
-    "'%value%' is an empty string" => "'%value%' é uma string vazia",
+    "Invalid type given. String, integer or float expected." => "O tipo especificado é inválido, o valor deve ser float, string, ou inteiro",
+    "'%value%' contains characters which are non alphabetic and no digits." => "'%value%' contém caracteres que não são alfabéticos e nem dígitos",
+    "'%value%' is an empty string." => "'%value%' é uma string vazia",
 
     // Zend_Validate_Alpha
-    "Invalid type given. String expected" => "O tipo especificado é inválido, o valor deve ser uma string",
-    "'%value%' contains non alphabetic characters" => "'%value%' contém caracteres não alfabéticos",
-    "'%value%' is an empty string" => "'%value%' é uma string vazia",
+    "Invalid type given. String expected." => "O tipo especificado é inválido, o valor deve ser uma string",
+    "'%value%' contains non alphabetic characters." => "'%value%' contém caracteres não alfabéticos",
+    "'%value%' is an empty string." => "'%value%' é uma string vazia",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "'%value%' falhou na validação do checksum",
     "'%value%' contains invalid characters" => "'%value%' contém caracteres inválidos",
     "'%value%' should have a length of %length% characters" => "'%value%' tem um comprimento de %length% caracteres",
-    "Invalid type given. String expected" => "O tipo especificado é inválido, o valor deve ser string",
+    "Invalid type given. String expected." => "O tipo especificado é inválido, o valor deve ser string",
 
     // Zend_Validate_Between
     "'%value%' is not between '%min%' and '%max%', inclusively" => "'%value%' não está entre '%min%' e '%max%', inclusivamente",
     "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' não está exatamente entre '%min%' e '%max%'",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "'%value%' não é válido",
-    "An exception has been raised within the callback" => "Falha na chamada de retorno, exceção retornada",
+    "'%value%' is not valid." => "'%value%' não é válido",
+    "An exception has been raised within the callback." => "Falha na chamada de retorno, exceção retornada",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' deve conter entre 13 e 19 dígitos",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "O algoritmo de Luhn (checksum de módulo 10) falhou em '%value%'",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' deve conter entre 13 e 19 dígitos",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "O algoritmo de Luhn (checksum de módulo 10) falhou em '%value%'",
 
     // Zend_Validate_CreditCard
-    "'%value%' seems to contain an invalid checksum" => "'%value%' contém um checksum inválido",
-    "'%value%' must contain only digits" => "'%value%' deve conter apenas dígitos",
-    "Invalid type given. String expected" => "O tipo especificado é inválido, o valor deve ser uma string",
-    "'%value%' contains an invalid amount of digits" => "'%value%' contém uma quantidade inválida de dígitos",
-    "'%value%' is not from an allowed institute" => "'%value%' não vem de uma instituição autorizada",
+    "'%value%' seems to contain an invalid checksum." => "'%value%' contém um checksum inválido",
+    "'%value%' must contain only digits." => "'%value%' deve conter apenas dígitos",
+    "Invalid type given. String expected." => "O tipo especificado é inválido, o valor deve ser uma string",
+    "'%value%' contains an invalid amount of digits." => "'%value%' contém uma quantidade inválida de dígitos",
+    "'%value%' is not from an allowed institute." => "'%value%' não vem de uma instituição autorizada",
     "'%value%' seems to be an invalid creditcard number" => "'%value%' é um número de cartão de crédito inválido",
-    "An exception has been raised while validating '%value%'" => "O serviço devolveu um erro enquanto validava '%value%'",
+    "An exception has been raised while validating '%value%'." => "O serviço devolveu um erro enquanto validava '%value%'",
 
     // Zend_Validate_Date
-    "Invalid type given. String, integer, array or Zend_Date expected" => "O tipo especificado é inválido, o valor deve ser string, inteiro, matriz ou Zend_Date",
-    "'%value%' does not appear to be a valid date" => "'%value%' não parece ser uma data válida",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' não se encaixa no formato de data '%format%'",
+    "Invalid type given. String, integer, array or Zend_Date expected." => "O tipo especificado é inválido, o valor deve ser string, inteiro, matriz ou Zend_Date",
+    "'%value%' does not appear to be a valid date." => "'%value%' não parece ser uma data válida",
+    "'%value%' does not fit the date format '%format%'." => "'%value%' não se encaixa no formato de data '%format%'",
 
     // Zend_Validate_Db_Abstract
-    "No record matching '%value%' was found" => "Não foram encontrados registros para '%value%'",
-    "A record matching '%value%' was found" => "Um registro foi encontrado para '%value%'",
+    "No record matching '%value%' was found." => "Não foram encontrados registros para '%value%'",
+    "A record matching '%value%' was found." => "Um registro foi encontrado para '%value%'",
 
     // Zend_Validate_Digits
-    "Invalid type given. String, integer or float expected" => "O tipo especificado é inválido, o valor deve ser string, inteiro ou float",
-    "'%value%' must contain only digits" => "'%value%' devem conter apenas dígitos",
-    "'%value%' is an empty string" => "'%value%' é uma string vazia",
+    "Invalid type given. String, integer or float expected." => "O tipo especificado é inválido, o valor deve ser string, inteiro ou float",
+    "'%value%' must contain only digits." => "'%value%' devem conter apenas dígitos",
+    "'%value%' is an empty string." => "'%value%' é uma string vazia",
 
     // Zend_Validate_EmailAddress
-    "Invalid type given. String expected" => "O tipo especificado é inválido, o valor deve ser uma string",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' não é um endereço de e-mail válido no formato local-part@hostname",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' não é um nome de host válido para o endereço de e-mail '%value%'",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' não parece ter um registro MX válido para o endereço de e-mail '%value%'",
+    "Invalid type given. String expected." => "O tipo especificado é inválido, o valor deve ser uma string",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "'%value%' não é um endereço de e-mail válido no formato local-part@hostname",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "'%hostname%' não é um nome de host válido para o endereço de e-mail '%value%'",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "'%hostname%' não parece ter um registro MX válido para o endereço de e-mail '%value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' não é um segmento de rede roteável. O endereço de e-mail '%value%' não deve ser resolvido a partir de um rede pública.",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' não corresponde com o formato dot-atom",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' não corresponde com o formato quoted-string",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' não é uma parte local válida para o endereço de e-mail '%value%'",
-    "'%value%' exceeds the allowed length" => "'%value%' excede o comprimento permitido",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' não corresponde com o formato dot-atom",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' não corresponde com o formato quoted-string",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "'%localPart%' não é uma parte local válida para o endereço de e-mail '%value%'",
+    "'%value%' exceeds the allowed length." => "'%value%' excede o comprimento permitido",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Há muitos arquivos, são permitidos no máximo '%max%', mas '%count%' foram fornecidos",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Há poucos arquivos, são esperados no mínimo '%min%', mas '%count%' foram fornecidos",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Há muitos arquivos, são permitidos no máximo '%max%', mas '%count%' foram fornecidos",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Há poucos arquivos, são esperados no mínimo '%min%', mas '%count%' foram fornecidos",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "O arquivo '%value%' não corresponde ao hash crc32 fornecido",
-    "A crc32 hash could not be evaluated for the given file" => "Não foi possível avaliar um hash crc32 para o arquivo fornecido",
-    "File '%value%' is not readable or does not exist" => "O arquivo '%value%' não pode ser lido ou não existe",
+    "File '%value%' does not match the given crc32 hashes." => "O arquivo '%value%' não corresponde ao hash crc32 fornecido",
+    "A crc32 hash could not be evaluated for the given file." => "Não foi possível avaliar um hash crc32 para o arquivo fornecido",
+    "File '%value%' is not readable or does not exist." => "O arquivo '%value%' não pode ser lido ou não existe",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "O arquivo '%value%' possui a extensão incorreta",
-    "File '%value%' is not readable or does not exist" => "O arquivo '%value%' não pode ser lido ou não existe",
+    "File '%value%' has a false extension." => "O arquivo '%value%' possui a extensão incorreta",
+    "File '%value%' is not readable or does not exist." => "O arquivo '%value%' não pode ser lido ou não existe",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "O arquivo '%value%' tem o mimetype incorreto: '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "O mimetype do arquivo '%value%' não pôde ser detectado",
-    "File '%value%' is not readable or does not exist" => "O arquivo '%value%' não pode ser lido ou não existe",
+    "File '%value%' has a false mimetype of '%type%'." => "O arquivo '%value%' tem o mimetype incorreto: '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "O mimetype do arquivo '%value%' não pôde ser detectado",
+    "File '%value%' is not readable or does not exist." => "O arquivo '%value%' não pode ser lido ou não existe",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "O arquivo '%value%' não existe",
+    "File '%value%' does not exist." => "O arquivo '%value%' não existe",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "O arquivo '%value%' possui a extensão incorreta",
-    "File '%value%' is not readable or does not exist" => "O arquivo '%value%' não pode ser lido ou não existe",
+    "File '%value%' has a false extension." => "O arquivo '%value%' possui a extensão incorreta",
+    "File '%value%' is not readable or does not exist." => "O arquivo '%value%' não pode ser lido ou não existe",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Todos os arquivos devem ter um tamanho máximo de '%max%', mas um tamanho de '%size%' foi detectado",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Todos os arquivos devem ter um tamanho mínimo de '%min%', mas um tamanho de '%size%' foi detectado",
-    "One or more files can not be read" => "Um ou mais arquivos não puderam ser lidos",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Todos os arquivos devem ter um tamanho máximo de '%max%', mas um tamanho de '%size%' foi detectado",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Todos os arquivos devem ter um tamanho mínimo de '%min%', mas um tamanho de '%size%' foi detectado",
+    "One or more files can not be read." => "Um ou mais arquivos não puderam ser lidos",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "O arquivo '%value%' não corresponde ao hash fornecido",
-    "A hash could not be evaluated for the given file" => "Não foi possível avaliar um hash para o arquivo fornecido",
-    "File '%value%' is not readable or does not exist"  => "O arquivo '%value%' não pode ser encontrado ou não existe",
+    "File '%value%' does not match the given hashes." => "O arquivo '%value%' não corresponde ao hash fornecido",
+    "A hash could not be evaluated for the given file." => "Não foi possível avaliar um hash para o arquivo fornecido",
+    "File '%value%' is not readable or does not exist."  => "O arquivo '%value%' não pode ser encontrado ou não existe",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "A largura máxima permitida para a imagem '%value%' deve ser '%maxwidth%', mas '%width%' foi detectada",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "A largura mínima esperada para a imagem '%value%' deve ser '%minwidth%', mas '%width%' foi detectada",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "A altura máxima permitida para a imagem '%value%' deve ser '%maxheight%', mas '%height%' foi detectada",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "A altura mínima esperada para a imagem '%value%' deve ser '%minheight%', mas '%height%' foi detectada",
-    "The size of image '%value%' could not be detected" => "O tamanho da imagem '%value%' não pôde ser detectado",
-    "File '%value%' is not readable or does not exist" => "O arquivo '%value%' não pode ser lido ou não existe",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "A largura máxima permitida para a imagem '%value%' deve ser '%maxwidth%', mas '%width%' foi detectada",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "A largura mínima esperada para a imagem '%value%' deve ser '%minwidth%', mas '%width%' foi detectada",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "A altura máxima permitida para a imagem '%value%' deve ser '%maxheight%', mas '%height%' foi detectada",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "A altura mínima esperada para a imagem '%value%' deve ser '%minheight%', mas '%height%' foi detectada",
+    "The size of image '%value%' could not be detected." => "O tamanho da imagem '%value%' não pôde ser detectado",
+    "File '%value%' is not readable or does not exist." => "O arquivo '%value%' não pode ser lido ou não existe",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "O arquivo '%value%' não está compactado: '%type%' detectado",
-    "The mimetype of file '%value%' could not be detected" => "O mimetype do arquivo '%value%' não pôde ser detectado",
-    "File '%value%' is not readable or does not exist" => "O arquivo '%value%' não pode ser lido ou não existe",
+    "File '%value%' is not compressed, '%type%' detected." => "O arquivo '%value%' não está compactado: '%type%' detectado",
+    "The mimetype of file '%value%' could not be detected." => "O mimetype do arquivo '%value%' não pôde ser detectado",
+    "File '%value%' is not readable or does not exist." => "O arquivo '%value%' não pode ser lido ou não existe",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "O arquivo '%value%' não é uma imagem: '%type%' detectado",
-    "The mimetype of file '%value%' could not be detected" => "O mimetype do arquivo '%value%' não pôde ser detectado",
-    "File '%value%' is not readable or does not exist" => "O arquivo '%value%' não pode ser lido ou não existe",
+    "File '%value%' is no image, '%type%' detected." => "O arquivo '%value%' não é uma imagem: '%type%' detectado",
+    "The mimetype of file '%value%' could not be detected." => "O mimetype do arquivo '%value%' não pôde ser detectado",
+    "File '%value%' is not readable or does not exist." => "O arquivo '%value%' não pode ser lido ou não existe",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "O arquivo '%value%' não corresponde ao hash md5 fornecido",
-    "A md5 hash could not be evaluated for the given file" => "Não foi possível avaliar um hash md5 para o arquivo fornecido",
-    "File '%value%' is not readable or does not exist" => "O arquivo '%value%' não pode ser lido ou não existe",
+    "File '%value%' does not match the given md5 hashes." => "O arquivo '%value%' não corresponde ao hash md5 fornecido",
+    "A md5 hash could not be evaluated for the given file." => "Não foi possível avaliar um hash md5 para o arquivo fornecido",
+    "File '%value%' is not readable or does not exist." => "O arquivo '%value%' não pode ser lido ou não existe",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "O arquivo '%value%' tem o mimetype incorreto: '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "O mimetype do arquivo '%value%' não pôde ser detectado",
-    "File '%value%' is not readable or does not exist" => "O arquivo '%value%' não pode ser lido ou não existe",
+    "File '%value%' has a false mimetype of '%type%'." => "O arquivo '%value%' tem o mimetype incorreto: '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "O mimetype do arquivo '%value%' não pôde ser detectado",
+    "File '%value%' is not readable or does not exist." => "O arquivo '%value%' não pode ser lido ou não existe",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "O arquivo '%value%' existe",
+    "File '%value%' exists." => "O arquivo '%value%' existe",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "O arquivo '%value%' não corresponde ao hash sha1 fornecido",
-    "A sha1 hash could not be evaluated for the given file" => "Não foi possível avaliar um hash sha1 para o arquivo fornecido",
-    "File '%value%' is not readable or does not exist" => "O arquivo '%value%' não pode ser lido ou não existe",
+    "File '%value%' does not match the given sha1 hashes." => "O arquivo '%value%' não corresponde ao hash sha1 fornecido",
+    "A sha1 hash could not be evaluated for the given file." => "Não foi possível avaliar um hash sha1 para o arquivo fornecido",
+    "File '%value%' is not readable or does not exist." => "O arquivo '%value%' não pode ser lido ou não existe",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "O tamanho máximo permitido para o arquivo '%value%' é '%max%', mas '%size%' foram detectados",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "O tamanho mínimo esperado para o arquivo '%value%' é '%min%', mas '%size%' foram detectados",
-    "File '%value%' is not readable or does not exist" => "O arquivo '%value%' não pode ser lido ou não existe",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "O tamanho máximo permitido para o arquivo '%value%' é '%max%', mas '%size%' foram detectados",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "O tamanho mínimo esperado para o arquivo '%value%' é '%min%', mas '%size%' foram detectados",
+    "File '%value%' is not readable or does not exist." => "O arquivo '%value%' não pode ser lido ou não existe",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "O arquivo '%value%' excede o tamanho definido na configuração",
-    "File '%value%' exceeds the defined form size" => "O arquivo '%value%' excede o tamanho definido do formulário",
-    "File '%value%' was only partially uploaded" => "O arquivo '%value%' foi apenas parcialmente enviado",
-    "File '%value%' was not uploaded" => "O arquivo '%value%' não foi enviado",
-    "No temporary directory was found for file '%value%'" => "Nenhum diretório temporário foi encontrado para o arquivo '%value%'",
-    "File '%value%' can't be written" => "O arquivo '%value%' não pôde ser escrito",
-    "A PHP extension returned an error while uploading the file '%value%'" => "Uma extensão do PHP retornou um erro enquanto o arquivo '%value%' era enviado",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "O arquivo '%value%' foi enviado ilegalmente. Este poderia ser um possível ataque",
-    "File '%value%' was not found" => "O arquivo '%value%' não foi encontrado",
-    "Unknown error while uploading file '%value%'" => "Erro desconhecido ao enviar o arquivo '%value%'",
+    "File '%value%' exceeds the defined ini size." => "O arquivo '%value%' excede o tamanho definido na configuração",
+    "File '%value%' exceeds the defined form size." => "O arquivo '%value%' excede o tamanho definido do formulário",
+    "File '%value%' was only partially uploaded." => "O arquivo '%value%' foi apenas parcialmente enviado",
+    "File '%value%' was not uploaded." => "O arquivo '%value%' não foi enviado",
+    "No temporary directory was found for file '%value%'." => "Nenhum diretório temporário foi encontrado para o arquivo '%value%'",
+    "File '%value%' can't be written." => "O arquivo '%value%' não pôde ser escrito",
+    "A PHP extension returned an error while uploading the file '%value%'." => "Uma extensão do PHP retornou um erro enquanto o arquivo '%value%' era enviado",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "O arquivo '%value%' foi enviado ilegalmente. Este poderia ser um possível ataque",
+    "File '%value%' was not found." => "O arquivo '%value%' não foi encontrado",
+    "Unknown error while uploading file '%value%'." => "Erro desconhecido ao enviar o arquivo '%value%'",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Há muitas palavras, são permitidas no máximo '%max%', mas '%count%' foram contadas",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Há poucas palavras, são esperadas no mínimo '%min%', mas '%count%' foram contadas",
-    "File '%value%' is not readable or does not exist" => "O arquivo '%value%' não pode ser lido ou não existe",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Há muitas palavras, são permitidas no máximo '%max%', mas '%count%' foram contadas",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Há poucas palavras, são esperadas no mínimo '%min%', mas '%count%' foram contadas",
+    "File '%value%' is not readable or does not exist." => "O arquivo '%value%' não pode ser lido ou não existe",
 
     // Zend_Validate_Float
-    "Invalid type given. String, integer or float expected" => "O tipo especificado é inválido, o valor deve ser float, string, ou inteiro",
-    "'%value%' does not appear to be a float" => "'%value%' não parece ser um float",
+    "Invalid type given. String, integer or float expected." => "O tipo especificado é inválido, o valor deve ser float, string, ou inteiro",
+    "'%value%' does not appear to be a float." => "'%value%' não parece ser um float",
 
     // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' não é maior que '%min%'",
+    "'%value%' is not greater than '%min%'." => "'%value%' não é maior que '%min%'",
 
     // Zend_Validate_Hex
-    "Invalid type given. String expected" => "O tipo especificado é inválido, o valor deve ser uma string",
-    "'%value%' has not only hexadecimal digit characters" => "'%value%' não contém somente caracteres hexadecimais",
+    "Invalid type given. String expected." => "O tipo especificado é inválido, o valor deve ser uma string",
+    "'%value%' has not only hexadecimal digit characters." => "'%value%' não contém somente caracteres hexadecimais",
 
     // Zend_Validate_Hostname
-    "Invalid type given. String expected" => "O tipo especificado é inválido, o valor deve ser uma string",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "'%value%' parece ser um endereço de IP, mas endereços de IP não são permitidos",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' parece ser um hostname de DNS, mas o TLD não corresponde a nenhum TLD conhecido",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' parece ser um hostname de DNS, mas contém um traço em uma posição inválida",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' parece ser um hostname de DNS, mas não corresponde ao esquema de hostname para o TLD '%tld%'",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' parece ser um hostname de DNS, mas o TLD não pôde ser extraído",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' não corresponde com a estrutura esperada para um hostname de DNS",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' não parece ser um nome de rede local válido",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' parece ser um nome de rede local, mas os nomes de rede local não são permitidos",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "'%value%' parece ser um hostname de DNS, mas a notação punycode fornecida não pode ser decodificada",
-    "'%value%' does not appear to be a valid URI hostname" => "'%value%' não parece ser um URI hostname válido",
+    "Invalid type given. String expected." => "O tipo especificado é inválido, o valor deve ser uma string",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => "'%value%' parece ser um endereço de IP, mas endereços de IP não são permitidos",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => "'%value%' parece ser um hostname de DNS, mas o TLD não corresponde a nenhum TLD conhecido",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => "'%value%' parece ser um hostname de DNS, mas contém um traço em uma posição inválida",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => "'%value%' parece ser um hostname de DNS, mas não corresponde ao esquema de hostname para o TLD '%tld%'",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => "'%value%' parece ser um hostname de DNS, mas o TLD não pôde ser extraído",
+    "'%value%' does not match the expected structure for a DNS hostname." => "'%value%' não corresponde com a estrutura esperada para um hostname de DNS",
+    "'%value%' does not appear to be a valid local network name." => "'%value%' não parece ser um nome de rede local válido",
+    "'%value%' appears to be a local network name but local network names are not allowed." => "'%value%' parece ser um nome de rede local, mas os nomes de rede local não são permitidos",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => "'%value%' parece ser um hostname de DNS, mas a notação punycode fornecida não pode ser decodificada",
+    "'%value%' does not appear to be a valid URI hostname." => "'%value%' não parece ser um URI hostname válido",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "País desconhecido para o IBAN '%value%'",
-    "'%value%' has a false IBAN format" => "'%value%' não é um formato IBAN válido",
-    "'%value%' has failed the IBAN check" => "'%value%' falhou na verificação do IBAN",
+    "Unknown country within the IBAN '%value%'." => "País desconhecido para o IBAN '%value%'",
+    "'%value%' has a false IBAN format." => "'%value%' não é um formato IBAN válido",
+    "'%value%' has failed the IBAN check." => "'%value%' falhou na verificação do IBAN",
 
     // Zend_Validate_Identical
-    "The two given tokens do not match" => "Os dois tokens fornecidos não combinam",
-    "No token was provided to match against" => "Nenhum token foi fornecido para a comparação",
+    "The two given tokens do not match." => "Os dois tokens fornecidos não combinam",
+    "No token was provided to match against." => "Nenhum token foi fornecido para a comparação",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "'%value%' não faz parte dos valores esperados",
+    "'%value%' was not found in the haystack." => "'%value%' não faz parte dos valores esperados",
 
     // Zend_Validate_Int
-    "Invalid type given. String or integer expected" => "O tipo especificado é inválido, o valor deve ser string ou inteiro",
-    "'%value%' does not appear to be an integer" => "'%value%' não parece ser um número inteiro",
+    "Invalid type given. String or integer expected." => "O tipo especificado é inválido, o valor deve ser string ou inteiro",
+    "'%value%' does not appear to be an integer." => "'%value%' não parece ser um número inteiro",
 
     // Zend_Validate_Ip
-    "Invalid type given. String expected" => "O tipo especificado é inválido, o valor deve ser uma string",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' não parece ser um endereço de IP válido",
+    "Invalid type given. String expected." => "O tipo especificado é inválido, o valor deve ser uma string",
+    "'%value%' does not appear to be a valid IP address." => "'%value%' não parece ser um endereço de IP válido",
 
     // Zend_Validate_Isbn
-    "Invalid type given. String or integer expected" => "O tipo especificado é inválido, o valor deve ser string ou inteiro",
-    "'%value%' is not a valid ISBN number" => "'%value%' não é um número ISBN válido",
+    "Invalid type given. String or integer expected." => "O tipo especificado é inválido, o valor deve ser string ou inteiro",
+    "'%value%' is not a valid ISBN number." => "'%value%' não é um número ISBN válido",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' não é menor que '%max%'",
+    "'%value%' is not less than '%max%'." => "'%value%' não é menor que '%max%'",
 
     // Zend_Validate_NotEmpty
-    "Invalid type given. String, integer, float, boolean or array expected" => "O tipo especificado é inválido, o valor deve ser float, string, matriz, booleano ou inteiro",
-    "Value is required and can't be empty" => "O valor é obrigatório e não pode estar vazio",
+    "Invalid type given. String, integer, float, boolean or array expected." => "O tipo especificado é inválido, o valor deve ser float, string, matriz, booleano ou inteiro",
+    "Value is required and can't be empty." => "O valor é obrigatório e não pode estar vazio",
 
     // Zend_Validate_PostCode
-    "Invalid type given. String or integer expected" => "O tipo especificado é inválido. O valor deve ser uma string ou um inteiro",
-    "'%value%' does not appear to be a postal code" => "'%value%' não parece ser um código postal",
+    "Invalid type given. String or integer expected." => "O tipo especificado é inválido. O valor deve ser uma string ou um inteiro",
+    "'%value%' does not appear to be a postal code." => "'%value%' não parece ser um código postal",
 
     // Zend_Validate_Regex
-    "Invalid type given. String, integer or float expected" => "O tipo especificado é inválido, o valor deve ser string, inteiro ou float",
-    "'%value%' does not match against pattern '%pattern%'" => "'%value%' não corresponde ao padrão '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "Houve um erro interno durante o uso do padrão '%pattern%'",
+    "Invalid type given. String, integer or float expected." => "O tipo especificado é inválido, o valor deve ser string, inteiro ou float",
+    "'%value%' does not match against pattern '%pattern%'." => "'%value%' não corresponde ao padrão '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "Houve um erro interno durante o uso do padrão '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => "'%value%' não é um changefreq de sitemap válido",
-    "Invalid type given. String expected" => "O tipo especificado é inválido, o valor deve ser uma string",
+    "'%value%' is not a valid sitemap changefreq." => "'%value%' não é um changefreq de sitemap válido",
+    "Invalid type given. String expected." => "O tipo especificado é inválido, o valor deve ser uma string",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => "'%value%' não é um lastmod de sitemap válido",
-    "Invalid type given. String expected" => "O tipo especificado é inválido, o valor deve ser uma string",
+    "'%value%' is not a valid sitemap lastmod." => "'%value%' não é um lastmod de sitemap válido",
+    "Invalid type given. String expected." => "O tipo especificado é inválido, o valor deve ser uma string",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => "'%value%' não é uma localização de sitemap válida",
-    "Invalid type given. String expected" => "O tipo especificado é inválido, o valor deve ser uma string",
+    "'%value%' is not a valid sitemap location." => "'%value%' não é uma localização de sitemap válida",
+    "Invalid type given. String expected." => "O tipo especificado é inválido, o valor deve ser uma string",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => "'%value%' não é uma prioridade de sitemap válida",
-    "Invalid type given. Numeric string, integer or float expected" => "O tipo especificado é inválido, o valor deve ser um inteiro, um float ou uma string numérica",
+    "'%value%' is not a valid sitemap priority." => "'%value%' não é uma prioridade de sitemap válida",
+    "Invalid type given. Numeric string, integer or float expected." => "O tipo especificado é inválido, o valor deve ser um inteiro, um float ou uma string numérica",
 
     // Zend_Validate_StringLength
-    "Invalid type given. String expected" => "O tipo especificado é inválido, o valor deve ser uma string",
-    "'%value%' is less than %min% characters long" => "O tamanho de '%value%' é inferior a %min% caracteres",
-    "'%value%' is more than %max% characters long" => "O tamanho de '%value%' é superior a %max% caracteres",
+    "Invalid type given. String expected." => "O tipo especificado é inválido, o valor deve ser uma string",
+    "'%value%' is less than %min% characters long." => "O tamanho de '%value%' é inferior a %min% caracteres",
+    "'%value%' is more than %max% characters long." => "O tamanho de '%value%' é superior a %max% caracteres",
 );

--- a/resources/languages/ru/Zend_Validate.php
+++ b/resources/languages/ru/Zend_Validate.php
@@ -25,13 +25,13 @@
 return array(
     // Zend_Validate_Alnum
     "Invalid type given, value should be float, string, or integer" => "Недопустимый тип данных, значение должно быть числом с плавающей точкой, строкой или целым числом",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' содержит недопустимые символы. Разрешены только буквенные символы и цифры",
-    "'%value%' is an empty string" => "'%value%' - пустая строка",
+    "'%value%' contains characters which are non alphabetic and no digits." => "'%value%' содержит недопустимые символы. Разрешены только буквенные символы и цифры",
+    "'%value%' is an empty string." => "'%value%' - пустая строка",
 
     // Zend_Validate_Alpha
     "Invalid type given, value should be a string" => "Недопустимый тип данных, значение должно быть строкой",
-    "'%value%' contains non alphabetic characters" => "'%value%' содержит не буквенные символы",
-    "'%value%' is an empty string" => "'%value%' - пустая строка",
+    "'%value%' contains non alphabetic characters." => "'%value%' содержит не буквенные символы",
+    "'%value%' is an empty string." => "'%value%' - пустая строка",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "'%value%' ошибка проверки контрольной суммы",
@@ -44,26 +44,26 @@ return array(
     "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' не в диапазоне от '%min%' до '%max%'",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "'%value%' недопустимое значение",
+    "'%value%' is not valid." => "'%value%' недопустимое значение",
     "Failure within the callback, exception returned" => "Ошибка в обратном вызове, возвращено исключение",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' должно содержать от 13 до 19 цифр",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Алгоритм Луна (вычисление контрольной цифры) вернул ошибку для '%value%'",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' должно содержать от 13 до 19 цифр",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Алгоритм Луна (вычисление контрольной цифры) вернул ошибку для '%value%'",
 
     // Zend_Validate_CreditCard
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Алгоритм Луна (вычисление контрольной цифры) вернул ошибку для '%value%'",
-    "'%value%' must contain only digits" => "'%value%' должно содержать только цифры",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Алгоритм Луна (вычисление контрольной цифры) вернул ошибку для '%value%'",
+    "'%value%' must contain only digits." => "'%value%' должно содержать только цифры",
     "Invalid type given, value should be a string" => "Недопустимый тип данных, значение должно быть строкой",
-    "'%value%' contains an invalid amount of digits" => "'%value%' содержит недопустимое количество цифр",
-    "'%value%' is not from an allowed institute" => "'%value%' не входит в список разрешенных платежных систем",
+    "'%value%' contains an invalid amount of digits." => "'%value%' содержит недопустимое количество цифр",
+    "'%value%' is not from an allowed institute." => "'%value%' не входит в список разрешенных платежных систем",
     "Validation of '%value%' has been failed by the service" => "Проверка '%value%' закончилась ошибкой сервиса",
     "The service returned a failure while validating '%value%'" => "Сервис возвратил ошибку во время проверки '%value%'",
 
     // Zend_Validate_Date
     "Invalid type given, value should be string, integer, array or Zend_Date" => "Недопустимый тип данных, значение должно быть строкой, целым числом, массивом или объектом Zend_Date",
-    "'%value%' does not appear to be a valid date" => "'%value%' не является корректной датой",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' не соответствует формату даты '%format%'",
+    "'%value%' does not appear to be a valid date." => "'%value%' не является корректной датой",
+    "'%value%' does not fit the date format '%format%'." => "'%value%' не соответствует формату даты '%format%'",
 
     // Zend_Validate_Db_Abstract
     "No record matching %value% was found" => "Не найдено записей, совпадающих с '%value%'",
@@ -72,164 +72,164 @@ return array(
     // Zend_Validate_Digits
     "Invalid type given, value should be string, integer or float" => "Недопустимый тип данных, значение должно быть числом с плавающей точкой, строкой, или целым числом",
     "'%value%' contains not only digit characters" => "Значение '%value%' должно содержать только цифровые символы",
-    "'%value%' is an empty string" => "'%value%' - пустая строка",
+    "'%value%' is an empty string." => "'%value%' - пустая строка",
 
     // Zend_Validate_EmailAddress
     "Invalid type given, value should be a string" => "Недопустимый тип данных, значение должно быть строкой",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' недопустимый адрес электронной почты. Введите его в формате имя@домен",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' недопустимое имя хоста для адреса '%value%'",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' не имеет корректной MX-записи об адресе '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "'%value%' недопустимый адрес электронной почты. Введите его в формате имя@домен",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "'%hostname%' недопустимое имя хоста для адреса '%value%'",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "'%hostname%' не имеет корректной MX-записи об адресе '%value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' не является маршрутизируемым сегментом сети. Адрес электронной почты '%value%' не может быть получен из публичной сети.",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart% не соответствует формату dot-atom",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' не соответствует формату quoted-string",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' недопустимое имя для адреса '%value%'",
-    "'%value%' exceeds the allowed length" => "'%value%' превышает допустимую длину",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart% не соответствует формату dot-atom",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' не соответствует формату quoted-string",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "'%localPart%' недопустимое имя для адреса '%value%'",
+    "'%value%' exceeds the allowed length." => "'%value%' превышает допустимую длину",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Слишком много файлов, максимально разрешено - '%max%', а получено - '%count%'",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Слишком мало файлов, минимально разрешено - '%min%', а получено - '%count%'",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Слишком много файлов, максимально разрешено - '%max%', а получено - '%count%'",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Слишком мало файлов, минимально разрешено - '%min%', а получено - '%count%'",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Файл '%value%' не соответствует заданному crc32 хешу",
-    "A crc32 hash could not be evaluated for the given file" => "crc32 хеш не может быть вычислен для данного файла",
+    "File '%value%' does not match the given crc32 hashes." => "Файл '%value%' не соответствует заданному crc32 хешу",
+    "A crc32 hash could not be evaluated for the given file." => "crc32 хеш не может быть вычислен для данного файла",
     "File '%value%' could not be found" => "Файл '%value%' не найден",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Файл '%value%' имеет недопустимое расширение",
+    "File '%value%' has a false extension." => "Файл '%value%' имеет недопустимое расширение",
     "File '%value%' could not be found" => "Файл '%value%' не найден",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "MIME-тип '%type%' файла '%value%' недопустим",
-    "The mimetype of file '%value%' could not be detected" => "Не удается определить MIME-тип файла '%value%'",
+    "File '%value%' has a false mimetype of '%type%'." => "MIME-тип '%type%' файла '%value%' недопустим",
+    "The mimetype of file '%value%' could not be detected." => "Не удается определить MIME-тип файла '%value%'",
     "File '%value%' can not be read" => "Файл '%value%' не может быть прочитан",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "Файл '%value%' не существует",
+    "File '%value%' does not exist." => "Файл '%value%' не существует",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "Файл '%value%' имеет недопустимое расширение",
+    "File '%value%' has a false extension." => "Файл '%value%' имеет недопустимое расширение",
     "File '%value%' could not be found" => "Файл '%value%' не найден",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Общий размер файлов не должен превышать '%max%', сейчас - '%size%'",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Общий размер файлов не должен быть менее '%min%', сейчас - '%size%'",
-    "One or more files can not be read" => "Один или более файлов не могут быть прочитаны",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Общий размер файлов не должен превышать '%max%', сейчас - '%size%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Общий размер файлов не должен быть менее '%min%', сейчас - '%size%'",
+    "One or more files can not be read." => "Один или более файлов не могут быть прочитаны",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "Файл '%value%' не соответствует указанному хешу",
-    "A hash could not be evaluated for the given file" => "Хеш не может быть подсчитан для указанного файла",
+    "File '%value%' does not match the given hashes." => "Файл '%value%' не соответствует указанному хешу",
+    "A hash could not be evaluated for the given file." => "Хеш не может быть подсчитан для указанного файла",
     "File '%value%' could not be found" => "Файл '%value%' не найден",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Максимально разрешённая ширина изображения '%value%' должна быть '%maxwidth%', сейчас - '%width%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Минимально ожидаемая ширина изображения '%value%' должна быть '%minwidth%', сейчас - '%width%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Максимально разрешённая высота изображения '%value%' должна быть '%maxheight%', сейчас - '%height%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Минимально ожидаемая высота изображения '%value%' должна быть '%minheight%', сейчас - '%height%'",
-    "The size of image '%value%' could not be detected" => "Невозможно определить размер изображения '%value%'",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Максимально разрешённая ширина изображения '%value%' должна быть '%maxwidth%', сейчас - '%width%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Минимально ожидаемая ширина изображения '%value%' должна быть '%minwidth%', сейчас - '%width%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Максимально разрешённая высота изображения '%value%' должна быть '%maxheight%', сейчас - '%height%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Минимально ожидаемая высота изображения '%value%' должна быть '%minheight%', сейчас - '%height%'",
+    "The size of image '%value%' could not be detected." => "Невозможно определить размер изображения '%value%'",
     "File '%value%' can not be read" => "Файл '%value%' не может быть прочитан",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Файл '%value%' не является сжатым. MIME-тип файла - '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Не удается определить MIME-тип файла '%value%'",
+    "File '%value%' is not compressed, '%type%' detected." => "Файл '%value%' не является сжатым. MIME-тип файла - '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Не удается определить MIME-тип файла '%value%'",
     "File '%value%' can not be read" => "Файл '%value%' не может быть прочитан",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Файл '%value%' не является изображением. MIME-тип файла - '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Не удается определить MIME-тип файла '%value%'",
+    "File '%value%' is no image, '%type%' detected." => "Файл '%value%' не является изображением. MIME-тип файла - '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Не удается определить MIME-тип файла '%value%'",
     "File '%value%' can not be read" => "Файл '%value%' не может быть прочитан",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Файл '%value%' не соответствует указанному md5 хешу",
-    "A md5 hash could not be evaluated for the given file" => "md5 хеш не может быть вычислен для указанного файла",
+    "File '%value%' does not match the given md5 hashes." => "Файл '%value%' не соответствует указанному md5 хешу",
+    "A md5 hash could not be evaluated for the given file." => "md5 хеш не может быть вычислен для указанного файла",
     "File '%value%' could not be found" => "Файл '%value%' не найден",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "MIME-тип '%type%' файла '%value%' недопустим",
-    "The mimetype of file '%value%' could not be detected" => "Не удается определить MIME-тип файла '%value%'",
+    "File '%value%' has a false mimetype of '%type%'." => "MIME-тип '%type%' файла '%value%' недопустим",
+    "The mimetype of file '%value%' could not be detected." => "Не удается определить MIME-тип файла '%value%'",
     "File '%value%' can not be read" => "Файл '%value%' не может быть прочитан",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "Файл '%value%' уже существует",
+    "File '%value%' exists." => "Файл '%value%' уже существует",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Файл '%value%' не соответствует указаному хешу sha1",
-    "A sha1 hash could not be evaluated for the given file" => "Хеш sha1 не может быть подсчитан для указанного файла",
+    "File '%value%' does not match the given sha1 hashes." => "Файл '%value%' не соответствует указаному хешу sha1",
+    "A sha1 hash could not be evaluated for the given file." => "Хеш sha1 не может быть подсчитан для указанного файла",
     "File '%value%' could not be found" => "Файл '%value%' не найден",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Максимальный разрешенный размер файла '%value%' это '%max%', сейчас - '%size%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Минимальный разрешенный размер файла '%value%' это '%min%', сейчас - '%size%'",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Максимальный разрешенный размер файла '%value%' это '%max%', сейчас - '%size%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Минимальный разрешенный размер файла '%value%' это '%min%', сейчас - '%size%'",
     "File '%value%' could not be found" => "Файл '%value%' не найден",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Размер файла '%value%' превышает допустимый размер, указанный в php.ini",
-    "File '%value%' exceeds the defined form size" => "Размер файла '%value%' превышает допустимый размер, указанный в форме",
-    "File '%value%' was only partially uploaded" => "Файл '%value%' был загружен только частично",
-    "File '%value%' was not uploaded" => "Файл '%value%' не был загружен",
-    "No temporary directory was found for file '%value%'" => "Не найдена временная директория для файла '%value%'",
-    "File '%value%' can't be written" => "Файл '%value%' не может быть записан",
-    "A PHP extension returned an error while uploading the file '%value%'" => "PHP расширение возвратило ошибку во время загрузки файла '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Файл '%value%' загружен некорректно. Возможна атака",
-    "File '%value%' was not found" => "Файл '%value%' не найден",
-    "Unknown error while uploading file '%value%'" => "Произошла неизвестная ошибка во время загрузки файла '%value%'",
+    "File '%value%' exceeds the defined ini size." => "Размер файла '%value%' превышает допустимый размер, указанный в php.ini",
+    "File '%value%' exceeds the defined form size." => "Размер файла '%value%' превышает допустимый размер, указанный в форме",
+    "File '%value%' was only partially uploaded." => "Файл '%value%' был загружен только частично",
+    "File '%value%' was not uploaded." => "Файл '%value%' не был загружен",
+    "No temporary directory was found for file '%value%'." => "Не найдена временная директория для файла '%value%'",
+    "File '%value%' can't be written." => "Файл '%value%' не может быть записан",
+    "A PHP extension returned an error while uploading the file '%value%'." => "PHP расширение возвратило ошибку во время загрузки файла '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Файл '%value%' загружен некорректно. Возможна атака",
+    "File '%value%' was not found." => "Файл '%value%' не найден",
+    "Unknown error while uploading file '%value%'." => "Произошла неизвестная ошибка во время загрузки файла '%value%'",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Слишком много слов, разрешено максимум '%max%' слов, но сейчас - '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Слишком мало слов, разрешено минимум '%min%' слов, но сейчас - '%count%'",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Слишком много слов, разрешено максимум '%max%' слов, но сейчас - '%count%'",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Слишком мало слов, разрешено минимум '%min%' слов, но сейчас - '%count%'",
     "File '%value%' could not be found" => "Файл '%value%' не найден",
 
     // Zend_Validate_Float
     "Invalid type given, value should be float, string, or integer" => "Недопустимый тип данных, значение должно быть числом с плавающей точкой, строкой, или целым числом",
-    "'%value%' does not appear to be a float" => "'%value%' не является числом с плавающей точкой",
+    "'%value%' does not appear to be a float." => "'%value%' не является числом с плавающей точкой",
 
     // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' не превышает '%min%'",
+    "'%value%' is not greater than '%min%'." => "'%value%' не превышает '%min%'",
 
     // Zend_Validate_Hex
     "Invalid type given, value should be a string" => "Недопустимый тип данных, значение должно быть строкой",
-    "'%value%' has not only hexadecimal digit characters" => "Значение '%value%' должно содержать только шестнадцатиричные символы",
+    "'%value%' has not only hexadecimal digit characters." => "Значение '%value%' должно содержать только шестнадцатиричные символы",
 
     // Zend_Validate_Hostname
     "Invalid type given, value should be a string" => "Недопустимый тип данных, значение должно быть строкой",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "Значение '%value%' выглядит как IP-адрес, но IP-адреса не разрешены",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' выглядит как DNS имя хоста, но оно не дожно быть из списка доменов верхнего уровня",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' выглядит как DNS имя хоста, но знак '-' находится в недопустимом месте",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' выглядит как DNS имя хоста, но оно не соответствует шаблону для доменных имен верхнего уровня '%tld%'",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' выглядит как DNS имя хоста, но не удаётся извлечь домен верхнего уровня",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' не соответствует ожидаемой структуре для DNS имени хоста",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' является недопустимым локальным сетевым адресом",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' выглядит как локальный сетевой адрес, но локальные сетевые адреса не разрешены",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "'%value%' выглядит как DNS имя хоста, но указанное значение не может быть преобразованно в допустимый для DNS набор символов",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => "Значение '%value%' выглядит как IP-адрес, но IP-адреса не разрешены",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => "'%value%' выглядит как DNS имя хоста, но оно не дожно быть из списка доменов верхнего уровня",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => "'%value%' выглядит как DNS имя хоста, но знак '-' находится в недопустимом месте",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => "'%value%' выглядит как DNS имя хоста, но оно не соответствует шаблону для доменных имен верхнего уровня '%tld%'",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => "'%value%' выглядит как DNS имя хоста, но не удаётся извлечь домен верхнего уровня",
+    "'%value%' does not match the expected structure for a DNS hostname." => "'%value%' не соответствует ожидаемой структуре для DNS имени хоста",
+    "'%value%' does not appear to be a valid local network name." => "'%value%' является недопустимым локальным сетевым адресом",
+    "'%value%' appears to be a local network name but local network names are not allowed." => "'%value%' выглядит как локальный сетевой адрес, но локальные сетевые адреса не разрешены",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => "'%value%' выглядит как DNS имя хоста, но указанное значение не может быть преобразованно в допустимый для DNS набор символов",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "Не известная страна IBAN '%value%'",
-    "'%value%' has a false IBAN format" => "'%value%' имеет недопустимый IBAN формат",
-    "'%value%' has failed the IBAN check" => "'%value%' не прошло IBAN проверку",
+    "Unknown country within the IBAN '%value%'." => "Не известная страна IBAN '%value%'",
+    "'%value%' has a false IBAN format." => "'%value%' имеет недопустимый IBAN формат",
+    "'%value%' has failed the IBAN check." => "'%value%' не прошло IBAN проверку",
 
     // Zend_Validate_Identical
     "The token '%token%' does not match the given token '%value%'" => "Значение '%token%' не совпадает с указанным значением '%value%'",
-    "No token was provided to match against" => "Не было указано значение для проверки на идентичность",
+    "No token was provided to match against." => "Не было указано значение для проверки на идентичность",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "'%value%' не найдено в перечисленных допустимых значениях",
+    "'%value%' was not found in the haystack." => "'%value%' не найдено в перечисленных допустимых значениях",
 
     // Zend_Validate_Int
     "Invalid type given, value should be string or integer" => "Недопустимый тип данных, значение должно быть строкой или целым числом",
-    "'%value%' does not appear to be an integer" => "'%value%' не является целым числом",
+    "'%value%' does not appear to be an integer." => "'%value%' не является целым числом",
 
     // Zend_Validate_Ip
     "Invalid type given, value should be a string" => "Недопустимый тип данных, значение должно быть строкой",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' не является корректным IP-адресом",
+    "'%value%' does not appear to be a valid IP address." => "'%value%' не является корректным IP-адресом",
 
     // Zend_Validate_Isbn
-    "'%value%' is not a valid ISBN number" => "'%value%' не является корректным номером ISBN",
+    "'%value%' is not a valid ISBN number." => "'%value%' не является корректным номером ISBN",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' не меньше, чем '%max%'",
+    "'%value%' is not less than '%max%'." => "'%value%' не меньше, чем '%max%'",
 
     // Zend_Validate_NotEmpty
     "Invalid type given, value should be float, string, array, boolean or integer" => "Недопустимый тип данных, значение должно быть числом с плавающей точкой, строкой, массивом, булевым значением или целым числом",
-    "Value is required and can't be empty" => "Значение обязательно для заполнения и не может быть пустым",
+    "Value is required and can't be empty." => "Значение обязательно для заполнения и не может быть пустым",
 
     // Zend_Validate_PostCode
     "Invalid type given, value should be string or integer" => "Недопустимый тип данных, значение должно быть строкой или целым числом",
@@ -237,22 +237,22 @@ return array(
 
     // Zend_Validate_Regex
     "Invalid type given, value should be string, integer or float" => "Недопустимый тип данных, значение должно быть числом с плавающей точкой, строкой, или целым числом",
-    "'%value%' does not match against pattern '%pattern%'" => "'%value%' не соответствует шаблону '%pattern%'",
+    "'%value%' does not match against pattern '%pattern%'." => "'%value%' не соответствует шаблону '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => "'%value%' недопустимое значение для sitemap changefreq",
+    "'%value%' is not a valid sitemap changefreq." => "'%value%' недопустимое значение для sitemap changefreq",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => "'%value%' недопустимое значение для sitemap lastmod",
+    "'%value%' is not a valid sitemap lastmod." => "'%value%' недопустимое значение для sitemap lastmod",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => "'%value%' недопустимое значение для sitemap location",
+    "'%value%' is not a valid sitemap location." => "'%value%' недопустимое значение для sitemap location",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => "'%value%' недопустимое значение для sitemap priority",
+    "'%value%' is not a valid sitemap priority." => "'%value%' недопустимое значение для sitemap priority",
 
     // Zend_Validate_StringLength
     "Invalid type given, value should be a string" => "Недопустимый тип данных, значение должно быть строкой",
-    "'%value%' is less than %min% characters long" => "'%value%' меньше разрешенной минимальной длины в %min% символов",
-    "'%value%' is more than %max% characters long" => "'%value%' больше разрешенной максимальной длины в %max% символов",
+    "'%value%' is less than %min% characters long." => "'%value%' меньше разрешенной минимальной длины в %min% символов",
+    "'%value%' is more than %max% characters long." => "'%value%' больше разрешенной максимальной длины в %max% символов",
 );

--- a/resources/languages/se/Zend_Captcha.php
+++ b/resources/languages/se/Zend_Captcha.php
@@ -24,12 +24,12 @@
  */
 return array(
     // Zend_Captcha_ReCaptcha
-    "Missing captcha fields" => "Saknade captchafält",
-    "Failed to validate captcha" => "Misslyckades att validera captcha",
-    "Captcha value is wrong: %value%" => "Captchavärdet är felaktigt: %value%",
+    "Missing captcha fields." => "Saknade captchafält",
+    "Failed to validate captcha." => "Misslyckades att validera captcha",
+    "Captcha value is wrong: %value%." => "Captchavärdet är felaktigt: %value%",
 
     // Zend_Captcha_Word
-    "Empty captcha value" => "Tomt captchavärde",
-    "Captcha ID field is missing" => "Fältet för captcha ID saknas",
-    "Captcha value is wrong" => "Captchavärdet är felaktigt",
+    "Empty captcha value." => "Tomt captchavärde",
+    "Captcha ID field is missing." => "Fältet för captcha ID saknas",
+    "Captcha value is wrong." => "Captchavärdet är felaktigt",
 );

--- a/resources/languages/se/Zend_Validate.php
+++ b/resources/languages/se/Zend_Validate.php
@@ -24,242 +24,242 @@
  */
 return array(
     // Zend_Validate_Alnum
-    "Invalid type given. String, integer or float expected" => "Ogiltig typ given. Sträng, heltal eller flyttal förväntat",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' innehåller tecken som är icke-alfabetiska och inga siffror",
-    "'%value%' is an empty string" => "'%value%' är en tom sträng",
+    "Invalid type given. String, integer or float expected." => "Ogiltig typ given. Sträng, heltal eller flyttal förväntat",
+    "'%value%' contains characters which are non alphabetic and no digits." => "'%value%' innehåller tecken som är icke-alfabetiska och inga siffror",
+    "'%value%' is an empty string." => "'%value%' är en tom sträng",
 
     // Zend_Validate_Alpha
-    "Invalid type given. String expected" => "Ogiltig typ given. Sträng förväntad",
-    "'%value%' contains non alphabetic characters" => "'%value%' innehåller icke-alfabetiska tecken",
-    "'%value%' is an empty string" => "'%value%' är en tom sträng",
+    "Invalid type given. String expected." => "Ogiltig typ given. Sträng förväntad",
+    "'%value%' contains non alphabetic characters." => "'%value%' innehåller icke-alfabetiska tecken",
+    "'%value%' is an empty string." => "'%value%' är en tom sträng",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "Kontrollsummans validering för '%value%' misslyckades",
     "'%value%' contains invalid characters" => "'%value%' innehåller ogiltiga tecken",
     "'%value%' should have a length of %length% characters" => "'%value%' bör vara %length% tecken långt",
-    "Invalid type given. String expected" => "Ogiltig typ given. Sträng förväntad",
+    "Invalid type given. String expected." => "Ogiltig typ given. Sträng förväntad",
 
     // Zend_Validate_Between
     "'%value%' is not between '%min%' and '%max%', inclusively" => "'%value%' är inte mellan '%min%' och '%max%', inklusive",
     "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' är inte strikt mellan '%min%' och '%max%'",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "'%value%' är inte giltigt",
-    "An exception has been raised within the callback" => "Ett undantag har utlösts inom callbacken",
+    "'%value%' is not valid." => "'%value%' är inte giltigt",
+    "An exception has been raised within the callback." => "Ett undantag har utlösts inom callbacken",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' måste innehålla mellan 13 och 19 siffror",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Luhn-algorithmen (mod-10 kontrollsumma) misslyckades för '%value%'",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' måste innehålla mellan 13 och 19 siffror",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Luhn-algorithmen (mod-10 kontrollsumma) misslyckades för '%value%'",
 
     // Zend_Validate_CreditCard
-    "'%value%' seems to contain an invalid checksum" => "'%value%' tycks innehålla en ogiltig kontrollsumma",
-    "'%value%' must contain only digits" => "'%value%' får endast innehålla siffror",
-    "Invalid type given. String expected" => "Ogiltig typ given. Sträng förväntades",
-    "'%value%' contains an invalid amount of digits" => "'%value%' innehåller ett ogiltigt antal siffror",
-    "'%value%' is not from an allowed institute" => "'%value%' är inte från ett tillåtet institut",
+    "'%value%' seems to contain an invalid checksum." => "'%value%' tycks innehålla en ogiltig kontrollsumma",
+    "'%value%' must contain only digits." => "'%value%' får endast innehålla siffror",
+    "Invalid type given. String expected." => "Ogiltig typ given. Sträng förväntades",
+    "'%value%' contains an invalid amount of digits." => "'%value%' innehåller ett ogiltigt antal siffror",
+    "'%value%' is not from an allowed institute." => "'%value%' är inte från ett tillåtet institut",
     "'%value%' seems to be an invalid creditcard number" => "'%value%' tycks vara ett ogiltigt kreditkortsnummer",
-    "An exception has been raised while validating '%value%'" => "Ett undantag har utlösts under valideringen av '%value%'",
+    "An exception has been raised while validating '%value%'." => "Ett undantag har utlösts under valideringen av '%value%'",
 
     // Zend_Validate_Date
-    "Invalid type given. String, integer, array or Zend_Date expected" => "Ogiltig typ given. Sträng, heltal, array eller Zend_Date förväntat",
-    "'%value%' does not appear to be a valid date" => "'%value%' tycks inte vara ett giltigt datum",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' passar inte datumformatet '%format%'",
+    "Invalid type given. String, integer, array or Zend_Date expected." => "Ogiltig typ given. Sträng, heltal, array eller Zend_Date förväntat",
+    "'%value%' does not appear to be a valid date." => "'%value%' tycks inte vara ett giltigt datum",
+    "'%value%' does not fit the date format '%format%'." => "'%value%' passar inte datumformatet '%format%'",
 
     // Zend_Validate_Db_Abstract
-    "No record matching '%value%' was found" => "Ingen post som matchar '%value%' kunde hittas",
-    "A record matching '%value%' was found" => "En post som matchar '%value%' hittades",
+    "No record matching '%value%' was found." => "Ingen post som matchar '%value%' kunde hittas",
+    "A record matching '%value%' was found." => "En post som matchar '%value%' hittades",
 
     // Zend_Validate_Digits
-    "Invalid type given. String, integer or float expected" => "Ogiltig typ given. Sträng, heltal eller flyttal förväntat",
-    "'%value%' must contain only digits" => "'%value%' får enbart innehålla siffror",
-    "'%value%' is an empty string" => "'%value%' är en tom sträng",
+    "Invalid type given. String, integer or float expected." => "Ogiltig typ given. Sträng, heltal eller flyttal förväntat",
+    "'%value%' must contain only digits." => "'%value%' får enbart innehålla siffror",
+    "'%value%' is an empty string." => "'%value%' är en tom sträng",
 
     // Zend_Validate_EmailAddress
-    "Invalid type given. String expected" => "Ogiltig typ given. Sträng förväntades",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' är inte en giltig e-postadress på standardformatet lokal-del@värdnamn",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' är inte ett giltigt värdnamn för en e-postadress '%value%'",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' tycks inte ha en giltig MX-post för e-postadressen '%value%'",
-    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network" => "'%hostname%' är inte ett dirigerbart nätverkssegment. E-postadressen '%value%' bör inte lösas ut från det publika nätverket",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' kunde inte matchas mot dot-atom formatet",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' kan inte matchas mot quoted-string formatet",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' är inte en giltig lokal del för e-postadressen '%value%'",
-    "'%value%' exceeds the allowed length" => "'%value%' överskrider den tillåtna längden",
+    "Invalid type given. String expected." => "Ogiltig typ given. Sträng förväntades",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "'%value%' är inte en giltig e-postadress på standardformatet lokal-del@värdnamn",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "'%hostname%' är inte ett giltigt värdnamn för en e-postadress '%value%'",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "'%hostname%' tycks inte ha en giltig MX-post för e-postadressen '%value%'",
+    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' är inte ett dirigerbart nätverkssegment. E-postadressen '%value%' bör inte lösas ut från det publika nätverket",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' kunde inte matchas mot dot-atom formatet",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' kan inte matchas mot quoted-string formatet",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "'%localPart%' är inte en giltig lokal del för e-postadressen '%value%'",
+    "'%value%' exceeds the allowed length." => "'%value%' överskrider den tillåtna längden",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "För många filer, maximalt '%max%' är tillåtna men '%count%' är angivna",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "För få filer, minst '%min%' förväntas men '%count%' är angivna",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "För många filer, maximalt '%max%' är tillåtna men '%count%' är angivna",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "För få filer, minst '%min%' förväntas men '%count%' är angivna",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Filen '%value%' matchar inte de givna crc32-hasharna",
-    "A crc32 hash could not be evaluated for the given file" => "En crc32-hash kunde inte utvärderas för den angivna filen",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' är inte läsbar eller existerar inte",
+    "File '%value%' does not match the given crc32 hashes." => "Filen '%value%' matchar inte de givna crc32-hasharna",
+    "A crc32 hash could not be evaluated for the given file." => "En crc32-hash kunde inte utvärderas för den angivna filen",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' är inte läsbar eller existerar inte",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Filen '%value%' har en felaktig filändelse",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' är inte läsbar eller existerar inte",
+    "File '%value%' has a false extension." => "Filen '%value%' har en felaktig filändelse",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' är inte läsbar eller existerar inte",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Filen '%value%' har mime-typen '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Mime-typen för filen '%value%' kunde inte detekteras",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' är inte läsbar eller existerar inte",
+    "File '%value%' has a false mimetype of '%type%'." => "Filen '%value%' har mime-typen '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Mime-typen för filen '%value%' kunde inte detekteras",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' är inte läsbar eller existerar inte",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "Filen '%value%' existerar inte",
+    "File '%value%' does not exist." => "Filen '%value%' existerar inte",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "Filen '%value%' har en felaktig filändelse",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' är inte läsbar eller existerar inte",
+    "File '%value%' has a false extension." => "Filen '%value%' har en felaktig filändelse",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' är inte läsbar eller existerar inte",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Alla filer bör totalt ha en maximal storlek av '%max%' men '%size%' upptäcktes",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Alla filer bör totalt ha en minimal storlek av '%min%' men '%size%' upptäcktes",
-    "One or more files can not be read" => "En eller flera filer kunde inte läsas",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Alla filer bör totalt ha en maximal storlek av '%max%' men '%size%' upptäcktes",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Alla filer bör totalt ha en minimal storlek av '%min%' men '%size%' upptäcktes",
+    "One or more files can not be read." => "En eller flera filer kunde inte läsas",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "Filen '%value%' matchar inte de givna hasharna",
-    "A hash could not be evaluated for the given file" => "En hash kunde inte utvärderas för den angivna filen",
-    "File '%value%' is not readable or does not exist" => "Filebn '%value%' är inte läsbar eller existerar inte",
+    "File '%value%' does not match the given hashes." => "Filen '%value%' matchar inte de givna hasharna",
+    "A hash could not be evaluated for the given file." => "En hash kunde inte utvärderas för den angivna filen",
+    "File '%value%' is not readable or does not exist." => "Filebn '%value%' är inte läsbar eller existerar inte",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Maximal tillåten bredd för bilden '%value%' är '%maxwidth%' men '%width%' upptäcktes",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Minimal förväntad bredd för bilden '%value%' är '%minwidth%' men '%width%' upptäcktes",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Maximal tillåten höjd för '%value%' är '%maxheight%' men '%height%' upptäcktes",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Minimal förväntad höjd för bilden '%value%' är '%minheight%' men '%height%' upptäcktes",
-    "The size of image '%value%' could not be detected" => "Storleken på bilden '%value%' kunde inte detekteras",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' är inte läsbar eller existerar inte",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Maximal tillåten bredd för bilden '%value%' är '%maxwidth%' men '%width%' upptäcktes",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Minimal förväntad bredd för bilden '%value%' är '%minwidth%' men '%width%' upptäcktes",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Maximal tillåten höjd för '%value%' är '%maxheight%' men '%height%' upptäcktes",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Minimal förväntad höjd för bilden '%value%' är '%minheight%' men '%height%' upptäcktes",
+    "The size of image '%value%' could not be detected." => "Storleken på bilden '%value%' kunde inte detekteras",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' är inte läsbar eller existerar inte",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Filen '%value%' är inte komprimerad, '%type%' upptäcktes",
-    "The mimetype of file '%value%' could not be detected" => "Mime-typen för filen '%value%' kunde inte detekteras",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' är inte läsbar eller existerar inte",
+    "File '%value%' is not compressed, '%type%' detected." => "Filen '%value%' är inte komprimerad, '%type%' upptäcktes",
+    "The mimetype of file '%value%' could not be detected." => "Mime-typen för filen '%value%' kunde inte detekteras",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' är inte läsbar eller existerar inte",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Filen '%value%' är ingen bild, '%type%' upptäcktes",
-    "The mimetype of file '%value%' could not be detected" => "Mime-typen för filen '%value%' kunde inte detekteras",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' är inte läsbar eller existerar inte",
+    "File '%value%' is no image, '%type%' detected." => "Filen '%value%' är ingen bild, '%type%' upptäcktes",
+    "The mimetype of file '%value%' could not be detected." => "Mime-typen för filen '%value%' kunde inte detekteras",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' är inte läsbar eller existerar inte",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Filen '%value%' matchar inte de givna md5-hasharna",
-    "A md5 hash could not be evaluated for the given file" => "En md5-hash kunde inte utvärderas för den angivna filen",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' är inte läsbar eller existerar inte",
+    "File '%value%' does not match the given md5 hashes." => "Filen '%value%' matchar inte de givna md5-hasharna",
+    "A md5 hash could not be evaluated for the given file." => "En md5-hash kunde inte utvärderas för den angivna filen",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' är inte läsbar eller existerar inte",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Filen '%value%' har en felaktig mime-typ av '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Mime-typen för filen '%value%' kunde inte detekteras",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' är inte läsbar eller existerar inte",
+    "File '%value%' has a false mimetype of '%type%'." => "Filen '%value%' har en felaktig mime-typ av '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Mime-typen för filen '%value%' kunde inte detekteras",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' är inte läsbar eller existerar inte",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "Filen '%value%' existerar",
+    "File '%value%' exists." => "Filen '%value%' existerar",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Filen '%value%' matchar inte de givna sha1-hasharna",
-    "A sha1 hash could not be evaluated for the given file" => "En sha1-hash kunde inte utvärderas för den angivna filen",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' är inte läsbar eller existerar inte",
+    "File '%value%' does not match the given sha1 hashes." => "Filen '%value%' matchar inte de givna sha1-hasharna",
+    "A sha1 hash could not be evaluated for the given file." => "En sha1-hash kunde inte utvärderas för den angivna filen",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' är inte läsbar eller existerar inte",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Maximal tillåten storlek för filen '%value%' är '%max%' men '%size%' upptäcktes",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Minimal förväntad storlek för filen '%value%' är '%min%' men '%size%' upptäcktes",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' är inte läsbar eller existerar inte",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Maximal tillåten storlek för filen '%value%' är '%max%' men '%size%' upptäcktes",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Minimal förväntad storlek för filen '%value%' är '%min%' men '%size%' upptäcktes",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' är inte läsbar eller existerar inte",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Filen '%value%' överskrider den definerade ini-storleken",
-    "File '%value%' exceeds the defined form size" => "Filen '%value%' överskrider den definerade formulär-storleken",
-    "File '%value%' was only partially uploaded" => "Filen '%value%' blev enbart delvis uppladdad",
-    "File '%value%' was not uploaded" => "Filen '%value%' laddades inte upp",
-    "No temporary directory was found for file '%value%'" => "Ingen temporär folder hittades för filen '%value%'",
-    "File '%value%' can't be written" => "Filen '%value%' kan inte skrivas",
-    "A PHP extension returned an error while uploading the file '%value%'" => "Ett PHP-tillägg returnerade ett fel när filen '%value%' laddades upp",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Filen '%value%' laddades upp olagligt. Det här kan vara en möjlig attack",
-    "File '%value%' was not found" => "Filen '%value%' hittades inte",
-    "Unknown error while uploading file '%value%'" => "Okänt fel när filen '%value%' laddades upp",
+    "File '%value%' exceeds the defined ini size." => "Filen '%value%' överskrider den definerade ini-storleken",
+    "File '%value%' exceeds the defined form size." => "Filen '%value%' överskrider den definerade formulär-storleken",
+    "File '%value%' was only partially uploaded." => "Filen '%value%' blev enbart delvis uppladdad",
+    "File '%value%' was not uploaded." => "Filen '%value%' laddades inte upp",
+    "No temporary directory was found for file '%value%'." => "Ingen temporär folder hittades för filen '%value%'",
+    "File '%value%' can't be written." => "Filen '%value%' kan inte skrivas",
+    "A PHP extension returned an error while uploading the file '%value%'." => "Ett PHP-tillägg returnerade ett fel när filen '%value%' laddades upp",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Filen '%value%' laddades upp olagligt. Det här kan vara en möjlig attack",
+    "File '%value%' was not found." => "Filen '%value%' hittades inte",
+    "Unknown error while uploading file '%value%'." => "Okänt fel när filen '%value%' laddades upp",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "För många ord, maximalt '%max%' är tillåtna men '%count%' räknades",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "För få ord, minimalt '%min%' förväntas men '%count%' räknades",
-    "File '%value%' is not readable or does not exist" => "Filen '%value%' är inte läsbar eller existerar inte",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "För många ord, maximalt '%max%' är tillåtna men '%count%' räknades",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "För få ord, minimalt '%min%' förväntas men '%count%' räknades",
+    "File '%value%' is not readable or does not exist." => "Filen '%value%' är inte läsbar eller existerar inte",
 
     // Zend_Validate_Float
-    "Invalid type given. String, integer or float expected" => "Ogiltig typ given. Sträng, heltal eller flyttal förväntat",
-    "'%value%' does not appear to be a float" => "'%value%' tycks inte vara ett flyttal",
+    "Invalid type given. String, integer or float expected." => "Ogiltig typ given. Sträng, heltal eller flyttal förväntat",
+    "'%value%' does not appear to be a float." => "'%value%' tycks inte vara ett flyttal",
 
     // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' är inte större än '%min%'",
+    "'%value%' is not greater than '%min%'." => "'%value%' är inte större än '%min%'",
 
     // Zend_Validate_Hex
-    "Invalid type given. String expected" => "Ogiltig typ given. Sträng förväntad",
-    "'%value%' has not only hexadecimal digit characters" => "'%value%' har inte enbart hexadecimala siffertecken",
+    "Invalid type given. String expected." => "Ogiltig typ given. Sträng förväntad",
+    "'%value%' has not only hexadecimal digit characters." => "'%value%' har inte enbart hexadecimala siffertecken",
 
     // Zend_Validate_Hostname
-    "Invalid type given. String expected" => "Ogiltig typ given. Sträng förväntad",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "'%value%' tycks vara en IP-adress, men IP-adresses är inte tillåtna",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' tycks vara ett DNS-värdnamn men kan inte matcha TLDn mot listan med kända",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' tycks vara ett DNS-värdnamn men innehåller ett bindestreck på en ogiltig position",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' tycks vara ett DNS-värdnamn men kan inte matcha mot värdnamnsschemat för TLDn '%tld%'",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' tycks vara ett DNS-värdnamn men kan inte extrahera TLD-delen",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' tycks inte matcha den förväntade strukturen för ett DNS-värdnamn",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' tycks inte vara ett giltigt lokalt nätverksnamn",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' tycks vara ett lokalt nätverksnamn men lokala nätverksnamn är inte tillåtna",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "'%value%' tycks vara ett DNS-värdnamn men den angivna punycode-notationen kan inte avkodas",
-    "'%value%' does not appear to be a valid URI hostname" => "'%value%' tycks inte vara ett giltigt URI-värdnamn",
+    "Invalid type given. String expected." => "Ogiltig typ given. Sträng förväntad",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => "'%value%' tycks vara en IP-adress, men IP-adresses är inte tillåtna",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => "'%value%' tycks vara ett DNS-värdnamn men kan inte matcha TLDn mot listan med kända",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => "'%value%' tycks vara ett DNS-värdnamn men innehåller ett bindestreck på en ogiltig position",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => "'%value%' tycks vara ett DNS-värdnamn men kan inte matcha mot värdnamnsschemat för TLDn '%tld%'",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => "'%value%' tycks vara ett DNS-värdnamn men kan inte extrahera TLD-delen",
+    "'%value%' does not match the expected structure for a DNS hostname." => "'%value%' tycks inte matcha den förväntade strukturen för ett DNS-värdnamn",
+    "'%value%' does not appear to be a valid local network name." => "'%value%' tycks inte vara ett giltigt lokalt nätverksnamn",
+    "'%value%' appears to be a local network name but local network names are not allowed." => "'%value%' tycks vara ett lokalt nätverksnamn men lokala nätverksnamn är inte tillåtna",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => "'%value%' tycks vara ett DNS-värdnamn men den angivna punycode-notationen kan inte avkodas",
+    "'%value%' does not appear to be a valid URI hostname." => "'%value%' tycks inte vara ett giltigt URI-värdnamn",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "Okänd land i IBAN-numret '%value%'",
-    "'%value%' has a false IBAN format" => "'%value%' har ett felaktigt IBAN-format",
-    "'%value%' has failed the IBAN check" => "IBAN-kontrollen har misslyckats för '%value%'",
+    "Unknown country within the IBAN '%value%'." => "Okänd land i IBAN-numret '%value%'",
+    "'%value%' has a false IBAN format." => "'%value%' har ett felaktigt IBAN-format",
+    "'%value%' has failed the IBAN check." => "IBAN-kontrollen har misslyckats för '%value%'",
 
     // Zend_Validate_Identical
-    "The two given tokens do not match" => "De två angivna symbolerna matchar inte varandra",
-    "No token was provided to match against" => "Ingen symbol angavs att matcha mot",
+    "The two given tokens do not match." => "De två angivna symbolerna matchar inte varandra",
+    "No token was provided to match against." => "Ingen symbol angavs att matcha mot",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "'%value%' hittades inte i höstacken",
+    "'%value%' was not found in the haystack." => "'%value%' hittades inte i höstacken",
 
     // Zend_Validate_Int
-    "Invalid type given. String or integer expected" => "Ogiltig typ given. Sträng eller heltal förväntat",
-    "'%value%' does not appear to be an integer" => "'%value%' tycks inte vara ett heltal",
+    "Invalid type given. String or integer expected." => "Ogiltig typ given. Sträng eller heltal förväntat",
+    "'%value%' does not appear to be an integer." => "'%value%' tycks inte vara ett heltal",
 
     // Zend_Validate_Ip
-    "Invalid type given. String expected" => "Ogiltig typ given. Sträng förväntad",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' tycks inte vara en giltig IP-adress",
+    "Invalid type given. String expected." => "Ogiltig typ given. Sträng förväntad",
+    "'%value%' does not appear to be a valid IP address." => "'%value%' tycks inte vara en giltig IP-adress",
 
     // Zend_Validate_Isbn
-    "Invalid type given. String or integer expected" => "Ogiltig typ given. Sträng eller heltal förväntat",
-    "'%value%' is not a valid ISBN number" => "'%value%' är inte ett giltigt ISBN-nummer",
+    "Invalid type given. String or integer expected." => "Ogiltig typ given. Sträng eller heltal förväntat",
+    "'%value%' is not a valid ISBN number." => "'%value%' är inte ett giltigt ISBN-nummer",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' är inte lägre än '%max%'",
+    "'%value%' is not less than '%max%'." => "'%value%' är inte lägre än '%max%'",
 
     // Zend_Validate_NotEmpty
-    "Invalid type given. String, integer, float, boolean or array expected" => "Ogiltig typ given. Sträng, heltal, flyttal, boolean eller array förväntad",
-    "Value is required and can't be empty" => "Värdet krävs och kan inte vara tomt",
+    "Invalid type given. String, integer, float, boolean or array expected." => "Ogiltig typ given. Sträng, heltal, flyttal, boolean eller array förväntad",
+    "Value is required and can't be empty." => "Värdet krävs och kan inte vara tomt",
 
     // Zend_Validate_PostCode
-    "Invalid type given. String or integer expected" => "Ogiltig typ given. Sträng eller heltal förväntat",
-    "'%value%' does not appear to be a postal code" => "'%value%' tycks inte vara ett postnummer",
+    "Invalid type given. String or integer expected." => "Ogiltig typ given. Sträng eller heltal förväntat",
+    "'%value%' does not appear to be a postal code." => "'%value%' tycks inte vara ett postnummer",
 
     // Zend_Validate_Regex
-    "Invalid type given. String, integer or float expected" => "Ogiltig typ given. Sträng, heltal eller flyttal förväntat",
-    "'%value%' does not match against pattern '%pattern%'" => "'%value%' matchar inte mönstret '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "Det uppstod ett internt serverfel när mönstret '%pattern%' användes",
+    "Invalid type given. String, integer or float expected." => "Ogiltig typ given. Sträng, heltal eller flyttal förväntat",
+    "'%value%' does not match against pattern '%pattern%'." => "'%value%' matchar inte mönstret '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "Det uppstod ett internt serverfel när mönstret '%pattern%' användes",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => "'%value%' är inte en giltig 'changefreq' för sajtkartor",
-    "Invalid type given. String expected" => "Ogiltig typ given. Sträng förväntad",
+    "'%value%' is not a valid sitemap changefreq." => "'%value%' är inte en giltig 'changefreq' för sajtkartor",
+    "Invalid type given. String expected." => "Ogiltig typ given. Sträng förväntad",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => "'%value%' är inte en giltig 'lastmod' för sajtkartor",
-    "Invalid type given. String expected" => "Ogiltig typ given. Sträng förväntad",
+    "'%value%' is not a valid sitemap lastmod." => "'%value%' är inte en giltig 'lastmod' för sajtkartor",
+    "Invalid type given. String expected." => "Ogiltig typ given. Sträng förväntad",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => "'%value%' är inte en giltig 'location' för sajtkartor",
-    "Invalid type given. String expected" => "Ogiltig typ given. Sträng förväntad",
+    "'%value%' is not a valid sitemap location." => "'%value%' är inte en giltig 'location' för sajtkartor",
+    "Invalid type given. String expected." => "Ogiltig typ given. Sträng förväntad",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => "'%value%' är inte en giltig 'priority' för sajtkartor",
-    "Invalid type given. Numeric string, integer or float expected" => "Ogiltig typ given. Sträng, heltal eller flyttal förväntat",
+    "'%value%' is not a valid sitemap priority." => "'%value%' är inte en giltig 'priority' för sajtkartor",
+    "Invalid type given. Numeric string, integer or float expected." => "Ogiltig typ given. Sträng, heltal eller flyttal förväntat",
 
     // Zend_Validate_StringLength
-    "Invalid type given. String expected" => "Ogiltig typ given. Sträng förväntad",
-    "'%value%' is less than %min% characters long" => "'%value%' är mindre än %min% tecken lång",
-    "'%value%' is more than %max% characters long" => "'%value%' är mer än %max% tecken lång",
+    "Invalid type given. String expected." => "Ogiltig typ given. Sträng förväntad",
+    "'%value%' is less than %min% characters long." => "'%value%' är mindre än %min% tecken lång",
+    "'%value%' is more than %max% characters long." => "'%value%' är mer än %max% tecken lång",
 );

--- a/resources/languages/sk/Zend_Captcha.php
+++ b/resources/languages/sk/Zend_Captcha.php
@@ -24,12 +24,12 @@
  */
 return array(
     // Zend_Captcha_ReCaptcha
-    "Missing captcha fields" => "Chýba captcha pole",
-    "Failed to validate captcha" => "Captchu sa nepodarilo overiť",
-    "Captcha value is wrong: %value%" => "Hodnota captchy neni správna: %value%",
+    "Missing captcha fields." => "Chýba captcha pole",
+    "Failed to validate captcha." => "Captchu sa nepodarilo overiť",
+    "Captcha value is wrong: %value%." => "Hodnota captchy neni správna: %value%",
 
     // Zend_Captcha_Word
-    "Empty captcha value" => "Hodnota captchy nebola zadaná",
-    "Captcha ID field is missing" => "Chýba pole captcha ID",
-    "Captcha value is wrong" => "Chybná hodnota catpcha",
+    "Empty captcha value." => "Hodnota captchy nebola zadaná",
+    "Captcha ID field is missing." => "Chýba pole captcha ID",
+    "Captcha value is wrong." => "Chybná hodnota catpcha",
 );

--- a/resources/languages/sk/Zend_Validate.php
+++ b/resources/languages/sk/Zend_Validate.php
@@ -24,242 +24,242 @@
  */
 return array(
     // Zend_Validate_Alnum
-    "Invalid type given. String, integer or float expected" => "Chybný typ. Bol očakávaný reťazec, celé alebo desatinné číslo",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' obsahuje aj iné znaky ako písmená a číslice",
-    "'%value%' is an empty string" => "'%value%' je prázdny reťazec",
+    "Invalid type given. String, integer or float expected." => "Chybný typ. Bol očakávaný reťazec, celé alebo desatinné číslo",
+    "'%value%' contains characters which are non alphabetic and no digits." => "'%value%' obsahuje aj iné znaky ako písmená a číslice",
+    "'%value%' is an empty string." => "'%value%' je prázdny reťazec",
 
     // Zend_Validate_Alpha
-    "Invalid type given. String expected" => "Chybný typ. Bol očakávaný reťazec",
-    "'%value%' contains non alphabetic characters" => "'%value%' obsahuje aj iné znaky ako písmená",
-    "'%value%' is an empty string" => "'%value%' je prázdny reťazec",
+    "Invalid type given. String expected." => "Chybný typ. Bol očakávaný reťazec",
+    "'%value%' contains non alphabetic characters." => "'%value%' obsahuje aj iné znaky ako písmená",
+    "'%value%' is an empty string." => "'%value%' je prázdny reťazec",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "'%value%' má chybný kontrolný súčet",
     "'%value%' contains invalid characters" => "'%value%' obsahuje neplatné znaky",
     "'%value%' should have a length of %length% characters" => "'%value%' by mal mať dĺžku %length% znakov",
-    "Invalid type given. String expected" => "Chybný typ. Bol očakávaný reťazec.",
+    "Invalid type given. String expected." => "Chybný typ. Bol očakávaný reťazec.",
 
     // Zend_Validate_Between
     "'%value%' is not between '%min%' and '%max%', inclusively" => "'%value%' nie je medzi '%min%' a '%max%', vrátane",
     "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' nie je ostro medzi '%min%' a '%max%'",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "Hodnota '%value%' nie je platná",
-    "An exception has been raised within the callback" => "Počas volania bola vyvolaná výnimka",
+    "'%value%' is not valid." => "Hodnota '%value%' nie je platná",
+    "An exception has been raised within the callback." => "Počas volania bola vyvolaná výnimka",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' musí obsahovať 13 až 19 číslic",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Luhnov algoritmus (kontrolný súčet mod-10) nevyšiel pre '%value%'",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' musí obsahovať 13 až 19 číslic",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Luhnov algoritmus (kontrolný súčet mod-10) nevyšiel pre '%value%'",
 
     // Zend_Validate_CreditCard
-    "'%value%' seems to contain an invalid checksum" => "'%value%' obsahuje neplatný kontrolný súčet",
-    "'%value%' must contain only digits" => "'%value%' musí obsahovať iba čísla",
-    "Invalid type given. String expected" => "Chybný typ. Bol očakávaný reťazec",
-    "'%value%' contains an invalid amount of digits" => "'%value%' obsahuje neplatný počet číslic",
-    "'%value%' is not from an allowed institute" => "'%value%' nie je od povolenej spoločnosti",
+    "'%value%' seems to contain an invalid checksum." => "'%value%' obsahuje neplatný kontrolný súčet",
+    "'%value%' must contain only digits." => "'%value%' musí obsahovať iba čísla",
+    "Invalid type given. String expected." => "Chybný typ. Bol očakávaný reťazec",
+    "'%value%' contains an invalid amount of digits." => "'%value%' obsahuje neplatný počet číslic",
+    "'%value%' is not from an allowed institute." => "'%value%' nie je od povolenej spoločnosti",
     "'%value%' seems to be an invalid creditcard number" => "'%value%' nie je platné číslo kreditnej karty",
-    "An exception has been raised while validating '%value%'" => "Počas validácie '%value%' bola vyvoláná výnimka",
+    "An exception has been raised while validating '%value%'." => "Počas validácie '%value%' bola vyvoláná výnimka",
 
     // Zend_Validate_Date
-    "Invalid type given. String, integer, array or Zend_Date expected" => "Chybný typ. Bol očakávaný reťazec, číslo, pole, alebo Zend_Date",
-    "'%value%' does not appear to be a valid date" => "'%value%' nie je platný dátum",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' nezodpovedá formátu dátumu '%format%'",
+    "Invalid type given. String, integer, array or Zend_Date expected." => "Chybný typ. Bol očakávaný reťazec, číslo, pole, alebo Zend_Date",
+    "'%value%' does not appear to be a valid date." => "'%value%' nie je platný dátum",
+    "'%value%' does not fit the date format '%format%'." => "'%value%' nezodpovedá formátu dátumu '%format%'",
 
     // Zend_Validate_Db_Abstract
-    "No record matching '%value%' was found" => "Nebol nájdený žiadny záznam zodpovedajúci '%value%'",
-    "A record matching '%value%' was found" => "Bol nájdený záznam zodpovedajúci '%value%'",
+    "No record matching '%value%' was found." => "Nebol nájdený žiadny záznam zodpovedajúci '%value%'",
+    "A record matching '%value%' was found." => "Bol nájdený záznam zodpovedajúci '%value%'",
 
     // Zend_Validate_Digits
-    "Invalid type given. String, integer or float expected" => "Chybný typ. Bol očakávaný reťazec, celé alebo desatinné číslo",
-    "'%value%' must contain only digits" => "'%value%' musí obsahovať len číslice",
-    "'%value%' is an empty string" => "'%value%' je prázdny reťazec",
+    "Invalid type given. String, integer or float expected." => "Chybný typ. Bol očakávaný reťazec, celé alebo desatinné číslo",
+    "'%value%' must contain only digits." => "'%value%' musí obsahovať len číslice",
+    "'%value%' is an empty string." => "'%value%' je prázdny reťazec",
 
     // Zend_Validate_EmailAddress
-    "Invalid type given. String expected" => "Chybný typ. Bol očakávaný reťazec",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' nie je platná e-mailová adresa vo formáte local-part@hostname",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' nie je platný hostname pre emailovú adresu '%value%'",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' neobsahuje platný MX záznam pre e-mailovú adresu '%value%'",
-    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network" => "'%hostname%' nie je v smerovateľnom úseku sieťe. E-mailová adresa '%value%' by nemala byť požadovaná z verejnej siete",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' nemôže byť porovnaný voči dot-atom formátu",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' nemôže byť porovnaný voči quoted-string formátu",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' nie je platná 'local part' pre e-mailovú adresu '%value%'",
-    "'%value%' exceeds the allowed length" => "'%value%' prekročil povolenú dĺžku",
+    "Invalid type given. String expected." => "Chybný typ. Bol očakávaný reťazec",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "'%value%' nie je platná e-mailová adresa vo formáte local-part@hostname",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "'%hostname%' nie je platný hostname pre emailovú adresu '%value%'",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "'%hostname%' neobsahuje platný MX záznam pre e-mailovú adresu '%value%'",
+    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' nie je v smerovateľnom úseku sieťe. E-mailová adresa '%value%' by nemala byť požadovaná z verejnej siete",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' nemôže byť porovnaný voči dot-atom formátu",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' nemôže byť porovnaný voči quoted-string formátu",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "'%localPart%' nie je platná 'local part' pre e-mailovú adresu '%value%'",
+    "'%value%' exceeds the allowed length." => "'%value%' prekročil povolenú dĺžku",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Príliš veľa súborov. Maximum je '%max%', ale bolo zadaných '%count%'",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Príliš málo súborov. Minimum je '%min%', ale bol zadaný len '%count%'",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Príliš veľa súborov. Maximum je '%max%', ale bolo zadaných '%count%'",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Príliš málo súborov. Minimum je '%min%', ale bol zadaný len '%count%'",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Súbor '%value%' nezodpovedá zadanému crc32 hashu",
-    "A crc32 hash could not be evaluated for the given file" => "Pre zadaný súbor nemohol byť vypočítaný crc32 hash",
-    "File '%value%' is not readable or does not exist" => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
+    "File '%value%' does not match the given crc32 hashes." => "Súbor '%value%' nezodpovedá zadanému crc32 hashu",
+    "A crc32 hash could not be evaluated for the given file." => "Pre zadaný súbor nemohol byť vypočítaný crc32 hash",
+    "File '%value%' is not readable or does not exist." => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Súbor '%value%' má nesprávnu príponu",
-    "File '%value%' is not readable or does not exist" => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
+    "File '%value%' has a false extension." => "Súbor '%value%' má nesprávnu príponu",
+    "File '%value%' is not readable or does not exist." => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "File '%value%' has a false mimetype of '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Mimetyp súboru '%value%' nebolo možné zistiť",
-    "File '%value%' is not readable or does not exist" => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
+    "File '%value%' has a false mimetype of '%type%'." => "File '%value%' has a false mimetype of '%type%'.",
+    "The mimetype of file '%value%' could not be detected." => "Mimetyp súboru '%value%' nebolo možné zistiť",
+    "File '%value%' is not readable or does not exist." => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "Súbor '%value%' neexistuje",
+    "File '%value%' does not exist." => "Súbor '%value%' neexistuje",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "Súbor '%value%' má nesprávnu príponu",
-    "File '%value%' is not readable or does not exist" => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
+    "File '%value%' has a false extension." => "Súbor '%value%' má nesprávnu príponu",
+    "File '%value%' is not readable or does not exist." => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Súčet veľkostí všetkých súborov by mal byť maximálne '%max%', ale je '%size%'",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Súčet veľkostí všetkých súborov by mal byť najmenej '%min%', ale je '%size%'",
-    "One or more files can not be read" => "Jeden, alebo viac súborov nie je možné načítať",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Súčet veľkostí všetkých súborov by mal byť maximálne '%max%', ale je '%size%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Súčet veľkostí všetkých súborov by mal byť najmenej '%min%', ale je '%size%'",
+    "One or more files can not be read." => "Jeden, alebo viac súborov nie je možné načítať",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "Súbor '%value%' nezodpovedá danému hashu",
-    "A hash could not be evaluated for the given file" => "Hash nemohol byť pre daný súbor vypočítaný",
-    "File '%value%' is not readable or does not exist" => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
+    "File '%value%' does not match the given hashes." => "Súbor '%value%' nezodpovedá danému hashu",
+    "A hash could not be evaluated for the given file." => "Hash nemohol byť pre daný súbor vypočítaný",
+    "File '%value%' is not readable or does not exist." => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Maximálna šírka obrázku '%value%' by mala byť '%maxwidth%', ale je '%width%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Minimálna šírka obrázku '%value%' by mala byť '%minwidth%', ale je '%width%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Maximálna výška obrázku '%value%' by mala byť '%maxheight%', ale je '%height%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Minimálna výška obrázku '%value%' by mala byť '%minheight%', ale je '%height%'",
-    "The size of image '%value%' could not be detected" => "Rozmery obrázku '%value%' nebolo možné zistiť",
-    "File '%value%' is not readable or does not exist" => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Maximálna šírka obrázku '%value%' by mala byť '%maxwidth%', ale je '%width%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Minimálna šírka obrázku '%value%' by mala byť '%minwidth%', ale je '%width%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Maximálna výška obrázku '%value%' by mala byť '%maxheight%', ale je '%height%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Minimálna výška obrázku '%value%' by mala byť '%minheight%', ale je '%height%'",
+    "The size of image '%value%' could not be detected." => "Rozmery obrázku '%value%' nebolo možné zistiť",
+    "File '%value%' is not readable or does not exist." => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Súbor '%value%' nie je komprimovaný, ale '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Mimetyp súboru '%value%' nebolo možné zisťit",
-    "File '%value%' is not readable or does not exist" => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
+    "File '%value%' is not compressed, '%type%' detected." => "Súbor '%value%' nie je komprimovaný, ale '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Mimetyp súboru '%value%' nebolo možné zisťit",
+    "File '%value%' is not readable or does not exist." => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Súbor '%value%' nie je obrázok, ale '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Mimetyp súboru '%value%' nebolo možné zistiť",
-    "File '%value%' is not readable or does not exist" => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
+    "File '%value%' is no image, '%type%' detected." => "Súbor '%value%' nie je obrázok, ale '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Mimetyp súboru '%value%' nebolo možné zistiť",
+    "File '%value%' is not readable or does not exist." => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Súbor '%value%' nezodpovedá danému md5 hashu",
-    "A md5 hash could not be evaluated for the given file" => "Md5 hash nemohol byť pre daný súbor vypočítaný",
-    "File '%value%' is not readable or does not exist" => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
+    "File '%value%' does not match the given md5 hashes." => "Súbor '%value%' nezodpovedá danému md5 hashu",
+    "A md5 hash could not be evaluated for the given file." => "Md5 hash nemohol byť pre daný súbor vypočítaný",
+    "File '%value%' is not readable or does not exist." => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Súbor '%value%' má neplatný mimetyp '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Mimetyp súboru '%value%' nebolo možné zistiť",
-    "File '%value%' is not readable or does not exist" => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
+    "File '%value%' has a false mimetype of '%type%'." => "Súbor '%value%' má neplatný mimetyp '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Mimetyp súboru '%value%' nebolo možné zistiť",
+    "File '%value%' is not readable or does not exist." => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "Súbor '%value%' existuje",
+    "File '%value%' exists." => "Súbor '%value%' existuje",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Súbor '%value%' nezodpovedá danému sha1 hashu",
-    "A sha1 hash could not be evaluated for the given file" => "Sha1 hash nemohol byť pre daný súbor vypočítaný",
-    "File '%value%' is not readable or does not exist" => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
+    "File '%value%' does not match the given sha1 hashes." => "Súbor '%value%' nezodpovedá danému sha1 hashu",
+    "A sha1 hash could not be evaluated for the given file." => "Sha1 hash nemohol byť pre daný súbor vypočítaný",
+    "File '%value%' is not readable or does not exist." => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Maximálna povolená veľkosť súboru je '%max%', ale '%value%' má '%size%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Minimálna veľkosť súboru je '%min%', ale '%value%' má '%size%'",
-    "File '%value%' is not readable or does not exist" => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Maximálna povolená veľkosť súboru je '%max%', ale '%value%' má '%size%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Minimálna veľkosť súboru je '%min%', ale '%value%' má '%size%'",
+    "File '%value%' is not readable or does not exist." => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Súbor '%value%' prekročil veľkosť definovanú v inom súbore",
-    "File '%value%' exceeds the defined form size" => "Súbor '%value%' prekročil veľkosť definovanú vo formulári",
-    "File '%value%' was only partially uploaded" => "Súbor '%value%' bol nahraný len čiastočne",
-    "File '%value%' was not uploaded" => "Súbor '%value%' nebol nahraný",
-    "No temporary directory was found for file '%value%'" => "Pre súbor '%value%' nebol nájdený žiadny dočasný adresár",
-    "File '%value%' can't be written" => "Súbor '%value%' nemôže byť zapísaný",
-    "A PHP extension returned an error while uploading the file '%value%'" => "PHP rozšírenie vrátilo chybu počas nahrávania súboru '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Súbor '%value%' bol neoprávnene nahraný. Môže se jednať o útok",
-    "File '%value%' was not found" => "Súbor '%value%' nebol nájdený",
-    "Unknown error while uploading file '%value%'" => "Počas nahrávania súboru '%value%' došlo k chybe",
+    "File '%value%' exceeds the defined ini size." => "Súbor '%value%' prekročil veľkosť definovanú v inom súbore",
+    "File '%value%' exceeds the defined form size." => "Súbor '%value%' prekročil veľkosť definovanú vo formulári",
+    "File '%value%' was only partially uploaded." => "Súbor '%value%' bol nahraný len čiastočne",
+    "File '%value%' was not uploaded." => "Súbor '%value%' nebol nahraný",
+    "No temporary directory was found for file '%value%'." => "Pre súbor '%value%' nebol nájdený žiadny dočasný adresár",
+    "File '%value%' can't be written." => "Súbor '%value%' nemôže byť zapísaný",
+    "A PHP extension returned an error while uploading the file '%value%'." => "PHP rozšírenie vrátilo chybu počas nahrávania súboru '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Súbor '%value%' bol neoprávnene nahraný. Môže se jednať o útok",
+    "File '%value%' was not found." => "Súbor '%value%' nebol nájdený",
+    "Unknown error while uploading file '%value%'." => "Počas nahrávania súboru '%value%' došlo k chybe",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Príliš veľa slov. Maximálne je ich dovolených '%max%', ale bolo zadaných '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Príliš málo slov. Musí ich byť aspoň '%min%', ale bolo zadaných len '%count%'",
-    "File '%value%' is not readable or does not exist" => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Príliš veľa slov. Maximálne je ich dovolených '%max%', ale bolo zadaných '%count%'",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Príliš málo slov. Musí ich byť aspoň '%min%', ale bolo zadaných len '%count%'",
+    "File '%value%' is not readable or does not exist." => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
 
     // Zend_Validate_Float
-    "Invalid type given. String, integer or float expected" => "Chybný typ. Bol očakávaný reťazec, celé alebo desatinné číslo",
-    "'%value%' does not appear to be a float" => "'%value%' nie je desatinné číslo",
+    "Invalid type given. String, integer or float expected." => "Chybný typ. Bol očakávaný reťazec, celé alebo desatinné číslo",
+    "'%value%' does not appear to be a float." => "'%value%' nie je desatinné číslo",
 
     // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' nie je väčšie ako '%min%'",
+    "'%value%' is not greater than '%min%'." => "'%value%' nie je väčšie ako '%min%'",
 
     // Zend_Validate_Hex
-    "Invalid type given. String expected" => "Chybný typ. Bol očakávaný reťazec",
-    "'%value%' has not only hexadecimal digit characters" => "'%value%' neobsahuje len znaky hexadecimálnych čísel",
+    "Invalid type given. String expected." => "Chybný typ. Bol očakávaný reťazec",
+    "'%value%' has not only hexadecimal digit characters." => "'%value%' neobsahuje len znaky hexadecimálnych čísel",
 
     // Zend_Validate_Hostname
-    "Invalid type given. String expected" => "Chybný typ. Bol očakávaný reťazec",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "'%value%' vyzerá ako IP adresa, ale tie nie sú dovolené",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' vyzerá ako hostname, ale nemohol byť overený voči známym TLD",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' vyzerá ako hostname, ale obsahuje pomlčku na nedovolenom mieste",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' vyzerá ako hostname, ale nezodpovedá formátu hostname pre '%tld%'",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' síce vyzerá ako hostname, ale nemožno určiť TLD",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' nezodpovedá očakávanej štruktúre hostname",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' nevyzerá ako platné sieťové meno",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' vyzerá ako hostname lokálnej siete, tie ale nie sú povolené",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "'%value%' vyzerá ako DNS hostname ale zadanú punycode notáciu nie je možné dekódovať",
-    "'%value%' does not appear to be a valid URI hostname" => "'%value%' nevyzerá ako platné URI hostname",
+    "Invalid type given. String expected." => "Chybný typ. Bol očakávaný reťazec",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => "'%value%' vyzerá ako IP adresa, ale tie nie sú dovolené",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => "'%value%' vyzerá ako hostname, ale nemohol byť overený voči známym TLD",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => "'%value%' vyzerá ako hostname, ale obsahuje pomlčku na nedovolenom mieste",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => "'%value%' vyzerá ako hostname, ale nezodpovedá formátu hostname pre '%tld%'",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => "'%value%' síce vyzerá ako hostname, ale nemožno určiť TLD",
+    "'%value%' does not match the expected structure for a DNS hostname." => "'%value%' nezodpovedá očakávanej štruktúre hostname",
+    "'%value%' does not appear to be a valid local network name." => "'%value%' nevyzerá ako platné sieťové meno",
+    "'%value%' appears to be a local network name but local network names are not allowed." => "'%value%' vyzerá ako hostname lokálnej siete, tie ale nie sú povolené",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => "'%value%' vyzerá ako DNS hostname ale zadanú punycode notáciu nie je možné dekódovať",
+    "'%value%' does not appear to be a valid URI hostname." => "'%value%' nevyzerá ako platné URI hostname",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "Neznámý štát v IBAN '%value%'",
-    "'%value%' has a false IBAN format" => "'%value%' nie je platný formát IBAN",
-    "'%value%' has failed the IBAN check" => "'%value%' neprešlo kontrolou IBAN",
+    "Unknown country within the IBAN '%value%'." => "Neznámý štát v IBAN '%value%'",
+    "'%value%' has a false IBAN format." => "'%value%' nie je platný formát IBAN",
+    "'%value%' has failed the IBAN check." => "'%value%' neprešlo kontrolou IBAN",
 
     // Zend_Validate_Identical
-    "The two given tokens do not match" => "Zadané položky nie su zhodné",
-    "No token was provided to match against" => "Nebola zadáná položka pre porovnanie",
+    "The two given tokens do not match." => "Zadané položky nie su zhodné",
+    "No token was provided to match against." => "Nebola zadáná položka pre porovnanie",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "'%value%' nebola nájdená v zozname",
+    "'%value%' was not found in the haystack." => "'%value%' nebola nájdená v zozname",
 
     // Zend_Validate_Int
-    "Invalid type given. String or integer expected" => "Chybný typ. Bol očakávaný reťazec, alebo celé číslo",
-    "'%value%' does not appear to be an integer" => "'%value%' nie je celé číslo",
+    "Invalid type given. String or integer expected." => "Chybný typ. Bol očakávaný reťazec, alebo celé číslo",
+    "'%value%' does not appear to be an integer." => "'%value%' nie je celé číslo",
 
     // Zend_Validate_Ip
-    "Invalid type given. String expected" => "Chybný typ. Bol očakávaný reťazec",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' nie je platná IP adresa",
+    "Invalid type given. String expected." => "Chybný typ. Bol očakávaný reťazec",
+    "'%value%' does not appear to be a valid IP address." => "'%value%' nie je platná IP adresa",
 
     // Zend_Validate_Isbn
-    "Invalid type given. String or integer expected" => "Chybný typ. Bol očakávaný reťazec, alebo celé číslo",
-    "'%value%' is not a valid ISBN number" => "'%value%' nie je platné ISBN",
+    "Invalid type given. String or integer expected." => "Chybný typ. Bol očakávaný reťazec, alebo celé číslo",
+    "'%value%' is not a valid ISBN number." => "'%value%' nie je platné ISBN",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' nie je menej ako '%max%'",
+    "'%value%' is not less than '%max%'." => "'%value%' nie je menej ako '%max%'",
 
     // Zend_Validate_NotEmpty
-    "Invalid type given. String, integer, float, boolean or array expected" => "Chybný typ. Bol očakávaný reťazec, celé alebo desatinné číslo, boolean alebo pole",
-    "Value is required and can't be empty" => "Položka je povinná a nesmie byť prázdna",
+    "Invalid type given. String, integer, float, boolean or array expected." => "Chybný typ. Bol očakávaný reťazec, celé alebo desatinné číslo, boolean alebo pole",
+    "Value is required and can't be empty." => "Položka je povinná a nesmie byť prázdna",
 
     // Zend_Validate_PostCode
-    "Invalid type given. String or integer expected" => "Chybný typ. Bol očakávaný reťazec, alebo celé číslo",
-    "'%value%' does not appear to be a postal code" => "'%value%' nevyzerá ako PSČ",
+    "Invalid type given. String or integer expected." => "Chybný typ. Bol očakávaný reťazec, alebo celé číslo",
+    "'%value%' does not appear to be a postal code." => "'%value%' nevyzerá ako PSČ",
 
     // Zend_Validate_Regex
-    "Invalid type given. String, integer or float expected" => "Chybný typ. Bol očakávaný reťazec, celé alebo desatinné číslo",
-    "'%value%' does not match against pattern '%pattern%'" => "'%value%' nezodpovedá šablóne '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "Počas spracovania šablóny '%pattern%' došlo k internej chybe",
+    "Invalid type given. String, integer or float expected." => "Chybný typ. Bol očakávaný reťazec, celé alebo desatinné číslo",
+    "'%value%' does not match against pattern '%pattern%'." => "'%value%' nezodpovedá šablóne '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "Počas spracovania šablóny '%pattern%' došlo k internej chybe",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => "'%value%' nie je platný 'changefreq' pre sitemapu",
-    "Invalid type given. String expected" => "Chybný typ. Bol očakávaný reťazec",
+    "'%value%' is not a valid sitemap changefreq." => "'%value%' nie je platný 'changefreq' pre sitemapu",
+    "Invalid type given. String expected." => "Chybný typ. Bol očakávaný reťazec",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => "'%value%' nie je platný 'lastmod' pre sitemapu",
-    "Invalid type given. String expected" => "Chybný typ. Bol očakávaný reťazec",
+    "'%value%' is not a valid sitemap lastmod." => "'%value%' nie je platný 'lastmod' pre sitemapu",
+    "Invalid type given. String expected." => "Chybný typ. Bol očakávaný reťazec",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => "'%value%' nie je platná 'location' pre sitemapu",
-    "Invalid type given. String expected" => "Chybný typ. Bol očakávaný reťazec",
+    "'%value%' is not a valid sitemap location." => "'%value%' nie je platná 'location' pre sitemapu",
+    "Invalid type given. String expected." => "Chybný typ. Bol očakávaný reťazec",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => "'%value%' nie je platná 'priority' pre sitemapu",
-    "Invalid type given. Numeric string, integer or float expected" => "Chybný typ. Bol očakávaný číselný reťazec, celé alebo desatinné číslo",
+    "'%value%' is not a valid sitemap priority." => "'%value%' nie je platná 'priority' pre sitemapu",
+    "Invalid type given. Numeric string, integer or float expected." => "Chybný typ. Bol očakávaný číselný reťazec, celé alebo desatinné číslo",
 
     // Zend_Validate_StringLength
-    "Invalid type given. String expected" => "Chybný typ. Bol očakávaný reťazec",
-    "'%value%' is less than %min% characters long" => "'%value%' je kratšia ako %min% znakov",
-    "'%value%' is more than %max% characters long" => "'%value%' je dlhšia ako %max% znakov",
+    "Invalid type given. String expected." => "Chybný typ. Bol očakávaný reťazec",
+    "'%value%' is less than %min% characters long." => "'%value%' je kratšia ako %min% znakov",
+    "'%value%' is more than %max% characters long." => "'%value%' je dlhšia ako %max% znakov",
 );

--- a/resources/languages/sl/Zend_Captcha.php
+++ b/resources/languages/sl/Zend_Captcha.php
@@ -24,12 +24,12 @@
  */
 return array(
     // Zend_Captcha_ReCaptcha
-    "Missing captcha fields" => "Manjka varnostna koda",
-    "Failed to validate captcha" => "Varnostne kode ni bilo mogoče preveriti",
-    "Captcha value is wrong: %value%" => "Napačna varnostna koda: %value%",
+    "Missing captcha fields." => "Manjka varnostna koda",
+    "Failed to validate captcha." => "Varnostne kode ni bilo mogoče preveriti",
+    "Captcha value is wrong: %value%." => "Napačna varnostna koda: %value%",
 
     // Zend_Captcha_Word
-    "Empty captcha value" => "Prazna varnostna koda",
-    "Captcha ID field is missing" => "Polje ID varnostne kode manjka",
-    "Captcha value is wrong" => "Varnostna koda je napačna",
+    "Empty captcha value." => "Prazna varnostna koda",
+    "Captcha ID field is missing." => "Polje ID varnostne kode manjka",
+    "Captcha value is wrong." => "Varnostna koda je napačna",
 );

--- a/resources/languages/sl/Zend_Validate.php
+++ b/resources/languages/sl/Zend_Validate.php
@@ -24,242 +24,242 @@
  */
 return array(
     // Zend_Validate_Alnum
-    "Invalid type given. String, integer or float expected" => "Podan neveljaven tip. Predviden je niz, celo število ali plavajoče število",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' vsebuje ne abecedne znake in nima številk",
-    "'%value%' is an empty string" => "'%value%' je prazen niz",
+    "Invalid type given. String, integer or float expected." => "Podan neveljaven tip. Predviden je niz, celo število ali plavajoče število",
+    "'%value%' contains characters which are non alphabetic and no digits." => "'%value%' vsebuje ne abecedne znake in nima številk",
+    "'%value%' is an empty string." => "'%value%' je prazen niz",
 
     // Zend_Validate_Alpha
-    "Invalid type given. String expected" => "Podan neveljaven tip. Predviden je niz",
-    "'%value%' contains non alphabetic characters" => "'%value%' vsebuje ne abecedne znake",
-    "'%value%' is an empty string" => "'%value%' je prazen niz",
+    "Invalid type given. String expected." => "Podan neveljaven tip. Predviden je niz",
+    "'%value%' contains non alphabetic characters." => "'%value%' vsebuje ne abecedne znake",
+    "'%value%' is an empty string." => "'%value%' je prazen niz",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "'%value%' neuspešno preverjena preizkusna vsota (checksum)",
     "'%value%' contains invalid characters" => "'%value%' vsebuje nedovoljene znake",
     "'%value%' should have a length of %length% characters" => "'%value%' mora biti dolžine %length% znakov",
-    "Invalid type given. String expected" => "Podan neveljaven tip. Predviden je niz",
+    "Invalid type given. String expected." => "Podan neveljaven tip. Predviden je niz",
 
     // Zend_Validate_Between
     "'%value%' is not between '%min%' and '%max%', inclusively" => "'%value%' ni med '%min%' in vključno '%max%'",
     "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' ni točno med '%min%' in '%max%'",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "'%value%' vrednost ni veljavna",
-    "An exception has been raised within the callback" => "Prišlo je do napake v povratnem klicu",
+    "'%value%' is not valid." => "'%value%' vrednost ni veljavna",
+    "An exception has been raised within the callback." => "Prišlo je do napake v povratnem klicu",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' mora biti med 13 in 19 številkami",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Algoritem 'Luhn' (mod-10 checksum) neuspešen pri '%value%'",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' mora biti med 13 in 19 številkami",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Algoritem 'Luhn' (mod-10 checksum) neuspešen pri '%value%'",
 
     // Zend_Validate_CreditCard
-    "'%value%' seems to contain an invalid checksum" => "'%value%' verjetno vključuje neveljavno preizkusno vsoto (checksum)",
-    "'%value%' must contain only digits" => "'%value%' mora vsebovati samo številke",
-    "Invalid type given. String expected" => "Neveljaven tip. Predviden je niz",
-    "'%value%' contains an invalid amount of digits" => "'%value%' vsebuje neveljavno število številk",
-    "'%value%' is not from an allowed institute" => "'%value%' ni iz dovoljenega inštituta",
+    "'%value%' seems to contain an invalid checksum." => "'%value%' verjetno vključuje neveljavno preizkusno vsoto (checksum)",
+    "'%value%' must contain only digits." => "'%value%' mora vsebovati samo številke",
+    "Invalid type given. String expected." => "Neveljaven tip. Predviden je niz",
+    "'%value%' contains an invalid amount of digits." => "'%value%' vsebuje neveljavno število številk",
+    "'%value%' is not from an allowed institute." => "'%value%' ni iz dovoljenega inštituta",
     "'%value%' seems to be an invalid creditcard number" => "'%value%' se zdi, da je napačna številka kreditne kartice",
-    "An exception has been raised while validating '%value%'" => "Prišlo je do napake pri preverjanju vrednosti '%value%'",
+    "An exception has been raised while validating '%value%'." => "Prišlo je do napake pri preverjanju vrednosti '%value%'",
 
     // Zend_Validate_Date
-    "Invalid type given. String, integer, array or Zend_Date expected" => "Neveljaven tip. Predviden je niz, celo število, polje ali Zend_Date",
-    "'%value%' does not appear to be a valid date" => "'%value%' se zdi, da ni veljaven datum",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' se ne ujema s formatom datuma '%format%'",
+    "Invalid type given. String, integer, array or Zend_Date expected." => "Neveljaven tip. Predviden je niz, celo število, polje ali Zend_Date",
+    "'%value%' does not appear to be a valid date." => "'%value%' se zdi, da ni veljaven datum",
+    "'%value%' does not fit the date format '%format%'." => "'%value%' se ne ujema s formatom datuma '%format%'",
 
     // Zend_Validate_Db_Abstract
-    "No record matching '%value%' was found" => "Zapis, ki bi ustrezal '%value%' ni bil najden",
-    "A record matching '%value%' was found" => "Zapis, ki se ujema '%value%' je bil najden",
+    "No record matching '%value%' was found." => "Zapis, ki bi ustrezal '%value%' ni bil najden",
+    "A record matching '%value%' was found." => "Zapis, ki se ujema '%value%' je bil najden",
 
     // Zend_Validate_Digits
-    "Invalid type given. String, integer or float expected" => "Neveljaven tip. Predviden je niz, celo število ali plavajoče število",
-    "'%value%' must contain only digits" => "'%value%' mora vsebovati samo številke",
-    "'%value%' is an empty string" => "'%value%' vrednost je prazna",
+    "Invalid type given. String, integer or float expected." => "Neveljaven tip. Predviden je niz, celo število ali plavajoče število",
+    "'%value%' must contain only digits." => "'%value%' mora vsebovati samo številke",
+    "'%value%' is an empty string." => "'%value%' vrednost je prazna",
 
     // Zend_Validate_EmailAddress
-    "Invalid type given. String expected" => "Neveljaven tip. Predviden je niz",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' ni veljavna e-pošta formata lokalni-del@hostname",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' ni veljavno ime gostitelja za e-poštni naslov '%value%'",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' nima veljavnega MX zapisa za e-pošto '%value%'",
-    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network" => "'%hostname%' ni v routable segmentu omrežja. E-pošta '%value%' ne bi smela biti določena iz javnega omrežja",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' se ne ujema s formatom dot-atom",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' se ne ujema s formatom 'quoted-string'",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' ni veljaven lokalni del e-pošte '%value%'",
-    "'%value%' exceeds the allowed length" => "'%value%' je večje od dovoljene dolžine",
+    "Invalid type given. String expected." => "Neveljaven tip. Predviden je niz",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "'%value%' ni veljavna e-pošta formata lokalni-del@hostname",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "'%hostname%' ni veljavno ime gostitelja za e-poštni naslov '%value%'",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "'%hostname%' nima veljavnega MX zapisa za e-pošto '%value%'",
+    "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' ni v routable segmentu omrežja. E-pošta '%value%' ne bi smela biti določena iz javnega omrežja",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' se ne ujema s formatom dot-atom",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' se ne ujema s formatom 'quoted-string'",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "'%localPart%' ni veljaven lokalni del e-pošte '%value%'",
+    "'%value%' exceeds the allowed length." => "'%value%' je večje od dovoljene dolžine",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Preveliko število datotek, dovoljenih je največ '%max%', poslanih je pa '%count%'",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Premajhno število datotek, najmanj predvidenih je '%min%', poslanih je pa '%count%'",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Preveliko število datotek, dovoljenih je največ '%max%', poslanih je pa '%count%'",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Premajhno število datotek, najmanj predvidenih je '%min%', poslanih je pa '%count%'",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Datoteka '%value%' se ne ujema z dano kodo crc32",
-    "A crc32 hash could not be evaluated for the given file" => "crc32 kode ni bila moč preveriti za dano datoteko",
-    "File '%value%' is not readable or does not exist" => "Datoteke '%value%' ni moč brati ali pa ne obstaja",
+    "File '%value%' does not match the given crc32 hashes." => "Datoteka '%value%' se ne ujema z dano kodo crc32",
+    "A crc32 hash could not be evaluated for the given file." => "crc32 kode ni bila moč preveriti za dano datoteko",
+    "File '%value%' is not readable or does not exist." => "Datoteke '%value%' ni moč brati ali pa ne obstaja",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Datoteka '%value%' ima napačno končnico",
-    "File '%value%' is not readable or does not exist" => "Datoteke '%value%' ni moč brati ali pa ne obstaja",
+    "File '%value%' has a false extension." => "Datoteka '%value%' ima napačno končnico",
+    "File '%value%' is not readable or does not exist." => "Datoteke '%value%' ni moč brati ali pa ne obstaja",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Datoteka '%value%' ima napačen 'mimetype' vrste '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "'Mimetype' datoteke '%value%' ni bilo moč zaznati",
-    "File '%value%' is not readable or does not exist" => "Datoteka '%value%' ni bralna ali pa ne obstaja",
+    "File '%value%' has a false mimetype of '%type%'." => "Datoteka '%value%' ima napačen 'mimetype' vrste '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "'Mimetype' datoteke '%value%' ni bilo moč zaznati",
+    "File '%value%' is not readable or does not exist." => "Datoteka '%value%' ni bralna ali pa ne obstaja",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "Datoteka '%value%' ne obstaja",
+    "File '%value%' does not exist." => "Datoteka '%value%' ne obstaja",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "Datoteka '%value%' ima napačno končnico",
-    "File '%value%' is not readable or does not exist" => "Datoteka '%value%' ni bralna ali pa ne obstaja",
+    "File '%value%' has a false extension." => "Datoteka '%value%' ima napačno končnico",
+    "File '%value%' is not readable or does not exist." => "Datoteka '%value%' ni bralna ali pa ne obstaja",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Vse datoteke skupaj bi morale imeti največjo velikost '%max%' vendar zaznano je bilo '%size%'",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Vse datoteke skupaj bi morale imeti najmanjšo velikost '%min%' vendar zaznano je bilo '%size%'",
-    "One or more files can not be read" => "Ene ali več datotek ni mogoče prebrati",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Vse datoteke skupaj bi morale imeti največjo velikost '%max%' vendar zaznano je bilo '%size%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Vse datoteke skupaj bi morale imeti najmanjšo velikost '%min%' vendar zaznano je bilo '%size%'",
+    "One or more files can not be read." => "Ene ali več datotek ni mogoče prebrati",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "Datoteka '%value%' se ne ujema z dano kodo",
-    "A hash could not be evaluated for the given file" => "Kode ni bilo moč oceniti",
-    "File '%value%' is not readable or does not exist" => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
+    "File '%value%' does not match the given hashes." => "Datoteka '%value%' se ne ujema z dano kodo",
+    "A hash could not be evaluated for the given file." => "Kode ni bilo moč oceniti",
+    "File '%value%' is not readable or does not exist." => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Največja dovoljena širina slike '%value%' bi morala biti '%maxwidth%' vendar zaznano je '%width%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Najmanjša predvidena širina slike '%value%' bi morala biti '%minwidth%' vendar zaznano je '%width%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Največja dovoljena višina slike '%value%' bi morala biti '%maxheight%' vendar zaznano je '%height%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Najmanjša predvidena višina '%value%' bi morala biti '%minheight%' vendar zaznano je '%height%'",
-    "The size of image '%value%' could not be detected" => "Velikost slike '%value%' ni bilo moč zaznati",
-    "File '%value%' is not readable or does not exist" => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Največja dovoljena širina slike '%value%' bi morala biti '%maxwidth%' vendar zaznano je '%width%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Najmanjša predvidena širina slike '%value%' bi morala biti '%minwidth%' vendar zaznano je '%width%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Največja dovoljena višina slike '%value%' bi morala biti '%maxheight%' vendar zaznano je '%height%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Najmanjša predvidena višina '%value%' bi morala biti '%minheight%' vendar zaznano je '%height%'",
+    "The size of image '%value%' could not be detected." => "Velikost slike '%value%' ni bilo moč zaznati",
+    "File '%value%' is not readable or does not exist." => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Datoteka '%value%' ni skrčena, '%type%' vrsta zaznana",
-    "The mimetype of file '%value%' could not be detected" => "'Mimetype' datoteke '%value%' ni bilo mogoče zaznati",
-    "File '%value%' is not readable or does not exist" => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
+    "File '%value%' is not compressed, '%type%' detected." => "Datoteka '%value%' ni skrčena, '%type%' vrsta zaznana",
+    "The mimetype of file '%value%' could not be detected." => "'Mimetype' datoteke '%value%' ni bilo mogoče zaznati",
+    "File '%value%' is not readable or does not exist." => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Datoteka '%value%' ni slika, '%type%' vrsta zaznana",
-    "The mimetype of file '%value%' could not be detected" => "'Mimetype' datoteke '%value%' ni bilo mogoče zaznati",
-    "File '%value%' is not readable or does not exist" => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
+    "File '%value%' is no image, '%type%' detected." => "Datoteka '%value%' ni slika, '%type%' vrsta zaznana",
+    "The mimetype of file '%value%' could not be detected." => "'Mimetype' datoteke '%value%' ni bilo mogoče zaznati",
+    "File '%value%' is not readable or does not exist." => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Datoteka '%value%' se ne ujema z dano md5 kodo",
-    "A md5 hash could not be evaluated for the given file" => "Kode md5 ni bilo mogoče preveriti za dano datoteko",
-    "File '%value%' is not readable or does not exist" => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
+    "File '%value%' does not match the given md5 hashes." => "Datoteka '%value%' se ne ujema z dano md5 kodo",
+    "A md5 hash could not be evaluated for the given file." => "Kode md5 ni bilo mogoče preveriti za dano datoteko",
+    "File '%value%' is not readable or does not exist." => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Datoteka '%value%' ima nepravilen 'mimetype' vrste '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "'Mimetype' datoteke '%value%' ni bilo mogoče zaznati",
-    "File '%value%' is not readable or does not exist" => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
+    "File '%value%' has a false mimetype of '%type%'." => "Datoteka '%value%' ima nepravilen 'mimetype' vrste '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "'Mimetype' datoteke '%value%' ni bilo mogoče zaznati",
+    "File '%value%' is not readable or does not exist." => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "Datoteka '%value%' obstaja",
+    "File '%value%' exists." => "Datoteka '%value%' obstaja",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Datoteka '%value%' se ne ujema s kodo sha1",
-    "A sha1 hash could not be evaluated for the given file" => "Za dano datoteko ni bilo mogoče preveriti kode sha1",
-    "File '%value%' is not readable or does not exist" => "Datoteke '%value%' ni mogoče prebrati ali pa ne obstaja",
+    "File '%value%' does not match the given sha1 hashes." => "Datoteka '%value%' se ne ujema s kodo sha1",
+    "A sha1 hash could not be evaluated for the given file." => "Za dano datoteko ni bilo mogoče preveriti kode sha1",
+    "File '%value%' is not readable or does not exist." => "Datoteke '%value%' ni mogoče prebrati ali pa ne obstaja",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Največja dovoljena velikost datoteke '%value%' je '%max%' vendar zaznano je '%size%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Najmanjša predvidena velikost datoteke '%value%' je '%min%' vendar zaznano je '%size%'",
-    "File '%value%' is not readable or does not exist" => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Največja dovoljena velikost datoteke '%value%' je '%max%' vendar zaznano je '%size%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Najmanjša predvidena velikost datoteke '%value%' je '%min%' vendar zaznano je '%size%'",
+    "File '%value%' is not readable or does not exist." => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Datoteka '%value%' presega definirano ini velikost",
-    "File '%value%' exceeds the defined form size" => "Datoteka '%value%' presega definirano velikost v formi",
-    "File '%value%' was only partially uploaded" => "Datoteka '%value%' je bila dodana samo naložena",
-    "File '%value%' was not uploaded" => "Datoteka '%value%' ni bila naložena",
-    "No temporary directory was found for file '%value%'" => "Začasna mapa ni bila najdena za datoteko '%value%'",
-    "File '%value%' can't be written" => "Datoteke '%value%' ni mogoče zapisati",
-    "A PHP extension returned an error while uploading the file '%value%'" => "PHP razširitev je vrnila napako med nalaganjem datoteke '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Datoteka '%value%' ni bila nedovoljeno naložena. Gre za potencialni napad",
-    "File '%value%' was not found" => "Datoteka '%value%' ni bila najdena",
-    "Unknown error while uploading file '%value%'" => "Neznana napaka pri nalaganju datoteke '%value%'",
+    "File '%value%' exceeds the defined ini size." => "Datoteka '%value%' presega definirano ini velikost",
+    "File '%value%' exceeds the defined form size." => "Datoteka '%value%' presega definirano velikost v formi",
+    "File '%value%' was only partially uploaded." => "Datoteka '%value%' je bila dodana samo naložena",
+    "File '%value%' was not uploaded." => "Datoteka '%value%' ni bila naložena",
+    "No temporary directory was found for file '%value%'." => "Začasna mapa ni bila najdena za datoteko '%value%'",
+    "File '%value%' can't be written." => "Datoteke '%value%' ni mogoče zapisati",
+    "A PHP extension returned an error while uploading the file '%value%'." => "PHP razširitev je vrnila napako med nalaganjem datoteke '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Datoteka '%value%' ni bila nedovoljeno naložena. Gre za potencialni napad",
+    "File '%value%' was not found." => "Datoteka '%value%' ni bila najdena",
+    "Unknown error while uploading file '%value%'." => "Neznana napaka pri nalaganju datoteke '%value%'",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Preveč besed, največ '%max%' je dovoljenih vendar preštetih je bilo '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Premalo besed, vsaj '%min%' je predvidenih vendar preštetih je bilo '%count%'",
-    "File '%value%' is not readable or does not exist" => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Preveč besed, največ '%max%' je dovoljenih vendar preštetih je bilo '%count%'",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Premalo besed, vsaj '%min%' je predvidenih vendar preštetih je bilo '%count%'",
+    "File '%value%' is not readable or does not exist." => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
 
     // Zend_Validate_Float
-    "Invalid type given. String, integer or float expected" => "Podan nedovoljen tip. Predviden je niz, celo število ali plavajoče število",
-    "'%value%' does not appear to be a float" => "'%value%' se zdi, da ni plavajoče število",
+    "Invalid type given. String, integer or float expected." => "Podan nedovoljen tip. Predviden je niz, celo število ali plavajoče število",
+    "'%value%' does not appear to be a float." => "'%value%' se zdi, da ni plavajoče število",
 
     // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' ni večje od '%min%'",
+    "'%value%' is not greater than '%min%'." => "'%value%' ni večje od '%min%'",
 
     // Zend_Validate_Hex
-    "Invalid type given. String expected" => "Podan nedovoljen tip. Predviden je niz",
-    "'%value%' has not only hexadecimal digit characters" => "'%value%' nima samo znake šestnajstiških števil",
+    "Invalid type given. String expected." => "Podan nedovoljen tip. Predviden je niz",
+    "'%value%' has not only hexadecimal digit characters." => "'%value%' nima samo znake šestnajstiških števil",
 
     // Zend_Validate_Hostname
-    "Invalid type given. String expected" => "Podan nedovoljen tip. Predviden je niz",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "'%value%' se zdi, da je IP naslov, vendar IP naslovi niso dovoljeni",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' se zdi, da je DNS ime gostitelja vendar se ne ujema s seznamom znanih TLD",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' se zdi, da je DNS ime gostitelja vendar vključuje pomišljaj na nedovoljenem mestu",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' se zdi, da je DNS ime gostitelja vendar se ne ujema s shemo imena gostitelja za TLD '%tld%'",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' se zdi, da je DNS ime gostitelja vendar ni mogoče pa izločiti TLD dela",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' se ne ujema s predvideno strukturo za DNS ime gostitelja",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' se zdi, da ni veljavno ime lokalnega omrežja",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' se zdi, da je ime lokalnega omrežja vendar imena lokalnih omrežij niso dovoljena",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "'%value%' se zdi, da je ime DNS ime gostitelja vendar danega 'punycode' označevanja ni mogoče dekodirati",
-    "'%value%' does not appear to be a valid URI hostname" => "'%value%' se zdi, da ni veljavno ime URI ime gostitelja",
+    "Invalid type given. String expected." => "Podan nedovoljen tip. Predviden je niz",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => "'%value%' se zdi, da je IP naslov, vendar IP naslovi niso dovoljeni",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => "'%value%' se zdi, da je DNS ime gostitelja vendar se ne ujema s seznamom znanih TLD",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => "'%value%' se zdi, da je DNS ime gostitelja vendar vključuje pomišljaj na nedovoljenem mestu",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => "'%value%' se zdi, da je DNS ime gostitelja vendar se ne ujema s shemo imena gostitelja za TLD '%tld%'",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => "'%value%' se zdi, da je DNS ime gostitelja vendar ni mogoče pa izločiti TLD dela",
+    "'%value%' does not match the expected structure for a DNS hostname." => "'%value%' se ne ujema s predvideno strukturo za DNS ime gostitelja",
+    "'%value%' does not appear to be a valid local network name." => "'%value%' se zdi, da ni veljavno ime lokalnega omrežja",
+    "'%value%' appears to be a local network name but local network names are not allowed." => "'%value%' se zdi, da je ime lokalnega omrežja vendar imena lokalnih omrežij niso dovoljena",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => "'%value%' se zdi, da je ime DNS ime gostitelja vendar danega 'punycode' označevanja ni mogoče dekodirati",
+    "'%value%' does not appear to be a valid URI hostname." => "'%value%' se zdi, da ni veljavno ime URI ime gostitelja",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "Neznana država v vrednosti IBAN '%value%'",
-    "'%value%' has a false IBAN format" => "'%value%' ima napačen IBAN format",
-    "'%value%' has failed the IBAN check" => "'%value%' ni uspelo IBAN preverjanja",
+    "Unknown country within the IBAN '%value%'." => "Neznana država v vrednosti IBAN '%value%'",
+    "'%value%' has a false IBAN format." => "'%value%' ima napačen IBAN format",
+    "'%value%' has failed the IBAN check." => "'%value%' ni uspelo IBAN preverjanja",
 
     // Zend_Validate_Identical
-    "The two given tokens do not match" => "Dana žetona se ne ujemata",
-    "No token was provided to match against" => "Žeton ni bil dan za ujemanje",
+    "The two given tokens do not match." => "Dana žetona se ne ujemata",
+    "No token was provided to match against." => "Žeton ni bil dan za ujemanje",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "'Haystack' ne vsebuje vrednosti '%value%'",
+    "'%value%' was not found in the haystack." => "'Haystack' ne vsebuje vrednosti '%value%'",
 
     // Zend_Validate_Int
-    "Invalid type given. String or integer expected" => "Podan nedovoljen tip. Predviden je niz ali celo število",
-    "'%value%' does not appear to be an integer" => "'%value%' se zdi, da ni celo število",
+    "Invalid type given. String or integer expected." => "Podan nedovoljen tip. Predviden je niz ali celo število",
+    "'%value%' does not appear to be an integer." => "'%value%' se zdi, da ni celo število",
 
     // Zend_Validate_Ip
-    "Invalid type given. String expected" => "Podan neveljaven tip. Predviden je niz",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' se zdi, da ni veljaven IP naslov",
+    "Invalid type given. String expected." => "Podan neveljaven tip. Predviden je niz",
+    "'%value%' does not appear to be a valid IP address." => "'%value%' se zdi, da ni veljaven IP naslov",
 
     // Zend_Validate_Isbn
-    "Invalid type given. String or integer expected" => "Podan neveljaven tip. Predviden je niz ali celo število",
-    "'%value%' is not a valid ISBN number" => "'%value%' ni veljavna ISBN številka",
+    "Invalid type given. String or integer expected." => "Podan neveljaven tip. Predviden je niz ali celo število",
+    "'%value%' is not a valid ISBN number." => "'%value%' ni veljavna ISBN številka",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' ni manjša kot '%max%'",
+    "'%value%' is not less than '%max%'." => "'%value%' ni manjša kot '%max%'",
 
     // Zend_Validate_NotEmpty
-    "Invalid type given. String, integer, float, boolean or array expected" => "Podan neveljaven tip. Predviden je niz, celo število, plavajoče število, logična vrednost ali polje",
-    "Value is required and can't be empty" => "Vrednost je obvezna in ne sme biti prazna",
+    "Invalid type given. String, integer, float, boolean or array expected." => "Podan neveljaven tip. Predviden je niz, celo število, plavajoče število, logična vrednost ali polje",
+    "Value is required and can't be empty." => "Vrednost je obvezna in ne sme biti prazna",
 
     // Zend_Validate_PostCode
-    "Invalid type given. String or integer expected" => "Podan neveljaven tip. Predviden je niz ali celo število",
-    "'%value%' does not appear to be a postal code" => "'%value%' se zdi, da ni poštna številka",
+    "Invalid type given. String or integer expected." => "Podan neveljaven tip. Predviden je niz ali celo število",
+    "'%value%' does not appear to be a postal code." => "'%value%' se zdi, da ni poštna številka",
 
     // Zend_Validate_Regex
-    "Invalid type given. String, integer or float expected" => "Podan neveljaven tip. Predviden je niz, celo število ali plavajoče število",
-    "'%value%' does not match against pattern '%pattern%'" => "'%value%' se ne ujema z vzorcem '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "Prišlo je do notranje napake med uporabo vzorca '%pattern%'",
+    "Invalid type given. String, integer or float expected." => "Podan neveljaven tip. Predviden je niz, celo število ali plavajoče število",
+    "'%value%' does not match against pattern '%pattern%'." => "'%value%' se ne ujema z vzorcem '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "Prišlo je do notranje napake med uporabo vzorca '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => "'%value%' ni veljavna 'sitemap changefreq' vrednost",
-    "Invalid type given. String expected" => "Podan neveljaven tip. Predviden je niz",
+    "'%value%' is not a valid sitemap changefreq." => "'%value%' ni veljavna 'sitemap changefreq' vrednost",
+    "Invalid type given. String expected." => "Podan neveljaven tip. Predviden je niz",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => "'%value%' ni veljavna 'sitemap lastmod' vrednost",
-    "Invalid type given. String expected" => "Podan neveljaven tip. Predviden je niz",
+    "'%value%' is not a valid sitemap lastmod." => "'%value%' ni veljavna 'sitemap lastmod' vrednost",
+    "Invalid type given. String expected." => "Podan neveljaven tip. Predviden je niz",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => "'%value%' ni veljavna 'sitemap location' vrednost",
-    "Invalid type given. String expected" => "Podan neveljaven tip. Predviden je niz",
+    "'%value%' is not a valid sitemap location." => "'%value%' ni veljavna 'sitemap location' vrednost",
+    "Invalid type given. String expected." => "Podan neveljaven tip. Predviden je niz",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => "'%value%' ni veljavna 'sitemap priority' vrednost",
-    "Invalid type given. Numeric string, integer or float expected" => "Podan neveljaven tip. Predviden je numerični niz znakov, celo število ali plavajoče število",
+    "'%value%' is not a valid sitemap priority." => "'%value%' ni veljavna 'sitemap priority' vrednost",
+    "Invalid type given. Numeric string, integer or float expected." => "Podan neveljaven tip. Predviden je numerični niz znakov, celo število ali plavajoče število",
 
     // Zend_Validate_StringLength
-    "Invalid type given. String expected" => "Podan neveljaven tip. Predviden je niz",
-    "'%value%' is less than %min% characters long" => "'%value%' je manjše od dolžine znakov %min%",
-    "'%value%' is more than %max% characters long" => "'%value%' je več od dolžine znakov %max%",
+    "Invalid type given. String expected." => "Podan neveljaven tip. Predviden je niz",
+    "'%value%' is less than %min% characters long." => "'%value%' je manjše od dolžine znakov %min%",
+    "'%value%' is more than %max% characters long." => "'%value%' je več od dolžine znakov %max%",
 );

--- a/resources/languages/sr/Zend_Validate.php
+++ b/resources/languages/sr/Zend_Validate.php
@@ -25,13 +25,13 @@
 return array(
     // Zend_Validate_Alnum
     "Invalid type given, value should be float, string, or integer" => "Nevalidan tip, vrednost treba da bude tekst ili broj",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' sadrži karaktere koji nisu slova niti cifre",
-    "'%value%' is an empty string" => "'%value%' je prazan tekst",
+    "'%value%' contains characters which are non alphabetic and no digits." => "'%value%' sadrži karaktere koji nisu slova niti cifre",
+    "'%value%' is an empty string." => "'%value%' je prazan tekst",
 
     // Zend_Validate_Alpha
     "Invalid type given, value should be a string" => "Nevalidan tip, vrednost treba da bude tekst",
-    "'%value%' contains non alphabetic characters" => "'%value%' sadrži karaktere koji nisu slova",
-    "'%value%' is an empty string" => "'%value%' je prazan tekst",
+    "'%value%' contains non alphabetic characters." => "'%value%' sadrži karaktere koji nisu slova",
+    "'%value%' is an empty string." => "'%value%' je prazan tekst",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "'%value%' greška u checksum validaciji",
@@ -44,26 +44,26 @@ return array(
     "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' nije strogo između '%min%' i '%max%'",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "'%value%' nije validno",
+    "'%value%' is not valid." => "'%value%' nije validno",
     "Failure within the callback, exception returned" => "Greška u pozivu",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' treba da sadrži između 13 i 19 cifara",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Luhn algoritam ne prolazi na '%value%'",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' treba da sadrži između 13 i 19 cifara",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Luhn algoritam ne prolazi na '%value%'",
 
     // Zend_Validate_CreditCard
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Luhn algoritam ne prolazi na '%value%'",
-    "'%value%' must contain only digits" => "'%value%' treba da sadrži samo cifre",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Luhn algoritam ne prolazi na '%value%'",
+    "'%value%' must contain only digits." => "'%value%' treba da sadrži samo cifre",
     "Invalid type given, value should be a string" => "Nevalidan tip, vrednost treba da bude tekst",
-    "'%value%' contains an invalid amount of digits" => "'%value%' sadrži nevalidu količinu cifara",
-    "'%value%' is not from an allowed institute" => "'%value%' nije iz dozvoljene institucije",
+    "'%value%' contains an invalid amount of digits." => "'%value%' sadrži nevalidu količinu cifara",
+    "'%value%' is not from an allowed institute." => "'%value%' nije iz dozvoljene institucije",
     "Validation of '%value%' has been failed by the service" => "Validacija '%value%' nije uspela od strane servisa",
     "The service returned a failure while validating '%value%'" => "Servis je vratio grešku pri validaciji '%value%'",
 
     // Zend_Validate_Date
     "Invalid type given, value should be string, integer, array or Zend_Date" => "Nevalidan tip, vrednost treba da bude tekst, ceo broj, niz ili Zend_Date",
-    "'%value%' does not appear to be a valid date" => "'%value%' nije validan datum",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' nije u formatu datuma '%format%'",
+    "'%value%' does not appear to be a valid date." => "'%value%' nije validan datum",
+    "'%value%' does not fit the date format '%format%'." => "'%value%' nije u formatu datuma '%format%'",
 
     // Zend_Validate_Db_Abstract
     "No record matching %value% was found" => "Zapis koji se poklapa sa %value% nije pronađen",
@@ -73,193 +73,193 @@ return array(
     "Invalid type given, value should be string, integer or float" => "Nevalidan tip, vrednost treba da bude tekst ili broj",
     "'%value%' contains characters which are not digits; but only digits are allowed" => "'%value%' sadrži karaktere koji nisu cifre, a samo cifre su dozvoljene",
     "'%value%' contains not only digit characters" => "'%value%' ne sadrži samo cifre",
-    "'%value%' is an empty string" => "'%value%' je prazan tekst",
+    "'%value%' is an empty string." => "'%value%' je prazan tekst",
 
     // Zend_Validate_EmailAddress
     "Invalid type given, value should be a string" => "Nevalidan tip, vrednost treba da bude tekst",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' nije validna adresa elektronske pošte u formatu adresa@imehosta",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' nije validno ime hosta za adresu elektronske pošte '%value%'",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' nema validan MX zapis za adresu elektronske pošte '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "'%value%' nije validna adresa elektronske pošte u formatu adresa@imehosta",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "'%hostname%' nije validno ime hosta za adresu elektronske pošte '%value%'",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "'%hostname%' nema validan MX zapis za adresu elektronske pošte '%value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' nije rutabilan mrežni segment. Adresa elektronske pošte '%value%' ne treba da bude razrešena sa javne mreže",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' se ne poklapa sa dot-atom formatom",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' se ne poklapa sa quoted-string formatom",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' nije validan deo adrese elektronske pošte '%value%'",
-    "'%value%' exceeds the allowed length" => "'%value%' prelazi dozvoljenu dužinu",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' se ne poklapa sa dot-atom formatom",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' se ne poklapa sa quoted-string formatom",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "'%localPart%' nije validan deo adrese elektronske pošte '%value%'",
+    "'%value%' exceeds the allowed length." => "'%value%' prelazi dozvoljenu dužinu",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Preveliki broj fajlova, maksimalno '%max%' je dozvoljeno, a '%count%' je prosleđeno",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Premali broj fajlova, minimalno '%min%' je očekivano, a '%count%' je prosleđeno",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Preveliki broj fajlova, maksimalno '%max%' je dozvoljeno, a '%count%' je prosleđeno",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Premali broj fajlova, minimalno '%min%' je očekivano, a '%count%' je prosleđeno",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Fajl '%value%' ne prolazi crc32 proveru",
-    "A crc32 hash could not be evaluated for the given file" => "Nema crc32 kodova za dati fajl",
+    "File '%value%' does not match the given crc32 hashes." => "Fajl '%value%' ne prolazi crc32 proveru",
+    "A crc32 hash could not be evaluated for the given file." => "Nema crc32 kodova za dati fajl",
     "File '%value%' could not be found" => "Fajl '%value%' ne može biti pronađen",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Fajl '%value%' ima nevalidnu ekstenziju",
+    "File '%value%' has a false extension." => "Fajl '%value%' ima nevalidnu ekstenziju",
     "File '%value%' could not be found" => "Fajl '%value%' ne može biti pronađen",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Fajl '%value%' ima nevalidan mime-tip '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Mime-tip fajla '%value%' ne može biti detektovan",
+    "File '%value%' has a false mimetype of '%type%'." => "Fajl '%value%' ima nevalidan mime-tip '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Mime-tip fajla '%value%' ne može biti detektovan",
     "File '%value%' can not be read" => "Fajl '%value%' ne može biti pročitan",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "Fajl '%value%' ne postoji",
+    "File '%value%' does not exist." => "Fajl '%value%' ne postoji",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "Fajl '%value%' ima nevalidnu ekstenziju",
+    "File '%value%' has a false extension." => "Fajl '%value%' ima nevalidnu ekstenziju",
     "File '%value%' could not be found" => "Fajl '%value%' ne može biti pronađen",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Svi fajlovi u zbiru treba da imaju maksimalnu veličinu '%max%', veličina poslatih fajlova je '%size%'",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Svi fajlovi u zbiru treba da imaju minimalnu veličinu '%min%', veličina poslatih fajlova je '%size%'",
-    "One or more files can not be read" => "Jedan ili više fajlova ne može biti pročitan",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Svi fajlovi u zbiru treba da imaju maksimalnu veličinu '%max%', veličina poslatih fajlova je '%size%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Svi fajlovi u zbiru treba da imaju minimalnu veličinu '%min%', veličina poslatih fajlova je '%size%'",
+    "One or more files can not be read." => "Jedan ili više fajlova ne može biti pročitan",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "Fajl '%value%' je nepravilno kodiran",
-    "A hash could not be evaluated for the given file" => "Heševi nisu pronađeni za dati fajl",
+    "File '%value%' does not match the given hashes." => "Fajl '%value%' je nepravilno kodiran",
+    "A hash could not be evaluated for the given file." => "Heševi nisu pronađeni za dati fajl",
     "File '%value%' could not be found" => "Fajl '%value%' ne može biti pronađen",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Maksimalna dozvoljena širina slike '%value%' je '%maxwidth%', data slika ima širinu '%width%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Minimalna očekivana širina slike '%value%' je '%minwidth%', data slika ima širinu '%width%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Maksimalna dozvoljena visina slike '%value%' je '%maxheight%', data slika ima visinu '%height%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Minimalna očekivana visina slike '%value%' je '%minheight%', data slika ima visinu '%height%'",
-    "The size of image '%value%' could not be detected" => "Veličina slike '%value%' ne može biti određena",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Maksimalna dozvoljena širina slike '%value%' je '%maxwidth%', data slika ima širinu '%width%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Minimalna očekivana širina slike '%value%' je '%minwidth%', data slika ima širinu '%width%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Maksimalna dozvoljena visina slike '%value%' je '%maxheight%', data slika ima visinu '%height%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Minimalna očekivana visina slike '%value%' je '%minheight%', data slika ima visinu '%height%'",
+    "The size of image '%value%' could not be detected." => "Veličina slike '%value%' ne može biti određena",
     "File '%value%' can not be read" => "Fajl '%value%' ne može biti pročitan",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Fajl '%value%' nije kompresovan, '%type%' detektovan",
-    "The mimetype of file '%value%' could not be detected" => "Mime-tip fajla '%value%' ne može biti detektovan",
+    "File '%value%' is not compressed, '%type%' detected." => "Fajl '%value%' nije kompresovan, '%type%' detektovan",
+    "The mimetype of file '%value%' could not be detected." => "Mime-tip fajla '%value%' ne može biti detektovan",
     "File '%value%' can not be read" => "Fajl '%value%' ne može biti pročitan",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Fajl '%value%' nije slika, '%type%' detektovan",
-    "The mimetype of file '%value%' could not be detected" => "Mime-tip fajla '%value%' ne može biti detektovan",
+    "File '%value%' is no image, '%type%' detected." => "Fajl '%value%' nije slika, '%type%' detektovan",
+    "The mimetype of file '%value%' could not be detected." => "Mime-tip fajla '%value%' ne može biti detektovan",
     "File '%value%' can not be read" => "Fajl '%value%' ne može biti pročitan",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Fajl '%value%' ne prolazi md5 proveru",
-    "A md5 hash could not be evaluated for the given file" => "Nema md5 heševa za dati fajl",
+    "File '%value%' does not match the given md5 hashes." => "Fajl '%value%' ne prolazi md5 proveru",
+    "A md5 hash could not be evaluated for the given file." => "Nema md5 heševa za dati fajl",
     "File '%value%' could not be found" => "Fajl '%value%' ne može biti pronađen",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Fajl '%value%' ima nevalidan mime-tip '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Mime-tip fajla '%value%' ne može biti detektovan",
+    "File '%value%' has a false mimetype of '%type%'." => "Fajl '%value%' ima nevalidan mime-tip '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Mime-tip fajla '%value%' ne može biti detektovan",
     "File '%value%' can not be read" => "Fajl '%value%' ne može biti pročitan",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "Fajl '%value%' postoji",
+    "File '%value%' exists." => "Fajl '%value%' postoji",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Fajl '%value%' ne prolazi sha1 proveru",
-    "A sha1 hash could not be evaluated for the given file" => "Nema sha1 heševa za dati fajl",
+    "File '%value%' does not match the given sha1 hashes." => "Fajl '%value%' ne prolazi sha1 proveru",
+    "A sha1 hash could not be evaluated for the given file." => "Nema sha1 heševa za dati fajl",
     "File '%value%' could not be found" => "Fajl '%value%' ne može biti pronađen",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Maksimalna dozvoljena veličina fajla '%value%' je '%max%', data veličina je '%size%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Minimalna očekivana veličina fajla '%value%' je '%min%', data veličina je '%size%'",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Maksimalna dozvoljena veličina fajla '%value%' je '%max%', data veličina je '%size%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Minimalna očekivana veličina fajla '%value%' je '%min%', data veličina je '%size%'",
     "File '%value%' could not be found" => "Fajl '%value%' ne može biti pronađen",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Fajl '%value%' prevazilazi maksimalnu dozvoljenu veličinu",
-    "File '%value%' exceeds the defined form size" => "Fajl '%value%' prevazilazi maksimalnu dozvoljenu veličinu",
-    "File '%value%' was only partially uploaded" => "Fajl '%value%' je samo parcijalno uploadovan",
-    "File '%value%' was not uploaded" => "Fajl '%value%' nije uploadovan",
-    "No temporary directory was found for file '%value%'" => "Privremeni direktorijum nije pronađen za fajl '%value%'",
-    "File '%value%' can't be written" => "Fajl '%value%' ne može biti izmenjen",
-    "A PHP extension returned an error while uploading the file '%value%'" => "Ekstenzija je vratila grešku tokom uploada fajla '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Fajl '%value%' je ilegalno uploadovan, moguć napad",
-    "File '%value%' was not found" => "Fajl '%value%' nije pronađen",
-    "Unknown error while uploading file '%value%'" => "Nepoznata greška pri uploadu fajla '%value%'",
+    "File '%value%' exceeds the defined ini size." => "Fajl '%value%' prevazilazi maksimalnu dozvoljenu veličinu",
+    "File '%value%' exceeds the defined form size." => "Fajl '%value%' prevazilazi maksimalnu dozvoljenu veličinu",
+    "File '%value%' was only partially uploaded." => "Fajl '%value%' je samo parcijalno uploadovan",
+    "File '%value%' was not uploaded." => "Fajl '%value%' nije uploadovan",
+    "No temporary directory was found for file '%value%'." => "Privremeni direktorijum nije pronađen za fajl '%value%'",
+    "File '%value%' can't be written." => "Fajl '%value%' ne može biti izmenjen",
+    "A PHP extension returned an error while uploading the file '%value%'." => "Ekstenzija je vratila grešku tokom uploada fajla '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Fajl '%value%' je ilegalno uploadovan, moguć napad",
+    "File '%value%' was not found." => "Fajl '%value%' nije pronađen",
+    "Unknown error while uploading file '%value%'." => "Nepoznata greška pri uploadu fajla '%value%'",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Previše reči, maksimalno '%max%' je dozvoljeno, '%count%' je izbrojano",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Premalo reči, minimalno '%min%' je očekivano, '%count%' je izbrojano",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Previše reči, maksimalno '%max%' je dozvoljeno, '%count%' je izbrojano",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Premalo reči, minimalno '%min%' je očekivano, '%count%' je izbrojano",
     "File '%value%' could not be found" => "Fajl '%value%' ne može biti pronađen",
 
     // Zend_Validate_Float
     "Invalid type given, value should be float, string, or integer" => "Nevalidan tip, vrednost treba da bude tekst ili broj",
-    "'%value%' does not appear to be a float" => "'%value%' nije razlomljeni broj",
+    "'%value%' does not appear to be a float." => "'%value%' nije razlomljeni broj",
 
     // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' nije veće od '%min%'",
+    "'%value%' is not greater than '%min%'." => "'%value%' nije veće od '%min%'",
 
     // Zend_Validate_Hex
     "Invalid type given, value should be a string" => "Nevalidan tip, vrednost treba da bude tekst",
-    "'%value%' has not only hexadecimal digit characters" => "'%value%' se ne sastoji samo od heksadecimalnih karaktera",
+    "'%value%' has not only hexadecimal digit characters." => "'%value%' se ne sastoji samo od heksadecimalnih karaktera",
 
     // Zend_Validate_Hostname
     "Invalid type given, value should be a string" => "Nevalidan tip, vrednost treba da bude tekst",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "'%value%' je IP adresa, IP adrese nisu dozvoljene",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' je DNS ime hosta, ali TLD nije u listi poznatih",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' je DNS ime hosta, ali sadrži srednju crtu (-) na nedozvoljenoj poziciji",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' je DNS ime hosta, ali se ne poklapa sa šemom za '%tld%' TLD",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' je DNS ime hosta, ali ne može da se ekstraktuje TLD deo '%tld%'",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' se ne poklapa sa očekivanom strukturom DNS imena hosta",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' nije validno ime lokalne mreže",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' je ime lokalne mreže, lokalna imena mreža nisu dozvoljena",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "'%value%' je DNS ime hosta, ali data punikod notacija ne može biti dekodirana",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => "'%value%' je IP adresa, IP adrese nisu dozvoljene",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => "'%value%' je DNS ime hosta, ali TLD nije u listi poznatih",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => "'%value%' je DNS ime hosta, ali sadrži srednju crtu (-) na nedozvoljenoj poziciji",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => "'%value%' je DNS ime hosta, ali se ne poklapa sa šemom za '%tld%' TLD",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => "'%value%' je DNS ime hosta, ali ne može da se ekstraktuje TLD deo '%tld%'",
+    "'%value%' does not match the expected structure for a DNS hostname." => "'%value%' se ne poklapa sa očekivanom strukturom DNS imena hosta",
+    "'%value%' does not appear to be a valid local network name." => "'%value%' nije validno ime lokalne mreže",
+    "'%value%' appears to be a local network name but local network names are not allowed." => "'%value%' je ime lokalne mreže, lokalna imena mreža nisu dozvoljena",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => "'%value%' je DNS ime hosta, ali data punikod notacija ne može biti dekodirana",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "Nepoznata zemlja u IBAN '%value%'",
-    "'%value%' has a false IBAN format" => "'%value%' nije u validnom IBAN formatu",
-    "'%value%' has failed the IBAN check" => "'%value%' ne prolazi IBAN proveru",
+    "Unknown country within the IBAN '%value%'." => "Nepoznata zemlja u IBAN '%value%'",
+    "'%value%' has a false IBAN format." => "'%value%' nije u validnom IBAN formatu",
+    "'%value%' has failed the IBAN check." => "'%value%' ne prolazi IBAN proveru",
 
     // Zend_Validate_Identical
-    "The two given tokens do not match" => "Tokeni se ne poklapaju",
-    "No token was provided to match against" => "Token za proveru nije prosleđen",
+    "The two given tokens do not match." => "Tokeni se ne poklapaju",
+    "No token was provided to match against." => "Token za proveru nije prosleđen",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "'%value%' nije pronađeno u gomili",
+    "'%value%' was not found in the haystack." => "'%value%' nije pronađeno u gomili",
 
     // Zend_Validate_Int
     "Invalid type given, value should be string or integer" => "Nevalidan tip, vrednost treba da bude tekst ili ceo broj",
-    "'%value%' does not appear to be an integer" => "'%value%' nije ceo broj",
+    "'%value%' does not appear to be an integer." => "'%value%' nije ceo broj",
 
     // Zend_Validate_Ip
     "Invalid type given, value should be a string" => "Nevalidan tip, vrednost treba da bude tekst",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' nije validna IP adresa",
+    "'%value%' does not appear to be a valid IP address." => "'%value%' nije validna IP adresa",
 
     // Zend_Validate_Isbn
     "Invalid type given, value should be string or integer" => "Nevalidan tip, vrednost treba da bude tekst ili ceo broj",
-    "'%value%' is not a valid ISBN number" => "'%value%' nije validan ISBN broj",
+    "'%value%' is not a valid ISBN number." => "'%value%' nije validan ISBN broj",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' je manje od '%max%'",
+    "'%value%' is not less than '%max%'." => "'%value%' je manje od '%max%'",
 
     // Zend_Validate_NotEmpty
     "Invalid type given, value should be float, string, array, boolean or integer" => "Nevalidan tip, vrednost treba da bude tekst, broj ili logička vrednost",
-    "Value is required and can't be empty" => "Vrednost je obavezna i ne sme biti prazna",
+    "Value is required and can't be empty." => "Vrednost je obavezna i ne sme biti prazna",
 
     // Zend_Validate_PostCode
     "Invalid type given. The value should be a string or a integer" => "Nevalidan tip. Vrednost treba da bude tekst ili ceo broj",
-    "'%value%' does not appear to be a postal code" => "'%value%' nije poštanski broj",
+    "'%value%' does not appear to be a postal code." => "'%value%' nije poštanski broj",
 
     // Zend_Validate_Regex
     "Invalid type given, value should be string, integer or float" => "Nevalidan tip, vrednost treba da bude tekst ili broj",
-    "'%value%' does not match against pattern '%pattern%'" => "'%value%' se ne poklapa sa formatom '%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "Dogodila se greška pri korišćenju formata '%pattern%'",
+    "'%value%' does not match against pattern '%pattern%'." => "'%value%' se ne poklapa sa formatom '%pattern%'",
+    "There was an internal error while using the pattern '%pattern%'." => "Dogodila se greška pri korišćenju formata '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => "'%value%' nije validna frekvencija promene mape sajta",
+    "'%value%' is not a valid sitemap changefreq." => "'%value%' nije validna frekvencija promene mape sajta",
     "Invalid type given, the value should be a string" => "Nevalidan tip, vrednost treba da bude tekst",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => "'%value%' nije validan datum izmene mape sajta",
+    "'%value%' is not a valid sitemap lastmod." => "'%value%' nije validan datum izmene mape sajta",
     "Invalid type given, the value should be a string" => "Nevalidan tip, vrednost treba da bude tekst",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => "'%value%' nije validna lokacija mape sajta",
+    "'%value%' is not a valid sitemap location." => "'%value%' nije validna lokacija mape sajta",
     "Invalid type given, the value should be a string" => "Nevalidan tip, vrednost treba da bude tekst",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => "'%value%' nije validan prioritet mape sajta",
+    "'%value%' is not a valid sitemap priority." => "'%value%' nije validan prioritet mape sajta",
     "Invalid type given, the value should be a integer, a float or a numeric string" => "Nevalidan tip, vrednost treba da bude broj ili numerički niz",
 
     // Zend_Validate_StringLength
     "Invalid type given, value should be a string" => "Nevalidan tip, vrednost treba da bude tekst",
-    "'%value%' is less than %min% characters long" => "'%value%' ima manje od %min% karaktera",
-    "'%value%' is more than %max% characters long" => "'%value%' ima više od %max% karaktera",
+    "'%value%' is less than %min% characters long." => "'%value%' ima manje od %min% karaktera",
+    "'%value%' is more than %max% characters long." => "'%value%' ima više od %max% karaktera",
 );

--- a/resources/languages/tr/Zend_Captcha.php
+++ b/resources/languages/tr/Zend_Captcha.php
@@ -24,12 +24,12 @@
  */
 return array(
     // Zend_Captcha_ReCaptcha
-    "Missing captcha fields" => "Eksik captcha alanı",
-    "Failed to validate captcha" => "Captcha doğrulaması başarısız oldu",
-    "Captcha value is wrong: %value%" => "Captcha da ki karakterleri yanlış girdiniz: %value%",
+    "Missing captcha fields." => "Eksik captcha alanı",
+    "Failed to validate captcha." => "Captcha doğrulaması başarısız oldu",
+    "Captcha value is wrong: %value%." => "Captcha da ki karakterleri yanlış girdiniz: %value%",
 
     // Zend_Captcha_Word
-    "Empty captcha value" => "Boş captcha boşluğu",
-    "Captcha ID field is missing" => "Captcha kimlik alanı eksik",
-    "Captcha value is wrong" => "Captcha değeri yanlış",
+    "Empty captcha value." => "Boş captcha boşluğu",
+    "Captcha ID field is missing." => "Captcha kimlik alanı eksik",
+    "Captcha value is wrong." => "Captcha değeri yanlış",
 );

--- a/resources/languages/tr/Zend_Validate.php
+++ b/resources/languages/tr/Zend_Validate.php
@@ -35,7 +35,7 @@ return array(
 
     // Zend_I18n_Validator_Float
     "Invalid type given. String, integer or float expected." => "Geçersiz tür verildi, Dize, tamsayı ya da ondalık sayı bekleniyor",
-    "The input does not appear to be a float" => "Girdi ondalık bir sayı olarak görünmüyor",
+    "The input does not appear to be a float." => "Girdi ondalık bir sayı olarak görünmüyor",
 
     // Zend_I18n_Validator_Int
     "Invalid type given. String or integer expected." => "Geçersiz tür verildi. Dize veya tamsayı bekleniyor",
@@ -43,8 +43,8 @@ return array(
 
     // Zend_I18n_Validator_PostCode
     "Invalid type given. String or integer expected." => "Geçersiz tür verildi. Dizge veya tamsayı bekleniyor",
-    "The input does not appear to be a postal code" => "Girdi bir posta kodu olarak görünmüyor",
-    "An exception has been raised while validating the input" => "Girdi doğrulanırken bir istisna meydana geldi",
+    "The input does not appear to be a postal code." => "Girdi bir posta kodu olarak görünmüyor",
+    "An exception has been raised while validating the input." => "Girdi doğrulanırken bir istisna meydana geldi",
 
     // Zend_Validator_Barcode
     "The input failed checksum validation." => "Girişin sağlama doğrulaması başarısız oldu",
@@ -67,7 +67,7 @@ return array(
     "The input contains an invalid amount of digits" => "Girdi geçersiz sayıda rakam içeriyor",
     "The input is not from an allowed institute" => "Girdi izin verilen bir kuruluştan değil",
     "The input seems to be an invalid creditcard number" => "Girdi geçersiz bir kredi kartı numarası gibi görünüyor",
-    "An exception has been raised while validating the input" => "Girdi doğrulanırken bir hata meydana geldi",
+    "An exception has been raised while validating the input." => "Girdi doğrulanırken bir hata meydana geldi",
 
     // Zend_Validator_Csrf
     "The form submitted did not originate from the expected site" => "Gönderilen form beklenen site kaynaklı gibi görünmüyor",

--- a/resources/languages/tr/Zend_Validate.php
+++ b/resources/languages/tr/Zend_Validate.php
@@ -24,33 +24,33 @@
  */
 return array(
     // Zend_I18n_Validator_Alnum
-    "Invalid type given. String, integer or float expected" => "Geçersiz tür verildi, Dize, tamsayı ya da ondalık sayı bekleniyor",
-    "The input contains characters which are non alphabetic and no digits" => "Girdi, harf ve rakam olmayan karakterler içeriyor",
-    "The input is an empty string" => "Girdi boş bir dizedir",
+    "Invalid type given. String, integer or float expected." => "Geçersiz tür verildi, Dize, tamsayı ya da ondalık sayı bekleniyor",
+    "The input contains characters which are non alphabetic and no digits." => "Girdi, harf ve rakam olmayan karakterler içeriyor",
+    "The input is an empty string." => "Girdi boş bir dizedir",
 
     // Zend_I18n_Validator_Alpha
-    "Invalid type given. String expected" => "Geçersiz tür verildi. Dize bekleniyor",
-    "The input contains non alphabetic characters" => "Girdi alfabetik olmayan karakterler içeriyor",
-    "The input is an empty string" => "Girdi boş bir dizedir",
+    "Invalid type given. String expected." => "Geçersiz tür verildi. Dize bekleniyor",
+    "The input contains non alphabetic characters." => "Girdi alfabetik olmayan karakterler içeriyor",
+    "The input is an empty string." => "Girdi boş bir dizedir",
 
     // Zend_I18n_Validator_Float
-    "Invalid type given. String, integer or float expected" => "Geçersiz tür verildi, Dize, tamsayı ya da ondalık sayı bekleniyor",
+    "Invalid type given. String, integer or float expected." => "Geçersiz tür verildi, Dize, tamsayı ya da ondalık sayı bekleniyor",
     "The input does not appear to be a float" => "Girdi ondalık bir sayı olarak görünmüyor",
 
     // Zend_I18n_Validator_Int
-    "Invalid type given. String or integer expected" => "Geçersiz tür verildi. Dize veya tamsayı bekleniyor",
-    "The input does not appear to be an integer" => "Girdi bir tamsayı olarak görünmüyor",
+    "Invalid type given. String or integer expected." => "Geçersiz tür verildi. Dize veya tamsayı bekleniyor",
+    "The input does not appear to be an integer." => "Girdi bir tamsayı olarak görünmüyor",
 
     // Zend_I18n_Validator_PostCode
-    "Invalid type given. String or integer expected" => "Geçersiz tür verildi. Dizge veya tamsayı bekleniyor",
+    "Invalid type given. String or integer expected." => "Geçersiz tür verildi. Dizge veya tamsayı bekleniyor",
     "The input does not appear to be a postal code" => "Girdi bir posta kodu olarak görünmüyor",
     "An exception has been raised while validating the input" => "Girdi doğrulanırken bir istisna meydana geldi",
 
     // Zend_Validator_Barcode
-    "The input failed checksum validation" => "Girişin sağlama doğrulaması başarısız oldu",
+    "The input failed checksum validation." => "Girişin sağlama doğrulaması başarısız oldu",
     "The input contains invalid characters" => "Girdi geçersiz karakterler içeriyor",
     "The input should have a length of %length% characters" => "Girdi %length% karakter uzunluğunda olmalıdır",
-    "Invalid type given. String expected" => "Yanlış tür verildi. Dizge bekleniyor",
+    "Invalid type given. String expected." => "Yanlış tür verildi. Dizge bekleniyor",
 
     // Zend_Validator_Between
     "The input is not between '%min%' and '%max%', inclusively" => "Girdi '%min%' ve '%max%' karakter arasında değil",
@@ -58,12 +58,12 @@ return array(
 
     // Zend_Validator_Callback
     "The input is not valid" => "Girdi geçerli değil",
-    "An exception has been raised within the callback" => "Callback içinde bir istisna meydana gelmiştir",
+    "An exception has been raised within the callback." => "Callback içinde bir istisna meydana gelmiştir",
 
     // Zend_Validator_CreditCard
     "The input seems to contain an invalid checksum" => "Girdi geçersiz bir sağlama toplamı içeriyor",
     "The input must contain only digits" => "Girdi sadece rakam içermelidir",
-    "Invalid type given. String expected" => "Yanlış tür verildi. Dizge bekleniyor",
+    "Invalid type given. String expected." => "Yanlış tür verildi. Dizge bekleniyor",
     "The input contains an invalid amount of digits" => "Girdi geçersiz sayıda rakam içeriyor",
     "The input is not from an allowed institute" => "Girdi izin verilen bir kuruluştan değil",
     "The input seems to be an invalid creditcard number" => "Girdi geçersiz bir kredi kartı numarası gibi görünüyor",
@@ -88,122 +88,122 @@ return array(
 
     // Zend_Validator_Digits
     "The input must contain only digits" => "Girdi sadece rakam içermelidir",
-    "The input is an empty string" => "Girdi boş bir dizedir",
-    "Invalid type given. String, integer or float expected" => "Geçersiz tür verildi, Dize, tamsayı ya da ondalık sayı bekleniyor",
+    "The input is an empty string." => "Girdi boş bir dizedir",
+    "Invalid type given. String, integer or float expected." => "Geçersiz tür verildi, Dize, tamsayı ya da ondalık sayı bekleniyor",
 
     // Zend_Validator_EmailAddress
-    "Invalid type given. String expected" => "Yanlış tür verildi. Dize bekleniyor",
+    "Invalid type given. String expected." => "Yanlış tür verildi. Dize bekleniyor",
     "The input is not a valid email address. Use the basic format local-part@hostname" => "Girdi geçerli bir E-posta adresi değil. local-part@hostname formatını kullanın",
     "'%hostname%' is not a valid hostname for the email address" => "'%hostname%' E-posta adresi için geçerli bir sağlayıcı değildir",
     "'%hostname%' does not appear to have any valid MX or A records for the email address" => "'%hostname%', E-posta adresi için geçerli bir A veya MX kaydına sahip gibi görünmüyor",
     "'%hostname%' is not in a routable network segment. The email address should not be resolved from public network" => "'%hostname%' yönlendirilebilir bir ağ katmanı değil. E-posta adresi açık bir ağdan çözümlenmemeli",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' dot-atom formatıyla uyuşmuyor",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' tırnaklı-dizge formatıyla uyuşmuyor",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart%' dot-atom formatıyla uyuşmuyor",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' tırnaklı-dizge formatıyla uyuşmuyor",
     "'%localPart%' is not a valid local part for the email address" => "'%localPart%' e-posta için geçerli bir yerel parça değil",
     "The input exceeds the allowed length" => "Girdi izin verilen uzunluğu aşıyor",
 
     // Zend_Validator_Explode
-    "Invalid type given. String expected" => "Yanlış tür verildi. Dize bekleniyor",
+    "Invalid type given. String expected." => "Yanlış tür verildi. Dize bekleniyor",
 
     // Zend_Validator_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Çok fazla dosya, en fazla '%max%' adete izin veriliyor fakat '%count%' adet verildi",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Çok faz dosya, en az '%min%' adet bekleniyor fakat '%count%' adet verildi",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Çok fazla dosya, en fazla '%max%' adete izin veriliyor fakat '%count%' adet verildi",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Çok faz dosya, en az '%min%' adet bekleniyor fakat '%count%' adet verildi",
 
     // Zend_Validator_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "'%value%' dosyası verilen crc32 hash'ları ile eşleşmiyor",
-    "A crc32 hash could not be evaluated for the given file" => "Bir crc32 hash'ı verilen dosya için değerlendirilemiyor",
-    "File '%value%' is not readable or does not exist" => "'%value%' dosyası okunamıyor ya da yok",
+    "File '%value%' does not match the given crc32 hashes." => "'%value%' dosyası verilen crc32 hash'ları ile eşleşmiyor",
+    "A crc32 hash could not be evaluated for the given file." => "Bir crc32 hash'ı verilen dosya için değerlendirilemiyor",
+    "File '%value%' is not readable or does not exist." => "'%value%' dosyası okunamıyor ya da yok",
 
     // Zend_Validator_File_ExcludeExtension
-    "File '%value%' has a false extension" => "'%value%' dosyası yanlış bir uzantıya sahip",
-    "File '%value%' is not readable or does not exist" => "'%value%' dosyası okunamıyor ya da yok",
+    "File '%value%' has a false extension." => "'%value%' dosyası yanlış bir uzantıya sahip",
+    "File '%value%' is not readable or does not exist." => "'%value%' dosyası okunamıyor ya da yok",
 
     // Zend_Validator_File_Exists
-    "File '%value%' does not exist" => "'%value%' dosyası yok",
+    "File '%value%' does not exist." => "'%value%' dosyası yok",
 
     // Zend_Validator_File_Extension
-    "File '%value%' has a false extension" => "'%value%' dosyası yanlış bir uzantıya sahip",
-    "File '%value%' is not readable or does not exist" => "'%value%' dosyası okunamıyor ya da yok",
+    "File '%value%' has a false extension." => "'%value%' dosyası yanlış bir uzantıya sahip",
+    "File '%value%' is not readable or does not exist." => "'%value%' dosyası okunamıyor ya da yok",
 
     // Zend_Validator_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Tüm dosyaların toplam boyutu en fazla '%max%' olmalıdır fakat '%size%' tespit edildi",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Tüm dosyaların toplam boyutu en az '%min%' olmalıdır fakat '%size%' tespit edildi",
-    "One or more files can not be read" => "Bir ya da daha fazla dosya okunamıyor",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Tüm dosyaların toplam boyutu en fazla '%max%' olmalıdır fakat '%size%' tespit edildi",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Tüm dosyaların toplam boyutu en az '%min%' olmalıdır fakat '%size%' tespit edildi",
+    "One or more files can not be read." => "Bir ya da daha fazla dosya okunamıyor",
 
     // Zend_Validator_File_Hash
-    "File '%value%' does not match the given hashes" => "'%value%' dosyası verilen hash ile uyuşmuyor",
-    "A hash could not be evaluated for the given file" => "Bir hash verilen dosya için değerlendirmeye alınamamıştır",
-    "File '%value%' is not readable or does not exist" => "'%value%' dosyası okunamıyor ya da yok",
+    "File '%value%' does not match the given hashes." => "'%value%' dosyası verilen hash ile uyuşmuyor",
+    "A hash could not be evaluated for the given file." => "Bir hash verilen dosya için değerlendirmeye alınamamıştır",
+    "File '%value%' is not readable or does not exist." => "'%value%' dosyası okunamıyor ya da yok",
 
     // Zend_Validator_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "'%value%' resim dosyasının genişliği en fazla '%maxwidth%' olmalıdır fakat '%width%' algılandı",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "'%value%' resim dosyasının genişliği en az '%minwidth%' olmalıdır fakat '%width%' algılandı",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "'%value%' resim dosyasının yüksekliği en fazla '%maxheight%' olmalıdır fakat '%height%' algılandı",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "'%value%' resim dosyasının yüksekliği en az '%minheight%' olmalıdır fakat '%height%' algılandı",
-    "The size of image '%value%' could not be detected" => "'%value%' resminin boyutları algılanamadı",
-    "File '%value%' is not readable or does not exist" => "'%value%' dosyası okunamıyor ya da yok",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "'%value%' resim dosyasının genişliği en fazla '%maxwidth%' olmalıdır fakat '%width%' algılandı",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "'%value%' resim dosyasının genişliği en az '%minwidth%' olmalıdır fakat '%width%' algılandı",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "'%value%' resim dosyasının yüksekliği en fazla '%maxheight%' olmalıdır fakat '%height%' algılandı",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "'%value%' resim dosyasının yüksekliği en az '%minheight%' olmalıdır fakat '%height%' algılandı",
+    "The size of image '%value%' could not be detected." => "'%value%' resminin boyutları algılanamadı",
+    "File '%value%' is not readable or does not exist." => "'%value%' dosyası okunamıyor ya da yok",
 
     // Zend_Validator_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "'%value%' dosyası sıkıştırılmış değil, '%type%' algılandı",
-    "The mimetype of file '%value%' could not be detected" => "'%value%' dosyasının mime-tipi algılanamadı",
-    "File '%value%' is not readable or does not exist" => "'%value%' dosyası okunamıyor ya da yok",
+    "File '%value%' is not compressed, '%type%' detected." => "'%value%' dosyası sıkıştırılmış değil, '%type%' algılandı",
+    "The mimetype of file '%value%' could not be detected." => "'%value%' dosyasının mime-tipi algılanamadı",
+    "File '%value%' is not readable or does not exist." => "'%value%' dosyası okunamıyor ya da yok",
 
     // Zend_Validator_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "'%value%' resim değil, '%type%' algılandı",
-    "The mimetype of file '%value%' could not be detected" => "'%value%' dosyasının mime-tipi algılanamadı",
-    "File '%value%' is not readable or does not exist" => "'%value%' dosyası okunamıyor ya da yok",
+    "File '%value%' is no image, '%type%' detected." => "'%value%' resim değil, '%type%' algılandı",
+    "The mimetype of file '%value%' could not be detected." => "'%value%' dosyasının mime-tipi algılanamadı",
+    "File '%value%' is not readable or does not exist." => "'%value%' dosyası okunamıyor ya da yok",
 
     // Zend_Validator_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "'%value%' dosyası verilen md5 hash'ları ile eşleşmiyor",
-    "A md5 hash could not be evaluated for the given file" => "Bir md5 hash'ı verilen dosya için eşleştirilemedi",
-    "File '%value%' is not readable or does not exist" => "'%value%' dosyası okunamıyor ya da yok",
+    "File '%value%' does not match the given md5 hashes." => "'%value%' dosyası verilen md5 hash'ları ile eşleşmiyor",
+    "A md5 hash could not be evaluated for the given file." => "Bir md5 hash'ı verilen dosya için eşleştirilemedi",
+    "File '%value%' is not readable or does not exist." => "'%value%' dosyası okunamıyor ya da yok",
 
     // Zend_Validator_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "'%value%' dosyası yanlış mime-tipine sahip: '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "'%value%' dosyasının mime-tipi algılanamadı",
-    "File '%value%' is not readable or does not exist" => "'%value%' dosyası okunamıyor ya da yok",
+    "File '%value%' has a false mimetype of '%type%'." => "'%value%' dosyası yanlış mime-tipine sahip: '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "'%value%' dosyasının mime-tipi algılanamadı",
+    "File '%value%' is not readable or does not exist." => "'%value%' dosyası okunamıyor ya da yok",
 
     // Zend_Validator_File_NotExists
-    "File '%value%' exists" => "'%value%' dosyası var",
+    "File '%value%' exists." => "'%value%' dosyası var",
 
     // Zend_Validator_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "'%value%' dosyası verilen sha1 hash'ları ile eşleşmiyor",
-    "A sha1 hash could not be evaluated for the given file" => "Bir sha1 hash'ı verilen dosya için eşleştirilemedi",
-    "File '%value%' is not readable or does not exist" => "'%value%' dosyası okunamıyor ya da yok",
+    "File '%value%' does not match the given sha1 hashes." => "'%value%' dosyası verilen sha1 hash'ları ile eşleşmiyor",
+    "A sha1 hash could not be evaluated for the given file." => "Bir sha1 hash'ı verilen dosya için eşleştirilemedi",
+    "File '%value%' is not readable or does not exist." => "'%value%' dosyası okunamıyor ya da yok",
 
     // Zend_Validator_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "'%value%' dosyası için izin verilen en büyük boyut '%max%' fakat '%size%' algılandı",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "'%value%' dosyası için izin verilen en az boyut '%min%' fakat '%size%' algılandı",
-    "File '%value%' is not readable or does not exist" => "'%value%' dosyası okunamıyor ya da yok",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "'%value%' dosyası için izin verilen en büyük boyut '%max%' fakat '%size%' algılandı",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "'%value%' dosyası için izin verilen en az boyut '%min%' fakat '%size%' algılandı",
+    "File '%value%' is not readable or does not exist." => "'%value%' dosyası okunamıyor ya da yok",
 
     // Zend_Validator_File_Upload
-    "File '%value%' exceeds the defined ini size" => "'%value%' dosyası tanımlanan ini boyutunu aşıyor",
-    "File '%value%' exceeds the defined form size" => "'%value%' dosyası tanımlanan form boyutunu aşıyor",
-    "File '%value%' was only partially uploaded" => "'%value%' dosyası kısmen yüklenmiştir",
-    "File '%value%' was not uploaded" => "'%value%' dosyası yüklenemedi",
-    "No temporary directory was found for file '%value%'" => "Geçici dizin '%value%' dosyası için bulunamamıştır",
-    "File '%value%' can't be written" => "'%value%' dosyasına yazılamıyor",
-    "A PHP extension returned an error while uploading the file '%value%'" => "Bir PHP uzantısı '%value%' dosyasını yüklerken bir hata verdi",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "'%value%' dosyası yasadışı bir biçimde yüklendi. Bu olası bir saldırı olabilir",
-    "File '%value%' was not found" => "'%value%' dosyası bulunamadı",
-    "Unknown error while uploading file '%value%'" => "'%value%' dosyasını yüklerken bilinmeyen bir hata ile karşılaşıldı",
+    "File '%value%' exceeds the defined ini size." => "'%value%' dosyası tanımlanan ini boyutunu aşıyor",
+    "File '%value%' exceeds the defined form size." => "'%value%' dosyası tanımlanan form boyutunu aşıyor",
+    "File '%value%' was only partially uploaded." => "'%value%' dosyası kısmen yüklenmiştir",
+    "File '%value%' was not uploaded." => "'%value%' dosyası yüklenemedi",
+    "No temporary directory was found for file '%value%'." => "Geçici dizin '%value%' dosyası için bulunamamıştır",
+    "File '%value%' can't be written." => "'%value%' dosyasına yazılamıyor",
+    "A PHP extension returned an error while uploading the file '%value%'." => "Bir PHP uzantısı '%value%' dosyasını yüklerken bir hata verdi",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "'%value%' dosyası yasadışı bir biçimde yüklendi. Bu olası bir saldırı olabilir",
+    "File '%value%' was not found." => "'%value%' dosyası bulunamadı",
+    "Unknown error while uploading file '%value%'." => "'%value%' dosyasını yüklerken bilinmeyen bir hata ile karşılaşıldı",
 
     // Zend_Validator_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Çok fazla kelime, en fazla '%max%' kelimeye izin veriliyor fakat '%count%' sayıldı",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Çok az kelime, en az '%min%' kelimeye izin veriliyor fakat '%count%' sayıldı",
-    "File '%value%' is not readable or does not exist" => "'%value%' dosyası okunamıyor ya da yok",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Çok fazla kelime, en fazla '%max%' kelimeye izin veriliyor fakat '%count%' sayıldı",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Çok az kelime, en az '%min%' kelimeye izin veriliyor fakat '%count%' sayıldı",
+    "File '%value%' is not readable or does not exist." => "'%value%' dosyası okunamıyor ya da yok",
 
     // Zend_Validator_GreaterThan
     "The input is not greater than '%min%'" => "Girdi '%min%' değerinden büyük değil",
     "The input is not greater or equal than '%min%'" => "Girdi '%min%' değerinden büyük ya da eşit değil",
 
     // Zend_Validator_Hex
-    "Invalid type given. String expected" => "Yanlış tür verildi. Dizge bekleniyor",
+    "Invalid type given. String expected." => "Yanlış tür verildi. Dizge bekleniyor",
     "The input contains non-hexadecimal characters" => "Giriş onaltılık olmayan karakterler içeriyor",
 
     // Zend_Validator_Hostname
     "The input appears to be a DNS hostname but the given punycode notation cannot be decoded" => "Girdi bir DNS host adı gibi görünüyor fakat verilen punycode gösteriminde deşifre edilemiyor",
-    "Invalid type given. String expected" => "Yanlış tür verildi. Dizge bekleniyor",
+    "Invalid type given. String expected." => "Yanlış tür verildi. Dizge bekleniyor",
     "The input appears to be a DNS hostname but contains a dash in an invalid position" => "Girdi bir DNS host adı gibi görünüyor fakat yanlış pozisyonda tire içeriyor",
     "The input does not match the expected structure for a DNS hostname" => "Girdi bir DNS host adının beklenen yapısıyla eşleşmiyor",
     "The input appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "Girdi DNS host adı gibi görünüyor fakat TLD '%tld%' şeması ile eşleştirilemiyor",
@@ -221,18 +221,18 @@ return array(
     "The input has failed the IBAN check" => "Girdinin IBAN denetimi başarısız oldu",
 
     // Zend_Validator_Identical
-    "The two given tokens do not match" => "Verilen iki belirteç eşleşmiyor",
-    "No token was provided to match against" => "Hiçbir eşleştirilecek belirteç sağlanmadı",
+    "The two given tokens do not match." => "Verilen iki belirteç eşleşmiyor",
+    "No token was provided to match against." => "Hiçbir eşleştirilecek belirteç sağlanmadı",
 
     // Zend_Validator_InArray
     "The input was not found in the haystack" => "Girdi samanlıkta bulunamadı",
 
     // Zend_Validator_Ip
-    "Invalid type given. String expected" => "Yanlış tür verildi. Dizge bekleniyor",
+    "Invalid type given. String expected." => "Yanlış tür verildi. Dizge bekleniyor",
     "The input does not appear to be a valid IP address" => "Girdi geçerli bir IP adresi gibi görünmüyor",
 
     // Zend_Validator_Isbn
-    "Invalid type given. String or integer expected" => "Geçersiz tür verildi. Dizge veya tamsayı bekleniyor",
+    "Invalid type given. String or integer expected." => "Geçersiz tür verildi. Dizge veya tamsayı bekleniyor",
     "The input is not a valid ISBN number" => "Girdi geçerli bir ISBN numarası değil",
 
     // Zend_Validator_LessThan
@@ -240,40 +240,40 @@ return array(
     "The input is not less or equal than '%max%'" => "Girdi '%max%' değerinden küçük ya da eşit değil",
 
     // Zend_Validator_NotEmpty
-    "Value is required and can't be empty" => "Değer gerekli ve boş olamaz",
-    "Invalid type given. String, integer, float, boolean or array expected" => "Geçersiz tür verildi. Dizge, tamsayı, ondalık sayı, mantıksal veya dizi bekleniyor",
+    "Value is required and can't be empty." => "Değer gerekli ve boş olamaz",
+    "Invalid type given. String, integer, float, boolean or array expected." => "Geçersiz tür verildi. Dizge, tamsayı, ondalık sayı, mantıksal veya dizi bekleniyor",
 
     // Zend_Validator_Regex
-    "Invalid type given. String, integer or float expected" => "Geçersiz tür verildi, Dizge, tamsayı ya da ondalık sayı bekleniyor",
+    "Invalid type given. String, integer or float expected." => "Geçersiz tür verildi, Dizge, tamsayı ya da ondalık sayı bekleniyor",
     "The input does not match against pattern '%pattern%'" => "Girdi '%pattern%' deseniyle eşleşmiyor",
-    "There was an internal error while using the pattern '%pattern%'" => "'%pattern%' deseni kullanılırken bir iç hata ile karşılaşıldı",
+    "There was an internal error while using the pattern '%pattern%'." => "'%pattern%' deseni kullanılırken bir iç hata ile karşılaşıldı",
 
     // Zend_Validator_Sitemap_Changefreq
     "The input is not a valid sitemap changefreq" => "Girdi geçerli bir site haritası changefreq'i olarak görünmüyor",
-    "Invalid type given. String expected" => "Yanlış tür verildi. Dizge bekleniyor",
+    "Invalid type given. String expected." => "Yanlış tür verildi. Dizge bekleniyor",
 
     // Zend_Validator_Sitemap_Lastmod
     "The input is not a valid sitemap lastmod" => "Girdi geçerli bir site haritası lastmod'u olarak görünmüyor",
-    "Invalid type given. String expected" => "Yanlış tür verildi. Dizge bekleniyor",
+    "Invalid type given. String expected." => "Yanlış tür verildi. Dizge bekleniyor",
 
     // Zend_Validator_Sitemap_Loc
     "The input is not a valid sitemap location" => "Girdi geçerli bir site haritası lokasyonu olarak görünmüyor",
-    "Invalid type given. String expected" => "Yanlış tür verildi. Dizge bekleniyor",
+    "Invalid type given. String expected." => "Yanlış tür verildi. Dizge bekleniyor",
 
     // Zend_Validator_Sitemap_Priority
     "The input is not a valid sitemap priority" => "Girdi geçerli bir site haritası önceliği olarak görünmüyor",
-    "Invalid type given. Numeric string, integer or float expected" => "Geçersiz tür verildi. Sayısal dizge, tamsayı ya da ondalık sayı bekleniyor",
+    "Invalid type given. Numeric string, integer or float expected." => "Geçersiz tür verildi. Sayısal dizge, tamsayı ya da ondalık sayı bekleniyor",
 
     // Zend_Validator_Step
     "Invalid value given. Scalar expected" => "Geçersiz değer verildi. Skalar bekleniyor",
     "The input is not a valid step" => "Girdi geçerli bir aşama değildir",
 
     // Zend_Validator_StringLength
-    "Invalid type given. String expected" => "Yanlış tür verildi. Dizge bekleniyor",
+    "Invalid type given. String expected." => "Yanlış tür verildi. Dizge bekleniyor",
     "The input is less than %min% characters long" => "Girdi %min% karakterden daha az",
     "The input is more than %max% characters long" => "Girdi %max% karakterden daha fazla",
 
     // Zend_Validator_Uri
-    "Invalid type given. String expected" => "Yanlış tür verildi. Dizge bekleniyor",
+    "Invalid type given. String expected." => "Yanlış tür verildi. Dizge bekleniyor",
     "The input does not appear to be a valid Uri" => "Girdi geçerli bir Uri olarak görünmüyor",
 );

--- a/resources/languages/uk/Zend_Validate.php
+++ b/resources/languages/uk/Zend_Validate.php
@@ -25,13 +25,13 @@
 return array(
     // Zend_Validate_Alnum
     "Invalid type given, value should be float, string, or integer" => "Неприпустимий тип даних, значення повинно бути числом з плаваючою крапкою, рядком чи цілим числом",
-    "'%value%' contains characters which are non alphabetic and no digits" => "'%value%' містить символи які не є літерами чи цифрами",
-    "'%value%' is an empty string" => "'%value%' - пустий рядок",
+    "'%value%' contains characters which are non alphabetic and no digits." => "'%value%' містить символи які не є літерами чи цифрами",
+    "'%value%' is an empty string." => "'%value%' - пустий рядок",
 
     // Zend_Validate_Alpha
     "Invalid type given, value should be a string" => "Неприпустимий тип даних, значення повинно бути рядком",
-    "'%value%' contains non alphabetic characters" => "'%value%' містить символи які не є літерами",
-    "'%value%' is an empty string" => "'%value%' - пустий рядок",
+    "'%value%' contains non alphabetic characters." => "'%value%' містить символи які не є літерами",
+    "'%value%' is an empty string." => "'%value%' - пустий рядок",
 
     // Zend_Validate_Barcode
     "'%value%' failed checksum validation" => "'%value%' помилка перевірки контрольної суми",
@@ -44,26 +44,26 @@ return array(
     "'%value%' is not strictly between '%min%' and '%max%'" => "'%value%' за межами діапазону від '%min%' до '%max%'",
 
     // Zend_Validate_Callback
-    "'%value%' is not valid" => "'%value%' - неприпустиме значення",
+    "'%value%' is not valid." => "'%value%' - неприпустиме значення",
     "Failure within the callback, exception returned" => "Помилка в зворотньому виклику, повернено виключення",
 
     // Zend_Validate_Ccnum
-    "'%value%' must contain between 13 and 19 digits" => "'%value%' має містити від 13 до 19 цифр",
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Алгоритм Луна (обчислення контрольної цифри) повернув помилку для '%value%'",
+    "'%value%' must contain between 13 and 19 digits." => "'%value%' має містити від 13 до 19 цифр",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Алгоритм Луна (обчислення контрольної цифри) повернув помилку для '%value%'",
 
     // Zend_Validate_CreditCard
-    "Luhn algorithm (mod-10 checksum) failed on '%value%'" => "Алгоритм Луна (обчислення контрольної цифри) повернув помилку для '%value%'",
-    "'%value%' must contain only digits" => "'%value%' має містити тільки цифри",
+    "Luhn algorithm (mod-10 checksum) failed on '%value%'." => "Алгоритм Луна (обчислення контрольної цифри) повернув помилку для '%value%'",
+    "'%value%' must contain only digits." => "'%value%' має містити тільки цифри",
     "Invalid type given, value should be a string" => "Неприпустимий тип даних, значення повинно бути рядком",
-    "'%value%' contains an invalid amount of digits" => "'%value%' містить неприпустиму кількість цифр",
-    "'%value%' is not from an allowed institute" => "'%value%' не відноситься до дозволенних платіжних систем",
+    "'%value%' contains an invalid amount of digits." => "'%value%' містить неприпустиму кількість цифр",
+    "'%value%' is not from an allowed institute." => "'%value%' не відноситься до дозволенних платіжних систем",
     "Validation of '%value%' has been failed by the service" => "Перевірка '%value%' закінчилась помилкою сервісу",
     "The service returned a failure while validating '%value%'" => "Сервіс повернув помилку під час перевірки '%value%'",
 
     // Zend_Validate_Date
     "Invalid type given, value should be string, integer, array or Zend_Date" => "Неприпустимий тип даних, значення повинно бути рядком, цілим числом, масивом чи об'єктом Zend_Date",
-    "'%value%' does not appear to be a valid date" => "'%value%' - некоректна дата",
-    "'%value%' does not fit the date format '%format%'" => "'%value%' не відповідає формату дати '%format%'",
+    "'%value%' does not appear to be a valid date." => "'%value%' - некоректна дата",
+    "'%value%' does not fit the date format '%format%'." => "'%value%' не відповідає формату дати '%format%'",
 
     // Zend_Validate_Db_Abstract
     "No record matching %value% was found" => "Не знайдено записів, що відповідають '%value%'",
@@ -72,164 +72,164 @@ return array(
     // Zend_Validate_Digits
     "Invalid type given, value should be string, integer or float" => "Неприпустимий тип даних, значення повинно бути числом з плаваючою крапкою, рядком чи цілим числом",
     "'%value%' contains characters which are not digits; but only digits are allowed" => "'%value%' має містити тільки цифри",
-    "'%value%' is an empty string" => "'%value%' - пустий рядок",
+    "'%value%' is an empty string." => "'%value%' - пустий рядок",
 
     // Zend_Validate_EmailAddress
     "Invalid type given, value should be a string" => "Неприпустимий тип даних, значення повинно рядком",
-    "'%value%' is not a valid email address in the basic format local-part@hostname" => "'%value%' неприпустима адреса електронної пошти для формату ім'я@домен",
-    "'%hostname%' is not a valid hostname for email address '%value%'" => "'%hostname%' неприпустиме ім'я хоста для адреси '%value%'",
-    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'" => "'%hostname%' не має коректного MX-запису про адресу '%value%'",
+    "'%value%' is not a valid email address in the basic format local-part@hostname." => "'%value%' неприпустима адреса електронної пошти для формату ім'я@домен",
+    "'%hostname%' is not a valid hostname for email address '%value%'." => "'%hostname%' неприпустиме ім'я хоста для адреси '%value%'",
+    "'%hostname%' does not appear to have a valid MX record for the email address '%value%'." => "'%hostname%' не має коректного MX-запису про адресу '%value%'",
     "'%hostname%' is not in a routable network segment. The email address '%value%' should not be resolved from public network." => "'%hostname%' не є маршрутизованим сегментом мережі. Адреса електронної пошти '%value%' не може бути отримана з публічної мережі.",
-    "'%localPart%' can not be matched against dot-atom format" => "'%localPart% не відповідає формату dot-atom",
-    "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' не відповідає формату quoted-string",
-    "'%localPart%' is not a valid local part for email address '%value%'" => "'%localPart%' неприпустиме ім'я для адреси '%value%'",
-    "'%value%' exceeds the allowed length" => "'%value%' перевищує дозволену довжину",
+    "'%localPart%' can not be matched against dot-atom format." => "'%localPart% не відповідає формату dot-atom",
+    "'%localPart%' can not be matched against quoted-string format." => "'%localPart%' не відповідає формату quoted-string",
+    "'%localPart%' is not a valid local part for email address '%value%'." => "'%localPart%' неприпустиме ім'я для адреси '%value%'",
+    "'%value%' exceeds the allowed length." => "'%value%' перевищує дозволену довжину",
 
     // Zend_Validate_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Занадто багато файлів, дозволено максимум - '%max%', отримано - '%count%'",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "Занадто мало файлів, дозволено мінімум - '%min%', отримано - '%count%'",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "Занадто багато файлів, дозволено максимум - '%max%', отримано - '%count%'",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "Занадто мало файлів, дозволено мінімум - '%min%', отримано - '%count%'",
 
     // Zend_Validate_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Файл '%value%' не відповідає заданому crc32 хешу",
-    "A crc32 hash could not be evaluated for the given file" => "crc32 хеш не може бути обчисленний для цього файлу",
+    "File '%value%' does not match the given crc32 hashes." => "Файл '%value%' не відповідає заданому crc32 хешу",
+    "A crc32 hash could not be evaluated for the given file." => "crc32 хеш не може бути обчисленний для цього файлу",
     "File '%value%' could not be found" => "Файл '%value%' не знайдено",
 
     // Zend_Validate_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Файл '%value%' має неприпустиме розширення",
+    "File '%value%' has a false extension." => "Файл '%value%' має неприпустиме розширення",
     "File '%value%' could not be found" => "Файл '%value%' не знайдено",
 
     // Zend_Validate_File_ExcludeMimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Файл '%value%' має неприпустимий MIME-тип '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Не вдається визначити MIME-тип файлу '%value%'",
+    "File '%value%' has a false mimetype of '%type%'." => "Файл '%value%' має неприпустимий MIME-тип '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Не вдається визначити MIME-тип файлу '%value%'",
     "File '%value%' can not be read" => "Файл '%value%' неможливо прочитати",
 
     // Zend_Validate_File_Exists
-    "File '%value%' does not exist" => "Файл '%value%' не існує",
+    "File '%value%' does not exist." => "Файл '%value%' не існує",
 
     // Zend_Validate_File_Extension
-    "File '%value%' has a false extension" => "Файл '%value%' має неприпустиме розширення",
+    "File '%value%' has a false extension." => "Файл '%value%' має неприпустиме розширення",
     "File '%value%' could not be found" => "Файл '%value%' не знайдено",
 
     // Zend_Validate_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "Загальний розмір файлів не повинен перевищувати '%max%', зараз - '%size%'",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "Загальний розмір файлів має бути менше '%min%', зараз - '%size%'",
-    "One or more files can not be read" => "Неможливо прочитати один чи декілька файлів",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "Загальний розмір файлів не повинен перевищувати '%max%', зараз - '%size%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "Загальний розмір файлів має бути менше '%min%', зараз - '%size%'",
+    "One or more files can not be read." => "Неможливо прочитати один чи декілька файлів",
 
     // Zend_Validate_File_Hash
-    "File '%value%' does not match the given hashes" => "Файл '%value%' не відповідає вказаному хешу",
-    "A hash could not be evaluated for the given file" => "Не можливо обчислити хеш для вказаного файла",
+    "File '%value%' does not match the given hashes." => "Файл '%value%' не відповідає вказаному хешу",
+    "A hash could not be evaluated for the given file." => "Не можливо обчислити хеш для вказаного файла",
     "File '%value%' could not be found" => "Файл '%value%' не знайдено",
 
     // Zend_Validate_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Максимально допустима ширина для зображення '%value%' - '%maxwidth%', зараз - '%width%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Мінімально очікувана ширина для зображення '%value%' - '%minwidth%', зараз - '%width%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Максимально допустима висота для зображення '%value%' - '%maxheight%', зараз - '%height%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Мінімально очікувана ширина для зображення '%value%' - '%minheight%', зараз - '%height%'",
-    "The size of image '%value%' could not be detected" => "Неможливо визначити розмір зображення '%value%'",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "Максимально допустима ширина для зображення '%value%' - '%maxwidth%', зараз - '%width%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "Мінімально очікувана ширина для зображення '%value%' - '%minwidth%', зараз - '%width%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "Максимально допустима висота для зображення '%value%' - '%maxheight%', зараз - '%height%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "Мінімально очікувана ширина для зображення '%value%' - '%minheight%', зараз - '%height%'",
+    "The size of image '%value%' could not be detected." => "Неможливо визначити розмір зображення '%value%'",
     "File '%value%' can not be read" => "Файл '%value%' неможливо прочитати",
 
     // Zend_Validate_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Файл '%value%' не є стислий. MIME-тип файлу - '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Неможливо визначити MIME-тип файлу '%value%'",
+    "File '%value%' is not compressed, '%type%' detected." => "Файл '%value%' не є стислий. MIME-тип файлу - '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Неможливо визначити MIME-тип файлу '%value%'",
     "File '%value%' can not be read" => "Файл '%value%' неможливо прочитати",
 
     // Zend_Validate_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Файл '%value%' не є зображенням. MIME-тип файлу - '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Неможливо визначити MIME-тип файлу '%value%'",
+    "File '%value%' is no image, '%type%' detected." => "Файл '%value%' не є зображенням. MIME-тип файлу - '%type%'",
+    "The mimetype of file '%value%' could not be detected." => "Неможливо визначити MIME-тип файлу '%value%'",
     "File '%value%' can not be read" => "Файл '%value%' неможливо прочитати",
 
     // Zend_Validate_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Файл '%value%' не відповідає вказаному md5 хешу",
-    "A md5 hash could not be evaluated for the given file" => "md5 хеш не може бути визначений для вказаного файлу",
+    "File '%value%' does not match the given md5 hashes." => "Файл '%value%' не відповідає вказаному md5 хешу",
+    "A md5 hash could not be evaluated for the given file." => "md5 хеш не може бути визначений для вказаного файлу",
     "File '%value%' could not be found" => "Файл '%value%' не знайдено",
 
     // Zend_Validate_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "MIME-тип '%type%' файлу '%value%' неприпустимий",
-    "The mimetype of file '%value%' could not be detected" => "Неможливо визначити MIME-тип файлу '%value%'",
+    "File '%value%' has a false mimetype of '%type%'." => "MIME-тип '%type%' файлу '%value%' неприпустимий",
+    "The mimetype of file '%value%' could not be detected." => "Неможливо визначити MIME-тип файлу '%value%'",
     "File '%value%' can not be read" => "Файл '%value%' не можливо прочитати",
 
     // Zend_Validate_File_NotExists
-    "File '%value%' exists" => "Файл '%value%' вже існує",
+    "File '%value%' exists." => "Файл '%value%' вже існує",
 
     // Zend_Validate_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Файл '%value%' не відповідає хешу sha1",
-    "A sha1 hash could not be evaluated for the given file" => "Неможливо визначити sha1 хеш для вказаного файлу",
+    "File '%value%' does not match the given sha1 hashes." => "Файл '%value%' не відповідає хешу sha1",
+    "A sha1 hash could not be evaluated for the given file." => "Неможливо визначити sha1 хеш для вказаного файлу",
     "File '%value%' could not be found" => "Файл '%value%' не знайдено",
 
     // Zend_Validate_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Максимально дозволений розмір файлу '%value%' - '%max%', зараз - '%size%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Мінімально дозволений розмір файлу '%value%' - '%min%', зараз - '%size%'",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "Максимально дозволений розмір файлу '%value%' - '%max%', зараз - '%size%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "Мінімально дозволений розмір файлу '%value%' - '%min%', зараз - '%size%'",
     "File '%value%' could not be found" => "Файл '%value%' не знайдено",
 
     // Zend_Validate_File_Upload
-    "File '%value%' exceeds the defined ini size" => "Розмір файлу '%value%' більше ніж дозволений, що вказаний в php.ini",
-    "File '%value%' exceeds the defined form size" => "Розмір файлу '%value%' більше ніж дозволений, що вказаний  в формі",
-    "File '%value%' was only partially uploaded" => "Файл '%value%' був завантажений тільки частково",
-    "File '%value%' was not uploaded" => "Файл '%value%' не був завантажений",
-    "No temporary directory was found for file '%value%'" => "Не знайдено тимчасову директорію для файлу '%value%'",
-    "File '%value%' can't be written" => "Файл '%value%' не може бути записаний",
-    "A PHP extension returned an error while uploading the file '%value%'" => "PHP розширення повернуло помилку під час завантаження фалу '%value%'",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "Файл '%value%' завантажений некоректно. Можлива атака",
-    "File '%value%' was not found" => "Файл '%value%' не знайдено",
-    "Unknown error while uploading file '%value%'" => "Під час завантаження файлу '%value%' виникла невідома помилка",
+    "File '%value%' exceeds the defined ini size." => "Розмір файлу '%value%' більше ніж дозволений, що вказаний в php.ini",
+    "File '%value%' exceeds the defined form size." => "Розмір файлу '%value%' більше ніж дозволений, що вказаний  в формі",
+    "File '%value%' was only partially uploaded." => "Файл '%value%' був завантажений тільки частково",
+    "File '%value%' was not uploaded." => "Файл '%value%' не був завантажений",
+    "No temporary directory was found for file '%value%'." => "Не знайдено тимчасову директорію для файлу '%value%'",
+    "File '%value%' can't be written." => "Файл '%value%' не може бути записаний",
+    "A PHP extension returned an error while uploading the file '%value%'." => "PHP розширення повернуло помилку під час завантаження фалу '%value%'",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "Файл '%value%' завантажений некоректно. Можлива атака",
+    "File '%value%' was not found." => "Файл '%value%' не знайдено",
+    "Unknown error while uploading file '%value%'." => "Під час завантаження файлу '%value%' виникла невідома помилка",
 
     // Zend_Validate_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Занадто багато слів, дозволено максимум '%max%' слів, зараз - '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Занадто мало слів, дозволено мінімум '%min%' слів, зараз - '%count%'",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "Занадто багато слів, дозволено максимум '%max%' слів, зараз - '%count%'",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "Занадто мало слів, дозволено мінімум '%min%' слів, зараз - '%count%'",
     "File '%value%' could not be found" => "Файл '%value%' не знайдено",
 
     // Zend_Validate_Float
     "Invalid type given, value should be float, string, or integer" => "Неприпустимий тип даних, значення повинно бути числом з плаваючою крапкою, рядком, або цілим числом",
-    "'%value%' does not appear to be a float" => "'%value%' не є числом з плаваючою крапкою",
+    "'%value%' does not appear to be a float." => "'%value%' не є числом з плаваючою крапкою",
 
     // Zend_Validate_GreaterThan
-    "'%value%' is not greater than '%min%'" => "'%value%' не більше ніж '%min%'",
+    "'%value%' is not greater than '%min%'." => "'%value%' не більше ніж '%min%'",
 
     // Zend_Validate_Hex
     "Invalid type given, value should be a string" => "Неприпустимий тип даних, значення повинно бути рядком",
-    "'%value%' has not only hexadecimal digit characters" => "Значення '%value%' повинно містити тільки шістнадцятирічні символи",
+    "'%value%' has not only hexadecimal digit characters." => "Значення '%value%' повинно містити тільки шістнадцятирічні символи",
 
     // Zend_Validate_Hostname
     "Invalid type given, value should be a string" => "Неприпустимий тип даних, значення повинно бути рядком",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "Значення '%value%' виглядає як IP-адреса, але IP-адреси не дозволені",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' виглядає як DNS ім’я хоста, але воно не повинно бути зі списку доменів верхнього рівня",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' виглядає як DNS ім’я хоста, але знак '-' знаходиться в неприпустимому місці",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' виглядає як DNS ім’я хоста, але воно не відповідає шаблону для доменних імен верхнього рівня '%tld%'",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' виглядає як DNS ім’я хоста, але не вдається визначити домен верхнього рівня",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' не відповідає очікуваній структурі для DNS імені хоста",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' є неприпустимим іменем локальної мережі",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' виглядає як ім’я локальної мережі, але імена локальних мереж не дозволені",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "'%value%' виглядає як DNS ім’я хоста, але вказане значення не може бути перетворене в припустимий для DNS набір символів",
+    "'%value%' appears to be an IP address, but IP addresses are not allowed." => "Значення '%value%' виглядає як IP-адреса, але IP-адреси не дозволені",
+    "'%value%' appears to be a DNS hostname but cannot match TLD against known list." => "'%value%' виглядає як DNS ім’я хоста, але воно не повинно бути зі списку доменів верхнього рівня",
+    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position." => "'%value%' виглядає як DNS ім’я хоста, але знак '-' знаходиться в неприпустимому місці",
+    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'." => "'%value%' виглядає як DNS ім’я хоста, але воно не відповідає шаблону для доменних імен верхнього рівня '%tld%'",
+    "'%value%' appears to be a DNS hostname but cannot extract TLD part." => "'%value%' виглядає як DNS ім’я хоста, але не вдається визначити домен верхнього рівня",
+    "'%value%' does not match the expected structure for a DNS hostname." => "'%value%' не відповідає очікуваній структурі для DNS імені хоста",
+    "'%value%' does not appear to be a valid local network name." => "'%value%' є неприпустимим іменем локальної мережі",
+    "'%value%' appears to be a local network name but local network names are not allowed." => "'%value%' виглядає як ім’я локальної мережі, але імена локальних мереж не дозволені",
+    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded." => "'%value%' виглядає як DNS ім’я хоста, але вказане значення не може бути перетворене в припустимий для DNS набір символів",
 
     // Zend_Validate_Iban
-    "Unknown country within the IBAN '%value%'" => "Невідома країна IBAN '%value%'",
-    "'%value%' has a false IBAN format" => "'%value%' має неприпустимий IBAN формат",
-    "'%value%' has failed the IBAN check" => "'%value%' не пройшло IBAN перевірку",
+    "Unknown country within the IBAN '%value%'." => "Невідома країна IBAN '%value%'",
+    "'%value%' has a false IBAN format." => "'%value%' має неприпустимий IBAN формат",
+    "'%value%' has failed the IBAN check." => "'%value%' не пройшло IBAN перевірку",
 
     // Zend_Validate_Identical
     "The token '%token%' does not match the given token '%value%'" => "Значення '%token%' не співпадає з вказаним значенням '%value%'",
-    "No token was provided to match against" => "Не вказано значення для перевірки на ідентичність",
+    "No token was provided to match against." => "Не вказано значення для перевірки на ідентичність",
 
     // Zend_Validate_InArray
-    "'%value%' was not found in the haystack" => "'%value%' не знайдено в списку допустимих значень",
+    "'%value%' was not found in the haystack." => "'%value%' не знайдено в списку допустимих значень",
 
     // Zend_Validate_Int
     "Invalid type given, value should be string or integer" => "Неприпустимий тип даних, значення повинно бути рядком чи цілим числом",
-    "'%value%' does not appear to be an integer" => "'%value%' не є цілим числом",
+    "'%value%' does not appear to be an integer." => "'%value%' не є цілим числом",
 
     // Zend_Validate_Ip
     "Invalid type given, value should be a string" => "Неприпустимий тип даних, значення повинно бути рядком",
-    "'%value%' does not appear to be a valid IP address" => "'%value%' - некоректна IP-адреса",
+    "'%value%' does not appear to be a valid IP address." => "'%value%' - некоректна IP-адреса",
 
     // Zend_Validate_Isbn
-    "'%value%' is not a valid ISBN number" => "'%value%' - некоректний номер ISBN",
+    "'%value%' is not a valid ISBN number." => "'%value%' - некоректний номер ISBN",
 
     // Zend_Validate_LessThan
-    "'%value%' is not less than '%max%'" => "'%value%' не менше ніж '%max%'",
+    "'%value%' is not less than '%max%'." => "'%value%' не менше ніж '%max%'",
 
     // Zend_Validate_NotEmpty
     "Invalid type given, value should be float, string, array, boolean or integer" => "Неприпустимий тип даних, значення повинно бути числом з плаваючою крапкою, рядком, масивом чи цілим числом",
-    "Value is required and can't be empty" => "Значення обов'язкове і не може бути порожнім",
+    "Value is required and can't be empty." => "Значення обов'язкове і не може бути порожнім",
 
     // Zend_Validate_PostCode
     "Invalid type given, value should be string or integer" => "Неприпустимий тип даних, значення повинно бути рядком чи цілим числом",
@@ -237,22 +237,22 @@ return array(
 
     // Zend_Validate_Regex
     "Invalid type given, value should be string, integer or float" => "Неприпустимий тип даних, значення повинно бути числом з плаваючою крапкою, рядком чи цілим числом",
-    "'%value%' does not match against pattern '%pattern%'" => "'%value%' не відповідає шаблону '%pattern%'",
+    "'%value%' does not match against pattern '%pattern%'." => "'%value%' не відповідає шаблону '%pattern%'",
 
     // Zend_Validate_Sitemap_Changefreq
-    "'%value%' is not a valid sitemap changefreq" => "'%value%' неприпустиме значення для sitemap changefreq",
+    "'%value%' is not a valid sitemap changefreq." => "'%value%' неприпустиме значення для sitemap changefreq",
 
     // Zend_Validate_Sitemap_Lastmod
-    "'%value%' is not a valid sitemap lastmod" => "'%value%' неприпустиме значення для sitemap lastmod",
+    "'%value%' is not a valid sitemap lastmod." => "'%value%' неприпустиме значення для sitemap lastmod",
 
     // Zend_Validate_Sitemap_Loc
-    "'%value%' is not a valid sitemap location" => "'%value%' неприпустиме значення для sitemap location",
+    "'%value%' is not a valid sitemap location." => "'%value%' неприпустиме значення для sitemap location",
 
     // Zend_Validate_Sitemap_Priority
-    "'%value%' is not a valid sitemap priority" => "'%value%' неприпустиме значення для sitemap priority",
+    "'%value%' is not a valid sitemap priority." => "'%value%' неприпустиме значення для sitemap priority",
 
     // Zend_Validate_StringLength
     "Invalid type given, value should be a string" => "Неприпустимий тип даних, значення повинно бути рядком",
-    "'%value%' is less than %min% characters long" => "Довжина '%value%' менше %min% символів",
-    "'%value%' is more than %max% characters long" => "Довжина '%value%' перевищує %max% символів",
+    "'%value%' is less than %min% characters long." => "Довжина '%value%' менше %min% символів",
+    "'%value%' is more than %max% characters long." => "Довжина '%value%' перевищує %max% символів",
 );

--- a/resources/languages/zh/Zend_Captcha.php
+++ b/resources/languages/zh/Zend_Captcha.php
@@ -24,12 +24,12 @@
  */
 return array(
     // Zend_Captcha_ReCaptcha
-    "Missing captcha fields" => "没有找到验证码区域",
-    "Failed to validate captcha" => "验证码校验失败",
-    "Captcha value is wrong: %value%" => "验证码不匹配: %value%",
+    "Missing captcha fields." => "没有找到验证码区域",
+    "Failed to validate captcha." => "验证码校验失败",
+    "Captcha value is wrong: %value%." => "验证码不匹配: %value%",
 
     // Zend_Captcha_Word
-    "Empty captcha value" => "请输入验证码",
-    "Captcha ID field is missing" => "没有找到验证码区域",
-    "Captcha value is wrong" => "验证码不匹配",
+    "Empty captcha value." => "请输入验证码",
+    "Captcha ID field is missing." => "没有找到验证码区域",
+    "Captcha value is wrong." => "验证码不匹配",
 );

--- a/resources/languages/zh/Zend_Validate.php
+++ b/resources/languages/zh/Zend_Validate.php
@@ -35,7 +35,7 @@ return array(
 
     // Zend_I18n_Validator_Float
     "Invalid type given. String, integer or float expected." => "请输入与一个整数或小数",
-    "The input does not appear to be a float" => "输入无效，请输入一个小数",
+    "The input does not appear to be a float." => "输入无效，请输入一个小数",
 
     // Zend_I18n_Validator_Int
     "Invalid type given. String or integer expected." => "输入无效，请输入字符或数字",
@@ -43,8 +43,8 @@ return array(
 
     // Zend_I18n_Validator_PostCode
     "Invalid type given. String or integer expected." => "输入无效，请输入一个字符或数字",
-    "The input does not appear to be a postal code" => "无效的邮政编码格式",
-    "An exception has been raised while validating the input" => "验证输入时有异常发生",
+    "The input does not appear to be a postal code." => "无效的邮政编码格式",
+    "An exception has been raised while validating the input." => "验证输入时有异常发生",
 
     // Zend_Validator_Barcode
     "The input failed checksum validation." => "输入的条码无法通过校验",
@@ -67,7 +67,7 @@ return array(
     "The input contains an invalid amount of digits" => "输入的卡号长度有误",
     "The input is not from an allowed institute" => "输入的卡号没有找到对应的发行机构",
     "The input seems to be an invalid creditcard number" => "输入的卡号无法通过校验",
-    "An exception has been raised while validating the input" => "验证输入时有异常发生",
+    "An exception has been raised while validating the input." => "验证输入时有异常发生",
 
     // Zend_Validator_Csrf
     "The form submitted did not originate from the expected site" => "表单提交来源网站未经过许可",

--- a/resources/languages/zh/Zend_Validate.php
+++ b/resources/languages/zh/Zend_Validate.php
@@ -24,33 +24,33 @@
  */
 return array(
     // Zend_I18n_Validator_Alnum
-    "Invalid type given. String, integer or float expected" => "请输入一个整数或小数",
-    "The input contains characters which are non alphabetic and no digits" => "输入不能为字母数字以外的字符",
-    "The input is an empty string" => "输入不能为空",
+    "Invalid type given. String, integer or float expected." => "请输入一个整数或小数",
+    "The input contains characters which are non alphabetic and no digits." => "输入不能为字母数字以外的字符",
+    "The input is an empty string." => "输入不能为空",
 
     // Zend_I18n_Validator_Alpha
-    "Invalid type given. String expected" => "输入无效，请输入一个字符串",
-    "The input contains non alphabetic characters" => "输入不能为字母以外的字符",
-    "The input is an empty string" => "输入不能为空",
+    "Invalid type given. String expected." => "输入无效，请输入一个字符串",
+    "The input contains non alphabetic characters." => "输入不能为字母以外的字符",
+    "The input is an empty string." => "输入不能为空",
 
     // Zend_I18n_Validator_Float
-    "Invalid type given. String, integer or float expected" => "请输入与一个整数或小数",
+    "Invalid type given. String, integer or float expected." => "请输入与一个整数或小数",
     "The input does not appear to be a float" => "输入无效，请输入一个小数",
 
     // Zend_I18n_Validator_Int
-    "Invalid type given. String or integer expected" => "输入无效，请输入字符或数字",
-    "The input does not appear to be an integer" => "请输入一个整数",
+    "Invalid type given. String or integer expected." => "输入无效，请输入字符或数字",
+    "The input does not appear to be an integer." => "请输入一个整数",
 
     // Zend_I18n_Validator_PostCode
-    "Invalid type given. String or integer expected" => "输入无效，请输入一个字符或数字",
+    "Invalid type given. String or integer expected." => "输入无效，请输入一个字符或数字",
     "The input does not appear to be a postal code" => "无效的邮政编码格式",
     "An exception has been raised while validating the input" => "验证输入时有异常发生",
 
     // Zend_Validator_Barcode
-    "The input failed checksum validation" => "输入的条码无法通过校验",
+    "The input failed checksum validation." => "输入的条码无法通过校验",
     "The input contains invalid characters" => "输入的条码包含无效的字符",
     "The input should have a length of %length% characters" => "输入的条码长度应为%length%个字符",
-    "Invalid type given. String expected" => "输入无效，请输入一个字符串",
+    "Invalid type given. String expected." => "输入无效，请输入一个字符串",
 
     // Zend_Validator_Between
     "The input is not between '%min%' and '%max%', inclusively" => "请输入大于等于'%min%'并小于等于'%max%'的值",
@@ -58,12 +58,12 @@ return array(
 
     // Zend_Validator_Callback
     "The input is not valid" => "输入无效",
-    "An exception has been raised within the callback" => "回调中有异常发生",
+    "An exception has been raised within the callback." => "回调中有异常发生",
 
     // Zend_Validator_CreditCard
     "The input seems to contain an invalid checksum" => "输入的卡号格式有误",
     "The input must contain only digits" => "卡号应为数字",
-    "Invalid type given. String expected" => "输入无效，请输入一个字符串",
+    "Invalid type given. String expected." => "输入无效，请输入一个字符串",
     "The input contains an invalid amount of digits" => "输入的卡号长度有误",
     "The input is not from an allowed institute" => "输入的卡号没有找到对应的发行机构",
     "The input seems to be an invalid creditcard number" => "输入的卡号无法通过校验",
@@ -88,122 +88,122 @@ return array(
 
     // Zend_Validator_Digits
     "The input must contain only digits" => "输入不能为数字以外的字符",
-    "The input is an empty string" => "输入不能为空",
-    "Invalid type given. String, integer or float expected" => "输入无效，请输入字符整数或小数",
+    "The input is an empty string." => "输入不能为空",
+    "Invalid type given. String, integer or float expected." => "输入无效，请输入字符整数或小数",
 
     // Zend_Validator_EmailAddress
-    "Invalid type given. String expected" => "输入无效，请输入一个字符串",
+    "Invalid type given. String expected." => "输入无效，请输入一个字符串",
     "The input is not a valid email address. Use the basic format local-part@hostname" => "输入邮件地址格式有误，请检查格式是否为local-part@hostname",
     "'%hostname%' is not a valid hostname for the email address" => "'%hostname%'不是一个可用的邮件域名",
     "'%hostname%' does not appear to have any valid MX or A records for the email address" => "'%hostname%'域名下没有找到可用的MX或A记录，邮件无法投递",
     "'%hostname%' is not in a routable network segment. The email address should not be resolved from public network" => "'%hostname%'域名所在网段无法被路由，邮件地址应位于公共网络",
-    "'%localPart%' can not be matched against dot-atom format" => "邮件用户名部分'%localPart%'格式无法匹配dot-atom格式",
-    "'%localPart%' can not be matched against quoted-string format" => "邮件用户名部分'%localPart%'格式无法匹配quoted-string格式",
+    "'%localPart%' can not be matched against dot-atom format." => "邮件用户名部分'%localPart%'格式无法匹配dot-atom格式",
+    "'%localPart%' can not be matched against quoted-string format." => "邮件用户名部分'%localPart%'格式无法匹配quoted-string格式",
     "'%localPart%' is not a valid local part for the email address" => "'%localPart%'不是一个有效的邮件用户名",
     "The input exceeds the allowed length" => "输入超出允许长度",
 
     // Zend_Validator_Explode
-    "Invalid type given. String expected" => "输入无效，请输入一个字符串",
+    "Invalid type given. String expected." => "输入无效，请输入一个字符串",
 
     // Zend_Validator_File_Count
-    "Too many files, maximum '%max%' are allowed but '%count%' are given" => "文件过多，最多允许'%max%'个文件，找到'%count%'个",
-    "Too few files, minimum '%min%' are expected but '%count%' are given" => "文件过少，至少需要'%min%'个文件，找到'%count%'个",
+    "Too many files, maximum '%max%' are allowed but '%count%' are given." => "文件过多，最多允许'%max%'个文件，找到'%count%'个",
+    "Too few files, minimum '%min%' are expected but '%count%' are given." => "文件过少，至少需要'%min%'个文件，找到'%count%'个",
 
     // Zend_Validator_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "文件'%value%'无法通过CRC32校验",
-    "A crc32 hash could not be evaluated for the given file" => "文件无法生成CRC32校验码",
-    "File '%value%' is not readable or does not exist" => "文件'%value%'无法读取或不存在",
+    "File '%value%' does not match the given crc32 hashes." => "文件'%value%'无法通过CRC32校验",
+    "A crc32 hash could not be evaluated for the given file." => "文件无法生成CRC32校验码",
+    "File '%value%' is not readable or does not exist." => "文件'%value%'无法读取或不存在",
 
     // Zend_Validator_File_ExcludeExtension
-    "File '%value%' has a false extension" => "文件'%value%'扩展名不允许",
-    "File '%value%' is not readable or does not exist" => "文件'%value%'无法读取或不存在",
+    "File '%value%' has a false extension." => "文件'%value%'扩展名不允许",
+    "File '%value%' is not readable or does not exist." => "文件'%value%'无法读取或不存在",
 
     // Zend_Validator_File_Exists
-    "File '%value%' does not exist" => "文件'%value%'不存在",
+    "File '%value%' does not exist." => "文件'%value%'不存在",
 
     // Zend_Validator_File_Extension
-    "File '%value%' has a false extension" => "文件'%value%'扩展名不允许",
-    "File '%value%' is not readable or does not exist" => "文件'%value%'无法读取或不存在",
+    "File '%value%' has a false extension." => "文件'%value%'扩展名不允许",
+    "File '%value%' is not readable or does not exist." => "文件'%value%'无法读取或不存在",
 
     // Zend_Validator_File_FilesSize
-    "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "所有文件总大小'%size%'超出，最大允许'%max%'",
-    "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "所有文件总大小'%size%'不足，至少需要'%min%'",
-    "One or more files can not be read" => "一个或多个文件无法读取",
+    "All files in sum should have a maximum size of '%max%' but '%size%' were detected." => "所有文件总大小'%size%'超出，最大允许'%max%'",
+    "All files in sum should have a minimum size of '%min%' but '%size%' were detected." => "所有文件总大小'%size%'不足，至少需要'%min%'",
+    "One or more files can not be read." => "一个或多个文件无法读取",
 
     // Zend_Validator_File_Hash
-    "File '%value%' does not match the given hashes" => "文件'%value%'无法通过哈希校验",
-    "A hash could not be evaluated for the given file" => "文件无法生成哈希校验码",
-    "File '%value%' is not readable or does not exist" => "文件'%value%'无法读取或不存在",
+    "File '%value%' does not match the given hashes." => "文件'%value%'无法通过哈希校验",
+    "A hash could not be evaluated for the given file." => "文件无法生成哈希校验码",
+    "File '%value%' is not readable or does not exist." => "文件'%value%'无法读取或不存在",
 
     // Zend_Validator_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "图片'%value%'的宽度'%width%'超出，最大允许'%maxwidth%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "图片'%value%'的宽度'%width%'不足，至少应为'%minwidth%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "图片'%value%'的高度'%height%'超出，最大允许'%maxheight%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "图片'%value%'的高度'%height%'不足，至少应为'%minheight%'",
-    "The size of image '%value%' could not be detected" => "图片'%value%'的尺寸无法读取",
-    "File '%value%' is not readable or does not exist" => "文件'%value%'无法读取或不存在",
+    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected." => "图片'%value%'的宽度'%width%'超出，最大允许'%maxwidth%'",
+    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected." => "图片'%value%'的宽度'%width%'不足，至少应为'%minwidth%'",
+    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected." => "图片'%value%'的高度'%height%'超出，最大允许'%maxheight%'",
+    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected." => "图片'%value%'的高度'%height%'不足，至少应为'%minheight%'",
+    "The size of image '%value%' could not be detected." => "图片'%value%'的尺寸无法读取",
+    "File '%value%' is not readable or does not exist." => "文件'%value%'无法读取或不存在",
 
     // Zend_Validator_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "文件'%value%'没有被压缩，检测到文件的媒体类型为'%type%'",
-    "The mimetype of file '%value%' could not be detected" => "文件'%value%'的媒体类型无法检测",
-    "File '%value%' is not readable or does not exist" => "文件'%value%'无法读取或不存在",
+    "File '%value%' is not compressed, '%type%' detected." => "文件'%value%'没有被压缩，检测到文件的媒体类型为'%type%'",
+    "The mimetype of file '%value%' could not be detected." => "文件'%value%'的媒体类型无法检测",
+    "File '%value%' is not readable or does not exist." => "文件'%value%'无法读取或不存在",
 
     // Zend_Validator_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "文件'%value%'不是图片，检测到文件的媒体类型为'%type%'",
-    "The mimetype of file '%value%' could not be detected" => "文件'%value%'的媒体类型无法检测",
-    "File '%value%' is not readable or does not exist" => "文件'%value%'无法读取或不存在",
+    "File '%value%' is no image, '%type%' detected." => "文件'%value%'不是图片，检测到文件的媒体类型为'%type%'",
+    "The mimetype of file '%value%' could not be detected." => "文件'%value%'的媒体类型无法检测",
+    "File '%value%' is not readable or does not exist." => "文件'%value%'无法读取或不存在",
 
     // Zend_Validator_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "文件'%value%'无法通过MD5校验",
-    "A md5 hash could not be evaluated for the given file" => "文件无法生成MD5校验码",
-    "File '%value%' is not readable or does not exist" => "文件'%value%'无法读取或不存在",
+    "File '%value%' does not match the given md5 hashes." => "文件'%value%'无法通过MD5校验",
+    "A md5 hash could not be evaluated for the given file." => "文件无法生成MD5校验码",
+    "File '%value%' is not readable or does not exist." => "文件'%value%'无法读取或不存在",
 
     // Zend_Validator_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "文件'%value%'的媒体类型'%type%'不允许",
-    "The mimetype of file '%value%' could not be detected" => "文件'%value%'的媒体类型无法检测",
-    "File '%value%' is not readable or does not exist" => "文件'%value%'无法读取或不存在",
+    "File '%value%' has a false mimetype of '%type%'." => "文件'%value%'的媒体类型'%type%'不允许",
+    "The mimetype of file '%value%' could not be detected." => "文件'%value%'的媒体类型无法检测",
+    "File '%value%' is not readable or does not exist." => "文件'%value%'无法读取或不存在",
 
     // Zend_Validator_File_NotExists
-    "File '%value%' exists" => "文件'%value%'已经存在",
+    "File '%value%' exists." => "文件'%value%'已经存在",
 
     // Zend_Validator_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "文件'%value%'无法通过SHA1校验",
-    "A sha1 hash could not be evaluated for the given file" => "文件无法生成SHA1校验码",
-    "File '%value%' is not readable or does not exist" => "文件'%value%'无法读取或不存在",
+    "File '%value%' does not match the given sha1 hashes." => "文件'%value%'无法通过SHA1校验",
+    "A sha1 hash could not be evaluated for the given file." => "文件无法生成SHA1校验码",
+    "File '%value%' is not readable or does not exist." => "文件'%value%'无法读取或不存在",
 
     // Zend_Validator_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "文件'%value%'的大小'%size%'超出，最大允许'%max%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "文件'%value%'的大小'%size%'不足，至少需要'%min%'",
-    "File '%value%' is not readable or does not exist" => "文件'%value%'无法读取或不存在",
+    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected." => "文件'%value%'的大小'%size%'超出，最大允许'%max%'",
+    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected." => "文件'%value%'的大小'%size%'不足，至少需要'%min%'",
+    "File '%value%' is not readable or does not exist." => "文件'%value%'无法读取或不存在",
 
     // Zend_Validator_File_Upload
-    "File '%value%' exceeds the defined ini size" => "文件'%value%'大小超出系统允许范围",
-    "File '%value%' exceeds the defined form size" => "文件'%value%'大小超出表单允许范围",
-    "File '%value%' was only partially uploaded" => "文件'%value%'上传不完整",
-    "File '%value%' was not uploaded" => "文件'%value%'没有被上传",
-    "No temporary directory was found for file '%value%'" => "没有找到临时文件夹存放文件'%value%'",
-    "File '%value%' can't be written" => "文件'%value%'无法被写入",
-    "A PHP extension returned an error while uploading the file '%value%'" => "文件'%value%'上传时发生了一个PHP扩展错误",
-    "File '%value%' was illegally uploaded. This could be a possible attack" => "文件'%value%'被非法上传，这可能被判定为一次入侵",
-    "File '%value%' was not found" => "文件'%value%'不存在",
-    "Unknown error while uploading file '%value%'" => "文件'%value%'上传时发生了一个未知错误",
+    "File '%value%' exceeds the defined ini size." => "文件'%value%'大小超出系统允许范围",
+    "File '%value%' exceeds the defined form size." => "文件'%value%'大小超出表单允许范围",
+    "File '%value%' was only partially uploaded." => "文件'%value%'上传不完整",
+    "File '%value%' was not uploaded." => "文件'%value%'没有被上传",
+    "No temporary directory was found for file '%value%'." => "没有找到临时文件夹存放文件'%value%'",
+    "File '%value%' can't be written." => "文件'%value%'无法被写入",
+    "A PHP extension returned an error while uploading the file '%value%'." => "文件'%value%'上传时发生了一个PHP扩展错误",
+    "File '%value%' was illegally uploaded. This could be a possible attack." => "文件'%value%'被非法上传，这可能被判定为一次入侵",
+    "File '%value%' was not found." => "文件'%value%'不存在",
+    "Unknown error while uploading file '%value%'." => "文件'%value%'上传时发生了一个未知错误",
 
     // Zend_Validator_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "输入的单词过多，最多允许'%max%'个单词，输入了'%count%'个",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "输入的单词过少，至少需要'%min%'个单词，输入了'%count%'个",
-    "File '%value%' is not readable or does not exist" => "文件'%value%'无法读取或不存在",
+    "Too much words, maximum '%max%' are allowed but '%count%' were counted." => "输入的单词过多，最多允许'%max%'个单词，输入了'%count%'个",
+    "Too less words, minimum '%min%' are expected but '%count%' were counted." => "输入的单词过少，至少需要'%min%'个单词，输入了'%count%'个",
+    "File '%value%' is not readable or does not exist." => "文件'%value%'无法读取或不存在",
 
     // Zend_Validator_GreaterThan
     "The input is not greater than '%min%'" => "输入应大于'%min%'",
     "The input is not greater or equal than '%min%'" => "输入应大于等于'%min%'",
 
     // Zend_Validator_Hex
-    "Invalid type given. String expected" => "输入无效，请输入一个字符串",
+    "Invalid type given. String expected." => "输入无效，请输入一个字符串",
     "The input contains non-hexadecimal characters" => "请输入十六进制允许的字符",
 
     // Zend_Validator_Hostname
     "The input appears to be a DNS hostname but the given punycode notation cannot be decoded" => "输入的DNS域名在解析中无法用给定的punycode正确解码",
-    "Invalid type given. String expected" => "输入无效，请输入一个字符串",
+    "Invalid type given. String expected." => "输入无效，请输入一个字符串",
     "The input appears to be a DNS hostname but contains a dash in an invalid position" => "输入的DNS域名中连接符位置不符合规定",
     "The input does not match the expected structure for a DNS hostname" => "输入的DNS域名结构组成有误",
     "The input appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "输入的DNS域名的顶级域名'%tld%'无法被解析",
@@ -221,18 +221,18 @@ return array(
     "The input has failed the IBAN check" => "输入的IBAN帐号校验失败",
 
     // Zend_Validator_Identical
-    "The two given tokens do not match" => "两个验证令牌不匹配",
-    "No token was provided to match against" => "没有令牌输入，无法匹配",
+    "The two given tokens do not match." => "两个验证令牌不匹配",
+    "No token was provided to match against." => "没有令牌输入，无法匹配",
 
     // Zend_Validator_InArray
     "The input was not found in the haystack" => "输入没有在指定的允许范围内",
 
     // Zend_Validator_Ip
-    "Invalid type given. String expected" => "输入无效，请输入一个字符串",
+    "Invalid type given. String expected." => "输入无效，请输入一个字符串",
     "The input does not appear to be a valid IP address" => "输入的IP地址格式不正确",
 
     // Zend_Validator_Isbn
-    "Invalid type given. String or integer expected" => "输入无效，请输入字符或整数",
+    "Invalid type given. String or integer expected." => "输入无效，请输入字符或整数",
     "The input is not a valid ISBN number" => "输入的ISBN编号格式不正确",
 
     // Zend_Validator_LessThan
@@ -240,40 +240,40 @@ return array(
     "The input is not less or equal than '%max%'" => "输入应小于等于'%max%'",
 
     // Zend_Validator_NotEmpty
-    "Value is required and can't be empty" => "输入不能为空",
-    "Invalid type given. String, integer, float, boolean or array expected" => "输入无效，只允许字符、整数、小数、布尔值、数组类型",
+    "Value is required and can't be empty." => "输入不能为空",
+    "Invalid type given. String, integer, float, boolean or array expected." => "输入无效，只允许字符、整数、小数、布尔值、数组类型",
 
     // Zend_Validator_Regex
-    "Invalid type given. String, integer or float expected" => "输入无效，请输入字符、整数或小数",
+    "Invalid type given. String, integer or float expected." => "输入无效，请输入字符、整数或小数",
     "The input does not match against pattern '%pattern%'" => "输入不匹配指定的模式'%pattern%'",
-    "There was an internal error while using the pattern '%pattern%'" => "匹配指定模式'%pattern%'时有内部错误发生",
+    "There was an internal error while using the pattern '%pattern%'." => "匹配指定模式'%pattern%'时有内部错误发生",
 
     // Zend_Validator_Sitemap_Changefreq
     "The input is not a valid sitemap changefreq" => "输入不符合网站地图的changefreq格式",
-    "Invalid type given. String expected" => "输入无效，请输入一个字符串",
+    "Invalid type given. String expected." => "输入无效，请输入一个字符串",
 
     // Zend_Validator_Sitemap_Lastmod
     "The input is not a valid sitemap lastmod" => "输入不符合网站地图的lastmod格式",
-    "Invalid type given. String expected" => "输入无效，请输入一个字符串",
+    "Invalid type given. String expected." => "输入无效，请输入一个字符串",
 
     // Zend_Validator_Sitemap_Loc
     "The input is not a valid sitemap location" => "输入不符合网站地图的location格式",
-    "Invalid type given. String expected" => "输入无效，请输入一个字符串",
+    "Invalid type given. String expected." => "输入无效，请输入一个字符串",
 
     // Zend_Validator_Sitemap_Priority
     "The input is not a valid sitemap priority" => "输入不符合网站地图的priority格式",
-    "Invalid type given. Numeric string, integer or float expected" => "输入无效，请输入一个数字",
+    "Invalid type given. Numeric string, integer or float expected." => "输入无效，请输入一个数字",
 
     // Zend_Validator_Step
     "Invalid value given. Scalar expected" => "输入无效，请输入一个数字",
     "The input is not a valid step" => "输入不在阶梯计算的结果范围内",
 
     // Zend_Validator_StringLength
-    "Invalid type given. String expected" => "输入无效，请输入一个字符串",
+    "Invalid type given. String expected." => "输入无效，请输入一个字符串",
     "The input is less than %min% characters long" => "输入字符个数应大于%min%",
     "The input is more than %max% characters long" => "输入字符个数应小于%max%",
 
     // Zend_Validator_Uri
-    "Invalid type given. String expected" => "输入无效，请输入一个字符串",
+    "Invalid type given. String expected." => "输入无效，请输入一个字符串",
     "The input does not appear to be a valid Uri" => "输入的Uri格式有误",
 );

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -317,6 +317,6 @@ class FormRowTest extends TestCase
         $element->setMessages($validator->getMessages());
 
         $markup = $this->helper->__invoke($element);
-        $this->assertEquals(2,  count(explode("<ul><li>The input does not appear to be a valid date</li></ul>", $markup)));
+        $this->assertEquals(2,  count(explode("<ul><li>The input does not appear to be a valid date.</li></ul>", $markup)));
     }
 }

--- a/tests/ZendTest/Validator/CsrfTest.php
+++ b/tests/ZendTest/Validator/CsrfTest.php
@@ -166,7 +166,7 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
         $this->validator->isValid('foo');
         $messages = $this->validator->getMessages();
         $this->assertArrayHasKey(Csrf::NOT_SAME, $messages);
-        $this->assertEquals("The form submitted did not originate from the expected site", $messages[Csrf::NOT_SAME]);
+        $this->assertEquals("The form submitted did not originate from the expected site.", $messages[Csrf::NOT_SAME]);
     }
 
     public function testIsValidReturnsTrueWhenValueMatchesHash()

--- a/tests/ZendTest/Validator/DigitsTest.php
+++ b/tests/ZendTest/Validator/DigitsTest.php
@@ -71,8 +71,8 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->isValid(''));
         $messages = $this->validator->getMessages();
         $arrayExpected = array(
-            Digits::STRING_EMPTY => 'The input is an empty string'
-            );
+            Digits::STRING_EMPTY => 'The input is an empty string.',
+        );
         $this->assertThat($messages, $this->identicalTo($arrayExpected));
     }
 
@@ -84,8 +84,8 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->isValid('#'));
         $messages = $this->validator->getMessages();
         $arrayExpected = array(
-            Digits::NOT_DIGITS => 'The input must contain only digits'
-            );
+            Digits::NOT_DIGITS => 'The input must contain only digits.',
+        );
         $this->assertThat($messages, $this->identicalTo($arrayExpected));
     }
 

--- a/tests/ZendTest/Validator/MessageTest.php
+++ b/tests/ZendTest/Validator/MessageTest.php
@@ -41,7 +41,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $inputInvalid = 'abcdefghij';
         $this->assertFalse($this->validator->isValid($inputInvalid));
         $messages = $this->validator->getMessages();
-        $this->assertEquals("The input is more than 8 characters long", current($messages));
+        $this->assertEquals("The input is more than 8 characters long.", current($messages));
 
         $this->validator->setMessage(
             'Your value is too long',


### PR DESCRIPTION
I also added a few `,` after the last item in the initialization of the validation message templates.
