### PR TITLE
Hotfix/case sensitive console

### DIFF
--- a/library/Zend/Console/Adapter/AbstractAdapter.php
+++ b/library/Zend/Console/Adapter/AbstractAdapter.php
@@ -562,7 +562,7 @@ abstract class AbstractAdapter implements AdapterInterface
         $f = fopen('php://stdin','r');
         do {
             $char = fread($f,1);
-        } while ($mask !== null && "" !== $char && false === stristr($mask, $char));
+        } while ("" === $char || ($mask !== null && false === strstr($mask, $char)));
         fclose($f);
         return $char;
     }

--- a/library/Zend/Console/Adapter/Posix.php
+++ b/library/Zend/Console/Adapter/Posix.php
@@ -306,7 +306,7 @@ class Posix extends AbstractAdapter
         $stream = fopen('php://stdin', 'rb');
         do {
             $char = fgetc($stream);
-        } while (strlen($char) !== 1 || ($mask !== null && stristr($mask, $char) === false));
+        } while (strlen($char) !== 1 || ($mask !== null && false === strstr($mask, $char)));
         fclose($stream);
 
         $this->restoreTTYMode();

--- a/library/Zend/Console/Adapter/Windows.php
+++ b/library/Zend/Console/Adapter/Windows.php
@@ -248,7 +248,7 @@ class Windows extends Virtual
 
                 // Fetch the char from mask
                 $char = substr($mask, $return - 1, 1);
-            } while (!$char || ($mask !== null && !stristr($mask, $char)));
+            } while ("" === $char || ($mask !== null && false === strstr($mask, $char)));
 
             return $char;
         }

--- a/library/Zend/Console/Adapter/WindowsAnsicon.php
+++ b/library/Zend/Console/Adapter/WindowsAnsicon.php
@@ -209,7 +209,7 @@ class WindowsAnsicon extends Posix
 
                 // Fetch the char from mask
                 $char = substr($mask, $return - 1, 1);
-            } while (!$char || ($mask !== null && !stristr($mask, $char)));
+            } while ("" === $char || ($mask !== null && false === strstr($mask, $char)));
 
             return $char;
         }

--- a/library/Zend/Console/Prompt/Char.php
+++ b/library/Zend/Console/Prompt/Char.php
@@ -88,34 +88,19 @@ class Char extends AbstractPrompt
             $mask = array_unique($mask); // remove duplicates
             $mask = implode("", $mask);   // convert back to string
         }
+        
+        /**
+         * Read char from console
+         */
+        $char = $this->getConsole()->readChar($mask);
 
-        do {
-            /**
-             * Read char from console
-             */
-            $char = $this->getConsole()->readChar($mask);
-
-            /**
-             * Lowercase the response if case is irrelevant
-             */
-            if ($this->ignoreCase) {
-                $char = strtolower($char);
+        if ($this->echo) {
+            echo trim($char)."\n";
+        } else {
+            if ($this->promptText) {
+                echo "\n";  // skip to next line but only if we had any prompt text
             }
-
-            /**
-             * Check if it is an allowed char
-             */
-            if (stristr($this->allowedChars, $char) !== false) {
-                if ($this->echo) {
-                    echo trim($char)."\n";
-                } else {
-                    if ($this->promptText) {
-                        echo "\n";  // skip to next line but only if we had any prompt text
-                    }
-                }
-                break;
-            }
-        } while (true);
+        }
 
         return $this->lastResponse = $char;
     }

--- a/library/Zend/Console/Prompt/Confirm.php
+++ b/library/Zend/Console/Prompt/Confirm.php
@@ -67,8 +67,13 @@ class Confirm extends Char
      * @return bool
      */
     public function show()
-    {
-        $response = parent::show() === $this->yesChar;
+    {   
+        $char = parent::show();
+        if($this->ignoreCase) {
+            $response = strtolower($char) === strtolower($this->yesChar);
+        } else {
+            $response = $char === $this->yesChar;
+        }
         return $this->lastResponse = $response;
     }
 

--- a/tests/ZendTest/Console/Adapater/AbstractAdapterTest.php
+++ b/tests/ZendTest/Console/Adapater/AbstractAdapterTest.php
@@ -92,20 +92,12 @@ class AbstractAdapterTest extends \PHPUnit_Framework_TestCase
         $char = $this->adapter->readChar('ar');
         $this->assertEquals($char, 'a');
     }
-
+    
     public function testReadCharWithMaskInsensitiveCase()
     {
         fwrite($this->adapter->stream, 'bAr');
 
         $char = $this->adapter->readChar('ar');
-        $this->assertEquals($char, 'A');
-    }
-
-    public function testReadCharWithNoReturn()
-    {
-        fwrite($this->adapter->stream, 'bar');
-
-        $char = $this->adapter->readChar('foo');
-        $this->assertEquals($char, '');
+        $this->assertEquals($char, 'r');
     }
 }

