### PR TITLE
Fix #3852

### DIFF
--- a/library/Zend/Mvc/Router/Http/Hostname.php
+++ b/library/Zend/Mvc/Router/Http/Hostname.php
@@ -170,7 +170,6 @@ class Hostname implements RouteInterface
     {
         $regex = '';
 
-        // Reverse the parts to build the regex in reverse
         foreach ($parts as $part) {
             switch ($part[0]) {
                 case 'literal':
@@ -275,7 +274,6 @@ class Hostname implements RouteInterface
         $uri  = $request->getUri();
         $host = $uri->getHost();
 
-        // reverse the host as the regex was built backwards
         $result = preg_match('(^' . $this->regex . '$)', $host, $matches);
 
         if (!$result) {
@@ -286,7 +284,6 @@ class Hostname implements RouteInterface
 
         foreach ($this->paramMap as $index => $name) {
             if (isset($matches[$index]) && $matches[$index] !== '') {
-                // reverse the param as the preg_match was done on reverse host
                 $params[$name] = $matches[$index];
             }
         }

--- a/library/Zend/Mvc/Router/Http/Hostname.php
+++ b/library/Zend/Mvc/Router/Http/Hostname.php
@@ -171,10 +171,10 @@ class Hostname implements RouteInterface
         $regex = '';
 
         // Reverse the parts to build the regex in reverse
-        foreach (array_reverse($parts) as $part) {
+        foreach ($parts as $part) {
             switch ($part[0]) {
                 case 'literal':
-                    $regex .= preg_quote(strrev($part[1]));
+                    $regex .= preg_quote($part[1]);
                     break;
 
                 case 'parameter':
@@ -276,7 +276,7 @@ class Hostname implements RouteInterface
         $host = $uri->getHost();
 
         // reverse the host as the regex was built backwards
-        $result = preg_match('(^' . $this->regex . '$)', strrev($host), $matches);
+        $result = preg_match('(^' . $this->regex . '$)', $host, $matches);
 
         if (!$result) {
             return null;
@@ -287,7 +287,7 @@ class Hostname implements RouteInterface
         foreach ($this->paramMap as $index => $name) {
             if (isset($matches[$index]) && $matches[$index] !== '') {
                 // reverse the param as the preg_match was done on reverse host
-                $params[$name] = strrev($matches[$index]);
+                $params[$name] = $matches[$index];
             }
         }
 

--- a/tests/ZendTest/Mvc/Router/Http/HostnameTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/HostnameTest.php
@@ -57,6 +57,15 @@ class HostnameTest extends TestCase
                 '123.example.com',
                 array('foo' => '123')
             ),
+            'constraints-allow-match-2' => array(
+                new Hostname(
+                    'www.:domain.com',
+                    array('domain' => '(mydomain|myaltdomain1|myaltdomain2)'),
+                    array('domain'    => 'mydomain')
+                ),
+                'www.mydomain.com',
+                array('domain' => 'mydomain')
+            ),
             'optional-subdomain' => array(
                 new Hostname('[:foo.]example.com'),
                 'bar.example.com',
@@ -75,10 +84,25 @@ class HostnameTest extends TestCase
             'one-of-two-missing-optional-subdomain' => array(
                 new Hostname('[:foo.][:bar.]example.com'),
                 'bat.example.com',
-                array('foo' => null, 'bar' => 'bat'),
+                array('foo' => null, 'foo' => 'bat'),
             ),
             'two-missing-optional-subdomain' => array(
                 new Hostname('[:foo.][:bar.]example.com'),
+                'example.com',
+                array('foo' => null, 'bar' => null),
+            ),
+            'two-optional-subdomain-nested' => array(
+                new Hostname('[[:foo.]:bar.]example.com'),
+                'baz.bat.example.com',
+                array('foo' => 'baz', 'bar' => 'bat'),
+            ),
+            'one-of-two-missing-optional-subdomain-nested' => array(
+                new Hostname('[[:foo.]:bar.]example.com'),
+                'bat.example.com',
+                array('foo' => null, 'bar' => 'bat'),
+            ),
+            'two-missing-optional-subdomain-nested' => array(
+                new Hostname('[[:foo.]:bar.]example.com'),
                 'example.com',
                 array('foo' => null, 'bar' => null),
             ),


### PR DESCRIPTION
Added test case from the aforementioned issue.
No longer reversing regex as it was problematic for constraints.
Fixing expectation for two optional subdomains with one missing.
Adding test cases for nested subdomains.
