### PR TITLE
Fix error checking on Zend\Http\Client\Adapter\Socket->write().

### DIFF
--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -360,7 +360,7 @@ class Socket implements HttpAdapter, StreamInterface
         ErrorHandler::start();
         $test  = fwrite($this->socket, $request);
         $error = ErrorHandler::stop();
-        if (!$test) {
+        if (false === $test) {
             throw new AdapterException\RuntimeException('Error writing request to server', 0, $error);
         }
 


### PR DESCRIPTION
This failed on CLI usage, giving:
Notice: fwrite(): send of 8192 bytes failed with errno=32 Broken pipe in [a-symfony-project-name-held]/vendor/zendframework/zendframework/library/Zend/Http/Client/Adapter/Socket.php on line 361

The PHP fwrite function can returns the bytes written, **which can be 0** – and returns false on error:
"fwrite() returns the number of bytes written, or FALSE on error."
http://php.net/manual/en/function.fwrite.php

This breaks the ZendService\Amazon\S3\S3->putFile(), when called from a CLI PHP script (using Symfony console).
