### PR TITLE
SessionManager: Throw exception when attempting to setId after the session has been started

### DIFF
--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -213,13 +213,10 @@ class SessionManager extends AbstractManager
      */
     public function setId($id)
     {
-        if (!$this->sessionExists()) {
-            session_id($id);
-            return $this;
+        if ($this->sessionExists()) {
+            throw new Exception\RuntimeException('Session has already been started, to change the session ID call regenerateId()');
         }
-        $this->destroy();
         session_id($id);
-        $this->start();
         return $this;
     }
 

--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -357,39 +357,13 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @runInSeparateProcess
      */
-    public function testIdShouldBeMutablePriorAfterSessionStarted()
+    public function testIdShouldNotBeMutableAfterSessionStarted()
     {
+        $this->setExpectedException('RuntimeException',
+            'Session has already been started, to change the session ID call regenerateId()');
         $this->manager->start();
         $origId = $this->manager->getId();
         $this->manager->setId(__METHOD__);
-        $this->assertNotSame($origId, $this->manager->getId());
-        $this->assertSame(__METHOD__, $this->manager->getId());
-        $this->assertSame(__METHOD__, session_id());
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testSettingIdAfterSessionStartedShouldSendExpireCookie()
-    {
-        if (!extension_loaded('xdebug')) {
-            $this->markTestSkipped('Xdebug required for this test');
-        }
-
-        $config = $this->manager->getConfig();
-        $config->setUseCookies(true);
-        $this->manager->start();
-        $origId = $this->manager->getId();
-        $this->manager->setId(__METHOD__);
-        $headers = xdebug_get_headers();
-        $found  = false;
-        $sName  = $this->manager->getName();
-        foreach ($headers as $header) {
-            if (stristr($header, 'Set-Cookie:') && stristr($header, $sName)) {
-                $found  = true;
-            }
-        }
-        $this->assertTrue($found, 'No session cookie found: ' . var_export($headers, true));
     }
 
     /**


### PR DESCRIPTION
## Overview

SessionManger attempts to destroy the current session and then set the id by starting the session again; this is actually invalid as once the session has been started the only way to set the id again is to regenerate the session.  In the event you want to set your own session id this MUST be done prior to the session start.  Please see the PHP documentation for session_id(): http://www.php.net/session_id

After the session has been started, SessionManager::setId will now throw a RuntimeException stating that regenerateId must be called to generate a new session ID.
## Issues Resolved
#2920
