### PR TITLE
Adding attributes for a lightweight export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/tests export-ignore
+/vendor export-ignore
+/demos export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+INSTALL.md export-ignore
+.php_cs export-ignore


### PR DESCRIPTION
Simply following @carlosbuenosvinos' idea also for ZF2.

This should basically reduce the size of the zipball produced by github on tagged releases.

Edit: this actually removes `ZendTest` from the distribution. If the test suite is meant to be shipped with composer, then please feel free to close this PR.
