### PR TITLE
Exception on destructing the SMTP Transport instance

### DIFF
--- a/library/Zend/Mail/Protocol/Smtp.php
+++ b/library/Zend/Mail/Protocol/Smtp.php
@@ -376,10 +376,18 @@ class Smtp extends AbstractProtocol
      */
     public function disconnect()
     {
-        $this->quit();
         $this->_disconnect();
     }
 
+    /**
+     * Disconnect from remote host and free resource
+     */
+    protected function _disconnect()
+    {
+        // Make sure the session gets closed
+        $this->quit();
+        parent::_disconnect();
+    }
 
     /**
      * Start mail session


### PR DESCRIPTION
When the SMTP destructs the socket gets closed automatically to free up resources which is good, hoewever when the SMTP Transport desctructs it also calls the disconnect on the SMTP Protocol which is in the middle of destruction and does not have a valid socket anymore. At that moment the sess is still set to true resulting in an Exception on destruction. Implementint / overriding the _disconnect from the SMTP protocol makes sure quit gets issued as well. Quit in itself already checks if the session is still there and makes sure the session gets set to false after quitting.
