### PR TITLE
Chain route

### DIFF
--- a/library/Zend/Mvc/Router/Http/Chain.php
+++ b/library/Zend/Mvc/Router/Http/Chain.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Router\Http;
+
+use Traversable;
+use Zend\Mvc\Router\Exception;
+use Zend\Mvc\Router\PriorityList;
+use Zend\Mvc\Router\RoutePluginManager;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Stdlib\RequestInterface as Request;
+
+/**
+ * Chain route.
+ */
+class Chain extends TreeRouteStack implements RouteInterface
+{
+    /**
+     * Chain routes.
+     *
+     * @var array
+     */
+    protected $chainRoutes;
+
+    /**
+     * List of assembled parameters.
+     *
+     * @var array
+     */
+    protected $assembledParams = array();
+
+    /**
+     * Create a new part route.
+     *
+     * @param  array              $routes
+     * @param  RoutePluginManager $routePlugins
+     * @throws Exception\InvalidArgumentException
+     */
+    public function __construct(array $routes, RoutePluginManager $routePlugins)
+    {
+        $this->chainRoutes         = array_reverse($routes);
+        $this->routePluginManager  = $routePlugins;
+        $this->routes              = new PriorityList();
+    }
+
+    /**
+     * factory(): defined by RouteInterface interface.
+     *
+     * @see    \Zend\Mvc\Router\RouteInterface::factory()
+     * @param  mixed $options
+     * @throws Exception\InvalidArgumentException
+     * @return Part
+     */
+    public static function factory($options = array())
+    {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        } elseif (!is_array($options)) {
+            throw new Exception\InvalidArgumentException(__METHOD__ . ' expects an array or Traversable set of options');
+        }
+
+        if (!isset($options['routes'])) {
+            throw new Exception\InvalidArgumentException('Missing "route" in options array');
+        }
+
+        if ($options['routes'] instanceof Traversable) {
+            $options['routes'] = ArrayUtils::iteratorToArray($options['child_routes']);
+        }
+
+        if (!isset($options['route_plugins'])) {
+            throw new Exception\InvalidArgumentException('Missing "route_plugins" in options array');
+        }
+
+        return new static($options['routes'], $options['route_plugins']);
+    }
+
+    /**
+     * match(): defined by RouteInterface interface.
+     *
+     * @see    \Zend\Mvc\Router\RouteInterface::match()
+     * @param  Request  $request
+     * @param  int|null $pathOffset
+     * @return RouteMatch|null
+     */
+    public function match(Request $request, $pathOffset = null)
+    {
+        if (!method_exists($request, 'getUri')) {
+            return null;
+        }
+
+        if ($pathOffset === null) {
+            $mustTerminate = true;
+            $pathOffset    = 0;
+        } else {
+            $mustTerminate = false;
+        }
+
+        if ($this->chainRoutes !== null) {
+            $this->addRoutes($this->chainRoutes);
+            $this->chainRoutes = null;
+        }
+
+        $match      = new RouteMatch(array());
+        $uri        = $request->getUri();
+        $pathLength = strlen($uri->getPath());
+
+        foreach ($this->routes as $route) {
+            $subMatch = $route->match($request, $pathOffset);
+
+            if ($subMatch === null) {
+                return null;
+            }
+
+            $match->merge($subMatch);
+            $pathOffset += $subMatch->getLength();
+        }
+
+        if ($mustTerminate && $pathOffset !== $pathLength) {
+            return null;
+        }
+
+        return $match;
+    }
+
+    /**
+     * assemble(): Defined by RouteInterface interface.
+     *
+     * @see    \Zend\Mvc\Router\RouteInterface::assemble()
+     * @param  array $params
+     * @param  array $options
+     * @return mixed
+     */
+    public function assemble(array $params = array(), array $options = array())
+    {
+       if ($this->chainRoutes !== null) {
+            $this->addRoutes($this->chainRoutes);
+            $this->chainRoutes = null;
+        }
+
+        $this->assembledParams = array();
+
+        end($this->routes);
+        $lastRouteKey = key($this->routes);
+        $path         = '';
+
+        foreach ($this->routes as $key => $route) {
+            $chainOptions = $options;
+            $chainOptions['has_child'] = ($options['has_child'] || $key !== $lastRouteKey);
+
+            $path   .= $route->assemble($params, $chainOptions);
+            $params  = array_diff_key($params, array_flip($route->getAssembledParams()));
+
+            $this->assembledParams += $route->getAssembledParams();
+        }
+
+        return $path;
+    }
+
+    /**
+     * getAssembledParams(): defined by RouteInterface interface.
+     *
+     * @see    RouteInterface::getAssembledParams
+     * @return array
+     */
+    public function getAssembledParams()
+    {
+        return $this->assembledParams;
+    }
+}

