### PR TITLE
fix dispatcher to catch legitimate exceptions

### DIFF
--- a/tests/ZendTest/Mvc/Controller/TestAsset/ControllerLoaderAbstractFactory.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/ControllerLoaderAbstractFactory.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc\Controller\TestAsset;
+
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ControllerLoaderAbstractFactory implements AbstractFactoryInterface
+{
+    protected $classmap = array(
+        'path' => 'ZendTest\Mvc\TestAsset\PathController',
+    );
+    
+    public function canCreateServiceWithName(ServiceLocatorInterface $sl, $cName, $rName)
+    {
+        $classname = $this->classmap[$cName];
+        return class_exists($classname);
+    }
+
+    public function createServiceWithName(ServiceLocatorInterface $sl, $cName, $rName)
+    {
+        $classname = $this->classmap[$cName];
+        $controller = new $classname;
+        return $controller;
+    }
+}
+

--- a/tests/ZendTest/Mvc/Controller/TestAsset/UnlocatableControllerLoaderAbstractFactory.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/UnlocatableControllerLoaderAbstractFactory.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc\Controller\TestAsset;
+
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class UnlocatableControllerLoaderAbstractFactory implements AbstractFactoryInterface
+{
+    public function canCreateServiceWithName(ServiceLocatorInterface $sl, $cName, $rName)
+    {
+        return false;
+    }
+
+    public function createServiceWithName(ServiceLocatorInterface $sl, $cName, $rName)
+    {
+    }
+}
+

--- a/tests/ZendTest/Mvc/DispatchListenerTest.php
+++ b/tests/ZendTest/Mvc/DispatchListenerTest.php
@@ -107,11 +107,20 @@ class DispatchListenerTest extends TestCase
         $controllerLoader = $this->serviceManager->get('ControllerLoader');
         $controllerLoader->addAbstractFactory('ZendTest\Mvc\Controller\TestAsset\ControllerLoaderAbstractFactory');
 
+        $log = array();
+        $this->application->getEventManager()->attach(MvcEvent::EVENT_DISPATCH_ERROR, function ($e) use (&$log) {
+            $log['error'] = $e->getError();
+        });
+
         $this->application->run();
 
         $event = $this->application->getMvcEvent();
         $dispatchListener = $this->serviceManager->get('DispatchListener');
         $return = $dispatchListener->onDispatch($event);
+
+        $this->assertEmpty($log);
+        $this->assertInstanceOf('Zend\Http\PhpEnvironment\Response', $return);
+        $this->assertSame(200, $return->getStatusCode());
     }
 
     public function testUnlocatableControllerLoaderComposedOfAbstractFactory()

