### PR TITLE
Zend\Db\Sql\Predicate\Predicate Fix for literal() usage

### DIFF
--- a/library/Zend/Db/Sql/Predicate/Predicate.php
+++ b/library/Zend/Db/Sql/Predicate/Predicate.php
@@ -215,6 +215,13 @@ class Predicate extends PredicateSet
         return $this;
     }
 
+    /**
+     * Create an expression, with parameter placeholders
+     *
+     * @param $expression
+     * @param $parameters
+     * @return $this
+     */
     public function expression($expression, $parameters)
     {
         $this->addPredicate(
@@ -229,19 +236,24 @@ class Predicate extends PredicateSet
     /**
      * Create "Literal" predicate
      *
-     * Utilizes Like predicate
+     * Literal predicate, for parameters, use expression()
      *
      * @param  string $literal
-     * @param  int|float|bool|string|array $parameter
      * @return Predicate
      */
-    public function literal($literal, $expressionParameters = null)
+    public function literal($literal)
     {
-        if ($expressionParameters) {
-            $predicate = new Expression($literal, $expressionParameters);
-        } else {
+        // process deprecated parameters from previous literal($literal, $parameters = null) signature
+        if (func_num_args() >= 2) {
+            $parameters = func_get_arg(1);
+            $predicate = new Expression($literal, $parameters);
+        }
+
+        // normal workflow for "Literals" here
+        if (!isset($predicate)) {
             $predicate = new Literal($literal);
         }
+
         $this->addPredicate(
             $predicate,
             ($this->nextPredicateCombineOperator) ?: $this->defaultCombination

--- a/tests/ZendTest/Db/Sql/Predicate/PredicateTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/PredicateTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Db\Sql\Predicate;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Db\Sql\Expression;
 use Zend\Db\Sql\Predicate\IsNull;
 use Zend\Db\Sql\Predicate\Predicate;
 
@@ -193,4 +194,55 @@ class PredicateTest extends TestCase
 
         $this->assertEquals(')', $parts[6]);
     }
+
+    /**
+     * @testdox Unit test: Test expression() is chainable and returns proper values
+     */
+    public function testExpression()
+    {
+        $predicate = new Predicate;
+
+        // is chainable
+        $this->assertSame($predicate, $predicate->expression('foo = ?', 0));
+        // with parameter
+        $this->assertEquals(
+            array(array('foo = %s', array(0), array(Expression::TYPE_VALUE))),
+            $predicate->getExpressionData()
+        );
+    }
+
+    /**
+     * @testdox Unit test: Test literal() is chainable, returns proper values, and is backwards compatible with 2.0.*
+     */
+    public function testLiteral()
+    {
+        $predicate = new Predicate;
+
+        // is chainable
+        $this->assertSame($predicate, $predicate->literal('foo = bar'));
+        // with parameter
+        $this->assertEquals(
+            array(array('foo = bar', array(), array())),
+            $predicate->getExpressionData()
+        );
+
+        // test literal() is backwards-compatible, and works with with parameters
+        $predicate = new Predicate;
+        $predicate->expression('foo = ?', 'bar');
+        // with parameter
+        $this->assertEquals(
+            array(array('foo = %s', array('bar'), array(Expression::TYPE_VALUE))),
+            $predicate->getExpressionData()
+        );
+
+        // test literal() is backwards-compatible, and works with with parameters, even 0 which tests as false
+        $predicate = new Predicate;
+        $predicate->expression('foo = ?', 0);
+        // with parameter
+        $this->assertEquals(
+            array(array('foo = %s', array(0), array(Expression::TYPE_VALUE))),
+            $predicate->getExpressionData()
+        );
+    }
+
 }


### PR DESCRIPTION
Fixes #3832 - ensures literal() is backwards compatible when non-null testing values are passed as 2nd parameter
