### PR TITLE
Added NTLM authentication support to Zend\Soap\Client\DotNet.

### DIFF
--- a/library/Zend/Soap/Client/DotNet.php
+++ b/library/Zend/Soap/Client/DotNet.php
@@ -10,8 +10,12 @@
 
 namespace Zend\Soap\Client;
 
+use Zend\Http\Client\Adapter\Curl as CurlClient;
+use Zend\Http\Response as HttpResponse;
 use Zend\Soap\Client as SOAPClient;
+use Zend\Soap\Client\Common as CommonClient;
 use Zend\Soap\Exception;
+use Zend\Uri\Http as HttpUri;
 
 /**
  * .NET SOAP client
@@ -42,6 +46,114 @@ class DotNet extends SOAPClient
         parent::__construct($wsdl, $options);
     }
 
+    /**
+     * Do request proxy method.
+     *
+     * @param  CommonClient $client   Actual SOAP client.
+     * @param  string       $request  The request body.
+     * @param  string       $location The SOAP URI.
+     * @param  string       $action   The SOAP action to call.
+     * @param  integer      $version  The SOAP version to use.
+     * @param  integer      $one_way  (Optional) The number 1 if a response is not expected.
+     * @return string The XML SOAP response.
+     */
+    public function _doRequest(CommonClient $client, $request, $location, $action, $version, $one_way = null)
+    {
+        if (!$this->useNtlm) {
+            return parent::_doRequest($client, $request, $location, $action, $version, $one_way);
+        }
+
+        $curlClient = $this->getCurlClient();
+        $headers    = array('Content-Type' => 'text/xml; charset=utf-8',
+                            'Method'       => 'POST',
+                            'SOAPAction'   => '"' . $action . '"',
+                            'User-Agent'   => 'PHP-SOAP-CURL');
+        $uri        = new HttpUri($location);
+
+        $curlClient->setCurlOption(CURLOPT_HTTPAUTH, CURLAUTH_NTLM)
+                   ->setCurlOption(CURLOPT_SSL_VERIFYHOST, false)
+                   ->setCurlOption(CURLOPT_SSL_VERIFYPEER, false)
+                   ->setCurlOption(CURLOPT_USERPWD, $this->options['login'] . ':' . $this->options['password']);
+
+        // Perform the cURL request and get the response
+        $curlClient->connect($uri->getHost(), $uri->getPort());
+        $curlClient->write('POST', $uri, 1.1, $headers, $request);
+        $response = HttpResponse::fromString($curlClient->read());
+        $curlClient->close();
+
+        // Save headers
+        $this->lastRequestHeaders  = $this->flattenHeaders($headers);
+        $this->lastResponseHeaders = $response->getHeaders()->toString();
+
+        // Return only the XML body
+        return $response->getBody();
+    }
+
+    /**
+     * Returns the cURL client that is being used.
+     *
+     * @return \Zend\Http\Client\Adapter\Curl The cURL client.
+     */
+    public function getCurlClient()
+    {
+        if ($this->curlClient === null) {
+            $this->curlClient = new CurlClient();
+        }
+
+        return $this->curlClient;
+    }
+
+    /**
+     * Retrieve request headers.
+     *
+     * @return string Request headers.
+     */
+    public function getLastRequestHeaders()
+    {
+        return $this->lastRequestHeaders;
+    }
+
+    /**
+     * Retrieve response headers (as string)
+     *
+     * @return string Response headers.
+     */
+    public function getLastResponseHeaders()
+    {
+        return $this->lastResponseHeaders;
+    }
+
+    /**
+     * Sets the cURL client to use.
+     *
+     * @param  CurlClient $curlClient The cURL client.
+     * @return self Fluent interface.
+     */
+    public function setCurlClient(CurlClient $curlClient)
+    {
+        $this->curlClient = $curlClient;
+        return $this;
+    }
+
+    /**
+     * Sets options.
+     *
+     * Allows setting options as an associative array of option => value pairs.
+     *
+     * @param  array|\Traversable $options Options.
+     * @throws \InvalidArgumentException If an unsupported option is passed.
+     * @return self Fluent interface.
+     */
+    public function setOptions($options)
+    {
+        if (isset($options['authentication']) && $options['authentication'] === 'ntlm') {
+            $this->useNtlm = true;
+            unset($options['authentication']);
+        }
+
+        $this->options = $options;
+        return parent::setOptions($options);
+    }
 
     /**
      * Perform arguments pre-processing
@@ -79,4 +191,55 @@ class DotNet extends SOAPClient
         return $result->$resultProperty;
     }
 
+    /**
+     * Flattens an HTTP headers array into a string.
+     *
+     * @param  array $headers The headers to flatten.
+     * @return string The headers string.
+     */
+    private function flattenHeaders(array $headers)
+    {
+        $result = '';
+
+        foreach ($headers as $name => $value) {
+            $result .= $name . ': ' . $value . "\r\n";
+        }
+
+        return $result;
+    }
+
+    /**
+     * Curl HTTP client adapter.
+     *
+     * @var \Zend\Http\Client\Adapter\Curl
+     */
+    private $curlClient = null;
+
+    /**
+     * The last request headers.
+     *
+     * @var string
+     */
+    private $lastRequestHeaders = '';
+
+    /**
+     * The last response headers.
+     *
+     * @var string
+     */
+    private $lastResponseHeaders = '';
+
+    /**
+     * SOAP client options.
+     *
+     * @var array
+     */
+    private $options = array();
+
+    /**
+     * Should NTLM authentication be used?
+     *
+     * @var boolean
+     */
+    private $useNtlm = false;
 }

