### PR TITLE
Fix sendmail key

### DIFF
--- a/library/Zend/Mail/Transport/Sendmail.php
+++ b/library/Zend/Mail/Transport/Sendmail.php
@@ -244,7 +244,7 @@ class Sendmail implements TransportInterface
 
         $sender = $message->getSender();
         if ($sender instanceof AddressInterface) {
-            $parameters .= ' -r ' . $sender->getEmail();
+            $parameters .= ' -f ' . $sender->getEmail();
             return $parameters;
         }
 


### PR DESCRIPTION
change key for additional_parameters argument

fix: 
sendmail error
sendmail: illegal option -- r
sendmail: usage: sendmail [ -t ] [ -fsender ] [ -Fname ] [ -bp ] [ -bs ] [ arg ... ]
