### PR TITLE
Added filter possibility

### DIFF
--- a/library/Zend/Stdlib/Hydrator/AbstractHydrator.php
+++ b/library/Zend/Stdlib/Hydrator/AbstractHydrator.php
@@ -138,6 +138,16 @@ abstract class AbstractHydrator implements HydratorInterface, StrategyEnabledInt
     }
 
     /**
+     * Get the filter instance
+     *
+     * @return Filter\FilterComposite
+     */
+    public function getFilter()
+    {
+        return $this->filterComposite;
+    }
+
+    /**
      * Add a new filter to take care of what needs to be hydrated.
      * To exclude e.g. the method getServiceLocator:
      *

--- a/library/Zend/Stdlib/Hydrator/AbstractHydrator.php
+++ b/library/Zend/Stdlib/Hydrator/AbstractHydrator.php
@@ -12,6 +12,7 @@ namespace Zend\Stdlib\Hydrator;
 
 use ArrayObject;
 use Zend\Stdlib\Exception;
+use Zend\Stdlib\Hydrator\Filter\FilterComposite;
 use Zend\Stdlib\Hydrator\StrategyEnabledInterface;
 use Zend\Stdlib\Hydrator\Strategy\StrategyInterface;
 
@@ -30,11 +31,18 @@ abstract class AbstractHydrator implements HydratorInterface, StrategyEnabledInt
     protected $strategies;
 
     /**
+     * Composite to filter the methods, that need to be hydrated
+     * @var Filter\FilterComposite
+     */
+    protected $filterComposite;
+
+    /**
      * Initializes a new instance of this class.
      */
     public function __construct()
     {
         $this->strategies = new ArrayObject();
+        $this->filterComposite = new FilterComposite();
     }
 
     /**
@@ -127,5 +135,58 @@ abstract class AbstractHydrator implements HydratorInterface, StrategyEnabledInt
             $value = $strategy->hydrate($value);
         }
         return $value;
+    }
+
+    /**
+     * Add a new filter to take care of what needs to be hydrated.
+     * To exclude e.g. the method getServiceLocator:
+     *
+     * <code>
+     * $composite->addFilter("servicelocator",
+     *     function($property) {
+     *         list($class, $method) = explode('::', $property);
+     *         if ($method === 'getServiceLocator') {
+     *             return false;
+     *         }
+     *         return true;
+     *     }, FilterComposite::CONDITION_AND
+     * );
+     * </code>
+     *
+     * @param string $name Index in the composite
+     * @param callable|Zend\Stdlib\Hydrator\Filter\FilterInterface $filter
+     * @param int $condition
+     * @return Filter\FilterComposite
+     */
+    public function addFilter($name, $filter, $condition = FilterComposite::CONDITION_OR)
+    {
+        return $this->filterComposite->addFilter($name, $filter, $condition);
+    }
+
+    /**
+     * Check whether a specific filter exists at key $name or not
+     *
+     * @param string $name Index in the composite
+     * @return bool
+     */
+    public function hasFilter($name)
+    {
+        return $this->filterComposite->hasFilter($name);
+    }
+
+    /**
+     * Remove a filter from the composition.
+     * To not extract "has" methods, you simply need to unregister it
+     *
+     * <code>
+     * $filterComposite->removeFilter('has');
+     * </code>
+     *
+     * @param $name
+     * @return Filter\FilterComposite
+     */
+    public function removeFilter($name)
+    {
+        return $this->filterComposite->removeFilter($name);
     }
 }

--- a/library/Zend/Stdlib/Hydrator/ArraySerializable.php
+++ b/library/Zend/Stdlib/Hydrator/ArraySerializable.php
@@ -46,7 +46,7 @@ class ArraySerializable extends AbstractHydrator
                 $value = $self->extractValue($name, $value);
             }
         });
-        #var_dump($data);
+
         return $data;
     }
 

--- a/library/Zend/Stdlib/Hydrator/ArraySerializable.php
+++ b/library/Zend/Stdlib/Hydrator/ArraySerializable.php
@@ -39,9 +39,14 @@ class ArraySerializable extends AbstractHydrator
 
         $self = $this;
         $data = $object->getArrayCopy();
-        array_walk($data, function (&$value, $name) use ($self) {
-            $value = $self->extractValue($name, $value);
+        array_walk($data, function (&$value, $name) use ($self, &$data) {
+            if (!$self->getFilter()->filter($name)) {
+                unset($data[$name]);
+            } else {
+                $value = $self->extractValue($name, $value);
+            }
         });
+        #var_dump($data);
         return $data;
     }
 

--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -11,9 +11,11 @@
 namespace Zend\Stdlib\Hydrator;
 
 use Zend\Stdlib\Exception;
+use Zend\Stdlib\Hydrator\Filter\FilterComposite;
 use Zend\Stdlib\Hydrator\Filter\GetFilter;
 use Zend\Stdlib\Hydrator\Filter\HasFilter;
 use Zend\Stdlib\Hydrator\Filter\IsFilter;
+use Zend\Stdlib\Hydrator\Filter\NumberOfParameterFilter;
 
 /**
  * @category   Zend
@@ -40,6 +42,7 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
         $this->filterComposite->addFilter("is", new IsFilter());
         $this->filterComposite->addFilter("has", new HasFilter());
         $this->filterComposite->addFilter("get", new GetFilter());
+        $this->filterComposite->addFilter("parameter", new NumberOfParameterFilter(), FilterComposite::CONDITION_AND);
     }
 
     /**

--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -10,11 +10,11 @@
 
 namespace Zend\Stdlib\Hydrator;
 
-use Zend\Stdlib\Exception,
-    Zend\Stdlib\Hydrator\Filter\FilterComposite,
-    Zend\Stdlib\Hydrator\Filter\IsFilter,
-    Zend\Stdlib\Hydrator\Filter\GetFilter,
-    Zend\Stdlib\Hydrator\Filter\HasFilter;
+use Zend\Stdlib\Exception;
+use Zend\Stdlib\Hydrator\Filter\FilterComposite;
+use Zend\Stdlib\Hydrator\Filter\GetFilter;
+use Zend\Stdlib\Hydrator\Filter\HasFilter;
+use Zend\Stdlib\Hydrator\Filter\IsFilter;
 
 /**
  * @category   Zend

--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -48,7 +48,7 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
     }
 
     /**
-     * @param  array|\Traversable $options
+     * @param  array|\Traversable                 $options
      * @return ClassMethods
      * @throws Exception\InvalidArgumentException
      */
@@ -69,12 +69,13 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
     }
 
     /**
-     * @param  boolean $underscoreSeparatedKeys
+     * @param  boolean      $underscoreSeparatedKeys
      * @return ClassMethods
      */
     public function setUnderscoreSeparatedKeys($underscoreSeparatedKeys)
     {
         $this->underscoreSeparatedKeys = $underscoreSeparatedKeys;
+
         return $this;
     }
 
