### PR TITLE
Zend\Permissions\Rbac roles should inherit parent permissions, not child permissions

### DIFF
--- a/library/Zend/Permissions/Rbac/AbstractRole.php
+++ b/library/Zend/Permissions/Rbac/AbstractRole.php
@@ -58,7 +58,7 @@ abstract class AbstractRole extends AbstractIterator
     }
 
     /**
-     * Checks if a permission exists for this role or any child roles.
+     * Checks if a permission exists for this role or any parent roles.
      *
      * @param  string $name
      * @return bool
@@ -69,12 +69,8 @@ abstract class AbstractRole extends AbstractIterator
             return true;
         }
 
-        $it = new RecursiveIteratorIterator($this, RecursiveIteratorIterator::CHILD_FIRST);
-        foreach ($it as $leaf) {
-            /** @var AbstractRole $leaf */
-            if ($leaf->hasPermission($name)) {
-                return true;
-            }
+        if($this->parent && $this->parent->hasPermission($name)) {
+            return true;
         }
 
         return false;

--- a/tests/ZendTest/Permissions/Rbac/RbacTest.php
+++ b/tests/ZendTest/Permissions/Rbac/RbacTest.php
@@ -68,7 +68,7 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(false, $this->rbac->isGranted('foo', 'can.baz'));
     }
 
-    public function testNotGrantedChildRoles()
+    public function testParentRolesNotGrantedChildPermissions()
     {
         $foo = new Rbac\Role('foo');
         $bar = new Rbac\Role('bar');
@@ -82,7 +82,10 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->rbac->isGranted('foo', 'can.bar'));
     }
 
-    public function testGrantedParentRoles()
+    /**
+     * @group xxx
+     */
+    public function testChildRolesInheritParentPermissions()
     {
         $foo = new Rbac\Role('foo');
         $bar = new Rbac\Role('bar');

--- a/tests/ZendTest/Permissions/Rbac/RbacTest.php
+++ b/tests/ZendTest/Permissions/Rbac/RbacTest.php
@@ -68,7 +68,7 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(false, $this->rbac->isGranted('foo', 'can.baz'));
     }
 
-    public function testIsGrantedChildRoles()
+    public function testNotGrantedChildRoles()
     {
         $foo = new Rbac\Role('foo');
         $bar = new Rbac\Role('bar');
@@ -79,12 +79,21 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $this->rbac->addRole($foo);
         $this->rbac->addRole($bar, $foo);
 
-        $this->assertEquals(true, $this->rbac->isGranted('foo', 'can.bar'));
-        $this->assertEquals(true, $this->rbac->isGranted('foo', 'can.foo'));
-        $this->assertEquals(true, $this->rbac->isGranted('bar', 'can.bar'));
+        $this->assertFalse($this->rbac->isGranted('foo', 'can.bar'));
+    }
 
-        $this->assertEquals(false, $this->rbac->isGranted('foo', 'can.baz'));
-        $this->assertEquals(false, $this->rbac->isGranted('bar', 'can.baz'));
+    public function testGrantedParentRoles()
+    {
+        $foo = new Rbac\Role('foo');
+        $bar = new Rbac\Role('bar');
+
+        $foo->addPermission('can.foo');
+        $bar->addPermission('can.bar');
+
+        $this->rbac->addRole($foo);
+        $this->rbac->addRole($bar, $foo);
+
+        $this->assertTrue($this->rbac->isGranted('bar', 'can.foo'));
     }
 
     public function testHasRole()


### PR DESCRIPTION
As (logically) stated in documentation "Child role will inherit the permissions of their parent." But current implementation defeats the main purpose on role inheritance, as parent roles will inherit all permissions of their children.

It really should be otherwise :)
