### PR TITLE
Feature/rest delete replace collection

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -358,25 +358,6 @@ abstract class AbstractRestfulController extends AbstractController
     }
 
     /**
-     * Process put data and call update
-     *
-     * @param Request $request
-     * @param $routeMatch
-     * @return mixed
-     */
-    public function processPutData(Request $request, $routeMatch)
-    {
-        $id   = $this->getIdentifier($routeMatch, $request);
-        $data = $this->processBodyContent($request);
-
-        if (!$id) {
-            return $this->replaceList($data);
-        }
-
-        return $this->update($id, $data);
-    }
-
-    /**
      * Check if request has certain content type
      *
      * @return boolean

--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -263,7 +263,7 @@ abstract class AbstractRestfulController extends AbstractController
             // DELETE
             case 'delete':
                 $id = $this->getIdentifier($routeMatch, $request);
-                if ($id) {
+                if ($id !== false) {
                     $action = 'delete';
                     $return = $this->delete($id);
                     break;
@@ -275,7 +275,7 @@ abstract class AbstractRestfulController extends AbstractController
             // GET
             case 'get':
                 $id = $this->getIdentifier($routeMatch, $request);
-                if ($id) {
+                if ($id !== false) {
                     $action = 'get';
                     $return = $this->get($id);
                     break;
@@ -286,7 +286,7 @@ abstract class AbstractRestfulController extends AbstractController
             // HEAD
             case 'head':
                 $id = $this->getIdentifier($routeMatch, $request);
-                if (!$id) {
+                if (!$id !== false) {
                     $id = null;
                 }
                 $action = 'head';
@@ -304,7 +304,7 @@ abstract class AbstractRestfulController extends AbstractController
             // PATCH
             case 'patch':
                 $id = $this->getIdentifier($routeMatch, $request);
-                if (!$id) {
+                if (!$id !== false) {
                     throw new Exception\DomainException('Missing identifier');
                 }
                 $data   = $this->processBodyContent($request);
@@ -318,10 +318,10 @@ abstract class AbstractRestfulController extends AbstractController
                 break;
             // PUT
             case 'put':
-                $id     = $this->getIdentifier($routeMatch, $request);
-                $data   = $this->processBodyContent($request);
+                $id   = $this->getIdentifier($routeMatch, $request);
+                $data = $this->processBodyContent($request);
 
-                if ($id) {
+                if ($id !== false) {
                     $action = 'update';
                     $return = $this->update($id, $data);
                     break;

--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -305,7 +305,9 @@ abstract class AbstractRestfulController extends AbstractController
             case 'patch':
                 $id = $this->getIdentifier($routeMatch, $request);
                 if ($id === false) {
-                    throw new Exception\DomainException('Missing identifier');
+                    $response = $e->getResponse();
+                    $response->setStatusCode(405);
+                    return $response;
                 }
                 $data   = $this->processBodyContent($request);
                 $action = 'patch';
@@ -332,7 +334,9 @@ abstract class AbstractRestfulController extends AbstractController
                 break;
             // All others...
             default:
-                throw new Exception\DomainException('Invalid HTTP method!');
+                $response = $e->getResponse();
+                $response->setStatusCode(405);
+                return $response;
         }
 
         $routeMatch->setParam('action', $action);

--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -72,6 +72,22 @@ abstract class AbstractRestfulController extends AbstractController
     abstract public function delete($id);
 
     /**
+     * Delete the entire resource collection
+     *
+     * Not marked as abstract, as that would introduce a BC break
+     * (introduced in 2.1.0); instead, raises an exception if not implemented.
+     *
+     * @return mixed
+     * @throws Exception\RuntimeException
+     */
+    public function deleteList()
+    {
+        throw new Exception\RuntimeException(sprintf(
+            '%s is unimplemented', __METHOD__
+        ));
+    }
+
+    /**
      * Return single resource
      *
      * @param  mixed $id
@@ -231,8 +247,9 @@ abstract class AbstractRestfulController extends AbstractController
             case 'delete':
                 if (null === $id = $routeMatch->getParam('id')) {
                     if (! ($id = $request->getQuery()->get('id', false))) {
-                        throw new Exception\DomainException(
-                                'Missing identifier');
+                        $action = 'deleteList';
+                        $return = $this->deleteList();
+                        break;
                     }
                 }
                 $action = 'delete';

--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -286,7 +286,7 @@ abstract class AbstractRestfulController extends AbstractController
             // HEAD
             case 'head':
                 $id = $this->getIdentifier($routeMatch, $request);
-                if (!$id !== false) {
+                if ($id !== false) {
                     $id = null;
                 }
                 $action = 'head';
@@ -304,7 +304,7 @@ abstract class AbstractRestfulController extends AbstractController
             // PATCH
             case 'patch':
                 $id = $this->getIdentifier($routeMatch, $request);
-                if (!$id !== false) {
+                if ($id === false) {
                     throw new Exception\DomainException('Missing identifier');
                 }
                 $data   = $this->processBodyContent($request);

--- a/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
+++ b/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
@@ -366,4 +366,18 @@ class RestfulControllerTest extends TestCase
         $this->request->getHeaders()->addHeaderLine('Content-Type', $contentType);
         $this->assertFalse($this->controller->requestHasContentType($this->request, TestAsset\RestfulTestController::CONTENT_TYPE_JSON));
     }
+
+    public function testDispatchViaPatchWithoutIdentifierRaisesException()
+    {
+        $entity = new stdClass;
+        $entity->name = 'foo';
+        $entity->type = 'standard';
+        $this->controller->entity = $entity;
+        $entity = array('name' => __FUNCTION__);
+        $string = http_build_query($entity);
+        $this->request->setMethod('PATCH')
+                      ->setContent($string);
+        $this->setExpectedException('Zend\Mvc\Exception\DomainException', 'identifier');
+        $result = $this->controller->dispatch($this->request, $this->response);
+    }
 }

--- a/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
+++ b/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
@@ -367,7 +367,7 @@ class RestfulControllerTest extends TestCase
         $this->assertFalse($this->controller->requestHasContentType($this->request, TestAsset\RestfulTestController::CONTENT_TYPE_JSON));
     }
 
-    public function testDispatchViaPatchWithoutIdentifierRaisesException()
+    public function testDispatchViaPatchWithoutIdentifierReturns405Response()
     {
         $entity = new stdClass;
         $entity->name = 'foo';
@@ -377,7 +377,16 @@ class RestfulControllerTest extends TestCase
         $string = http_build_query($entity);
         $this->request->setMethod('PATCH')
                       ->setContent($string);
-        $this->setExpectedException('Zend\Mvc\Exception\DomainException', 'identifier');
         $result = $this->controller->dispatch($this->request, $this->response);
+        $this->assertInstanceOf('Zend\Http\Response', $result);
+        $this->assertEquals(405, $result->getStatusCode());
+    }
+
+    public function testDispatchWithUnrecognizedMethodReturns405Response()
+    {
+        $this->request->setMethod('PROPFIND');
+        $result = $this->controller->dispatch($this->request, $this->response);
+        $this->assertInstanceOf('Zend\Http\Response', $result);
+        $this->assertEquals(405, $result->getStatusCode());
     }
 }

--- a/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
+++ b/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
@@ -90,6 +90,21 @@ class RestfulControllerTest extends TestCase
         $this->assertEquals('update', $this->routeMatch->getParam('action'));
     }
 
+    public function testDispatchInvokesReplaceListMethodWhenNoActionPresentAndPutInvokedWithoutIdentifier()
+    {
+        $entities = array(
+            array('id' => uniqid(), 'name' => __FUNCTION__),
+            array('id' => uniqid(), 'name' => __FUNCTION__),
+            array('id' => uniqid(), 'name' => __FUNCTION__),
+        );
+        $string = http_build_query($entities);
+        $this->request->setMethod('PUT')
+                      ->setContent($string);
+        $result = $this->controller->dispatch($this->request, $this->response);
+        $this->assertEquals($entities, $result);
+        $this->assertEquals('replaceList', $this->routeMatch->getParam('action'));
+    }
+
     public function testDispatchInvokesDeleteMethodWhenNoActionPresentAndDeleteInvokedWithIdentifier()
     {
         $entity = array('id' => 1, 'name' => __FUNCTION__);

--- a/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
+++ b/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
@@ -102,6 +102,16 @@ class RestfulControllerTest extends TestCase
         $this->assertEquals('delete', $this->routeMatch->getParam('action'));
     }
 
+    public function testDispatchInvokesDeleteListMethodWhenNoActionPresentAndDeleteInvokedWithoutIdentifier()
+    {
+        $this->request->setMethod('DELETE');
+        $result = $this->controller->dispatch($this->request, $this->response);
+        $this->assertSame($this->response, $result);
+        $this->assertEquals(204, $result->getStatusCode());
+        $this->assertTrue($result->getHeaders()->has('X-Deleted'));
+        $this->assertEquals('deleteList', $this->routeMatch->getParam('action'));
+    }
+
     public function testDispatchInvokesOptionsMethodWhenNoActionPresentAndOptionsInvoked()
     {
         $this->request->setMethod('OPTIONS');

--- a/tests/ZendTest/Mvc/Controller/TestAsset/RestfulTestController.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/RestfulTestController.php
@@ -112,6 +112,17 @@ class RestfulTestController extends AbstractRestfulController
     }
 
     /**
+     * Replace the entire resource collection
+     *
+     * @param  array|Traversable $items
+     * @return array|Traversable
+     */
+    public function replaceList($items)
+    {
+        return $items;
+    }
+
+    /**
      * Update an existing resource
      *
      * @param  mixed $id

--- a/tests/ZendTest/Mvc/Controller/TestAsset/RestfulTestController.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/RestfulTestController.php
@@ -41,6 +41,19 @@ class RestfulTestController extends AbstractRestfulController
     }
 
     /**
+     * Delete the collection
+     *
+     * @return \Zend\Http\Response
+     */
+    public function deleteList()
+    {
+        $response = $this->getResponse();
+        $response->setStatusCode(204);
+        $response->getHeaders()->addHeaderLine('X-Deleted', 'true');
+        return $response;
+    }
+
+    /**
      * Return single resource
      *
      * @param  mixed $id

--- a/tests/ZendTest/Mvc/Controller/TestAsset/RestfulTestController.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/RestfulTestController.php
@@ -114,8 +114,8 @@ class RestfulTestController extends AbstractRestfulController
     /**
      * Replace the entire resource collection
      *
-     * @param  array|Traversable $items
-     * @return array|Traversable
+     * @param  array|\Traversable $items
+     * @return array|\Traversable
      */
     public function replaceList($items)
     {


### PR DESCRIPTION
In reviewing the `AbstractRestfulController` implementation against various docs, I discovered two capabilities we currently not only do not support, but raise exceptions for:
- **DELETE** to a _collection_ (i.e., to "/users" vs "/users/1"). While rarely used, this method is allowed, and is used to indicate that the entire collection should be _deleted_.
- **PUT** to a _collection_ (i.e., to "/users" vs "/users/1"). While rarely used, this method is allowed, and is used to indicate that the entire collection should be _replaced_ with what is provided in the request.

This PR adds support for both operations. It adds two new methods, `deleteList()` and `replaceList()`, which were chosen to mirror the existing `getList()` method while semantically indicating purpose.
