### PR TITLE
Write clean new line for writeLine method (no background color)

### DIFF
--- a/library/Zend/Console/Adapter/AbstractAdapter.php
+++ b/library/Zend/Console/Adapter/AbstractAdapter.php
@@ -101,7 +101,8 @@ abstract class AbstractAdapter implements AdapterInterface
         } elseif ($width == $consoleWidth) {
             $this->write($text, $color, $bgColor);
         } else {
-            $this->write($text . "\n", $color, $bgColor);
+            $this->write($text, $color, $bgColor);
+            $this->write("\n");
         }
     }
 


### PR DESCRIPTION
The writeLine method didn't return a clean \n (had the same colors (front and background) as string) resulting in messed up output.
