### PR TITLE
[#3173] Incorrect creating instance Zend/Code/Generator/ClassGenerator.php by fromArray

### DIFF
--- a/library/Zend/Code/Generator/ClassGenerator.php
+++ b/library/Zend/Code/Generator/ClassGenerator.php
@@ -70,7 +70,7 @@ class ClassGenerator extends AbstractGenerator
     /**
      * Build a Code Generation Php Object from a Class Reflection
      *
-     * @param ClassReflection $classReflection
+     * @param  ClassReflection $classReflection
      * @return ClassGenerator
      */
     public static function fromReflection(ClassReflection $classReflection)
@@ -142,7 +142,7 @@ class ClassGenerator extends AbstractGenerator
      * @configkey methods
      *
      * @throws Exception\InvalidArgumentException
-     * @param array $array
+     * @param  array                              $array
      * @return ClassGenerator
      */
     public static function fromArray(array $array)
@@ -182,7 +182,7 @@ class ClassGenerator extends AbstractGenerator
                     break;
             }
         }
-        
+
         return $cg;
     }
 
@@ -226,7 +226,7 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * @param string $name
+     * @param  string         $name
      * @return ClassGenerator
      */
     public function setName($name)
@@ -238,6 +238,7 @@ class ClassGenerator extends AbstractGenerator
         }
 
         $this->name = $name;
+
         return $this;
     }
 
@@ -258,7 +259,7 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * @param string $namespaceName
+     * @param  string         $namespaceName
      * @return ClassGenerator
      */
     public function setNamespaceName($namespaceName)
@@ -269,7 +270,7 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * @param FileGenerator $fileGenerator
+     * @param  FileGenerator  $fileGenerator
      * @return ClassGenerator
      */
     public function setContainingFileGenerator(FileGenerator $fileGenerator)
@@ -288,7 +289,7 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * @param DocBlockGenerator $docBlock
+     * @param  DocBlockGenerator $docBlock
      * @return ClassGenerator
      */
     public function setDocBlock(DocBlockGenerator $docBlock)
@@ -307,7 +308,7 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * @param array|string $flags
+     * @param  array|string                        $flags
      * @return \Zend\Code\Generator\ClassGenerator
      */
     public function setFlags($flags)
@@ -321,31 +322,34 @@ class ClassGenerator extends AbstractGenerator
         }
         // check that visibility is one of three
         $this->flags = $flags;
+
         return $this;
     }
 
     /**
-     * @param string $flag
+     * @param  string         $flag
      * @return ClassGenerator
      */
     public function addFlag($flag)
     {
         $this->setFlags($this->flags | $flag);
+
         return $this;
     }
 
     /**
-     * @param string $flag
+     * @param  string         $flag
      * @return ClassGenerator
      */
     public function removeFlag($flag)
     {
         $this->setFlags($this->flags & ~$flag);
+
         return $this;
     }
 
     /**
-     * @param bool $isAbstract
+     * @param  bool                    $isAbstract
      * @return AbstractMemberGenerator
      */
     public function setAbstract($isAbstract)
@@ -358,11 +362,11 @@ class ClassGenerator extends AbstractGenerator
      */
     public function isAbstract()
     {
-        return (boolean)($this->flags & self::FLAG_ABSTRACT);
+        return (boolean) ($this->flags & self::FLAG_ABSTRACT);
     }
 
     /**
-     * @param bool $isFinal
+     * @param  bool                    $isFinal
      * @return AbstractMemberGenerator
      */
     public function setFinal($isFinal)
@@ -379,12 +383,13 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * @param string $extendedClass
+     * @param  string         $extendedClass
      * @return ClassGenerator
      */
     public function setExtendedClass($extendedClass)
     {
         $this->extendedClass = $extendedClass;
+
         return $this;
     }
 
@@ -397,12 +402,13 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * @param array $implementedInterfaces
+     * @param  array          $implementedInterfaces
      * @return ClassGenerator
      */
     public function setImplementedInterfaces(array $implementedInterfaces)
     {
         $this->implementedInterfaces = $implementedInterfaces;
+
         return $this;
     }
 
@@ -415,7 +421,7 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * @param array $properties
+     * @param  array          $properties
      * @return ClassGenerator
      */
     public function addProperties(array $properties)
