### PR TITLE
Zend\Stdlib\ArrayObject::offsetExists() returning by reference

### DIFF
--- a/library/Zend/Session/compatibility/autoload.php
+++ b/library/Zend/Session/compatibility/autoload.php
@@ -1,5 +1,11 @@
 <?php
 if (version_compare(PHP_VERSION, '5.3.4', 'lt')) {
+    if (!class_exists('Zend\Stdlib\ArrayObject', false)
+        && file_exists(__DIR__ . '/../../Stdlib/compatibility/autoload.php')
+    ) {
+        require __DIR__ . '/../../Stdlib/compatibility/autoload.php';
+    }
+
     require_once __DIR__ . '/Container.php';
     require_once __DIR__ . '/Storage/SessionArrayStorage.php';
 }

--- a/library/Zend/Stdlib/compatibility/autoload.php
+++ b/library/Zend/Stdlib/compatibility/autoload.php
@@ -1,4 +1,6 @@
 <?php
-if (version_compare(PHP_VERSION, '5.3.4', 'lt')) {
+if (version_compare(PHP_VERSION, '5.3.4', 'lt')
+    && !class_exists('Zend\Stdlib\ArrayObject', false)
+) {
     require_once __DIR__ . '/ArrayObject.php';
 }


### PR DESCRIPTION
Since the release of Zend Framework 2.1.1 I have got the following error message when developing:

``` php
Fatal error: Declaration of Zend\Stdlib\ArrayObject::offsetExists() must be compatible with that of ArrayAccess::offsetExists() .../vendor/zendframework/zendframework/library/Zend/Stdlib/ArrayObject.php on line 25
```

The problem is, that the latest version of debian squeeze only provides php5 (5.3.3-7 source: http://packages.debian.org/squeeze/php5).
The returning by reference feature from the ArrayAccess::offsetGet() method is only implemented since version 5.3.4 (Starting with PHP 5.3.4, the prototype checks were relaxed and it's possible for implementations of this method to return by reference. source: http://www.php.net/manual/en/arrayaccess.offsetget.php).

There is no stable release from debian which provides a greater php version. So everyone which uses debian squeeze has to compile a newer php version by themself.  

The current system requirements from Zend Framework 2 are 5.3.3 (source: https://github.com/zendframework/zf2). Did you bump up the requirements to php 5.3.4 for ZF 2.1.1 on purpose?
