### PR TITLE
Removing the separator between the hidden and the visible inputs. As the...

### DIFF
--- a/library/Zend/Form/View/Helper/Captcha/AbstractWord.php
+++ b/library/Zend/Form/View/Helper/Captcha/AbstractWord.php
@@ -130,9 +130,8 @@ abstract class AbstractWord extends FormInput
 
         $hidden    = $this->renderCaptchaHidden($captcha, $attributes);
         $input     = $this->renderCaptchaInput($captcha, $attributes);
-        $separator = $this->getSeparator();
 
-        return $hidden . $separator . $input;
+        return $hidden . $input;
     }
 
     /**

--- a/tests/ZendTest/Form/View/Helper/Captcha/DumbTest.php
+++ b/tests/ZendTest/Form/View/Helper/Captcha/DumbTest.php
@@ -92,4 +92,13 @@ class DumbTest extends CommonTestCase
 
         $this->assertEquals('-', $this->helper->getSeparator());
     }
+
+    public function testRenderSeparatorOneTimeAfterText()
+    {
+        $element = $this->getElement();
+        $this->helper->setSeparator('<br />');
+        $markup  = $this->helper->render($element);
+        $this->assertContains($this->captcha->getLabel() . ' <b>' . strrev($this->captcha->getWord()) . '</b>' . $this->helper->getSeparator() . '<input name="foo[id]" type="hidden"', $markup);
+        $this->assertNotContains($this->helper->getSeparator() . '<input name="foo[input]" type="text"', $markup);
+    }
 }


### PR DESCRIPTION
... captcha helpers already include the separator between the text and the helpers, just removing from AbstractWord helper does the trick. #3023
