### PR TITLE
Zend\Db\Sql Fix for Insert's Merge and Set capabilities with simlar keys

### DIFF
--- a/library/Zend/Db/Sql/Insert.php
+++ b/library/Zend/Db/Sql/Insert.php
@@ -101,24 +101,27 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
             throw new \InvalidArgumentException('values() expects an array of values');
         }
 
+        // determine if this is assoc or a set of values
         $keys = array_keys($values);
         $firstKey = current($keys);
 
-        if (is_string($firstKey)) {
-            if ($flag == self::VALUES_MERGE) {
-                $this->columns(array_merge($this->columns, $keys));
-            } else {
-                $this->columns($keys);
-            }
-            $values = array_values($values);
-        } elseif (is_int($firstKey)) {
-            $values = array_values($values);
+        if ($flag == self::VALUES_SET) {
+            $this->columns = array();
+            $this->values = array();
         }
 
-        if ($flag == self::VALUES_MERGE) {
-            $this->values = array_merge($this->values, $values);
-        } else {
-            $this->values = $values;
+        if (is_string($firstKey)) {
+            foreach ($keys as $key) {
+                if (($index = array_search($key, $this->columns)) !== false) {
+                    $this->values[$index] = $values[$key];
+                } else {
+                    $this->columns[] = $key;
+                    $this->values[] = $values[$key];
+                }
+            }
+        } elseif (is_int($firstKey)) {
+            // determine if count of columns should match count of values
+            $this->values = array_merge($this->values, array_values($values));
         }
 
         return $this;

--- a/tests/ZendTest/Db/Sql/InsertTest.php
+++ b/tests/ZendTest/Db/Sql/InsertTest.php
@@ -55,6 +55,16 @@ class InsertTest extends \PHPUnit_Framework_TestCase
         $this->insert->values(array('foo' => 'bar'));
         $this->assertEquals(array('foo'), $this->readAttribute($this->insert, 'columns'));
         $this->assertEquals(array('bar'), $this->readAttribute($this->insert, 'values'));
+
+        // test will merge cols and values of previously set stuff
+        $this->insert->values(array('foo' => 'bax'), Insert::VALUES_MERGE);
+        $this->insert->values(array('boom' => 'bam'), Insert::VALUES_MERGE);
+        $this->assertEquals(array('foo', 'boom'), $this->readAttribute($this->insert, 'columns'));
+        $this->assertEquals(array('bax', 'bam'), $this->readAttribute($this->insert, 'values'));
+
+        $this->insert->values(array('foo' => 'bax'));
+        $this->assertEquals(array('foo'), $this->readAttribute($this->insert, 'columns'));
+        $this->assertEquals(array('bax'), $this->readAttribute($this->insert, 'values'));
     }
 
 


### PR DESCRIPTION
- A better fix and unit test for #2579 and #2999
