### PR TITLE
Filter\File\RenameUpload: allow filtering multiple times

### DIFF
--- a/tests/ZendTest/Filter/File/RenameUploadTest.php
+++ b/tests/ZendTest/Filter/File/RenameUploadTest.php
@@ -249,14 +249,12 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetRandomizedFile()
     {
+        $fileNoExt = $this->_filesPath . '/newfile';
         $filter = new RenameUploadMock(array(
             'target'          => $this->_newFile,
             'randomize'       => true,
         ));
 
-        $this->assertEquals($this->_newFile, $filter->getTarget());
-        $this->assertTrue($filter->getRandomize());
-        $fileNoExt = $this->_filesPath . '/newfile';
         $this->assertRegExp('#' . $fileNoExt . '_.{13}\.xml#', $filter($this->_oldFile));
     }
 
@@ -271,8 +269,6 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
             'randomize'       => true,
         ));
 
-        $this->assertEquals($fileNoExt, $filter->getTarget());
-        $this->assertTrue($filter->getRandomize());
         $this->assertRegExp('#' . $fileNoExt . '_.{13}#', $filter($this->_oldFile));
     }
 
@@ -283,5 +279,24 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'Invalid target');
         $filter = new FileRenameUpload(1234);
+    }
+
+    /**
+     * @return void
+     */
+    public function testCanFilterMultipleTimesWithsameResult()
+    {
+        $filter = new RenameUploadMock(array(
+            'target'          => $this->_newFile,
+            'randomize'       => true,
+        ));
+
+        $firstResult = $filter($this->_oldFile);
+
+        $this->assertContains('newfile', $firstResult);
+
+        $secondResult = $filter($this->_oldFile);
+
+        $this->assertSame($firstResult, $secondResult);
     }
 }

--- a/tests/ZendTest/Filter/File/RenameUploadTest.php
+++ b/tests/ZendTest/Filter/File/RenameUploadTest.php
@@ -284,7 +284,7 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
     /**
      * @return void
      */
-    public function testCanFilterMultipleTimesWithsameResult()
+    public function testCanFilterMultipleTimesWithSameResult()
     {
         $filter = new RenameUploadMock(array(
             'target'          => $this->_newFile,


### PR DESCRIPTION
Calling:

``` php
$form->isValid();
$form->getData();
```

now will _always_ fail because `Zend\Filter\File\RenameUpload` attemps to `move_uploaded_file` the value two times, the first on validating and the second on retrieving.

I've added an internal cache to store the result, based on `$sourceFile`: this is safe because every field has it's own filter instance, and every PHP uploaded file has it's own unique name.

PS: I've deleted some

``` php
$this->assertEquals($fileNoExt, $filter->getTarget());
$this->assertTrue($filter->getRandomize());
```

because those are already tested in `testOptions`, so no need to test them every time.
