### PR TITLE
Authentication Validator

### DIFF
--- a/library/Zend/Authentication/Adapter/AbstractAdapter.php
+++ b/library/Zend/Authentication/Adapter/AbstractAdapter.php
@@ -15,7 +15,7 @@ namespace Zend\Authentication\Adapter;
  * @package    Zend_Authentication
  * @subpackage Adapter
  */
-abstract class AbstractAdapter implements AdapterInterface
+abstract class AbstractAdapter implements ValidatableAdapterInterface
 {
 
     /**
@@ -42,12 +42,13 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Sets the credential for binding
      *
-     * @param  mixed $credential
+     * @param  mixed           $credential
      * @return AbstractAdapter
      */
     public function setCredential($credential)
     {
         $this->credential = $credential;
+
         return $this;
     }
 
@@ -65,12 +66,13 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Sets the identity for binding
      *
-     * @param  mixed $identity
+     * @param  mixed          $identity
      * @return AbstractAdpter
      */
     public function setIdentity($identity)
     {
         $this->identity = $identity;
+
         return $this;
     }
 }

--- a/library/Zend/Authentication/Adapter/AbstractAdapter.php
+++ b/library/Zend/Authentication/Adapter/AbstractAdapter.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Authentication
+ */
+
+namespace Zend\Authentication\Adapter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Authentication
+ * @subpackage Adapter
+ */
+abstract class AbstractAdapter implements AdapterInterface
+{
+
+    /**
+     * @var mixed
+     */
+    protected $credential;
+
+    /**
+     * @var mixed
+     */
+    protected $identity;
+
+    /**
+     * Returns the credential of the account being authenticated, or
+     * NULL if none is set.
+     *
+     * @return mixed
+     */
+    public function getCredential()
+    {
+        return $this->credential;
+    }
+
+    /**
+     * Sets the credential for binding
+     *
+     * @param  mixed $credential
+     * @return AbstractAdapter
+     */
+    public function setCredential($credential)
+    {
+        $this->credential = $credential;
+        return $this;
+    }
+
+    /**
+     * Returns the identity of the account being authenticated, or
+     * NULL if none is set.
+     *
+     * @return mixed
+     */
+    public function getIdentity()
+    {
+        return $this->identity;
+    }
+
+    /**
+     * Sets the identity for binding
+     *
+     * @param  mixed $identity
+     * @return AbstractAdpter
+     */
+    public function setIdentity($identity)
+    {
+        $this->identity = $identity;
+        return $this;
+    }
+}

--- a/library/Zend/Authentication/Adapter/DbTable.php
+++ b/library/Zend/Authentication/Adapter/DbTable.php
@@ -22,7 +22,7 @@ use Zend\Db\Sql\Select as DbSelect;
  * @package    Zend_Authentication
  * @subpackage Adapter
  */
