### PR TITLE
Missed the Zend\Text dependency for Zend\Mvc in composer.json

### DIFF
--- a/library/Zend/Mvc/composer.json
+++ b/library/Zend/Mvc/composer.json
@@ -22,6 +22,7 @@
         "zendframework/zend-uri": "self.version",
         "zendframework/zend-servicemanager": "self.version",
         "zendframework/zend-stdlib": "self.version",
-        "zendframework/zend-view": "self.version"
+        "zendframework/zend-view": "self.version",
+        "zendframework/zend-text": "self.version"
     }
 }


### PR DESCRIPTION
The Zend\Mvc\View\Console\RouteNotFoundStrategy requires Zend\Text, added this dependency in composer.json of Zend\Mvc.
