### PR TITLE
remove quoting for LIMIT and OFFSET parameters

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -740,7 +740,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $sql = $driver->formatParameterName('limit');
             $parameterContainer->offsetSet('limit', $this->limit, ParameterContainer::TYPE_INTEGER);
         } else {
-            $sql = $platform->quoteValue($this->limit);
+            $sql = $this->limit;
         }
 
         return array($sql);
@@ -752,11 +752,13 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             return null;
         }
         if ($driver) {
+            $sql = $driver->formatParameterName('offset');
             $parameterContainer->offsetSet('offset', $this->offset, ParameterContainer::TYPE_INTEGER);
-            return array($driver->formatParameterName('offset'));
+        } else {
+            $sql = $this->offset;
         }
 
-        return array($platform->quoteValue($this->offset));
+        return array($sql);
     }
 
     /**

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -788,7 +788,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $select26 = new Select;
         $select26->from('foo')->limit(5);
         $sqlPrep26 = 'SELECT "foo".* FROM "foo" LIMIT ?';
-        $sqlStr26 = 'SELECT "foo".* FROM "foo" LIMIT \'5\'';
+        $sqlStr26 = 'SELECT "foo".* FROM "foo" LIMIT 5';
         $params26 = array('limit' => 5);
         $internalTests26 = array(
             'processSelect' => array(array(array('"foo".*')), '"foo"'),
@@ -799,7 +799,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $select27 = new Select;
         $select27->from('foo')->limit(5)->offset(10);
         $sqlPrep27 = 'SELECT "foo".* FROM "foo" LIMIT ? OFFSET ?';
-        $sqlStr27 = 'SELECT "foo".* FROM "foo" LIMIT \'5\' OFFSET \'10\'';
+        $sqlStr27 = 'SELECT "foo".* FROM "foo" LIMIT 5 OFFSET 10';
         $params27 = array('limit' => 5, 'offset' => 10);
         $internalTests27 = array(
             'processSelect' => array(array(array('"foo".*')), '"foo"'),


### PR DESCRIPTION
Minor fix for #3224

Not sure if any implementation of SQL requires the LIMIT and OFFSET params to be quoted. So, we should be good.
