### PR TITLE
Zend\Db\Metadata\Source\AbstractSource Notice: Undefined index

### DIFF
--- a/library/Zend/Db/Metadata/Source/AbstractSource.php
+++ b/library/Zend/Db/Metadata/Source/AbstractSource.php
@@ -380,7 +380,7 @@ abstract class AbstractSource implements MetadataInterface
             $schema = $this->defaultSchema;
         }
 
-        $this->loadConstraintData($table, $schema);
+        $this->loadConstraintReferences($table, $schema);
 
         // organize references first
         $references = array();
@@ -389,6 +389,8 @@ abstract class AbstractSource implements MetadataInterface
                 $references[$refKeyInfo['constraint_name']] = $refKeyInfo;
             }
         }
+
+        $this->loadConstraintDataKeys($schema);
 
         $keys = array();
         foreach ($this->data['constraint_keys'][$schema] as $constraintKeyInfo) {

--- a/library/Zend/Db/Metadata/Source/AbstractSource.php
+++ b/library/Zend/Db/Metadata/Source/AbstractSource.php
@@ -537,6 +537,24 @@ abstract class AbstractSource implements MetadataInterface
         $this->prepareDataHierarchy('constraints', $schema);
     }
 
+    protected function loadConstraintDataKeys($schema)
+    {
+        if (isset($this->data['constraint_keys'][$schema])) {
+            return;
+        }
+
+        $this->prepareDataHierarchy('constraint_keys', $schema);
+    }
+
+    protected function loadConstraintReferences($table, $schema)
+    {
+        if (isset($this->data['constraint_references'][$schema])) {
+            return;
+        }
+
+        $this->prepareDataHierarchy('constraint_references', $schema);
+    }
+
     protected function loadTriggerData($schema)
     {
         if (isset($this->data['triggers'][$schema])) {

--- a/library/Zend/Db/Metadata/Source/AbstractSource.php
+++ b/library/Zend/Db/Metadata/Source/AbstractSource.php
@@ -506,10 +506,18 @@ abstract class AbstractSource implements MetadataInterface
         }
     }
 
+    /**
+     * Load schema data
+     */
     protected function loadSchemaData()
     {
     }
 
