### PR TITLE
Fix #3161 by checking if the server port already exists in the host

### DIFF
--- a/library/Zend/View/Helper/ServerUrl.php
+++ b/library/Zend/View/Helper/ServerUrl.php
@@ -98,7 +98,7 @@ class ServerUrl extends AbstractHelper
         if (($scheme == 'http' && (null === $port || $port == 80))
             || ($scheme == 'https' && (null === $port || $port == 443))
         ) {
-            $this->host = $host;;
+            $this->host = $host;
             return $this;
         }
 
@@ -180,6 +180,15 @@ class ServerUrl extends AbstractHelper
         }
 
         if (isset($_SERVER['HTTP_HOST']) && !empty($_SERVER['HTTP_HOST'])) {
+            // Detect if the port is set in SERVER_PORT and included in HTTP_HOST
+            if (isset($_SERVER['SERVER_PORT'])) {
+                $portStr = ':' . $_SERVER['SERVER_PORT'];
+                if (substr($_SERVER['HTTP_HOST'], 0-strlen($portStr), strlen($portStr)) == $portStr) {
+                    $this->setHost(substr($_SERVER['HTTP_HOST'], 0, 0-strlen($portStr)));
+                    return;
+                }
+            }
+
             $this->setHost($_SERVER['HTTP_HOST']);
             return;
         }

--- a/tests/ZendTest/View/Helper/ServerUrlTest.php
+++ b/tests/ZendTest/View/Helper/ServerUrlTest.php
@@ -91,6 +91,15 @@ class ServerUrlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('https://example.com:8181', $url->__invoke());
     }
 
+    public function testConstructorWithHttpHostIncludingPortAndPortSet()
+    {
+        $_SERVER['HTTP_HOST'] = 'example.com:8181';
+        $_SERVER['SERVER_PORT'] = 8181;
+
+        $url = new Helper\ServerUrl();
+        $this->assertEquals('http://example.com:8181', $url->__invoke());
+    }
+
     public function testConstructorWithHttpHostAndServerNameAndPortSet()
     {
         $_SERVER['HTTP_HOST'] = 'example.com';


### PR DESCRIPTION
This occurs when running the PHP built-in webserver. HTTP_HOST is set
with the host passed to the script (which can include the port number).
SERVER_PORT is also set.
#3161
