### PR TITLE
Allow to set arbitrary status code for Exception strategy

### DIFF
--- a/library/Zend/Mvc/View/Http/ExceptionStrategy.php
+++ b/library/Zend/Mvc/View/Http/ExceptionStrategy.php
@@ -160,6 +160,11 @@ class ExceptionStrategy implements ListenerAggregateInterface
                     $response = new HttpResponse();
                     $response->setStatusCode(500);
                     $e->setResponse($response);
+                } else {
+                    $statusCode = $response->getStatusCode();
+                    if ($statusCode === 200) {
+                        $response->setStatusCode(500);
+                    }
                 }
 
                 break;

--- a/library/Zend/Mvc/View/Http/ExceptionStrategy.php
+++ b/library/Zend/Mvc/View/Http/ExceptionStrategy.php
@@ -158,9 +158,10 @@ class ExceptionStrategy implements ListenerAggregateInterface
                 $response = $e->getResponse();
                 if (!$response) {
                     $response = new HttpResponse();
+                    $response->setStatusCode(500);
                     $e->setResponse($response);
                 }
-                $response->setStatusCode(500);
+                $response->setStatusCode($response->getStatusCode());
                 break;
         }
     }

--- a/library/Zend/Mvc/View/Http/ExceptionStrategy.php
+++ b/library/Zend/Mvc/View/Http/ExceptionStrategy.php
@@ -161,7 +161,7 @@ class ExceptionStrategy implements ListenerAggregateInterface
                     $response->setStatusCode(500);
                     $e->setResponse($response);
                 }
-                $response->setStatusCode($response->getStatusCode());
+
                 break;
         }
     }

--- a/tests/ZendTest/Mvc/View/ExceptionStrategyTest.php
+++ b/tests/ZendTest/Mvc/View/ExceptionStrategyTest.php
@@ -169,4 +169,25 @@ class ExceptionStrategyTest extends TestCase
         $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
         $this->assertEquals(0, count($listeners));
     }
+
+    public function testReuseResponseStatusCodeIfItExists()
+    {
+        $event = new MvcEvent();
+        $response = new Response();
+        $response->setStatusCode(401);
+        $event->setResponse($response);
+        $this->strategy->prepareExceptionViewModel($event);
+        $response = $event->getResponse();
+        if (null !== $response) {
+            $this->assertEquals(401, $response->getStatusCode());
+        }
+        $model = $event->getResult();
+        if (null !== $model) {
+            $variables = $model->getVariables();
+            $this->assertArrayNotHasKey('message', $variables);
+            $this->assertArrayNotHasKey('exception', $variables);
+            $this->assertArrayNotHasKey('display_exceptions', $variables);
+            $this->assertNotEquals('error', $model->getTemplate());
+        }
+    }
 }


### PR DESCRIPTION
While working on ZfrRest, I realized Exception strategy always set the response status code to 500, even if another status code was set after an error (for instance in another listener).

This PR set 500 status code if the Response did not exist, and if it already exists, it sets it to the set status code, hence not always overriding it.
