### PR TITLE
Implement query and fragment assembling into the HTTP router itself

### DIFF
--- a/library/Zend/Mvc/Router/Http/Query.php
+++ b/library/Zend/Mvc/Router/Http/Query.php
@@ -19,6 +19,7 @@ use Zend\Stdlib\RequestInterface as Request;
  * Query route.
  *
  * @see        http://guides.rubyonrails.org/routing.html
+ * @deprecated
  */
 class Query implements RouteInterface
 {

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -217,6 +217,14 @@ class TreeRouteStack extends SimpleRouteStack
 
         $path = $this->baseUrl . $route->assemble(array_merge($this->defaultParams, $params), $options);
 
+        if (isset($options['query'])) {
+            $uri->setQuery($options['query']);
+        }
+
+        if (isset($options['fragment'])) {
+            $uri->setFragment($options['fragment']);
+        }
+
         if ((isset($options['force_canonical']) && $options['force_canonical']) || $uri->getHost() !== null) {
             if ($uri->getScheme() === null) {
                 if ($this->requestUri === null) {

--- a/tests/ZendTest/Mvc/Router/Http/TreeRouteStackTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/TreeRouteStackTest.php
@@ -212,6 +212,38 @@ class TreeRouteStackTest extends TestCase
         $this->assertEquals('/?bar=baz', $stack->assemble(array('bar' => 'baz'), array('name' => 'index/query')));
     }
 
+    public function testAssembleWithQueryParams()
+    {
+        $stack = new TreeRouteStack();
+        $stack->addRoute(
+            'index',
+            array(
+                'type' => 'Literal',
+                'options' => array(
+                    'route' => '/',
+                ),
+            )
+        );
+
+        $this->assertEquals('/?foo=bar', $stack->assemble(array(), array('name' => 'index', 'query' => array('foo' => 'bar'))));
+    }
+
+    public function testAssembleWithFragment()
+    {
+        $stack = new TreeRouteStack();
+        $stack->addRoute(
+            'index',
+            array(
+                'type' => 'Literal',
+                'options' => array(
+                    'route' => '/',
+                ),
+            )
+        );
+
+        $this->assertEquals('/#foobar', $stack->assemble(array(), array('name' => 'index', 'fragment' => 'foobar')));
+    }
+
     public function testAssembleWithoutNameOption()
     {
         $this->setExpectedException('Zend\Mvc\Router\Exception\InvalidArgumentException', 'Missing "name" option');


### PR DESCRIPTION
This is an implementation meant to show how the assembling process of query parameters and fragments can easily be integrated into the HTTP router itself, thus solving problems which normally occur when having the query assembling implemented as a route.

Open for discussion.
