### PR TITLE
create controller via Zend\Mvc\Controller\ControllerManager

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -255,6 +255,7 @@ abstract class AbstractController implements
             $this->setPluginManager(new PluginManager());
         }
 
+        $this->plugins->setController($this);
         return $this->plugins;
     }
 

--- a/tests/ZendTest/Mvc/Controller/IntegrationTest.php
+++ b/tests/ZendTest/Mvc/Controller/IntegrationTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc\Controller;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\EventManager\SharedEventManager;
+use Zend\Mvc\Controller\ControllerManager;
+use Zend\Mvc\Controller\PluginManager;
+use Zend\ServiceManager\ServiceManager;
+
+class IntegrationTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->plugins      = new PluginManager();
+        $this->sharedEvents = new SharedEventManager();
+        $this->services     = new ServiceManager();
+        $this->services->setService('ControllerPluginManager', $this->plugins);
+        $this->services->setService('SharedEventManager', $this->sharedEvents);
+        $this->services->setService('Zend\ServiceManager\ServiceLocatorInterface', $this->services);
+
+        $this->controllers = new ControllerManager();
+        $this->controllers->setServiceLocator($this->services);
+    }
+
+    public function testPluginReceivesCurrentController()
+    {
+        $this->controllers->setInvokableClass('first', 'ZendTest\Mvc\Controller\TestAsset\SampleController');
+        $this->controllers->setInvokableClass('second', 'ZendTest\Mvc\Controller\TestAsset\SampleController');
+
+        $first  = $this->controllers->get('first');
+        $second = $this->controllers->get('second');
+        $this->assertNotSame($first, $second);
+
+        $plugin1 = $first->plugin('url');
+        $this->assertSame($first, $plugin1->getController());
+
+        $plugin2 = $second->plugin('url');
+        $this->assertSame($second, $plugin2->getController());
+
+        $this->assertSame($plugin1, $plugin2);
+    }
+}


### PR DESCRIPTION
when create controller via Zend\Mvc\Controller\ControllerManager,
ControllerManager injecting into public PluginManager new controller instance.
If I have another controller (early createt), and try to use plugin, such as params() - this plugin is linked to second controller, and not work correctly.

workarround :

```
class AbstractActionController extends \Zend\Mvc\Controller\AbstractActionController {
    public function getPluginManager() {
        return parent::getPluginManager()->setController($this);
    }
}
```