@@ -438,9 +444,9 @@ class ClassGenerator extends AbstractGenerator
     /**
      * Add Property from scalars
      *
-     * @param string       $name
-     * @param string|array $defaultValue
-     * @param int          $flags
+     * @param  string                             $name
+     * @param  string|array                       $defaultValue
+     * @param  int                                $flags
      * @throws Exception\InvalidArgumentException
      * @return ClassGenerator
      */
@@ -458,7 +464,7 @@ class ClassGenerator extends AbstractGenerator
     /**
      * Add property from PropertyGenerator
      *
-     * @param  string|PropertyGenerator $property
+     * @param  string|PropertyGenerator           $property
      * @throws Exception\InvalidArgumentException
      * @return ClassGenerator
      */
@@ -471,6 +477,7 @@ class ClassGenerator extends AbstractGenerator
         }
 
         $this->properties[$propertyName] = $property;
+
         return $this;
     }
 
@@ -483,7 +490,7 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * @param string $propertyName
+     * @param  string                  $propertyName
      * @return PropertyGenerator|false
      */
     public function getProperty($propertyName)
@@ -493,11 +500,12 @@ class ClassGenerator extends AbstractGenerator
                 return $property;
             }
         }
+
         return false;
     }
 
     /**
-     * @param string $propertyName
+     * @param  string $propertyName
      * @return bool
      */
     public function hasProperty($propertyName)
@@ -506,7 +514,7 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * @param array $methods
+     * @param  array          $methods
      * @return ClassGenerator
      */
     public function addMethods(array $methods)
@@ -522,17 +530,18 @@ class ClassGenerator extends AbstractGenerator
                 }
             }
         }
+
         return $this;
     }
 
     /**
      * Add Method from scalars
      *
-     * @param string  $name
-     * @param array $parameters
-     * @param int   $flags
-     * @param string  $body
-     * @param string  $docBlock
+     * @param  string                             $name
+     * @param  array                              $parameters
+     * @param  int                                $flags
+     * @param  string                             $body
+     * @param  string                             $docBlock
      * @throws Exception\InvalidArgumentException
      * @return ClassGenerator
      */
@@ -551,7 +560,7 @@ class ClassGenerator extends AbstractGenerator
     /**
      * Add Method from MethodGenerator
      *
-     * @param  MethodGenerator $method
+     * @param  MethodGenerator                    $method
      * @throws Exception\InvalidArgumentException
      * @return ClassGenerator
      */
@@ -564,6 +573,7 @@ class ClassGenerator extends AbstractGenerator
         }
 
         $this->methods[$methodName] = $method;
+
         return $this;
     }
 
@@ -576,7 +586,7 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * @param string $methodName
+     * @param  string                $methodName
      * @return MethodGenerator|false
      */
     public function getMethod($methodName)
@@ -586,11 +596,12 @@ class ClassGenerator extends AbstractGenerator
                 return $method;
             }
         }
+
         return false;
     }
 
     /**
-     * @param string $methodName
+     * @param  string $methodName
      * @return bool
      */
     public function hasMethod($methodName)

