### PR TITLE
Paginator: Group by must be reseted

### DIFF
--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -107,6 +107,7 @@ class DbSelect implements AdapterInterface
         $select->reset(Select::LIMIT);
         $select->reset(Select::OFFSET);
         $select->reset(Select::ORDER);
+        $select->reset(Select::GROUP);
 
         $select->columns(array('c' => new Expression('COUNT(1)')));
 

--- a/tests/ZendTest/Paginator/Adapter/DbSelectTest.php
+++ b/tests/ZendTest/Paginator/Adapter/DbSelectTest.php
@@ -62,7 +62,7 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
     {
         $this->mockSelect->expects($this->once())->method('columns')->with($this->equalTo(array('c' => new Expression('COUNT(1)'))));
         $this->mockResult->expects($this->any())->method('current')->will($this->returnValue(array('c' => 5)));
-        $this->mockSelect->expects($this->exactly(4))->method('reset'); // called for columns, limit, offset, order
+        $this->mockSelect->expects($this->exactly(5))->method('reset'); // called for columns, limit, offset, order
         $count = $this->dbSelect->count();
         $this->assertEquals(5, $count);
     }


### PR DESCRIPTION
The group by part has also to be reseted, when COUNT(1) is used
