### PR TITLE
Add root namespace character

### DIFF
--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -283,7 +283,7 @@ class Socket implements HttpAdapter, StreamInterface
                 if (!$test || $error) {
                     // Error handling is kind of difficult when it comes to SSL
                     $errorString = '';
-                    while (($sslError = openssl_error_string()) != false) {
+                    while (($sslError = \openssl_error_string()) != false) {
                         $errorString .= "; SSL error: $sslError";
                     }
                     $this->close();

--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -283,8 +283,10 @@ class Socket implements HttpAdapter, StreamInterface
                 if (!$test || $error) {
                     // Error handling is kind of difficult when it comes to SSL
                     $errorString = '';
-                    while (($sslError = \openssl_error_string()) != false) {
-                        $errorString .= "; SSL error: $sslError";
+                    if (extension_loaded('openssl')) {
+                        while (($sslError = openssl_error_string()) != false) {
+                            $errorString .= "; SSL error: $sslError";
+                        }
                     }
                     $this->close();
 


### PR DESCRIPTION
The backslash for the root namespace of openssl_error_string() is not defined. Should solve #3332
