### PR TITLE
SessionArrayStorage Request Access Time and Storage Initialization

### DIFF
--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -103,8 +103,8 @@ class SessionManager extends AbstractManager
                 $storage->fromArray($_SESSION);
             }
             $_SESSION = $storage;
-        } elseif ($storage instanceof Storage\SessionArrayStorage) {
-            $storage->fromArray($_SESSION);
+        } elseif ($storage instanceof Storage\StorageInitializationInterface) {
+            $storage->init($_SESSION);
         }
 
         if (!$this->isValid()) {

--- a/library/Zend/Session/Storage/AbstractSessionArrayStorage.php
+++ b/library/Zend/Session/Storage/AbstractSessionArrayStorage.php
@@ -19,7 +19,7 @@ use Zend\Session\Exception;
  * Replaces the $_SESSION superglobal with an ArrayObject that allows for
  * property access, metadata storage, locking, and immutability.
  */
-abstract class AbstractSessionArrayStorage implements IteratorAggregate, StorageInterface
+abstract class AbstractSessionArrayStorage implements IteratorAggregate, StorageInterface, StorageInitializationInterface
 {
     /**
      * Constructor
@@ -27,6 +27,19 @@ abstract class AbstractSessionArrayStorage implements IteratorAggregate, Storage
      * @param array|null $input
      */
     public function __construct($input = null)
+    {
+        // this is here for B.C.
+        $this->init($input);
+    }
+
+
+    /**
+     * Initialize Storage
+     *
+     * @param  array $input
+     * @return void
+     */
+    public function init($input = null)
     {
         if ((null === $input) && isset($_SESSION)) {
             $input = $_SESSION;

--- a/library/Zend/Session/Storage/StorageInitializationInterface.php
+++ b/library/Zend/Session/Storage/StorageInitializationInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Session\Storage;
+
+/**
+ * Session storage interface
+ *
+ * Defines the minimum requirements for handling userland, in-script session
+ * storage (e.g., the $_SESSION superglobal array).
+ */
+interface StorageInitializationInterface
+{
+    /**
+     * Initialize Session Storage
+     *
+     * @param  array $input
+     * @return void
+     */
+    public function init($input = null);
+}

--- a/tests/ZendTest/Session/SessionArrayStorageTest.php
+++ b/tests/ZendTest/Session/SessionArrayStorageTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Session;
 
 use Zend\Session\Storage\SessionArrayStorage;
+use Zend\Session\SessionManager;
 use Zend\Session\Container;
 
 /**
@@ -164,6 +165,43 @@ class SessionArrayStorageTest extends \PHPUnit_Framework_TestCase
             'baz' => array('foo' => 'bar'),
         );
         $this->assertSame($expected, $this->storage->toArray(true));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testExpirationHops()
+    {
+        // since we cannot explicitly test reinitalizing the session
+        // we will act in how session manager would in this case.
+        $storage = new SessionArrayStorage();
+        $manager = new SessionManager(null, $storage);
+        $manager->start();
+
+        $container = new Container('test');
+        $container->foo = 'bar';
+        $container->setExpirationHops(1);
+
+        $copy = $_SESSION;
+        $_SESSION = null;
+        $storage->init($copy);
+        $this->assertEquals('bar', $container->foo);
+
+        $copy = $_SESSION;
+        $_SESSION = null;
+        $storage->init($copy);
+        $this->assertNull($container->foo);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testPreserveRequestAccessTimeAfterStart()
+    {
+        $manager = new SessionManager(null, $this->storage);
+        $this->assertGreaterThan(0, $this->storage->getRequestAccessTime());
+        $manager->start();
+        $this->assertGreaterThan(0, $this->storage->getRequestAccessTime());
     }
 
 }


### PR DESCRIPTION
Resolved #3963 #3971

This change adds a new interface: StorageInitializationInterface which is used by SessionArrayStorage to populate the RequestAccessTime.  

If I can get anyone in the referenced issues to please test this out and ensure that the issues that they are seeing have been resolved.  Additionally I have put this into my own sample code to verify that it is not expiring hops too soon and so it should be good to go.

Test, test away :+1: 
