### PR TITLE
Provide support for more HTTP methods in the AbstractRestfulController

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -75,12 +75,28 @@ abstract class AbstractRestfulController extends AbstractController
     abstract public function get($id);
 
     /**
+     * Return list of resources
+     *
+     * @return mixed
+     */
+    abstract public function getList();
+
+    /**
      * Retrieve HEAD metadata for the resource
+     *
+     * Not marked as abstract, as that would introduce a BC break
+     * (introduced in 2.1.0); instead, raises an exception if not implemented.
      *
      * @param  null|mixed $id
      * @return mixed
+     * @throws Exception\RuntimeException
      */
-    abstract public function head($id = null);
+    public function head($id = null)
+    {
+        throw new Exception\RuntimeException(sprintf(
+            '%s is unimplemented', __METHOD__
+        ));
+    }
 
     /**
      * Respond to the OPTIONS method
@@ -88,16 +104,34 @@ abstract class AbstractRestfulController extends AbstractController
      * Typically, set the Allow header with allowed HTTP methods, and
      * return the response.
      *
-     * @return mixed
-     */
-    abstract public function options();
-
-    /**
-     * Return list of resources
+     * Not marked as abstract, as that would introduce a BC break
+     * (introduced in 2.1.0); instead, raises an exception if not implemented.
      *
      * @return mixed
+     * @throws Exception\RuntimeException
      */
-    abstract public function getList();
+    public function options()
+    {
+        throw new Exception\RuntimeException(sprintf(
+            '%s is unimplemented', __METHOD__
+        ));
+    }
+
+    /**
+     * Respond to the PATCH method
+     *
+     * Not marked as abstract, as that would introduce a BC break
+     * (introduced in 2.1.0); instead, raises an exception if not implemented.
+     *
+     * @return mixed
+     * @throws Exception\RuntimeException
+     */
+    public function patch($id, $data)
+    {
+        throw new Exception\RuntimeException(sprintf(
+            '%s is unimplemented', __METHOD__
+        ));
+    }
 
     /**
      * Update an existing resource

--- a/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
+++ b/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
@@ -13,7 +13,6 @@ namespace ZendTest\Mvc\Controller;
 use PHPUnit_Framework_TestCase as TestCase;
 use stdClass;
 use Zend\EventManager\SharedEventManager;
-use Zend\Http\Request;
 use Zend\Http\Response;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;
@@ -29,7 +28,8 @@ class RestfulControllerTest extends TestCase
     public function setUp()
     {
         $this->controller = new TestAsset\RestfulTestController();
-        $this->request    = new Request();
+        $this->request    = new TestAsset\Request();
+        $this->response   = new Response();
         $this->routeMatch = new RouteMatch(array('controller' => 'controller-restful'));
         $this->event      = new MvcEvent;
         $this->event->setRouteMatch($this->routeMatch);
@@ -100,6 +100,83 @@ class RestfulControllerTest extends TestCase
         $this->assertEquals(array(), $result);
         $this->assertEquals(array(), $this->controller->entity);
         $this->assertEquals('delete', $this->routeMatch->getParam('action'));
+    }
+
+    public function testDispatchInvokesOptionsMethodWhenNoActionPresentAndOptionsInvoked()
+    {
+        $this->request->setMethod('OPTIONS');
+        $result = $this->controller->dispatch($this->request, $this->response);
+        $this->assertSame($this->response, $result);
+        $this->assertEquals('options', $this->routeMatch->getParam('action'));
+        $headers = $result->getHeaders();
+        $this->assertTrue($headers->has('Allow'));
+        $allow = $headers->get('Allow');
+        $expected = explode(', ', 'GET, POST, PUT, DELETE, PATCH, HEAD, TRACE');
+        sort($expected);
+        $test     = explode(', ', $allow->getFieldValue());
+        sort($test);
+        $this->assertEquals($expected, $test);
+    }
+
+    public function testDispatchInvokesPatchMethodWhenNoActionPresentAndPatchInvokedWithIdentifier()
+    {
+        $entity = new stdClass;
+        $entity->name = 'foo';
+        $entity->type = 'standard';
+        $this->controller->entity = $entity;
+        $entity = array('name' => __FUNCTION__);
+        $string = http_build_query($entity);
+        $this->request->setMethod('PATCH')
+                      ->setContent($string);
+        $this->routeMatch->setParam('id', 1);
+        $result = $this->controller->dispatch($this->request, $this->response);
+        $this->assertArrayHasKey('entity', $result);
+        $test = $result['entity'];
+        $this->assertArrayHasKey('id', $test);
+        $this->assertEquals(1, $test['id']);
+        $this->assertArrayHasKey('name', $test);
+        $this->assertEquals(__FUNCTION__, $test['name']);
+        $this->assertArrayHasKey('type', $test);
+        $this->assertEquals('standard', $test['type']);
+        $this->assertEquals('patch', $this->routeMatch->getParam('action'));
+    }
+
+    public function testDispatchInvokesHeadMethodWhenNoActionPresentAndHeadInvokedWithoutIdentifier()
+    {
+        $entities = array(
+            new stdClass,
+            new stdClass,
+            new stdClass,
+        );
+        $this->controller->entities = $entities;
+        $this->request->setMethod('HEAD');
+        $result = $this->controller->dispatch($this->request, $this->response);
+        $this->assertSame($this->response, $result);
+        $content = $result->getContent();
+        $this->assertEquals('', $content);
+        $this->assertEquals('head', $this->routeMatch->getParam('action'));
+    }
+
+    public function testDispatchInvokesHeadMethodWhenNoActionPresentAndHeadInvokedWithIdentifier()
+    {
+        $entity = new stdClass;
+        $this->controller->entity = $entity;
+        $this->routeMatch->setParam('id', 1);
+        $this->request->setMethod('HEAD');
+        $result = $this->controller->dispatch($this->request, $this->response);
+        $this->assertSame($this->response, $result);
+        $content = $result->getContent();
+        $this->assertEquals('', $content);
+        $this->assertEquals('head', $this->routeMatch->getParam('action'));
+    }
+
+    public function testAllowsRegisteringCustomHttpMethodsWithHandlers()
+    {
+        $this->controller->addHttpMethodHandler('DESCRIBE', array($this->controller, 'describe'));
+        $this->request->setMethod('DESCRIBE');
+        $result = $this->controller->dispatch($this->request, $this->response);
+        $this->assertArrayHasKey('description', $result);
+        $this->assertContains('::describe', $result['description']);
     }
 
     public function testDispatchCallsActionMethodBasedOnNormalizingAction()

--- a/tests/ZendTest/Mvc/Controller/TestAsset/Request.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/Request.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc\Controller\TestAsset;
+
+use Zend\Http\Request as HttpRequest;
+
+/**
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+class Request extends HttpRequest
+{
+    /**
+     * Override the method setter, to allow arbitrary HTTP methods
+     *
+     * @param  string $method
+     * @return Request
+     */
+    public function setMethod($method)
+    {
+        $method = strtoupper($method);
+        $this->method = $method;
+        return $this;
+    }
+}

