### PR TITLE
Added the ability to disable the getValidator input specification on Select Elements

### DIFF
--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -233,10 +233,13 @@ class Select extends Element implements InputProviderInterface
         $spec = array(
             'name' => $this->getName(),
             'required' => true,
-            'validators' => array(
-                $this->getValidator()
-            )
-        );
+        );  
+
+        if ($validator = $this->getValidator()) {
+            $spec['validators'] = array(
+                $validator,
+            );  
+        }   
 
         return $spec;
     }

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -47,6 +47,11 @@ class Select extends Element implements InputProviderInterface
     protected $validator;
 
     /**
+     * @var bool
+     */
+    protected $disableInArrayValidator = false;
+
+    /**
      * Create an empty option (option with label but no value). If set to null, no option is created
      *
      * @var bool
@@ -119,6 +124,10 @@ class Select extends Element implements InputProviderInterface
             $this->setEmptyOption($this->options['empty_option']);
         }
 
+        if (isset($this->options['disable_inarray_validator'])) {
+            $this->setDisableInArrayValidator($this->options['disable_inarray_validator']);
+        }
+
         return $this;
     }
 
@@ -138,6 +147,28 @@ class Select extends Element implements InputProviderInterface
             return $this;
         }
         return parent::setAttribute($key, $value);
+    }
+
+    /**
+     * Set the flag to allow for disabling the automatic addition of an InArray validator.
+     *
+     * @param bool $disableOption
+     * @return Select
+     */
+    public function setDisableInArrayValidator($disableOption)
+    {
+        $this->disableInArrayValidator = (bool) $disableOption;
+        return $this;
+    }
+
+    /**
+     * Get the disable in array validator flag.
+     *
+     * @return bool
+     */
+    public function disableInArrayValidator()
+    {
+        return $this->disableInArrayValidator;
     }
 
     /**
@@ -169,7 +200,7 @@ class Select extends Element implements InputProviderInterface
      */
     protected function getValidator()
     {
-        if (null === $this->validator) {
+        if (null === $this->validator && !$this->disableInArrayValidator()) {
             $validator = new InArrayValidator(array(
                 'haystack' => $this->getValueOptionsValues(),
                 'strict'   => false

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -205,5 +205,27 @@ class SelectTest extends TestCase
         $this->assertEquals(array('baz' => 'foo'), $element->getOption('empty_option'));
     }
 
+    public function testDisableInputSpecification()
+    {
+        $element = new SelectElement();
+        $element->setValueOptions(array(
+            'Option 1' => 'option1',
+            'Option 2' => 'option2',
+            'Option 3' => 'option3',
+        ));
+        $element->setDisableInArrayValidator(true);
+
+        $inputSpec = $element->getInputSpecification();
+        $this->assertArrayHasKey('validators', $inputSpec);
+        $this->assertInternalType('array', $inputSpec['validators']);
+
+        $unexpectedClasses = array(
+            'Zend\Validator\InArray'
+        );
+        foreach ($inputSpec['validators'] as $validator) {
+            $class = get_class($validator);
+            $this->assertFalse(in_array($class, $unexpectedClasses), $class);
+        }
+    }
 
 }

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -216,16 +216,7 @@ class SelectTest extends TestCase
         $element->setDisableInArrayValidator(true);
 
         $inputSpec = $element->getInputSpecification();
-        $this->assertArrayHasKey('validators', $inputSpec);
-        $this->assertInternalType('array', $inputSpec['validators']);
-
-        $unexpectedClasses = array(
-            'Zend\Validator\InArray'
-        );
-        foreach ($inputSpec['validators'] as $validator) {
-            $class = get_class($validator);
-            $this->assertFalse(in_array($class, $unexpectedClasses), $class);
-        }
+        $this->assertArrayNotHasKey('validators', $inputSpec);
     }
 
 }


### PR DESCRIPTION
## Overview

I've seen this requested quite a few times where people want to disable the automatic in array validator that gets added onto select elements.  Mainly this is for cases where you are validating your data differently when doing things such as ajax calls to set a different set of data based on a field.  

In my case I use the context to grab a value of a different select that then loads a different validator to check the input.  This saves a lot of questions as well as saves people from having to always provide their own Select form element in the event that they do not want this validator.
