### PR TITLE
Avoid the check of resource existence before calling isAllow() in the

### DIFF
--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -774,7 +774,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
 
         if ($resource || $privilege) {
             // determine using helper role and page resource/privilege
-            return $acl->hasResource($resource) && $acl->isAllowed($role, $resource, $privilege);
+            return $acl->isAllowed($role, $resource, $privilege);
         }
 
         return true;


### PR DESCRIPTION
The function acceptAcl() calls hasResource() before calling isAllowed() making you have to explicitly register all of your resources beforehand. My patch enables you to lazy load resource registration on the fly in your Acl implementation.

acceptAcl() method.

Change-Id: I47444e0ee26a896066af56208670180bd7ce4fa7
Signed-off-by: Antoine Delamarre antoine.delamarre@vaconsulting.lu
