### PR TITLE
Allow NodeList to be accessed via array like syntax.

### DIFF
--- a/library/Zend/Dom/Exception/BadMethodCallException.php
+++ b/library/Zend/Dom/Exception/BadMethodCallException.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Dom
+ */
+
+namespace Zend\Dom\Exception;
+
+/**
+ * Zend_Dom Exceptions
+ *
+ * @category   Zend
+ * @package    Zend_Dom
+ */
+class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
+{
+}

--- a/library/Zend/Dom/NodeList.php
+++ b/library/Zend/Dom/NodeList.php
@@ -16,6 +16,7 @@ use DOMNodeList;
 use DOMNode;
 use DOMXPath;
 use Iterator;
+use ArrayAccess;
 
 /**
  * Nodelist for DOM XPath query
@@ -23,7 +24,7 @@ use Iterator;
  * @package    Zend_Dom
  * @subpackage Query
  */
-class NodeList implements Iterator, Countable
+class NodeList implements Iterator, Countable, ArrayAccess
 {
     /**
      * Number of results
@@ -174,5 +175,50 @@ class NodeList implements Iterator, Countable
     public function count()
     {
         return $this->nodeList->length;
+    }
+
+    /**
+     * ArrayAccess: offset exists
+     *
+     * @return bool
+     */
+    public function offsetExists($key)
+    {
+        if (in_array($key, range(0, $this->nodeList->length - 1)) && $this->nodeList->length > 0) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * ArrayAccess: get offset
+     *
+     * @return mixed
+     */
+    public function offsetGet($key)
+    {
+        return $this->nodeList->item($key);
+    }
+
+    /**
+     * ArrayAccess: set offset
+     *
+     * @return void
+     * @throws Exception\BadMethodCallException when attemptingn to write to a read-only item
+     */
+    public function offsetSet($key, $value)
+    {
+        throw new Exception\BadMethodCallException('Attempting to write to a read-only list');
+    }
+
+    /**
+     * ArrayAccess: unset offset
+     *
+     * @return void
+     * @throws Exception\BadMethodCallException when attemptingn to unset a read-only item
+     */
+    public function offsetUnset($key)
+    {
+        throw new Exception\BadMethodCallException('Attempting to unset on a read-only list');
     }
 }

--- a/tests/ZendTest/Dom/QueryTest.php
+++ b/tests/ZendTest/Dom/QueryTest.php
@@ -356,4 +356,48 @@ XML;
         $this->setExpectedException("\Zend\Dom\Exception\RuntimeException");
         $this->query->queryXpath('/');
     }
+
+    public function testOffsetExists()
+    {
+        $this->loadHtml();
+        $results = $this->query->execute('input');
+
+        $this->assertEquals(3, $results->count());
+        $this->assertFalse($results->offsetExists(3));
+        $this->assertTrue($results->offsetExists(2));
+    }
+
+    public function testOffsetGet()
+    {
+        $this->loadHtml();
+        $results = $this->query->execute('input');
+
+        $this->assertEquals(3, $results->count());
+        $this->assertEquals('login', $results[2]->getAttribute('id'));
+    }
+
+    /**
+     * @expectedException Zend\Dom\Exception\BadMethodCallException
+     */
+    public function testOffsetSet()
+    {
+        $this->loadHtml();
+        $results = $this->query->execute('input');
+        $this->assertEquals(3, $results->count());
+
+        $results[0] = '<foobar />';
+    }
+
+
+    /**
+     * @expectedException Zend\Dom\Exception\BadMethodCallException
+     */
+    public function testOffsetUnset()
+    {
+        $this->loadHtml();
+        $results = $this->query->execute('input');
+        $this->assertEquals(3, $results->count());
+
+        unset($results[2]);
+    }
 }


### PR DESCRIPTION
If we do a execute a selector and get back a NodeList and want just the first element we can now access it like so:

``` php
<?php
use Zend\Dom\Query;

$dom = new Query($html);
$results = $dom->execute('.foo .bar a');

$count = count($results); // get number of matches: 4

$results[2]->getAttribute('id'); // access individually

foreach ($results as $result) { // or iterate
    // $result is a DOMElement
}
?>
```

Where before you could only iterate them which is really ineffective for a lot of projects.
