### PR TITLE
Check $exception type before throw

### DIFF
--- a/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -246,7 +246,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
         }
 
         $exception = $this->getApplication()->getMvcEvent()->getParam('exception');
-        if ($exception) {
+        if ($exception instanceof \Exception) {
             throw $exception;
         }
     }


### PR DESCRIPTION
Params of MvcEvent (that extends the general Event) can be anything, with no type restriction.
It's better to check if we can really throw it.