@@ -91,7 +92,7 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
      *
      * Extracts the getter/setter of the given $object.
      *
-     * @param  object $object
+     * @param  object                           $object
      * @return array
      * @throws Exception\BadMethodCallException for a non-object $object
      */
@@ -115,6 +116,7 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
 
         $transform = function ($letters) {
             $letter = array_shift($letters);
+
             return '_' . strtolower($letter);
         };
         $attributes = array();
@@ -149,8 +151,8 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
      *
      * Hydrates an object by getter/setter methods of the object.
      *
-     * @param  array $data
-     * @param  object $object
+     * @param  array                            $data
+     * @param  object                           $object
      * @return object
      * @throws Exception\BadMethodCallException for a non-object $object
      */
@@ -164,6 +166,7 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
 
         $transform = function ($letters) {
             $letter = substr(array_shift($letters), 1, 1);
+
             return ucfirst($letter);
         };
 
@@ -178,6 +181,7 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
                 $object->$method($value);
             }
         }
+
         return $object;
     }
 

--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -78,7 +78,6 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
     public function setUnderscoreSeparatedKeys($underscoreSeparatedKeys)
     {
         $this->underscoreSeparatedKeys = $underscoreSeparatedKeys;
-
         return $this;
     }
 
@@ -88,7 +87,6 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
     public function getUnderscoreSeparatedKeys()
     {
         return $this->underscoreSeparatedKeys;
-
     }
 
     /**

--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -11,7 +11,6 @@
 namespace Zend\Stdlib\Hydrator;
 
 use Zend\Stdlib\Exception;
-use Zend\Stdlib\Hydrator\Filter\FilterComposite;
 use Zend\Stdlib\Hydrator\Filter\GetFilter;
 use Zend\Stdlib\Hydrator\Filter\HasFilter;
 use Zend\Stdlib\Hydrator\Filter\IsFilter;
@@ -30,12 +29,6 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
     protected $underscoreSeparatedKeys = true;
 
     /**
-     * Composite to filter the methods, that need to be hydrated
-     * @var Filter\FilterComposite
-     */
-    protected $filterComposite;
-
-    /**
      * Define if extract values will use camel case or name with underscore
      * @param boolean|array $underscoreSeparatedKeys
      */
@@ -44,7 +37,6 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
         parent::__construct();
         $this->setUnderscoreSeparatedKeys($underscoreSeparatedKeys);
 
-        $this->filterComposite = new FilterComposite();
         $this->filterComposite->addFilter("is", new IsFilter());
         $this->filterComposite->addFilter("has", new HasFilter());
         $this->filterComposite->addFilter("get", new GetFilter());
@@ -174,54 +166,4 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
         return $object;
     }
 
-    /**
-     * Add a new filter to take care of what needs to be hydrated.
-     * To exclude e.g. the method getServiceLocator:
-     *
-     * <code>
-     * $composite->addFilter("servicelocator",
-     *     function($property) {
-     *         list($class, $method) = explode('::', $property);
-     *         if ($method === 'getServiceLocator') {
-     *             return false;
-     *         }
-     *         return true;
-     *     }, FilterComposite::CONDITION_AND
-     * );
-     * </code>
-     *
-     * @param string $name Index in the composite
-     * @param callable|Zend\Stdlib\Hydrator\Filter\FilterInterface $filter
-     * @param int $condition
-     */
-    public function addFilter($name, $filter, $condition = FilterComposite::CONDITION_OR)
-    {
-        $this->filterComposite->addFilter($name, $filter, $condition);
-    }
-
-    /**
-     * Check whether a specific filter exists at key $name or not
-     *
-     * @param string $name Index in the composite
-     * @return bool
-     */
-    public function hasFilter($name)
-    {
-        return $this->filterComposite->hasFilter($name);
-    }
-
-    /**
-     * Remove a filter from the composition.
-     * To not extract "has" methods, you simply need to unregister it
-     *
-     * <code>
-     * $filterComposite->removeFilter('has');
-     * </code>
-     *
-     * @param $name
-     */
-    public function removeFilter($name)
-    {
-        $this->filterComposite->removeFilter($name);
-    }
 }

--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -105,15 +105,10 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
 
         $filter = null;
         if ($object instanceof FilterProviderInterface) {
-            $filter = $object->getFilter();
-            if ($filter instanceof FilterComposite)
-            {
-                $filter->addFilter(
-                    "getfilter",
-                    new MethodMatchFilter("getFilter"),
-                    FilterComposite::CONDITION_AND
-                );
-            }
+            $filter = new FilterComposite(
+                array($object->getFilter()),
+                array(new MethodMatchFilter("getFilter"))
+            );
         } else {
             $filter = $this->filterComposite;
         }

--- a/library/Zend/Stdlib/Hydrator/Filter/FilterComposite.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/FilterComposite.php
@@ -9,6 +9,8 @@
  */
 namespace Zend\Stdlib\Hydrator\Filter;
 
