### PR TITLE
Zend\Mail SMTP Fix Connection Handling

### DIFF
--- a/library/Zend/Mail/Protocol/Smtp.php
+++ b/library/Zend/Mail/Protocol/Smtp.php
@@ -193,6 +193,15 @@ class Smtp extends AbstractProtocol
         $this->auth();
     }
 
+    /**
+     * Returns the perceived session status
+     *
+     * @return boolean
+     */
+    public function hasSession()
+    {
+        return $this->sess;
+    }
 
     /**
      * Send EHLO or HELO depending on capabilities of smtp host
@@ -367,6 +376,7 @@ class Smtp extends AbstractProtocol
      */
     public function disconnect()
     {
+        $this->quit();
         $this->_disconnect();
     }
 

--- a/tests/ZendTest/Mail/Protocol/SmtpTest.php
+++ b/tests/ZendTest/Mail/Protocol/SmtpTest.php
@@ -46,7 +46,7 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
             ->setBody('testSendMailWithoutMinimalHeaders')
             ->addTo('zf-devteam@zend.com', 'ZF DevTeam')
         ;
-        $expectedMessage = "RSET\r\n"
+        $expectedMessage = "EHLO localhost\r\n"
                            . "MAIL FROM:<ralph.schindler@zend.com>\r\n"
                            . "DATA\r\n"
                            . "Date: Sun, 10 Jun 2012 20:07:24 +0200\r\n"

--- a/tests/ZendTest/Mail/TestAsset/SmtpProtocolSpy.php
+++ b/tests/ZendTest/Mail/TestAsset/SmtpProtocolSpy.php
@@ -24,12 +24,17 @@ class SmtpProtocolSpy extends Smtp
     protected $connect = false;
     protected $mail;
     protected $rcptTest = array();
-    protected $sess = true;
 
     public function connect()
     {
         $this->connect = true;
         return true;
+    }
+
+    public function disconnect()
+    {
+        $this->connect = false;
+        parent::disconnect();
     }
 
     public function helo($serverName = '127.0.0.1')
@@ -39,13 +44,7 @@ class SmtpProtocolSpy extends Smtp
 
     public function quit()
     {
-        $this->rset();
-    }
-
-    public function disconnect()
-    {
-        $this->connect = false;
-        $this->rset();
+        parent::quit();
     }
 
     public function rset()

--- a/tests/ZendTest/Mail/Transport/SmtpTest.php
+++ b/tests/ZendTest/Mail/Transport/SmtpTest.php
@@ -157,7 +157,7 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
     {
         $this->connection->connect();
         unset($this->transport);
-        $this->assertFalse($this->connection->isConnected());
+        $this->assertFalse($this->connection->hasSession());
     }
 
     public function testAutoDisconnectFalse()
@@ -174,5 +174,17 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->connection->isConnected());
         $this->transport->disconnect();
         $this->assertFalse($this->connection->isConnected());
+    }
+
+    public function testDisconnectSendReconnects()
+    {
+        $this->assertFalse($this->connection->hasSession());
+        $this->transport->send($this->getMessage());
+        $this->assertTrue($this->connection->hasSession());
+        $this->connection->disconnect();
+
+        $this->assertFalse($this->connection->hasSession());
+        $this->transport->send($this->getMessage());
+        $this->assertTrue($this->connection->hasSession());
     }
 }


### PR DESCRIPTION
## Overview

Zend\Mail contains some issues for connection handling; generally most people will not run into this unless they utilize the SMTP transport in say a worker from a message queue.  Take the scenario of your worker runs out of work and disconnects from the SMTP server; if you go to send the mail again (without manually handling all connection semantics) it will fail.  Further, there is a bug where it attempts to lazily load the connection but if there is already a connection object it doesn't check the state.  
## Changes

_There are no BC breaks_

The unit test asset for the SMTP protocol spy was not in good shape itself; it did not properly call many methods that it was extending from.  A new method is in the Smtp protocol called hasSession which contains the variable from our start session and stop session code.

Additionally the Smtp transport now checks for the existence of the connection object and the new hasSession status.  The code has been slightly refactored to keep BC but also to keep code duplication down.
