### PR TITLE
fix #3523: Missing Zend\Stdlib as requirement on components using it

### DIFF
--- a/library/Zend/Captcha/composer.json
+++ b/library/Zend/Captcha/composer.json
@@ -14,7 +14,8 @@
     "target-dir": "Zend/Captcha",
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-math": "self.version"
+        "zendframework/zend-math": "self.version",
+        "zendframework/zend-stdlib": "self.version"
     },
     "require-dev": {
         "zendframework/zendservice-recaptcha": "*"

--- a/library/Zend/Config/composer.json
+++ b/library/Zend/Config/composer.json
@@ -13,6 +13,7 @@
     },
     "target-dir": "Zend/Config",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "zendframework/zend-stdlib": "self.version"
     }
 }

--- a/library/Zend/Console/composer.json
+++ b/library/Zend/Console/composer.json
@@ -13,6 +13,7 @@
     },
     "target-dir": "Zend/Console",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "zendframework/zend-stdlib": "self.version"
     }
 }

--- a/library/Zend/Db/composer.json
+++ b/library/Zend/Db/composer.json
@@ -13,6 +13,7 @@
     },
     "target-dir": "Zend/Db",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "zendframework/zend-stdlib": "self.version"
     }
 }

--- a/library/Zend/Di/composer.json
+++ b/library/Zend/Di/composer.json
@@ -14,6 +14,7 @@
     "target-dir": "Zend/Di",
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-code": "self.version"
+        "zendframework/zend-code": "self.version",
+        "zendframework/zend-stdlib": "self.version"
     }
 }

--- a/library/Zend/Filter/composer.json
+++ b/library/Zend/Filter/composer.json
@@ -13,7 +13,8 @@
     },
     "target-dir": "Zend/Filter",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "zendframework/zend-stdlib": "self.version"
     },
     "require-dev": {
         "zendframework/zend-crypt": "self.version"

--- a/library/Zend/Form/composer.json
+++ b/library/Zend/Form/composer.json
@@ -14,7 +14,8 @@
     "target-dir": "Zend/Form",
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-inputfilter": "self.version"
+        "zendframework/zend-inputfilter": "self.version",
+        "zendframework/zend-stdlib": "self.version"
     },
     "require-dev": {
         "zendframework/zendservice-recaptcha": "*"

--- a/library/Zend/Paginator/composer.json
+++ b/library/Zend/Paginator/composer.json
@@ -13,6 +13,7 @@
     },
     "target-dir": "Zend/Paginator",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "zendframework/zend-stdlib": "self.version"
     }
 }

--- a/library/Zend/Serializer/composer.json
+++ b/library/Zend/Serializer/composer.json
@@ -14,8 +14,8 @@
     "target-dir": "Zend/Serializer",
     "require": {
         "php": ">=5.3.3",
-		"zendframework/zend-stdlib": "self.version",
-		"zendframework/zend-json": "self.version",
-		"zendframework/zend-math": "self.version"
+        "zendframework/zend-stdlib": "self.version",
+        "zendframework/zend-json": "self.version",
+        "zendframework/zend-math": "self.version"
     }
 }

--- a/library/Zend/Session/composer.json
+++ b/library/Zend/Session/composer.json
@@ -13,7 +13,8 @@
     },
     "target-dir": "Zend/Session",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "zendframework/zend-stdlib": "self.version"
     },
     "suggest": {
         "zendframework/zend-validator": "Zend\\Validator component",

--- a/library/Zend/Tag/composer.json
+++ b/library/Zend/Tag/composer.json
@@ -14,6 +14,7 @@
     "target-dir": "Zend/Tag",
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-escaper": "self.version"
+        "zendframework/zend-escaper": "self.version",
+        "zendframework/zend-stdlib": "self.version"
     }
 }


### PR DESCRIPTION
Missing `zendframework/zend-stdlib` as requirement on components using it

PS: The only difference for 2.1 is that `Zend\Filter` already marked `zendframework/zend-stdlib` as a requirement - so it shouldn't conflict on merging to 2.1, too
