### PR TITLE
change HOST_DNS_OR_IPV4_OR_IPV6 to 0x13 for $validHostTypes

### DIFF
--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -33,7 +33,7 @@ class Http extends Uri
     /**
      * @see Uri::$validHostTypes
      */
-    protected $validHostTypes = self::HOST_DNS_OR_IPV4_OR_IPV6;
+    protected $validHostTypes = 0x13;
 
     /**
      * User name as provided in authority of URI

--- a/tests/ZendTest/Uri/HttpTest.php
+++ b/tests/ZendTest/Uri/HttpTest.php
@@ -250,4 +250,10 @@ class HttpTest extends TestCase
         $uri->getPort();
         $this->assertEquals($origUri, $uri->toString());
     }
+
+    public function testValidHostTypesWithUnderScore()
+    {
+        $uri = new HttpUri('http://zf2_app.local');
+        $this->assertTrue($uri->isValid());
+    }
 }


### PR DESCRIPTION
to validate if URI host consists of  underscore ( _ )  character.
