### PR TITLE
Fix for #3374

### DIFF
--- a/library/Zend/Feed/Reader/Extension/Atom/Entry.php
+++ b/library/Zend/Feed/Reader/Extension/Atom/Entry.php
@@ -175,13 +175,11 @@ class Entry extends Extension\AbstractEntry
         }
 
         if ($dateCreated) {
-            if( $dateCreated[19] === '.'){
+            $format = DateTime::ISO8601;
+            if ($dateCreated[19] === '.') {
                 $format = 'Y-m-d\TH:i:s.uO';
-            } else {
-                $format = DateTime::ISO8601;
             }
-            
-            $date = DateTime::createFromFormat( $format, $dateCreated);
+            $date = DateTime::createFromFormat($format, $dateCreated);
         }
 
         $this->data['datecreated'] = $date;
@@ -209,7 +207,11 @@ class Entry extends Extension\AbstractEntry
         }
 
         if ($dateModified) {
-            $date = DateTime::createFromFormat(DateTime::ISO8601, $dateModified);
+            $format = DateTime::ISO8601;
+            if ($dateCreated[19] === '.') {
+                $format = 'Y-m-d\TH:i:s.uO';
+            }
+            $date = DateTime::createFromFormat($format, $dateCreated);
         }
 
         $this->data['datemodified'] = $date;

--- a/library/Zend/Feed/Reader/Extension/Atom/Entry.php
+++ b/library/Zend/Feed/Reader/Extension/Atom/Entry.php
@@ -10,13 +10,13 @@
 
 namespace Zend\Feed\Reader\Extension\Atom;
 
-use DateTime;
 use DOMDocument;
 use DOMElement;
 use stdClass;
 use Zend\Feed\Reader;
 use Zend\Feed\Reader\Collection;
 use Zend\Feed\Reader\Extension;
