### PR TITLE
SessionArrayStorage doesn't preserve _REQUEST_ACCESS_TIME

### DIFF
--- a/tests/ZendTest/Session/SessionArrayStorageTest.php
+++ b/tests/ZendTest/Session/SessionArrayStorageTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Session;
 
 use Zend\Session\Storage\SessionArrayStorage;
 use Zend\Session\Container;
+use Zend\Session\SessionManager;
 
 /**
  * @category   Zend
@@ -166,4 +167,17 @@ class SessionArrayStorageTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $this->storage->toArray(true));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
+    public function testPreserveRequestAccessTimeAfterStart()
+    {
+        $manager = new SessionManager(null, $this->storage);
+
+        $this->assertGreaterThan(0, $this->storage->getRequestAccessTime());
+
+        $manager->start();
+
+        $this->assertGreaterThan(0, $this->storage->getRequestAccessTime());
+    }
 }


### PR DESCRIPTION
This PR **intentionally fails**, because I wrote only the test and not the solution.

Now I'll explain the issue, and why I didn't write any solution, yet.

When `SessionManager` is instantiated, immediatly a storage is built, calling its contructor. Both `SessionStorage` (extending `ArrayStorage`) and `SessionArrayStorage` (extending `AbstractSessionArrayStorage`) have in their `__construct`:

``` php
$this->setRequestAccessTime(microtime(true));
```

Setting this metadata at start.

Calling `$sessionManager->start()` will also call `session_start();`, clearing all metadata in both storages, including the `_REQUEST_ACCESS_TIME`.

So why, after SessionManager start call, `SessionStorage` retains the _RAT, and `SessionArrayStorage` doesn't? Because `SessionStorage` sets the _RAT to `$this` (itself), and then SessionManager sets `$_SESSION = $storage`.

We can't take the same approach for `SessionArrayStorage`: it does not set anything to itself, so `$_SESSION = $storage` is meaningless in this case.

IMHO, the best way to resolve definitively these type of issues is to refactor at root the problem: no `StorageInterface` has to play with `$_SESSION` until `session_start` is called, but this involves a lot of code, and probably a lot of compatiblity breaks.

What are your thoughts?
