### PR TITLE
[#3705] Fix autoload.files setting in composer.json

### DIFF
--- a/library/Zend/Session/composer.json
+++ b/library/Zend/Session/composer.json
@@ -11,7 +11,7 @@
             "Zend\\Session\\": ""
         },
         "files": [
-            "compatibility/autoload.php"
+            "Zend/Session/compatibility/autoload.php"
         ]
     },
     "target-dir": "Zend/Session",

--- a/library/Zend/Stdlib/composer.json
+++ b/library/Zend/Stdlib/composer.json
@@ -11,7 +11,7 @@
             "Zend\\Stdlib\\": ""
         },
         "files": [
-            "compatibility/autoload.php"
+            "Zend/Stdlib/compatibility/autoload.php"
         ]
     },
     "target-dir": "Zend/Stdlib",


### PR DESCRIPTION
- Because we have a target-dir, the autoload.files path needed to be prefixed
  with that target-dir to continue to be valid.

Fixes #3705
