### PR TITLE
Session Container Mismatch & Version Compare fixes for 5.3.3

### DIFF
--- a/library/Zend/Session/AbstractContainer.php
+++ b/library/Zend/Session/AbstractContainer.php
@@ -198,7 +198,7 @@ abstract class AbstractContainer extends ArrayObject
             }
             $storage[$name] = $this->createContainer();
         }
-        if (!is_array($storage[$name]) && !$storage[$name] instanceof ArrayObject) {
+        if (!is_array($storage[$name]) && !$storage[$name] instanceof Traversable) {
             throw new Exception\RuntimeException('Container cannot write to storage due to type mismatch');
         }
 

--- a/library/Zend/Session/compatibility/autoload.php
+++ b/library/Zend/Session/compatibility/autoload.php
@@ -1,5 +1,5 @@
 <?php
-if (version_compare(PHP_VERSION, '5.3.3', 'le')) {
+if (version_compare(PHP_VERSION, '5.3.4', 'lt')) {
     require_once __DIR__ . '/Container.php';
     require_once __DIR__ . '/Storage/SessionArrayStorage.php';
 }

--- a/library/Zend/Stdlib/compatibility/autoload.php
+++ b/library/Zend/Stdlib/compatibility/autoload.php
@@ -1,4 +1,4 @@
 <?php
-if (version_compare(PHP_VERSION, '5.3.3', 'le')) {
+if (version_compare(PHP_VERSION, '5.3.4', 'lt')) {
     require_once __DIR__ . '/ArrayObject.php';
 }

--- a/tests/ZendTest/Session/ContainerTest.php
+++ b/tests/ZendTest/Session/ContainerTest.php
@@ -71,6 +71,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     public function run(\PHPUnit_Framework_TestResult $result = NULL)
     {
         $this->setPreserveGlobalState(false);
+
         return parent::run($result);
     }
 
@@ -541,7 +542,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     {
         $storage = $this->manager->getStorage();
         $storage['foo'] = new \ArrayObject(array('bar' => 'baz'));
-        
+
         $container = new Container('foo', $this->manager);
         $this->assertEquals('baz', $container->bar);
         $container->baz = 'boo';

--- a/tests/ZendTest/Session/ContainerTest.php
+++ b/tests/ZendTest/Session/ContainerTest.php
@@ -529,11 +529,22 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testMultiDimensionalUnset()
     {
-        if (version_compare(PHP_VERSION, '5.3.3') <= 0) {
-            $this->markTestSkipped('Known issue on versions of PHP 5.3.3 or less');
+        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
+            $this->markTestSkipped('Known issue on versions of PHP less than 5.3.4');
         }
         $this->container->foo = array('bar' => 'baz');
         unset($this->container['foo']['bar']);
         $this->assertSame(array(), $this->container->foo);
+    }
+
+    public function testUpgradeBehaviors()
+    {
+        $storage = $this->manager->getStorage();
+        $storage['foo'] = new \ArrayObject(array('bar' => 'baz'));
+        
+        $container = new Container('foo', $this->manager);
+        $this->assertEquals('baz', $container->bar);
+        $container->baz = 'boo';
+        $this->assertEquals('boo', $storage['foo']['baz']);
     }
 }

--- a/tests/ZendTest/Session/SessionArrayStorageTest.php
+++ b/tests/ZendTest/Session/SessionArrayStorageTest.php
@@ -111,8 +111,8 @@ class SessionArrayStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testMultiDimensionalUnset()
     {
-        if (version_compare(PHP_VERSION, '5.3.3') <= 0) {
-            $this->markTestSkipped('Known issue on versions of PHP 5.3.3 or less');
+        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
+            $this->markTestSkipped('Known issue on versions of PHP less than 5.3.4');
         }
         $this->storage['foo'] = array('bar' => array('baz' => 'boo'));
         unset($this->storage['foo']['bar']['baz']);

--- a/tests/ZendTest/Session/SessionStorageTest.php
+++ b/tests/ZendTest/Session/SessionStorageTest.php
@@ -98,8 +98,8 @@ class SessionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testMultiDimensionalUnset()
     {
-        if (version_compare(PHP_VERSION, '5.3.3') <= 0) {
-            $this->markTestSkipped('Known issue on versions of PHP 5.3.3 or less');
+        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
+            $this->markTestSkipped('Known issue on versions of PHP less than 5.3.4');
         }
         $this->storage['foo'] = array('bar' => array('baz' => 'boo'));
         unset($this->storage['foo']['bar']['baz']);

--- a/tests/ZendTest/Session/StorageTest.php
+++ b/tests/ZendTest/Session/StorageTest.php
@@ -246,8 +246,8 @@ class StorageTest extends \PHPUnit_Framework_TestCase
 
     public function testUnsetMultidimensional()
     {
-        if (version_compare(PHP_VERSION, '5.3.3') <= 0) {
-            $this->markTestSkipped('Known issue on versions of PHP 5.3.3 or less');
+        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
+            $this->markTestSkipped('Known issue on versions of PHP less than 5.3.4');
         }
         $this->storage['foo'] = array('bar' => array('baz' => 'boo'));
         unset($this->storage['foo']['bar']['baz']);

--- a/tests/ZendTest/Stdlib/ArrayObjectTest.php
+++ b/tests/ZendTest/Stdlib/ArrayObjectTest.php
@@ -53,7 +53,7 @@ class ArrayObjectTest extends TestCase
 
     public function testStdPropListCannotAccessObjectVars()
     {
-        if (version_compare(PHP_VERSION, '5.3.3') <= 0) {
+        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
             $this->markTestSkipped('Behavior is for overwritten ArrayObject in greater than 5.3.3');
         }
         $this->setExpectedException('InvalidArgumentException');
@@ -162,7 +162,7 @@ class ArrayObjectTest extends TestCase
 
     public function testInvalidIteratorClassThrowsInvalidArgumentException()
     {
-        if (version_compare(PHP_VERSION, '5.3.3') <= 0) {
+        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
             $this->markTestSkipped('Behavior is for overwritten ArrayObject in greater than 5.3.3');
         }
         $this->setExpectedException('InvalidArgumentException');
@@ -210,7 +210,7 @@ class ArrayObjectTest extends TestCase
 
     public function testOffsetExistsThrowsExceptionOnProtectedProperty()
     {
-        if (version_compare(PHP_VERSION, '5.3.3') <= 0) {
+        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
             $this->markTestSkipped('Behavior is for overwritten ArrayObject in greater than 5.3.3');
         }
         $this->setExpectedException('InvalidArgumentException');
@@ -232,7 +232,7 @@ class ArrayObjectTest extends TestCase
 
     public function testOffsetGetThrowsExceptionOnProtectedProperty()
     {
-        if (version_compare(PHP_VERSION, '5.3.3') <= 0) {
+        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
             $this->markTestSkipped('Behavior is for overwritten ArrayObject in greater than 5.3.3');
         }
         $this->setExpectedException('InvalidArgumentException');
@@ -242,7 +242,7 @@ class ArrayObjectTest extends TestCase
 
     public function testOffsetSetThrowsExceptionOnProtectedProperty()
     {
-        if (version_compare(PHP_VERSION, '5.3.3') <= 0) {
+        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
             $this->markTestSkipped('Behavior is for overwritten ArrayObject in greater than 5.3.3');
         }
         $this->setExpectedException('InvalidArgumentException');
@@ -264,7 +264,7 @@ class ArrayObjectTest extends TestCase
 
     public function testOffsetUnsetMultidimensional()
     {
-        if (version_compare(PHP_VERSION, '5.3.3') <= 0) {
+        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
             $this->markTestSkipped('Behavior is for overwritten ArrayObject in greater than 5.3.3');
         }
         $ar = new ArrayObject();
@@ -274,7 +274,7 @@ class ArrayObjectTest extends TestCase
 
     public function testOffsetUnsetThrowsExceptionOnProtectedProperty()
     {
-        if (version_compare(PHP_VERSION, '5.3.3') <= 0) {
+        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
             $this->markTestSkipped('Behavior is for overwritten ArrayObject in greater than 5.3.3');
         }
         $this->setExpectedException('InvalidArgumentException');


### PR DESCRIPTION
## Overview

The changes with the new Zend\Stdlib\ArrayObject caused an overall break in Zend\Session\Container when the code was not tested in isolation (meaning there was previous Containers in the session).  This is because they were of type \ArrayObject causing an object mismatch; in general the logic was flawed because we should only care if it is Traversable since the main contract is pretty much an array.  Overall this causes an upgrade issue for people upgrading on production.  The current workaround is to remove all sessions.

Secondly; Zend\Stdlib\ArrayObject and friends that provide functionality for 5.3.4+ accidentally matches builds from distribution patch fixes; for example:
var_dump(version_compare('5.3.3-7+squeeze14', '5.3.3'))
int(1)
When you'd likely expect it to be of int(0).   To solve this version compare must be made against the higher version: 
var_dump(version_compare('5.3.3-7+squeeze14', '5.3.4'))
int(-1)
