### PR TITLE
[WIP] Zend\Db\Sql Literal Objects

### DIFF
--- a/library/Zend/Db/Sql/Expression.php
+++ b/library/Zend/Db/Sql/Expression.php
@@ -125,6 +125,7 @@ class Expression implements ExpressionInterface
         if ($parametersCount == 0 && strpos($this->expression, self::PLACEHOLDER) !== false) {
             // if there are no parameters, but there is a placeholder
             $parametersCount = substr_count($this->expression, self::PLACEHOLDER);
+            $parameters = array_fill(0, $parametersCount, null);
         }
 
         for ($i = 0; $i < $parametersCount; $i++) {

--- a/library/Zend/Db/Sql/Expression.php
+++ b/library/Zend/Db/Sql/Expression.php
@@ -121,6 +121,12 @@ class Expression implements ExpressionInterface
 
         $types = array();
         $parametersCount = count($parameters);
+
+        if ($parametersCount == 0 && strpos($this->expression, self::PLACEHOLDER) !== false) {
+            // if there are no parameters, but there is a placeholder
+            $parametersCount = substr_count($this->expression, self::PLACEHOLDER);
+        }
+
         for ($i = 0; $i < $parametersCount; $i++) {
             $types[$i] = (isset($this->types[$i]) && ($this->types[$i] == self::TYPE_IDENTIFIER || $this->types[$i] == self::TYPE_LITERAL))
                 ? $this->types[$i] : self::TYPE_VALUE;

--- a/library/Zend/Db/Sql/Literal.php
+++ b/library/Zend/Db/Sql/Literal.php
@@ -12,7 +12,7 @@ class Literal implements ExpressionInterface
     /**
      * @param $literal
      */
-    public function __construct($literal)
+    public function __construct($literal = '')
     {
         $this->literal = $literal;
     }

--- a/library/Zend/Db/Sql/Literal.php
+++ b/library/Zend/Db/Sql/Literal.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Zend\Db\Sql;
+
+class Literal implements ExpressionInterface
+{
+    /**
+     * @var string
+     */
+    protected $literal = '';
+
+    /**
+     * @param $literal
+     */
+    public function __construct($literal)
+    {
+        $this->literal = $literal;
+    }
+
+    /**
+     * @param string $literal
+     * @return Literal
+     */
+    public function setLiteral($literal)
+    {
+        $this->literal = $literal;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLiteral()
+    {
+        return $this->literal;
+    }
+
+    /**
+     * @return array
+     */
+    public function getExpressionData()
+    {
+        return array(array(
+            $this->literal,
+            array(),
+            array()
+        ));
+    }
+}

--- a/library/Zend/Db/Sql/Predicate/Literal.php
+++ b/library/Zend/Db/Sql/Predicate/Literal.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Zend\Db\Sql\Predicate;
+
+use Zend\Db\Sql\Literal as BaseLiteral;
+
+class Literal extends BaseLiteral implements PredicateInterface
+{
+
+}

--- a/library/Zend/Db/Sql/Predicate/Predicate.php
+++ b/library/Zend/Db/Sql/Predicate/Predicate.php
@@ -215,6 +215,17 @@ class Predicate extends PredicateSet
         return $this;
     }
 
+    public function expression($expression, $parameters)
+    {
+        $this->addPredicate(
+            new Expression($expression, $parameters),
+            ($this->nextPredicateCombineOperator) ?: $this->defaultCombination
+        );
+        $this->nextPredicateCombineOperator = null;
+
+        return $this;
+    }
+
     /**
      * Create "Literal" predicate
      *
@@ -224,10 +235,15 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string|array $parameter
      * @return Predicate
      */
-    public function literal($literal, $parameter)
+    public function literal($literal, $expressionParameters = null)
     {
+        if ($expressionParameters) {
+            $predicate = new Expression($literal, $expressionParameters);
+        } else {
+            $predicate = new Literal($literal);
+        }
         $this->addPredicate(
-            new Expression($literal, $parameter),
+            $predicate,
             ($this->nextPredicateCombineOperator) ?: $this->defaultCombination
         );
         $this->nextPredicateCombineOperator = null;

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -245,7 +245,8 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         } else {
             if (is_string($predicate)) {
                 // String $predicate should be passed as an expression
-                $predicate = new Predicate\Expression($predicate);
+                $predicate = (strpos($predicate, Expression::PLACEHOLDER) !== false)
+                    ? new Predicate\Expression($predicate) : new Predicate\Literal($predicate);
                 $this->where->addPredicate($predicate, $combination);
             } elseif (is_array($predicate)) {
 
@@ -275,7 +276,8 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                         $predicate = $pvalue;
                     } else {
                         // must be an array of expressions (with int-indexed array)
-                        $predicate = new Predicate\Expression($pvalue);
+                        $predicate = (strpos($pvalue, Expression::PLACEHOLDER) !== false)
+                            ? new Predicate\Expression($pvalue) : new Predicate\Literal($pvalue);
                     }
                     $this->where->addPredicate($predicate, $combination);
                 }

--- a/tests/ZendTest/Db/Sql/LiteralTest.php
+++ b/tests/ZendTest/Db/Sql/LiteralTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Db
+ */
+
+namespace ZendTest\Db\Sql;
+
+use Zend\Db\Sql\Literal;
+
+class LiteralTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetLiteral()
+    {
+        $literal = new Literal('bar');
+        $this->assertSame($literal, $literal->setLiteral('foo'));
+    }
+
+    public function testGetLiteral()
+    {
+        $literal = new Literal('bar');
+        $this->assertEquals('bar', $literal->getLiteral());
+    }
+
+    public function testGetExpressionData()
+    {
+        $literal = new Literal('bar');
+        $this->assertEquals(array(array('bar', array(), array())), $literal->getExpressionData());
+    }
+}

--- a/tests/ZendTest/Db/Sql/Predicate/LiteralTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/LiteralTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Db
+ */
+
+namespace ZendTest\Db\Sql\Predicate;
+
+use Zend\Db\Sql\Predicate\Literal;
+
+class LiteralTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetLiteral()
+    {
+        $literal = new Literal('bar');
+        $this->assertSame($literal, $literal->setLiteral('foo'));
+    }
+
+    public function testGetLiteral()
+    {
+        $literal = new Literal('bar');
+        $this->assertEquals('bar', $literal->getLiteral());
+    }
+
+    public function testGetExpressionData()
+    {
+        $literal = new Literal('bar');
+        $this->assertEquals(array(array('bar', array(), array())), $literal->getExpressionData());
+    }
+}

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -148,7 +148,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
     public function testWhereArgument1IsString()
     {
         $select = new Select;
-        $select->where('x = y');
+        $select->where('x = ?');
 
         /** @var $where Where */
         $where = $select->getRawState('where');
@@ -156,7 +156,15 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($predicates));
         $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[0][1]);
         $this->assertEquals(Where::OP_AND, $predicates[0][0]);
