### PR TITLE
Fixing the problem with Limit/Offset in SqlServerDecorator

### DIFF
--- a/library/Zend/Db/Sql/Platform/SqlServer/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/SqlServer/SelectDecorator.php
@@ -121,7 +121,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
             $orderBy = $sqls[self::ORDER];
             unset($sqls[self::ORDER]);
         } else {
-            $orderBy = 'SELECT 1';
+            $orderBy = 'ORDER BY (SELECT 1)';
         }
 
         // add a column for row_number() using the order specification

--- a/tests/ZendTest/Db/Sql/Platform/SqlServer/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/SqlServer/SelectDecoratorTest.php
@@ -76,9 +76,9 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
 
         $select1 = new Select;
         $select1->from('foo')->columns(array('bar', 'bam' => 'baz'))->limit(5)->offset(10);
-        $expectedPrepareSql1 = 'SELECT [bar], [bam] FROM ( SELECT [foo].[bar] AS [bar], [foo].[baz] AS [bam], ROW_NUMBER() OVER (SELECT 1) AS [__ZEND_ROW_NUMBER] FROM [foo] ) AS [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION] WHERE [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION].[__ZEND_ROW_NUMBER] BETWEEN ?+1 AND ?+?';
+        $expectedPrepareSql1 = 'SELECT [bar], [bam] FROM ( SELECT [foo].[bar] AS [bar], [foo].[baz] AS [bam], ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS [__ZEND_ROW_NUMBER] FROM [foo] ) AS [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION] WHERE [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION].[__ZEND_ROW_NUMBER] BETWEEN ?+1 AND ?+?';
         $expectedParams1 = array('offset' => 10, 'limit' => 5, 'offsetForSum' => 10);
-        $expectedSql1 = 'SELECT [bar], [bam] FROM ( SELECT [foo].[bar] AS [bar], [foo].[baz] AS [bam], ROW_NUMBER() OVER (SELECT 1) AS [__ZEND_ROW_NUMBER] FROM [foo] ) AS [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION] WHERE [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION].[__ZEND_ROW_NUMBER] BETWEEN 10+1 AND 5+10';
+        $expectedSql1 = 'SELECT [bar], [bam] FROM ( SELECT [foo].[bar] AS [bar], [foo].[baz] AS [bam], ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS [__ZEND_ROW_NUMBER] FROM [foo] ) AS [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION] WHERE [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION].[__ZEND_ROW_NUMBER] BETWEEN 10+1 AND 5+10';
 
         $select2 = new Select;
         $select2->from('foo')->order('bar')->limit(5)->offset(10);


### PR DESCRIPTION
Fixing the problem with Limit/Offset in SqlServerDecorator when OrderBy is not defined

Issue - https://github.com/zendframework/zf2/issues/3198