--- a/library/Zend/Mvc/Router/Http/Chain.php
+++ b/library/Zend/Mvc/Router/Http/Chain.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Mvc\Router\Http;
 
+use ArrayObject;
 use Traversable;
 use Zend\Mvc\Router\Exception;
 use Zend\Mvc\Router\PriorityList;
@@ -40,13 +41,14 @@ class Chain extends TreeRouteStack implements RouteInterface
      *
      * @param  array              $routes
      * @param  RoutePluginManager $routePlugins
-     * @throws Exception\InvalidArgumentException
+     * @param  ArrayObject        $prototypes
      */
-    public function __construct(array $routes, RoutePluginManager $routePlugins)
+    public function __construct(array $routes, RoutePluginManager $routePlugins, ArrayObject $prototypes)
     {
         $this->chainRoutes         = array_reverse($routes);
         $this->routePluginManager  = $routePlugins;
         $this->routes              = new PriorityList();
+        $this->prototypes          = $prototypes;
     }
 
     /**
@@ -69,6 +71,10 @@ class Chain extends TreeRouteStack implements RouteInterface
             throw new Exception\InvalidArgumentException('Missing "route" in options array');
         }
 
+        if (!isset($options['prototypes'])) {
+            throw new Exception\InvalidArgumentException('Missing "prototypes" in options array');
+        }
+
         if ($options['routes'] instanceof Traversable) {
             $options['routes'] = ArrayUtils::iteratorToArray($options['child_routes']);
         }
@@ -77,7 +83,11 @@ class Chain extends TreeRouteStack implements RouteInterface
             throw new Exception\InvalidArgumentException('Missing "route_plugins" in options array');
         }
 
-        return new static($options['routes'], $options['route_plugins']);
+        return new static(
+            $options['routes'],
+            $options['route_plugins'],
+            $options['prototypes']
+        );
     }
 
     /**

--- a/library/Zend/Mvc/Router/Http/Chain.php
+++ b/library/Zend/Mvc/Router/Http/Chain.php
@@ -41,9 +41,9 @@ class Chain extends TreeRouteStack implements RouteInterface
      *
      * @param  array              $routes
      * @param  RoutePluginManager $routePlugins
-     * @param  ArrayObject        $prototypes
+     * @param  ArrayObject|null   $prototypes
      */
