### PR TITLE
Remove unnecessary autoload.php from composer config.

### DIFF
--- a/library/Zend/Stdlib/composer.json
+++ b/library/Zend/Stdlib/composer.json
@@ -9,10 +9,7 @@
     "autoload": {
         "psr-0": {
             "Zend\\Stdlib\\": ""
-        },
-        "files": [
-            "Zend/Stdlib/compatibility/autoload.php"
-        ]
+        }
     },
     "target-dir": "Zend/Stdlib",
     "suggest": {


### PR DESCRIPTION
I'm not a Composer expert, but it looks like this is an unwanted reference to the old compatibility code.