--- a/tests/ZendTest/Console/Prompt/CharTest.php
+++ b/tests/ZendTest/Console/Prompt/CharTest.php
@@ -49,14 +49,14 @@ class CharTest extends \PHPUnit_Framework_TestCase
 
     public function testCanPromptCharWithCharNotInDefaultMask()
     {
-        fwrite($this->adapter->stream, 'zywa');
+        fwrite($this->adapter->stream, '*zywa');
 
         $char = new Char();
         $char->setEcho(false);
         $char->setConsole($this->adapter);
         ob_start();
         $response = $char->show();
-        $text = ob_get_clean();
+        ob_get_clean();
         $this->assertEquals('z', $response);
     }
 
@@ -72,5 +72,32 @@ class CharTest extends \PHPUnit_Framework_TestCase
         $text = ob_get_clean();
         $this->assertEquals($text, "Give a number\n");
         $this->assertEquals('1', $response);
+    }
+    
+    public function testCanPromptCharWithIgnoreCaseByDefault()
+    {
+        fwrite($this->adapter->stream, 'FOObar');
+        
+        $char = new Char();
+        $char->setEcho(false);
+        $char->setConsole($this->adapter);
+        ob_start();
+        $response = $char->show();
+        ob_get_clean();
+        $this->assertEquals('F', $response);
+    }
+    
+    public function testCanPromptCharWithoutIgnoreCase()
+    {
+        fwrite($this->adapter->stream, 'FOObar');
+        
+        $char = new Char();
+        $char->setEcho(false);
+        $char->setConsole($this->adapter);
+        $char->setIgnoreCase(false);
+        ob_start();
+        $response = $char->show();
+        ob_get_clean();
+        $this->assertEquals('b', $response);
     }
 }

--- a/tests/ZendTest/Console/Prompt/ConfirmTest.php
+++ b/tests/ZendTest/Console/Prompt/ConfirmTest.php
@@ -37,13 +37,13 @@ class ConfirmTest extends \PHPUnit_Framework_TestCase
     {
         fwrite($this->adapter->stream, 'y');
 
-        $confirm = new Confirm("ZF2 is the better framework ?");
+        $confirm = new Confirm("Is ZF2 the best framework ?");
         $confirm->setEcho(false);
         $confirm->setConsole($this->adapter);
         ob_start();
         $response = $confirm->show();
         $text = ob_get_clean();
-        $this->assertEquals($text, "ZF2 is the better framework ?\n");
+        $this->assertEquals($text, "Is ZF2 the best framework ?\n");
         $this->assertTrue($response);
     }
     
@@ -51,13 +51,13 @@ class ConfirmTest extends \PHPUnit_Framework_TestCase
     {
         fwrite($this->adapter->stream, 'Y');
 
-        $confirm = new Confirm("ZF2 is the better framework ?");
+        $confirm = new Confirm("Is ZF2 the best framework ?");
         $confirm->setEcho(false);
         $confirm->setConsole($this->adapter);
         ob_start();
         $response = $confirm->show();
         $text = ob_get_clean();
-        $this->assertEquals($text, "ZF2 is the better framework ?\n");
+        $this->assertEquals($text, "Is ZF2 the best framework ?\n");
         $this->assertTrue($response);
     }
     
@@ -65,14 +65,14 @@ class ConfirmTest extends \PHPUnit_Framework_TestCase
     {
         fwrite($this->adapter->stream, 'Yn');
 
-        $confirm = new Confirm("ZF2 is the better framework ?");
+        $confirm = new Confirm("Is ZF2 the best framework ?");
         $confirm->setEcho(false);
         $confirm->setConsole($this->adapter);
         $confirm->setIgnoreCase(false);
         ob_start();
         $response = $confirm->show();
         $text = ob_get_clean();
-        $this->assertEquals($text, "ZF2 is the better framework ?\n");
+        $this->assertEquals($text, "Is ZF2 the best framework ?\n");
         $this->assertFalse($response);
     }
     
@@ -80,13 +80,13 @@ class ConfirmTest extends \PHPUnit_Framework_TestCase
     {
         fwrite($this->adapter->stream, 'on0');
 
-        $confirm = new Confirm("ZF2 is the better framework ?", "1", "0");
+        $confirm = new Confirm("Is ZF2 the best framework ?", "1", "0");
         $confirm->setEcho(false);
         $confirm->setConsole($this->adapter);
         ob_start();
         $response = $confirm->show();
         $text = ob_get_clean();
-        $this->assertEquals($text, "ZF2 is the better framework ?\n");
+        $this->assertEquals($text, "Is ZF2 the best framework ?\n");
         $this->assertFalse($response);
     }
     