-    public function __construct(array $routes, RoutePluginManager $routePlugins, ArrayObject $prototypes)
+    public function __construct(array $routes, RoutePluginManager $routePlugins, ArrayObject $prototypes = null)
     {
         $this->chainRoutes         = array_reverse($routes);
         $this->routePluginManager  = $routePlugins;
@@ -68,11 +68,11 @@ class Chain extends TreeRouteStack implements RouteInterface
         }
 
         if (!isset($options['routes'])) {
-            throw new Exception\InvalidArgumentException('Missing "route" in options array');
+            throw new Exception\InvalidArgumentException('Missing "routes" in options array');
         }
 
         if (!isset($options['prototypes'])) {
-            throw new Exception\InvalidArgumentException('Missing "prototypes" in options array');
+            $options['prototypes'] = null;
         }
 
         if ($options['routes'] instanceof Traversable) {
@@ -96,9 +96,10 @@ class Chain extends TreeRouteStack implements RouteInterface
      * @see    \Zend\Mvc\Router\RouteInterface::match()
      * @param  Request  $request
      * @param  int|null $pathOffset
+     * @param  array    $options
      * @return RouteMatch|null
      */
-    public function match(Request $request, $pathOffset = null)
+    public function match(Request $request, $pathOffset = null, array $options = array())
     {
         if (!method_exists($request, 'getUri')) {
             return null;
@@ -121,7 +122,7 @@ class Chain extends TreeRouteStack implements RouteInterface
         $pathLength = strlen($uri->getPath());
 
         foreach ($this->routes as $route) {
-            $subMatch = $route->match($request, $pathOffset);
+            $subMatch = $route->match($request, $pathOffset, $options);
 
             if ($subMatch === null) {
                 return null;
@@ -161,7 +162,7 @@ class Chain extends TreeRouteStack implements RouteInterface
 
         foreach ($this->routes as $key => $route) {
             $chainOptions = $options;
-            $chainOptions['has_child'] = ($options['has_child'] || $key !== $lastRouteKey);
+            $chainOptions['has_child'] = ((isset($options['has_child']) ? $options['has_child'] : false) || $key !== $lastRouteKey);
 
             $path   .= $route->assemble($params, $chainOptions);
             $params  = array_diff_key($params, array_flip($route->getAssembledParams()));

--- a/library/Zend/Mvc/Router/Http/Part.php
+++ b/library/Zend/Mvc/Router/Http/Part.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Mvc\Router\Http;
 
+use ArrayObject;
 use Traversable;
 use Zend\Mvc\Router\Exception;
 use Zend\Mvc\Router\PriorityList;
@@ -48,12 +49,13 @@ class Part extends TreeRouteStack implements RouteInterface
      * Create a new part route.
      *
      * @param  mixed              $route
-     * @param  bool            $mayTerminate
+     * @param  bool               $mayTerminate
      * @param  RoutePluginManager $routePlugins
      * @param  array|null         $childRoutes
+     * @param  ArrayObject        $prototypes
      * @throws Exception\InvalidArgumentException
      */
-    public function __construct($route, $mayTerminate, RoutePluginManager $routePlugins, array $childRoutes = null)
+    public function __construct($route, $mayTerminate, RoutePluginManager $routePlugins, array $childRoutes = null, ArrayObject $prototypes = null)
     {
         $this->routePluginManager = $routePlugins;
 
@@ -68,6 +70,7 @@ class Part extends TreeRouteStack implements RouteInterface
         $this->route        = $route;
         $this->mayTerminate = $mayTerminate;
         $this->childRoutes  = $childRoutes;
+        $this->prototypes   = $prototypes;
         $this->routes       = new PriorityList();
     }
 
@@ -95,6 +98,10 @@ class Part extends TreeRouteStack implements RouteInterface
             throw new Exception\InvalidArgumentException('Missing "route_plugins" in options array');
         }
 
+        if (!isset($options['prototypes'])) {
+            $options['prototypes'] = null;
+        }
+
         if (!isset($options['may_terminate'])) {
             $options['may_terminate'] = false;
         }
@@ -106,7 +113,13 @@ class Part extends TreeRouteStack implements RouteInterface
             $options['child_routes'] = ArrayUtils::iteratorToArray($options['child_routes']);
         }
 
-        return new static($options['route'], $options['may_terminate'], $options['route_plugins'], $options['child_routes']);
+        return new static(
+            $options['route'],
+            $options['may_terminate'],
+            $options['route_plugins'],
+            $options['child_routes'],
+            $options['prototypes']
+        );
     }
 
     /**

--- a/library/Zend/Mvc/Router/Http/Part.php
+++ b/library/Zend/Mvc/Router/Http/Part.php
@@ -52,7 +52,7 @@ class Part extends TreeRouteStack implements RouteInterface
      * @param  bool               $mayTerminate
      * @param  RoutePluginManager $routePlugins
      * @param  array|null         $childRoutes
-     * @param  ArrayObject        $prototypes
+     * @param  ArrayObject|null   $prototypes
      * @throws Exception\InvalidArgumentException
      */
     public function __construct($route, $mayTerminate, RoutePluginManager $routePlugins, array $childRoutes = null, ArrayObject $prototypes = null)

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -145,7 +145,7 @@ class TreeRouteStack extends SimpleRouteStack
                 throw new Exception\InvalidArgumentException('Chain routes must be an array or Traversable object');
             }
 
-            $chainRoutes = array($specs) + $specs['chain_routes'];
+            $chainRoutes = array_merge(array($specs), $specs['chain_routes']);
             unset($chainRoutes[0]['chain_routes']);
 
             $options = array(

--- a/tests/ZendTest/Mvc/Router/Http/ChainTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/ChainTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc\Router\Http;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Http\Request as Request;
+use Zend\Mvc\Router\RoutePluginManager;
+use Zend\Mvc\Router\Http\Chain;
+use ZendTest\Mvc\Router\FactoryTester;
+
+class ChainTest extends TestCase
+{
+    public static function getRoute()
+    {
+        $routePlugins = new RoutePluginManager();
+
+        return new Chain(
+            array(
+                array(
+                    'type'    => 'Zend\Mvc\Router\Http\Segment',
+                    'options' => array(
+                        'route'    => '/:controller',
+                        'defaults' => array(
+                            'controller' => 'foo'
+                        )
+                    ),
+                ),
+                array(
+                    'type'    => 'Zend\Mvc\Router\Http\Segment',
+                    'options' => array(
+                        'route'    => '/:bar',
+                        'defaults' => array(
+                            'bar' => 'bar'
+                        )
+                    ),
+                ),
+                array(
+                    'type' => 'Zend\Mvc\Router\Http\Wildcard',
+                ),
+            ),
+            $routePlugins
+        );
+    }
+
+    public static function routeProvider()
+    {
+        return array(
+            'simple-match' => array(
+                self::getRoute(),
+                '/foo/bar',
+                null,
+                array('controller' => 'foo', 'bar' => 'bar')
+            ),
+            'offset-skips-beginning' => array(
+                self::getRoute(),
+                '/baz/foo/bar',
+                4,
+                array('controller' => 'foo', 'bar' => 'bar')
+            ),
+            'parameters-are-used-only-once' => array(
+                self::getRoute(),
+                '/foo/baz',
+                null,
+                array('controller' => 'foo', 'bar' => 'baz')
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider routeProvider
+     * @param        Chain   $route
+     * @param        string  $path
+     * @param        integer $offset
+     * @param        array   $params
+     */
+    public function testMatching(Chain $route, $path, $offset, array $params = null)
+    {
+        $request = new Request();
+        $request->setUri('http://example.com' . $path);
+        $match = $route->match($request, $offset);
+
+        if ($params === null) {
+            $this->assertNull($match);
+        } else {
+            $this->assertInstanceOf('Zend\Mvc\Router\Http\RouteMatch', $match);
+
+            if ($offset === null) {
+                $this->assertEquals(strlen($path), $match->getLength());
+            }
+
+            foreach ($params as $key => $value) {
+                $this->assertEquals($value, $match->getParam($key));
+            }
+        }
+    }
+
+    /**
+     * @dataProvider routeProvider
+     * @param        Chain   $route
+     * @param        string  $path
+     * @param        integer $offset
+     * @param        string  $routeName
+     * @param        array   $params
+     */
+    public function testAssembling(Chain $route, $path, $offset, array $params = null)
+    {
+        if ($params === null) {
+            // Data which will not match are not tested for assembling.
+            return;
+        }
+
+        $result = $route->assemble($params);
+
+        if ($offset !== null) {
+            $this->assertEquals($offset, strpos($path, $result, $offset));
+        } else {
+            $this->assertEquals($path, $result);
+        }
+    }
+
+    public function testFactory()
+    {
+        $tester = new FactoryTester($this);
+        $tester->testFactory(
+            'Zend\Mvc\Router\Http\Chain',
+            array(
+                'routes'        => 'Missing "routes" in options array',
+                'route_plugins' => 'Missing "route_plugins" in options array'
+            ),
+            array(
+                'routes'        => array(),
+                'route_plugins' => new RoutePluginManager()
+            )
+        );
+    }
+}

--- a/tests/ZendTest/Mvc/Router/Http/TreeRouteStackTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/TreeRouteStackTest.php
@@ -350,6 +350,39 @@ class TreeRouteStackTest extends TestCase
         $this->assertEquals(1000, $routes->get('foo')->priority);
     }
 
+    public function testPrototypeRoute()
+    {
+        $stack = new TreeRouteStack();
+        $stack->addPrototype(
+            'bar',
+            array('type' => 'literal', 'options' => array('route' => '/bar'))
+        );
+        $stack->addRoute('foo', 'bar');
+        $this->assertEquals('/bar', $stack->assemble(array(), array('name' => 'foo')));
+    }
+
+    public function testChainRouteAssembling()
+    {
+        $stack = new TreeRouteStack();
+        $stack->addPrototype(
+            'bar',
+            array('type' => 'literal', 'options' => array('route' => '/bar'))
+        );
+        $stack->addRoute(
+            'foo',
+            array(
+                'type' => 'literal',
+                'options' => array(
+                    'route' => '/foo'
+                ),
+                'chain_routes' => array(
+                    'bar'
+                ),
+            )
+        );
+        $this->assertEquals('/foo/bar', $stack->assemble(array(), array('name' => 'foo')));
+    }
+
     public function testFactory()
     {
         $tester = new FactoryTester($this);


### PR DESCRIPTION
This new route type allows to glue multiple routes together under a single route. This allows to address them with a single name. Common use-cases are:
- Connecting a path route with a scheme route (forcing HTTPS)
- Connecting a path route with a wildcard route
- Basically any case where you have "may_terminate = false" on the parent and only a single child

Here is a simple example of how the feature can be used:

``` php
array(
    'routes' => array(
        'login' => array(
            'type' => 'literal',
            'options' => array(
                'route'    => '/login',
                'defaults' => array(/* … */)
            ),
            'chain_routes' => array(
                array(
                    'type' => 'scheme',
                    'options' => array(
                        'scheme' => 'https'
                    )
                )
            )
        )
    )
);
```

The chains are processed in FIFO order. In the above example, the 'login' route may also have child_routes, in which case the base route of that branch becomes the combined chain of the literal and the scheme route.

The route and factory is designed that way that it allows other modules to easily add conditions (like HTTPS) on a login route without changing the assembling structure.

This PR is so far feature complete, but yet lacks unit tests.
