### PR TITLE
Modified Zend\Crypt\Password\Bcrypt to store random salt

### DIFF
--- a/library/Zend/Crypt/Password/Bcrypt.php
+++ b/library/Zend/Crypt/Password/Bcrypt.php
@@ -73,11 +73,10 @@ class Bcrypt implements PasswordInterface
     public function create($password)
     {
         if (empty($this->salt)) {
-            $salt = Rand::getBytes(self::MIN_SALT_SIZE);
-        } else {
-            $salt = $this->salt;
+            $this->setSalt(Rand::getBytes(self::MIN_SALT_SIZE));
         }
-        $salt64 = substr(str_replace('+', '.', base64_encode($salt)), 0, 22);
+        
+        $salt64 = substr(str_replace('+', '.', base64_encode($this->salt)), 0, 22);
         /**
          * Check for security flaw in the bcrypt implementation used by crypt()
          * @see http://php.net/security/crypt_blowfish.php


### PR DESCRIPTION
Currently, if salt is empty, a randomly generated string is used and then thrown away. Although not necessary, it can be advantageous to allow the user to retrieve the salt which was randomly generated.

This fork modifies the create method, so that if $this->salt is empty, it calls $this->setSalt(randomsalt) instead. This allows the subsequent getSalt method to return the randomly generated salt.
