### PR TITLE
dead code clean up.

### DIFF
--- a/library/Zend/ModuleManager/Listener/ConfigListener.php
+++ b/library/Zend/ModuleManager/Listener/ConfigListener.php
@@ -82,17 +82,6 @@ class ConfigListener extends AbstractListener implements
     }
 
     /**
-     * __invoke proxy to loadModule for easier attaching
-     *
-     * @param  ModuleEvent $e
-     * @return ConfigListener
-     */
-    public function __invoke(ModuleEvent $e)
-    {
-        return $this->loadModule($e);
-    }
-
-    /**
      * Attach one or more listeners
      *
      * @param  EventManagerInterface $events


### PR DESCRIPTION
ConfigListener now implements ListenerAggregateInterface, so we don't need to use __invoke for attach any more. Besides, __invoke calls a function that doesn't exist any more, it's quite confused.
