### PR TITLE
Update library/Zend/Form/Form.php

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -280,7 +280,7 @@ class Form extends Fieldset implements FormInterface
         }
 
         $filter = $this->getInputFilter();
-
+        $filter->setData($this->data);      /*This line to initialize the filter if inputfilter is pulled from bind object */
         switch ($this->bindAs) {
             case FormInterface::VALUES_RAW:
                 $data = $filter->getRawValues();


### PR DESCRIPTION
In the bindValues() method the filter is not initialized with form data. if there is a binded object to the form, calling getInputFilter() fetch new filter from the binded object. This filter is not initialized with data, which result in empty data on hydrator calls to the binded object. Adding filter->setData($this->data); after getInputFilter() call (Line:282) solved the issue.
