### PR TITLE
[#2899] Remove redundant method declaration

### DIFF
--- a/library/Zend/Console/Prompt/AbstractPrompt.php
+++ b/library/Zend/Console/Prompt/AbstractPrompt.php
@@ -27,13 +27,6 @@ abstract class AbstractPrompt implements PromptInterface
     protected $lastResponse;
 
     /**
-     * Show a prompt
-     *
-     * @return void
-     */
-    abstract public function show();
-
-    /**
      * Return last answer to this prompt.
      *
      * @return mixed


### PR DESCRIPTION
- Re-declaring a method as abstract when defined in an interface being
  implemented can lead to issues under some versions of PHP. Removing
  the abstract method in the abstract class fixes the issue.

Fixes #2899
