### PR TITLE
Add default prototype tags in reflection

### DIFF
--- a/library/Zend/Code/Reflection/DocBlock/Tag/AuthorTag.php
+++ b/library/Zend/Code/Reflection/DocBlock/Tag/AuthorTag.php
@@ -43,7 +43,7 @@ class AuthorTag implements TagInterface
     {
         $match = array();
 
-        if (!preg_match('/^([^\<]*)(\<([^\>]*)\>)?$/u', $tagDocblockLine, $match)) {
+        if (!preg_match('/^([^\<]*)(\<([^\>]*)\>)?(.*)$/u', $tagDocblockLine, $match)) {
             return;
         }
 

--- a/library/Zend/Code/Reflection/DocBlock/TagManager.php
+++ b/library/Zend/Code/Reflection/DocBlock/TagManager.php
@@ -56,6 +56,8 @@ class TagManager
         $this->addTagPrototype(new Tag\ReturnTag());
         $this->addTagPrototype(new Tag\MethodTag());
         $this->addTagPrototype(new Tag\PropertyTag());
+        $this->addTagPrototype(new Tag\AuthorTag());
+        $this->addTagPrototype(new Tag\LicenseTag());
         $this->addTagPrototype(new Tag\ThrowsTag());
         $this->addTagPrototype(new Tag\GenericTag());
     }

--- a/tests/ZendTest/Code/Reflection/FileReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FileReflectionTest.php
@@ -99,8 +99,12 @@ class FileReflectionTest extends \PHPUnit_Framework_TestCase
         include_once $fileToReflect;
         $reflectionFile = new FileReflection($fileToReflect);
 
-        $this->assertTrue($reflectionFile->getDocBlock() instanceof \Zend\Code\Reflection\DocBlockReflection);
-        $this->assertEquals('Jeremiah Small <jsmall@soliantconsulting.com>', $reflectionFile->getDocBlock()->getTag('author')->getContent());
+        $reflectionDocBlock = $reflectionFile->getDocBlock();
+        $this->assertTrue($reflectionDocBlock instanceof \Zend\Code\Reflection\DocBlockReflection);
+
+        $authorTag = $reflectionDocBlock->getTag('author');
+        $this->assertEquals('Jeremiah Small', $authorTag->getAuthorName());
+        $this->assertEquals('jsmall@soliantconsulting.com', $authorTag->getAuthorEmail());
     }
 
     public function testFileGetFunctionsReturnsFunctions()

--- a/tests/ZendTest/Code/Reflection/ReflectionDocBlockTagTest.php
+++ b/tests/ZendTest/Code/Reflection/ReflectionDocBlockTagTest.php
@@ -27,7 +27,8 @@ class ReflectionDocBlockTagTest extends \PHPUnit_Framework_TestCase
         $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
 
         $authorTag = $classReflection->getDocBlock()->getTag('author');
-        $this->assertEquals('Ralph Schindler <ralph.schindler@zend.com>', $authorTag->getContent());
+        $this->assertEquals('Ralph Schindler', $authorTag->getAuthorName());
+        $this->assertEquals('ralph.schindler@zend.com', $authorTag->getAuthorEmail());
     }
 
     public function testTagShouldAllowJustTagNameInDocBlockTagLine()


### PR DESCRIPTION
Add author and license tags in default prototype tags. These tags were created and merged with develop branch recently.
