### PR TITLE
Cannot validate form when keys of collection in data are non consecutive

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -558,10 +558,8 @@ class Form extends Fieldset implements FormInterface
                 $values = array();
 
                 if (isset($data[$key])) {
-                    $count = count($data[$key]);
-
-                    for ($i = 0; $i != $count; ++$i) {
-                        $values[] = $value;
+                    foreach(array_keys($data[$key]) as $cKey) {
+                        $values[$cKey] = $value;
                     }
                 }
 

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1124,6 +1124,38 @@ class FormTest extends TestCase
         $this->assertTrue($this->form->isValid());
     }
 
+    public function testFormValidationCanHandleNonConsecutiveKeysOfCollectionInData()
+    {
+        $dataWithCollection = array(
+            'foo' => 'bar',
+            'categories' => array(
+                0 => array('name' => 'cat1'),
+                1 => array('name' => 'cat2'),
+                3 => array('name' => 'cat3'),
+            ),
+        );
+        $this->populateForm();
+        $this->form->add(array(
+            'type' => 'Zend\Form\Element\Collection',
+            'name' => 'categories',
+            'options' => array(
+                'count' => 1,
+                'allow_add' => true,
+                'target_element' => array(
+                    'type' => 'ZendTest\Form\TestAsset\CategoryFieldset'
+                )
+            )
+        ));
+        $this->form->setValidationGroup(array(
+            'foo',
+            'categories' => array(
+                'name'
+            )
+        ));
+        $this->form->setData($dataWithCollection);
+        $this->assertTrue($this->form->isValid());
+    }
+
     public function testAddNonBaseFieldsetObjectInputFilterToFormInputFilter()
     {
         $fieldset = new Fieldset('foobar');


### PR DESCRIPTION
As the `InputFilter` tests the keys of the `validationGroup` to the keys of the `data`, the `prepareValidationGroup` should in case of a `Collection` use the keys of the corresponding `data` when multiplying that validationGroup to match the amount of Collection items in `data`.
Most of the time the keys of a collection inside `data` are consecutive, but not per se. The test attached to this PR shows this more clearly.
