### PR TITLE
Update toString() to use late static binding for encoding methods

### DIFF
--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -359,17 +359,17 @@ class Uri implements UriInterface
         }
 
         if ($this->path) {
-            $uri .= self::encodePath($this->path);
+            $uri .= static::encodePath($this->path);
         } elseif ($this->host && ($this->query || $this->fragment)) {
             $uri .= '/';
         }
 
         if ($this->query) {
-            $uri .= "?" . self::encodeQueryFragment($this->query);
+            $uri .= "?" . static::encodeQueryFragment($this->query);
         }
 
         if ($this->fragment) {
-            $uri .= "#" . self::encodeQueryFragment($this->fragment);
+            $uri .= "#" . static::encodeQueryFragment($this->fragment);
         }
 
         return $uri;


### PR DESCRIPTION
Updated the toString() method in \Zend\Uri\Uri so it uses late static binding to call the encoding methods.

Replaced `self::` calls with `static::` calls in toString().

This resolves problems when writing your own custom Uri classes.

Change-Id: I470379b8527852d5f36145c88ab05cbb51582103
