### PR TITLE
Allow new route plugins to be added to existing TreeRouteStack

### DIFF
--- a/library/Zend/Mvc/Router/SimpleRouteStack.php
+++ b/library/Zend/Mvc/Router/SimpleRouteStack.php
@@ -70,9 +70,16 @@ class SimpleRouteStack implements RouteStackInterface
         }
 
         $instance = new static();
-
+        
         if (isset($options['route_plugins'])) {
-            $instance->setRoutePluginManager($options['route_plugins']);
+            if (is_array($options['route_plugins'])) {
+                $rpm = $instance->getRoutePluginManager();
+                foreach($options['route_plugins'] as $name => $class) {
+                    $rpm->setInvokableClass($name, $class);
+                }
+            } else {
+                $instance->setRoutePluginManager($options['route_plugins']);
+            }
         }
 
         if (isset($options['routes'])) {


### PR DESCRIPTION
Adding the following to the module config does not allow new route plugins to be used

'route_plugins' => array(
    'Segment2' => 'Application\Mvc\Router\Http\Segment2',
),
