### PR TITLE
Render name of alias that already exists in exception message

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -631,7 +631,8 @@ class ServiceManager implements ServiceLocatorInterface
 
         if ($this->allowOverride === false && $this->has(array($cAlias, $alias), false)) {
             throw new Exception\InvalidServiceNameException(sprintf(
-                'An alias by the name "%s" already exists',
+                'An alias by the name "%s" or "%s" already exists',
+                $cAlias,
                 $alias
             ));
         }

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -630,7 +630,10 @@ class ServiceManager implements ServiceLocatorInterface
         }
 
         if ($this->allowOverride === false && $this->has(array($cAlias, $alias), false)) {
-            throw new Exception\InvalidServiceNameException('An alias by this name already exists');
+            throw new Exception\InvalidServiceNameException(sprintf(
+                'An alias by the name "%s" already exists',
+                $alias
+            ));
         }
 
         $this->aliases[$cAlias] = $nameOrAlias;


### PR DESCRIPTION
I find it quite useful to see the name of the alias that already exists, therefore I added it to the exception message.
