### PR TITLE
Hotfix/zend test with console route

### DIFF
--- a/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -197,7 +197,17 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         $request = $this->getRequest();
         if ($this->useConsoleRequest) {
-            $params = preg_split('#\s+#', $url);
+            // split on space to get console argument
+            // but don't split on space between quote
+            $_url = $url;
+            preg_match_all('/"([^"]+)"/', $url, $matches);
+            array_walk($matches, function($v) use (&$_url) { $_url = str_replace($v, "%s", $_url); });
+            $params = preg_split('#\s+#', $_url);
+            foreach($params as &$v) {
+                if(preg_match('/%s/', $v)) {
+                    $v = sprintf($v, array_shift($matches[1]));
+                }
+            }
             $request->params()->exchangeArray($params);
             return $this;
         }

--- a/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -197,17 +197,8 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         $request = $this->getRequest();
         if ($this->useConsoleRequest) {
-            // split on space to get console argument
-            // but don't split on space between quote
-            $_url = $url;
-            preg_match_all('/"([^"]+)"/', $url, $matches);
-            array_walk($matches, function($v) use (&$_url) { $_url = str_replace($v, "%s", $_url); });
-            $params = preg_split('#\s+#', $_url);
-            foreach($params as &$v) {
-                if(preg_match('/%s/', $v)) {
-                    $v = sprintf($v, array_shift($matches[1]));
-                }
-            }
+            preg_match_all('/(--\S+[= ]"\S*\s*\S*")|(--\S+=\S+|--\S+\s\S+|\S+)/', $url, $matches);
+            $params = str_replace(array(' "', '"'), array('=', ''), $matches[0]);
             $request->params()->exchangeArray($params);
             return $this;
         }

--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractConsoleControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractConsoleControllerTestCaseTest.php
@@ -94,4 +94,13 @@ class AbstractConsoleControllerTestCaseTest extends AbstractConsoleControllerTes
         $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
         $this->assertNotConsoleOutputContains('foo');
     }
+    
+    public function testAssertMatchedArguments()
+    {
+        $this->dispatch('filter --date="2013-03-07 00:00:00" --id=10 --text="custom text"');
+        $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
+        $this->assertEquals("2013-03-07 00:00:00", $routeMatch->getParam('date'));
+        $this->assertEquals("10", $routeMatch->getParam('id'));
+        $this->assertEquals("custom text", $routeMatch->getParam('text'));
+    }
 }

--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractConsoleControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractConsoleControllerTestCaseTest.php
@@ -95,9 +95,18 @@ class AbstractConsoleControllerTestCaseTest extends AbstractConsoleControllerTes
         $this->assertNotConsoleOutputContains('foo');
     }
     
-    public function testAssertMatchedArguments()
+    public function testAssertMatchedArgumentsWithValue()
     {
         $this->dispatch('filter --date="2013-03-07 00:00:00" --id=10 --text="custom text"');
+        $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
+        $this->assertEquals("2013-03-07 00:00:00", $routeMatch->getParam('date'));
+        $this->assertEquals("10", $routeMatch->getParam('id'));
+        $this->assertEquals("custom text", $routeMatch->getParam('text'));
+    }
+
+    public function testAssertMatchedArgumentsWithValueWithoutEqualsSign()
+    {
+        $this->dispatch('filter --date "2013-03-07 00:00:00" --id=10 --text="custom text"');
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
         $this->assertEquals("2013-03-07 00:00:00", $routeMatch->getParam('date'));
         $this->assertEquals("10", $routeMatch->getParam('id'));

--- a/tests/ZendTest/Test/_files/Baz/config/module.config.php
+++ b/tests/ZendTest/Test/_files/Baz/config/module.config.php
@@ -13,6 +13,16 @@ return array(
                         ),
                     ),
                 ),
+                'arguments' => array(
+                    'type' => 'simple',
+                    'options' => array(
+                        'route'    => 'filter --date= --id= --text=',
+                        'defaults' => array(
+                            'controller' => 'baz_index',
+                            'action'     => 'console',
+                        ),
+                    ),
+                ),
             ),
         ),
     ),


### PR DESCRIPTION
Fix split on space to retrieve argument console. I used array and temporary string to fix, but i am sure a regex can be better.
