### PR TITLE
Zend\Form\View\Helper\Captcha\AbstractWord input and hidden attributes

### DIFF
--- a/library/Zend/Form/View/Helper/Captcha/AbstractWord.php
+++ b/library/Zend/Form/View/Helper/Captcha/AbstractWord.php
@@ -43,7 +43,7 @@ abstract class AbstractWord extends FormInput
     /**
      * Set value for captchaPosition
      *
-     * @param mixed $captchaPosition
+     * @param  mixed                              $captchaPosition
      * @throws Exception\InvalidArgumentException
      * @return self
      */
@@ -60,6 +60,7 @@ abstract class AbstractWord extends FormInput
             ));
         }
         $this->captchaPosition = $captchaPosition;
+
         return $this;
     }
 
@@ -76,12 +77,13 @@ abstract class AbstractWord extends FormInput
     /**
      * Set separator string for captcha and inputs
      *
-     * @param  string $separator
+     * @param  string       $separator
      * @return AbstractWord
      */
     public function setSeparator($separator)
     {
         $this->separator = (string) $separator;
+
         return $this;
     }
 
@@ -104,7 +106,7 @@ abstract class AbstractWord extends FormInput
      *
      * More specific renderers will consume this and render it.
      *
-     * @param  ElementInterface $element
+     * @param  ElementInterface          $element
      * @throws Exception\DomainException
      * @return string
      */
@@ -126,8 +128,7 @@ abstract class AbstractWord extends FormInput
                 __METHOD__
             ));
         }
-        
-        
+
         $inputAttributes = $element->getAttributes();
         $hiddenAttributes = $inputAttributes;
         unset($hiddenAttributes['id']);
@@ -159,7 +160,7 @@ abstract class AbstractWord extends FormInput
      * Render the hidden input with the captcha identifier
      *
      * @param  CaptchaAdapter $captcha
-     * @param  array $attributes
+     * @param  array          $attributes
      * @return string
      */
     protected function renderCaptchaHidden(CaptchaAdapter $captcha, array $attributes)
@@ -179,6 +180,7 @@ abstract class AbstractWord extends FormInput
             $this->createAttributesString($attributes),
             $closingBracket
         );
+
         return $hidden;
     }
 
@@ -186,7 +188,7 @@ abstract class AbstractWord extends FormInput
      * Render the input for capturing the captcha value from the client
      *
      * @param  CaptchaAdapter $captcha
-     * @param  array $attributes
+     * @param  array          $attributes
      * @return string
      */
     protected function renderCaptchaInput(CaptchaAdapter $captcha, array $attributes)
@@ -202,6 +204,7 @@ abstract class AbstractWord extends FormInput
             $this->createAttributesString($attributes),
             $closingBracket
         );
+
         return $input;
     }
 }

--- a/library/Zend/Form/View/Helper/Captcha/AbstractWord.php
+++ b/library/Zend/Form/View/Helper/Captcha/AbstractWord.php
@@ -118,7 +118,6 @@ abstract class AbstractWord extends FormInput
             ));
         }
 
-        $attributes = $element->getAttributes();
         $captcha = $element->getCaptcha();
 
         if ($captcha === null || !$captcha instanceof CaptchaAdapter) {
@@ -127,9 +126,14 @@ abstract class AbstractWord extends FormInput
                 __METHOD__
             ));
         }
+        
+        
+        $inputAttributes = $element->getAttributes();
+        $hiddenAttributes = $inputAttributes;
+        unset($hiddenAttributes['id']);
 
-        $hidden    = $this->renderCaptchaHidden($captcha, $attributes);
-        $input     = $this->renderCaptchaInput($captcha, $attributes);
+        $hidden    = $this->renderCaptchaHidden($captcha, $hiddenAttributes);
+        $input     = $this->renderCaptchaInput($captcha, $inputAttributes);
 
         return $hidden . $input;
     }

--- a/library/Zend/Form/View/Helper/Captcha/AbstractWord.php
+++ b/library/Zend/Form/View/Helper/Captcha/AbstractWord.php
@@ -120,6 +120,7 @@ abstract class AbstractWord extends FormInput
             ));
         }
 
