### PR TITLE
Made the dependency from the 'zendframework/zend-servicemanager' suggested (optional).

### DIFF
--- a/library/Zend/Validator/composer.json
+++ b/library/Zend/Validator/composer.json
@@ -21,7 +21,7 @@
         "zendframework/zend-math": "self.version"
     },
     "suggest": {
-        "zendframework/zend-servicemanager": "self.version",
+        "zendframework/zend-servicemanager": "Zend\\ServiceManager component",
         "zendframework/zend-db": "Zend\\Db component",
         "zendframework/zend-math": "Zend\\Math component"
     }

--- a/library/Zend/Validator/composer.json
+++ b/library/Zend/Validator/composer.json
@@ -15,13 +15,13 @@
     "require": {
         "php": ">=5.3.3",
         "zendframework/zend-i18n": "self.version",
-        "zendframework/zend-servicemanager": "self.version",
         "zendframework/zend-stdlib": "self.version"
     },
     "require-dev": {
         "zendframework/zend-math": "self.version"
     },
     "suggest": {
+        "zendframework/zend-servicemanager": "self.version",
         "zendframework/zend-db": "Zend\\Db component",
         "zendframework/zend-math": "Zend\\Math component"
     }


### PR DESCRIPTION
There is only one class that depends from the zendframework/zend-servicemanager package, it is Zend\Validator\ValidatorPluginManager (https://github.com/zendframework/zf2/blob/master/library/Zend/Validator/ValidatorPluginManager.php). Due such dependency the zendframework/zend-validator package can be not used in other frameworks/libraries because other packages can use different implementation of the Service Locator/DI, for example from the Symfony.

For example, I would like to use the "zendframework/zend-http" package in the Myak Framework (https://github.com/myak/framework/tree/master/lib). However the  "zendframework/zend-http" depends from the "zendframework/zend-uri", which depends from the "zendframework/zend-validator", which depends from the "zendframework/zend-servicemanager".

So to install of the  "zendframework/zend-http" I am forced to install the "zendframework/zend-servicemanager" also. Due that I need to use the "symfony/http-foundation" package. However I would like to use the "zendframework/zend-http" instead.

There are other packages that don't require to install optional packages, for example, let's see on the composer.json for the like zendframework/zend-session:

``` json
    "suggest": {
        "zendframework/zend-validator": "Zend\\Validator component",
        "zendframework/zend-eventmanager": "Zend\\EventManager component"
    }
```

so why don't apply the same approach here? I suggest to move the dependency from the "zendframework/zend-servicemanager" to the "suggest" section of the composer.json.

This pull request does it.
