### PR TITLE
[#2629] Add charset to Content-Type header

### DIFF
--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -25,6 +25,13 @@ use Zend\View\ViewEvent;
 class JsonStrategy implements ListenerAggregateInterface
 {
     /**
+     * Character set for associated content-type
+     *
+     * @var string
+     */
+    protected $charset = 'utf-8';
+
+    /**
      * @var \Zend\Stdlib\CallbackHandler[]
      */
     protected $listeners = array();
@@ -73,6 +80,18 @@ class JsonStrategy implements ListenerAggregateInterface
     }
 
     /**
+     * Set the content-type character set
+     *
+     * @param  string $charset
+     * @return JsonStrategy
+     */
+    public function setCharset($charset)
+    {
+        $this->charset = (string) $charset;
+        return $this;
+    }
+
+    /**
      * Detect if we should use the JsonRenderer based on model type and/or
      * Accept header
      *
@@ -116,10 +135,14 @@ class JsonStrategy implements ListenerAggregateInterface
         $response = $e->getResponse();
         $response->setContent($result);
         $headers = $response->getHeaders();
+
         if ($this->renderer->hasJsonpCallback()) {
-            $headers->addHeaderLine('content-type', 'application/javascript');
+            $contentType = 'application/javascript';
         } else {
-            $headers->addHeaderLine('content-type', 'application/json');
+            $contentType = 'application/json';
         }
+
+        $contentType .= '; charset=' . $this->charset;
+        $headers->addHeaderLine('content-type', $contentType);
     }
 }

--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -37,6 +37,16 @@ class JsonStrategy implements ListenerAggregateInterface
     protected $listeners = array();
 
     /**
+     * Multibyte character sets that will trigger a binary content-transfer-encoding
+     *
+     * @var array
+     */
+    protected $multibyteCharsets = array(
+        'UTF-16',
+        'UTF-32',
+    );
+
+    /**
      * @var JsonRenderer
      */
     protected $renderer;
@@ -92,6 +102,16 @@ class JsonStrategy implements ListenerAggregateInterface
     }
 
     /**
+     * Retrieve the current character set
+     *
+     * @return string
+     */
+    public function getCharset()
+    {
+        return $this->charset;
+    }
+
+    /**
      * Detect if we should use the JsonRenderer based on model type and/or
      * Accept header
      *
@@ -144,5 +164,9 @@ class JsonStrategy implements ListenerAggregateInterface
 
         $contentType .= '; charset=' . $this->charset;
         $headers->addHeaderLine('content-type', $contentType);
+
+        if (in_array(strtoupper($this->charset), $this->multibyteCharsets)) {
+            $headers->addHeaderLine('content-transfer-encoding', 'BINARY');
+        }
     }
 }

--- a/tests/ZendTest/View/Strategy/JsonStrategyTest.php
+++ b/tests/ZendTest/View/Strategy/JsonStrategyTest.php
@@ -288,4 +288,41 @@ class JsonStrategyTest extends TestCase
         $this->assertTrue($headers->has('content-type'));
         $this->assertContains('application/json; charset=utf-16', $headers->get('content-type')->getFieldValue());
     }
+
+    public function testCharsetIsUtf8ByDefault()
+    {
+        $this->assertEquals('utf-8', $this->strategy->getCharset());
+    }
+
+    public function testCharsetIsMutable()
+    {
+        $this->strategy->setCharset('iso-8859-1');
+        $this->assertEquals('iso-8859-1', $this->strategy->getCharset());
+    }
+
+    public function multibyteCharsets()
+    {
+        return array(
+            'utf-16' => array('utf-16'),
+            'utf-32' => array('utf-32'),
+        );
+    }
+
+    /**
+     * @dataProvider multibyteCharsets
+     */
+    public function testContentTransferEncodingHeaderSetToBinaryForSpecificMultibyteCharsets($charset)
+    {
+        $this->strategy->setCharset($charset);
+
+        $this->event->setResponse($this->response);
+        $this->event->setRenderer($this->renderer);
+        $this->event->setResult(json_encode(array('foo' => 'bar')));
+
+        $this->strategy->injectResponse($this->event);
+        $content = $this->response->getContent();
+        $headers = $this->response->getHeaders();
+        $this->assertTrue($headers->has('content-transfer-encoding'));
+        $this->assertEquals('BINARY', $headers->get('content-transfer-encoding')->getFieldValue());
+    }
 }

