### PR TITLE
Fix for the issue #3541 - salt size for Encrypt/Decrypt Filter

### DIFF
--- a/library/Zend/Crypt/BlockCipher.php
+++ b/library/Zend/Crypt/BlockCipher.php
@@ -360,7 +360,7 @@ class BlockCipher
         // generate the encryption key and the HMAC key for the authentication
         $hash = Pbkdf2::calc(self::KEY_DERIV_HMAC,
                              $this->getKey(),
-                             $this->cipher->getSalt(),
+                             substr($this->cipher->getSalt(), 0, $this->cipher->getSaltSize()),
                              $this->keyIteration,
                              $keySize * 2);
         // set the encryption key

--- a/library/Zend/Crypt/BlockCipher.php
+++ b/library/Zend/Crypt/BlockCipher.php
@@ -48,11 +48,11 @@ class BlockCipher
     protected $hash = 'sha256';
 
     /**
-     * Salt (IV)
+     * Check if the salt has been set
      *
-     * @var string
+     * @var boolean
      */
-    protected $salt;
+    protected $saltSetted = false;
 
     /**
      * The output is binary?
@@ -62,18 +62,18 @@ class BlockCipher
     protected $binaryOutput = false;
 
     /**
-     * User's key
-     *
-     * @var string
-     */
-    protected $key;
-
-    /**
      * Number of iterations for Pbkdf2
      *
      * @var string
      */
     protected $keyIteration = 5000;
+
+    /**
+     * Key
+     *
+     * @var string
+     */
+    protected $key;
 
     /**
      * Constructor
@@ -88,14 +88,15 @@ class BlockCipher
     /**
      * Factory.
      *
-     * @param  string $adapter
-     * @param  array  $options
+     * @param  string      $adapter
+     * @param  array       $options
      * @return BlockCipher
      */
     public static function factory($adapter, $options = array())
     {
         $plugins = static::getSymmetricPluginManager();
         $adapter = $plugins->get($adapter, (array) $options);
+
         return new static($adapter);
     }
 
@@ -116,7 +117,7 @@ class BlockCipher
     /**
      * Set the symmetric cipher plugin manager
      *
-     * @param  string|SymmetricPluginManager $plugins
+     * @param  string|SymmetricPluginManager      $plugins
      * @throws Exception\InvalidArgumentException
      */
     public static function setSymmetricPluginManager($plugins)
@@ -165,12 +166,13 @@ class BlockCipher
     /**
      * Set the number of iterations for Pbkdf2
      *
-     * @param  integer $num
+     * @param  integer     $num
      * @return BlockCipher
      */
     public function setKeyIteration($num)
     {
-        $this->keyIteration = (integer)$num;
+        $this->keyIteration = (integer) $num;
+
         return $this;
     }
 
@@ -187,16 +189,19 @@ class BlockCipher
     /**
      * Set the salt (IV)
      *
-     * @param string $salt
+     * @param  string                             $salt
      * @return BlockCipher
      * @throws Exception\InvalidArgumentException
      */
     public function setSalt($salt)
     {
-        if (empty($salt)) {
-            throw new Exception\InvalidArgumentException("The salt (IV) cannot be empty");
+        try {
+            $this->cipher->setSalt($salt);
+        } catch (Symmetric\Exception\InvalidArgumentException $e) {
+            throw new Exception\InvalidArgumentException("The salt is not valid: " . $e->getMessage());
         }
-        $this->salt = $salt;
+        $this->saltSetted = true;
+
         return $this;
     }
 
@@ -207,18 +212,19 @@ class BlockCipher
      */
     public function getSalt()
     {
-        return $this->salt;
+        return $this->cipher->getSalt();
     }
 
     /**
      * Enable/disable the binary output
      *
-     * @param  bool $value
+     * @param  bool        $value
      * @return BlockCipher
      */
     public function setBinaryOutput($value)
     {
         $this->binaryOutput = (bool) $value;
+
         return $this;
     }
 
@@ -235,7 +241,7 @@ class BlockCipher
     /**
      * Set the encryption/decryption key
      *
-     * @param  string $key
+     * @param  string                             $key
      * @return BlockCipher
      * @throws Exception\InvalidArgumentException
      */
@@ -245,6 +251,7 @@ class BlockCipher
             throw new Exception\InvalidArgumentException('The key cannot be empty');
         }
         $this->key = $key;
+
         return $this;
     }
 
@@ -261,7 +268,7 @@ class BlockCipher
     /**
      * Set algorithm of the symmetric cipher
      *
-     * @param  string $algo
+     * @param  string                             $algo
      * @return BlockCipher
      * @throws Exception\InvalidArgumentException
      */
@@ -275,6 +282,7 @@ class BlockCipher
         } catch (Symmetric\Exception\InvalidArgumentException $e) {
             throw new Exception\InvalidArgumentException($e->getMessage());
         }
+
         return $this;
     }
 
