### PR TITLE
Restored chunk delimiters to chunked response received by Zend\H...

### DIFF
--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -437,7 +437,7 @@ class Socket implements HttpAdapter, StreamInterface
                     $line  = fgets($this->socket);
                     $this->_checkSocketReadTimeout();
 
-                    $chunk = '';
+                    $chunk = $line;
 
                     // Figure out the next chunk size
                     $chunksize = trim($line);


### PR DESCRIPTION
Fix for issues #3036 and #3267.

Issue #3036 was raised (and "fixed" by PR #3169) because of a misunderstanding of the proper use of `Zend\Http\Response::getContent()`.  PR #3169 broke `Zend\Http\Response::getBody()` (when used with `Zend\Http\Client\Adapter\Socket`) by decoding chunked responses when it shouldn't have.

The proper resolution for issue #3036 should have been to recommend use of `Zend\Http\Response::getBody()` instead of `Zend\Http\Response::getContent()`. 
