### PR TITLE
i18n View Helper Tests Depend on intl version fix

### DIFF
--- a/tests/ZendTest/I18n/View/Helper/DateFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/DateFormatTest.php
@@ -56,15 +56,15 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
     public function dateTestsDataProvider()
     {
         $date = new DateTime('2012-07-02T22:44:03Z');
+
         return array(
-            // FULL format varies based on OS
-            // array(
-            //     'de_DE',
-            //     'Europe/Berlin',
-            //     IntlDateFormatter::FULL,
-            //     IntlDateFormatter::FULL,
-            //     $date,
-            // ),
+            array(
+                'de_DE',
+                'Europe/Berlin',
+                IntlDateFormatter::FULL,
+                IntlDateFormatter::FULL,
+                $date,
+            ),
             array(
                 'de_DE',
                 'Europe/Berlin',
@@ -86,22 +86,20 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 IntlDateFormatter::SHORT,
                 $date,
             ),
-            // FULL format varies based on OS
-            // array(
-            //     'ru_RU',
-            //     'Europe/Moscow',
-            //     IntlDateFormatter::FULL,
-            //     IntlDateFormatter::FULL,
-            //     $date,
-            // ),
-            // LONG format varies based on OS for ru_RU locale
-            // array(
-            //     'ru_RU',
-            //     'Europe/Moscow',
-            //     IntlDateFormatter::LONG,
-            //     IntlDateFormatter::LONG,
-            //     $date,
-            // ),
+            array(
+                'ru_RU',
+                'Europe/Moscow',
+                IntlDateFormatter::FULL,
+                IntlDateFormatter::FULL,
+                $date,
+            ),
+            array(
+                'ru_RU',
+                'Europe/Moscow',
+                IntlDateFormatter::LONG,
+                IntlDateFormatter::LONG,
+                $date,
+            ),
             array(
                 'ru_RU',
                 'Europe/Moscow',
@@ -116,14 +114,13 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 IntlDateFormatter::SHORT,
                 $date,
             ),
-            // FULL format varies based on OS
-            // array(
-            //     'en_US',
-            //     'America/New_York',
-            //     IntlDateFormatter::FULL,
-            //     IntlDateFormatter::FULL,
-            //     $date,
-            // ),
+            array(
+                'en_US',
+                'America/New_York',
+                IntlDateFormatter::FULL,
+                IntlDateFormatter::FULL,
+                $date,
+            ),
             array(
                 'en_US',
                 'America/New_York',
@@ -151,15 +148,16 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
     public function dateTestsDataProviderWithPattern()
     {
         $date = new DateTime('2012-07-02T22:44:03Z');
+
         return array(
-            // FULL format varies based on OS
-            // array(
-            //     'de_DE',
-            //     'Europe/Berlin',
-            //     IntlDateFormatter::FULL,
-            //     IntlDateFormatter::FULL,
-            //     $date,
-            // ),
+            array(
+                'de_DE',
+                'Europe/Berlin',
+                IntlDateFormatter::FULL,
+                IntlDateFormatter::FULL,
+                'dd-MM',
+                $date,
+            ),
             array(
                 'de_DE',
                 'Europe/Berlin',
@@ -192,8 +190,12 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
      */
     public function testBasic($locale, $timezone, $timeType, $dateType, $date)
     {
-        $this->helper->setTimezone($timezone);
-        $expected = $this->getIntlDateFormatter($locale, $dateType, $timeType, $timezone)->format($date);
+        $this->helper
+             ->setTimezone($timezone);
+
+        $expected = $this->getIntlDateFormatter($locale, $dateType, $timeType, $timezone)
+                         ->format($date->getTimestamp());
+
         $this->assertMbStringEquals($expected, $this->helper->__invoke(
             $date, $dateType, $timeType, $locale, null
         ));
@@ -208,7 +210,8 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
             ->setTimezone($timezone)
             ->setLocale($locale);
 
-        $expected = $this->getIntlDateFormatter($locale, $dateType, $timeType, $timezone)->format($date);
+        $expected = $this->getIntlDateFormatter($locale, $dateType, $timeType, $timezone)
+                         ->format($date->getTimestamp());
 
         $this->assertMbStringEquals($expected, $this->helper->__invoke(
             $date, $dateType, $timeType
@@ -220,8 +223,12 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
      */
     public function testUseCustomPattern($locale, $timezone, $timeType, $dateType, $pattern, $date)
     {
-        $this->helper->setTimezone($timezone);
-        $expected = $this->getIntlDateFormatter($locale, $dateType, $timeType, $timezone, $pattern)->format($date);
+        $this->helper
+             ->setTimezone($timezone);
+
+        $expected = $this->getIntlDateFormatter($locale, $dateType, $timeType, $timezone, $pattern)
+                         ->format($date->getTimestamp());
+
         $this->assertMbStringEquals($expected, $this->helper->__invoke(
             $date, $dateType, $timeType, $locale, $pattern
         ));

--- a/tests/ZendTest/I18n/View/Helper/DateFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/DateFormatTest.php
@@ -64,7 +64,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
             //     IntlDateFormatter::FULL,
             //     IntlDateFormatter::FULL,
             //     $date,
-            //     'Dienstag, 3. Juli 2012 00:44:03 Deutschland',
             // ),
             array(
                 'de_DE',
@@ -72,7 +71,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 IntlDateFormatter::LONG,
                 IntlDateFormatter::LONG,
                 $date,
-                '3. Juli 2012 00:44:03 MESZ',
             ),
             array(
                 'de_DE',
@@ -80,7 +78,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 IntlDateFormatter::MEDIUM,
                 IntlDateFormatter::MEDIUM,
                 $date,
-                '03.07.2012 00:44:03',
             ),
             array(
                 'de_DE',
@@ -88,7 +85,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 IntlDateFormatter::SHORT,
                 IntlDateFormatter::SHORT,
                 $date,
-                '03.07.12 00:44',
             ),
             // FULL format varies based on OS
             // array(
@@ -97,7 +93,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
             //     IntlDateFormatter::FULL,
             //     IntlDateFormatter::FULL,
             //     $date,
-            //     '3 июля 2012 г. 2:44:03 Россия (Москва)',
             // ),
             // LONG format varies based on OS for ru_RU locale
             // array(
@@ -106,7 +101,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
             //     IntlDateFormatter::LONG,
             //     IntlDateFormatter::LONG,
             //     $date,
-            //     '3 июля 2012 г. 2:44:03 GMT+04:00',
             // ),
             array(
                 'ru_RU',
@@ -114,7 +108,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 IntlDateFormatter::MEDIUM,
                 IntlDateFormatter::MEDIUM,
                 $date,
-                '03.07.2012 2:44:03',
             ),
             array(
                 'ru_RU',
@@ -122,7 +115,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 IntlDateFormatter::SHORT,
                 IntlDateFormatter::SHORT,
                 $date,
-                '03.07.12 2:44',
             ),
             // FULL format varies based on OS
             // array(
@@ -131,7 +123,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
             //     IntlDateFormatter::FULL,
             //     IntlDateFormatter::FULL,
             //     $date,
-            //     'Monday, July 2, 2012 6:44:03 PM ET',
             // ),
             array(
                 'en_US',
@@ -139,7 +130,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 IntlDateFormatter::LONG,
                 IntlDateFormatter::LONG,
                 $date,
-                'July 2, 2012 6:44:03 PM EDT',
             ),
             array(
                 'en_US',
@@ -147,7 +137,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 IntlDateFormatter::MEDIUM,
                 IntlDateFormatter::MEDIUM,
                 $date,
-                'Jul 2, 2012 6:44:03 PM',
             ),
             array(
                 'en_US',
@@ -155,7 +144,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 IntlDateFormatter::SHORT,
                 IntlDateFormatter::SHORT,
                 $date,
-                '7/2/12 6:44 PM',
             ),
         );
     }
@@ -171,7 +159,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
             //     IntlDateFormatter::FULL,
             //     IntlDateFormatter::FULL,
             //     $date,
-            //     'Dienstag, 3. Juli 2012 00:44:03 Deutschland',
             // ),
             array(
                 'de_DE',
@@ -180,7 +167,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 null,
                 'MMMM',
                 $date,
-                'Juli',
             ),
             array(
                 'de_DE',
@@ -189,7 +175,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 null,
                 'MMMM.Y',
                 $date,
-                'Juli.2012',
             ),
             array(
                 'de_DE',
@@ -198,7 +183,6 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 null,
                 'dd/Y',
                 $date,
-                '03/2012',
             ),
         );
     }
@@ -206,9 +190,10 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider dateTestsDataProvider
      */
-    public function testBasic($locale, $timezone, $timeType, $dateType, $date, $expected)
+    public function testBasic($locale, $timezone, $timeType, $dateType, $date)
     {
         $this->helper->setTimezone($timezone);
+        $expected = $this->getIntlDateFormatter($locale, $dateType, $timeType, $timezone)->format($date);
         $this->assertMbStringEquals($expected, $this->helper->__invoke(
             $date, $dateType, $timeType, $locale, null
         ));
@@ -217,11 +202,13 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider dateTestsDataProvider
      */
-    public function testSettersProvideDefaults($locale, $timezone, $timeType, $dateType, $date, $expected)
+    public function testSettersProvideDefaults($locale, $timezone, $timeType, $dateType, $date)
     {
         $this->helper
             ->setTimezone($timezone)
             ->setLocale($locale);
+
+        $expected = $this->getIntlDateFormatter($locale, $dateType, $timeType, $timezone)->format($date);
 
         $this->assertMbStringEquals($expected, $this->helper->__invoke(
             $date, $dateType, $timeType
@@ -231,9 +218,10 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider dateTestsDataProviderWithPattern
      */
-    public function testUseCustomPattern($locale, $timezone, $timeType, $dateType, $pattern, $date, $expected)
+    public function testUseCustomPattern($locale, $timezone, $timeType, $dateType, $pattern, $date)
     {
         $this->helper->setTimezone($timezone);
+        $expected = $this->getIntlDateFormatter($locale, $dateType, $timeType, $timezone, $pattern)->format($date);
         $this->assertMbStringEquals($expected, $this->helper->__invoke(
             $date, $dateType, $timeType, $locale, $pattern
         ));
@@ -259,5 +247,10 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
         $expected = str_replace(array("\xC2\xA0", ' '), '', $expected);
         $test     = str_replace(array("\xC2\xA0", ' '), '', $test);
         $this->assertEquals($expected, $test, $message);
+    }
+
+    public function getIntlDateFormatter($locale, $dateType, $timeType, $timezone, $pattern=null)
+    {
+        return new IntlDateFormatter($locale, $dateType, $timeType, $timezone, null, $pattern);
     }
 }


### PR DESCRIPTION
The tests borked due to an intl upgrade:
Internationalization support => enabled
version => 1.1.0
ICU version => 49.1.2
ICU Data version => 49.1.2

This changes the tests for the date formatter to now check the output against the IntlDateFormatter directly. This also allowed for several of the tests to be uncommented.  Previously there was a static date that was being tested against.
