### PR TITLE
Hotfix/3376

### DIFF
--- a/library/Zend/Filter/PregReplace.php
+++ b/library/Zend/Filter/PregReplace.php
@@ -69,6 +69,17 @@ class PregReplace extends AbstractFilter
                 (is_object($pattern) ? get_class($pattern) : gettype($pattern))
             ));
         }
+
+        if (is_array($pattern)) {
+            foreach ($pattern as $p) {
+                $this->validatePattern($p);
+            }
+        }
+
+        if (is_string($pattern)) {
+            $this->validatePattern($pattern);
+        }
+
         $this->options['pattern'] = $pattern;
         return $this;
     }
@@ -131,5 +142,25 @@ class PregReplace extends AbstractFilter
         }
 
         return preg_replace($this->options['pattern'], $this->options['replacement'], $value);
+    }
+
+    /**
+     * Validate a pattern and ensure it does not contain the "e" modifier
+     *
+     * @param  string $pattern
+     * @throws Exception\InvalidArgumentException
+     */
+    protected function validatePattern($pattern)
+    {
+        if (!preg_match('/(?<modifier>[imsxeADSUXJu]+)$/', $pattern, $matches)) {
+            return true;
+        }
+
+        if (false !== strstr($matches['modifier'], 'e')) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Pattern for a PregReplace filter may not contain the "e" pattern modifier; received "%s"',
+                $pattern
+            ));
+        }
     }
 }

--- a/library/Zend/Filter/Word/SeparatorToCamelCase.php
+++ b/library/Zend/Filter/Word/SeparatorToCamelCase.php
@@ -28,17 +28,48 @@ class SeparatorToCamelCase extends AbstractSeparator
         $pregQuotedSeparator = preg_quote($this->separator, '#');
 
         if (self::hasPcreUnicodeSupport()) {
-            parent::setPattern(array('#(' . $pregQuotedSeparator.')(\p{L}{1})#eu','#(^\p{Ll}{1})#eu'));
+            $patterns = array(
+                '#(' . $pregQuotedSeparator.')(\p{L}{1})#u',
+                '#(^\p{Ll}{1})#u',
+            );
             if (!extension_loaded('mbstring')) {
-                parent::setReplacement(array("strtoupper('\\2')","strtoupper('\\1')"));
+                $replacements = array(
+                    function ($matches) {
+                        return strtoupper($matches[2]);
+                    },
+                    function ($matches) {
+                        return strtoupper($matches[1]);
+                    },
+                );
             } else {
-                parent::setReplacement(array("mb_strtoupper('\\2', 'UTF-8')","mb_strtoupper('\\1', 'UTF-8')"));
+                $replacements = array(
+                    function ($matches) {
+                        return mb_strtoupper($matches[2], 'UTF-8');
+                    },
+                    function ($matches) {
+                        return mb_strtoupper($matches[1], 'UTF-8');
+                    },
+                );
             }
         } else {
-            parent::setPattern(array('#(' . $pregQuotedSeparator.')([A-Za-z]{1})#e','#(^[A-Za-z]{1})#e'));
-            parent::setReplacement(array("strtoupper('\\2')","strtoupper('\\1')"));
+            $patterns = array(
+                '#(' . $pregQuotedSeparator.')([A-Za-z]{1})#',
+                '#(^[A-Za-z]{1})#',
+            );
+            $replacements = array(
+                function ($matches) {
+                    return strtoupper($matches[2]);
+                },
+                function ($matches) {
+                    return strtoupper($matches[1]);
+                },
+            );
         }
 
-        return parent::filter($value);
+        $filtered = $value;
+        foreach ($patterns as $index => $pattern) {
+            $filtered = preg_replace_callback($pattern, $replacements[$index], $filtered);
+        }
+        return $filtered;
     }
 }

--- a/library/Zend/Ldap/Converter/Converter.php
+++ b/library/Zend/Ldap/Converter/Converter.php
@@ -64,7 +64,9 @@ class Converter
      */
     public static function hex32ToAsc($string)
     {
-        $string = preg_replace('/\\\([0-9A-Fa-f]{2})/e', "''.chr(hexdec('\\1')).''", $string);
+        $string = preg_replace_callback('/\\\([0-9A-Fa-f]{2})/', function ($matches) {
+            return chr(hexdec($matches[1]));
+        }, $string);
         return $string;
     }
 

--- a/tests/ZendTest/Filter/PregReplaceTest.php
+++ b/tests/ZendTest/Filter/PregReplaceTest.php
@@ -97,4 +97,11 @@ class PregReplaceTest extends \PHPUnit_Framework_TestCase
                                     'does not have a valid pattern set');
         $filtered = $filter($string);
     }
+
+    public function testPassingPatternWithExecModifierRaisesException()
+    {
+        $filter = new PregReplaceFilter();
+        $this->setExpectedException('Zend\Filter\Exception\InvalidArgumentException', '"e" pattern modifier');
+        $filter->setPattern('/foo/e');
+    }
 }


### PR DESCRIPTION
This PR addresses #3376 which notes that we had a number of locations that were still using the `/e` modifier to `preg_replace`, which has been marked deprecated in PHP 5.5, and which is a bad practice anyways.

I found two locations where this was happening:
- `Zend\Filter\Word\SeparatorToCamelCase`, which most other Word filters inherit from, was setting a PCRE pattern that used the "e" modifier. I modified the filter to no longer call on `parent::filter`, and instead call `preg_replace_callback`; the eval expressions were converted to closures, and the "e" modifier removed.
- `Zend\Ldap\Converter\Converter` was using the "e" modifier; I modified the code to remove this, and instead call `preg_replace_callback` with a closure for the replacement.

At this point, all tests are now running for me on 5.5.0alpha3; once merged, I'll provide an additional PR adding 5.5 to our travis builds.
