### PR TITLE
Proper typehints in ServiceLocatorAwareTrait

### DIFF
--- a/library/Zend/ServiceManager/ServiceLocatorAwareTrait.php
+++ b/library/Zend/ServiceManager/ServiceLocatorAwareTrait.php
@@ -14,7 +14,7 @@ use Zend\ServiceManager\ServiceLocatorInterface;
 trait ServiceLocatorAwareTrait
 {
     /**
-     * @var ServiceLocator
+     * @var ServiceLocatorInterface
      */
     protected $serviceLocator = null;
 
@@ -34,7 +34,7 @@ trait ServiceLocatorAwareTrait
     /**
      * Get service locator
      *
-     * @return ServiceLocator
+     * @return ServiceLocatorInterface
      */
     public function getServiceLocator()
     {


### PR DESCRIPTION
The typehints are wrong. Either import the ServiceLocator class, or, what's the right thing, declare the types as what they are: ServiceLocatorInterface.