@@ -288,6 +296,7 @@ class BlockCipher
         if (!empty($this->cipher)) {
             return $this->cipher->getAlgorithm();
         }
+
         return false;
     }
 
@@ -301,13 +310,14 @@ class BlockCipher
         if (!empty($this->cipher)) {
             return $this->cipher->getSupportedAlgorithms();
         }
+
         return array();
     }
 
     /**
      * Set the hash algorithm for HMAC authentication
      *
-     * @param  string $hash
+     * @param  string                             $hash
      * @return BlockCipher
      * @throws Exception\InvalidArgumentException
      */
@@ -319,6 +329,7 @@ class BlockCipher
             );
         }
         $this->hash = $hash;
+
         return $this;
     }
 
@@ -335,7 +346,7 @@ class BlockCipher
     /**
      * Encrypt then authenticate using HMAC
      *
-     * @param  string $data
+     * @param  string                             $data
      * @return string
      * @throws Exception\InvalidArgumentException
      */
@@ -344,23 +355,21 @@ class BlockCipher
         if (empty($data)) {
             throw new Exception\InvalidArgumentException('The data to encrypt cannot be empty');
         }
-        if (empty($this->key)) {
-            throw new Exception\InvalidArgumentException('No key specified for the encryption');
-        }
         if (empty($this->cipher)) {
             throw new Exception\InvalidArgumentException('No symmetric cipher specified');
         }
-        $keySize = $this->cipher->getKeySize();
-        $salt = $this->getSalt();
-        // generate a random salt (IV) if empty
-        if (empty($salt)) {
-            $salt = Rand::getBytes($this->cipher->getSaltSize(), true);
+        if (empty($this->key)) {
+            throw new Exception\InvalidArgumentException('No key specified for the encryption');
         }
-        $this->cipher->setSalt($salt);
+        $keySize = $this->cipher->getKeySize();
+        // generate a random salt (IV) if the salt has not been set
+        if (!$this->saltSetted) {
+            $this->cipher->setSalt(Rand::getBytes($this->cipher->getSaltSize(), true));
+        }
         // generate the encryption key and the HMAC key for the authentication
         $hash = Pbkdf2::calc(self::KEY_DERIV_HMAC,
                              $this->getKey(),
-                             substr($this->cipher->getSalt(), 0, $this->cipher->getSaltSize()),
+                             $this->getSalt(),
                              $this->keyIteration,
                              $keySize * 2);
         // set the encryption key
@@ -376,13 +385,14 @@ class BlockCipher
         if (!$this->binaryOutput) {
             $ciphertext = base64_encode($ciphertext);
         }
+
         return $hmac . $ciphertext;
     }
 
     /**
      * Decrypt
      *
-     * @param  string $data
+     * @param  string                             $data
      * @return string|bool
      * @throws Exception\InvalidArgumentException
      */
@@ -424,6 +434,7 @@ class BlockCipher
         if (!Utils::compareStrings($hmacNew, $hmac)) {
             return false;
         }
+
         return $this->cipher->decrypt($ciphertext);
     }
 }

