### PR TITLE
Fix: Setting libOptions on an existing memcached resource didn't work

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/MemcachedResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/MemcachedResourceManager.php
@@ -213,7 +213,7 @@ class MemcachedResourceManager
         $resource = & $this->resources[$id];
         if ($resource instanceof MemcachedResource) {
             if (method_exists($resource, 'setOptions')) {
-                $resource->setOptions($resource);
+                $resource->setOptions($libOptions);
             } else {
                 foreach ($libOptions as $key => $value) {
                     $resource->setOption($key, $value);

--- a/tests/ZendTest/Cache/Storage/Adapter/CommonAdapterTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/CommonAdapterTest.php
@@ -1024,7 +1024,7 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->_storage->hasItem('key2'));
     }
 
-    public function testTagable()
+    public function testTaggable()
     {
         if (!($this->_storage instanceof TaggableInterface)) {
             $this->markTestSkipped("Storage doesn't implement TaggableInterface");

--- a/tests/ZendTest/Cache/Storage/Adapter/MemcachedResourceManagerTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/MemcachedResourceManagerTest.php
@@ -233,4 +233,25 @@ class MemcachedResourceManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->resourceManager, $this->resourceManager->removeResource($resourceId));
         $this->assertFalse($this->resourceManager->hasResource($resourceId));
     }
+
+    public function testSetLibOptionsOnExistingResource()
+    {
+        $memcachedInstalled = class_exists('Memcached', false);
+
+        $libOptions = array('compression' => false);
+        $resourceId = 'testResourceId';
+        $resourceMock = $this->getMock('Memcached', array('setOptions'));
+
+        if (!$memcachedInstalled) {
+            $this->setExpectedException('Zend\Cache\Exception\InvalidArgumentException');
+        } else {
+            $resourceMock
+                ->expects($this->once())
+                ->method('setOptions')
+                ->with($this->isType('array'));
+        }
+
+        $this->resourceManager->setResource($resourceId, $resourceMock);
+        $this->resourceManager->setLibOptions($resourceId, $libOptions);
+    }
 }


### PR DESCRIPTION
Added another [commit](https://github.com/bramstroker/zf2/commit/8b8c5b9aa4da0a48a02ffc0b297c9e39740e5396) to the same branch. My intention was to create a seperate pull request for this one, but forgot to create a seperate branch for this one.
