### PR TITLE
[2.1][File Upload] Change file upload filtering to preserve the $_FILES array

### DIFF
--- a/library/Zend/Filter/File/Decrypt.php
+++ b/library/Zend/Filter/File/Decrypt.php
@@ -55,13 +55,20 @@ class Decrypt extends Filter\Decrypt
      *
      * Decrypts the file $value with the defined settings
      *
-     * @param  string $value Full path of file to change
-     * @return string The filename which has been set, or false when there were errors
+     * @param  string|array $value Full path of file to change or $_FILES data array
+     * @return string|array The filename which has been set
      * @throws Exception\InvalidArgumentException
      * @throws Exception\RuntimeException
      */
     public function filter($value)
     {
+        // An uploaded file? Retrieve the 'tmp_name'
+        $isFileUpload = (is_array($value) && isset($value['tmp_name']));
+        if ($isFileUpload) {
+            $uploadData = $value;
+            $value      = $value['tmp_name'];
+        }
+
         if (!file_exists($value)) {
             throw new Exception\InvalidArgumentException("File '$value' not found");
         }
@@ -86,6 +93,10 @@ class Decrypt extends Filter\Decrypt
             throw new Exception\RuntimeException("Problem while writing file '{$this->filename}'");
         }
 
+        if ($isFileUpload) {
+            $uploadData['tmp_name'] = $this->filename;
+            return $uploadData;
+        }
         return $this->filename;
     }
 }

--- a/library/Zend/Filter/File/Encrypt.php
+++ b/library/Zend/Filter/File/Encrypt.php
@@ -55,13 +55,20 @@ class Encrypt extends Filter\Encrypt
      *
      * Encrypts the file $value with the defined settings
      *
-     * @param  string $value Full path of file to change
-     * @return string The filename which has been set, or false when there were errors
+     * @param  string|array $value Full path of file to change or $_FILES data array
+     * @return string|array The filename which has been set, or false when there were errors
      * @throws Exception\InvalidArgumentException
      * @throws Exception\RuntimeException
      */
     public function filter($value)
     {
+        // An uploaded file? Retrieve the 'tmp_name'
+        $isFileUpload = (is_array($value) && isset($value['tmp_name']));
+        if ($isFileUpload) {
+            $uploadData = $value;
+            $value      = $value['tmp_name'];
+        }
+
         if (!file_exists($value)) {
             throw new Exception\InvalidArgumentException("File '$value' not found");
         }
@@ -86,6 +93,10 @@ class Encrypt extends Filter\Encrypt
             throw new Exception\RuntimeException("Problem while writing file '{$this->filename}'");
         }
 
+        if ($isFileUpload) {
+            $uploadData['tmp_name'] = $this->filename;
+            return $uploadData;
+        }
         return $this->filename;
     }
 }

--- a/library/Zend/Filter/File/LowerCase.php
+++ b/library/Zend/Filter/File/LowerCase.php
@@ -24,13 +24,20 @@ class LowerCase extends StringToLower
      *
      * Does a lowercase on the content of the given file
      *
-     * @param  string $value Full path of file to change
-     * @return string The given $value
+     * @param  string|array $value Full path of file to change or $_FILES data array
+     * @return string|array The given $value
      * @throws Exception\InvalidArgumentException
      * @throws Exception\RuntimeException
      */
     public function filter($value)
     {
+        // An uploaded file? Retrieve the 'tmp_name'
+        $isFileUpload = (is_array($value) && isset($value['tmp_name']));
+        if ($isFileUpload) {
+            $uploadData = $value;
+            $value      = $value['tmp_name'];
+        }
+
         if (!file_exists($value)) {
             throw new Exception\InvalidArgumentException("File '$value' not found");
         }
@@ -51,6 +58,9 @@ class LowerCase extends StringToLower
             throw new Exception\RuntimeException("Problem while writing file '$value'");
         }
 
+        if ($isFileUpload) {
+            return $uploadData;
+        }
         return $value;
     }
 }

