### PR TITLE
[2.1][develop] PRG Plugins fix

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/FilePostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/FilePostRedirectGet.php
@@ -36,6 +36,8 @@ class FilePostRedirectGet extends AbstractPlugin
         $container  = $this->getSessionContainer();
 
         if ($request->isPost()) {
+            $container->setExpirationHops(1, array('post', 'errors'));
+
             $post = array_merge(
                 $request->getPost()->toArray(),
                 $request->getFiles()->toArray()
@@ -46,7 +48,6 @@ class FilePostRedirectGet extends AbstractPlugin
             if (!$form->isValid()) {
                 $container->errors = $form->getMessages();
             }
-            $container->setExpirationHops(1, array('post', 'errors'));
 
             return $this->redirect($redirect, $redirectToUrl);
         } else {

--- a/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
@@ -35,8 +35,8 @@ class PostRedirectGet extends AbstractPlugin
         $container  = $this->getSessionContainer();
 
         if ($request->isPost()) {
-            $container->post = $request->getPost()->toArray();
             $container->setExpirationHops(1, 'post');
+            $container->post = $request->getPost()->toArray();
             return $this->redirect($redirect, $redirectToUrl);
         } else {
             if ($container->post !== null) {


### PR DESCRIPTION
If the session container `setExpirationHops()` is called _after_ a value is set, that value can be inadvertently expired. Reordered the commands so that `setExpirationHops()` is called first.

This seems like faulty behavior in the session container, but I might not be understanding Zend\Session completely. Regardless, this fix uses the same order of commands as the PRG plugin in master branch.
