### PR TITLE
[Form] [FormElementManager] don't overwrite form factory if already set

### DIFF
--- a/library/Zend/Form/FormElementManager.php
+++ b/library/Zend/Form/FormElementManager.php
@@ -84,7 +84,7 @@ class FormElementManager extends AbstractPluginManager
     public function injectFactory($element)
     {
         if ($element instanceof FormFactoryAwareInterface) {
-            $element->setFormFactory(new Factory($this));
+            $element->getFormFactory()->setFormElementManager($this);
         }
     }
 


### PR DESCRIPTION
Don't overwrite factory in case other initializers are called beforehand that set the form factory, or attach an input filter factory to it.
