### PR TITLE
[ZF-8825] Lower-case lookup for "authorization" header

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -211,6 +211,13 @@ class Request extends HttpRequest
             ) {
                 $this->serverParams->set('HTTP_AUTHORIZATION', $apacheRequestHeaders['Authorization']);
             }
+
+            // CordovaJS and some other libraries send with the header name all lowercase; test for this
+            if (!isset($this->serverParams['HTTP_AUTHORIZATION'])
+                && isset($apacheRequestHeaders['authorization'])
+            ) {
+                $this->serverParams->set('HTTP_AUTHORIZATION', $apacheRequestHeaders['authorization']);
+            }
         }
 
         // set headers


### PR DESCRIPTION
- A number of libraries, including CordovaJS, send the Authorization
  header as "authorization" (all lowercase); added a conditional check
  for this.
- Cannot test this, as it depends on the output of
  apache_request_headers().

See http://framework.zend.com/issues/browse/ZF-8825 for a related ZF1 issue, and https://issues.apache.org/jira/browse/CB-1455 for a related CordovaJS issue.
