### PR TITLE
Enable ExceptionStrategy to return json

### DIFF
--- a/library/Zend/Mvc/View/Http/ExceptionStrategy.php
+++ b/library/Zend/Mvc/View/Http/ExceptionStrategy.php
@@ -142,13 +142,14 @@ class ExceptionStrategy implements ListenerAggregateInterface
 
             case Application::ERROR_EXCEPTION:
             default:
-                if ($e->getRequest()->getHeaders()->get('Accept')->match('application/json')){
+                $accept = $e->getRequest()->getHeaders()->get('Accept');
+                if ($accept && $accept->match('application/json')){
                     $model = new JsonModel;
                 } else {
                     $model = new ViewModel;
                 }
 
-                $model->setVariables(array(                
+                $model->setVariables(array(
                     'message'            => 'An error occurred during execution; please try again later.',
                     'exception'          => $e->getParam('exception'),
                     'display_exceptions' => $this->displayExceptions(),

--- a/library/Zend/Mvc/View/Http/ExceptionStrategy.php
+++ b/library/Zend/Mvc/View/Http/ExceptionStrategy.php
@@ -16,6 +16,7 @@ use Zend\Mvc\Application;
 use Zend\Mvc\MvcEvent;
 use Zend\Stdlib\ResponseInterface as Response;
 use Zend\View\Model\ViewModel;
+use Zend\View\Model\JsonModel;
 
 class ExceptionStrategy implements ListenerAggregateInterface
 {
@@ -141,7 +142,13 @@ class ExceptionStrategy implements ListenerAggregateInterface
 
             case Application::ERROR_EXCEPTION:
             default:
-                $model = new ViewModel(array(
+                if ($e->getRequest()->getHeaders()->get('Accept')->match('application/json')){
+                    $model = new JsonModel;
+                } else {
+                    $model = new ViewModel;
+                }
+
+                $model->setVariables(array(                
                     'message'            => 'An error occurred during execution; please try again later.',
                     'exception'          => $e->getParam('exception'),
                     'display_exceptions' => $this->displayExceptions(),


### PR DESCRIPTION
Modifies the ExceptionStrategy to return a JsonViewModel if the Accept `applicaton/json` header is set. This means when an exception occurs on something such as a rest service, the client will be returned an exception that can be consumed, rather than a html document.
