### PR TITLE
[#3446] Allow generic traversable configuration to Captcha element

### DIFF
--- a/library/Zend/Form/Element/Captcha.php
+++ b/library/Zend/Form/Element/Captcha.php
@@ -39,8 +39,8 @@ class Captcha extends Element implements InputProviderInterface
     {
         parent::setOptions($options);
 
-        if (isset($options['captcha'])) {
-            $this->setCaptcha($options['captcha']);
+        if (isset($this->options['captcha'])) {
+            $this->setCaptcha($this->options['captcha']);
         }
 
         return $this;

--- a/tests/ZendTest/Form/Element/CaptchaTest.php
+++ b/tests/ZendTest/Form/Element/CaptchaTest.php
@@ -11,10 +11,12 @@
 namespace ZendTest\Form\Element;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use ArrayIterator;
 use ArrayObject;
 use Zend\Captcha;
 use Zend\Form\Element\Captcha as CaptchaElement;
 use Zend\Form\Factory;
+use ZendTest\Form\TestAsset;
 
 class CaptchaTest extends TestCase
 {
@@ -106,5 +108,23 @@ class CaptchaTest extends TestCase
         $this->assertInternalType('array', $inputSpec['validators']);
         $test = array_shift($inputSpec['validators']);
         $this->assertSame($captcha, $test);
+    }
+
+    /**
+     * @group 3446
+     */
+    public function testAllowsPassingTraversableOptionsToConstructor()
+    {
+        $options = new TestAsset\IteratorAggregate(new ArrayIterator(array(
+            'captcha' => array(
+                'class'   => 'dumb',
+                'options' => array(
+                    'sessionClass' => 'ZendTest\Captcha\TestAsset\SessionContainer',
+                ),
+            ),
+        )));
+        $element = new CaptchaElement('captcha', $options);
+        $captcha = $element->getCaptcha();
+        $this->assertInstanceOf('Zend\Captcha\Dumb', $captcha);
     }
 }

--- a/tests/ZendTest/Form/TestAsset/IteratorAggregate.php
+++ b/tests/ZendTest/Form/TestAsset/IteratorAggregate.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Traversable;
+use IteratorAggregate as IteratorAggregateInterface;
+
+class IteratorAggregate implements IteratorAggregateInterface
+{
+    protected $iterator;
+
+    public function __construct(Traversable $iterator)
+    {
+        $this->iterator = $iterator;
+    }
+
+    public function getIterator()
+    {
+        return $this->iterator;
+    }
+}


### PR DESCRIPTION
Resolve #3446 - allow using a generic traversable as options passed to a Captcha element. The only way I could confirm it was an issue was to use an IteratorAggregate -- hence the new TestAsset in this patch.
