### PR TITLE
fix misspelled getCacheStorge()

### DIFF
--- a/library/Zend/Session/SaveHandler/Cache.php
+++ b/library/Zend/Session/SaveHandler/Cache.php
@@ -86,7 +86,7 @@ class Cache implements SaveHandlerInterface
      */
     public function read($id)
     {
-        return $this->getCacheStorge()->getItem($id);
+        return $this->getCacheStorage()->getItem($id);
     }
 
     /**
@@ -98,7 +98,7 @@ class Cache implements SaveHandlerInterface
      */
     public function write($id, $data)
     {
-        return $this->getCacheStorge()->setItem($id, $data);
+        return $this->getCacheStorage()->setItem($id, $data);
     }
 
     /**
@@ -109,7 +109,7 @@ class Cache implements SaveHandlerInterface
      */
     public function destroy($id)
     {
-        return $this->getCacheStorge()->removeItem($id);
+        return $this->getCacheStorage()->removeItem($id);
     }
 
     /**
@@ -120,7 +120,7 @@ class Cache implements SaveHandlerInterface
      */
     public function gc($maxlifetime)
     {
-        $cache = $this->getCacheStorge();
+        $cache = $this->getCacheStorage();
         if ($cache instanceof ClearExpiredCacheStorage) {
             return $cache->clearExpired();
         }
@@ -140,12 +140,20 @@ class Cache implements SaveHandlerInterface
     }
 
     /**
-     * Get Cache Storage Adapter Object
+     * Get cache storage
      *
      * @return CacheStorage
      */
-    public function getCacheStorge()
+    public function getCacheStorage()
     {
         return $this->cacheStorage;
+    }
+
+    /**
+     * @deprecated Misspelled method - use getCacheStorage() instead
+     */
+    public function getCacheStorge()
+    {
+        return $this->getCacheStorage();
     }
 }


### PR DESCRIPTION
- Add a new method: getCacheStorage()
- Mark old method as deprecated and have it call the new method
