### PR TITLE
Adding $opensslconfig to openssl_pkey_export()

### DIFF
--- a/library/Zend/Crypt/PublicKey/RsaOptions.php
+++ b/library/Zend/Crypt/PublicKey/RsaOptions.php
@@ -205,7 +205,7 @@ class RsaOptions extends AbstractOptions
 
          // export key
          $passPhrase = $this->getPassPhrase();
-         $result     = openssl_pkey_export($resource, $private, $passPhrase);
+         $result     = openssl_pkey_export($resource, $private, $passPhrase, $opensslConfig);
          if (false === $result) {
              throw new Exception\RuntimeException(
                  'Can not export key; openssl ' . openssl_error_string()


### PR DESCRIPTION
In some situations openssl_pkey_export needs the configPath to openssl.cnf otherwise openssl is throwing strange errors - see attachment.
![Screen Shot 2013-03-01 at 14 51 24](https://f.cloud.github.com/assets/1678209/209674/38e74f94-8277-11e2-9c00-974564abfa2f.png)
