### PR TITLE
hotfix : add  '$argName' as 'argument %s' in sprintf ( at 1st parameter )

### DIFF
--- a/library/Zend/Soap/Server/DocumentLiteralWrapper.php
+++ b/library/Zend/Soap/Server/DocumentLiteralWrapper.php
@@ -133,7 +133,7 @@ class DocumentLiteralWrapper
             if (!isset($params[$argName])) {
                 throw new UnexpectedValueException(sprintf(
                     "Received unknown argument %s which is not an argument to %s::%s",
-                    get_class($this->object), $method
+                    $argName, get_class($this->object), $method
                 ));
             }
             $delegateArgs[$params[$argName]->getPosition()] = $argValue;


### PR DESCRIPTION
sprintf should pass 3 parameters in Zend\Soap\Server\DocumentLiteralWrapper
