### PR TITLE
[Router] non existent child route during assembly doesn't throw exception

### DIFF
--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -188,6 +188,9 @@ class TreeRouteStack extends SimpleRouteStack
         }
 
         if (isset($names[1])) {
+            if (!$route instanceof TreeRouteStack) {
+                throw new Exception\RuntimeException(sprintf('Route with name "%s" does not have child routes', $names[0]));
+            }
             $options['name'] = $names[1];
         } else {
             unset($options['name']);

--- a/tests/ZendTest/Mvc/Router/Http/TreeRouteStackTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/TreeRouteStackTest.php
@@ -285,6 +285,22 @@ class TreeRouteStackTest extends TestCase
         $stack->assemble(array(), array('name' => 'foo'));
     }
 
+    public function testAssembleNonExistentChildRoute()
+    {
+        $this->setExpectedException('Zend\Mvc\Router\Exception\RuntimeException', 'Route with name "index" does not have child routes');
+        $stack = new TreeRouteStack();
+        $stack->addRoute(
+            'index',
+            array(
+                'type' => 'Literal',
+                'options' => array(
+                    'route' => '/',
+                ),
+            )
+        );
+        $stack->assemble(array(), array('name' => 'index/foo'));
+    }
+
     public function testDefaultParamIsAddedToMatch()
     {
         $stack = new TreeRouteStack();


### PR DESCRIPTION
The router will not throw exceptions if a user tries to assemble a multi-part route where child routes don't actually exist.

So, let's say we have a valid route `app/entry/view` but the user assembles a route `app/entry/view/foo` no exceptions are thrown and the router quietly outputs the valid part of route.