-class DbTable implements AdapterInterface
+class DbTable extends AbstractAdapter
 {
 
     /**
@@ -57,20 +57,6 @@ class DbTable implements AdapterInterface
      * @var string
      */
     protected $credentialColumn = null;
-
-    /**
-     * $identity - Identity value
-     *
-     * @var string
-     */
-    protected $identity = null;
-
-    /**
-     * $credential - Credential values
-     *
-     * @var string
-     */
-    protected $credential = null;
 
     /**
      * $credentialTreatment - Treatment applied to the credential, such as MD5() or PASSWORD()
@@ -190,31 +176,6 @@ class DbTable implements AdapterInterface
     public function setCredentialTreatment($treatment)
     {
         $this->credentialTreatment = $treatment;
-        return $this;
-    }
-
-    /**
-     * setIdentity() - set the value to be used as the identity
-     *
-     * @param  string $value
-     * @return DbTable Provides a fluent interface
-     */
-    public function setIdentity($value)
-    {
-        $this->identity = $value;
-        return $this;
-    }
-
-    /**
-     * setCredential() - set the credential value to be used, optionally can specify a treatment
-     * to be used, should be supplied in parametrized form, such as 'MD5(?)' or 'PASSWORD(?)'
-     *
-     * @param  string $credential
-     * @return DbTable Provides a fluent interface
-     */
-    public function setCredential($credential)
-    {
-        $this->credential = $credential;
         return $this;
     }
 

--- a/library/Zend/Authentication/Adapter/Digest.php
+++ b/library/Zend/Authentication/Adapter/Digest.php
@@ -18,7 +18,7 @@ use Zend\Stdlib\ErrorHandler;
  * @package    Zend_Authentication
  * @subpackage Adapter
  */
-class Digest implements AdapterInterface
+class Digest extends AbstractAdapter
 {
     /**
      * Filename against which authentication queries are performed
@@ -35,35 +35,26 @@ class Digest implements AdapterInterface
     protected $realm;
 
     /**
-     * Digest authentication user
-     *
-     * @var string
-     */
-    protected $username;
-
-    /**
-     * Password for the user of the realm
-     *
-     * @var string
-     */
-    protected $password;
-
-    /**
      * Sets adapter options
      *
      * @param  mixed $filename
      * @param  mixed $realm
-     * @param  mixed $username
-     * @param  mixed $password
+     * @param  mixed $identity
+     * @param  mixed $credential
      */
-    public function __construct($filename = null, $realm = null, $username = null, $password = null)
+    public function __construct($filename = null, $realm = null, $identity = null, $credential = null)
     {
-        $options = array('filename', 'realm', 'username', 'password');
-        foreach ($options as $option) {
-            if (null !== $$option) {
-                $methodName = 'set' . ucfirst($option);
-                $this->$methodName($$option);
-            }
+        if ($filename !== null) {
+            $this->setFilename($filename);
+        }
+        if ($realm !== null) {
+            $this->setRealm($realm);
+        }
+        if ($identity !== null) {
+            $this->setIdentity($identity);
+        }
+        if ($credential !== null) {
+            $this->setCredential($credential);
         }
     }
 
@@ -118,7 +109,7 @@ class Digest implements AdapterInterface
      */
     public function getUsername()
     {
-        return $this->username;
+        return $this->getIdentity();
     }
 
     /**
@@ -129,8 +120,7 @@ class Digest implements AdapterInterface
      */
     public function setUsername($username)
     {
-        $this->username = (string) $username;
-        return $this;
+        return $this->setIdentity($username);
     }
 
     /**
@@ -140,7 +130,7 @@ class Digest implements AdapterInterface
      */
     public function getPassword()
     {
-        return $this->password;
+        return $this->getCredential();
     }
 
     /**
@@ -151,8 +141,7 @@ class Digest implements AdapterInterface
      */
     public function setPassword($password)
     {
-        $this->password = (string) $password;
-        return $this;
+        return $this->setCredential($password);
     }
 
     /**
@@ -163,7 +152,7 @@ class Digest implements AdapterInterface
      */
     public function authenticate()
     {
-        $optionsRequired = array('filename', 'realm', 'username', 'password');
+        $optionsRequired = array('filename', 'realm', 'identity', 'credential');
         foreach ($optionsRequired as $optionRequired) {
             if (null === $this->$optionRequired) {
                 throw new Exception\RuntimeException("Option '$optionRequired' must be set before authentication");
@@ -177,14 +166,14 @@ class Digest implements AdapterInterface
             throw new Exception\UnexpectedValueException("Cannot open '$this->filename' for reading", 0, $error);
         }
 
-        $id       = "$this->username:$this->realm";
+        $id       = "$this->identity:$this->realm";
         $idLength = strlen($id);
 
         $result = array(
             'code'  => AuthenticationResult::FAILURE,
             'identity' => array(
                 'realm'    => $this->realm,
-                'username' => $this->username,
+                'username' => $this->identity,
             ),
             'messages' => array()
         );
@@ -195,7 +184,7 @@ class Digest implements AdapterInterface
                 break;
             }
             if (substr($line, 0, $idLength) === $id) {
-                if ($this->_secureStringCompare(substr($line, -32), md5("$this->username:$this->realm:$this->password"))) {
+                if ($this->_secureStringCompare(substr($line, -32), md5("$this->identity:$this->realm:$this->credential"))) {
                     $result['code'] = AuthenticationResult::SUCCESS;
                 } else {
                     $result['code'] = AuthenticationResult::FAILURE_CREDENTIAL_INVALID;
@@ -206,7 +195,7 @@ class Digest implements AdapterInterface
         }
 
         $result['code'] = AuthenticationResult::FAILURE_IDENTITY_NOT_FOUND;
-        $result['messages'][] = "Username '$this->username' and realm '$this->realm' combination not found";
+        $result['messages'][] = "Username '$this->identity' and realm '$this->realm' combination not found";
         return new AuthenticationResult($result['code'], $result['identity'], $result['messages']);
     }
 

--- a/library/Zend/Authentication/Adapter/Http.php
+++ b/library/Zend/Authentication/Adapter/Http.php
@@ -27,7 +27,7 @@ use Zend\Uri\UriFactory;
  * @todo       Track nonces, nonce-count, opaque for replay protection and stale support
  * @todo       Support Authentication-Info header
  */
-class Http extends AbstractAdapter
+class Http implements AdapterInterface
 {
     /**
      * Reference to the HTTP Request object

--- a/library/Zend/Authentication/Adapter/Http.php
+++ b/library/Zend/Authentication/Adapter/Http.php
@@ -27,7 +27,7 @@ use Zend\Uri\UriFactory;
  * @todo       Track nonces, nonce-count, opaque for replay protection and stale support
  * @todo       Support Authentication-Info header
  */
-class Http implements AdapterInterface
+class Http extends AbstractAdapter
 {
     /**
      * Reference to the HTTP Request object

--- a/library/Zend/Authentication/Adapter/Ldap.php
+++ b/library/Zend/Authentication/Adapter/Ldap.php
@@ -20,7 +20,7 @@ use Zend\Ldap\Exception\LdapException;
  * @package    Zend_Authentication
  * @subpackage Adapter
  */
-class Ldap implements AdapterInterface
+class Ldap extends AbstractAdapter
 {
 
     /**
@@ -38,20 +38,6 @@ class Ldap implements AdapterInterface
     protected $options = null;
 
     /**
-     * The username of the account being authenticated.
-     *
-     * @var string
-     */
-    protected $username = null;
-
-    /**
-     * The password of the account being authenticated.
-     *
-     * @var string
-     */
-    protected $password = null;
-
-    /**
      * The DN of the authenticated account. Used to retrieve the account entry on request.
      *
      * @var string
@@ -61,18 +47,18 @@ class Ldap implements AdapterInterface
     /**
      * Constructor
      *
-     * @param  array  $options  An array of arrays of Zend\Ldap\Ldap options
-     * @param  string $username The username of the account being authenticated
-     * @param  string $password The password of the account being authenticated
+     * @param  array  $options    An array of arrays of Zend\Ldap\Ldap options
+     * @param  string $identity   The username of the account being authenticated
+     * @param  string $credential The password of the account being authenticated
      */
-    public function __construct(array $options = array(), $username = null, $password = null)
+    public function __construct(array $options = array(), $identity = null, $credential = null)
     {
         $this->setOptions($options);
-        if ($username !== null) {
-            $this->setUsername($username);
+        if ($identity !== null) {
+            $this->setIdentity($identity);
         }
-        if ($password !== null) {
-            $this->setPassword($password);
+        if ($credential !== null) {
+            $this->setCredential($credential);
         }
     }
 
@@ -96,6 +82,12 @@ class Ldap implements AdapterInterface
     public function setOptions($options)
     {
         $this->options = is_array($options) ? $options : array();
+        if (array_key_exists('identity', $this->options)) {
+            $this->options['username'] = $this->options['identity'];
+        }
+        if (array_key_exists('credential', $this->options)) {
+            $this->options['password'] = $this->options['credential'];
+        }
         return $this;
     }
 
@@ -107,7 +99,7 @@ class Ldap implements AdapterInterface
      */
     public function getUsername()
     {
-        return $this->username;
+        return $this->getIdentity();
     }
 
     /**
@@ -118,8 +110,7 @@ class Ldap implements AdapterInterface
      */
     public function setUsername($username)
     {
-        $this->username = (string) $username;
-        return $this;
+        return $this->setIdentity($username);
     }
 
     /**
@@ -130,7 +121,7 @@ class Ldap implements AdapterInterface
      */
     public function getPassword()
     {
-        return $this->password;
+        return $this->getCredential();
     }
 
     /**
@@ -141,38 +132,7 @@ class Ldap implements AdapterInterface
      */
     public function setPassword($password)
     {
-        $this->password = (string) $password;
-        return $this;
-    }
-
-    /**
-     * setIdentity() - set the identity (username) to be used
-     *
-     * Proxies to {@see setUsername()}
-     *
-     * Closes ZF-6813
-     *
-     * @param  string $identity
-     * @return Ldap Provides a fluent interface
-     */
-    public function setIdentity($identity)
-    {
-        return $this->setUsername($identity);
-    }
-
-    /**
-     * setCredential() - set the credential (password) value to be used
-     *
-     * Proxies to {@see setPassword()}
-     *
-     * Closes ZF-6813
-     *
-     * @param  string $credential
-     * @return Ldap Provides a fluent interface
-     */
-    public function setCredential($credential)
-    {
-        return $this->setPassword($credential);
+        return $this->setCredential($password);
     }
 
     /**
@@ -231,8 +191,8 @@ class Ldap implements AdapterInterface
         $messages[0] = ''; // reserved
         $messages[1] = ''; // reserved
 
-        $username = $this->username;
-        $password = $this->password;
+        $username = $this->identity;
+        $password = $this->credential;
 
         if (!$username) {
             $code = AuthenticationResult::FAILURE_IDENTITY_NOT_FOUND;
@@ -489,10 +449,12 @@ class Ldap implements AdapterInterface
     {
         $str = '';
         foreach ($options as $key => $val) {
-            if ($key === 'password')
+            if ($key === 'password' || $key === 'credential') {
                 $val = '*****';
-            if ($str)
+            }
+            if ($str) {
                 $str .= ',';
+            }
             $str .= $key . '=' . $val;
         }
         return $str;

--- a/library/Zend/Authentication/Adapter/ValidatableAdapterInterface.php
+++ b/library/Zend/Authentication/Adapter/ValidatableAdapterInterface.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Authentication
+ */
+
+namespace Zend\Authentication\Adapter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Authentication
+ * @subpackage Adapter
+ */
+interface ValidatableAdapterInterface extends AdapterInterface
+{
+    /**
+     * Returns the identity of the account being authenticated, or
+     * NULL if none is set.
+     *
+     * @return mixed
+     */
+    public function getIdentity();
+
+    /**
+     * Sets the identity for binding
+     *
+     * @param  mixed                       $identity
+     * @return ValidatableAdapterInterface
+     */
+    public function setIdentity($identity);
+
+    /**
+     * Returns the credential of the account being authenticated, or
+     * NULL if none is set.
+     *
+     * @return mixed
+     */
+    public function getCredential();
+
+    /**
+     * Sets the credential for binding
+     *
+     * @param  mixed                       $credential
+     * @return ValidatableAdapterInterface
+     */
+    public function setCredential($credential);
+}

--- a/library/Zend/Authentication/Validator/Authentication.php
+++ b/library/Zend/Authentication/Validator/Authentication.php
@@ -13,7 +13,7 @@
 namespace Zend\Authentication\Validator;
 
 use Traversable;
-use Zend\Authentication\Adapter\AdapterInterface;
+use Zend\Authentication\Adapter\ValidatableAdapterInterface;
 use Zend\Authentication\AuthenticationService;
 use Zend\Authentication\Result;
 use Zend\Authentication\Exception;
@@ -106,7 +106,7 @@ class Authentication extends AbstractValidator
     /**
      * Get Adapter
      *
-     * @return Zend\Authentication\Adapter\AdapterInterface
+     * @return Zend\Authentication\Adapter\ValidatableAdapterInterface
      */
     public function getAdapter()
     {
@@ -116,10 +116,10 @@ class Authentication extends AbstractValidator
     /**
      * Set Adapter
      *
-     * @param  Zend\Authentication\Adapter\AdapterInterface $adapter
+     * @param  Zend\Authentication\Adapter\ValidatableAdapterInterface $adapter
      * @return Authentication
      */
-    public function setAdapter(AdapterInterface $adapter)
+    public function setAdapter(ValidatableAdapterInterface $adapter)
     {
         $this->adapter = $adapter;
 

--- a/library/Zend/Authentication/Validator/Authentication.php
+++ b/library/Zend/Authentication/Validator/Authentication.php
@@ -116,12 +116,13 @@ class Authentication extends AbstractValidator
     /**
      * Set Adapter
      *
-     * @param Zend\Authentication\Adapter\AdapterInterface $adapter
+     * @param  Zend\Authentication\Adapter\AdapterInterface $adapter
      * @return Authentication
      */
     public function setAdapter(AdapterInterface $adapter)
     {
         $this->adapter = $adapter;
+
         return $this;
     }
 
@@ -138,12 +139,13 @@ class Authentication extends AbstractValidator
     /**
      * Set Identity
      *
-     * @param  mixed $identity
+     * @param  mixed          $identity
      * @return Authentication
      */
     public function setIdentity($identity)
     {
         $this->identity = $identity;
+
         return $this;
     }
 
@@ -160,12 +162,13 @@ class Authentication extends AbstractValidator
     /**
      * Set Credential
      *
-     * @param  mixed $credential
+     * @param  mixed          $credential
      * @return Authentication
      */
     public function setCredential($credential)
     {
         $this->credential = $credential;
+
         return $this;
     }
 
@@ -182,20 +185,21 @@ class Authentication extends AbstractValidator
     /**
      * Set Service
      *
-     * @param Zend\Authentication\AuthenticationService $service
+     * @param  Zend\Authentication\AuthenticationService $service
      * @return Authentication
      */
     public function setService(AuthenticationService $service)
     {
         $this->service = $service;
+
         return $this;
     }
 
     /**
      * Is Valid
      *
-     * @param mixed $value
-     * @param array $context
+     * @param  mixed $value
+     * @param  array $context
      * @return bool
      */
     public function isValid($value = null, $context = null)
@@ -224,12 +228,12 @@ class Authentication extends AbstractValidator
         }
         $this->adapter->setIdentity($identity);
         $this->adapter->setCredential($credential);
-        
+
         if (!$this->service) {
             throw new Exception\RuntimeException('AuthenticationService must be set prior to validation');
         }
         $result = $this->service->authenticate($this->adapter);
-        
+
         if ($result->getCode() != Result::SUCCESS) {
             switch ($result->getCode()) {
                 case Result::FAILURE_IDENTITY_NOT_FOUND:
@@ -247,8 +251,10 @@ class Authentication extends AbstractValidator
                 default:
                     $this->error(self::GENERAL);
             }
+
             return false;
         }
+
         return true;
     }
 }

--- a/library/Zend/Authentication/Validator/Authentication.php
+++ b/library/Zend/Authentication/Validator/Authentication.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link       http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd New BSD License
+ * @category   Zend
+ * @package    Zend_Authentication
+ * @subpackage Validator
+ */
+
+namespace Zend\Authentication\Validator;
+
+use Traversable;
+use Zend\Authentication\Adapter\AdapterInterface;
+use Zend\Authentication\AuthenticationService;
+use Zend\Authentication\Result;
+use Zend\Authentication\Exception;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Validator\AbstractValidator;
+
+/**
+ * Authentication Validator
+ *
+ * @category   Zend
+ * @package    Zend_Authentication
+ * @subpackage Validator
+ */
+class Authentication extends AbstractValidator
+{
+    /**
+     * Error codes
+     * @const string
+     */
+    const IDENTITY_NOT_FOUND = 'identityNotFound';
+    const IDENTITY_AMBIGUOUS = 'identityAmbiguous';
+    const CREDENTIAL_INVALID = 'credentialInvalid';
+    const UNCATEGORIZED      = 'uncategorized';
+    const GENERAL            = 'general';
+
+    /**
+     * Error Messages
+     * @var array
+     */
+    protected $messageTemplates = array(
+        self::IDENTITY_NOT_FOUND => 'Invalid identity',
+        self::IDENTITY_AMBIGUOUS => 'Identity is ambiguous',
+        self::CREDENTIAL_INVALID => 'Invalid password',
+        self::UNCATEGORIZED      => 'Authentication failed',
+        self::GENERAL            => 'Authentication failed',
+    );
+
+    /**
+     * Authentication Adapter
+     * @var Zend\Authentication\Adapter\Adapter
+     */
+    protected $adapter;
+
+    /**
+     * Identity (or field)
+     * @var string
+     */
+    protected $identity;
+
+    /**
+     * Credential (or field)
+     * @var string
+     */
+    protected $credential;
+
+    /**
+     * Authentication Service
+     * @var Zend\Authentication\AuthenticationService
+     */
+    protected $service;
+
+    /**
+     * Sets validator options
+     *
+     * @param mixed $options
+     */
+    public function __construct($options = null)
+    {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+
+        if (is_array($options)) {
+            if (array_key_exists('adapter', $options)) {
+                $this->setAdapter($options['adapter']);
+            }
+            if (array_key_exists('identity', $options)) {
+                $this->setIdentity($options['identity']);
+            }
+            if (array_key_exists('credential', $options)) {
+                $this->setCredential($options['credential']);
+            }
+            if (array_key_exists('service', $options)) {
+                $this->setService($options['service']);
+            }
+        }
+        parent::__construct($options);
+    }
+
+    /**
+     * Get Adapter
+     *
+     * @return Zend\Authentication\Adapter\AdapterInterface
+     */
+    public function getAdapter()
+    {
+        return $this->adapter;
+    }
+
+    /**
+     * Set Adapter
+     *
+     * @param Zend\Authentication\Adapter\AdapterInterface $adapter
+     * @return Authentication
+     */
+    public function setAdapter(AdapterInterface $adapter)
+    {
+        $this->adapter = $adapter;
+        return $this;
+    }
+
+    /**
+     * Get Identity
+     *
+     * @return mixed
+     */
+    public function getIdentity()
+    {
+        return $this->identity;
+    }
+
+    /**
+     * Set Identity
+     *
+     * @param  mixed $identity
+     * @return Authentication
+     */
+    public function setIdentity($identity)
+    {
+        $this->identity = $identity;
+        return $this;
+    }
+
+    /**
+     * Get Credential
+     *
+     * @return mixed
+     */
+    public function getCredential()
+    {
+        return $this->credential;
+    }
+
+    /**
+     * Set Credential
+     *
+     * @param  mixed $credential
+     * @return Authentication
+     */
+    public function setCredential($credential)
+    {
+        $this->credential = $credential;
+        return $this;
+    }
+
+    /**
+     * Get Service
+     *
+     * @return Zend\Authentication\AuthenticationService
+     */
+    public function getService()
+    {
+        return $this->service;
+    }
+
+    /**
+     * Set Service
+     *
+     * @param Zend\Authentication\AuthenticationService $service
+     * @return Authentication
+     */
+    public function setService(AuthenticationService $service)
+    {
+        $this->service = $service;
+        return $this;
+    }
+
+    /**
+     * Is Valid
+     *
+     * @param mixed $value
+     * @param array $context
+     * @return bool
+     */
+    public function isValid($value = null, $context = null)
+    {
+        if ($value !== null) {
+            $this->setCredential($value);
+        }
+
+        if (($context !== null) && array_key_exists($this->identity, $context)) {
+            $identity = $context[$this->identity];
+        } else {
+            $identity = $this->identity;
+        }
+        if (!$this->identity) {
+            throw new Exception\RuntimeException('Identity must be set prior to validation');
+        }
+
+        if (($context !== null) && array_key_exists($this->credential, $context)) {
+            $credential = $context[$this->credential];
+        } else {
+            $credential = $this->credential;
+        }
+
+        if (!$this->adapter) {
+            throw new Exception\RuntimeException('Adapter must be set prior to validation');
+        }
+        $this->adapter->setIdentity($identity);
+        $this->adapter->setCredential($credential);
+        
+        if (!$this->service) {
+            throw new Exception\RuntimeException('AuthenticationService must be set prior to validation');
+        }
+        $result = $this->service->authenticate($this->adapter);
+        
+        if ($result->getCode() != Result::SUCCESS) {
+            switch ($result->getCode()) {
+                case Result::FAILURE_IDENTITY_NOT_FOUND:
+                    $this->error(self::IDENTITY_NOT_FOUND);
+                    break;
+                case Result::FAILURE_CREDENTIAL_INVALID:
+                    $this->error(self::CREDENTIAL_INVALID);
+                    break;
+                case Result::FAILURE_IDENTITY_AMBIGUOUS:
+                    $this->error(self::IDENTITY_AMBIGUOUS);
+                    break;
+                case Result::FAILURE_UNCATEGORIZED:
+                    $this->error(self::UNCATEGORIZED);
+                    break;
+                default:
+                    $this->error(self::GENERAL);
+            }
+            return false;
+        }
+        return true;
+    }
+}

--- a/tests/ZendTest/Authentication/TestAsset/SuccessAdapter.php
+++ b/tests/ZendTest/Authentication/TestAsset/SuccessAdapter.php
@@ -10,10 +10,10 @@
 
 namespace ZendTest\Authentication\TestAsset;
 
-use Zend\Authentication\Adapter\AdapterInterface as AuthenticationAdapter;
+use Zend\Authentication\Adapter\AbstractAdapter as AuthenticationAdapter;
 use Zend\Authentication\Result as AuthenticationResult;
 
-class SuccessAdapter implements AuthenticationAdapter
+class SuccessAdapter extends AuthenticationAdapter
 {
     public function authenticate()
     {

--- a/tests/ZendTest/Authentication/Validator/AuthenticationTest.php
+++ b/tests/ZendTest/Authentication/Validator/AuthenticationTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_I18n
+ */
+
+namespace ZendTest\Validator;
+
+use Zend\Authentication\Validator\Authentication as AuthenticationValidator;
+use Zend\Authentication\AuthenticationService;
+use Zend\Authentication as Auth;
+use ZendTest\Authentication as AuthTest;
+
+/**
+ * @category   Zend
+ * @package    Zend_Validator
+ * @subpackage UnitTests
+ * @group      Zend_Validator
+ */
+class AthenticationTest extends \PHPUnit_Framework_TestCase
+{
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new AuthenticationValidator();
+        $this->authService = new AuthenticationService();
+        $this->authAdapter = new AuthTest\TestAsset\SuccessAdapter();
+    }
+
+    public function testOptions()
+    {
+        $auth = new AuthenticationValidator(array(
+            'adapter' => $this->authAdapter,
+            'service' => $this->authService,
+            'identity' => 'username',
+            'credential' => 'password',
+        ));
+        $this->assertSame($auth->getAdapter(), $this->authAdapter);
+        $this->assertSame($auth->getService(), $this->authService);
+        $this->assertSame($auth->getIdentity(), 'username');
+        $this->assertSame($auth->getCredential(), 'password');
+    }
+
+    public function testSetters()
+    {
+        $this->validator->setAdapter($this->authAdapter);
+        $this->validator->setService($this->authService);
+        $this->validator->setIdentity('username');
+        $this->validator->setCredential('credential');
+        $this->assertSame($this->validator->getAdapter(), $this->authAdapter);
+        $this->assertSame($this->validator->getService(), $this->authService);
+        $this->assertSame($this->validator->getIdentity(), 'username');
+        $this->assertSame($this->validator->getCredential(), 'credential');
+    }
+
+    public function testNoIdentityThrowsRuntimeException()
+    {
+        $this->setExpectedException('RuntimeException', 'Identity must be set prior to validation');
+        $this->validator->isValid('password');
+    }
+
+    public function testNoAdapterThrowsRuntimeException()
+    {
+        $this->setExpectedException('RuntimeException', 'Adapter must be set prior to validation');
+        $this->validator->setIdentity('username');
+        $this->validator->isValid('password');
+    }
+
+    public function testNoServiceThrowsRuntimeException()
+    {
+        $this->setExpectedException('RuntimeException', 'AuthenticationService must be set prior to validation');
+        $this->validator->setIdentity('username');
+        $this->validator->setAdapter($this->authAdapter);
+        $this->validator->isValid('password');
+    }
+
+    public function testEqualsMessageTemplates()
+    {
+        $validator = $this->validator;
+        $this->assertAttributeEquals($validator->getOption('messageTemplates'),
+                                     'messageTemplates', $validator);
+    }
+
+    public function testWithoutContext()
+    {
+        $this->validator->setAdapter($this->authAdapter);
+        $this->validator->setService($this->authService);
+        $this->validator->setIdentity('username');
+        $this->validator->setCredential('credential');
+
+        $this->assertEquals('username', $this->validator->getIdentity());
+        $this->assertEquals('credential', $this->validator->getCredential());
+        $this->assertTrue($this->validator->isValid());
+    }
+
+    public function testWithContext()
+    {
+        $this->validator->setAdapter($this->authAdapter);
+        $this->validator->setService($this->authService);
+        $this->validator->setIdentity('username');
+        $this->validator->isValid('password', array(
+            'username' => 'myusername',
+            'password' => 'mypassword',
+        ));
+        $adapter = $this->validator->getAdapter();
+        $this->assertEquals('myusername', $adapter->getIdentity());
+        $this->assertEquals('mypassword', $adapter->getCredential());
+    }
+}


### PR DESCRIPTION
## Overview

The Authentication Validator implements a common validator that can be leveraged on forms and the like to be able to ease authentication.  It utilizes the AuthenticationService internally providing much of the functionality.
### Usage

While the example below is explicit; you may specify the identity and credential as fields to be leveraged in the context.  This allows for things like an InputFilter inside of a form to set the proper fields.
#### Explicit

``` php
use Zend\Authentication\Validator\Authentication as AuthenticationValidator;
use Zend\Authentication\AuthenticationService;
use Zend\Authentication\Adapter\Ldap;

$validator = new AuthenticationValidator(
    'adapter' => new Ldap(),
    'service' => new AuthenticationService()
);
$validator->setIdentity('myidentity');
$validator->isValid('mycredential');
```
## Changes

All Authentication Adapters must now extend AbstractAdapter which implements a (set|get)Identity and (set|get)Credential.  The adapters do not always have to leverage them such as the case with the Http adapter (which you would not leverage in this context).  However, when using the validator the validator requires these columns to be utilized.
