### PR TITLE
Better capabilities surrounding console notFoundAction

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractActionController.php
+++ b/library/Zend/Mvc/Controller/AbstractActionController.php
@@ -13,6 +13,7 @@ namespace Zend\Mvc\Controller;
 use Zend\Http\Response as HttpResponse;
 use Zend\Mvc\Exception;
 use Zend\Mvc\MvcEvent;
+use Zend\View\Model\ConsoleModel;
 use Zend\View\Model\ViewModel;
 
 /**
@@ -51,15 +52,16 @@ abstract class AbstractActionController extends AbstractController
         $response   = $this->response;
         $event      = $this->getEvent();
         $routeMatch = $event->getRouteMatch();
-
-        if ($response instanceof HttpResponse) {
-            $response->setStatusCode(404);
-        }
         $routeMatch->setParam('action', 'not-found');
 
-        return new ViewModel(array(
-            'content' => 'Page not found'
-        ));
+        if ($response instanceof HttpResponse) {
+            $viewModel = $this->createHttpNotFoundModel($response);
+        }
+        if (!$response instanceof HttpResponse) {
+            $viewModel = $this->createConsoleNotFoundModel($response);
+        }
+
+        return $viewModel;
     }
 
     /**
@@ -92,5 +94,33 @@ abstract class AbstractActionController extends AbstractController
         $e->setResult($actionResponse);
 
         return $actionResponse;
+    }
+
+    /**
+     * Create an HTTP view model representing a "not found" page
+     *
+     * @param  HttpResponse $response
+     * @return ViewModel
+     */
+    protected function createHttpNotFoundModel(HttpResponse $response)
+    {
+        $response->setStatusCode(404);
+        return new ViewModel(array(
+            'content' => 'Page not found',
+        ));
+    }
+
+    /**
+     * Create a console view model representing a "not found" action
+     *
+     * @param  \Zend\Stdlib\ResponseInterface $response
+     * @return ConsoleModel
+     */
+    protected function createConsoleNotFoundModel($response)
+    {
+        $viewModel = new ConsoleModel();
+        $viewModel->setErrorLevel(1);
+        $viewModel->setResult('Page not found');
+        return $viewModel;
     }
 }

--- a/library/Zend/Mvc/Controller/AbstractActionController.php
+++ b/library/Zend/Mvc/Controller/AbstractActionController.php
@@ -55,13 +55,9 @@ abstract class AbstractActionController extends AbstractController
         $routeMatch->setParam('action', 'not-found');
 
         if ($response instanceof HttpResponse) {
-            $viewModel = $this->createHttpNotFoundModel($response);
+            return $this->createHttpNotFoundModel($response);
         }
-        if (!$response instanceof HttpResponse) {
-            $viewModel = $this->createConsoleNotFoundModel($response);
-        }
-
-        return $viewModel;
+        return $this->createConsoleNotFoundModel($response);
     }
 
     /**

--- a/library/Zend/Mvc/View/Console/DefaultRenderingStrategy.php
+++ b/library/Zend/Mvc/View/Console/DefaultRenderingStrategy.php
@@ -83,7 +83,6 @@ class DefaultRenderingStrategy implements ListenerAggregateInterface
         // Collect results from child models
         $responseText = '';
         if ($result->hasChildren()) {
-            /* @var $child ViewModel */
             foreach ($result->getChildren() as $child) {
                 // Do not use ::getResult() method here as we cannot be sure if children are also console models.
                 $responseText .= $child->getVariable(ConsoleViewModel::RESULT);
@@ -91,7 +90,12 @@ class DefaultRenderingStrategy implements ListenerAggregateInterface
         }
 
         // Fetch result from primary model
