### PR TITLE
[2.1] Added Zend\Stdlib\StringUtils::hasPcreUnicodeSupport()

### DIFF
--- a/library/Zend/Stdlib/StringUtils.php
+++ b/library/Zend/Stdlib/StringUtils.php
@@ -10,6 +10,7 @@
 
 namespace Zend\Stdlib;
 
+use Zend\Stdlib\ErrorHandler;
 use Zend\Stdlib\StringWrapper\StringWrapperInterface;
 
 /**
@@ -44,6 +45,13 @@ abstract class StringUtils
         'CP-1251', 'CP-1252',
         // TODO
     );
+
+    /**
+     * Is PCRE compiled with Unicode support?
+     *
+     * @var bool
+     **/
+    protected static $hasPcreUnicodeSupport = null;
 
     /**
      * Get registered wrapper classes
@@ -166,5 +174,20 @@ abstract class StringUtils
     public static function isValidUtf8($str)
     {
         return is_string($str) && ($str === '' || preg_match('/^./su', $str) == 1);
+    }
+
+    /**
+     * Is PCRE compiled with Unicode support?
+     *
+     * @return bool
+     */
+    public static function hasPcreUnicodeSupport()
+    {
+        if (static::$hasPcreUnicodeSupport === null) {
+            ErrorHandler::start();
+            static::$hasPcreUnicodeSupport = defined('PREG_BAD_UTF8_OFFSET_ERROR') && preg_match('/\pL/u', 'a') == 1;
+            ErrorHandler::stop();
+        }
+        return static::$hasPcreUnicodeSupport;
     }
 }

--- a/tests/ZendTest/Stdlib/StringUtilsTest.php
+++ b/tests/ZendTest/Stdlib/StringUtilsTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Stdlib;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Stdlib\ErrorHandler;
 use Zend\Stdlib\StringUtils;
 
 class StringUtilsTest extends TestCase
@@ -146,5 +147,14 @@ class StringUtilsTest extends TestCase
     public function testIsValidUtf8($str, $valid)
     {
         $this->assertSame($valid, StringUtils::isValidUtf8($str));
+    }
+
+    public function testHasPcreUnicodeSupport()
+    {
+        ErrorHandler::start();
+        $expected = defined('PREG_BAD_UTF8_OFFSET_ERROR') && preg_match('/\pL/u', 'a') == 1;
+        ErrorHandler::stop();
+
+        $this->assertSame($expected, StringUtils::hasPcreUnicodeSupport());
     }
 }


### PR DESCRIPTION
The method is a copy of `Zend\Filter\AbstractFilter::hasPcreUnicodeSupport()` but within `Zend\Stdlib\StringUtils` it's more reusable an can be used without `Zend\Filter`.

`Zend\Stdlib` isn't marked as a dependency of `Zend\Filter` but this method is using `Zend\Stdlib\ErrorHandler`. If we mark it as a dependency we could redirect and deprecate the method else the use of `ErrorHandler` should be removed.
