### PR TITLE
Fix hook in plugin manager

### DIFF
--- a/library/Zend/Form/Factory.php
+++ b/library/Zend/Form/Factory.php
@@ -16,7 +16,6 @@ use Zend\InputFilter\Factory as InputFilterFactory;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\Hydrator;
-use Zend\Stdlib\InitializableInterface;
 
 /**
  * @category   Zend
@@ -215,11 +214,6 @@ class Factory
 
         if (is_array($attributes) || $attributes instanceof Traversable || $attributes instanceof ArrayAccess) {
             $element->setAttributes($attributes);
-        }
-
-        // Hook to perform stuff, once all the configuration work has been done
-        if ($element instanceof InitializableInterface) {
-            $element->init();
         }
 
         return $element;

--- a/library/Zend/Form/FormElementManager.php
+++ b/library/Zend/Form/FormElementManager.php
@@ -12,6 +12,7 @@ namespace Zend\Form;
 
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ConfigInterface;
+use Zend\Stdlib\InitializableInterface;
 
 /**
  * Plugin manager implementation for form elements.
@@ -102,6 +103,11 @@ class FormElementManager extends AbstractPluginManager
      */
     public function validatePlugin($plugin)
     {
+        // Hook to perform various initialization, when the element is not created through the factory
+        if ($plugin instanceof InitializableInterface) {
+            $plugin->init();
+        }
+
         if ($plugin instanceof ElementInterface) {
             return; // we're okay
         }


### PR DESCRIPTION
This fix is needed in order for the new approach to create elements to work. Basically, the init function was called correctly when creating element through factory, but was not otherwise (for instance, when you simply pull an invokable form from service manager).

Maybe this could be moved in AbstractPluginManager for every class that implements InitializableInterface.
