### PR TITLE
ClassMethods hydrator and wrong method definition

### DIFF
--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -64,6 +64,11 @@ class ClassMethods extends AbstractHydrator
                 continue;
             }
 
+            $reflectionMethod = new \ReflectionMethod(get_class($object) . '::' . $method);
+            if ($reflectionMethod->getNumberOfParameters() > 0) {
+                continue;
+            }
+
             $attribute = $method;
             if (preg_match('/^get/', $method)) {
                 $attribute = substr($method, 3);

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -215,5 +215,9 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
     {
         $hydrator = new ClassMethods(false);
         $datas = $hydrator->extract($this->classMethodsInvalidParameter);
+
+        $this->assertTrue($datas['hasBar']);
+        $this->assertEquals('Bar', $datas['foo']);
+        $this->assertFalse($datas['isBla']);
     }
 }

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -15,6 +15,7 @@ use Zend\Stdlib\Hydrator\Reflection;
 use ZendTest\Stdlib\TestAsset\ClassMethodsCamelCase;
 use ZendTest\Stdlib\TestAsset\ClassMethodsUnderscore;
 use ZendTest\Stdlib\TestAsset\ClassMethodsCamelCaseMissing;
+use ZendTest\Stdlib\TestAsset\ClassMethodsInvalidParameter;
 use ZendTest\Stdlib\TestAsset\Reflection as ReflectionAsset;
 
 /**
@@ -42,6 +43,11 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
     protected $classMethodsUnderscore;
 
     /**
+     * @var ClassMethodsInvalidParameter
+     */
+    protected $classMethodsInvalidParameter;
+
+    /**
      * @var ReflectionAsset
      */
     protected $reflection;
@@ -51,6 +57,7 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->classMethodsCamelCase = new ClassMethodsCamelCase();
         $this->classMethodsCamelCaseMissing = new ClassMethodsCamelCaseMissing();
         $this->classMethodsUnderscore = new ClassMethodsUnderscore();
+        $this->classMethodsInvalidParameter = new ClassMethodsInvalidParameter();
         $this->reflection = new ReflectionAsset;
     }
 
@@ -202,5 +209,11 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->classMethodsCamelCaseMissing, $test);
         $this->assertEquals($test->getFooBar(), 'foo');
         $this->assertEquals($test->getFooBarBaz(), '2');
+    }
+
+    public function testHydratorClassMethodsWithServiceManager()
+    {
+        $hydrator = new ClassMethods(false);
+        $datas = $hydrator->extract($this->classMethodsInvalidParameter);
     }
 }

--- a/tests/ZendTest/Stdlib/TestAsset/ClassMethodsInvalidParameter.php
+++ b/tests/ZendTest/Stdlib/TestAsset/ClassMethodsInvalidParameter.php
@@ -15,4 +15,29 @@ class ClassMethodsInvalidParameter
     {
         return $alias;
     }
+
+    public function getTest($foo)
+    {
+        return $foo;
+    }
+
+    public function isTest($bar)
+    {
+        return $bar;
+    }
+
+    public function hasBar()
+    {
+        return true;
+    }
+
+    public function getFoo()
+    {
+        return "Bar";
+    }
+
+    public function isBla()
+    {
+        return false;
+    }
 }

--- a/tests/ZendTest/Stdlib/TestAsset/ClassMethodsInvalidParameter.php
+++ b/tests/ZendTest/Stdlib/TestAsset/ClassMethodsInvalidParameter.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+namespace ZendTest\Stdlib\TestAsset;
+
+class ClassMethodsInvalidParameter
+{
+    public function hasAlias($alias)
+    {
+        return $alias;
+    }
+}


### PR DESCRIPTION
I've noticed, that the ClassMethods hydrator will cause a fatal php error, if the function definition for has/get/is - method (no parameter) does not match. I know the conventions, but sometimes you may need a parameter (see https://github.com/zendframework/zf2/blob/master/library/Zend/ServiceManager/ServiceManager.php#L646 ). 

This will simply skip the method, if the number of parameters is > 0. 

P.S.: Are you interested in a hydrator, that does the same as the ClassMethods recursivly? I need the hydrator, to transform my objects to complete-non-object datatypes (for phing in my case). Is that a valid use-case for you?
