### PR TITLE
\Zend\Json\Server Fix _getDefaultParams if request-params are an associative array

### DIFF
--- a/library/Zend/Json/Server/Server.php
+++ b/library/Zend/Json/Server/Server.php
@@ -371,7 +371,7 @@ class Server extends AbstractServer
             if (array_key_exists('default', $param)) {
                 $value = $param['default'];
             }
-            array_push($args, $value);
+            $args[$param['name']] = $value;
         }
         return $args;
     }

--- a/tests/ZendTest/Json/ServerTest.php
+++ b/tests/ZendTest/Json/ServerTest.php
@@ -277,6 +277,24 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($result[2]);
     }
 
+    public function testHandleValidMethodWithTooFewAssociativeParamsShouldPassDefaultsOrNullsForMissingParams()
+    {
+        $this->server->setClass('ZendTest\Json\Foo')
+                     ->setReturnResponse(true);
+        $request = $this->server->getRequest();
+        $request->setMethod('bar')
+                ->setParams(array('one' => true))
+                ->setId('foo');
+        $response = $this->server->handle();
+        $this->assertTrue($response instanceof Response);
+        $this->assertFalse($response->isError());
+        $result = $response->getResult();
+        $this->assertTrue(is_array($result));
+        $this->assertTrue(3 == count($result));
+        $this->assertEquals('two', $result[1], var_export($result, 1));
+        $this->assertNull($result[2]);
+    }
+
     public function testHandleValidMethodWithTooManyParamsShouldWork()
     {
         $this->server->setClass('ZendTest\Json\Foo')


### PR DESCRIPTION
The error occurs when Request->setParams is set with an associative array.