-        $responseText .= $result->getResult();
+        if ($result instanceof ConsoleViewModel) {
+            $responseText .= $result->getResult();
+        }
+        if (!$result instanceof ConsoleViewModel) {
+            $responseText .= $result->getVariable(ConsoleViewModel::RESULT);
+        }
 
         // Append console response to response object
         $response->setContent(

--- a/library/Zend/Mvc/View/Console/DefaultRenderingStrategy.php
+++ b/library/Zend/Mvc/View/Console/DefaultRenderingStrategy.php
@@ -92,8 +92,7 @@ class DefaultRenderingStrategy implements ListenerAggregateInterface
         // Fetch result from primary model
         if ($result instanceof ConsoleViewModel) {
             $responseText .= $result->getResult();
-        }
-        if (!$result instanceof ConsoleViewModel) {
+        } else {
             $responseText .= $result->getVariable(ConsoleViewModel::RESULT);
         }
 

--- a/tests/ZendTest/Mvc/Controller/ActionControllerTest.php
+++ b/tests/ZendTest/Mvc/Controller/ActionControllerTest.php
@@ -208,10 +208,10 @@ class ActionControllerTest extends TestCase
         $result       = $this->controller->dispatch($this->request, $response);
         $testResponse = $this->controller->getResponse();
         $this->assertSame($response, $testResponse);
-        $this->assertInstanceOf('Zend\View\Model\ModelInterface', $result);
-        $this->assertEquals('content', $result->captureTo());
+        $this->assertInstanceOf('Zend\View\Model\ConsoleModel', $result);
         $vars = $result->getVariables();
-        $this->assertArrayHasKey('content', $vars, var_export($vars, 1));
-        $this->assertContains('Page not found', $vars['content']);
+        $this->assertTrue(isset($vars['result']));
+        $this->assertContains('Page not found', $vars['result']);
+        $this->assertEquals(1, $result->getErrorLevel());
     }
 }

--- a/tests/ZendTest/Mvc/View/Console/DefaultRenderingStrategyTest.php
+++ b/tests/ZendTest/Mvc/View/Console/DefaultRenderingStrategyTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc\View\Console;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\EventManager\Event;
+use Zend\EventManager\EventManager;
+use Zend\Mvc\MvcEvent;
+use Zend\Mvc\View\Console\DefaultRenderingStrategy;
+use Zend\Stdlib\Response;
+use Zend\View\Model;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage UnitTest
+ */
+class DefaultRenderingStrategyTest extends TestCase
+{
+    protected $strategy;
+
+    public function setUp()
+    {
+        $this->strategy = new DefaultRenderingStrategy();
+    }
+
+    public function testAttachesRendererAtExpectedPriority()
+    {
+        $events = new EventManager();
+        $events->attachAggregate($this->strategy);
+        $listeners = $events->getListeners(MvcEvent::EVENT_RENDER);
+
+        $expectedCallback = array($this->strategy, 'render');
+        $expectedPriority = -10000;
+        $found            = false;
+        foreach ($listeners as $listener) {
+            $callback = $listener->getCallback();
+            if ($callback === $expectedCallback) {
+                if ($listener->getMetadatum('priority') == $expectedPriority) {
+                    $found = true;
+                    break;
+                }
+            }
+        }
+        $this->assertTrue($found, 'Renderer not found');
+    }
+
+    public function testCanDetachListenersFromEventManager()
+    {
+        $events = new EventManager();
+        $events->attachAggregate($this->strategy);
+        $this->assertEquals(1, count($events->getListeners(MvcEvent::EVENT_RENDER)));
+
+        $events->detachAggregate($this->strategy);
+        $this->assertEquals(0, count($events->getListeners(MvcEvent::EVENT_RENDER)));
+    }
+
+    public function testIgnoresNonConsoleModelNotContainingResultKeyWhenObtainingResult()
+    {
+        $event    = new MvcEvent();
+        $model    = new Model\ViewModel(array('content' => 'Page not found'));
+        $response = new Response();
+        $event->setResult($model);
+        $event->setResponse($response);
+        $this->strategy->render($event);
+        $content = $response->getContent();
+        $this->assertNotContains('Page not found', $content);
+    }
+}


### PR DESCRIPTION
- Return a console response for non-HTTP response types; resolves comment noted
  in zendframework/zf2#3186
