### PR TITLE
Update library/Zend/InputFilter/BaseInputFilter.php

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -41,6 +41,14 @@ class BaseInputFilter implements InputFilterInterface
     }
 
     /**
+     * Get list of input filters
+     * @return array
+     */
+    public function getInputs() {
+        return $this->inputs;
+    }
+
+    /**
      * Add an input to the input filter
      *
      * @param  InputInterface|InputFilterInterface $input


### PR DESCRIPTION
I think an access to that list is necessary, for eg if you want to 
retrieve the full list and apply to all validators a translator instance

foreach($inputFilter->getInputs() as $input)
foreach($input->getValidatorChain()->getValidators() as $validator)
$validator->setTranslator()

I know there is AbstractValidator::setDefaultTranslator(); for example above
