### PR TITLE
[2.1] Zend\Filter\Word\* no longer extends Zend\Filter\PregReplace

### DIFF
--- a/library/Zend/Filter/Word/AbstractSeparator.php
+++ b/library/Zend/Filter/Word/AbstractSeparator.php
@@ -11,16 +11,16 @@
 namespace Zend\Filter\Word;
 
 use Zend\Filter\Exception;
-use Zend\Filter\PregReplace as PregReplaceFilter;
+use Zend\Filter\AbstractFilter;
 
 /**
  * @category   Zend
  * @package    Zend_Filter
  */
-abstract class AbstractSeparator extends PregReplaceFilter
+abstract class AbstractSeparator extends AbstractFilter
 {
 
-    protected $separator = null;
+    protected $separator = ' ';
 
     /**
      * Constructor

--- a/library/Zend/Filter/Word/CamelCaseToSeparator.php
+++ b/library/Zend/Filter/Word/CamelCaseToSeparator.php
@@ -25,13 +25,13 @@ class CamelCaseToSeparator extends AbstractSeparator
     public function filter($value)
     {
         if (self::hasPcreUnicodeSupport()) {
-            parent::setPattern(array('#(?<=(?:\p{Lu}))(\p{Lu}\p{Ll})#','#(?<=(?:\p{Ll}|\p{Nd}))(\p{Lu})#'));
-            parent::setReplacement(array($this->separator . '\1', $this->separator . '\1'));
+            $pattern     = array('#(?<=(?:\p{Lu}))(\p{Lu}\p{Ll})#', '#(?<=(?:\p{Ll}|\p{Nd}))(\p{Lu})#');
+            $replacement = array($this->separator . '\1', $this->separator . '\1');
         } else {
-            parent::setPattern(array('#(?<=(?:[A-Z]))([A-Z]+)([A-Z][A-z])#', '#(?<=(?:[a-z0-9]))([A-Z])#'));
-            parent::setReplacement(array('\1' . $this->separator . '\2', $this->separator . '\1'));
+            $pattern     = array('#(?<=(?:[A-Z]))([A-Z]+)([A-Z][A-z])#', '#(?<=(?:[a-z0-9]))([A-Z])#');
+            $replacement = array('\1' . $this->separator . '\2', $this->separator . '\1');
         }
 
-        return parent::filter($value);
+        return preg_replace($pattern, $replacement, $value);
     }
 }

--- a/library/Zend/Filter/Word/DashToSeparator.php
+++ b/library/Zend/Filter/Word/DashToSeparator.php
@@ -24,8 +24,6 @@ class DashToSeparator extends AbstractSeparator
      */
     public function filter($value)
     {
-        $this->setPattern('#-#');
-        $this->setReplacement($this->separator);
-        return parent::filter($value);
+        return preg_replace('#-#', $this->separator, $value);
     }
 }

--- a/library/Zend/Filter/Word/SeparatorToSeparator.php
+++ b/library/Zend/Filter/Word/SeparatorToSeparator.php
@@ -10,13 +10,14 @@
 
 namespace Zend\Filter\Word;
 
+use Zend\Filter\AbstractFilter;
 use Zend\Filter\Exception;
 
 /**
  * @category   Zend
  * @package    Zend_Filter
  */
-class SeparatorToSeparator extends \Zend\Filter\PregReplace
+class SeparatorToSeparator extends AbstractFilter
 {
     protected $searchSeparator = null;
     protected $replacementSeparator = null;
@@ -87,27 +88,11 @@ class SeparatorToSeparator extends \Zend\Filter\PregReplace
      */
     public function filter($value)
     {
-        return $this->_separatorToSeparatorFilter($value);
-    }
-
-    /**
-     * Do the real work, replaces the seperator to search for with the replacement seperator
-     *
-     * Returns the replaced string
-     *
-     * @param  string $value
-     * @return string
-     * @throws Exception\RuntimeException
-     */
-    protected function _separatorToSeparatorFilter($value)
-    {
         if ($this->searchSeparator == null) {
             throw new Exception\RuntimeException('You must provide a search separator for this filter to work.');
         }
 
-        $this->setPattern('#' . preg_quote($this->searchSeparator, '#') . '#');
-        $this->setReplacement($this->replacementSeparator);
-        return parent::filter($value);
+        $pattern = '#' . preg_quote($this->searchSeparator, '#') . '#';
+        return preg_replace($pattern, $this->replacementSeparator, $value);
     }
-
 }


### PR DESCRIPTION
This PR fixes some my notes mentioned in #3376.
- `Zend\Filter\Word\*` no longer extends `Zend\Filter\PregReplace` but call `preg_replace` directly
- Set default value of `Zend\Filter\Word\AbstractSeparator->separator` to the same as defined in `__construct`
- `Zend\Filter\Word\SeparatorToSeparator::filter()` works without the need of the protected method `_separatorToSeparatorFilter()` and removed the protected method
