### PR TITLE
Cast $step to float in \Zend\Validator\Step

### DIFF
--- a/library/Zend/Validator/Step.php
+++ b/library/Zend/Validator/Step.php
@@ -98,7 +98,7 @@ class Step extends AbstractValidator
      */
     public function setStep($step)
     {
-        $this->step = $step;
+        $this->step = (float) $step;
         return $this;
     }
 

--- a/tests/ZendTest/Validator/StepTest.php
+++ b/tests/ZendTest/Validator/StepTest.php
@@ -190,4 +190,18 @@ class StepTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($validator->getOption('messageTemplates'),
                                      'messageTemplates', $validator);
     }
+    
+    public function testSetStepFloat()
+    {
+        $step = 0.01;
+        $this->_validator->setStep($step);
+        $this->assertAttributeSame($step, 'step', $this->_validator);
+    }
+    
+    public function testSetStepString()
+    {
+        $step = '0.01';
+        $this->_validator->setStep($step);
+        $this->assertAttributeSame((float) $step, 'step', $this->_validator);
+    }
 }

--- a/tests/ZendTest/Validator/StepTest.php
+++ b/tests/ZendTest/Validator/StepTest.php
@@ -190,14 +190,14 @@ class StepTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($validator->getOption('messageTemplates'),
                                      'messageTemplates', $validator);
     }
-    
+
     public function testSetStepFloat()
     {
         $step = 0.01;
         $this->_validator->setStep($step);
         $this->assertAttributeSame($step, 'step', $this->_validator);
     }
-    
+
     public function testSetStepString()
     {
         $step = '0.01';


### PR DESCRIPTION
When creating a Number element on a form, setting a step attribute of 0.01 (for example, to accept a currency value) adds a Step validator to its validators.

If the number element is created with a string for the step attribute , eg: '0.01', instead of a float, this value is set as a string in the validator.

The is valid function uses strict comparisons between the float value returned by fmod and the step value, and naturally 0.01 !== '0.01'.

This pull request simply casts the value of step to float in the setStep function.
