### PR TITLE
Method scanner returns invalid last parameter default value

### DIFF
--- a/library/Zend/Code/Scanner/MethodScanner.php
+++ b/library/Zend/Code/Scanner/MethodScanner.php
@@ -495,6 +495,8 @@ class MethodScanner implements ScannerInterface
                                 $MACRO_INFO_ADVANCE();
                             }
                             $context = 'body';
+                        } elseif($parentCount === 1) {
+                            goto SCANNER_CONTINUE_SIGNATURE;
                         }
                         goto SCANNER_CONTINUE_BODY;
                     case ',':

--- a/tests/ZendTest/Code/Scanner/MethodScannerTest.php
+++ b/tests/ZendTest/Code/Scanner/MethodScannerTest.php
@@ -75,4 +75,15 @@ class MethodScannerTest extends TestCase
         $this->assertEquals($expected, $method->getBody());
     }
 
+    public function testMethodScannerReturnsLastParamDefaultArray()
+    {
+        $fileScanner = new FileScanner(__DIR__ . '/../TestAsset/BarClass.php');
+        $classScanner = $fileScanner->getClass('ZendTest\Code\TestAsset\BarClass');
+        $methodScanner = $classScanner->getMethod('four');
+        $paramScanner = $methodScanner->getParameter('bbfa');
+        $default = $paramScanner->getDefaultValue();
+        $default = trim($default);
+        $this->assertSame('array()', $default);
+    }
+
 }

--- a/tests/ZendTest/Code/TestAsset/BarClass.php
+++ b/tests/ZendTest/Code/TestAsset/BarClass.php
@@ -30,4 +30,9 @@ abstract class BarClass
         $y = 'this string';
     }
 
+    protected function four(\ArrayObject $o, &$t = 2, FooBarBaz\BazBarFoo $bbf = self::BAR, $bbfa = array())
+    {
+        // four
+    }
+
 }


### PR DESCRIPTION
Default value of last parameter is invalid until last parameter has default value array().
This commit will fix this.
