### PR TITLE
Response Json Client

### DIFF
--- a/library/Zend/Json/Server/Response.php
+++ b/library/Zend/Json/Server/Response.php
@@ -121,7 +121,7 @@ class Response
      * @param  mixed $error
      * @return Response
      */
-    public function setError($error)
+    public function setError(Error $error = null)
     {
         $this->error = $error;
         return $this;

--- a/library/Zend/Json/Server/Response.php
+++ b/library/Zend/Json/Server/Response.php
@@ -118,10 +118,10 @@ class Response
     /**
      * Set result error
      *
-     * @param  Error $error
+     * @param  mixed $error
      * @return Response
      */
-    public function setError(Error $error)
+    public function setError($error)
     {
         $this->error = $error;
         return $this;

--- a/tests/ZendTest/Json/Server/ResponseTest.php
+++ b/tests/ZendTest/Json/Server/ResponseTest.php
@@ -66,7 +66,14 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->response->setError($error);
         $this->assertSame($error, $this->response->getError());
     }
-
+    
+    public function testErrorAccesorsShouldWorkWithNullInput()
+    {
+        $this->response->setError(null);
+        $this->assertNull($this->response->getError());
+        $this->assertFalse($this->response->isError());
+    }
+    
     public function testIdShouldBeNullByDefault()
     {
         $this->assertNull($this->response->getId());


### PR DESCRIPTION
As http://www.json-rpc.org/wiki/specification

1.2 Response
error - An Error object if there was an error invoking the method. It must be null if there was no error. 

Not always is an Error this parameter it could be null.
To be more explicit, when using json-client the response come with error as null if there is no error
