### PR TITLE
Fixed a bug where mail messages were malformed when using the Sendmail

### DIFF
--- a/library/Zend/Mail/Transport/Sendmail.php
+++ b/library/Zend/Mail/Transport/Sendmail.php
@@ -190,8 +190,9 @@ class Sendmail implements TransportInterface
     protected function prepareBody(Mail\Message $message)
     {
         if (!$this->isWindowsOs()) {
-            // *nix platforms can simply return the body text
-            return $message->getBodyText();
+            // On *nix platforms, we should replace \r\n with \n
+            // sendmail is not an SMTP server, it is a unix command - it expects LF
+            return str_replace("\r\n", "\n", $message->getBodyText());
         }
 
         // On windows, lines beginning with a full stop need to be fixed
@@ -217,7 +218,10 @@ class Sendmail implements TransportInterface
         $headers = clone $message->getHeaders();
         $headers->removeHeader('To');
         $headers->removeHeader('Subject');
-        return $headers->toString();
+
+        // On *nix platforms, we should replace \r\n with \n
+        // sendmail is not an SMTP server, it is a unix command - it expects LF
+        return str_replace("\r\n", "\n", $headers->toString());
     }
 
     /**

--- a/tests/ZendTest/Mail/Transport/SendmailTest.php
+++ b/tests/ZendTest/Mail/Transport/SendmailTest.php
@@ -83,12 +83,12 @@ class SendmailTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('ZF DevTeam <zf-devteam@zend.com>', $this->to);
         $this->assertEquals('Testing Zend\Mail\Transport\Sendmail', $this->subject);
         $this->assertEquals('This is only a test.', trim($this->message));
-        $this->assertNotContains("To: ZF DevTeam <zf-devteam@zend.com>\r\n", $this->additional_headers);
-        $this->assertContains("Cc: matthew@zend.com\r\n", $this->additional_headers);
-        $this->assertContains("Bcc: \"CR-Team, ZF Project\" <zf-crteam@lists.zend.com>\r\n", $this->additional_headers);
-        $this->assertContains("From: zf-devteam@zend.com,\r\n Matthew <matthew@zend.com>\r\n", $this->additional_headers);
-        $this->assertContains("X-Foo-Bar: Matthew\r\n", $this->additional_headers);
-        $this->assertContains("Sender: Ralph Schindler <ralph.schindler@zend.com>\r\n", $this->additional_headers);
+        $this->assertNotContains("To: ZF DevTeam <zf-devteam@zend.com>\n", $this->additional_headers);
+        $this->assertContains("Cc: matthew@zend.com\n", $this->additional_headers);
+        $this->assertContains("Bcc: \"CR-Team, ZF Project\" <zf-crteam@lists.zend.com>\n", $this->additional_headers);
+        $this->assertContains("From: zf-devteam@zend.com,\n Matthew <matthew@zend.com>\n", $this->additional_headers);
+        $this->assertContains("X-Foo-Bar: Matthew\n", $this->additional_headers);
+        $this->assertContains("Sender: Ralph Schindler <ralph.schindler@zend.com>\n", $this->additional_headers);
         $this->assertEquals('-R hdrs -f ralph.schindler@zend.com', $this->additional_parameters);
     }
 


### PR DESCRIPTION
transport on Unix systems with certain versions of sendmail (e.g.
Postfix < 2.9). Specifically, message headers spilled into the body
and the body text was double-spaced.

The source of the problem was the use of CRLF as the EOL sequence
when sending messages via PHP's built-in mail() function on Unix
systems. Despite what the PHP manual says, LF should be used as the
sole EOL character on Unix. This is because mail() is a wrapper for
sendmail on Unix and does not speak SMTP except on Windows.

See http://zend-framework-community.634137.n4.nabble.com/Zend-Mail-and-Postfix-lt-2-9-td4658920.html for further discussion.
