### PR TITLE
Fix Zend\Console\Getopt::getUsageMessage()

### DIFF
--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -565,6 +565,9 @@ class Getopt
         $maxLen = 20;
         $lines = array();
         foreach ($this->rules as $rule) {
+            if (isset($rule['isFreeformFlag'])) {
+                continue;
+            }
             $flags = array();
             if (is_array($rule['alias'])) {
                 foreach ($rule['alias'] as $flag) {
@@ -763,7 +766,10 @@ class Getopt
             // Magic methods in future will use this mark as real flag value
             $this->ruleMap[$flag] = $flag;
             $realFlag = $flag;
-            $this->rules[$realFlag] = array('param' => 'optional');
+            $this->rules[$realFlag] = array(
+                'param'          => 'optional',
+                'isFreeformFlag' => true
+            );
         } else {
             $realFlag = $this->ruleMap[$flag];
         }

--- a/tests/ZendTest/Console/GetoptTest.php
+++ b/tests/ZendTest/Console/GetoptTest.php
@@ -589,6 +589,35 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('test', $opts->freeform);
     }
 
+    public function testGetoptWithFreeformFlagOptionShowHelpAfterParseDoesNotThrowNotices()
+    {
+        // this formerly failed, because the index 'alias' is not set for freeform flags.
+        $opts = new Getopt(
+            array('colors' => 'Colors-option'),
+            array('color', '--freeform', 'test', 'zend'),
+            array(Getopt::CONFIG_FREEFORM_FLAGS => true)
+        );
+        $opts->parse();
+
+        $opts->getUsageMessage();
+    }
+
+    public function testGetoptWithFreeformFlagOptionShowHelpAfterParseDoesNotShowFreeformFlags()
+    {
+        $opts = new Getopt(
+            array('colors' => 'Colors-option'),
+            array('color', '--freeform', 'test', 'zend'),
+            array(Getopt::CONFIG_FREEFORM_FLAGS => true)
+        );
+        $opts->parse();
+
+        $message = preg_replace('/Usage: .* \[ options \]/',
+            'Usage: <progname> [ options ]',
+            $opts->getUsageMessage());
+        $message = preg_replace('/ /', '_', $message);
+        $this->assertEquals($message, "Usage:_<progname>_[_options_]\n--colors_____________Colors-option\n");
+    }
+
     public function testGetoptRaiseExceptionForNumericOptionsByDefault()
     {
         $opts = new Getopt(


### PR DESCRIPTION
Getopt::getUsageMessage() no longer throws a warning, when freeform flags
are available and the parameters are already parsed via Getopt::parse().
Freeform flags will not show up in Getopt::getUsageMessage().

Added two tests to ensure this.
