### PR TITLE
[+BUGFIX] Fixed column names bug Zend\Db\Sql\Select

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -297,10 +297,10 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                             // if the value is an array, assume IN() is desired
                             $predicate = new Predicate\In($pkey, $pvalue);
                         } elseif ($pvalue instanceof Predicate\PredicateInterface) {
-                            // 
+                            //
                             throw new Exception\InvalidArgumentException(
                                 'Using Predicate must not use string keys'
-                            ); 
+                            );
                         } else {
                             // otherwise assume that array('foo' => 'bar') means "foo" = 'bar'
                             $predicate = new Predicate\Operator($pkey, Predicate\Operator::OP_EQ, $pvalue);
@@ -587,10 +587,14 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $fromTable = $platform->quoteIdentifier($alias);
             $table .= ' AS ' . $fromTable;
         } else {
-            $fromTable = ($this->prefixColumnsWithTable) ? $table : '';
+            $fromTable = $table;
         }
 
-        $fromTable .= ($this->prefixColumnsWithTable) ? $platform->getIdentifierSeparator() : '';
+        if ($this->prefixColumnsWithTable) {
+            $fromTable .= $platform->getIdentifierSeparator();
+        } else {
+            $fromTable = '';
+        }
 
         // process table columns
         $columns = array();

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -239,7 +239,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $predicates = $where->getPredicates();
         $this->assertInstanceOf('Zend\Db\Sql\Predicate\Literal', $predicates[0][1]);
     }
-    
+
     /**
      * @testdox unit test: Test where() will accept any array with string key (without ?) with Predicate throw Exception
      * @covers Zend\Db\Sql\Select::where
@@ -254,7 +254,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Db\Sql\Exception\InvalidArgumentException', 'Using Predicate must not use string keys');
         $select->where($where);
     }
-    
+
     /**
      * @testdox unit test: Test where() will accept an indexed array to be used by joining string expressions
      * @covers Zend\Db\Sql\Select::where
@@ -1032,6 +1032,13 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             'processSelect' => array('TOP ?', array(array('"foo".*')), '"foo"'),
         );
 
+        $select43 = new Select();
+        $select43->from(array('x' => 'foo'))->columns(array('bar'), false);
+        $sqlPrep43 = 'SELECT "bar" AS "bar" FROM "foo" AS "x"';
+        $sqlStr43 = 'SELECT "bar" AS "bar" FROM "foo" AS "x"';
+        $internalTests43 = array(
+            'processSelect' => array(array(array('"bar"', '"bar"')), '"foo" AS "x"')
+        );
 
         /**
          * $select = the select object
@@ -1086,6 +1093,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             array($select40, $sqlPrep40, array(),    $sqlStr40, $internalTests40),
             array($select41, $sqlPrep41, array(),    $sqlStr41, $internalTests41),
             array($select42, $sqlPrep42, array(),    $sqlStr42, $internalTests42),
+            array($select43, $sqlPrep43, array(),    $sqlStr43, $internalTests43),
         );
     }
 }


### PR DESCRIPTION
Zend\Db\Sql\Select will prepare the column names incorrectly in the rare case when the table is specified with an alias (`array('alias' => 'table')`) but `columns()` is called with `$prefixColumnsWithTable = false`.

Example:

```
 $select = new Select();
 $select->from(array('x' => 'foo'))->columns(array('bar'), false);
```

I added a UnitTest case and fixed this bug.

I know this is a rare case but it might happen to someone some day.
