### PR TITLE
[WIP] Adding a test exhibiting issue with SessionStorage

### DIFF
--- a/tests/ZendTest/Session/SessionStorageThirdPartyTest.php
+++ b/tests/ZendTest/Session/SessionStorageThirdPartyTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Session
+ */
+
+namespace ZendTest\Session;
+
+use Zend\Session\Storage\SessionStorage;
+use Zend\Session\Storage\ArrayStorage;
+
+/**
+ * @category   Zend
+ * @package    Zend_Session
+ * @subpackage UnitTests
+ * @group      Zend_Session
+ */
+class SessionStorageThirdPartyTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SessionStorage
+     */
+    protected $storage;
+
+    public function setUp()
+    {
+        $_SESSION = array();
+        $this->storage = new SessionStorage();
+    }
+
+    public function tearDown()
+    {
+        $_SESSION = array();
+    }
+
+    public function testAssignment()
+    {
+        $_SESSION['foo'] = 'bar';
+        $this->assertEquals('bar', $this->storage['foo']);
+    }
+
+    public function testMultiDimensionalAssignment()
+    {
+        $_SESSION['foo']['bar'] = 'baz';
+        $this->assertEquals('baz', $this->storage['foo']['bar']);
+    }
+
+    public function testUnset()
+    {
+        $_SESSION['foo'] = 'bar';
+        unset($_SESSION['foo']);
+        $this->assertFalse(isset($this->storage['foo']));
+    }
+
+    public function testMultiDimensionalUnset()
+    {
+        $_SESSION['foo']['bar'] = 'baz';
+        unset($_SESSION['foo']['bar']);
+        $this->assertFalse(isset($this->storage['foo']['bar']));
+    }
+}


### PR DESCRIPTION
These tests show that the SessionStorage implementation is not compatible with 3rd party PHP libraries that manipulate the $_SESSION directly. If the library tries to unset a multi-dimensional session array, a Notice is thrown and the item is not unset:

```
$storage = new \Zend\Session\Storage\SessionStorage();
$_SESSION['foo']['bar'] = 'baz';
unset($_SESSION['foo']['bar']);
\Zend\Debug\Debug::dump($_SESSION);

/* OUTPUT

Notice: Indirect modification of overloaded element of Zend\Session\Storage\SessionStorage has no effect in /Users/ncalugar/Zend/workspaces/DefaultWorkspace/phantom/public/index.php on line 16

object(Zend\Session\Storage\SessionStorage)#2 (2) {
  ["isImmutable":protected] => bool(false)
  ["storage":"ArrayObject":private] => array(2) {
    ["__ZF"] => array(1) {
      ["_REQUEST_ACCESS_TIME"] => float(1356130641.3591)
    }
    ["foo"] => array(1) {
      ["bar"] => string(3) "baz"
    }
  }
}
*/
```

This seems to be related to: https://bugs.php.net/bug.php?id=52861
