### PR TITLE
remove surplus call deep namespace

### DIFF
--- a/library/Zend/Mvc/Router/Console/Catchall.php
+++ b/library/Zend/Mvc/Router/Console/Catchall.php
@@ -72,12 +72,12 @@ class Catchall implements RouteInterface
     protected $assembledParams = array();
 
     /**
-     * @var \Zend\Validator\ValidatorChain
+     * @var ValidatorChain
      */
     protected $validators;
 
     /**
-     * @var \Zend\Filter\FilterChain
+     * @var FilterChain
      */
     protected $filters;
 

--- a/library/Zend/Mvc/Service/ControllerLoaderFactory.php
+++ b/library/Zend/Mvc/Service/ControllerLoaderFactory.php
@@ -25,7 +25,7 @@ class ControllerLoaderFactory implements FactoryInterface
     /**
      * Create the controller loader service
      *
-     * Creates and returns an instance of Controller\ControllerManager. The
+     * Creates and returns an instance of ControllerManager. The
      * only controllers this manager will allow are those defined in the
      * application configuration's "controllers" array. If a controller is
      * matched, the scoped manager will attempt to load the controller.


### PR DESCRIPTION
because already defined in 'use' statement
