### PR TITLE
Remove obsolete catch statement

### DIFF
--- a/library/Zend/Filter/Encrypt/BlockCipher.php
+++ b/library/Zend/Filter/Encrypt/BlockCipher.php
@@ -251,8 +251,6 @@ class BlockCipher implements EncryptionAlgorithmInterface
             $encrypted = $this->blockCipher->encrypt($value);
         } catch (CryptException\InvalidArgumentException $e) {
             throw new Exception\InvalidArgumentException($e->getMessage());
-        } catch (SymmetricException\InvalidArgumentException $e) {
-            throw new Exception\InvalidArgumentException($e->getMessage());
         }
         return $encrypted;
     }


### PR DESCRIPTION
Since the `SymmetricException\InvalidArgumentException` extends the `CryptException\InvalidArgumentException`, there is no need for the second catch statement.