--- a/library/Zend/Code/Generator/ClassGenerator.php
+++ b/library/Zend/Code/Generator/ClassGenerator.php
@@ -68,7 +68,7 @@ class ClassGenerator extends AbstractGenerator
     protected $methods = array();
 
     /**
-     * fromReflection() - build a Code Generation Php Object from a Class Reflection
+     * Build a Code Generation Php Object from a Class Reflection
      *
      * @param ClassReflection $classReflection
      * @return ClassGenerator
@@ -141,7 +141,6 @@ class ClassGenerator extends AbstractGenerator
      * @configkey properties
      * @configkey methods
      *
-     *
      * @throws Exception\InvalidArgumentException
      * @param array $array
      * @return ClassGenerator
@@ -151,6 +150,7 @@ class ClassGenerator extends AbstractGenerator
         if (!isset($array['name'])) {
             throw new Exception\InvalidArgumentException('Class generator requires that a name is provided for this object');
         }
+
         $cg = new static($array['name']);
         foreach ($array as $name => $value) {
             // normalize key
@@ -162,7 +162,8 @@ class ClassGenerator extends AbstractGenerator
                     $cg->setNamespaceName($value);
                     break;
                 case 'docblock':
-                    $cg->setDocBlock((!$value instanceof DocBlockGenerator) ? : DocBlockGenerator::fromArray($value));
+                    $docBlock = ($value instanceof DocBlockGenerator) ? $value : DocBlockGenerator::fromArray($value);
+                    $cg->setDocBlock($docBlock);
                     break;
                 case 'flags':
                     $cg->setFlags($value);
@@ -181,9 +182,20 @@ class ClassGenerator extends AbstractGenerator
                     break;
             }
         }
+        
         return $cg;
     }
 
+    /**
+     * @param string            $name
+     * @param string            $namespaceName
+     * @param array|string      $flags
+     * @param string            $extends
+     * @param array             $interfaces
+     * @param array             $properties
+     * @param array             $methods
+     * @param DocBlockGenerator $docBlock
+     */
     public function __construct($name = null, $namespaceName = null, $flags = null, $extends = null,
                                 $interfaces = array(), $properties = array(), $methods = array(), $docBlock = null)
     {
@@ -214,8 +226,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * setName()
-     *
      * @param string $name
      * @return ClassGenerator
      */
@@ -232,8 +242,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * getName()
-     *
      * @return string
      */
     public function getName()
@@ -242,8 +250,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * getNamespaceName()
-     *
      * @return string
      */
     public function getNamespaceName()
@@ -252,9 +258,7 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * setNamespaceName()
-     *
-     * @param $namespaceName
+     * @param string $namespaceName
      * @return ClassGenerator
      */
     public function setNamespaceName($namespaceName)
@@ -294,10 +298,7 @@ class ClassGenerator extends AbstractGenerator
         return $this;
     }
 
-
     /**
-     * getDocBlock()
-     *
      * @return DocBlockGenerator
      */
     public function getDocBlock()
@@ -305,6 +306,10 @@ class ClassGenerator extends AbstractGenerator
         return $this->docBlock;
     }
 
