### PR TITLE
Ensure run() always returns Application instance

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -324,7 +324,7 @@ class Application implements
      * event object.
      *
      * @param  MvcEvent $event
-     * @return ResponseInterface
+     * @return Application
      */
     protected function completeRequest(MvcEvent $event)
     {
@@ -332,6 +332,6 @@ class Application implements
         $event->setTarget($this);
         $events->trigger(MvcEvent::EVENT_RENDER, $event);
         $events->trigger(MvcEvent::EVENT_FINISH, $event);
-        return $event->getResponse();
+        return $this;
     }
 }

--- a/tests/ZendTest/Mvc/ApplicationTest.php
+++ b/tests/ZendTest/Mvc/ApplicationTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Mvc;
 
 use ArrayObject;
 use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionObject;
 use stdClass;
 use Zend\Config\Config;
 use Zend\Http\Request;
@@ -643,5 +644,17 @@ class ApplicationTest extends TestCase
 
         $this->application->run();
         $this->assertTrue($triggered);
+    }
+
+    public function testCompleteRequestShouldReturnApplicationInstance()
+    {
+        $r      = new ReflectionObject($this->application);
+        $method = $r->getMethod('completeRequest');
+        $method->setAccessible(true);
+
+        $this->application->bootstrap();
+        $event  = $this->application->getMvcEvent();
+        $result = $method->invoke($this->application, $event);
+        $this->assertSame($this->application, $result);
     }
 }


### PR DESCRIPTION
- Some paths through `Application::run()` would call
  `return $this->completeRequest($event)`; this particular method was returning
  a response object, which meant that `send()` was resulting in a double-render.
  The main `run()` routine typically returns the Application instance, where
  `send()` is a no-op, and thus no double-render can occur.
- The workaround until this is merged and released is to remove the call to
  `->send()` in your `public/index.php`.

This fixes a situtation reported by Demian Katz on the contributors mailing list.
