### PR TITLE
Hostname RouteInterface non standard port handling

### DIFF
--- a/library/Zend/Mvc/Router/Http/Hostname.php
+++ b/library/Zend/Mvc/Router/Http/Hostname.php
@@ -129,7 +129,9 @@ class Hostname implements RouteInterface
         if (count($hostname) !== count($this->route)) {
             return null;
         }
-
+        if(!is_null($this->port) && $uri->getPort() != $this->port) {
+            return null;
+        }
         foreach ($this->route as $index => $routePart) {
             if (preg_match('(^:(?P<name>.+)$)', $routePart, $matches)) {
                 if (isset($this->constraints[$matches['name']]) && !preg_match('(^' . $this->constraints[$matches['name']] . '$)', $hostname[$index])) {

--- a/library/Zend/Mvc/Router/Http/Hostname.php
+++ b/library/Zend/Mvc/Router/Http/Hostname.php
@@ -53,6 +53,13 @@ class Hostname implements RouteInterface
     protected $assembledParams = array();
 
     /**
+     * Non standard port
+     *
+     * @var string
+     */
+    protected $port = null;
+
+    /**
      * Create a new hostname route.
      *
      * @param  string $route
@@ -61,7 +68,12 @@ class Hostname implements RouteInterface
      */
     public function __construct($route, array $constraints = array(), array $defaults = array())
     {
-        $this->route       = explode('.', $route);
+        if (preg_match('|\:(\d+)$|', $route, $matches )) {
+            $this->route = explode('.',substr($route, 0, -1 * (strlen($matches[1]) + 1)));
+            $this->port = isset($matches[1]) ? $matches[1] : null;
+        } else {
+            $this->route = explode('.', $route);
+        }
         $this->constraints = $constraints;
         $this->defaults    = $defaults;
     }
@@ -109,7 +121,7 @@ class Hostname implements RouteInterface
         if (!method_exists($request, 'getUri')) {
             return null;
         }
-
+        
         $uri      = $request->getUri();
         $hostname = explode('.', $uri->getHost());
         $params   = array();
@@ -165,6 +177,7 @@ class Hostname implements RouteInterface
             }
 
             $options['uri']->setHost(implode('.', $parts));
+            $options['uri']->setPort($this->port); 
         }
 
         // A hostname does not contribute to the path, thus nothing is returned.

--- a/tests/ZendTest/Mvc/Router/Http/HostnameTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/HostnameTest.php
@@ -52,6 +52,12 @@ class HostnameTest extends TestCase
                 '123.example.com',
                 array('foo' => '123')
             ),
+            'non-standard-port' => array(
+                new Hostname('foo.example.com:8080'),
+                'foo.example.com',
+                array(),
+                '8080',
+            ),
         );
     }
 
@@ -83,8 +89,9 @@ class HostnameTest extends TestCase
      * @param        Hostname $route
      * @param        string   $hostname
      * @param        array    $params
+     * @param        string   $port
      */
-    public function testAssembling(Hostname $route, $hostname, array $params = null)
+    public function testAssembling(Hostname $route, $hostname, array $params = null, $port = null)
     {
         if ($params === null) {
             // Data which will not match are not tested for assembling.
@@ -96,6 +103,7 @@ class HostnameTest extends TestCase
 
         $this->assertEquals('', $path);
         $this->assertEquals($hostname, $uri->getHost());
+        $this->assertEquals($port, $uri->getPort());
     }
 
     public function testNoMatchWithoutUriMethod()

--- a/tests/ZendTest/Mvc/Router/Http/HostnameTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/HostnameTest.php
@@ -66,11 +66,13 @@ class HostnameTest extends TestCase
      * @param        Hostname $route
      * @param        string   $hostname
      * @param        array    $params
+     * @param        string   $port
      */
-    public function testMatching(Hostname $route, $hostname, array $params = null)
+    public function testMatching(Hostname $route, $hostname, array $params = null, $port = null)
     {
         $request = new Request();
         $request->setUri('http://' . $hostname . '/');
+        $request->getUri()->setPort($port);
         $match = $route->match($request);
 
         if ($params === null) {


### PR DESCRIPTION
Added test "non-standard-port" to demonstrate failed handling of non standard port specifications for Hostname. 
eg. foo.example.com:8080

Modification of  'testMatching' to use non standard port if specified.

Modification of Hostname RouteInterface to allow matching and assembling of non standard ports.

Modification of Hostname RouteInterface to match non standard port if specified.