+    /**
+     * @param array|string $flags
+     * @return \Zend\Code\Generator\ClassGenerator
+     */
     public function setFlags($flags)
     {
         if (is_array($flags)) {
@@ -319,12 +324,20 @@ class ClassGenerator extends AbstractGenerator
         return $this;
     }
 
+    /**
+     * @param string $flag
+     * @return ClassGenerator
+     */
     public function addFlag($flag)
     {
         $this->setFlags($this->flags | $flag);
         return $this;
     }
 
+    /**
+     * @param string $flag
+     * @return ClassGenerator
+     */
     public function removeFlag($flag)
     {
         $this->setFlags($this->flags & ~$flag);
@@ -332,8 +345,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * setAbstract()
-     *
      * @param bool $isAbstract
      * @return AbstractMemberGenerator
      */
@@ -343,8 +354,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * isAbstract()
-     *
      * @return bool
      */
     public function isAbstract()
@@ -353,8 +362,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * setFinal()
-     *
      * @param bool $isFinal
      * @return AbstractMemberGenerator
      */
@@ -364,8 +371,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * isFinal()
-     *
      * @return bool
      */
     public function isFinal()
@@ -374,8 +379,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * setExtendedClass()
-     *
      * @param string $extendedClass
      * @return ClassGenerator
      */
@@ -386,8 +389,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * getExtendedClass()
-     *
      * @return string
      */
     public function getExtendedClass()
@@ -396,8 +397,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * setImplementedInterfaces()
-     *
      * @param array $implementedInterfaces
      * @return ClassGenerator
      */
@@ -408,8 +407,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * getImplementedInterfaces
-     *
      * @return array
      */
     public function getImplementedInterfaces()
@@ -418,8 +415,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * addProperties()
-     *
      * @param array $properties
      * @return ClassGenerator
      */
@@ -461,7 +456,7 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * add property from PropertyGenerator
+     * Add property from PropertyGenerator
      *
      * @param  string|PropertyGenerator $property
      * @throws Exception\InvalidArgumentException
@@ -480,8 +475,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * getProperties()
-     *
      * @return PropertyGenerator[]
      */
     public function getProperties()
@@ -490,8 +483,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * getProperty()
-     *
      * @param string $propertyName
      * @return PropertyGenerator|false
      */
@@ -506,8 +497,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * hasProperty()
-     *
      * @param string $propertyName
      * @return bool
      */
@@ -517,8 +506,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * addMethods()
-     *
      * @param array $methods
      * @return ClassGenerator
      */
@@ -561,7 +548,6 @@ class ClassGenerator extends AbstractGenerator
         return $this->addMethodFromGenerator(new MethodGenerator($name, $parameters, $flags, $body, $docBlock));
     }
 
-
     /**
      * Add Method from MethodGenerator
      *
@@ -582,8 +568,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * getMethods()
-     *
      * @return MethodGenerator[]
      */
     public function getMethods()
@@ -592,8 +576,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * getMethod()
-     *
      * @param string $methodName
      * @return MethodGenerator|false
      */
@@ -608,8 +590,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * hasMethod()
-     *
      * @param string $methodName
      * @return bool
      */
@@ -619,8 +599,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * isSourceDirty()
-     *
      * @return bool
      */
     public function isSourceDirty()
@@ -645,8 +623,6 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * generate()
-     *
      * @return string
      */
     public function generate()

--- a/library/Zend/Code/Generator/DocBlockGenerator.php
+++ b/library/Zend/Code/Generator/DocBlockGenerator.php
@@ -41,7 +41,7 @@ class DocBlockGenerator extends AbstractGenerator
     /**
      * Build a DocBlock generator object from a reflection object
      *
-     * @param DocBlockReflection $reflectionDocBlock
+     * @param  DocBlockReflection $reflectionDocBlock
      * @return DocBlockGenerator
      */
     public static function fromReflection(DocBlockReflection $reflectionDocBlock)
@@ -69,13 +69,13 @@ class DocBlockGenerator extends AbstractGenerator
      * @configkey tags             array
      *
      * @throws Exception\InvalidArgumentException
-     * @param array $array
+     * @param  array                              $array
      * @return DocBlockGenerator
      */
     public static function fromArray(array $array)
     {
         $docBlock = new static();
-        
+
         foreach ($array as $name => $value) {
             // normalize key
             switch (strtolower(str_replace(array('.', '-', '_'), '', $name))) {
@@ -112,12 +112,13 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * @param string $shortDescription
+     * @param  string            $shortDescription
      * @return DocBlockGenerator
      */
     public function setShortDescription($shortDescription)
     {
         $this->shortDescription = $shortDescription;
+
         return $this;
     }
 
@@ -130,12 +131,13 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * @param string $longDescription
+     * @param  string            $longDescription
      * @return DocBlockGenerator
      */
     public function setLongDescription($longDescription)
     {
         $this->longDescription = $longDescription;
+
         return $this;
     }
 
@@ -148,7 +150,7 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * @param array $tags
+     * @param  array             $tags
      * @return DocBlockGenerator
      */
     public function setTags(array $tags)
@@ -161,7 +163,7 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * @param array|DocBlock\Tag $tag
+     * @param  array|DocBlock\Tag                 $tag
      * @throws Exception\InvalidArgumentException
      * @return DocBlockGenerator
      */
@@ -214,7 +216,7 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * @param string $content
+     * @param  string $content
      * @return string
      */
     protected function docCommentize($content)
@@ -231,6 +233,7 @@ class DocBlockGenerator extends AbstractGenerator
             $output .= self::LINE_FEED;
         }
         $output .= $indent . ' */' . self::LINE_FEED;
+
         return $output;
     }
 

--- a/library/Zend/Code/Generator/DocBlockGenerator.php
+++ b/library/Zend/Code/Generator/DocBlockGenerator.php
@@ -39,7 +39,7 @@ class DocBlockGenerator extends AbstractGenerator
     protected $indentation = '';
 
     /**
-     * fromReflection() - Build a DocBlock generator object from a reflection object
+     * Build a DocBlock generator object from a reflection object
      *
      * @param DocBlockReflection $reflectionDocBlock
      * @return DocBlockGenerator
@@ -61,6 +61,43 @@ class DocBlockGenerator extends AbstractGenerator
         return $docBlock;
     }
 
+    /**
+     * Generate from array
+     *
+     * @configkey shortdescription string The short description for this doc block
+     * @configkey longdescription  string The long description for this doc block
+     * @configkey tags             array
+     *
+     * @throws Exception\InvalidArgumentException
+     * @param array $array
+     * @return DocBlockGenerator
+     */
+    public static function fromArray(array $array)
+    {
+        $docBlock = new static();
+        
+        foreach ($array as $name => $value) {
+            // normalize key
+            switch (strtolower(str_replace(array('.', '-', '_'), '', $name))) {
+                case 'shortdescription':
+                    $docBlock->setShortDescription($value);
+                case 'longdescription':
+                    $docBlock->setLongDescription($value);
+                    break;
+                case 'tags':
+                    $docBlock->setTags($value);
+                    break;
+            }
+        }
+
+        return $docBlock;
+    }
+
+    /**
+     * @param string $shortDescription
+     * @param string $longDescription
+     * @param array  $tags
+     */
     public function __construct($shortDescription = null, $longDescription = null, array $tags = array())
     {
         if ($shortDescription !== null) {
@@ -72,12 +109,9 @@ class DocBlockGenerator extends AbstractGenerator
         if ($this->tags !== array()) {
             $this->setTag($tags);
         }
-
     }
 
     /**
-     * setShortDescription()
-     *
      * @param string $shortDescription
      * @return DocBlockGenerator
      */
@@ -88,8 +122,6 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * getShortDescription()
-     *
      * @return string
      */
     public function getShortDescription()
@@ -98,8 +130,6 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * setLongDescription()
-     *
      * @param string $longDescription
      * @return DocBlockGenerator
      */
@@ -110,8 +140,6 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * getLongDescription()
-     *
      * @return string
      */
     public function getLongDescription()
@@ -120,8 +148,6 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * setTags()
-     *
      * @param array $tags
      * @return DocBlockGenerator
      */
@@ -135,8 +161,6 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * setTag()
-     *
      * @param array|DocBlock\Tag $tag
      * @throws Exception\InvalidArgumentException
      * @return DocBlockGenerator
@@ -158,9 +182,7 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * getTags
-     *
-     * @return DocBlock\Tag[]
+     * @return array
      */
     public function getTags()
     {
@@ -168,8 +190,6 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * generate()
-     *
      * @return string
      */
     public function generate()
@@ -194,8 +214,6 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * docCommentize()
-     *
      * @param string $content
      * @return string
      */

--- a/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
@@ -37,7 +37,6 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
         $classGenerator = new ClassGenerator();
         $classGenerator->setName('TestClass');
         $this->assertEquals($classGenerator->getName(), 'TestClass');
-
     }
 
     public function testClassDocBlockAccessors()
@@ -73,7 +72,7 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
         $classGenerator->addProperties(array(
             'propOne',
             new PropertyGenerator('propTwo')
-            ));
+        ));
 
         $properties = $classGenerator->getProperties();
         $this->assertEquals(count($properties), 2);
@@ -96,7 +95,7 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(
             'Zend\Code\Generator\Exception\InvalidArgumentException',
             'A property by name prop3 already exists in this class'
-            );
+        );
         $classGenerator->addProperty('prop3');
     }
 
