### PR TITLE
render view one last time in case exception thrown from inside view

### DIFF
--- a/library/Zend/Mvc/View/Http/DefaultRenderingStrategy.php
+++ b/library/Zend/Mvc/View/Http/DefaultRenderingStrategy.php
@@ -133,8 +133,7 @@ class DefaultRenderingStrategy implements ListenerAggregateInterface
         } catch(\Exception $ex) {
             if ($e->getName() === MvcEvent::EVENT_RENDER_ERROR) {
                 throw $ex;
-            }
-            else {
+            } else {
                 $application = $e->getApplication();
                 $events      = $application->getEventManager();
                 $e->setError(Application::ERROR_EXCEPTION)

--- a/library/Zend/Mvc/View/Http/DefaultRenderingStrategy.php
+++ b/library/Zend/Mvc/View/Http/DefaultRenderingStrategy.php
@@ -63,6 +63,7 @@ class DefaultRenderingStrategy implements ListenerAggregateInterface
     public function attach(EventManagerInterface $events)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER, array($this, 'render'), -10000);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER_ERROR, array($this, 'render'), -10000);
     }
 
     /**
@@ -130,11 +131,16 @@ class DefaultRenderingStrategy implements ListenerAggregateInterface
         try {
             $view->render($viewModel);
         } catch(\Exception $ex) {
-            $application = $e->getApplication();
-            $events      = $application->getEventManager();
-            $e->setError(Application::ERROR_EXCEPTION)
-              ->setParam('exception', $ex);
-            $events->trigger(MvcEvent::EVENT_RENDER_ERROR, $e);
+            if ($e->getName() === MvcEvent::EVENT_RENDER_ERROR) {
+                throw $ex;
+            }
+            else {
+                $application = $e->getApplication();
+                $events      = $application->getEventManager();
+                $e->setError(Application::ERROR_EXCEPTION)
+                  ->setParam('exception', $ex);
+                $events->trigger(MvcEvent::EVENT_RENDER_ERROR, $e);
+            }
         }
 
         return $response;

--- a/tests/ZendTest/Mvc/View/DefaultRendereringStrategyTest.php
+++ b/tests/ZendTest/Mvc/View/DefaultRendereringStrategyTest.php
@@ -56,23 +56,27 @@ class DefaultRenderingStrategyTest extends TestCase
 
     public function testAttachesRendererAtExpectedPriority()
     {
-        $events = new EventManager();
-        $events->attachAggregate($this->strategy);
-        $listeners = $events->getListeners(MvcEvent::EVENT_RENDER);
+        $evm = new EventManager();
+        $evm->attachAggregate($this->strategy);
+        $events = array(MvcEvent::EVENT_RENDER, MvcEvent::EVENT_RENDER_ERROR);
 
-        $expectedCallback = array($this->strategy, 'render');
-        $expectedPriority = -10000;
-        $found            = false;
-        foreach ($listeners as $listener) {
-            $callback = $listener->getCallback();
-            if ($callback === $expectedCallback) {
-                if ($listener->getMetadatum('priority') == $expectedPriority) {
-                    $found = true;
-                    break;
+        foreach ($events as $event) {
+            $listeners = $evm->getListeners($event);
+
+            $expectedCallback = array($this->strategy, 'render');
+            $expectedPriority = -10000;
+            $found            = false;
+            foreach ($listeners as $listener) {
+                $callback = $listener->getCallback();
+                if ($callback === $expectedCallback) {
+                    if ($listener->getMetadatum('priority') == $expectedPriority) {
+                        $found = true;
+                        break;
+                    }
                 }
             }
+            $this->assertTrue($found, 'Renderer not found');
         }
-        $this->assertTrue($found, 'Renderer not found');
     }
 
     public function testCanDetachListenersFromEventManager()
@@ -132,6 +136,7 @@ class DefaultRenderingStrategyTest extends TestCase
         $resolver = new TemplateMapResolver();
         $resolver->add('exception', __DIR__ . '/_files/exception.phtml');
         $this->renderer->setResolver($resolver);
+
         $strategy = new PhpRendererStrategy($this->renderer);
         $this->view->getEventManager()->attach($strategy);
 

--- a/tests/ZendTest/View/PhpRendererTest.php
+++ b/tests/ZendTest/View/PhpRendererTest.php
@@ -330,6 +330,20 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($model, $helper->getCurrent());
     }
 
+    public function testRendererRaisesExceptionInCaseOfExceptionInView()
+    {
+        $resolver = new TemplateMapResolver(array(
+            'exception' => __DIR__ . '../../Mvc/View/_files/exception.phtml',
+        ));
+        $this->renderer->setResolver($resolver);
+
+        $model = new ViewModel();
+        $model->setTemplate('exception');
+
+        $this->setExpectedException('Exception', 'thrown from view script');
+        $this->renderer->render($model);
+    }
+
     public function testRendererRaisesExceptionIfResolverCannotResolveTemplate()
     {
         $expected = '10 &gt; 9';


### PR DESCRIPTION
Try to render the view one last time in case a render.error is triggered by an exception from within the view or one of the child views. If the view continues to throw exceptions, bail out and just re-throw the exception.
