### PR TITLE
Fix PHP Notice in Translator class

### DIFF
--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -533,10 +533,8 @@ class Translator
 
         if (!$messagesLoaded) {
             $this->messages[$textDomain][$locale] = null;
-        } else {
-            if ($cache !== null) {
-                $cache->setItem($cacheId, $this->messages[$textDomain][$locale]);
-            }
+        } elseif ($cache !== null) {
+            $cache->setItem($cacheId, $this->messages[$textDomain][$locale]);
         }
     }
 

--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -399,10 +399,6 @@ class Translator
             $this->loadMessages($textDomain, $locale);
         }
 
-        if (!isset($this->messages[$textDomain][$locale])) {
-            return null;
-        }
-
         if (is_array($this->messages[$textDomain][$locale])) {
             foreach ($this->messages[$textDomain][$locale] as $textDomain) {
                 if (isset($textDomain[$message])) {
@@ -535,8 +531,12 @@ class Translator
             || $this->loadMessagesFromFiles($textDomain, $locale)
         );
 
-        if ($messagesLoaded && $cache !== null) {
-            $cache->setItem($cacheId, $this->messages[$textDomain][$locale]);
+        if (!$messagesLoaded) {
+            $this->messages[$textDomain][$locale] = null;
+        } else {
+            if ($cache !== null) {
+                $cache->setItem($cacheId, $this->messages[$textDomain][$locale]);
+            }
         }
     }
 

--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -399,6 +399,10 @@ class Translator
             $this->loadMessages($textDomain, $locale);
         }
 
+        if (!isset($this->messages[$textDomain][$locale])) {
+            return null;
+        }
+
         if (is_array($this->messages[$textDomain][$locale])) {
             foreach ($this->messages[$textDomain][$locale] as $textDomain) {
                 if (isset($textDomain[$message])) {

--- a/tests/ZendTest/I18n/Translator/TranslatorTest.php
+++ b/tests/ZendTest/I18n/Translator/TranslatorTest.php
@@ -194,20 +194,22 @@ class TranslatorTest extends TestCase
 
     public function testTranslateNonExistantLocale()
     {
-        $translator = Translator::factory(array(
-            'locale' => 'es_ES',
-            'translation_file_patterns' => array(
-                array(
-                    'type' => 'phparray',
-                    'base_dir' => $this->testFilesDir . '/testarray',
-                    'pattern' => 'translation-%s.php'
-                )
-            )
-        ));
+        $this->translator->addTranslationFilePattern(
+            'phparray',
+            $this->testFilesDir . '/testarray',
+            'translation-%s.php'
+        );
 
-        $this->assertInstanceOf('Zend\I18n\Translator\Translator', $translator);
+        // Test that a locale without translations does not cause warnings
 
-        $this->assertEquals('Message 1', $translator->translate('Message 1'));
-        $this->assertEquals('Message 9', $translator->translate('Message 9'));
+        $this->translator->setLocale('es_ES');
+
+        $this->assertEquals('Message 1', $this->translator->translate('Message 1'));
+        $this->assertEquals('Message 9', $this->translator->translate('Message 9'));
+
+        $this->translator->setLocale('fr_FR');
+
+        $this->assertEquals('Message 1', $this->translator->translate('Message 1'));
+        $this->assertEquals('Message 9', $this->translator->translate('Message 9'));
     }
 }

--- a/tests/ZendTest/I18n/Translator/TranslatorTest.php
+++ b/tests/ZendTest/I18n/Translator/TranslatorTest.php
@@ -191,4 +191,23 @@ class TranslatorTest extends TestCase
         $this->assertEquals('Message 5 (en) Plural 1', $pl1);
         $this->assertEquals('Message 5 (en) Plural 2', $pl2);
     }
+
+    public function testTranslateNonExistantLocale()
+    {
+        $translator = Translator::factory(array(
+            'locale' => 'es_ES',
+            'translation_file_patterns' => array(
+                array(
+                    'type' => 'phparray',
+                    'base_dir' => $this->testFilesDir . '/testarray',
+                    'pattern' => 'translation-%s.php'
+                )
+            )
+        ));
+
+        $this->assertInstanceOf('Zend\I18n\Translator\Translator', $translator);
+
+        $this->assertEquals('Message 1', $translator->translate('Message 1'));
+        $this->assertEquals('Message 9', $translator->translate('Message 9'));
+    }
 }


### PR DESCRIPTION
`Translator::getTranslatedMessage()` causes a PHP Notice due to a change made in https://github.com/zendframework/zf2/commit/7422c37dd8c24dc892ea0a2aa92054c60f18a794#L0R398

```
Notice: Undefined index: en_US in .../Zend/I18n/Translator/Translator.php on line 402
```

This change adds an `isset()` to fix this, so that the index is checked as it used to be.
