### PR TITLE
Bug: EventManager class, attachAggregatemethod expects second parameter to be $priority.

### DIFF
--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -274,7 +274,7 @@ class EventManager implements EventManagerInterface
     {
         // Proxy ListenerAggregateInterface arguments to attachAggregate()
         if ($event instanceof ListenerAggregateInterface) {
-            return $this->attachAggregate($event, $callback);
+            return $this->attachAggregate($event, $priority);
         }
 
         // Null callback is invalid


### PR DESCRIPTION
If $event to attach() method was passed as instance of ListenerAggregateInterface, it will be passed to:

$this->attachAggregate($event, $callback); //where second parameter $callback.

But function reads second parameter to be $priority:

public function attachAggregate(ListenerAggregateInterface $aggregate, $priority = 1)

Fix attached.
