### PR TITLE
Render the name of the alias in the exception message if an alias already exists

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -630,7 +630,10 @@ class ServiceManager implements ServiceLocatorInterface
         }
 
         if ($this->allowOverride === false && $this->has(array($cAlias, $alias), false)) {
-            throw new Exception\InvalidServiceNameException('An alias by this name already exists');
+            throw new Exception\InvalidServiceNameException(sprintf(
+                'An alias by the name "%s" already exists',
+                $alias
+            ));
         }
 
         $this->aliases[$cAlias] = $nameOrAlias;


### PR DESCRIPTION
I find it quite useful to see _which_ alias already exists. Therefore I added this to the exception message.