--- a/library/Zend/Filter/File/Rename.php
+++ b/library/Zend/Filter/File/Rename.php
@@ -158,12 +158,19 @@ class Rename extends Filter\AbstractFilter
      * Renames the file $value to the new name set before
      * Returns the file $value, removing all but digit characters
      *
-     * @param  string $value Full path of file to change
+     * @param  string|array $value Full path of file to change or $_FILES data array
      * @throws Exception\RuntimeException
-     * @return string The new filename which has been set, or false when there were errors
+     * @return string|array The new filename which has been set
      */
     public function filter($value)
     {
+        // An uploaded file? Retrieve the 'tmp_name'
+        $isFileUpload = (is_array($value) && isset($value['tmp_name']));
+        if ($isFileUpload) {
+            $uploadData = $value;
+            $value      = $value['tmp_name'];
+        }
+
         $file = $this->getNewName($value, true);
         if (is_string($file)) {
             return $file;
@@ -181,6 +188,10 @@ class Rename extends Filter\AbstractFilter
             );
         }
 
+        if ($isFileUpload) {
+            $uploadData['tmp_name'] = $file['target'];
+            return $uploadData;
+        }
         return $file['target'];
     }
 

--- a/library/Zend/Filter/File/RenameUpload.php
+++ b/library/Zend/Filter/File/RenameUpload.php
@@ -25,12 +25,19 @@ class RenameUpload extends Rename
      * Renames the file $value to the new name set before
      * Returns the file $value, removing all but digit characters
      *
-     * @param  string $value Full path of file to change
+     * @param  string|array $value Full path of file to change or $_FILES data array
      * @throws Exception\RuntimeException
-     * @return string The new filename which has been set, or false when there were errors
+     * @return string|array The new filename which has been set, or false when there were errors
      */
     public function filter($value)
     {
+        // An uploaded file? Retrieve the 'tmp_name'
+        $isFileUpload = (is_array($value) && isset($value['tmp_name']));
+        if ($isFileUpload) {
+            $uploadData = $value;
+            $value      = $value['tmp_name'];
+        }
+
         $file   = $this->getNewName($value, true);
         if (is_string($file)) {
             return $file;
@@ -46,6 +53,10 @@ class RenameUpload extends Rename
             );
         }
 
+        if ($isFileUpload) {
+            $uploadData['tmp_name'] = $file['target'];
+            return $uploadData;
+        }
         return $file['target'];
     }
 }

--- a/library/Zend/Filter/File/UpperCase.php
+++ b/library/Zend/Filter/File/UpperCase.php
@@ -24,13 +24,20 @@ class UpperCase extends StringToUpper
      *
      * Does a lowercase on the content of the given file
      *
-     * @param  string $value Full path of file to change
-     * @return string The given $value
+     * @param  string|array $value Full path of file to change or $_FILES data array
+     * @return string|array The given $value
      * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException
      */
     public function filter($value)
     {
+        // An uploaded file? Retrieve the 'tmp_name'
+        $isFileUpload = (is_array($value) && isset($value['tmp_name']));
+        if ($isFileUpload) {
+            $uploadData = $value;
+            $value      = $value['tmp_name'];
+        }
+
         if (!file_exists($value)) {
             throw new Exception\InvalidArgumentException("File '$value' not found");
         }
@@ -51,6 +58,9 @@ class UpperCase extends StringToUpper
             throw new Exception\RuntimeException("Problem while writing file '$value'");
         }
 
+        if ($isFileUpload) {
+            return $uploadData;
+        }
         return $value;
     }
 }

