### PR TITLE
update to FlashMessenger view helper to allow for classes on separator

### DIFF
--- a/library/Zend/View/Helper/FlashMessenger.php
+++ b/library/Zend/View/Helper/FlashMessenger.php
@@ -124,7 +124,7 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
 
         // Generate markup
         $markup  = sprintf($this->getMessageOpenFormat(), ' class="' . implode(' ', $classes) . '"');
-        $markup .= implode($this->getMessageSeparatorString(), $messagesToPrint);
+        $markup .= implode(sprintf($this->getMessageSeparatorString(), ' class="' . implode(' ', $classes) . '"'), $messagesToPrint);
         $markup .= $this->getMessageCloseString();
 
         return $markup;

--- a/tests/ZendTest/View/Helper/FlashMessengerTest.php
+++ b/tests/ZendTest/View/Helper/FlashMessengerTest.php
@@ -149,6 +149,19 @@ class FlashMessengerTest extends TestCase
         $this->assertEquals($displayInfoAssertion, $displayInfo);
     }
 
+    public function testCanDisplayListOfMessagesCustomisedSeparator()
+    {
+        $this->seedMessages();
+
+        $displayInfoAssertion = '<div><p class="foo-baz foo-bar">foo</p><p class="foo-baz foo-bar">bar</p></div>';
+        $displayInfo = $this->helper
+                ->setMessageOpenFormat('<div><p%s>')
+                ->setMessageSeparatorString('</p><p%s>')
+                ->setMessageCloseString('</p></div>')
+                ->render(PluginFlashMessenger::NAMESPACE_DEFAULT, array('foo-baz', 'foo-bar'));
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
     public function testCanDisplayListOfMessagesCustomisedByConfig()
     {
         $this->seedMessages();

--- a/tests/ZendTest/View/Helper/FlashMessengerTest.php
+++ b/tests/ZendTest/View/Helper/FlashMessengerTest.php
@@ -197,6 +197,41 @@ class FlashMessengerTest extends TestCase
         $this->assertEquals($displayInfoAssertion, $displayInfo);
     }
 
+    public function testCanDisplayListOfMessagesCustomisedByConfigSeparator()
+    {
+        $this->seedMessages();
+
+        $config = array(
+            'view_helper_config' => array(
+                'flashmessenger' => array(
+                    'message_open_format' => '<div><ul><li%s>',
+                    'message_separator_string' => '</li><li%s>',
+                    'message_close_string' => '</li></ul></div>',
+                ),
+            ),
+        );
+        $sm = new ServiceManager();
+        $sm->setService('Config', $config);
+        $helperPluginManager = new HelperPluginManager(new Config(array(
+            'factories' => array(
+                'flashmessenger' => 'Zend\View\Helper\Service\FlashMessengerFactory',
+            ),
+        )));
+        $controllerPluginManager = new PluginManager(new Config(array(
+            'invokables' => array(
+                'flashmessenger' => 'Zend\Mvc\Controller\Plugin\FlashMessenger',
+            ),
+        )));
+        $helperPluginManager->setServiceLocator($sm);
+        $controllerPluginManager->setServiceLocator($sm);
+        $sm->setService('ControllerPluginManager', $controllerPluginManager);
+        $helper = $helperPluginManager->get('flashmessenger');
+
+        $displayInfoAssertion = '<div><ul><li class="foo-baz foo-bar">foo</li><li class="foo-baz foo-bar">bar</li></ul></div>';
+        $displayInfo = $helper->render(PluginFlashMessenger::NAMESPACE_DEFAULT, array('foo-baz', 'foo-bar'));
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
     public function testCanTranslateMessages()
     {
         $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');


### PR DESCRIPTION
This Update to FlashMessenger allows for the user to utilise the classes within the separator as well as the opening part for the render method;

``` php
$flashMessenger = $this->flashMessenger();

$flashMessenger
    ->setMessageOpenFormat('<div%s>')
    ->setMessageSeparatorString('</div><div%s>')
    ->setMessageCloseString('</div>');

echo $flashMessenger->render('error', array('alert', 'alert-error'));
```
