### PR TITLE
Constraints in Zend\Db\Metadata\Source\AbstractSource::getTable not initalised

### DIFF
--- a/library/Zend/Db/Metadata/Source/AbstractSource.php
+++ b/library/Zend/Db/Metadata/Source/AbstractSource.php
@@ -146,6 +146,7 @@ abstract class AbstractSource implements MetadataInterface
                 throw new \Exception('Table "' . $tableName . '" is of an unsupported type "' . $data['table_type'] . '"');
         }
         $table->setColumns($this->getColumns($tableName, $schema));
+        $table->setConstraints($this->getConstraints($tableName, $schema));
         return $table;
     }
 


### PR DESCRIPTION
The Constraints of a Table will always be empty as they are not set by default

With the following code you will always get an empty array.
$metadata = new Zend\Db\Metadata\Metadata($db->getAdapter());
$table = $metadata->getTable($tableName);
var_dump($table->getConstraints());

in the last line of the  methode Zend\Db\Metadata\Source\AbstractSource::getTable you should add the following code:

```
    $table->setConstraints($this->getConstraints($tableName, $schema));
```

that worked for me to fix it.
