### PR TITLE
Remove unnecessary white-space before semicolons in statements

### DIFF
--- a/library/Zend/Barcode/Object/Ean5.php
+++ b/library/Zend/Barcode/Object/Ean5.php
@@ -101,7 +101,7 @@ class Ean5 extends Ean13
         $this->checkText($text);
         $checksum = 0;
 
-        for ($i = 0 ; $i < $this->barcodeLength; $i ++) {
+        for ($i = 0; $i < $this->barcodeLength; $i ++) {
             $checksum += intval($text{$i}) * ($i % 2 ? 9 : 3);
         }
 

--- a/library/Zend/Code/Scanner/TokenArrayScanner.php
+++ b/library/Zend/Code/Scanner/TokenArrayScanner.php
@@ -319,7 +319,6 @@ class TokenArrayScanner implements ScannerInterface
             return $tokenIndex;
         };
         $MACRO_TOKEN_LOGICAL_START_INDEX = function() use (&$tokenIndex, &$docCommentIndex) {
-            ;
             return ($docCommentIndex === false) ? $tokenIndex : $docCommentIndex;
         };
         $MACRO_DOC_COMMENT_START         = function() use (&$tokenIndex, &$docCommentIndex) {

--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -496,7 +496,7 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
     public function prepareFieldset()
     {
         if ($this->targetElement !== null) {
-            for ($i = 0 ; $i != $this->count ; ++$i) {
+            for ($i = 0; $i != $this->count; ++$i) {
                 $elementOrFieldset = $this->createNewTargetElementInstance();
                 $elementOrFieldset->setName($i);
 

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -552,7 +552,7 @@ class Form extends Fieldset implements FormInterface
                 if (isset($data[$key])) {
                     $count = count($data[$key]);
 
-                    for ($i = 0 ; $i != $count ; ++$i) {
+                    for ($i = 0; $i != $count; ++$i) {
                         $values[] = $value;
                     }
                 }

--- a/library/Zend/Validator/Hostname.php
+++ b/library/Zend/Validator/Hostname.php
@@ -665,7 +665,7 @@ class Hostname extends AbstractValidator
         $char  = 0x80;
 
         for ($indexe = ($separator) ? ($separator + 1) : 0; $indexe < $lengthe; ++$lengthd) {
-            for ($old_index = $index, $pos = 1, $key = 36; 1 ; $key += 36) {
+            for ($old_index = $index, $pos = 1, $key = 36; 1; $key += 36) {
                 $hex   = ord($encoded[$indexe++]);
                 $digit = ($hex - 48 < 10) ? $hex - 22
                        : (($hex - 65 < 26) ? $hex - 65

--- a/library/Zend/View/Helper/Cycle.php
+++ b/library/Zend/View/Helper/Cycle.php
@@ -30,7 +30,7 @@ class Cycle extends AbstractHelper implements \Iterator
      *
      * @var array
      */
-    protected $pointers = array(self::DEFAULT_NAME =>-1) ;
+    protected $pointers = array(self::DEFAULT_NAME =>-1);
 
     /**
      * Array of values

--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -413,7 +413,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
         $type = ($this->autoEscape) ? $this->escape($item->type) : $item->type;
         $html  = '<script type="' . $type . '"' . $attrString . '>';
         if (!empty($item->source)) {
-            $html .= PHP_EOL ;
+            $html .= PHP_EOL;
 
             if ($addScriptEscape) {
                 $html .= $indent . '    ' . $escapeStart . PHP_EOL;

--- a/tests/ZendTest/Dom/QueryTest.php
+++ b/tests/ZendTest/Dom/QueryTest.php
@@ -195,7 +195,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         try {
             $this->query->queryXpath('//meta[php:functionString("strtolower", @http-equiv) = "content-type"]');
         } catch (\Exception $e) {
-            return ;
+            return;
         }
         $this->assertFails('XPath PHPFunctions should be disable by default');
     }
@@ -218,7 +218,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
             $this->query->queryXpath('//meta[php:functionString("strtolower", @http-equiv) = "content-type"]');
         } catch (\Exception $e) {
             // $e->getMessage() - Not allowed to call handler 'strtolower()
-            return ;
+            return;
         }
         $this->assertFails('Not allowed to call handler strtolower()');
     }

--- a/tests/ZendTest/Json/JsonTest.php
+++ b/tests/ZendTest/Json/JsonTest.php
@@ -381,11 +381,11 @@ class JsonTest extends \PHPUnit_Framework_TestCase
      */
     public function testZf461()
     {
-        $item1 = new Item() ;
-        $item2 = new Item() ;
-        $everything = array() ;
-        $everything['allItems'] = array($item1, $item2) ;
-        $everything['currentItem'] = $item1 ;
+        $item1 = new Item();
+        $item2 = new Item();
+        $everything = array();
+        $everything['allItems'] = array($item1, $item2);
+        $everything['currentItem'] = $item1;
 
         // should not fail
         $encoded = Json\Encoder::encode($everything);
@@ -403,11 +403,11 @@ class JsonTest extends \PHPUnit_Framework_TestCase
      */
     public function testZf4053()
     {
-        $item1 = new Item() ;
-        $item2 = new Item() ;
-        $everything = array() ;
-        $everything['allItems'] = array($item1, $item2) ;
-        $everything['currentItem'] = $item1 ;
+        $item1 = new Item();
+        $item2 = new Item();
+        $everything = array();
+        $everything['allItems'] = array($item1, $item2);
+        $everything['currentItem'] = $item1;
 
         $options = array('silenceCyclicalExceptions'=>true);
 


### PR DESCRIPTION
See, for example, https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md#54-for.
