### PR TITLE
Session Metadata and SessionArrayStorage requestaccesstime fixes.

### DIFF
--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -103,7 +103,7 @@ class SessionManager extends AbstractManager
                 $storage->fromArray($_SESSION);
             }
             $_SESSION = $storage;
-        } else if ($storage instanceof Storage\SessionArrayStorage) {
+        } elseif ($storage instanceof Storage\SessionArrayStorage) {
             $storage->fromArray($_SESSION);
         }
 

--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -103,7 +103,10 @@ class SessionManager extends AbstractManager
                 $storage->fromArray($_SESSION);
             }
             $_SESSION = $storage;
+        } else if ($storage instanceof Storage\SessionArrayStorage) {
+            $storage->fromArray($_SESSION);
         }
+
         if (!$this->isValid()) {
             throw new Exception\RuntimeException('Session validation failed');
         }
@@ -159,7 +162,7 @@ class SessionManager extends AbstractManager
         // object isImmutable.
         $storage  = $this->getStorage();
         if (!$storage->isImmutable()) {
-            $_SESSION = $storage->toArray();
+            $_SESSION = $storage->toArray(true);
             session_write_close();
             $storage->fromArray($_SESSION);
             $storage->markImmutable();

--- a/library/Zend/Session/Storage/ArrayStorage.php
+++ b/library/Zend/Session/Storage/ArrayStorage.php
@@ -337,9 +337,12 @@ class ArrayStorage extends ArrayObject implements StorageInterface
      *
      * @return array
      */
-    public function toArray()
+    public function toArray($metaData = false)
     {
         $values = $this->getArrayCopy();
+        if ($metaData) {
+            return $values;
+        }
         if (isset($values['__ZF'])) {
             unset($values['__ZF']);
         }

--- a/library/Zend/Session/Storage/SessionArrayStorage.php
+++ b/library/Zend/Session/Storage/SessionArrayStorage.php
@@ -197,6 +197,9 @@ class SessionArrayStorage implements IteratorAggregate, StorageInterface
     public function fromArray(array $array)
     {
         $ts = $this->getRequestAccessTime();
+        if (!$ts) {
+            $ts = microtime(true);
+        }
         $_SESSION = $array;
         $this->setRequestAccessTime($ts);
         return $this;
@@ -346,10 +349,7 @@ class SessionArrayStorage implements IteratorAggregate, StorageInterface
             }
         } else {
             if ((null === $value) && isset($_SESSION['__ZF'][$key])) {
-                $array = $_SESSION['__ZF'];
-                unset($array[$key]);
-                $_SESSION['__ZF'] = $array;
-                unset($array);
+                unset($_SESSION['__ZF'][$key]);
             } elseif (null !== $value) {
                 $_SESSION['__ZF'][$key] = $value;
             }
@@ -444,13 +444,18 @@ class SessionArrayStorage implements IteratorAggregate, StorageInterface
      *
      * @return array
      */
-    public function toArray()
+    public function toArray($metaData = false)
     {
         if (isset($_SESSION)) {
             $values = $_SESSION;
         } else {
             $values = array();
         }
+
+        if ($metaData) {
+            return $values;
+        }
+
         if (isset($values['__ZF'])) {
             unset($values['__ZF']);
         }

--- a/library/Zend/Session/Storage/StorageInterface.php
+++ b/library/Zend/Session/Storage/StorageInterface.php
@@ -37,5 +37,5 @@ interface StorageInterface extends Traversable, ArrayAccess, Serializable, Count
     public function clear($key = null);
 
     public function fromArray(array $array);
-    public function toArray();
+    public function toArray($metaData = false);
 }

--- a/tests/ZendTest/Session/SessionArrayStorageTest.php
+++ b/tests/ZendTest/Session/SessionArrayStorageTest.php
@@ -125,4 +125,20 @@ class SessionArrayStorageTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function testToArrayWithMetaData()
+    {
+        $this->storage->foo = 'bar';
+        $this->storage->bar = 'baz';
+        $this->storage->setMetadata('foo', 'bar');
+        $expected = array(
+            '__ZF' => array(
+                '_REQUEST_ACCESS_TIME' => $this->storage->getRequestAccessTime(),
+                'foo' => 'bar',
+            ),
+            'foo' => 'bar',
+            'bar' => 'baz',
+        );
+        $this->assertSame($expected, $this->storage->toArray(true));
+    }
+
 }

--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -525,4 +525,18 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Session\Exception\RuntimeException', 'failed');
         $this->manager->start();
     }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSessionWriteCloseStoresMetadata()
+    {
+        $this->manager->start();
+        $storage = $this->manager->getStorage();
+        $storage->setMetadata('foo', 'bar');
+        $metaData = $storage->getMetadata();
+        $this->manager->writeClose();
+        $this->assertSame($_SESSION['__ZF'], $metaData);
+    }
+
 }

--- a/tests/ZendTest/Session/StorageTest.php
+++ b/tests/ZendTest/Session/StorageTest.php
@@ -227,4 +227,20 @@ class StorageTest extends \PHPUnit_Framework_TestCase
         $this->storage->fromArray(array());
         $this->assertNotEmpty($this->storage->getRequestAccessTime());
     }
+
+    public function testToArrayWithMetaData()
+    {
+        $this->storage->foo = 'bar';
+        $this->storage->bar = 'baz';
+        $this->storage->setMetadata('foo', 'bar');
+        $expected = array(
+            '__ZF' => array(
+                '_REQUEST_ACCESS_TIME' => $this->storage->getRequestAccessTime(),
+                'foo' => 'bar',
+            ),
+            'foo' => 'bar',
+            'bar' => 'baz',
+        );
+        $this->assertSame($expected, $this->storage->toArray(true));
+    }
 }


### PR DESCRIPTION
## Overview

2.1 changed slightly in how the session manager retrieved results from the storage; unfortunately this caused the meta data to be blown away.  Unfortunately in 2.0.x it was not clear that the type cast was working around the toArray method.  Now toArray has a $metaData = false parameter to ensure that we can save the metadata when writing the session.

Additionally the Storage containers were never meant to directly modify $_SESSION; however, to fix issues with storage containers from ArrayObject this was made.  Unfortunately when it is initialized it attempts to set the request access time; this has been changed to do it on session start by utilizing the fromArray method.
