### PR TITLE
Pull zend filter compress snappy

### DIFF
--- a/library/Zend/Filter/Compress/Snappy.php
+++ b/library/Zend/Filter/Compress/Snappy.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Filter
+ */
+
+namespace Zend\Filter\Compress;
+
+
+use Zend\Filter\Exception;
+
+/**
+ * Compression adapter for php snappy (http://code.google.com/p/php-snappy/)
+ *
+ * @category   Zend
+ * @package    Zend_Filter
+ */
+class Snappy implements CompressionAlgorithmInterface
+{
+    /**
+     * Class constructor
+     *
+     * @param null|array|\Traversable $options (Optional) Options to set
+     * @throws Exception\ExtensionNotLoadedException if snappy extension not loaded
+     */
+    public function __construct($options = null)
+    {
+        if (!extension_loaded('snappy')) {
+            throw new Exception\ExtensionNotLoadedException('This filter needs the snappy extension');
+        }
+        parent::__construct($options);
+    }
+
+    /**
+     * Compresses the given content
+     *
+     * @param  string $content
+     * @return string
+     * @throws Exception\RuntimeException on memory, output length or data warning
+     */
+    public function compress($content)
+    {
+        $compressed = snappy_compress($content);
+
+        if ($compressed === false) {
+            throw new Exception\RuntimeException('Error while compressing.');
+        }
+
+        return $compressed;
+    }
+
+    /**
+     * Decompresses the given content
+     *
+     * @param  string $content
+     * @return string
+     * @throws Exception\RuntimeException on memory, output length or data warning
+     */
+    public function decompress($content)
+    {
+        $compressed = snappy_uncompress($content);
+
+        if ($compressed === false) {
+            throw new Exception\RuntimeException('Error while uncompressing.');
+        }
+
+        return $compressed;
+    }
+
+    /**
+     * Returns the adapter name
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'Snappy';
+    }
+}

--- a/library/Zend/Filter/Compress/Snappy.php
+++ b/library/Zend/Filter/Compress/Snappy.php
@@ -32,7 +32,6 @@ class Snappy implements CompressionAlgorithmInterface
         if (!extension_loaded('snappy')) {
             throw new Exception\ExtensionNotLoadedException('This filter needs the snappy extension');
         }
-        parent::__construct($options);
     }
 
     /**

--- a/library/Zend/Filter/Compress/Snappy.php
+++ b/library/Zend/Filter/Compress/Snappy.php
@@ -64,7 +64,7 @@ class Snappy implements CompressionAlgorithmInterface
         $compressed = snappy_uncompress($content);
 
         if ($compressed === false) {
-            throw new Exception\RuntimeException('Error while uncompressing.');
+            throw new Exception\RuntimeException('Error while decompressing.');
         }
 
         return $compressed;

--- a/library/Zend/Filter/Compress/Snappy.php
+++ b/library/Zend/Filter/Compress/Snappy.php
@@ -10,7 +10,6 @@
 
 namespace Zend\Filter\Compress;
 
-
 use Zend\Filter\Exception;
 
 /**

--- a/library/Zend/Filter/FilterPluginManager.php
+++ b/library/Zend/Filter/FilterPluginManager.php
@@ -40,6 +40,7 @@ class FilterPluginManager extends AbstractPluginManager
         'compressgz'                => 'Zend\Filter\Compress\Gz',
         'compresslzf'               => 'Zend\Filter\Compress\Lzf',
         'compressrar'               => 'Zend\Filter\Compress\Rar',
+        'compresssnappy'            => 'Zend\Filter\Compress\Snappy',
         'compresstar'               => 'Zend\Filter\Compress\Tar',
         'compresszip'               => 'Zend\Filter\Compress\Zip',
         'decompress'                => 'Zend\Filter\Decompress',

--- a/tests/ZendTest/Filter/Compress/SnappyTest.php
+++ b/tests/ZendTest/Filter/Compress/SnappyTest.php
@@ -43,11 +43,58 @@ class SnappyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('compress me', $content);
     }
 
-    // TODO test all three warnings (on each method)
-    // TODO test exception
-    // TODO test recompression
-    // TODO test null/ false compression
-    // TODO test invalid argument cases
+    /**
+     * Snappy should return NULL on invalid arguments.
+     *
+     * @return void
+     */
+    public function testNonScalarInput()
+    {
+        $filter = new SnappyCompression();
+
+        // restore_error_handler can emit an E_WARNING; let's ignore that, as
+        // we want to test the returned value
+        set_error_handler(array($this, 'errorHandler'), E_WARNING);
+        $content = $filter->compress(array());
+        restore_error_handler();
+
+        $this->assertNull($content);
+    }
+
+    /**
+     * Snappy should handle empty input data correctly.
+     *
+     * @return void
+     */
+    public function testEmptyString()
+    {
+        $filter = new SnappyCompression();
+
+        $content = $filter->compress(false);
+        $content = $filter->decompress($content);
+        $this->assertEquals('', $content, 'Snappy failed to decompress empty string.');
+    }
+
+    /**
+     * Snappy should throw an exception when decompressing invalid data.
+     *
+     * @return void
+     */
+    public function testInvalidData()
+    {
+        $filter = new SnappyCompression();
+
+        $this->setExpectedException(
+            'Zend\Filter\Exception\RuntimeException',
+            'Error while decompressing.'
+        );
+
+        // restore_error_handler can emit an E_WARNING; let's ignore that, as
+        // we want to test the returned value
+        set_error_handler(array($this, 'errorHandler'), E_WARNING);
+        $content = $filter->decompress('123');
+        restore_error_handler();
+    }
 
     /**
      * testing toString
@@ -58,5 +105,12 @@ class SnappyTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new SnappyCompression();
         $this->assertEquals('Snappy', $filter->toString());
+    }
+
+    /**
+     * Null error handler; used when wanting to ignore specific error types
+     */
+    public function errorHandler($errno, $errstr)
+    {
     }
 }

