### PR TITLE
Feature CollectionInputFilter

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -53,6 +53,15 @@ class FormRow extends AbstractHelper
      */
     protected $elementErrorsHelper;
 
+    /**
+     * @var string
+     */
+    protected $partial;
+
+    /**
+     * @var array
+     */
+    protected $partialVars = array();
 
     /**
      * Utility form helper that renders a label (if it exists), an element and errors
@@ -119,6 +128,19 @@ class FormRow extends AbstractHelper
                     $label = '<span>' . $label . '</span>';
                 }
 
+                if ($this->partial) {
+                    $vars = array(
+                        'element'       => $elementString,
+                        'label'         => $label,
+                        'labelOpen'     => $labelOpen,
+                        'labelClose'    => $labelClose,
+                        'labelPosition' => $this->labelPosition,
+                        'errors'        => $elementErrors,
+                        'renderErrors'  => $this->renderErrors
+                    );
+                    return $this->view->render($this->partial, array_merge($vars, $this->partialVars));
+                }
+
                 switch ($this->labelPosition) {
                     case self::LABEL_PREPEND:
                         $markup = $labelOpen . $label . $elementString . $labelClose;
@@ -134,6 +156,15 @@ class FormRow extends AbstractHelper
                 $markup .= $elementErrors;
             }
         } else {
+            if ($this->partial) {
+                $vars = array(
+                    'element'       => $elementString,
+                    'errors'        => $elementErrors,
+                    'renderErrors'  => $this->renderErrors
+                );
+                return $this->view->render($this->partial, array_merge($vars, $this->partialVars));
+            }
+
             if ($this->renderErrors) {
                 $markup = $elementString . $elementErrors;
             } else {
@@ -152,9 +183,10 @@ class FormRow extends AbstractHelper
      * @param null|ElementInterface $element
      * @param null|string           $labelPosition
      * @param bool                  $renderErrors
+     * @param string|array          $partial
      * @return string|FormRow
      */
