### PR TITLE
Reset SessionArrayStorage RequestAccessTime on fromArray when RequestAccessTime is false

### DIFF
--- a/library/Zend/Session/Storage/AbstractSessionArrayStorage.php
+++ b/library/Zend/Session/Storage/AbstractSessionArrayStorage.php
@@ -197,6 +197,9 @@ abstract class AbstractSessionArrayStorage implements IteratorAggregate, Storage
     {
         $ts = $this->getRequestAccessTime();
         $_SESSION = $array;
+        if (!$ts) {
+            $ts = microtime(true);
+        }
         $this->setRequestAccessTime($ts);
 
         return $this;

--- a/tests/ZendTest/Session/SessionArrayStorageTest.php
+++ b/tests/ZendTest/Session/SessionArrayStorageTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Session;
 
 use Zend\Session\Storage\SessionArrayStorage;
+use Zend\Session\SessionManager;
 use Zend\Session\Container;
 
 /**
@@ -164,6 +165,17 @@ class SessionArrayStorageTest extends \PHPUnit_Framework_TestCase
             'baz' => array('foo' => 'bar'),
         );
         $this->assertSame($expected, $this->storage->toArray(true));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRequestTimeFalseSetsToCurrentTime()
+    {
+        $ts = $this->storage->getRequestAccessTime();
+        $manager = new SessionManager(null, $this->storage);
+        $manager->start();
+        $this->assertNotEmpty($this->storage->getRequestAccessTime());
     }
 
 }


### PR DESCRIPTION
This resolves #3963 where RequestAccessTime is false for the SessionArrayStorage.  This happens since the storage is actually started prior to the SessionManager calling session_start.  Unfortunately it would break BC to add in a session initialization flag to assist in generating the storage.  Therefore the fix is to utilize the fromArray method and reset it instead.
