### PR TITLE
Fixes an issue when binding a model to a form collection element

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -477,6 +477,12 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
                 $targetElement = clone $this->targetElement;
                 $targetElement->object = $value;
                 $values[$key] = $targetElement->extract();
+                if ($this->has($key)) {
+                    $fieldset = $this->get($key);
+                    if ($fieldset instanceof Fieldset && $fieldset->allowObjectBinding($value)) {
+                        $fieldset->setObject($value);
+                    }
+                }
             }
         }
 

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -284,6 +284,44 @@ class CollectionTest extends TestCase
         $this->assertSame($originalObjectHash,$objectAfterExtractHash);
     }
 
+    public function testDoesNotCreateNewObjects()
+    {
+        $form = new \Zend\Form\Form();
+        $form->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
+        $this->productFieldset->setUseAsBaseFieldset(true);
+        $form->add($this->productFieldset);
+
+        $product = new Product();
+        $product->setName("foo");
+        $product->setPrice(42);
+        $cat1 = new \ZendTest\Form\TestAsset\Entity\Category();
+        $cat1->setName("bar");
+        $cat2 = new \ZendTest\Form\TestAsset\Entity\Category();
+        $cat2->setName("bar2");
+
+        $product->setCategories(array($cat1,$cat2));
+
+        $form->bind($product);
+
+        $form->setData(
+            array("product"=>
+                array(
+                    "name" => "franz",
+                    "price" => 13,
+                    "categories" => array(
+                        array("name" => "sepp"),
+                        array("name" => "herbert")
+                    )
+                )
+            )
+        );
+        $form->isValid();
+
+        $categories = $product->getCategories();
+        $this->assertSame($categories[0], $cat1);
+        $this->assertSame($categories[1], $cat2);
+    }
+
     public function testExtractDefaultIsEmptyArray()
     {
         $collection = $this->form->get('fieldsets');


### PR DESCRIPTION
When binding an object to a form using \Zend\Form\Element\Collection the collection of objects for the fieldsets should not be created new after form validation. During data extraction, all fieldsets in the collection are given their respective object.
