### PR TITLE
Zend\Db\Sql\Select problems with Reset containing Joins

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -395,6 +395,10 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 $this->table = null;
                 break;
             case self::COLUMNS:
+                foreach ($this->joins as $key => $join) {
+                    $join['columns'] = array();
+                    $this->joins[$key] = $join;
+                }
                 $this->columns = array();
                 break;
             case self::JOINS:


### PR DESCRIPTION
Actually the RESET on columns works only with the actual tables columns, but this RESET should reset each JOIN column too, because when you do a \Zend\Paginator\Adapter\DbSelect::COUNT on a PostgreSQL database you need to reset all columns, including columns on joins.
