### PR TITLE
Callback Options as 2nd param

### DIFF
--- a/library/Zend/Validator/Callback.php
+++ b/library/Zend/Validator/Callback.php
@@ -136,8 +136,8 @@ class Callback extends AbstractValidator
             $args = array_merge($args, $options);
         }
         if (!empty($options) && !empty($context)) {
-            $args[] = $context;
             $args   = array_merge($args, $options);
+            $args[] = $context;
         }
 
         try {

--- a/tests/ZendTest/Validator/CallbackTest.php
+++ b/tests/ZendTest/Validator/CallbackTest.php
@@ -97,8 +97,8 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $value     = 'bar';
         $context   = array('foo' => 'bar', 'bar' => 'baz');
         $options   = array('baz' => 'bat');
-        $validator = new Callback(function($v, $c, $baz) use ($value, $context, $options) {
-            return (($value == $v) && ($context == $c) && ($options['baz'] == $baz));
+        $validator = new Callback(function($v, $baz, $c) use ($value, $options, $context) {
+            return (($value == $v) && ($options['baz'] == $baz) && ($context == $c));
         });
         $validator->setCallbackOptions($options);
         $this->assertTrue($validator->isValid($value, $context));


### PR DESCRIPTION
http://framework.zend.com/manual/2.0/en/modules/zend.validator.set.html#adding-options

callbackOptions should be the 2nd param to pass to the callbackFunction
not the last param (it could be the $context as optional)
