### PR TITLE
Restoring the error handler

### DIFF
--- a/library/Zend/Config/Writer/AbstractWriter.php
+++ b/library/Zend/Config/Writer/AbstractWriter.php
@@ -11,7 +11,6 @@
 namespace Zend\Config\Writer;
 
 use Traversable;
-use Zend\Config\Config;
 use Zend\Config\Exception;
 use Zend\Stdlib\ArrayUtils;
 
@@ -52,7 +51,17 @@ abstract class AbstractWriter implements WriterInterface
                 ), $error);
             }, E_WARNING
         );
-        file_put_contents($filename, $this->toString($config), $flags);
+
+        try
+        {
+            file_put_contents($filename, $this->toString($config), $flags);
+        }
+        catch( Exception\RuntimeException $e )
+        {
+            restore_error_handler();
+            throw $e;
+        }
+
         restore_error_handler();
     }
 

--- a/library/Zend/Config/Writer/AbstractWriter.php
+++ b/library/Zend/Config/Writer/AbstractWriter.php
@@ -52,12 +52,9 @@ abstract class AbstractWriter implements WriterInterface
             }, E_WARNING
         );
 
-        try
-        {
+        try {
             file_put_contents($filename, $this->toString($config), $flags);
-        }
-        catch( \Exception $e )
-        {
+        } catch( \Exception $e ) {
             restore_error_handler();
             throw $e;
         }

--- a/library/Zend/Config/Writer/AbstractWriter.php
+++ b/library/Zend/Config/Writer/AbstractWriter.php
@@ -56,7 +56,7 @@ abstract class AbstractWriter implements WriterInterface
         {
             file_put_contents($filename, $this->toString($config), $flags);
         }
-        catch( Exception\RuntimeException $e )
+        catch( \Exception $e )
         {
             restore_error_handler();
             throw $e;


### PR DESCRIPTION
Restoring the error handler in the "toFile" function, even if an exception occurs. 
This is something we have to do manually if we catch the Exception somewhere else.
