### PR TITLE
Added database adapter abstract service factory.

### DIFF
--- a/library/Zend/Db/Adapter/AdapterAbstractServiceFactory.php
+++ b/library/Zend/Db/Adapter/AdapterAbstractServiceFactory.php
@@ -25,15 +25,7 @@ class AdapterAbstractServiceFactory implements AbstractFactoryInterface
     public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
         $config = $serviceLocator->get('Config');
-
-        if (isset($config['db'][$name])) {
-            return true;
-
-        } else if (isset($config['db'][$requestedName])) {
-            return true;
-        }
-
-        return false;
+        return isset($config['db']['adapters'][$requestedName]);
     }
 
     /**
@@ -42,11 +34,6 @@ class AdapterAbstractServiceFactory implements AbstractFactoryInterface
     public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
         $config = $serviceLocator->get('Config');
-
-        if (isset($config['db'][$name])) {
-            return new Adapter($config['db'][$name]);
-        }
-
-        return new Adapter($config['db'][$requestedName]);
+        return new Adapter($config['db']['adapters'][$requestedName]);
     }
 }

--- a/library/Zend/Db/Adapter/AdapterAbstractServiceFactory.php
+++ b/library/Zend/Db/Adapter/AdapterAbstractServiceFactory.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Adapter;
+
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Database adapter abstract service factory.
+ *
+ * Allow configure several database instances (writer and reader).
+ */
+class AdapterAbstractServiceFactory implements AbstractFactoryInterface
+{
+    /**
+     * @see \Zend\ServiceManager\AbstractFactoryInterface::canCreateServiceWithName()
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        $config = $serviceLocator->get('Config');
+
+        if (isset($config['db'][$name])) {
+            return true;
+
+        } else if (isset($config['db'][$requestedName])) {
+            return true;
+
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @see \Zend\ServiceManager\AbstractFactoryInterface::createServiceWithName()
+     */
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        $config = $serviceLocator->get('Config');
+
+        if (isset($config['db'][$name])) {
+            return new Adapter($config['db'][$name]);
+
+        } else if (isset($config['db'][$requestedName])) {
+            return new Adapter($config['db'][$requestedName]);
+        }
+    }
+}

--- a/library/Zend/Db/Adapter/AdapterAbstractServiceFactory.php
+++ b/library/Zend/Db/Adapter/AdapterAbstractServiceFactory.php
@@ -31,10 +31,9 @@ class AdapterAbstractServiceFactory implements AbstractFactoryInterface
 
         } else if (isset($config['db'][$requestedName])) {
             return true;
-
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -46,9 +45,8 @@ class AdapterAbstractServiceFactory implements AbstractFactoryInterface
 
         if (isset($config['db'][$name])) {
             return new Adapter($config['db'][$name]);
-
-        } else if (isset($config['db'][$requestedName])) {
-            return new Adapter($config['db'][$requestedName]);
         }
+
+        return new Adapter($config['db'][$requestedName]);
     }
 }

--- a/tests/ZendTest/Db/Adapter/AdapterAbstractServiceFactoryTest.php
+++ b/tests/ZendTest/Db/Adapter/AdapterAbstractServiceFactoryTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Db
+ */
+
+namespace ZendTest\Db\Adapter;
+
+use Zend\ServiceManager\ServiceManager;
+use Zend\Mvc\Service\ServiceManagerConfig;
+
+class AdapterAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Zend\ServiceManager\ServiceLocatorInterface
+     */
+    private $serviceManager;
+
+    /**
+     * Set up service manager and database configuration.
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    protected function setUp()
+    {
+        $this->serviceManager = new ServiceManager(new ServiceManagerConfig(array(
+            'abstract_factories' => array('Zend\Db\Adapter\AdapterAbstractServiceFactory'),
+        )));
+
+        $this->serviceManager->setService('Config', array(
+            'db' => array(
+                'Zend\Db\Adapter\Writer' => array(
+                    'driver' => 'mysqli',
+                ),
+                'Zend\Db\Adapter\Reader' => array(
+                    'driver' => 'mysqli',
+                ),
+            ),
+        ));
+    }
+
+    /**
+     * @return array
+     */
+    public function providerValidService()
+    {
+        return array(
+            array('Zend\Db\Adapter\Writer'),
+            array('Zend\Db\Adapter\Reader'),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function providerInvalidService()
+    {
+        return array(
+            array('Zend\Db\Adapter\Unknown'),
+        );
+    }
+
+    /**
+     * @param string $service
+     * @dataProvider providerValidService
+     */
+    public function testValidService($service)
+    {
+        $actual = $this->serviceManager->get($service);
+        $this->assertInstanceOf('Zend\Db\Adapter\Adapter', $actual);
+    }
+
+    /**
+     * @param string $service
+     * @dataProvider providerInvalidService
+     * @expectedException \Zend\ServiceManager\Exception\ServiceNotFoundException
+     */
+    public function testInvalidService($service)
+    {
+        $actual = $this->serviceManager->get($service);
+    }
+}

--- a/tests/ZendTest/Db/Adapter/AdapterAbstractServiceFactoryTest.php
+++ b/tests/ZendTest/Db/Adapter/AdapterAbstractServiceFactoryTest.php
@@ -33,11 +33,13 @@ class AdapterAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->serviceManager->setService('Config', array(
             'db' => array(
-                'Zend\Db\Adapter\Writer' => array(
-                    'driver' => 'mysqli',
-                ),
-                'Zend\Db\Adapter\Reader' => array(
-                    'driver' => 'mysqli',
+                'adapters' => array(
+                    'Zend\Db\Adapter\Writer' => array(
+                        'driver' => 'mysqli',
+                    ),
+                    'Zend\Db\Adapter\Reader' => array(
+                        'driver' => 'mysqli',
+                    ),
                 ),
             ),
         ));


### PR DESCRIPTION
Added database adapter abstract service factory to configure multiple database adapters for application. This abstract factory reserved _db.adapters_ key in configuration array.

``` php
array(
            'db' => array(
                'adapters' => array(
                    'Zend\Db\Adapter\Master' => array(
                        'driver' => 'mysqli',
                    ),
                    'Zend\Db\Adapter\Slave' => array(
                        'driver' => 'mysqli',
                    ),
                ),
            ),
)
```
