### PR TITLE
Non-matching argument type for ArrayObject

### DIFF
--- a/library/Zend/Session/Container.php
+++ b/library/Zend/Session/Container.php
@@ -9,6 +9,8 @@
 
 namespace Zend\Session;
 
+use Zend\Stdlib\ArrayObject;
+
 /**
  * Session storage container
  *
@@ -26,8 +28,14 @@ class Container extends AbstractContainer
      * @return array        Returns the old array
      * @see ArrayObject::exchangeArray()
      */
-    public function exchangeArray(array $input)
+    public function exchangeArray($input)
     {
+        if (!is_array($input) && !$input instanceof ArrayObject) {
+            throw new Exception\InvalidArgumentException(
+                'Name passed to container is invalid; must consist of alphanumerics, backslashes and underscores only'
+            );
+        }
+
         return parent::exchangeArrayCompat($input);
     }
 
@@ -40,12 +48,14 @@ class Container extends AbstractContainer
     public function &offsetGet($key)
     {
         $ret = null;
+
         if (!$this->offsetExists($key)) {
             return $ret;
         }
+
         $storage = $this->getStorage();
         $name    = $this->getName();
-        $ret =& $storage[$name][$key];
+        $ret     =& $storage[$name][$key];
 
         return $ret;
     }

--- a/library/Zend/Session/Container.php
+++ b/library/Zend/Session/Container.php
@@ -9,8 +9,6 @@
 
 namespace Zend\Session;
 
-use Zend\Stdlib\ArrayObject;
-
 /**
  * Session storage container
  *
@@ -30,9 +28,9 @@ class Container extends AbstractContainer
      */
     public function exchangeArray($input)
     {
-        if (!is_array($input) && !$input instanceof ArrayObject) {
+        if (!is_array($input) && !is_object($input)) {
             throw new Exception\InvalidArgumentException(
-                'Name passed to container is invalid; must consist of alphanumerics, backslashes and underscores only'
+                'Invalid input type supplied. Expected array or object.'
             );
         }
 

--- a/library/Zend/Stdlib/ArrayObject.php
+++ b/library/Zend/Stdlib/ArrayObject.php
@@ -181,10 +181,15 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @param  array $data
      * @return array
      */
-    public function exchangeArray(array $data)
+    public function exchangeArray($data)
     {
-        $storage = $this->storage;
+        if (!is_array($data)) {
+            throw new Exception\InvalidArgumentException(
+                'Invalid data type supplied. Expected array.'
+            );
+        }
 
+        $storage       = $this->storage;
         $this->storage = $data;
 
         return $storage;

--- a/tests/ZendTest/Session/ContainerTest.php
+++ b/tests/ZendTest/Session/ContainerTest.php
@@ -528,6 +528,17 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->container->offsetExists('new'), "'exchangeArray' doesn't add the new array items");
     }
 
+    public function testExchangeArrayObject()
+    {
+        $this->container->offsetSet('old', 'old');
+        $this->assertTrue($this->container->offsetExists('old'));
+
+        $old = $this->container->exchangeArray(new \Zend\Stdlib\ArrayObject(array('new' => 'new')));
+        $this->assertArrayHasKey('old', $old, "'exchangeArray' doesn't return an array of old items");
+        $this->assertFalse($this->container->offsetExists('old'), "'exchangeArray' doesn't remove old items");
+        $this->assertTrue($this->container->offsetExists('new'), "'exchangeArray' doesn't add the new array items");
+    }
+
     public function testMultiDimensionalUnset()
     {
         if (version_compare(PHP_VERSION, '5.3.4') < 0) {

--- a/tests/ZendTest/Stdlib/ArrayObjectTest.php
+++ b/tests/ZendTest/Stdlib/ArrayObjectTest.php
@@ -121,6 +121,15 @@ class ArrayObjectTest extends TestCase
         $this->assertSame(array('bar' => 'baz'), $ar->getArrayCopy());
     }
 
+    /**
+     * @expectedException Zend\Stdlib\Exception\InvalidArgumentException
+     */
+    public function testExchangeArrayStringArgumentFail()
+    {
+        $ar     = new ArrayObject(array('foo' => 'bar'));
+        $old    = $ar->exchangeArray('Bacon');
+    }
+
     public function testGetArrayCopy()
     {
         $ar = new ArrayObject(array('foo' => 'bar'));

--- a/tests/ZendTest/Stdlib/ArrayObjectTest.php
+++ b/tests/ZendTest/Stdlib/ArrayObjectTest.php
@@ -122,7 +122,7 @@ class ArrayObjectTest extends TestCase
     }
 
     /**
-     * @expectedException Zend\Stdlib\Exception\InvalidArgumentException
+     * @expectedException InvalidArgumentException
      */
     public function testExchangeArrayStringArgumentFail()
     {


### PR DESCRIPTION
Documentation specifies that the accepted type is array|object. This only accepted arrays.
I haven't completely fixed the ArraObject in Stdlib yet. It's missing object support.

What I _have_ done, however, is make it compatible. So remove array from the method. To catch other types I've added a conditional and I'm throwing an exception. I've added the unit test for these changes and they work as expected

@mwillbanks I assume that you'll build the object support seeing how it's your class? If not, I might be able to add it in a later PR