--- a/library/Zend/Crypt/BlockCipher.php
+++ b/library/Zend/Crypt/BlockCipher.php
@@ -206,13 +206,23 @@ class BlockCipher
     }
 
     /**
-     * Get the salt (IV)
+     * Get the salt (IV) according to the size requested by the algorithm
      *
      * @return string
      */
     public function getSalt()
     {
         return $this->cipher->getSalt();
+    }
+
+    /**
+     * Get the original salt value
+     *
+     * @return type
+     */
+    public function getOriginalSalt()
+    {
+        return $this->cipher->getOriginalSalt();
     }
 
     /**

--- a/library/Zend/Crypt/Symmetric/Mcrypt.php
+++ b/library/Zend/Crypt/Symmetric/Mcrypt.php
@@ -250,12 +250,9 @@ class Mcrypt implements SymmetricInterface
      */
     public function getKey()
     {
-        if (strlen($this->key) < $this->getKeySize()) {
-             throw new Exception\InvalidArgumentException(
-                'The size of the key must be at least of ' . $this->getKeySize() . ' bytes'
-             );
+        if (empty($this->key)) {
+            return null;
         }
-
         return substr($this->key, 0, $this->getKeySize());
     }
 

--- a/library/Zend/Crypt/Symmetric/Mcrypt.php
+++ b/library/Zend/Crypt/Symmetric/Mcrypt.php
@@ -441,6 +441,16 @@ class Mcrypt implements SymmetricInterface
     }
 
     /**
+     * Get the original salt value
+     *
+     * @return string
+     */
+    public function getOriginalSalt()
+    {
+        return $this->iv;
+    }
+
+    /**
      * Set the cipher mode
      *
      * @param  string                             $mode

--- a/library/Zend/Crypt/Symmetric/Mcrypt.php
+++ b/library/Zend/Crypt/Symmetric/Mcrypt.php
@@ -161,9 +161,6 @@ class Mcrypt implements SymmetricInterface
      */
     protected function setDefaultOptions($options = array())
     {
-        if (empty($options)) {
-            return;
-        }
         if (!isset($options['padding'])) {
             $plugins       = static::getPaddingPluginManager();
             $padding       = $plugins->get(self::DEFAULT_PADDING);
@@ -321,11 +318,6 @@ class Mcrypt implements SymmetricInterface
         if (null === $this->getSalt()) {
             throw new Exception\InvalidArgumentException('The salt (IV) cannot be empty');
         }
-        if (strlen($this->getSalt()) < $this->getSaltSize()) {
-            throw new Exception\InvalidArgumentException(
-                'The size of the salt (IV) is not enough. You need ' . $this->getSaltSize() . ' bytes'
-            );
-        }
         if (null === $this->getPadding()) {
             throw new Exception\InvalidArgumentException('You have to specify a padding method');
         }
@@ -408,6 +400,11 @@ class Mcrypt implements SymmetricInterface
         if (empty($salt)) {
             throw new Exception\InvalidArgumentException('The salt (IV) cannot be empty');
         }
+        if (strlen($salt) < $this->getSaltSize()) {
+            throw new Exception\InvalidArgumentException(
+                'The size of the salt (IV) must be at least ' . $this->getSaltSize() . ' bytes'
+            );
+        } 
         $this->iv = $salt;
         return $this;
     }

--- a/library/Zend/Crypt/Symmetric/Mcrypt.php
+++ b/library/Zend/Crypt/Symmetric/Mcrypt.php
@@ -107,7 +107,7 @@ class Mcrypt implements SymmetricInterface
     /**
      * Constructor
      *
-     * @param  array|Traversable $options
+     * @param  array|Traversable                  $options
      * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException
      */
@@ -185,7 +185,7 @@ class Mcrypt implements SymmetricInterface
     /**
      * Set the padding plugin manager
      *
-     * @param  string|PaddingPluginManager $plugins
+     * @param  string|PaddingPluginManager        $plugins
      * @throws Exception\InvalidArgumentException
      * @return void
      */
@@ -224,7 +224,7 @@ class Mcrypt implements SymmetricInterface
     /**
      * Set the encryption key
      *
-     * @param  string $key
+     * @param  string                             $key
      * @throws Exception\InvalidArgumentException
      * @return Mcrypt
      */
@@ -233,7 +233,13 @@ class Mcrypt implements SymmetricInterface
         if (empty($key)) {
             throw new Exception\InvalidArgumentException('The key cannot be empty');
         }
+        if (strlen($key) < $this->getKeySize()) {
+             throw new Exception\InvalidArgumentException(
+                'The size of the key must be at least of ' . $this->getKeySize() . ' bytes'
+             );
+        }
         $this->key = $key;
+
         return $this;
     }
 
@@ -244,13 +250,19 @@ class Mcrypt implements SymmetricInterface
      */
     public function getKey()
     {
-        return $this->key;
+        if (strlen($this->key) < $this->getKeySize()) {
+             throw new Exception\InvalidArgumentException(
+                'The size of the key must be at least of ' . $this->getKeySize() . ' bytes'
+             );
+        }
+
+        return substr($this->key, 0, $this->getKeySize());
     }
 
     /**
      * Set the encryption algorithm (cipher)
      *
-     * @param  string $algo
+     * @param  string                             $algo
      * @throws Exception\InvalidArgumentException
      * @return Mcrypt
      */
@@ -262,6 +274,7 @@ class Mcrypt implements SymmetricInterface
             );
         }
         $this->algo = $algo;
+
         return $this;
     }
 
@@ -284,6 +297,7 @@ class Mcrypt implements SymmetricInterface
     public function setPadding(Padding\PaddingInterface $padding)
     {
         $this->padding = $padding;
+
         return $this;
     }
 
@@ -300,7 +314,7 @@ class Mcrypt implements SymmetricInterface
     /**
      * Encrypt
      *
-     * @param  string $data
+     * @param  string                             $data
      * @throws Exception\InvalidArgumentException
      * @return string
      */
@@ -312,9 +326,6 @@ class Mcrypt implements SymmetricInterface
         if (null === $this->getKey()) {
             throw new Exception\InvalidArgumentException('No key specified for the encryption');
         }
-        if (strlen($this->getKey()) < $this->getKeySize()) {
-            throw new Exception\InvalidArgumentException('The key is not long enough for the cipher');
-        }
         if (null === $this->getSalt()) {
             throw new Exception\InvalidArgumentException('The salt (IV) cannot be empty');
         }
@@ -323,23 +334,23 @@ class Mcrypt implements SymmetricInterface
         }
         // padding
         $data = $this->padding->pad($data, $this->getBlockSize());