+use Zend\Stdlib\Exception\InvalidArgumentException;
+
 /**
  * @category   Zend
  * @package    Zend_Stdlib
@@ -36,9 +38,39 @@ class FilterComposite implements FilterInterface
 
     /**
      * Define default Filter
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($orFilter = array(), $andFilter = array())
     {
+        array_walk($orFilter,
+            function($value, $key) {
+                if(
+                    !is_callable($value) &&
+                    !$value instanceof FilterInterface
+                ) {
+                    throw new InvalidArgumentException(
+                        'The value of ' . $key . ' should be either a callable or ' .
+                        'an instance of Zend\Stdlib\Hydrator\Filter\FilterInterface'
+                    );
+                }
+            }
+        );
+
+        array_walk($andFilter,
+            function($value, $key) {
+                if(
+                    !is_callable($value) &&
+                    !$value instanceof FilterInterface
+                ) {
+                    throw new InvalidArgumentException(
+                        'The value of ' . $key . '  should be either a callable or ' .
+                        'an instance of Zend\Stdlib\Hydrator\Filter\FilterInterface'
+                    );
+                }
+            }
+        );
+
         $this->orFilter = new \ArrayObject($orFilter);
         $this->andFilter = new \ArrayObject($andFilter);
     }
@@ -62,6 +94,7 @@ class FilterComposite implements FilterInterface
      * @param string $name
      * @param callable|FilterInterface $filter
      * @param int $condition Can be either FilterComposite::CONDITION_OR or FilterComposite::CONDITION_AND
+     * @throws InvalidArgumentException
      */
     public function addFilter($name, $filter, $condition = self::CONDITION_OR)
     {
@@ -71,10 +104,14 @@ class FilterComposite implements FilterInterface
         ) {
             if ($condition === self::CONDITION_OR) {
                 $this->orFilter[$name] = $filter;
-            }
-            if ($condition === self::CONDITION_AND) {
+            } elseif ($condition === self::CONDITION_AND) {
                 $this->andFilter[$name] = $filter;
             }
+        } else {
+            throw new InvalidArgumentException(
+                'The value of ' . $name . ' should be either a callable or ' .
+                'an instance of Zend\Stdlib\Hydrator\Filter\FilterInterface'
+            );
         }
     }
 

