### PR TITLE
Issue #3753 - Added option to disable word wrap in DocBlockGenerator

### DIFF
--- a/library/Zend/Code/Generator/DocBlockGenerator.php
+++ b/library/Zend/Code/Generator/DocBlockGenerator.php
@@ -35,6 +35,11 @@ class DocBlockGenerator extends AbstractGenerator
     protected $indentation = '';
 
     /**
+     * @var boolean
+     */
+    protected $wordwrap = true;
+
+    /**
      * Build a DocBlock generator object from a reflection object
      *
      * @param  DocBlockReflection $reflectionDocBlock
@@ -189,6 +194,29 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
+     * Set the word wrap
+     *
+     * @param boolean $value
+     * @return \Zend\Code\Generator\DocBlockGenerator
+     */
+    public function setWordWrap($value)
+    {
+        $this->wordwrap = (boolean) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the word wrap
+     *
+     * @return boolean
+     */
+    public function getWordWrap()
+    {
+        return $this->wordwrap;
+    }
+
+    /**
      * @return string
      */
     public function generate()
@@ -220,7 +248,7 @@ class DocBlockGenerator extends AbstractGenerator
     {
         $indent  = $this->getIndentation();
         $output  = $indent . '/**' . self::LINE_FEED;
-        $content = wordwrap($content, 80, self::LINE_FEED);
+        $content = $this->getWordWrap() == true ? wordwrap($content, 80, self::LINE_FEED) : $content;
         $lines   = explode(self::LINE_FEED, $content);
         foreach ($lines as $line) {
             $output .= $indent . ' *';

--- a/tests/ZendTest/Code/Generator/DocBlockGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/DocBlockGeneratorTest.php
@@ -109,4 +109,30 @@ EOS;
         $this->assertCount(1, $docBlock->getTags());
     }
 
+    /**
+     * @group dev
+     */
+    public function testGenerateWordWrapIsEnabledByDefault()
+    {
+        $largeStr = '@var This is a very large string that will be wrapped if it contains more than 80 characters';
+        $this->docBlockGenerator->setLongDescription($largeStr);
+
+        $expected = '/**' . DocBlockGenerator::LINE_FEED
+            . ' * @var This is a very large string that will be wrapped if it contains more than'
+            . DocBlockGenerator::LINE_FEED.' * 80 characters'. DocBlockGenerator::LINE_FEED
+            . ' */' . DocBlockGenerator::LINE_FEED;
+        $this->assertEquals($expected, $this->docBlockGenerator->generate());
+    }
+
+    public function testGenerateWithWordWrapDisabled()
+    {
+        $largeStr = '@var This is a very large string that will not be wrapped if it contains more than 80 characters';
+        $this->docBlockGenerator->setLongDescription($largeStr);
+        $this->docBlockGenerator->setWordWrap(false);
+
+        $expected = '/**' . DocBlockGenerator::LINE_FEED
+            . ' * @var This is a very large string that will not be wrapped if it contains more than'
+            . ' 80 characters'. DocBlockGenerator::LINE_FEED . ' */' . DocBlockGenerator::LINE_FEED;
+        $this->assertEquals($expected, $this->docBlockGenerator->generate());
+    }
 }

--- a/tests/ZendTest/Code/Generator/DocBlockGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/DocBlockGeneratorTest.php
@@ -110,7 +110,7 @@ EOS;
     }
 
     /**
-     * @group dev
+     * @group #3753
      */
     public function testGenerateWordWrapIsEnabledByDefault()
     {
@@ -124,6 +124,9 @@ EOS;
         $this->assertEquals($expected, $this->docBlockGenerator->generate());
     }
 
+    /**
+     * @group #3753
+     */
     public function testGenerateWithWordWrapDisabled()
     {
         $largeStr = '@var This is a very large string that will not be wrapped if it contains more than 80 characters';


### PR DESCRIPTION
Word wrapping can now be disabled in DocBlockGenerator

Issue #3753
