### PR TITLE
Fixed Client to allow also empty passwords in HTTP Authentication.

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -631,8 +631,8 @@ class Client implements Stdlib\DispatchableInterface
         if (!defined('self::AUTH_' . strtoupper($type))) {
             throw new Exception\InvalidArgumentException("Invalid or not supported authentication type: '$type'");
         }
-        if (empty($user) || empty($password)) {
-            throw new Exception\InvalidArgumentException("The username and the password cannot be empty");
+        if (empty($user)) {
+            throw new Exception\InvalidArgumentException("The username cannot be empty");
         }
 
         $this->auth = array (


### PR DESCRIPTION
RFC 2617 nor RFC1945 does not require that in HTTP Authentication, the password must be set. There are use cases (for example in some API keys) that only username is used and password is left intentionally empty.

This commit fixes Zend\Http\Client component to allow also empty passwords.
