### PR TITLE
Feature/datetime factory format

### DIFF
--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -56,7 +56,7 @@ class DateTime extends Element implements InputProviderInterface
      * - format: A \DateTime compatible string
      *
      * @param array|\Traversable $options
-     * @return DateSelect
+     * @return DateTime
      */
     public function setOptions($options)
     {

--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -49,6 +49,24 @@ class DateTime extends Element implements InputProviderInterface
     protected $validators;
 
     /**
+     * Accepted options for DateTime:
+     * - format: A PHP date() compatible string
+     *
+     * @param array|\Traversable $options
+     * @return DateSelect
+     */
+    public function setOptions($options)
+    {
+        parent::setOptions($options);
+
+        if (isset($options['format'])) {
+            $this->setFormat($options['format']);
+        }
+
+        return $this;
+    }
+
+    /**
      * Retrieve the element value
      *
      * If the value is a DateTime object, and $returnFormattedValue is true

--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -53,7 +53,7 @@ class DateTime extends Element implements InputProviderInterface
 
     /**
      * Accepted options for DateTime:
-     * - format: A PHP date() compatible string
+     * - format: A \DateTime compatible string
      *
      * @param array|\Traversable $options
      * @return DateSelect
@@ -62,8 +62,8 @@ class DateTime extends Element implements InputProviderInterface
     {
         parent::setOptions($options);
 
-        if (isset($options['format'])) {
-            $this->setFormat($options['format']);
+        if (isset($this->options['format'])) {
+            $this->setFormat($this->options['format']);
         }
 
         return $this;

--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -52,6 +52,24 @@ class DateTime extends Element implements InputProviderInterface
     protected $validators;
 
     /**
+     * Accepted options for DateTime:
+     * - format: A PHP date() compatible string
+     *
+     * @param array|\Traversable $options
+     * @return DateSelect
+     */
+    public function setOptions($options)
+    {
+        parent::setOptions($options);
+
+        if (isset($options['format'])) {
+            $this->setFormat($options['format']);
+        }
+
+        return $this;
+    }
+
+    /**
      * Retrieve the element value
      *
      * If the value is a DateTime object, and $returnFormattedValue is true

--- a/tests/ZendTest/Form/Element/DateTimeTest.php
+++ b/tests/ZendTest/Form/Element/DateTimeTest.php
@@ -88,4 +88,16 @@ class DateTimeTest extends TestCase
         $element->setValue($date);
         $this->assertSame($date, $element->getValue(false));
     }
+
+    public function testSetFormatWithOptions()
+    {
+
+        $format = 'Y-m-d';
+        $element = new DateTimeElement('foo');
+        $element->setOptions(array(
+            'format' => $format,
+        ));
+
+        $this->assertSame($format, $element->getFormat());
+    }
 }


### PR DESCRIPTION
Added the setOptions function to the DateTime form element, which allows to set the accepted format, i.e. when using the array notation to define your elements and the factory.
