### PR TITLE
ClassGenerator::fromReflection not generate class properties

### DIFF
--- a/library/Zend/Code/Generator/ClassGenerator.php
+++ b/library/Zend/Code/Generator/ClassGenerator.php
@@ -110,7 +110,7 @@ class ClassGenerator extends AbstractGenerator
 
         $properties = array();
         foreach ($classReflection->getProperties() as $reflectionProperty) {
-            if ($reflectionProperty->getDeclaringClass()->getName() == $cg->getName()) {
+            if ($reflectionProperty->getDeclaringClass()->getName() == $classReflection->getName()) {
                 $properties[] = PropertyGenerator::fromReflection($reflectionProperty);
             }
         }

--- a/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
@@ -391,4 +391,19 @@ CODE;
         $docBlock = $classGenerator->getDocBlock();
         $this->assertInstanceOf('Zend\Code\Generator\DocBlockGenerator', $docBlock);
     }
+
+    public function testExtendedClassProperies()
+    {
+        $reflClass = new ClassReflection('ZendTest\Code\Generator\TestAsset\ExtendedClassWithProperties');
+        $classGenerator = ClassGenerator::fromReflection($reflClass);
+        $code = $classGenerator->generate();
+        $this->assertContains('publicExtendedClassProperty', $code);
+        $this->assertContains('protectedExtendedClassProperty', $code);
+        $this->assertContains('privateExtendedClassProperty', $code);
+        $this->assertNotContains('publicClassProperty', $code);
+        $this->assertNotContains('protectedClassProperty', $code);
+        $this->assertNotContains('privateClassProperty', $code);
+
+
+    }
 }

--- a/tests/ZendTest/Code/Generator/TestAsset/ClassWithProperties.php
+++ b/tests/ZendTest/Code/Generator/TestAsset/ClassWithProperties.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ZendTest\Code\Generator\TestAsset;
+
+class ClassWithProperties
+{
+    public $publicClassProperty;
+    protected $protectedClassProperty;
+    private $privateClassProperty;
+}

--- a/tests/ZendTest/Code/Generator/TestAsset/ExtendedClassWithProperties.php
+++ b/tests/ZendTest/Code/Generator/TestAsset/ExtendedClassWithProperties.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ZendTest\Code\Generator\TestAsset;
+
+class ExtendedClassWithProperties extends ClassWithProperties
+{
+    public $publicExtendedClassProperty;
+    protected $protectedExtendedClassProperty;
+    private $privateExtendedClassProperty;
+}


### PR DESCRIPTION
Method ClassGenerator::getName() return class name without namespace, but it compared in code with namespaced class name returned from reflection
