### PR TITLE
Move service listener registrations to plugin managers

### DIFF
--- a/library/Zend/Mvc/Service/ControllerLoaderFactory.php
+++ b/library/Zend/Mvc/Service/ControllerLoaderFactory.php
@@ -44,6 +44,18 @@ class ControllerLoaderFactory implements FactoryInterface
             $controllerLoader->addAbstractFactory($serviceLocator->get('DiStrictAbstractServiceFactory'));
         }
 
+        /** @var $serviceListener \Zend\ModuleManager\Listener\ServiceListener */
+        $serviceListener = $serviceLocator->get('ServiceListener');
+
+        // This will allow to register new controllers easily, either by implementing the ControllerProviderInterface
+        // in your Module.php file, or by adding the "controllers" key in your module.config.php file
+        $serviceListener->addServiceManager(
+            'ControllerLoader',
+            'controllers',
+            'Zend\ModuleManager\Feature\ControllerProviderInterface',
+            'getControllerConfig'
+        );
+
         return $controllerLoader;
     }
 }

--- a/library/Zend/Mvc/Service/ControllerPluginManagerFactory.php
+++ b/library/Zend/Mvc/Service/ControllerPluginManagerFactory.php
@@ -24,7 +24,19 @@ class ControllerPluginManagerFactory extends AbstractPluginManagerFactory
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $plugins = parent::createService($serviceLocator);
-        return $plugins;
+        /** @var $serviceListener \Zend\ModuleManager\Listener\ServiceListener */
+        $serviceListener = $serviceLocator->get('ServiceListener');
+
+        // This will allow to register new controller plugins easily, either by implementing the
+        // ControllerPluginProviderInterface in your Module.php file, or by adding the "controller_plugins"
+        // key in your module.config.php file
+        $serviceListener->addServiceManager(
+            'ControllerPluginManager',
+            'controller_plugins',
+            'Zend\ModuleManager\Feature\ControllerPluginProviderInterface',
+            'getControllerPluginConfig'
+        );
+
+        return parent::createService($serviceLocator);
     }
 }

--- a/library/Zend/Mvc/Service/FilterManagerFactory.php
+++ b/library/Zend/Mvc/Service/FilterManagerFactory.php
@@ -20,11 +20,22 @@ class FilterManagerFactory extends AbstractPluginManagerFactory
      * Create and return the filter plugin manager
      *
      * @param  ServiceLocatorInterface $serviceLocator
-     * @return FilterPluginManager
+     * @return \Zend\Filter\FilterPluginManager
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $plugins = parent::createService($serviceLocator);
-        return $plugins;
+        /** @var $serviceListener \Zend\ModuleManager\Listener\ServiceListener */
+        $serviceListener = $serviceLocator->get('ServiceListener');
+
+        // This will allow to register new filters easily, either by implementing the FilterProviderInterface
+        // in your Module.php file, or by adding the "filters" key in your module.config.php file
+        $serviceListener->addServiceManager(
+            'FilterManager',
+            'filters',
+            'Zend\ModuleManager\Feature\FilterProviderInterface',
+            'getFilterConfig'
+        );
+
+        return parent::createService($serviceLocator);
     }
 }

--- a/library/Zend/Mvc/Service/FormElementManagerFactory.php
+++ b/library/Zend/Mvc/Service/FormElementManagerFactory.php
@@ -9,7 +9,6 @@
 
 namespace Zend\Mvc\Service;
 
-use Zend\Form\FormElementManager;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class FormElementManagerFactory extends AbstractPluginManagerFactory
@@ -20,11 +19,22 @@ class FormElementManagerFactory extends AbstractPluginManagerFactory
      * Create and return the MVC controller plugin manager
      *
      * @param  ServiceLocatorInterface $serviceLocator
-     * @return FormElementManager
+     * @return \Zend\Form\FormElementManager
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $plugins = parent::createService($serviceLocator);
-        return $plugins;
+        /** @var $serviceListener \Zend\ModuleManager\Listener\ServiceListener */
+        $serviceListener = $serviceLocator->get('ServiceListener');
+
+        // This will allow to register new form elements easily, either by implementing the FormElementProviderInterface
+        // in your Module.php file, or by adding the "form_elements" key in your module.config.php file
+        $serviceListener->addServiceManager(
+            'FormElementManager',
+            'form_elements',
+            'Zend\ModuleManager\Feature\FormElementProviderInterface',
+            'getFormElementConfig'
+        );
+
+        return parent::createService($serviceLocator);
     }
 }

--- a/library/Zend/Mvc/Service/ModuleManagerFactory.php
+++ b/library/Zend/Mvc/Service/ModuleManagerFactory.php
@@ -49,48 +49,6 @@ class ModuleManagerFactory implements FactoryInterface
             'Zend\ModuleManager\Feature\ServiceProviderInterface',
             'getServiceConfig'
         );