@@ -107,7 +106,7 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(
             'Zend\Code\Generator\Exception\InvalidArgumentException',
             'addProperty() expects string for name'
-            );
+        );
         $classGenerator->addProperty(true);
     }
 
@@ -117,7 +116,7 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
         $classGenerator->addMethods(array(
             'methodOne',
             new MethodGenerator('methodTwo')
-            ));
+        ));
 
         $methods = $classGenerator->getMethods();
         $this->assertEquals(count($methods), 2);
@@ -139,7 +138,7 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(
             'Zend\Code\Generator\Exception\ExceptionInterface',
             'addMethod() expects string for name'
-            );
+        );
 
         $classGenerator->addMethod(true);
     }
@@ -154,7 +153,10 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
         $classGenerator = new ClassGenerator();
         $classGenerator->addMethodFromGenerator($methodA);
 
-        $this->setExpectedException('Zend\Code\Generator\Exception\InvalidArgumentException', 'A method by name foo already exists in this class.');
+        $this->setExpectedException(
+            'Zend\Code\Generator\Exception\InvalidArgumentException',
+            'A method by name foo already exists in this class.'
+        );
 
         $classGenerator->addMethodFromGenerator($methodB);
     }
@@ -193,7 +195,6 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
             array('baz')
         );
 
-
         $classGenerator = ClassGenerator::fromArray(
             array(
             'name' => 'SampleClass',
@@ -204,12 +205,11 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
             'implementedInterfaces' => array('Iterator', 'Traversable'),
             'properties' => array('foo',
                 array('name' => 'bar')
-                ),
+            ),
             'methods' => array(
                 array('name' => 'baz')
-                ),
-            ));
-
+            ),
+        ));
 
         $expectedOutput = <<<EOS
 abstract class SampleClass extends ExtendedClassName implements Iterator, Traversable
