### PR TITLE
Update library/Zend/Db/Sql/Predicate/Predicate.php | parameter default value

### DIFF
--- a/library/Zend/Db/Sql/Predicate/Predicate.php
+++ b/library/Zend/Db/Sql/Predicate/Predicate.php
@@ -222,7 +222,7 @@ class Predicate extends PredicateSet
      * @param $parameters
      * @return $this
      */
-    public function expression($expression, $parameters)
+    public function expression($expression, $parameters = null)
     {
         $this->addPredicate(
             new Expression($expression, $parameters),


### PR DESCRIPTION
Set parameter default value to null (like in Expression).
So the parameter can be skipped, if not needed.

Example:

``` php
$select->where->expression('
                NOT (
                    column1 = column2
                )
            ',null);
```
