### PR TITLE
Zend\Test PUT method with data has no content

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -377,7 +377,7 @@ abstract class AbstractRestfulController extends AbstractController
         $requestedContentType = trim($requestedContentType);
         if (array_key_exists($contentType, $this->contentTypes)) {
             foreach ($this->contentTypes[$contentType] as $contentTypeValue) {
-                if (stripos($contentTypeValue, $requestedContentType) === 0) {
+                if (stripos($contentTypeValue, $requestedContentType) !== false) {
                     return true;
                 }
             }


### PR DESCRIPTION
The Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase may have a bug when using the HTTP method PUT with data. Testing a RESTful API's update method:

```
$this->dispatch('/v1/endpoint/1', 'PUT', array('name' => 'My Name'));
$this->assertResponseStatusCode(200);
```

The 3rd argument to dispatch, the $params for the request, don't seem to get transformed into the request in anyway. They seem to just get dropped.The Zend\Test\PHPUnit\Controller\AbstractControllerTestCase::url() method just seems to look for "GET" and "POST" methods) The result is that the update($id, $data) method of my Zend\Mvc\Controller\AbstractRestfulController never receives any data. If I run the method via curl, everything checks out. Can anyone else confirm this? I don't find this to be expected behavior.

Thanks,
-Seth

EDIT: Setting the content seems to work a little better. 

```
$this->getRequest()->setContent(json_encode(array('name' => 'My Name')));
```

Is this the recommended way to use these test methods? Maybe all that is wrong is the need to add to the documentation a bit. I can certainly help with that.
