### PR TITLE
Zf2946

### DIFF
--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -133,6 +133,9 @@ class SetCookie implements MultipleHeaderInterface
 
         list($name, $value) = explode(': ', $headerLine, 2);
 
+        // some sites return set-cookie::value, this is to get rid of the second :
+        $name = (strtolower($name) =='set-cookie:') ? 'set-cookie' : $name;
+
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'set-cookie') {
             throw new Exception\InvalidArgumentException('Invalid header line for Set-Cookie string: "' . $name . '"');


### PR DESCRIPTION
When calling google news feed i.e http://news.google.com/news?q=something&hl=en&output=atom using the Zend\Http\Client I receive an Exception Undefined offset: 1 in \Zend\Http\Header\SetCookie.php:134. It turns out google sends an empty set-cookie header Set-Cookie:. As SetCookie::fromString expects a space after the colon it fails at this point.
