### PR TITLE
canCreate unproper behavior in ServiceManager?

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -499,6 +499,11 @@ class ServiceManager implements ServiceLocatorInterface
             $cName = $this->canonicalizeName($rName);
         }
 
+        if ($this->hasAlias($cName)) {
+            do {
+                $cName = $this->aliases[$cName];
+            } while ($this->hasAlias($cName));
+        }
 
         if (isset($this->factories[$cName])) {
             $instance = $this->createFromFactory($cName, $rName);

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -549,11 +549,15 @@ class ServiceManager implements ServiceLocatorInterface
             $cName = $this->canonicalizeName($rName);
         }
 
+        if ($this->hasAlias($cName)) {
+            do {
+                $cName = $this->aliases[$cName];
+            } while ($this->hasAlias($cName));
+        }
+
         if (
             isset($this->invokableClasses[$cName])
             || isset($this->factories[$cName])
-            || isset($this->aliases[$cName])
-            || isset($this->instances[$cName])
         ) {
             return true;
         }
@@ -578,6 +582,13 @@ class ServiceManager implements ServiceLocatorInterface
         } else {
             $rName = $name;
             $cName = $this->canonicalizeName($rName);
+        }
+
+        if(
+           isset($this->instances[$cName])
+           || isset($this->aliases[$cName])
+        ) {
+            return true;
         }
 
         if ($this->canCreate(array($cName, $rName), $checkAbstractFactories)) {

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -903,7 +903,7 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($this->serviceManager->has($aFoo));
 
-        return array($this->serviceManager,$nFoo, $foo_returns);
+        return array($this->serviceManager,$aFoo, $foo_returns);
     }
 
     /**

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -806,4 +806,152 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $serviceManagerParent->setAlias($foo1, $boo2);
         $this->assertTrue($serviceManagerParent->hasAlias($foo1));
     }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::setService
+     * @covers Zend\ServiceManager\ServiceManager::canCreate
+     * @covers Zend\ServiceManager\ServiceManager::getRegisteredServices
+     * @covers Zend\ServiceManager\ServiceManager::has
+     */
+    public function testCanCreateMethodShouldNotCheckInstanceContainerForServiceCreation()
+    {
+        $nFoo   = "service1";
+        $foo    = new \stdClass();
+        $instances_container_key = 'instances';
+
+        $this->assertFalse($this->serviceManager->canCreate($nFoo));
+
+        $this->serviceManager->setService($nFoo, $foo);
+
+        $services_list = $this->serviceManager->getRegisteredServices();
+        $this->assertEquals($services_list[$instances_container_key][0], $nFoo);
+
+        $this->assertFalse($this->serviceManager->canCreate($nFoo));
+
+        $this->assertTrue($this->serviceManager->has($nFoo));
+
+        return array($this->serviceManager,$nFoo);
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::create
+     * @expectedException \Zend\ServiceManager\Exception\ServiceNotFoundException
+     * @depends testCanCreateMethodShouldNotCheckInstanceContainerForServiceCreation
+     */
+    public function testCreateMethodWillThrowExceptionBecauseInstanceIsNotForCreation(Array $values)
+    {
+        $this->serviceManager   = $values[0];
+        $nFoo                   = $values[1];
+
+        $this->serviceManager->create($nFoo);
+    }
+
+    public function testCanCreateMethodReturnsFalseIfPassedAliasPointsToValueWithinInstanceContainer()
+    {
+        $nFoo   = "service1";
+        $aFoo   = "AliasToService1";
+        $foo    = new \stdClass();
+        $instances_container_key = 'instances';
+
+        $this->assertFalse($this->serviceManager->canCreate($nFoo));
+
+        $this->serviceManager->setService($nFoo, $foo);
+
+        $services_list = $this->serviceManager->getRegisteredServices();
+        $this->assertEquals($services_list[$instances_container_key][0], $nFoo);
+
+        $this->assertTrue($this->serviceManager->setAlias($aFoo, $nFoo)->hasAlias($aFoo));
+
+        $this->assertFalse($this->serviceManager->canCreate($aFoo));
+
+        $this->assertTrue($this->serviceManager->has($aFoo));
+
+        return array($this->serviceManager,$nFoo);
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::create
+     * @expectedException \Zend\ServiceManager\Exception\ServiceNotFoundException
+     * @depends testCanCreateMethodReturnsFalseIfPassedAliasPointsToValueWithinInstanceContainer
+     */
+    public function testCreateMethodWillThrowExceptionBecauseAliasPointsOnInstanceWhichIsNotForCreation(Array $values)
+    {
+        $this->serviceManager   = $values[0];
+        $nFoo                   = $values[1];
+
+        $this->serviceManager->create($nFoo);
+    }
+
+    public function testCanCreateMethodReturnsTrueIfPassedAliasPointsToFactoryContainer()
+    {
+        $nFoo   = "service1";
+        $aFoo   = "AliasToService1";
+        $foo    = "ZendTest\ServiceManager\TestAsset\FooFactory";
+        $foo_returns = "ZendTest\ServiceManager\TestAsset\Foo";
+        $instances_container_key = 'factories';
+
+        $this->assertFalse($this->serviceManager->canCreate($nFoo));
+
+        $this->serviceManager->setFactory($nFoo, $foo);
+
+        $services_list = $this->serviceManager->getRegisteredServices();
+        $this->assertEquals($services_list[$instances_container_key][0], $nFoo);
+
+        $this->assertTrue($this->serviceManager->setAlias($aFoo, $nFoo)->hasAlias($aFoo));
+
+        $this->assertTrue($this->serviceManager->canCreate($aFoo));
+
+        $this->assertTrue($this->serviceManager->has($aFoo));
+
+        return array($this->serviceManager,$nFoo, $foo_returns);
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::create
+     * @depends testCanCreateMethodReturnsTrueIfPassedAliasPointsToFactoryContainer
+     */
+    public function testCreateMethodWillCreateInstanceOfFactory(Array $values)
+    {
+        $this->serviceManager   = $values[0];
+        $nFoo                   = $values[1];
+        $foo_returns            = $values[2];
+
+        $this->assertInstanceOf($foo_returns, $this->serviceManager->create($nFoo));
+    }
+
+    public function testCanCreateMethodReturnsTrueIfPassedAliasPointsToInvokableContainer()
+    {
+        $nFoo   = "service1";
+        $aFoo   = "AliasToService1";
+        $foo    = "ZendTest\ServiceManager\TestAsset\Foo";
+        $instances_container_key = 'invokableClasses';
+
+        $this->assertFalse($this->serviceManager->canCreate($nFoo));
+
+        $this->serviceManager->setInvokableClass($nFoo, $foo);
+
+        $services_list = $this->serviceManager->getRegisteredServices();
+        $this->assertEquals($services_list[$instances_container_key][0], $nFoo);
+
+        $this->assertTrue($this->serviceManager->setAlias($aFoo, $nFoo)->hasAlias($aFoo));
+
+        $this->assertTrue($this->serviceManager->canCreate($aFoo));
+
+        $this->assertTrue($this->serviceManager->has($aFoo));
+
+        return array($this->serviceManager,$nFoo, $foo);
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::create
+     * @depends testCanCreateMethodReturnsTrueIfPassedAliasPointsToInvokableContainer
+     */
+    public function testCreateMethodWillCreateInstanceOfInvokableClass(Array $values)
+    {
+        $this->serviceManager   = $values[0];
+        $nFoo                   = $values[1];
+        $foo                    = $values[2];
+
+        $this->assertInstanceOf($foo, $this->serviceManager->create($nFoo));
+    }
 }


### PR DESCRIPTION
canCreate() method I understand as a helper for create() method, before to create a service, I have to be sure that I can create one. canCreate() method,also looks for service inside both $aliases and $instances containers. This behavior is a little bit misleading as $instances used for services, that already created or not instances at all, or instances that passed to SM straightforward; and aliases they are aliases you never know what behind the scene. So if I would do:

$this->setService($foo, $bar);
$this->canCreate($foo); //will get true
$this->create($foo); //I expect $bar, but will get Exception.

$this->setAlias($foo, $bar);
$this->canCreate($foo); //will get true
$this->create($foo); //I expect $bar, but will get Exception.

To resolve this I would suggest following changes:
1. Do not include $instances and $aliases containers within canCreate() method, it only will check in those containers in which it will be able to create a new instance ($invokableClasses, $factories and $abstract_factories).
2. If Alias was passed to canCreate(), resolve alias and than perform checks.
3. Move $instances and $aliases checks into has() method before canCreate().

In this way, I presume checks will have semantics and single responsibility. Code attached. The only backward incompatibility after this check will be for people that uses SM in this way:

$this->setService($foo, $bar);
$this->canCreate($foo); //after attached changes will return false, use has() instead.