--- a/library/Zend/InputFilter/FileInput.php
+++ b/library/Zend/InputFilter/FileInput.php
@@ -51,22 +51,24 @@ class FileInput extends Input
      */
     public function getValue()
     {
-        $filter = $this->getFilterChain();
-        $value  = (is_array($this->value) && isset($this->value['tmp_name']))
-                ? $this->value['tmp_name'] : $this->value;
-        if (is_scalar($value) && $this->isValid) {
-            // Single file input
-            $value = $filter->filter($value);
-        } elseif (is_array($value)) {
-            // Multi file input (multiple attribute set)
-            $newValue = array();
-            foreach ($value as $multiFileData) {
-                $fileName = (is_array($multiFileData) && isset($multiFileData['tmp_name']))
-                            ? $multiFileData['tmp_name'] : $multiFileData;
-                $newValue[] = ($this->isValid) ? $filter->filter($fileName) : $fileName;
+        $value = $this->value;
+        if ($this->isValid && is_array($value)) {
+            $filter = $this->getFilterChain();
+            if (isset($value['tmp_name'])) {
+                // Single file input
+                $value = $filter->filter($value);
+            } else {
+                // Multi file input (multiple attribute set)
+                $newValue = array();
+                foreach ($value as $fileData) {
+                    if (is_array($fileData) && isset($fileData['tmp_name'])) {
+                        $newValue[] = $filter->filter($fileData);
+                    }
+                }
+                $value = $newValue;
             }
-            $value = $newValue;
         }
+
         return $value;
     }
 

--- a/tests/ZendTest/Filter/File/DecryptTest.php
+++ b/tests/ZendTest/Filter/File/DecryptTest.php
@@ -80,6 +80,38 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
             trim(file_get_contents(dirname(__DIR__).'/_files/newencryption.txt')));
     }
 
+    /**
+     * @return void
+     */
+    public function testBasicWithFileArray()
+    {
+        $filter = new FileEncrypt();
+        $filter->setFilename(dirname(__DIR__).'/_files/newencryption.txt');
+
+        $this->assertEquals(
+            dirname(__DIR__).'/_files/newencryption.txt',
+            $filter->getFilename());
+
+        $filter->setVector('1234567890123456');
+        $filter->filter(array('tmp_name' => dirname(__DIR__).'/_files/encryption.txt'));
+
+        $filter = new FileDecrypt();
+
+        $this->assertNotEquals(
+            'Encryption',
+            file_get_contents(dirname(__DIR__).'/_files/newencryption.txt'));
+
+        $filter->setVector('1234567890123456');
+        $this->assertEquals(
+            array('tmp_name' => dirname(__DIR__).'/_files/newencryption.txt'),
+            $filter->filter(array('tmp_name' => dirname(__DIR__).'/_files/newencryption.txt'))
+        );
+
+        $this->assertEquals(
+            'Encryption',
+            trim(file_get_contents(dirname(__DIR__).'/_files/newencryption.txt')));
+    }
+
     public function testEncryptionWithDecryption()
     {
         $filter = new FileEncrypt();

--- a/tests/ZendTest/Filter/File/EncryptTest.php
+++ b/tests/ZendTest/Filter/File/EncryptTest.php
@@ -66,6 +66,33 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
             file_get_contents(dirname(__DIR__).'/_files/newencryption.txt'));
     }
 
