### PR TITLE
Hotfix/random crypt test fail

### DIFF
--- a/library/Zend/Crypt/PublicKey/Rsa.php
+++ b/library/Zend/Crypt/PublicKey/Rsa.php
@@ -24,6 +24,10 @@ use Zend\Stdlib\ArrayUtils;
  */
 class Rsa
 {
+    const MODE_AUTO   = 1;
+    const MODE_BASE64 = 2;
+    const MODE_RAW    = 3;
+
     /**
      * @var RsaOptions
      */
@@ -173,22 +177,45 @@ class Rsa
     /**
      * Verify signature with public key
      *
+     * $signature can be encoded in base64 or not. $mode sets how the input must be processed:
+     *  - MODE_AUTO: Try to guess if $signature is base64 encoded or not. This mode is not recommended.
+     *  - MODE_BASE64: Decode $signature using base64 algorithm.
+     *  - MODE_RAW: $signature is not encoded.
+     *
      * @param  string $data
      * @param  string $signature
      * @param  null|Rsa\PublicKey $publicKey
+     * @param  int                $mode Input encoding
      * @return bool
      * @throws Rsa\Exception\RuntimeException
+     * @see Rsa::MODE_AUTO
+     * @see Rsa::MODE_BASE64
+     * @see Rsa::MODE_RAW
      */
-    public function verify($data, $signature, Rsa\PublicKey $publicKey = null)
-    {
+    public function verify(
+        $data,
+        $signature,
+        Rsa\PublicKey $publicKey = null,
+        $mode = self::MODE_AUTO
+    ) {
         if (null === $publicKey) {
             $publicKey = $this->options->getPublicKey();
         }
 
-        // check if signature is encoded in Base64
-        $output = base64_decode($signature, true);
-        if (false !== $output) {
-            $signature = $output;
+        switch ($mode) {
+            case self::MODE_AUTO:
+                // check if data is encoded in Base64
+                $output = base64_decode($signature, true);
+                if ((false !== $output) && ($signature === base64_encode($output))) {
+                    $signature = $output;
+                }
+                break;
+            case self::MODE_BASE64:
+                $signature = base64_decode($signature);
+                break;
+            case self::MODE_RAW:
+            default:
+                break;
         }
 
         $result = openssl_verify(
@@ -236,13 +263,25 @@ class Rsa
     /**
      * Decrypt with private/public key
      *
+     * $data can be encoded in base64 or not. $mode sets how the input must be processed:
+     *  - MODE_AUTO: Try to guess if $data is base64 encoded or not. This mode is not recommended.
+     *  - MODE_BASE64: Decode $data using base64 algorithm.
+     *  - MODE_RAW: $data is not encoded.
+     *
      * @param  string          $data
      * @param  Rsa\AbstractKey $key
+     * @param  int             $mode Input encoding
      * @return string
      * @throws Rsa\Exception\InvalidArgumentException
+     * @see Rsa::MODE_AUTO
+     * @see Rsa::MODE_BASE64
+     * @see Rsa::MODE_RAW
      */
-    public function decrypt($data, Rsa\AbstractKey $key = null)
-    {
+    public function decrypt(
+        $data,
+        Rsa\AbstractKey $key = null,
+        $mode = self::MODE_AUTO
+    ) {
         if (null === $key) {
             $key = $this->options->getPrivateKey();
         }
@@ -251,10 +290,20 @@ class Rsa
             throw new Exception\InvalidArgumentException('No key specified for the decryption');
         }
 
-        // check if data is encoded in Base64
-        $output = base64_decode($data, true);
-        if (false !== $output) {
-            $data = $output;
+        switch ($mode) {
+            case self::MODE_AUTO:
+                // check if data is encoded in Base64
+                $output = base64_decode($data, true);
+                if ((false !== $output) && ($data === base64_encode($output))) {
+                    $data = $output;
+                }
+                break;
+            case self::MODE_BASE64:
+                $data = base64_decode($data);
+                break;
+            case self::MODE_RAW:
+            default:
+                break;
         }
 
         return $key->decrypt($data);

--- a/library/Zend/Crypt/PublicKey/Rsa.php
+++ b/library/Zend/Crypt/PublicKey/Rsa.php
@@ -178,7 +178,7 @@ class Rsa
      * Verify signature with public key
      *
      * $signature can be encoded in base64 or not. $mode sets how the input must be processed:
-     *  - MODE_AUTO: Try to guess if $signature is base64 encoded or not. This mode is not recommended.
+     *  - MODE_AUTO: Check if the $signature is encoded in base64. Not recommended for performance.
      *  - MODE_BASE64: Decode $signature using base64 algorithm.
      *  - MODE_RAW: $signature is not encoded.
      *
@@ -264,7 +264,7 @@ class Rsa
      * Decrypt with private/public key
      *
      * $data can be encoded in base64 or not. $mode sets how the input must be processed:
-     *  - MODE_AUTO: Try to guess if $data is base64 encoded or not. This mode is not recommended.
+     *  - MODE_AUTO: Check if the $signature is encoded in base64. Not recommended for performance.
      *  - MODE_BASE64: Decode $data using base64 algorithm.
      *  - MODE_RAW: $data is not encoded.
      *

--- a/tests/ZendTest/Crypt/PublicKey/RsaTest.php
+++ b/tests/ZendTest/Crypt/PublicKey/RsaTest.php
@@ -413,4 +413,66 @@ CERT;
             'private_key' => $rsaOptions->getPrivateKey()->toString(),
         ));
     }
+
+    public function testZf3492Base64DetectDecrypt()
+    {
+        $data = 'vNKINbWV6qUKGsmawN8ii0mak7PPNoVQPC7fwXJOgMNfCgdT+9W4PUte4fic6U4A6fMra4gv7NCTESxap2qpBQ==';
+        $this->assertEquals('1234567890', $this->rsa->decrypt($data));
+    }
+
+    public function testZf3492Base64DetectVerify()
+    {
+        $data = 'sMHpp3u6DNecIm5RIkDD3xyKaH6qqP8roUWDs215iOGHehfK1ypqwoETKNP7NaksGS2C1Up813ixlGXkipPVbQ==';
+        $this->assertTrue($this->rsa->verify('1234567890', $data));
+    }
+
+    public function testDecryptBase64()
+    {
+        $data = 'vNKINbWV6qUKGsmawN8ii0mak7PPNoVQPC7fwXJOgMNfCgdT+9W4PUte4fic6U4A6fMra4gv7NCTESxap2qpBQ==';
+        $this->assertEquals('1234567890', $this->rsa->decrypt($data, null, Rsa::MODE_BASE64));
+    }
+
+    public function testDecryptCorruptBase64()
+    {
+        $data = 'vNKINbWV6qUKGsmawN8ii0mak7PPNoVQPC7fwXJOgMNfCgdT+9W4PUte4fic6U4A6fMra4gv7NCTESxap2qpBQ==';
+        $this->setExpectedException('Zend\Crypt\PublicKey\Rsa\Exception\RuntimeException');
+        $this->rsa->decrypt(base64_decode($data), null, Rsa::MODE_BASE64);
+    }
+
+    public function testDecryptRaw()
+    {
+        $data = 'vNKINbWV6qUKGsmawN8ii0mak7PPNoVQPC7fwXJOgMNfCgdT+9W4PUte4fic6U4A6fMra4gv7NCTESxap2qpBQ==';
+        $this->assertEquals('1234567890', $this->rsa->decrypt(base64_decode($data), null, Rsa::MODE_RAW));
+    }
+
+    public function testDecryptCorruptRaw()
+    {
+        $data = 'vNKINbWV6qUKGsmawN8ii0mak7PPNoVQPC7fwXJOgMNfCgdT+9W4PUte4fic6U4A6fMra4gv7NCTESxap2qpBQ==';
+        $this->setExpectedException('Zend\Crypt\PublicKey\Rsa\Exception\RuntimeException');
+        $this->rsa->decrypt($data, null, Rsa::MODE_RAW);
+    }
+
+    public function testVerifyBase64()
+    {
+        $data = 'sMHpp3u6DNecIm5RIkDD3xyKaH6qqP8roUWDs215iOGHehfK1ypqwoETKNP7NaksGS2C1Up813ixlGXkipPVbQ==';
+        $this->assertTrue($this->rsa->verify('1234567890', $data, null, Rsa::MODE_BASE64));
+    }
+
+    public function testVerifyCorruptBase64()
+    {
+        $data = 'sMHpp3u6DNecIm5RIkDD3xyKaH6qqP8roUWDs215iOGHehfK1ypqwoETKNP7NaksGS2C1Up813ixlGXkipPVbQ==';
+        $this->assertFalse($this->rsa->verify('1234567890', base64_decode($data), null, Rsa::MODE_BASE64));
+    }
+
+    public function testVerifyRaw()
+    {
+        $data = 'sMHpp3u6DNecIm5RIkDD3xyKaH6qqP8roUWDs215iOGHehfK1ypqwoETKNP7NaksGS2C1Up813ixlGXkipPVbQ==';
+        $this->assertTrue($this->rsa->verify('1234567890', base64_decode($data), null, Rsa::MODE_RAW));
+    }
+
+    public function testVerifyCorruptRaw()
+    {
+        $data = 'sMHpp3u6DNecIm5RIkDD3xyKaH6qqP8roUWDs215iOGHehfK1ypqwoETKNP7NaksGS2C1Up813ixlGXkipPVbQ==';
+        $this->assertFalse($this->rsa->verify('1234567890', $data, null, Rsa::MODE_RAW));
+    }
 }


### PR DESCRIPTION
The problem is that base64_decode strict check is not enough for ensure base64 encoding detection.

See http://stackoverflow.com/questions/2556345/detect-base64-encoding-in-php
