### PR TITLE
Hotfix: Undeprecate PhpEnvironement Response methods

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Response.php
+++ b/library/Zend/Http/PhpEnvironment/Response.php
@@ -69,7 +69,6 @@ class Response extends HttpResponse
 
     /**
      * @return bool
-     * @deprecated
      */
     public function contentSent()
     {
@@ -80,7 +79,6 @@ class Response extends HttpResponse
      * Send HTTP headers
      *
      * @return Response
-     * @deprecated
      */
     public function sendHeaders()
     {
@@ -108,7 +106,6 @@ class Response extends HttpResponse
      * Send content
      *
      * @return Response
-     * @deprecated
      */
     public function sendContent()
     {
@@ -125,7 +122,6 @@ class Response extends HttpResponse
      * Send HTTP response
      *
      * @return Response
-     * @deprecated
      */
     public function send()
     {

--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -13,6 +13,7 @@ use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Stdlib\ResponseInterface;
+use Zend\Stdlib\Nop;
 
 /**
  * Main application class for invoking applications
@@ -304,8 +305,16 @@ class Application implements
 
         $response = $this->getResponse();
         $event->setResponse($response);
+        $this->completeRequest($event);
 
-        return $this->completeRequest($event);
+        return $this;
+    }
+
+    /**
+     * @deprecated
+     */
+    public function send()
+    {
     }
 
     /**


### PR DESCRIPTION
Simply b/c facilities have been added so that Zend\Mvc can send responses does not remove the requirement that a PhpEnvironment\Response must be able to send itself.

Also, Zend\Http does not have a dependency on Zend\Mvc, so changes in behavior in Zend\Mvc should be of no consequence to Zend\Http.
