### PR TITLE
Explode validator: allow any value type to be validated

### DIFF
--- a/library/Zend/Validator/Explode.php
+++ b/library/Zend/Validator/Explode.php
@@ -10,6 +10,9 @@
 
 namespace Zend\Validator;
 
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
 /**
  * @category   Zend
  * @package    Zend_Validator
@@ -22,7 +25,7 @@ class Explode extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID => "Invalid type given. String expected",
+        self::INVALID => "Invalid type given.",
     );
 
     /**
@@ -116,20 +119,21 @@ class Explode extends AbstractValidator
      *
      * Returns true if all values validate true
      *
-     * @param  string|array $value
+     * @param  mixed $value
      * @return bool
      * @throws Exception\RuntimeException
      */
     public function isValid($value)
     {
-        if (!is_string($value) && !is_array($value)) {
-            $this->error(self::INVALID);
-            return false;
-        }
-
         $this->setValue($value);
 
-        if (!is_array($value)) {
+        if ($value instanceof Traversable) {
+            $value = ArrayUtils::iteratorToArray($value);
+        }
+
+        if (is_array($value)) {
+            $values = $value;
+        } elseif (is_string($value)) {
             $delimiter = $this->getValueDelimiter();
             // Skip explode if delimiter is null,
             // used when value is expected to be either an
@@ -139,7 +143,7 @@ class Explode extends AbstractValidator
                       ? explode($this->valueDelimiter, $value)
                       : array($value);
         } else {
-            $values = $value;
+            $values = array($value);
         }
 
         $retval    = true;

--- a/tests/ZendTest/Validator/ExplodeTest.php
+++ b/tests/ZendTest/Validator/ExplodeTest.php
@@ -44,7 +44,10 @@ class ExplodeTest extends \PHPUnit_Framework_TestCase
             array(array('a', 'b'),   null, false, 2, true,  array(),                   true),
             array(array('a', 'b'),   null, false, 2, false, array('X', 'X'),           false),
             array('foo',             null, false, 1, true,  array(),                   true),
-            array(1,                  ',', false, 0, true,  array(Explode::INVALID => 'Invalid'), false),
+            array(1,                  ',', false, 1, true,  array(),                   true),
+            array(null,               ',', false, 1, true,  array(),                   true),
+            array(new \stdClass(),    ',', false, 1, true,  array(),                   true),
+            array(new \ArrayObject(array('a', 'b')), null, false, 2, true,  array(),   true),
         );
     }
 
@@ -62,7 +65,6 @@ class ExplodeTest extends \PHPUnit_Framework_TestCase
             'valueDelimiter'      => $delimiter,
             'breakOnFirstFailure' => $breakOnFirst,
         ));
-        $validator->setMessage('Invalid', Explode::INVALID);
 
         $this->assertEquals($expects,  $validator->isValid($value));
         $this->assertEquals($messages, $validator->getMessages());


### PR DESCRIPTION
Currently, the explode validator only allows string and array types to be tested. This PR relaxes the type checking to allow any type to be passed to isValid(), and defer/proxy the validity check to the bound validator(s). This allows the Explode validator to be more flexible and handle additional use-cases.

Also added support for iterating Traversables (not just arrays).
