### PR TITLE
Zend\Db\Sql\Select Quantifier (DISTINCT, ALL, + Expression) support - supersedes #3455

### DIFF
--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -112,19 +112,30 @@ abstract class AbstractSql
     }
 
     /**
-     * @param $specification
+     * @param $specifications
      * @param $parameters
      * @return string
      * @throws Exception\RuntimeException
      */
-    protected function createSqlFromSpecificationAndParameters($specification, $parameters)
+    protected function createSqlFromSpecificationAndParameters($specifications, $parameters)
     {
-        if (is_string($specification)) {
-            return vsprintf($specification, $parameters);
+        if (is_string($specifications)) {
+            return vsprintf($specifications, $parameters);
         }
 
-        $topSpec = key($specification);
-        $paramSpecs = $specification[$topSpec];
+        $parametersCount = count($parameters);
+        foreach ($specifications as $specificationString => $paramSpecs) {
+            if ($parametersCount == count($paramSpecs)) {
+                break;
+            }
+            unset($specificationString, $paramSpecs);
+        }
+
+        if (!isset($specificationString)) {
+            throw new Exception\RuntimeException(
+                'A number of parameters was found that is not supported by this specification'
+            );
+        }
 
         $topParameters = array();
         foreach ($parameters as $position => $paramsForPosition) {
@@ -148,7 +159,7 @@ abstract class AbstractSql
                 $topParameters[] = $paramsForPosition;
             }
         }
-        return vsprintf($topSpec, $topParameters);
+        return vsprintf($specificationString, $topParameters);
     }
 
     protected function processSubSelect(Select $subselect, PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -54,6 +54,28 @@ class SelectTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @testdox unit test: Test quantifier() returns Select object (is chainable)
+     * @covers Zend\Db\Sql\Select::quantifier
+     */
+    public function testQuantifier()
+    {
+        $select = new Select;
+        $return = $select->quantifier($select::QUANTIFIER_DISTINCT);
+        $this->assertSame($select, $return);
+        return $return;
+    }
+
+    /**
+     * @testdox unit test: Test getRawState() returns infromation populated via from()
+     * @covers Zend\Db\Sql\Select::getRawState
+     * @depends testQuantifier
+     */
+    public function testGetRawStateViaQuantifier(Select $select)
+    {
+        $this->assertEquals(Select::QUANTIFIER_DISTINCT, $select->getRawState('quantifier'));
+    }
+
+    /**
      * @testdox unit test: Test columns() returns Select object (is chainable)
      * @covers Zend\Db\Sql\Select::columns
      */
@@ -979,6 +1001,23 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             ))
         );
 
+        $select41 = new Select;
+        $select41->from('foo')->quantifier(Select::QUANTIFIER_DISTINCT);
+        $sqlPrep41 = // same
+        $sqlStr41 = 'SELECT DISTINCT "foo".* FROM "foo"';
+        $internalTests41 = array(
+            'processSelect' => array(SELECT::QUANTIFIER_DISTINCT, array(array('"foo".*')), '"foo"'),
+        );
+
+        $select42 = new Select;
+        $select42->from('foo')->quantifier(new Expression('TOP ?', array(10)));
+        $sqlPrep42 = 'SELECT TOP ? "foo".* FROM "foo"';
+        $sqlStr42 = 'SELECT TOP \'10\' "foo".* FROM "foo"';
+        $internalTests42 = array(
+            'processSelect' => array('TOP ?', array(array('"foo".*')), '"foo"'),
+        );
+
+
         /**
          * $select = the select object
          * $sqlPrep = the sql as a result of preparation
@@ -1030,6 +1069,8 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             array($select38, $sqlPrep38, array(),    $sqlStr38, $internalTests38),
             array($select39, $sqlPrep39, array(),    $sqlStr39, $internalTests39),
             array($select40, $sqlPrep40, array(),    $sqlStr40, $internalTests40),
+            array($select41, $sqlPrep41, array(),    $sqlStr41, $internalTests41),
+            array($select42, $sqlPrep42, array(),    $sqlStr42, $internalTests42),
         );
     }
 }


### PR DESCRIPTION
- Added Quantifier support to Zend\Db\Sql\Select (DISTINCT, ALL and Expression)
- See #3455 for discussion
