### PR TITLE
hotfix: FormElement render checked checkbox value

### DIFF
--- a/library/Zend/Form/Element/Checkbox.php
+++ b/library/Zend/Form/Element/Checkbox.php
@@ -222,7 +222,7 @@ class Checkbox extends Element implements InputProviderInterface
             $this->value = $value;
         } else {
             $this->setCheckedValue((string) $value);
-            if (parent::getOption('value') === $this->getCheckedValue()) {
+            if ($this->getOption('value') === $this->getCheckedValue()) {
                 $this->value = (string) $value === $this->getCheckedValue();
             }
         }

--- a/library/Zend/Form/Element/Checkbox.php
+++ b/library/Zend/Form/Element/Checkbox.php
@@ -221,7 +221,7 @@ class Checkbox extends Element implements InputProviderInterface
         if (is_bool($value)) {
             $this->value = $value;
         } else {
-            $this->value = $value === $this->getCheckedValue();
+            $this->value = $value == $this->getCheckedValue();
         }
         return $this;
     }

--- a/library/Zend/Form/Element/Checkbox.php
+++ b/library/Zend/Form/Element/Checkbox.php
@@ -221,7 +221,7 @@ class Checkbox extends Element implements InputProviderInterface
         if (is_bool($value)) {
             $this->value = $value;
         } else {
-            $this->value = $value == $this->getCheckedValue();
+            $this->value = (string) $value === $this->getCheckedValue();
         }
         return $this;
     }

--- a/library/Zend/Form/Element/Checkbox.php
+++ b/library/Zend/Form/Element/Checkbox.php
@@ -221,7 +221,10 @@ class Checkbox extends Element implements InputProviderInterface
         if (is_bool($value)) {
             $this->value = $value;
         } else {
-            $this->value = (string) $value === $this->getCheckedValue();
+            $this->setCheckedValue((string) $value);
+            if (parent::getOption('value') === $this->getCheckedValue()) {
+                $this->value = (string) $value === $this->getCheckedValue();
+            }
         }
         return $this;
     }

--- a/tests/ZendTest/Form/View/Helper/FormElementTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormElementTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Form\View\Helper;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Captcha;
+use Zend\Form\Form;
 use Zend\Form\Element;
 use Zend\Form\View\HelperConfig;
 use Zend\Form\View\Helper\FormElement as FormElementHelper;
@@ -207,5 +208,23 @@ class FormElementTest extends TestCase
     {
         $element = new Element('foo');
         $this->assertSame($this->helper, $this->helper->__invoke());
+    }
+
+    public function testRenderCheckedValue()
+    {
+        $form = new Form();
+        $form->add(array(
+            'type' => 'Zend\Form\Element\Checkbox',
+            'name' => 'product_soldout_status',
+            'options' => array(
+                'value' => '1'
+            ),
+        ));
+
+        $form->get('product_soldout_status')->setValue(1);
+        $form->prepare();
+        $markup = $this->helper->render($form->get('product_soldout_status'));
+
+        $this->assertContains('value="1" checked="checked"', $markup);
     }
 }

--- a/tests/ZendTest/Form/View/Helper/FormElementTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormElementTest.php
@@ -227,4 +227,40 @@ class FormElementTest extends TestCase
 
         $this->assertContains('value="1" checked="checked"', $markup);
     }
+
+    public function testRenderCheckedValueTypeJugglingIntVsString()
+    {
+        $form = new Form();
+        $form->add(array(
+            'type' => 'Zend\Form\Element\Checkbox',
+            'name' => 'product_soldout_status',
+            'options' => array(
+                'value' => 1
+            ),
+        ));
+
+        $form->get('product_soldout_status')->setValue('1A');
+        $form->prepare();
+        $markup = $this->helper->render($form->get('product_soldout_status'));
+
+        $this->assertNotContains('value="1A" checked="checked"', $markup);
+    }
+
+    public function testRenderCheckedValueTypeJugglingStringVsInt()
+    {
+        $form = new Form();
+        $form->add(array(
+            'type' => 'Zend\Form\Element\Checkbox',
+            'name' => 'product_soldout_status',
+            'options' => array(
+                'value' => '1A'
+            ),
+        ));
+
+        $form->get('product_soldout_status')->setValue(1);
+        $form->prepare();
+        $markup = $this->helper->render($form->get('product_soldout_status'));
+
+        $this->assertNotContains('value="1" checked="checked"', $markup);
+    }
 }


### PR DESCRIPTION
when checkbox rendered by formElement, and form get checkbox setValue, there is fail.

for example, I have form like this : 

```
class SampleForm extends Form
{
        public function __construct($name = null)
        {
           parent::__construct('PluginProductForm');
            $this->add(array(
                'type' => 'Zend\Form\Element\Checkbox',
                'name' => 'product_soldout_status'
                'options' => array(
                    'label' => 'Product is Sold Out :',
                    'value' => 1
                ),
            ));
        }
}
```

and, I set the checkbox in controller :  

```
 $form  = new SampleForm;
 $form->get('product_soldout_status')->setValue(1);
```

and in the view :  

```
 echo $this->formElement($form->get('product_soldout_status'));
```

and in the view, checkbox is not checked.
