### PR TITLE
Pass ClassGenerator instance instead of boolean

### DIFF
--- a/library/Zend/Code/Generator/FileGenerator.php
+++ b/library/Zend/Code/Generator/FileGenerator.php
@@ -185,7 +185,7 @@ class FileGenerator extends AbstractGenerator
                     $fileGenerator->setFilename($value);
                     continue;
                 case 'class':
-                    $fileGenerator->setClass(($value instanceof ClassGenerator) ? : ClassGenerator::fromArray($value));
+                    $fileGenerator->setClass(($value instanceof ClassGenerator) ? $value : ClassGenerator::fromArray($value));
                     continue;
                 case 'requiredfiles':
                     $fileGenerator->setRequiredFiles($value);

--- a/tests/ZendTest/Code/Generator/FileGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/FileGeneratorTest.php
@@ -277,4 +277,25 @@ EOS;
         $this->assertContains('use Another\\Baz as Baz2;', $generated);
     }
 
+    public function testCreateFromArrayWithClassInstance()
+    {
+        $fileGenerator = FileGenerator::fromArray(array(
+            'filename'  => 'foo.php',
+            'class'     => new ClassGenerator('bar'),
+        ));
+        $class = $fileGenerator->getClass('bar');
+        $this->assertInstanceOf('Zend\Code\Generator\ClassGenerator', $class);
+    }
+
+    public function testCreateFromArrayWithClassFromArray()
+    {
+        $fileGenerator = FileGenerator::fromArray(array(
+            'filename'  => 'foo.php',
+            'class'     => array(
+                'name' => 'bar',
+            ),
+        ));
+        $class = $fileGenerator->getClass('bar');
+        $this->assertInstanceOf('Zend\Code\Generator\ClassGenerator', $class);
+    }
 }


### PR DESCRIPTION
We should pass the ClassGenerator instance value (instead of the boolean returned by instanceof) to the setClass method call. 

Added testCreateFromArrayWithClassInstance which directly addresses issue 4006, also added testCreateFromArrayWithClassFromArray since it was not there
