### PR TITLE
Fix for URIs with a query string not matching

### DIFF
--- a/library/Zend/Mvc/Router/Http/Part.php
+++ b/library/Zend/Mvc/Router/Http/Part.php
@@ -136,7 +136,7 @@ class Part extends TreeRouteStack implements RouteInterface
             $uri        = $request->getUri();
             $pathLength = strlen($uri->getPath());
 
-            if ($this->mayTerminate && $nextOffset === $pathLength && trim($uri->getQuery()) == "") {
+            if ($this->mayTerminate && $nextOffset === $pathLength) {
                 return $match;
             }
 

--- a/library/Zend/Mvc/Router/Http/Part.php
+++ b/library/Zend/Mvc/Router/Http/Part.php
@@ -136,7 +136,7 @@ class Part extends TreeRouteStack implements RouteInterface
             $uri        = $request->getUri();
             $pathLength = strlen($uri->getPath());
 
-            if ($this->mayTerminate && $nextOffset === $pathLength) {
+            if ($this->mayTerminate && $nextOffset === $pathLength && trim($uri->getQuery()) == '') {
                 return $match;
             }
 


### PR DESCRIPTION
Fix for https://github.com/zendframework/zf2/issues/3711 — URIs with query strings no longer match in 2.1, matched fine in 2.0.5.
