### PR TITLE
Extending the phpunit-version-unsupported error message

### DIFF
--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -17,7 +17,9 @@ error_reporting( E_ALL | E_STRICT );
 if (class_exists('PHPUnit_Runner_Version', true)) {
     $phpUnitVersion = PHPUnit_Runner_Version::id();
     if ('@package_version@' !== $phpUnitVersion && version_compare($phpUnitVersion, '3.7.0', '<')) {
-        echo 'This version of PHPUnit (' . PHPUnit_Runner_Version::id() . ') is not supported in Zend Framework 2.x unit tests.' . PHP_EOL;
+        echo 'This version of PHPUnit (' . PHPUnit_Runner_Version::id() . ') is not supported'
+           . ' in Zend Framework 2.x unit tests. Supported is version 3.7.0  or higher.'
+           . ' See also: https://github.com/zendframework/zf2/blob/master/CONTRIBUTING.md#running-tests' . PHP_EOL;
         exit(1);
     }
     unset($phpUnitVersion);


### PR DESCRIPTION
The original message did not provide any further pointers as to
what someone should do or look for, other than change their
version of phpunit (up? down?). This commit fixes that.
