### PR TITLE
validateMultiValue throws exception if valid is empty array

### DIFF
--- a/library/Zend/Form/View/Helper/FormSelect.php
+++ b/library/Zend/Form/View/Helper/FormSelect.php
@@ -237,7 +237,11 @@ class FormSelect extends AbstractHelper
      */
     protected function validateMultiValue($value, array $attributes)
     {
-        if (empty($value)) {
+        if (null === $value) {
+            return array();
+        }
+        
+        if (is_array($value) && empty($value)) {
             return array();
         }
 

--- a/library/Zend/Form/View/Helper/FormSelect.php
+++ b/library/Zend/Form/View/Helper/FormSelect.php
@@ -237,7 +237,7 @@ class FormSelect extends AbstractHelper
      */
     protected function validateMultiValue($value, array $attributes)
     {
-        if (null === $value) {
+        if (empty($value)) {
             return array();
         }
 


### PR DESCRIPTION
take:
 protected function validateMultiValue($value, array $attributes)

if $value is equal array() this method throws an exception, wich is not actually correct since some elements (e.g.  DoctrineModule\Form\Element\ObjectSelect ) could pass an empty array to this function.
