### PR TITLE
Correctly parse empty Subject header

### DIFF
--- a/library/Zend/Mail/Header/Subject.php
+++ b/library/Zend/Mail/Header/Subject.php
@@ -32,7 +32,8 @@ class Subject implements UnstructuredInterface
     public static function fromString($headerLine)
     {
         $decodedLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-        list($name, $value) = explode(': ', $decodedLine, 2);
+        list($name, $value) = explode(':', $decodedLine, 2);
+        $value = ltrim($value);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'subject') {


### PR DESCRIPTION
Without this fix parsing an email with an empty subject header "Subject:" (no whitespace after the colon) fails.

```
Notice: Undefined offset: 1 in library/Zend/Mail/Header/Subject.php on line 35

Fatal error: Uncaught exception 'Zend\Mail\Header\Exception\InvalidArgumentException' with message 'Invalid header line for Subject string' in library/Zend/Mail/Header/Subject.php:39
Stack trace:
#0 library/Zend/Mail/Headers.php(453): Zend\Mail\Header\Subject::fromString('Subject: ')
#1 library/Zend/Mail/Headers.php(288): Zend\Mail\Headers->lazyLoadHeader(10)
#2 library/Zend/Mail/Storage/Part.php(297): Zend\Mail\Headers->get('Subject')
#3 library/Zend/Mail/Storage/Part.php(372): Zend\Mail\Storage\Part->getHeader('Subject', 'string')
#4 mail-bouncer.php(14): Zend\Mail\Storage\Part->__get('Subject')
```
