### PR TITLE
Allow new route plugins to be added via class name config

### DIFF
--- a/library/Zend/Mvc/Router/SimpleRouteStack.php
+++ b/library/Zend/Mvc/Router/SimpleRouteStack.php
@@ -72,7 +72,14 @@ class SimpleRouteStack implements RouteStackInterface
         $instance = new static();
 
         if (isset($options['route_plugins'])) {
-            $instance->setRoutePluginManager($options['route_plugins']);
+            if (is_array($options['route_plugins'])) {
+                $rpm = $instance->getRoutePluginManager();
+                foreach($options['route_plugins'] as $name => $class) {
+                    $rpm->setInvokableClass($name, $class);
+                }
+            } else {
+                $instance->setRoutePluginManager($options['route_plugins']);
+            }
         }
 
         if (isset($options['routes'])) {


### PR DESCRIPTION
The following does not allow new route plugins to be added to the existing TreeRouteStack plugins

```
'route_plugins' => array(
    'Segment2' => 'Application\Mvc\Router\Http\Segment2',
),
```

This commit will check to see if `route_plugins` is an array and add them to the plugin manager.
