### PR TITLE
Hotfix/session mutability

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/FlashMessenger.php
+++ b/library/Zend/Mvc/Controller/Plugin/FlashMessenger.php
@@ -15,7 +15,6 @@ use Countable;
 use IteratorAggregate;
 use Zend\Session\Container;
 use Zend\Session\ManagerInterface as Manager;
-use Zend\Session\SessionManager;
 use Zend\Stdlib\SplQueue;
 
 /**
@@ -79,7 +78,7 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
     public function getSessionManager()
     {
         if (!$this->session instanceof Manager) {
-            $this->setSessionManager(new SessionManager());
+            $this->setSessionManager(Container::getDefaultManager());
         }
         return $this->session;
     }

--- a/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
@@ -56,6 +56,24 @@ class PostRedirectGet extends AbstractPlugin
         return $this->session;
     }
 
+    /**
+     * Perform PRG logic
+     *
+     * If a null value is present for the $redirect, the current route is
+     * retrieved and use to generate the URL for redirect.
+     *
+     * If the request method is POST, creates a session container set to expire
+     * after 1 hop containing the values of the POST. It then redirects to the
+     * specified URL using a status 303.
+     *
+     * If the request method is GET, checks to see if we have values in the
+     * session container, and, if so, returns them; otherwise, it returns a
+     * boolean false.
+     *
+     * @param  null|string $redirect
+     * @param  bool $redirectToUrl
+     * @return \Zend\Http\Response|array|Traversable|false
+     */
     public function __invoke($redirect = null, $redirectToUrl = false)
     {
         $controller = $this->getController();
@@ -100,14 +118,14 @@ class PostRedirectGet extends AbstractPlugin
             $response->setStatusCode(303);
 
             return $response;
-        } else {
-            if ($container->post !== null) {
-                $post = $container->post;
-                unset($container->post);
-                return $post;
-            }
-
-            return false;
         }
+
+        if ($container->post !== null) {
+            $post = $container->post;
+            unset($container->post);
+            return $post;
+        }
+
+        return false;
     }
 }

--- a/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
@@ -13,6 +13,7 @@ namespace Zend\Mvc\Controller\Plugin;
 
 use Zend\Mvc\Exception\RuntimeException;
 use Zend\Session\Container;
