### PR TITLE
Added new option to fix a little issue originated from last PR

### DIFF
--- a/library/Zend/Validator/Identical.php
+++ b/library/Zend/Validator/Identical.php
@@ -150,21 +150,13 @@ class Identical extends AbstractValidator
      * @return bool
      * @throws Exception\RuntimeException if the token doesn't exist in the context array
      */
-    public function isValid($value, $context = null)
+    public function isValid($value, array $context = null)
     {
         $this->setValue($value);
 
         $token = $this->getToken();
 
         if (!$this->getLiteral() && $context !== null) {
-            if (!is_array($context)) {
-                throw new Exception\InvalidArgumentException(sprintf(
-                    'Context passed to %s must be an array or null; received "%s"',
-                    __METHOD__,
-                    (is_object($context) ? get_class($context) : gettype($context))
-                ));
-            }
-
             if (is_array($token)) {
                 while (is_array($token)){
                     $key = key($token);

--- a/library/Zend/Validator/Identical.php
+++ b/library/Zend/Validator/Identical.php
@@ -43,7 +43,8 @@ class Identical extends AbstractValidator
      */
     protected $tokenString;
     protected $token;
-    protected $strict = true;
+    protected $strict  = true;
+    protected $literal = false;
 
     /**
      * Sets validator options
@@ -59,6 +60,10 @@ class Identical extends AbstractValidator
         if (is_array($token) && array_key_exists('token', $token)) {
             if (array_key_exists('strict', $token)) {
                 $this->setStrict($token['strict']);
+            }
+
+            if (array_key_exists('literal', $token)) {
+                $this->setLiteral($token['literal']);
             }
 
             $this->setToken($token['token']);
@@ -115,6 +120,28 @@ class Identical extends AbstractValidator
     }
 
     /**
+     * Returns the literal parameter
+     *
+     * @return bool
+     */
+    public function getLiteral()
+    {
+        return $this->literal;
+    }
+
+    /**
+     * Sets the literal parameter
+     *
+     * @param Zend\Validator\Identical
+     * @return Identical
+     */
+    public function setLiteral($literal)
+    {
+        $this->literal = (bool) $literal;
+        return $this;
+    }
+
+    /**
      * Returns true if and only if a token has been set and the provided value
      * matches that token.
      *
@@ -129,7 +156,7 @@ class Identical extends AbstractValidator
 
         $token = $this->getToken();
 
-        if ($context !== null) {
+        if (!$this->getLiteral() && $context !== null) {
             if (!is_array($context)) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'Context passed to %s must be an array or null; received "%s"',

--- a/library/Zend/Validator/Identical.php
+++ b/library/Zend/Validator/Identical.php
@@ -77,7 +77,7 @@ class Identical extends AbstractValidator
     /**
      * Retrieve token
      *
-     * @return string
+     * @return mixed
      */
     public function getToken()
     {
@@ -110,7 +110,7 @@ class Identical extends AbstractValidator
     /**
      * Sets the strict parameter
      *
-     * @param Zend\Validator\Identical
+     * @param  bool $strict
      * @return Identical
      */
     public function setStrict($strict)
@@ -132,7 +132,7 @@ class Identical extends AbstractValidator
     /**
      * Sets the literal parameter
      *
-     * @param Zend\Validator\Identical
+     * @param  bool $literal
      * @return Identical
      */
     public function setLiteral($literal)

--- a/tests/ZendTest/Validator/IdenticalTest.php
+++ b/tests/ZendTest/Validator/IdenticalTest.php
@@ -213,4 +213,34 @@ class IdenticalTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
+
+    public function testCanSetLiteralParameterThroughConstructor()
+    {
+        $validator = new Identical(array('token' => 'foo', 'literal' => true));
+        // Default is false
+        $validator->setLiteral(true);
+        $this->assertTrue($validator->getLiteral());
+    }
+
+    public function testLiteralParameterDoesNotAffectValidationWhenNoContextIsProvided()
+    {
+        $this->validator->setToken(array('foo' => 'bar'));
+
+        $this->validator->setLiteral(false);
+        $this->assertTrue($this->validator->isValid(array('foo' => 'bar')));
+
+        $this->validator->setLiteral(true);
+        $this->assertTrue($this->validator->isValid(array('foo' => 'bar')));
+    }
+
+    public function testLiteralParameterWorksWhenContextIsProvided()
+    {
+        $this->validator->setToken(array('foo' => 'bar'));
+        $this->validator->setLiteral(true);
+
+        $this->assertTrue($this->validator->isValid(
+            array('foo' => 'bar'),
+            array('foo' => 'baz') // Provide a context to make sure the literal parameter will work
+        ));
+    }
 }


### PR DESCRIPTION
After I sent [this PR](https://github.com/zendframework/zf2/pull/3803), I realised a little problem:
When identical validator is used in a form scope, the form will always provide a context, because of this, it wouldn't be possible to validate a `literal` token, see the example.

``` PHP
use Zend\Form\Form;
use Zend\InputFilter\InputFilter;

$form = new Form('form');
$form->add(array(
    'name' => 'humanCheck',
    'options' => array(
        'label' => 'How much is 1 + 2?',
    ),
));

$inputFilter = new InputFilter();
$inputFilter->add(array(
    'name' => 'humanCheck',
    'required' => true,
    'validators' => array(
        array(
            'name' => 'Identical',
            'options' => array(
                'token' => '3',
            ),
        ),
    ),
));

$form->setInputFilter($inputFilter);
...
```

This would not work because on validation the validator would try to find `'3'` in the context, and then rise an exception when it doesn't find it.

To solve this I add a new option, `literal`. Setting this to true (it's false by default) would allow a 'literal' validation even when the context is provided. So the above input filter would look like this:

``` PHP
$inputFilter->add(array(
    'name' => 'humanCheck',
    'required' => true,
    'validators' => array(
        array(
            'name' => 'Identical',
            'options' => array(
                'literal' => true,
                'token' => '3',
            ),
        ),
    ),
));
```

This would tell the validator to skip the look up in the context and just use the string `'3'`.
**_Note: this option has no affect when context is not provided.**_
