### PR TITLE
Fix for chained Joins having at least one table alias set

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -665,6 +665,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 }
                 $joinSpecArgArray[$j][2] = $joinSpecArgArray[$j][2]->getSql();
             }
+            unset($joinAs);
         }
 
         return array($joinSpecArgArray);


### PR DESCRIPTION
The (optional) alias of a Join is now unset at the end of each loop, preventing an incorrect alias to be set when chaining multiple Joins.
