### PR TITLE
Zend\Db Fix for #3290

### DIFF
--- a/library/Zend/Db/Adapter/Platform/Mysql.php
+++ b/library/Zend/Db/Adapter/Platform/Mysql.php
@@ -113,7 +113,8 @@ class Mysql implements PlatformInterface
      */
     public function quoteIdentifierInFragment($identifier, array $safeWords = array())
     {
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        // regex taken from @link http://dev.mysql.com/doc/refman/5.0/en/identifiers.html
+        $parts = preg_split('#([^0-9,a-z,A-Z$_])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         foreach ($parts as $i => $part) {
             if ($safeWords && in_array($part, $safeWords)) {
                 continue;

--- a/tests/ZendTest/Db/Adapter/Platform/MysqlTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/MysqlTest.php
@@ -108,6 +108,7 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('`foo`.`bar`', $this->platform->quoteIdentifierInFragment('foo.bar'));
         $this->assertEquals('`foo` as `bar`', $this->platform->quoteIdentifierInFragment('foo as bar'));
+        $this->assertEquals('`$TableName`.`bar`', $this->platform->quoteIdentifierInFragment('$TableName.bar'));
     }
 
     /**


### PR DESCRIPTION
Zend\Db\Adapter\Platform\Mysql should have wider rage of possible identifiers in fragment quoting.
See #3290
