### PR TITLE
Reduced the #calls of rawurlencode() using a cache mechanism

### DIFF
--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -25,6 +25,11 @@ use Zend\Stdlib\RequestInterface as Request;
 class Segment implements RouteInterface
 {
     /**
+     * @var array Cache for the encode output
+     */
+    private static $__cacheEncode = array();
+
+    /**
      * Map of allowed special chars in path segments.
      *
      * http://tools.ietf.org/html/rfc3986#appendix-A
@@ -408,9 +413,11 @@ class Segment implements RouteInterface
      */
     private function encode($value)
     {
-        $encoded = rawurlencode($value);
-        $encoded = strtr($encoded, static::$urlencodeCorrectionMap);
-        return $encoded;
+        if (!isset(static::$__cacheEncode[$value])) {
+            static::$__cacheEncode[$value] = rawurlencode($value);
+            static::$__cacheEncode[$value] = strtr(static::$__cacheEncode[$value], static::$urlencodeCorrectionMap);
+        }
+        return static::$__cacheEncode[$value];
     }
 
     /**


### PR DESCRIPTION
This patch reduce the #calls of the rawurlencode() for the Zend\Mvc\Router\Http\Segment->encode(). In the zf2-tutorial application this reduce the rawurlencode() calls from 181 to 48 with a reduction of 1% of the total response time.
