### PR TITLE
Update ArrayStack.php

### DIFF
--- a/library/Zend/Stdlib/ArrayStack.php
+++ b/library/Zend/Stdlib/ArrayStack.php
@@ -10,12 +10,12 @@
 namespace Zend\Stdlib;
 
 use ArrayIterator;
-use ArrayObject;
+use ArrayObject as PhpArrayObject;
 
 /**
  * ArrayObject that acts as a stack with regards to iteration
  */
-class ArrayStack extends ArrayObject
+class ArrayStack extends PhpArrayObject
 {
     /**
      * Retrieve iterator


### PR DESCRIPTION
Array object cannot be defined twice, this is a minor typo because it is not the php ArrayObject that is needed in this, but the Stdlib\ArrayObject.

stack call:
Fatal error: Cannot use ArrayObject as ArrayObject because the name is already in use

error is found with the 
skeleton application
doctrine module
doctrine orm module
doctrine dbal

Rectified the error from my last pull request