--- a/tests/ZendTest/Filter/Compress/SnappyTest.php
+++ b/tests/ZendTest/Filter/Compress/SnappyTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Filter
+ */
+
+namespace ZendTest\Filter\Compress;
+
+use Zend\Filter\Compress\Snappy as SnappyCompression;
+
+/**
+ * @category   Zend
+ * @package    Zend_Filter
+ * @subpackage UnitTests
+ * @group      Zend_Filter
+ */
+class SnappyTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (!extension_loaded('snappy')) {
+            $this->markTestSkipped('This adapter needs the snappy extension');
+        }
+    }
+
+    /**
+     * Basic usage
+     *
+     * @return void
+     */
+    public function testBasicUsage()
+    {
+        $filter  = new SnappyCompression();
+
+        $content = $filter->compress('compress me');
+        $this->assertNotEquals('compress me', $content);
+
+        $content = $filter->decompress($content);
+        $this->assertEquals('compress me', $content);
+    }
+
+    // TODO test all three warnings (on each method)
+    // TODO test exception
+    // TODO test recompression
+    // TODO test null/ false compression
+    // TODO test invalid argument cases
+
+    /**
+     * testing toString
+     *
+     * @return void
+     */
+    public function testSnappyToString()
+    {
+        $filter = new SnappyCompression();
+        $this->assertEquals('Snappy', $filter->toString());
+    }
+}


### PR DESCRIPTION
Added a Zend\Filter\Compress\Snappy to utilise [php-snappy](http://code.google.com/p/php-snappy/).

The php-extension provides a minimal API for google [snappy](http://code.google.com/p/snappy/) (formerly Zippy). The snappy library itself is intended to provide fast, reasonable compressions and is widely available as `libsnappy1` package.

Php-snappy is not hosted on pecl.php.net.

UnitTests supplied and passing. Code is PSR-2 compatible and closely matches other filter implementations. 