+    /**
+     * @return void
+     */
+    public function testBasicWithFileArray()
+    {
+        $filter = new FileEncrypt();
+        $filter->setFilename(dirname(__DIR__).'/_files/newencryption.txt');
+
+        $this->assertEquals(
+            dirname(__DIR__).'/_files/newencryption.txt',
+            $filter->getFilename());
+
+        $filter->setVector('1234567890123456');
+        $this->assertEquals(
+            array('tmp_name' => dirname(__DIR__).'/_files/newencryption.txt'),
+            $filter->filter(array('tmp_name' => dirname(__DIR__).'/_files/encryption.txt'))
+        );
+
+        $this->assertEquals(
+            'Encryption',
+            file_get_contents(dirname(__DIR__).'/_files/encryption.txt'));
+
+        $this->assertNotEquals(
+            'Encryption',
+            file_get_contents(dirname(__DIR__).'/_files/newencryption.txt'));
+    }
+
     public function testEncryptionWithDecryption()
     {
         $filter = new FileEncrypt();

--- a/tests/ZendTest/Filter/File/LowerCaseTest.php
+++ b/tests/ZendTest/Filter/File/LowerCaseTest.php
@@ -83,6 +83,17 @@ class LowerCaseTest extends \PHPUnit_Framework_TestCase
     /**
      * @return void
      */
+    public function testNormalWorkflowWithFilesArray()
+    {
+        $this->assertContains('This is a File', file_get_contents($this->_newFile));
+        $filter = new FileLowerCase();
+        $filter(array('tmp_name' => $this->_newFile));
+        $this->assertContains('this is a file', file_get_contents($this->_newFile));
+    }
+
+    /**
+     * @return void
+     */
     public function testFileNotFoundException()
     {
         $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'not found');

--- a/tests/ZendTest/Filter/File/RenameTest.php
+++ b/tests/ZendTest/Filter/File/RenameTest.php
@@ -138,6 +138,31 @@ class RenameTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test single parameter filter
+     *
+     * @return void
+     */
+    public function testConstructSingleValueWithFilesArray()
+    {
+        $filter = new FileRename($this->_newFile);
+
+        $this->assertEquals(
+            array(0 => array(
+                'source'    => '*',
+                'target'    => $this->_newFile,
+                'overwrite' => false,
+                'randomize' => false,
+            )),
+            $filter->getFile()
+        );
+        $this->assertEquals(
+            array('tmp_name' => $this->_newFile),
+            $filter(array('tmp_name' => $this->_oldFile))
+        );
+        $this->assertEquals('falsefile', $filter('falsefile'));
+    }
+
+    /**
      * Test single array parameter filter
      *
      * @return void

--- a/tests/ZendTest/Filter/File/RenameUploadTest.php
+++ b/tests/ZendTest/Filter/File/RenameUploadTest.php
@@ -191,6 +191,31 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testConstructSingleValueWithFilesArray()
+    {
+        $this->setUpMockMoveUploadedFile();
+
+        $filter = new FileRenameUpload($this->_newFile);
+
+        $this->assertEquals(
+            array(0 => array(
+                'source'    => '*',
+                'target'    => $this->_newFile,
+                'overwrite' => false,
+                'randomize' => false,
+            )),
+            $filter->getFile()
+        );
+        $this->assertEquals(
+            array('tmp_name' => $this->_newFile),
+            $filter(array('tmp_name' => $this->_oldFile))
+        );
+        $this->assertEquals('falsefile', $filter('falsefile'));
+    }
+
+    /**
      * Test single array parameter filter
      *
      * @return void

--- a/tests/ZendTest/Filter/File/UpperCaseTest.php
+++ b/tests/ZendTest/Filter/File/UpperCaseTest.php
@@ -83,6 +83,17 @@ class UpperCaseTest extends \PHPUnit_Framework_TestCase
     /**
      * @return void
      */
+    public function testNormalWorkflowWithFilesArray()
+    {
+        $this->assertContains('This is a File', file_get_contents($this->_newFile));
+        $filter = new FileUpperCase();
+        $filter(array('tmp_name' => $this->_newFile));
+        $this->assertContains('THIS IS A FILE', file_get_contents($this->_newFile));
+    }
+
+    /**
+     * @return void
+     */
     public function testFileNotFoundException()
     {
         $filter = new FileUpperCase();


### PR DESCRIPTION
Prior to these changes, the `\Zend\InputFilter\FileInput` would pull out the `$file['tmp_name']` and pass that value along through the `$filterChain->filter($tmp_name)`. This had the unfortunate affect of losing the `$_FILES` data when doing a `$form->getData()` - only the `'tmp_name'` value would be returned for file inputs. 

The PR changes `\Zend\InputFilter\FileInput` so that the `$_FILES` array data is sent through the filter chain, and the `\Zend\Filter\File` filters now accept an array of `$_FILES` data or a file path string (without any BC). `$form->getData()` will also return the expected `$_FILES` array for any file inputs.

Also patched the `FilePostRedirectGet` controller plugin, which was affected by these changes.
