### PR TITLE
[2.1][File Upload] RenameUpload filter rewrite w/option to use uploaded 'name'

### DIFF
--- a/library/Zend/Filter/File/Rename.php
+++ b/library/Zend/Filter/File/Rename.php
@@ -34,6 +34,7 @@ class Rename extends Filter\AbstractFilter
      * 'source'    => Source filename or directory which will be renamed
      * 'target'    => Target filename or directory, the new name of the source file
      * 'overwrite' => Shall existing files be overwritten ?
+     * 'randomize' => Shall target files have a random postfix attached?
      *
      * @param  string|array|Traversable $options Target file or directory to be renamed
      * @throws Exception\InvalidArgumentException
@@ -173,7 +174,11 @@ class Rename extends Filter\AbstractFilter
 
         $file = $this->getNewName($value, true);
         if (is_string($file)) {
-            return $file;
+            if ($isFileUpload) {
+                return $uploadData;
+            } else {
+                return $file;
+            }
         }
 
         $result = rename($file['source'], $file['target']);

--- a/library/Zend/Filter/File/RenameUpload.php
+++ b/library/Zend/Filter/File/RenameUpload.php
@@ -25,7 +25,7 @@ class RenameUpload extends AbstractFilter
      */
     protected $options = array(
         'target'          => null,
-        'use_upload_name' => true,
+        'use_upload_name' => false,
         'overwrite'       => false,
         'randomize'       => false,
     );
@@ -42,8 +42,6 @@ class RenameUpload extends AbstractFilter
         } else {
             $this->setTarget($targetOrOptions);
         }
-
-
     }
 
     /**
@@ -145,7 +143,7 @@ class RenameUpload extends AbstractFilter
         } else {
             $uploadData = array(
                 'tmp_name' => $value,
-                'name' => $value,
+                'name'     => $value,
             );
             $sourceFile = $value;
         }

--- a/library/Zend/Filter/File/RenameUpload.php
+++ b/library/Zend/Filter/File/RenameUpload.php
@@ -10,6 +10,7 @@
 
 namespace Zend\Filter\File;
 
+use Zend\Filter\AbstractFilter;
 use Zend\Filter\Exception;
 use Zend\Stdlib\ErrorHandler;
 
@@ -17,8 +18,113 @@ use Zend\Stdlib\ErrorHandler;
  * @category   Zend
  * @package    Zend_Filter
  */