@@ -245,8 +245,8 @@ EOS;
         $code = $classGenerator->generate();
 
         $expectedClassDef = 'class ClassWithInterface'
-                          . ' implements ZendTest\Code\Generator\TestAsset\OneInterface'
-                          . ', ZendTest\Code\Generator\TestAsset\TwoInterface';
+            . ' implements ZendTest\Code\Generator\TestAsset\OneInterface'
+            . ', ZendTest\Code\Generator\TestAsset\TwoInterface';
         $this->assertContains($expectedClassDef, $code);
     }
 
@@ -263,8 +263,8 @@ EOS;
         $code = $classGenerator->generate();
 
         $expectedClassDef = 'class NewClassWithInterface'
-                          . ' extends ZendTest\Code\Generator\TestAsset\ClassWithInterface'
-                          . ' implements ZendTest\Code\Generator\TestAsset\ThreeInterface';
+            . ' extends ZendTest\Code\Generator\TestAsset\ClassWithInterface'
+            . ' implements ZendTest\Code\Generator\TestAsset\ThreeInterface';
         $this->assertContains($expectedClassDef, $code);
     }
 
@@ -274,8 +274,9 @@ EOS;
     public function testSetextendedclassShouldIgnoreEmptyClassnameOnGenerate()
     {
         $classGeneratorClass = new ClassGenerator();
-        $classGeneratorClass->setName( 'MyClass' )
-                     ->setExtendedClass('');
+        $classGeneratorClass
+            ->setName('MyClass')
+            ->setExtendedClass('');
 
         $expected = <<<CODE
 class MyClass
@@ -285,7 +286,7 @@ class MyClass
 }
 
 CODE;
