### PR TITLE
MVC Bootstap Config

### DIFF
--- a/library/Zend/Mvc/Bootstrap/ConfigManager.php
+++ b/library/Zend/Mvc/Bootstrap/ConfigManager.php
@@ -1,0 +1,329 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Bootstrap;
+
+use Traversable;
+use Zend\Config\Config;
+use Zend\Config\Factory as ConfigFactory;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Stdlib\Glob;
+
+/**
+ * Config listener
+ */
+class ConfigManager implements
+    ConfigMergerInterface
+{
+    const STATIC_PATH = 'static_path';
+    const GLOB_PATH   = 'glob_path';
+
+    /**
+     * @var ConfigOptions
+     */
+    protected $options;
+
+    /**
+     * @var array
+     */
+    protected $configs = array();
+
+    /**
+     * @var array
+     */
+    protected $mergedConfig = array();
+
+    /**
+     * @var Config
+     */
+    protected $mergedConfigObject;
+
+    /**
+     * @var array
+     */
+    protected $paths = array();
+
+    /**
+     * @param ConfigOptions $options
+     */
+    public function __construct(ConfigOptions $options = null)
+    {
+        if (null === $options) {
+            $this->setOptions(new ConfigOptions);
+        } else {
+            $this->setOptions($options);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function loadMergedConfig()
+    {
+        if ($this->hasCachedConfig()) {
+            $this->setMergedConfig($this->getCachedConfig());
+            return $this->mergedConfig;
+        } else {
+            $this->addConfigGlobPaths($this->getOptions()->getConfigGlobPaths());
+            $this->addConfigStaticPaths($this->getOptions()->getConfigStaticPaths());
+        }
+
+        // Load the config files
+        foreach ($this->paths as $path) {
+            $this->addConfigByPath($path['path'], $path['type']);
+        }
+
+        // Merge all of the collected configs
+        $this->mergedConfig = $this->getOptions()->getExtraConfig() ?: array();
+        foreach ($this->configs as $config) {
+            $this->mergedConfig = ArrayUtils::merge($this->mergedConfig, $config);
+        }
+
+        $configFile = $this->getOptions()->getConfigCacheFile();
+        $this->writeArrayToFile($configFile, $this->getMergedConfig(false));
+
+        return $this->mergedConfig;
+    }
+
+    /**
+     * getMergedConfig
+     *
+     * @param  bool $returnConfigAsObject
+     * @return mixed
+     */
+    public function getMergedConfig($returnConfigAsObject = true)
+    {
+        if ($returnConfigAsObject === true) {
+            if ($this->mergedConfigObject === null) {
+                $this->mergedConfigObject = new Config($this->mergedConfig);
+            }
+            return $this->mergedConfigObject;
+        }
+
+        return $this->mergedConfig;
+    }
+
+    /**
+     * setMergedConfig
+     *
+     * @param  array $config
+     * @return ConfigManager
+     */
+    public function setMergedConfig(array $config)
+    {
+        $this->mergedConfig = $config;
+        $this->mergedConfigObject = null;
+        return $this;
+    }
+
+    /**
+     * Add an array of glob paths of config files to merge after loading modules
+     *
+     * @param  array|Traversable $globPaths
+     * @return ConfigManager
+     */
+    public function addConfigGlobPaths($globPaths)
+    {
+        $this->addConfigPaths($globPaths, self::GLOB_PATH);
+        return $this;
+    }
+
+    /**
+     * Add a glob path of config files to merge after loading modules
+     *
+     * @param  string $globPath
+     * @return ConfigManager
+     */
+    public function addConfigGlobPath($globPath)
+    {
+        $this->addConfigPath($globPath, self::GLOB_PATH);
+        return $this;
+    }
+
+    /**
+     * Add an array of static paths of config files to merge after loading modules
+     *
+     * @param  array|Traversable $staticPaths
+     * @return ConfigManager
+     */
+    public function addConfigStaticPaths($staticPaths)
+    {
+        $this->addConfigPaths($staticPaths, self::STATIC_PATH);
+        return $this;
+    }
+
+    /**
+     * Add a static path of config files to merge after loading modules
+     *
+     * @param  string $staticPath
+     * @return ConfigManager
+     */
+    public function addConfigStaticPath($staticPath)
+    {
+        $this->addConfigPath($staticPath, self::STATIC_PATH);
+        return $this;
+    }
+
+    /**
+     * Add an array of paths of config files to merge after loading modules
+     *
+     * @param  Traversable|array $paths
+     * @param string $type
+     * @throws Exception\InvalidArgumentException
+     * @return ConfigManager
+     */
+    protected function addConfigPaths($paths, $type)
+    {
+        if ($paths instanceof Traversable) {
+            $paths = ArrayUtils::iteratorToArray($paths);
+        }
+
+        if (!is_array($paths)) {
+            throw new Exception\InvalidArgumentException(
+                sprintf('Argument passed to %::%s() must be an array, '
+                . 'implement the Traversable interface, or be an '
+                . 'instance of Zend\Config\Config. %s given.',
+                __CLASS__, __METHOD__, gettype($paths))
+            );
+        }
+
+        foreach ($paths as $path) {
+            $this->addConfigPath($path, $type);
+        }
+    }
+
+    /**
+     * Add a path of config files to load and merge after loading modules
+     *
+     * @param  string $path
+     * @param  string $type
+     * @throws Exception\InvalidArgumentException
+     * @return ConfigManager
+     */
+    protected function addConfigPath($path, $type)
+    {
+        if (!is_string($path)) {
+            throw new Exception\InvalidArgumentException(
+                sprintf('Parameter to %s::%s() must be a string; %s given.',
+                __CLASS__, __METHOD__, gettype($path))
+            );
+        }
+        $this->paths[] = array('type' => $type, 'path' => $path);
+        return $this;
+    }
+
+    /**
+     * @param string $key
+     * @param array|Traversable $config
+     * @throws Exception\InvalidArgumentException
+     * @return ConfigManager
+     */
+    protected function addConfig($key, $config)
+    {
+        if ($config instanceof Traversable) {
+            $config = ArrayUtils::iteratorToArray($config);
+        }
+
+        if (!is_array($config)) {
+            throw new Exception\InvalidArgumentException(
+                sprintf('Config being merged must be an array, '
+                . 'implement the Traversable interface, or be an '
+                . 'instance of Zend\Config\Config. %s given.', gettype($config))
+            );
+        }
+
+        $this->configs[$key] = $config;
+
+        return $this;
+    }
+
+    /**
+     * Given a path (glob or static), fetch the config and add it to the array
+     * of configs to merge.
+     *
+     * @param string $path
+     * @param string $type
+     * @return ConfigManager
+     */
+    protected function addConfigByPath($path, $type)
+    {
+        switch ($type) {
+            case self::STATIC_PATH:
+                $this->addConfig($path, ConfigFactory::fromFile($path));
+                break;
+
+            case self::GLOB_PATH:
+                // We want to keep track of where each value came from so we don't
+                // use ConfigFactory::fromFiles() since it does merging internally.
+                foreach (Glob::glob($path, Glob::GLOB_BRACE) as $file) {
+                    $this->addConfig($file, ConfigFactory::fromFile($file));
+                }
+                break;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function hasCachedConfig()
+    {
+        if (($this->getOptions()->getConfigCacheEnabled())
+            && (file_exists($this->getOptions()->getConfigCacheFile()))
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @return mixed
+     */
+    protected function getCachedConfig()
+    {
+        return include $this->getOptions()->getConfigCacheFile();
+    }
+
+    /**
+     * Get options.
+     *
+     * @return ConfigOptions
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * Set options.
+     *
+     * @param ConfigOptions $options the value to be set
+     * @return ConfigManager
+     */
+    public function setOptions(ConfigOptions $options)
+    {
+        $this->options = $options;
+        return $this;
+    }
+
+    /**
+     * Write a simple array of scalars to a file
+     *
+     * @param  string $filePath
+     * @param  array $array
+     * @return ConfigManager
+     */
+    protected function writeArrayToFile($filePath, $array)
+    {
+        $content = "<?php\nreturn " . var_export($array, 1) . ';';
+        file_put_contents($filePath, $content);
+        return $this;
+    }
+}

--- a/library/Zend/Mvc/Bootstrap/ConfigMergerInterface.php
+++ b/library/Zend/Mvc/Bootstrap/ConfigMergerInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Bootstrap;
+
+/**
+ * Config merger interface
+ */
+interface ConfigMergerInterface
+{
+    /**
+     * getMergedConfig
+     *
+     * @param  bool $returnConfigAsObject
+     * @return mixed
+     */
+    public function getMergedConfig($returnConfigAsObject = true);
+
+    /**
+     * setMergedConfig
+     *
+     * @param  array $config
+     * @return ConfigMergerInterface
+     */
+    public function setMergedConfig(array $config);
+}

--- a/library/Zend/Mvc/Bootstrap/ConfigOptions.php
+++ b/library/Zend/Mvc/Bootstrap/ConfigOptions.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Bootstrap;
+
+use Traversable;
+use Zend\Stdlib\AbstractOptions;
+
+/**
+ * Config options
+ */
+class ConfigOptions extends AbstractOptions
+{
+
+    /**
+     * @var array
+     */
+    protected $configGlobPaths = array();
+
+    /**
+     * @var array
+     */
+    protected $configStaticPaths = array();
+
+    /**
+     * @var array
+     */
+    protected $extraConfig = array();
+
+    /**
+     * @var bool
+     */
+    protected $configCacheEnabled = false;
+
+    /**
+     * @var string
+     */
+    protected $configCacheKey;
+
+    /**
+     * @var string
+     */
+    protected $cacheDir;
+
+    /**
+     * Get the glob patterns to load additional config files
+     *
+     * @return array
+     */
+    public function getConfigGlobPaths()
+    {
+        return $this->configGlobPaths;
+    }
+
+    /**
+     * Get the static paths to load additional config files
+     *
+     * @return array
+     */
+    public function getConfigStaticPaths()
+    {
+        return $this->configStaticPaths;
+    }
+
+    /**
+     * Set the glob patterns to use for loading additional config files
+     *
+     * @param array|Traversable $configGlobPaths
+     * @throws Exception\InvalidArgumentException
+     * @return ConfigOptions Provides fluent interface
+     */
+    public function setConfigGlobPaths($configGlobPaths)
+    {
+        if (!is_array($configGlobPaths) && !$configGlobPaths instanceof Traversable) {
+            throw new Exception\InvalidArgumentException(
+                sprintf('Argument passed to %s::%s() must be an array, '
+                . 'implement the Traversable interface, or be an '
+                . 'instance of Zend\Config\Config. %s given.',
+                __CLASS__, __METHOD__, gettype($configGlobPaths))
+            );
+        }
+
+        $this->configGlobPaths = $configGlobPaths;
+        return $this;
+    }
+
+    /**
+     * Set the static paths to use for loading additional config files
+     *
+     * @param array|Traversable $configStaticPaths
+     * @throws Exception\InvalidArgumentException
+     * @return ConfigOptions Provides fluent interface
+     */
+    public function setConfigStaticPaths($configStaticPaths)
+    {
+        if (!is_array($configStaticPaths) && !$configStaticPaths instanceof Traversable) {
+            throw new Exception\InvalidArgumentException(
+                sprintf('Argument passed to %s::%s() must be an array, '
+                . 'implement the Traversable interface, or be an '
+                . 'instance of Zend\Config\Config. %s given.',
+                __CLASS__, __METHOD__, gettype($configStaticPaths))
+            );
+        }
+
+        $this->configStaticPaths = $configStaticPaths;
+        return $this;
+    }
+
+    /**
+     * Get any extra config to merge in.
+     *
+     * @return array|Traversable
+     */
+    public function getExtraConfig()
+    {
+        return $this->extraConfig;
+    }
+
+    /**
+     * Add some extra config array to the main config. This is mainly useful
+     * for unit testing purposes.
+     *
+     * @param array|Traversable $extraConfig
+     * @throws Exception\InvalidArgumentException
+     * @return ConfigOptions Provides fluent interface
+     */
+    public function setExtraConfig($extraConfig)
+    {
+        if (!is_array($extraConfig) && !$extraConfig instanceof Traversable) {
+            throw new Exception\InvalidArgumentException(
+                sprintf('Argument passed to %s::%s() must be an array, '
+                . 'implement the Traversable interface, or be an '
+                . 'instance of Zend\Config\Config. %s given.',
+                __CLASS__, __METHOD__, gettype($extraConfig))
+            );
+        }
+
+        $this->extraConfig = $extraConfig;
+        return $this;
+    }
+
+    /**
+     * Check if the config cache is enabled
+     *
+     * @return bool
+     */
+    public function getConfigCacheEnabled()
+    {
+        return $this->configCacheEnabled;
+    }
+
+    /**
+     * Set if the config cache should be enabled or not
+     *
+     * @param  bool $enabled
+     * @return ConfigOptions
+     */
+    public function setConfigCacheEnabled($enabled)
+    {
+        $this->configCacheEnabled = (bool) $enabled;
+        return $this;
+    }
+
+    /**
+     * Get key used to create the cache file name
+     *
+     * @return string
+     */
+    public function getConfigCacheKey()
+    {
+        return (string) $this->configCacheKey;
+    }
+
+    /**
+     * Set key used to create the cache file name
+     *
+     * @param  string $configCacheKey the value to be set
+     * @return ConfigOptions
+     */
+    public function setConfigCacheKey($configCacheKey)
+    {
+        $this->configCacheKey = $configCacheKey;
+        return $this;
+    }
+
+    /**
+     * Get the path to the config cache
+     *
+     * Should this be an option, or should the dir option include the
+     * filename, or should it simply remain hard-coded? Thoughts?
+     *
+     * @return string
+     */
+    public function getConfigCacheFile()
+    {
+        return $this->getCacheDir() . DIRECTORY_SEPARATOR . $this->getConfigCacheKey().'.php';
+    }
+
+    /**
+     * Get the path where cache file(s) are stored
+     *
+     * @throws Exception\RuntimeException
+     * @return string
+     */
+    public function getCacheDir()
+    {
+        if (isset($this->cacheDir)) {
+            return $this->cacheDir;
+        }
+
+        throw new Exception\RuntimeException('Cache directory not specified');
+    }
+
+    /**
+     * Set the path where cache files can be stored
+     *
+     * @param  string $cacheDir the value to be set
+     * @return ConfigOptions
+     */
+    public function setCacheDir($cacheDir)
+    {
+        if (null === $cacheDir) {
+            $this->cacheDir = $cacheDir;
+        } else {
+            $this->cacheDir = static::normalizePath($cacheDir);
+        }
+        return $this;
+    }
+
+    /**
+     * Normalize a path for insertion in the stack
+     *
+     * @param  string $path
+     * @return string
+     */
+    public static function normalizePath($path)
+    {
+        $path = rtrim($path, '/');
+        $path = rtrim($path, '\\');
+        return $path;
+    }
+}

--- a/library/Zend/Mvc/Bootstrap/ConfigOptions.php
+++ b/library/Zend/Mvc/Bootstrap/ConfigOptions.php
@@ -46,6 +46,11 @@ class ConfigOptions extends AbstractOptions
     /**
      * @var string
      */
+    protected $configCacheKeyPrefix;
+
+    /**
+     * @var string
+     */
     protected $cacheDir;
 
     /**
@@ -190,6 +195,28 @@ class ConfigOptions extends AbstractOptions
     }
 
     /**
+     * Get key prefix used to create the cache file name
+     *
+     * @return string
+     */
+    public function getConfigCacheKeyPrefix()
+    {
+        return (string) $this->configCacheKeyPrefix;
+    }
+
+    /**
+     * Set key prefix used to create the cache file name
+     *
+     * @param  string $configCacheKeyPrefix the value to be set
+     * @return ConfigOptions
+     */
+    public function setConfigCacheKeyPrefix($configCacheKeyPrefix)
+    {
+        $this->configCacheKeyPrefix = $configCacheKeyPrefix;
+        return $this;
+    }
+
+    /**
      * Get the path to the config cache
      *
      * Should this be an option, or should the dir option include the
@@ -199,7 +226,7 @@ class ConfigOptions extends AbstractOptions
      */
     public function getConfigCacheFile()
     {
-        return $this->getCacheDir() . DIRECTORY_SEPARATOR . $this->getConfigCacheKey().'.php';
+        return $this->getCacheDir() . DIRECTORY_SEPARATOR . $this->getConfigCacheKeyPrefix() . $this->getConfigCacheKey() . '.php';
     }
 
     /**

--- a/library/Zend/Mvc/Bootstrap/Exception/ExceptionInterface.php
+++ b/library/Zend/Mvc/Bootstrap/Exception/ExceptionInterface.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Bootstrap\Exception;
+
+interface ExceptionInterface
+{
+}

--- a/library/Zend/Mvc/Bootstrap/Exception/InvalidArgumentException.php
+++ b/library/Zend/Mvc/Bootstrap/Exception/InvalidArgumentException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Bootstrap\Exception;
+
+/**
+ * Invalid Argument Exception
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/library/Zend/Mvc/Bootstrap/Exception/RuntimeException.php
+++ b/library/Zend/Mvc/Bootstrap/Exception/RuntimeException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Bootstrap\Exception;
+
+/**
+ * Runtime Exception
+ */
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}


### PR DESCRIPTION
If the structure of the ZF2 application is flattened with no modules, chances are, there is no need to use a module manager. This PR provides a MVC\Bootstrap\ConfigManager which replicates ModuleManager\ConfigListener, but does not require a ModuleManager and is not event based. 

Example usage

``` php
$options = array(
    'cache_dir'            => 'data/cache',
    'config_cache_enabled' => true,
    'config_cache_key'     => 'cache-config.php',
    'config_glob_paths' => array(
       'config/autoload/{,*.}{global,local}.php',
    )
);

$cm = new ConfigManager(new ConfigOptions($options));

$cm->addConfigStaticPaths((array) $config);

//Just like ConfigListener::onLoadModulesPost
$config = $cm->loadMergedConfig(); 

$smConfig = isset($config['service_manager']) ? $config['service_manager'] : array();

$serviceManager = new ServiceManager(new ServiceManagerConfig($smConfig));
$serviceManager->setService('Config', $config);

$application = $serviceManager->get('Application');

$application->bootstrap();
```