-        // get the correct iv size
-        $iv = substr($this->iv, 0, $this->getSaltSize());
+        $iv   = $this->getSalt();
         // encryption
         $result = mcrypt_encrypt(
             $this->supportedAlgos[$this->algo],
-            substr($this->key, 0, $this->getKeySize()),
+            $this->getKey(),
             $data,
             $this->supportedModes[$this->mode],
             $iv
         );
+
         return $iv . $result;
     }
 
     /**
      * Decrypt
      *
-     * @param  string $data
+     * @param  string                             $data
      * @throws Exception\InvalidArgumentException
      * @return string
      */
@@ -358,7 +369,7 @@ class Mcrypt implements SymmetricInterface
         $ciphertext = substr($data, $this->getSaltSize());
         $result     = mcrypt_decrypt(
             $this->supportedAlgos[$this->algo],
-            substr($this->key, 0, $this->getKeySize()),
+            $this->getKey(),
             $ciphertext,
             $this->supportedModes[$this->mode],
             $iv
@@ -391,7 +402,7 @@ class Mcrypt implements SymmetricInterface
     /**
      * Set the salt (IV)
      *
-     * @param  string $salt
+     * @param  string                             $salt
      * @throws Exception\InvalidArgumentException
      * @return Mcrypt
      */
@@ -404,25 +415,35 @@ class Mcrypt implements SymmetricInterface
             throw new Exception\InvalidArgumentException(
                 'The size of the salt (IV) must be at least ' . $this->getSaltSize() . ' bytes'
             );
-        } 
+        }
         $this->iv = $salt;
+
         return $this;
     }
 
     /**
-     * Get the salt (IV)
+     * Get the salt (IV) according to the size requested by the algorithm
      *
      * @return string
      */
     public function getSalt()
     {
-        return $this->iv;
+        if (empty($this->iv)) {
+            return null;
+        }
+        if (strlen($this->iv) < $this->getSaltSize()) {
+            throw new Exception\RuntimeException(
+                'The size of the salt (IV) must be at least ' . $this->getSaltSize() . ' bytes'
+            );
+        }
+
+        return substr($this->iv, 0, $this->getSaltSize());
     }
 
     /**
      * Set the cipher mode
      *
-     * @param  string $mode
+     * @param  string                             $mode
      * @throws Exception\InvalidArgumentException
      * @return Mcrypt
      */
@@ -437,6 +458,7 @@ class Mcrypt implements SymmetricInterface
             }
             $this->mode = $mode;
         }
+
         return $this;
     }
 

--- a/library/Zend/Filter/Encrypt/BlockCipher.php
+++ b/library/Zend/Filter/Encrypt/BlockCipher.php
@@ -34,7 +34,7 @@ class BlockCipher implements EncryptionAlgorithmInterface
      *     'key_iteration' => the number of iterations for the PBKDF2 key generation
      *     'algorithm      => cipher algorithm to use
      *     'hash'          => algorithm to use for the authentication
