### PR TITLE
Native abstract controller plugin methods

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -302,7 +302,7 @@ abstract class AbstractController implements
      */
     public function layout($template = null)
     {
-    	return $this->plugin('layout', $template);
+    	return $this->plugin('layout', array($template));
     }
     
     /**

--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -275,6 +275,76 @@ abstract class AbstractController implements
     }
 
     /**
+     * Get the flashMessenger plugin
+     *
+     * @return \Zend\Mvc\Controller\Plugin\FlashMessenger
+     */
+    public function flashMessenger()
+    {
+    	return $this->plugin('flashMessenger');
+    }
+    
+    /**
+     * Get the forward plugin
+     *
+     * @return \Zend\Mvc\Controller\Plugin\Forward
+     */
+    public function forward()
+    {
+    	return $this->plugin('forward');
+    }
+    
+    /**
+     * Get the layout plugin
+     *
+     * @return \Zend\Mvc\Controller\Plugin\Layout
+     */
+    public function layout()
+    {
+    	return $this->plugin('layout');
+    }
+    
+    /**
+     * Get the params plugin
+     *
+     * @return \Zend\Mvc\Controller\Plugin\FlashMessenger
+     */
+    public function params()
+    {
+    	return $this->plugin('params');
+    }
+    
+    /**
+     * Get the PostRedirectGet plugin
+     *
+     * @return \Zend\Mvc\Controller\Plugin\PostRedirectGet
+     */
+    public function postRedirectGet()
+    {
+    	return $this->plugin('postRedirectGet');
+    }
+    
+    /**
+     * Get the Redirect plugin
+     *
+     * @return \Zend\Mvc\Controller\Plugin\Redirect
+     */
+    public function redirect()
+    {
+    	return $this->plugin('redirect');
+    }
+    
+    /**
+     * Get the Url plugin
+     *
+     * @return \Zend\Mvc\Controller\Plugin\Url
+     */
+    public function url()
+    {
+    	return $this->plugin('url');
+    }
+    
+    /**
      * Method overloading: return/call plugins
      *
      * If the plugin is a functor, call it, passing the parameters provided.

--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -297,11 +297,12 @@ abstract class AbstractController implements
     /**
      * Get the layout plugin
      *
+     * @param  null|string $template
      * @return \Zend\Mvc\Controller\Plugin\Layout
      */
-    public function layout()
+    public function layout($template = null)
     {
-    	return $this->plugin('layout');
+    	return $this->plugin('layout', $template);
     }
     
     /**

--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -302,7 +302,10 @@ abstract class AbstractController implements
      */
     public function layout($template = null)
     {
-    	return $this->plugin('layout', array($template));
+    	if($template !== null){
+    		$template = array($template);
+    	}
+    	return $this->plugin('layout', $template);
     }
     
     /**

--- a/tests/ZendTest/Mvc/Controller/ActionControllerTest.php
+++ b/tests/ZendTest/Mvc/Controller/ActionControllerTest.php
@@ -188,8 +188,32 @@ class ActionControllerTest extends TestCase
 
     public function testMethodOverloadingShouldReturnPluginWhenFound()
     {
-        $plugin = $this->controller->url();
-        $this->assertInstanceOf('Zend\Mvc\Controller\Plugin\Url', $plugin);
+        $plugin = $this->controller->prg();
+        $this->assertInstanceOf('Zend\Mvc\Controller\Plugin\PostRedirectGet ', $plugin);
+    }
+    
+    public function testMethodControllerPluginsAreAvailable()
+    {
+    	$plugin = $this->controller->flashMessenger();
+    	$this->assertInstanceOf('Zend\Mvc\Controller\Plugin\FlashMessenger', $plugin);
+    	
+    	$plugin = $this->controller->forward();
+    	$this->assertInstanceOf('Zend\Mvc\Controller\Plugin\Forward', $plugin);
+    	
+    	$plugin = $this->controller->layout();
+    	$this->assertInstanceOf('Zend\Mvc\Controller\Plugin\Layout', $plugin);
+    	
+    	$plugin = $this->controller->params();
+    	$this->assertInstanceOf('Zend\Mvc\Controller\Plugin\Params', $plugin);
+    	
+    	$plugin = $this->controller->postRedirectGet();
+    	$this->assertInstanceOf('Zend\Mvc\Controller\Plugin\PostRedirectGet', $plugin);
+    	
+    	$plugin = $this->controller->redirect();
+    	$this->assertInstanceOf('Zend\Mvc\Controller\Plugin\Redirect', $plugin);
+    	
+    	$plugin = $this->controller->url();
+    	$this->assertInstanceOf('Zend\Mvc\Controller\Plugin\Url', $plugin);
     }
 
     public function testMethodOverloadingShouldInvokePluginAsFunctorIfPossible()


### PR DESCRIPTION
Currently only the magic method __call or plugin with name parameter can get used for controller plugins.

With this methods the IDE known that these methods/plugins are available (and also users).

IMPORTANT!
I hope it's fine, because i'm not a Git expert until yet...
