### PR TITLE
Specify actual class name when service manager fails

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -148,7 +148,7 @@ class ServiceManager implements ServiceLocatorInterface
         if ($this->allowOverride === false) {
             throw new Exception\RuntimeException(sprintf(
                 '%s: cannot alter default shared service setting; container is marked immutable (allow_override is false)',
-                __METHOD__
+                get_class($this) .'::'. __FUNCTION__
             ));
         }
         $this->shareByDefault = (bool) $shareByDefault;
@@ -362,7 +362,7 @@ class ServiceManager implements ServiceLocatorInterface
             if ($this->allowOverride === false) {
                 throw new Exception\InvalidServiceNameException(sprintf(
                     '%s: A service by the name "%s" or alias already exists and cannot be overridden, please use an alternate name.',
-                    __METHOD__,
+                    get_class($this) .'::'. __FUNCTION__,
                     $name
                 ));
             }
@@ -391,7 +391,7 @@ class ServiceManager implements ServiceLocatorInterface
         ) {
             throw new Exception\ServiceNotFoundException(sprintf(
                 '%s: A service by the name "%s" was not found and could not be marked as shared',
-                __METHOD__,
+                get_class($this) .'::'. __FUNCTION__,
                 $name
             ));
         }
@@ -455,7 +455,7 @@ class ServiceManager implements ServiceLocatorInterface
 
             throw new Exception\ServiceNotFoundException(sprintf(
                 '%s was unable to fetch or create an instance for %s',
-                __METHOD__,
+                get_class($this) .'::'. __FUNCTION__,
                 $name
             ));
         }
@@ -838,7 +838,7 @@ class ServiceManager implements ServiceLocatorInterface
         if (!class_exists($invokable)) {
             throw new Exception\ServiceNotFoundException(sprintf(
                 '%s: failed retrieving "%s%s" via invokable class "%s"; class does not exist',
-                __METHOD__,
+                get_class($this) .'::'. __FUNCTION__,
                 $canonicalName,
                 ($requestedName ? '(alias: ' . $requestedName . ')' : ''),
                 $invokable


### PR DESCRIPTION
Specify the name of the called class in exception messages so it's easier to debug and figure out which service locator actually failed locating a service.
