### PR TITLE
Added feature to render a form in a one-liner

### DIFF
--- a/library/Zend/Form/View/Helper/Form.php
+++ b/library/Zend/Form/View/Helper/Form.php
@@ -10,6 +10,7 @@
 
 namespace Zend\Form\View\Helper;
 
+use Zend\Form\FieldsetInterface;
 use Zend\Form\FormInterface;
 
 /**
@@ -40,11 +41,41 @@ class Form extends AbstractHelper
     /**
      * Invoke as function
      *
+     * @param  null|FormInterface $form
      * @return Form
      */
-    public function __invoke()
+    public function __invoke(FormInterface $form = null)
     {
-        return $this;
+        if (!$form) {
+            return $this;
+        }
+
+        return $this->render($form);
+    }
+
+    /**
+     * Render a form from the provided $form,
+     *
+     * @param  ElementInterface $element
+     * @param  null|string $buttonContent
+     * @throws Exception\DomainException
+     * @return string
+     */
+    public function render(FormInterface $form)
+    {
+        $openTag = $this->openTag($form);
+
+        $formContent = '';
+        
+        foreach ($form as $element) {
+            if ($element instanceof FieldsetInterface) {
+                $formContent.= $this->getView()->formCollection($element);
+            } else {
+                $formContent.= $this->getView()->formRow($element);
+            }
+        }
+        
+        return $openTag . $formContent . $this->closeTag();
     }
 
     /**

--- a/library/Zend/Validator/ValidatorChain.php
+++ b/library/Zend/Validator/ValidatorChain.php
@@ -88,7 +88,7 @@ class ValidatorChain implements
     }
 
     /**
-     * Adds a validator to the end of the chain
+     * Attach a validator to the end of the chain
      *
      * If $breakChainOnFailure is true, then if the validator fails, the next validator in the chain,
      * if one exists, will not be executed.
@@ -97,13 +97,25 @@ class ValidatorChain implements
      * @param  boolean                 $breakChainOnFailure
      * @return ValidatorChain Provides a fluent interface
      */
-    public function addValidator(ValidatorInterface $validator, $breakChainOnFailure = false)
+    public function attach(ValidatorInterface $validator, $breakChainOnFailure = false)
     {
         $this->validators[] = array(
             'instance'            => $validator,
             'breakChainOnFailure' => (boolean)$breakChainOnFailure
         );
         return $this;
+    }
+
+    /**
+     * Proxy to attach() to keep BC
+     *
+     * @param  ValidatorInterface      $validator
+     * @param  boolean                 $breakChainOnFailure
+     * @return ValidatorChain Provides a fluent interface
+     */
+    public function addValidator(ValidatorInterface $validator, $breakChainOnFailure = false)
+    {
+        return $this->attach($validator, $breakChainOnFailure);
     }
 
     /**
@@ -135,11 +147,24 @@ class ValidatorChain implements
      * @param  bool   $breakChainOnFailure
      * @return ValidatorChain
      */
