### PR TITLE
Fix (un)subscribe operation to a PubSubHubbub server

### DIFF
--- a/library/Zend/Feed/PubSubHubbub/Subscriber.php
+++ b/library/Zend/Feed/PubSubHubbub/Subscriber.php
@@ -625,7 +625,7 @@ class Subscriber
             }
             $client->setUri($url);
             $client->setRawBody($this->_getRequestParameters($url, $mode));
-            $response = $client->getResponse();
+            $response = $client->send();
             if ($response->getStatusCode() !== 204
                 && $response->getStatusCode() !== 202
             ) {


### PR DESCRIPTION
The HTTP POST request was never sent to the hub. The http client send() was never invoked.  This basically resulted into a no-op.
