### PR TITLE
Zend-Form: Allow Input Filter Preference Over Element Defaults

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -106,6 +106,13 @@ class Form extends Fieldset implements FormInterface
     protected $isPrepared = false;
 
     /**
+     * Prefer form input filter over input filter defaults
+     *
+     * @var bool
+     */
+    protected $preferFormInputFilter = false;
+
+    /**
      * Are the form elements/fieldsets wrapped by the form name ?
      *
      * @var bool
@@ -639,6 +646,28 @@ class Form extends Fieldset implements FormInterface
     }
 
     /**
+     * Set flag indicating whether or not to prefer the form input filter over element and fieldset defaults
+     *
+     * @param  bool $preferFormInputFilter
+     * @return Form
+     */
+    public function setPreferFormInputFilter($preferFormInputFilter)
+    {
+        $this->preferFormInputFilter = (bool) $preferFormInputFilter;
+        return $this;
+    }
+
+    /**
+     * Should we use form input filter over element input filter defaults from elements and fieldsets?
+     *
+     * @return bool
+     */
+    public function getPreferFormInputFilter()
+    {
+        return $this->preferFormInputFilter;
+    }
+
+    /**
      * Attach defaults provided by the elements to the input filter
      *
      * @param  InputFilterInterface $inputFilter
@@ -651,6 +680,10 @@ class Form extends Fieldset implements FormInterface
         $inputFactory = $formFactory->getInputFilterFactory();
         foreach ($fieldset->getElements() as $element) {
             $name = $element->getName();
+
+            if ($this->preferFormInputFilter && $inputFilter->has($name)) {
+                continue;
+            }
 
             if (!$element instanceof InputProviderInterface) {
                 if ($inputFilter->has($name)) {

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -804,6 +804,33 @@ class FormTest extends TestCase
         $this->assertEquals('foo', $input->getName());
     }
 
+    public function testWillUseFormInputFilterOverrideOverInputSpecificationFromElement()
+    {
+        $element = new TestAsset\ElementWithFilter('foo');
+        $filter  = new InputFilter();
+        $filterFactory = new InputFilterFactory();
+        $filter = $filterFactory->createInputFilter(array(
+            'foo' => array(
+                'name'       => 'foo',
+                'required'   => false,
+            ),
+        ));
+        $this->form->setPreferFormInputFilter(true);
+        $this->form->setInputFilter($filter);
+        $this->form->add($element);
+
+        $test = $this->form->getInputFilter();
+        $this->assertSame($filter, $test);
+        $this->assertTrue($filter->has('foo'));
+        $input = $filter->get('foo');
+        $filters = $input->getFilterChain();
+        $this->assertEquals(0, count($filters));
+        $validators = $input->getValidatorChain();
+        $this->assertEquals(0, count($validators));
+        $this->assertFalse($input->isRequired());
+        $this->assertEquals('foo', $input->getName());
+    }
+
     public function testDisablingUseInputFilterDefaultsFlagDisablesInputFilterScanning()
     {
         $element        = new TestAsset\ElementWithFilter('foo');


### PR DESCRIPTION
_Purpose:_
When building out forms you may want to give preference to the InputFilter set on the form while maintaining defaults that you have not overwritten.

_The Change_
A new property and 2 methods in Zend\Form\Form which set preferFormInputFilter variable
When checking for input filters; this property is utilized to simply continue if we find one otherwise it does what it did before.
The change is BC friendly.

_Simple Example_
1. Email element has defaults
2. Eliminate the validation portion
3. Utilize NotEmpty validator
4. Set a custom message.
5. Only NotEmpty validator is now set with custom error message (this wouldn't work previously)
**NOTE**
1. This drops off all filters and any other validators, basically this overrides element defaults completely.

``` php
$form->setPreferFormInputFilter(true);
$form->setInputFilter($inputFilterFactory->createInputFilter(array(
    'email' => array(
        'name' => 'email',
        'required' => true,
        'validators' => array(
             array(
                 'name' => 'NotEmpty',
                 'options' => array(
                     'messages' => array(
                          'notEmpty' => 'My new message for not empty',
                     ),
                 ),
             ),
         ),
    ),
));
```
