### PR TITLE
Fix an issue with inheritance of placeholder registry

### DIFF
--- a/library/Zend/Code/Generator/DocBlock/Tag.php
+++ b/library/Zend/Code/Generator/DocBlock/Tag.php
@@ -70,7 +70,7 @@ class Tag extends AbstractGenerator
     {
         $tagName = $reflectionTag->getName();
 
-        $codeGenDocBlockTag = new self();
+        $codeGenDocBlockTag = new static();
         $codeGenDocBlockTag->setName($tagName);
 
         // transport any properties via accessors and mutators from reflection to codegen object

--- a/library/Zend/Code/Generator/DocBlock/Tag/LicenseTag.php
+++ b/library/Zend/Code/Generator/DocBlock/Tag/LicenseTag.php
@@ -48,7 +48,7 @@ class LicenseTag extends Tag
      */
     public static function fromReflection(ReflectionDocBlockTag $reflectionTagLicense)
     {
-        $returnTag = new self();
+        $returnTag = new static();
 
         $returnTag->setName('license');
         $returnTag->setUrl($reflectionTagLicense->getUrl());

--- a/library/Zend/Code/Generator/DocBlock/Tag/ParamTag.php
+++ b/library/Zend/Code/Generator/DocBlock/Tag/ParamTag.php
@@ -38,7 +38,7 @@ class ParamTag extends Tag
      */
     public static function fromReflection(ReflectionDocBlockTag $reflectionTagParam)
     {
-        $paramTag = new self();
+        $paramTag = new static();
 
         $paramTag->setName('param');
         $paramTag->setDatatype($reflectionTagParam->getType()); // @todo rename

--- a/library/Zend/Code/Generator/DocBlock/Tag/ReturnTag.php
+++ b/library/Zend/Code/Generator/DocBlock/Tag/ReturnTag.php
@@ -33,7 +33,7 @@ class ReturnTag extends Tag
      */
     public static function fromReflection(ReflectionDocBlockTag $reflectionTagReturn)
     {
-        $returnTag = new self();
+        $returnTag = new static();
 
         $returnTag->setName('return');
         $returnTag->setDatatype($reflectionTagReturn->getType()); // @todo rename

--- a/library/Zend/Code/Generator/FileGenerator.php
+++ b/library/Zend/Code/Generator/FileGenerator.php
@@ -104,7 +104,7 @@ class FileGenerator extends AbstractGenerator
      */
     public static function fromReflection(FileReflection $fileReflection)
     {
-        $file = new self();
+        $file = new static();
 
         $file->setSourceContent($fileReflection->getContents());
         $file->setSourceDirty(false);

--- a/library/Zend/Code/Generator/MethodGenerator.php
+++ b/library/Zend/Code/Generator/MethodGenerator.php
@@ -44,7 +44,7 @@ class MethodGenerator extends AbstractMemberGenerator
      */
     public static function fromReflection(MethodReflection $reflectionMethod)
     {
-        $method = new self();
+        $method = new static();
 
         $method->setSourceContent($reflectionMethod->getContents(false));
         $method->setSourceDirty(false);

--- a/library/Zend/Code/Generator/PropertyGenerator.php
+++ b/library/Zend/Code/Generator/PropertyGenerator.php
@@ -39,7 +39,7 @@ class PropertyGenerator extends AbstractMemberGenerator
      */
     public static function fromReflection(PropertyReflection $reflectionProperty)
     {
-        $property = new self();
+        $property = new static();
 
         $property->setName($reflectionProperty->getName());
 

--- a/library/Zend/Config/Config.php
+++ b/library/Zend/Config/Config.php
@@ -71,7 +71,7 @@ class Config implements Countable, Iterator, ArrayAccess
 
         foreach ($array as $key => $value) {
             if (is_array($value)) {
-                $this->data[$key] = new self($value, $this->allowModifications);
+                $this->data[$key] = new static($value, $this->allowModifications);
             } else {
                 $this->data[$key] = $value;
             }
@@ -123,7 +123,7 @@ class Config implements Countable, Iterator, ArrayAccess
         if ($this->allowModifications) {
 
             if (is_array($value)) {
-                $value = new self($value, true);
+                $value = new static($value, true);
             }
 
             if (null === $name) {
@@ -354,14 +354,14 @@ class Config implements Countable, Iterator, ArrayAccess
                     $this->data[$key]->merge($value);
                 } else {
                     if ($value instanceof self) {
-                        $this->data[$key] = new self($value->toArray(), $this->allowModifications);
+                        $this->data[$key] = new static($value->toArray(), $this->allowModifications);
                     } else {
                         $this->data[$key] = $value;
                     }
                 }
             } else {
                 if ($value instanceof self) {
-                    $this->data[$key] = new self($value->toArray(), $this->allowModifications);
+                    $this->data[$key] = new static($value->toArray(), $this->allowModifications);
                 } else {
                     $this->data[$key] = $value;
                 }

--- a/library/Zend/Crypt/BlockCipher.php
+++ b/library/Zend/Crypt/BlockCipher.php
@@ -96,7 +96,7 @@ class BlockCipher
     {
         $plugins = static::getSymmetricPluginManager();
         $adapter = $plugins->get($adapter, (array) $options);
-        return new self($adapter);
+        return new static($adapter);
     }
 
     /**

--- a/library/Zend/Feed/Reader/FeedSet.php
+++ b/library/Zend/Feed/Reader/FeedSet.php
@@ -57,7 +57,7 @@ class FeedSet extends ArrayObject
             } elseif (!isset($this->rdf) && $link->getAttribute('type') == 'application/rdf+xml') {
                 $this->rdf = $this->absolutiseUri(trim($link->getAttribute('href')), $uri);
             }
-            $this[] = new self(array(
+            $this[] = new static(array(
                 'rel' => 'alternate',
                 'type' => $link->getAttribute('type'),
                 'href' => $this->absolutiseUri(trim($link->getAttribute('href')), $uri),

--- a/library/Zend/Http/Client/Cookies.php
+++ b/library/Zend/Http/Client/Cookies.php
@@ -340,7 +340,7 @@ class Cookies
      */
     public static function fromResponse(Response $response, $ref_uri)
     {
-        $jar = new self();
+        $jar = new static();
         $jar->addCookiesFromResponse($response, $ref_uri);
         return $jar;
     }

--- a/library/Zend/Http/Cookies.php
+++ b/library/Zend/Http/Cookies.php
@@ -317,7 +317,7 @@ class Cookies extends Headers
      */
     public static function fromResponse(Response $response, $ref_uri)
     {
-        $jar = new self();
+        $jar = new static();
         $jar->addCookiesFromResponse($response, $ref_uri);
         return $jar;
     }

--- a/library/Zend/I18n/Translator/Plural/Rule.php
+++ b/library/Zend/I18n/Translator/Plural/Rule.php
@@ -205,7 +205,7 @@ class Rule
         $tree = static::$parser->parse($match['plural']);
         $ast  = static::createAst($tree);
 
-        return new self($numPlurals, $ast);
+        return new static($numPlurals, $ast);
     }
 
     /**

--- a/library/Zend/Json/Decoder.php
+++ b/library/Zend/Json/Decoder.php
@@ -137,7 +137,7 @@ class Decoder
      */
     public static function decode($source, $objectDecodeType = Json::TYPE_OBJECT)
     {
-        $decoder = new self($source, $objectDecodeType);
+        $decoder = new static($source, $objectDecodeType);
         return $decoder->_decodeValue();
     }
 

--- a/library/Zend/Json/Encoder.php
+++ b/library/Zend/Json/Encoder.php
@@ -68,7 +68,7 @@ class Encoder
      */
     public static function encode($value, $cycleCheck = false, $options = array())
     {
-        $encoder = new self(($cycleCheck) ? true : false, $options);
+        $encoder = new static(($cycleCheck) ? true : false, $options);
 
         return $encoder->_encodeValue($value);
     }

--- a/library/Zend/Ldap/Dn.php
+++ b/library/Zend/Ldap/Dn.php
@@ -77,7 +77,7 @@ class Dn implements \ArrayAccess
         } else {
             $dnArray = static::explodeDn((string) $dn);
         }
-        return new self($dnArray, $caseFold);
+        return new static($dnArray, $caseFold);
     }
 
     /**
@@ -90,7 +90,7 @@ class Dn implements \ArrayAccess
      */
     public static function fromArray(array $dn, $caseFold = null)
     {
-        return new self($dn, $caseFold);
+        return new static($dn, $caseFold);
     }
 
     /**
@@ -145,7 +145,7 @@ class Dn implements \ArrayAccess
             throw new Exception\LdapException(null, 'Cannot retrieve parent DN with given $levelUp');
         }
         $newDn = array_slice($this->dn, $levelUp);
-        return new self($newDn, $this->caseFold);
+        return new static($newDn, $this->caseFold);
     }
 
     /**

--- a/library/Zend/Ldap/Filter.php
+++ b/library/Zend/Ldap/Filter.php
@@ -36,7 +36,7 @@ class Filter extends Filter\StringFilter
      */
     public static function equals($attr, $value)
     {
-        return new self($attr, $value, self::TYPE_EQUALS, null, null);
+        return new static($attr, $value, self::TYPE_EQUALS, null, null);
     }
 
     /**
@@ -49,7 +49,7 @@ class Filter extends Filter\StringFilter
      */
     public static function begins($attr, $value)
     {
-        return new self($attr, $value, self::TYPE_EQUALS, null, '*');
+        return new static($attr, $value, self::TYPE_EQUALS, null, '*');
     }
 
     /**
@@ -62,7 +62,7 @@ class Filter extends Filter\StringFilter
      */
     public static function ends($attr, $value)
     {
-        return new self($attr, $value, self::TYPE_EQUALS, '*', null);
+        return new static($attr, $value, self::TYPE_EQUALS, '*', null);
     }
 
     /**
@@ -75,7 +75,7 @@ class Filter extends Filter\StringFilter
      */
     public static function contains($attr, $value)
     {
-        return new self($attr, $value, self::TYPE_EQUALS, '*', '*');
+        return new static($attr, $value, self::TYPE_EQUALS, '*', '*');
     }
 
     /**
@@ -88,7 +88,7 @@ class Filter extends Filter\StringFilter
      */
     public static function greater($attr, $value)
     {
-        return new self($attr, $value, self::TYPE_GREATER, null, null);
+        return new static($attr, $value, self::TYPE_GREATER, null, null);
     }
 
     /**
@@ -101,7 +101,7 @@ class Filter extends Filter\StringFilter
      */
     public static function greaterOrEqual($attr, $value)
     {
-        return new self($attr, $value, self::TYPE_GREATEROREQUAL, null, null);
+        return new static($attr, $value, self::TYPE_GREATEROREQUAL, null, null);
     }
 
     /**
@@ -114,7 +114,7 @@ class Filter extends Filter\StringFilter
      */
     public static function less($attr, $value)
     {
-        return new self($attr, $value, self::TYPE_LESS, null, null);
+        return new static($attr, $value, self::TYPE_LESS, null, null);
     }
 
     /**
@@ -127,7 +127,7 @@ class Filter extends Filter\StringFilter
      */
     public static function lessOrEqual($attr, $value)
     {
-        return new self($attr, $value, self::TYPE_LESSOREQUAL, null, null);
+        return new static($attr, $value, self::TYPE_LESSOREQUAL, null, null);
     }
 
     /**
@@ -140,7 +140,7 @@ class Filter extends Filter\StringFilter
      */
     public static function approx($attr, $value)
     {
-        return new self($attr, $value, self::TYPE_APPROX, null, null);
+        return new static($attr, $value, self::TYPE_APPROX, null, null);
     }
 
     /**
@@ -152,7 +152,7 @@ class Filter extends Filter\StringFilter
      */
     public static function any($attr)
     {
-        return new self($attr, '', self::TYPE_EQUALS, '*', null);
+        return new static($attr, '', self::TYPE_EQUALS, '*', null);
     }
 
     /**

--- a/library/Zend/Ldap/Ldif/Encoder.php
+++ b/library/Zend/Ldap/Ldif/Encoder.php
@@ -55,7 +55,7 @@ class Encoder
      */
     public static function decode($string)
     {
-        $encoder = new self(array());
+        $encoder = new static(array());
         return $encoder->_decode($string);
     }
 
@@ -136,7 +136,7 @@ class Encoder
      */
     public static function encode($value, array $options = array())
     {
-        $encoder = new self($options);
+        $encoder = new static($options);
 
         return $encoder->_encode($value);
     }

--- a/library/Zend/Ldap/Node.php
+++ b/library/Zend/Ldap/Node.php
@@ -245,7 +245,7 @@ class Node extends Node\AbstractNode implements \Iterator, \RecursiveIterator
         } else {
             throw new Exception\LdapException(null, '$dn is of a wrong data type.');
         }
-        $new = new self($dn, array(), false, null);
+        $new = new static($dn, array(), false, null);
         $new->ensureRdnAttributeValues();
         $new->setAttribute('objectClass', $objectClass);
 
@@ -273,7 +273,7 @@ class Node extends Node\AbstractNode implements \Iterator, \RecursiveIterator
         if ($data === null) {
             return null;
         }
-        $entry = new self($dn, $data, true, $ldap);
+        $entry = new static($dn, $data, true, $ldap);
 
         return $entry;
     }
@@ -299,7 +299,7 @@ class Node extends Node\AbstractNode implements \Iterator, \RecursiveIterator
             throw new Exception\LdapException(null, '\'dn\' key is of a wrong data type.');
         }
         $fromDataSource = ($fromDataSource === true) ? true : false;
-        $new            = new self($dn, $data, $fromDataSource, null);
+        $new            = new static($dn, $data, $fromDataSource, null);
         $new->ensureRdnAttributeValues();
 
         return $new;

--- a/library/Zend/Ldap/Node/RootDse.php
+++ b/library/Zend/Ldap/Node/RootDse.php
@@ -45,7 +45,7 @@ class RootDse extends AbstractNode
         ) {
             return new RootDse\OpenLdap($dn, $data);
         } else {
-            return new self($dn, $data);
+            return new static($dn, $data);
         }
     }
 

--- a/library/Zend/Ldap/Node/Schema.php
+++ b/library/Zend/Ldap/Node/Schema.php
@@ -43,7 +43,7 @@ class Schema extends AbstractNode
                 return new Schema\OpenLdap($dn, $data, $ldap);
             case RootDse::SERVER_TYPE_EDIRECTORY:
             default:
-                return new self($dn, $data, $ldap);
+                return new static($dn, $data, $ldap);
         }
     }
 

