### PR TITLE
Removing service initializer as of zendframework/zf2#3537

### DIFF
--- a/library/Zend/Mvc/Service/AbstractPluginManagerFactory.php
+++ b/library/Zend/Mvc/Service/AbstractPluginManagerFactory.php
@@ -36,7 +36,6 @@ abstract class AbstractPluginManagerFactory implements FactoryInterface
 
         if (isset($configuration['di']) && $serviceLocator->has('Di')) {
             $plugins->addAbstractFactory($serviceLocator->get('DiAbstractServiceFactory'));
-            $plugins->addInitializer($serviceLocator->get('DiServiceInitializer'));
         }
 
         return $plugins;

--- a/library/Zend/Mvc/Service/DiServiceInitializerFactory.php
+++ b/library/Zend/Mvc/Service/DiServiceInitializerFactory.php
@@ -24,13 +24,6 @@ class DiServiceInitializerFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $initializer = new DiServiceInitializer($serviceLocator->get('Di'), $serviceLocator);
-
-        if ($serviceLocator instanceof ServiceManager) {
-            /* @var $serviceLocator ServiceManager */
-            $serviceLocator->addInitializer($initializer);
-        }
-
-        return $initializer;
+        return new DiServiceInitializer($serviceLocator->get('Di'), $serviceLocator);
     }
 }

--- a/tests/ZendTest/Mvc/Service/DiFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/DiFactoryTest.php
@@ -15,7 +15,7 @@ use Zend\ServiceManager\ServiceManager;
 
 class DiFactoryTest extends \PHPUnit_Framework_TestCase
 {
-    public function testWillInitializeDiAndDiAbstractFactoryAndDiInitializer()
+    public function testWillInitializeDiAndDiAbstractFactory()
     {
         $serviceManager = new ServiceManager();
         $serviceManager->setService('Config', array('di' => array('')));


### PR DESCRIPTION
Fix for #3537

This PR removes Di service initialization from the default initializers when `$sm->get('Config')['di']` is set in an MVC application.