-     *     'vector         => initialization vector
+     *     'vector'        => initialization vector
      * )
      */
     protected $encryption = array(

--- a/library/Zend/Filter/Encrypt/BlockCipher.php
+++ b/library/Zend/Filter/Encrypt/BlockCipher.php
@@ -34,15 +34,13 @@ class BlockCipher implements EncryptionAlgorithmInterface
      *     'key_iteration' => the number of iterations for the PBKDF2 key generation
      *     'algorithm      => cipher algorithm to use
      *     'hash'          => algorithm to use for the authentication
-     *     'iv'            => initialization vector
+     *     'vector         => initialization vector
      * )
      */
     protected $encryption = array(
-        'key'                 => 'ZendFramework',
         'key_iteration'       => 5000,
         'algorithm'           => 'aes',
         'hash'                => 'sha256',
-        'vector'              => null,
     );
 
     /**
@@ -180,6 +178,34 @@ class BlockCipher implements EncryptionAlgorithmInterface
         }
         $this->encryption['vector'] = $vector;
         return $this;
+    }
+
+    /**
+     * Set the encryption key
+     *
+     * @param  string $key
+     * @return BlockCipher
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setKey($key)
+    {
+        try {
+            $this->blockCipher->setKey($key);
+        } catch (CryptException\InvalidArgumentException $e) {
+            throw new Exception\InvalidArgumentException($e->getMessage());
+        }
+        $this->encryption['key'] = $key;
+        return $this;
+    }
+
+    /**
+     * Get the encryption key
+     *
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->encryption['key'];
     }
 
     /**

--- a/tests/ZendTest/Crypt/BlockCipherTest.php
+++ b/tests/ZendTest/Crypt/BlockCipherTest.php
@@ -71,6 +71,14 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('test', $this->blockCipher->getKey());
     }
 
+    public function testSetSalt()
+    {
+        $salt = str_repeat('a', $this->blockCipher->getCipher()->getSaltSize());
+        $result = $this->blockCipher->setSalt($salt);
+        $this->assertEquals($result, $this->blockCipher);
+        $this->assertEquals($salt, $this->blockCipher->getSalt());
+    }
+        
     public function testSetAlgorithm()
     {
         $result = $this->blockCipher->setCipherAlgorithm('blowfish');

--- a/tests/ZendTest/Crypt/BlockCipherTest.php
+++ b/tests/ZendTest/Crypt/BlockCipherTest.php
@@ -73,12 +73,14 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
 
     public function testSetSalt()
     {
-        $salt = str_repeat('a', $this->blockCipher->getCipher()->getSaltSize());
+        $salt = str_repeat('a', $this->blockCipher->getCipher()->getSaltSize() + 2);
         $result = $this->blockCipher->setSalt($salt);
         $this->assertEquals($result, $this->blockCipher);
-        $this->assertEquals($salt, $this->blockCipher->getSalt());
+        $this->assertEquals(substr($salt, 0,  $this->blockCipher->getCipher()->getSaltSize()),
+                            $this->blockCipher->getSalt());
+        $this->assertEquals($salt, $this->blockCipher->getOriginalSalt());
     }
-        
+
     public function testSetAlgorithm()
     {
         $result = $this->blockCipher->setCipherAlgorithm('blowfish');

--- a/tests/ZendTest/Crypt/Symmetric/McryptTest.php
+++ b/tests/ZendTest/Crypt/Symmetric/McryptTest.php
@@ -125,17 +125,17 @@ class McryptTest extends \PHPUnit_Framework_TestCase
 
     public function testSetSalt()
     {
-        $this->mcrypt->setSalt($this->salt);
-        $this->assertEquals($this->salt, $this->mcrypt->getSalt());
+        $salt = substr($this->salt, 0, $this->mcrypt->getSaltSize());
+        $this->mcrypt->setSalt($salt);
+        $this->assertEquals($salt, $this->mcrypt->getSalt());
     }
 
+    /**
+     * @expectedException Zend\Crypt\Symmetric\Exception\InvalidArgumentException
+     */
     public function testShortSalt()
     {
         $this->mcrypt->setSalt('short');
-        $this->mcrypt->setKey($this->key);
-        $this->setExpectedException('Zend\Crypt\Symmetric\Exception\InvalidArgumentException',
-                                    'The size of the salt (IV) is not enough. You need 16 bytes');
-        $output = $this->mcrypt->encrypt('test');
     }
 
     public function testSetMode()
