### PR TITLE
Hotfix/2463

### DIFF
--- a/library/Zend/View/Renderer/JsonRenderer.php
+++ b/library/Zend/View/Renderer/JsonRenderer.php
@@ -130,6 +130,8 @@ class JsonRenderer implements Renderer, TreeRendererInterface
         // Serialize variables in view model
         if ($nameOrModel instanceof Model) {
             if ($nameOrModel instanceof JsonModel) {
+                $children = $this->recurseModel($nameOrModel, false);
+                $this->injectChildren($nameOrModel, $children);
                 $values = $nameOrModel->serialize();
             } else {
                 $values = $this->recurseModel($nameOrModel);
@@ -185,9 +187,13 @@ class JsonRenderer implements Renderer, TreeRendererInterface
      * @param  Model $model
      * @return array
      */
-    protected function recurseModel(Model $model)
+    protected function recurseModel(Model $model, $mergeWithVariables = true)
     {
-        $values = $model->getVariables();
+        $values = array();
+        if ($mergeWithVariables) {
+            $values = $model->getVariables();
+        }
+
         if ($values instanceof Traversable) {
             $values = ArrayUtils::iteratorToArray($values);
         }
@@ -207,7 +213,8 @@ class JsonRenderer implements Renderer, TreeRendererInterface
             $childValues = $this->recurseModel($child);
             if ($captureTo) {
                 // Capturing to a specific key
-                //TODO please complete if append is true. must change old value to array and append to array?
+                // TODO please complete if append is true. must change old
+                // value to array and append to array?
                 $values[$captureTo] = $childValues;
             } elseif ($mergeChildren) {
                 // Merging values with parent
@@ -215,5 +222,20 @@ class JsonRenderer implements Renderer, TreeRendererInterface
             }
         }
         return $values;
+    }
+
+    /**
+     * Inject discovered child model values into parent model
+     *
+     * @todo   detect collisions and decide whether to append and/or aggregate?
+     * @param  Model $model
+     * @param  array $children
+     */
+    protected function injectChildren(Model $model, array $children)
+    {
+        foreach ($children as $child => $value) {
+            // TODO detect collisions and decide whether to append and/or aggregate?
+            $model->setVariable($child, $value);
+        }
     }
 }

--- a/library/Zend/View/Renderer/JsonRenderer.php
+++ b/library/Zend/View/Renderer/JsonRenderer.php
@@ -185,6 +185,8 @@ class JsonRenderer implements Renderer, TreeRendererInterface
      * Retrieve values from a model and recurse its children to build a data structure
      *
      * @param  Model $model
+     * @param  bool $mergeWithVariables Whether or not to merge children with
+     *         the variables of the $model
      * @return array
      */
     protected function recurseModel(Model $model, $mergeWithVariables = true)

--- a/tests/ZendTest/View/Renderer/JsonRendererTest.php
+++ b/tests/ZendTest/View/Renderer/JsonRendererTest.php
@@ -14,6 +14,7 @@ use ArrayObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use stdClass;
 use Zend\View\Renderer\JsonRenderer;
+use Zend\View\Model\JsonModel;
 use Zend\View\Model\ViewModel;
 
 /**
@@ -233,5 +234,31 @@ class JsonRendererTest extends TestCase
         $this->renderer->setJsonpCallback('callback');
         $test       = $this->renderer->render($model);
         $this->assertEquals($expected, $test);
+    }
+
+    /**
+     * @group 2463
+     */
+    public function testRecursesJsonModelChildrenWhenRendering()
+    {
+        $root   = new JsonModel(array('foo' => 'bar'));
+        $child1 = new JsonModel(array('foo' => 'bar'));
+        $child2 = new JsonModel(array('foo' => 'bar'));
+        $child1->setCaptureTo('child1');
+        $child2->setCaptureTo('child2');
+        $root->addChild($child1)
+             ->addChild($child2);
+
+        $expected = array(
+            'foo' => 'bar',
+            'child1' => array(
+                'foo' => 'bar',
+            ),
+            'child2' => array(
+                'foo' => 'bar',
+            ),
+        );
+        $test  = $this->renderer->render($root);
+        $this->assertEquals(json_encode($expected), $test);
     }
 }


### PR DESCRIPTION
Fixes #2463 -- allows recursion of children in JsonModels when using the JsonRenderer.
