### PR TITLE
Fixing ansiColorMap by removing extra m's showed in the console

### DIFF
--- a/library/Zend/Console/Adapter/Posix.php
+++ b/library/Zend/Console/Adapter/Posix.php
@@ -43,8 +43,8 @@ class Posix extends AbstractAdapter
      */
     protected static $ansiColorMap = array(
         'fg' => array(
-            Color::NORMAL        => '22;39m',
-            Color::RESET         => '22;39m',
+            Color::NORMAL        => '22;39',
+            Color::RESET         => '22;39',
 
             Color::BLACK         => '0;30',
             Color::RED           => '0;31',
@@ -65,8 +65,8 @@ class Posix extends AbstractAdapter
             Color::LIGHT_WHITE   => '1;37',
         ),
         'bg' => array(
-            Color::NORMAL        => '0;49m',
-            Color::RESET         => '0;49m',
+            Color::NORMAL        => '0;49',
+            Color::RESET         => '0;49',
 
             Color::BLACK         => '40',
             Color::RED           => '41',


### PR DESCRIPTION
When using Color::NORMAL and Color::RESET

```
$console = Console::getInstance();

$color = Color::NORMAL;
$bgColor = Color::GREEN;
$console->write('My input', $color, $bgColor);
```

Produced : 

> mMy input
