### PR TITLE
Hotfix #3046 - set /dev/urandom as entropy file for Session

### DIFF
--- a/library/Zend/Session/Config/StandardConfig.php
+++ b/library/Zend/Session/Config/StandardConfig.php
@@ -595,7 +595,7 @@ class StandardConfig implements ConfigInterface
      */
     public function setEntropyFile($entropyFile)
     {
-        if (!is_file($entropyFile) || !is_readable($entropyFile)) {
+        if (!is_readable($entropyFile)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 "Invalid entropy_file provided: '%s'; doesn't exist or not readable",
                 $entropyFile

--- a/tests/ZendTest/Session/Config/SessionConfigTest.php
+++ b/tests/ZendTest/Session/Config/SessionConfigTest.php
@@ -460,12 +460,6 @@ class SessionConfigTest extends \PHPUnit_Framework_TestCase
         $this->config->setEntropyFile(__DIR__ . '/foobarboguspath');
     }
 
-    public function testSetEntropyFileErrorsOnDirectory()
-    {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid entropy_file provided');
-        $this->config->setEntropyFile(__DIR__);
-    }
-
     public function testEntropyFileDefaultsToIniSettings()
     {
         $this->assertSame(ini_get('session.entropy_file'), $this->config->getEntropyFile());

--- a/tests/ZendTest/Session/Config/StandardConfigTest.php
+++ b/tests/ZendTest/Session/Config/StandardConfigTest.php
@@ -266,12 +266,6 @@ class StandardConfigTest extends \PHPUnit_Framework_TestCase
         $this->config->setEntropyFile(__DIR__ . '/foobarboguspath');
     }
 
-    public function testSetEntropyFileErrorsOnDirectory()
-    {
-        $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid entropy_file provided');
-        $this->config->setEntropyFile(__DIR__);
-    }
-
     public function testEntropyFileIsMutable()
     {
         $this->config->setEntropyFile(__FILE__);
@@ -564,5 +558,21 @@ class StandardConfigTest extends \PHPUnit_Framework_TestCase
                 'a=href',
             ),
         );
+    }
+    
+    /**
+     * Set entropy file /dev/urandom, see issue #3046
+     * 
+     * @link https://github.com/zendframework/zf2/issues/3046
+     */
+    public function testSetEntropyDevUrandom()
+    {
+        if (!file_exists('/dev/urandom')) {
+            $this->markTestSkipped(
+                "This test doesn't work because /dev/urandom file doesn't exist."
+            );
+        }
+        $result = $this->config->setEntropyFile('/dev/urandom');
+        $this->assertInstanceOf('Zend\Session\Config\StandardConfig', $result);
     }
 }


### PR DESCRIPTION
I removed the is_file() check in setEntropyFile() of Zend\Session\Config\StandardConfig in order to accept /dev/urandom, /dev/random or /dev/arandom if it is available.
I addded a unit test for that case and removed the dir tests.
See https://github.com/zendframework/zf2/issues/3046
