### PR TITLE
Update library/Zend/Validator/Hostname.php

### DIFF
--- a/library/Zend/Validator/Hostname.php
+++ b/library/Zend/Validator/Hostname.php
@@ -519,7 +519,7 @@ class Hostname extends AbstractValidator
                     $regexChars = array(0 => '/^[a-z0-9\x2d]{1,63}$/i');
                     if ($this->getIdnCheck() &&  isset($this->validIdns[strtoupper($this->tld)])) {
                         if (is_string($this->validIdns[strtoupper($this->tld)])) {
-                            $regexChars += include ($this->validIdns[strtoupper($this->tld)]);
+                            $regexChars += include __DIR__ .'/'. $this->validIdns[strtoupper($this->tld)];
                         } else {
                             $regexChars += $this->validIdns[strtoupper($this->tld)];
                         }


### PR DESCRIPTION
[EdpSuperluminal](https://github.com/EvanDotPro/EdpSuperluminal) fails due to faulty path.

Warning: include(Hostname/Com.php): failed to open stream: No such file or directory in /path/to/application/data/cache/classes.php.cache on line 2
Warning: include(): Failed opening 'Hostname/Com.php' for inclusion (include_path='.:/usr/local/share/pear') in /path/to/application/data/cache/classes.php.cache on line 2
Fatal error: Unsupported operand types in /path/to/application/data/cache/classes.php.cache on line 2
