### PR TITLE
setShared in the service manager fails with existing services

### DIFF
--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -165,6 +165,16 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\ServiceManager\ServiceManager::setShared
      */
+    public function testSetSharedOnService()
+    {
+        $this->serviceManager->setService('foo', new \stdClass());
+        $ret = $this->serviceManager->setShared('foo', true);
+        $this->assertSame($this->serviceManager, $ret);
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::setShared
+     */
     public function testSetSharedAbstractFactory()
     {
         $this->serviceManager->addAbstractFactory('ZendTest\ServiceManager\TestAsset\FooAbstractFactory');


### PR DESCRIPTION
When a service has been set in the service manager via the `setService()` method (or the `service` key in the `service_manager` configuration), the `setShared()` method is not able to update the shared flag for the service. The call to `setShared()` fails with the following exception:

```
A service by the name "<service>" was not found and could not be marked as shared
```

This is because the service manager does not include a call to `canCreate()` when checking if the service exists when trying to set the shared flag for the service.

When using the following service manager configuration, the above message can be seen:

``` php
<?php
return array(
    'service_manager' => array(
        'service' => array(
            'myservice' => new myservice(),
        ),
        'shared' => array(
            'myservice' => false,
        ),
    ),
);
```

The PR includes a failing test which uses the `setService()` and `setShared()` methods.

A possible fix would be to extend the check in the `setShared()` method with a call to `canCreate()`. The fix has been tested locally, and I can commit it if you feel it's a valid fix.
