### PR TITLE
Added missing constructor parameter

### DIFF
--- a/library/Zend/Http/Client/Cookies.php
+++ b/library/Zend/Http/Client/Cookies.php
@@ -11,7 +11,8 @@
 namespace Zend\Http\Client;
 
 use ArrayIterator;
-use Zend\Http\Header\Cookie;
+use Zend\Http\Header\SetCookie;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Http\Response;
 use Zend\Uri;
 
@@ -93,7 +94,7 @@ class Cookies
      * Add a cookie to the class. Cookie should be passed either as a Zend\Http\Header\Cookie object
      * or as a string - in which case an object is created from the string.
      *
-     * @param Cookie|string $cookie
+     * @param SetCookie|string $cookie
      * @param Uri\Uri|string    $ref_uri Optional reference URI (for domain, path, secure)
      * @throws Exception\InvalidArgumentException if invalid $cookie value
      */
@@ -103,7 +104,7 @@ class Cookies
             $cookie = Cookie::fromString($cookie, $ref_uri);
         }
 
-        if ($cookie instanceof Cookie) {
+        if ($cookie instanceof SetCookie) {
             $domain = $cookie->getDomain();
             $path   = $cookie->getPath();
             if (!isset($this->cookies[$domain])) {
@@ -128,6 +129,9 @@ class Cookies
     public function addCookiesFromResponse(Response $response, $ref_uri)
     {
         $cookie_hdrs = $response->getHeaders()->get('Set-Cookie');
+        if ($cookie_hdrs instanceof \ArrayIterator) {
+            $cookie_hdrs = ArrayUtils::iteratorToArray($cookie_hdrs);
+        }
 
         if (is_array($cookie_hdrs)) {
             foreach ($cookie_hdrs as $cookie) {

--- a/library/Zend/Http/Cookies.php
+++ b/library/Zend/Http/Cookies.php
@@ -92,10 +92,8 @@ class Cookies extends Headers
         );
     }
 
-    public function __construct(Headers $headers)
-    {
-        $this->headers = $headers;
-    }
+    public function __construct()
+    { }
 
     /**
      * Add a cookie to the class. Cookie should be passed either as a Zend\Http\Header\Cookie object
@@ -348,7 +346,7 @@ class Cookies extends Headers
      */
     public static function fromResponse(Response $response, $ref_uri)
     {
-        $jar = new self($response->getHeaders());
+        $jar = new self();
         $jar->addCookiesFromResponse($response, $ref_uri);
         return $jar;
     }

--- a/library/Zend/Http/Cookies.php
+++ b/library/Zend/Http/Cookies.php
@@ -348,7 +348,7 @@ class Cookies extends Headers
      */
     public static function fromResponse(Response $response, $ref_uri)
     {
-        $jar = new self();
+        $jar = new self($response->getHeaders());
         $jar->addCookiesFromResponse($response, $ref_uri);
         return $jar;
     }

--- a/tests/ZendTest/Http/CookiesTest.php
+++ b/tests/ZendTest/Http/CookiesTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
+
+namespace ZendTest\Http;
+
+use Zend\Http\Header\SetCookie;
+use Zend\Http\Response;
+use \Zend\Http\Headers;
+
+
+class CookiesTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFromResponseInSetCookie()
+    {
+        $response = new Response();
+        $headers = new Headers();
+        $header = new \Zend\Http\Header\SetCookie("foo", "bar");
+        $header->setDomain("www.zend.com");
+        $header->setPath("/");
+        $headers->addHeader($header);
+        $response->setHeaders($headers);
+
+
+        $response = \Zend\Http\Cookies::fromResponse($response, "http://www.zend.com");
+        $this->assertSame($header, $response->getCookie('http://www.zend.com', 'foo'));
+    }
+}

--- a/tests/ZendTest/Http/CookiesTest.php
+++ b/tests/ZendTest/Http/CookiesTest.php
@@ -27,8 +27,21 @@ class CookiesTest extends \PHPUnit_Framework_TestCase
         $headers->addHeader($header);
         $response->setHeaders($headers);
 
-
         $response = \Zend\Http\Cookies::fromResponse($response, "http://www.zend.com");
+        $this->assertSame($header, $response->getCookie('http://www.zend.com', 'foo'));
+    }
+
+    public function testFromResponseInCookie()
+    {
+        $response = new Response();
+        $headers = new Headers();
+        $header = new \Zend\Http\Header\SetCookie("foo", "bar");
+        $header->setDomain("www.zend.com");
+        $header->setPath("/");
+        $headers->addHeader($header);
+        $response->setHeaders($headers);
+
+        $response = \Zend\Http\Client\Cookies::fromResponse($response, "http://www.zend.com");
         $this->assertSame($header, $response->getCookie('http://www.zend.com', 'foo'));
     }
 }


### PR DESCRIPTION
Is someone working on the cookie stuff? If I understand it correct, Zend\Http\Cookie and Zend\Http\Client\Cookie should handle <code>Header\Cookie</code> and <code>Header\SetCookie</code> - but it looks like there are a few copy & paste issues here. 

E.g. [this](https://github.com/zendframework/zf2/blob/develop/library/Zend/Http/Client/Cookies.php#L107) will always fail:

``` php
if ($cookie instanceof Cookie) {
        $domain = $cookie->getDomain();
        $path = $cookie->getPath();
        if (!isset($this->cookies[$domain])) {
            $this->cookies[$domain] = array();
        }
        if (!isset($this->cookies[$domain][$path])) {
            $this->cookies[$domain][$path] = array();
        }
        $this->cookies[$domain][$path][$cookie->getName()] = $cookie;
        $this->rawCookies[] = $cookie;
} else {
        throw new Exception\InvalidArgumentException('Supplient argument is not a valid cookie string or object');
}
```

Cause Cookie does not have the method <code>getDomain</code> (same with <code>getPath</code>) - but <code>SetCookie</code> has that method. From the [internal architecture](https://github.com/zendframework/zf2/blob/develop/library/Zend/Http/Client/Cookies.php#L115) I guess <code>Cookie</code> needs this method.
