### PR TITLE
[#3625] Do not query abstract factories for registered invokables

### DIFF
--- a/library/Zend/Mvc/Router/RoutePluginManager.php
+++ b/library/Zend/Mvc/Router/RoutePluginManager.php
@@ -27,6 +27,27 @@ class RoutePluginManager extends AbstractPluginManager
     protected $shareByDefault = false;
 
     /**
+     * Override setInvokableClass()
+     *
+     * Performs normal operation, but also auto-aliases the class name to the
+     * service name. This ensures that providing the FQCN does not trigger an
+     * abstract factory later.
+     *
+     * @param  string $name
+     * @param  string $invokableClass
+     * @param  null|bool $shared
+     * @return RoutePluginManager
+     */
+    public function setInvokableClass($name, $invokableClass, $shared = null)
+    {
+        parent::setInvokableClass($name, $invokableClass, $shared);
+        if ($name != $invokableClass) {
+            $this->setAlias($invokableClass, $name);
+        }
+        return $this;
+    }
+
+    /**
      * Validate the plugin
      *
      * Checks that the filter loaded is either a valid callback or an instance


### PR DESCRIPTION
- Prior to this patch, if a route has been registered as an invokable,
  but the DiAbstractServiceFactory was also present, using the FQCN to
  retrieve the route would result in DI being invoked. In the case of
  the various shipped ZF routes, this was undesirable, as the factory
  method for these classes was intended for instantiation; usage if DI
  caused failures.
- This patch overrides the setInvokableClass() method of the router
  plugin manager such that it also calls setAlias() to alias the FQCN to
  the service name; this ensures that usage of the FQCN for a class
  already registered as an invokable will work properly.

FIxes #3625
