### PR TITLE
Remove BC break in Identical validator

### DIFF
--- a/library/Zend/Validator/Identical.php
+++ b/library/Zend/Validator/Identical.php
@@ -152,7 +152,7 @@ class Identical extends AbstractValidator
             // if $token is an array it means the above loop didn't went all the way down to the leaf,
             // so the $token structure doesn't match the $context structure
             if (is_array($token) || !isset($context[$token])) {
-                throw new Exception\RuntimeException("The token doesn't exist in the context");
+                $token = $this->getToken();
             } else {
                 $token = $context[$token];
             }

--- a/tests/ZendTest/Validator/IdenticalTest.php
+++ b/tests/ZendTest/Validator/IdenticalTest.php
@@ -181,36 +181,4 @@ class IdenticalTest extends \PHPUnit_Framework_TestCase
             )
         ));
     }
-
-    public function testSetStringTokenNonExistentInContext()
-    {
-        $this->validator->setToken('email');
-        $this->setExpectedException(
-            'Zend\Validator\Exception\RuntimeException',
-            "The token doesn't exist in the context"
-        );
-
-        $this->validator->isValid(
-            'john@doe.com',
-            array('name' => 'john') // There's no 'email' key here, must throw an exception
-        );
-    }
-
-    public function testSetArrayTokenNonExistentInContext()
-    {
-        $this->validator->setToken(array('user' => 'email'));
-        $this->setExpectedException(
-            'Zend\Validator\Exception\RuntimeException',
-            "The token doesn't exist in the context"
-        );
-
-        $this->validator->isValid(
-            'john@doe.com',
-            array(
-                'admin' => array( // Here is 'admin' instead of 'user', must throw an exception
-                    'email' => 'john@doe.com'
-                )
-            )
-        );
-    }
 }


### PR DESCRIPTION
A BC break was introduced a few days ago in Identical component (https://github.com/zendframework/zf2/commit/fcbe185a24d10a90a17c0907fff02ea14a18a403#library/Zend/Validator/Identical.php).

My use case which was valid was specifying the token as a single value:

``` php
$inputFilter->add(array(
            'name'       => 'accept',
            'validators' => array(
                array(
                    'name'    => 'Identical',
                    'options' => array(
                        'token' => '1',
                        'messages' => array(
                            'notSame' => 'Vous devez d\'abord accepter la charte de Capitaine Job !'
                        )
                    )
                )
            )
        ));
```

However this was not accepted anymore because it threw in exception.