+    /**
+     * Load table name data
+     *
+     * @param string $schema
+     */
     protected function loadTableNameData($schema)
     {
         if (isset($this->data['table_names'][$schema])) {
@@ -519,6 +527,12 @@ abstract class AbstractSource implements MetadataInterface
         $this->prepareDataHierarchy('table_names', $schema);
     }
 
+    /**
+     * Load column data
+     *
+     * @param string $table
+     * @param string $schema
+     */
     protected function loadColumnData($table, $schema)
     {
         if (isset($this->data['columns'][$schema][$table])) {
@@ -528,6 +542,12 @@ abstract class AbstractSource implements MetadataInterface
         $this->prepareDataHierarchy('columns', $schema, $table);
     }
 
+    /**
+     * Load constraint data
+     *
+     * @param string $table
+     * @param string $schema
+     */
     protected function loadConstraintData($table, $schema)
     {
         if (isset($this->data['constraints'][$schema])) {
@@ -537,6 +557,11 @@ abstract class AbstractSource implements MetadataInterface
         $this->prepareDataHierarchy('constraints', $schema);
     }
 
+    /**
+     * Load constraint data keys
+     *
+     * @param string $schema
+     */
     protected function loadConstraintDataKeys($schema)
     {
         if (isset($this->data['constraint_keys'][$schema])) {
@@ -546,6 +571,12 @@ abstract class AbstractSource implements MetadataInterface
         $this->prepareDataHierarchy('constraint_keys', $schema);
     }
 
+    /**
+     * Load constraint references
+     *
+     * @param string $table
+     * @param string $schema
+     */
     protected function loadConstraintReferences($table, $schema)
     {
         if (isset($this->data['constraint_references'][$schema])) {
@@ -555,6 +586,11 @@ abstract class AbstractSource implements MetadataInterface
         $this->prepareDataHierarchy('constraint_references', $schema);
     }
 
+    /**
+     * Load trigger data
+     *
+     * @param string $schema
+     */
     protected function loadTriggerData($schema)
     {
         if (isset($this->data['triggers'][$schema])) {

--- a/tests/ZendTest/Db/Metadata/Source/SqliteMetadataTest.php
+++ b/tests/ZendTest/Db/Metadata/Source/SqliteMetadataTest.php
@@ -82,6 +82,9 @@ class SqliteMetadataTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @group ZF2-3719
+     */
     public function testGetConstraintKeys()
     {
         $keys = $this->metadata->getConstraintKeys(

--- a/tests/ZendTest/Db/Metadata/Source/SqliteMetadataTest.php
+++ b/tests/ZendTest/Db/Metadata/Source/SqliteMetadataTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Metadata\Source;
+
+use Zend\Db\Adapter\Adapter;
+use Zend\Db\Metadata\Source\SqliteMetadata;
+
+/**
+ * @requires extension sqlite
+ */
+class SqliteMetadataTest extends \PHPUnit_Framework_TestCase
+{
+    const DBFILE = 'zftest.sqlite';
+
+    /**
+     * @var SqliteMetadata
+     */
+    protected $metadata;
+
+    /**
+     * @var Adapter
+     */
+    protected $adapter;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->adapter = new Adapter(array(
+            'driver' => 'Pdo',
+            'dsn' => 'sqlite:' . self::DBFILE
+        ));
+        $this->metadata = new SqliteMetadata($this->adapter);
+
+    }
+
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        unlink(self::DBFILE);
+    }
+
+    public function testGetSchemas()
+    {
+        $schemas = $this->metadata->getSchemas();
+        $this->assertContains('main', $schemas);
+        $this->assertCount(1, $schemas);
+    }
+
+    public function testGetTableNames()
+    {
+        $tables = $this->metadata->getTableNames('main');
+        $this->assertCount(0, $tables);
+    }
+
+    public function testGetColumnNames()
+    {
+        $columns = $this->metadata->getColumnNames(null, 'main');
+        $this->assertCount(0, $columns);
+    }
+
+    public function testGetConstraints()
+    {
+        $constraints = $this->metadata->getConstraints(null, 'main');
+        $this->assertCount(0, $constraints);
+        $this->assertContainsOnlyInstancesOf(
+            'Zend\Db\Metadata\Object\ConstraintObject',
+            $constraints
+        );
+    }
+
+    public function testGetConstraintKeys()
+    {
+        $keys = $this->metadata->getConstraintKeys(
+            null, null, 'main'
+        );
+        $this->assertCount(0, $keys);
+        $this->assertContainsOnlyInstancesOf(
+            'Zend\Db\Metadata\Object\ConstraintKeyObject',
+            $keys
+        );
+    }
+
+    public function testGetTriggers()
+    {
+        $triggers = $this->metadata->getTriggers('main');
+        $this->assertCount(0, $triggers);
+        $this->assertContainsOnlyInstancesOf(
+            'Zend\Db\Metadata\Object\TriggerObject',
+            $triggers
+        );
+    }
+}


### PR DESCRIPTION
I'm using my own Metadata source, but I'm pretty confident this occurs for the existing sources (Mysql, Postgresql, Sqlserver, ...).

``` php
$metadata = new Zend\Db\Metadata\Metadata($adapter);
$constraints = $metadata->getConstraints('TABLE', 'SCHEMA');
foreach($constraints as $constraint) {
    $constraintKeys = $metadata->getConstraintKeys(
        $constraint->getName(),
        'TABLE', 'SCHEMA'
    );
}
```

Produces the following errors:

```
Notice: Undefined index: constraint_references in library/Zend/Db/Metadata/Source/AbstractSource.php on line 393
Notice: Undefined index: constraint_keys in library/Zend/Db/Metadata/Source/AbstractSource.php on line 400
```

Note that after this fixing this error I run into the next one:

```
 Fatal error: Class 'Zend\Db\Metadata\Object\ConstraintKeyObject' not found on line 398
```

Was that class just never committed?
