### PR TITLE
Certain servers may not set a whitespace after a colon (Set-Cookie: header)

### DIFF
--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -228,7 +228,7 @@ class SetCookie implements MultipleHeaderInterface
     public function getFieldValue()
     {
         if ($this->getName() == '') {
-            throw new Exception\RuntimeException('A cookie name is required to generate a field value for this cookie');
+            return '';
         }
 
         $value = $this->getValue();

--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -132,7 +132,8 @@ class SetCookie implements MultipleHeaderInterface
             };
         }
 
-        list($name, $value) = explode(': ', $headerLine, 2);
+        list($name, $value) = explode(':', $headerLine, 2);
+        $value = ltrim($value);
 
         // some sites return set-cookie::value, this is to get rid of the second :
         $name = (strtolower($name) =='set-cookie:') ? 'set-cookie' : $name;

--- a/tests/ZendTest/Http/Header/SetCookieTest.php
+++ b/tests/ZendTest/Http/Header/SetCookieTest.php
@@ -334,7 +334,16 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
                 ),
                 'myname=myvalue; Expires=Wed, 13-Jan-2021 22:23:01 GMT; Domain=docs.foo.com; Path=/accounts; Secure; HttpOnly'
             ),
+            array(
+                'Set-Cookie:',
+                array(),
+                ''
+            ),
+            array(
+                'Set-Cookie: ',
+                array(),
+                ''
+            ),
         );
     }
-
 }


### PR DESCRIPTION
If there is no whitespace after a colon, PHP Notice `Undefined offset: 1 in \Zend\Http\Header\SetCookie.php:135 is raised`. This PR fixes also the issue https://github.com/zendframework/zf2/issues/2946 .
