### PR TITLE
 Allows several translation files for same domain / locale 

### DIFF
--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -87,7 +87,7 @@ class Translator
     /**
      * Instantiate a translator
      *
-     * @param  array|Traversable $options
+     * @param  array|Traversable                  $options
      * @return Translator
      * @throws Exception\InvalidArgumentException
      */
@@ -208,12 +208,13 @@ class Translator
     /**
      * Set the default locale.
      *
-     * @param  string $locale
+     * @param  string     $locale
      * @return Translator
      */
     public function setLocale($locale)
     {
         $this->locale = $locale;
+
         return $this;
     }
 
@@ -234,12 +235,13 @@ class Translator
     /**
      * Set the fallback locale.
      *
-     * @param  string $locale
+     * @param  string     $locale
      * @return Translator
      */
     public function setFallbackLocale($locale)
     {
         $this->fallbackLocale = $locale;
+
         return $this;
     }
 
@@ -262,6 +264,7 @@ class Translator
     public function setCache(CacheStorage $cache = null)
     {
         $this->cache = $cache;
+
         return $this;
     }
 
@@ -284,6 +287,7 @@ class Translator
     public function setPluginManager(LoaderPluginManager $pluginManager)
     {
         $this->pluginManager = $pluginManager;
+
         return $this;
     }
 
@@ -332,11 +336,11 @@ class Translator
     /**
      * Translate a plural message.
      *
-     * @param  string      $singular
-     * @param  string      $plural
-     * @param  int         $number
-     * @param  string      $textDomain
-     * @param  string|null $locale
+     * @param  string                         $singular
+     * @param  string                         $plural
+     * @param  int                            $number
+     * @param  string                         $textDomain
+     * @param  string|null                    $locale
      * @return string
      * @throws Exception\OutOfBoundsException
      */
@@ -382,9 +386,9 @@ class Translator
     /**
      * Get a translated message.
      *
-     * @param  string $message
-     * @param  string $locale
-     * @param  string $textDomain
+     * @param  string      $message
+     * @param  string      $locale
+     * @param  string      $textDomain
      * @return string|null
      */
     protected function getTranslatedMessage(
@@ -410,10 +414,10 @@ class Translator
     /**
      * Add a translation file.
      *
-     * @param  string $type
-     * @param  string $filename
-     * @param  string $textDomain
-     * @param  string $locale
+     * @param  string     $type
+     * @param  string     $filename
+     * @param  string     $textDomain
+     * @param  string     $locale
      * @return Translator
      */
     public function addTranslationFile(
@@ -429,19 +433,20 @@ class Translator
         }
 
         $this->files[$textDomain][$locale][] = array(
-			'type' => $type,
-			'filename' => $filename,
-		);
+            'type' => $type,
+            'filename' => $filename,
+        );
+
         return $this;
     }
 
     /**
      * Add multiple translations with a file pattern.
      *
-     * @param  string $type
-     * @param  string $baseDir
-     * @param  string $pattern
-     * @param  string $textDomain
+     * @param  string     $type
+     * @param  string     $baseDir
+     * @param  string     $pattern
+     * @param  string     $textDomain
      * @return Translator
      */
     public function addTranslationFilePattern(
@@ -466,8 +471,8 @@ class Translator
     /**
      * Add remote translations.
      *
-     * @param  string $type
-     * @param  string $textDomain
+     * @param  string     $type
+     * @param  string     $textDomain
      * @return Translator
      */
     public function addRemoteTranslations($type, $textDomain = 'default')
@@ -484,8 +489,8 @@ class Translator
     /**
      * Load messages for a given language and domain.
      *
-     * @param  string $textDomain
-     * @param  string $locale
+     * @param  string                     $textDomain
+     * @param  string                     $locale
      * @throws Exception\RuntimeException
      * @return void
      */
@@ -500,10 +505,11 @@ class Translator
 
             if (null !== ($result = $cache->getItem($cacheId))) {
                 $this->messages[$textDomain][$locale] = $result;
+
                 return;
             }
         }
-        
+
         $hasToCache = false;
 
         // Try to load from remote sources
@@ -516,12 +522,12 @@ class Translator
                 }
 
                 if (isset($this->messages[$textDomain][$locale])) {
-                	$this->messages[$textDomain][$locale]->exchangeArray(array_merge(
-	                	(array)$this->messages[$textDomain][$locale],
-	                	(array)$loader->load($locale, $textDomain)
-	                ));
+                    $this->messages[$textDomain][$locale]->exchangeArray(array_merge(
+                        (array) $this->messages[$textDomain][$locale],
+                        (array) $loader->load($locale, $textDomain)
+                    ));
                 } else {
-                	$this->messages[$textDomain][$locale] = $loader->load($locale, $textDomain);
+                    $this->messages[$textDomain][$locale] = $loader->load($locale, $textDomain);
                 }
                 $hasToCache = true;
             }
