### PR TITLE
[Log] fixes #3366: Now Logger::registerErrorHandler() accepts continue

### DIFF
--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -53,7 +53,7 @@ class Logger implements LoggerInterface
         E_RECOVERABLE_ERROR => self::ERR,
         E_STRICT            => self::DEBUG,
         E_DEPRECATED        => self::DEBUG,
-        E_USER_DEPRECATED   => self::DEBUG
+        E_USER_DEPRECATED   => self::DEBUG,
     );
 
     /**
@@ -67,7 +67,7 @@ class Logger implements LoggerInterface
      * Registered exception handler
      *
      * @var bool
-    */
+     */
     protected static $registeredExceptionHandler = false;
 
     /**
@@ -534,7 +534,7 @@ class Logger implements LoggerInterface
                     'errno'   => $level,
                     'file'    => $file,
                     'line'    => $line,
-                    'context' => $context
+                    'context' => $context,
                 ));
             }
 

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -256,8 +256,10 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Logger::registerErrorHandler($this->logger));
         // check for single error handler instance
         $this->assertFalse(Logger::registerErrorHandler($this->logger));
+
         // generate a warning
-        echo $test;
+        echo $test; // $test is not defined
+
         Logger::unregisterErrorHandler();
         $this->assertEquals($writer->events[0]['message'], 'Undefined variable: test');
     }


### PR DESCRIPTION
- fixes #3366 
- Added an argument to `Zend\Log\Logger::registerErrorHandler()` to continue native error handling.
- Now the error<->priority map is a public static array instead of a scope variable
- Remove check of `$logger === null` because `$logger` can't be `null` by type-hint
- Ordered static variables to top

Don't know how to write a test to continue the native error handler?
