### PR TITLE
Fix default value unavailable exception for in-build php classes

### DIFF
--- a/library/Zend/Di/Definition/RuntimeDefinition.php
+++ b/library/Zend/Di/Definition/RuntimeDefinition.php
@@ -346,7 +346,7 @@ class RuntimeDefinition implements DefinitionInterface
             // set the class name, if it exists
             $def['parameters'][$methodName][$fqName][] = $actualParamName;
             $def['parameters'][$methodName][$fqName][] = ($p->getClass() !== null) ? $p->getClass()->getName() : null;
-            $def['parameters'][$methodName][$fqName][] = !($optional =$p->isOptional());
+            $def['parameters'][$methodName][$fqName][] = !($optional =$p->isOptional() && $p->isDefaultValueAvailable());
             $def['parameters'][$methodName][$fqName][] = $optional ? $p->getDefaultValue() : null;
         }
 

--- a/tests/ZendTest/Di/Definition/RuntimeDefinitionTest.php
+++ b/tests/ZendTest/Di/Definition/RuntimeDefinitionTest.php
@@ -59,4 +59,38 @@ class RuntimeDefinitionTest extends TestCase
             )
         );
     }
+
+    public function testExceptionDefaultValue()
+    {
+        $definition = new RuntimeDefinition();
+
+        $definition->forceLoadClass('RecursiveIteratorIterator');
+
+        $this->assertSame(
+            array(
+                'RecursiveIteratorIterator::__construct:0' => array(
+                    'iterator',
+                    'Traversable',
+                    true,
+                    null,
+                ),
+                'RecursiveIteratorIterator::__construct:1' => Array (
+                    'mode',
+                    null,
+                    true,
+                    null,
+                ),
+                'RecursiveIteratorIterator::__construct:2' => Array (
+                    'flags',
+                    null,
+                    true,
+                    null,
+                ),
+            ),
+            $definition->getMethodParameters(
+                'RecursiveIteratorIterator',
+                '__construct'
+            )
+        );
+    }
 }


### PR DESCRIPTION
Main trouble: https://bugs.php.net/bug.php?id=50798
Getting Reflection for default value for internal php extension
I caught this in GearmanClient
The best solution is using "isDefaultValueAvailable" method
http://www.php.net/manual/en/reflectionparameter.isdefaultvalueavailable.php
