### PR TITLE
Insecure value quoting/escaping in platform implementations

### DIFF
--- a/library/Zend/Db/Adapter/Platform/IbmDb2.php
+++ b/library/Zend/Db/Adapter/Platform/IbmDb2.php
@@ -109,7 +109,7 @@ class IbmDb2 implements PlatformInterface
      */
     public function quoteValue($value)
     {
-        return '\'' . str_replace('\'', '\\' . '\'', $value) . '\'';
+        return '\'' . addcslashes($value, '\\\'') . '\'';
     }
 
     /**
@@ -120,11 +120,15 @@ class IbmDb2 implements PlatformInterface
      */
     public function quoteValueList($valueList)
     {
-        $valueList = str_replace('\'', '\\' . '\'', $valueList);
         if (is_array($valueList)) {
-            $valueList = implode('\', \'', $valueList);
+            $value = reset($valueList);
+            do {
+                $valueList[key($valueList)] = addcslashes($value, '\\\'');
+            } while ($value = next($valueList));
+            return '\'' . implode('\', \'', $valueList) . '\'';
+        } else {
+            return '\'' . addcslashes($valueList, '\\\'') . '\'';
         }
-        return '\'' . $valueList . '\'';
     }
 
     /**

--- a/library/Zend/Db/Adapter/Platform/Mysql.php
+++ b/library/Zend/Db/Adapter/Platform/Mysql.php
@@ -76,7 +76,7 @@ class Mysql implements PlatformInterface
      */
     public function quoteValue($value)
     {
-        return '\'' . str_replace('\'', '\\' . '\'', $value) . '\'';
+        return '\'' . addcslashes($value, '\\\'') . '\'';
     }
 
     /**
@@ -87,11 +87,15 @@ class Mysql implements PlatformInterface
      */
     public function quoteValueList($valueList)
     {
-        $valueList = str_replace('\'', '\\' . '\'', $valueList);
         if (is_array($valueList)) {
-            $valueList = implode('\', \'', $valueList);
+            $value = reset($valueList);
+            do {
+                $valueList[key($valueList)] = addcslashes($value, '\\\'');
+            } while ($value = next($valueList));
+            return '\'' . implode('\', \'', $valueList) . '\'';
+        } else {
+            return '\'' . addcslashes($valueList, '\\\'') . '\'';
         }
-        return '\'' . $valueList . '\'';
     }
 
     /**

--- a/library/Zend/Db/Adapter/Platform/Oracle.php
+++ b/library/Zend/Db/Adapter/Platform/Oracle.php
@@ -100,7 +100,7 @@ class Oracle implements PlatformInterface
      */
     public function quoteValue($value)
     {
-        return '\'' . str_replace('\'', '\\' . '\'', $value) . '\'';
+        return '\'' . addcslashes($value, '\\\'') . '\'';
     }
 
     /**
@@ -111,11 +111,15 @@ class Oracle implements PlatformInterface
      */
     public function quoteValueList($valueList)
     {
-        $valueList = str_replace('\'', '\\' . '\'', $valueList);
         if (is_array($valueList)) {
-            $valueList = implode('\', \'', $valueList);
+            $value = reset($valueList);
+            do {
+                $valueList[key($valueList)] = addcslashes($value, '\\\'');
+            } while ($value = next($valueList));
+            return '\'' . implode('\', \'', $valueList) . '\'';
+        } else {
+            return '\'' . addcslashes($valueList, '\\\'') . '\'';
         }
-        return '\'' . $valueList . '\'';
     }
 
     /**

--- a/library/Zend/Db/Adapter/Platform/Postgresql.php
+++ b/library/Zend/Db/Adapter/Platform/Postgresql.php
@@ -75,7 +75,7 @@ class Postgresql implements PlatformInterface
      */
     public function quoteValue($value)
     {
-        return '\'' . str_replace('\'', '\\' . '\'', $value) . '\'';
+        return '\'' . addcslashes($value, '\\\'') . '\'';
     }
 
     /**
@@ -86,11 +86,15 @@ class Postgresql implements PlatformInterface
      */
     public function quoteValueList($valueList)
     {
-        $valueList = str_replace('\'', '\\' . '\'', $valueList);
         if (is_array($valueList)) {
-            $valueList = implode('\', \'', $valueList);
+            $value = reset($valueList);
+            do {
+                $valueList[key($valueList)] = addcslashes($value, '\\\'');
+            } while ($value = next($valueList));
+            return '\'' . implode('\', \'', $valueList) . '\'';
+        } else {
+            return '\'' . addcslashes($valueList, '\\\'') . '\'';
         }
-        return '\'' . $valueList . '\'';
     }
 
     /**

--- a/library/Zend/Db/Adapter/Platform/Sql92.php
+++ b/library/Zend/Db/Adapter/Platform/Sql92.php
@@ -75,7 +75,7 @@ class Sql92 implements PlatformInterface
      */
     public function quoteValue($value)
     {
-        return '\'' . str_replace('\'', '\\' . '\'', $value) . '\'';
+        return '\'' . addcslashes($value, '\\\'') . '\'';
     }
 
     /**
@@ -86,11 +86,15 @@ class Sql92 implements PlatformInterface
      */
     public function quoteValueList($valueList)
     {
-        $valueList = str_replace('\'', '\\' . '\'', $valueList);
         if (is_array($valueList)) {
-            $valueList = implode('\', \'', $valueList);
+            $value = reset($valueList);
+            do {
+                $valueList[key($valueList)] = addcslashes($value, '\\\'');
+            } while ($value = next($valueList));
+            return '\'' . implode('\', \'', $valueList) . '\'';
+        } else {
+            return '\'' . addcslashes($valueList, '\\\'') . '\'';
         }
-        return '\'' . $valueList . '\'';
     }
 
     /**

--- a/library/Zend/Db/Adapter/Platform/Sqlite.php
+++ b/library/Zend/Db/Adapter/Platform/Sqlite.php
@@ -76,7 +76,7 @@ class Sqlite implements PlatformInterface
      */
     public function quoteValue($value)
     {
-        return '\'' . str_replace('\'', '\\' . '\'', $value) . '\'';
+        return '\'' . addcslashes($value, '\\\'') . '\'';
     }
 
     /**
@@ -87,11 +87,15 @@ class Sqlite implements PlatformInterface
      */
     public function quoteValueList($valueList)
     {
-        $valueList = str_replace('\'', '\\' . '\'', $valueList);
         if (is_array($valueList)) {
-            $valueList = implode('\', \'', $valueList);
+            $value = reset($valueList);
+            do {
+                $valueList[key($valueList)] = addcslashes($value, '\\\'');
+            } while ($value = next($valueList));
+            return '\'' . implode('\', \'', $valueList) . '\'';
+        } else {
+            return '\'' . addcslashes($valueList, '\\\'') . '\'';
         }
-        return '\'' . $valueList . '\'';
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/IbmDb2Test.php
+++ b/tests/ZendTest/Db/Adapter/Platform/IbmDb2Test.php
@@ -87,6 +87,11 @@ class IbmDb2Test extends \PHPUnit_Framework_TestCase
     public function testQuoteValue()
     {
         $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+        $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValue("Foo O'Bar"));
+        $this->assertEquals('\'\\\'; DELETE FROM some_table; -- \'', $this->platform->quoteValue('\'; DELETE FROM some_table; -- '));
+
+        //                   '\\\'; DELETE FROM some_table; -- '  <- actual below
+        $this->assertEquals("'\\\\\\'; DELETE FROM some_table; -- '", $this->platform->quoteValue('\\\'; DELETE FROM some_table; -- '));
     }
 
     /**
@@ -97,6 +102,10 @@ class IbmDb2Test extends \PHPUnit_Framework_TestCase
         $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList("Foo O'Bar"));
         $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList(array("Foo O'Bar")));
         $this->assertEquals("'value', 'Foo O\\'Bar'", $this->platform->quoteValueList(array('value',"Foo O'Bar")));
+        $this->assertEquals(
+            "'value', 'Foo O\\'Bar', '\\\\\\'; DELETE FROM some_table; -- '",
+            $this->platform->quoteValueList(array('value',"Foo O'Bar",'\\\'; DELETE FROM some_table; -- '))
+        );
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/MysqlTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/MysqlTest.php
@@ -81,6 +81,11 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
     public function testQuoteValue()
     {
         $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+        $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValue("Foo O'Bar"));
+        $this->assertEquals('\'\\\'; DELETE FROM some_table; -- \'', $this->platform->quoteValue('\'; DELETE FROM some_table; -- '));
+
+        //                   '\\\'; DELETE FROM some_table; -- '  <- actual below
+        $this->assertEquals("'\\\\\\'; DELETE FROM some_table; -- '", $this->platform->quoteValue('\\\'; DELETE FROM some_table; -- '));
     }
 
     /**
@@ -91,6 +96,10 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList("Foo O'Bar"));
         $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList(array("Foo O'Bar")));
         $this->assertEquals("'value', 'Foo O\\'Bar'", $this->platform->quoteValueList(array('value',"Foo O'Bar")));
+        $this->assertEquals(
+            "'value', 'Foo O\\'Bar', '\\\\\\'; DELETE FROM some_table; -- '",
+            $this->platform->quoteValueList(array('value',"Foo O'Bar",'\\\'; DELETE FROM some_table; -- '))
+        );
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/OracleTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/OracleTest.php
@@ -84,6 +84,11 @@ class OracleTest extends \PHPUnit_Framework_TestCase
     public function testQuoteValue()
     {
         $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+        $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValue("Foo O'Bar"));
+        $this->assertEquals('\'\\\'; DELETE FROM some_table; -- \'', $this->platform->quoteValue('\'; DELETE FROM some_table; -- '));
+
+        //                   '\\\'; DELETE FROM some_table; -- '  <- actual below
+        $this->assertEquals("'\\\\\\'; DELETE FROM some_table; -- '", $this->platform->quoteValue('\\\'; DELETE FROM some_table; -- '));
     }
 
     /**
@@ -94,6 +99,10 @@ class OracleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList("Foo O'Bar"));
         $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList(array("Foo O'Bar")));
         $this->assertEquals("'value', 'Foo O\\'Bar'", $this->platform->quoteValueList(array('value',"Foo O'Bar")));
+        $this->assertEquals(
+            "'value', 'Foo O\\'Bar', '\\\\\\'; DELETE FROM some_table; -- '",
+            $this->platform->quoteValueList(array('value',"Foo O'Bar",'\\\'; DELETE FROM some_table; -- '))
+        );
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/PostgresqlTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/PostgresqlTest.php
@@ -76,6 +76,11 @@ class PostgresqlTest extends \PHPUnit_Framework_TestCase
     public function testQuoteValue()
     {
         $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+        $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValue("Foo O'Bar"));
+        $this->assertEquals('\'\\\'; DELETE FROM some_table; -- \'', $this->platform->quoteValue('\'; DELETE FROM some_table; -- '));
+
+        //                   '\\\'; DELETE FROM some_table; -- '  <- actual below
+        $this->assertEquals("'\\\\\\'; DELETE FROM some_table; -- '", $this->platform->quoteValue('\\\'; DELETE FROM some_table; -- '));
     }
 
     /**
@@ -86,6 +91,10 @@ class PostgresqlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList("Foo O'Bar"));
         $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList(array("Foo O'Bar")));
         $this->assertEquals("'value', 'Foo O\\'Bar'", $this->platform->quoteValueList(array('value',"Foo O'Bar")));
+        $this->assertEquals(
+            "'value', 'Foo O\\'Bar', '\\\\\\'; DELETE FROM some_table; -- '",
+            $this->platform->quoteValueList(array('value',"Foo O'Bar",'\\\'; DELETE FROM some_table; -- '))
+        );
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/Sql92Test.php
+++ b/tests/ZendTest/Db/Adapter/Platform/Sql92Test.php
@@ -76,6 +76,11 @@ class Sql92Test extends \PHPUnit_Framework_TestCase
     public function testQuoteValue()
     {
         $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+        $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValue("Foo O'Bar"));
+        $this->assertEquals('\'\\\'; DELETE FROM some_table; -- \'', $this->platform->quoteValue('\'; DELETE FROM some_table; -- '));
+
+        //                   '\\\'; DELETE FROM some_table; -- '  <- actual below
+        $this->assertEquals("'\\\\\\'; DELETE FROM some_table; -- '", $this->platform->quoteValue('\\\'; DELETE FROM some_table; -- '));
     }
 
     /**
@@ -86,6 +91,10 @@ class Sql92Test extends \PHPUnit_Framework_TestCase
         $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList("Foo O'Bar"));
         $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList(array("Foo O'Bar")));
         $this->assertEquals("'value', 'Foo O\\'Bar'", $this->platform->quoteValueList(array('value',"Foo O'Bar")));
+        $this->assertEquals(
+            "'value', 'Foo O\\'Bar', '\\\\\\'; DELETE FROM some_table; -- '",
+            $this->platform->quoteValueList(array('value',"Foo O'Bar",'\\\'; DELETE FROM some_table; -- '))
+        );
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/SqlServerTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/SqlServerTest.php
@@ -76,6 +76,11 @@ class SqlServerTest extends \PHPUnit_Framework_TestCase
     public function testQuoteValue()
     {
         $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+        $this->assertEquals("'Foo O''Bar'", $this->platform->quoteValue("Foo O'Bar"));
+        $this->assertEquals("'''; DELETE FROM some_table; -- '", $this->platform->quoteValue('\'; DELETE FROM some_table; -- '));
+
+        //                   '\\\'; DELETE FROM some_table; -- '  <- actual below
+        $this->assertEquals("'\\''; DELETE FROM some_table; -- '", $this->platform->quoteValue('\\\'; DELETE FROM some_table; -- '));
     }
 
     /**
@@ -86,6 +91,10 @@ class SqlServerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("'Foo O''Bar'", $this->platform->quoteValueList("Foo O'Bar"));
         $this->assertEquals("'Foo O''Bar'", $this->platform->quoteValueList(array("Foo O'Bar")));
         $this->assertEquals("'value', 'Foo O''Bar'", $this->platform->quoteValueList(array('value',"Foo O'Bar")));
+        $this->assertEquals(
+            "'value', 'Foo O''Bar', '\\''; DELETE FROM some_table; -- '",
+            $this->platform->quoteValueList(array('value',"Foo O'Bar",'\\\'; DELETE FROM some_table; -- '))
+        );
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/SqliteTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/SqliteTest.php
@@ -76,6 +76,11 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
     public function testQuoteValue()
     {
         $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+        $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValue("Foo O'Bar"));
+        $this->assertEquals('\'\\\'; DELETE FROM some_table; -- \'', $this->platform->quoteValue('\'; DELETE FROM some_table; -- '));
+
+        //                   '\\\'; DELETE FROM some_table; -- '  <- actual below
+        $this->assertEquals("'\\\\\\'; DELETE FROM some_table; -- '", $this->platform->quoteValue('\\\'; DELETE FROM some_table; -- '));
     }
 
     /**
@@ -86,6 +91,10 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList("Foo O'Bar"));
         $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList(array("Foo O'Bar")));
         $this->assertEquals("'value', 'Foo O\\'Bar'", $this->platform->quoteValueList(array('value',"Foo O'Bar")));
+        $this->assertEquals(
+            "'value', 'Foo O\\'Bar', '\\\\\\'; DELETE FROM some_table; -- '",
+            $this->platform->quoteValueList(array('value',"Foo O'Bar",'\\\'; DELETE FROM some_table; -- '))
+        );
     }
 
     /**


### PR DESCRIPTION
In almost all platform implementation value quoting is done by doing this:

``` php
return '\'' . str_replace('\'', '\\' . '\'', $value) . '\'';
```

This is insecure and an attacker could inject sql by simply providing:

```
'\'; DELETE FROM some_table; -- '
```

This would become:

```
'\\'; DELETE FROM some_table; -- '
```

Since the the single backslash is now escaped the literal ends at ";" and the Injected statement will become part of the SQL.

You should switch to add(c)slashes or better to the appropriate platform specific method (mysql_escape_string, etc ...).

Also `quoteValueList()` should utilize `quoteValue()` instead of using copy & paste code.
