### PR TITLE
Fix for issue 3001 Zend\Db\Sql\Predicate\Between fails with min and max ...

### DIFF
--- a/library/Zend/Db/Sql/Predicate/Between.php
+++ b/library/Zend/Db/Sql/Predicate/Between.php
@@ -34,10 +34,10 @@ class Between implements PredicateInterface
         if ($identifier) {
             $this->setIdentifier($identifier);
         }
-        if ($minValue) {
+        if (!is_null($minValue)) {
             $this->setMinValue($minValue);
         }
-        if ($maxValue) {
+        if (!is_null($maxValue)) {
             $this->setMaxValue($maxValue);
         }
     }


### PR DESCRIPTION
Fix for issue 3001 Zend\Db\Sql\Predicate\Between fails with min and max values of 0.

Added !is_null()

Not sure how to add a testcase yet.