+use Zend\Stdlib\DateTime;
 use Zend\Uri;
 
 /**
@@ -175,11 +175,7 @@ class Entry extends Extension\AbstractEntry
         }
 
         if ($dateCreated) {
-            $format = DateTime::ISO8601;
-            if ($dateCreated[19] === '.') {
-                $format = 'Y-m-d\TH:i:s.uO';
-            }
-            $date = DateTime::createFromFormat($format, $dateCreated);
+            $date = DateTime::createISO8601Date($dateCreated);
         }
 
         $this->data['datecreated'] = $date;
@@ -207,11 +203,7 @@ class Entry extends Extension\AbstractEntry
         }
 
         if ($dateModified) {
-            $format = DateTime::ISO8601;
-            if ($dateModified[19] === '.') {
-                $format = 'Y-m-d\TH:i:s.uO';
-            }
-            $date = DateTime::createFromFormat($format, $dateModified);
+            $date = DateTime::createISO8601Date($dateModified);
         }
 
         $this->data['datemodified'] = $date;

--- a/library/Zend/Feed/Reader/Extension/Atom/Entry.php
+++ b/library/Zend/Feed/Reader/Extension/Atom/Entry.php
@@ -175,7 +175,7 @@ class Entry extends Extension\AbstractEntry
         }
 
         if ($dateCreated) {
-            $date = DateTime::createISO8601Date($dateCreated);
+            $date = DateTime::createFromISO8601($dateCreated);
         }
 
         $this->data['datecreated'] = $date;
@@ -203,7 +203,7 @@ class Entry extends Extension\AbstractEntry
         }
 
         if ($dateModified) {
-            $date = DateTime::createISO8601Date($dateModified);
+            $date = DateTime::createFromISO8601($dateModified);
         }
 
         $this->data['datemodified'] = $date;

--- a/library/Zend/Feed/Reader/Extension/Atom/Entry.php
+++ b/library/Zend/Feed/Reader/Extension/Atom/Entry.php
@@ -208,10 +208,10 @@ class Entry extends Extension\AbstractEntry
 
         if ($dateModified) {
             $format = DateTime::ISO8601;
-            if ($dateCreated[19] === '.') {
+            if ($dateModified[19] === '.') {
                 $format = 'Y-m-d\TH:i:s.uO';
             }
-            $date = DateTime::createFromFormat($format, $dateCreated);
+            $date = DateTime::createFromFormat($format, $dateModified);
         }
 
         $this->data['datemodified'] = $date;

--- a/library/Zend/Feed/Reader/Extension/Atom/Entry.php
+++ b/library/Zend/Feed/Reader/Extension/Atom/Entry.php
@@ -175,7 +175,13 @@ class Entry extends Extension\AbstractEntry
         }
 
         if ($dateCreated) {
-            $date = DateTime::createFromFormat(DateTime::ISO8601, $dateCreated);
+            if( $dateCreated[19] === '.'){
+                $format = 'Y-m-d\TH:i:s.uO';
+            } else {
+                $format = DateTime::ISO8601;
+            }
+            
+            $date = DateTime::createFromFormat( $format, $dateCreated);
         }
 
         $this->data['datecreated'] = $date;

--- a/library/Zend/Feed/Reader/Extension/Atom/Feed.php
+++ b/library/Zend/Feed/Reader/Extension/Atom/Feed.php
@@ -125,7 +125,7 @@ class Feed extends Extension\AbstractFeed
         }
 
         if ($dateCreated) {
-            $date = DateTime::createISO8601Date($dateCreated);
+            $date = DateTime::createFromISO8601($dateCreated);
         }
 
         $this->data['datecreated'] = $date;
@@ -153,7 +153,7 @@ class Feed extends Extension\AbstractFeed
         }
 
         if ($dateModified) {
-            $date = DateTime::createISO8601Date($dateModified);
+            $date = DateTime::createFromISO8601($dateModified);
         }
 
         $this->data['datemodified'] = $date;

--- a/library/Zend/Feed/Reader/Extension/Atom/Feed.php
+++ b/library/Zend/Feed/Reader/Extension/Atom/Feed.php
@@ -10,11 +10,11 @@
 
 namespace Zend\Feed\Reader\Extension\Atom;
 
-use DateTime;
 use DOMElement;
 use Zend\Feed\Reader;
 use Zend\Feed\Reader\Collection;
 use Zend\Feed\Reader\Extension;
+use Zend\Stdlib\DateTime;
 use Zend\Uri;
 
 /**
@@ -125,7 +125,7 @@ class Feed extends Extension\AbstractFeed
         }
 
         if ($dateCreated) {
-            $date = DateTime::createFromFormat(DateTime::ISO8601, $dateCreated);
+            $date = DateTime::createISO8601Date($dateCreated);
         }
 
         $this->data['datecreated'] = $date;
@@ -153,7 +153,7 @@ class Feed extends Extension\AbstractFeed
         }
 
         if ($dateModified) {
-            $date = DateTime::createFromFormat(DateTime::ISO8601, $dateModified);
+            $date = DateTime::createISO8601Date($dateModified);
         }
 
         $this->data['datemodified'] = $date;

--- a/library/Zend/Feed/Reader/Extension/DublinCore/Entry.php
+++ b/library/Zend/Feed/Reader/Extension/DublinCore/Entry.php
@@ -10,10 +10,10 @@
 
 namespace Zend\Feed\Reader\Extension\DublinCore;
 
-use DateTime;
 use Zend\Feed\Reader;
 use Zend\Feed\Reader\Collection;
 use Zend\Feed\Reader\Extension;
+use Zend\Stdlib\DateTime;
 
 /**
 * @category Zend
@@ -222,7 +222,7 @@ class Entry extends Extension\AbstractEntry
         }
 
         if ($date) {
-            $d = DateTime::createFromFormat(DateTime::ISO8601, $date);
+            $d = DateTime::createISO8601Date($date);
         }
 
         $this->data['date'] = $d;

--- a/library/Zend/Feed/Reader/Extension/DublinCore/Entry.php
+++ b/library/Zend/Feed/Reader/Extension/DublinCore/Entry.php
@@ -222,7 +222,7 @@ class Entry extends Extension\AbstractEntry
         }
 
         if ($date) {
-            $d = DateTime::createISO8601Date($date);
+            $d = DateTime::createFromISO8601($date);
         }
 
         $this->data['date'] = $d;

--- a/library/Zend/Feed/Reader/Extension/DublinCore/Feed.php
+++ b/library/Zend/Feed/Reader/Extension/DublinCore/Feed.php
@@ -10,10 +10,10 @@
 
 namespace Zend\Feed\Reader\Extension\DublinCore;
 
-use DateTime;
 use Zend\Feed\Reader;
 use Zend\Feed\Reader\Collection;
 use Zend\Feed\Reader\Extension;
+use Zend\Stdlib\DateTime;
 
 /**
 * @category Zend
@@ -231,7 +231,7 @@ class Feed extends Extension\AbstractFeed
         }
 
         if ($date) {
-            $d = DateTime::createFromFormat(DateTime::ISO8601, $date);
+            $d = DateTime::createISO8601Date($date);
         }
 
         $this->data['date'] = $d;

--- a/library/Zend/Feed/Reader/Extension/DublinCore/Feed.php
+++ b/library/Zend/Feed/Reader/Extension/DublinCore/Feed.php
@@ -231,7 +231,7 @@ class Feed extends Extension\AbstractFeed
         }
 
         if ($date) {
-            $d = DateTime::createISO8601Date($date);
+            $d = DateTime::createFromISO8601($date);
         }
 
         $this->data['date'] = $d;

--- a/library/Zend/Stdlib/DateTime.php
+++ b/library/Zend/Stdlib/DateTime.php
@@ -23,13 +23,15 @@ use DateTimeZone;
 class DateTime extends \DateTime {
     
     /**
-     * Creates a DateTime object from a string and (optional) timezone.
+     * The DateTime::ISO8601 constant used by php's native DateTime object does
+     * not allow for fractions of a second. This function better handles ISO8601
+     * formatted date strings.
      * 
      * @param string $time
      * @param DateTimeZone $timezone
      * @return mixed
      */
