### PR TITLE
[2.1] Added the Apache htpasswd support for HTTP Authentication

### DIFF
--- a/library/Zend/Authentication/Adapter/Http/ApacheResolver.php
+++ b/library/Zend/Authentication/Adapter/Http/ApacheResolver.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Authentication\Adapter\Http;
+
+use Zend\Crypt\Password\Apache as ApachePassword;
+use Zend\Stdlib\ErrorHandler;
+use Zend\Authentication\Result as AuthResult;
+
+/**
+ * Apache Authentication Resolver
+ *
+ * @see http://httpd.apache.org/docs/2.2/misc/password_encryptions.html
+ */
+class ApacheResolver implements ResolverInterface
+{
+    /**
+     * Path to credentials file
+     *
+     * @var string
+     */
+    protected $file;
+
+    /**
+     * Apache password object
+     *
+     * @var ApachePassword
+     */
+    protected $apachePassword;
+
+    /**
+     * Constructor
+     *
+     * @param  string $path Complete filename where the credentials are stored
+     */
+    public function __construct($path = '')
+    {
+        if (!empty($path)) {
+            $this->setFile($path);
+        }
+    }
+
+    /**
+     * Set the path to the credentials file
+     *
+     * @param  string $path
+     * @return FileResolver Provides a fluent interface
+     * @throws Exception\InvalidArgumentException if path is not readable
+     */
+    public function setFile($path)
+    {
+        if (empty($path) || !is_readable($path)) {
+            throw new Exception\InvalidArgumentException('Path not readable: ' . $path);
+        }
+        $this->file = $path;
+
+        return $this;
+    }
+
+    /**
+     * Returns the path to the credentials file
+     *
+     * @return string
+     */
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    /**
+     * Returns the Apache Password object
+     *
+     * @return ApachePassword
+     */
+    protected function getApachePassword()
+    {
+        if (empty($this->apachePassword)) {
+            $this->apachePassword = new ApachePassword();
+        }
+        return $this->apachePassword;
+    }
+
+    /**
+     * Resolve credentials
+     *
+     *
+     *
+     * @param  string $username Username
+     * @param  string $realm    Authentication Realm
+     * @param  string $password The password to authenticate
+     * @return AuthResult
+     * @throws Exception\ExceptionInterface
+     */
+    public function resolve($username, $realm, $password = null)
+    {
+        if (empty($username)) {
+            throw new Exception\InvalidArgumentException('Username is required');
+        } elseif (!ctype_print($username) || strpos($username, ':') !== false) {
+            throw new Exception\InvalidArgumentException('Username must consist only of printable characters, '
+                                                              . 'excluding the colon');
+        }
+        if (!empty($realm) && (!ctype_print($realm) || strpos($realm, ':') !== false)) {
+            throw new Exception\InvalidArgumentException('Realm must consist only of printable characters, '
+                                                              . 'excluding the colon.');
+        }
+        if (empty($password)) {
+            throw new Exception\InvalidArgumentException('Password is required');
+        }
+        // Open file, read through looking for matching credentials
+        ErrorHandler::start(E_WARNING);
+        $fp     = fopen($this->file, 'r');
+        $error = ErrorHandler::stop();
+        if (!$fp) {
+            throw new Exception\RuntimeException('Unable to open password file: ' . $this->file, 0, $error);
+        }
+
+        // No real validation is done on the contents of the password file. The
+        // assumption is that we trust the administrators to keep it secure.
+        while (($line = fgetcsv($fp, 512, ':')) !== false) {
+            if ($line[0] == $username) {
+                if (isset($line[2])) {
+                    if ($line[1] == $realm) {
+                        $matchedHash = $line[2];
+                        break;
+                    }
+                } else {
+                    $matchedHash = $line[1];
+                    break;
+                }
+            }
+        }
+        fclose($fp);
+
+        if (!isset($matchedHash)) {
+            return new AuthResult(AuthResult::FAILURE_IDENTITY_NOT_FOUND, null, array('Username not found in provided htpasswd file'));
+        }
+
+        // Plaintext password
+        if ($matchedHash === $password) {
+            return new AuthResult(AuthResult::SUCCESS, $username);
+        }
+
+        $apache = $this->getApachePassword();
+        $apache->setUserName($username);
+        if (!empty($realm)) {
+            $apache->setAuthName($realm);
+        }
+
+        if ($apache->verify($password, $matchedHash)) {
+            return new AuthResult(AuthResult::SUCCESS, $username);
+        } else {
+            return new AuthResult(AuthResult::FAILURE_CREDENTIAL_INVALID, null, array('Passwords did not match.'));
+        }
+    }
+}

