### PR TITLE
[Form] Check $data[$name] is set when NOT dealing with a fieldset

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -215,8 +215,10 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
             }
         } else {
             foreach ($this->byName as $name => $element) {
-                $element->setAttribute('value', $data[$name]);
-                unset($data[$name]);
+                if (isset($data[$name])) {
+                    $element->setAttribute('value', $data[$name]);
+                    unset($data[$name]);
+                }
             }
         }
 


### PR DESCRIPTION
Issue [#1988] fixes a bug when setting multiple data values from a fieldset.

This code change fixes the same problem but for the other side of that if-statement, which currently ends up in an ungraceful fatal error from clone().

([#3274] is a duplicate of this, sorry! I posted that before creating the pull request and couldn't work out how to pin the commit to it directly.)
