### PR TITLE
Fixed FileGenerator::setUse() to ignore already added uses.

### DIFF
--- a/library/Zend/Code/Generator/FileGenerator.php
+++ b/library/Zend/Code/Generator/FileGenerator.php
@@ -350,7 +350,9 @@ class FileGenerator extends AbstractGenerator
      */
     public function setUse($use, $as = null)
     {
-        $this->uses[] = array($use, $as);
+        if (!in_array(array($use, $as), $this->uses)) {
+            $this->uses[] = array($use, $as);
+        }
         return $this;
     }
 

--- a/tests/ZendTest/Code/Generator/FileGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/FileGeneratorTest.php
@@ -202,4 +202,37 @@ EOS;
         $generated = $file->generate();
         $this->assertContains('namespace Foo\\Bar', $generated, $generated);
     }
+
+    public function testSetUseDoesntGenerateMultipleIdenticalUseStatements()
+    {
+        $file = new FileGenerator();
+        $file->setUse('My\Baz')
+             ->setUse('My\Baz');
+        $generated = $file->generate();
+        $this->assertSame(strpos($generated, 'use My\\Baz'), strrpos($generated, 'use My\\Baz'));
+    }
+
+    public function testSetUsesDoesntGenerateMultipleIdenticalUseStatements()
+    {
+        $file = new FileGenerator();
+        $file->setUses(array(
+                 array('Your\Bar', 'bar'),
+                 array('Your\Bar', 'bar'),
+        ));
+        $generated = $file->generate();
+        $this->assertSame(strpos($generated, 'use Your\\Bar as bar;'), strrpos($generated, 'use Your\\Bar as bar;'));
+    }
+
+    public function testSetUseAllowsMultipleAliasedUseStatements()
+    {
+        $file = new FileGenerator();
+        $file->setUses(array(
+                 array('Your\Bar', 'bar'),
+                 array('Your\Bar', 'bar2'),
+        ));
+        $generated = $file->generate();
+        $this->assertContains('use Your\\Bar as bar;', $generated);
+        $this->assertContains('use Your\\Bar as bar2;', $generated);
+    }
+
 }


### PR DESCRIPTION
Multiple calls to setUse() with the same parameters was leading to multiple identical use statements being inserted in the generated file. This was causing a PHP Fatal error 'name is already in use' in the generated code.

This patch overcomes this by first testing whether the 'use' has been added to the $uses array. If it has, then it ignores it (doesn't add it again).
