### PR TITLE
ZF HTTP Status Code overwritten

### DIFF
--- a/library/Zend/Mvc/ResponseSender/AbstractResponseSender.php
+++ b/library/Zend/Mvc/ResponseSender/AbstractResponseSender.php
@@ -26,8 +26,6 @@ abstract class AbstractResponseSender implements ResponseSenderInterface
         }
 
         $response = $event->getResponse();
-        $status   = $response->renderStatusLine();
-        header($status);
 
         foreach ($response->getHeaders() as $header) {
             if ($header instanceof MultipleHeaderInterface) {
@@ -36,6 +34,9 @@ abstract class AbstractResponseSender implements ResponseSenderInterface
             }
             header($header->toString());
         }
+
+        $status = $response->renderStatusLine();
+        header($status);
 
         $event->setHeadersSent();
         return $this;

--- a/tests/ZendTest/Mvc/ResponseSender/AbstractResponseSenderTest.php
+++ b/tests/ZendTest/Mvc/ResponseSender/AbstractResponseSenderTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Mvc\ResponseSender;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Http\Headers;
 use Zend\Http\Response;
 
 /**
@@ -52,5 +53,35 @@ class AbstractResponseSenderTest extends TestCase
 
         $responseSender->sendHeaders($mockSendResponseEvent);
         $this->assertEquals(array(), xdebug_get_headers());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSendHeadersSendsStatusLast()
+    {
+        if (!function_exists('xdebug_get_headers')) {
+            $this->markTestSkipped('Xdebug extension needed, skipped test');
+        }
+
+        $mockResponse = $this->getMock('Zend\Http\Response');
+        $mockResponse->expects($this->once())->method('getHeaders')->will($this->returnValue(Headers::fromString('Location: example.com')));
+        $mockResponse->expects($this->once())->method('renderStatusLine')->will($this->returnValue('X-Test: HTTP/1.1 202 Accepted'));
+
+        $mockSendResponseEvent = $this->getMock('Zend\Mvc\ResponseSender\SendResponseEvent', array('getResponse'));
+        $mockSendResponseEvent->expects($this->any())->method('getResponse')->will($this->returnValue($mockResponse));
+
+        $responseSender = $this->getMockForAbstractClass('Zend\Mvc\ResponseSender\AbstractResponseSender');
+        $responseSender->sendHeaders($mockSendResponseEvent);
+
+        $sentHeaders = xdebug_get_headers();
+
+        $this->assertCount(2, $sentHeaders);
+        $this->assertEquals('Location: example.com', $sentHeaders[0]);
+        $this->assertEquals(
+            'X-Test: HTTP/1.1 202 Accepted',
+            $sentHeaders[1],
+            'Status header is sent last to prevent header() from overwriting the ZF status code when a Location header is used'
+        );
     }
 }


### PR DESCRIPTION
Using code as below (in any call order):

```
$response->setStatusCode(HttpResponse::STATUS_CODE_202);
$response->getHeaders()->addHeaderLine('Location', $location);
```

In a controller does not work because PHP's header() function sets a 302 code whenever a Location header is sent.

By sending the ZF "status header line" last we can make sure that the correct code is sent to the client. Unfortunately this cannot be tested explicitly because xdebug_get_headers() does not seem to return the status header.

Ref: http://php.net/manual/en/function.header.php
