### PR TITLE
Fix inconsistent return statements

### DIFF
--- a/library/Zend/Cache/Pattern/ObjectCache.php
+++ b/library/Zend/Cache/Pattern/ObjectCache.php
@@ -208,7 +208,7 @@ class ObjectCache extends CallbackCache
      */
     public function __set($name, $value)
     {
-        return $this->call('__set', array($name, $value));
+        $this->call('__set', array($name, $value));
     }
 
     /**
@@ -257,7 +257,7 @@ class ObjectCache extends CallbackCache
      */
     public function __unset($name)
     {
-        return $this->call('__unset', array($name));
+        $this->call('__unset', array($name));
     }
 
     /**

--- a/library/Zend/Cache/Storage/Adapter/ApcIterator.php
+++ b/library/Zend/Cache/Storage/Adapter/ApcIterator.php
@@ -153,6 +153,6 @@ class ApcIterator implements IteratorInterface
      */
     public function rewind()
     {
-        return $this->baseIterator->rewind();
+        $this->baseIterator->rewind();
     }
 }

--- a/library/Zend/Cache/Storage/Adapter/FilesystemIterator.php
+++ b/library/Zend/Cache/Storage/Adapter/FilesystemIterator.php
@@ -168,6 +168,6 @@ class FilesystemIterator implements IteratorInterface
      */
     public function rewind()
     {
-        return $this->globIterator->rewind();
+        $this->globIterator->rewind();
     }
 }

--- a/library/Zend/Log/Writer/FirePhp/FirePhpBridge.php
+++ b/library/Zend/Log/Writer/FirePhp/FirePhpBridge.php
@@ -54,7 +54,7 @@ class FirePhpBridge implements FirePhpInterface
      * Log an error message
      *
      * @param  string $line
-     * @return void
+     * @return bool
      */
     public function error($line)
     {
@@ -65,7 +65,7 @@ class FirePhpBridge implements FirePhpInterface
      * Log a warning
      *
      * @param  string $line
-     * @return void
+     * @return bool
      */
     public function warn($line)
     {
@@ -76,7 +76,7 @@ class FirePhpBridge implements FirePhpInterface
      * Log informational message
      *
      * @param  string $line
-     * @return void
+     * @return bool
      */
     public function info($line)
     {
@@ -87,7 +87,7 @@ class FirePhpBridge implements FirePhpInterface
      * Log a trace
      *
      * @param  string $line
-     * @return void
+     * @return bool
      */
     public function trace($line)
     {
@@ -98,7 +98,7 @@ class FirePhpBridge implements FirePhpInterface
      * Log a message
      *
      * @param  string $line
-     * @return void
+     * @return bool
      */
     public function log($line)
     {

--- a/library/Zend/Mvc/ResponseSender/SimpleStreamResponseSender.php
+++ b/library/Zend/Mvc/ResponseSender/SimpleStreamResponseSender.php
@@ -29,6 +29,7 @@ class SimpleStreamResponseSender extends AbstractResponseSender
         $stream   = $response->getStream();
         fpassthru($stream);
         $event->setContentSent();
+        return $this;
     }
 
     /**

--- a/library/Zend/Mvc/Router/Console/Simple.php
+++ b/library/Zend/Mvc/Router/Console/Simple.php
@@ -523,7 +523,7 @@ class Simple implements RouteInterface
      * @see     Route::match()
      * @param   Request             $request
      * @param   null|int            $pathOffset
-     * @return  RouteMatch
+     * @return  null|RouteMatch
      */
     public function match(Request $request, $pathOffset = null)
     {

--- a/library/Zend/Session/Config/SessionConfig.php
+++ b/library/Zend/Session/Config/SessionConfig.php
@@ -76,7 +76,7 @@ class SessionConfig extends StandardConfig
         switch ($storageName) {
             case 'remember_me_seconds':
                 // do nothing; not an INI option
-                return;
+                return $this;
             case 'url_rewriter_tags':
                 $key = 'url_rewriter.tags';
                 break;

--- a/library/Zend/Session/Storage/AbstractSessionArrayStorage.php
+++ b/library/Zend/Session/Storage/AbstractSessionArrayStorage.php
@@ -62,7 +62,7 @@ abstract class AbstractSessionArrayStorage implements IteratorAggregate, Storage
      */
     public function __set($key, $value)
     {
-        return $this->offsetSet($key, $value);
+        $this->offsetSet($key, $value);
     }
 
     /**
@@ -84,7 +84,7 @@ abstract class AbstractSessionArrayStorage implements IteratorAggregate, Storage
      */
     public function __unset($key)
     {
-        return $this->offsetUnset($key);
+        $this->offsetUnset($key);
     }
 
     /**


### PR DESCRIPTION
This pull request fixes some inconsistent return statements where the docblock does not correspond with the code.