--- a/library/Zend/Stdlib/Hydrator/Filter/FilterComposite.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/FilterComposite.php
@@ -162,8 +162,8 @@ class FilterComposite implements FilterInterface
         $orCount = count($this->orFilter);
         // return true if no filters are registered
         if (
-            $orCount === 0 &&
-            $andCount === 0
+            $orCount === 0
+            && $andCount === 0
         ) {
             return true;
         } elseif ($orCount === 0 && $andCount !== 0) {

--- a/library/Zend/Stdlib/Hydrator/Filter/FilterComposite.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/FilterComposite.php
@@ -158,16 +158,21 @@ class FilterComposite implements FilterInterface
      */
     public function filter($property)
     {
+        $andCount = count($this->andFilter);
+        $orCount = count($this->orFilter);
         // return true if no filters are registered
         if (
-            count($this->orFilter) === 0 &&
-            count($this->andFilter) === 0
+            $orCount === 0 &&
+            $andCount === 0
         ) {
             return true;
+        } elseif ($orCount === 0 && $andCount !== 0) {
+            $returnValue = true;
+        } else {
+            $returnValue = false;
         }
 
         // Check if 1 from the or filters return true
-        $returnValue = false;
         foreach($this->orFilter as $filter) {
             if (is_callable($filter)) {
                 if( $filter($property) === true)

--- a/library/Zend/Stdlib/Hydrator/Filter/FilterComposite.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/FilterComposite.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link           http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright      Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license        http://framework.zend.com/license/new-bsd New BSD License
+ * @package        Zend_Service
+ */
+namespace Zend\Stdlib\Hydrator\Filter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage Hydrator
+ */
+class FilterComposite implements FilterInterface
+{
+    /**
+     * @var \ArrayObject
+     */
+    protected $orFilter;
+    /**
+     * @var \ArrayObject
+     */
+    protected $andFilter;
+
+    /**
+     * Constant to add with "or" conditition
+     */
+    const CONDITION_OR = 1;
+    /**
+     * Constant to add with "and" conditition
+     */
+    const CONDITION_AND = 2;
+
+    /**
+     * Define default Filter
+     */
+    public function __construct($orFilter = array(), $andFilter = array())
+    {
+        $this->orFilter = new \ArrayObject($orFilter);
+        $this->andFilter = new \ArrayObject($andFilter);
+    }
+
+    /**
+     * Add a filter to the composite. Has to be indexed with $name in
+     * order to identify a specific filter.
+     *
+     * This example will exclude all methods from the hydration, that starts with 'getService'
+     * <code>
+     * $composite->addFilter('exclude',
+     *     function($method) {
+     *         if (preg_match('/^getService/', $method) {
+     *             return false;
+     *         }
+     *         return true;
+     *     }, FilterComposite::CONDITION_AND
+     * );
+     * </code>
+     *
+     * @param string $name
+     * @param callable|FilterInterface $filter
+     * @param int $condition Can be either FilterComposite::CONDITION_OR or FilterComposite::CONDITION_AND
+     */
+    public function addFilter($name, $filter, $condition = self::CONDITION_OR)
+    {
+        if (
+            is_callable($filter) ||
+            $filter instanceof FilterInterface
+        ) {
+            if ($condition === self::CONDITION_OR) {
+                $this->orFilter[$name] = $filter;
+            }
+            if ($condition === self::CONDITION_AND) {
+                $this->andFilter[$name] = $filter;
+            }
+        }
+    }
+
+    /**
+     * Remove a filter from the composition
+     *
+     * @param $name string Identifier for the filter
+     */
+    public function removeFilter($name)
+    {
+        if( isset($this->orFilter[$name])) {
+            unset($this->orFilter[$name]);
+        }
+
+        if( isset($this->andFilter[$name])) {
+            unset($this->andFilter[$name]);
+        }
+    }
+
+    /**
+     * Check if $name has a filter registered
+     *
+     * @param $name string Identifier for the filter
+     * @return bool
+     */
+    public function hasFilter($name)
+    {
+        return
+            isset($this->orFilter[$name]) || isset($this->andFilter[$name]);
+    }
+
+    /**
+     * Filter the composite based on the AND and OR condition
+     * Will return true if one from the "or conditions" and all from
+     * the "and condition" returns true. Otherwise false
+     *
+     * @param $property string Parameter will be e.g. Parent\Namespace\Class::method
+     * @return bool
+     */
+    public function filter($property)
+    {
+        // return true if no filters are registered
+        if (
+            count($this->orFilter) === 0 &&
+            count($this->andFilter) === 0
+        ) {
+            return true;
+        }
+
+        // Check if 1 from the or filters return true
+        $returnValue = false;
+        foreach($this->orFilter as $filter) {
+            if (is_callable($filter)) {
+                if( $filter($property) === true)
+                {
+                    $returnValue = true;
+                    break;
+                }
+            } else {
+                if ( $filter->filter($property) === true) {
+                    $returnValue = true;
+                    break;
+                }
+            }
+        }
+
+        // Check if all of the and condition return true
+        foreach($this->andFilter as $filter) {
+            if (is_callable($filter)) {
+                if( $filter($property) === false) {
+                    return false;
+                }
+            } else {
+                if( $filter->filter($property) === false) {
+                    return false;
+                }
+            }
+        }
+
+        return $returnValue;
+    }
+}

--- a/library/Zend/Stdlib/Hydrator/Filter/FilterComposite.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/FilterComposite.php
@@ -48,7 +48,7 @@ class FilterComposite implements FilterInterface
     {
         array_walk($orFilter,
             function($value, $key) {
-                if(
+                if (
                     !is_callable($value)
                     && !$value instanceof FilterInterface
                 ) {
@@ -62,7 +62,7 @@ class FilterComposite implements FilterInterface
 
         array_walk($andFilter,
             function($value, $key) {
-                if(
+                if (
                     !is_callable($value)
                     && !$value instanceof FilterInterface
                 ) {
@@ -94,9 +94,9 @@ class FilterComposite implements FilterInterface
      * );
      * </code>
      *
-     * @param string $name
-     * @param callable|FilterInterface $filter
-     * @param int $condition Can be either FilterComposite::CONDITION_OR or FilterComposite::CONDITION_AND
+     * @param  string                   $name
+     * @param  callable|FilterInterface $filter
+     * @param  int                      $condition Can be either FilterComposite::CONDITION_OR or FilterComposite::CONDITION_AND
      * @throws InvalidArgumentException
      * @return FilterComposite
      */
@@ -126,11 +126,11 @@ class FilterComposite implements FilterInterface
      */
     public function removeFilter($name)
     {
-        if( isset($this->orFilter[$name])) {
+        if (isset($this->orFilter[$name])) {
             unset($this->orFilter[$name]);
         }
 
-        if( isset($this->andFilter[$name])) {
+        if (isset($this->andFilter[$name])) {
             unset($this->andFilter[$name]);
         }
 
@@ -161,10 +161,7 @@ class FilterComposite implements FilterInterface
         $andCount = count($this->andFilter);
         $orCount = count($this->orFilter);
         // return true if no filters are registered
-        if (
-            $orCount === 0
-            && $andCount === 0
-        ) {
+        if ($orCount === 0 && $andCount === 0) {
             return true;
         } elseif ($orCount === 0 && $andCount !== 0) {
             $returnValue = true;
@@ -173,10 +170,9 @@ class FilterComposite implements FilterInterface
         }
 
         // Check if 1 from the or filters return true
-        foreach($this->orFilter as $filter) {
+        foreach ($this->orFilter as $filter) {
             if (is_callable($filter)) {
-                if( $filter($property) === true)
-                {
+                if ( $filter($property) === true) {
                     $returnValue = true;
                     break;
                 }
@@ -190,14 +186,14 @@ class FilterComposite implements FilterInterface
         }
 
         // Check if all of the and condition return true
-        foreach($this->andFilter as $filter) {
+        foreach ($this->andFilter as $filter) {
             if (is_callable($filter)) {
-                if( $filter($property) === false) {
+                if ($filter($property) === false) {
                     return false;
                 }
                 continue;
             } else {
-                if( $filter->filter($property) === false) {
+                if ($filter->filter($property) === false) {
                     return false;
                 }
             }

--- a/library/Zend/Stdlib/Hydrator/Filter/FilterInterface.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/FilterInterface.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link           http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright      Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license        http://framework.zend.com/license/new-bsd New BSD License
+ * @package        Zend_Service
+ */
+namespace Zend\Stdlib\Hydrator\Filter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage Hydrator
+ */
+interface FilterInterface
+{
+    public function filter($property);
+}

--- a/library/Zend/Stdlib/Hydrator/Filter/FilterInterface.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/FilterInterface.php
@@ -16,5 +16,12 @@ namespace Zend\Stdlib\Hydrator\Filter;
  */
 interface FilterInterface
 {
+    /**
+     * Should return true, if the given filter
+     * does not match
+     *
+     * @param string $property The name of the property
+     * @return bool
+     */
     public function filter($property);
 }

--- a/library/Zend/Stdlib/Hydrator/Filter/FilterProviderInterface.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/FilterProviderInterface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link           http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright      Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license        http://framework.zend.com/license/new-bsd New BSD License
+ * @package        Zend_Service
+ */
+namespace Zend\Stdlib\Hydrator\Filter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage Hydrator
+ */
+interface FilterProviderInterface
+{
+    /**
+     * Provides a filter for hydration
+     *
+     * @return FilterInterface
+     */
+    public function getFilter();
+}

--- a/library/Zend/Stdlib/Hydrator/Filter/GetFilter.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/GetFilter.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link           http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright      Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license        http://framework.zend.com/license/new-bsd New BSD License
+ * @package        Zend_Service
+ */
+namespace Zend\Stdlib\Hydrator\Filter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage Hydrator
+ */
+class GetFilter implements FilterInterface
+{
+    public function filter($property)
+    {
+        $pos = strpos($property, '::');
+        if ($pos !== false) {
+            $pos += 2;
+        } else {
+            $pos = 0;
+        }
+
+        if (substr($property, $pos, 3) === 'get') {
+            return true;
+        }
+        return false;
+    }
+}

--- a/library/Zend/Stdlib/Hydrator/Filter/HasFilter.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/HasFilter.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link           http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright      Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license        http://framework.zend.com/license/new-bsd New BSD License
+ * @package        Zend_Service
+ */
+namespace Zend\Stdlib\Hydrator\Filter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage Hydrator
+ */
+class HasFilter implements FilterInterface
+{
+    public function filter($property)
+    {
+        $pos = strpos($property, '::');
+        if ($pos !== false) {
+            $pos += 2;
+        } else {
+            $pos = 0;
+        }
+
+        if (substr($property, $pos, 3) === 'has') {
+            return true;
+        }
+        return false;
+    }
+}

--- a/library/Zend/Stdlib/Hydrator/Filter/IsFilter.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/IsFilter.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link           http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright      Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license        http://framework.zend.com/license/new-bsd New BSD License
+ * @package        Zend_Service
+ */
+namespace Zend\Stdlib\Hydrator\Filter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage Hydrator
+ */
+class IsFilter implements FilterInterface
+{
+    public function filter($property)
+    {
+        $pos = strpos($property, '::');
+        if ($pos !== false) {
+            $pos += 2;
+        } else {
+            $pos = 0;
+        }
+
+        if (substr($property, $pos, 2) === 'is') {
+            return true;
+        }
+        return false;
+    }
+}

--- a/library/Zend/Stdlib/Hydrator/Filter/MethodMatchFilter.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/MethodMatchFilter.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link           http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright      Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license        http://framework.zend.com/license/new-bsd New BSD License
+ * @package        Zend_Service
+ */
+namespace Zend\Stdlib\Hydrator\Filter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage Hydrator
+ */
+class MethodMatchFilter implements FilterInterface
+{
+    /**
+     * The method to exclude
+     * @var string
+     */
+    protected $method = null;
+
+    /**
+     * Either an exclude or an include
+     * @var bool
+     */
+    protected $exclude = null;
+
+    /**
+     * @param string $method The method to exclude
+     */
+    public function __construct($method, $exclude = true)
+    {
+        $this->method = $method;
+        $this->exclude = $exclude;
+    }
+
+    public function filter($property)
+    {
+        $pos = strpos($property, '::');
+        if ($pos !== false) {
+            $pos += 2;
+        } else {
+            $pos = 0;
+        }
+        if (substr($property, $pos) === $this->method) {
+            return $this->exclude ? false : true;
+        }
+        return $this->exclude ? true : false;
+    }
+}

--- a/library/Zend/Stdlib/Hydrator/Filter/NumberOfParameterFilter.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/NumberOfParameterFilter.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link           http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright      Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license        http://framework.zend.com/license/new-bsd New BSD License
+ * @package        Zend_Service
+ */
+
+namespace Zend\Stdlib\Hydrator\Filter;
+
+use ReflectionMethod;
+use ReflectionException;
+use Zend\Stdlib\Exception\InvalidArgumentException;
+use Zend\Stdlib\Hydrator\Filter\FilterInterface;
+
+/**
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage Hydrator
+ */
+class NumberOfParameterFilter implements FilterInterface
+{
+    /**
+     * The number of parameters beeing accepted
+     * @var int
+     */
+    protected $numberOfParameters = null;
+
+    /**
+     * @param int $numberOfParameters Number of accepted parameters
+     */
+    public function __construct($numberOfParameters = 0)
+    {
+        $this->numberOfParameters = 0;
+    }
+
+    /**
+     * @param string $property the name of the property
+     * @throws InvalidArgumentException
+     */
+    public function filter($property)
+    {
+        try {
+            $reflectionMethod = new ReflectionMethod($property);
+        } catch( ReflectionException $exception) {
+            throw new InvalidArgumentException(
+                "Method $property doesn't exist"
+            );
+        }
+
+        if ($reflectionMethod->getNumberOfParameters() !== $this->numberOfParameters) {
+            return false;
+        }
+
+        return true;
+    }
+}
+

--- a/library/Zend/Stdlib/Hydrator/Filter/NumberOfParameterFilter.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/NumberOfParameterFilter.php
@@ -57,4 +57,3 @@ class NumberOfParameterFilter implements FilterInterface
         return true;
     }
 }
-

--- a/library/Zend/Stdlib/Hydrator/ObjectProperty.php
+++ b/library/Zend/Stdlib/Hydrator/ObjectProperty.php
@@ -38,8 +38,12 @@ class ObjectProperty extends AbstractHydrator
 
         $self = $this;
         $data = get_object_vars($object);
-        array_walk($data, function (&$value, $name) use ($self) {
-            $value = $self->extractValue($name, $value);
+        array_walk($data, function (&$value, $name) use ($self, &$data) {
+            if (!$self->getFilter()->filter($name)) {
+                unset($data[$name]);
+            } else {
+                $value = $self->extractValue($name, $value);
+            }
         });
         return $data;
     }

--- a/library/Zend/Stdlib/Hydrator/Reflection.php
+++ b/library/Zend/Stdlib/Hydrator/Reflection.php
@@ -37,6 +37,9 @@ class Reflection extends AbstractHydrator
         $result = array();
         foreach (self::getReflProperties($object) as $property) {
             $propertyName = $property->getName();
+            if (!$this->filterComposite->filter($propertyName)) {
+                continue;
+            }
 
             $value = $property->getValue($object);
             $result[$propertyName] = $this->extractValue($propertyName, $value);

--- a/tests/ZendTest/Stdlib/FilterTest.php
+++ b/tests/ZendTest/Stdlib/FilterTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link           http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright      Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license        http://framework.zend.com/license/new-bsd New BSD License
+ * @package        Zend_Service
+ */
+
+namespace ZendTest\Stdlib;
+
+use Zend\Stdlib\Hydrator\Filter\HasFilter,
+    Zend\Stdlib\Hydrator\Filter\IsFilter,
+    Zend\Stdlib\Hydrator\Filter\GetFilter;
+
+class ValidationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHasValidation()
+    {
+        $hasValidation = new HasFilter();
+        $this->assertTrue($hasValidation->filter('hasFoo'));
+        $this->assertTrue($hasValidation->filter('Foo::hasFoo'));
+        $this->assertFalse($hasValidation->filter('FoohasFoo'));
+        $this->assertFalse($hasValidation->filter('Bar::FoohasFoo'));
+        $this->assertFalse($hasValidation->filter('hAsFoo'));
+        $this->assertFalse($hasValidation->filter('Blubb::hAsFoo'));
+        $this->assertFalse($hasValidation->filter(get_class($this). '::hAsFoo'));
+    }
+
+    public function testGetValidation()
+    {
+        $hasValidation = new GetFilter();
+        $this->assertTrue($hasValidation->filter('getFoo'));
+        $this->assertTrue($hasValidation->filter('Bar::getFoo'));
+        $this->assertFalse($hasValidation->filter('GetFooBar'));
+        $this->assertFalse($hasValidation->filter('Foo::GetFooBar'));
+        $this->assertFalse($hasValidation->filter('GETFoo'));
+        $this->assertFalse($hasValidation->filter('Blubb::GETFoo'));
+        $this->assertFalse($hasValidation->filter(get_class($this).'::GETFoo'));
+    }
+
+    public function testIsValidation()
+    {
+        $hasValidation = new IsFilter();
+        $this->assertTrue($hasValidation->filter('isFoo'));
+        $this->assertTrue($hasValidation->filter('Blubb::isFoo'));
+        $this->assertFalse($hasValidation->filter('IsFooBar'));
+        $this->assertFalse($hasValidation->filter('Foo::IsFooBar'));
+        $this->assertFalse($hasValidation->filter('ISFoo'));
+        $this->assertFalse($hasValidation->filter('Bar::ISFoo'));
+        $this->assertFalse($hasValidation->filter(get_class($this).'::ISFoo'));
+    }
+
+}

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -274,7 +274,7 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(isset($datas['hasBar'])); //method is hasBar
     }
 
-    public function testHydratorClassMethodsWithCostumFilter()
+    public function testHydratorClassMethodsWithCustomFilter()
     {
         $hydrator = new ClassMethods(false);
         $datas = $hydrator->extract($this->classMethodsCamelCase);

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -12,13 +12,18 @@ namespace ZendTest\Stdlib;
 
 use Zend\Stdlib\Hydrator\ClassMethods;
 use Zend\Stdlib\Hydrator\Reflection;
+use Zend\Stdlib\Hydrator\ObjectProperty;
+use Zend\Stdlib\Hydrator\ArraySerializable;
 use Zend\Stdlib\Hydrator\Filter\FilterComposite;
 use ZendTest\Stdlib\TestAsset\ClassMethodsCamelCase;
 use ZendTest\Stdlib\TestAsset\ClassMethodsUnderscore;
 use ZendTest\Stdlib\TestAsset\ClassMethodsCamelCaseMissing;
 use ZendTest\Stdlib\TestAsset\Reflection as ReflectionAsset;
+use ZendTest\Stdlib\TestAsset\ObjectProperty as ObjectPropertyAsset;
+use ZendTest\Stdlib\TestAsset\ArraySerializable as ArraySerializableAsset;
 use Zend\Stdlib\Hydrator\Strategy\DefaultStrategy;
 use Zend\Stdlib\Hydrator\Strategy\SerializableStrategy;
+
 
 /**
  * @category   Zend
@@ -294,10 +299,11 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(isset($datas['hasFoo']));
     }
 
-    public function testArraySerializableFilter()
+    /**
+     * @dataProvider filterProvider
+     */
+    public function testArraySerializableFilter($hydrator, $serializable)
     {
-        $hydrator = new \Zend\Stdlib\Hydrator\ArraySerializable();
-        $serializable = new \ZendTest\Stdlib\TestAsset\ArraySerializable();
         $this->assertSame(
             array(
                 "foo" => "bar",
@@ -350,6 +356,14 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
                 "quo" => "blubb"
             ),
             $hydrator->extract($serializable)
+        );
+    }
+
+    public function filterProvider()
+    {
+        return array(
+            array(new ObjectProperty(), new ObjectPropertyAsset),
+            array(new ArraySerializable(), new ArraySerializableAsset)
         );
     }
 }

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -18,6 +18,7 @@ use Zend\Stdlib\Hydrator\Filter\FilterComposite;
 use ZendTest\Stdlib\TestAsset\ClassMethodsCamelCase;
 use ZendTest\Stdlib\TestAsset\ClassMethodsUnderscore;
 use ZendTest\Stdlib\TestAsset\ClassMethodsCamelCaseMissing;
+use ZendTest\Stdlib\TestAsset\ClassMethodsInvalidParameter;
 use ZendTest\Stdlib\TestAsset\Reflection as ReflectionAsset;
 use ZendTest\Stdlib\TestAsset\ReflectionFilter;
 use ZendTest\Stdlib\TestAsset\ObjectProperty as ObjectPropertyAsset;
@@ -51,6 +52,11 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
     protected $classMethodsUnderscore;
 
     /**
+     * @var ClassMethodsInvalidParameter
+     */
+    protected $classMethodsInvalidParameter;
+
+    /**
      * @var ReflectionAsset
      */
     protected $reflection;
@@ -61,6 +67,7 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->classMethodsCamelCaseMissing = new ClassMethodsCamelCaseMissing();
         $this->classMethodsUnderscore = new ClassMethodsUnderscore();
         $this->reflection = new ReflectionAsset;
+        $this->classMethodsInvalidParameter = new ClassMethodsInvalidParameter();
     }
 
     public function testInitiateValues()
@@ -367,5 +374,15 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
             array(new ArraySerializable(), new ArraySerializableAsset),
             array(new Reflection(), new ReflectionFilter)
         );
+    }
+
+    public function testHydratorClassMethodsWithInvalidNumberOfParameters()
+    {
+        $hydrator = new ClassMethods(false);
+        $datas = $hydrator->extract($this->classMethodsInvalidParameter);
+
+        $this->assertTrue($datas['hasBar']);
+        $this->assertEquals('Bar', $datas['foo']);
+        $this->assertFalse($datas['isBla']);
     }
 }

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -16,6 +16,7 @@ use Zend\Stdlib\Hydrator\ObjectProperty;
 use Zend\Stdlib\Hydrator\ArraySerializable;
 use Zend\Stdlib\Hydrator\Filter\FilterComposite;
 use ZendTest\Stdlib\TestAsset\ClassMethodsCamelCase;
+use ZendTest\Stdlib\TestAsset\ClassMethodsFilterProviderInterface;
 use ZendTest\Stdlib\TestAsset\ClassMethodsUnderscore;
 use ZendTest\Stdlib\TestAsset\ClassMethodsCamelCaseMissing;
 use ZendTest\Stdlib\TestAsset\ClassMethodsInvalidParameter;
@@ -384,5 +385,15 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($datas['hasBar']);
         $this->assertEquals('Bar', $datas['foo']);
         $this->assertFalse($datas['isBla']);
+    }
+
+    public function testObjectBasedFilters()
+    {
+        $hydrator = new ClassMethods(false);
+        $foo = new ClassMethodsFilterProviderInterface();
+        $data = $hydrator->extract($foo);
+        $this->assertFalse(array_key_exists("filter", $data));
+        $this->assertSame("bar", $data["foo"]);
+        $this->assertSame("foo", $data["bar"]);
     }
 }

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -19,6 +19,7 @@ use ZendTest\Stdlib\TestAsset\ClassMethodsCamelCase;
 use ZendTest\Stdlib\TestAsset\ClassMethodsUnderscore;
 use ZendTest\Stdlib\TestAsset\ClassMethodsCamelCaseMissing;
 use ZendTest\Stdlib\TestAsset\Reflection as ReflectionAsset;
+use ZendTest\Stdlib\TestAsset\ReflectionFilter;
 use ZendTest\Stdlib\TestAsset\ObjectProperty as ObjectPropertyAsset;
 use ZendTest\Stdlib\TestAsset\ArraySerializable as ArraySerializableAsset;
 use Zend\Stdlib\Hydrator\Strategy\DefaultStrategy;
@@ -363,7 +364,8 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(new ObjectProperty(), new ObjectPropertyAsset),
-            array(new ArraySerializable(), new ArraySerializableAsset)
+            array(new ArraySerializable(), new ArraySerializableAsset),
+            array(new Reflection(), new ReflectionFilter)
         );
     }
 }

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -293,4 +293,63 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $datas = $hydrator->extract($this->classMethodsCamelCase);
         $this->assertFalse(isset($datas['hasFoo']));
     }
+
+    public function testArraySerializableFilter()
+    {
+        $hydrator = new \Zend\Stdlib\Hydrator\ArraySerializable();
+        $serializable = new \ZendTest\Stdlib\TestAsset\ArraySerializable();
+        $this->assertSame(
+            array(
+                "foo" => "bar",
+                "bar" => "foo",
+                "blubb" => "baz",
+                "quo" => "blubb"
+            ),
+            $hydrator->extract($serializable)
+        );
+
+        $hydrator->addFilter("foo", function($property) {
+                if ($property == "foo") {
+                    return false;
+                }
+                return true;
+            });
+
+        $this->assertSame(
+            array(
+                "bar" => "foo",
+                "blubb" => "baz",
+                "quo" => "blubb"
+            ),
+            $hydrator->extract($serializable)
+        );
+
+        $hydrator->addFilter("len", function($property) {
+                if (strlen($property) !== 3) {
+                    return false;
+                }
+                return true;
+            }, FilterComposite::CONDITION_AND);
+
+        $this->assertSame(
+            array(
+                "bar" => "foo",
+                "quo" => "blubb"
+            ),
+            $hydrator->extract($serializable)
+        );
+
+        $hydrator->removeFilter("len");
+        $hydrator->removeFilter("foo");
+
+        $this->assertSame(
+            array(
+                "foo" => "bar",
+                "bar" => "foo",
+                "blubb" => "baz",
+                "quo" => "blubb"
+            ),
+            $hydrator->extract($serializable)
+        );
+    }
 }

--- a/tests/ZendTest/Stdlib/TestAsset/ArraySerializable.php
+++ b/tests/ZendTest/Stdlib/TestAsset/ArraySerializable.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+
+namespace ZendTest\Stdlib\TestAsset;
+
+/**
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage UnitTests
+ * @group      Zend_Stdlib
+ */
+class ArraySerializable implements \Zend\Stdlib\ArraySerializableInterface
+{
+    protected $data = array();
+
+    public function __construct()
+    {
+        $this->data = array(
+            "foo" => "bar",
+            "bar" => "foo",
+            "blubb" => "baz",
+            "quo" => "blubb"
+        );
+    }
+
+    /**
+     * Exchange internal values from provided array
+     *
+     * @param  array $array
+     * @return void
+     */
+    public function exchangeArray(array $array)
+    {
+        $this->data = $array;
+    }
+
+    /**
+     * Return an array representation of the object
+     *
+     * @return array
+     */
+    public function getArrayCopy()
+    {
+        return $this->data;
+    }
+}
+

--- a/tests/ZendTest/Stdlib/TestAsset/ClassMethodsFilterProviderInterface.php
+++ b/tests/ZendTest/Stdlib/TestAsset/ClassMethodsFilterProviderInterface.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+
+namespace ZendTest\Stdlib\TestAsset;
+
+use Zend\Stdlib\Hydrator\Filter\FilterComposite;
+use Zend\Stdlib\Hydrator\Filter\FilterProviderInterface;
+use Zend\Stdlib\Hydrator\Filter\MethodMatchFilter;
+use Zend\Stdlib\Hydrator\Filter\GetFilter;
+
+class ClassMethodsFilterProviderInterface implements FilterProviderInterface
+{
+    public function getBar()
+    {
+        return "foo";
+    }
+
+    public function getFoo()
+    {
+        return "bar";
+    }
+
+    public function isScalar($foo)
+    {
+        return false;
+    }
+
+    public function hasFooBar()
+    {
+        return true;
+    }
+
+    public function getServiceManager()
+    {
+        return "servicemanager";
+    }
+
+    public function getEventManager()
+    {
+        return "eventmanager";
+    }
+
+    public function getFilter()
+    {
+        $filterComposite = new FilterComposite();
+
+        $filterComposite->addFilter("get", new GetFilter());
+        $excludes = new FilterComposite();
+        $excludes->addFilter(
+            "servicemanager",
+            new MethodMatchFilter("getServiceManager"),
+            FilterComposite::CONDITION_AND
+        );
+        $excludes->addFilter(
+            "eventmanager",
+            new MethodMatchFilter("getEventManager"),
+            FilterComposite::CONDITION_AND
+        );
+        $filterComposite->addFilter("excludes", $excludes, FilterComposite::CONDITION_AND);
+
+        return $filterComposite;
+    }
+}

--- a/tests/ZendTest/Stdlib/TestAsset/ClassMethodsInvalidParameter.php
+++ b/tests/ZendTest/Stdlib/TestAsset/ClassMethodsInvalidParameter.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+namespace ZendTest\Stdlib\TestAsset;
+
+class ClassMethodsInvalidParameter
+{
+    public function hasAlias($alias)
+    {
+        return $alias;
+    }
+
+    public function getTest($foo)
+    {
+        return $foo;
+    }
+
+    public function isTest($bar)
+    {
+        return $bar;
+    }
+
+    public function hasBar()
+    {
+        return true;
+    }
+
+    public function getFoo()
+    {
+        return "Bar";
+    }
+
+    public function isBla()
+    {
+        return false;
+    }
+}

--- a/tests/ZendTest/Stdlib/TestAsset/FilterCompositeTest.php
+++ b/tests/ZendTest/Stdlib/TestAsset/FilterCompositeTest.php
@@ -106,6 +106,55 @@ class FilterCompositeTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($filterComposite->filter('hasFoo'));
     }
 
+    public function testWithOnlyAndFiltersAdded()
+    {
+        $filter = new FilterComposite();
+        $filter->addFilter("foobarbaz", function($property) {
+                return true;
+            }, FilterComposite::CONDITION_AND);
+        $filter->addFilter("foobar", function($property) {
+                return true;
+            }, FilterComposite::CONDITION_AND);
+        $this->assertTrue($filter->filter("foo"));
+    }
+
+    public function testWithOnlyOrFiltersAdded()
+    {
+        $filter = new FilterComposite();
+        $filter->addFilter("foobarbaz", function($property) {
+                return true;
+            });
+        $filter->addFilter("foobar", function($property) {
+                return false;
+            });
+        $this->assertTrue($filter->filter("foo"));
+    }
+
+    public function testWithComplexCompositeAdded()
+    {
+        $filter1 = new FilterComposite();
+        $filter1->addFilter("foobarbaz", function($property) {
+                return true;
+            });
+        $filter1->addFilter("foobar", function($property) {
+                return false;
+            });
+        $filter2 = new FilterComposite();
+        $filter2->addFilter("bar", function($property) {
+                return true;
+            }, FilterComposite::CONDITION_AND);
+        $filter2->addFilter("barblubb", function($property) {
+                return true;
+            }, FilterComposite::CONDITION_AND);
+        $this->assertTrue($filter1->filter("foo"));
+        $this->assertTrue($filter2->filter("foo"));
+        $filter1->addFilter("bar", $filter2);
+        $this->assertTrue($filter1->filter("blubb"));
+
+        $filter1->addFilter("blubb", function($property) { return false; }, FilterComposite::CONDITION_AND);
+        $this->assertFalse($filter1->filter("test"));
+    }
+
     /**
      * @expectedException Zend\Stdlib\Exception\InvalidArgumentException
      * @expectedExceptionMessage The value of test should be either a callable

--- a/tests/ZendTest/Stdlib/TestAsset/FilterCompositeTest.php
+++ b/tests/ZendTest/Stdlib/TestAsset/FilterCompositeTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link           http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright      Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license        http://framework.zend.com/license/new-bsd New BSD License
+ * @package        Zend_Service
+ */
+
+namespace ZendTest\Stdlib;
+
+use Zend\Stdlib\Hydrator\Filter\FilterComposite;
+
+class ValidationCompositeTest extends \PHPUnit_Framework_TestCase
+{
+    protected $validatorComposite;
+
+    public function setUp()
+    {
+        $this->validatorComposite = new FilterComposite();
+    }
+
+    public function testValidationAdd()
+    {
+        $this->assertTrue($this->validatorComposite->filter("foo"));
+        $this->validatorComposite->addFilter("has",
+            function($property) {
+                return false;
+            }
+        );
+        $this->assertFalse($this->validatorComposite->filter("foo"));
+    }
+
+    public function testValidationRemove()
+    {
+        $this->validatorComposite->addFilter("has",
+            function($property) {
+                return false;
+            }
+        );
+        $this->assertFalse($this->validatorComposite->filter("foo"));
+        $this->validatorComposite->removeFilter("has");
+        $this->assertTrue($this->validatorComposite->filter("foo"));
+    }
+
+    public function testValidationHas()
+    {
+        $this->validatorComposite->addFilter("has",
+            function($property) {
+                return false;
+            }
+        );
+        $this->assertFalse($this->validatorComposite->filter("foo"));
+        $this->assertTrue($this->validatorComposite->hasFilter("has"));
+    }
+
+    public function testComplexValidation()
+    {
+        $this->validatorComposite->addFilter("has", new \Zend\Stdlib\Hydrator\Filter\HasFilter());
+        $this->validatorComposite->addFilter("get", new \Zend\Stdlib\Hydrator\Filter\GetFilter());
+        $this->validatorComposite->addFilter("is", new \Zend\Stdlib\Hydrator\Filter\IsFilter());
+
+        $this->validatorComposite->addFilter("exclude",
+            function($property) {
+                $method = substr($property, strpos($property, '::'));
+
+                if ($method === 'getServiceLocator') {
+                    return false;
+                }
+
+                return true;
+            }, FilterComposite::CONDITION_AND
+        );
+
+        $this->assertTrue($this->validatorComposite->filter('getFooBar'));
+        $this->assertFalse($this->validatorComposite->filter('getServiceLocator'));
+    }
+}

--- a/tests/ZendTest/Stdlib/TestAsset/ObjectProperty.php
+++ b/tests/ZendTest/Stdlib/TestAsset/ObjectProperty.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+
+namespace ZendTest\Stdlib\TestAsset;
+
+/**
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage UnitTests
+ * @group      Zend_Stdlib
+ */
+class ObjectProperty
+{
+    public $foo = null;
+    public $bar = null;
+    public $blubb = null;
+    public $quo = null;
+
+    public function __construct()
+    {
+        $this->foo = "bar";
+        $this->bar = "foo";
+        $this->blubb = "baz";
+        $this->quo = "blubb";
+    }
+
+}
+

--- a/tests/ZendTest/Stdlib/TestAsset/ReflectionFilter.php
+++ b/tests/ZendTest/Stdlib/TestAsset/ReflectionFilter.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+
+namespace ZendTest\Stdlib\TestAsset;
+
+/**
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage UnitTests
+ * @group      Zend_Stdlib
+ */
+class ReflectionFilter
+{
+    protected $foo = null;
+    protected $bar = null;
+    protected $blubb = null;
+    protected  $quo = null;
+
+    public function __construct()
+    {
+        $this->foo = "bar";
+        $this->bar = "foo";
+        $this->blubb = "baz";
+        $this->quo = "blubb";
+    }
+
+}
+


### PR DESCRIPTION
I often came around with the ClassMethods hydrator, that there are parts in the hydration that shouldn't be there. Or related to #3352 that the method definition does not match.
Those few lines will give you the possibility, to easily ignore the "has" methods in your hydration e.g:

``` php
$hydrator = new ClassMethods(false);
$hydrator->removeFilter('has');
$hydrator->extract($myObject);
```

Or you can easily add custom filters:

``` php
$hydrator = new ClassMethods(false);
$hydrator->addFilter('serviceLocator',
    function($property) {
        list($class, $method) = explode('::', $property);
        // do not hydrate getServiceLocator
        if ($method === 'getServiceLocator') {
            return false;
        }
        return true;
    }, FilterComposite::CONDITION_AND
);
$hydrator->extract($myObject);
```

Heavily tested code may have more getters and setters than necessary, but if you want to transform your objects to the userland, you may want to strip some getters and setters.

Internally, there are 2 arrays, where the composition is working on. The "OR", where only 1 method from that collection has to return true and on the other hand, the "AND" condition, where all filters has to return true to get hydrated. With this implementation, #3352 can be easily implemented as another filter. If you want me to do so, close #3352 and give me a hint here. What do you think about the idea/use-case/implementation? If you like the idea behind, I can make it work the abstract-hydrator too. 
