### PR TITLE
Stdlib\ArrayObject & Zend\Session\Container Compatibility with ArrayObject

### DIFF
--- a/library/Zend/Session/AbstractContainer.php
+++ b/library/Zend/Session/AbstractContainer.php
@@ -456,8 +456,16 @@ abstract class AbstractContainer extends ArrayObject
      * @return array        Returns the old array
      * @see ArrayObject::exchangeArray()
      */
-    protected function exchangeArrayCompat($input)
+    public function exchangeArray($input)
     {
+        // handle arrayobject, iterators and the like:
+        if (is_object($input) && ($input instanceof ArrayObject || $input instanceof \ArrayObject)) {
+            $input = $input->getArrayCopy();
+        }
+        if (!is_array($input)) {
+            $input = (array) $input;
+        }
+
         $storage = $this->verifyNamespace();
         $name    = $this->getName();
 
@@ -484,6 +492,7 @@ abstract class AbstractContainer extends ArrayObject
         if ($container instanceof Traversable) {
             return $container;
         }
+
         return new ArrayIterator($container);
     }
 

--- a/library/Zend/Session/Container.php
+++ b/library/Zend/Session/Container.php
@@ -20,18 +20,6 @@ namespace Zend\Session;
 class Container extends AbstractContainer
 {
     /**
-     * Exchange the current array with another array or object.
-     *
-     * @param  array|object $input
-     * @return array        Returns the old array
-     * @see ArrayObject::exchangeArray()
-     */
-    public function exchangeArray(array $input)
-    {
-        return parent::exchangeArrayCompat($input);
-    }
-
-    /**
      * Retrieve a specific key in the container
      *
      * @param  string $key

--- a/library/Zend/Session/compatibility/Container.php
+++ b/library/Zend/Session/compatibility/Container.php
@@ -14,15 +14,4 @@ namespace Zend\Session;
  */
 class Container extends AbstractContainer
 {
-    /**
-     * Exchange the current array with another array or object.
-     *
-     * @param  array|object $input
-     * @return array        Returns the old array
-     * @see ArrayObject::exchangeArray()
-     */
-    public function exchangeArray($input)
-    {
-        return parent::exchangeArrayCompat($input);
-    }
 }

--- a/library/Zend/Stdlib/ArrayObject.php
+++ b/library/Zend/Stdlib/ArrayObject.php
@@ -178,11 +178,22 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     /**
      * Exchange the array for another one.
      *
-     * @param  array $data
+     * @param  array|ArrayObject $data
      * @return array
      */
-    public function exchangeArray(array $data)
+    public function exchangeArray($data)
     {
+        if (!is_array($data) && !is_object($data)) {
+            throw new Exception\InvalidArgumentException('Passed variable is not an array or object, using empty array instead');
+        }
+
+        if (is_object($data) && ($data instanceof ArrayObject || $data instanceof \ArrayObject)) {
+            $data = $data->getArrayCopy();
+        }
+        if (!is_array($data)) {
+            $data = (array) $data;
+        }
+
         $storage = $this->storage;
 
         $this->storage = $data;

--- a/tests/ZendTest/Session/ContainerTest.php
+++ b/tests/ZendTest/Session/ContainerTest.php
@@ -528,6 +528,17 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->container->offsetExists('new'), "'exchangeArray' doesn't add the new array items");
     }
 
