### PR TITLE
Update Travis to start running tests on PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ php:
   - 5.3.3
   - 5.3
   - 5.4
+  - 5.5
+
+matrix:
+  allow_failures:
+    - php: 5.5
 
 before_install:
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php


### PR DESCRIPTION
Allow travis to test PHP 5.5 alphas and allow failures for now.
