### PR TITLE
Added @method annotations for view helpers

### DIFF
--- a/library/Zend/View/Renderer/PhpRenderer.php
+++ b/library/Zend/View/Renderer/PhpRenderer.php
@@ -27,6 +27,48 @@ use Zend\View\Variables;
  * Note: all private variables in this class are prefixed with "__". This is to
  * mark them as part of the internal implementation, and thus prevent conflict
  * with variables injected into the renderer.
+ *
+ * Convenience methods for build in helpers (@see __call):
+ *
+ * @method \Zend\View\Helper\BasePath basePath($file = null)
+ * @method \Zend\View\Helper\Cycle cycle(array $data = array(), $name = self::DEFAULT_NAME)
+ * @method \Zend\View\Helper\DeclareVars declareVars()
+ * @method \Zend\View\Helper\Doctype doctype($doctype = null)
+ * @method mixed escapeCss($value, $recurse = self::RECURSE_NONE)
+ * @method mixed escapeHtml($value, $recurse = self::RECURSE_NONE)
+ * @method mixed escapeHtmlAttr($value, $recurse = self::RECURSE_NONE)
+ * @method mixed escapeJs($value, $recurse = self::RECURSE_NONE)
+ * @method mixed escapeUrl($value, $recurse = self::RECURSE_NONE)
+ * @method \Zend\View\Helper\FlashMessenger flashMessenger($namespace = null)
+ * @method \Zend\View\Helper\Gravatar gravatar($email = "", $options = array(), $attribs = array())
+ * @method \Zend\View\Helper\HeadLink headLink(array $attributes = null, $placement = \Zend\View\Helper\Placeholder\Container\AbstractContainer::APPEND)
+ * @method \Zend\View\Helper\HeadMeta headMeta($content = null, $keyValue = null, $keyType = 'name', $modifiers = array(), $placement = \Zend\View\Helper\Placeholder\Container\AbstractContainer::APPEND)
+ * @method \Zend\View\Helper\HeadScript headScript($mode = HeadScript::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
+ * @method \Zend\View\Helper\HeadStyle headStyle($content = null, $placement = 'APPEND', $attributes = array())
+ * @method \Zend\View\Helper\HeadTitle headTitle($title = null, $setType = null)
+ * @method string htmlFlash($data, array $attribs = array(), array $params = array(), $content = null)
+ * @method string htmlList(array $items, $ordered = false, $attribs = false, $escape = true)
+ * @method string htmlObject($data = null, $type = null, array $attribs = array(), array $params = array(), $content = null)
+ * @method string htmlPage($data, array $attribs = array(), array $params = array(), $content = null)
+ * @method string htmlQuicktime($data, array $attribs = array(), array $params = array(), $content = null)
+ * @method mixed|null identity()
+ * @method \Zend\View\Helper\InlineScript inlineScript($mode = HeadScript::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
+ * @method string|void json($data, array $jsonOptions = array())
+ * @method \Zend\View\Helper\Layout layout($template = null)
+ * @method \Zend\View\Helper\Navigation navigation($container = null)
+ * @method string paginationControl(\Zend\Paginator\Paginator $paginator = null, $scrollingStyle = null, $partial = null, $params = null)
+ * @method string|\Zend\View\Helper\Partial partial($name = null, $values = null)
+ * @method string partialLoop($name = null, $values = null)
+ * @method \Zend\View\Helper\Placeholder\Container\AbstractContainer placeHolder($name = null)
+ * @method string renderChildModel($child)
+ * @method void renderToPlaceholder($script, $placeholder)
+ * @method string serverUrl($requestUri = null)
+ * @method string url($name = null, array $params = array(), $options = array(), $reuseMatchedParams = false)
+ * @method \Zend\View\Helper\ViewModel viewModel()
+ * @method \Zend\View\Helper\Navigation\Breadcrumbs breadCrumbs($container = null)
+ * @method \Zend\View\Helper\Navigation\Links links($container = null)
+ * @method \Zend\View\Helper\Navigation\Menu menu($container = null)
+ * @method \Zend\View\Helper\Navigation\Sitemap sitemap($container = null)
  */
 class PhpRenderer implements Renderer, TreeRendererInterface
 {


### PR DESCRIPTION
I have added @method annotations for all the builtin view helpers, so we can have IDE completion for the view helpers.
This is based on my [discussion](http://stackoverflow.com/questions/15138746/autocompletion-for-zf2-view-helpers-in-phpstorm) with Ocramius at StackOverflow. The same thing is already implemented in the [AbstractController](https://github.com/zendframework/zf2/blob/master/library/Zend/Mvc/Controller/AbstractController.php) for controller plugins.

I was not sure if I also need to add the translation view helpers which are located in the `zend_i18n` package. The `zend_view` component doesn't have a dependency on `zend_i18n` so that's why I left them out.
