### PR TITLE
Allows tests to fail when required but not existing

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -173,7 +173,7 @@ class BaseInputFilter implements InputFilterInterface
                         continue;
                     }
                     // - test if input allows empty
-                    if ($input->allowEmpty()) {
+                    if ($input->allowEmpty() &&  array_key_exists($name, $this->data)) {
                         $this->validInputs[$name] = $input;
                         continue;
                     }

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -433,7 +433,7 @@ class BaseInputFilterTest extends TestCase
         $data = array('bar' => 124);
         $filter->setData($data);
 
-        $this->assertTrue($filter->isValid());
+        $this->assertFalse($filter->isValid());
         $this->assertEquals('', $filter->getValue('foo'));
     }
 


### PR DESCRIPTION
This addresses issue #3109

The PullRequest adds a check for not existing data when the field is
required but allowed to be empty. Therefore there has to be an empty
value for the field otherwise it would not be required.

This also changes a test that is inconsequently allowing a nonexisting
value even though the field is required.

THIS CAN BE SEEN AS A BC-BREAK!!
