### PR TITLE
The hasACL and hasRole don't check their default member variables

### DIFF
--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -567,8 +567,8 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      */
     public function hasAcl()
     {
-        if ($this->acl instanceof \Zend\Permissions\Acl\Acl ||
-            static::$defaultAcl instanceof \Zend\Permissions\Acl\Acl) {
+        if ($this->acl instanceof Acl\Acl ||
+            static::$defaultAcl instanceof Acl\Acl) {
             return true;
         }
 
@@ -584,9 +584,9 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      */
     public function hasRole()
     {
-        if ($this->role instanceof \Zend\Permissions\Acl\Role\RoleInterface ||
+        if ($this->role instanceof Acl\Role\RoleInterface ||
             is_string($this->role) ||
-            static::$defaultRole instanceof \Zend\Permissions\Acl\Role\RoleInterface ||
+            static::$defaultRole instanceof Acl\Role\RoleInterface ||
             is_string(static::$defaultRole)) {
             return true;
         }

--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -567,7 +567,12 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      */
     public function hasAcl()
     {
-        return null !== $this->acl;
+        if ($this->acl instanceof \Zend\Permissions\Acl\Acl ||
+            static::$defaultAcl instanceof \Zend\Permissions\Acl\Acl) {
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -579,7 +584,14 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      */
     public function hasRole()
     {
-        return null !== $this->role;
+        if ($this->role instanceof \Zend\Permissions\Acl\Role\RoleInterface ||
+            is_string($this->role) ||
+            static::$defaultRole instanceof \Zend\Permissions\Acl\Role\RoleInterface ||
+            is_string(static::$defaultRole)) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/ZendTest/View/Helper/Navigation/AbstractHelperTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/AbstractHelperTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ *
+ * User: Timo Tewes
+ * Date: 19.01.13
+ * Time: 10:08
+ */
+namespace ZendTest\View\Helper\Navigation;
+
+
+class AbstractHelperTest extends AbstractTest
+{
+    /**
+     * Class name for view helper to test
+     *
+     * @var string
+     */
+    protected $_helperName = 'Zend\View\Helper\Navigation';
+
+    /**
+     * View helper
+     *
+     * @var \Zend\View\Helper\Navigation\Breadcrumbs
+     */
+    protected $_helper;
+
+    public function testHasACLChecksDefaultACL()
+    {
+        $aclContainer = $this->_getAcl();
+        /** @var $acl \Zend\Permissions\Acl\Acl */
+        $acl = $aclContainer['acl'];
+
+        $this->assertEquals(false, $this->_helper->hasACL());
+        $this->_helper->setDefaultAcl($acl);
+        $this->assertEquals(true, $this->_helper->hasAcl());
+    }
+
+    public function testHasACLChecksMemberVariable()
+    {
+        $aclContainer = $this->_getAcl();
+        /** @var $acl \Zend\Permissions\Acl\Acl */
+        $acl = $aclContainer['acl'];
+
+        $this->assertEquals(false, $this->_helper->hasAcl());
+        $this->_helper->setAcl($acl);
+        $this->assertEquals(true, $this->_helper->hasAcl());
+    }
+
+    public function testHasRoleChecksDefaultRole()
+    {
+        $aclContainer = $this->_getAcl();
+        /** @var $role \Zend\Permissions\Acl\Role */
+        $role = $aclContainer['role'];
+
+        $this->assertEquals(false, $this->_helper->hasRole());
+        $this->_helper->setDefaultRole($role);
+        $this->assertEquals(true, $this->_helper->hasRole());
+    }
+
+    public function testHasRoleChecksMemberVariable()
+    {
+        $aclContainer = $this->_getAcl();
+        /** @var $role \Zend\Permissions\Acl\Role */
+        $role = $aclContainer['role'];
+
+        $this->assertEquals(false, $this->_helper->hasRole());
+        $this->_helper->setRole($role);
+        $this->assertEquals(true, $this->_helper->hasRole());
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        $this->_helper->setDefaultAcl(null);
+        $this->_helper->setAcl(null);
+        $this->_helper->setDefaultRole(null);
+        $this->_helper->setRole(null);
+    }
+
+
+}

--- a/tests/ZendTest/View/Helper/Navigation/AbstractHelperTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/AbstractHelperTest.php
@@ -5,6 +5,16 @@ namespace ZendTest\View\Helper\Navigation;
 
 class AbstractHelperTest extends AbstractTest
 {
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        $this->_helper->setDefaultAcl(null);
+        $this->_helper->setAcl(null);
+        $this->_helper->setDefaultRole(null);
+        $this->_helper->setRole(null);
+    }
+
     /**
      * Class name for view helper to test
      *
@@ -62,15 +72,5 @@ class AbstractHelperTest extends AbstractTest
         $this->_helper->setRole($role);
         $this->assertEquals(true, $this->_helper->hasRole());
     }
-
-    protected function tearDown()
-    {
-        parent::tearDown();
-        $this->_helper->setDefaultAcl(null);
-        $this->_helper->setAcl(null);
-        $this->_helper->setDefaultRole(null);
-        $this->_helper->setRole(null);
-    }
-
 
 }

--- a/tests/ZendTest/View/Helper/Navigation/AbstractHelperTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/AbstractHelperTest.php
@@ -1,10 +1,5 @@
 <?php
-/**
- *
- * User: Timo Tewes
- * Date: 19.01.13
- * Time: 10:08
- */
+
 namespace ZendTest\View\Helper\Navigation;
 
 

--- a/tests/ZendTest/View/Helper/Navigation/AbstractHelperTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/AbstractHelperTest.php
@@ -5,16 +5,6 @@ namespace ZendTest\View\Helper\Navigation;
 
 class AbstractHelperTest extends AbstractTest
 {
-
-    protected function tearDown()
-    {
-        parent::tearDown();
-        $this->_helper->setDefaultAcl(null);
-        $this->_helper->setAcl(null);
-        $this->_helper->setDefaultRole(null);
-        $this->_helper->setRole(null);
-    }
-
     /**
      * Class name for view helper to test
      *
@@ -28,6 +18,15 @@ class AbstractHelperTest extends AbstractTest
      * @var \Zend\View\Helper\Navigation\Breadcrumbs
      */
     protected $_helper;
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        $this->_helper->setDefaultAcl(null);
+        $this->_helper->setAcl(null);
+        $this->_helper->setDefaultRole(null);
+        $this->_helper->setRole(null);
+    }
 
     public function testHasACLChecksDefaultACL()
     {


### PR DESCRIPTION
As described in https://github.com/zendframework/zf2/issues/3507 the functions hasACL and hasRole don't check their default member variables.
It's just a small bug, but i think it should be fixed.