@@ -540,12 +546,12 @@ class Translator
                     }
 
                     if (isset($this->messages[$textDomain][$locale])) {
-                    	$this->messages[$textDomain][$locale]->exchangeArray(array_merge(
-	                    	(array)$this->messages[$textDomain][$locale],
-	                    	(array)$loader->load($locale, $filename)
-	                    ));
+                        $this->messages[$textDomain][$locale]->exchangeArray(array_merge(
+                            (array) $this->messages[$textDomain][$locale],
+                            (array) $loader->load($locale, $filename)
+                        ));
                     } else {
-                    	$this->messages[$textDomain][$locale] = $loader->load($locale, $filename);
+                        $this->messages[$textDomain][$locale] = $loader->load($locale, $filename);
                     }
                     $hasToCache = true;
                 }
@@ -557,23 +563,22 @@ class Translator
             if (!isset($this->files[$textDomain][$currentLocale])) {
                 continue;
             }
-            foreach($this->files[$textDomain][$currentLocale] as $file){
-	            $loader = $this->getPluginManager()->get($file['type']);
-	
-	            if (!$loader instanceof FileLoaderInterface) {
-	                throw new Exception\RuntimeException('Specified loader is not a file loader');
-	            }
-	
-	            if (isset($this->messages[$textDomain][$locale])) {
-	            	$this->messages[$textDomain][$locale]->exchangeArray(array_merge(
-		            	(array)$this->messages[$textDomain][$locale],
-		            	(array)$loader->load($locale, $file['filename'])
-		            ));
-	            }
-	            else {
-	            	$this->messages[$textDomain][$locale] = $loader->load($locale, $file['filename']);
-	            }
-            	$hasToCache = true;
+            foreach ($this->files[$textDomain][$currentLocale] as $file) {
+                $loader = $this->getPluginManager()->get($file['type']);
+
+                if (!$loader instanceof FileLoaderInterface) {
+                    throw new Exception\RuntimeException('Specified loader is not a file loader');
+                }
+
+                if (isset($this->messages[$textDomain][$locale])) {
+                    $this->messages[$textDomain][$locale]->exchangeArray(array_merge(
+                        (array) $this->messages[$textDomain][$locale],
+                        (array) $loader->load($locale, $file['filename'])
+                    ));
+                } else {
+                    $this->messages[$textDomain][$locale] = $loader->load($locale, $file['filename']);
+                }
+                $hasToCache = true;
             }
             unset($this->files[$textDomain][$currentLocale]);
         }

--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -515,11 +515,14 @@ class Translator
                     throw new Exception\RuntimeException('Specified loader is not a remote loader');
                 }
 
-                if(isset($this->messages[$textDomain][$locale]))$this->messages[$textDomain][$locale]->exchangeArray(array_merge(
-                	(array)$this->messages[$textDomain][$locale],
-                	(array)$loader->load($locale, $textDomain)
-                ));
-                else $this->messages[$textDomain][$locale] = $loader->load($locale, $textDomain);
+                if (isset($this->messages[$textDomain][$locale])) {
+                	$this->messages[$textDomain][$locale]->exchangeArray(array_merge(
+	                	(array)$this->messages[$textDomain][$locale],
+	                	(array)$loader->load($locale, $textDomain)
+	                ));
+                } else {
+                	$this->messages[$textDomain][$locale] = $loader->load($locale, $textDomain);
+                }
                 $hasToCache = true;
             }
         }
@@ -536,11 +539,14 @@ class Translator
                         throw new Exception\RuntimeException('Specified loader is not a file loader');
                     }
 
-                    if(isset($this->messages[$textDomain][$locale]))$this->messages[$textDomain][$locale]->exchangeArray(array_merge(
-                    	(array)$this->messages[$textDomain][$locale],
-                    	(array)$loader->load($locale, $filename)
-                    ));
-                    else $this->messages[$textDomain][$locale] = $loader->load($locale, $filename);
+                    if (isset($this->messages[$textDomain][$locale])) {
+                    	$this->messages[$textDomain][$locale]->exchangeArray(array_merge(
+	                    	(array)$this->messages[$textDomain][$locale],
+	                    	(array)$loader->load($locale, $filename)
+	                    ));
+                    } else {
+                    	$this->messages[$textDomain][$locale] = $loader->load($locale, $filename);
+                    }
                     $hasToCache = true;
                 }
             }
