### PR TITLE
Reduced #calls of plugin() in PhpRenderer using a cache mechanism

### DIFF
--- a/library/Zend/View/Renderer/PhpRenderer.php
+++ b/library/Zend/View/Renderer/PhpRenderer.php
@@ -94,6 +94,11 @@ class PhpRenderer implements Renderer, TreeRendererInterface
     private $__varsCache = array();
 
     /**
+     * @var array Cache for the plugin call
+     */
+    private $__pluginCache = array();
+
+    /**
      * Constructor.
      *
      *
@@ -350,11 +355,13 @@ class PhpRenderer implements Renderer, TreeRendererInterface
      */
     public function __call($method, $argv)
     {
-        $helper = $this->plugin($method);
-        if (is_callable($helper)) {
-            return call_user_func_array($helper, $argv);
+        if (!isset($this->__pluginCache[$method])) {
+            $this->__pluginCache[$method] = $this->plugin($method);
         }
-        return $helper;
+        if (is_callable($this->__pluginCache[$method])) {
+            return call_user_func_array($this->__pluginCache[$method], $argv);
+        }
+        return $this->__pluginCache[$method];
     }
 
     /**


### PR DESCRIPTION
Added a caching mechanism for plugin() call in Zend\View\Renderer\PhpRenderer->__call.  For the f2-tutorial application, this change reduced the #calls of plugin() from 196 to 8, with a 13% reduction of the total response time.
