### PR TITLE
Allow to add serializers through config

### DIFF
--- a/library/Zend/ModuleManager/Feature/SerializerProviderInterface.php
+++ b/library/Zend/ModuleManager/Feature/SerializerProviderInterface.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ModuleManager\Feature;
+
+interface SerializerProviderInterface
+{
+    /**
+     * @return array
+     */
+    public function getSerializerConfig();
+}

--- a/library/Zend/Mvc/Service/SerializerAdapterPluginManagerFactory.php
+++ b/library/Zend/Mvc/Service/SerializerAdapterPluginManagerFactory.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Service;
+
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class SerializerAdapterPluginManagerFactory extends AbstractPluginManagerFactory
+{
+    const PLUGIN_MANAGER_CLASS = 'Zend\Serializer\AdapterPluginManager';
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        /** @var $serviceListener \Zend\ModuleManager\Listener\ServiceListener */
+        $serviceListener = $serviceLocator->get('ServiceListener');
+
+        // This will allow to register new serializers easily, either by implementing the SerializerProviderInterface
+        // in your Module.php file, or by adding the "serializers" key in your module.config.php file
+        $serviceListener->addServiceManager(
+            $serviceLocator,
+            'serializers',
+            'Zend\ModuleManager\Feature\SerializerProviderInterface',
+            'getSerializerConfig'
+        );
+
+        return parent::createService($serviceLocator);
+    }
+}


### PR DESCRIPTION
This allow to add serializers to the SerializerAdapter plugin manager the same way as many other ZF 2 components. Basically, you can either implement SerializerProviderInterface in your module class, or adding the serializers key in your config array.

@weierophinney > Could you merge this for 2.1 plz ? Btw, in this PR I've done what I told you about previous time (moving the service listener stuff into the own manager factory). If it's ok for you I'll do this for all others plugin managers once ZF 2.1 is out.