@@ -558,11 +564,15 @@ class Translator
 	                throw new Exception\RuntimeException('Specified loader is not a file loader');
 	            }
 	
-	            if(isset($this->messages[$textDomain][$locale]))$this->messages[$textDomain][$locale]->exchangeArray(array_merge(
-	            	(array)$this->messages[$textDomain][$locale],
-	            	(array)$loader->load($locale, $file['filename'])
-	            ));
-	            else $this->messages[$textDomain][$locale] = $loader->load($locale, $file['filename']);
+	            if (isset($this->messages[$textDomain][$locale])) {
+	            	$this->messages[$textDomain][$locale]->exchangeArray(array_merge(
+		            	(array)$this->messages[$textDomain][$locale],
+		            	(array)$loader->load($locale, $file['filename'])
+		            ));
+	            }
+	            else {
+	            	$this->messages[$textDomain][$locale] = $loader->load($locale, $file['filename']);
+	            }
             	$hasToCache = true;
             }
             unset($this->files[$textDomain][$currentLocale]);

--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -559,8 +559,8 @@ class Translator
 	            }
 	
 	            if(isset($this->messages[$textDomain][$locale]))$this->messages[$textDomain][$locale]->exchangeArray(array_merge(
-	            		(array)$this->messages[$textDomain][$locale],
-	            		(array)$loader->load($locale, $file['filename'])
+	            	(array)$this->messages[$textDomain][$locale],
+	            	(array)$loader->load($locale, $file['filename'])
 	            ));
 	            else $this->messages[$textDomain][$locale] = $loader->load($locale, $file['filename']);
             	$hasToCache = true;

--- a/tests/ZendTest/I18n/Translator/TranslatorTest.php
+++ b/tests/ZendTest/I18n/Translator/TranslatorTest.php
@@ -71,6 +71,32 @@ class TranslatorTest extends TestCase
         $this->assertEquals('de_DE', $translator->getLocale());
     }
 
+    public function testTranslationFromSeveralTranslationFiles()
+    {
+        $translator = Translator::factory(array(
+            'locale' => 'de_DE',
+            'translation_file_patterns' => array(
+                array(
+                    'type' => 'phparray',
+                    'base_dir' => $this->testFilesDir . '/testarray',
+                    'pattern' => 'translation-%s.php'
+                ),
+                array(
+                    'type' => 'phparray',
+                    'base_dir' => $this->testFilesDir . '/testarray',
+                    'pattern' => 'translation-more-%s.php'
+                )
+            )
+        ));
+
+        //Test translator instance
+        $this->assertInstanceOf('Zend\I18n\Translator\Translator', $translator);
+
+        //Test translations
+        $this->assertEquals('Nachricht 1', $translator->translate('Message 1')); //translation-de_DE.php
+        $this->assertEquals('Nachricht 9', $translator->translate('Message 9')); //translation-more-de_DE.php
+    }
+
     public function testFactoryCreatesTranslatorWithCache()
     {
         $translator = Translator::factory(array(

--- a/tests/ZendTest/I18n/Translator/_files/testarray/translation-more-de_DE.php
+++ b/tests/ZendTest/I18n/Translator/_files/testarray/translation-more-de_DE.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_I18n
+ */
+
+return array(
+    'Message 2' => 'Nachricht 2',
+    'Message 9' => 'Nachricht 9'
+);

--- a/tests/ZendTest/I18n/Translator/_files/testarray/translation-more-en_US.php
+++ b/tests/ZendTest/I18n/Translator/_files/testarray/translation-more-en_US.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_I18n
+ */
+
+return array(
+    'Message 5' => 'Message 5 (en)',
+    'Message 6' => 'Message 6 (en)',
+    'Message 7' => 'Message 7 (en)',
+    'Message 8' => 'Message 8 (en)',
+);


### PR DESCRIPTION
For exemple : 

Translator config 

``` php
//Add Zend translations files for validator (Zend_Validate & Zend_Captcha)
'translation_files' => array(           
    array(
        'type' => 'phparray',
        'filename' =>  getcwd().'/vendor/zendframework/zendframework/resources/languages/en/Zend_Validate.php',
        'locale'  => 'en_US',
        'text_domain' => 'validator'
    ),          
    array(
        'type' => 'phparray',
        'filename' =>  getcwd().'/vendor/zendframework/zendframework/resources/languages/en/Zend_Captcha.php',
        'locale'  => 'en_US',
        'text_domain' => 'validator'
    )
)
```
