### PR TITLE
Strings are not acceptable types for dates.

### DIFF
--- a/library/Zend/Feed/Writer/Entry.php
+++ b/library/Zend/Feed/Writer/Entry.php
@@ -177,7 +177,7 @@ class Entry
     /**
      * Set the feed creation date
      *
-     * @param string|null|DateTime $date
+     * @param null|integer|DateTime $date
      * @throws Exception\InvalidArgumentException
      * @return Entry
      */
@@ -198,7 +198,7 @@ class Entry
     /**
      * Set the feed modification date
      *
-     * @param string|null|DateTime $date
+     * @param null|integer|DateTime $date
      * @throws Exception\InvalidArgumentException
      * @return Entry
      */


### PR DESCRIPTION
Strings are not acceptable types for dates. Matches the behaviour of the AbstractFeed class for setting dates there.

Fix for https://github.com/zendframework/zf2/issues/3760
