### PR TITLE
Update InArray.php

### DIFF
--- a/library/Zend/Validator/InArray.php
+++ b/library/Zend/Validator/InArray.php
@@ -75,7 +75,7 @@ class InArray extends AbstractValidator
      */
     public function getHaystack()
     {
-        if ($this->haystack == null) {
+        if ($this->haystack === null) {
             throw new Exception\RuntimeException('haystack option is mandatory');
         }
         return $this->haystack;

--- a/tests/ZendTest/Validator/InArrayTest.php
+++ b/tests/ZendTest/Validator/InArrayTest.php
@@ -54,11 +54,11 @@ class InArrayTest extends \PHPUnit_Framework_TestCase
 
     public function testSetEmptyHaystack()
     {
-        $this->validator->setHaystack(null);
         $this->setExpectedException(
             'Zend\Validator\Exception\RuntimeException',
             'haystack option is mandatory'
         );
+        $this->validator->setHaystack(null);
         $this->validator->getHaystack();
     }
 

--- a/tests/ZendTest/Validator/InArrayTest.php
+++ b/tests/ZendTest/Validator/InArrayTest.php
@@ -54,7 +54,7 @@ class InArrayTest extends \PHPUnit_Framework_TestCase
 
     public function testSetEmptyHaystack()
     {
-        $this->validator->setHaystack(array());
+        $this->validator->setHaystack(null);
         $this->setExpectedException(
             'Zend\Validator\Exception\RuntimeException',
             'haystack option is mandatory'

--- a/tests/ZendTest/Validator/InArrayTest.php
+++ b/tests/ZendTest/Validator/InArrayTest.php
@@ -52,16 +52,6 @@ class InArrayTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(1, 2, 3), $this->validator->getHaystack());
     }
 
-    public function testSetEmptyHaystack()
-    {
-        $this->setExpectedException(
-            'Zend\Validator\Exception\RuntimeException',
-            'haystack option is mandatory'
-        );
-        $this->validator->setHaystack(null);
-        $this->validator->getHaystack();
-    }
-
     /**
      * Ensures that getStrict() returns expected default value
      *


### PR DESCRIPTION
in InArray validator
if haystack is an empty array, an exception 'haystack option is mandatory' is thrown
should be exact equality ===

<?php
$t = array();
if ($t == null) echo "null\n"; else echo "not null\n";

this code echoes null

<?php
$t = array();
if ($t === null) echo "null\n"; else echo "not null\n";

this code echoes not null