@@ -153,13 +153,13 @@ class McryptTest extends \PHPUnit_Framework_TestCase
 
     public function testEncryptDecrypt()
     {
-        $this->mcrypt->setSalt($this->salt);
         $this->mcrypt->setKey($this->key);
         $this->mcrypt->setPadding(new PKCS7());
         foreach ($this->mcrypt->getSupportedAlgorithms() as $algo) {
             foreach ($this->mcrypt->getSupportedModes() as $mode) {
                 $this->mcrypt->setAlgorithm($algo);
                 $this->mcrypt->setMode($mode);
+                $this->mcrypt->setSalt($this->salt);
                 $encrypted = $this->mcrypt->encrypt($this->plaintext);
                 $this->assertTrue(!empty($encrypted));
                 $decrypted = $this->mcrypt->decrypt($encrypted);
@@ -191,15 +191,6 @@ class McryptTest extends \PHPUnit_Framework_TestCase
         $ciphertext = $this->mcrypt->encrypt($this->plaintext);
     }
 
-    public function testEncryptWithoutPadding()
-    {
-        $this->mcrypt->setKey($this->key);
-        $this->mcrypt->setSalt($this->salt);
-        $this->setExpectedException('Zend\Crypt\Symmetric\Exception\InvalidArgumentException',
-                                    'You have to specify a padding method');
-        $ciphertext = $this->mcrypt->encrypt($this->plaintext);
-    }
-
     public function testDecryptEmptyData()
     {
         $this->setExpectedException('Zend\Crypt\Symmetric\Exception\InvalidArgumentException',
@@ -211,14 +202,6 @@ class McryptTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Zend\Crypt\Symmetric\Exception\InvalidArgumentException',
                                     'No key specified for the decryption');
-        $this->mcrypt->decrypt($this->plaintext);
-    }
-
-    public function testDecryptWihoutPadding()
-    {
-        $this->mcrypt->setKey($this->key);
-        $this->setExpectedException('Zend\Crypt\Symmetric\Exception\InvalidArgumentException',
-                                    'You have to specify a padding method');
         $this->mcrypt->decrypt($this->plaintext);
     }
 }

--- a/tests/ZendTest/Crypt/Symmetric/McryptTest.php
+++ b/tests/ZendTest/Crypt/Symmetric/McryptTest.php
@@ -154,11 +154,11 @@ class McryptTest extends \PHPUnit_Framework_TestCase
     {
         $this->mcrypt->setKey($this->key);
         $this->mcrypt->setPadding(new PKCS7());
+        $this->mcrypt->setSalt($this->salt);
         foreach ($this->mcrypt->getSupportedAlgorithms() as $algo) {
             foreach ($this->mcrypt->getSupportedModes() as $mode) {
                 $this->mcrypt->setAlgorithm($algo);
                 $this->mcrypt->setMode($mode);
-                $this->mcrypt->setSalt($this->salt);
                 $encrypted = $this->mcrypt->encrypt($this->plaintext);
                 $this->assertTrue(!empty($encrypted));
                 $decrypted = $this->mcrypt->decrypt($encrypted);

--- a/tests/ZendTest/Crypt/Symmetric/McryptTest.php
+++ b/tests/ZendTest/Crypt/Symmetric/McryptTest.php
@@ -124,9 +124,10 @@ class McryptTest extends \PHPUnit_Framework_TestCase
 
     public function testSetSalt()
     {
-        $salt = substr($this->salt, 0, $this->mcrypt->getSaltSize());
-        $this->mcrypt->setSalt($salt);
-        $this->assertEquals($salt, $this->mcrypt->getSalt());
+        $this->mcrypt->setSalt($this->salt);
+        $this->assertEquals(substr($this->salt, 0, $this->mcrypt->getSaltSize()),
+                            $this->mcrypt->getSalt());
+        $this->assertEquals($this->salt, $this->mcrypt->getOriginalSalt());
     }
 
     /**

--- a/tests/ZendTest/Crypt/Symmetric/McryptTest.php
+++ b/tests/ZendTest/Crypt/Symmetric/McryptTest.php
@@ -56,8 +56,8 @@ class McryptTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($mcrypt instanceof Mcrypt);
         $this->assertEquals($mcrypt->getAlgorithm(), MCRYPT_BLOWFISH);
         $this->assertEquals($mcrypt->getMode(), MCRYPT_MODE_CFB);
-        $this->assertEquals($mcrypt->getKey(), $this->key);
-        $this->assertEquals($mcrypt->getSalt(), $this->salt);
+        $this->assertEquals($mcrypt->getKey(), substr($this->key, 0, $mcrypt->getKeySize()));
+        $this->assertEquals($mcrypt->getSalt(), substr($this->salt, 0, $mcrypt->getSaltSize()));
         $this->assertTrue($mcrypt->getPadding() instanceof PKCS7);
     }
 
@@ -75,8 +75,8 @@ class McryptTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($mcrypt instanceof Mcrypt);
         $this->assertEquals($mcrypt->getAlgorithm(), MCRYPT_BLOWFISH);
         $this->assertEquals($mcrypt->getMode(), MCRYPT_MODE_CFB);
-        $this->assertEquals($mcrypt->getKey(), $this->key);
-        $this->assertEquals($mcrypt->getSalt(), $this->salt);
+        $this->assertEquals($mcrypt->getKey(), substr($this->key, 0, $mcrypt->getKeySize()));
+        $this->assertEquals($mcrypt->getSalt(), substr($this->salt, 0, $mcrypt->getSaltSize()));
         $this->assertTrue($mcrypt->getPadding() instanceof PKCS7);
     }
 
@@ -117,8 +117,7 @@ class McryptTest extends \PHPUnit_Framework_TestCase
 
     public function testSetShortKey()
     {
-        $this->setExpectedException('Zend\Crypt\Symmetric\Exception\InvalidArgumentException',
-                                    'The key is not long enough for the cipher');
+        $this->setExpectedException('Zend\Crypt\Symmetric\Exception\InvalidArgumentException');
         $result = $this->mcrypt->setKey('short');
         $output = $this->mcrypt->encrypt('test');
     }
@@ -171,8 +170,7 @@ class McryptTest extends \PHPUnit_Framework_TestCase
 
     public function testEncryptWithoutKey()
     {
-        $this->setExpectedException('Zend\Crypt\Symmetric\Exception\InvalidArgumentException',
-                                    'No key specified for the encryption');
+        $this->setExpectedException('Zend\Crypt\Symmetric\Exception\InvalidArgumentException');
         $ciphertext = $this->mcrypt->encrypt('test');
     }
 
@@ -200,8 +198,7 @@ class McryptTest extends \PHPUnit_Framework_TestCase
 
     public function testDecryptWithoutKey()
     {
-        $this->setExpectedException('Zend\Crypt\Symmetric\Exception\InvalidArgumentException',
-                                    'No key specified for the decryption');
+        $this->setExpectedException('Zend\Crypt\Symmetric\Exception\InvalidArgumentException');
         $this->mcrypt->decrypt($this->plaintext);
     }
 }

--- a/tests/ZendTest/Filter/DecryptTest.php
+++ b/tests/ZendTest/Filter/DecryptTest.php
@@ -54,6 +54,20 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Ensures that the encryption works fine 
+     */
+    public function testDecryptBlockCipher()
+    {
+        if (!extension_loaded('mcrypt')) {
+            $this->markTestSkipped('Mcrypt extension not installed');
+        }
+        $decrypt = new DecryptFilter(array('adapter' => 'BlockCipher', 'key' => 'testkey'));
+        $decrypt->setVector('1234567890123456890');
+        $decrypted = $decrypt->filter('ec133eb7460682b0020b736ad6d2ef14c35de0f1e5976330ae1dd096ef3b4cb7MTIzNDU2Nzg5MDEyMzQ1NoZvxY1JkeL6TnQP3ug5F0k=');
+        $this->assertEquals($decrypted, 'test');
+    }
+    
+    /**
      * Ensures that the filter follows expected behavior
      *
      * @return void

--- a/tests/ZendTest/Filter/DecryptTest.php
+++ b/tests/ZendTest/Filter/DecryptTest.php
@@ -46,15 +46,14 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
         );
 
         $enc = $filter->getEncryption();
-        $filter->setVector('1234567890123456');
-        $this->assertEquals('ZendFramework', $enc['key']);
+        $filter->setKey('1234567890123456');
         foreach ($valuesExpected as $input => $output) {
             $this->assertNotEquals($output, $filter($input));
         }
     }
 
     /**
-     * Ensures that the encryption works fine 
+     * Ensures that the encryption works fine
      */
     public function testDecryptBlockCipher()
     {
@@ -66,7 +65,7 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
         $decrypted = $decrypt->filter('ec133eb7460682b0020b736ad6d2ef14c35de0f1e5976330ae1dd096ef3b4cb7MTIzNDU2Nzg5MDEyMzQ1NoZvxY1JkeL6TnQP3ug5F0k=');
         $this->assertEquals($decrypted, 'test');
     }
-    
+
     /**
      * Ensures that the filter follows expected behavior
      *

--- a/tests/ZendTest/Filter/Encrypt/BlockCipherTest.php
+++ b/tests/ZendTest/Filter/Encrypt/BlockCipherTest.php
@@ -58,14 +58,18 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetSetVector()
     {
-        $filter = new BlockCipherEncryption(array('key' => 'testkey'));
-        $filter->setVector('testvect');
-        $this->assertEquals('testvect', $filter->getVector());
 
-        $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException');
-        $output = $filter->encrypt('test');
+        $filter = new BlockCipherEncryption(array('key' => 'testkey'));
+        $filter->setVector('1234567890123456');
+        $this->assertEquals('1234567890123456', $filter->getVector());
     }
 
+    public function testWrongSizeVector()
+    {
+        $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException');
+        $filter = new BlockCipherEncryption(array('key' => 'testkey'));
+        $filter->setVector('testvect');
+    }
     /**
      * Ensures that the filter allows default encryption
      *
@@ -74,13 +78,13 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
     public function testDefaultEncryption()
     {
         $filter = new BlockCipherEncryption(array('key' => 'testkey'));
-        $filter->setVector('testvect');
+        $filter->setVector('1234567890123456');
         $this->assertEquals(
-            array('key' => 'testkey',
-                  'algorithm' => 'aes',
-                  'vector' => 'testvect',
+            array('key'           => 'testkey',
+                  'algorithm'     => 'aes',
+                  'vector'        => '1234567890123456',
                   'key_iteration' => 5000,
-                  'hash' => 'sha256'),
+                  'hash'          => 'sha256'),
             $filter->getEncryption()
         );
     }
@@ -93,16 +97,16 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
     public function testGetSetEncryption()
     {
         $filter = new BlockCipherEncryption(array('key' => 'testkey'));
-        $filter->setVector('testvect');
+        $filter->setVector('1234567890123456');
         $filter->setEncryption(
             array('algorithm' => '3des')
         );
         $this->assertEquals(
-            array('key' => 'testkey',
-                  'algorithm' => '3des',
-                  'vector' => 'testvect',
+            array('key'           => 'testkey',
+                  'algorithm'     => '3des',
+                  'vector'        => '1234567890123456',
                   'key_iteration' => 5000,
-                  'hash' => 'sha256'),
+                  'hash'          => 'sha256'),
             $filter->getEncryption()
         );
     }

--- a/tests/ZendTest/Filter/EncryptTest.php
+++ b/tests/ZendTest/Filter/EncryptTest.php
@@ -54,6 +54,20 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Ensures that the encryption works fine 
+     */
+    public function testEncryptBlockCipher()
+    {
+        if (!extension_loaded('mcrypt')) {
+            $this->markTestSkipped('Mcrypt extension not installed');
+        }
+        $encrypt = new EncryptFilter(array('adapter' => 'BlockCipher', 'key' => 'testkey'));
+        $encrypt->setVector('1234567890123456890');
+        $encrypted = $encrypt->filter('test');
+        $this->assertEquals($encrypted, 'ec133eb7460682b0020b736ad6d2ef14c35de0f1e5976330ae1dd096ef3b4cb7MTIzNDU2Nzg5MDEyMzQ1NoZvxY1JkeL6TnQP3ug5F0k=');
+    }
+    
+    /**
      * Ensures that the filter follows expected behavior
      *
      * @return void

--- a/tests/ZendTest/Filter/EncryptTest.php
+++ b/tests/ZendTest/Filter/EncryptTest.php
@@ -54,7 +54,7 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that the encryption works fine 
+     * Ensures that the encryption works fine
      */
     public function testEncryptBlockCipher()
     {
@@ -66,7 +66,7 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
         $encrypted = $encrypt->filter('test');
         $this->assertEquals($encrypted, 'ec133eb7460682b0020b736ad6d2ef14c35de0f1e5976330ae1dd096ef3b4cb7MTIzNDU2Nzg5MDEyMzQ1NoZvxY1JkeL6TnQP3ug5F0k=');
     }
-    
+
     /**
      * Ensures that the filter follows expected behavior
      *

--- a/tests/ZendTest/Filter/File/DecryptTest.php
+++ b/tests/ZendTest/Filter/File/DecryptTest.php
@@ -61,7 +61,7 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
             dirname(__DIR__).'/_files/newencryption.txt',
             $filter->getFilename());
 
-        $filter->setVector('1234567890123456');
+        $filter->setKey('1234567890123456');
         $filter->filter(dirname(__DIR__).'/_files/encryption.txt');
 
         $filter = new FileDecrypt();
@@ -70,7 +70,7 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
             'Encryption',
             file_get_contents(dirname(__DIR__).'/_files/newencryption.txt'));
 
-        $filter->setVector('1234567890123456');
+        $filter->setKey('1234567890123456');
         $this->assertEquals(
             dirname(__DIR__).'/_files/newencryption.txt',
             $filter->filter(dirname(__DIR__).'/_files/newencryption.txt'));
@@ -84,7 +84,7 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FileEncrypt();
         $filter->setFilename(dirname(__DIR__).'/_files/newencryption.txt');
-        $filter->setVector('1234567890123456');
+        $filter->setKey('1234567890123456');
         $this->assertEquals(dirname(__DIR__).'/_files/newencryption.txt',
             $filter->filter(dirname(__DIR__).'/_files/encryption.txt'));
 
@@ -99,7 +99,7 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
             dirname(__DIR__).'/_files/newencryption2.txt',
             $filter->getFilename());
 
-        $filter->setVector('1234567890123456');
+        $filter->setKey('1234567890123456');
         $input = $filter->filter(dirname(__DIR__).'/_files/newencryption.txt');
         $this->assertEquals(dirname(__DIR__).'/_files/newencryption2.txt', $input);
 

--- a/tests/ZendTest/Filter/File/EncryptTest.php
+++ b/tests/ZendTest/Filter/File/EncryptTest.php
@@ -53,7 +53,7 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
             dirname(__DIR__).'/_files/newencryption.txt',
             $filter->getFilename());
 
-        $filter->setVector('1234567890123456');
+        $filter->setKey('1234567890123456');
         $this->assertEquals(dirname(__DIR__).'/_files/newencryption.txt',
             $filter->filter(dirname(__DIR__).'/_files/encryption.txt'));
 
@@ -70,7 +70,7 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FileEncrypt();
         $filter->setFilename(dirname(__DIR__).'/_files/newencryption.txt');
-        $filter->setVector('1234567890123456');
+        $filter->setKey('1234567890123456');
         $this->assertEquals(dirname(__DIR__).'/_files/newencryption.txt',
             $filter->filter(dirname(__DIR__).'/_files/encryption.txt'));
 
@@ -79,7 +79,7 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
             file_get_contents(dirname(__DIR__).'/_files/newencryption.txt'));
 
         $filter = new FileDecrypt();
-        $filter->setVector('1234567890123456');
+        $filter->setKey('1234567890123456');
         $input = $filter->filter(dirname(__DIR__).'/_files/newencryption.txt');
         $this->assertEquals(dirname(__DIR__).'/_files/newencryption.txt', $input);
 
@@ -94,7 +94,7 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
     public function testNonExistingFile()
     {
         $filter = new FileEncrypt();
-        $filter->setVector('1234567890123456');
+        $filter->setKey('1234567890123456');
 
         $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'not found');
         echo $filter->filter(dirname(__DIR__).'/_files/nofile.txt');
@@ -106,7 +106,7 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
     public function testEncryptionInSameFile()
     {
         $filter = new FileEncrypt();
-        $filter->setVector('1234567890123456');
+        $filter->setKey('1234567890123456');
 
         copy(dirname(__DIR__).'/_files/encryption.txt', dirname(__DIR__).'/_files/newencryption.txt');
         $filter->filter(dirname(__DIR__).'/_files/newencryption.txt');


### PR DESCRIPTION
This PR fix the issue #3541. In the BlockCipher used by Encrypt/Decrypt Filter the salt (vector) value has been resize to the correct value during the authentication , according to the encryption algorithm.
This PR is a replacement of the pull #3547.

More changes have been introduced, see comments below.
