### PR TITLE
Hotfix/restful head identifier

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -281,7 +281,7 @@ abstract class AbstractRestfulController extends AbstractController
             // HEAD
             case 'head':
                 $id = $this->getIdentifier($routeMatch, $request);
-                if ($id !== false) {
+                if ($id === false) {
                     $id = null;
                 }
                 $action = 'head';

--- a/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
+++ b/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
@@ -193,6 +193,11 @@ class RestfulControllerTest extends TestCase
         $content = $result->getContent();
         $this->assertEquals('', $content);
         $this->assertEquals('head', $this->routeMatch->getParam('action'));
+
+        $headers = $this->controller->getResponse()->getHeaders();
+        $this->assertTrue($headers->has('X-ZF2-Id'));
+        $header  = $headers->get('X-ZF2-Id');
+        $this->assertEquals(1, $header->getFieldValue());
     }
 
     public function testAllowsRegisteringCustomHttpMethodsWithHandlers()

--- a/tests/ZendTest/Mvc/Controller/TestAsset/RestfulTestController.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/RestfulTestController.php
@@ -81,6 +81,9 @@ class RestfulTestController extends AbstractRestfulController
      */
     public function head($id = null)
     {
+        if ($id) {
+            $this->getResponse()->getHeaders()->addHeaderLine('X-ZF2-Id', $id);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes an issue reported by andrer in zftalk.dev (IRC). Essentially, HEAD calls with an identifier were always resetting the identifier to null, which meant that `head()` was never being called with the identifier. This patch (a) fixes the test to properly show that the identifier should be passed, and (b) fixes the issue.
