### PR TITLE
Zf2634 - Adding missing method Client::encodeAuthHeader

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1336,7 +1336,7 @@ class Client implements Stdlib\DispatchableInterface
             default:
                 throw new Client\Exception\InvalidArgumentException("Not a supported HTTP authentication type: '$type'");
 
-                return $authHeader;
         }
+        return $authHeader;
     }
 }

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1301,4 +1301,42 @@ class Client implements Stdlib\DispatchableInterface
 
         return $this->adapter->read();
     }
+
+    /**
+     * Create a HTTP authentication "Authorization:" header according to the
+     * specified user, password and authentication method.
+     *
+     * @see http://www.faqs.org/rfcs/rfc2617.html
+     * @param string $user
+     * @param string $password
+     * @param string $type
+     * @return string
+     * @throws Zend_Http_Client_Exception
+     */
+    public static function encodeAuthHeader($user, $password, $type = self::AUTH_BASIC)
+    {
+        $authHeader = null;
+
+        switch ($type) {
+            case self::AUTH_BASIC:
+                // In basic authentication, the user name cannot contain ":"
+                if (strpos($user, ':') !== false) {
+                    throw new Client\Exception\InvalidArgumentException("The user name cannot contain ':' in 'Basic' HTTP authentication");
+                }
+
+                $authHeader = 'Basic ' . base64_encode($user . ':' . $password);
+                break;
+
+                //case self::AUTH_DIGEST:
+                /**
+                * @todo Implement digest authentication
+                */
+                //    break;
+
+                default:
+                    throw new Client\Exception\InvalidArgumentException("Not a supported HTTP authentication type: '$type'");
+        }
+
+        return $authHeader;
+    }
 }

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1301,4 +1301,42 @@ class Client implements Stdlib\DispatchableInterface
 
         return $this->adapter->read();
     }
+
+    /**
+     * Create a HTTP authentication "Authorization:" header according to the
+     * specified user, password and authentication method.
+     *
+     * @see http://www.faqs.org/rfcs/rfc2617.html
+     * @param string $user
+     * @param string $password
+     * @param string $type
+     * @return string
+     * @throws Zend_Http_Client_Exception
+     */
+    public static function encodeAuthHeader($user, $password, $type = self::AUTH_BASIC)
+    {
+        $authHeader = null;
+
+        switch ($type) {
+            case self::AUTH_BASIC:
+                // In basic authentication, the user name cannot contain ":"
+                if (strpos($user, ':') !== false) {
+                    throw new Client\Exception\InvalidArgumentException("The user name cannot contain ':' in 'Basic' HTTP authentication");
+                }
+
+                $authHeader = 'Basic ' . base64_encode($user . ':' . $password);
+                break;
+
+            //case self::AUTH_DIGEST:
+                /**
+                * @todo Implement digest authentication
+                */
+                //    break;
+
+            default:
+                throw new Client\Exception\InvalidArgumentException("Not a supported HTTP authentication type: '$type'");
+
+                return $authHeader;
+        }
+    }
 }

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1311,7 +1311,7 @@ class Client implements Stdlib\DispatchableInterface
      * @param string $password
      * @param string $type
      * @return string
-     * @throws Zend_Http_Client_Exception
+     * @throws Zend\Http\Client\Exception\InvalidArgumentException
      */
     public static function encodeAuthHeader($user, $password, $type = self::AUTH_BASIC)
     {

--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -133,6 +133,9 @@ class SetCookie implements MultipleHeaderInterface
 
         list($name, $value) = explode(': ', $headerLine, 2);
 
+        // some sites return set-cookie::value, this is to get rid of the second :
+        $name = (strtolower($name) =='set-cookie:') ? 'set-cookie' : $name;
+
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'set-cookie') {
             throw new Exception\InvalidArgumentException('Invalid header line for Set-Cookie string: "' . $name . '"');

--- a/tests/ZendTest/Http/ClientTest.php
+++ b/tests/ZendTest/Http/ClientTest.php
@@ -79,4 +79,26 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $cookies = $client->getCookies();
         $this->assertEquals(2, count($cookies));
     }
+
+    public function testEncodeAuthHeaderWorksAsExpected()
+    {
+    	$encoded = Client::encodeAuthHeader('test', 'test');
+    	$this->assertEquals('Basic ' . base64_encode('test:test'), $encoded);
+    }
+
+    /**
+     * @expectedException Zend\Http\Client\Exception\InvalidArgumentException
+     */
+    public function testEncodeAuthHeaderThrowsExceptionWhenUsernameContainsSemiColon()
+    {
+    	$encoded = Client::encodeAuthHeader('test:', 'test');
+    }
+
+    /**
+     * @expectedException Zend\Http\Client\Exception\InvalidArgumentException
+     */
+    public function testEncodeAuthHeaderThrowsExceptionWhenInvalidAuthTypeIsUsed()
+    {
+    	$encoded = Client::encodeAuthHeader('test', 'test', 'test');
+    }
 }


### PR DESCRIPTION
Putting the static method back in place so that the ProxyAdapter will work as it was calling the missing method of Client::encodeAuthHeader.
