### PR TITLE
Custom password checker for database adapter

### DIFF
--- a/library/Zend/Authentication/Adapter/DbTable.php
+++ b/library/Zend/Authentication/Adapter/DbTable.php
@@ -103,6 +103,12 @@ class DbTable implements AdapterInterface
     protected $ambiguityIdentity = false;
 
     /**
+     * Closure for custom password checker
+     * @val Closure
+     */
+    protected $passwordChecker = null;
+
+    /**
      * __construct() - Sets configuration options
      *
      * @param  DbAdapter $zendDb
@@ -303,6 +309,27 @@ class DbTable implements AdapterInterface
         return $returnObject;
     }
 
+
+    /**
+     * Set the password checker callback
+     * @param Closure $callback
+     */
+    public function setPasswordChecker( $callback ) {
+        
+        if(!is_callable($callback)) {
+    		throw new \InvalidArgumentException("Password checker must be callable");
+		}
+        
+        $this->passwordChecker = $callback;
+    }
+
+    /**
+     * Get the password cehcker closure
+     */
+    public function getPasswordChecker() {
+        return $this->passwordChecker;
+    }
+
     /**
      * This method is called to attempt an authentication. Previous to this
      * call, this adapter would have already been configured with all
@@ -459,6 +486,13 @@ class DbTable implements AdapterInterface
      */
     protected function _authenticateValidateResult($resultIdentity)
     {
+        if($this->passwordChecker != null) {
+    	    $callback = $this->passwordChecker;	
+            if (!$callback($resultIdentity[$this->credentialColumn], $this->credential)) {
+                $resultIdentity['zend_auth_credential_match'] = '1';
+            }
+		}
+        
         if ($resultIdentity['zend_auth_credential_match'] != '1') {
             $this->authenticateResultInfo['code']       = AuthenticationResult::FAILURE_CREDENTIAL_INVALID;
             $this->authenticateResultInfo['messages'][] = 'Supplied credential is invalid.';

--- a/library/Zend/Authentication/Adapter/DbTable.php
+++ b/library/Zend/Authentication/Adapter/DbTable.php
@@ -318,7 +318,7 @@ class DbTable implements AdapterInterface
         
         if(!is_callable($callback)) {
     		throw new \InvalidArgumentException("Password checker must be callable");
-		}
+	}
         
         $this->passwordChecker = $callback;
     }
@@ -488,10 +488,10 @@ class DbTable implements AdapterInterface
     {
         if($this->passwordChecker != null) {
     	    $callback = $this->passwordChecker;	
-            if (!$callback($resultIdentity[$this->credentialColumn], $this->credential)) {
+            if ($callback($resultIdentity[$this->credentialColumn], $this->credential)) {
                 $resultIdentity['zend_auth_credential_match'] = '1';
             }
-		}
+	}
         
         if ($resultIdentity['zend_auth_credential_match'] != '1') {
             $this->authenticateResultInfo['code']       = AuthenticationResult::FAILURE_CREDENTIAL_INVALID;


### PR DESCRIPTION
``` php
$auth = new AuthenticationService();
$authAdapter = new DbTable( $this->services->get('db') );

$authAdapter->setPasswordChecker(function($dbpass, $userpass){
    $bcrypt = new Bcrypt();
    return $bcrypt->verify($userpass, $dbpass);
});

$authAdapter->setTableName("users");
$authAdapter->setIdentityColumn($this->emailAuth ? "email":"username");
$authAdapter->setCredentialColumn("password");
$authAdapter->setIdentity($username);
$authAdapter->setCredential($password);
$auth->setAdapter($authAdapter);
$result = $auth->authenticate();
```

PS: REMOVE NEGATION FROM CALLBACK CALL :D
