### PR TITLE
Sets specific attributes (as class,title...) to "Zend\Form\Select" options

### DIFF
--- a/library/Zend/Form/View/Helper/FormSelect.php
+++ b/library/Zend/Form/View/Helper/FormSelect.php
@@ -160,6 +160,11 @@ class FormSelect extends AbstractHelper
             }
 
             $attributes = compact('value', 'selected', 'disabled');
+
+            if (isset($optionSpec['attributes']) && is_array($optionSpec['attributes'])) {
+            	$attributes = array_merge($attributes, $optionSpec['attributes']);
+            }
+
             $this->validTagAttributes = $this->validOptionAttributes;
             $optionStrings[] = sprintf(
                 $template,

--- a/tests/ZendTest/Form/View/Helper/FormSelectTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormSelectTest.php
@@ -37,6 +37,9 @@ class FormSelectTest extends CommonTestCase
             array(
                 'label' => 'This is the third label',
                 'value' => 'value3',
+                'attributes' => array(
+                    'class' => 'test-class',
+                ),
             ),
         );
         $element->setValueOptions($options);
@@ -58,6 +61,9 @@ class FormSelectTest extends CommonTestCase
         $this->assertContains('value="value1"', $markup);
         $this->assertContains('value="value2"', $markup);
         $this->assertContains('value="value3"', $markup);
+
+        //Test class attribute on third option
+        $this->assertRegexp('#option .*?value="value3" class="test-class"#', $markup);
     }
 
     public function testCanMarkSingleOptionAsSelected()


### PR DESCRIPTION
Exemple : 

``` php
$element = new SelectElement('foo');
$options = array(
    array(
        'label' => 'This is the label',
        'value' => 'value',
        'attributes' => array(
            'class' => 'test-class'
        ),
    ),
);
$element->setValueOptions($options);
```