--- a/tests/ZendTest/View/Strategy/JsonStrategyTest.php
+++ b/tests/ZendTest/View/Strategy/JsonStrategyTest.php
@@ -135,7 +135,7 @@ class JsonStrategyTest extends TestCase
         $headers = $this->response->getHeaders();
         $this->assertEquals($expected, $content);
         $this->assertTrue($headers->has('content-type'));
-        $this->assertEquals('application/json', $headers->get('content-type')->getFieldValue());
+        $this->assertContains('application/json', $headers->get('content-type')->getFieldValue());
     }
 
     public function testMatchingRendererAndStringResultInjectsResponseJsonp()
@@ -151,7 +151,7 @@ class JsonStrategyTest extends TestCase
         $headers = $this->response->getHeaders();
         $this->assertEquals($expected, $content);
         $this->assertTrue($headers->has('content-type'));
-        $this->assertEquals('application/javascript', $headers->get('content-type')->getFieldValue());
+        $this->assertContains('application/javascript', $headers->get('content-type')->getFieldValue());
     }
 
     public function testReturnsNullWhenCannotSelectRenderer()
@@ -223,5 +223,69 @@ class JsonStrategyTest extends TestCase
         $this->assertEquals(0, count($listeners));
         $listeners = $events->getListeners('response');
         $this->assertEquals(0, count($listeners));
+    }
+
+    public function testDefaultsToUtf8CharsetWhenCreatingJavascriptHeader()
+    {
+        $expected = json_encode(array('foo' => 'bar'));
+        $this->renderer->setJsonpCallback('foo');
+        $this->event->setResponse($this->response);
+        $this->event->setRenderer($this->renderer);
+        $this->event->setResult($expected);
+
+        $this->strategy->injectResponse($this->event);
+        $content = $this->response->getContent();
+        $headers = $this->response->getHeaders();
+        $this->assertEquals($expected, $content);
+        $this->assertTrue($headers->has('content-type'));
+        $this->assertContains('application/javascript; charset=utf-8', $headers->get('content-type')->getFieldValue());
+    }
+
+    public function testDefaultsToUtf8CharsetWhenCreatingJsonHeader()
+    {
+        $expected = json_encode(array('foo' => 'bar'));
+        $this->event->setResponse($this->response);
+        $this->event->setRenderer($this->renderer);
+        $this->event->setResult($expected);
+
+        $this->strategy->injectResponse($this->event);
+        $content = $this->response->getContent();
+        $headers = $this->response->getHeaders();
+        $this->assertEquals($expected, $content);
+        $this->assertTrue($headers->has('content-type'));
+        $this->assertContains('application/json; charset=utf-8', $headers->get('content-type')->getFieldValue());
+    }
+
+    public function testUsesProvidedCharsetWhenCreatingJavascriptHeader()
+    {
+        $expected = json_encode(array('foo' => 'bar'));
+        $this->renderer->setJsonpCallback('foo');
+        $this->event->setResponse($this->response);
+        $this->event->setRenderer($this->renderer);
+        $this->event->setResult($expected);
+
+        $this->strategy->setCharset('utf-16');
+        $this->strategy->injectResponse($this->event);
+        $content = $this->response->getContent();
+        $headers = $this->response->getHeaders();
+        $this->assertEquals($expected, $content);
+        $this->assertTrue($headers->has('content-type'));
+        $this->assertContains('application/javascript; charset=utf-16', $headers->get('content-type')->getFieldValue());
+    }
+
+    public function testUsesProvidedCharsetWhenCreatingJsonHeader()
+    {
+        $expected = json_encode(array('foo' => 'bar'));
+        $this->event->setResponse($this->response);
+        $this->event->setRenderer($this->renderer);
+        $this->event->setResult($expected);
+
+        $this->strategy->setCharset('utf-16');
+        $this->strategy->injectResponse($this->event);
+        $content = $this->response->getContent();
+        $headers = $this->response->getHeaders();
+        $this->assertEquals($expected, $content);
+        $this->assertTrue($headers->has('content-type'));
+        $this->assertContains('application/json; charset=utf-16', $headers->get('content-type')->getFieldValue());
     }
 }


### PR DESCRIPTION
- Defaults to UTF-8
- Allows setting via a setter
- charset is always used in generated content-type header

Addresses #2629
