### PR TITLE
Fixed DefinitionList::hasMethod()

### DIFF
--- a/library/Zend/Di/Config.php
+++ b/library/Zend/Di/Config.php
@@ -59,11 +59,9 @@ class Config
         if (isset($this->data['definition'])) {
             $this->configureDefinition($di, $this->data['definition']);
         }
-
         if (isset($this->data['instance'])) {
             $this->configureInstance($di, $this->data['instance']);
         }
-
     }
 
     /**
@@ -90,8 +88,8 @@ class Config
                                 $definitions[] = $definition;
                             }
                         }
-                        $definitions = new DefinitionList($definitions);
-                        $di->setDefinitionList($definitions);
+                        $definitionList = new DefinitionList($definitions);
+                        $di->setDefinitionList($definitionList);
                     } elseif (isset($definitionData['use_annotations']) && $definitionData['use_annotations']) {
                         /* @var $runtimeDefinition Definition\RuntimeDefinition */
                         $runtimeDefinition = $di
@@ -146,9 +144,7 @@ class Config
                         }
                     }
             }
-
         }
-
     }
 
     /**
@@ -200,7 +196,6 @@ class Config
                     }
             }
         }
-
     }
 
 }

--- a/library/Zend/Di/DefinitionList.php
+++ b/library/Zend/Di/DefinitionList.php
@@ -146,9 +146,11 @@ class DefinitionList extends SplDoublyLinkedList implements Definition\Definitio
         foreach ($this as $definition) {
             if ($definition->hasClass($class)) {
                 $supertypes = array_merge($supertypes, $definition->getClassSupertypes($class));
-                if (!$definition instanceof Definition\PartialMarker) {
-                    return $supertypes;
+                if ($definition instanceof Definition\PartialMarker) {
+                    continue;
                 }
+
+                return $supertypes;
             }
         }
         return $supertypes;
@@ -165,9 +167,9 @@ class DefinitionList extends SplDoublyLinkedList implements Definition\Definitio
                 $value = $definition->getInstantiator($class);
                 if ($value === null && $definition instanceof Definition\PartialMarker) {
                     continue;
-                } else {
-                    return $value;
                 }
+
+                return $value;
             }
         }
 
@@ -184,9 +186,9 @@ class DefinitionList extends SplDoublyLinkedList implements Definition\Definitio
             if ($definition->hasClass($class)) {
                 if ($definition->hasMethods($class) === false && $definition instanceof Definition\PartialMarker) {
                     continue;
-                } else {
-                    return $definition->hasMethods($class);
                 }
+
+                return $definition->hasMethods($class);
             }
         }
 
@@ -198,14 +200,14 @@ class DefinitionList extends SplDoublyLinkedList implements Definition\Definitio
      */
     public function hasMethod($class, $method)
     {
+        if (!$this->hasMethods($class)) {
+            return false;
+        }
+
         /** @var $definition Definition\DefinitionInterface */
         foreach ($this as $definition) {
-            if ($definition->hasClass($class)) {
-                if ($definition->hasMethods($class) === false && $definition instanceof Definition\PartialMarker) {
-                    continue;
-                } else {
-                    return $definition->hasMethods($class);
-                }
+            if ($definition->hasMethod($class, $method)) {
+                return true;
             }
         }
 
@@ -221,11 +223,11 @@ class DefinitionList extends SplDoublyLinkedList implements Definition\Definitio
         $methods = array();
         foreach ($this as $definition) {
             if ($definition->hasClass($class)) {
-                if ($definition instanceof Definition\PartialMarker) {
-                    $methods = array_merge($definition->getMethods($class), $methods);
-                } else {
+                if (!$definition instanceof Definition\PartialMarker) {
                     return array_merge($definition->getMethods($class), $methods);
                 }
+
+                $methods = array_merge($definition->getMethods($class), $methods);
             }
         }
 

--- a/tests/ZendTest/Di/DefinitionListTest.php
+++ b/tests/ZendTest/Di/DefinitionListTest.php
@@ -29,6 +29,80 @@ class DefinitionListTest extends TestCase
         $definitionList = new DefinitionList(array($definitionClassA, $definitionClassB));
 
         $this->assertEquals($superTypesA, $definitionList->getClassSupertypes("A"));
+    }
 
+    public function testHasMethods()
+    {
+        $definition = $this->getMock('Zend\Di\Definition\ClassDefinition', array(), array(), '', false);
+
+        $definition->expects($this->any())
+            ->method('hasClass')
+            ->will($this->returnValue(true));
+
+        $definition->expects($this->any())
+            ->method('hasMethods')
+            ->will($this->returnValue(true));
+
+        $definitionList = new DefinitionList(array($definition));
+
+        $this->assertTrue($definitionList->hasMethods('foo'));
+    }
+
+    public function testHasMethodsWhenDefinitionHasNotClass()
+    {
+        $definition = $this->getMock('Zend\Di\Definition\ClassDefinition', array(), array(), '', false);
+
+        $definition->expects($this->any())
+            ->method('hasClass')
+            ->will($this->returnValue(false));
+
+        $definitionList = new DefinitionList(array($definition));
+
+        $this->assertFalse($definitionList->hasMethods('foo'));
+    }
+
+    public function testHasMethodsWhenDefinitionHasNotMethods()
+    {
+        $definition = $this->getMock('Zend\Di\Definition\ClassDefinition', array(), array(), '', false);
+
+        $definition->expects($this->any())
+            ->method('hasClass')
+            ->will($this->returnValue(true));
+
+        $definition->expects($this->any())
+            ->method('hasMethods')
+            ->will($this->returnValue(false));
+
+        $definitionList = new DefinitionList(array($definition));
+
+        $this->assertFalse($definitionList->hasMethods('foo'));
+    }
+
+    public function testHasMethod()
+    {
+        $definition = $this->getMock('Zend\Di\Definition\ClassDefinition', array(), array(), '', false);
+
+        $definition->expects($this->any())
+            ->method('hasClass')
+            ->will($this->returnValue(true));
+
+        $definition->expects($this->any())
+            ->method('hasMethods')
+            ->will($this->returnValue(true));
+
+        $definition->expects($this->any())
+            ->method('hasMethod')
+            ->will($this->returnValue(true));
+
+        $definitionList = new DefinitionList(array($definition));
+
+        $this->assertTrue($definitionList->hasMethod('foo', 'doFoo'));
+    }
+
+    public function testHasMethodWithoutDefinitions()
+    {
+        $definitionList = new DefinitionList(array());
+
+        $this->assertFalse($definitionList->hasMethod('foo', 'doFoo'));
     }
 }

--- a/tests/ZendTest/Di/DefinitionListTest.php
+++ b/tests/ZendTest/Di/DefinitionListTest.php
@@ -31,78 +31,17 @@ class DefinitionListTest extends TestCase
         $this->assertEquals($superTypesA, $definitionList->getClassSupertypes("A"));
     }
 
