### PR TITLE
Individual shared setting does not override the shareByDefault setting of the ServiceManager

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -223,7 +223,7 @@ class ServiceManager implements ServiceLocatorInterface
      * @return ServiceManager
      * @throws Exception\InvalidServiceNameException
      */
-    public function setInvokableClass($name, $invokableClass, $shared = true)
+    public function setInvokableClass($name, $invokableClass, $shared = null)
     {
         $cName = $this->canonicalizeName($name);
 
@@ -235,6 +235,10 @@ class ServiceManager implements ServiceLocatorInterface
                 ));
             }
             $this->unregisterService($cName);
+        }
+        
+        if ($shared === null) {
+            $shared = $this->shareByDefault();
         }
 
         $this->invokableClasses[$cName] = $invokableClass;
@@ -253,7 +257,7 @@ class ServiceManager implements ServiceLocatorInterface
      * @throws Exception\InvalidArgumentException
      * @throws Exception\InvalidServiceNameException
      */
-    public function setFactory($name, $factory, $shared = true)
+    public function setFactory($name, $factory, $shared = null)
     {
         $cName = $this->canonicalizeName($name);
 
@@ -273,6 +277,10 @@ class ServiceManager implements ServiceLocatorInterface
             $this->unregisterService($cName);
         }
 
+        if ($shared === null) {
+            $shared = $this->shareByDefault();
+        }
+        
         $this->factories[$cName] = $factory;
         $this->shared[$cName]    = (bool) $shared;
 
@@ -352,7 +360,7 @@ class ServiceManager implements ServiceLocatorInterface
      * @return ServiceManager
      * @throws Exception\InvalidServiceNameException
      */
-    public function setService($name, $service, $shared = true)
+    public function setService($name, $service, $shared = null)
     {
         $cName = $this->canonicalizeName($name);
 
@@ -367,6 +375,10 @@ class ServiceManager implements ServiceLocatorInterface
             $this->unregisterService($cName);
         }
 
+        if ($shared === null) {
+            $shared = $this->shareByDefault();
+        }
+        
         $this->instances[$cName] = $service;
         $this->shared[$cName]    = (bool) $shared;
         return $this;
@@ -458,7 +470,10 @@ class ServiceManager implements ServiceLocatorInterface
             ));
         }
 
-        if ($this->shareByDefault() && (!isset($this->shared[$cName]) || $this->shared[$cName] === true)) {
+        if (
+            ($this->shareByDefault() && !isset($this->shared[$cName]))
+            || (isset($this->shared[$cName]) && $this->shared[$cName] === true)
+        ) {
             $this->instances[$cName] = $instance;
         }
 

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -211,6 +211,23 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\ServiceManager\ServiceManager::get
      */
+    public function testGetUsesIndivualSharedSettingWhenSetAndDeviatesFromShareByDefaultSetting()
+    {
+        $this->serviceManager->setAllowOverride(true);
+        $this->serviceManager->setShareByDefault(false);
+        $this->serviceManager->setInvokableClass('foo', 'ZendTest\ServiceManager\TestAsset\Foo');
+        $this->serviceManager->setShared('foo', true);
+        $this->assertSame($this->serviceManager->get('foo'), $this->serviceManager->get('foo'));
+        
+        $this->serviceManager->setShareByDefault(true);
+        $this->serviceManager->setInvokableClass('foo', 'ZendTest\ServiceManager\TestAsset\Foo');
+        $this->serviceManager->setShared('foo', false);
+        $this->assertNotSame($this->serviceManager->get('foo'), $this->serviceManager->get('foo'));
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::get
+     */
     public function testGetWithAlias()
     {
         $this->serviceManager->setService('foo', 'bar');


### PR DESCRIPTION
This PR currently contains just a failing test.
_Edit: Added possible fix._

Fixing is not as easy as it looks.

Making the tests succeed can be achieved by changing the following 3 lines https://github.com/zendframework/zf2/blob/master/library/Zend/ServiceManager/ServiceManager.php#L461

``` php
if ($this->shareByDefault() && (!isset($this->shared[$cName]) || $this->shared[$cName] === true)) {
    $this->instances[$cName] = $instance;
}
```

into

``` php
if (
    ($this->shareByDefault() && !isset($this->shared[$cName]))
    || (isset($this->shared[$cName]) && $this->shared[$cName] === true)
) {
    $this->instances[$cName] = $instance;
}
```

But another problem lies in how the shared setting of the indivual services are set: as the third parameter of `setInvokableClass($name, $invokableClass, $shared = true)` and `setFactory($name, $factory, $shared = true)` which sets the **_individual**_ shared setting always to yes by default which is a problem when shareByDefault is set to false.

Any ideas are welcome.