+    public function testExchangeArrayObject()
+    {
+        $this->container->offsetSet('old', 'old');
+        $this->assertTrue($this->container->offsetExists('old'));
+
+        $old = $this->container->exchangeArray(new \Zend\Stdlib\ArrayObject(array('new' => 'new')));
+        $this->assertArrayHasKey('old', $old, "'exchangeArray' doesn't return an array of old items");
+        $this->assertFalse($this->container->offsetExists('old'), "'exchangeArray' doesn't remove old items");
+        $this->assertTrue($this->container->offsetExists('new'), "'exchangeArray' doesn't add the new array items");
+    }
+
     public function testMultiDimensionalUnset()
     {
         if (version_compare(PHP_VERSION, '5.3.4') < 0) {

--- a/tests/ZendTest/Stdlib/ArrayObjectTest.php
+++ b/tests/ZendTest/Stdlib/ArrayObjectTest.php
@@ -121,6 +121,51 @@ class ArrayObjectTest extends TestCase
         $this->assertSame(array('bar' => 'baz'), $ar->getArrayCopy());
     }
 
+    public function testExchangeArrayPhpArrayObject()
+    {
+        $ar = new ArrayObject(array('foo' => 'bar'));
+        $old = $ar->exchangeArray(new \ArrayObject(array('bar' => 'baz')));
+
+        $this->assertSame(array('foo' => 'bar'), $old);
+        $this->assertSame(array('bar' => 'baz'), $ar->getArrayCopy());
+    }
+
+    public function testExchangeArrayStdlibArrayObject()
+    {
+        $ar = new ArrayObject(array('foo' => 'bar'));
+        $old = $ar->exchangeArray(new ArrayObject(array('bar' => 'baz')));
+
+        $this->assertSame(array('foo' => 'bar'), $old);
+        $this->assertSame(array('bar' => 'baz'), $ar->getArrayCopy());
+    }
+
+    public function testExchangeArrayTestAssetIterator()
+    {
+        $ar = new ArrayObject();
+        $ar->exchangeArray(new TestAsset\ArrayObjectIterator(array('foo' => 'bar')));
+
+        // make sure it does what php array object does:
+        $ar2 = new \ArrayObject();
+        $ar2->exchangeArray(new TestAsset\ArrayObjectIterator(array('foo' => 'bar')));
+
+        $this->assertEquals($ar2->getArrayCopy(), $ar->getArrayCopy());
+    }
+
+    public function testExchangeArrayArrayIterator()
+    {
+        $ar = new ArrayObject();
+        $ar->exchangeArray(new \ArrayIterator(array('foo' => 'bar')));
+
+        $this->assertEquals(array('foo' => 'bar'), $ar->getArrayCopy());
+    }
+
+    public function testExchangeArrayStringArgumentFail()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $ar     = new ArrayObject(array('foo' => 'bar'));
+        $old    = $ar->exchangeArray('Bacon');
+    }
+
     public function testGetArrayCopy()
     {
         $ar = new ArrayObject(array('foo' => 'bar'));
@@ -302,6 +347,7 @@ class ArrayObjectTest extends TestCase
             if ($a == $b) {
                 return 0;
             }
+
             return ($a < $b) ? -1 : 1;
         };
         $ar = new ArrayObject(array('a' => 4, 'b' => 8, 'c' => -1, 'd' => -9, 'e' => 2, 'f' => 5, 'g' => 3, 'h' => -4));
@@ -316,6 +362,7 @@ class ArrayObjectTest extends TestCase
         $function = function ($a, $b) {
             $a = preg_replace('@^(a|an|the) @', '', $a);
             $b = preg_replace('@^(a|an|the) @', '', $b);
+
             return strcasecmp($a, $b);
         };
 

--- a/tests/ZendTest/Stdlib/TestAsset/ArrayObjectIterator.php
+++ b/tests/ZendTest/Stdlib/TestAsset/ArrayObjectIterator.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+
+namespace ZendTest\Stdlib\TestAsset;
+class ArrayObjectIterator implements \Iterator
+{
+
+    private $var = array();
+
+    public function __construct($array)
+    {
+        if (is_array($array)) {
+            $this->var = $array;
+        }
+    }
+
+    public function rewind()
+    {
+        reset($this->var);
+    }
+
+    public function current()
+    {
+        return current($this->var);
+    }
+
+    public function key()
+    {
+        return key($this->var);
+    }
+
+    public function next()
+    {
+        return next($this->var);
+    }
+
+    public function valid()
+    {
+        $key = key($this->var);
+        $var = ($key !== NULL && $key !== FALSE);
+
+        return $var;
+    }
+}


### PR DESCRIPTION
As noted in #3831 for non-object types; this is not currently handled correctly; this resolves it.
