### PR TITLE
ZF2 dispatch.error to Zend Monitor event integration (ZSRV-8626)

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -241,6 +241,8 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     {
         if ($predicate instanceof Where) {
             $this->where = $predicate;
+        } elseif ($predicate instanceof Predicate\PredicateInterface) {
+            $this->where->addPredicate($predicate, $combination);
         } elseif ($predicate instanceof \Closure) {
             $predicate($this->where);
         } else {

--- a/library/Zend/Mvc/DispatchListener.php
+++ b/library/Zend/Mvc/DispatchListener.php
@@ -55,6 +55,9 @@ class DispatchListener implements ListenerAggregateInterface
     public function attach(EventManagerInterface $events)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'onDispatch'));
+        if (function_exists('zend_monitor_custom_event_ex')) {
+            $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($this, 'reportMonitorEvent'));
+        }
     }
 
     /**
@@ -124,6 +127,18 @@ class DispatchListener implements ListenerAggregateInterface
         }
 
         return $this->complete($return, $e);
+    }
+
+    /**
+     * @param MvcEvent $e
+     */
+    public function reportMonitorEvent(MvcEvent $e) {
+        $error = $e->getError();
+    	$exception = $e->getParam('exception');
+    	if ($exception instanceof \Exception) {
+    		\zend_monitor_custom_event_ex($error, $exception->getMessage(), 'Zend Framework Exception', array('code' => $exception->getCode(), 'trace' => $exception->getTraceAsString()));
+    	}
+    	return true;
     }
 
     /**

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -240,6 +240,26 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         });
     }
 
+    
+    /**
+     * @testdox unit test: Test where() will accept any Predicate object as-is
+     * @covers Zend\Db\Sql\Select::where
+     */
+    public function testWhereArgument1IsPredicate()
+    {
+        $select = new Select;
+    	$predicate = new \Zend\Db\Sql\Predicate\Predicate(array(
+	    			new \Zend\Db\Sql\Predicate\Expression('name = ?', 'Ralph'),
+	    			new \Zend\Db\Sql\Predicate\Expression('age = ?', 33),
+    			));
+    	$select->where($predicate);
+    
+    	/** @var $where Where */
+    	$where = $select->getRawState('where');
+    	$predicates = $where->getPredicates();
+    	$this->assertSame($predicate, $predicates[0][1]);
+    }
+
     /**
      * @testdox unit test: Test where() will accept a Where object
      * @covers Zend\Db\Sql\Select::where


### PR DESCRIPTION
Added monitor custome event reporting
Reporting is hooked on dispatch.error event only if
zend_monitor_custom_event_ex function is available
