### PR TITLE
Add __destruct to SessionManager

### DIFF
--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -43,6 +43,17 @@ class SessionManager extends AbstractManager
     protected $validatorChain;
 
     /**
+     * Destructor
+     * Ensures that writeClose is called.
+     *
+     * @return void
+     */
+    public function __destruct()
+    {
+        $this->writeClose();
+    }
+
+    /**
      * Does a session exist and is it currently active?
      *
      * @return bool
@@ -149,10 +160,12 @@ class SessionManager extends AbstractManager
         // flushed to the session handler. As such, we now mark the storage
         // object isImmutable.
         $storage  = $this->getStorage();
-        $_SESSION = (array) $storage;
-        session_write_close();
-        $storage->fromArray($_SESSION);
-        $storage->markImmutable();
+        if (!$storage->isImmutable()) {
+            $_SESSION = (array) $storage;
+            session_write_close();
+            $storage->fromArray($_SESSION);
+            $storage->markImmutable();
+        }
     }
 
     /**

--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -329,6 +329,18 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @runInSeparateProcess
      */
+    public function testCallingDestructorMarksStorageAsImmutable()
+    {
+        $this->manager->start();
+        $storage = $this->manager->getStorage();
+        $storage['foo'] = 'bar';
+        $this->manager = null;
+        $this->assertTrue($storage->isImmutable());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
     public function testCallingWriteCloseShouldNotAlterSessionExistsStatus()
     {
         $this->manager->start();


### PR DESCRIPTION
## Overview

Adds a __destruct method into the SessionManager to ensure that writeClose is called prior to PHP destroying the object references from a session becoming closed.  When the destructor is called it will then call writeClose; in the event that writeClose was already called the storage would then be marked as Immutable.  Therefore writeClose now additionally checks to ensure that if the storage is immutable it will not execute the closing again.

This issue happens primarily when utilizing a database storage handler or something that rewrite other resources.
## Issues Resolved
#2628
#3075
#3108
#3182
