### PR TITLE
Proposing removal of subscription record upon unsubscribe

### DIFF
--- a/library/Zend/Feed/PubSubHubbub/Subscriber.php
+++ b/library/Zend/Feed/PubSubHubbub/Subscriber.php
@@ -744,7 +744,7 @@ class Subscriber
             'verify_token'       => hash('sha256', $params['hub.verify_token']),
             'secret'             => null,
             'expiration_time'    => $expires,
-            'subscription_state' => PubSubHubbub::SUBSCRIPTION_NOTVERIFIED,
+            'subscription_state' => ($mode == 'unsubscribe')? PubSubHubbub::SUBSCRIPTION_TODELETE : PubSubHubbub::SUBSCRIPTION_NOTVERIFIED,
         );
         $this->getStorage()->setSubscription($data);
 

--- a/library/Zend/Feed/PubSubHubbub/Subscriber/Callback.php
+++ b/library/Zend/Feed/PubSubHubbub/Subscriber/Callback.php
@@ -93,13 +93,19 @@ class Callback extends PubSubHubbub\AbstractCallback
          * Handle any (un)subscribe confirmation requests
          */
         } elseif ($this->isValidHubVerification($httpGetData)) {
-            $data = $this->currentSubscriptionData;
             $this->getHttpResponse()->setContent($httpGetData['hub_challenge']);
-            $data['subscription_state'] = PubSubHubbub\PubSubHubbub::SUBSCRIPTION_VERIFIED;
-            if (isset($httpGetData['hub_lease_seconds'])) {
-                $data['lease_seconds'] = $httpGetData['hub_lease_seconds'];
+
+            if ($httpGetData['hub_mode'] == 'subscribe') {
+            	$data = $this->currentSubscriptionData;
+                $data['subscription_state'] = PubSubHubbub\PubSubHubbub::SUBSCRIPTION_VERIFIED;
+                if (isset($httpGetData['hub_lease_seconds'])) {
+                    $data['lease_seconds'] = $httpGetData['hub_lease_seconds'];
+                }
+                $this->getStorage()->setSubscription($data);
+            } else {
+                $verifyTokenKey = $this->_detectVerifyTokenKey($httpGetData);
+                $this->getStorage()->deleteSubscription($verifyTokenKey);
             }
-            $this->getStorage()->setSubscription($data);
         /**
          * Hey, C'mon! We tried everything else!
          */

--- a/tests/ZendTest/Feed/PubSubHubbub/Subscriber/CallbackTest.php
+++ b/tests/ZendTest/Feed/PubSubHubbub/Subscriber/CallbackTest.php
@@ -286,7 +286,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
                                  'verify_token'      => hash('sha256', 'cba'),
                                  'created_time'      => $t->getTimestamp(),
                                  'lease_seconds'     => 1234567,
-                                 'subscription_state'=> 'verified',
+                                 'subscription_state'=> 'to_delete',
                                  'expiration_time'   => $t->add(new DateInterval('PT1234567S'))
                                      ->format('Y-m-d H:i:s'))),
             $this->equalTo(array('id' => 'verifytokenkey'))
@@ -294,6 +294,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
 
         $this->_callback->handle($this->_get);
         $this->assertTrue($this->_callback->getHttpResponse()->getStatusCode() == 200);
+        $this->assertTrue($this->_callback->getStorage()->hasSubscription('verifytokenkey') == false);
     }
 
     public function testRespondsToValidConfirmationWithBodyContainingHubChallenge()

--- a/tests/ZendTest/Feed/PubSubHubbub/SubscriberHttpTest.php
+++ b/tests/ZendTest/Feed/PubSubHubbub/SubscriberHttpTest.php
@@ -97,6 +97,9 @@ class SubscriberHttpTest extends \PHPUnit_Framework_TestCase
             .'%3A%2F%2Fwww.example.com%2Ftopic&hub.verify=sync&hub.verify=async'
             .'&hub.verify_token=abc',
             $this->client->getResponse()->getBody());
+
+        $subscriptionRecord = $this->subscriber->getStorage()->getSubscription();
+        $this->assertEquals($subscriptionRecord['subscription_state'], PubSubHubbub::SUBSCRIPTION_TODELETE);
     }
 
     protected function _getCleanMock($className)


### PR DESCRIPTION
Currently both subscribe and unsubscribe operations to a feed execute the same code resulting into the same behavior.  As a result subscription records created in the database have the same state and we can't tell which ones were unsubscribed and which ones are still subscribed.

I am proposing to keep the subscribe operation as currently implemented but tweak to unsubscribe operation as the following:
1) when the unsubscribe request is sent to the hub, update the subscription record STATE column as to_delete
2) once the hub sends the callback and it's been verified, delete the subscription record

Please let me know if this fit the original design ideas.