-    public function addByName($name, $options = array(), $breakChainOnFailure = false)
+    public function attachByName($name, $options = array(), $breakChainOnFailure = false)
     {
         $validator = $this->plugin($name, $options);
-        $this->addValidator($validator, $breakChainOnFailure);
+        $this->attach($validator, $breakChainOnFailure);
         return $this;
+    }
+
+    /**
+     * Proxy to attach() to keep BC
+     *
+     * @param  string $name
+     * @param  array  $options
+     * @param  bool   $breakChainOnFailure
+     * @return ValidatorChain
+     */
+    public function addByName($name, $options = array(), $breakChainOnFailure = false)
+    {
+        return $this->attachByName($name, $options, $breakChainOnFailure);
     }
 
     /**

--- a/tests/ZendTest/Form/View/Helper/FormTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormTest.php
@@ -10,6 +10,10 @@
 
 namespace ZendTest\Form\View\Helper;
 
+use Zend\Form\Element\Submit;
+
+use ZendTest\Form\TestAsset\CityFieldset;
+
 use Zend\Form\Form;
 use Zend\Form\View\Helper\Form as FormHelper;
 
@@ -77,5 +81,25 @@ class FormTest extends CommonTestCase
         $markup = $this->helper->openTag($form);
         $this->assertContains('name="login-form"', $markup);
         $this->assertContains('id="login-form"', $markup);
+    }
+
+    public function testFullFormRendering()
+    {
+        $form = new Form();
+        $attributes = array(
+            'name'  => 'login-form',
+        );
+        $form->setAttributes($attributes);
+        $form->add(new CityFieldset());
+        $form->add(new Submit('send'));
+
+        $markup = $this->helper->__invoke($form);
+        
+        $this->assertContains('<form', $markup);
+        $this->assertContains('id="login-form"', $markup);
+        $this->assertContains('<label><span>Name of the city</span>', $markup);
+        $this->assertContains('<fieldset><legend>Country</legend>', $markup);
+        $this->assertContains('<input type="submit" name="send"', $markup);
+        $this->assertContains('</form>', $markup);
     }
 }

--- a/tests/ZendTest/Validator/ValidatorChainTest.php
+++ b/tests/ZendTest/Validator/ValidatorChainTest.php
@@ -50,8 +50,8 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
 
     public function populateValidatorChain()
     {
-        $this->validator->addValidator(new NotEmpty());
-        $this->validator->addValidator(new Between());
+        $this->validator->attach(new NotEmpty());
+        $this->validator->attach(new Between());
     }
 
     public function testValidatorChainIsEmptyByDefault()
@@ -77,7 +77,7 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
      */
     public function testTrue()
     {
-        $this->validator->addValidator($this->getValidatorTrue());
+        $this->validator->attach($this->getValidatorTrue());
         $this->assertTrue($this->validator->isValid(null));
         $this->assertEquals(array(), $this->validator->getMessages());
     }
@@ -89,7 +89,7 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
      */
     public function testFalse()
     {
-        $this->validator->addValidator($this->getValidatorFalse());
+        $this->validator->attach($this->getValidatorFalse());
         $this->assertFalse($this->validator->isValid(null));
         $this->assertEquals(array('error' => 'validation failed'), $this->validator->getMessages());
     }
@@ -101,8 +101,8 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
      */
     public function testBreakChainOnFailure()
     {
-        $this->validator->addValidator($this->getValidatorFalse(), true)
-            ->addValidator($this->getValidatorFalse());
+        $this->validator->attach($this->getValidatorFalse(), true)
+            ->attach($this->getValidatorFalse());
         $this->assertFalse($this->validator->isValid(null));
         $this->assertEquals(array('error' => 'validation failed'), $this->validator->getMessages());
     }
@@ -148,7 +148,7 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
 
     public function testAllowsPrependingValidators()
     {
-        $this->validator->addValidator($this->getValidatorTrue())
+        $this->validator->attach($this->getValidatorTrue())
             ->prependValidator($this->getValidatorFalse(), true);
         $this->assertFalse($this->validator->isValid(true));
         $messages = $this->validator->getMessages();
@@ -157,7 +157,7 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
 
     public function testAllowsPrependingValidatorsByName()
     {
-        $this->validator->addValidator($this->getValidatorTrue())
+        $this->validator->attach($this->getValidatorTrue())
             ->prependByName('NotEmpty', array(), true);
         $this->assertFalse($this->validator->isValid(''));
         $messages = $this->validator->getMessages();
@@ -232,7 +232,7 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
      */
     public function testCanAttachMultipleValidatorsOfTheSameTypeAsDiscreteInstances()
     {
-        $this->validator->addByName('Callback', array(
+        $this->validator->attachByName('Callback', array(
             'callback' => function ($value) {
                 return true;
             },
@@ -240,7 +240,7 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
                 'callbackValue' => 'This should not be seen in the messages',
             ),
         ));
-        $this->validator->addByName('Callback', array(
+        $this->validator->attachByName('Callback', array(
             'callback' => function ($value) {
                 return false;
             },


### PR DESCRIPTION
Amended the __invoke() method to start rendering the form when a FormInterface object is passed.

Added render() method to render form with open-tag, a loop through all elements and the close-tag.

Added one unit test for it
