### PR TITLE
Flash Messenger fixes for PHP < 5.4, and fix for default namespacing

### DIFF
--- a/library/Zend/View/Helper/FlashMessenger.php
+++ b/library/Zend/View/Helper/FlashMessenger.php
@@ -83,11 +83,13 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     }
 
     /**
+     * Render Messages
      *
-     *
-     * @param type $namespace
+     * @param  string $namespace
+     * @param  array  $classes
+     * @return string
      */
-    public function render($namespace = null, array $classes = array())
+    public function render($namespace = PluginFlashMessenger::NAMESPACE_DEFAULT, array $classes = array())
     {
         $flashMessenger = $this->getPluginFlashMessenger();
         $messages = $flashMessenger->getMessagesFromNamespace($namespace);
@@ -102,10 +104,14 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
         // Flatten message array
         $escapeHtml      = $this->getEscapeHtmlHelper();
         $messagesToPrint = array();
-        array_walk_recursive($messages, function($item) use (&$messagesToPrint, $escapeHtml) {
-            if (($translator = $this->getTranslator()) !== null) {
+
+        $translator = $this->getTranslator();
+        $translatorTextDomain = $this->getTranslatorTextDomain();
+
+        array_walk_recursive($messages, function($item) use (&$messagesToPrint, $escapeHtml, $translator, $translatorTextDomain) {
+            if ($translator !== null) {
                 $item = $translator->translate(
-                        $item, $this->getTranslatorTextDomain()
+                        $item, $translatorTextDomain
                 );
             }
             $messagesToPrint[] = $escapeHtml($item);

--- a/tests/ZendTest/View/Helper/FlashMessengerTest.php
+++ b/tests/ZendTest/View/Helper/FlashMessengerTest.php
@@ -116,6 +116,16 @@ class FlashMessengerTest extends TestCase
         $this->assertEquals($displayInfoAssertion, $displayInfo);
     }
 
+    public function testCanDisplayListOfMessagesByDefaultParameters()
+    {
+        $helper = $this->helper;
+        $this->seedMessages();
+
+        $displayInfoAssertion = '<ul class="default"><li>foo</li><li>bar</li></ul>';
+        $displayInfo = $helper()->render();
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
     public function testCanDisplayListOfMessagesByInvoke()
     {
         $helper = $this->helper;


### PR DESCRIPTION
## Overview

Flash Messenger view helper is broken for less than PHP 5.4; this is due to the use of a closure and utilize the variable $this.  The fix for that was to ensure that we could just use the variables.

Secondly when one attempts the utilize the view helper using the defaults much like you add a message inside of the controller

``` php
$this->plugin('flashMessenger')->addMessage('foo');
```

Then you should be able to get that value similarly in the view like:

``` php
$this->plugin('flashMessenger')->render();
```
