### PR TITLE
Fix bug when $indent have some string

### DIFF
--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -422,7 +422,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
             $html .= $indent . '    ' . $item->source;
 
             if ($addScriptEscape) {
-                $html .= $indent . PHP_EOL . '    ' . $escapeEnd;
+                $html .= PHP_EOL . $indent . '    ' . $escapeEnd;
             }
 
             $html .= PHP_EOL . $indent;


### PR DESCRIPTION
assuming `$ident = '¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨'`:
before:

```
¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨<script type="text/javascript">
¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨    //<!--
¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨    Some script here...¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨
    //-->
¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨</script>
```

now:

```
¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨<script type="text/javascript">
¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨    //<!--
¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨    Some script here...
¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨    //-->
¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨</script>
```
