### PR TITLE
#2607 - Fixing how headers are accessed

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1040,7 +1040,7 @@ class Client implements Stdlib\DispatchableInterface
 
         // Set the Accept-encoding header if not set - depending on whether
         // zlib is available or not.
-        if (! isset($this->headers['accept-encoding'])) {
+        if (!$this->getRequest()->getHeaders()->has('Accept-Encoding')) {
             if (function_exists('gzinflate')) {
                 $headers['Accept-encoding'] = 'gzip, deflate';
             } else {


### PR DESCRIPTION
I have modified how the headers were accessed as it was using the old method, now it is using the new method of: $this->getRequest()->getHeaders()->has('Accept-Encoding')
