### PR TITLE
Allow the ModuleManager ConfigListener to remove config keys

### DIFF
--- a/library/Zend/ModuleManager/Listener/ConfigListener.php
+++ b/library/Zend/ModuleManager/Listener/ConfigListener.php
@@ -152,7 +152,7 @@ class ConfigListener extends AbstractListener implements
         foreach ($this->configs as $config) {
             $this->mergedConfig = ArrayUtils::merge($this->mergedConfig, $config);
 
-            if (array_key_exists('config_merge_remove_keys', $this->mergedConfig)){
+            if (array_key_exists('config_merge_remove_keys', $this->mergedConfig)) {
                 $this->configMergeRemoveKeys(
                     $this->mergedConfig,
                     array_merge($this->mergedConfig['config_merge_remove_keys'], array('config_merge_remove_keys'))
@@ -172,10 +172,11 @@ class ConfigListener extends AbstractListener implements
         return $this;
     }
 
-    protected function configMergeRemoveKeys(array &$array, array $keys){
+    protected function configMergeRemoveKeys(array &$array, array $keys)
+    {
 
-        foreach ($keys as $key => $value){
-            if (array_key_exists($key, $array)){
+        foreach ($keys as $key => $value) {
+            if (array_key_exists($key, $array)) {
                 if (is_array($value)){
                     $this->configMergeRemoveKeys($array[$key], $value);
                 } else {

--- a/library/Zend/ModuleManager/Listener/ConfigListener.php
+++ b/library/Zend/ModuleManager/Listener/ConfigListener.php
@@ -151,6 +151,13 @@ class ConfigListener extends AbstractListener implements
         $this->mergedConfig = $this->getOptions()->getExtraConfig() ?: array();
         foreach ($this->configs as $config) {
             $this->mergedConfig = ArrayUtils::merge($this->mergedConfig, $config);
+
+            if (array_key_exists('config_merge_remove_keys', $this->mergedConfig)){
+                $this->configMergeRemoveKeys(
+                    $this->mergedConfig,
+                    array_merge($this->mergedConfig['config_merge_remove_keys'], array('config_merge_remove_keys'))
+                );
+            }
         }
 
         // If enabled, update the config cache
@@ -163,6 +170,21 @@ class ConfigListener extends AbstractListener implements
         }
 
         return $this;
+    }
+
+    protected function configMergeRemoveKeys(array &$array, array $keys){
+
+        foreach ($keys as $key => $value){
+            if (array_key_exists($key, $array)){
+                if (is_array($value)){
+                    $this->configMergeRemoveKeys($array[$key], $value);
+                } else {
+                    unset($array[$key]);
+                }
+            } elseif (array_key_exists($value, $array)){
+                unset($array[$value]);
+            }
+        }
     }
 
     /**

--- a/tests/ZendTest/ModuleManager/Listener/ConfigListenerTest.php
+++ b/tests/ZendTest/ModuleManager/Listener/ConfigListenerTest.php
@@ -370,6 +370,28 @@ class ConfigListenerTest extends TestCase
         $this->assertSame('bar', $mergedConfig['keyed']);
     }
 
+    public function testMergesWithRemoveKeyBehavior()
+    {
+        $configListener = new ConfigListener();
+
+        $moduleManager = $this->moduleManager;
+        $moduleManager->setModules(array('SomeModule'));
+
+        $configListener->addConfigStaticPaths(array(
+            __DIR__ . '/_files/good/mergeRemoveKey1.php',
+            __DIR__ . '/_files/good/mergeRemoveKey2.php',
+        ));
+
+        $moduleManager->getEventManager()->attachAggregate($configListener);
+        $moduleManager->loadModules();
+
+        $mergedConfig = $configListener->getMergedConfig(false);
+        $this->assertSame(array('foo', 'bar'), $mergedConfig['indexed']);
+        $this->assertArrayNotHasKey('keyed', $mergedConfig);
+        $this->assertArrayNotHasKey('key1', $mergedConfig['nested']);
+        $this->assertArrayNotHasKey('config_merge_remove_keys', $mergedConfig);
+    }
+
     public function testConfigListenerFunctionsAsAggregateListener()
     {
         $configListener = new ConfigListener;

--- a/tests/ZendTest/ModuleManager/Listener/_files/good/mergeRemoveKey1.php
+++ b/tests/ZendTest/ModuleManager/Listener/_files/good/mergeRemoveKey1.php
@@ -1,0 +1,9 @@
+<?php
+return array(
+    'indexed' => array('foo'),
+    'keyed'   => 'foo',
+    'nested'  => array(
+        'key1' => 'biz',
+        'key2' => 'baz'
+    )
+);

--- a/tests/ZendTest/ModuleManager/Listener/_files/good/mergeRemoveKey2.php
+++ b/tests/ZendTest/ModuleManager/Listener/_files/good/mergeRemoveKey2.php
@@ -1,0 +1,8 @@
+<?php
+return array(
+    'indexed' => array('bar'),
+    'config_merge_remove_keys' => array(
+        'keyed',
+        'nested' => array('key1')
+    )
+);


### PR DESCRIPTION
The motivation for this change is to make is possible to unregister config keys when ModuleManager merges all config arrays together.

This pr previously suggested changes to ArrayUtils::merge, but the approach has been changed.

See also http://stackoverflow.com/questions/14423983/zf2-modulemanager-config-merge-remove-key
