### PR TITLE
Zend\Filter\File\RenameUpload - Added possibility to maintain original file extension

### DIFF
--- a/library/Zend/Filter/File/RenameUpload.php
+++ b/library/Zend/Filter/File/RenameUpload.php
@@ -19,10 +19,11 @@ class RenameUpload extends AbstractFilter
      * @var array
      */
     protected $options = array(
-        'target'          => null,
-        'use_upload_name' => false,
-        'overwrite'       => false,
-        'randomize'       => false,
+        'target'               => null,
+        'use_upload_name'      => false,
+        'use_upload_extension' => false,
+        'overwrite'            => false,
+        'randomize'            => false,
     );
 
     /**
@@ -89,6 +90,25 @@ class RenameUpload extends AbstractFilter
     public function getUseUploadName()
     {
         return $this->options['use_upload_name'];
+    }
+
+    /**
+     * @param boolean $flag When true, this filter will use the original file
+     *                      extension for the target filename
+     * @return RenameUpload
+     */
+    public function setUseUploadExtension($flag = true)
+    {
+        $this->options['use_upload_extension'] = (boolean) $flag;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getUseUploadExtension()
+    {
+        return $this->options['use_upload_extension'];
     }
 
     /**
@@ -242,12 +262,19 @@ class RenameUpload extends AbstractFilter
             $targetFile = basename($uploadData['name']);
         } elseif (!is_dir($target)) {
             $targetFile = basename($target);
+            if ($this->getUseUploadExtension() && !$this->getRandomize()) {
+                $targetInfo = pathinfo($targetFile);
+                $sourceinfo = pathinfo($uploadData['name']);
+                if (isset($sourceinfo['extension'])) {
+                    $targetFile = $targetInfo['filename'] . '.' . $sourceinfo['extension'];
+                }
+            }
         } else {
             $targetFile = basename($source);
         }
 
         if ($this->getRandomize()) {
-            $targetFile = $this->applyRandomToFilename($targetFile);
+            $targetFile = $this->applyRandomToFilename($uploadData['name'], $targetFile);
         }
 
         return $targetDir . $targetFile;
@@ -257,13 +284,20 @@ class RenameUpload extends AbstractFilter
      * @param  string $filename
      * @return string
      */
-    protected function applyRandomToFilename($filename)
+    protected function applyRandomToFilename($source,$filename)
     {
         $info = pathinfo($filename);
         $filename = $info['filename'] . uniqid('_');
-        if (isset($info['extension'])) {
-            $filename .= '.' . $info['extension'];
+
+        $sourceinfo = pathinfo($source);
+
+        $extension = '';
+        if ($this->getUseUploadExtension() === true && isset($sourceinfo['extension'])) {
+            $extension .= '.' . $sourceinfo['extension'];
+        } else if (isset($info['extension'])) {
+            $extension .= '.' . $info['extension'];
         }
-        return $filename;
+
+        return $filename . $extension;
     }
 }

--- a/tests/ZendTest/Filter/File/RenameUploadTest.php
+++ b/tests/ZendTest/Filter/File/RenameUploadTest.php
@@ -258,6 +258,40 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('#' . $fileNoExt . '_.{13}\.xml#', $filter($this->_oldFile));
     }
 
+    public function testGetFileWithOriginalExtension()
+    {
+        $fileNoExt = $this->_filesPath . '/newfile';
+        $filter = new RenameUploadMock(array(
+            'target'          => $this->_newFile,
+            'use_upload_extension' => true,
+            'randomize'       => false,
+        ));
+
+        $oldFilePathInfo = pathinfo($this->_oldFile);
+
+        $this->assertRegExp(
+            '#' . $fileNoExt . '.'.$oldFilePathInfo['extension'].'#',
+            $filter($this->_oldFile)
+        );
+    }
+
+    public function testGetRandomizedFileWithOriginalExtension()
+    {
+        $fileNoExt = $this->_filesPath . '/newfile';
+        $filter = new RenameUploadMock(array(
+            'target'          => $this->_newFile,
+            'use_upload_extension' => true,
+            'randomize'       => true,
+        ));
+
+        $oldFilePathInfo = pathinfo($this->_oldFile);
+
+        $this->assertRegExp(
+            '#' . $fileNoExt . '_.{13}\.'.$oldFilePathInfo['extension'].'#',
+            $filter($this->_oldFile)
+        );
+    }
+
     /**
      * @return void
      */


### PR DESCRIPTION
When using the Zend\Filter\File\RenameUpload filter on a file upload (that can have any extension) the extension is lost if the target does not specify it.

Added a new option (use_upload_extension) that, when specified, maintains the original extension.

Example :

If the user uploads a .png image **test.png** :

``` php
<?php
$filter = new RenameUpload(array(
    'target'  => pictures,
    'use_upload_extension'  => true,
    'randomize'  => true,
 ));
```

The filter will return something like **pictures_ad321e2r5ty5s.png**

Works with randomize on and off.
