### PR TITLE
Added fix to store salt after random generation.

### DIFF
--- a/library/Zend/Crypt/Password/Bcrypt.php
+++ b/library/Zend/Crypt/Password/Bcrypt.php
@@ -73,7 +73,7 @@ class Bcrypt implements PasswordInterface
     public function create($password)
     {
         if (empty($this->salt)) {
-            $salt = Rand::getBytes(self::MIN_SALT_SIZE);
+            $salt = $this->salt = Rand::getBytes(self::MIN_SALT_SIZE);
         } else {
             $salt = $this->salt;
         }


### PR DESCRIPTION
Relating to the github issue 3120...

https://github.com/zendframework/zf2/issues/3120

Added fix to store salt after random generation. Allows later extraction using getSalt() method for greater flexibility.

ise
