### PR TITLE
Give StdLib\ArrayUtils::merge the ability to remove keys

### DIFF
--- a/library/Zend/Stdlib/ArrayUtils.php
+++ b/library/Zend/Stdlib/ArrayUtils.php
@@ -226,21 +226,28 @@ abstract class ArrayUtils
      *
      * @param  array $a
      * @param  array $b
+     * @param  string $remove Any array values set to this string in $b will be unset in $a
      * @return array
      */
-    public static function merge(array $a, array $b)
+    public static function merge(array $a, array $b, $remove = '__remove__')
     {
+        $remove = (string) $remove;
+
         foreach ($b as $key => $value) {
             if (array_key_exists($key, $a)) {
                 if (is_int($key)) {
-                    $a[] = $value;
+                    $value != $remove ? $a[] = $value : null;
                 } elseif (is_array($value) && is_array($a[$key])) {
                     $a[$key] = static::merge($a[$key], $value);
                 } else {
-                    $a[$key] = $value;
+                    if ($value == $remove){
+                        unset($a[$key]);
+                    } else {
+                        $a[$key] = $value;
+                    }
                 }
             } else {
-                $a[$key] = $value;
+                $value != $remove ? $a[$key] = $value : null;
             }
         }
 

--- a/tests/ZendTest/Stdlib/ArrayUtilsTest.php
+++ b/tests/ZendTest/Stdlib/ArrayUtilsTest.php
@@ -153,6 +153,7 @@ class ArrayUtilsTest extends TestCase
                 array(
                     'baz',
                 ),
+                null,
                 array(
                     0     => 'foo',
                     3     => 'bar',
@@ -171,6 +172,7 @@ class ArrayUtilsTest extends TestCase
                         'baz'
                     )
                 ),
+                null,
                 array(
                     'foo' => array(
                         0 => 'baz',
@@ -187,11 +189,38 @@ class ArrayUtilsTest extends TestCase
                     'foo' => 'baz',
                     'bar' => 'bat'
                 ),
+                null,
                 array(
                     'foo' => 'baz',
                     'bar' => 'bat'
                 )
             ),
+            'remove-key' => array(
+                array(
+                    'foo' => 'bar',
+                    'bar' => 'bat'
+                ),
+                array(
+                    'foo' => '__remove__'
+                ),
+                null,
+                array(
+                    'bar' => 'bat'
+                )
+            ),
+            'remove-key-with-alterate-remove-string' => array(
+                array(
+                    'foo' => 'bar',
+                    'bar' => 'bat'
+                ),
+                array(
+                    'foo' => 'alternate_remove'
+                ),
+                'alternate_remove',
+                array(
+                    'bar' => 'bat'
+                )
+            )
         );
     }
 
@@ -341,9 +370,13 @@ class ArrayUtilsTest extends TestCase
     /**
      * @dataProvider mergeArrays
      */
-    public function testMerge($a, $b, $expected)
+    public function testMerge($a, $b, $remove, $expected)
     {
-        $this->assertEquals($expected, ArrayUtils::merge($a, $b));
+        if (isset($remove)){
+            $this->assertEquals($expected, ArrayUtils::merge($a, $b, $remove));
+        } else {
+            $this->assertEquals($expected, ArrayUtils::merge($a, $b));
+        }
     }
 
     /**


### PR DESCRIPTION
The motivation for this change is to make is possible to unregister config keys when ModuleManager merges all config arrays together.

At present the 'magic' value for key removal is **remove**.