--- a/tests/ZendTest/Authentication/Adapter/Http/ApacheResolverTest.php
+++ b/tests/ZendTest/Authentication/Adapter/Http/ApacheResolverTest.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Authentication
+ */
+
+namespace ZendTest\Authentication\Adapter\Http;
+
+use Zend\Authentication\Adapter\Http\ApacheResolver as Apache;
+use Zend\Authentication\Result as AuthResult;
+
+/**
+ * @category   Zend
+ * @package    Zend_Auth
+ * @subpackage UnitTests
+ * @group      Zend_Auth
+ */
+class ApacheTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Path to test files
+     *
+     * @var string
+     */
+    protected $_filesPath;
+
+    /**
+     * Path to a valid file
+     *
+     * @var string
+     */
+    protected $_validPath;
+
+    /**
+     * Invalid path; does not exist
+     *
+     * @var string
+     */
+    protected $_badPath;
+
+    /**
+     * Resolver instance
+     *
+     * @var Zend_Auth_Adapter_Http_Resolver_File
+     */
+    protected $_resolver;
+
+    /**
+     * Sets the paths to files used in this test, and creates a shared resolver instance
+     * having a valid path.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->_path      = __DIR__ . '/TestAsset';
+        $this->_validPath = $this->_path . '/htbasic.plaintext';
+        $this->_digest    = $this->_path . '/htdigest';
+        $this->_apache    = new Apache($this->_validPath);
+        $this->_badPath   = 'invalid path';
+    }
+
+    /**
+     * Ensures that setFile() works as expected for valid input
+     *
+     * @return void
+     */
+    public function testSetFileValid()
+    {
+        $this->_apache->setFile($this->_validPath);
+        $this->assertEquals($this->_validPath, $this->_apache->getFile());
+    }
+
+    /**
+     * Ensures that setFile() works as expected for invalid input
+     *
+     * @return void
+     */
+    public function testSetFileInvalid()
+    {
+        $this->setExpectedException('Zend\\Authentication\\Adapter\\Http\\Exception\\ExceptionInterface', 'Path not readable');
+        $this->_apache->setFile($this->_badPath);
+    }
+
+    /**
+     * Ensures that __construct() works as expected for valid input
+     *
+     * @return void
+     */
+    public function testConstructValid()
+    {
+        $apache = new Apache($this->_validPath);
+        $this->assertEquals($this->_validPath, $apache->getFile());
+    }
+
+    /**
+     * Ensures that __construct() works as expected for invalid input
+     *
+     * @return void
+     */
+    public function testConstructInvalid()
+    {
+        $this->setExpectedException('Zend\\Authentication\\Adapter\\Http\\Exception\\ExceptionInterface', 'Path not readable');
+        $apache = new Apache($this->_badPath);
+    }
+
+    /**
+     *
+     */
+    public function providePasswordFiles()
+    {
+        $path = __DIR__ . '/TestAsset';
+        return array(
+            array( $path . '/htbasic.plaintext' ),
+            array( $path . '/htbasic.md5' ),
+            array( $path . '/htbasic.sha1' ),
+            array( $path . '/htbasic.crypt' )
+        );
+    }
+
+    /**
+     * Ensure that resolve() works fine with the specified password format
+     *
+     * @dataProvider providePasswordFiles
+     */
+    public function testResolveValidBasic($file)
+    {
+        $this->_apache->setFile($file);
+        $result = $this->_apache->resolve('test', null, 'password');
+        $this->assertTrue($result instanceof AuthResult);
+        $this->assertTrue($result->isValid());
+    }
+
+    /**
+     * Ensure that resolve() works fine with the specified password format
+     * even if we pass a realm fake string for a basic authentication
+     *
+     * @dataProvider providePasswordFiles
+     */
+    public function testResolveValidBasicWithRealm($file)
+    {
+        $this->_apache->setFile($file);
+        $result = $this->_apache->resolve('test', 'realm', 'password');
+        $this->assertTrue($result instanceof AuthResult);
+        $this->assertTrue($result->isValid());
+    }
+
+    /**
+     * Ensure that resolve() failed for not valid users
+     *
+     * @dataProvider providePasswordFiles
+     */
+    public function testResolveNoUsers($file)
+    {
+        $this->_apache->setFile($file);
+        $result = $this->_apache->resolve('foo', null, 'password');
+        $this->assertTrue($result instanceof AuthResult);
+        $this->assertFalse($result->isValid());
+    }
+
+        /**
+     * Ensure that resolve() failed for not valid password
+     *
+     * @dataProvider providePasswordFiles
+     */
+    public function testResolveNoValidPassword($file)
+    {
+        $this->_apache->setFile($file);
+        $result = $this->_apache->resolve('test', null, 'bar');
+        $this->assertTrue($result instanceof AuthResult);
+        $this->assertFalse($result->isValid());
+    }
+
+    /**
+     *  Ensure that resolve() works fine with the digest password format
+     */
+    public function testResolveValidDigest()
+    {
+        $this->_apache->setFile($this->_digest);
+        $result = $this->_apache->resolve('test', 'auth', 'password');
+        $this->assertTrue($result instanceof AuthResult);
+        $this->assertTrue($result->isValid());
+    }
+}

