### PR TITLE
stdClass with little 's'

### DIFF
--- a/library/Zend/Json/Decoder.php
+++ b/library/Zend/Json/Decoder.php
@@ -119,12 +119,12 @@ class Decoder
      *        - float
      *        - boolean
      *        - null
-     *      - StdClass
+     *      - stdClass
      *      - array
      *         - array of one or more of the above types
      *
      * By default, decoded objects will be returned as associative arrays; to
-     * return a StdClass object instead, pass {@link Zend_Json::TYPE_OBJECT} to
+     * return a stdClass object instead, pass {@link Zend_Json::TYPE_OBJECT} to
      * the $objectDecodeType parameter.
      *
      * @static
@@ -174,7 +174,7 @@ class Decoder
      * a special attribute called __className which specifies a class
      * name that should wrap the data contained within the encoded source.
      *
-     * Decodes to either an array or StdClass object, based on the value of
+     * Decodes to either an array or stdClass object, based on the value of
      * {@link $decodeType}. If invalid $decodeType present, returns as an
      * array.
      *
@@ -215,7 +215,7 @@ class Decoder
 
         switch ($this->decodeType) {
             case Json::TYPE_OBJECT:
-                // Create new StdClass and populate with $members
+                // Create new stdClass and populate with $members
                 $result = new stdClass();
                 foreach ($members as $key => $value) {
                     if ($key === '') {

--- a/library/Zend/Json/Json.php
+++ b/library/Zend/Json/Json.php
@@ -23,7 +23,7 @@ use Zend\Json\Exception\RuntimeException;
 class Json
 {
     /**
-     * How objects should be encoded -- arrays or as StdClass. TYPE_ARRAY is 1
+     * How objects should be encoded -- arrays or as stdClass. TYPE_ARRAY is 1
      * so that it is a boolean true value, allowing it to be used with
      * ext/json's functions.
      */

--- a/tests/ZendTest/Barcode/Renderer/ImageTest.php
+++ b/tests/ZendTest/Barcode/Renderer/ImageTest.php
@@ -49,7 +49,7 @@ class ImageTest extends TestCommon
     public function testObjectImageResource()
     {
         $this->setExpectedException('\Zend\Barcode\Renderer\Exception\ExceptionInterface');
-        $imageResource = new \StdClass();
+        $imageResource = new \stdClass();
         $this->renderer->setResource($imageResource);
     }
 

--- a/tests/ZendTest/Json/JsonTest.php
+++ b/tests/ZendTest/Json/JsonTest.php
@@ -250,7 +250,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase
         $encoded = Json\Encoder::encode($value);
         $decoded = Json\Decoder::decode($encoded, Json\Json::TYPE_OBJECT);
         $this->assertTrue(is_object($decoded), 'Not decoded as an object');
-        $this->assertTrue($decoded instanceof \StdClass, 'Not a StdClass object');
+        $this->assertTrue($decoded instanceof \stdClass, 'Not a stdClass object');
         $this->assertTrue(isset($decoded->one), 'Expected property not set');
         $this->assertEquals($value->one, $decoded->one, 'Unexpected value');
     }

--- a/tests/ZendTest/Log/Writer/AbstractTest.php
+++ b/tests/ZendTest/Log/Writer/AbstractTest.php
@@ -35,7 +35,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->_writer->addFilter(1);
         $this->_writer->addFilter(new RegexFilter('/mess/'));
         $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException');
-        $this->_writer->addFilter(new \StdClass());
+        $this->_writer->addFilter(new \stdClass());
     }
 
     public function testAddMockFilterByName()

--- a/tests/ZendTest/ModuleManager/ModuleEventTest.php
+++ b/tests/ZendTest/ModuleManager/ModuleEventTest.php
@@ -47,7 +47,7 @@ class ModuleEventTest extends TestCase
     public function testPassingNonStringToSetModuleNameRaisesException()
     {
         $this->setExpectedException('Zend\ModuleManager\Exception\InvalidArgumentException');
-        $this->event->setModuleName(new StdClass);
+        $this->event->setModuleName(new stdClass);
     }
 
     public function testSettingConfigListenerProxiesToParameters()

--- a/tests/ZendTest/Serializer/Adapter/PythonPickleSerializeProtocol0Test.php
+++ b/tests/ZendTest/Serializer/Adapter/PythonPickleSerializeProtocol0Test.php
@@ -164,7 +164,7 @@ class PythonPickleSerializeProtocol0Test extends \PHPUnit_Framework_TestCase
 
     public function testSerializeObject()
     {
-        $value = new \StdClass();
+        $value = new \stdClass();
         $value->test  = 'test';
         $value->test2 = 2;
         $expected = "(dp0\r\n"

--- a/tests/ZendTest/Soap/TestAsset/commontypes.php
+++ b/tests/ZendTest/Soap/TestAsset/commontypes.php
@@ -84,7 +84,7 @@ function TestFunc7()
 /**
  * Return Object
  *
- * @return StdClass
+ * @return stdClass
  */
 function TestFunc8()
 {

--- a/tests/ZendTest/Soap/_files/commontypes.php
+++ b/tests/ZendTest/Soap/_files/commontypes.php
@@ -82,7 +82,7 @@ function Zend_Soap_AutoDiscover_TestFunc7()
 /**
  * Return Object
  *
- * @return StdClass
+ * @return stdClass
  */
 function Zend_Soap_AutoDiscover_TestFunc8()
 {


### PR DESCRIPTION
StdClass should be stdClass with little 's' in first word for consistency.
