### PR TITLE
Allow to pull route manager from sl

### DIFF
--- a/library/Zend/ModuleManager/Feature/RouteProviderInterface.php
+++ b/library/Zend/ModuleManager/Feature/RouteProviderInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ModuleManager\Feature;
+
+interface RouteProviderInterface
+{
+    /**
+     * Expected to return \Zend\ServiceManager\Config object or array to
+     * seed such an object.
+     *
+     * @return array|\Zend\ServiceManager\Config
+     */
+    public function getRouteConfig();
+}

--- a/library/Zend/Mvc/Router/SimpleRouteStack.php
+++ b/library/Zend/Mvc/Router/SimpleRouteStack.php
@@ -41,11 +41,18 @@ class SimpleRouteStack implements RouteStackInterface
 
     /**
      * Create a new simple route stack.
+     *
+     * @param RoutePluginManager $routePluginManager
      */
-    public function __construct()
+    public function __construct(RoutePluginManager $routePluginManager = null)
     {
-        $this->routes             = new PriorityList();
-        $this->routePluginManager = new RoutePluginManager();
+        $this->routes = new PriorityList();
+
+        if ($routePluginManager === null) {
+            $routePluginManager = new RoutePluginManager();
+        }
+
+        $this->routePluginManager = $routePluginManager;
 
         $this->init();
     }

--- a/library/Zend/Mvc/Router/SimpleRouteStack.php
+++ b/library/Zend/Mvc/Router/SimpleRouteStack.php
@@ -48,7 +48,7 @@ class SimpleRouteStack implements RouteStackInterface
     {
         $this->routes = new PriorityList();
 
-        if ($routePluginManager === null) {
+        if (null === $routePluginManager) {
             $routePluginManager = new RoutePluginManager();
         }
 

--- a/library/Zend/Mvc/Service/ModuleManagerFactory.php
+++ b/library/Zend/Mvc/Service/ModuleManagerFactory.php
@@ -85,6 +85,12 @@ class ModuleManagerFactory implements FactoryInterface
             'Zend\ModuleManager\Feature\FormElementProviderInterface',
             'getFormElementConfig'
         );
+        $serviceListener->addServiceManager(
+            'RoutePluginManager',
+            'routes',
+            'Zend\ModuleManager\Feature\RouteProviderInterface',
+            'getRouteConfig'
+        );
 
         $events = $serviceLocator->get('EventManager');
         $events->attach($defaultListeners);

--- a/library/Zend/Mvc/Service/ModuleManagerFactory.php
+++ b/library/Zend/Mvc/Service/ModuleManagerFactory.php
@@ -87,7 +87,7 @@ class ModuleManagerFactory implements FactoryInterface
         );
         $serviceListener->addServiceManager(
             'RoutePluginManager',
-            'routes',
+            'route_manager',
             'Zend\ModuleManager\Feature\RouteProviderInterface',
             'getRouteConfig'
         );

--- a/library/Zend/Mvc/Service/RoutePluginManagerFactory.php
+++ b/library/Zend/Mvc/Service/RoutePluginManagerFactory.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Service;
+
+class RoutePluginManagerFactory extends AbstractPluginManagerFactory
+{
+    const PLUGIN_MANAGER_CLASS = 'Zend\Mvc\Router\RoutePluginManager';
+}

--- a/library/Zend/Mvc/Service/RouterFactory.php
+++ b/library/Zend/Mvc/Service/RouterFactory.php
@@ -25,13 +25,14 @@ class RouterFactory implements FactoryInterface
      * default.
      *
      * @param  ServiceLocatorInterface        $serviceLocator
-     * @param string|null                     $cName
-     * @param string|null                     $rName
+     * @param  string|null                     $cName
+     * @param  string|null                     $rName
      * @return \Zend\Mvc\Router\RouteStackInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator, $cName = null, $rName = null)
     {
-        $config = $serviceLocator->get('Config');
+        $config             = $serviceLocator->get('Config');
+        $routePluginManager = $serviceLocator->get('RoutePluginManager');
 
         if (
             $rName === 'ConsoleRouter' ||                   // force console router
@@ -44,12 +45,25 @@ class RouterFactory implements FactoryInterface
                 $routerConfig = array();
             }
 
-            $router = ConsoleRouter::factory($routerConfig);
+            $router = new ConsoleRouter($routePluginManager);
         } else {
             // This is an HTTP request, so use HTTP router
+            $router       = new HttpRouter($routePluginManager);
             $routerConfig = isset($config['router']) ? $config['router'] : array();
-            $router = HttpRouter::factory($routerConfig);
         }
+
+        if (isset($routerConfig['route_plugins'])) {
+            $router->setRoutePluginManager($routerConfig['route_plugins']);
+        }
+
+        if (isset($routerConfig['routes'])) {
+            $router->addRoutes($routerConfig['routes']);
+        }
+
+        if (isset($routerConfig['default_params'])) {
+            $router->setDefaultParams($routerConfig['default_params']);
+        }
+
         return $router;
     }
 }

