### PR TITLE
Rename variable to what it probably should be

### DIFF
--- a/library/Zend/Validator/Barcode/Code128.php
+++ b/library/Zend/Validator/Barcode/Code128.php
@@ -406,8 +406,8 @@ class Code128 extends AbstractAdapter
                 return -1;
             }
         } else {
-            if ($ord <= 106) {
-                return ($ord + 32);
+            if ($value <= 106) {
+                return ($value + 32);
             } else {
                 return -1;
             }


### PR DESCRIPTION
In `Zend\Validator\Barcode\Code128::chr128($value, $set)` a variable `$ord` is used to return a value, but the variable does not exist. I changed it to what it likely should be, `$value`.
