### PR TITLE
Mysqli connection class update to reset autocommit option

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
@@ -267,8 +267,9 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         }
 
         $this->resource->commit();
-        $this->resource->autocommit(true);
+        
         $this->inTransaction = false;
+        $this->resource->autocommit(true);
     }
 
     /**

--- a/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
@@ -289,6 +289,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         }
 
         $this->resource->rollback();
+        $this->resource->autocommit(true);
         return $this;
     }
 

--- a/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
@@ -267,7 +267,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         }
 
         $this->resource->commit();
-
+        $this->resource->autocommit(true);
         $this->inTransaction = false;
     }
 


### PR DESCRIPTION
In the beginTransaction method of the Zend\Db\Adapter\Driver\Mysqli\Connection class the autocommit option is set to false. It should be set back to true following the commit or rollback methods to allow the connection to be used again under normal operating conditions. I have updated the Connection.php file to reset the adapter autocommit option back to true.
