### PR TITLE
Zend\Db Fix/Feature for #3294

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -629,12 +629,25 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         $joinSpecArgArray = array();
         foreach ($this->joins as $j => $join) {
             $joinSpecArgArray[$j] = array();
+
             // type
             $joinSpecArgArray[$j][] = strtoupper($join['type']);
+
             // table name
-            $joinSpecArgArray[$j][] = (is_array($join['name']))
-                ? $platform->quoteIdentifier(current($join['name'])) . ' AS ' . $platform->quoteIdentifier(key($join['name']))
-                : $platform->quoteIdentifier($join['name']);
+            if (is_array($join['name'])) {
+                $joinName = current($join['name']);
+                $joinAs = $platform->quoteIdentifier(key($join['name']));
+            } else {
+                $joinName = $join['name'];
+            }
+            if ($joinName instanceof TableIdentifier) {
+                $joinName = $joinName->getTableAndSchema();
+                $joinName = $platform->quoteIdentifier($joinName[1]) . $platform->getIdentifierSeparator() . $platform->quoteIdentifier($joinName[0]);
+            } else {
+                $joinName = $platform->quoteIdentifier($joinName);
+            }
+            $joinSpecArgArray[$j][] = (isset($joinAs)) ? $joinName . ' AS ' . $joinAs : $joinName;
+
             // on expression
             // note: for Expression objects, pass them to processExpression with a prefix specific to each join (used for named parameters)
             $joinSpecArgArray[$j][] = ($join['on'] instanceof ExpressionInterface)

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -924,6 +924,17 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             'processSelect' => array(array(array('"bar"', '"bar"')), '"foo"')
         );
 
+        // @link https://github.com/zendframework/zf2/issues/3294
+        // Test TableIdentifier In Joins
+        $select38 = new Select;
+        $select38->from('foo')->columns(array())->join(new TableIdentifier('bar', 'baz'), 'm = n', array('thecount' => new Expression("COUNT(*)")));
+        $sqlPrep38 = // same
+        $sqlStr38 = 'SELECT COUNT(*) AS "thecount" FROM "foo" INNER JOIN "baz"."bar" ON "m" = "n"';
+        $internalTests38 = array(
+            'processSelect' => array(array(array('COUNT(*)', '"thecount"')), '"foo"'),
+            'processJoins'   => array(array(array('INNER', '"baz"."bar"', '"m" = "n"')))
+        );
+
         /**
          * $select = the select object
          * $sqlPrep = the sql as a result of preparation
@@ -972,6 +983,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             array($select35, $sqlPrep35, array(),    $sqlStr35, $internalTests35),
             array($select36, $sqlPrep36, array(),    $sqlStr36, $internalTests36,  $useNamedParams36),
             array($select37, $sqlPrep37, array(),    $sqlStr37, $internalTests37),
+            array($select38, $sqlPrep38, array(),    $sqlStr38, $internalTests38),
         );
     }
 }


### PR DESCRIPTION
Allow TableIdentifier in joins for cross schema joins
See #3294
