### PR TITLE
[2.1] fixed tons of missing/wrong use statements

### DIFF
--- a/library/Zend/Http/Client/Cookies.php
+++ b/library/Zend/Http/Client/Cookies.php
@@ -10,10 +10,11 @@
 
 namespace Zend\Http\Client;
 
+use ArrayIterator;
 use Traversable;
 use Zend\Http\Header\SetCookie;
-use Zend\Stdlib\ArrayUtils;
 use Zend\Http\Response;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Uri;
 
 /**
@@ -259,7 +260,7 @@ class Cookies
                 }
             }
             return $ret;
-        } elseif ($ptr instanceof Cookie) {
+        } elseif ($ptr instanceof SetCookie) {
             switch ($retAs) {
                 case self::COOKIE_STRING_ARRAY:
                     return array($ptr->__toString());
@@ -290,7 +291,7 @@ class Cookies
         $ret = array();
 
         foreach (array_keys($this->cookies) as $cdom) {
-            if (Cookie::matchCookieDomain($cdom, $domain)) {
+            if (SetCookie::matchCookieDomain($cdom, $domain)) {
                 $ret[$cdom] = $this->cookies[$cdom];
             }
         }
@@ -311,7 +312,7 @@ class Cookies
 
         foreach ($domains as $dom => $pathsArray) {
             foreach (array_keys($pathsArray) as $cpath) {
-                if (Cookie::matchCookiePath($cpath, $path)) {
+                if (SetCookie::matchCookiePath($cpath, $path)) {
                     if (! isset($ret[$dom])) {
                         $ret[$dom] = array();
                     }

--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -11,6 +11,7 @@
 namespace Zend\Http\Header;
 
 use Closure;
+use Zend\Uri\UriFactory;
 
 /**
  * @throws Exception\InvalidArgumentException
@@ -510,7 +511,7 @@ class SetCookie implements MultipleHeaderInterface
     /**
      * Checks whether the cookie should be sent or not in a specific scenario
      *
-     * @param string|Zend\Uri $uri URI to check against (secure, domain, path)
+     * @param string|Zend\Uri\Uri $uri URI to check against (secure, domain, path)
      * @param boolean $matchSessionCookies Whether to send session cookies
      * @param int $now Override the current time when checking for expiry time
      * @return boolean
@@ -518,8 +519,8 @@ class SetCookie implements MultipleHeaderInterface
     public function match($uri, $matchSessionCookies = true, $now = null)
     {
         if (is_string ($uri)) {
-            $uri = Zend\Uri\UriFactory::factory($uri);
-    }
+            $uri = UriFactory::factory($uri);
+        }
 
         // Make sure we have a valid Zend_Uri_Http object
         if (! ($uri->isValid() && ($uri->getScheme() == 'http' || $uri->getScheme() =='https'))) {

--- a/library/Zend/Log/Writer/MongoDB.php
+++ b/library/Zend/Log/Writer/MongoDB.php
@@ -110,7 +110,7 @@ class MongoDB extends AbstractWriter
     protected function doWrite(array $event)
     {
         if (null === $this->mongoCollection) {
-            throw new RuntimeException('MongoCollection must be defined');
+            throw new Exception\RuntimeException('MongoCollection must be defined');
         }
 
         if (isset($event['timestamp']) && $event['timestamp'] instanceof DateTime) {

--- a/library/Zend/Session/Storage/SessionArrayStorage.php
+++ b/library/Zend/Session/Storage/SessionArrayStorage.php
@@ -11,7 +11,9 @@
 namespace Zend\Session\Storage;
 
 use ArrayAccess;
+use ArrayIterator;
 use IteratorAggregate;
+use Zend\Session\Exception;
 
 /**
  * Session storage in $_SESSION

--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -11,7 +11,9 @@
 namespace Zend\Stdlib\Hydrator;
 
 use ReflectionMethod;
+use Traversable;
 use Zend\Stdlib\Exception;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\Hydrator\Filter\FilterComposite;
 use Zend\Stdlib\Hydrator\Filter\FilterProviderInterface;
 use Zend\Stdlib\Hydrator\Filter\MethodMatchFilter;

--- a/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -18,6 +18,7 @@ use Zend\Mvc\MvcEvent;
 use Zend\Mvc\SendResponseListener;
 use Zend\Stdlib\Exception\LogicException;
 use Zend\Stdlib\Parameters;
+use Zend\Stdlib\ResponseInterface;
 use Zend\Uri\Http as HttpUri;
 use Zend\View\Helper\Placeholder;
 
@@ -180,7 +181,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
 
     /**
      * Get the application response object
-     * @return \Zend\Stdlib\ResponseInterface
+     * @return ResponseInterface
      */
     public function getResponse()
     {

--- a/library/Zend/XmlRpc/Client/ServerIntrospection.php
+++ b/library/Zend/XmlRpc/Client/ServerIntrospection.php
@@ -48,7 +48,7 @@ class ServerIntrospection
 
         try {
             $signatures = $this->getSignatureForEachMethodByMulticall($methods);
-        } catch (FaultException $e) {
+        } catch (Exception\FaultException $e) {
             // degrade to looping
         }
 


### PR DESCRIPTION
On the following errors I need help to resolve
- `Zend\Db\Metadata\Source\AbstractSource` uses the not existing class `Object\ConstraintKeyObject`
- `Zend\XmlRpc\Server\Exception\Stdin::____construct()` uses `new ServerException` which is defined as `use Zend\XmlRpc\Server\Exception as ServerException`
- `Zend\XmlRpc\AbstractValue::_phpVarToNativeXmlRpc` checks against the not existing class `Zend\Math\BigInteger`
