### PR TITLE
Validator File MimeType (IsImage & IsCompressed)

### DIFF
--- a/library/Zend/Validator/File/IsCompressed.php
+++ b/library/Zend/Validator/File/IsCompressed.php
@@ -79,10 +79,14 @@ class IsCompressed extends MimeType
             $options = ArrayUtils::iteratorToArray($options);
         }
 
-        if (empty($options)) {
-            $options = array('mimeType' => $default);
+        if ($options === null) {
+            $options = array();
         }
 
         parent::__construct($options);
+
+        if (!$this->getMimeType()) {
+            $this->setMimeType($default);
+        }
     }
 }

--- a/library/Zend/Validator/File/IsImage.php
+++ b/library/Zend/Validator/File/IsImage.php
@@ -103,11 +103,14 @@ class IsImage extends MimeType
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         }
-
-        if (empty($options)) {
-            $options = array('mimeType' => $default);
+        if ($options === null) {
+            $options = array();
         }
 
         parent::__construct($options);
+
+        if (!$this->getMimeType()) {
+            $this->setMimeType($default);
+        }
     }
 }

--- a/library/Zend/Validator/File/IsImage.php
+++ b/library/Zend/Validator/File/IsImage.php
@@ -103,6 +103,7 @@ class IsImage extends MimeType
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         }
+
         if ($options === null) {
             $options = array();
         }

--- a/tests/ZendTest/Validator/File/IsCompressedTest.php
+++ b/tests/ZendTest/Validator/File/IsCompressedTest.php
@@ -182,6 +182,15 @@ class IsCompressedTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('image/gif,image/jpg', $validator->getMimeType());
     }
 
+    public function testNonMimeOptionsAtConstructorStillSetsDefaults()
+    {
+        $validator = new File\IsCompressed(array(
+            'enableHeaderCheck' => true,
+        ));
+
+        $this->assertNotEmpty($validator->getMimeType());
+    }
+
     /**
      * @group ZF-11258
      */

--- a/tests/ZendTest/Validator/File/IsImageTest.php
+++ b/tests/ZendTest/Validator/File/IsImageTest.php
@@ -173,6 +173,15 @@ class IsImageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('image/gif,image/jpg', $validator->getMimeType());
     }
 
+    public function testNonMimeOptionsAtConstructorStillSetsDefaults()
+    {
+        $validator = new File\IsImage(array(
+            'enableHeaderCheck' => true,
+        ));
+
+        $this->assertNotEmpty($validator->getMimeType());
+    }
+
     /**
      * @group ZF-11258
      */


### PR DESCRIPTION
## Overview

The validators for items that extend MimeType take several options; the design of which causes some potential issues.  This design is still left intact but should be looked at for future versions.

I came over a bug where the default mimetypes were not set when using input filters.  When you utilize one of these as an input filter and pass in custom messages or set any other option the default mimetype options will not be set due to a check of empty in the constructor.  Additionally the parent constructor does a lot of magic to determine if there is indeed a mimetype that can be applied.

The change now allows the parent constructor to set any mimetypes if it can find any and then check to see if any mimetypes have been set; if not it will set the default mimetypes.
## Example that caused the pain

This is a quick example; I have some additional logic that takes some of the fields and automatically creates labels and such so don't pick apart the element too much here... Note that due to the messages section of File\IsImage on the validator causes the default mime types to not be leveraged here.

``` php
namespace MyModule\Form;

use Zend\Form\Form;
use Zend\InputFilter\InputFilter;
use Zend\InputFilter\Factory as InputFactory;

ImageUpload extends Form
{
    public function __construct()
    {
        parent::__construct();
        $this->add(array(
            'name' => 'image',
            'attributes' => array(
                'type' => 'file',
                'required' => 'required',
            ),  
        )); 
        $this->add(array(
            'name' => 'upload',
            'attributes' => array(
                'class' => 'button',
                'type' => 'submit',
                'required' => 'required',
            ),  
        )); 
    }

    public function getInputFilter()
    {   
        if (!$this->filter) {
            $this->filter = new InputFilter();
            $factory = new InputFactory();
            $this->filter->add($factory->createInput(array(
                'name' => 'image',
                'required' => true,
                'validators' => array(
                    array(
                        'name' => 'NotEmpty',
                        'options' => array(
                            'messages' => array(
                                'isEmpty' => 'Please select an icon to upload.',
                            ),
                        ),
                    ),
                    array(
                        'name' => 'File\IsImage',
                        'options' => array(
                            'messages' => array(
                                'fileIsImageFalseType' => 'Please select a valid icon image to upload.',
                                'fileIsImageNotDetected' => 'The icon image is missing mime encoding, please verify you have saved the image with mime encoding.',
                            ),
                        ),
                    ),
                ),
            )));
        }
        return parent::getInputFilter();
    }
}
```