--- a/tests/ZendTest/Mvc/Controller/TestAsset/RestfulTestController.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/RestfulTestController.php
@@ -18,27 +18,6 @@ class RestfulTestController extends AbstractRestfulController
     public $entity   = array();
 
     /**
-     * Return list of resources
-     *
-     * @return mixed
-     */
-    public function getList()
-    {
-        return array('entities' => $this->entities);
-    }
-
-    /**
-     * Return single resource
-     *
-     * @param  mixed $id
-     * @return mixed
-     */
-    public function get($id)
-    {
-        return array('entity' => $this->entity);
-    }
-
-    /**
      * Create a new resource
      *
      * @param  mixed $data
@@ -46,19 +25,6 @@ class RestfulTestController extends AbstractRestfulController
      */
     public function create($data)
     {
-        return array('entity' => $data);
-    }
-
-    /**
-     * Update an existing resource
-     *
-     * @param  mixed $id
-     * @param  mixed $data
-     * @return mixed
-     */
-    public function update($id, $data)
-    {
-        $data['id'] = $id;
         return array('entity' => $data);
     }
 
@@ -74,6 +40,77 @@ class RestfulTestController extends AbstractRestfulController
         return array();
     }
 
+    /**
+     * Return single resource
+     *
+     * @param  mixed $id
+     * @return mixed
+     */
+    public function get($id)
+    {
+        return array('entity' => $this->entity);
+    }
+
+    /**
+     * Return list of resources
+     *
+     * @return mixed
+     */
+    public function getList()
+    {
+        return array('entities' => $this->entities);
+    }
+
+    /**
+     * Retrieve the headers for a given resource
+     *
+     * @return void
+     */
+    public function head($id = null)
+    {
+    }
+
+    /**
+     * Return list of allowed HTTP methods
+     *
+     * @return \Zend\Http\Response
+     */
+    public function options()
+    {
+        $response = $this->getResponse();
+        $headers  = $response->getHeaders();
+        $headers->addHeaderLine('Allow', 'GET, POST, PUT, DELETE, PATCH, HEAD, TRACE');
+        return $response;
+    }
+
+    /**
+     * Patch (partial update) an entity
+     *
+     * @param  int $id
+     * @param  array $data
+     * @return array
+     */
+    public function patch($id, $data)
+    {
+        $entity     = (array) $this->entity;
+        $data['id'] = $id;
+        $updated    = array_merge($entity, $data);
+        return array('entity' => $updated);
+    }
+
+    /**
+     * Update an existing resource
+     *
+     * @param  mixed $id
+     * @param  mixed $data
+     * @return mixed
+     */
+    public function update($id, $data)
+    {
+        $data['id'] = $id;
+        return array('entity' => $data);
+    }
+
     public function editAction()
     {
         return array('content' => __FUNCTION__);
@@ -82,5 +119,10 @@ class RestfulTestController extends AbstractRestfulController
     public function testSomeStrangelySeparatedWordsAction()
     {
         return array('content' => 'Test Some Strangely Separated Words');
+    }
+
+    public function describe()
+    {
+        return array('description' => __METHOD__);
     }
 }


### PR DESCRIPTION
- Adds explicit support for OPTIONS, PATCH, and HEAD
- Adds ability to register handler methods for custom HTTP methods
- Refactors:
  - DRY up identifier retrieval -- added getIdentifier() method
  - DRY up parsing of content body -- added processBodyContent()
  - Moved RESTful method handling out of conditional
