### PR TITLE
Removed unused variable in Zend\Json\Decoder.php

### DIFF
--- a/library/Zend/Json/Decoder.php
+++ b/library/Zend/Json/Decoder.php
@@ -244,7 +244,7 @@ class Decoder
     protected function _decodeArray()
     {
         $result = array();
-        $starttok = $tok = $this->_getNextToken(); // Move past the '['
+        $tok = $this->_getNextToken(); // Move past the '['
         $index  = 0;
 
         while ($tok && $tok != self::RBRACKET) {


### PR DESCRIPTION
There is an unused variable in Zend\Json\Decoder::_decodeArray()

``` php
$starttok = $tok = $this->_getNextToken(); // Move past the '['
```

However, $starttok is never used.
