### PR TITLE
Adding config to openssl_pkey_export()

### DIFF
--- a/library/Zend/Crypt/PublicKey/RsaOptions.php
+++ b/library/Zend/Crypt/PublicKey/RsaOptions.php
@@ -205,7 +205,7 @@ class RsaOptions extends AbstractOptions
 
          // export key
          $passPhrase = $this->getPassPhrase();
-         $result     = openssl_pkey_export($resource, $private, $passPhrase);
+         $result     = openssl_pkey_export($resource, $private, $passPhrase, $opensslConfig);
          if (false === $result) {
              throw new Exception\RuntimeException(
                  'Can not export key; openssl ' . openssl_error_string()


### PR DESCRIPTION
Closed pull request by mistake (https://github.com/zendframework/zf2/pull/3927)

openssl_pkey_export throws strange errors - Adding the optional config parameter (with config path) fixes the problem. 

![Screen Shot 2013-03-01 at 14 51 24](https://f.cloud.github.com/assets/1678209/216190/9457cb8c-84b7-11e2-89c7-d346a1730432.png)
