### PR TITLE
Update library/Zend/Log/Logger.php

### DIFF
--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -467,7 +467,7 @@ class Logger implements LoggerInterface
      * Ends a group in the Firebug Console
      *
      * @return TRUE if the group instruction was added to the response headers or buffered.
-     *//
+     */
     public function groupEnd()
     {
 		Zend_Wildfire_Plugin_FirePhp::groupEnd();

--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -450,4 +450,26 @@ class Logger implements LoggerInterface
         restore_exception_handler();
         static::$registeredExceptionHandler = false;
     }
+    
+    /**
+     * Starts a group in the Firebug Console
+     *
+     * @param string $title The title of the group
+     * @param array $options OPTIONAL Setting 'Collapsed' to true will initialize group collapsed instead of expanded
+     * @return TRUE if the group instruction was added to the response headers or buffered.
+     */
+    public function group($messsage, $options=array())
+    {
+    	Zend_Wildfire_Plugin_FirePhp::group($messsage, $options);
+    }
+
+	 /**
+     * Ends a group in the Firebug Console
+     *
+     * @return TRUE if the group instruction was added to the response headers or buffered.
+     *//
+    public function groupEnd()
+    {
+		Zend_Wildfire_Plugin_FirePhp::groupEnd();
+    }
 }


### PR DESCRIPTION
we i used the ZF log() it work grate but now in my team 5 people are working on same page (controller). so on initial day it was grate to see and search the log but now it become very very difficult to do that. So for same i was decided to use the FirePHP group() and groupEnd() method, which going to resolve my all problem by categorizing them in respective set.

But issue is then when i try to to do that it not working, and then i dig in the Core Log.php file and i had found that there was not method define for same.

I had added two new method in the Log.php called group() and groupEnd().

Both this method are calling the static method of the FirePHP plugins static method to this job in order to get log() and group() feature at one place.
