### PR TITLE
[wip] Zend\Http\Client makes 2 requests to url if setStream(true) is called

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -582,6 +582,10 @@ class Client implements Stdlib\DispatchableInterface
      */
     public function getStream()
     {
+        if (!is_null($this->streamName)) {
+            return $this->streamName;
+        }
+
         return $this->config['outputstream'];
     }
 
@@ -832,10 +836,6 @@ class Client implements Stdlib\DispatchableInterface
             if ($this->config['outputstream']) {
                 $stream = $this->getStream();
                 if (!is_resource($stream) && is_string($stream)) {
-                    $stream = fopen($stream, 'r');
-                }
-                if (!is_resource($stream)) {
-                    $stream = $this->getUri()->toString();
                     $stream = fopen($stream, 'r');
                 }
                 $streamMetaData = stream_get_meta_data($stream);


### PR DESCRIPTION
If you were to call

``` php
$client->setStream(true);
```

the config['outputstream'] variable is set to true.

As a result, the send function will actually send 2 requests to to the request url - 1 request when $response is populated by doRequest(), and 1 request when we fopen the stream itself.

Take a look at the following:

``` php
if ($this->config['outputstream']) {
    $stream = $this->getStream();
    if (!is_resource($stream) && is_string($stream)) {
        $stream = fopen($stream, 'r');
    }
    if (!is_resource($stream)) {
        $stream = $this->getUri()->toString();
        $stream = fopen($stream, 'r');
    }
    ...
```

$this->config['outputstream'] has been set to true by the setStream() call.
$this->getStream() returns $this->config['outputstream'], so $stream is true.

$stream is not a resource, nor is it a string, so we are making use of the second fopen call. This is opening a new stream to the url we have already sent a request to.

This behaviour might be fine in some instances, however, consider a situation like streaming a file from Amazon S3 in a private bucket. The first request would be accepted because we _should_ have set a specific Authorization header based upon the original request timestamp. By calling fopen on the url again this header is missing from the second request - which would result in a 401 response code.

With this pull request, getStream() will return the streamName property if it has been set. In a situation where setStream() is called with a file name, the return value is the same, but if setStream() is called with true, the response will be the temporary file name instead. As a result, the first fopen will always be called, so I have also removed the second fopen.

Tests to follow
