### PR TITLE
SplFileInfo::getRealPath returns false when ZF2 app is packaged within a phar.

### DIFF
--- a/library/Zend/Loader/ModuleAutoloader.php
+++ b/library/Zend/Loader/ModuleAutoloader.php
@@ -199,9 +199,9 @@ class ModuleAutoloader implements SplAutoloader
         $file = new SplFileInfo($dirPath . '/Module.php');
         if ($file->isReadable() && $file->isFile()) {
             // Found directory with Module.php in it
-            require_once $file->getRealPath();
+            require_once $dirPath . '/Module.php';
             if (class_exists($class)) {
-                $this->moduleClassMap[$class] = $file->getRealPath();
+                $this->moduleClassMap[$class] = $dirPath . '/Module.php';
                 return $class;
             }
         }


### PR DESCRIPTION
When packaging a ZF2 app into a single phar SplFileInfo::getRealPath returns false even though the isReadable and isFile both return true. By explicitly stating the path and file that we know are ok, the app continues to work whether it is in a phar or not.
