### PR TITLE
Prevent helo and connect from being called twice.

### DIFF
--- a/library/Zend/Mail/Transport/Smtp.php
+++ b/library/Zend/Mail/Transport/Smtp.php
@@ -308,19 +308,20 @@ class Smtp implements TransportInterface
     }
 
     /**
-     * Lazy load the connection, and pass it helo
+     * Lazy load the connection
      *
      * @return Protocol\Smtp
      */
     protected function lazyLoadConnection()
     {
         // Check if authentication is required and determine required class
-        $options        = $this->getOptions();
-        $config         = $options->getConnectionConfig();
-        $config['host'] = $options->getHost();
-        $config['port'] = $options->getPort();
-        $connection = $this->plugin($options->getConnectionClass(), $config);
+        $options          = $this->getOptions();
+        $config           = $options->getConnectionConfig();
+        $config['host']   = $options->getHost();
+        $config['port']   = $options->getPort();
+        $connection       = $this->plugin($options->getConnectionClass(), $config);
         $this->connection = $connection;
+
         return $this->connect();
     }
 
@@ -332,10 +333,12 @@ class Smtp implements TransportInterface
     protected function connect()
     {
         if (!$this->connection instanceof Protocol\Smtp) {
-            $this->lazyLoadConnection();
+            return $this->lazyLoadConnection();
         }
+
         $this->connection->connect();
         $this->connection->helo($this->getOptions()->getName());
+
         return $this->connection;
     }
 }


### PR DESCRIPTION
line 336 is all that really matters, the rest is indentation.

5 days ago, the PR broke the smtp transport method because it didn't return in method connect(). This (obviously) caused connect to call helo twice, which is not permitted.

What happens now is that connect gets called, which calls lazyload, which then calls connect again. Without the return helo will be sent twice.