--- a/tests/ZendTest/Mvc/DispatchListenerTest.php
+++ b/tests/ZendTest/Mvc/DispatchListenerTest.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc;
+
+use ArrayObject;
+use PHPUnit_Framework_TestCase as TestCase;
+use stdClass;
+use Zend\Config\Config;
+use Zend\Http\Request;
+use Zend\Http\PhpEnvironment\Response;
+use Zend\Mvc\Application;
+use Zend\Mvc\MvcEvent;
+use Zend\Mvc\Router;
+use Zend\Mvc\Service\ServiceManagerConfig;
+use Zend\ServiceManager\ServiceManager;
+use Zend\Uri\UriFactory;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mvc
+ * @subpackage UnitTest
+ */
+class DispatchListenerTest extends TestCase
+{
+    /**
+     * @var ServiceManager
+     */
+    protected $serviceManager;
+
+    /**
+     * @var Application
+     */
+    protected $application;
+
+    public function setUp()
+    {
+        $appConfig = array(
+            'modules' => array(),
+            'module_listener_options' => array(
+                'config_cache_enabled' => false,
+                'cache_dir'            => 'data/cache',
+                'module_paths'         => array(),
+            ),
+        );
+        $config = function ($s) {
+            return new Config(array());
+        };
+        $sm = $this->serviceManager = new ServiceManager(
+            new ServiceManagerConfig(array(
+                'invokables' => array(
+                    'DispatchListener' => 'Zend\Mvc\DispatchListener',
+                    'Request'          => 'Zend\Http\PhpEnvironment\Request',
+                    'Response'         => 'Zend\Http\PhpEnvironment\Response',
+                    'RouteListener'    => 'Zend\Mvc\RouteListener',
+                    'ViewManager'      => 'ZendTest\Mvc\TestAsset\MockViewManager',
+                    'SendResponseListener' => 'ZendTest\Mvc\TestAsset\MockSendResponseListener'
+                ),
+                'factories' => array(
+                    'ControllerLoader'        => 'Zend\Mvc\Service\ControllerLoaderFactory',
+                    'ControllerPluginManager' => 'Zend\Mvc\Service\ControllerPluginManagerFactory',
+                    'Application'             => 'Zend\Mvc\Service\ApplicationFactory',
+                    'HttpRouter'              => 'Zend\Mvc\Service\RouterFactory',
+                    'Config'                  => $config,
+                ),
+                'aliases' => array(
+                    'Router'                 => 'HttpRouter',
+                    'Configuration'          => 'Config',
+                ),
+            ))
+        );
+        $sm->setService('ApplicationConfig', $appConfig);
+        $sm->setFactory('ServiceListener', 'Zend\Mvc\Service\ServiceListenerFactory');
+        $sm->setAllowOverride(true);
+
+        $this->application = $sm->get('Application');
+    }
+
+    public function setupPathController()
+    {
+        $request = $this->serviceManager->get('Request');
+        $uri     = UriFactory::factory('http://example.local/path');
+        $request->setUri($uri);
+
+        $router = $this->serviceManager->get('HttpRouter');
+        $route  = Router\Http\Literal::factory(array(
+            'route'    => '/path',
+            'defaults' => array(
+                'controller' => 'path',
+            ),
+        ));
+        $router->addRoute('path', $route);
+        $this->application->bootstrap();
+    }
+
+    public function testControllerLoaderComposedOfAbstractFactory()
+    {
+        $this->setupPathController();
+
+        $controllerLoader = $this->serviceManager->get('ControllerLoader');
+        $controllerLoader->addAbstractFactory('ZendTest\Mvc\Controller\TestAsset\ControllerLoaderAbstractFactory');
+
+        $this->application->run();
+
+        $event = $this->application->getMvcEvent();
+        $dispatchListener = $this->serviceManager->get('DispatchListener');
+        $return = $dispatchListener->onDispatch($event);
+    }
+
+    public function testUnlocatableControllerLoaderComposedOfAbstractFactory()
+    {
+        $this->setupPathController();
+
+        $controllerLoader = $this->serviceManager->get('ControllerLoader');
+        $controllerLoader->addAbstractFactory('ZendTest\Mvc\Controller\TestAsset\UnlocatableControllerLoaderAbstractFactory');
+
+        $log = array();
+        $this->application->getEventManager()->attach(MvcEvent::EVENT_DISPATCH_ERROR, function ($e) use (&$log) {
+            $log['error'] = $e->getError();
+        });
+
+        $this->application->run();
+        $event = $this->application->getMvcEvent();
+        $dispatchListener = $this->serviceManager->get('DispatchListener');
+        $return = $dispatchListener->onDispatch($event);
+
+        $this->assertArrayHasKey('error', $log);
+        $this->assertSame('error-controller-not-found', $log['error']);
+    }
+}


### PR DESCRIPTION
All service managers throw the same `ServiceNotFound` and `ServiceNotCreated` exceptions.

The dispatcher made no distinctions between:
- exceptions thrown in the event a controller can't be loaded; and
- exceptions thrown from initializers within `ControllerLoader`

The first case is a legitimate "controller-not-found" error and can be tested for using the `ServiceManager::has()` method whereas the second case needs to be caught and forwarded to a 500 status page.
