### PR TITLE
Bug fix for GlobIterator extending service

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -445,7 +445,7 @@ class ServiceManager implements ServiceLocatorInterface
         }
 
         // Still no instance? raise an exception
-        if (!$instance && !is_array($instance)) {
+        if ($instance === null && !is_array($instance)) {
             if ($isAlias) {
                 throw new Exception\ServiceNotFoundException(sprintf(
                     'An alias "%s" was requested but no service could be found.',
@@ -494,11 +494,11 @@ class ServiceManager implements ServiceLocatorInterface
             $instance = $this->createFromFactory($cName, $rName);
         }
 
-        if (!$instance && isset($this->invokableClasses[$cName])) {
+        if ($instance === false && isset($this->invokableClasses[$cName])) {
             $instance = $this->createFromInvokable($cName, $rName);
         }
 
-        if (!$instance && $this->canCreateFromAbstractFactory($cName, $rName)) {
+        if ($instance === false && $this->canCreateFromAbstractFactory($cName, $rName)) {
             $instance = $this->createFromAbstractFactory($cName, $rName);
         }
 

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -560,6 +560,18 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $result = $this->serviceManager->addInitializer(get_class($this));
     }
 
+    public function testGetGlobIteratorServiceWorksProperly()
+    {
+        $config = new Config(array(
+            'invokables' => array(
+                'foo' => 'ZendTest\ServiceManager\TestAsset\GlobIteratorService',
+            ),
+        ));
+        $serviceManager = new ServiceManager($config);
+        $foo = $serviceManager->get('foo');
+        $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\GlobIteratorService', $foo);
+    }
+
     public function duplicateService()
     {
         $self = $this;

--- a/tests/ZendTest/ServiceManager/TestAsset/GlobIteratorService.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/GlobIteratorService.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_ServiceManager
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+class GlobIteratorService extends \GlobIterator
+{
+    public function __construct()
+    {
+    }
+}
+


### PR DESCRIPTION
Reported by andrer on IRC... If a service extends GlobIterator, there
was a problem where we were checking if (!$instance) which would yield a
catchable fatal error that GlobIterator cannot be casted to a boolean.
To solve this, the comparison operators should be strict so PHP does not
try to convert the type internally. The types checked against are the
expected types if no services have been returned, so the overall
behavior should not be changed by this fix at all.
