### PR TITLE
Added the Zend\Form decepence in composer.json for Zend\Mvc

### DIFF
--- a/library/Zend/Mvc/composer.json
+++ b/library/Zend/Mvc/composer.json
@@ -23,6 +23,7 @@
         "zendframework/zend-servicemanager": "self.version",
         "zendframework/zend-stdlib": "self.version",
         "zendframework/zend-text": "self.version",
-        "zendframework/zend-view": "self.version"
+        "zendframework/zend-view": "self.version",
+        "zendframework/zend-form": "self.version"
     }
 }


### PR DESCRIPTION
The Zend\Mvc\Service\ModuleManagerFactory create a FormElementManager service. This requires the dependence with Zend\Form.
