### PR TITLE
[Form] [DateTimeSelect] Filter, manager, and view helper fixes

### DIFF
--- a/library/Zend/Form/Element/DateTimeSelect.php
+++ b/library/Zend/Form/Element/DateTimeSelect.php
@@ -291,6 +291,9 @@ class DateTimeSelect extends DateSelect
                         'callback' => function($date) {
                             // Convert the date to a specific format
                             if (is_array($date)) {
+                                if (!isset($date['second'])) {
+                                    $date['second'] = '00';
+                                }
                                 $date = sprintf('%s-%s-%s %s:%s:%s',
                                     $date['year'], $date['month'], $date['day'],
                                     $date['hour'], $date['minute'], $date['second']

--- a/library/Zend/Form/FormElementManager.php
+++ b/library/Zend/Form/FormElementManager.php
@@ -36,6 +36,7 @@ class FormElementManager extends AbstractPluginManager
         'dateselect'    => 'Zend\Form\Element\DateSelect',
         'datetime'      => 'Zend\Form\Element\DateTime',
         'datetimelocal' => 'Zend\Form\Element\DateTimeLocal',
+        'datetimeselect' => 'Zend\Form\Element\DateTimeSelect',
         'element'       => 'Zend\Form\Element',
         'email'         => 'Zend\Form\Element\Email',
         'fieldset'      => 'Zend\Form\Fieldset',

--- a/library/Zend/Form/View/Helper/FormDateTimeSelect.php
+++ b/library/Zend/Form/View/Helper/FormDateTimeSelect.php
@@ -234,7 +234,7 @@ class FormDateTimeSelect extends FormDateSelectHelper
         $date           = new DateTime('1970-01-01 00:00:00');
 
         $result = array();
-        for ($hour = 1; $hour <= 31; $hour++) {
+        for ($hour = 1; $hour <= 24; $hour++) {
             $key   = $keyFormatter->format($date);
             $value = $valueFormatter->format($date);
             $result[$key] = $value;
@@ -258,7 +258,7 @@ class FormDateTimeSelect extends FormDateSelectHelper
         $date           = new DateTime('1970-01-01 00:00:00');
 
         $result = array();
-        for ($hour = 1; $hour <= 31; $hour++) {
+        for ($min = 1; $min <= 60; $min++) {
             $key   = $keyFormatter->format($date);
             $value = $valueFormatter->format($date);
             $result[$key] = $value;
@@ -282,7 +282,7 @@ class FormDateTimeSelect extends FormDateSelectHelper
         $date           = new DateTime('1970-01-01 00:00:00');
 
         $result = array();
-        for ($hour = 1; $hour <= 31; $hour++) {
+        for ($sec = 1; $sec <= 60; $sec++) {
             $key   = $keyFormatter->format($date);
             $value = $valueFormatter->format($date);
             $result[$key] = $value;

--- a/tests/ZendTest/Form/Element/DateTimeSelectTest.php
+++ b/tests/ZendTest/Form/Element/DateTimeSelectTest.php
@@ -15,6 +15,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element\DateTimeSelect as DateTimeSelectElement;
 use Zend\Form\Factory;
 use Zend\Form\Exception;
+use Zend\InputFilter\Factory as InputFilterFactory;
 
 class DateTimeSelectTest extends TestCase
 {
@@ -40,6 +41,25 @@ class DateTimeSelectTest extends TestCase
                     break;
             }
         }
+    }
+
+    public function testInputSpecificationFilterIfSecondNotProvided()
+    {
+        $element = new DateTimeSelectElement('test');
+        $factory = new InputFilterFactory();
+        $inputFilter = $factory->createInputFilter(array(
+            'test' => $element->getInputSpecification(),
+        ));
+        $inputFilter->setData(array(
+            'test' => array(
+                'year' => '2013',
+                'month' => '02',
+                'day' => '07',
+                'hour' => '03',
+                'minute' => '14'
+            ),
+        ));
+        $this->assertTrue($inputFilter->isValid());
     }
 
     public function testCanSetDateFromDateTime()


### PR DESCRIPTION
The filter has been fixed for when the second is not provided.

The view helpers have been fixed with the correct ranges for the hour, minute, and second value options.

The `DateTimeSelect` element has been added to the `FormElementManager` service locator.
