### PR TITLE
A fix for issue #3195. Date formats are now used during validation.

### DIFF
--- a/library/Zend/Form/Element/Date.php
+++ b/library/Zend/Form/Element/Date.php
@@ -40,16 +40,6 @@ class Date extends DateTimeElement
     protected $format = 'Y-m-d';
 
     /**
-     * Retrieves a Date Validator configured for a DateTime Input type
-     *
-     * @return \Zend\Validator\ValidatorInterface
-     */
-    protected function getDateValidator()
-    {
-        return new DateValidator(array('format' => 'Y-m-d'));
-    }
-
-    /**
      * Retrieves a DateStep Validator configured for a Date Input type
      *
      * @return \Zend\Validator\ValidatorInterface
@@ -60,10 +50,10 @@ class Date extends DateTimeElement
                      ? $this->attributes['step'] : 1; // Days
 
         $baseValue = (isset($this->attributes['min']))
-                     ? $this->attributes['min'] : '1970-01-01';
+                     ? $this->attributes['min'] : date($this->format, 0);
 
         return new DateStepValidator(array(
-            'format'    => 'Y-m-d',
+            'format'    => $this->format,
             'baseValue' => $baseValue,
             'step'      => new \DateInterval("P{$stepValue}D"),
         ));

--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -153,7 +153,7 @@ class DateTime extends Element implements InputProviderInterface
                    ? $this->attributes['step'] : 1; // Minutes
 
         $baseValue = (isset($this->attributes['min']))
-                   ? $this->attributes['min'] : '1970-01-01T00:00Z';
+                   ? $this->attributes['min'] : date($this->format, 0);
 
         return new DateStepValidator(array(
             'format'    => $this->format,

--- a/library/Zend/Form/Element/Time.php
+++ b/library/Zend/Form/Element/Time.php
@@ -28,11 +28,11 @@ class Time extends DateTime
         'type' => 'time',
     );
 
-	/**
-	 * The format for this element.
-	 *
-	 * @var string
-	 */
+    /**
+     * The format for this element.
+     *
+     * @var string
+     */
     protected $format = 'H:i:s';
 
     /**

--- a/library/Zend/Form/Element/Time.php
+++ b/library/Zend/Form/Element/Time.php
@@ -10,8 +10,6 @@
 
 namespace Zend\Form\Element;
 
-use Zend\Form\Element;
-use Zend\Validator\Date as DateValidator;
 use Zend\Validator\DateStep as DateStepValidator;
 
 /**
@@ -30,15 +28,12 @@ class Time extends DateTime
         'type' => 'time',
     );
 
-    /**
-     * Retrieves a Date Validator configured for a DateTime Input type
-     *
-     * @return \Zend\Validator\ValidatorInterface
-     */
-    protected function getDateValidator()
-    {
-        return new DateValidator(array('format' => 'H:i:s'));
-    }
+	/**
+	 * The format for this element.
+	 *
+	 * @var string
+	 */
+    protected $format = 'H:i:s';
 
     /**
      * Retrieves a DateStepValidator configured for a Date Input type
@@ -51,10 +46,10 @@ class Time extends DateTime
                      ? $this->attributes['step'] : 60; // Seconds
 
         $baseValue = (isset($this->attributes['min']))
-                     ? $this->attributes['min'] : '00:00:00';
+                     ? $this->attributes['min'] : date($this->format, 0);
 
         return new DateStepValidator(array(
-            'format'    => 'H:i:s',
+            'format'    => $this->format,
             'baseValue' => $baseValue,
             'step'      => new \DateInterval("PT{$stepValue}S"),
         ));


### PR DESCRIPTION
The formats of the date elements were not used during validation, now they are.
