### PR TITLE
[#2678] Sqlsrv driver incorrectly throwing exception when $sqlOrResource...

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Sqlsrv.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Sqlsrv.php
@@ -128,22 +128,21 @@ class Sqlsrv implements DriverInterface
 
     /**
      * @param string|resource $sqlOrResource
-     * @throws Exception\InvalidArgumentException
      * @return Statement
      */
     public function createStatement($sqlOrResource = null)
     {
         $statement = clone $this->statementPrototype;
-        if (is_string($sqlOrResource)) {
-            $statement->setSql($sqlOrResource);
+        if ($sqlOrResource instanceof Statement) {
+            $statement->setResource($sqlOrResource);
+        } else {
+            if (is_string($sqlOrResource)) {
+                $statement->setSql($sqlOrResource);
+            }
             if (!$this->connection->isConnected()) {
                 $this->connection->connect();
             }
             $statement->initialize($this->connection->getResource());
-        } elseif (is_resource($sqlOrResource)) {
-            $statement->initialize($sqlOrResource); // will check the resource type
-        } else {
-            throw new Exception\InvalidArgumentException('createStatement() only accepts an SQL string or a Sqlsrv resource');
         }
         return $statement;
     }


### PR DESCRIPTION
This is a fix for issue [#2678]. The Sqlsrv driver is broken out-of-the-box at the moment as the createStatement() method erroneously throws an error when $sqlOrResource is null when it should create a statement object and return that as per the Mysqli driver's equivalent method. I suspect I'm the only person actually using this driver. :)
