### PR TITLE
[2.1][FileUploads] FileInput AJAX Post fix

### DIFF
--- a/library/Zend/InputFilter/FileInput.php
+++ b/library/Zend/InputFilter/FileInput.php
@@ -81,6 +81,16 @@ class FileInput extends Input
         //$value   = $this->getValue(); // Do not run the filters yet for File uploads
 
         $rawValue = $this->getRawValue();
+        if (!is_array($rawValue)) {
+            // This can happen in an AJAX POST, where the input comes across as a string
+            $rawValue = array(
+                'tmp_name' => $rawValue,
+                'name'     => $rawValue,
+                'size'     => 0,
+                'type'     => '',
+                'error'    => UPLOAD_ERR_NO_FILE,
+            );
+        }
         if (is_array($rawValue) && isset($rawValue['tmp_name'])) {
             // Single file input
             $this->isValid = $validator->isValid($rawValue, $context);
@@ -93,10 +103,6 @@ class FileInput extends Input
                     break; // Do not continue processing files if validation fails
                 }
             }
-        } else {
-            // RawValue does not contain a file data array
-            $this->setErrorMessage('Invalid type given. File array expected');
-            $this->isValid = false;
         }
 
         return $this->isValid;

--- a/tests/ZendTest/InputFilter/FileInputTest.php
+++ b/tests/ZendTest/InputFilter/FileInputTest.php
@@ -296,6 +296,27 @@ class FileInputTest extends TestCase
         $this->assertEquals($uploadMock, $validators[0]['instance']);
     }
 
+    public function testValidationsRunWithoutFileArrayDueToAjaxPost()
+    {
+        $this->input->setAutoPrependUploadValidator(true);
+        $this->assertTrue($this->input->getAutoPrependUploadValidator());
+        $this->assertTrue($this->input->isRequired());
+        $this->input->setValue('');
+
+        $uploadMock = $this->getMock('Zend\Validator\File\Upload', array('isValid'));
+        $uploadMock->expects($this->exactly(1))
+            ->method('isValid')
+            ->will($this->returnValue(false));
+
+        $validatorChain = $this->input->getValidatorChain();
+        $validatorChain->prependValidator($uploadMock);
+        $this->assertFalse($this->input->isValid());
+
+        $validators = $validatorChain->getValidators();
+        $this->assertEquals(1, count($validators));
+        $this->assertEquals($uploadMock, $validators[0]['instance']);
+    }
+
     public function testMerge()
     {
         $value  = array('tmp_name' => 'bar');


### PR DESCRIPTION
When doing a form POST with AJAX, file upload values can come across as empty strings and not part of the $_FILES array. 

Fixed the FileInput to allow non-array values, which helps the AJAX case.

Example usage can be found here, under the "Partial Session Progress" example: https://github.com/cgmartin/ZF2FileUploadExamples
