### PR TITLE
The method delete on the RowGateway now returns the affected rows

### DIFF
--- a/library/Zend/Db/RowGateway/AbstractRowGateway.php
+++ b/library/Zend/Db/RowGateway/AbstractRowGateway.php
@@ -205,10 +205,13 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
         $statement = $this->sql->prepareStatementForSqlObject($this->sql->delete()->where($where));
         $result = $statement->execute();
 
-        if ($result->getAffectedRows() == 1) {
+        $affectedRows = $result->getAffectedRows();
+        if ($affectedRows == 1) {
             // detach from database
             $this->primaryKeyData = null;
         }
+
+        return $affectedRows;
     }
 
     /**

--- a/tests/ZendTest/Db/RowGateway/AbstractRowGatewayTest.php
+++ b/tests/ZendTest/Db/RowGateway/AbstractRowGatewayTest.php
@@ -208,6 +208,7 @@ class AbstractRowGatewayTest extends \PHPUnit_Framework_TestCase
         $this->rowGateway->foo = 'bar';
         $affectedRows = $this->rowGateway->delete();
         $this->assertFalse($this->rowGateway->rowExistsInDatabase());
+        $this->assertEquals(1, $affectedRows);
     }
 
     /**


### PR DESCRIPTION
This fixes issue #3862
