### PR TITLE
Hotfix/db parametercontainer mixed use

### DIFF
--- a/library/Zend/Db/Adapter/ParameterContainer.php
+++ b/library/Zend/Db/Adapter/ParameterContainer.php
@@ -91,10 +91,27 @@ class ParameterContainer implements \Iterator, \ArrayAccess, \Countable
      */
     public function offsetSet($name, $value, $errata = null)
     {
-        $this->data[$name] = $value;
+        $position = false;
 
-        $names = array_keys($this->data);
-        $this->positions[array_search($name, $names)] = $name;
+        // if integer, get name for this position
+        if (is_int($name)) {
+            if (isset($this->positions[$name])) {
+                $position = $name;
+                $name = $this->positions[$name];
+            } else {
+                $name = (string) $name;
+            }
+        } else {
+            // is a string:
+            $currentNames = array_keys($this->data);
+            $position = array_search($name, $currentNames, true);
+        }
+
+        if ($position === false) {
+            $this->positions[] = $name;
+        }
+
+        $this->data[$name] = $value;
 
         if ($errata) {
             $this->offsetSetErrata($name, $errata);
@@ -109,7 +126,7 @@ class ParameterContainer implements \Iterator, \ArrayAccess, \Countable
      */
     public function offsetUnset($name)
     {
-        if (is_int($name)) {
+        if (is_int($name) && isset($this->positions[$name])) {
             $name = $this->positions[$name];
         }
         unset($this->data[$name]);

--- a/library/Zend/Db/Adapter/ParameterContainer.php
+++ b/library/Zend/Db/Adapter/ParameterContainer.php
@@ -101,10 +101,14 @@ class ParameterContainer implements \Iterator, \ArrayAccess, \Countable
             } else {
                 $name = (string) $name;
             }
-        } else {
+        } elseif (is_string($name)) {
             // is a string:
             $currentNames = array_keys($this->data);
             $position = array_search($name, $currentNames, true);
+        } elseif ($name === null) {
+            $name = (string) count($this->data);
+        } else {
+            throw new Exception\InvalidArgumentException('Keys must be string, integer or null');
         }
 
         if ($position === false) {

--- a/tests/ZendTest/Db/Adapter/ParameterContainerTest.php
+++ b/tests/ZendTest/Db/Adapter/ParameterContainerTest.php
@@ -72,6 +72,14 @@ class ParameterContainerTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals('string', $this->parameterContainer->offsetGetErrata('1'));
+
+        // test that setting an index applies to correct named parameter
+        $this->parameterContainer[0] = 'Zero';
+        $this->parameterContainer[1] = 'One';
+        $this->assertEquals(
+            array('foo' => 'Zero', 'boo' => 'One', '1' => 'book'),
+            $this->parameterContainer->getNamedArray()
+        );
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/ParameterContainerTest.php
+++ b/tests/ZendTest/Db/Adapter/ParameterContainerTest.php
@@ -80,6 +80,23 @@ class ParameterContainerTest extends \PHPUnit_Framework_TestCase
             array('foo' => 'Zero', 'boo' => 'One', '1' => 'book'),
             $this->parameterContainer->getNamedArray()
         );
+        $this->assertEquals(
+            array(0 => 'Zero', 1 => 'One', 2 => 'book'),
+            $this->parameterContainer->getPositionalArray()
+        );
+
+        // test no-index applies
+        $this->parameterContainer['buffer'] = 'A buffer Element';
+        $this->parameterContainer[] = 'Second To Last';
+        $this->parameterContainer[] = 'Last';
+        $this->assertEquals(
+            array('foo' => 'Zero', 'boo' => 'One', '1' => 'book', 'buffer' => 'A buffer Element', '4' => 'Second To Last', '5' => 'Last'),
+            $this->parameterContainer->getNamedArray()
+        );
+        $this->assertEquals(
+            array(0 => 'Zero', 1 => 'One', 2 => 'book', 3 => 'A buffer Element', 4 => 'Second To Last', 5 => 'Last'),
+            $this->parameterContainer->getPositionalArray()
+        );
     }
 
     /**


### PR DESCRIPTION
Fixed ParameterContainer to do lookups when index provided offsets are provided, and when named parameters are already supplied.