+        $attributes = $element->getAttributes();
         $captcha = $element->getCaptcha();
 
         if ($captcha === null || !$captcha instanceof CaptchaAdapter) {
@@ -129,12 +130,8 @@ abstract class AbstractWord extends FormInput
             ));
         }
 
-        $inputAttributes = $element->getAttributes();
-        $hiddenAttributes = $inputAttributes;
-        unset($hiddenAttributes['id']);
-
-        $hidden    = $this->renderCaptchaHidden($captcha, $hiddenAttributes);
-        $input     = $this->renderCaptchaInput($captcha, $inputAttributes);
+        $hidden    = $this->renderCaptchaHidden($captcha, $attributes);
+        $input     = $this->renderCaptchaInput($captcha, $attributes);
 
         return $hidden . $input;
     }
@@ -167,6 +164,11 @@ abstract class AbstractWord extends FormInput
     {
         $attributes['type']  = 'hidden';
         $attributes['name'] .= '[id]';
+
+        if (isset($attributes['id'])) {
+            $attributes['id'] .= '-hidden';
+        }
+
         if (method_exists($captcha, 'getId')) {
             $attributes['value'] = $captcha->getId();
         } elseif (array_key_exists('value', $attributes)) {

--- a/library/Zend/Form/View/Helper/Captcha/Image.php
+++ b/library/Zend/Form/View/Helper/Captcha/Image.php
@@ -24,7 +24,7 @@ class Image extends AbstractWord
     /**
      * Render the captcha
      *
-     * @param  ElementInterface $element
+     * @param  ElementInterface          $element
      * @throws Exception\DomainException
      * @return string
      */
@@ -47,6 +47,11 @@ class Image extends AbstractWord
             'alt'    => $captcha->getImgAlt(),
             'src'    => $captcha->getImgUrl() . $captcha->getId() . $captcha->getSuffix(),
         );
+
+        if ($element->hasAttribute('id')) {
+            $imgAttributes['id'] = $element->getAttribute('id') . '-image';
+        }
+
         $closingBracket = $this->getInlineClosingBracket();
         $img = sprintf(
             '<img %s%s',

--- a/tests/ZendTest/Form/View/Helper/FormCaptchaTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCaptchaTest.php
@@ -85,8 +85,11 @@ class FormCaptchaTest extends CommonTestCase
         ));
         $element = $this->getElement();
         $element->setCaptcha($captcha);
+        $element->setAttribute('id', 'foo');
         $markup = $this->helper->render($element);
-        $this->assertContains($captcha->getLabel(), $markup);
+        $this->assertContains($captcha->getLabel(), $markup);        
+        $this->assertRegExp('#<[^>]*(id="' . $element->getAttribute('id') . '")[^>]*(type="text")[^>]*>#', $markup);
+        $this->assertRegExp('#<[^>]*(id="' . $element->getAttribute('id') . '-hidden")[^>]*(type="hidden")[^>]*>#', $markup);
     }
 
     public function testPassingElementWithFigletCaptchaRendersCorrectly()
@@ -96,8 +99,11 @@ class FormCaptchaTest extends CommonTestCase
         ));
         $element = $this->getElement();
         $element->setCaptcha($captcha);
+        $element->setAttribute('id', 'foo');
         $markup = $this->helper->render($element);
-        $this->assertContains('<pre>' . $captcha->getFiglet()->render($captcha->getWord()) . '</pre>', $markup);
+        $this->assertContains('<pre>' . $captcha->getFiglet()->render($captcha->getWord()) . '</pre>', $markup);        
+        $this->assertRegExp('#<[^>]*(id="' . $element->getAttribute('id') . '")[^>]*(type="text")[^>]*>#', $markup);
+        $this->assertRegExp('#<[^>]*(id="' . $element->getAttribute('id') . '-hidden")[^>]*(type="hidden")[^>]*>#', $markup);
     }
 
     public function testPassingElementWithImageCaptchaRendersCorrectly()
@@ -125,10 +131,16 @@ class FormCaptchaTest extends CommonTestCase
         ));
         $element = $this->getElement();
         $element->setCaptcha($captcha);
+        $element->setAttribute('id', 'foo');
+        
         $markup = $this->helper->render($element);
+        
         $this->assertContains('<img ', $markup);
         $this->assertContains($captcha->getImgUrl(), $markup);
         $this->assertContains($captcha->getId(), $markup);
