### PR TITLE
The method setDefaultValue MUST not use an array with indexes value and type

### DIFF
--- a/library/Zend/Code/Generator/PropertyGenerator.php
+++ b/library/Zend/Code/Generator/PropertyGenerator.php
@@ -162,21 +162,17 @@ class PropertyGenerator extends AbstractMemberGenerator
     }
 
     /**
-     * @param  PropertyValueGenerator|string|array $defaultValue
+     * @param PropertyValueGenerator|mixed $defaultValue
+     * @param string                       $defaultValueType
+     * @param string                       $defaultValueOutputMode
+     *
      * @return PropertyGenerator
      */
-    public function setDefaultValue($defaultValue)
+    public function setDefaultValue($defaultValue, $defaultValueType = PropertyValueGenerator::TYPE_AUTO, $defaultValueOutputMode = PropertyValueGenerator::OUTPUT_MULTIPLE_LINE)
     {
-        // if it looks like
-        if (is_array($defaultValue)
-            && isset($defaultValue['value'])
-            && isset($defaultValue['type'])
-        ) {
-            $defaultValue = new PropertyValueGenerator($defaultValue);
-        }
-
         if (!($defaultValue instanceof PropertyValueGenerator)) {
-            $defaultValue = new PropertyValueGenerator($defaultValue);
+
+            $defaultValue = new PropertyValueGenerator($defaultValue, $defaultValueType, $defaultValueOutputMode);
         }
 
         $this->defaultValue = $defaultValue;

--- a/tests/ZendTest/Code/Generator/PropertyGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/PropertyGeneratorTest.php
@@ -266,4 +266,20 @@ EOS;
         $this->assertEquals('var', $tag->getName());
     }
 
+
+    /**
+     * @dataProvider dataSetTypeSetValueGenerate
+     * @param string $type
+     * @param mixed $value
+     * @param string $code
+     */
+    public function testSetDefaultValue($type, $value, $code)
+    {
+        $property = new PropertyGenerator();
+        $property->setDefaultValue($value, $type);
+
+        $this->assertEquals($type, $property->getDefaultValue()->getType());
+        $this->assertEquals($value, $property->getDefaultValue()->getValue());
+    }
+
 }


### PR DESCRIPTION
If my property will like it:

``` php
protected $defaultValue = array(
        'someThing' =>'superValue', 
        'type' => 2, 
        'value' => 3
    );
```

The method defined it like a property with type 'auto' and value '3' but must defined like an assoc array with 3 elements
