### PR TITLE
Deprecate Zend\Stdlib\DateTime and use \DateTime constructor internally instead

### DIFF
--- a/library/Zend/Feed/Reader/Extension/Atom/Entry.php
+++ b/library/Zend/Feed/Reader/Extension/Atom/Entry.php
@@ -9,13 +9,13 @@
 
 namespace Zend\Feed\Reader\Extension\Atom;
 
+use DateTime;
 use DOMDocument;
 use DOMElement;
 use stdClass;
 use Zend\Feed\Reader;
 use Zend\Feed\Reader\Collection;
 use Zend\Feed\Reader\Extension;
-use Zend\Stdlib\DateTime;
 use Zend\Uri;
 
 class Entry extends Extension\AbstractEntry
@@ -170,7 +170,7 @@ class Entry extends Extension\AbstractEntry
         }
 
         if ($dateCreated) {
-            $date = DateTime::createFromISO8601($dateCreated);
+            $date = new DateTime($dateCreated);
         }
 
         $this->data['datecreated'] = $date;
@@ -198,7 +198,7 @@ class Entry extends Extension\AbstractEntry
         }
 
         if ($dateModified) {
-            $date = DateTime::createFromISO8601($dateModified);
+            $date = new DateTime($dateModified);
         }
 
         $this->data['datemodified'] = $date;

--- a/library/Zend/Feed/Reader/Extension/Atom/Feed.php
+++ b/library/Zend/Feed/Reader/Extension/Atom/Feed.php
@@ -9,11 +9,11 @@
 
 namespace Zend\Feed\Reader\Extension\Atom;
 
+use DateTime;
 use DOMElement;
 use Zend\Feed\Reader;
 use Zend\Feed\Reader\Collection;
 use Zend\Feed\Reader\Extension;
-use Zend\Stdlib\DateTime;
 use Zend\Uri;
 
 class Feed extends Extension\AbstractFeed
@@ -120,7 +120,7 @@ class Feed extends Extension\AbstractFeed
         }
 
         if ($dateCreated) {
-            $date = DateTime::createFromISO8601($dateCreated);
+            $date = new DateTime($dateCreated);
         }
 
         $this->data['datecreated'] = $date;
@@ -148,7 +148,7 @@ class Feed extends Extension\AbstractFeed
         }
 
         if ($dateModified) {
-            $date = DateTime::createFromISO8601($dateModified);
+            $date = new DateTime($dateModified);
         }
 
         $this->data['datemodified'] = $date;

--- a/library/Zend/Feed/Reader/Extension/DublinCore/Entry.php
+++ b/library/Zend/Feed/Reader/Extension/DublinCore/Entry.php
@@ -9,10 +9,10 @@
 
 namespace Zend\Feed\Reader\Extension\DublinCore;
 
+use DateTime;
 use Zend\Feed\Reader;
 use Zend\Feed\Reader\Collection;
 use Zend\Feed\Reader\Extension;
-use Zend\Stdlib\DateTime;
 
 class Entry extends Extension\AbstractEntry
 {
@@ -217,7 +217,7 @@ class Entry extends Extension\AbstractEntry
         }
 
         if ($date) {
-            $d = DateTime::createFromISO8601($date);
+            $d = new DateTime($date);
         }
 
         $this->data['date'] = $d;

--- a/library/Zend/Feed/Reader/Extension/DublinCore/Feed.php
+++ b/library/Zend/Feed/Reader/Extension/DublinCore/Feed.php
@@ -9,10 +9,10 @@
 
 namespace Zend\Feed\Reader\Extension\DublinCore;
 
+use DateTime;
 use Zend\Feed\Reader;
 use Zend\Feed\Reader\Collection;
 use Zend\Feed\Reader\Extension;
-use Zend\Stdlib\DateTime;
 
 class Feed extends Extension\AbstractFeed
 {
@@ -226,7 +226,7 @@ class Feed extends Extension\AbstractFeed
         }
 
         if ($date) {
-            $d = DateTime::createFromISO8601($date);
+            $d = new DateTime($date);
         }
 
         $this->data['date'] = $d;

--- a/library/Zend/Stdlib/DateTime.php
+++ b/library/Zend/Stdlib/DateTime.php
@@ -11,10 +11,14 @@ namespace Zend\Stdlib;
 
 use DateTimeZone;
 
+trigger_error('DateTime extension deprecated as of ZF 2.1.4; use the \DateTime constructor to parse extended ISO8601 dates instead', E_USER_DEPRECATED);
+
 /**
  * DateTime
  *
  * An extension of the \DateTime object.
+ *
+ * @deprecated
  */
 class DateTime extends \DateTime
 {

--- a/tests/ZendTest/Feed/Reader/Entry/AtomTest.php
+++ b/tests/ZendTest/Feed/Reader/Entry/AtomTest.php
@@ -109,6 +109,16 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($edate, $entry->getDateCreated());
     }
 
+    public function testGetsDateCreatedWithFractional()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath . '/datecreated/plain/fractional.xml')
+        );
+        $entry = $feed->current();
+        $edate = DateTime::createFromFormat(DateTime::ISO8601, '2009-03-07T08:03:50Z');
+        $this->assertEquals($edate, $entry->getDateCreated());
+    }
+
     /**
      * Get modification date (Unencoded Text)
      */
@@ -126,6 +136,16 @@ class AtomTest extends \PHPUnit_Framework_TestCase
     {
         $feed = Reader\Reader::importString(
             file_get_contents($this->feedSamplePath . '/datemodified/plain/atom10.xml')
+        );
+        $entry = $feed->current();
+        $edate = DateTime::createFromFormat(DateTime::ISO8601, '2009-03-07T08:03:50Z');
+        $this->assertEquals($edate, $entry->getDateModified());
+    }
+
+    public function testGetsDateModifiedWithFractional()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath . '/datemodified/plain/fractional.xml')
         );
         $entry = $feed->current();
         $edate = DateTime::createFromFormat(DateTime::ISO8601, '2009-03-07T08:03:50Z');

--- a/tests/ZendTest/Feed/Reader/Entry/_files/Atom/datecreated/plain/fractional.xml
+++ b/tests/ZendTest/Feed/Reader/Entry/_files/Atom/datecreated/plain/fractional.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed version="0.3" xmlns="http://purl.org/atom/ns#">
+    <entry>
+		<created>2009-03-07T08:03:50.80Z</created>
+    </entry>
+</feed>

--- a/tests/ZendTest/Feed/Reader/Entry/_files/Atom/datemodified/plain/fractional.xml
+++ b/tests/ZendTest/Feed/Reader/Entry/_files/Atom/datemodified/plain/fractional.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed version="0.3" xmlns="http://purl.org/atom/ns#">
+    <entry>
+        <modified>2009-03-07T08:03:50.80Z</modified>
+    </entry>
+</feed>


### PR DESCRIPTION
Zend\Stdlib\DateTime was introduced for no real reason; at least not without looking more deeply into how the native DateTime object works. The main reason was to be able to parse fractional seconds in ISO8601 dates, which was not possible with DateTime::createFromFormat(), but is actually possible with the DateTime constructor itself.

This PR deprecates that unnecessary class again and puts the DateTime constructor in place where needed.
