### PR TITLE
Update library/Zend/Validator/AbstractValidator.php

### DIFF
--- a/library/Zend/Validator/AbstractValidator.php
+++ b/library/Zend/Validator/AbstractValidator.php
@@ -145,7 +145,7 @@ abstract class AbstractValidator implements
             } elseif (isset($this->options)) {
                 $this->options[$name] = $option;
             } else {
-                $this->abstractOptions[$name] = $options;
+                $this->abstractOptions[$name] = $option;
             }
         }
 


### PR DESCRIPTION
why all the parameters are set to abstractOptions? AbstractValidator148:
