### PR TITLE
Allow input to have custom options

### DIFF
--- a/library/Zend/InputFilter/ConfigurableInputInterface.php
+++ b/library/Zend/InputFilter/ConfigurableInputInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_InputFilter
+ */
+
+namespace Zend\InputFilter;
+
+/**
+ * @category   Zend
+ * @package    Zend_InputFilter
+ */
+interface ConfigurableInputInterface
+{
+    /**
+     * Set options for an input
+     *
+     * @param  array $options
+     * @return mixed
+     */
+    public function setOptions($options);
+
+    /**
+     * Get options for an input
+     *
+     * @return array
+     */
+    public function getOptions();
+}

--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -10,6 +10,7 @@
 
 namespace Zend\InputFilter;
 
+use ArrayAccess;
 use Traversable;
 use Zend\Filter\FilterChain;
 use Zend\Stdlib\ArrayUtils;
@@ -188,6 +189,13 @@ class Factory
                         ));
                     }
                     $this->populateValidators($input->getValidatorChain(), $value);
+                    break;
+                case 'options':
+                    if ($input instanceof ConfigurableInputInterface &&
+                        (is_array($value) || $value instanceof Traversable || $value instanceof ArrayAccess)
+                    ) {
+                        $input->setOptions($value);
+                    }
                     break;
                 default:
                     // ignore unknown keys

--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -191,8 +191,8 @@ class Factory
                     $this->populateValidators($input->getValidatorChain(), $value);
                     break;
                 case 'options':
-                    if ($input instanceof ConfigurableInputInterface &&
-                        (is_array($value) || $value instanceof Traversable || $value instanceof ArrayAccess)
+                    if ($input instanceof ConfigurableInputInterface
+                        && (is_array($value) || $value instanceof Traversable || $value instanceof ArrayAccess)
                     ) {
                         $input->setOptions($value);
                     }

--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -10,7 +10,9 @@
 
 namespace Zend\InputFilter;
 
+use Traversable;
 use Zend\Filter\FilterChain;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\ValidatorChain;
 use Zend\Validator\NotEmpty;
 
@@ -18,7 +20,7 @@ use Zend\Validator\NotEmpty;
  * @category   Zend
  * @package    Zend_InputFilter
  */
-class Input implements InputInterface
+class Input implements InputInterface, ConfigurableInputInterface
 {
     /**
      * @var boolean
@@ -70,9 +72,19 @@ class Input implements InputInterface
      */
     protected $fallbackValue;
 
-    public function __construct($name = null)
+    /**
+     * @var array
+     */
+    protected $options;
+
+
+    public function __construct($name = null, $options = array())
     {
         $this->name = $name;
+
+        if (!empty($options)) {
+            $this->setOptions($options);
+        }
     }
 
     /**
@@ -329,5 +341,37 @@ class Input implements InputInterface
 
         $chain->prependByName('NotEmpty', array(), true);
         $this->notEmptyValidator = true;
+    }
+
+    /**
+     * Set options for an input
+     *
+     * @param  array $options
+     * @throws Exception\InvalidArgumentException
+     * @return mixed
+     */
+    public function setOptions($options)
+    {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        } elseif (!is_array($options)) {
+            throw new Exception\InvalidArgumentException(
+                'The options parameter must be an array or a Traversable'
+            );
+        }
+
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * Get options for an input
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
     }
 }

--- a/tests/ZendTest/InputFilter/FactoryTest.php
+++ b/tests/ZendTest/InputFilter/FactoryTest.php
@@ -47,6 +47,20 @@ class FactoryTest extends TestCase
         $this->assertSame($validatorChain, $factory->getDefaultValidatorChain());
     }
 
+    public function testFactoryAllowsInjectingCustomOptions()
+    {
+        $factory = new Factory();
+        $input   = $factory->createInput(array(
+            'type'    => 'ZendTest\InputFilter\TestAsset\CustomInputWithOptions',
+            'options' => array(
+                'do_something_funny' => 'barFooBaz'
+            )
+        ));
+
+        $this->assertInstanceOf('ZendTest\InputFilter\TestAsset\CustomInputWithOptions', $input);
+        $this->assertEquals('barFooBaz', $input->getDoSomethingFunny());
+    }
+
     public function testFactoryUsesComposedFilterChainWhenCreatingNewInputObjects()
     {
         $factory       = new Factory();

--- a/tests/ZendTest/InputFilter/InputTest.php
+++ b/tests/ZendTest/InputFilter/InputTest.php
@@ -14,6 +14,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\InputFilter\Input;
 use Zend\Filter;
 use Zend\Validator;
+use ZendTest\InputFilter\TestAsset\CustomInputWithOptions;
 
 class InputTest extends TestCase
 {
@@ -239,5 +240,12 @@ class InputTest extends TestCase
 
         $filters = $filterChain->getFilters()->toArray();
         $this->assertInstanceOf('Zend\Filter\StringTrim', $filters[0]);
+    }
+
+    public function testCanSetCustomValueThroughOptions()
+    {
+        $input = new CustomInputWithOptions('foo', array('do_something_funny' => 'fooBarBaz'));
+
+        $this->assertEquals('fooBarBaz', $input->getDoSomethingFunny());
     }
 }

--- a/tests/ZendTest/InputFilter/TestAsset/CustomInputWithOptions.php
+++ b/tests/ZendTest/InputFilter/TestAsset/CustomInputWithOptions.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_InputFilter
+ */
+
+namespace ZendTest\InputFilter\TestAsset;
+
+use Zend\InputFilter\Input;
+
+/**
+ * @category   Zend
+ * @package    Zend_InputFilter
+ * @subpackage UnitTest
+ */
+class CustomInputWithOptions extends Input
+{
+    /**
+     * @var string
+     */
+    protected $doSomethingFunny;
+
+    /**
+     * Set options for an input
+     *
+     * @param  array $options
+     * @return mixed
+     */
+    public function setOptions($options)
+    {
+        parent::setOptions($options);
+
+        if (isset($options['do_something_funny'])) {
+            $this->setDoSomethingFunny($options['do_something_funny']);
+        }
+    }
+
+    public function setDoSomethingFunny($doSomethingFunny)
+    {
+        $this->doSomethingFunny = $doSomethingFunny;
+    }
+
+    public function getDoSomethingFunny()
+    {
+        return $this->doSomethingFunny;
+    }
+}


### PR DESCRIPTION
This PR addresses this problem: https://github.com/zendframework/zf2/issues/3216#issuecomment-11350772

It mimics how Form element deals with options. It may not be the best way (the problem is... what is options or what is not ? is "required" an options ? This is something we may think a little bit, as the same problem occurs in Zend\Form... it's not always obvious why some properties are options and some are not, anyway, this is just a side note...).

Note that InputFilter would need some love, the factory class has some very large functions. I'll try to clean it up a little bit next time.