-class RenameUpload extends Rename
+class RenameUpload extends AbstractFilter
 {
+    /**
+     * @var array
+     */
+    protected $options = array(
+        'target'          => null,
+        'use_upload_name' => true,
+        'overwrite'       => false,
+        'randomize'       => false,
+    );
+
+    /**
+     * Constructor
+     *
+     * @param array|string $targetOrOptions The target file path or an options array
+     */
+    public function __construct($targetOrOptions)
+    {
+        if (is_array($targetOrOptions)) {
+            $this->setOptions($targetOrOptions);
+        } else {
+            $this->setTarget($targetOrOptions);
+        }
+
+
+    }
+
+    /**
+     * @param  string $target Target file path or directory
+     * @return RenameUpload
+     */
+    public function setTarget($target)
+    {
+        if (!is_string($target)) {
+            throw new Exception\InvalidArgumentException(
+                'Invalid target, must be a string'
+            );
+        }
+        $this->options['target'] = $target;
+        return $this;
+    }
+
+    /**
+     * @return string Target file path or directory
+     */
+    public function getTarget()
+    {
+        return $this->options['target'];
+    }
+
+    /**
+     * @param  boolean $flag When true, this filter will use the $_FILES['name']
+     *                       as the target filename.
+     *                       Otherwise, it uses the default 'target' rules.
+     * @return RenameUpload
+     */
+    public function setUseUploadName($flag = true)
+    {
+        $this->options['use_upload_name'] = (boolean) $flag;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getUseUploadName()
+    {
+        return $this->options['use_upload_name'];
+    }
+
+    /**
+     * @param  boolean $flag Shall existing files be overwritten?
+     * @return RenameUpload
+     */
+    public function setOverwrite($flag = true)
+    {
+        $this->options['overwrite'] = (boolean) $flag;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getOverwrite()
+    {
+        return $this->options['overwrite'];
+    }
+
+    /**
+     * @param  boolean $flag Shall target files have a random postfix attached?
+     * @return RenameUpload
+     */
+    public function setRandomize($flag = true)
+    {
+        $this->options['randomize'] = (boolean) $flag;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getRandomize()
+    {
+        return $this->options['randomize'];
+    }
+
     /**
      * Defined by Zend\Filter\Filter
      *
@@ -35,16 +141,24 @@ class RenameUpload extends Rename
         $isFileUpload = (is_array($value) && isset($value['tmp_name']));
         if ($isFileUpload) {
             $uploadData = $value;
-            $value      = $value['tmp_name'];
+            $sourceFile = $value['tmp_name'];
+        } else {
+            $uploadData = array(
+                'tmp_name' => $value,
+                'name' => $value,
+            );
+            $sourceFile = $value;
         }
 
-        $file   = $this->getNewName($value, true);
-        if (is_string($file)) {
-            return $file;
+        $targetFile = $this->getFinalTarget($uploadData);
+        if (!file_exists($sourceFile) || $sourceFile == $targetFile) {
+            return $value;
         }
+
+        $this->checkFileExists($targetFile);
 
         ErrorHandler::start();
-        $result = move_uploaded_file($file['source'], $file['target']);
+        $result = move_uploaded_file($sourceFile, $targetFile);
         $warningException = ErrorHandler::stop();
         if (!$result || null !== $warningException) {
             throw new Exception\RuntimeException(
@@ -54,9 +168,80 @@ class RenameUpload extends Rename
         }
 
         if ($isFileUpload) {
-            $uploadData['tmp_name'] = $file['target'];
+            $uploadData['tmp_name'] = $targetFile;
             return $uploadData;
         }
-        return $file['target'];
+        return $targetFile;
+    }
+
+    /**
+     * @param  string $targetFile Target file path
+     * @throws \Zend\Filter\Exception\InvalidArgumentException
+     */
+    protected function checkFileExists($targetFile)
+    {
+        if (file_exists($targetFile)) {
+            if ($this->getOverwrite()) {
+                unlink($targetFile);
+            } else {
+                throw new Exception\InvalidArgumentException(
+                    sprintf("File '%s' could not be renamed. It already exists.", $targetFile)
+                );
+            }
+        }
+    }
+
+    /**
+     * @param  array $uploadData $_FILES array
+     * @return string
+     */
+    protected function getFinalTarget($uploadData)
+    {
+        $source = $uploadData['tmp_name'];
+        $target = $this->getTarget();
+        if (!isset($target) || $target == '*') {
+            $target = $source;
+        }
+
+        // Get the target directory
+        if (is_dir($target)) {
+            $targetDir = $target;
+            $last      = $target[strlen($target) - 1];
+            if (($last != '/') && ($last != '\\')) {
+                $targetDir .= DIRECTORY_SEPARATOR;
+            }
+        } else {
+            $info      = pathinfo($target);
+            $targetDir = $info['dirname'] . DIRECTORY_SEPARATOR;
+        }
+
+        // Get the target filename
+        if ($this->getUseUploadName()) {
+            $targetFile = basename($uploadData['name']);
+        } elseif (!is_dir($target)) {
+            $targetFile = basename($target);
+        } else {
+            $targetFile = basename($source);
+        }
+
+        if ($this->getRandomize()) {
+            $targetFile = $this->applyRandomToFilename($targetFile);
+        }
+
+        return $targetDir . $targetFile;
+    }
+
+    /**
+     * @param  string $filename
+     * @return string
+     */
+    protected function applyRandomToFilename($filename)
+    {
+        $info = pathinfo($filename);
+        $filename = $info['filename'] . uniqid('_');
+        if (isset($info['extension'])) {
+            $filename .= '.' . $info['extension'];
+        }
+        return $filename;
     }
 }

--- a/tests/ZendTest/Filter/File/RenameUploadTest.php
+++ b/tests/ZendTest/Filter/File/RenameUploadTest.php
@@ -130,16 +130,8 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
     public function testThrowsExceptionWithNonUploadedFile()
     {
         $filter = new FileRenameUpload($this->_newFile);
-
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => '*',
-                'target'    => $this->_newFile,
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
+        $filter->setUseUploadName(false);
+        $this->assertEquals($this->_newFile, $filter->getTarget());
         $this->assertEquals('falsefile', $filter('falsefile'));
         $this->setExpectedException(
             'Zend\Filter\Exception\RuntimeException', 'could not be renamed'
@@ -167,283 +159,104 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test single parameter filter
-     *
      * @return void
      */
-    public function testConstructSingleValue()
+    public function testOptions()
     {
-        $this->setUpMockMoveUploadedFile();
-
         $filter = new FileRenameUpload($this->_newFile);
-
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => '*',
-                'target'    => $this->_newFile,
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
-        $this->assertEquals($this->_newFile, $filter($this->_oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
-    }
-
-    /**
-     * @return void
-     */
-    public function testConstructSingleValueWithFilesArray()
-    {
-        $this->setUpMockMoveUploadedFile();
-
-        $filter = new FileRenameUpload($this->_newFile);
-
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => '*',
-                'target'    => $this->_newFile,
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
-        $this->assertEquals(
-            array('tmp_name' => $this->_newFile),
-            $filter(array('tmp_name' => $this->_oldFile))
-        );
-        $this->assertEquals('falsefile', $filter('falsefile'));
-    }
-
-    /**
-     * Test single array parameter filter
-     *
-     * @return void
-     */
-    public function testConstructSingleArray()
-    {
-        $this->setUpMockMoveUploadedFile();
+        $this->assertEquals($this->_newFile, $filter->getTarget());
+        $this->assertTrue($filter->getUseUploadName());
+        $this->assertFalse($filter->getOverwrite());
+        $this->assertFalse($filter->getRandomize());
 
         $filter = new FileRenameUpload(array(
-            'source' => $this->_oldFile,
-            'target' => $this->_newFile));
-
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => $this->_oldFile,
-                'target'    => $this->_newFile,
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
-        $this->assertEquals($this->_newFile, $filter($this->_oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
-    }
-
-    /**
-     * Test full array parameter filter
-     *
-     * @return void
-     */
-    public function testConstructFullOptionsArray()
-    {
-        $this->setUpMockMoveUploadedFile();
-
-        $filter = new FileRenameUpload(array(
-            'source' => $this->_oldFile,
-            'target' => $this->_newFile,
-            'overwrite' => true,
-            'randomize' => false,
-            'unknown'   => false
+            'target'          => $this->_oldFile,
+            'use_upload_name' => false,
+            'overwrite'       => true,
+            'randomize'       => true,
         ));
+        $this->assertEquals($this->_oldFile, $filter->getTarget());
+        $this->assertFalse($filter->getUseUploadName());
+        $this->assertTrue($filter->getOverwrite());
+        $this->assertTrue($filter->getRandomize());
+    }
 
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => $this->_oldFile,
-                'target'    => $this->_newFile,
-                'overwrite' => true,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
+    /**
+     * @return void
+     */
+    public function testStringConstructorParam()
+    {
+        $this->setUpMockMoveUploadedFile();
+
+        $filter = new FileRenameUpload($this->_newFile);
+        $filter->setUseUploadName(false);
+        $this->assertEquals($this->_newFile, $filter->getTarget());
         $this->assertEquals($this->_newFile, $filter($this->_oldFile));
         $this->assertEquals('falsefile', $filter('falsefile'));
     }
 
     /**
-     * Test single array parameter filter
-     *
      * @return void
      */
-    public function testConstructDoubleArray()
+    public function testStringConstructorWithFilesArray()
+    {
+        $this->setUpMockMoveUploadedFile();
+
+        $filter = new FileRenameUpload($this->_newFile);
+        $this->assertEquals($this->_newFile, $filter->getTarget());
+        $this->assertEquals(
+            array(
+                'tmp_name' => $this->_newFile,
+                'name'     => $this->_newFile,
+            ),
+            $filter(array(
+                'tmp_name' => $this->_oldFile,
+                'name' => $this->_newFile,
+            ))
+        );
+        $this->assertEquals('falsefile', $filter('falsefile'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testArrayConstructorParam()
     {
         $this->setUpMockMoveUploadedFile();
 
         $filter = new FileRenameUpload(array(
-            0 => array(
-                'source' => $this->_oldFile,
-                'target' => $this->_newFile)));
-
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => $this->_oldFile,
-                'target'    => $this->_newFile,
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
+            'target'          => $this->_newFile,
+            'use_upload_name' => false,
+            'overwrite'       => false,
+            'randomize'       => false,
+        ));
+        $this->assertEquals($this->_newFile, $filter->getTarget());
         $this->assertEquals($this->_newFile, $filter($this->_oldFile));
         $this->assertEquals('falsefile', $filter('falsefile'));
     }
 
     /**
-     * Test single array parameter filter
-     *
      * @return void
      */
     public function testConstructTruncatedTarget()
     {
-        $filter = new FileRenameUpload(array(
-            'source' => $this->_oldFile));
-
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => $this->_oldFile,
-                'target'    => '*',
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
+        $filter = new FileRenameUpload('*');
+        $filter->setUseUploadName(false);
+        $this->assertEquals('*', $filter->getTarget());
         $this->assertEquals($this->_oldFile, $filter($this->_oldFile));
         $this->assertEquals('falsefile', $filter('falsefile'));
     }
 
     /**
-     * Test single array parameter filter
-     *
      * @return void
      */
-    public function testConstructTruncatedSource()
-    {
-        $this->setUpMockMoveUploadedFile();
-
-        $filter = new FileRenameUpload(array(
-            'target' => $this->_newFile));
-
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => '*',
-                'target'    => $this->_newFile,
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
-        $this->assertEquals($this->_newFile, $filter($this->_oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
-    }
-
-    /**
-     * Test single parameter filter by using directory only
-     *
-     * @return void
-     */
-    public function testConstructSingleDirectory()
+    public function testTargetDirectory()
     {
         $this->setUpMockMoveUploadedFile();
 
         $filter = new FileRenameUpload($this->_newDir);
-
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => '*',
-                'target'    => $this->_newDir,
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
-        $this->assertEquals($this->_newDirFile, $filter($this->_oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
-    }
-
-    /**
-     * Test single array parameter filter by using directory only
-     *
-     * @return void
-     */
-    public function testConstructSingleArrayDirectory()
-    {
-        $this->setUpMockMoveUploadedFile();
-
-        $filter = new FileRenameUpload(array(
-            'source' => $this->_oldFile,
-            'target' => $this->_newDir));
-
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => $this->_oldFile,
-                'target'    => $this->_newDir,
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
-        $this->assertEquals($this->_newDirFile, $filter($this->_oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
-    }
-
-    /**
-     * Test single array parameter filter by using directory only
-     *
-     * @return void
-     */
-    public function testConstructDoubleArrayDirectory()
-    {
-        $this->setUpMockMoveUploadedFile();
-
-        $filter = new FileRenameUpload(array(
-            0 => array(
-                'source' => $this->_oldFile,
-                'target' => $this->_newDir)));
-
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => $this->_oldFile,
-                'target'    => $this->_newDir,
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
-        $this->assertEquals($this->_newDirFile, $filter($this->_oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
-    }
-
-    /**
-     * Test single array parameter filter by using directory only
-     *
-     * @return void
-     */
-    public function testConstructTruncatedSourceDirectory()
-    {
-        $this->setUpMockMoveUploadedFile();
-
-        $filter = new FileRenameUpload(array(
-            'target' => $this->_newDir));
-
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => '*',
-                'target'    => $this->_newDir,
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
+        $filter->setUseUploadName(false);
+        $this->assertEquals($this->_newDir, $filter->getTarget());
         $this->assertEquals($this->_newDirFile, $filter($this->_oldFile));
         $this->assertEquals('falsefile', $filter('falsefile'));
     }
@@ -451,98 +264,43 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
     /**
      * @return void
      */
-    public function testAddSameFileAgainAndOverwriteExistingTarget()
+    public function testOverwriteWithExistingFile()
     {
         $this->setUpMockMoveUploadedFile();
 
         $filter = new FileRenameUpload(array(
-            'source' => $this->_oldFile,
-            'target' => $this->_newDir));
-
-        $filter->addFile(array(
-            'source' => $this->_oldFile,
-            'target' => $this->_newFile));
-
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => $this->_oldFile,
-                'target'    => $this->_newFile,
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
-        $this->assertEquals($this->_newFile, $filter($this->_oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
-    }
-
-    /**
-     * @return void
-     */
-    public function testGetNewName()
-    {
-        $filter = new FileRenameUpload(array(
-            'source' => $this->_oldFile,
-            'target' => $this->_newDir));
-
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => $this->_oldFile,
-                'target'    => $this->_newDir,
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
-        $this->assertEquals($this->_newDirFile, $filter->getNewName($this->_oldFile));
-    }
-
-    /**
-     * @return void
-     */
-    public function testGetNewNameExceptionWithExistingFile()
-    {
-        $filter = new FileRenameUpload(array(
-            'source' => $this->_oldFile,
-            'target' => $this->_newFile));
+            'target'          => $this->_newFile,
+            'overwrite'       => true,
+            'use_upload_name' => false,
+        ));
 
         copy($this->_oldFile, $this->_newFile);
 
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => $this->_oldFile,
-                'target'    => $this->_newFile,
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
-        $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'could not be renamed');
-        $this->assertEquals($this->_newFile, $filter->getNewName($this->_oldFile));
+        $this->assertEquals($this->_newFile, $filter->getTarget());
+        $this->assertEquals($this->_newFile, $filter->filter($this->_oldFile));
     }
 
     /**
      * @return void
      */
-    public function testGetNewNameOverwriteWithExistingFile()
+    public function testCannotOverwriteExistingFile()
     {
+        $this->setUpMockMoveUploadedFile();
+
         $filter = new FileRenameUpload(array(
-            'source'    => $this->_oldFile,
-            'target'    => $this->_newFile,
-            'overwrite' => true));
+            'target'          => $this->_newFile,
+            'overwrite'       => false,
+            'use_upload_name' => false,
+        ));
 
         copy($this->_oldFile, $this->_newFile);
 
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => $this->_oldFile,
-                'target'    => $this->_newFile,
-                'overwrite' => true,
-                'randomize' => false,
-            )),
-            $filter->getFile()
+        $this->assertEquals($this->_newFile, $filter->getTarget());
+        $this->assertFalse($filter->getOverwrite());
+        $this->setExpectedException(
+            'Zend\Filter\Exception\InvalidArgumentException', 'already exists'
         );
-        $this->assertEquals($this->_newFile, $filter->getNewName($this->_oldFile));
+        $this->assertEquals($this->_newFile, $filter->filter($this->_oldFile));
     }
 
     /**
@@ -550,21 +308,16 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetRandomizedFile()
     {
+        $this->setUpMockMoveUploadedFile();
+
         $filter = new FileRenameUpload(array(
-            'source'    => $this->_oldFile,
-            'target'    => $this->_newFile,
-            'randomize' => true
+            'target'          => $this->_newFile,
+            'randomize'       => true,
+            'use_upload_name' => false,
         ));
 
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => $this->_oldFile,
-                'target'    => $this->_newFile,
-                'overwrite' => false,
-                'randomize' => true,
-            )),
-            $filter->getFile()
-        );
+        $this->assertEquals($this->_newFile, $filter->getTarget());
+        $this->assertTrue($filter->getRandomize());
         $fileNoExt = $this->_filesPath . 'newfile';
         $this->assertRegExp('#' . $fileNoExt . '_.{13}\.xml#', $filter->getNewName($this->_oldFile));
     }
@@ -574,56 +327,18 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetRandomizedFileWithoutExtension()
     {
-        $fileNoExt = $this->_filesPath . 'newfile';
-        $filter = new FileRenameUpload(array(
-            'source'    => $this->_oldFile,
-            'target'    => $fileNoExt,
-            'randomize' => true
-        ));
-
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => $this->_oldFile,
-                'target'    => $fileNoExt,
-                'overwrite' => false,
-                'randomize' => true,
-            )),
-            $filter->getFile()
-        );
-        $this->assertRegExp('#' . $fileNoExt . '_.{13}#', $filter->getNewName($this->_oldFile));
-    }
-
-    /**
-     * @return void
-     */
-    public function testAddFileWithString()
-    {
         $this->setUpMockMoveUploadedFile();
 
-        $filter = new FileRenameUpload($this->_oldFile);
-        $filter->addFile($this->_newFile);
+        $fileNoExt = $this->_filesPath . 'newfile';
+        $filter = new FileRenameUpload(array(
+            'target'          => $fileNoExt,
+            'randomize'       => true,
+            'use_upload_name' => false,
+        ));
 
-        $this->assertEquals(
-            array(0 => array(
-                'source'    => '*',
-                'target'    => $this->_newFile,
-                'overwrite' => false,
-                'randomize' => false,
-            )),
-            $filter->getFile()
-        );
-        $this->assertEquals($this->_newFile, $filter($this->_oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
-    }
-
-    /**
-     * @return void
-     */
-    public function testAddFileWithInvalidOption()
-    {
-        $filter = new FileRenameUpload($this->_oldFile);
-        $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'Invalid options');
-        $filter->addFile(1234);
+        $this->assertEquals($fileNoExt, $filter->getTarget());
+        $this->assertTrue($filter->getRandomize());
+        $this->assertRegExp('#' . $fileNoExt . '_.{13}#', $filter->getNewName($this->_oldFile));
     }
 
     /**
@@ -631,7 +346,7 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidConstruction()
     {
-        $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'Invalid options');
+        $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'Invalid target');
         $filter = new FileRenameUpload(1234);
     }
 }

--- a/tests/ZendTest/Filter/File/RenameUploadTest.php
+++ b/tests/ZendTest/Filter/File/RenameUploadTest.php
@@ -130,7 +130,6 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
     public function testThrowsExceptionWithNonUploadedFile()
     {
         $filter = new FileRenameUpload($this->_newFile);
-        $filter->setUseUploadName(false);
         $this->assertEquals($this->_newFile, $filter->getTarget());
         $this->assertEquals('falsefile', $filter('falsefile'));
         $this->setExpectedException(
@@ -165,18 +164,18 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FileRenameUpload($this->_newFile);
         $this->assertEquals($this->_newFile, $filter->getTarget());
-        $this->assertTrue($filter->getUseUploadName());
+        $this->assertFalse($filter->getUseUploadName());
         $this->assertFalse($filter->getOverwrite());
         $this->assertFalse($filter->getRandomize());
 
         $filter = new FileRenameUpload(array(
             'target'          => $this->_oldFile,
-            'use_upload_name' => false,
+            'use_upload_name' => true,
             'overwrite'       => true,
             'randomize'       => true,
         ));
         $this->assertEquals($this->_oldFile, $filter->getTarget());
-        $this->assertFalse($filter->getUseUploadName());
+        $this->assertTrue($filter->getUseUploadName());
         $this->assertTrue($filter->getOverwrite());
         $this->assertTrue($filter->getRandomize());
     }
@@ -189,7 +188,6 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
         $this->setUpMockMoveUploadedFile();
 
         $filter = new FileRenameUpload($this->_newFile);
-        $filter->setUseUploadName(false);
         $this->assertEquals($this->_newFile, $filter->getTarget());
         $this->assertEquals($this->_newFile, $filter($this->_oldFile));
         $this->assertEquals('falsefile', $filter('falsefile'));
@@ -225,10 +223,7 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
         $this->setUpMockMoveUploadedFile();
 
         $filter = new FileRenameUpload(array(
-            'target'          => $this->_newFile,
-            'use_upload_name' => false,
-            'overwrite'       => false,
-            'randomize'       => false,
+            'target' => $this->_newFile,
         ));
         $this->assertEquals($this->_newFile, $filter->getTarget());
         $this->assertEquals($this->_newFile, $filter($this->_oldFile));
@@ -241,7 +236,6 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
     public function testConstructTruncatedTarget()
     {
         $filter = new FileRenameUpload('*');
-        $filter->setUseUploadName(false);
         $this->assertEquals('*', $filter->getTarget());
         $this->assertEquals($this->_oldFile, $filter($this->_oldFile));
         $this->assertEquals('falsefile', $filter('falsefile'));
@@ -255,7 +249,6 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
         $this->setUpMockMoveUploadedFile();
 
         $filter = new FileRenameUpload($this->_newDir);
-        $filter->setUseUploadName(false);
         $this->assertEquals($this->_newDir, $filter->getTarget());
         $this->assertEquals($this->_newDirFile, $filter($this->_oldFile));
         $this->assertEquals('falsefile', $filter('falsefile'));
@@ -271,7 +264,6 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
         $filter = new FileRenameUpload(array(
             'target'          => $this->_newFile,
             'overwrite'       => true,
-            'use_upload_name' => false,
         ));
 
         copy($this->_oldFile, $this->_newFile);
@@ -290,7 +282,6 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
         $filter = new FileRenameUpload(array(
             'target'          => $this->_newFile,
             'overwrite'       => false,
-            'use_upload_name' => false,
         ));
 
         copy($this->_oldFile, $this->_newFile);
@@ -313,7 +304,6 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
         $filter = new FileRenameUpload(array(
             'target'          => $this->_newFile,
             'randomize'       => true,
-            'use_upload_name' => false,
         ));
 
         $this->assertEquals($this->_newFile, $filter->getTarget());
@@ -333,7 +323,6 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
         $filter = new FileRenameUpload(array(
             'target'          => $fileNoExt,
             'randomize'       => true,
-            'use_upload_name' => false,
         ));
 
         $this->assertEquals($fileNoExt, $filter->getTarget());


### PR DESCRIPTION
Rewrite of the `Zend\Filter\File\RenameUpload` filter to be easier to use, and with an additional feature to use the `$_FILES['name']` as the target filename.

Also, some misc docs cleanup and a cornercase fix of `Zend\Filter\File\Rename` (from my earlier $_FILES-support-in-filters changes).

RenameUpload usage example:

``` php
use Zend\Http\PhpEnvironment\Request;

$request = new Request();
$files   = $request->getFiles();
// i.e. $files['my-upload']['name'] === 'myfile.txt'

$filter = \Zend\Filter\File\RenameUpload("./data/uploads/");
$filter->setUseUploadName(true); // Use the original upload filename
echo $filter->filter($files['my-upload']);
// File has been moved to "./data/uploads/myfile.txt"
```

Docs: https://raw.github.com/cgmartin/zf2-documentation/f32980cd35bdea21b6560d5dee4d878af002313f/docs/languages/en/modules/zend.filter.file.rename-upload.rst
