### PR TITLE
Decouple Zend\Db\Sql from concrete Zend\Db\Adapter implementations

### DIFF
--- a/library/Zend/Db/Adapter/Adapter.php
+++ b/library/Zend/Db/Adapter/Adapter.php
@@ -20,7 +20,7 @@ use Zend\Db\ResultSet;
  * @property Driver\DriverInterface $driver
  * @property Platform\PlatformInterface $platform
  */
-class Adapter
+class Adapter implements AdapterInterface
 {
     /**
      * Query Mode Constants

--- a/library/Zend/Db/Adapter/AdapterInterface.php
+++ b/library/Zend/Db/Adapter/AdapterInterface.php
@@ -29,4 +29,13 @@ interface AdapterInterface
      * @return Platform\PlatformInterface
      */
     public function getPlatform();
+
+    /**
+     * Create statement
+     *
+     * @param  string $initialSql
+     * @param  ParameterContainer $initialParameters
+     * @return Driver\StatementInterface
+     */
+    public function createStatement($initialSql = null, $initialParameters = null);
 }

--- a/library/Zend/Db/Adapter/AdapterInterface.php
+++ b/library/Zend/Db/Adapter/AdapterInterface.php
@@ -8,23 +8,25 @@
  * @package   Zend_Db
  */
 
-namespace Zend\Db\Sql;
-
-use Zend\Db\Adapter\AdapterInterface;
-use Zend\Db\Adapter\StatementContainerInterface;
+namespace Zend\Db\Adapter;
 
 /**
  * @category   Zend
  * @package    Zend_Db
- * @subpackage Sql
+ * @subpackage Adapter
+ *
+ * @property Driver\DriverInterface $driver
+ * @property Platform\PlatformInterface $platform
  */
-interface PreparableSqlInterface
+interface AdapterInterface
 {
+    /**
+     * @return Driver\DriverInterface
+     */
+    public function getDriver();
 
     /**
-     * @param AdapterInterface $adapter
-     * @param StatementContainerInterface $statementContainer
-     * @return void
+     * @return Platform\PlatformInterface
      */
-    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer);
+    public function getPlatform();
 }

--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -10,7 +10,7 @@
 
 namespace Zend\Db\Sql;
 
-use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\StatementContainer;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
@@ -27,12 +27,12 @@ abstract class AbstractSql
      */
     protected $processInfo = array('paramPrefix' => '', 'subselectCount' => 0);
 