-        $serviceListener->addServiceManager(
-            'ControllerLoader',
-            'controllers',
-            'Zend\ModuleManager\Feature\ControllerProviderInterface',
-            'getControllerConfig'
-        );
-        $serviceListener->addServiceManager(
-            'ControllerPluginManager',
-            'controller_plugins',
-            'Zend\ModuleManager\Feature\ControllerPluginProviderInterface',
-            'getControllerPluginConfig'
-        );
-        $serviceListener->addServiceManager(
-            'ViewHelperManager',
-            'view_helpers',
-            'Zend\ModuleManager\Feature\ViewHelperProviderInterface',
-            'getViewHelperConfig'
-        );
-        $serviceListener->addServiceManager(
-            'ValidatorManager',
-            'validators',
-            'Zend\ModuleManager\Feature\ValidatorProviderInterface',
-            'getValidatorConfig'
-        );
-        $serviceListener->addServiceManager(
-            'FilterManager',
-            'filters',
-            'Zend\ModuleManager\Feature\FilterProviderInterface',
-            'getFilterConfig'
-        );
-        $serviceListener->addServiceManager(
-            'FormElementManager',
-            'form_elements',
-            'Zend\ModuleManager\Feature\FormElementProviderInterface',
-            'getFormElementConfig'
-        );
-        $serviceListener->addServiceManager(
-            'RoutePluginManager',
-            'route_manager',
-            'Zend\ModuleManager\Feature\RouteProviderInterface',
-            'getRouteConfig'
-        );
 
         $events = $serviceLocator->get('EventManager');
         $events->attach($defaultListeners);

--- a/library/Zend/Mvc/Service/PaginatorPluginManagerFactory.php
+++ b/library/Zend/Mvc/Service/PaginatorPluginManagerFactory.php
@@ -19,11 +19,10 @@ class PaginatorPluginManagerFactory extends AbstractPluginManagerFactory
      * Create and return the MVC controller plugin manager
      *
      * @param  ServiceLocatorInterface $serviceLocator
-     * @return ControllerPluginManager
+     * @return \Zend\Paginator\AdapterPluginManager
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $plugins = parent::createService($serviceLocator);
-        return $plugins;
+        return parent::createService($serviceLocator);
     }
 }

--- a/library/Zend/Mvc/Service/RoutePluginManagerFactory.php
+++ b/library/Zend/Mvc/Service/RoutePluginManagerFactory.php
@@ -9,7 +9,29 @@
 
 namespace Zend\Mvc\Service;
 
+use Zend\ServiceManager\ServiceLocatorInterface;
+
 class RoutePluginManagerFactory extends AbstractPluginManagerFactory
 {
     const PLUGIN_MANAGER_CLASS = 'Zend\Mvc\Router\RoutePluginManager';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        /** @var $serviceListener \Zend\ModuleManager\Listener\ServiceListener */
+        $serviceListener = $serviceLocator->get('ServiceListener');
+
+        // This will allow to register new routes easily, either by implementing the RouteProviderInterface
+        // in your Module.php file, or by adding the "route_manager" key in your module.config.php file
+        $serviceListener->addServiceManager(
+            'RoutePluginManager',
+            'route_manager',
+            'Zend\ModuleManager\Feature\RouteProviderInterface',
+            'getRouteConfig'
+        );
+
+        return parent::createService($serviceLocator);
+    }
 }

--- a/library/Zend/Mvc/Service/ValidatorManagerFactory.php
+++ b/library/Zend/Mvc/Service/ValidatorManagerFactory.php
@@ -9,7 +9,6 @@
 
 namespace Zend\Mvc\Service;
 
-use Zend\ServiceManager\ConfigInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class ValidatorManagerFactory extends AbstractPluginManagerFactory
@@ -20,11 +19,22 @@ class ValidatorManagerFactory extends AbstractPluginManagerFactory
      * Create and return the validator plugin manager
      *
      * @param  ServiceLocatorInterface $serviceLocator
-     * @return ValidatorPluginManager
+     * @return \Zend\Validator\ValidatorPluginManager
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $plugins = parent::createService($serviceLocator);
-        return $plugins;
+        /** @var $serviceListener \Zend\ModuleManager\Listener\ServiceListener */
+        $serviceListener = $serviceLocator->get('ServiceListener');
+
+        // This will allow to register new validators easily, either by implementing the ValidatorProviderInterface
+        // in your Module.php file, or by adding the "validators" key in your module.config.php file
+        $serviceListener->addServiceManager(
+            'ValidatorManager',
+            'validators',
+            'Zend\ModuleManager\Feature\ValidatorProviderInterface',
+            'getValidatorConfig'
+        );
+
+        return parent::createService($serviceLocator);
     }
 }

--- a/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
+++ b/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
@@ -105,6 +105,19 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
             return $doctypeHelper;
         });
 
+        /** @var $serviceListener \Zend\ModuleManager\Listener\ServiceListener */
+        $serviceListener = $serviceLocator->get('ServiceListener');
+
+        // This will allow to register new view helpers easily, either by implementing the
+        // ViewHelperProviderInterface in your Module.php file, or by adding the "view_helpers"
+        // key in your module.config.php file
+        $serviceListener->addServiceManager(
+            'ViewHelperManager',
+            'view_helpers',
+            'Zend\ModuleManager\Feature\ViewHelperProviderInterface',
+            'getViewHelperConfig'
+        );
+
         return $plugins;
     }
 }


### PR DESCRIPTION
The ModuleManagerFactory was getting really messy, furthermore it was hard to know under which keys which plugin manager was registered because they were all done in the ModuleManagerFactory.

This PR just moves the creation of those plugin managers from the ModuleManagerFactory to their respective factories.
