### PR TITLE
Zend\Config - Fix count after merge

### DIFF
--- a/library/Zend/Config/Config.php
+++ b/library/Zend/Config/Config.php
@@ -365,6 +365,8 @@ class Config implements Countable, Iterator, ArrayAccess
                 } else {
                     $this->data[$key] = $value;
                 }
+
+                $this->count++;
             }
         }
 

--- a/tests/ZendTest/Config/ConfigTest.php
+++ b/tests/ZendTest/Config/ConfigTest.php
@@ -181,6 +181,15 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, count($data->button));
     }
 
+    public function testCountAfterMerge()
+    {
+        $data = new Config($this->toCombineB);
+        $data->merge(
+            new Config($this->toCombineA)
+        );
+        $this->assertEquals(count($data->toArray()), $data->count());
+    }
+
     public function testIterator()
     {
         // top level


### PR DESCRIPTION
The following test fails.  The count never gets updated after a merge

**ZendTest\Config\ConfigTest.php**

``` php
public function testCountAfterMerge()
{
      $data = new Config($this->toCombineB);
      $data->merge(
          new Config($this->toCombineA)
      );
      $this->assertEquals(count($data->toArray()), $data->count());
}
```
