### PR TITLE
Update library/Zend/Paginator/Adapter/DbSelect.php

### DIFF
--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -111,6 +111,7 @@ class DbSelect implements AdapterInterface
         $select->reset(Select::COLUMNS);
         $select->reset(Select::LIMIT);
         $select->reset(Select::OFFSET);
+        $select->reset(Select::ORDER);
 
         $select->columns(array('c' => new Expression('COUNT(1)')));
 


### PR DESCRIPTION
DbSelect adatper don't reset ORDER BY on count query, this leads to an exception if your DbSelect object uses order function.

This patch should resolve this problem.
