### PR TITLE
DefinitionList hasMethod fix

### DIFF
--- a/library/Zend/Di/DefinitionList.php
+++ b/library/Zend/Di/DefinitionList.php
@@ -202,7 +202,7 @@ class DefinitionList extends SplDoublyLinkedList implements Definition\Definitio
 
         /** @var $definition Definition\DefinitionInterface */
         foreach ($this as $definition) {
-            if ($definition->hasMethod($class, $method)) {
+            if ($definition->hasClass($class) && $definition->hasMethod($class, $method)) {
                 return true;
             }
         }

--- a/tests/ZendTest/Di/DefinitionListTest.php
+++ b/tests/ZendTest/Di/DefinitionListTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Di;
 
 use Zend\Di\DefinitionList;
 use Zend\Di\Definition\ClassDefinition;
+use Zend\Di\Definition\BuilderDefinition;
 
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -43,5 +44,17 @@ class DefinitionListTest extends TestCase
         $definitionClass->addMethod('doBar');
 
         $this->assertTrue($definitionList->hasMethod('foo', 'doBar'));
+    }
+
+    public function testHasMethodAvoidAskingFromDefinitionsWhichDoNotIncludeClass()
+    {
+        $builderDefinition = new BuilderDefinition();
+
+        $definitionClass = new ClassDefinition('foo');
+        $definitionClass->addMethod('doFoo');
+
+        $definitionList = new DefinitionList(array($builderDefinition, $definitionClass));
+
+        $this->assertTrue($definitionList->hasMethod('foo', 'doFoo'));
     }
 }


### PR DESCRIPTION
Call to child definition only if it has given class

If first element in list is BuilderDefinition and it has not given class then it will raise exception regardless of next definitions.

```
    $builderDefinition = new BuilderDefinition();

    // some builder definition initialization

    $definitionClass = new ClassDefinition('foo');
    $definitionClass->addMethod('doFoo');

    $definitionList = new DefinitionList(array($builderDefinition, $definitionClass));

    $definitionList->hasMethod('foo', 'doFoo')
```
