### PR TITLE
Zend\Db\Sql\Literal Fix when % is used in string

### DIFF
--- a/library/Zend/Db/Sql/Literal.php
+++ b/library/Zend/Db/Sql/Literal.php
@@ -41,7 +41,7 @@ class Literal implements ExpressionInterface
     public function getExpressionData()
     {
         return array(array(
-            $this->literal,
+            str_replace('%', '%%', $this->literal),
             array(),
             array()
         ));

--- a/tests/ZendTest/Db/Sql/LiteralTest.php
+++ b/tests/ZendTest/Db/Sql/LiteralTest.php
@@ -31,4 +31,17 @@ class LiteralTest extends \PHPUnit_Framework_TestCase
         $literal = new Literal('bar');
         $this->assertEquals(array(array('bar', array(), array())), $literal->getExpressionData());
     }
+
+    public function testGetExpressionDataWillEscapePercent()
+    {
+        $expression = new Literal('X LIKE "foo%"');
+        $this->assertEquals(array(array(
+                'X LIKE "foo%%"',
+                array(),
+                array()
+            )),
+            $expression->getExpressionData()
+        );
+    }
+
 }


### PR DESCRIPTION
- Fixed escaping of sprintf character: %
- Fixes: #3737