--- a/library/Zend/Mail/Storage/Part.php
+++ b/library/Zend/Mail/Storage/Part.php
@@ -198,7 +198,7 @@ class Part implements RecursiveIterator, Part\PartInterface
         }
         $counter = 1;
         foreach ($parts as $part) {
-            $this->parts[$counter++] = new self(array('headers' => $part['header'], 'content' => $part['body']));
+            $this->parts[$counter++] = new static(array('headers' => $part['header'], 'content' => $part['body']));
         }
     }
 

--- a/library/Zend/Mail/Storage/Part/File.php
+++ b/library/Zend/Mail/Storage/Part/File.php
@@ -155,7 +155,7 @@ class File extends Part
             throw new Exception\RuntimeException('part not found');
         }
 
-        return new self(array('file' => $this->fh, 'startPos' => $this->partPos[$num][0],
+        return new static(array('file' => $this->fh, 'startPos' => $this->partPos[$num][0],
                               'endPos' => $this->partPos[$num][1]));
     }
 }

--- a/library/Zend/Mime/Message.php
+++ b/library/Zend/Mime/Message.php
@@ -225,7 +225,7 @@ class Message
     {
         $parts = Decode::splitMessageStruct($message, $boundary, $EOL);
 
-        $res = new self();
+        $res = new static();
         foreach ($parts as $part) {
             // now we build a new MimePart for the current Message Part:
             $newPart = new Part($part['body']);

--- a/library/Zend/Server/Reflection/Node.php
+++ b/library/Zend/Server/Reflection/Node.php
@@ -81,7 +81,7 @@ class Node
      */
     public function createChild($value)
     {
-        $child = new self($value, $this);
+        $child = new static($value, $this);
 
         return $child;
     }

--- a/library/Zend/Uri/File.php
+++ b/library/Zend/Uri/File.php
@@ -72,7 +72,7 @@ class File extends Uri
      */
     public static function fromUnixPath($path)
     {
-        $url = new self('file:');
+        $url = new static('file:');
         if (substr($path, 0, 1) == '/') {
             $url->setHost('');
         }
@@ -89,7 +89,7 @@ class File extends Uri
      */
     public static function fromWindowsPath($path)
     {
-        $url = new self('file:');
+        $url = new static('file:');
 
         // Convert directory separators
         $path = str_replace(array('/', '\\'), array('%2F', '/'), $path);

--- a/library/Zend/View/Helper/Placeholder/Registry.php
+++ b/library/Zend/View/Helper/Placeholder/Registry.php
@@ -45,7 +45,7 @@ class Registry
     public static function getRegistry()
     {
         if (null === static::$instance) {
-            static::$instance = new self();
+            static::$instance = new static();
         }
 
         return static::$instance;

--- a/library/Zend/XmlRpc/Fault.php
+++ b/library/Zend/XmlRpc/Fault.php
@@ -239,7 +239,7 @@ class Fault
      */
     public static function isFault($xml)
     {
-        $fault = new self();
+        $fault = new static();
         try {
             $isFault = $fault->loadXml($xml);
         } catch (Exception\ExceptionInterface $e) {

--- a/library/Zend/XmlRpc/Server/Fault.php
+++ b/library/Zend/XmlRpc/Server/Fault.php
@@ -84,7 +84,7 @@ class Fault extends \Zend\XmlRpc\Fault
      */
     public static function getInstance(\Exception $e)
     {
-        return new self($e);
+        return new static($e);
     }
 
     /**


### PR DESCRIPTION
This small patch fixes an issue with logic of Registry `getRegistry()` method. Method should use `static` keyword instead of `self` to allow inheritance.

Issue was detected automatically during the tests with aspect-oriented programming in ZF2 https://github.com/lisachenko/zf2-aspect