-    public function testHasMethods()
-    {
-        $definition = $this->getMock('Zend\Di\Definition\ClassDefinition', array(), array(), '', false);
-
-        $definition->expects($this->any())
-            ->method('hasClass')
-            ->will($this->returnValue(true));
-
-        $definition->expects($this->any())
-            ->method('hasMethods')
-            ->will($this->returnValue(true));
-
-        $definitionList = new DefinitionList(array($definition));
-
-        $this->assertTrue($definitionList->hasMethods('foo'));
-    }
-
-    public function testHasMethodsWhenDefinitionHasNotClass()
-    {
-        $definition = $this->getMock('Zend\Di\Definition\ClassDefinition', array(), array(), '', false);
-
-        $definition->expects($this->any())
-            ->method('hasClass')
-            ->will($this->returnValue(false));
-
-        $definitionList = new DefinitionList(array($definition));
-
-        $this->assertFalse($definitionList->hasMethods('foo'));
-    }
-
-    public function testHasMethodsWhenDefinitionHasNotMethods()
-    {
-        $definition = $this->getMock('Zend\Di\Definition\ClassDefinition', array(), array(), '', false);
-
-        $definition->expects($this->any())
-            ->method('hasClass')
-            ->will($this->returnValue(true));
-
-        $definition->expects($this->any())
-            ->method('hasMethods')
-            ->will($this->returnValue(false));
-
-        $definitionList = new DefinitionList(array($definition));
-
-        $this->assertFalse($definitionList->hasMethods('foo'));
-    }
-
     public function testHasMethod()
     {
-        $definition = $this->getMock('Zend\Di\Definition\ClassDefinition', array(), array(), '', false);
-
-        $definition->expects($this->any())
-            ->method('hasClass')
-            ->will($this->returnValue(true));
-
-        $definition->expects($this->any())
-            ->method('hasMethods')
-            ->will($this->returnValue(true));
-
-        $definition->expects($this->any())
-            ->method('hasMethod')
-            ->will($this->returnValue(true));
-
-        $definitionList = new DefinitionList(array($definition));
+        $definitionClass = new ClassDefinition('foo');
+        $definitionClass->addMethod('doFoo');
+        $definitionList = new DefinitionList(array($definitionClass));
 
         $this->assertTrue($definitionList->hasMethod('foo', 'doFoo'));
-    }
+        $this->assertFalse($definitionList->hasMethod('foo', 'doBar'));
 
-    public function testHasMethodWithoutDefinitions()
-    {
-        $definitionList = new DefinitionList(array());
-
-        $this->assertFalse($definitionList->hasMethod('foo', 'doFoo'));
+        $definitionClass->addMethod('doBar');
+        
+        $this->assertTrue($definitionList->hasMethod('foo', 'doBar'));
     }
 }


### PR DESCRIPTION
The method DefinitionList::hasMethods() was simply duplicated to create method DefinitionList::hasMethod() and therefore it did not work correctly.
