### PR TITLE
	modified:   library/Zend/Mvc/Router/Http/Wildcard.php

### DIFF
--- a/library/Zend/Mvc/Router/Http/Wildcard.php
+++ b/library/Zend/Mvc/Router/Http/Wildcard.php
@@ -125,7 +125,7 @@ class Wildcard implements RouteInterface
         $matches = array();
         $params  = explode($this->paramDelimiter, $path);
 
-        if (count($params) > 1 && ($params[0] !== '' || end($params) === '')) {
+        if (count($params) > 1 && $params[0] !== '') {
             return null;
         }
 

--- a/tests/ZendTest/Mvc/Router/Http/WildcardTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/WildcardTest.php
@@ -39,12 +39,6 @@ class WildcardTest extends TestCase
                 5,
                 null
             ),
-            'no-match-with-trailing-slash' => array(
-                new Wildcard(),
-                '/foo/bar/baz/bat/',
-                null,
-                null
-            ),
             'match-overrides-default' => array(
                 new Wildcard('/', '/', array('foo' => 'baz')),
                 '/foo/bat',


### PR DESCRIPTION
end($params) === '' condition deny urls with empty last value, e.g.
/key/value/key2/
but allow empty values in the middle
/key/value/key2//key3/value3...  
maybe there some reason for that but don't get atm
