### PR TITLE
Mvc router/base relative option

### DIFF
--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -192,9 +192,18 @@ class TreeRouteStack extends SimpleRouteStack
         } else {
             unset($options['name']);
         }
+        
+        $prependBase = true;
+        if (isset($options['base_relative'])) {
+            if($options['base_relative']) {
+                $prependBase = false;
+            }
+            unset($options['base_relative']);
+        }
 
         if (isset($options['only_return_path']) && $options['only_return_path']) {
-            return $this->baseUrl . $route->assemble(array_merge($this->defaultParams, $params), $options);
+            $path = $route->assemble(array_merge($this->defaultParams, $params), $options);
+            return $this->prependBaseUrl($path, $prependBase);
         }
 
         if (!isset($options['uri'])) {
@@ -215,8 +224,6 @@ class TreeRouteStack extends SimpleRouteStack
             $uri = $options['uri'];
         }
 
-        $path = $this->baseUrl . $route->assemble(array_merge($this->defaultParams, $params), $options);
-
         if (isset($options['query'])) {
             $uri->setQuery($options['query']);
         }
@@ -224,6 +231,10 @@ class TreeRouteStack extends SimpleRouteStack
         if (isset($options['fragment'])) {
             $uri->setFragment($options['fragment']);
         }
+        
+        $path = $this->prependBaseUrl(
+            $route->assemble(array_merge($this->defaultParams, $params), $options),
+            $prependBase);
 
         if ((isset($options['force_canonical']) && $options['force_canonical']) || $uri->getHost() !== null) {
             if ($uri->getScheme() === null) {
@@ -238,9 +249,19 @@ class TreeRouteStack extends SimpleRouteStack
         } elseif (!$uri->isAbsolute() && $uri->isValidRelative()) {
             return $uri->setPath($path)->normalize()->toString();
         }
-
+        
         return $path;
     }
+    
+    protected function prependBaseUrl($path, $prepend = true)
+    {
+        if(!$prepend) {
+            $path = ltrim($path, '/');
+            return $path;
+        }
+        
+        return $this->baseUrl . $path;
+    } 
 
     /**
      * Set the base URL.

--- a/library/Zend/View/Helper/HeadTitle.php
+++ b/library/Zend/View/Helper/HeadTitle.php
@@ -116,7 +116,7 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
     }
 
     /**
-     * Turn helper into string
+     * Render title (wrapped by title tag)
      *
      * @param  string|null $indent
      * @return string
@@ -132,6 +132,11 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
         return $indent . '<title>' . $output . '</title>';
     }
     
+    /**
+     * Render title string
+     *
+     * @return string
+     */
     public function renderTitle()
     {
         $items = array();

--- a/library/Zend/View/Helper/HeadTitle.php
+++ b/library/Zend/View/Helper/HeadTitle.php
@@ -127,6 +127,13 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
                 ? $this->getWhitespace($indent)
                 : $this->getIndent();
 
+        $output = $this->renderTitle();
+
+        return $indent . '<title>' . $output . '</title>';
+    }
+    
+    public function renderTitle()
+    {
         $items = array();
 
         if (null !== ($translator = $this->getTranslator())) {
@@ -158,7 +165,7 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
 
         $output = ($this->autoEscape) ? $this->escape($output) : $output;
 
-        return $indent . '<title>' . $output . '</title>';
+        return $output;
     }
 
     // Translator methods - Good candidate to refactor as a trait with PHP 5.4


### PR DESCRIPTION
This allows to specify option 'base_relative' = true to assemble() route interface. First route which receives this does not prepend baseUrl to it's route def.