-        $this->assertEquals('x = y', $predicates[0][1]->getExpression());
+        $this->assertEquals('x = ?', $predicates[0][1]->getExpression());
+
+        $select = new Select;
+        $select->where('x = y');
+
+        /** @var $where Where */
+        $where = $select->getRawState('where');
+        $predicates = $where->getPredicates();
+        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Literal', $predicates[0][1]);
     }
 
     /**
@@ -201,6 +209,13 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(Where::OP_AND, $predicates[1][0]);
         $this->assertEquals('age', $predicates[1][1]->getLeft());
         $this->assertEquals(33, $predicates[1][1]->getRight());
+
+        $select = new Select;
+        $select->where(array('x = y'));
+
+        $where = $select->getRawState('where');
+        $predicates = $where->getPredicates();
+        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Literal', $predicates[0][1]);
     }
 
     /**
@@ -217,9 +232,9 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $predicates = $where->getPredicates();
         $this->assertEquals(1, count($predicates));
 
-        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[0][1]);
+        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Literal', $predicates[0][1]);
         $this->assertEquals(Where::OP_AND, $predicates[0][0]);
-        $this->assertEquals('name = "Ralph"', $predicates[0][1]->getExpression());
+        $this->assertEquals('name = "Ralph"', $predicates[0][1]->getLiteral());
     }
 
     /**
@@ -236,9 +251,9 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $predicates = $where->getPredicates();
         $this->assertEquals(1, count($predicates));
 
-        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[0][1]);
+        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Literal', $predicates[0][1]);
         $this->assertEquals(Where::OP_OR, $predicates[0][0]);
-        $this->assertEquals('name = "Ralph"', $predicates[0][1]->getExpression());
+        $this->assertEquals('name = "Ralph"', $predicates[0][1]->getLiteral());
     }
 
     /**


### PR DESCRIPTION
Added Literal object to Zend\Db\Sql and Zend\Db\Sql\Predicate.
This is partly related to code in #2656 when a user wants to provide an expression with placeholders, but does not want to provide values or an array of values at Expression creation time / and yet still after statement production time.
