### PR TITLE
Fixed wrong return usage and added @throws docblock

### DIFF
--- a/library/Zend/Http/Client/Adapter/Proxy.php
+++ b/library/Zend/Http/Client/Adapter/Proxy.php
@@ -85,12 +85,13 @@ class Proxy extends Socket
      * @param string  $host
      * @param int     $port
      * @param boolean $secure
+     * @throws AdapterException\RuntimeException
      */
     public function connect($host, $port = 80, $secure = false)
     {
         // If no proxy is set, fall back to Socket adapter
         if (! $this->config['proxy_host']) {
-            return parent::connect($host, $port, $secure);
+            parent::connect($host, $port, $secure);
         }
 
         /* Url might require stream context even if proxy connection doesn't */
@@ -99,7 +100,7 @@ class Proxy extends Socket
         }
 
         // Connect (a non-secure connection) to the proxy server
-        return parent::connect(
+        parent::connect(
             $this->config['proxy_host'],
             $this->config['proxy_port'],
             false


### PR DESCRIPTION
As seen in https://github.com/zendframework/zf2/blob/master/library/Zend/Http/Client/Adapter/Socket.php#L189 - the parent will never return anything, it throws an exception in case of an error and does not return a boolean
