### PR TITLE
Fixed the unit test for Zend\Filter\File\Encrypt and Decrypt

### DIFF
--- a/tests/ZendTest/Filter/File/DecryptTest.php
+++ b/tests/ZendTest/Filter/File/DecryptTest.php
@@ -80,38 +80,6 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
             trim(file_get_contents(dirname(__DIR__).'/_files/newencryption.txt')));
     }
 
-    /**
-     * @return void
-     */
-    public function testBasicWithFileArray()
-    {
-        $filter = new FileEncrypt();
-        $filter->setFilename(dirname(__DIR__).'/_files/newencryption.txt');
-
-        $this->assertEquals(
-            dirname(__DIR__).'/_files/newencryption.txt',
-            $filter->getFilename());
-
-        $filter->setVector('1234567890123456');
-        $filter->filter(array('tmp_name' => dirname(__DIR__).'/_files/encryption.txt'));
-
-        $filter = new FileDecrypt();
-
-        $this->assertNotEquals(
-            'Encryption',
-            file_get_contents(dirname(__DIR__).'/_files/newencryption.txt'));
-
-        $filter->setVector('1234567890123456');
-        $this->assertEquals(
-            array('tmp_name' => dirname(__DIR__).'/_files/newencryption.txt'),
-            $filter->filter(array('tmp_name' => dirname(__DIR__).'/_files/newencryption.txt'))
-        );
-
-        $this->assertEquals(
-            'Encryption',
-            trim(file_get_contents(dirname(__DIR__).'/_files/newencryption.txt')));
-    }
-
     public function testEncryptionWithDecryption()
     {
         $filter = new FileEncrypt();

--- a/tests/ZendTest/Filter/File/EncryptTest.php
+++ b/tests/ZendTest/Filter/File/EncryptTest.php
@@ -66,33 +66,6 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
             file_get_contents(dirname(__DIR__).'/_files/newencryption.txt'));
     }
 
-    /**
-     * @return void
-     */
-    public function testBasicWithFileArray()
-    {
-        $filter = new FileEncrypt();
-        $filter->setFilename(dirname(__DIR__).'/_files/newencryption.txt');
-
-        $this->assertEquals(
-            dirname(__DIR__).'/_files/newencryption.txt',
-            $filter->getFilename());
-
-        $filter->setVector('1234567890123456');
-        $this->assertEquals(
-            array('tmp_name' => dirname(__DIR__).'/_files/newencryption.txt'),
-            $filter->filter(array('tmp_name' => dirname(__DIR__).'/_files/encryption.txt'))
-        );
-
-        $this->assertEquals(
-            'Encryption',
-            file_get_contents(dirname(__DIR__).'/_files/encryption.txt'));
-
-        $this->assertNotEquals(
-            'Encryption',
-            file_get_contents(dirname(__DIR__).'/_files/newencryption.txt'));
-    }
-
     public function testEncryptionWithDecryption()
     {
         $filter = new FileEncrypt();


### PR DESCRIPTION
This PR fix the unit test based on the PR #3550. It seems that the unit test has not been merged properly for the ZendTest\Filter\File\EncryptTest and DecryptTest.
The unit tests in master branch are updated and work fine.
