### PR TITLE
Fixed namespaced call to openssl function

### DIFF
--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -283,7 +283,7 @@ class Socket implements HttpAdapter, StreamInterface
                 if (!$test || $error) {
                     // Error handling is kind of difficult when it comes to SSL
                     $errorString = '';
-                    while (($sslError = openssl_error_string()) != false) {
+                    while (($sslError = \openssl_error_string()) != false) {
                         $errorString .= "; SSL error: $sslError";
                     }
                     $this->close();


### PR DESCRIPTION
This fixes an error triggered by a call to the openssl_error_string() function that is searched inside the Zend\Http\Client\Adapter namespace.
