### PR TITLE
[Hotfix] Fixed incorrect PDO_Oci platform recognition

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Pdo.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Pdo.php
@@ -187,6 +187,9 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
             switch ($name) {
                 case 'pgsql':
                     return 'Postgresql';
+                case 'oci':
+                    return 'Oracle';
+
                 default:
                     return ucfirst($name);
             }
@@ -198,6 +201,8 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
                     return 'MySQL';
                 case 'pgsql':
                     return 'PostgreSQL';
+                case 'oci':
+                    return 'Oracle';
                 default:
                     return ucfirst($name);
             }


### PR DESCRIPTION
When instanciating the PDO driver with pdo_oci, it will return "Oci" as
platform name which is not correct. The correct Platform name is
"Oracle"
