### PR TITLE
Mail Sender: no header when empty

### DIFF
--- a/library/Zend/Mail/Header/Sender.php
+++ b/library/Zend/Mail/Header/Sender.php
@@ -98,7 +98,9 @@ class Sender implements HeaderInterface
 
     public function toString()
     {
-        return 'Sender: ' . $this->getFieldValue(HeaderInterface::FORMAT_ENCODED);
+        $name  = $this->getFieldName();
+        $value = $this->getFieldValue(HeaderInterface::FORMAT_ENCODED);
+        return (empty($value)) ? '' : sprintf('%s: %s', $name, $value);
     }
 
     /**

--- a/tests/ZendTest/Mail/Header/SenderTest.php
+++ b/tests/ZendTest/Mail/Header/SenderTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mail
+ */
+
+namespace ZendTest\Mail\Header;
+
+use Zend\Mail\Header;
+
+/**
+ * This test is primarily to test that AbstractAddressList headers perform
+ * header folding and MIME encoding properly.
+ *
+ * @category   Zend
+ * @package    Zend_Mail
+ * @subpackage UnitTests
+ * @group      Zend_Mail
+ */
+class SenderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefault()
+    {
+        $header = new Header\Sender();
+        $header->setAddress('foo@bar.com', 'Foobar');
+
+        $this->assertSame('Sender: Foobar <foo@bar.com>', $header->toString());
+    }
+
+    public function testEmptyWhenNoAddressSpecified()
+    {
+        $header = new Header\Sender();
+
+        $this->assertEmpty($header->toString());
+    }
+}


### PR DESCRIPTION
As of yet, Sender header is **always** written in a mail message sent with Stmp or Sendmail, becase it always returns a non-empty string, and so `Zend\Mail\Headers::toString()` can't skip it.

Despites other headers, Sender is always created because of this calls:
- `Zend\Mail\Transport\Smtp::prepareFromAddress line 252`
- `Zend\Mail\Transport\Sendmail::prepareParameters line 254`

With this PR, just like `Zend\Mail\Header\AbstractAddressList`, now Sender will return empty string if no sender address is specified, and during headers creation, it can be skipped.
