### PR TITLE
[#3684] Polyfill support for version-dependent classes

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,8 +1,28 @@
 <?php
-echo "Loading " . __FILE__ . "\n";
 $finder = Symfony\CS\Finder\DefaultFinder::create()
     ->notName('TestSampleClass10.php')
     ->exclude('demos')
-    ->in(__DIR__);
-return Symfony\CS\Config\Config::create()
-    ->finder($finder);
+    ->exclude('resources')
+    ->filter(function (SplFileInfo $file) {
+        if (strstr($file->getPath(), 'compatibility')) {
+            return false;
+        }
+    })
+    ->in(__DIR__ . '/library')
+    ->in(__DIR__ . '/tests')
+    ->in(__DIR__ . '/bin');
+$config = Symfony\CS\Config\Config::create();
+$config->fixers(array(
+    'indentation',
+    'linefeed',
+    'trailing_spaces',
+    'php_closing_tag',
+    'short_tag',
+    'visibility',
+    'braces',
+    'eof_ending',
+    'psr0',
+    'elseif',
+));
+$config->finder($finder);
+return $config;

--- a/.php_cs
+++ b/.php_cs
@@ -12,17 +12,6 @@ $finder = Symfony\CS\Finder\DefaultFinder::create()
     ->in(__DIR__ . '/tests')
     ->in(__DIR__ . '/bin');
 $config = Symfony\CS\Config\Config::create();
-$config->fixers(array(
-    'indentation',
-    'linefeed',
-    'trailing_spaces',
-    'php_closing_tag',
-    'short_tag',
-    'visibility',
-    'braces',
-    'eof_ending',
-    'psr0',
-    'elseif',
-));
+$config->fixers(Symfony\CS\FixerInterface::PSR2_LEVEL);
 $config->finder($finder);
 return $config;

--- a/bin/travis-build.sh
+++ b/bin/travis-build.sh
@@ -4,44 +4,20 @@ php ./tests/run-tests.php
 testresults=$?
 echo "Unit tests exited with status $testresults"
 
-output=$(php php-cs-fixer.phar fix -v --dry-run --level=psr2 library)
+output=$(php php-cs-fixer.phar fix -v --dry-run --level=psr2 .)
 echo $output
-cslibrary=0
+cs=0
 if [[ "$output" -ne "" ]];then
-    cslibrary=2
+    cs=2
 fi
-echo "Coding standards (library) exited with status $cslibrary"
-
-output=$(php php-cs-fixer.phar fix -v --dry-run --level=psr2 tests)
-echo $output
-cstests=0
-if [[ "$output" -ne "" ]];then
-    cstests=2
-fi
-echo "Coding standards (tests) exited with status $cstests"
-
-output=$(php php-cs-fixer.phar fix -v --dry-run --level=psr2 bin)
-echo $output
-csbin=0
-if [[ "$output" -ne "" ]];then
-    csbin=2
-fi
-echo "Coding standards (bin) exited with status $csbin"
+echo "Coding standards exited with status $cs"
 
 if [[ "$testresults" -ne "0" ]]; then
     echo "Exiting with status 2 due to test failures" ; 
     exit 2 ;
 fi
-if [[ "$cslibrary" -eq "2" ]]; then
-    echo "Exiting with status 2 due to CS (library)" ; 
-    exit 2 ;
-fi
-if [[ "$cstests" -eq "2" ]]; then
-    echo "Exiting with status 2 due to CS (tests)" ; 
-    exit 2 ;
-fi
-if [[ "$csbin" -eq "2" ]]; then
-    echo "Exiting with status 2 due to CS (bin)" ; 
+if [[ "$cs" -eq "2" ]]; then
+    echo "Exiting with status 2 due to CS" ; 
     exit 2 ;
 fi
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
             "ZendTest\\": "tests/"
         },
         "files": [
-            "library/Zend/Stdlib/compatibility/autoload.php"
+            "library/Zend/Stdlib/compatibility/autoload.php",
+            "library/Zend/Session/compatibility/autoload.php"
         ]
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,10 @@
         "psr-0": {
             "Zend\\": "library/",
             "ZendTest\\": "tests/"
-        }
+        },
+        "files": [
+            "library/Zend/Stdlib/compatibility/autoload.php"
+        ]
     },
     "bin": [
         "bin/classmap_generator.php"

--- a/library/Zend/Session/Container.php
+++ b/library/Zend/Session/Container.php
@@ -9,64 +9,44 @@
 
 namespace Zend\Session;
 
-if (version_compare(PHP_VERSION, '5.3.3') > 0) {
+/**
+ * Session storage container
+ *
+ * Allows for interacting with session storage in isolated containers, which
+ * may have their own expiries, or even expiries per key in the container.
+ * Additionally, expiries may be absolute TTLs or measured in "hops", which
+ * are based on how many times the key or container were accessed.
+ */
+class Container extends AbstractContainer
+{
     /**
-     * Session storage container
+     * Exchange the current array with another array or object.
      *
-     * Allows for interacting with session storage in isolated containers, which
-     * may have their own expiries, or even expiries per key in the container.
-     * Additionally, expiries may be absolute TTLs or measured in "hops", which
-     * are based on how many times the key or container were accessed.
+     * @param  array|object $input
+     * @return array        Returns the old array
+     * @see ArrayObject::exchangeArray()
      */
-    class Container extends AbstractContainer
+    public function exchangeArray(array $input)
     {
-        /**
-         * Exchange the current array with another array or object.
-         *
-         * @param  array|object $input
-         * @return array        Returns the old array
-         * @see ArrayObject::exchangeArray()
-         */
-        public function exchangeArray(array $input)
-        {
-            return parent::exchangeArrayCompat($input);
-        }
+        return parent::exchangeArrayCompat($input);
+    }
 
-        /**
-         * Retrieve a specific key in the container
-         *
-         * @param  string $key
-         * @return mixed
-         */
-        public function &offsetGet($key)
-        {
-            $ret = null;
-            if (!$this->offsetExists($key)) {
-                return $ret;
-            }
-            $storage = $this->getStorage();
-            $name    = $this->getName();
-            $ret =& $storage[$name][$key];
-
+    /**
+     * Retrieve a specific key in the container
+     *
+     * @param  string $key
+     * @return mixed
+     */
+    public function &offsetGet($key)
+    {
+        $ret = null;
+        if (!$this->offsetExists($key)) {
             return $ret;
         }
-    }
-} else {
-    /**
-     * Session storage container for PHP 5.3.3 and less
-     */
-    class Container extends AbstractContainer
-    {
-        /**
-         * Exchange the current array with another array or object.
-         *
-         * @param  array|object $input
-         * @return array        Returns the old array
-         * @see ArrayObject::exchangeArray()
-         */
-        public function exchangeArray($input)
-        {
-            return parent::exchangeArrayCompat($input);
-        }
+        $storage = $this->getStorage();
+        $name    = $this->getName();
+        $ret =& $storage[$name][$key];
+
+        return $ret;
     }
 }

--- a/library/Zend/Session/Storage/SessionArrayStorage.php
+++ b/library/Zend/Session/Storage/SessionArrayStorage.php
@@ -9,48 +9,38 @@
 
 namespace Zend\Session\Storage;
 
-use ArrayIterator;
-use IteratorAggregate;
-use Zend\Session\Exception;
-
-if (version_compare(PHP_VERSION, '5.3.3') > 0) {
+/**
+ * Session storage in $_SESSION
+ */
+class SessionArrayStorage extends AbstractSessionArrayStorage
+{
     /**
-     * Session storage in $_SESSION
+     * Get Offset
+     *
+     * @param  mixed $key
+     * @return mixed
      */
-    class SessionArrayStorage extends AbstractSessionArrayStorage
+    public function &__get($key)
     {
-        /**
-         * Get Offset
-         *
-         * @param  mixed $key
-         * @return mixed
-         */
-        public function &__get($key)
-        {
-            if (isset($_SESSION[$key])) {
-                return $_SESSION[$key];
-            }
-
-            return null;
+        if (isset($_SESSION[$key])) {
+            return $_SESSION[$key];
         }
 
-        /**
-         * Offset Get
-         *
-         * @param  mixed $key
-         * @return mixed
-         */
-        public function &offsetGet($key)
-        {
-            if (isset($_SESSION[$key])) {
-                return $_SESSION[$key];
-            }
-
-            return null;
-        }
+        return null;
     }
-} else {
-    class SessionArrayStorage extends AbstractSessionArrayStorage
+
+    /**
+     * Offset Get
+     *
+     * @param  mixed $key
+     * @return mixed
+     */
+    public function &offsetGet($key)
     {
+        if (isset($_SESSION[$key])) {
+            return $_SESSION[$key];
+        }
+
+        return null;
     }
 }

--- a/library/Zend/Session/compatibility/Container.php
+++ b/library/Zend/Session/compatibility/Container.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Session;
+
+/**
+ * Session storage container for PHP 5.3.3 and less
+ */
+class Container extends AbstractContainer
+{
+    /**
+     * Exchange the current array with another array or object.
+     *
+     * @param  array|object $input
+     * @return array        Returns the old array
+     * @see ArrayObject::exchangeArray()
+     */
+    public function exchangeArray($input)
+    {
+        return parent::exchangeArrayCompat($input);
+    }
+}

--- a/library/Zend/Session/compatibility/Storage/SessionArrayStorage.php
+++ b/library/Zend/Session/compatibility/Storage/SessionArrayStorage.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Session\Storage;
+
+/**
+ * PHP 5.3.3 variant of SessionArrayStorage
+ */
+class SessionArrayStorage extends AbstractSessionArrayStorage
+{
+}

--- a/library/Zend/Session/compatibility/autoload.php
+++ b/library/Zend/Session/compatibility/autoload.php
@@ -1,0 +1,5 @@
+<?php
+if (version_compare(PHP_VERSION, '5.3.3', 'le')) {
+    require_once __DIR__ . '/Container.php';
+    require_once __DIR__ . '/Storage/SessionArrayStorage.php';
+}

--- a/library/Zend/Session/composer.json
+++ b/library/Zend/Session/composer.json
@@ -9,7 +9,10 @@
     "autoload": {
         "psr-0": {
             "Zend\\Session\\": ""
-        }
+        },
+        "files": [
+            "compatibility/autoload.php"
+        ]
     },
     "target-dir": "Zend/Session",
     "require": {

--- a/library/Zend/Stdlib/ArrayObject.php
+++ b/library/Zend/Stdlib/ArrayObject.php
@@ -9,430 +9,411 @@
 
 namespace Zend\Stdlib;
 
-use ArrayObject as PhpArrayObject;
 use IteratorAggregate;
 use ArrayAccess;
 use Serializable;
 use Countable;
 
-// use our own version of arrayobject to handle references
-if (version_compare(PHP_VERSION, '5.3.3') > 0) {
+/**
+ * ArrayObject
+ *
+ * This ArrayObject is a rewrite of the implementation to fix
+ * issues with php's implementation of ArrayObject where you
+ * are unable to unset multi-dimensional arrays because you
+ * need to fetch the properties / lists as references.
+ */
+class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Countable
+{
     /**
-     * ArrayObject
-     * This ArrayObject is a rewrite of the implementation to fix
-     * issues with php's implementation of ArrayObject where you
-     * are unable to unset multi-dimensional arrays because you
-     * need to fetch the properties / lists as references.
+     * Properties of the object have their normal functionality
+     * when accessed as list (var_dump, foreach, etc.).
      */
-    class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Countable
+    const STD_PROP_LIST = 1;
+
+    /**
+     * Entries can be accessed as properties (read and write).
+     */
+    const ARRAY_AS_PROPS = 2;
+
+    /**
+     * @var array
+     */
+    protected $storage;
+
+    /**
+     * @var int
+     */
+    protected $flag;
+
+    /**
+     * @var string
+     */
+    protected $iteratorClass;
+
+    /**
+     * @var array
+     */
+    protected $protectedProperties;
+
+    /**
+     * Constructor
+     *
+     * @param  array       $input
+     * @param  int         $flags
+     * @param  string      $iteratorClass
+     * @return ArrayObject
+     */
+    public function __construct($input = array(), $flags = self::STD_PROP_LIST, $iteratorClass = 'ArrayIterator')
     {
-        /**
-         * Properties of the object have their normal functionality
-         * when accessed as list (var_dump, foreach, etc.).
-         */
-        const STD_PROP_LIST = 1;
+        $this->setFlags($flags);
+        $this->storage = $input;
+        $this->setIteratorClass($iteratorClass);
+        $this->protectedProperties = array_keys(get_object_vars($this));
+    }
 
-        /**
-         * Entries can be accessed as properties (read and write).
-         */
-        const ARRAY_AS_PROPS = 2;
-
-        /**
-         * @var array
-         */
-        protected $storage;
-
-        /**
-         * @var int
-         */
-        protected $flag;
-
-        /**
-         * @var string
-         */
-        protected $iteratorClass;
-
-        /**
-         * @var array
-         */
-        protected $protectedProperties;
-
-        /**
-         * Constructor
-         *
-         * @param  array       $input
-         * @param  int         $flags
-         * @param  string      $iteratorClass
-         * @return ArrayObject
-         */
-        public function __construct($input = array(), $flags = self::STD_PROP_LIST, $iteratorClass = 'ArrayIterator')
-        {
-            $this->setFlags($flags);
-            $this->storage = $input;
-            $this->setIteratorClass($iteratorClass);
-            $this->protectedProperties = array_keys(get_object_vars($this));
+    /**
+     * Returns whether the requested key exists
+     *
+     * @return boolean
+     */
+    public function __isset($key)
+    {
+        if ($this->flag == self::ARRAY_AS_PROPS) {
+            return $this->offsetExists($key);
+        }
+        if (in_array($key, $this->protectedProperties)) {
+            throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
         }
 
-        /**
-         * Returns whether the requested key exists
-         *
-         * @return boolean
-         */
-        public function __isset($key)
-        {
-            if ($this->flag == self::ARRAY_AS_PROPS) {
-                return $this->offsetExists($key);
-            }
-            if (in_array($key, $this->protectedProperties)) {
-                throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
-            }
+        return isset($this->$key);
+    }
 
-            return isset($this->$key);
+    /**
+     * Sets the value at the specified key to value
+     *
+     * @param  mixed $key
+     * @param  mixed $value
+     * @return void
+     */
+    public function __set($key, $value)
+    {
+        if ($this->flag == self::ARRAY_AS_PROPS) {
+            return $this->offsetSet($key, $value);
         }
-
-        /**
-         * Sets the value at the specified key to value
-         *
-         * @param  mixed $key
-         * @param  mixed $value
-         * @return void
-         */
-        public function __set($key, $value)
-        {
-            if ($this->flag == self::ARRAY_AS_PROPS) {
-                return $this->offsetSet($key, $value);
-            }
-            if (in_array($key, $this->protectedProperties)) {
-                throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
-            }
-            $this->$key = $value;
+        if (in_array($key, $this->protectedProperties)) {
+            throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
         }
+        $this->$key = $value;
+    }
 
-        /**
-         * Unsets the value at the specified key
-         *
-         * @param  mixed $key
-         * @return void
-         */
-        public function __unset($key)
-        {
-            if ($this->flag == self::ARRAY_AS_PROPS) {
-                return $this->offsetUnset($key);
-            }
-            if (in_array($key, $this->protectedProperties)) {
-                throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
-            }
-            unset($this->$key);
+    /**
+     * Unsets the value at the specified key
+     *
+     * @param  mixed $key
+     * @return void
+     */
+    public function __unset($key)
+    {
+        if ($this->flag == self::ARRAY_AS_PROPS) {
+            return $this->offsetUnset($key);
         }
-
-        /**
-         * Returns the value at the specified key by reference
-         *
-         * @param  mixed $key
-         * @return mixed
-         */
-        public function &__get($key)
-        {
-            $ret = null;
-            if ($this->flag == self::ARRAY_AS_PROPS) {
-                $ret =& $this->offsetGet($key);
-
-                return $ret;
-            }
-            if (in_array($key, $this->protectedProperties)) {
-                throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
-            }
-
-            return $this->$key;
+        if (in_array($key, $this->protectedProperties)) {
+            throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
         }
+        unset($this->$key);
+    }
 
-        /**
-         * Appends the value
-         *
-         * @param  mixed $value
-         * @return void
-         */
-        public function append($value)
-        {
-            $this->storage[] = $value;
-        }
-
-        /**
-         * Sort the entries by value
-         *
-         * @return void
-         */
-        public function asort()
-        {
-            asort($this->storage);
-        }
-
-        /**
-         * Get the number of public properties in the ArrayObject
-         *
-         * @return int
-         */
-        public function count()
-        {
-            return count($this->storage);
-        }
-
-        /**
-         * Exchange the array for another one.
-         *
-         * @param  array $data
-         * @return array
-         */
-        public function exchangeArray(array $data)
-        {
-            $storage = $this->storage;
-
-            $this->storage = $data;
-
-            return $storage;
-        }
-
-        /**
-         * Creates a copy of the ArrayObject.
-         *
-         * @return array
-         */
-        public function getArrayCopy()
-        {
-            return $this->storage;
-        }
-
-        /**
-         * Gets the behavior flags.
-         *
-         * @return int
-         */
-        public function getFlags()
-        {
-            return $this->flag;
-        }
-
-        /**
-         * Create a new iterator from an ArrayObject instance
-         *
-         * @return Iterator
-         */
-        public function getIterator()
-        {
-            $class = $this->iteratorClass;
-
-            return new $class($this->storage);
-        }
-
-        /**
-         * Gets the iterator classname for the ArrayObject.
-         *
-         * @return string
-         */
-        public function getIteratorClass()
-        {
-            return $this->iteratorClass;
-        }
-
-        /**
-         * Sort the entries by key
-         *
-         * @return void
-         */
-        public function ksort()
-        {
-            ksort($this->storage);
-        }
-
-        /**
-         * Sort an array using a case insensitive "natural order" algorithm
-         *
-         * @return void
-         */
-        public function natcasesort()
-        {
-            natcasesort($this->storage);
-        }
-
-        /**
-         * Sort entries using a "natural order" algorithm
-         *
-         * @return void
-         */
-        public function natsort()
-        {
-            natsort($this->storage);
-        }
-
-        /**
-         * Returns whether the requested key exists
-         *
-         * @return boolean
-         */
-        public function offsetExists($key)
-        {
-            return isset($this->storage[$key]);
-        }
-
-        /**
-         * Returns the value at the specified key
-         *
-         * @param  mixed $key
-         * @return mixed
-         */
-        public function &offsetGet($key)
-        {
-            $ret = null;
-            if (!$this->offsetExists($key)) {
-                return $ret;
-            }
-            $ret =& $this->storage[$key];
+    /**
+     * Returns the value at the specified key by reference
+     *
+     * @param  mixed $key
+     * @return mixed
+     */
+    public function &__get($key)
+    {
+        $ret = null;
+        if ($this->flag == self::ARRAY_AS_PROPS) {
+            $ret =& $this->offsetGet($key);
 
             return $ret;
         }
-
-        /**
-         * Sets the value at the specified key to value
-         *
-         * @param  mixed $key
-         * @param  mixed $value
-         * @return void
-         */
-        public function offsetSet($key, $value)
-        {
-            $this->storage[$key] = $value;
+        if (in_array($key, $this->protectedProperties)) {
+            throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
         }
 
-        /**
-         * Unsets the value at the specified key
-         *
-         * @return void
-         */
-        public function offsetUnset($key)
-        {
-            if ($this->offsetExists($key)) {
-                unset($this->storage[$key]);
-            }
+        return $this->$key;
+    }
+
+    /**
+     * Appends the value
+     *
+     * @param  mixed $value
+     * @return void
+     */
+    public function append($value)
+    {
+        $this->storage[] = $value;
+    }
+
+    /**
+     * Sort the entries by value
+     *
+     * @return void
+     */
+    public function asort()
+    {
+        asort($this->storage);
+    }
+
+    /**
+     * Get the number of public properties in the ArrayObject
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->storage);
+    }
+
+    /**
+     * Exchange the array for another one.
+     *
+     * @param  array $data
+     * @return array
+     */
+    public function exchangeArray(array $data)
+    {
+        $storage = $this->storage;
+
+        $this->storage = $data;
+
+        return $storage;
+    }
+
+    /**
+     * Creates a copy of the ArrayObject.
+     *
+     * @return array
+     */
+    public function getArrayCopy()
+    {
+        return $this->storage;
+    }
+
+    /**
+     * Gets the behavior flags.
+     *
+     * @return int
+     */
+    public function getFlags()
+    {
+        return $this->flag;
+    }
+
+    /**
+     * Create a new iterator from an ArrayObject instance
+     *
+     * @return Iterator
+     */
+    public function getIterator()
+    {
+        $class = $this->iteratorClass;
+
+        return new $class($this->storage);
+    }
+
+    /**
+     * Gets the iterator classname for the ArrayObject.
+     *
+     * @return string
+     */
+    public function getIteratorClass()
+    {
+        return $this->iteratorClass;
+    }
+
+    /**
+     * Sort the entries by key
+     *
+     * @return void
+     */
+    public function ksort()
+    {
+        ksort($this->storage);
+    }
+
+    /**
+     * Sort an array using a case insensitive "natural order" algorithm
+     *
+     * @return void
+     */
+    public function natcasesort()
+    {
+        natcasesort($this->storage);
+    }
+
+    /**
+     * Sort entries using a "natural order" algorithm
+     *
+     * @return void
+     */
+    public function natsort()
+    {
+        natsort($this->storage);
+    }
+
+    /**
+     * Returns whether the requested key exists
+     *
+     * @return boolean
+     */
+    public function offsetExists($key)
+    {
+        return isset($this->storage[$key]);
+    }
+
+    /**
+     * Returns the value at the specified key
+     *
+     * @param  mixed $key
+     * @return mixed
+     */
+    public function &offsetGet($key)
+    {
+        $ret = null;
+        if (!$this->offsetExists($key)) {
+            return $ret;
+        }
+        $ret =& $this->storage[$key];
+
+        return $ret;
+    }
+
+    /**
+     * Sets the value at the specified key to value
+     *
+     * @param  mixed $key
+     * @param  mixed $value
+     * @return void
+     */
+    public function offsetSet($key, $value)
+    {
+        $this->storage[$key] = $value;
+    }
+
+    /**
+     * Unsets the value at the specified key
+     *
+     * @return void
+     */
+    public function offsetUnset($key)
+    {
+        if ($this->offsetExists($key)) {
+            unset($this->storage[$key]);
+        }
+    }
+
+    /**
+     * Serialize an ArrayObject
+     *
+     * @return string
+     */
+    public function serialize()
+    {
+        return serialize(get_object_vars($this));
+    }
+
+    /**
+     * Sets the behavior flags
+     *
+     * @param  int  $flags
+     * @return void
+     */
+    public function setFlags($flags)
+    {
+        $this->flag = $flags;
+    }
+
+    /**
+     * Sets the iterator classname for the ArrayObject
+     *
+     * @param  string $class
+     * @return void
+     */
+    public function setIteratorClass($class)
+    {
+        if (class_exists($class)) {
+            $this->iteratorClass = $class;
+
+            return ;
         }
 
-        /**
-         * Serialize an ArrayObject
-         *
-         * @return string
-         */
-        public function serialize()
-        {
-            return serialize(get_object_vars($this));
-        }
-
-        /**
-         * Sets the behavior flags
-         *
-         * @param  int  $flags
-         * @return void
-         */
-        public function setFlags($flags)
-        {
-            $this->flag = $flags;
-        }
-
-        /**
-         * Sets the iterator classname for the ArrayObject
-         *
-         * @param  string $class
-         * @return void
-         */
-        public function setIteratorClass($class)
-        {
+        if (strpos($class, '\\') === 0) {
+            $class = '\\' . $class;
             if (class_exists($class)) {
                 $this->iteratorClass = $class;
 
                 return ;
             }
-
-            if (strpos($class, '\\') === 0) {
-                $class = '\\' . $class;
-                if (class_exists($class)) {
-                    $this->iteratorClass = $class;
-
-                    return ;
-                }
-            }
-
-            throw new Exception\InvalidArgumentException('The iterator class does not exist');
         }
 
-        /**
-         * Sort the entries with a user-defined comparison function and maintain key association
-         *
-         * @param  callable $function
-         * @return void
-         */
-        public function uasort($function)
-        {
-            if (is_callable($function)) {
-                uasort($this->storage, $function);
-            }
-        }
+        throw new Exception\InvalidArgumentException('The iterator class does not exist');
+    }
 
-        /**
-         * Sort the entries by keys using a user-defined comparison function
-         *
-         * @param  callable $function
-         * @return void
-         */
-        public function uksort($function)
-        {
-            if (is_callable($function)) {
-                uksort($this->storage, $function);
-            }
-        }
-
-        /**
-         * Unserialize an ArrayObject
-         *
-         * @param  string $data
-         * @return void
-         */
-        public function unserialize($data)
-        {
-            $ar = unserialize($data);
-            $this->setFlags($ar['flag']);
-            $this->exchangeArray($ar['storage']);
-            $this->setIteratorClass($ar['iteratorClass']);
-            foreach ($ar as $k => $v) {
-                switch ($k) {
-                    case 'flag':
-                        $this->setFlags($v);
-                        break;
-                    case 'storage':
-                        $this->exchangeArray($v);
-                        break;
-                    case 'iteratorClass':
-                        $this->setIteratorClass($v);
-                        break;
-                    case 'protectedProperties':
-                        continue;
-                    default:
-                        $this->__set($k, $v);
-                }
-            }
+    /**
+     * Sort the entries with a user-defined comparison function and maintain key association
+     *
+     * @param  callable $function
+     * @return void
+     */
+    public function uasort($function)
+    {
+        if (is_callable($function)) {
+            uasort($this->storage, $function);
         }
     }
-} else {
-    class ArrayObject extends PhpArrayObject
+
+    /**
+     * Sort the entries by keys using a user-defined comparison function
+     *
+     * @param  callable $function
+     * @return void
+     */
+    public function uksort($function)
     {
-        /**
-         * Constructor
-         *
-         * @param  array       $input
-         * @param  int         $flags
-         * @param  string      $iteratorClass
-         * @return ArrayObject
-         */
-        public function __construct($input = array(), $flags = self::STD_PROP_LIST, $iteratorClass = 'ArrayIterator')
-        {
-            parent::__construct($input, $flags, $iteratorClass);
+        if (is_callable($function)) {
+            uksort($this->storage, $function);
+        }
+    }
+
+    /**
+     * Unserialize an ArrayObject
+     *
+     * @param  string $data
+     * @return void
+     */
+    public function unserialize($data)
+    {
+        $ar = unserialize($data);
+        $this->setFlags($ar['flag']);
+        $this->exchangeArray($ar['storage']);
+        $this->setIteratorClass($ar['iteratorClass']);
+        foreach ($ar as $k => $v) {
+            switch ($k) {
+                case 'flag':
+                    $this->setFlags($v);
+                    break;
+                case 'storage':
+                    $this->exchangeArray($v);
+                    break;
+                case 'iteratorClass':
+                    $this->setIteratorClass($v);
+                    break;
+                case 'protectedProperties':
+                    continue;
+                default:
+                    $this->__set($k, $v);
+            }
         }
     }
 }

--- a/library/Zend/Stdlib/compatibility/ArrayObject.php
+++ b/library/Zend/Stdlib/compatibility/ArrayObject.php
@@ -22,13 +22,13 @@ use ArrayObject as PhpArrayObject;
 class ArrayObject extends PhpArrayObject
 {
     /**
-        * Constructor
-        *
-        * @param  array       $input
-        * @param  int         $flags
-        * @param  string      $iteratorClass
-        * @return ArrayObject
-        */
+     * Constructor
+     *
+     * @param  array       $input
+     * @param  int         $flags
+     * @param  string      $iteratorClass
+     * @return ArrayObject
+     */
     public function __construct($input = array(), $flags = self::STD_PROP_LIST, $iteratorClass = 'ArrayIterator')
     {
         parent::__construct($input, $flags, $iteratorClass);

--- a/library/Zend/Stdlib/compatibility/ArrayObject.php
+++ b/library/Zend/Stdlib/compatibility/ArrayObject.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib;
+
+use ArrayObject as PhpArrayObject;
+
+/**
+ * ArrayObject
+ *
+ * Since we need to substitute an alternate ArrayObject implementation for
+ * versions > 5.3.3, we need to provide a stub for 5.3.3. This stub
+ * simply extends the PHP ArrayObject implementation, and provides default
+ * behavior in the constructor.
+ */
+class ArrayObject extends PhpArrayObject
+{
+    /**
+        * Constructor
+        *
+        * @param  array       $input
+        * @param  int         $flags
+        * @param  string      $iteratorClass
+        * @return ArrayObject
+        */
+    public function __construct($input = array(), $flags = self::STD_PROP_LIST, $iteratorClass = 'ArrayIterator')
+    {
+        parent::__construct($input, $flags, $iteratorClass);
+    }
+}

--- a/library/Zend/Stdlib/compatibility/autoload.php
+++ b/library/Zend/Stdlib/compatibility/autoload.php
@@ -1,0 +1,4 @@
+<?php
+if (version_compare(PHP_VERSION, '5.3.3', 'le')) {
+    require_once __DIR__ . '/ArrayObject.php';
+}

--- a/library/Zend/Stdlib/composer.json
+++ b/library/Zend/Stdlib/composer.json
@@ -9,7 +9,10 @@
     "autoload": {
         "psr-0": {
             "Zend\\Stdlib\\": ""
-        }
+        },
+        "files": [
+            "compatibility/autoload.php"
+        ]
     },
     "target-dir": "Zend/Stdlib",
     "suggest": {


### PR DESCRIPTION
- Per ideas from @ircmaxell, removed the conditional declaration of classes in
  favor of an autoloading solution. If using 5.3.3, composer will now load
  alternate `Zend\Stdlib\ArrayObject`, `Zend\Session\Container`, and `Zend\Session\Storage\SessionArrayStorage` implementations.
  
  Both the project- and component-level composer.json files were modified so
  that the change will take place regardless of whether you install the full
  framework or just the component.
- Made changes to the php-code-sniffer configuration to ensure that the
  PHP-5.3.3-specific compatibility implementations are not checked, as they violate
  PSR-0 intentionally.
  - Realized that travis-build could be simplified, as .php_cs has the expected
    configuration for the full framework.

This builds on the ideas in #3684 and addresses the concerns about having the solution work for the individual component install versus a full framework install, and addresses the Session component as well.
