### PR TITLE
#3629 : Zend\Db\Select using alias in joins can results in wrong SQL

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -641,6 +641,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 $joinAs = $platform->quoteIdentifier(key($join['name']));
             } else {
                 $joinName = $join['name'];
+                $joinAs = null;
             }
             if ($joinName instanceof TableIdentifier) {
                 $joinName = $joinName->getTableAndSchema();


### PR DESCRIPTION
reset join alias (otherwise it uses the alias defined in the previous iteration)
