### PR TITLE
[develop] Fix for fatal errors from ElementPrepareAwareInterface change

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -16,7 +16,7 @@ use Zend\Form\Exception;
 use Zend\Form\Fieldset;
 use Zend\Form\FieldsetInterface;
 use Zend\Form\FieldsetPrepareAwareInterface;
-use Zend\Form\Form;
+use Zend\Form\FormInterface;
 use Zend\Stdlib\ArrayUtils;
 
 class Collection extends Fieldset implements FieldsetPrepareAwareInterface
@@ -434,10 +434,10 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
     /**
      * Prepare the collection by adding a dummy template element if the user want one
      *
-     * @param Form $form
+     * @param  FormInterface $form
      * @return mixed|void
      */
-    public function prepareElement(Form $form)
+    public function prepareElement(FormInterface $form)
     {
         // Create a template that will also be prepared
         if ($this->shouldCreateTemplate) {

--- a/library/Zend/Form/Element/Csrf.php
+++ b/library/Zend/Form/Element/Csrf.php
@@ -11,7 +11,7 @@ namespace Zend\Form\Element;
 
 use Zend\Form\Element;
 use Zend\Form\ElementPrepareAwareInterface;
-use Zend\Form\Form;
+use Zend\Form\FormInterface;
 use Zend\InputFilter\InputProviderInterface;
 use Zend\Validator\Csrf as CsrfValidator;
 
@@ -149,7 +149,7 @@ class Csrf extends Element implements InputProviderInterface, ElementPrepareAwar
     /**
      * Prepare the form element
      */
-    public function prepareElement(Form $form)
+    public function prepareElement(FormInterface $form)
     {
         $this->getCsrfValidator()->getHash(true);
     }

--- a/library/Zend/Form/Element/DateSelect.php
+++ b/library/Zend/Form/Element/DateSelect.php
@@ -10,7 +10,7 @@
 namespace Zend\Form\Element;
 
 use DateTime as PhpDateTime;
-use Zend\Form\Form;
+use Zend\Form\FormInterface;
 use Zend\Validator\ValidatorInterface;
 use Zend\Validator\Date as DateValidator;
 use Zend\Form\Exception\InvalidArgumentException;
@@ -117,10 +117,10 @@ class DateSelect extends MonthSelect
     /**
      * Prepare the form element (mostly used for rendering purposes)
      *
-     * @param Form $form
+     * @param  FormInterface $form
      * @return mixed
      */
-    public function prepareElement(Form $form)
+    public function prepareElement(FormInterface $form)
     {
         parent::prepareElement($form);
 

--- a/library/Zend/Form/Element/DateTimeSelect.php
+++ b/library/Zend/Form/Element/DateTimeSelect.php
@@ -10,7 +10,7 @@
 namespace Zend\Form\Element;
 
 use DateTime as PhpDateTime;
-use Zend\Form\Form;
+use Zend\Form\FormInterface;
 use Zend\Validator\ValidatorInterface;
 use Zend\Validator\Date as DateValidator;
 use Zend\Form\Exception\InvalidArgumentException;
@@ -246,10 +246,10 @@ class DateTimeSelect extends DateSelect
     /**
      * Prepare the form element (mostly used for rendering purposes)
      *
-     * @param Form $form
+     * @param  FormInterface $form
      * @return mixed
      */
-    public function prepareElement(Form $form)
+    public function prepareElement(FormInterface $form)
     {
         parent::prepareElement($form);
 

--- a/library/Zend/Form/Element/File.php
+++ b/library/Zend/Form/Element/File.php
@@ -18,7 +18,7 @@
 
 namespace Zend\Form\Element;
 
-use Zend\Form\Form;
+use Zend\Form\FormInterface;
 use Zend\Form\Element;
 use Zend\Form\ElementPrepareAwareInterface;
 use Zend\InputFilter\InputProviderInterface;
@@ -41,10 +41,10 @@ class File extends Element implements InputProviderInterface, ElementPrepareAwar
     /**
      * Prepare the form element (mostly used for rendering purposes)
      *
-     * @param  Form $form
+     * @param  FormInterface $form
      * @return mixed
      */
-    public function prepareElement(Form $form)
+    public function prepareElement(FormInterface $form)
     {
         // Ensure the form is using correct enctype
         $form->setAttribute('enctype', 'multipart/form-data');

--- a/library/Zend/Form/Element/MonthSelect.php
+++ b/library/Zend/Form/Element/MonthSelect.php
@@ -12,7 +12,7 @@ namespace Zend\Form\Element;
 use DateTime;
 use Zend\Form\Element;
 use Zend\Form\ElementPrepareAwareInterface;
-use Zend\Form\Form;
+use Zend\Form\FormInterface;
 use Zend\InputFilter\InputProviderInterface;
 use Zend\Validator\ValidatorInterface;
 use Zend\Validator\Regex as RegexValidator;
@@ -249,10 +249,10 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
     /**
      * Prepare the form element (mostly used for rendering purposes)
      *
-     * @param Form $form
+     * @param  FormInterface $form
      * @return mixed
      */
-    public function prepareElement(Form $form)
+    public function prepareElement(FormInterface $form)
     {
         $name = $this->getName();
         $this->monthElement->setName($name . '[month]');

--- a/library/Zend/Form/Element/Password.php
+++ b/library/Zend/Form/Element/Password.php
@@ -18,7 +18,7 @@
 
 namespace Zend\Form\Element;
 
-use Zend\Form\Form;
+use Zend\Form\FormInterface;
 use Zend\Form\Element;
 use Zend\Form\ElementPrepareAwareInterface;
 
@@ -40,10 +40,10 @@ class Password extends Element implements ElementPrepareAwareInterface
     /**
      * Remove the password before rendering if the form fails in order to avoid any security issue
      *
-     * @param  Form $form
+     * @param  FormInterface $form
      * @return mixed
      */
-    public function prepareElement(Form $form)
+    public function prepareElement(FormInterface $form)
     {
         $this->setValue('');
     }

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -353,10 +353,10 @@ class Fieldset extends Element implements FieldsetInterface
      * Ensures state is ready for use. Here, we append the name of the fieldsets to every elements in order to avoid
      * name clashes if the same fieldset is used multiple times
      *
-     * @param  Form $form
+     * @param  FormInterface $form
      * @return mixed|void
      */
-    public function prepareElement(Form $form)
+    public function prepareElement(FormInterface $form)
     {
         $name = $this->getName();
 


### PR DESCRIPTION
Recent change to `ElementPrepareAwareInterface` did not include changes to the classes that implemented it: af58ac25f8459e72ef6e95c9bba5fb3368af7a00

Tests reporting failures:

```
Fatal error: Declaration of Zend\Form\Element\DateTimeSelect::prepareElement() must be compatible with Zend\Form\ElementPrepareAwareInterface::prepareElement(Zend\Form\FormInterface $form) in /zf2/library/Zend/Form/Element/DateTimeSelect.php on line 323
```