-    protected function processExpression(ExpressionInterface $expression, PlatformInterface $platform, Adapter $adapter = null, $namedParameterPrefix = null)
+    protected function processExpression(ExpressionInterface $expression, PlatformInterface $platform, DriverInterface $driver = null, $namedParameterPrefix = null)
     {
         // static counter for the number of times this method was invoked across the PHP runtime
         static $runtimeExpressionPrefix = 0;
 
-        if ($adapter && ((!is_string($namedParameterPrefix) || $namedParameterPrefix == ''))) {
+        if ($driver && ((!is_string($namedParameterPrefix) || $namedParameterPrefix == ''))) {
             $namedParameterPrefix = sprintf('expr%04dParam', ++$runtimeExpressionPrefix);
         }
 
@@ -64,26 +64,26 @@ abstract class AbstractSql
                     $values[$vIndex] = $platform->quoteIdentifierInFragment($value);
                 } elseif (isset($types[$vIndex]) && $types[$vIndex] == ExpressionInterface::TYPE_VALUE && $value instanceof Select) {
                     // process sub-select
-                    if ($adapter) {
-                        $values[$vIndex] = '(' . $this->processSubSelect($value, $platform, $adapter, $parameterContainer) . ')';
+                    if ($driver) {
+                        $values[$vIndex] = '(' . $this->processSubSelect($value, $platform, $driver, $parameterContainer) . ')';
                     } else {
                         $values[$vIndex] = '(' . $this->processSubSelect($value, $platform) . ')';
                     }
                 } elseif (isset($types[$vIndex]) && $types[$vIndex] == ExpressionInterface::TYPE_VALUE && $value instanceof ExpressionInterface) {
                     // recursive call to satisfy nested expressions
-                    $innerStatementContainer = $this->processExpression($value, $platform, $adapter, $namedParameterPrefix . $vIndex . 'subpart');
+                    $innerStatementContainer = $this->processExpression($value, $platform, $driver, $namedParameterPrefix . $vIndex . 'subpart');
                     $values[$vIndex] = $innerStatementContainer->getSql();
-                    if ($adapter) {
+                    if ($driver) {
                         $parameterContainer->merge($innerStatementContainer->getParameterContainer());
                     }
                 } elseif (isset($types[$vIndex]) && $types[$vIndex] == ExpressionInterface::TYPE_VALUE) {
 
                     // if prepareType is set, it means that this particular value must be
                     // passed back to the statement in a way it can be used as a placeholder value
-                    if ($adapter) {
+                    if ($driver) {
                         $name = $namedParameterPrefix . $expressionParamIndex++;
                         $parameterContainer->offsetSet($name, $value);
-                        $values[$vIndex] = $adapter->getDriver()->formatParameterName($name);
+                        $values[$vIndex] = $driver->formatParameterName($name);
                         continue;
                     }
 
@@ -142,9 +142,9 @@ abstract class AbstractSql
         return vsprintf($topSpec, $topParameters);
     }
 
-    protected function processSubSelect(Select $subselect, PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null)
+    protected function processSubSelect(Select $subselect, PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
-        if ($adapter) {
+        if ($driver) {
             $stmtContainer = new \Zend\Db\Adapter\StatementContainer;
 
             // Track subselect prefix and count for parameters
@@ -153,7 +153,7 @@ abstract class AbstractSql
             $subselect->processInfo['paramPrefix'] = 'subselect' . $subselect->processInfo['subselectCount'];
 
             // call subselect
-            $subselect->prepareStatement($adapter, $stmtContainer);
+            $subselect->prepareStatement(new \Zend\Db\Adapter\Adapter($driver, $platform), $stmtContainer);
 
             // copy count
             $this->processInfo['subselectCount'] = $subselect->processInfo['subselectCount'];

--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -10,7 +10,7 @@
 
 namespace Zend\Db\Sql;
 
-use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\AdapterInterface;
 use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
@@ -155,12 +155,13 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
     /**
      * Prepare the delete statement
      *
-     * @param  Adapter $adapter
+     * @param  AdapterInterface $adapter
      * @param  StatementContainerInterface $statementContainer
      * @return void
      */
-    public function prepareStatement(Adapter $adapter, StatementContainerInterface $statementContainer)
+    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
     {
+        $driver = $adapter->getDriver();
         $platform = $adapter->getPlatform();
         $parameterContainer = $statementContainer->getParameterContainer();
 
@@ -175,7 +176,7 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
         // process where
         if ($this->where->count() > 0) {
-            $whereParts = $this->processExpression($this->where, $platform, $adapter, 'where');
+            $whereParts = $this->processExpression($this->where, $platform, $driver, 'where');
             $parameterContainer->merge($whereParts->getParameterContainer());
             $sql .= ' ' . sprintf($this->specifications[self::SPECIFICATION_WHERE], $whereParts->getSql());
         }

--- a/library/Zend/Db/Sql/Having.php
+++ b/library/Zend/Db/Sql/Having.php
@@ -10,8 +10,6 @@
 
 namespace Zend\Db\Sql;
 
-use Zend\Db\Adapter\Adapter;
-
 /**
  * @category   Zend
  * @package    Zend_Db

--- a/library/Zend/Db/Sql/Insert.php
+++ b/library/Zend/Db/Sql/Insert.php
@@ -10,7 +10,7 @@
 
 namespace Zend\Db\Sql;
 
-use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\AdapterInterface;
 use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
@@ -137,11 +137,11 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
     /**
      * Prepare statement
      *
-     * @param  Adapter $adapter
+     * @param  AdapterInterface $adapter
      * @param  StatementContainerInterface $statementContainer
      * @return void
      */
-    public function prepareStatement(Adapter $adapter, StatementContainerInterface $statementContainer)
+    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
     {
         $driver   = $adapter->getDriver();
         $platform = $adapter->getPlatform();
@@ -160,7 +160,7 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
         foreach ($this->columns as $cIndex => $column) {
             $columns[$cIndex] = $platform->quoteIdentifier($column);
             if ($this->values[$cIndex] instanceof Expression) {
-                $exprData = $this->processExpression($this->values[$cIndex], $platform, $adapter);
+                $exprData = $this->processExpression($this->values[$cIndex], $platform, $driver);
                 $values[$cIndex] = $exprData->getSql();
                 $parameterContainer->merge($exprData->getParameterContainer());
             } else {

--- a/library/Zend/Db/Sql/Platform/AbstractPlatform.php
+++ b/library/Zend/Db/Sql/Platform/AbstractPlatform.php
@@ -10,7 +10,7 @@
 
 namespace Zend\Db\Sql\Platform;
 
-use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\AdapterInterface;
 use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Sql\PreparableSqlInterface;
@@ -55,12 +55,12 @@ class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInter
     }
 
     /**
-     * @param Adapter $adapter
+     * @param AdapterInterface $adapter
      * @param StatementContainerInterface $statementContainer
      * @throws Exception\RuntimeException
      * @return void
      */
-    public function prepareStatement(Adapter $adapter, StatementContainerInterface $statementContainer)
+    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
     {
         if (!$this->subject instanceof PreparableSqlInterface) {
             throw new Exception\RuntimeException('The subject does not appear to implement Zend\Db\Sql\PreparableSqlInterface, thus calling prepareStatement() has no effect');

--- a/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
@@ -10,7 +10,8 @@
 
 namespace Zend\Db\Sql\Platform\Mysql;
 
-use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\AdapterInterface;
+use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
@@ -33,10 +34,10 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
     }
 
     /**
-     * @param Adapter $adapter
+     * @param AdapterInterface $adapter
      * @param StatementContainerInterface $statementContainer
      */
-    public function prepareStatement(Adapter $adapter, StatementContainerInterface $statementContainer)
+    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
     {
         // localize variables
         foreach (get_object_vars($this->select) as $name => $value) {
@@ -58,13 +59,12 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         return parent::getSqlString($platform);
     }
 
-    protected function processLimit(PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null)
+    protected function processLimit(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         if ($this->limit === null) {
             return null;
         }
-        if ($adapter) {
-            $driver = $adapter->getDriver();
+        if ($driver) {
             $sql = $driver->formatParameterName('limit');
             $parameterContainer->offsetSet('limit', $this->limit, ParameterContainer::TYPE_INTEGER);
         } else {
@@ -74,14 +74,14 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         return array($sql);
     }
 
-    protected function processOffset(PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null)
+    protected function processOffset(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         if ($this->offset === null) {
             return null;
         }
-        if ($adapter) {
+        if ($driver) {
             $parameterContainer->offsetSet('offset', $this->offset, ParameterContainer::TYPE_INTEGER);
-            return array($adapter->getDriver()->formatParameterName('offset'));
+            return array($driver->formatParameterName('offset'));
         } else {
             return array($this->offset);
         }

--- a/library/Zend/Db/Sql/Platform/Platform.php
+++ b/library/Zend/Db/Sql/Platform/Platform.php
@@ -10,17 +10,17 @@
 
 namespace Zend\Db\Sql\Platform;
 
-use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\AdapterInterface;
 
 class Platform extends AbstractPlatform
 {
 
     /**
-     * @var Adapter
+     * @var AdapterInterface
      */
     protected $adapter = null;
 
-    public function __construct(Adapter $adapter)
+    public function __construct(AdapterInterface $adapter)
     {
         $this->adapter = $adapter;
         $platform = $adapter->getPlatform();

--- a/library/Zend/Db/Sql/Platform/SqlServer/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/SqlServer/SelectDecorator.php
@@ -10,7 +10,8 @@
 
 namespace Zend\Db\Sql\Platform\SqlServer;
 
-use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\AdapterInterface;
+use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
@@ -33,10 +34,10 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
     }
 
     /**
-     * @param Adapter $adapter
+     * @param AdapterInterface $adapter
      * @param StatementContainerInterface $statementContainer
      */
-    public function prepareStatement(Adapter $adapter, StatementContainerInterface $statementContainer)
+    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
     {
         // localize variables
         foreach (get_object_vars($this->select) as $name => $value) {
@@ -72,13 +73,13 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
 
     /**
      * @param PlatformInterface $platform
-     * @param Adapter $adapter
+     * @param DriverInterface $driver
      * @param ParameterContainer $parameterContainer
      * @param $sqls
      * @param $parameters
      * @return null
      */
-    protected function processLimitOffset(PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null, &$sqls, &$parameters)
+    protected function processLimitOffset(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null, &$sqls, &$parameters)
     {
         if ($this->limit === null && $this->offset === null) {
             return null;

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -10,7 +10,8 @@
 
 namespace Zend\Db\Sql;
 
-use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\AdapterInterface;
+use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
@@ -443,11 +444,11 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     /**
      * Prepare statement
      *
-     * @param Adapter $adapter
+     * @param AdapterInterface $adapter
      * @param StatementContainerInterface $statementContainer
      * @return void
      */
-    public function prepareStatement(Adapter $adapter, StatementContainerInterface $statementContainer)
+    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
     {
         // ensure statement has a ParameterContainer
         $parameterContainer = $statementContainer->getParameterContainer();
@@ -459,9 +460,10 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         $sqls = array();
         $parameters = array();
         $platform = $adapter->getPlatform();
+        $driver = $adapter->getDriver();
 
         foreach ($this->specifications as $name => $specification) {
-            $parameters[$name] = $this->{'process' . $name}($platform, $adapter, $parameterContainer, $sqls, $parameters);
+            $parameters[$name] = $this->{'process' . $name}($platform, $driver, $parameterContainer, $sqls, $parameters);
             if ($specification && is_array($parameters[$name])) {
                 $sqls[$name] = $this->createSqlFromSpecificationAndParameters($specification, $parameters[$name]);
             }
@@ -498,7 +500,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         return $sql;
     }
 
-    protected function processSelect(PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null)
+    protected function processSelect(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         $expr = 1;
 
@@ -520,7 +522,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         }
 
         if ($table instanceof Select) {
-            $table = '(' . $this->processSubselect($table, $platform, $adapter, $parameterContainer) . ')';
+            $table = '(' . $this->processSubselect($table, $platform, $driver, $parameterContainer) . ')';
         } else {
             $table = $platform->quoteIdentifier($table);
         }
@@ -552,7 +554,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 $columnParts = $this->processExpression(
                     $column,
                     $platform,
-                    $adapter,
+                    $driver,
                     $this->processInfo['paramPrefix'] . ((is_string($columnIndexOrAs)) ? $columnIndexOrAs : 'column')
                 );
                 if ($parameterContainer) {
@@ -582,7 +584,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                     $jColumnParts = $this->processExpression(
                         $jColumn,
                         $platform,
-                        $adapter,
+                        $driver,
                         $this->processInfo['paramPrefix'] . ((is_string($jKey)) ? $jKey : 'column')
                     );
                     if ($parameterContainer) {
@@ -605,7 +607,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         return array($columns, $table);
     }
 
-    protected function processJoins(PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null)
+    protected function processJoins(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         if (!$this->joins) {
             return null;
@@ -624,7 +626,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             // on expression
             // note: for Expression objects, pass them to processExpression with a prefix specific to each join (used for named parameters)
             $joinSpecArgArray[$j][] = ($join['on'] instanceof ExpressionInterface)
-                ? $this->processExpression($join['on'], $platform, $adapter, $this->processInfo['paramPrefix'] . 'join' . ($j+1) . 'part')
+                ? $this->processExpression($join['on'], $platform, $driver, $this->processInfo['paramPrefix'] . 'join' . ($j+1) . 'part')
                 : $platform->quoteIdentifierInFragment($join['on'], array('=', 'AND', 'OR', '(', ')', 'BETWEEN')); // on
             if ($joinSpecArgArray[$j][2] instanceof StatementContainerInterface) {
                 if ($parameterContainer) {
@@ -637,19 +639,19 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         return array($joinSpecArgArray);
     }
 
-    protected function processWhere(PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null)
+    protected function processWhere(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         if ($this->where->count() == 0) {
             return null;
         }
-        $whereParts = $this->processExpression($this->where, $platform, $adapter, $this->processInfo['paramPrefix'] . 'where');
+        $whereParts = $this->processExpression($this->where, $platform, $driver, $this->processInfo['paramPrefix'] . 'where');
         if ($parameterContainer) {
             $parameterContainer->merge($whereParts->getParameterContainer());
         }
         return array($whereParts->getSql());
     }
 
-    protected function processGroup(PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null)
+    protected function processGroup(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         if ($this->group === null) {
             return null;
@@ -659,7 +661,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         foreach ($this->group as $column) {
             $columnSql = '';
             if ($column instanceof Expression) {
-                $columnParts = $this->processExpression($column, $platform, $adapter, $this->processInfo['paramPrefix'] . 'group');
+                $columnParts = $this->processExpression($column, $platform, $driver, $this->processInfo['paramPrefix'] . 'group');
                 if ($parameterContainer) {
                     $parameterContainer->merge($columnParts->getParameterContainer());
                 }
@@ -672,19 +674,19 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         return array($groups);
     }
 
-    protected function processHaving(PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null)
+    protected function processHaving(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         if ($this->having->count() == 0) {
             return null;
         }
-        $whereParts = $this->processExpression($this->having, $platform, $adapter, $this->processInfo['paramPrefix'] . 'having');
+        $whereParts = $this->processExpression($this->having, $platform, $driver, $this->processInfo['paramPrefix'] . 'having');
         if ($parameterContainer) {
             $parameterContainer->merge($whereParts->getParameterContainer());
         }
         return array($whereParts->getSql());
     }
 
-    protected function processOrder(PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null)
+    protected function processOrder(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         if (empty($this->order)) {
             return null;
@@ -693,7 +695,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         foreach ($this->order as $k => $v) {
             if ($v instanceof Expression) {
                 /** @var $orderParts \Zend\Db\Adapter\StatementContainer */
-                $orderParts = $this->processExpression($v, $platform, $adapter);
+                $orderParts = $this->processExpression($v, $platform, $driver);
                 if ($parameterContainer) {
                     $parameterContainer->merge($orderParts->getParameterContainer());
                 }
@@ -717,13 +719,12 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         return array($orders);
     }
 
-    protected function processLimit(PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null)
+    protected function processLimit(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         if ($this->limit === null) {
             return null;
         }
-        if ($adapter) {
-            $driver = $adapter->getDriver();
+        if ($driver) {
             $sql = $driver->formatParameterName('limit');
             $parameterContainer->offsetSet('limit', $this->limit, ParameterContainer::TYPE_INTEGER);
         } else {
@@ -733,14 +734,14 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         return array($sql);
     }
 
-    protected function processOffset(PlatformInterface $platform, Adapter $adapter = null, ParameterContainer $parameterContainer = null)
+    protected function processOffset(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         if ($this->offset === null) {
             return null;
         }
-        if ($adapter) {
+        if ($driver) {
             $parameterContainer->offsetSet('offset', $this->offset, ParameterContainer::TYPE_INTEGER);
-            return array($adapter->getDriver()->formatParameterName('offset'));
+            return array($driver->formatParameterName('offset'));
         } else {
             return array($platform->quoteValue($this->offset));
         }

--- a/library/Zend/Db/Sql/Sql.php
+++ b/library/Zend/Db/Sql/Sql.php
@@ -10,7 +10,7 @@
 
 namespace Zend\Db\Sql;
 
-use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\AdapterInterface;
 use Zend\Db\Adapter\Driver\StatementInterface;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 
@@ -25,7 +25,7 @@ class Sql
     protected $table = null;
     protected $sqlPlatform = null;
 
-    public function __construct(Adapter $adapter, $table = null, Platform\AbstractPlatform $sqlPlatform = null)
+    public function __construct(AdapterInterface $adapter, $table = null, Platform\AbstractPlatform $sqlPlatform = null)
     {
         $this->adapter = $adapter;
         if ($table) {

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -10,7 +10,7 @@
 
 namespace Zend\Db\Sql;
 
-use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\AdapterInterface;
 use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
@@ -187,11 +187,11 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
     /**
      * Prepare statement
      *
-     * @param Adapter $adapter
+     * @param AdapterInterface $adapter
      * @param StatementContainerInterface $statementContainer
      * @return void
      */
-    public function prepareStatement(Adapter $adapter, StatementContainerInterface $statementContainer)
+    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
     {
         $driver   = $adapter->getDriver();
         $platform = $adapter->getPlatform();
@@ -209,7 +209,7 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $setSql = array();
             foreach ($set as $column => $value) {
                 if ($value instanceof Expression) {
-                    $exprData = $this->processExpression($value, $platform, $adapter);
+                    $exprData = $this->processExpression($value, $platform, $driver);
                     $setSql[] = $platform->quoteIdentifier($column) . ' = ' . $exprData->getSql();
                     $parameterContainer->merge($exprData->getParameterContainer());
                 } else {
@@ -224,7 +224,7 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
         // process where
         if ($this->where->count() > 0) {
-            $whereParts = $this->processExpression($this->where, $platform, $adapter, 'where');
+            $whereParts = $this->processExpression($this->where, $platform, $driver, 'where');
             $parameterContainer->merge($whereParts->getParameterContainer());
             $sql .= ' ' . sprintf($this->specifications[self::SPECIFICATION_WHERE], $whereParts->getSql());
         }

--- a/library/Zend/Db/Sql/Where.php
+++ b/library/Zend/Db/Sql/Where.php
@@ -10,8 +10,6 @@
 
 namespace Zend\Db\Sql;
 
-use Zend\Db\Adapter\Adapter;
-
 /**
  * @category   Zend
  * @package    Zend_Db

--- a/tests/ZendTest/Db/Sql/AbstractSqlTest.php
+++ b/tests/ZendTest/Db/Sql/AbstractSqlTest.php
@@ -53,10 +53,9 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
         $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnCallback(function ($x) {
             return ':' . $x;
         }));
-        $mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver));
 
         $expression = new Expression('? > ? AND y < ?', array('x', 5, 10), array(Expression::TYPE_IDENTIFIER));
-        $sqlAndParams = $this->invokeProcessExpressionMethod($expression, $mockAdapter);
+        $sqlAndParams = $this->invokeProcessExpressionMethod($expression, $mockDriver);
 
         $parameterContainer = $sqlAndParams->getParameterContainer();
         $parameters = $parameterContainer->getNamedArray();
@@ -74,7 +73,7 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, current($parameters));
 
         // ensure next invocation increases number by 1
-        $sqlAndParamsNext = $this->invokeProcessExpressionMethod($expression, $mockAdapter);
+        $sqlAndParamsNext = $this->invokeProcessExpressionMethod($expression, $mockDriver);
 
         $parameterContainer = $sqlAndParamsNext->getParameterContainer();
         $parameters = $parameterContainer->getNamedArray();
@@ -132,11 +131,11 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
      * @param \Zend\Db\Adapter\Adapter|null $adapter
      * @return \Zend\Db\Adapter\StatementContainer
      */
-    protected function invokeProcessExpressionMethod(ExpressionInterface $expression, $adapter = null)
+    protected function invokeProcessExpressionMethod(ExpressionInterface $expression, $driver = null)
     {
         $method = new \ReflectionMethod($this->abstractSql, 'processExpression');
         $method->setAccessible(true);
-        return $method->invoke($this->abstractSql, $expression, new Sql92, $adapter);
+        return $method->invoke($this->abstractSql, $expression, new Sql92, $driver);
     }
 
 }

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -462,7 +462,6 @@ class SelectTest extends \PHPUnit_Framework_TestCase
 
         $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
         $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
-        $mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver));
         $parameterContainer = new ParameterContainer();
 
         $sr = new \ReflectionObject($select);
@@ -470,7 +469,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         foreach ($internalTests as $method => $expected) {
             $mr = $sr->getMethod($method);
             $mr->setAccessible(true);
-            $return = $mr->invokeArgs($select, array(new Sql92, $mockAdapter, $parameterContainer));
+            $return = $mr->invokeArgs($select, array(new Sql92, $mockDriver, $parameterContainer));
             $this->assertEquals($expected, $return);
         }
     }


### PR DESCRIPTION
By typehinting only interfaces we can fully decouple `Zend\Db\Sql` from concrete `Zend\Db\Adapter\Adapter` implementation.

As you can see in the diff, I've changed no test, expect two protected-method tests, so there is no breaks.

I consider `Zend\Db\Sql` a good sql builder, and in order to use it with non-zend adapter, like Doctrine2, we need to provide only interface dependancies.