--- a/tests/ZendTest/Authentication/Adapter/Http/TestAsset/htbasic.crypt
+++ b/tests/ZendTest/Authentication/Adapter/Http/TestAsset/htbasic.crypt
@@ -1,0 +1,1 @@
+test:SjPCVdR9pFLD6

--- a/tests/ZendTest/Authentication/Adapter/Http/TestAsset/htbasic.md5
+++ b/tests/ZendTest/Authentication/Adapter/Http/TestAsset/htbasic.md5
@@ -1,0 +1,1 @@
+test:$apr1$a.MCgxT6$pqOaHg34Cz4igEf9U128w0

--- a/tests/ZendTest/Authentication/Adapter/Http/TestAsset/htbasic.plaintext
+++ b/tests/ZendTest/Authentication/Adapter/Http/TestAsset/htbasic.plaintext
@@ -1,0 +1,1 @@
+test:password

--- a/tests/ZendTest/Authentication/Adapter/Http/TestAsset/htbasic.sha1
+++ b/tests/ZendTest/Authentication/Adapter/Http/TestAsset/htbasic.sha1
@@ -1,0 +1,1 @@
+test:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=

--- a/tests/ZendTest/Authentication/Adapter/Http/TestAsset/htdigest
+++ b/tests/ZendTest/Authentication/Adapter/Http/TestAsset/htdigest
@@ -1,0 +1,1 @@
+test:auth:d7409a25bfd8bb8ad87de5f4888398de


### PR DESCRIPTION
Added the Zend\Authentication\Adapter\Http\ApacheResolver component that supports the htpasswd format for authentication. The ApacheResolver uses the new Zend\Crypt\Password\Apache class to encrypt and check the passwords according with the htpasswd format.
For more detail: http://httpd.apache.org/docs/2.2/misc/password_encryptions.html
