### PR TITLE
[2.1] Fixed an issue on salt check in Apache Password

### DIFF
--- a/library/Zend/Crypt/Password/Apache.php
+++ b/library/Zend/Crypt/Password/Apache.php
@@ -256,7 +256,7 @@ class Apache implements PasswordInterface
                 );
             }
             for ($i = 0; $i < 8; $i++) {
-                if (strpos(self::ALPHA64, $password[$i]) === false) {
+                if (strpos(self::ALPHA64, $salt[$i]) === false) {
                     throw new Exception\InvalidArgumentException(
                         'The salt value must be a string in the alphabet "./0-9A-Za-z"'
                     );


### PR DESCRIPTION
Fixed the salt check for the APR1 MD5 algorithm in Zend\Crypt\Password\Apache.
