### PR TITLE
Fix Zend\Db\Adapter\Adapter::Query to allow ParameterContainer parameter

### DIFF
--- a/library/Zend/Db/Adapter/Adapter.php
+++ b/library/Zend/Db/Adapter/Adapter.php
@@ -135,7 +135,7 @@ class Adapter
         if (is_string($parametersOrQueryMode) && in_array($parametersOrQueryMode, array(self::QUERY_MODE_PREPARE, self::QUERY_MODE_EXECUTE))) {
             $mode = $parametersOrQueryMode;
             $parameters = null;
-        } elseif (is_array($parametersOrQueryMode)) {
+        } elseif (is_array($parametersOrQueryMode) || $parametersOrQueryMode instanceof ParameterContainer) {
             $mode = self::QUERY_MODE_PREPARE;
             $parameters = $parametersOrQueryMode;
         } else {

--- a/library/Zend/Db/Adapter/Adapter.php
+++ b/library/Zend/Db/Adapter/Adapter.php
@@ -126,7 +126,7 @@ class Adapter
      * query() is a convenience function
      *
      * @param string $sql
-     * @param string|array $parametersOrQueryMode
+     * @param string|array|ParameterContainer $parametersOrQueryMode
      * @throws Exception\InvalidArgumentException
      * @return Driver\StatementInterface|ResultSet\ResultSet
      */

--- a/tests/ZendTest/Db/Adapter/AdapterTest.php
+++ b/tests/ZendTest/Db/Adapter/AdapterTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Db\Adapter;
 
 use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\ParameterContainer;
 
 class AdapterTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/ZendTest/Db/Adapter/AdapterTest.php
+++ b/tests/ZendTest/Db/Adapter/AdapterTest.php
@@ -170,6 +170,43 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @testdox unit test: Test query() in prepare mode, with array of parameters, produces a result object
+     * @covers Zend\Db\Adapter\Adapter::query
+     */
+    public function testQueryWhenPreparedWithParameterArrayProducesResult()
+    {
+        $parray = array('bar'=>'foo');
+        $sql = 'SELECT foo, :bar';
+        $statement = $this->getMock('\Zend\Db\Adapter\Driver\StatementInterface');
+        $result = $this->getMock('Zend\Db\Adapter\Driver\ResultInterface');
+        $this->mockDriver->expects($this->any())->method('createStatement')->with($sql)->will($this->returnValue($statement));
+        $this->mockStatement->expects($this->any())->method('execute')->will($this->returnValue($result));
+
+        $r = $this->adapter->query($sql, $parray);
+        $this->assertSame($result, $r);
+    }
+
+    /**
+     * @testdox unit test: Test query() in prepare mode, with ParameterContainer, produces a result object
+     * @covers Zend\Db\Adapter\Adapter::query
+     */
+    public function testQueryWhenPreparedWithParameterContainerProducesResult()
+    {
+        $parameterContainer = new ParameterContainer(array('bar'=>'foo'));
+        $sql = 'SELECT foo, :bar';
+        $parameterContainer = $this->getMock('Zend\Db\Adapter\ParameterContainer');
+        $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $result = $this->getMock('Zend\Db\Adapter\Driver\ResultInterface');
+        $this->mockDriver->expects($this->any())->method('createStatement')->with($sql)->will($this->returnValue($statement));
+        $this->mockStatement->expects($this->any())->method('setParameterContainer')->with($parameterContainer)->will($this->returnValue($statement));
+        $this->mockStatement->expects($this->any())->method('execute')->will($this->returnValue($result));
+        $result->expects($this->any())->method('isQueryResult')->will($this->returnValue(true));
+
+        $r = $this->adapter->query($sql, $parameterContainer);
+        $this->assertSame($result, $r);
+    }
+
+    /**
      * @testdox unit test: Test query() in execute mode produces a driver result object
      * @covers Zend\Db\Adapter\Adapter::query
      */

--- a/tests/ZendTest/Db/Adapter/AdapterTest.php
+++ b/tests/ZendTest/Db/Adapter/AdapterTest.php
@@ -11,7 +11,6 @@
 namespace ZendTest\Db\Adapter;
 
 use Zend\Db\Adapter\Adapter;
-use Zend\Db\Adapter\ParameterContainer;
 
 class AdapterTest extends \PHPUnit_Framework_TestCase
 {
@@ -193,18 +192,15 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
      */
     public function testQueryWhenPreparedWithParameterContainerProducesResult()
     {
-        $parameterContainer = new ParameterContainer(array('bar'=>'foo'));
-        $sql = 'SELECT foo, :bar';
+        $sql = 'SELECT foo';
         $parameterContainer = $this->getMock('Zend\Db\Adapter\ParameterContainer');
-        $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
         $result = $this->getMock('Zend\Db\Adapter\Driver\ResultInterface');
-        $this->mockDriver->expects($this->any())->method('createStatement')->with($sql)->will($this->returnValue($statement));
-        $this->mockStatement->expects($this->any())->method('setParameterContainer')->with($parameterContainer)->will($this->returnValue($statement));
+        $this->mockDriver->expects($this->any())->method('createStatement')->with($sql)->will($this->returnValue($this->mockStatement));
         $this->mockStatement->expects($this->any())->method('execute')->will($this->returnValue($result));
         $result->expects($this->any())->method('isQueryResult')->will($this->returnValue(true));
 
         $r = $this->adapter->query($sql, $parameterContainer);
-        $this->assertSame($result, $r);
+        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $r);
     }
 
     /**


### PR DESCRIPTION
Added unit tests for parametersOrQueryMode param of `Zend\Db\Adapter\Adapter::Query`
Testing input array and input ParameterContainer.

I have added the check in `Zend\Db\Adapter\Adapter::Query` for the ParamterContainer object.
I also fixed the unit test so it doesn't require `Zend\Db\Adapter\ParameterContainer.`
