### PR TITLE
Parse docblock indented with tabs

### DIFF
--- a/library/Zend/Code/Reflection/DocBlockReflection.php
+++ b/library/Zend/Code/Reflection/DocBlockReflection.php
@@ -245,11 +245,11 @@ class DocBlockReflection implements ReflectionInterface
         $docComment = $this->docComment; // localize variable
 
         // create a clean docComment
-        $this->cleanDocComment = preg_replace("#[ \t]*(?:\/\*\*|\*\/|\*)?[ ]{0,1}(.*)?#", '$1', $docComment);
+        $this->cleanDocComment = preg_replace("#[ \t]*(?:/\*\*|\*/|\*)[ ]{0,1}(.*)?#", '$1', $docComment);
         $this->cleanDocComment = ltrim($this->cleanDocComment,
                                        "\r\n"); // @todo should be changed to remove first and last empty line
 
-        $scanner                = new DocBlockScanner($this->cleanDocComment);
+        $scanner                = new DocBlockScanner($docComment);
         $this->shortDescription = ltrim($scanner->getShortDescription());
         $this->longDescription  = ltrim($scanner->getLongDescription());
         foreach ($scanner->getTags() as $tag) {

--- a/library/Zend/Code/Reflection/DocBlockReflection.php
+++ b/library/Zend/Code/Reflection/DocBlockReflection.php
@@ -245,11 +245,11 @@ class DocBlockReflection implements ReflectionInterface
         $docComment = $this->docComment; // localize variable
 
         // create a clean docComment
-        $this->cleanDocComment = preg_replace('#[ \t]*(?:\/\*\*|\*\/|\*)?[ ]{0,1}(.*)?#', '$1', $docComment);
+        $this->cleanDocComment = preg_replace("#[ \t]*(?:\/\*\*|\*\/|\*)?[ ]{0,1}(.*)?#", '$1', $docComment);
         $this->cleanDocComment = ltrim($this->cleanDocComment,
                                        "\r\n"); // @todo should be changed to remove first and last empty line
 
-        $scanner                = new DocBlockScanner($docComment);
+        $scanner                = new DocBlockScanner($this->cleanDocComment);
         $this->shortDescription = ltrim($scanner->getShortDescription());
         $this->longDescription  = ltrim($scanner->getLongDescription());
         foreach ($scanner->getTags() as $tag) {

--- a/library/Zend/Code/Scanner/DocBlockScanner.php
+++ b/library/Zend/Code/Scanner/DocBlockScanner.php
@@ -269,7 +269,7 @@ class DocBlockScanner implements ScannerInterface
             goto TOKENIZER_TOP;
         }
 
-        if ($currentChar === ' ') {
+        if ($currentChar === ' ' or $currentChar === "\t") {
             $MACRO_TOKEN_SET_TYPE(($context & $CONTEXT_INSIDE_ASTERISK) ? 'DOCBLOCK_WHITESPACE' : 'DOCBLOCK_WHITESPACE_INDENT');
             $MACRO_TOKEN_APPEND_WORD();
             $MACRO_TOKEN_ADVANCE();

--- a/library/Zend/Code/Scanner/DocBlockScanner.php
+++ b/library/Zend/Code/Scanner/DocBlockScanner.php
@@ -269,7 +269,7 @@ class DocBlockScanner implements ScannerInterface
             goto TOKENIZER_TOP;
         }
 
-        if ($currentChar === ' ' or $currentChar === "\t") {
+        if ($currentChar === ' ' || $currentChar === "\t") {
             $MACRO_TOKEN_SET_TYPE(($context & $CONTEXT_INSIDE_ASTERISK) ? 'DOCBLOCK_WHITESPACE' : 'DOCBLOCK_WHITESPACE_INDENT');
             $MACRO_TOKEN_APPEND_WORD();
             $MACRO_TOKEN_ADVANCE();

--- a/tests/ZendTest/Code/Reflection/DocBlockReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/DocBlockReflectionTest.php
@@ -65,6 +65,30 @@ class DocBlockReflectionTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function testTabbedDocBlockTags()
+    {
+        $classReflection = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass10');
+
+        $this->assertEquals(3, count($classReflection->getDocBlock()->getTags()));
+        $this->assertEquals(1, count($classReflection->getDocBlock()->getTags('author')));
+        $this->assertEquals(1, count($classReflection->getDocBlock()->getTags('property')));
+        $this->assertEquals(1, count($classReflection->getDocBlock()->getTags('method')));
+
+        $methodTag = $classReflection->getDocBlock()->getTag('method');
+        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\MethodTag', $methodTag);
+
+        $propertyTag = $classReflection->getDocBlock()->getTag('property');
+        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\PropertyTag', $propertyTag);
+
+        $this->assertFalse($classReflection->getDocBlock()->getTag('version'));
+
+        $this->assertTrue($classReflection->getMethod('doSomething')->getDocBlock()->hasTag('return'));
+
+        $returnTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('return');
+        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\TagInterface', $returnTag);
+        $this->assertEquals('mixed', $returnTag->getType());
+    }
+
     public function testDocBlockLines()
     {
         //$this->markTestIncomplete('Line numbers incomplete');

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass10.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass10.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace ZendTest\Code\Reflection\TestAsset;
+
+/**
+ * TestSampleClass10 DocBlock Short Desc
+ *
+ * This is a long description for
+ * the docblock of this class, it
+ * should be longer than 3 lines.
+ * It indeed is longer than 3 lines
+ * now.
+ *
+ * @author Ralph Schindler <ralph.schindler@zend.com>
+ * @method test()
+ * @property $test
+ */
+class TestSampleClass10
+{
+
+	/**
+	 * Method ShortDescription
+	 *
+	 * Method LongDescription
+	 * This is a long description for
+	 * the docblock of this class, it
+	 * should be longer than 3 lines.
+	 * It indeed is longer than 3 lines
+	 * now.
+	 *
+	 * @param int $one Description for one
+	 * @param int Description for two
+	 * @param string $three Description for three
+	 *                      which spans multiple lines
+	 * @return mixed Some return descr
+	 */
+	public function doSomething($one, $two = 2, $three = 'three')
+	{
+		return 'mixedValue';
+	}
+
+	/**
+	 * Method ShortDescription
+	 *
+	 * @param int $one Description for one
+	 * @param int Description for two
+	 * @param string $three Description for three
+	 *                      which spans multiple lines
+	 * @return int
+	 */
+	public function doSomethingElse($one, $two = 2, $three = 'three')
+	{
+		return 'mixedValue';
+	}
+
+}


### PR DESCRIPTION
This fixes the regular expression used to clean-up the docComments.
The tab escape (\t) was not parsed correctly because it was specified inside a single quoted string.

Additionally the DocBlockScanner did not catch tabs as whitespace tokens.

This fixes #2445
