### PR TITLE
Added ability to ignore namespaces to classmap generator

### DIFF
--- a/bin/classmap_generator.php
+++ b/bin/classmap_generator.php
@@ -53,6 +53,7 @@ $rules = array(
     'output|o-s'  => 'Where to write autoload file; if not provided, assumes "autoload_classmap.php" in library directory',
     'append|a'    => 'Append to autoload file if it exists',
     'overwrite|w' => 'Whether or not to overwrite existing autoload file',
+    'ignore|i-s'    => 'Comma-separated namespaces to ignore',
 );
 
 try {
@@ -66,6 +67,11 @@ try {
 if ($opts->getOption('h')) {
     echo $opts->getUsageMessage();
     exit(0);
+}
+
+$ignoreNamespaces = array();
+if (isset($opts->i)) {
+    $ignoreNamespaces = explode(',', $opts->i);
 }
 
 $relativePathForClassmap = '';
@@ -157,6 +163,12 @@ foreach ($l as $file) {
     $filename  = $relativePathForClassmap . $filename;
 
     foreach ($file->getClasses() as $class) {
+        foreach ($ignoreNamespaces as $ignoreNs) {
+            if ($ignoreNs == substr($class, 0, strlen($ignoreNs))) {
+                continue 2;
+            }
+        }
+
         $map->{$class} = $filename;
     }
 }

--- a/bin/classmap_generator.php
+++ b/bin/classmap_generator.php
@@ -24,6 +24,7 @@ use Zend\Loader\StandardAutoloader;
  * --append|-a                  Append to autoload file if it exists
  * --overwrite|-w               Whether or not to overwrite existing autoload
  *                              file
+ * --ignore|-i [ <string> ]     Comma-separated namespaces to ignore
  */
 
 $zfLibraryPath = getenv('LIB_PATH') ? getenv('LIB_PATH') : __DIR__ . '/../library';
@@ -53,7 +54,7 @@ $rules = array(
     'output|o-s'  => 'Where to write autoload file; if not provided, assumes "autoload_classmap.php" in library directory',
     'append|a'    => 'Append to autoload file if it exists',
     'overwrite|w' => 'Whether or not to overwrite existing autoload file',
-    'ignore|i-s'    => 'Comma-separated namespaces to ignore',
+    'ignore|i-s'  => 'Comma-separated namespaces to ignore',
 );
 
 try {


### PR DESCRIPTION
This PR allows one to scan an entire project dir at once, and merely specify the namespaces he doesn't want to index (e.g. ZendTest).
