### PR TITLE
Mark module as loaded before trigginer EVENT_LOAD_MODULE

### DIFF
--- a/library/Zend/ModuleManager/ModuleManager.php
+++ b/library/Zend/ModuleManager/ModuleManager.php
@@ -148,8 +148,8 @@ class ModuleManager implements ModuleManagerInterface
         }
         $event->setModule($module);
 
-        $this->getEventManager()->trigger(ModuleEvent::EVENT_LOAD_MODULE, $this, $event);
         $this->loadedModules[$moduleName] = $module;
+        $this->getEventManager()->trigger(ModuleEvent::EVENT_LOAD_MODULE, $this, $event);
 
         $this->loadFinished = true;
 


### PR DESCRIPTION
- Allows one module to check if another has been loaded yet, without
  getting into a recursive situation.

Addresses the issue raised in #2821 -- without requiring a new event.