-        $this->assertEquals( $expected, $classGeneratorClass->generate() );
+        $this->assertEquals($expected, $classGeneratorClass->generate());
     }
 
     /**
@@ -294,8 +295,9 @@ CODE;
     public function testSetextendedclassShouldNotIgnoreNonEmptyClassnameOnGenerate()
     {
         $classGeneratorClass = new ClassGenerator();
-        $classGeneratorClass->setName( 'MyClass' )
-                     ->setExtendedClass('ParentClass');
+        $classGeneratorClass
+            ->setName('MyClass')
+            ->setExtendedClass('ParentClass');
 
         $expected = <<<CODE
 class MyClass extends ParentClass
@@ -305,7 +307,7 @@ class MyClass extends ParentClass
 }
 
 CODE;
-        $this->assertEquals( $expected, $classGeneratorClass->generate() );
+        $this->assertEquals($expected, $classGeneratorClass->generate());
     }
 
     /**

--- a/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Code\Generator;
 
 use Zend\Code\Generator\ClassGenerator;
+use Zend\Code\Generator\DocBlockGenerator;
 use Zend\Code\Generator\PropertyGenerator;
 use Zend\Code\Generator\MethodGenerator;
 use Zend\Code\Reflection\ClassReflection;
@@ -29,7 +30,7 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testConstruction()
     {
         $class = new ClassGenerator();
-        $this->isInstanceOf($class, '\Zend\Code\Generator\ClassGenerator');
+        $this->isInstanceOf($class, 'Zend\Code\Generator\ClassGenerator');
     }
 
     public function testNameAccessors()
@@ -185,22 +186,10 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testToString()
     {
-        $classGenerator = new ClassGenerator(
-            'SampleClass',
-            null,
-            ClassGenerator::FLAG_ABSTRACT,
-            'ExtendedClassName',
-            array('Iterator', 'Traversable'),
-            array('foo', 'bar'),
-            array('baz')
-        );
-
         $classGenerator = ClassGenerator::fromArray(
             array(
             'name' => 'SampleClass',
-            //'abstract' => true,
             'flags' => ClassGenerator::FLAG_ABSTRACT,
-            'name' => 'SampleClass',
             'extendedClass' => 'ExtendedClassName',
             'implementedInterfaces' => array('Iterator', 'Traversable'),
             'properties' => array('foo',
@@ -255,7 +244,7 @@ EOS;
      */
     public function testClassFromReflectionDiscardParentImplementedInterfaces()
     {
-        $reflClass = new ClassReflection('\ZendTest\Code\Generator\TestAsset\NewClassWithInterface');
+        $reflClass = new ClassReflection('ZendTest\Code\Generator\TestAsset\NewClassWithInterface');
 
         $classGenerator = ClassGenerator::fromReflection($reflClass);
         $classGenerator->setSourceDirty(true);
@@ -363,5 +352,31 @@ CODE;
         $classGeneratorClass->setName('My\Namespaced\FunClass');
         $received = $classGeneratorClass->generate();
         $this->assertContains('class FunClass', $received, $received);
+    }
+
+    public function testCreateFromArrayWithDocBlockFromArray()
+    {
+        $classGenerator = ClassGenerator::fromArray(
+            array(
+            'name' => 'SampleClass',
+            'docblock' => array(
+                'shortdescription' => 'foo',
+            ),
+        ));
+
+        $docBlock = $classGenerator->getDocBlock();
+        $this->assertInstanceOf('Zend\Code\Generator\DocBlockGenerator', $docBlock);
+    }
+
+    public function testCreateFromArrayWithDocBlockInstance()
+    {
+        $classGenerator = ClassGenerator::fromArray(
+            array(
+            'name' => 'SampleClass',
+            'docblock' => new DocBlockGenerator('foo'),
+        ));
+
+        $docBlock = $classGenerator->getDocBlock();
+        $this->assertInstanceOf('Zend\Code\Generator\DocBlockGenerator', $docBlock);
     }
 }

--- a/tests/ZendTest/Code/Generator/DocBlockGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/DocBlockGeneratorTest.php
@@ -23,7 +23,9 @@ use Zend\Code\Generator\DocBlock\Tag;
  */
 class DocBlockGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var DocBlockGenerator */
+    /**
+     * @var DocBlockGenerator
+     */
     protected $docBlockGenerator;
 
     protected function setUp()
@@ -66,7 +68,6 @@ class DocBlockGeneratorTest extends \PHPUnit_Framework_TestCase
 EOS;
 
         $this->assertEquals($target, $this->docBlockGenerator->generate());
-
     }
 
     public function testGenerationOfDocBlock()
@@ -76,6 +77,24 @@ EOS;
         $expected = '/**' . DocBlockGenerator::LINE_FEED . ' * @var Foo this is foo bar'
             . DocBlockGenerator::LINE_FEED . ' */' . DocBlockGenerator::LINE_FEED;
         $this->assertEquals($expected, $this->docBlockGenerator->generate());
+    }
+
+    public function testCreateFormArray()
+    {
+        $docBlock = DocBlockGenerator::fromArray(array(
+            'shortdescription' => 'foo',
+            'longdescription'  => 'bar',
+            'tags' => array(
+                array(
+                    'name'        => 'foo',
+                    'description' => 'bar',
+                )
+            ),
+        ));
+
+        $this->assertEquals('foo', $docBlock->getShortDescription());
+        $this->assertEquals('bar', $docBlock->getLongDescription());
+        $this->assertCount(1, $docBlock->getTags());
     }
 
 }

--- a/tests/ZendTest/Code/Generator/DocBlockGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/DocBlockGeneratorTest.php
@@ -79,7 +79,7 @@ EOS;
         $this->assertEquals($expected, $this->docBlockGenerator->generate());
     }
 
-    public function testCreateFormArray()
+    public function testCreateFromArray()
     {
         $docBlock = DocBlockGenerator::fromArray(array(
             'shortdescription' => 'foo',


### PR DESCRIPTION
This is a fix for issue [#3173]. I had fromArray() method into Zend/Code/Generator/DocBlockGenerator class and modify ternary operator. I also fix CS.