-    public static function createISO8601Date($time, DateTimeZone $timezone = null){
+    public static function createFromISO8601($time, DateTimeZone $timezone = null){
         $format = self::ISO8601;
         if (isset($time[19]) && $time[19] === '.') {
             $format = 'Y-m-d\TH:i:s.uO';

--- a/library/Zend/Stdlib/DateTime.php
+++ b/library/Zend/Stdlib/DateTime.php
@@ -20,27 +20,29 @@ use DateTimeZone;
  * @category   Zend
  * @package    Zend_Stdlib
  */
-class DateTime extends \DateTime {
-    
+class DateTime extends \DateTime
+{
     /**
      * The DateTime::ISO8601 constant used by php's native DateTime object does
      * not allow for fractions of a second. This function better handles ISO8601
      * formatted date strings.
-     * 
-     * @param string $time
-     * @param DateTimeZone $timezone
+     *
+     * @param  string       $time
+     * @param  DateTimeZone $timezone
      * @return mixed
      */
-    public static function createFromISO8601($time, DateTimeZone $timezone = null){
+    public static function createFromISO8601($time, DateTimeZone $timezone = null)
+    {
         $format = self::ISO8601;
         if (isset($time[19]) && $time[19] === '.') {
             $format = 'Y-m-d\TH:i:s.uO';
         }
-        
-        if( $timezone !== null )
+
+        if ($timezone !== null) {
             return self::createFromFormat($format, $time, $timezone);
+        }
 
         return self::createFromFormat($format, $time);
     }
-    
+
 }

--- a/library/Zend/Stdlib/DateTime.php
+++ b/library/Zend/Stdlib/DateTime.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+
+namespace Zend\Stdlib;
+
+use DateTimeZone;
+
+/**
+ * DateTime
+ *
+ * An extension of the \DateTime object.
+ *
+ * @category   Zend
+ * @package    Zend_Stdlib
+ */
+class DateTime extends \DateTime {
+    
+    /**
+     * Creates a DateTime object from a string and (optional) timezone.
+     * 
+     * @param string $time
+     * @param DateTimeZone $timezone
+     * @return mixed
+     */
+    public static function createISO8601Date($time, DateTimeZone $timezone = null){
+        $format = self::ISO8601;
+        if (isset($time[19]) && $time[19] === '.') {
+            $format = 'Y-m-d\TH:i:s.uO';
+        }
+        
+        if( $timezone !== null )
+            return self::createFromFormat($format, $time, $timezone);
+
+        return self::createFromFormat($format, $time);
+    }
+    
+}

--- a/tests/ZendTest/Filter/_files/web/frameworks/zf2-iso8601-fork/tests/ZendTest/Filter/_files/zipextracted.txt
+++ b/tests/ZendTest/Filter/_files/web/frameworks/zf2-iso8601-fork/tests/ZendTest/Filter/_files/zipextracted.txt
@@ -1,1 +1,0 @@
-compress me

--- a/tests/ZendTest/Filter/_files/web/frameworks/zf2-iso8601-fork/tests/ZendTest/Filter/_files/zipextracted.txt
+++ b/tests/ZendTest/Filter/_files/web/frameworks/zf2-iso8601-fork/tests/ZendTest/Filter/_files/zipextracted.txt
@@ -1,0 +1,1 @@
+compress me

--- a/tests/ZendTest/Stdlib/DateTimeTest.php
+++ b/tests/ZendTest/Stdlib/DateTimeTest.php
@@ -5,7 +5,7 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Feed
+ * @package   Zend_Stdlib
  */
 
 namespace ZendTest\Stdlib;
@@ -27,7 +27,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
     {
         $time = '2009-03-07T08:03:50Z';
         
-        $date = DateTime::createISO8601Date($time);
+        $date = DateTime::createFromISO8601($time);
         
         $this->assertEquals( \DateTime::createFromFormat(\DateTime::ISO8601, $time), $date);
     }
@@ -36,11 +36,10 @@ class AtomTest extends \PHPUnit_Framework_TestCase
     {
         $time = '2009-03-07T08:03:50.012Z';
         
-        $date = DateTime::createISO8601Date($time);
+        $date = DateTime::createFromISO8601($time);
         
         $standard = \DateTime::createFromFormat('Y-m-d\TH:i:s.uO', $time);
         
         $this->assertEquals( $standard, $date);
     }
-    
 }

--- a/tests/ZendTest/Stdlib/DateTimeTest.php
+++ b/tests/ZendTest/Stdlib/DateTimeTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Feed
+ */
+
+namespace ZendTest\Stdlib;
+
+use Zend\Stdlib\DateTime;
+
+/**
+* @category Zend
+* @package Zend_Feed
+* @subpackage UnitTests
+* @group Zend_Feed
+* @group Zend_Feed_Reader
+*/
+class AtomTest extends \PHPUnit_Framework_TestCase
+{
+    public $dateTime;
+    
+    public function testCreatesIS08601WithoutFractionalSeconds()
+    {
+        $time = '2009-03-07T08:03:50Z';
+        
+        $date = DateTime::createISO8601Date($time);
+        
+        $this->assertEquals( \DateTime::createFromFormat(\DateTime::ISO8601, $time), $date);
+    }
+    
+    public function testCreatesIS08601WithFractionalSeconds()
+    {
+        $time = '2009-03-07T08:03:50.012Z';
+        
+        $date = DateTime::createISO8601Date($time);
+        
+        $standard = \DateTime::createFromFormat('Y-m-d\TH:i:s.uO', $time);
+        
+        $this->assertEquals( $standard, $date);
+    }
+    
+}

--- a/tests/ZendTest/Stdlib/DateTimeTest.php
+++ b/tests/ZendTest/Stdlib/DateTimeTest.php
@@ -21,24 +21,24 @@ use Zend\Stdlib\DateTime;
 class DateTimeTest extends \PHPUnit_Framework_TestCase
 {
     public $dateTime;
-    
+
     public function testCreatesIS08601WithoutFractionalSeconds()
     {
         $time = '2009-03-07T08:03:50Z';
-        
+
         $date = DateTime::createFromISO8601($time);
-        
+
         $this->assertEquals( \DateTime::createFromFormat(\DateTime::ISO8601, $time), $date);
     }
-    
+
     public function testCreatesIS08601WithFractionalSeconds()
     {
         $time = '2009-03-07T08:03:50.012Z';
-        
+
         $date = DateTime::createFromISO8601($time);
-        
+
         $standard = \DateTime::createFromFormat('Y-m-d\TH:i:s.uO', $time);
-        
+
         $this->assertEquals( $standard, $date);
     }
 }

--- a/tests/ZendTest/Stdlib/DateTimeTest.php
+++ b/tests/ZendTest/Stdlib/DateTimeTest.php
@@ -13,13 +13,12 @@ namespace ZendTest\Stdlib;
 use Zend\Stdlib\DateTime;
 
 /**
-* @category Zend
-* @package Zend_Feed
-* @subpackage UnitTests
-* @group Zend_Feed
-* @group Zend_Feed_Reader
-*/
-class AtomTest extends \PHPUnit_Framework_TestCase
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage UnitTests
+ * @group      Zend_Stdlib
+ */
+class DateTimeTest extends \PHPUnit_Framework_TestCase
 {
     public $dateTime;
     


### PR DESCRIPTION
DateTime::ISO8601 doesn't properly handle fractions of a second. This patch fixes that problem.
