### PR TITLE
Fixed PHPDoc block

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Mysqli/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Mysqli/Statement.php
@@ -220,7 +220,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * Execute
      *
-     * @param  ParameterContainer $parameters
+     * @param  ParameterContainer|array $parameters
      * @throws Exception\RuntimeException
      * @return mixed
      */


### PR DESCRIPTION
From what I see in [line 243](https://github.com/wryck7/zf2/blob/3b01784d54b7ffd8fb4f66ddb9ef2bc48b0ec608/library/Zend/Db/Adapter/Driver/Mysqli/Statement.php#L243), this method accepts array as well.
