### PR TITLE
[Router] no need to correct ~ in the path encoding

### DIFF
--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -58,7 +58,7 @@ class Segment implements RouteInterface
         '%3D' => "=", // sub-delims
         '%40' => "@", // pchar
 //      '%5F' => "_", // unreserved - not touched by rawurlencode
-        '%7E' => "~", // unreserved
+//      '%7E' => "~", // unreserved - not touched by rawurlencode
     );
 
     /**


### PR DESCRIPTION
The ~ is not encoded by rawurlencode, so we don't need to decode it again.
