### PR TITLE
Better content-type negotiation

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -347,9 +347,15 @@ abstract class AbstractRestfulController extends AbstractController
             return false;
         }
 
+        $requestedContentType = $headerContentType->getFieldValue();
+        if (strstr($requestedContentType, ';')) {
+            $headerData = explode(';', $requestedContentType);
+            $requestedContentType = array_shift($headerData);
+        }
+        $requestedContentType = trim($requestedContentType);
         if (array_key_exists($contentType, $this->contentTypes)) {
             foreach ($this->contentTypes[$contentType] as $contentTypeValue) {
-                if (stripos($contentTypeValue, $headerContentType->getFieldValue()) === 0) {
+                if (stripos($contentTypeValue, $requestedContentType) === 0) {
                     return true;
                 }
             }

--- a/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
+++ b/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
@@ -305,4 +305,40 @@ class RestfulControllerTest extends TestCase
         $this->assertInternalType('array', $result);
         $this->assertEquals(array('entity' => array('foo' => 'bar')), $result);
     }
+
+    public function matchingContentTypes()
+    {
+        return array(
+            'exact-first' => array('application/hal+json'),
+            'exact-second' => array('application/json'),
+            'with-charset' => array('application/json; charset=utf-8'),
+            'with-whitespace' => array('application/json '),
+        );
+    }
+
+    /**
+     * @dataProvider matchingContentTypes
+     */
+    public function testRequestingContentTypeReturnsTrueForValidMatches($contentType)
+    {
+        $this->request->getHeaders()->addHeaderLine('Content-Type', $contentType);
+        $this->assertTrue($this->controller->requestHasContentType($this->request, TestAsset\RestfulTestController::CONTENT_TYPE_JSON));
+    }
+
+    public function nonMatchingContentTypes()
+    {
+        return array(
+            'specific-type' => array('application/xml'),
+            'generic-type' => array('text/json'),
+        );
+    }
+
+    /**
+     * @dataProvider nonMatchingContentTypes
+     */
+    public function testRequestingContentTypeReturnsFalseForInvalidMatches($contentType)
+    {
+        $this->request->getHeaders()->addHeaderLine('Content-Type', $contentType);
+        $this->assertFalse($this->controller->requestHasContentType($this->request, TestAsset\RestfulTestController::CONTENT_TYPE_JSON));
+    }
 }


### PR DESCRIPTION
- Don't pull the header value on each iteration of the loop
- Get the media type of the header value before comparisons
- Ensure there is no whitespace around the media type
