### PR TITLE
Fixes #2993 - Add missing asterisk to method docblock

### DIFF
--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -440,7 +440,7 @@ class Request extends AbstractMessage implements RequestInterface
         return ($this->method === self::METHOD_CONNECT);
     }
 
-    /*
+    /**
      * Is this a PATCH method request?
      *
      * @return bool


### PR DESCRIPTION
The docblock for this method was missing an asterisk, mainly resulting in improper syntax highlighting; I'm not sure if this actually affected documentation generation. Regardless, here's the quick fix.
