### PR TITLE
Add legend translation support into formCollection view helper

### DIFF
--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -88,6 +88,13 @@ class FormCollection extends AbstractHelper
             $label = $element->getLabel();
 
             if (!empty($label)) {
+                
+                if (null !== ($translator = $this->getTranslator())) {
+                    $label = $translator->translate(
+                            $label, $this->getTranslatorTextDomain()
+                    );
+                }
+                
                 $label = $escapeHtmlHelper($label);
 
                 $markup = sprintf(

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -88,13 +88,13 @@ class FormCollection extends AbstractHelper
             $label = $element->getLabel();
 
             if (!empty($label)) {
-                
+
                 if (null !== ($translator = $this->getTranslator())) {
                     $label = $translator->translate(
                             $label, $this->getTranslatorTextDomain()
                     );
                 }
-                
+
                 $label = $escapeHtmlHelper($label);
 
                 $markup = sprintf(

--- a/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
@@ -162,4 +162,24 @@ class FormCollectionTest extends TestCase
         $this->assertContains('<span data-template', $markup);
         $this->assertContains($collection->getTemplatePlaceholder(), $markup);
     }
+
+    public function testCanTranslateLegend()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setLabel('untranslated legend');
+        $this->helper->setShouldWrap(true);
+
+        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+        $mockTranslator->expects($this->exactly(1))
+                       ->method('translate')
+                       ->will($this->returnValue('translated legend'));
+
+        $this->helper->setTranslator($mockTranslator);
+        $this->assertTrue($this->helper->hasTranslator());
+
+        $markup = $this->helper->render($collection);
+
+        $this->assertContains('>translated legend<', $markup);
+    }
 }


### PR DESCRIPTION
When using the form collections, the legend was not translated. I added a fix to use the translator when a label is set

Change-Id: I9abfb33c76f93d3674394412d0683bcd3e917bbb
