### PR TITLE
[#3711] Fix regression in query string matching

### DIFF
--- a/library/Zend/Mvc/Router/Http/Part.php
+++ b/library/Zend/Mvc/Router/Http/Part.php
@@ -136,8 +136,11 @@ class Part extends TreeRouteStack implements RouteInterface
             $uri        = $request->getUri();
             $pathLength = strlen($uri->getPath());
 
-            if ($this->mayTerminate && $nextOffset === $pathLength && trim($uri->getQuery()) == "") {
-                return $match;
+            if ($this->mayTerminate && $nextOffset === $pathLength) {
+                $query = $uri->getQuery();
+                if ('' == trim($query) || !$this->hasQueryChild()) {
+                    return $match;
+                }
             }
 
             foreach ($this->routes as $name => $route) {
@@ -199,5 +202,20 @@ class Part extends TreeRouteStack implements RouteInterface
         // Part routes may not occur as base route of other part routes, so we
         // don't have to return anything here.
         return array();
+    }
+
+    /**
+     * Is one of the child routes a query route?
+     *
+     * @return bool
+     */
+    protected function hasQueryChild()
+    {
+        foreach ($this->routes as $route) {
+            if ($route instanceof Query) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/tests/ZendTest/Mvc/Router/Http/PartTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/PartTest.php
@@ -13,9 +13,10 @@ namespace ZendTest\Mvc\Router\Http;
 use ArrayObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Http\Request as Request;
-use Zend\Stdlib\Request as BaseRequest;
 use Zend\Mvc\Router\RoutePluginManager;
 use Zend\Mvc\Router\Http\Part;
+use Zend\Stdlib\Parameters;
+use Zend\Stdlib\Request as BaseRequest;
 use ZendTest\Mvc\Router\FactoryTester;
 
 class PartTest extends TestCase
@@ -381,5 +382,91 @@ class PartTest extends TestCase
 
         $route = Part::factory($options);
         $this->assertInstanceOf('Zend\Mvc\Router\Http\Part', $route);
+    }
+
+    /**
+     * @group 3711
+     */
+    public function testPartRouteMarkedAsMayTerminateCanMatchWhenQueryStringPresent()
+    {
+        $options = array(
+            'route' => array(
+                'type' => 'Zend\Mvc\Router\Http\Literal',
+                'options' => array(
+                    'route' => '/resource',
+                    'defaults' => array(
+                        'controller' => 'ResourceController',
+                        'action'     => 'resource',
+                    ),
+                ),
+            ),
+            'route_plugins' => new RoutePluginManager(),
+            'may_terminate' => true,
+            'child_routes'  => array(
+                'child' => array(
+                    'type' => 'Zend\Mvc\Router\Http\Literal',
+                    'options' => array(
+                        'route' => '/child',
+                        'defaults' => array(
+                            'action' => 'child',
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $route = Part::factory($options);
+        $request = new Request();
+        $request->setUri('http://example.com/resource?foo=bar');
+        $query = new Parameters(array('foo' => 'bar'));
+        $request->setQuery($query);
+        $query = $request->getQuery();
+
+        $match = $route->match($request);
+        $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $match);
+        $this->assertEquals('resource', $match->getParam('action'));
+    }
+
+    /**
+     * @group 3711
+     */
+    public function testPartRouteMarkedAsMayTerminateButWithQueryRouteChildWillMatchChildRoute()
+    {
+        $options = array(
+            'route' => array(
+                'type' => 'Zend\Mvc\Router\Http\Literal',
+                'options' => array(
+                    'route' => '/resource',
+                    'defaults' => array(
+                        'controller' => 'ResourceController',
+                        'action'     => 'resource',
+                    ),
+                ),
+            ),
+            'route_plugins' => new RoutePluginManager(),
+            'may_terminate' => true,
+            'child_routes'  => array(
+                'query' => array(
+                    'type' => 'Zend\Mvc\Router\Http\Query',
+                    'options' => array(
+                        'defaults' => array(
+                            'query' => 'string',
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $route = Part::factory($options);
+        $request = new Request();
+        $request->setUri('http://example.com/resource?foo=bar');
+        $query = new Parameters(array('foo' => 'bar'));
+        $request->setQuery($query);
+        $query = $request->getQuery();
+
+        $match = $route->match($request);
+        $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $match);
+        $this->assertEquals('string', $match->getParam('query'));
+        $this->assertEquals('bar', $match->getParam('foo'));
     }
 }


### PR DESCRIPTION
If a route is marked may_terminate, and a query string is present, in
most cases, we should match; the query route is primarily for the
convenience of _generating_ URIs via the assemble() method, and only
matches if a query string is present.

This patch adds tests that do the following:
- If the route is marked may_terminate and a query string is present,
  but there is no Query route child, match and return immediately.
- If the route is marked may_terminate, and a query string is present,
  and a Query route child is present, pass matching on to child routes.

This fixes #3711 and replaces #3712