--- a/library/Zend/Soap/Client/DotNet.php
+++ b/library/Zend/Soap/Client/DotNet.php
@@ -92,7 +92,7 @@ class DotNet extends SOAPClient
     /**
      * Returns the cURL client that is being used.
      *
-     * @return \Zend\Http\Client\Adapter\Curl The cURL client.
+     * @return CurlClient The cURL client.
      */
     public function getCurlClient()
     {

--- a/tests/ZendTest/Soap/Client/DotNetTest.php
+++ b/tests/ZendTest/Soap/Client/DotNetTest.php
@@ -8,8 +8,6 @@
  * @package   Zend_Soap
  */
 
-// @codingStandardsIgnoreStart
-
 namespace Zend\Soap
 {
     use ZendTest\Soap\Client\MockCallUserFunc;
@@ -259,4 +257,3 @@ namespace ZendTest\Soap\Client
     }
 }
 
-// @codingStandardsIgnoreEnd

--- a/tests/ZendTest/Soap/Client/DotNetTest.php
+++ b/tests/ZendTest/Soap/Client/DotNetTest.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Soap
+ */
+
+// @codingStandardsIgnoreStart
+
+namespace Zend\Soap
+{
+    use ZendTest\Soap\Client\MockCallUserFunc;
+
+    /**
+     * Function interceptor for call_user_func.
+     *
+     * @return mixed Return value.
+     */
+    function call_user_func()
+    {
+        if (MockCallUserFunc::$mock)
+        {
+            MockCallUserFunc::$params = func_get_args();
+
+            $result = '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">'
+                . '<s:Body>';
+
+            $result .= '<TestMethodResponse xmlns="http://unit/test">'
+                . '<TestMethodResult>'
+                . '<TestMethodResult><dummy></dummy></TestMethodResult>'
+                . '</TestMethodResult>'
+                . '</TestMethodResponse>';
+
+            $result .= '</s:Body>'
+                . '</s:Envelope>';
+            return $result;
+        }
+        else
+        {
+            return call_user_func_array('\call_user_func', func_get_args());
+        }
+    }
+}
+
+namespace ZendTest\Soap\Client
+{
+    use Zend\Soap\Client\DotNet as DotNetClient;
+    use PHPUnit_Framework_TestCase;
+
+    /**
+     * Allows mocking of call_user_func.
+     */
+    class MockCallUserFunc
+    {
+        /**
+         * Whether to mock the call_user_func function.
+         *
+         * @var boolean
+         */
+        public static $mock = false;
+
+        /**
+         * Passed parameters.
+         *
+         * @var array
+         */
+        public static $params = array();
+    }
+
+
+    /**
+     * .NET SOAP client tester.
+     *
+     * @category   Zend
+     * @package    Zend_Soap
+     * @subpackage UnitTests
+     * @group      Zend_Soap
+     */
+    class DotNetTest extends PHPUnit_Framework_TestCase
+    {
+        /**
+         * Tests that a default cURL client is used if none is injected.
+         *
+         * @return void
+         * @covers Zend\Soap\Client\DotNet::getCurlClient
+         */
+        public function testADefaultCurlClientIsUsedIfNoneIsInjected()
+        {
+            $this->assertInstanceOf('Zend\Http\Client\Adapter\Curl', $this->client->getCurlClient());
+        }
+
+        /**
+         * Tests that the cURL client can be injected.
+         *
+         * @return void
+         * @covers Zend\Soap\Client\DotNet::getCurlClient
+         * @covers Zend\Soap\Client\DotNet::setCurlClient
+         */
+        public function testCurlClientCanBeInjected()
+        {
+            $this->mockCurlClient();
+            $this->assertSame($this->curlClient, $this->client->getCurlClient());
+        }
+
+        /**
+         * Tests that a cURL client request is done when using NTLM
+         * authentication.
+         *
+         * @return void
+         * @covers Zend\Soap\Client\DotNet::_doRequest
+         */
+        public function testCurlClientRequestIsDoneWhenUsingNtlmAuthentication()
+        {
+            $this->mockNtlmRequest();
+            $this->assertInstanceOf('stdClass', $this->client->TestMethod());
+        }
+
+        /**
+         * Tests that the default SOAP client request is done when not using NTLM authentication.
+         *
+         * @return void
+         * @covers Zend\Soap\Client\DotNet::_doRequest
+         */
+        public function testDefaultSoapClientRequestIsDoneWhenNotUsingNtlmAuthentication()
+        {
+            $soapClient = $this->getMock('Zend\Soap\Client\Common',
+                                         array('_doRequest'),
+                                         array(array($this->client, '_doRequest'),
+                                               null,
+                                               array('location' => 'http://unit/test',
+                                                     'uri'      => 'http://unit/test')));
+
+            MockCallUserFunc::$mock = true;
+            $this->client->setSoapClient($soapClient);
+            $this->client->TestMethod();
+
+            $this->assertSame('http://unit/test#TestMethod', MockCallUserFunc::$params[3]);
+
+            MockCallUserFunc::$mock = false;
+        }
+
+        /**
+         * Tests that the last request headers can be fetched correctly.
+         *
+         * @return void
+         * @covers Zend\Soap\Client\DotNet::getLastRequestHeaders
+         */
+        public function testLastRequestHeadersCanBeFetchedCorrectly()
+        {
+            $expectedHeaders = "Content-Type: text/xml; charset=utf-8\r\n"
+                             . "Method: POST\r\n"
+                             . "SOAPAction: \"http://unithost/test#TestMethod\"\r\n"
+                             . "User-Agent: PHP-SOAP-CURL\r\n";
+
+            $this->mockNtlmRequest();
+            $this->client->TestMethod();
+
+            $this->assertSame($expectedHeaders, $this->client->getLastRequestHeaders());
+        }
+
+        /**
+         * Tests that the last response headers can be fetched correctly.
+         *
+         * @return void
+         * @covers Zend\Soap\Client\DotNet::getLastResponseHeaders
+         */
+        public function testLastResponseHeadersCanBeFetchedCorrectly()
+        {
+            $expectedHeaders = "Cache-Control: private\r\n"
+                             . "Content-Type: text/xml; charset=utf-8\r\n";
+
+            $this->mockNtlmRequest();
+            $this->client->TestMethod();
+
+            $this->assertSame($expectedHeaders, $this->client->getLastResponseHeaders());
+        }
+
+        /**
+         * Sets up the fixture.
+         *
+         * @return void
+         */
+        protected function setUp()
+        {
+            $this->client = new DotNetClient(null, array('location' => 'http://unithost/test',
+                                                         'uri'      => 'http://unithost/test'));
+        }
+
+        /**
+         * Mocks the cURL client.
+         *
+         * @return void
+         */
+        private function mockCurlClient()
+        {
+            $this->curlClient = $this->getMock('Zend\Http\Client\Adapter\Curl',
+                                               array('close', 'connect', 'read', 'write'));
+            $this->client->setCurlClient($this->curlClient);
+        }
+
+        /**
+         * Mocks an NTLM SOAP request.
+         *
+         * @return void
+         */
+        private function mockNtlmRequest()
+        {
+            $headers  = array('Content-Type' => 'text/xml; charset=utf-8',
+                              'Method'       => 'POST',
+                              'SOAPAction'   => '"http://unithost/test#TestMethod"',
+                              'User-Agent'   => 'PHP-SOAP-CURL');
+            $response = "HTTP/1.1 200 OK\n"
+                      . "Cache-Control: private\n"
+                      . "Content-Type: text/xml; charset=utf-8\n"
+                      . "\n\n"
+                      . '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">'
+                      . '<s:Body>'
+                      . '<TestMethodResponse xmlns="http://unit/test">'
+                      . '<TestMethodResult>'
+                      . '<TestMethodResult><dummy></dummy></TestMethodResult>'
+                      . '</TestMethodResult>'
+                      . '</TestMethodResponse>'
+                      . '</s:Body>'
+                      . '</s:Envelope>';
+
+            $this->mockCurlClient();
+
+            $this->curlClient->expects($this->once())
+                             ->method('connect')
+                             ->with('unithost', 80);
+            $this->curlClient->expects($this->once())
+                             ->method('read')
+                             ->will($this->returnValue($response));
+            $this->curlClient->expects($this->any())
+                             ->method('write')
+                             ->with('POST', $this->isInstanceOf('Zend\Uri\Http'), 1.1, $headers, $this->stringContains('<SOAP-ENV'));
+
+            $this->client->setOptions(array('authentication' => 'ntlm',
+                                            'login'          => 'username',
+                                            'password'       => 'testpass'));
+        }
+
+        /**
+         * .NET SOAP client.
+         *
+         * @var \HolaDoctor\Cms\Translation\Soap\Client\DotNet
+         */
+        private $client = null;
+
+        /**
+         * cURL client.
+         *
+         * @var \Zend\Http\Client\Adapter\Curl
+         */
+        private $curlClient = null;
+    }
+}
+
+// @codingStandardsIgnoreEnd


### PR DESCRIPTION
This commit adds NTLM authentication support to the DotNet SOAP client, which I needed for a project I'm working on at my job. I'm a newbie to git (I use SVN for the most part), so if I did anything wrong just let me know. I ran the tests successfully locally, though I had to change a $this->once() call in the test to $this->any(), as I was getting a Bus error from PHPUnit (it does not happen on the test suite I have at work).

Comments/suggestions welcome.
