### PR TITLE
Update render FormRow (fieldset attributes, use for jquery mobile)

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -33,6 +33,11 @@ class Element implements ElementInterface
      * @var array
      */
     protected $labelAttributes;
+    
+    /**
+     * @var array
+     */
+    protected $fieldsetAttributes;
 
     /**
      * @var array Validation error messages
@@ -114,6 +119,10 @@ class Element implements ElementInterface
             $this->setLabelAttributes($options['label_attributes']);
         }
 
+        if (isset($options['fieldset_attributes'])) {
+        	$this->setFieldsetAttributes($options['fieldset_attributes']);
+        }
+        
         $this->options = $options;
 
         return $this;
@@ -301,6 +310,28 @@ class Element implements ElementInterface
         return $this->labelAttributes;
     }
 
+    /**
+     * Set the attributes to use with the fieldset (radio and multicheckbox)
+     * 
+     * @param array $fieldsetAttributes
+     * @return Element|ElementInterface 
+     */
+    public function setFieldsetAttributes(array $fieldsetAttributes)
+    {
+    	$this->fieldsetAttributes = $fieldsetAttributes;
+    	return $this;
+    }
+    
+    /**
+     * Get the attributes to use with the fieldset (radio and multicheckbox)
+     * 
+     * @return array
+     */
+    public function getFieldsetAttributes()
+    {
+    	return $this->fieldsetAttributes;
+    }
+     
     /**
      * Set a list of messages to report when validation fails
      *

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -40,6 +40,11 @@ class FormRow extends AbstractHelper
     protected $labelAttributes;
 
     /**
+     * @var array
+     */
+    protected $fieldsetAttributes;
+    
+    /**
      * @var string
      */
     protected $inputErrorClass = 'input-error';
@@ -107,9 +112,21 @@ class FormRow extends AbstractHelper
             // labels. The semantic way is to group them inside a fieldset
             $type = $element->getAttribute('type');
             if ($type === 'multi_checkbox' || $type === 'radio') {
+            	
+            	$fieldsetAttributes = $element->getFieldsetAttributes();
+            	if (empty($fieldsetAttributes)) {
+            		$fieldsetAttributes = $this->fieldsetAttributes;
+            	}
+            	
+            	if (is_array($fieldsetAttributes)) {
+            		$fieldsetAttributes = ' ' . $this->createAttributesString($fieldsetAttributes);
+            	}
+            	
                 $markup = sprintf(
-                    '<fieldset><legend>%s</legend>%s</fieldset>',
-                    $label,
+                    '<fieldset%s><legend>%s</legend>%s</fieldset>',
+
+                	$fieldsetAttributes,
+                	$label,
                     $elementString);
             } else {
                 if ($element->hasAttribute('id')) {
@@ -251,6 +268,28 @@ class FormRow extends AbstractHelper
         return $this->labelAttributes;
     }
 
+    /**
+     * Set the attributes for the row fieldset
+     *
+     * @param  array $fieldsetAttributes
+     * @return FormRow
+     */
+    public function setFieldsetAttributes($fieldsetAttributes)
+    {
+    	$this->fieldsetAttributes = $fieldsetAttributes;
+    	return $this;
+    }
+    
+    /**
+     * Get the attributes for the row fieldset
+     *
+     * @return array
+     */
+    public function getFieldsetAttributes()
+    {
+    	return $this->fieldsetAttributes;
+    }
+    
     /**
      * Set the class that is added to element that have errors
      *


### PR DESCRIPTION
...when the render method of Formrow is called.

This update is necessary when we use jquery mobile to add attributes (for example : 'data-role' => 'controlgroup', 'data-type' => 'horizontal') in the fieldset auto generated.

https://github.com/CLigeron/zf2.git

branch : master