--- a/library/Zend/Mvc/Service/ServiceListenerFactory.php
+++ b/library/Zend/Mvc/Service/ServiceListenerFactory.php
@@ -57,6 +57,7 @@ class ServiceListenerFactory implements FactoryInterface
             'Request'                        => 'Zend\Mvc\Service\RequestFactory',
             'Response'                       => 'Zend\Mvc\Service\ResponseFactory',
             'Router'                         => 'Zend\Mvc\Service\RouterFactory',
+            'RoutePluginManager'             => 'Zend\Mvc\Service\RoutePluginManagerFactory',
             'ValidatorManager'               => 'Zend\Mvc\Service\ValidatorManagerFactory',
             'ViewHelperManager'              => 'Zend\Mvc\Service\ViewHelperManagerFactory',
             'ViewFeedRenderer'               => 'Zend\Mvc\Service\ViewFeedRendererFactory',

--- a/tests/ZendTest/Mvc/ApplicationTest.php
+++ b/tests/ZendTest/Mvc/ApplicationTest.php
@@ -76,6 +76,7 @@ class ApplicationTest extends TestCase
                 'factories' => array(
                     'ControllerLoader'        => 'Zend\Mvc\Service\ControllerLoaderFactory',
                     'ControllerPluginManager' => 'Zend\Mvc\Service\ControllerPluginManagerFactory',
+                    'RoutePluginManager'      => 'Zend\Mvc\Service\RoutePluginManagerFactory',
                     'Application'             => 'Zend\Mvc\Service\ApplicationFactory',
                     'HttpRouter'              => 'Zend\Mvc\Service\RouterFactory',
                     'Config'                  => $config,

--- a/tests/ZendTest/Mvc/DispatchListenerTest.php
+++ b/tests/ZendTest/Mvc/DispatchListenerTest.php
@@ -66,6 +66,7 @@ class DispatchListenerTest extends TestCase
                 'factories' => array(
                     'ControllerLoader'        => 'Zend\Mvc\Service\ControllerLoaderFactory',
                     'ControllerPluginManager' => 'Zend\Mvc\Service\ControllerPluginManagerFactory',
+                    'RoutePluginManager'      => 'Zend\Mvc\Service\RoutePluginManagerFactory',
                     'Application'             => 'Zend\Mvc\Service\ApplicationFactory',
                     'HttpRouter'              => 'Zend\Mvc\Service\RouterFactory',
                     'Config'                  => $config,

--- a/tests/ZendTest/Mvc/Router/RoutePluginManagerTest.php
+++ b/tests/ZendTest/Mvc/Router/RoutePluginManagerTest.php
@@ -27,4 +27,13 @@ class RoutePluginManagerTest extends TestCase
         $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotFoundException');
         $routes->get('foo');
     }
+
+    public function testCanLoadAnyRoute()
+    {
+        $routes = new RoutePluginManager();
+        $routes->setInvokableClass('DummyRoute', 'ZendTest\Mvc\Router\TestAsset\DummyRoute');
+        $route = $routes->get('DummyRoute');
+
+        $this->assertInstanceOf('ZendTest\Mvc\Router\TestAsset\DummyRoute', $route);
+    }
 }

--- a/tests/ZendTest/View/Helper/UrlIntegrationTest.php
+++ b/tests/ZendTest/View/Helper/UrlIntegrationTest.php
@@ -74,6 +74,7 @@ class UrlIntegrationTest extends \PHPUnit_Framework_TestCase
                 'Router'                  => 'Zend\Mvc\Service\RouterFactory',
                 'ConsoleRouter'           => 'Zend\Mvc\Service\RouterFactory',
                 'HttpRouter'              => 'Zend\Mvc\Service\RouterFactory',
+                'RoutePluginManager'      => 'Zend\Mvc\Service\RoutePluginManagerFactory',
                 'ViewManager'             => 'Zend\Mvc\Service\ViewManagerFactory',
                 'ViewResolver'            => 'Zend\Mvc\Service\ViewResolverFactory',
                 'ViewTemplateMapResolver' => 'Zend\Mvc\Service\ViewTemplateMapResolverFactory',


### PR DESCRIPTION
This PR addresses the following issue : https://github.com/zendframework/zf2/issues/3516#issuecomment-12552600

It was not easy because the Router uses static factories too much and doing it the clean way (by using invokables set in the plugin manager and properly pull everything from the service locator) would without any doubt bring some BC...

So I just did it the easy way by not calling the factory of default Http and Console routers and copy/pasting the code from the static function factory to the factory class itself. Not really that beautiful but well... I think this is a BC we should do as it makes the code quite hard to extend.

Anyway, this PR adds a new ModuleManager feature that allow to add routes either from a getRouteConfig in your Module.php, or using the routes key in service manager config:

``` php
return array(
    'routes' => array(
        'invokables' => array(
            'Rest' => 'ZfrRest\Mvc\Router\Route\Rest'
        )
    )
);
```

And then use it in the router:

``` php
return array(
    'router' => array(
        'routes' => array(
            'dummy' => array(
                   'type' => 'Rest'
            )
        )
    )
);
```

EDIT : @weierophinney , regarding this file: https://github.com/zendframework/zf2/blob/develop/library/Zend/Mvc/Service/ModuleManagerFactory.php#L82

It's just growing and growing. Don't you think we could allow each plugin manager to register itself to the ServiceListener. It makes things easier to discover (jsut open the plugin maanger and you immediately know what is the config key and so...). I never remember this file...
