### PR TITLE
Fix identical validator

### DIFF
--- a/library/Zend/Validator/Identical.php
+++ b/library/Zend/Validator/Identical.php
@@ -131,17 +131,19 @@ class Identical extends AbstractValidator
 
         if ($context !== null) {
             if (is_array($token)) {
-                do {
-                    $context = $context[key($token)];
-                    $token   = $token[key($token)];
-                    $key     = is_array($token) ? key($token) : $token;
+                while (is_array($token)){
+                    $key = key($token);
                     if (!isset($context[$key])) {
                         break;
                     }
-                } while (is_array($token));
+                    $context = $context[$key];
+                    $token   = $token[$key];
+                }
             }
 
-            if (!isset($context[$token])) {
+            // if $token is an array it means the above loop didn't went all the way down to the leaf,
+            // so the $token structure doesn't match the $context structure
+            if (is_array($token) || !isset($context[$token])) {
                 throw new Exception\RuntimeException("The token doesn't exist in the context");
             } else {
                 $token = $context[$token];

--- a/tests/ZendTest/Validator/IdenticalTest.php
+++ b/tests/ZendTest/Validator/IdenticalTest.php
@@ -192,7 +192,7 @@ class IdenticalTest extends \PHPUnit_Framework_TestCase
 
         $this->validator->isValid(
             'john@doe.com',
-            array('name' => 'john') // There's no 'email' key here
+            array('name' => 'john') // There's no 'email' key here, must throw an exception
         );
     }
 
@@ -207,8 +207,8 @@ class IdenticalTest extends \PHPUnit_Framework_TestCase
         $this->validator->isValid(
             'john@doe.com',
             array(
-                'user' => array(
-                    'name' => 'john' // There's no 'email' key here
+                'admin' => array( // Here is 'admin' instead of 'user', must throw an exception
+                    'email' => 'john@doe.com'
                 )
             )
         );

--- a/tests/ZendTest/Validator/IdenticalTest.php
+++ b/tests/ZendTest/Validator/IdenticalTest.php
@@ -129,4 +129,88 @@ class IdenticalTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($validator->getOption('messageVariables'),
                                      'messageVariables', $validator);
     }
+
+    public function testValidatingStringTokenInContext()
+    {
+        $this->validator->setToken('email');
+
+        $this->assertTrue($this->validator->isValid(
+            'john@doe.com',
+            array('email' => 'john@doe.com')
+        ));
+
+        $this->assertFalse($this->validator->isValid(
+            'john@doe.com',
+            array('email' => 'harry@hoe.com')
+        ));
+
+        $this->assertFalse($this->validator->isValid(
+            'harry@hoe.com',
+            array('email' => 'john@doe.com')
+        ));
+    }
+
+    public function testValidatingArrayTokenInContext()
+    {
+        $this->validator->setToken(array('user' => 'email'));
+
+        $this->assertTrue($this->validator->isValid(
+            'john@doe.com',
+            array(
+                'user' => array(
+                    'email' => 'john@doe.com'
+                )
+            )
+        ));
+
+        $this->assertFalse($this->validator->isValid(
+            'john@doe.com',
+            array(
+                'user' => array(
+                    'email' => 'harry@hoe.com'
+                )
+            )
+        ));
+
+        $this->assertFalse($this->validator->isValid(
+            'harry@hoe.com',
+            array(
+                'user' => array(
+                    'email' => 'john@doe.com'
+                )
+            )
+        ));
+    }
+
+    public function testSetStringTokenNonExistentInContext()
+    {
+        $this->validator->setToken('email');
+        $this->setExpectedException(
+            'Zend\Validator\Exception\RuntimeException',
+            "The token doesn't exist in the context"
+        );
+
+        $this->validator->isValid(
+            'john@doe.com',
+            array('name' => 'john') // There's no 'email' key here
+        );
+    }
+
+    public function testSetArrayTokenNonExistentInContext()
+    {
+        $this->validator->setToken(array('user' => 'email'));
+        $this->setExpectedException(
+            'Zend\Validator\Exception\RuntimeException',
+            "The token doesn't exist in the context"
+        );
+
+        $this->validator->isValid(
+            'john@doe.com',
+            array(
+                'user' => array(
+                    'name' => 'john' // There's no 'email' key here
+                )
+            )
+        );
+    }
 }


### PR DESCRIPTION
These changes adds the possibility to use `Zend\Validator\Identical` to validate a form input that lives inside a fieldset:

See exemple below:

``` PHP
use Zend\Form\Element;
use Zend\Form\Fieldset;
use Zend\Form\Form;
use Zend\InputFilter\Input;
use Zend\InputFilter\InputFilter;

$user = new Fieldset('user'); // (1)
$user->add(array(
    'name' => 'email', // (2)
    'type' => 'Zend\Form\Element\Email',
    'attributes' => array(
        'required' => 'required',
    ),
    'options' => array(
        'label' => 'Email',
    ),
));

$signUp = new Form('signUp');
$signUp->add($user);
$signUp->add(array(
    'name' => 'confirmEmail', // (3)
    'type', 'Zend\Form\Element\Email',
    'options' => array(
        'label' => 'Confirm your email',
    ),
));

$inputFilter = new InputFilter();
$inputFilter->add(array(
    'name' => 'confirmEmail', // references (3)
    'required' => true,
    'validators' => array(
        array(
            'name' => 'Identical',
            'options' => array(
                // 'user' references 'user' fieldset (1), and 'email'
                // references 'email' element inside 'user' fieldset (2)
                'token' => array('user' => 'email'),
            ),
        ),
    ),
));

$signUp->setInputFilter($inputFilter);

$signUp->setData(array(
    'user' => array(
        'email' => 'josias@duarte.com',
    ),
    'confirmEmail' => 'josias@duarte.com',
));

// Will return true because "user['email']" == "confirmEmail"
if ($signUp->isValid()) {
}
```
