### PR TITLE
fixed Zend\Session\Container::exchangeArray

### DIFF
--- a/library/Zend/Session/Container.php
+++ b/library/Zend/Session/Container.php
@@ -439,6 +439,23 @@ class Container extends ArrayObject
     }
 
     /**
+     * Exchange the current array with another array or object.
+     *
+     * @param array|object $input
+     * @return array Returns the old array
+     * @see ArrayObject::exchangeArray()
+     */
+    public function exchangeArray($input)
+    {
+        $storage = $this->verifyNamespace();
+        $name    = $this->getName();
+
+        $old = $storage[$name];
+        $storage[$name] = $input;
+        return (array) $old;
+    }
+
+    /**
      * Iterate over session container
      *
      * @return Iterator

--- a/tests/ZendTest/Session/ContainerTest.php
+++ b/tests/ZendTest/Session/ContainerTest.php
@@ -515,4 +515,15 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $session->test = 42;
         $this->assertEquals(42, $session->test);
     }
+
+    public function testExchangeArray()
+    {
+        $this->container->offsetSet('old', 'old');
+        $this->assertTrue($this->container->offsetExists('old'));
+
+        $old = $this->container->exchangeArray(array('new' => 'new'));
+        $this->assertArrayHasKey('old', $old, "'exchangeArray' doesn't return an array of old items");
+        $this->assertFalse($this->container->offsetExists('old'), "'exchangeArray' doesn't remove old items");
+        $this->assertTrue($this->container->offsetExists('new'), "'exchangeArray' doesn't add the new array items");
+    }
 }


### PR DESCRIPTION
Because of `Zend\Session\Container extends ArrayObject` which implements that method.
http://php.net/manual/arrayobject.exchangearray.php

It will be used to implement `flush()` within a session storage adapter of `Zend\Cache`.
https://github.com/marc-mabe/zf2/blob/feature/cache-session-storage/library/Zend/Cache/Storage/Adapter/Session.php#L104
