### PR TITLE
Zend\Form\View\Helper\FormSelect

### DIFF
--- a/library/Zend/Form/View/Helper/FormSelect.php
+++ b/library/Zend/Form/View/Helper/FormSelect.php
@@ -13,6 +13,7 @@ namespace Zend\Form\View\Helper;
 use Zend\Form\ElementInterface;
 use Zend\Form\Element\Select as SelectElement;
 use Zend\Form\Exception;
+use Zend\Stdlib\ArrayUtils;
 
 /**
  * @category   Zend
@@ -154,7 +155,7 @@ class FormSelect extends AbstractHelper
                 $disabled = $optionSpec['disabled'];
             }
 
-            if (in_array($value, $selectedOptions)) {
+            if (ArrayUtils::inArray($value, $selectedOptions)) {
                 $selected = true;
             }
 

--- a/library/Zend/Stdlib/ArrayUtils.php
+++ b/library/Zend/Stdlib/ArrayUtils.php
@@ -165,6 +165,36 @@ abstract class ArrayUtils
     }
 
     /**
+     * Checks if a value exists in an array.
+     *
+     * Due to "foo" == 0 === TRUE with in_array when strict = false, an option
+     * has been added to prevent this. When $strict = 0/false, the most secure
+     * non-strict check is implemented. if $strict = -1, the default in_array
+     * non-strict behaviour is used.
+     *
+     * @param mixed $needle
+     * @param array $haystack
+     * @param int|bool $strict
+     * @return bool
+     */
+    public static function inArray($needle, array $haystack, $strict = false)
+    {
+        if (!$strict) {
+            if (is_int($needle) || is_float($needle)) {
+                $needle = (string) $needle;
+            }
+            if (is_string($needle)) {
+                foreach ($haystack as &$h) {
+                    if (is_int($h) || is_float($h)) {
+                        $h = (string) $h;
+                    }
+                }
+            }
+        }
+        return in_array($needle, $haystack, $strict);
+    }
+
+    /**
      * Convert an iterator to an array.
      *
      * Converts an iterator to an array. The $recursive flag, on by default,

--- a/tests/ZendTest/Form/View/Helper/FormSelectTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormSelectTest.php
@@ -322,6 +322,26 @@ class FormSelectTest extends CommonTestCase
         $this->assertNotContains('<option value=""></option>', $markup);
     }
 
+    public function testCanMarkOptionsAsSelectedWhenEmptyOptionOrZeroValueSelected()
+    {
+        $element = new SelectElement('foo');
+        $element->setEmptyOption('empty');
+        $element->setValueOptions(array(
+            0 => 'label0',
+            1 => 'label1',
+        ));
+
+        $element->setValue('');
+        $markup = $this->helper->render($element);
+        $this->assertContains('<option value="" selected="selected">empty</option>', $markup);
+        $this->assertContains('<option value="0">label0</option>', $markup);
+
+        $element->setValue('0');
+        $markup = $this->helper->render($element);
+        $this->assertContains('<option value="">empty</option>', $markup);
+        $this->assertContains('<option value="0" selected="selected">label0</option>', $markup);
+    }
+
     public function testRenderInputNotSelectElementRaisesException()
     {
         $element = new Element\Text('foo');


### PR DESCRIPTION
Fix for issue #3426

Secure non-strict checking of string/int values when rendering `Zend\Form\Element\Select` to test which value option needs to be marked as selected.

The native `in_array` call has been replaced by `Zend\Stdlib\ArrayUtils::inArray`. This new method was modeled off of the `InArray` validator.
