### PR TITLE
The display_exceptions config-option is not passed to 404 views.

### DIFF
--- a/library/Zend/Mvc/View/Http/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/Http/RouteNotFoundStrategy.php
@@ -276,6 +276,8 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
             return;
         }
 
+        $model->setVariable('display_exceptions', true);
+
         $exception = $e->getParam('exception', false);
         if (!$exception instanceof \Exception) {
             return;

--- a/tests/ZendTest/Mvc/View/RouteNotFoundStrategyTest.php
+++ b/tests/ZendTest/Mvc/View/RouteNotFoundStrategyTest.php
@@ -223,6 +223,7 @@ class RouteNotFoundStrategyTest extends TestCase
             $this->assertInstanceOf('Zend\View\Model\ModelInterface', $model);
             $variables = $model->getVariables();
             if ($allow) {
+                $this->assertTrue($variables['display_exceptions']);
                 $this->assertTrue(isset($variables['exception']));
                 $this->assertSame($exception, $variables['exception']);
             } else {


### PR DESCRIPTION
Fixes https://github.com/zendframework/ZendSkeletonApplication/issues/155

When setting display_exceptions to true the exception is injected to the 404 view, but not the display_exception option.
