### PR TITLE
Fixing abstract factory instantiation time

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -591,7 +591,7 @@ class ServiceManager implements ServiceLocatorInterface
         foreach ($this->abstractFactories as $index => $abstractFactory) {
             // Support string abstract factory class names
             if (is_string($abstractFactory) && class_exists($abstractFactory, true)) {
-                $this->abstractFactory[$index] = $abstractFactory = new $abstractFactory();
+                $this->abstractFactories[$index] = $abstractFactory = new $abstractFactory();
             }
 
             if (

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -17,6 +17,8 @@ use Zend\ServiceManager\Exception;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Config;
 
+use ZendTest\ServiceManager\TestAsset\FooCounterAbstractFactory;
+
 class ServiceManagerTest extends \PHPUnit_Framework_TestCase
 {
 
@@ -598,5 +600,19 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, $this->serviceManager->has('foo-bar'));
         $this->assertEquals(true, $this->serviceManager->has('foo/bar'));
         $this->assertEquals(true, $this->serviceManager->has('foo bar'));
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::canCreateFromAbstractFactory
+     */
+    public function testWanCreateFromAbstractFactoryWillNotInstantiateAbstractFactoryOnce()
+    {
+        $count = FooCounterAbstractFactory::$instantiationCount;
+        $this->serviceManager->addAbstractFactory(__NAMESPACE__ . '\TestAsset\FooCounterAbstractFactory');
+
+        $this->serviceManager->canCreateFromAbstractFactory('foo', 'foo');
+        $this->serviceManager->canCreateFromAbstractFactory('foo', 'foo');
+
+        $this->assertSame($count + 1, FooCounterAbstractFactory::$instantiationCount);
     }
 }

--- a/tests/ZendTest/ServiceManager/TestAsset/FooCounterAbstractFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/FooCounterAbstractFactory.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_ServiceManager
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Abstract factory that keeps track of the number of times it is instantiated
+ */
+class FooCounterAbstractFactory implements AbstractFactoryInterface
+{
+    /**
+     * @var int
+     */
+    public static $instantiationCount = 0;
+
+    /**
+     * Increments instantiation count
+     */
+    public function __construct()
+    {
+        self::$instantiationCount += 1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        if ($name == 'foo') {
+            return true;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        return new Foo;
+    }
+}


### PR DESCRIPTION
Abstract factories instantiated from FQCN string were instantiated more than once
