### PR TITLE
[#3055] Remove array to string conversion notice

### DIFF
--- a/library/Zend/Validator/AbstractValidator.php
+++ b/library/Zend/Validator/AbstractValidator.php
@@ -303,7 +303,7 @@ abstract class AbstractValidator implements
         ) {
             $value = get_class($value) . ' object';
         } elseif (is_array($value)) {
-            $value = '[' . implode(', ', $value) . ']';
+            $value = var_export($value, 1);
         } else {
             $value = (string) $value;
         }

--- a/tests/ZendTest/Validator/AbstractTest.php
+++ b/tests/ZendTest/Validator/AbstractTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\Validator;
 
+use ReflectionMethod;
 use Zend\I18n\Translator\Translator;
 use Zend\Validator\AbstractValidator;
 
@@ -225,6 +226,17 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', AbstractValidator::getDefaultTranslatorTextDomain());
         $this->assertEquals('foo', $this->validator->getTranslatorTextDomain());
         $this->assertTrue(AbstractValidator::hasDefaultTranslator());
+    }
+
+    public function testMessageCreationWithNestedArrayValueDoesNotRaiseNotice()
+    {
+        $r = new ReflectionMethod($this->validator, 'createMessage');
+        $r->setAccessible(true);
+
+        $message = $r->invoke($this->validator, 'fooMessage', array('foo' => array('bar' => 'baz')));
+        $this->assertContains('foo', $message);
+        $this->assertContains('bar', $message);
+        $this->assertContains('baz', $message);
     }
 
     /**


### PR DESCRIPTION
- Removes an array to string conversion notice when nested arrays are
  provided as values

Addresses #3055
