### PR TITLE
Don't add a checksum to valid EAN13 barcode

### DIFF
--- a/library/Zend/Barcode/Object/Ean13.php
+++ b/library/Zend/Barcode/Object/Ean13.php
@@ -59,7 +59,6 @@ class Ean13 extends AbstractObject
     protected function getDefaultOptions()
     {
         $this->barcodeLength = 13;
-        $this->mandatoryChecksum = true;
         $this->mandatoryQuietZones = true;
     }
 


### PR DESCRIPTION
This prevents appending another 0 character at a barcode before
it will get rendered.  This way the barcode validator does not claim
a former perfectly valid barcode would be longer than 13 characters.

@see \Zend\Barcode\Object\AbstractObject::validateSpecificText