@@ -94,7 +94,7 @@ class ConfirmTest extends \PHPUnit_Framework_TestCase
     {
         fwrite($this->adapter->stream, 'oaB');
 
-        $confirm = new Confirm("ZF2 is the better framework ?", "1", "0");
+        $confirm = new Confirm("Is ZF2 the best framework ?", "1", "0");
         $confirm->setYesChar("A");
         $confirm->setNoChar("B");
         $confirm->setEcho(false);
@@ -102,7 +102,7 @@ class ConfirmTest extends \PHPUnit_Framework_TestCase
         ob_start();
         $response = $confirm->show();
         $text = ob_get_clean();
-        $this->assertEquals($text, "ZF2 is the better framework ?\n");
+        $this->assertEquals($text, "Is ZF2 the best framework ?\n");
         $this->assertTrue($response);
     }
 }

--- a/tests/ZendTest/Console/Prompt/ConfirmTest.php
+++ b/tests/ZendTest/Console/Prompt/ConfirmTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Console\Char;
+
+use Zend\Console\Prompt\Confirm;
+use ZendTest\Console\TestAssets\ConsoleAdapter;
+
+/**
+ * @group      Zend_Console
+ */
+class ConfirmTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ConsoleAdapter
+     */
+    protected $adapter;
+
+    public function setUp()
+    {
+        $this->adapter = new ConsoleAdapter();
+        $this->adapter->stream = fopen('php://memory', 'w+');
+    }
+
+    public function tearDown()
+    {
+        fclose($this->adapter->stream);
+    }
+    
+    public function testCanPromptConfirm()
+    {
+        fwrite($this->adapter->stream, 'y');
+
+        $confirm = new Confirm("ZF2 is the better framework ?");
+        $confirm->setEcho(false);
+        $confirm->setConsole($this->adapter);
+        ob_start();
+        $response = $confirm->show();
+        $text = ob_get_clean();
+        $this->assertEquals($text, "ZF2 is the better framework ?\n");
+        $this->assertTrue($response);
+    }
+    
+    public function testCanPromptConfirmWithDefaultIgnoreCase()
+    {
+        fwrite($this->adapter->stream, 'Y');
+
+        $confirm = new Confirm("ZF2 is the better framework ?");
+        $confirm->setEcho(false);
+        $confirm->setConsole($this->adapter);
+        ob_start();
+        $response = $confirm->show();
+        $text = ob_get_clean();
+        $this->assertEquals($text, "ZF2 is the better framework ?\n");
+        $this->assertTrue($response);
+    }
+    
+    public function testCanPromptConfirmWithoutIgnoreCase()
+    {
+        fwrite($this->adapter->stream, 'Yn');
+
+        $confirm = new Confirm("ZF2 is the better framework ?");
+        $confirm->setEcho(false);
+        $confirm->setConsole($this->adapter);
+        $confirm->setIgnoreCase(false);
+        ob_start();
+        $response = $confirm->show();
+        $text = ob_get_clean();
+        $this->assertEquals($text, "ZF2 is the better framework ?\n");
+        $this->assertFalse($response);
+    }
+    
+    public function testCanPromptConfirmWithYesNoCharChanged()
+    {
+        fwrite($this->adapter->stream, 'on0');
+
+        $confirm = new Confirm("ZF2 is the better framework ?", "1", "0");
+        $confirm->setEcho(false);
+        $confirm->setConsole($this->adapter);
+        ob_start();
+        $response = $confirm->show();
+        $text = ob_get_clean();
+        $this->assertEquals($text, "ZF2 is the better framework ?\n");
+        $this->assertFalse($response);
+    }
+    
+    public function testCanPromptConfirmWithYesNoCharChangedWithSetter()
+    {
+        fwrite($this->adapter->stream, 'oaB');
+
+        $confirm = new Confirm("ZF2 is the better framework ?", "1", "0");
+        $confirm->setYesChar("A");
+        $confirm->setNoChar("B");
+        $confirm->setEcho(false);
+        $confirm->setConsole($this->adapter);
+        ob_start();
+        $response = $confirm->show();
+        $text = ob_get_clean();
+        $this->assertEquals($text, "ZF2 is the better framework ?\n");
+        $this->assertTrue($response);
+    }
+}

--- a/tests/ZendTest/Console/TestAssets/ConsoleAdapter.php
+++ b/tests/ZendTest/Console/TestAssets/ConsoleAdapter.php
@@ -48,7 +48,7 @@ class ConsoleAdapter extends AbstractAdapter
         }
         do {
             $char = fread($this->stream, 1);
-        } while ($mask !== null && "" !== $char && false === stristr($mask, $char));
+        } while ("" === $char || ($mask !== null && false === strstr($mask, $char)));
         return $char;
     }
 }


### PR DESCRIPTION
After write the tests on Console, i see a bug on the sensitive case.
It was possible to configure sensitive case (or not sensitive), but the reading was only always insensitive.

This bug is fix and i had tests on the Prompt\Confirm.

I make a consistency between console reading char too and delete a useless loop on the reading char which are already done in the console adapter.
