### PR TITLE
Implement AssetUrl view helper

### DIFF
--- a/library/Zend/View/Helper/AssetUrl.php
+++ b/library/Zend/View/Helper/AssetUrl.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_View
+ */
+
+namespace Zend\View\Helper;
+
+use Zend\View\Exception;
+use Zend\View\Helper\AbstractHelper;
+
+/**
+ * Helper for rendering asset urls, e.g. for assets located at a CDN.
+ *
+ * @package    Zend_View
+ * @subpackage Helper
+ */
+class AssetUrl extends AbstractHelper
+{
+
+    /**
+     * A map of registered asset urls.
+     *
+     * @var array
+     */
+    protected $assetUrls;
+
+    /**
+     * The default key.
+     *
+     * @var string
+     */
+    protected $defaultKey;
+
+    /**
+     * Constructs instance.
+     *
+     * @param  array $options
+     * @throws Exception\InvalidArgumentException
+     */
+    public function __construct($options = array())
+    {
+        if (!is_array($options)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Parameter "%s" needs to be specified as %s.',
+                'options',
+                'an array'
+            ));
+        }
+
+        if (isset($options['default_key'])) {
+            $this->setDefaultKey($options['default_key']);
+        }
+
+        if (isset($options['asset_urls'])) {
+            $this->setAssetUrls($options['asset_urls']);
+        }
+    }
+
+    /**
+     * Invokes the helper.
+     *
+     * @param  string $file
+     * @param  string $key
+     * @return string
+     * @throws Exception\InvalidArgumentException
+     * @throws Exception\BadMethodCallException
+     */
+    public function __invoke($file, $key = null)
+    {
+        if (!is_string($file)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Parameter "%s" needs to be specified as %s.',
+                'file',
+                'a string'
+            ));
+        }
+
+        if (null !== $key) {
+
+            if (!is_string($key)) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Parameter "%s" needs to be specified as %s.',
+                    'key',
+                    'a string'
+                ));
+            }
+
+            if (!isset($this->assetUrls[$key])) {
+                throw new Exception\BadMethodCallException(sprintf(
+                    'An asset url has not been registered for the key "%s".',
+                    $key
+                ));
+            }
+
+        }
+
+        if (null === $key) {
+            $key = $this->getDefaultKey();
+        }
+
+        if (null === $key) {
+            return $file;
+        }
+
+        $url = $file;
+
+        if ('' != $this->assetUrls[$key]['prefix']) {
+
+            $url = sprintf(
+                '%s/%s',
+                $this->assetUrls[$key]['prefix'],
+                ltrim(
+                    $url,
+                    '/'
+                )
+            );
+        }
+
+        if ('' != $this->assetUrls[$key]['suffix']) {
+            if (false === strpos($url, '?')) {
+                $url = sprintf(
+                    '%s?%s',
+                    $url,
+                    urlencode($this->assetUrls[$key]['suffix'])
+                );
+            } else {
+                $url = sprintf(
+                    '%s&%s',
+                    $url,
+                    urlencode($this->assetUrls[$key]['suffix'])
+                );
+            }
+        }
+
+        return $url;
+    }
+
+    /**
+     * Sets a bunch of asset urls.
+     *
+     * @param  array $assetUrls
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setAssetUrls($assetUrls = array())
+    {
+        if (!is_array($assetUrls)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Parameter "%s" needs to be specified as %s.',
+                'assetUrls',
+                'an array'
+            ));
+        }
+
+        $this->defaultKey = null;
+        $this->assetUrls = array();
+
+        foreach ($assetUrls as $key => $assetUrlOptions) {
+            $this->setAssetUrl(
+                $key,
+                isset($assetUrlOptions['prefix']) ? $assetUrlOptions['prefix'] : '',
+                isset($assetUrlOptions['suffix']) ? $assetUrlOptions['suffix'] : ''
+            );
+        }
+
+    }
+
+    /**
+     * Sets an asset url.
+     *
+     * @param  string $key
+     * @param  string $prefix
+     * @param  string $suffix
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setAssetUrl($key = null, $prefix = '', $suffix = '')
+    {
+        if (!is_string($key)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Parameter "%s" needs to be specified as %s.',
+                'key',
+                'a string'
+            ));
+        }
+
+        if (!is_string($prefix)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Parameter "%s" needs to be specified as %s.',
+                'prefix',
+                'a string'
+            ));
+        }
+
+        if (!is_string($suffix)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Parameter "%s" needs to be specified as %s.',
+                'suffix',
+                'a string'
+            ));
+        }
+
+        $prefix = rtrim(
+            $prefix,
+            '/'
+        );
+
+        if ('' == $prefix) {
+            $prefix = null;
+        }
+
+        $suffix = ltrim(
+            $suffix,
+            '?'
+        );
+
+        if ('' == $suffix) {
+            $suffix = null;
+        }
+
+        $this->assetUrls[$key] = array(
+            'prefix' => $prefix,
+            'suffix' => $suffix,
+        );
+    }
+
+    /**
+     * Returns default key.
+     *
+     * @return null|string
+     */
+    public function getDefaultKey()
+    {
+        if (null === $this->defaultKey
+            && is_array($this->assetUrls)
+            && 0 < count($this->assetUrls)) {
+
+            $keys = array_keys($this->assetUrls);
+            $this->defaultKey = reset($keys);
+
+        }
+
+        return $this->defaultKey;
+    }
+
+    /**
+     * Sets default key.
+     *
+     * @param  string $key
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setDefaultKey($key)
+    {
+        if (!is_string($key)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Parameter "%s" needs to be specified as %s.',
+                'file',
+                'a string'
+            ));
+        }
+
+        $this->defaultKey = $key;
+    }
+
+}

--- a/tests/ZendTest/View/Helper/AssetUrlTest.php
+++ b/tests/ZendTest/View/Helper/AssetUrlTest.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_View
+ */
+
+namespace ZendTest\View\Helper;
+
+use PhpUnit_Framework_TestCase as TestCase;
+use Zend\View\Helper\AssetUrl;
+use Zend\View\Exception;
+
+/**
+ * @category   Zend
+ * @package    Zend_View
+ * @subpackage UnitTests
+ * @group      Zend_View
+ * @group      Zend_View_Helper
+ */
+class AssetUrlTest extends TestCase
+{
+
+    public function testConstructorDoesNotThrowExceptionIfNoOptionsAreSpecified()
+    {
+        $assetUrlHelper = new AssetUrl();
+
+        $this->assertInstanceOf(
+            'Zend\View\Helper\AssetUrl',
+            $assetUrlHelper
+        );
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     */
+    public function testConstructorThrowsZendViewExceptionInvalidArgumentExceptionIfOptionsAreNotSpecifiedAsAnArray()
+    {
+        $assetUrlHelper = new AssetUrl('arbitrary string');
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     */
+    public function testRegisterAssetUrlThrowsZendViewExceptionInvalidArgumentExceptionIfKeyIsNotAString()
+    {
+        $assetUrlHelper = new AssetUrl();
+        $assetUrlHelper->setAssetUrl(new \stdClass());
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     */
+    public function testSetAssetUrlThrowsZendViewExceptionInvalidArgumentExceptionIfPrefixIsNotAString()
+    {
+        $assetUrlHelper = new AssetUrl();
+        $assetUrlHelper->setAssetUrl(
+            'scvbafrfvqwcn',
+            new \stdClass()
+        );
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     */
+    public function testSetAssetUrlThrowsZendViewExceptionInvalidArgumentExceptionIfSuffixIsNotAString()
+    {
+        $assetUrlHelper = new AssetUrl();
+        $assetUrlHelper->setAssetUrl(
+            'scvbafrfvqwcn',
+            'pefjwpefj',
+            new \stdClass()
+        );
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     */
+    public function testInvokeThrowsZendViewExceptionInvalidArgumentExceptionIfFileIsNotAString()
+    {
+        $assetUrlHelper = new AssetUrl();
+        $assetUrlHelper(new \stdClass());
+    }
+
+    public function testGetDefaultKeyReturnsFirstRegisteredAssetUrlIfNotExplicitlySpecified()
+    {
+
+        $assetUrlHelper = new AssetUrl();
+
+        $key = 'opamama';
+
+        $assetUrlHelper->setAssetUrl($key);
+
+        $this->assertEquals(
+            $key,
+            $assetUrlHelper->getDefaultKey()
+        );
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     */
+    public function testSetDefaultKeyThrowsZendViewExceptionInvalidArgumentExceptionIfKeyIsNotAString()
+    {
+        $assetUrlHelper = new AssetUrl();
+        $assetUrlHelper->setDefaultKey(new \stdClass());
+    }
+
+    public function testSetDefaultKeySetsDefaultKey()
+    {
+        $assetUrlHelper = new AssetUrl();
+
+        $key = 'opamama';
+
+        $assetUrlHelper->setDefaultKey($key);
+
+        $this->assertEquals(
+            $key,
+            $assetUrlHelper->getDefaultKey()
+        );
+    }
+
+    public function testConstructorSetsDefaultKey()
+    {
+        $key = 'opamama';
+
+        $assetUrlHelper = new AssetUrl(array(
+            'default_key' => $key,
+        ));
+
+        $this->assertEquals(
+            $key,
+            $assetUrlHelper->getDefaultKey()
+        );
+    }
+
+    public function testInvokeReturnsFilenameIfNoAssetUrlsAreSet()
+    {
+        $assetUrlHelper = new AssetUrl();
+
+        $file = 'css/styles.css';
+
+        $this->assertEquals(
+            $file,
+            $assetUrlHelper($file)
+        );
+    }
+
+    public function testInvokeReturnsFilenameWithDefaultAssetUrlIfNoKeyIsSpecified()
+    {
+        $assetUrlHelper = new AssetUrl();
+
+        $key = 'opamama';
+        $prefix = '/assets/';
+        $suffix = '12345';
+
+        $file = 'css/styles.css?456';
+
+        $assetUrlHelper->setAssetUrl(
+            $key,
+            $prefix,
+            $suffix
+        );
+
+        $this->assertEquals(
+            '/assets/css/styles.css?456&12345',
+            $assetUrlHelper($file)
+        );
+
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     */
+    public function testInvokeThrowsInvalidArgumentExceptionIfKeyIsNotSpecifiedAsString()
+    {
+        $assetUrlHelper = new AssetUrl();
+
+        $file = 'css/styles.css';
+        $key = new \stdClass();
+
+        $assetUrlHelper(
+            $file,
+            $key
+        );
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\BadMethodCallException
+     */
+    public function testInvokeThrowsBadMethodCallExceptionIfKeyIsSpecifiedForWhichNoAssetUrlHasBeenSet()
+    {
+        $assetUrlHelper = new AssetUrl();
+
+        $file = 'css/styles.css';
+        $key = 'opamama';
+
+        $assetUrlHelper(
+            $file,
+            $key
+        );
+    }
+
+    public function testConstructorSetsAssetUrls()
+    {
+
+        $assetUrlHelper = new AssetUrl(array(
+            'asset_urls' => array(
+                'opa' => array(
+                    'prefix' => 'assets/opa',
+                    'suffix' => 'heinz',
+                ),
+            ),
+        ));
+
+        $this->assertEquals(
+            'opa',
+            $assetUrlHelper->getDefaultKey()
+        );
+
+        $this->assertEquals(
+            'assets/opa/css/styles.css?heinz',
+            $assetUrlHelper(
+                'css/styles.css',
+                'opa'
+            )
+        );
+    }
+
+    public function testInvokeLeftTrimsSlashOfAsset()
+    {
+        $assetUrlHelper = new AssetUrl(array(
+            'asset_urls' => array(
+                'opa' => array(
+                    'prefix' => 'assets/opa/',
+                ),
+            ),
+        ));
+
+        $this->assertEquals(
+            'assets/opa/js/opa.js',
+            $assetUrlHelper(
+                '/js/opa.js',
+                'opa'
+            )
+        );
+    }
+
+}


### PR DESCRIPTION
This is based on @DASPRiD's work in
- https://github.com/DASPRiD/zf2/tree/feature/asset-url-view-helper

Construct an instance of the `AssetUrl` view helper like this:

``` php
$assetUrl = new AssetUrl(array(
    'asset_urls' => array(
        'example-baz' => array(
            'prefix' => '/assets/example-baz',
        ),
        'example-foo' => array(
            'prefix' => 'http://assets.example.com/',
            'suffix' => '?123',
        ),
    ),
));
```
