### PR TITLE
user of app. should not see these exception

### DIFF
--- a/library/Zend/Authentication/Adapter/DbTable.php
+++ b/library/Zend/Authentication/Adapter/DbTable.php
@@ -351,10 +351,6 @@ class DbTable implements AdapterInterface
             $exception = 'An identity column must be supplied for the DbTable authentication adapter.';
         } elseif ($this->credentialColumn == '') {
             $exception = 'A credential column must be supplied for the DbTable authentication adapter.';
-        } elseif ($this->identity == '') {
-            $exception = 'A value for the identity was not provided prior to authentication with DbTable.';
-        } elseif ($this->credential === null) {
-            $exception = 'A credential value was not provided prior to authentication with DbTable.';
         }
 
         if (null !== $exception) {


### PR DESCRIPTION
tableName, identityColumn, and credentialColumn are developer matter. but not for the value of identity/credential. User should not see the exception if accidentally login with no identity or credential. if user see the exception, user know that developer using DbTable adapter for his auth. 
