### PR TITLE
Update ArrayStack.php

### DIFF
--- a/library/Zend/Stdlib/ArrayStack.php
+++ b/library/Zend/Stdlib/ArrayStack.php
@@ -10,7 +10,7 @@
 namespace Zend\Stdlib;
 
 use ArrayIterator;
-use ArrayObject;
+use Zend\Stdlib\ArrayObject;
 
 /**
  * ArrayObject that acts as a stack with regards to iteration


### PR DESCRIPTION
Array object cannot be defined twice, this is a minor typo because it is not the php ArrayObject that is needed in this, but the Stdlib\ArrayObject.

stack call:
Fatal error: Cannot use ArrayObject as ArrayObject because the name is already in use

error is found with the 
skeleton application
doctrine module
doctrine orm module
doctrine dbal

EDIT:
"use ArrayObject;" must be "use Zend\Stdlib\ArrayObject;"
