### PR TITLE
[develop] PRG Plugin fixes: Incorrect use of session hops expiration

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/FilePostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/FilePostRedirectGet.php
@@ -46,6 +46,7 @@ class FilePostRedirectGet extends AbstractPlugin
             if (!$form->isValid()) {
                 $container->errors = $form->getMessages();
             }
+            $container->setExpirationHops(1, array('post', 'errors'));
 
             return $this->redirect($redirect, $redirectToUrl);
         } else {
@@ -67,11 +68,10 @@ class FilePostRedirectGet extends AbstractPlugin
         }
     }
 
-    protected function getSessionContainer()
+    public function getSessionContainer()
     {
         if (!isset($this->sessionContainer)) {
             $this->sessionContainer = new Container('file_prg_post1');
-            $this->sessionContainer->setExpirationHops(1, array('post', 'errors'));
         }
         return $this->sessionContainer;
     }

--- a/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
@@ -36,6 +36,7 @@ class PostRedirectGet extends AbstractPlugin
 
         if ($request->isPost()) {
             $container->post = $request->getPost()->toArray();
+            $container->setExpirationHops(1, 'post');
             return $this->redirect($redirect, $redirectToUrl);
         } else {
             if ($container->post !== null) {
@@ -48,11 +49,10 @@ class PostRedirectGet extends AbstractPlugin
         }
     }
 
-    protected function getSessionContainer()
+    public function getSessionContainer()
     {
         if (!isset($this->sessionContainer)) {
             $this->sessionContainer = new Container('prg_post1');
-            $this->sessionContainer->setExpirationHops(1, 'post');
         }
         return $this->sessionContainer;
     }

--- a/tests/ZendTest/Mvc/Controller/Plugin/FilePostRedirectGetTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/FilePostRedirectGetTest.php
@@ -194,6 +194,13 @@ class FilePostRedirectGetTest extends TestCase
 
         $this->assertEquals($params, $prgResult);
         $this->assertEquals($params['postval1'], $this->form->get('postval1')->getValue());
+
+        // Do GET again to make sure data is empty
+        $this->request = new Request();
+        $this->controller->dispatch($this->request, $this->response);
+        $prgResult = $this->controller->fileprg($this->form, '/test/getPage', true);
+
+        $this->assertFalse($prgResult);
     }
 
     public function testAppliesFormErrorsOnPostRedirectGet()

--- a/tests/ZendTest/Mvc/Controller/Plugin/PostRedirectGetTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/PostRedirectGetTest.php
@@ -108,6 +108,37 @@ class PostRedirectGetTest extends TestCase
         $this->assertEquals(303, $prgResultRoute->getStatusCode());
     }
 
+    public function testReturnsPostOnRedirectGet()
+    {
+        $params = array(
+            'postval1' => 'value1'
+        );
+        $this->request->setMethod('POST');
+        $this->request->setPost(new Parameters($params));
+
+        $result         = $this->controller->dispatch($this->request, $this->response);
+        $prgResultRoute = $this->controller->prg('home');
+
+        $this->assertInstanceOf('Zend\Http\Response', $prgResultRoute);
+        $this->assertTrue($prgResultRoute->getHeaders()->has('Location'));
+        $this->assertEquals('/', $prgResultRoute->getHeaders()->get('Location')->getUri());
+        $this->assertEquals(303, $prgResultRoute->getStatusCode());
+
+        // Do GET
+        $this->request = new Request();
+        $this->controller->dispatch($this->request, $this->response);
+        $prgResult = $this->controller->prg('home');
+
+        $this->assertEquals($params, $prgResult);
+
+        // Do GET again to make sure data is empty
+        $this->request = new Request();
+        $this->controller->dispatch($this->request, $this->response);
+        $prgResult = $this->controller->prg('home');
+
+        $this->assertFalse($prgResult);
+    }
+
     /**
      * @expectedException Zend\Mvc\Exception\RuntimeException
      */


### PR DESCRIPTION
When I recently refactored the PRG plugin and added the new FilePRG plugin I incorrectly set up the session container expiration hops, which would extend the session data. Fixed to correct that.

Also, made the getSessionContainer method public, which seemed helpful if you wanted access to it.