-    public function __invoke(ElementInterface $element = null, $labelPosition = null, $renderErrors = null)
+    public function __invoke(ElementInterface $element = null, $labelPosition = null, $renderErrors = null, $partial = null)
     {
         if (!$element) {
             return $this;
@@ -164,8 +196,12 @@ class FormRow extends AbstractHelper
             $this->setLabelPosition($labelPosition);
         }
 
-        if ($renderErrors !== null){
+        if ($renderErrors !== null) {
             $this->setRenderErrors($renderErrors);
+        }
+
+        if ($partial != null) {
+            $this->setPartial($partial);
         }
 
         return $this->render($element);
@@ -245,6 +281,24 @@ class FormRow extends AbstractHelper
     public function getLabelAttributes()
     {
         return $this->labelAttributes;
+    }
+
+    /**
+     * Set a partial view script to use for rendering the row,
+     * can optionally accept an array containing partial name and extra vars
+     *
+     * @param string|array $partial
+     * @return FormRow
+     */
+    public function setPartial($partial)
+    {
+        if (is_array($partial)) {
+            $this->partial = key(reset($partial));
+            $this->partialVars = (array) reset($partial);
+        } else {
+            $this->partial = $partial;
+        }
+        return $this;
     }
 
     /**

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -152,11 +152,22 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
             ));
         }
 
+        $inputs = $this->validationGroup ?: array_keys($this->inputs);
+        return $this->validateInputs($inputs);
+    }
+
+    /**
+     * Validate a set of inputs against the current data
+     *
+     * @param array $inputs
+     * @return boolean
+     */
+    protected function validateInputs(array $inputs)
+    {
         $this->validInputs   = array();
         $this->invalidInputs = array();
         $valid               = true;
 
-        $inputs = $this->validationGroup ?: array_keys($this->inputs);
         foreach ($inputs as $name) {
             $input = $this->inputs[$name];
             if (!array_key_exists($name, $this->data)
@@ -494,5 +505,15 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
         }
 
         return $unknownInputs;
+    }
+
+    /**
+     * Get an array of all inputs
+     *
+     * @return array
+     */
+    public function getInputs()
+    {
+        return $this->inputs;
     }
 }

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\InputFilter;
+
+use Traversable;
+
+class CollectionInputFilter extends InputFilter
+{
+    /*
+     * @var array
+     */
+    protected $collectionData;
+
+    /*
+     * @var array
+     */
+    protected $collectionValidInputs;
+
+    /*
+     * @var array
+     */
+    protected $collectionInvalidInputs;
+
+    /*
+     * @var int
+     */
+    protected $count;
+
+    /*
+     * @var array
+     */
+    protected $collectionValues = array();
+
+    /*
+     * @var array
+     */
+    protected $collectionRawValues = array();
+
+    /**
+     * @var BaseInputFilter
+     */
+    protected $inputFilter;
+
+    /**
+     * Set the input filter to use when looping the data
+     *
+     * @param BaseInputFilter|array|Traversable $inputFilter
+     * @return CollectionInputFilter
+     */
+    public function setInputFilter($inputFilter)
+    {
+        if (is_array($inputFilter) || $inputFilter instanceof Traversable) {
+            $inputFilter = $this->getFactory()->createInputFilter($inputFilter);
+        }
+
+        if (!$inputFilter instanceof BaseInputFilter) {
+            throw new Exception\RuntimeException(sprintf(
+                '%s expects an instance of %s; received "%s"',
+                __METHOD__,
+                'Zend\InputFilter\BaseInputFilter',
+                (is_object($inputFilter) ? get_class($inputFilter) : gettype($inputFilter))
+            ));
+        }
+
+        $this->inputFilter = $inputFilter;
+        $this->inputs = $inputFilter->getInputs();
+        return $this;
+    }
+
+    /**
+     * Get the input filter used when looping the data
+     *
+     * @return BaseInputFilter
+     */
+    public function getInputFilter()
+    {
+        if (null === $this->inputFilter) {
+            $this->setInputFilter(new InputFilter());
+        }
+        return $this->inputFilter;
+    }
+
+    /**
+     * Set the count of data to validate
+     *
+     * @param int $count
+     * @return CollectionInputFilter
+     */
+    public function setCount($count)
+    {
+        $this->count = $count > 0 ? $count : 0;
+        return $this;
+    }
+
+    /**
+     * Get the count of data to validate, use the count of data by default
+     *
+     * @return int
+     */
+    public function getCount()
+    {
+        if (null === $this->count) {
+            $this->count = count($this->collectionData);
+        }
+        return $this->count;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setData($data)
+    {
+        $this->collectionData = array_values($data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isValid()
+    {
+        $inputCollection = array();
+        $valid = true;
+
+        $i = 0;
+        while ($i <= $this->getCount() - 1) {
+            $inputCollection[] = $this->validationGroup ?: array_keys($this->inputs);
+            $i++;
+        }
+
+        foreach ($inputCollection as $key => $inputs) {
+            $this->data = array();
+            if (isset($this->collectionData[$key])) {
+               $this->data = $this->collectionData[$key];
+            }
+            $this->populate();
+
+            if ($this->validateInputs($inputs)) {
+                $this->collectionValidInputs[$key] = $this->validInputs;
+            } else {
+                $this->collectionInvalidInputs[$key] = $this->invalidInputs;
+                $valid = false;
+            }
+
+            $values    = array();
+            $rawValues = array();
+            foreach ($inputs as $name) {
+                $input = $this->inputs[$name];
+
+                if ($input instanceof InputFilterInterface) {
+                    $values[$name]    = $input->getValues();
+                    $rawValues[$name] = $input->getRawValues();
+                    continue;
+                }
+                $values[$name]    = $input->getValue($this->data);
+                $rawValues[$name] = $input->getRawValue();
+            }
+            $this->collectionValues[$key]    = $values;
+            $this->collectionRawValues[$key] = $rawValues;
+        }
+
+        return $valid;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setValidationGroup($name)
+    {
+        if ($name === self::VALIDATE_ALL) {
+            $this->validationGroup = null;
+            return $this;
+        }
+
+        if (is_array($name)) {
+            // Best effort check if the validation group was set by a form for BC
+            if (count($name) == count($this->collectionData) && is_array(reset($name))) {
+                return parent::setValidationGroup(reset($name));
+            }
+            return parent::setValidationGroup($name);
+        }
+
+        return parent::setValidationGroup(func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInvalidInput()
+    {
+        return (is_array($this->collectionInvalidInputs) ? $this->collectionInvalidInputs : array());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValidInput()
+    {
+        return (is_array($this->collectionValidInputs) ? $this->collectionValidInputs : array());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValues()
+    {
+        return $this->collectionValues;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRawValues()
+    {
+        return $this->collectionRawValues;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessages()
+    {
+        $messages = array();
+        foreach ($this->getInvalidInput() as $key => $inputs) {
+            foreach ($inputs as $name => $input) {
+                $messages[$key][$name] = $input->getMessages();
+            }
+        }
+        return $messages;
+    }
+}

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -125,14 +125,9 @@ class CollectionInputFilter extends InputFilter
      */
     public function isValid()
     {
-        $inputCollection = array();
         $valid = true;
 
-        $i = 0;
-        while ($i <= $this->getCount() - 1) {
-            $inputCollection[] = $this->validationGroup ?: array_keys($this->inputs);
-            $i++;
-        }
+        $inputCollection = array_fill(0, $this->getCount(), $this->validationGroup ?: array_keys($this->inputs));
 
         foreach ($inputCollection as $key => $inputs) {
             $this->data = array();

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -31,7 +31,7 @@ class CollectionInputFilter extends InputFilter
     /*
      * @var int
      */
-    protected $count;
+    protected $count = null;
 
     /*
      * @var array

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -127,7 +127,11 @@ class CollectionInputFilter extends InputFilter
     {
         $valid = true;
 
-        $inputCollection = array_fill(0, $this->getCount(), $this->validationGroup ?: array_keys($this->inputs));
+        if ($this->getCount() < 1) {
+            return $valid;
+        }
+
+        $inputCollection = array_fill(0, $this->getCount() , $this->validationGroup ?: array_keys($this->inputs));
 
         foreach ($inputCollection as $key => $inputs) {
             $this->data = array();

--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -237,6 +237,9 @@ class Factory
             if (isset($inputFilterSpecification['inputfilter'])) {
                 $inputFilter->setInputFilter($inputFilterSpecification['inputfilter']);
             }
+            if (isset($inputFilterSpecification['count'])) {
+                $inputFilter->setCount($inputFilterSpecification['count']);
+            }
             return $inputFilter;
         }
 

--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -233,6 +233,13 @@ class Factory
                 'Zend\InputFilter\InputFilterInterface', $class));
         }
 
+        if ($inputFilter instanceof CollectionInputFilter) {
+            if (isset($inputFilterSpecification['inputfilter'])) {
+                $inputFilter->setInputFilter($inputFilterSpecification['inputfilter']);
+            }
+            return $inputFilter;
+        }
+
         foreach ($inputFilterSpecification as $key => $value) {
 
             if (($value instanceof InputInterface)

--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -234,8 +234,8 @@ class Factory
         }
 
         if ($inputFilter instanceof CollectionInputFilter) {
-            if (isset($inputFilterSpecification['inputfilter'])) {
-                $inputFilter->setInputFilter($inputFilterSpecification['inputfilter']);
+            if (isset($inputFilterSpecification['input_filter'])) {
+                $inputFilter->setInputFilter($inputFilterSpecification['input_filter']);
             }
             if (isset($inputFilterSpecification['count'])) {
                 $inputFilter->setCount($inputFilterSpecification['count']);

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1124,6 +1124,30 @@ class FormTest extends TestCase
         $this->assertTrue($this->form->isValid());
     }
 
+    public function testDonNotApplyEmptyInputFiltersToSubFieldsetOfCollectionElementsWithCollectionInputFilters()
+    {
+        $collectionFieldset = new Fieldset('item');
+        $collectionFieldset->add(new Element('foo'));
+
+        $collection = new Element\Collection('items');
+        $collection->setCount(3);
+        $collection->setTargetElement($collectionFieldset);
+        $this->form->add($collection);
+
+        $inputFilterFactory = new InputFilterFactory();
+        $inputFilter = $inputFilterFactory->createInputFilter(array(
+            'items' => array(
+                'type'        => 'Zend\InputFilter\CollectionInputFilter',
+                'inputfilter' => new InputFilter(),
+            ),
+        ));
+
+        $this->form->setInputFilter($inputFilter);
+
+        $this->assertInstanceOf('Zend\InputFilter\CollectionInputFilter', $this->form->getInputFilter()->get('items'));
+        $this->assertCount(0, $this->form->getInputFilter()->get('items')->getInputs());
+    }
+
     public function testFormValidationCanHandleNonConsecutiveKeysOfCollectionInData()
     {
         $dataWithCollection = array(

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1137,8 +1137,8 @@ class FormTest extends TestCase
         $inputFilterFactory = new InputFilterFactory();
         $inputFilter = $inputFilterFactory->createInputFilter(array(
             'items' => array(
-                'type'        => 'Zend\InputFilter\CollectionInputFilter',
-                'inputfilter' => new InputFilter(),
+                'type'         => 'Zend\InputFilter\CollectionInputFilter',
+                'input_filter' => new InputFilter(),
             ),
         ));
 

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -640,6 +640,22 @@ class BaseInputFilterTest extends TestCase
 
         $filter->setData($data);
         $this->assertTrue($filter->isValid());
+    }
 
+    public function testGetInputs()
+    {
+        $filter = new InputFilter();
+
+        $foo = new Input('foo');
+        $bar = new Input('bar');
+
+        $filter->add($foo);
+        $filter->add($bar);
+
+        $filters = $filter->getInputs();
+
+        $this->assertCount(2, $filters);
+        $this->assertEquals('foo', $filters['foo']->getName());
+        $this->assertEquals('bar', $filters['bar']->getName());
     }
 }

--- a/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
@@ -1,0 +1,357 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\InputFilter;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\InputFilter\BaseInputFilter;
+use Zend\InputFilter\CollectionInputFilter;
+use Zend\InputFilter\Input;
+use Zend\Validator;
+
+class CollectionInputFilterTest extends TestCase
+{
+    /**
+     * @var \Zend\InputFilter\CollectionInputFilter
+     */
+    protected $filter;
+
+    public function setUp()
+    {
+        $this->filter = new CollectionInputFilter();
+    }
+
+    public function getBaseInputFilter()
+    {
+        $filter = new BaseInputFilter();
+
+        $foo = new Input();
+        $foo->getFilterChain()->attachByName('stringtrim')
+                              ->attachByName('alpha');
+        $foo->getValidatorChain()->attach(new Validator\StringLength(3, 6));
+
+        $bar = new Input();
+        $bar->getFilterChain()->attachByName('stringtrim');
+        $bar->getValidatorChain()->attach(new Validator\Digits());
+
+        $baz = new Input();
+        $baz->setRequired(false);
+        $baz->getFilterChain()->attachByName('stringtrim');
+        $baz->getValidatorChain()->attach(new Validator\StringLength(1, 6));
+
+        $filter->add($foo, 'foo')
+               ->add($bar, 'bar')
+               ->add($baz, 'baz')
+               ->add($this->getChildInputFilter(), 'nest');
+
+        return $filter;
+    }
+
+    public function getChildInputFilter()
+    {
+        $filter = new BaseInputFilter();
+
+        $foo = new Input();
+        $foo->getFilterChain()->attachByName('stringtrim')
+                              ->attachByName('alpha');
+        $foo->getValidatorChain()->attach(new Validator\StringLength(3, 6));
+
+        $bar = new Input();
+        $bar->getFilterChain()->attachByName('stringtrim');
+        $bar->getValidatorChain()->attach(new Validator\Digits());
+
+        $baz = new Input();
+        $baz->setRequired(false);
+        $baz->getFilterChain()->attachByName('stringtrim');
+        $baz->getValidatorChain()->attach(new Validator\StringLength(1, 6));
+
+        $filter->add($foo, 'foo')
+               ->add($bar, 'bar')
+               ->add($baz, 'baz');
+        return $filter;
+    }
+
+    public function getValidCollectionData()
+    {
+        return array(
+            array(
+                'foo' => ' bazbat ',
+                'bar' => '12345',
+                'baz' => '',
+                'nest' => array(
+                    'foo' => ' bazbat ',
+                    'bar' => '12345',
+                    'baz' => '',
+                ),
+            ),
+            array(
+                'foo' => ' batbaz ',
+                'bar' => '54321',
+                'baz' => '',
+                'nest' => array(
+                    'foo' => ' batbaz ',
+                    'bar' => '54321',
+                    'baz' => '',
+                ),
+            )
+        );
+    }
+
+    public function testSetInputFilter()
+    {
+        $this->filter->setInputFilter(new BaseInputFilter());
+        $this->assertInstanceOf('Zend\InputFilter\BaseInputFilter', $this->filter->getInputFilter());
+    }
+
+    public function testInputFilterInputsAppliedToCollection()
+    {
+        $this->filter->setInputFilter($this->getBaseInputFilter());
+
+        $this->assertCount(4, $this->filter->getInputs());
+    }
+
+    public function testGetDefaultInputFilter()
+    {
+        $this->assertInstanceOf('Zend\InputFilter\BaseInputFilter', $this->filter->getInputFilter());
+    }
+
+    public function testSetCount()
+    {
+        $this->filter->setCount(5);
+        $this->assertEquals(5, $this->filter->getCount());
+    }
+
+    public function testSetCountBelowZero()
+    {
+        $this->filter->setCount(-1);
+        $this->assertEquals(0, $this->filter->getCount());
+    }
+
+    public function testGetCountUsesCountOfCollectionDataWhenNotSet()
+    {
+        $collectionData = array(
+            array('foo' => 'bar'),
+            array('foo' => 'baz')
+        );
+
+        $this->filter->setData($collectionData);
+        $this->assertEquals(2, $this->filter->getCount());
+    }
+
+    public function testGetCountUsesSpecifiedCount()
+    {
+        $collectionData = array(
+            array('foo' => 'bar'),
+            array('foo' => 'baz')
+        );
+
+        $this->filter->setCount(3);
+        $this->filter->setData($collectionData);
+        $this->assertEquals(3, $this->filter->getCount());
+    }
+
+    public function testCanValidateValidData()
+    {
+        $this->filter->setInputFilter($this->getBaseInputFilter());
+        $this->filter->setData($this->getValidCollectionData());
+        $this->assertTrue($this->filter->isValid());
+    }
+
+    public function testInvalidDataReturnsFalse()
+    {
+        $invalidCollectionData = array(
+            array(
+                'foo' => ' bazbatlong ',
+                'bar' => '12345',
+                'baz' => '',
+            ),
+            array(
+                'foo' => ' bazbat ',
+                'bar' => '12345',
+                'baz' => '',
+            )
+        );
+
+        $this->filter->setInputFilter($this->getBaseInputFilter());
+        $this->filter->setData($invalidCollectionData);
+        $this->assertFalse($this->filter->isValid());
+    }
+
+    public function testDataLessThanCountIsInvalid()
+    {
+        $invalidCollectionData = array(
+            array(
+                'foo' => ' bazbat ',
+                'bar' => '12345',
+                'baz' => '',
+                'nest' => array(
+                    'foo' => ' bazbat ',
+                    'bar' => '12345',
+                    'baz' => '',
+                ),
+            ),
+        );
+
+        $this->filter->setCount(2);
+        $this->filter->setInputFilter($this->getBaseInputFilter());
+        $this->filter->setData($invalidCollectionData);
+        $this->assertFalse($this->filter->isValid());
+    }
+
+    public function testGetValues()
+    {
+        $expectedData = array(
+            array(
+                'foo' => 'bazbat',
+                'bar' => '12345',
+                'baz' => '',
+                'nest' => array(
+                    'foo' => 'bazbat',
+                    'bar' => '12345',
+                    'baz' => '',
+                ),
+            ),
+            array(
+                'foo' => 'batbaz',
+                'bar' => '54321',
+                'baz' => '',
+                'nest' => array(
+                    'foo' => 'batbaz',
+                    'bar' => '54321',
+                    'baz' => '',
+                ),
+            )
+        );
+
+        $this->filter->setInputFilter($this->getBaseInputFilter());
+        $this->filter->setData($this->getValidCollectionData());
+
+        $this->assertTrue($this->filter->isValid());
+        $this->assertEquals($expectedData, $this->filter->getValues());
+
+        $this->assertCount(2, $this->filter->getValidInput());
+        foreach ($this->filter->getValidInput() as $validInputs) {
+            $this->assertCount(4, $validInputs);
+        }
+    }
+
+    public function testGetRawValues()
+    {
+        $expectedData = array(
+            array(
+                'foo' => ' bazbat ',
+                'bar' => '12345',
+                'baz' => '',
+                'nest' => array(
+                    'foo' => ' bazbat ',
+                    'bar' => '12345',
+                    'baz' => '',
+                ),
+            ),
+            array(
+                'foo' => ' batbaz ',
+                'bar' => '54321',
+                'baz' => '',
+                'nest' => array(
+                    'foo' => ' batbaz ',
+                    'bar' => '54321',
+                    'baz' => '',
+                ),
+            )
+        );
+
+        $this->filter->setInputFilter($this->getBaseInputFilter());
+        $this->filter->setData($this->getValidCollectionData());
+
+        $this->assertTrue($this->filter->isValid());
+        $this->assertEquals($expectedData, $this->filter->getRawValues());
+    }
+
+    public function testGetMessagesForInvalidInputs()
+    {
+        $invalidCollectionData = array(
+            array(
+                'foo' => ' bazbattoolong ',
+                'bar' => '12345',
+                'baz' => '',
+                'nest' => array(
+                    'foo' => ' bazbat ',
+                    'bar' => '12345',
+                    'baz' => '',
+                ),
+            ),
+            array(
+                'foo' => ' bazbat ',
+                'bar' => 'notstring',
+                'baz' => '',
+                'nest' => array(
+                    'foo' => ' bazbat ',
+                    'bar' => '12345',
+                    'baz' => '',
+                ),
+            ),
+        );
+
+        $this->filter->setInputFilter($this->getBaseInputFilter());
+        $this->filter->setData($invalidCollectionData);
+
+        $this->assertFalse($this->filter->isValid());
+
+        $this->assertCount(2, $this->filter->getInvalidInput());
+        foreach ($this->filter->getInvalidInput() as $invalidInputs) {
+            $this->assertCount(1, $invalidInputs);
+        }
+
+        $messages = $this->filter->getMessages();
+
+        $this->assertCount(2, $messages);
+        $this->assertArrayHasKey('foo', $messages[0]);
+        $this->assertArrayHasKey('bar', $messages[1]);
+    }
+
+    public function testSetValidationGroupUsingFormStyle()
+    {
+        // forms set an array of identical validation groups for each set of data
+        $formValidationGroup = array(
+            array(
+                'foo',
+                'bar',
+            ),
+            array(
+                'foo',
+                'bar',
+            ),
+            array(
+                'foo',
+                'bar',
+            )
+        );
+
+        $data = array(
+            array(
+                'foo' => ' bazbat ',
+                'bar' => '12345'
+            ),
+            array(
+                'foo' => ' batbaz ',
+                'bar' => '54321'
+            ),
+            array(
+                'foo' => ' batbaz ',
+                'bar' => '54321'
+            )
+        );
+
+        $this->filter->setInputFilter($this->getBaseInputFilter());
+        $this->filter->setData($data);
+        $this->filter->setValidationGroup($formValidationGroup);
+
+        $this->assertTrue($this->filter->isValid());
+    }
+}

--- a/tests/ZendTest/InputFilter/FactoryTest.php
+++ b/tests/ZendTest/InputFilter/FactoryTest.php
@@ -413,4 +413,19 @@ class FactoryTest extends TestCase
         $test = $input->getFilterChain();
         $this->assertSame($chain, $test);
     }
+
+    public function testFactoryAcceptsCollectionInputFilter()
+    {
+        $factory = new Factory();
+
+        $inputFilter = $factory->createInputFilter(array(
+            'type'        => 'Zend\InputFilter\CollectionInputFilter',
+            'inputfilter' => new InputFilter(),
+            'count'       => 3
+        ));
+
+        $this->assertInstanceOf('Zend\InputFilter\CollectionInputFilter', $inputFilter);
+        $this->assertInstanceOf('Zend\InputFilter\InputFilter', $inputFilter->getInputFilter());
+        $this->assertEquals(3, $inputFilter->getCount());
+    }
 }


### PR DESCRIPTION
Currently, there is no way to directly specify a _single_ InputFilter that can loop and filter a subset of data (for example when using the Collection Element on a form). This makes it near impossible to inject dependencies into custom validators used on collections.

This PR introduces a CollectionInputFilter which allows attaching a single input filter to a collection of data in the following way;

``` php
$this->add(array(
    'type' => 'Zend\InputFilter\CollectionInputFilter',
    'inputfilter' => new InvoiceItemFilter()
), 'items');
```

 or

``` php
$items = new CollectionInputFilter();
$items->setInputFilter(new InvoiceItemFilter());
$this->add($items, 'items');
```
