### PR TITLE
[WIP] Zend\Di\Di::get() with call parameters ignored shared instances.

### DIFF
--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -163,12 +163,13 @@ class Di implements DependencyInjectionInterface
                 array_pop($this->instanceContext);
                 return $im->getSharedInstanceWithParameters(null, array(), $fastHash);
             }
-        } else {
-            if ($im->hasSharedInstance($name, $callParameters)) {
-                array_pop($this->instanceContext);
-                return $im->getSharedInstance($name, $callParameters);
-            }
         }
+
+        if ($im->hasSharedInstance($name, $callParameters)) {
+            array_pop($this->instanceContext);
+            return $im->getSharedInstance($name, $callParameters);
+        }
+
 
         $config   = $im->getConfig($name);
         $instance = $this->newInstance($name, $params, $config['shared']);

--- a/tests/ZendTest/Di/TestAsset/ConstructorInjection/C.php
+++ b/tests/ZendTest/Di/TestAsset/ConstructorInjection/C.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Di
+ */
+
+namespace ZendTest\Di\TestAsset\ConstructorInjection;
+
+class C
+{
+    public $a = null;
+    public $params = array();
+    public function __construct(A $a, array $params = array())
+    {
+        $this->a = $a;
+        $this->params = $params;
+    }
+}


### PR DESCRIPTION
[WIP] Zend\Di\Di::get() with call parameters ignored shared instances. All I did was removing an else  clause. This fix has worked in our application since zf2.0.0 and still works with 2.1.0.