+use Zend\Session\ManagerInterface as Manager;
 
 /**
  * Plugin to help facilitate Post/Redirect/Get (http://en.wikipedia.org/wiki/Post/Redirect/Get)
@@ -23,6 +24,38 @@ use Zend\Session\Container;
  */
 class PostRedirectGet extends AbstractPlugin
 {
+    /**
+     * @var Manager
+     */
+    protected $session;
+
+    /**
+     * Set the session manager
+     *
+     * @param  Manager $manager
+     * @return FlashMessenger
+     */
+    public function setSessionManager(Manager $manager)
+    {
+        $this->session = $manager;
+        return $this;
+    }
+
+    /**
+     * Retrieve the session manager
+     *
+     * If none composed, lazy-loads a SessionManager instance
+     *
+     * @return Manager
+     */
+    public function getSessionManager()
+    {
+        if (!$this->session instanceof Manager) {
+            $this->setSessionManager(Container::getDefaultManager());
+        }
+        return $this->session;
+    }
+
     public function __invoke($redirect = null, $redirectToUrl = false)
     {
         $controller = $this->getController();
@@ -36,7 +69,7 @@ class PostRedirectGet extends AbstractPlugin
             $params   = $routeMatch->getParams();
         }
 
-        $container = new Container('prg_post1');
+        $container = new Container('prg_post1', $this->getSessionManager());
 
         if ($request->isPost()) {
             $container->setExpirationHops(1, 'post');

--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -11,9 +11,6 @@
 namespace Zend\Session;
 
 use Zend\EventManager\EventManagerInterface;
-use Zend\Session\Config\ConfigInterface as Config;
-use Zend\Session\SaveHandler\SaveHandlerInterface as SaveHandler;
-use Zend\Session\Storage\StorageInterface as Storage;
 
 /**
  * Session ManagerInterface implementation utilizing ext/session
@@ -47,12 +44,12 @@ class SessionManager extends AbstractManager
     /**
      * Constructor
      *
-     * @param  Config|null $config
-     * @param  Storage|null $storage
-     * @param  SaveHandler|null $saveHandler
+     * @param  Config\ConfigInterface|null $config
+     * @param  Storage\StorageInterface|null $storage
+     * @param  SaveHandler\SaveHandlerInterface|null $saveHandler
      * @throws Exception\RuntimeException
      */
-    public function __construct(Config $config = null, Storage $storage = null, SaveHandler $saveHandler = null)
+    public function __construct(Config\ConfigInterface $config = null, Storage\StorageInterface $storage = null, SaveHandler\SaveHandlerInterface $saveHandler = null)
     {
         parent::__construct($config, $storage, $saveHandler);
         register_shutdown_function(array($this, 'writeClose'));
@@ -94,7 +91,7 @@ class SessionManager extends AbstractManager
         }
 
         $saveHandler = $this->getSaveHandler();
-        if ($saveHandler instanceof SaveHandler) {
+        if ($saveHandler instanceof SaveHandler\SaveHandlerInterface) {
             // register the session handler with ext/session
             $this->registerSaveHandler($saveHandler);
         }
@@ -404,10 +401,10 @@ class SessionManager extends AbstractManager
      * Since ext/session is coupled to this particular session manager
      * register the save handler with ext/session.
      *
-     * @param SaveHandler $saveHandler
+     * @param SaveHandler\SaveHandlerInterface $saveHandler
      * @return bool
      */
-    protected function registerSaveHandler(SaveHandler $saveHandler)
+    protected function registerSaveHandler(SaveHandler\SaveHandlerInterface $saveHandler)
     {
         return session_set_save_handler(
             array($saveHandler, 'open'),

--- a/tests/ZendTest/Mvc/Controller/Plugin/FlashMessengerTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/FlashMessengerTest.php
@@ -27,6 +27,11 @@ class FlashMessengerTest extends \PHPUnit_Framework_TestCase
         $this->helper->setSessionManager($this->session);
     }
 
+    public function tearDown()
+    {
+        $this->session->getStorage()->clear();
+    }
+
     public function seedMessages()
     {
         $helper = new FlashMessenger();

--- a/tests/ZendTest/Mvc/Controller/Plugin/PostRedirectGetTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/PostRedirectGetTest.php
@@ -65,7 +65,9 @@ class PostRedirectGetTest extends TestCase
         $this->sessionManager->destroy();
 
         $this->controller->setEvent($this->event);
-        $this->controller->flashMessenger()->setSessionManager($this->sessionManager);
+        $plugins = $this->controller->getPluginManager();
+        $plugins->get('flashmessenger')->setSessionManager($this->sessionManager);
+        $plugins->get('prg')->setSessionManager($this->sessionManager);
     }
 
     public function testReturnsFalseOnIntialGet()

--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -329,18 +329,6 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @runInSeparateProcess
      */
-    public function testCallingDestructorMarksStorageAsImmutable()
-    {
-        $this->manager->start();
-        $storage = $this->manager->getStorage();
-        $storage['foo'] = 'bar';
-        $this->manager = null;
-        $this->assertTrue($storage->isImmutable());
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
     public function testCallingWriteCloseShouldNotAlterSessionExistsStatus()
     {
         $this->manager->start();

--- a/tests/ZendTest/Session/TestAsset/TestSaveHandlerWithValidator.php
+++ b/tests/ZendTest/Session/TestAsset/TestSaveHandlerWithValidator.php
@@ -15,7 +15,9 @@ use Zend\Session\SaveHandler\SaveHandlerInterface as SaveHandler;
 class TestSaveHandlerWithValidator implements SaveHandler
 {
     public function open($save_path, $name)
-    {return true;}
+    {
+        return true;
+    }
 
     public function close()
     {}


### PR DESCRIPTION
Fixes issues introduced earlier this week when we added the ability to call the session's writeClose() method on shutdown. Doing it in `__destruct` caused issues, so @mwillbanks has moved it to a `register_shutdown_function`, which ensures the original issue is fixed, while simultaneously fixing the regression.

In this PR, I also made it possible to inject the PRG plugin with a session manager, to make mocking and test isolation easier.
