### PR TITLE
Filter\File\RenameUpload: wrap move_uploaded_file to be easly mocked

### DIFF
--- a/library/Zend/Filter/File/RenameUpload.php
+++ b/library/Zend/Filter/File/RenameUpload.php
@@ -149,22 +149,34 @@ class RenameUpload extends AbstractFilter
         }
 
         $this->checkFileExists($targetFile);
-
-        ErrorHandler::start();
-        $result = move_uploaded_file($sourceFile, $targetFile);
-        $warningException = ErrorHandler::stop();
-        if (!$result || null !== $warningException) {
-            throw new Exception\RuntimeException(
-                sprintf("File '%s' could not be renamed. An error occurred while processing the file.", $value),
-                0, $warningException
-            );
-        }
+        $this->moveUploadedFile($sourceFile, $targetFile);
 
         if ($isFileUpload) {
             $uploadData['tmp_name'] = $targetFile;
             return $uploadData;
         }
         return $targetFile;
+    }
+
+    /**
+     * @param  string $sourceFile Source file path
+     * @param  string $targetFile Target file path
+     * @throws \Zend\Filter\Exception\RuntimeException
+     * @return boolean
+     */
+    protected function moveUploadedFile($sourceFile, $targetFile)
+    {
+        ErrorHandler::start();
+        $result = move_uploaded_file($sourceFile, $targetFile);
+        $warningException = ErrorHandler::stop();
+        if (!$result || null !== $warningException) {
+            throw new Exception\RuntimeException(
+                sprintf("File '%s' could not be renamed. An error occurred while processing the file.", $sourceFile),
+                0, $warningException
+            );
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -93,12 +93,3 @@ if (defined('TESTS_ZEND_OB_ENABLED') && constant('TESTS_ZEND_OB_ENABLED')) {
  * Unset global variables that are no longer needed.
  */
 unset($zfRoot, $zfCoreLibrary, $zfCoreTests, $path);
-
-/**
- * Internal PHP function mocks
- * To be used with runkit_function_rename()
- */
-function move_uploaded_file_mock($source, $dest)
-{
-    return rename($source, $dest);
-}

--- a/tests/ZendTest/Filter/File/RenameUploadMock.php
+++ b/tests/ZendTest/Filter/File/RenameUploadMock.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Filter\File;
+
+use Zend\Filter\File\RenameUpload;
+
+class RenameUploadMock extends RenameUpload
+{
+    /**
+     * @param  string $sourceFile Source file path
+     * @param  string $targetFile Target file path
+     * @return boolean
+     */
+    protected function moveUploadedFile($sourceFile, $targetFile)
+    {
+        return rename($sourceFile, $targetFile);
+    }
+}


### PR DESCRIPTION
As of yet, `ZendTest\Filter\File\RenameUploadTest` used `runkit_function_rename` to test the class that wraps `move_uploaded_file`.

Runkit extension is powerfull, but very old and almost no CI server has it.
If you run the tests with it, they fail because of a trivial bug in a test (method getNewName doesn't exist), not shown in Travis because it has not the extension.

I moved the blocking `move_uploaded_file` in a separate method, that is overwritten by the `ZendTest\Filter\File\RenameUploadMock`, a simple subclass to test the original class.

Runkit extension is no more needed, and no test is skipped.
