### PR TITLE
New DateTimeFormatter Filter (#3617)

### DIFF
--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -10,7 +10,6 @@
 namespace Zend\Filter;
 
 use DateTime;
-use Exception;
 
 class DateTimeFormatter extends AbstractFilter
 {
@@ -55,7 +54,7 @@ class DateTimeFormatter extends AbstractFilter
     {
         try {
             $result = $this->normalizeDateTime($value);
-        } catch (Exception $ex) {
+        } catch (\Exception $ex) {
             // DateTime threw an exception, an invalid date string was provided
             return $value;
         }

--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -24,7 +24,7 @@ class DateTimeFormatter extends AbstractFilter
     /**
      * Sets filter options
      *
-     * @param  string|array|\Zend\Config\Config $options
+     * @param array|Traversable $options
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -13,7 +13,7 @@ use DateTime;
 use Exception;
 use Zend\Filter\AbstractFilter;
 
-class DateTimeNormalize extends AbstractFilter
+class DateTimeFormatter extends AbstractFilter
 {
     /**
      * A valid format string accepted by date()
@@ -75,16 +75,11 @@ class DateTimeNormalize extends AbstractFilter
     protected function normalizeDateTime($value)
     {
         if (is_int($value)) {
-            $dateTime = new DateTime();
-            $dateTime = $dateTime->setTimestamp($value);
+            $dateTime = new DateTime('@' . $value);
         } else {
             $dateTime = new DateTime($value);
         }
 
-        if ($dateTime) {
-            return $dateTime->format($this->format);
-        }
-
-        return $value;
+        return $dateTime->format($this->format);
     }
 }

--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -48,6 +48,7 @@ class DateTimeFormatter extends AbstractFilter
      * Filter a datetime string by normalizing it to the filters specified format
      *
      * @param  string $value
+     * @throws Exception\InvalidArgumentException
      * @return string
      */
     public function filter($value)
@@ -56,24 +57,23 @@ class DateTimeFormatter extends AbstractFilter
             $result = $this->normalizeDateTime($value);
         } catch (\Exception $ex) {
             // DateTime threw an exception, an invalid date string was provided
-            return $value;
+            throw new Exception\InvalidArgumentException($ex);
         }
 
         return $result;
     }
 
     /**
-     * Attempt to convert a string into a valid DateTime object
+     * Normalize the provided value to a formatted string
      *
-     * @param string $value
-     * @returns DateTime
-     * @throws Exception
+     * @param string|int|DateTime $value
+     * @returns string
      */
     protected function normalizeDateTime($value)
     {
         if (is_int($value)) {
             $dateTime = new DateTime('@' . $value);
-        } else {
+        } elseif (!$value instanceof DateTime) {
             $dateTime = new DateTime($value);
         }
 

--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -11,7 +11,6 @@ namespace Zend\Filter;
 
 use DateTime;
 use Exception;
-use Zend\Filter\AbstractFilter;
 
 class DateTimeFormatter extends AbstractFilter
 {
@@ -26,7 +25,6 @@ class DateTimeFormatter extends AbstractFilter
      * Sets filter options
      *
      * @param  string|array|\Zend\Config\Config $options
-     * @return void
      */
     public function __construct($options = null)
     {
@@ -36,10 +34,10 @@ class DateTimeFormatter extends AbstractFilter
     }
 
     /**
-     * Set the format string accepted by date() to use when normalizing a string
+     * Set the format string accepted by date() to use when formatting a string
      *
      * @param  string $format
-     * @return \Zend\Filter\DateTimeNormalize
+     * @return \Zend\Filter\DateTimeFormatter
      */
     public function setFormat($format)
     {

--- a/library/Zend/Filter/DateTimeNormalize.php
+++ b/library/Zend/Filter/DateTimeNormalize.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Filter;
+
+use DateTime;
+use Exception;
+use Zend\Filter\AbstractFilter;
+
+class DateTimeNormalize extends AbstractFilter
+{
+    /**
+     * A valid format string accepted by date()
+     *
+     * @var string
+     */
+    protected $format = DateTime::ISO8601;
+
+    /**
+     * Sets filter options
+     *
+     * @param  string|array|\Zend\Config\Config $options
+     * @return void
+     */
+    public function __construct($options = null)
+    {
+        if ($options) {
+            $this->setOptions($options);
+        }
+    }
+
+    /**
+     * Set the format string accepted by date() to use when normalizing a string
+     *
+     * @param  string $format
+     * @return \Zend\Filter\DateTimeNormalize
+     */
+    public function setFormat($format)
+    {
+        $this->format = $format;
+        return $this;
+    }
+
+    /**
+     * Filter a datetime string by normalizing it to the filters specified format
+     *
+     * @param  string $value
+     * @return string
+     */
+    public function filter($value)
+    {
+        try {
+            $result = $this->normalizeDateTime($value);
+        } catch (Exception $ex) {
+            // DateTime threw an exception, an invalid date string was provided
+            return $value;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Attempt to convert a string into a valid DateTime object
+     *
+     * @param string $value
+     * @returns DateTime
+     * @throws Exception
+     */
+    protected function normalizeDateTime($value)
+    {
+        if (is_int($value)) {
+            $dateTime = new DateTime();
+            $dateTime = $dateTime->setTimestamp($value);
+        } else {
+            $dateTime = new DateTime($value);
+        }
+
+        if ($dateTime) {
+            return $dateTime->format($this->format);
+        }
+
+        return $value;
+    }
+}

--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -20,6 +20,8 @@ use Zend\Validator\LessThan as LessThanValidator;
 
 class DateTime extends Element implements InputProviderInterface
 {
+    const DATETIME_FORMAT = 'Y-m-d\TH:iP';
+    
     /**
      * Seed attributes
      *
@@ -186,7 +188,7 @@ class DateTime extends Element implements InputProviderInterface
             'filters' => array(
                 array('name' => 'Zend\Filter\StringTrim'),
                 array(
-                    'name' => 'Zend\Filter\DateTimeNormalize',
+                    'name' => 'Zend\Filter\DateTimeFormatter',
                     'options' => array(
                         'format' => $this->getFormat(),
                     )

--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -21,7 +21,7 @@ use Zend\Validator\LessThan as LessThanValidator;
 class DateTime extends Element implements InputProviderInterface
 {
     const DATETIME_FORMAT = 'Y-m-d\TH:iP';
-    
+
     /**
      * Seed attributes
      *
@@ -36,7 +36,7 @@ class DateTime extends Element implements InputProviderInterface
      *
      * @var string
      */
-    protected $format = PhpDateTime::W3C;
+    protected $format = self::DATETIME_FORMAT;
 
     /**
      * @var array

--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -20,8 +20,6 @@ use Zend\Validator\LessThan as LessThanValidator;
 
 class DateTime extends Element implements InputProviderInterface
 {
-    const DATETIME_FORMAT = 'Y-m-d\TH:iP';
-
     /**
      * Seed attributes
      *
@@ -32,13 +30,11 @@ class DateTime extends Element implements InputProviderInterface
     );
 
     /**
-     *
-     * Opera and mobile browsers support datetime input, and display a datepicker control
-     * But the submitted value does not include seconds.
+     * A valid format string accepted by date()
      *
      * @var string
      */
-    protected $format = self::DATETIME_FORMAT;
+    protected $format = PhpDateTime::W3C;
 
     /**
      * @var array
@@ -189,6 +185,12 @@ class DateTime extends Element implements InputProviderInterface
             'required' => true,
             'filters' => array(
                 array('name' => 'Zend\Filter\StringTrim'),
+                array(
+                    'name' => 'Zend\Filter\DateTimeNormalize',
+                    'options' => array(
+                        'format' => $this->getFormat(),
+                    )
+                )
             ),
             'validators' => $this->getValidators(),
         );

--- a/library/Zend/Form/Element/DateTimeLocal.php
+++ b/library/Zend/Form/Element/DateTimeLocal.php
@@ -9,7 +9,6 @@
 
 namespace Zend\Form\Element;
 
-use Zend\Form\Element;
 use Zend\Validator\DateStep as DateStepValidator;
 
 class DateTimeLocal extends DateTime
@@ -26,11 +25,7 @@ class DateTimeLocal extends DateTime
     );
 
     /**
-     *
-     * Opera and mobile browsers support datetime input, and display a datepicker control
-     * But the submitted value does not include seconds.
-     *
-     * @var string
+     * {@inheritDoc}
      */
     protected $format = self::DATETIME_LOCAL_FORMAT;
 

--- a/tests/ZendTest/Filter/DateTimeFormatterTest.php
+++ b/tests/ZendTest/Filter/DateTimeFormatterTest.php
@@ -76,10 +76,11 @@ class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('2013-02-01T17:30:01+0000', $result);
     }
 
-    public function testOriginalValueReturnedOnInvalidInput()
+    public function testInvalidArgumentExceptionThrownOnInvalidInput()
     {
+        $this->setExpectedException('Zend\Filter\Exception\InvalidArgumentException');
+
         $filter = new DateTimeFormatter();
         $result = $filter->filter('2013-31-31');
-        $this->assertEquals('2013-31-31', $result);
     }
 }

--- a/tests/ZendTest/Filter/DateTimeFormatterTest.php
+++ b/tests/ZendTest/Filter/DateTimeFormatterTest.php
@@ -21,20 +21,46 @@ use Zend\Filter\DateTimeFormatter;
  */
 class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
 {
+    protected $defaultTimezone;
+
     public function setUp()
     {
-        date_default_timezone_set('UTC');
+        $this->defaultTimezone = date_default_timezone_get();
+    }
+
+    public function tearDown()
+    {
+        date_default_timezone_set($this->defaultTimezone);
     }
 
     public function testDateTimeFormatted()
     {
+        date_default_timezone_set('UTC');
+
         $filter = new DateTimeFormatter();
         $result = $filter->filter('2012-01-01');
         $this->assertEquals('2012-01-01T00:00:00+0000', $result);
     }
 
+    public function testDateTimeFormattedWithAlternateTimezones()
+    {
+        $filter = new DateTimeFormatter();
+
+        date_default_timezone_set('Europe/Paris');
+
+        $resultParis = $filter->filter('2012-01-01');
+        $this->assertEquals('2012-01-01T00:00:00+0100', $resultParis);
+
+        date_default_timezone_set('America/New_York');
+
+        $resultNewYork = $filter->filter('2012-01-01');
+        $this->assertEquals('2012-01-01T00:00:00-0500', $resultNewYork);
+    }
+
     public function testSetFormat()
     {
+        date_default_timezone_set('UTC');
+
         $filter = new DateTimeFormatter();
         $filter->setFormat(DateTime::RFC1036);
         $result = $filter->filter('2012-01-01');
@@ -43,6 +69,8 @@ class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function testFormatDateTimeFromTimestamp()
     {
+        date_default_timezone_set('UTC');
+
         $filter = new DateTimeFormatter();
         $result = $filter->filter(1359739801);
         $this->assertEquals('2013-02-01T17:30:01+0000', $result);

--- a/tests/ZendTest/Filter/DateTimeFormatterTest.php
+++ b/tests/ZendTest/Filter/DateTimeFormatterTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Filter
+ */
+
+namespace ZendTest\Filter;
+
+use DateTime;
+use Zend\Filter\DateTimeFormatter;
+
+/**
+ * @category   Zend
+ * @package    Zend_Filter
+ * @subpackage UnitTests
+ * @group      Zend_Filter
+ */
+class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        date_default_timezone_set('UTC');
+    }
+
+    public function testDateTimeFormatted()
+    {
+        $filter = new DateTimeFormatter();
+        $result = $filter->filter('2012-01-01');
+        $this->assertEquals('2012-01-01T00:00:00+0000', $result);
+    }
+
+    public function testSetFormat()
+    {
+        $filter = new DateTimeFormatter();
+        $filter->setFormat(DateTime::RFC1036);
+        $result = $filter->filter('2012-01-01');
+        $this->assertEquals('Sun, 01 Jan 12 00:00:00 +0000', $result);
+    }
+
+    public function testFormatDateTimeFromTimestamp()
+    {
+        $filter = new DateTimeFormatter();
+        $result = $filter->filter(1359739801);
+        $this->assertEquals('2013-02-01T17:30:01+0000', $result);
+    }
+
+    public function testOriginalValueReturnedOnInvalidInput()
+    {
+        $filter = new DateTimeFormatter();
+        $result = $filter->filter('2013-31-31');
+        $this->assertEquals('2013-31-31', $result);
+    }
+}

--- a/tests/ZendTest/Form/Element/DateTimeTest.php
+++ b/tests/ZendTest/Form/Element/DateTimeTest.php
@@ -58,6 +58,27 @@ class DateTimeTest extends TestCase
         }
     }
 
+    public function testProvidesInputSpecificationThatIncludesDateTimeFormatterBasedOnAttributes()
+    {
+        $element = new DateTimeElement('foo');
+        $element->setFormat(DateTime::W3C);
+
+        $inputSpec = $element->getInputSpecification();
+        $this->assertArrayHasKey('filters', $inputSpec);
+        $this->assertInternalType('array', $inputSpec['filters']);
+
+        foreach ($inputSpec['filters'] as $filter) {
+            switch ($filter['name']) {
+                case 'Zend\Filter\DateTimeFormatter':
+                    $this->assertEquals($filter['options']['format'], DateTime::W3C);
+                    $this->assertEquals($filter['options']['format'], $element->getFormat());
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
     public function testUsesBrowserFormatByDefault()
     {
         $element = new DateTimeElement('foo');


### PR DESCRIPTION
This PR introduces a simple `DateTimeFormatter` Filter class that will attempt to format a provided string using the specified date() style format.

The main advantage of this is to allow pre-formatting of a provided datetime value on a `Zend\Form\Element\DateTime` where the HTML5 spec and different browsers may pass values with or without seconds which can cause the validator to fail.

See #3617 
