### PR TITLE
Improve module manager to accept instance

### DIFF
--- a/tests/ZendTest/ModuleManager/ModuleManagerTest.php
+++ b/tests/ZendTest/ModuleManager/ModuleManagerTest.php
@@ -165,8 +165,12 @@ class ModuleManagerTest extends TestCase
     public function testCanLoadSomeObjectModule()
     {
         require_once __DIR__ . '/TestAsset/SomeModule/Module.php';
+        require_once __DIR__ . '/TestAsset/SubModule/Sub/Module.php';
         $configListener = $this->defaultListeners->getConfigListener();
-        $moduleManager  = new ModuleManager(array(new \SomeModule\Module()), new EventManager);
+        $moduleManager  = new ModuleManager(array(
+            'SomeModule' => new \SomeModule\Module(),
+            'SubModule' => new \SubModule\Sub\Module(),
+        ), new EventManager);
         $moduleManager->getEventManager()->attachAggregate($this->defaultListeners);
         $moduleManager->loadModules();
         $loadedModules = $moduleManager->getLoadedModules();
@@ -179,12 +183,22 @@ class ModuleManagerTest extends TestCase
     {
         require_once __DIR__ . '/TestAsset/SomeModule/Module.php';
         $configListener = $this->defaultListeners->getConfigListener();
-        $moduleManager  = new ModuleManager(array(new \SomeModule\Module(), 'BarModule'), new EventManager);
+        $moduleManager  = new ModuleManager(array('SomeModule' => new \SomeModule\Module(), 'BarModule'), new EventManager);
         $moduleManager->getEventManager()->attachAggregate($this->defaultListeners);
         $moduleManager->loadModules();
         $loadedModules = $moduleManager->getLoadedModules();
         $this->assertInstanceOf('SomeModule\Module', $loadedModules['SomeModule']);
         $config = $configListener->getMergedConfig();
         $this->assertSame($config->some, 'thing');
+    }
+    
+    public function testCanNotLoadSomeObjectModuleWithoutIdentifier()
+    {
+        require_once __DIR__ . '/TestAsset/SomeModule/Module.php';
+        $configListener = $this->defaultListeners->getConfigListener();
+        $moduleManager  = new ModuleManager(array(new \SomeModule\Module()), new EventManager);
+        $moduleManager->getEventManager()->attachAggregate($this->defaultListeners);
+        $this->setExpectedException('Zend\ModuleManager\Exception\RuntimeException');
+        $moduleManager->loadModules();
     }
 }

--- a/tests/ZendTest/ModuleManager/ModuleManagerTest.php
+++ b/tests/ZendTest/ModuleManager/ModuleManagerTest.php
@@ -161,4 +161,30 @@ class ModuleManagerTest extends TestCase
         $this->assertArrayHasKey('BarModule', $test->modules);
         $this->assertInstanceOf('BarModule\Module', $test->modules['BarModule']);
     }
+
+    public function testCanLoadSomeObjectModule()
+    {
+        require_once __DIR__ . '/TestAsset/SomeModule/Module.php';
+        $configListener = $this->defaultListeners->getConfigListener();
+        $moduleManager  = new ModuleManager(array(new \SomeModule\Module()), new EventManager);
+        $moduleManager->getEventManager()->attachAggregate($this->defaultListeners);
+        $moduleManager->loadModules();
+        $loadedModules = $moduleManager->getLoadedModules();
+        $this->assertInstanceOf('SomeModule\Module', $loadedModules['SomeModule']);
+        $config = $configListener->getMergedConfig();
+        $this->assertSame($config->some, 'thing');
+    }
+
+    public function testCanLoadMultipleModulesObjectWithString()
+    {
+        require_once __DIR__ . '/TestAsset/SomeModule/Module.php';
+        $configListener = $this->defaultListeners->getConfigListener();
+        $moduleManager  = new ModuleManager(array(new \SomeModule\Module(), 'BarModule'), new EventManager);
+        $moduleManager->getEventManager()->attachAggregate($this->defaultListeners);
+        $moduleManager->loadModules();
+        $loadedModules = $moduleManager->getLoadedModules();
+        $this->assertInstanceOf('SomeModule\Module', $loadedModules['SomeModule']);
+        $config = $configListener->getMergedConfig();
+        $this->assertSame($config->some, 'thing');
+    }
 }

--- a/tests/ZendTest/ModuleManager/TestAsset/SubModule/Sub/Module.php
+++ b/tests/ZendTest/ModuleManager/TestAsset/SubModule/Sub/Module.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_ModuleManager
+ */
+
+namespace SubModule\Sub;
+
+class Module
+{
+    
+}


### PR DESCRIPTION
Hi,

For the performance and to make learning easier, we can accept modules instances :

Before :

``` php
<?php
return array(
    'modules' => array(
        'Application',
        'Cron',
        'Administration',
        'Blog',
    ),
    'module_paths' => array(// my paths),
);
?>
```

Now, i do :

``` php
<?php
return array(
    'modules' => array(
        'Application' => new Application\Module(),
        'Cron' => new Cron\Module(),
        'Administration' => new Administration\Module(),
        'Blog' => new Blog\Module(),
    ),
);
?>
```

There is no BC, more natural, and perf little better.
