### PR TITLE
Zend\Db: Adapter construction features + IbmDb2 & Oracle Platform features

### DIFF
--- a/library/Zend/Db/Adapter/Platform/IbmDb2.php
+++ b/library/Zend/Db/Adapter/Platform/IbmDb2.php
@@ -11,6 +11,34 @@ namespace Zend\Db\Adapter\Platform;
 
 class IbmDb2 implements PlatformInterface
 {
+
+    /**
+     * @var bool
+     */
+    protected $quoteIdentifiers = true;
+
+    /**
+     * @var string
+     */
+    protected $identifierSeparator = '.';
+
+    /**
+     * @param array $options
+     */
+    public function __construct($options = array())
+    {
+        if (isset($options['quote_identifiers'])
+            && ($options['quote_identifiers'] == false
+            || $options['quote_identifiers'] === 'false'))
+        {
+            $this->quoteIdentifiers = false;
+        }
+
+        if (isset($options['identifier_separator'])) {
+            $this->identifierSeparator = $options['identifier_separator'];
+        }
+    }
+
     /**
      * Get name
      *
@@ -39,6 +67,9 @@ class IbmDb2 implements PlatformInterface
      */
     public function quoteIdentifier($identifier)
     {
+        if ($this->quoteIdentifiers === false) {
+            return $identifier;
+        }
         return '"' . str_replace('"', '\\' . '"', $identifier) . '"';
     }
 
@@ -50,9 +81,12 @@ class IbmDb2 implements PlatformInterface
      */
     public function quoteIdentifierChain($identifierChain)
     {
+        if ($this->quoteIdentifiers === false) {
+            return (is_array($identifierChain)) ? implode($this->identifierSeparator, $identifierChain) : $identifierChain;
+        }
         $identifierChain = str_replace('"', '\\"', $identifierChain);
         if (is_array($identifierChain)) {
-            $identifierChain = implode('"."', $identifierChain);
+            $identifierChain = implode('"' . $this->identifierSeparator . '"', $identifierChain);
         }
         return '"' . $identifierChain . '"';
     }
@@ -100,7 +134,7 @@ class IbmDb2 implements PlatformInterface
      */
     public function getIdentifierSeparator()
     {
-        return '.';
+        return $this->identifierSeparator;
     }
 
     /**
@@ -112,6 +146,9 @@ class IbmDb2 implements PlatformInterface
      */
     public function quoteIdentifierInFragment($identifier, array $safeWords = array())
     {
+        if ($this->quoteIdentifiers === false) {
+            return $identifier;
+        }
         $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
 
         foreach ($parts as $i => $part) {

--- a/library/Zend/Db/Adapter/Platform/Oracle.php
+++ b/library/Zend/Db/Adapter/Platform/Oracle.php
@@ -13,6 +13,24 @@ class Oracle implements PlatformInterface
 {
 
     /**
+     * @var bool
+     */
+    protected $quoteIdentifiers = true;
+
+    /**
+     * @param array $options
+     */
+    public function __construct($options = array())
+    {
+        if (isset($options['quote_identifiers'])
+            && ($options['quote_identifiers'] == false
+            || $options['quote_identifiers'] === 'false'))
+        {
+            $this->quoteIdentifiers = false;
+        }
+    }
+
+    /**
      * Get name
      *
      * @return string
@@ -40,6 +58,9 @@ class Oracle implements PlatformInterface
      */
     public function quoteIdentifier($identifier)
     {
+        if ($this->quoteIdentifiers === false) {
+            return $identifier;
+        }
         return '"' . str_replace('"', '\\' . '"', $identifier) . '"';
     }
 
@@ -51,6 +72,9 @@ class Oracle implements PlatformInterface
      */
     public function quoteIdentifierChain($identifierChain)
     {
+        if ($this->quoteIdentifiers === false) {
+            return (is_array($identifierChain)) ? implode('.', $identifierChain) : $identifierChain;
+        }
         $identifierChain = str_replace('"', '\\"', $identifierChain);
         if (is_array($identifierChain)) {
             $identifierChain = implode('"."', $identifierChain);
@@ -113,6 +137,9 @@ class Oracle implements PlatformInterface
      */
     public function quoteIdentifierInFragment($identifier, array $safeWords = array())
     {
+        if ($this->quoteIdentifiers === false) {
+            return $identifier;
+        }
         $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         foreach ($parts as $i => $part) {
             if ($safeWords && in_array($part, $safeWords)) {
@@ -128,7 +155,7 @@ class Oracle implements PlatformInterface
                 case 'as':
                     break;
                 default:
-                    $parts[$i] = strtoupper('"' . str_replace('"', '\\' . '"', $part) . '"');
+                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
             }
         }
         return implode('', $parts);

--- a/tests/ZendTest/Db/Adapter/AdapterTest.php
+++ b/tests/ZendTest/Db/Adapter/AdapterTest.php
@@ -54,9 +54,9 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @testdox unit test: Test createDriverFromParameters() will create proper driver type
-     * @covers Zend\Db\Adapter\Adapter::createDriverFromParameters
+     * @covers Zend\Db\Adapter\Adapter::createDriver
      */
-    public function testCreateDriverFromParameters()
+    public function testCreateDriver()
     {
         if (extension_loaded('mysqli')) {
             $adapter = new Adapter(array('driver' => 'mysqli'), $this->mockPlatform);
@@ -85,9 +85,9 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @testdox unit test: Test createPlatformFromDriver() will create proper platform from driver
-     * @covers Zend\Db\Adapter\Adapter::createPlatformFromDriver
+     * @covers Zend\Db\Adapter\Adapter::createPlatform
      */
-    public function testCreatePlatformFromDriver()
+    public function testCreatePlatform()
     {
         $driver = clone $this->mockDriver;
         $driver->expects($this->any())->method('getDatabasePlatformName')->will($this->returnValue('Mysql'));
@@ -114,11 +114,29 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         unset($adapter, $driver);
 
         $driver = clone $this->mockDriver;
+        $driver->expects($this->any())->method('getDatabasePlatformName')->will($this->returnValue('IbmDb2'));
+        $adapter = new Adapter($driver);
+        $this->assertInstanceOf('Zend\Db\Adapter\Platform\IbmDb2', $adapter->platform);
+        unset($adapter, $driver);
+
+        $driver = clone $this->mockDriver;
+        $driver->expects($this->any())->method('getDatabasePlatformName')->will($this->returnValue('Oracle'));
+        $adapter = new Adapter($driver);
+        $this->assertInstanceOf('Zend\Db\Adapter\Platform\Oracle', $adapter->platform);
+        unset($adapter, $driver);
+
+        $driver = clone $this->mockDriver;
         $driver->expects($this->any())->method('getDatabasePlatformName')->will($this->returnValue('Foo'));
         $adapter = new Adapter($driver);
         $this->assertInstanceOf('Zend\Db\Adapter\Platform\Sql92', $adapter->platform);
         unset($adapter, $driver);
 
+        // ensure platform can created via string, and also that it passed in options to platform object
+        $driver = array('driver' => 'pdo_sqlite', 'platform' => 'Oracle', 'platform_options' => array('quote_identifiers' => false));
+        $adapter = new Adapter($driver);
+        $this->assertInstanceOf('Zend\Db\Adapter\Platform\Oracle', $adapter->platform);
+        $this->assertEquals('foo', $adapter->getPlatform()->quoteIdentifier('foo'));
+        unset($adapter, $driver);
     }
 
 

--- a/tests/ZendTest/Db/Adapter/Platform/IbmDb2Test.php
+++ b/tests/ZendTest/Db/Adapter/Platform/IbmDb2Test.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Db
+ */
+
+namespace ZendTest\Db\Adapter\Platform;
+
+use Zend\Db\Adapter\Platform\IbmDb2;
+
+class IbmDb2Test extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var IbmDb2
+     */
+    protected $platform;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->platform = new IbmDb2;
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\IbmDb2::getName
+     */
+    public function testGetName()
+    {
+        $this->assertEquals('IBM DB2', $this->platform->getName());
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\IbmDb2::getQuoteIdentifierSymbol
+     */
+    public function testGetQuoteIdentifierSymbol()
+    {
+        $this->assertEquals('"', $this->platform->getQuoteIdentifierSymbol());
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\IbmDb2::quoteIdentifier
+     */
+    public function testQuoteIdentifier()
+    {
+        $this->assertEquals('"identifier"', $this->platform->quoteIdentifier('identifier'));
+
+        $platform = new IbmDb2(array('quote_identifiers' => false));
+        $this->assertEquals('identifier', $platform->quoteIdentifier('identifier'));
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\IbmDb2::quoteIdentifierChain
+     */
+    public function testQuoteIdentifierChain()
+    {
+        $this->assertEquals('"identifier"', $this->platform->quoteIdentifierChain('identifier'));
+        $this->assertEquals('"identifier"', $this->platform->quoteIdentifierChain(array('identifier')));
+        $this->assertEquals('"schema"."identifier"', $this->platform->quoteIdentifierChain(array('schema','identifier')));
+
+        $platform = new IbmDb2(array('quote_identifiers' => false));
+        $this->assertEquals('identifier', $platform->quoteIdentifierChain('identifier'));
+        $this->assertEquals('identifier', $platform->quoteIdentifierChain(array('identifier')));
+        $this->assertEquals('schema.identifier', $platform->quoteIdentifierChain(array('schema','identifier')));
+
+        $platform = new IbmDb2(array('identifier_separator' => '\\'));
+        $this->assertEquals('"schema"\"identifier"', $platform->quoteIdentifierChain(array('schema','identifier')));
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\IbmDb2::getQuoteValueSymbol
+     */
+    public function testGetQuoteValueSymbol()
+    {
+        $this->assertEquals("'", $this->platform->getQuoteValueSymbol());
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\IbmDb2::quoteValue
+     */
+    public function testQuoteValue()
+    {
+        $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\IbmDb2::quoteValueList
+     */
+    public function testQuoteValueList()
+    {
+        $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList("Foo O'Bar"));
+        $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList(array("Foo O'Bar")));
+        $this->assertEquals("'value', 'Foo O\\'Bar'", $this->platform->quoteValueList(array('value',"Foo O'Bar")));
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\IbmDb2::getIdentifierSeparator
+     */
+    public function testGetIdentifierSeparator()
+    {
+        $this->assertEquals('.', $this->platform->getIdentifierSeparator());
+
+        $platform = new IbmDb2(array('identifier_separator' => '\\'));
+        $this->assertEquals('\\', $platform->getIdentifierSeparator());
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\IbmDb2::quoteIdentifierInFragment
+     */
+    public function testQuoteIdentifierInFragment()
+    {
+        $this->assertEquals('"foo"."bar"', $this->platform->quoteIdentifierInFragment('foo.bar'));
+        $this->assertEquals('"foo" as "bar"', $this->platform->quoteIdentifierInFragment('foo as bar'));
+
+        $platform = new IbmDb2(array('quote_identifiers' => false));
+        $this->assertEquals('foo.bar', $platform->quoteIdentifierInFragment('foo.bar'));
+        $this->assertEquals('foo as bar', $platform->quoteIdentifierInFragment('foo as bar'));
+    }
+
+    /**
+     * @group ZF2-386
+     * @covers Zend\Db\Adapter\Platform\IbmDb2::quoteIdentifierInFragment
+     */
+    public function testQuoteIdentifierInFragmentIgnoresSingleCharSafeWords()
+    {
+        $this->assertEquals('("foo"."bar" = "boo"."baz")', $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz)', array('(', ')', '=')));
+    }
+
+}

--- a/tests/ZendTest/Db/Adapter/Platform/OracleTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/OracleTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Db
+ */
+
+namespace ZendTest\Db\Adapter\Platform;
+
+use Zend\Db\Adapter\Platform\Oracle;
+
+class OracleTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Oracle
+     */
+    protected $platform;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->platform = new Oracle;
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\Oracle::getName
+     */
+    public function testGetName()
+    {
+        $this->assertEquals('Oracle', $this->platform->getName());
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\Oracle::getQuoteIdentifierSymbol
+     */
+    public function testGetQuoteIdentifierSymbol()
+    {
+        $this->assertEquals('"', $this->platform->getQuoteIdentifierSymbol());
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\Oracle::quoteIdentifier
+     */
+    public function testQuoteIdentifier()
+    {
+        $this->assertEquals('"identifier"', $this->platform->quoteIdentifier('identifier'));
+
+        $platform = new Oracle(array('quote_identifiers' => false));
+        $this->assertEquals('identifier', $platform->quoteIdentifier('identifier'));
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\Oracle::quoteIdentifierChain
+     */
+    public function testQuoteIdentifierChain()
+    {
+        $this->assertEquals('"identifier"', $this->platform->quoteIdentifierChain('identifier'));
+        $this->assertEquals('"identifier"', $this->platform->quoteIdentifierChain(array('identifier')));
+        $this->assertEquals('"schema"."identifier"', $this->platform->quoteIdentifierChain(array('schema','identifier')));
+
+        $platform = new Oracle(array('quote_identifiers' => false));
+        $this->assertEquals('identifier', $platform->quoteIdentifierChain('identifier'));
+        $this->assertEquals('identifier', $platform->quoteIdentifierChain(array('identifier')));
+        $this->assertEquals('schema.identifier', $platform->quoteIdentifierChain(array('schema','identifier')));
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\Oracle::getQuoteValueSymbol
+     */
+    public function testGetQuoteValueSymbol()
+    {
+        $this->assertEquals("'", $this->platform->getQuoteValueSymbol());
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\Oracle::quoteValue
+     */
+    public function testQuoteValue()
+    {
+        $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\Oracle::quoteValueList
+     */
+    public function testQuoteValueList()
+    {
+        $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList("Foo O'Bar"));
+        $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList(array("Foo O'Bar")));
+        $this->assertEquals("'value', 'Foo O\\'Bar'", $this->platform->quoteValueList(array('value',"Foo O'Bar")));
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\Oracle::getIdentifierSeparator
+     */
+    public function testGetIdentifierSeparator()
+    {
+        $this->assertEquals('.', $this->platform->getIdentifierSeparator());
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\Oracle::quoteIdentifierInFragment
+     */
+    public function testQuoteIdentifierInFragment()
+    {
+        $this->assertEquals('"foo"."bar"', $this->platform->quoteIdentifierInFragment('foo.bar'));
+        $this->assertEquals('"foo" as "bar"', $this->platform->quoteIdentifierInFragment('foo as bar'));
+
+        $platform = new Oracle(array('quote_identifiers' => false));
+        $this->assertEquals('foo.bar', $platform->quoteIdentifierInFragment('foo.bar'));
+        $this->assertEquals('foo as bar', $platform->quoteIdentifierInFragment('foo as bar'));
+    }
+
+    /**
+     * @group ZF2-386
+     * @covers Zend\Db\Adapter\Platform\Oracle::quoteIdentifierInFragment
+     */
+    public function testQuoteIdentifierInFragmentIgnoresSingleCharSafeWords()
+    {
+        $this->assertEquals('("foo"."bar" = "boo"."baz")', $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz)', array('(', ')', '=')));
+    }
+
+}


### PR DESCRIPTION
- Added platform_options to Adapter for passing onto Platform objects
- Added ability to not-quote identifiers in IbmDb2 and Oracle
- Fixed automatic uppercasing in fragment quoting of Oracle Platform
- Added Tests for platform objects
- Deprecated the createDriverFromParameters() and createPlatformFormDriver methods
