### PR TITLE
Fixed FileGenerator::setUses() to allow passing in array of strings.

### DIFF
--- a/library/Zend/Code/Generator/FileGenerator.php
+++ b/library/Zend/Code/Generator/FileGenerator.php
@@ -336,7 +336,11 @@ class FileGenerator extends AbstractGenerator
     public function setUses(array $uses)
     {
         foreach ($uses as $use) {
-            $this->setUse($use[0], $use[1]);
+            if (is_array($use)) {
+                $this->setUse($use[0], $use[1]);
+            } else {
+                $this->setUse($use);
+            }
         }
         return $this;
     }

--- a/tests/ZendTest/Code/Generator/FileGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/FileGeneratorTest.php
@@ -202,4 +202,31 @@ EOS;
         $generated = $file->generate();
         $this->assertContains('namespace Foo\\Bar', $generated, $generated);
     }
+
+    public function testSetUsesWithArrays()
+    {
+        $file = new FileGenerator();
+        $file->setUses(array(
+                 array('Your\\Bar', 'bar'),
+                 array('My\\Baz', 'FooBaz')
+             ));
+        $generated = $file->generate();
+        $this->assertContains('use My\\Baz as FooBaz;', $generated);
+        $this->assertContains('use Your\\Bar as bar;', $generated);
+    }
+
+    public function testSetUsesWithString()
+    {
+        $file = new FileGenerator();
+        $file->setUses(array(
+            'Your\\Bar',
+            'My\\Baz',
+            array('Another\\Baz', 'Baz2')
+        ));
+        $generated = $file->generate();
+        $this->assertContains('use My\\Baz;', $generated);
+        $this->assertContains('use Your\\Bar;', $generated);
+        $this->assertContains('use Another\\Baz as Baz2;', $generated);
+    }
+
 }


### PR DESCRIPTION
This patch allows setUses() to be called with an array of string 'uses'. This makes it easier to call when the 'as' part is not needed.

In my use case I had an existing array of strings that I wanted to pass directly to setUses().

This patch actually allows mixing of strings (without the 'as') and arrays of the form array('use', 'as') in the array that's passed to setUses(). This is demonstrated in testSetUsesWithString().
