### PR TITLE
Inject shared event manager in initializer

### DIFF
--- a/library/Zend/Mvc/Service/ServiceManagerConfig.php
+++ b/library/Zend/Mvc/Service/ServiceManagerConfig.php
@@ -130,10 +130,14 @@ class ServiceManagerConfig implements ConfigInterface
         }
 
         $serviceManager->addInitializer(function ($instance) use ($serviceManager) {
-            if ($instance instanceof EventManagerAwareInterface
-                && !$instance->getEventManager() instanceof EventManagerInterface
-            ) {
-                $instance->setEventManager($serviceManager->get('EventManager'));
+            if ($instance instanceof EventManagerAwareInterface) {
+                if ($instance->getEventManager() instanceof EventManagerInterface) {
+                    $instance->getEventManager()->setSharedManager(
+                        $serviceManager->get('SharedEventManager')
+                    );
+                } else {
+                    $instance->setEventManager($serviceManager->get('EventManager'));
+                }
             }
         });
 


### PR DESCRIPTION
if EventManagerAwareInterface implementation instantiates event manager on getEventManager(), initializer will be ignored and shared event manager will not be set.
