### PR TITLE
Process X-Forwarded-For header in correct order

### DIFF
--- a/library/Zend/Session/Validator/RemoteAddr.php
+++ b/library/Zend/Session/Validator/RemoteAddr.php
@@ -102,7 +102,7 @@ class RemoteAddr implements SessionValidator
             // proxy IP address
             if (isset($_SERVER['HTTP_X_FORWARDED_FOR']) && $_SERVER['HTTP_X_FORWARDED_FOR']) {
                 $ips = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
-                return trim($ips[0]);
+                return trim(end($ips));
             }
         }
 

--- a/tests/ZendTest/Session/Validator/RemoteAddrTest.php
+++ b/tests/ZendTest/Session/Validator/RemoteAddrTest.php
@@ -106,7 +106,7 @@ class RemoteAddrTest extends \PHPUnit_Framework_TestCase
     {
         $this->backup();
         $_SERVER['REMOTE_ADDR'] = '0.1.2.3';
-        $_SERVER['HTTP_X_FORWARDED_FOR'] = '2.1.2.3, 1.1.2.3';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '1.1.2.3, 2.1.2.3';
         RemoteAddr::setUseProxy(true);
         $validator = new RemoteAddr();
         RemoteAddr::setUseProxy(false);


### PR DESCRIPTION
See http://en.wikipedia.org/wiki/X-Forwarded-For#Format. The IP addresses are appended to the right side so the server communicating with my managed proxy server is the last. This is the only value that can be trusted if I am behind managed proxy server, all others can be easily spoofed. The last value is also the equivalent of REMOTE_ADDR if I am not behind a reverse proxy.