+        $this->assertRegExp('#<img[^>]*(id="' . $element->getAttribute('id') . '-image")[^>]*>#', $markup);
+        $this->assertRegExp('#<input[^>]*(id="' . $element->getAttribute('id') . '")[^>]*(type="text")[^>]*>#', $markup);
+        $this->assertRegExp('#<input[^>]*(id="' . $element->getAttribute('id') . '-hidden")[^>]*(type="hidden")[^>]*>#', $markup);   
     }
 
     public function testPassingElementWithReCaptchaRendersCorrectly()

--- a/tests/ZendTest/Form/View/Helper/FormCaptchaTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCaptchaTest.php
@@ -62,12 +62,14 @@ class FormCaptchaTest extends CommonTestCase
         if (null === $this->tmpDir) {
             $this->tmpDir = sys_get_temp_dir();
         }
+
         return $this->tmpDir;
     }
 
     public function getElement()
     {
         $element = new CaptchaElement('foo');
+
         return $element;
     }
 
@@ -87,7 +89,7 @@ class FormCaptchaTest extends CommonTestCase
         $element->setCaptcha($captcha);
         $element->setAttribute('id', 'foo');
         $markup = $this->helper->render($element);
-        $this->assertContains($captcha->getLabel(), $markup);        
+        $this->assertContains($captcha->getLabel(), $markup);
         $this->assertRegExp('#<[^>]*(id="' . $element->getAttribute('id') . '")[^>]*(type="text")[^>]*>#', $markup);
         $this->assertRegExp('#<[^>]*(id="' . $element->getAttribute('id') . '-hidden")[^>]*(type="hidden")[^>]*>#', $markup);
     }
@@ -101,7 +103,7 @@ class FormCaptchaTest extends CommonTestCase
         $element->setCaptcha($captcha);
         $element->setAttribute('id', 'foo');
         $markup = $this->helper->render($element);
-        $this->assertContains('<pre>' . $captcha->getFiglet()->render($captcha->getWord()) . '</pre>', $markup);        
+        $this->assertContains('<pre>' . $captcha->getFiglet()->render($captcha->getWord()) . '</pre>', $markup);
         $this->assertRegExp('#<[^>]*(id="' . $element->getAttribute('id') . '")[^>]*(type="text")[^>]*>#', $markup);
         $this->assertRegExp('#<[^>]*(id="' . $element->getAttribute('id') . '-hidden")[^>]*(type="hidden")[^>]*>#', $markup);
     }
@@ -110,6 +112,7 @@ class FormCaptchaTest extends CommonTestCase
     {
         if (!extension_loaded('gd')) {
             $this->markTestSkipped('The GD extension is not available.');
+
             return;
         }
         if (!function_exists("imagepng")) {
@@ -132,15 +135,15 @@ class FormCaptchaTest extends CommonTestCase
         $element = $this->getElement();
         $element->setCaptcha($captcha);
         $element->setAttribute('id', 'foo');
-        
+
         $markup = $this->helper->render($element);
-        
+
         $this->assertContains('<img ', $markup);
         $this->assertContains($captcha->getImgUrl(), $markup);
         $this->assertContains($captcha->getId(), $markup);
         $this->assertRegExp('#<img[^>]*(id="' . $element->getAttribute('id') . '-image")[^>]*>#', $markup);
         $this->assertRegExp('#<input[^>]*(id="' . $element->getAttribute('id') . '")[^>]*(type="text")[^>]*>#', $markup);
-        $this->assertRegExp('#<input[^>]*(id="' . $element->getAttribute('id') . '-hidden")[^>]*(type="hidden")[^>]*>#', $markup);   
+        $this->assertRegExp('#<input[^>]*(id="' . $element->getAttribute('id') . '-hidden")[^>]*(type="hidden")[^>]*>#', $markup);
     }
 
     public function testPassingElementWithReCaptchaRendersCorrectly()


### PR DESCRIPTION
`AbstractWord::renderCaptchaInputs()` gives the same attributes to both input and hidden html tags. This may lead to the same `id` attribute, if set, in both tags, wich is not W3C compliant and prevents from using `<label>` `for` attribute correctly.

Since the `id` attribute is unlikely to be used on the hidden element, one possible solution is to pass a copy of the attributes array without the `id` key to `renderCaptchaHidden()`.
