### PR TITLE
[#3739 & #3740] Using version-compare in accept header handler params.

### DIFF
--- a/library/Zend/Http/Header/AbstractAccept.php
+++ b/library/Zend/Http/Header/AbstractAccept.php
@@ -168,7 +168,7 @@ abstract class AbstractAccept implements HeaderInterface
                 $explode = explode('=', $param, 2);
 
                 $value = trim($explode[1]);
-                if ($value[0] == '"' && substr($value, -1) == '"') {
+                if (isset($value[0]) && $value[0] == '"' && substr($value, -1) == '"') {
                     $value = substr(substr($value, 1), 0, -1);
                 }
 
@@ -341,10 +341,17 @@ abstract class AbstractAccept implements HeaderInterface
         foreach ($match2->params as $key => $value) {
             if (isset($match1->params[$key])) {
                 if (strpos($value, '-')) {
-                    $values = explode('-', $value, 2);
-                    if ($values[0] > $match1->params[$key] ||
-                            $values[1] < $match1->params[$key])
-                    {
+                    preg_match(
+                        '/^(?|([^"-]*)|"([^"]*)")-(?|([^"-]*)|"([^"]*)")\z/',
+                        $value,
+                        $pieces
+                    );
+
+                    if (count($pieces) == 3 &&
+                        (version_compare($pieces[1], $match1->params[$key], '<=')  xor
+                         version_compare($pieces[2], $match1->params[$key], '>=')
+                        )
+                    ) {
                         return false;
                     }
                 } elseif (strpos($value, '|')) {


### PR DESCRIPTION
This commit provides functionality to define a set of version number
ranges to use in your accept header handling. Support for mere
integers was already present, but now support for ranges like
3.1.1-4.0.0 has been added.

Also, support for development stages like DEV or BETA was added. This
allows one to define ranges like 4.0.0-"5.0.0-Beta".

Beware, when using inside an accept header, the parameter value must
be quoted as well, and the quotes inside the parameter should be
escaped: application/vnd.com.example+xml; version="3.1-\"3.1.1-DEV\""
