### PR TITLE
Hotfix/3650

### DIFF
--- a/library/Zend/Mvc/Controller/ControllerManager.php
+++ b/library/Zend/Mvc/Controller/ControllerManager.php
@@ -10,6 +10,7 @@
 namespace Zend\Mvc\Controller;
 
 use Zend\EventManager\EventManagerAwareInterface;
+use Zend\EventManager\EventManagerInterface;
 use Zend\Mvc\Exception;
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ConfigInterface;
@@ -66,7 +67,17 @@ class ControllerManager extends AbstractPluginManager
         }
 
         if ($controller instanceof EventManagerAwareInterface) {
-            $controller->setEventManager($parentLocator->get('EventManager'));
+            // If we have an event manager composed already, make sure it gets
+            // injected with the shared event manager.
+            // The AbstractController lazy-instantiates an EM instance, which
+            // is why the shared EM injection needs to happen; the conditional
+            // will always pass.
+            $events = $controller->getEventManager();
+            if (!$events instanceof EventManagerInterface) {
+                $controller->setEventManager($parentLocator->get('EventManager'));
+            } else {
+                $events->setSharedManager($parentLocator->get('SharedEventManager'));
+            }
         }
 
         if (method_exists($controller, 'setPluginManager')) {

--- a/tests/ZendTest/Mvc/Controller/ControllerManagerTest.php
+++ b/tests/ZendTest/Mvc/Controller/ControllerManagerTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Controller;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\EventManager\EventManager;
+use Zend\EventManager\SharedEventManager;
+use Zend\Mvc\Controller\ControllerManager;
+use Zend\Mvc\Controller\PluginManager as ControllerPluginManager;
+use Zend\ServiceManager\ServiceManager;
+
+class ControllerManagerTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->events       = new EventManager();
+        $this->sharedEvents = new SharedEventManager;
+        $this->events->setSharedManager($this->sharedEvents);
+
+        $this->plugins  = new ControllerPluginManager();
+        $this->services = new ServiceManager();
+        $this->services->setService('Zend\ServiceManager\ServiceLocatorInterface', $this->services);
+        $this->services->setService('EventManager', $this->events);
+        $this->services->setService('SharedEventManager', $this->sharedEvents);
+        $this->services->setService('ControllerPluginManager', $this->plugins);
+
+        $this->controllers = new ControllerManager();
+        $this->controllers->setServiceLocator($this->services);
+    }
+
+    public function testInjectControllerDependenciesInjectsExpectedDependencies()
+    {
+        $controller = new TestAsset\SampleController();
+        $this->controllers->injectControllerDependencies($controller, $this->controllers);
+        $this->assertSame($this->services, $controller->getServiceLocator());
+        $this->assertSame($this->plugins, $controller->getPluginManager());
+
+        // The default AbstractController implementation lazy instantiates an EM
+        // instance, which means we need to check that that instance gets injected
+        // with the shared EM instance.
+        $events = $controller->getEventManager();
+        $this->assertInstanceOf('Zend\EventManager\EventManagerInterface', $events);
+        $this->assertSame($this->sharedEvents, $events->getSharedManager());
+    }
+
+    public function testInjectControllerDependenciesWillNotOverwriteExistingEventManager()
+    {
+        $events     = new EventManager();
+        $controller = new TestAsset\SampleController();
+        $controller->setEventManager($events);
+        $this->controllers->injectControllerDependencies($controller, $this->controllers);
+        $this->assertSame($events, $controller->getEventManager());
+        $this->assertSame($this->sharedEvents, $events->getSharedManager());
+    }
+}

--- a/tests/ZendTest/Mvc/Service/TestAsset/Dispatchable.php
+++ b/tests/ZendTest/Mvc/Service/TestAsset/Dispatchable.php
@@ -5,4 +5,11 @@ use Zend\Mvc\Controller\AbstractActionController;
 
 class Dispatchable extends AbstractActionController
 {
+    /**
+     * Override, so we can test injection
+     */
+    public function getEventManager()
+    {
+        return $this->events;
+    }
 }


### PR DESCRIPTION
The `ControllerManager` was injecting an `EventManager` instance, even if one was available. This meant that if you attached an EM instance inside a factory, it would be overwritten -- losing any listeners attached to it.

This PR does the following:
- If an EM instance is not present, it will do as it did previously, and inject the EM instance from the parent service manager.
- If an EM instance _is_ present, it will inject that instance with the shared EM instance form the parent service manager, but otherwise _not_ inject a new EM instance. This feature is present because the default `AbstractController` implementation lazy-instantiates an EM instance in `getEventManager()`; since this will mean no EM instance is injected, we need to inject the `SharedEventManager` to ensure the lazy instance can tie into application listeners.

This is completely BC, as previously, a new EM instance was _always_ injected by the `ControllerManager`; there was no opportunity to opt-out if your controller was `EventManagerAware`.

Fixes #3650
