### PR TITLE
Translable routing segments

### DIFF
--- a/library/Zend/Mvc/Router/Http/Hostname.php
+++ b/library/Zend/Mvc/Router/Http/Hostname.php
@@ -16,8 +16,6 @@ use Zend\Stdlib\RequestInterface as Request;
 
 /**
  * Hostname route.
- *
- * @see        http://guides.rubyonrails.org/routing.html
  */
 class Hostname implements RouteInterface
 {
@@ -75,8 +73,8 @@ class Hostname implements RouteInterface
      *
      * @see    \Zend\Mvc\Router\RouteInterface::factory()
      * @param  array|Traversable $options
-     * @throws \Zend\Mvc\Router\Exception\InvalidArgumentException
      * @return Hostname
+     * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = array())
     {
@@ -204,7 +202,7 @@ class Hostname implements RouteInterface
      *
      * @param  array   $parts
      * @param  array   $mergedParams
-     * @param  bool $isOptional
+     * @param  boolean $isOptional
      * @return string
      * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException
@@ -263,7 +261,7 @@ class Hostname implements RouteInterface
      *
      * @see    \Zend\Mvc\Router\RouteInterface::match()
      * @param  Request $request
-     * @return RouteMatch
+     * @return RouteMatch|null
      */
     public function match(Request $request)
     {
@@ -280,7 +278,7 @@ class Hostname implements RouteInterface
             return null;
         }
 
-        $params        = array();
+        $params = array();
 
         foreach ($this->paramMap as $index => $name) {
             if (isset($matches[$index]) && $matches[$index] !== '') {

--- a/library/Zend/Mvc/Router/Http/Literal.php
+++ b/library/Zend/Mvc/Router/Http/Literal.php
@@ -16,8 +16,6 @@ use Zend\Stdlib\RequestInterface as Request;
 
 /**
  * Literal route.
- *
- * @see        http://guides.rubyonrails.org/routing.html
  */
 class Literal implements RouteInterface
 {
@@ -52,8 +50,8 @@ class Literal implements RouteInterface
      *
      * @see    \Zend\Mvc\Router\RouteInterface::factory()
      * @param  array|Traversable $options
-     * @throws Exception\InvalidArgumentException
      * @return Literal
+     * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = array())
     {
@@ -78,8 +76,8 @@ class Literal implements RouteInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    \Zend\Mvc\Router\RouteInterface::match()
-     * @param  Request  $request
-     * @param  int|null $pathOffset
+     * @param  Request      $request
+     * @param  integer|null $pathOffset
      * @return RouteMatch|null
      */
     public function match(Request $request, $pathOffset = null)

--- a/library/Zend/Mvc/Router/Http/Method.php
+++ b/library/Zend/Mvc/Router/Http/Method.php
@@ -86,8 +86,8 @@ class Method implements RouteInterface
         }
 
         $requestVerb = strtoupper($request->getMethod());
-        $matchVerbs = explode(',', strtoupper($this->verb));
-        $matchVerbs = array_map('trim', $matchVerbs);
+        $matchVerbs  = explode(',', strtoupper($this->verb));
+        $matchVerbs  = array_map('trim', $matchVerbs);
 
         if (in_array($requestVerb, $matchVerbs)) {
             return new RouteMatch($this->defaults);

--- a/library/Zend/Mvc/Router/Http/Method.php
+++ b/library/Zend/Mvc/Router/Http/Method.php
@@ -50,8 +50,8 @@ class Method implements RouteInterface
      *
      * @see    \Zend\Mvc\Router\RouteInterface::factory()
      * @param  array|Traversable $options
-     * @throws Exception\InvalidArgumentException
      * @return Method
+     * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = array())
     {

--- a/library/Zend/Mvc/Router/Http/Part.php
+++ b/library/Zend/Mvc/Router/Http/Part.php
@@ -18,8 +18,6 @@ use Zend\Stdlib\RequestInterface as Request;
 
 /**
  * RouteInterface part.
- *
- * @see        http://guides.rubyonrails.org/routing.html
  */
 class Part extends TreeRouteStack implements RouteInterface
 {
@@ -48,7 +46,7 @@ class Part extends TreeRouteStack implements RouteInterface
      * Create a new part route.
      *
      * @param  mixed              $route
-     * @param  bool            $mayTerminate
+     * @param  boolean            $mayTerminate
      * @param  RoutePluginManager $routePlugins
      * @param  array|null         $childRoutes
      * @throws Exception\InvalidArgumentException
@@ -76,8 +74,8 @@ class Part extends TreeRouteStack implements RouteInterface
      *
      * @see    \Zend\Mvc\Router\RouteInterface::factory()
      * @param  mixed $options
-     * @throws Exception\InvalidArgumentException
      * @return Part
+     * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = array())
     {
@@ -102,6 +100,7 @@ class Part extends TreeRouteStack implements RouteInterface
         if (!isset($options['child_routes']) || !$options['child_routes']) {
             $options['child_routes'] = null;
         }
+
         if ($options['child_routes'] instanceof Traversable) {
             $options['child_routes'] = ArrayUtils::iteratorToArray($options['child_routes']);
         }
@@ -113,17 +112,18 @@ class Part extends TreeRouteStack implements RouteInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    \Zend\Mvc\Router\RouteInterface::match()
-     * @param  Request  $request
-     * @param  int|null $pathOffset
+     * @param  Request      $request
+     * @param  integer|null $pathOffset
+     * @param  array        $options
      * @return RouteMatch|null
      */
-    public function match(Request $request, $pathOffset = null)
+    public function match(Request $request, $pathOffset = null, array $options = array())
     {
         if ($pathOffset === null) {
             $pathOffset = 0;
         }
 
-        $match = $this->route->match($request, $pathOffset);
+        $match = $this->route->match($request, $pathOffset, $options);
 
         if ($match !== null && method_exists($request, 'getUri')) {
             if ($this->childRoutes !== null) {
@@ -144,7 +144,7 @@ class Part extends TreeRouteStack implements RouteInterface
             }
 
             foreach ($this->routes as $name => $route) {
-                if (($subMatch = $route->match($request, $nextOffset)) instanceof RouteMatch) {
+                if (($subMatch = $route->match($request, $nextOffset, $options)) instanceof RouteMatch) {
                     if ($match->getLength() + $subMatch->getLength() + $pathOffset === $pathLength) {
                         return $match->merge($subMatch)->setMatchedRouteName($name);
                     }

--- a/library/Zend/Mvc/Router/Http/Part.php
+++ b/library/Zend/Mvc/Router/Http/Part.php
@@ -17,7 +17,7 @@ use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\RequestInterface as Request;
 
 /**
- * RouteInterface part.
+ * Part route.
  */
 class Part extends TreeRouteStack implements RouteInterface
 {

--- a/library/Zend/Mvc/Router/Http/Query.php
+++ b/library/Zend/Mvc/Router/Http/Query.php
@@ -66,7 +66,6 @@ class Query implements RouteInterface
             throw new Exception\InvalidArgumentException(__METHOD__ . ' expects an array or Traversable set of options');
         }
 
-
         if (!isset($options['defaults'])) {
             $options['defaults'] = array();
         }
@@ -98,6 +97,7 @@ class Query implements RouteInterface
     protected function recursiveUrldecode(array $array)
     {
         $matches = array();
+
         foreach ($array as $key => $value) {
             if (is_array($value)) {
                 $matches[urldecode($key)] = $this->recursiveUrldecode($value);
@@ -105,6 +105,7 @@ class Query implements RouteInterface
                 $matches[urldecode($key)] = urldecode($value);
             }
         }
+        
         return $matches;
     }
 

--- a/library/Zend/Mvc/Router/Http/Query.php
+++ b/library/Zend/Mvc/Router/Http/Query.php
@@ -18,12 +18,10 @@ use Zend\Stdlib\RequestInterface as Request;
 /**
  * Query route.
  *
- * @see        http://guides.rubyonrails.org/routing.html
  * @deprecated
  */
 class Query implements RouteInterface
 {
-
     /**
      * Default values.
      *
@@ -57,8 +55,8 @@ class Query implements RouteInterface
      *
      * @see    \Zend\Mvc\Router\RouteInterface::factory()
      * @param  array|Traversable $options
-     * @throws Exception\InvalidArgumentException
      * @return Query
+     * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = array())
     {
@@ -81,10 +79,9 @@ class Query implements RouteInterface
      *
      * @see    \Zend\Mvc\Router\RouteInterface::match()
      * @param  Request $request
-     * @param  int|null $pathOffset
      * @return RouteMatch
      */
-    public function match(Request $request, $pathOffset = null)
+    public function match(Request $request)
     {
         // We don't merge the query parameters into the rotue match here because
         // of possible security problems. Use the Query object instead which is
@@ -95,7 +92,7 @@ class Query implements RouteInterface
     /**
      * Recursively urldecodes keys and values from an array
      *
-     * @param array $array
+     * @param  array $array
      * @return array
      */
     protected function recursiveUrldecode(array $array)
@@ -113,8 +110,8 @@ class Query implements RouteInterface
 
     /**
      * assemble(): Defined by RouteInterface interface.
-     * @see    \Zend\Mvc\Router\RouteInterface::assemble()
      *
+     * @see    \Zend\Mvc\Router\RouteInterface::assemble()
      * @param  array $params
      * @param  array $options
      * @return mixed

--- a/library/Zend/Mvc/Router/Http/Regex.php
+++ b/library/Zend/Mvc/Router/Http/Regex.php
@@ -16,8 +16,6 @@ use Zend\Stdlib\RequestInterface as Request;
 
 /**
  * Regex route.
- *
- * @see        http://guides.rubyonrails.org/routing.html
  */
 class Regex implements RouteInterface
 {
@@ -70,8 +68,8 @@ class Regex implements RouteInterface
      *
      * @see    \Zend\Mvc\Router\RouteInterface::factory()
      * @param  array|Traversable $options
-     * @throws \Zend\Mvc\Router\Exception\InvalidArgumentException
      * @return Regex
+     * @throws \Zend\Mvc\Router\Exception\InvalidArgumentException
      */
     public static function factory($options = array())
     {
@@ -101,7 +99,7 @@ class Regex implements RouteInterface
      *
      * @param  Request $request
      * @param  integer $pathOffset
-     * @return RouteMatch
+     * @return RouteMatch|null
      */
     public function match(Request $request, $pathOffset = null)
     {

--- a/library/Zend/Mvc/Router/Http/Scheme.php
+++ b/library/Zend/Mvc/Router/Http/Scheme.php
@@ -79,7 +79,7 @@ class Scheme implements RouteInterface
      *
      * @see    \Zend\Mvc\Router\RouteInterface::match()
      * @param  Request $request
-     * @return RouteMatch
+     * @return RouteMatch|null
      */
     public function match(Request $request)
     {

--- a/library/Zend/Mvc/Router/Http/Scheme.php
+++ b/library/Zend/Mvc/Router/Http/Scheme.php
@@ -16,8 +16,6 @@ use Zend\Stdlib\RequestInterface as Request;
 
 /**
  * Scheme route.
- *
- * @see        http://guides.rubyonrails.org/routing.html
  */
 class Scheme implements RouteInterface
 {

--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -423,7 +423,7 @@ class Segment implements RouteInterface
     /**
      * Encode a path segment.
      *
-     * @param string $value
+     * @param  string $value
      * @return string
      */
     protected function encode($value)
@@ -438,7 +438,7 @@ class Segment implements RouteInterface
     /**
      * Decode a path segment.
      *
-     * @param string $value
+     * @param  string $value
      * @return string
      */
     protected function decode($value)

--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -10,19 +10,20 @@
 namespace Zend\Mvc\Router\Http;
 
 use Traversable;
+use Zend\I18n\Translator\Translator;
 use Zend\Mvc\Router\Exception;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\RequestInterface as Request;
 
 /**
  * Segment route.
- *
- * @see        http://guides.rubyonrails.org/routing.html
  */
 class Segment implements RouteInterface
 {
     /**
-     * @var array Cache for the encode output
+     * Cache for the encode output.
+     *
+     * @var array
      */
     protected static $cacheEncode = array();
 
@@ -94,6 +95,13 @@ class Segment implements RouteInterface
     protected $assembledParams = array();
 
     /**
+     * Translation keys used in the regex.
+     *
+     * @var array
+     */
+    protected $translationKeys = array();
+
+    /**
      * Create a new regex route.
      *
      * @param  string $route
@@ -112,8 +120,8 @@ class Segment implements RouteInterface
      *
      * @see    \Zend\Mvc\Router\RouteInterface::factory()
      * @param  array|Traversable $options
-     * @throws \Zend\Mvc\Router\Exception\InvalidArgumentException
      * @return Segment
+     * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = array())
     {
@@ -163,19 +171,11 @@ class Segment implements RouteInterface
             }
 
             if ($matches['token'] === ':') {
-                if (isset($def[$currentPos]) && $def[$currentPos] === '{') {
-                    if (!preg_match('(\G\{(?P<name>[^}]+)\}:?)', $def, $matches, 0, $currentPos)) {
-                        throw new Exception\RuntimeException('Translated parameter missing closing bracket');
-                    }
-
-                    $levelParts[$level][] = array('translated-parameter', $matches['name']);
-                } else {
-                    if (!preg_match('(\G(?P<name>[^:/{\[\]]+)(?:{(?P<delimiters>[^}]+)})?:?)', $def, $matches, 0, $currentPos)) {
-                        throw new Exception\RuntimeException('Found empty parameter name');
-                    }
-
-                    $levelParts[$level][] = array('parameter', $matches['name'], isset($matches['delimiters']) ? $matches['delimiters'] : null);
+                if (!preg_match('(\G(?P<name>[^:/{\[\]]+)(?:{(?P<delimiters>[^}]+)})?:?)', $def, $matches, 0, $currentPos)) {
+                    throw new Exception\RuntimeException('Found empty parameter name');
                 }
+
+                $levelParts[$level][] = array('parameter', $matches['name'], isset($matches['delimiters']) ? $matches['delimiters'] : null);
 
                 $currentPos += strlen($matches[0]);
             } elseif ($matches['token'] === '{') {
@@ -217,7 +217,6 @@ class Segment implements RouteInterface
      * @param  array   $constraints
      * @param  integer $groupIndex
      * @return string
-     * @throws Exception\RuntimeException
      */
     protected function buildRegex(array $parts, array $constraints, &$groupIndex = 1)
     {
@@ -247,15 +246,10 @@ class Segment implements RouteInterface
                     $regex .= '(?:' . $this->buildRegex($part[1], $constraints, $groupIndex) . ')?';
                     break;
 
-                // @codeCoverageIgnoreStart
                 case 'translated-literal':
-                    throw new Exception\RuntimeException('Translated literals are not implemented yet');
+                    $regex .= '#' . $part[1] . '#';
+                    $this->translationKeys[] = $part[1];
                     break;
-
-                case 'translated-parameter':
-                    throw new Exception\RuntimeException('Translated parameters are not implemented yet');
-                    break;
-                // @codeCoverageIgnoreEnd
             }
         }
 
@@ -267,14 +261,25 @@ class Segment implements RouteInterface
      *
      * @param  array   $parts
      * @param  array   $mergedParams
-     * @param  bool $isOptional
-     * @param  bool $hasChild
+     * @param  boolean $isOptional
+     * @param  boolean $hasChild
+     * @param  array   $options
      * @return string
-     * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException
+     * @throws Exception\RuntimeException
      */
-    protected function buildPath(array $parts, array $mergedParams, $isOptional, $hasChild)
+    protected function buildPath(array $parts, array $mergedParams, $isOptional, $hasChild, array $options)
     {
+        if ($this->translationKeys) {
+            if (!isset($options['translator']) || !$options['translator'] instanceof Translator) {
+                throw new Exception\RuntimeException('No translator provided');
+            }
+
+            $translator = $options['translator'];
+            $textDomain = (isset($options['text_domain']) ? $options['text_domain'] : 'default');
+            $locale     = (isset($options['locale']) ? $options['locale'] : null);
+        }
+
         $path      = '';
         $skip      = true;
         $skippable = false;
@@ -305,7 +310,7 @@ class Segment implements RouteInterface
 
                 case 'optional':
                     $skippable    = true;
-                    $optionalPart = $this->buildPath($part[1], $mergedParams, true, $hasChild);
+                    $optionalPart = $this->buildPath($part[1], $mergedParams, true, $hasChild, $options);
 
                     if ($optionalPart !== '') {
                         $path .= $optionalPart;
@@ -313,15 +318,9 @@ class Segment implements RouteInterface
                     }
                     break;
 
-                // @codeCoverageIgnoreStart
                 case 'translated-literal':
-                    throw new Exception\RuntimeException('Translated literals are not implemented yet');
+                    $path .= $translator->translate($part[1], $textDomain, $locale);
                     break;
-
-                case 'translated-parameter':
-                    throw new Exception\RuntimeException('Translated parameters are not implemented yet');
-                    break;
-                // @codeCoverageIgnoreEnd
             }
         }
 
@@ -336,11 +335,13 @@ class Segment implements RouteInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    \Zend\Mvc\Router\RouteInterface::match()
-     * @param  Request $request
+     * @param  Request     $request
      * @param  string|null $pathOffset
-     * @return RouteMatch
+     * @param  array       $options
+     * @return RouteMatch|null
+     * @throws Exception\RuntimeException
      */
-    public function match(Request $request, $pathOffset = null)
+    public function match(Request $request, $pathOffset = null, array $options = array())
     {
         if (!method_exists($request, 'getUri')) {
             return null;
@@ -349,10 +350,26 @@ class Segment implements RouteInterface
         $uri  = $request->getUri();
         $path = $uri->getPath();
 
+        $regex = $this->regex;
+
+        if ($this->translationKeys) {
+            if (!isset($options['translator']) || !$options['translator'] instanceof Translator) {
+                throw new Exception\RuntimeException('No translator provided');
+            }
+
+            $translator = $options['translator'];
+            $textDomain = (isset($options['text_domain']) ? $options['text_domain'] : 'default');
+            $locale     = (isset($options['locale']) ? $options['locale'] : null);
+
+            foreach ($this->translationKeys as $key) {
+                $regex = str_replace('#' . $key . '#', $translator->translate($key, $textDomain, $locale), $regex);
+            }
+        }
+
         if ($pathOffset !== null) {
-            $result = preg_match('(\G' . $this->regex . ')', $path, $matches, null, $pathOffset);
+            $result = preg_match('(\G' . $regex . ')', $path, $matches, null, $pathOffset);
         } else {
-            $result = preg_match('(^' . $this->regex . '$)', $path, $matches);
+            $result = preg_match('(^' . $regex . '$)', $path, $matches);
         }
 
         if (!$result) {
@@ -387,7 +404,8 @@ class Segment implements RouteInterface
             $this->parts,
             array_merge($this->defaults, $params),
             false,
-            (isset($options['has_child']) ? $options['has_child'] : false)
+            (isset($options['has_child']) ? $options['has_child'] : false),
+            $options
         );
     }
 

--- a/library/Zend/Mvc/Router/Http/TranslatorAwareTreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TranslatorAwareTreeRouteStack.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Router\Http;
+
+use Zend\I18n\Translator\Translator;
+use Zend\I18n\Translator\TranslatorAwareInterface;
+
+/**
+ * Translator aware tree route stack.
+ */
+class TranslatorAwareTreeRouteStack extends TreeRouteStack implements TranslatorAwareInterface
+{
+    /**
+     * Translator used for translatable segments.
+     *
+     * @var Translator
+     */
+    protected $translator;
+
+    /**
+     * Whether the translator is enabled.
+     *
+     * @var boolean
+     */
+    protected $translatorEnabled = true;
+
+    /**
+     * Translator text domain to use.
+     *
+     * @var string
+     */
+    protected $translatorTextDomain = 'default';
+
+    /**
+     * match(): defined by \Zend\Mvc\Router\RouteInterface
+     *
+     * @see    \Zend\Mvc\Router\RouteInterface::match()
+     * @param  Request      $request
+     * @param  integer|null $pathOffset
+     * @param  array        $options
+     * @return RouteMatch|null
+     */
+    public function match(Request $request, $pathOffset = null, array $options = array())
+    {
+        if ($this->hasTranslator() && $this->isTranslatorEnabled() && !isset($options['translator'])) {
+            $options['translator'] = $this->getTranslator();
+        }
+
+        if (!isset($options['text_domain'])) {
+            $options['text_domain'] = $this->getTranslatorTextDomain();
+        }
+
+        return parent::match($request, $pathOffset, $options);
+    }
+
+    /**
+     * assemble(): defined by \Zend\Mvc\Router\RouteInterface interface.
+     *
+     * @see    \Zend\Mvc\Router\RouteInterface::assemble()
+     * @param  array $params
+     * @param  array $options
+     * @return mixed
+     * @throws Exception\InvalidArgumentException
+     * @throws Exception\RuntimeException
+     */
+    public function assemble(array $params = array(), array $options = array())
+    {
+        if ($this->hasTranslator() && $this->isTranslatorEnabled() && !isset($options['translator'])) {
+            $options['translator'] = $this->getTranslator();
+        }
+
+        if (!isset($options['text_domain'])) {
+            $options['text_domain'] = $this->getTranslatorTextDomain();
+        }
+
+        return parent::assemble($params, $options);
+    }
+
+    /**
+     * setTranslator(): defined by TranslatorAwareInterface.
+     *
+     * @see    TranslatorAwareInterface::setTranslator()
+     * @param  Translator $translator
+     * @param  string     $textDomain
+     * @return TreeRouteStack
+     */
+    public function setTranslator(Translator $translator = null, $textDomain = null)
+    {
+        $this->translator = $translator;
+
+        if ($textDomain !== null) {
+            $this->setTranslatorTextDomain($textDomain);
+        }
+
+        return $this;
+    }
+
+    /**
+     * getTranslator(): defined by TranslatorAwareInterface.
+     *
+     * @see    TranslatorAwareInterface::getTranslator()
+     * @return Translator
+     */
+    public function getTranslator()
+    {
+        return $this->translator;
+    }
+
+    /**
+     * hasTranslator(): defined by TranslatorAwareInterface.
+     *
+     * @see    TranslatorAwareInterface::hasTranslator()
+     * @return boolean
+     */
+    public function hasTranslator()
+    {
+        return $this->translator !== null;
+    }
+
+    /**
+     * setTranslatorEnabled(): defined by TranslatorAwareInterface.
+     *
+     * @see    TranslatorAwareInterface::setTranslatorEnabled()
+     * @param  boolean $enabled
+     * @return TreeRouteStack
+     */
+    public function setTranslatorEnabled($enabled = true)
+    {
+        $this->translatorEnabled = $enabled;
+        return $this;
+    }
+
+    /**
+     * isTranslatorEnabled(): defined by TranslatorAwareInterface.
+     *
+     * @see    TranslatorAwareInterface::isTranslatorEnabled()
+     * @return boolean
+     */
+    public function isTranslatorEnabled()
+    {
+        return $this->translatorEnabled;
+    }
+
+    /**
+     * setTranslatorTextDomain(): defined by TranslatorAwareInterface.
+     *
+     * @see    TranslatorAwareInterface::setTranslatorTextDomain()
+     * @param  string $textDomain
+     * @return mixed
+     */
+    public function setTranslatorTextDomain($textDomain = 'default')
+    {
+        $this->translatorTextDomain = $textDomain;
+
+        return $this;
+    }
+
+    /**
+     * getTranslatorTextDomain(): defined by TranslatorAwareInterface.
+     *
+     * @see    TranslatorAwareInterface::getTranslatorTextDomain()
+     * @return string
+     */
+    public function getTranslatorTextDomain()
+    {
+        return $this->translatorTextDomain;
+    }
+}

--- a/library/Zend/Mvc/Router/Http/TranslatorAwareTreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TranslatorAwareTreeRouteStack.php
@@ -11,6 +11,7 @@ namespace Zend\Mvc\Router\Http;
 
 use Zend\I18n\Translator\Translator;
 use Zend\I18n\Translator\TranslatorAwareInterface;
+use Zend\Stdlib\RequestInterface as Request;
 
 /**
  * Translator aware tree route stack.

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -344,7 +344,7 @@ class TreeRouteStack extends SimpleRouteStack implements TranslatorAwareInterfac
      * @param  string     $textDomain
      * @return TreeRouteStack
      */
-    public function setTranslator(Translator\Translator $translator = null, $textDomain = null)
+    public function setTranslator(Translator $translator = null, $textDomain = null)
     {
         $this->translator = $translator;
 

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -10,8 +10,6 @@
 namespace Zend\Mvc\Router\Http;
 
 use Traversable;
-use Zend\I18n\Translator\Translator;
-use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\Mvc\Router\Exception;
 use Zend\Mvc\Router\SimpleRouteStack;
 use Zend\Stdlib\ArrayUtils;
@@ -21,7 +19,7 @@ use Zend\Uri\Http as HttpUri;
 /**
  * Tree search implementation.
  */
-class TreeRouteStack extends SimpleRouteStack implements TranslatorAwareInterface
+class TreeRouteStack extends SimpleRouteStack
 {
     /**
      * Base URL.
@@ -36,27 +34,6 @@ class TreeRouteStack extends SimpleRouteStack implements TranslatorAwareInterfac
      * @var HttpUri
      */
     protected $requestUri;
-
-    /**
-     * Translator used for translatable segments.
-     *
-     * @var Translator
-     */
-    protected $translator;
-
-    /**
-     * Whether the translator is enabled.
-     *
-     * @var boolean
-     */
-    protected $translatorEnabled = true;
-
-    /**
-     * Translator text domain to use.
-     *
-     * @var string
-     */
-    protected $translatorTextDomain = 'default';
 
     /**
      * init(): defined by SimpleRouteStack.
@@ -171,14 +148,6 @@ class TreeRouteStack extends SimpleRouteStack implements TranslatorAwareInterfac
             $this->setRequestUri($uri);
         }
 
-        if ($this->hasTranslator() && $this->isTranslatorEnabled() && !isset($options['translator'])) {
-            $options['translator'] = $this->getTranslator();
-        }
-
-        if (!isset($options['text_domain'])) {
-            $options['text_domain'] = $this->getTranslatorTextDomain();
-        }
-
         if ($baseUrlLength !== null) {
             $pathLength = strlen($uri->getPath()) - $baseUrlLength;
 
@@ -251,14 +220,6 @@ class TreeRouteStack extends SimpleRouteStack implements TranslatorAwareInterfac
             $options['uri'] = $uri;
         } else {
             $uri = $options['uri'];
-        }
-
-        if ($this->hasTranslator() && $this->isTranslatorEnabled() && !isset($options['translator'])) {
-            $options['translator'] = $this->getTranslator();
-        }
-
-        if (!isset($options['text_domain'])) {
-            $options['text_domain'] = $this->getTranslatorTextDomain();
         }
 
         $path = $this->baseUrl . $route->assemble(array_merge($this->defaultParams, $params), $options);
@@ -334,95 +295,5 @@ class TreeRouteStack extends SimpleRouteStack implements TranslatorAwareInterfac
     public function getRequestUri()
     {
         return $this->requestUri;
-    }
-
-    /**
-     * setTranslator(): defined by TranslatorAwareInterface.
-     *
-     * @see    TranslatorAwareInterface::setTranslator()
-     * @param  Translator $translator
-     * @param  string     $textDomain
-     * @return TreeRouteStack
-     */
-    public function setTranslator(Translator $translator = null, $textDomain = null)
-    {
-        $this->translator = $translator;
-
-        if ($textDomain !== null) {
-            $this->setTranslatorTextDomain($textDomain);
-        }
-
-        return $this;
-    }
-
-    /**
-     * getTranslator(): defined by TranslatorAwareInterface.
-     *
-     * @see    TranslatorAwareInterface::getTranslator()
-     * @return Translator
-     */
-    public function getTranslator()
-    {
-        return $this->translator;
-    }
-
-    /**
-     * hasTranslator(): defined by TranslatorAwareInterface.
-     *
-     * @see    TranslatorAwareInterface::hasTranslator()
-     * @return boolean
-     */
-    public function hasTranslator()
-    {
-        return $this->translator !== null;
-    }
-
-    /**
-     * setTranslatorEnabled(): defined by TranslatorAwareInterface.
-     *
-     * @see    TranslatorAwareInterface::setTranslatorEnabled()
-     * @param  boolean $enabled
-     * @return TreeRouteStack
-     */
-    public function setTranslatorEnabled($enabled = true)
-    {
-        $this->translatorEnabled = $enabled;
-        return $this;
-    }
-
-    /**
-     * isTranslatorEnabled(): defined by TranslatorAwareInterface.
-     *
-     * @see    TranslatorAwareInterface::isTranslatorEnabled()
-     * @return boolean
-     */
-    public function isTranslatorEnabled()
-    {
-        return $this->translatorEnabled;
-    }
-
-    /**
-     * setTranslatorTextDomain(): defined by TranslatorAwareInterface.
-     *
-     * @see    TranslatorAwareInterface::setTranslatorTextDomain()
-     * @param  string $textDomain
-     * @return mixed
-     */
-    public function setTranslatorTextDomain($textDomain = 'default')
-    {
-        $this->translatorTextDomain = $textDomain;
-
-        return $this;
-    }
-
-    /**
-     * getTranslatorTextDomain(): defined by TranslatorAwareInterface.
-     *
-     * @see    TranslatorAwareInterface::getTranslatorTextDomain()
-     * @return string
-     */
-    public function getTranslatorTextDomain()
-    {
-        return $this->translatorTextDomain;
     }
 }

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -10,7 +10,8 @@
 namespace Zend\Mvc\Router\Http;
 
 use Traversable;
-use Zend\I18n\Translator;
+use Zend\I18n\Translator\Translator;
+use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\Mvc\Router\Exception;
 use Zend\Mvc\Router\SimpleRouteStack;
 use Zend\Stdlib\ArrayUtils;
@@ -20,7 +21,7 @@ use Zend\Uri\Http as HttpUri;
 /**
  * Tree search implementation.
  */
-class TreeRouteStack extends SimpleRouteStack implements Translator\TranslatorAwareInterface
+class TreeRouteStack extends SimpleRouteStack implements TranslatorAwareInterface
 {
     /**
      * Base URL.
@@ -39,7 +40,7 @@ class TreeRouteStack extends SimpleRouteStack implements Translator\TranslatorAw
     /**
      * Translator used for translatable segments.
      *
-     * @var Translator\Translator
+     * @var Translator
      */
     protected $translator;
 
@@ -65,7 +66,8 @@ class TreeRouteStack extends SimpleRouteStack implements Translator\TranslatorAw
     protected function init()
     {
         $routes = $this->routePluginManager;
-        foreach (array(
+        foreach (
+            array(
                 'hostname' => __NAMESPACE__ . '\Hostname',
                 'literal'  => __NAMESPACE__ . '\Literal',
                 'part'     => __NAMESPACE__ . '\Part',
@@ -335,11 +337,11 @@ class TreeRouteStack extends SimpleRouteStack implements Translator\TranslatorAw
     }
 
     /**
-     * setTranslator(): defined by Translator\TranslatorAwareInterface.
+     * setTranslator(): defined by TranslatorAwareInterface.
      *
-     * @see    Translator\TranslatorAwareInterface::setTranslator()
-     * @param  Translator\Translator $translator
-     * @param  string                $textDomain
+     * @see    TranslatorAwareInterface::setTranslator()
+     * @param  Translator $translator
+     * @param  string     $textDomain
      * @return TreeRouteStack
      */
     public function setTranslator(Translator\Translator $translator = null, $textDomain = null)
@@ -354,10 +356,10 @@ class TreeRouteStack extends SimpleRouteStack implements Translator\TranslatorAw
     }
 
     /**
-     * getTranslator(): defined by Translator\TranslatorAwareInterface.
+     * getTranslator(): defined by TranslatorAwareInterface.
      *
-     * @see    Translator\TranslatorAwareInterface::getTranslator()
-     * @return Translator\Translator
+     * @see    TranslatorAwareInterface::getTranslator()
+     * @return Translator
      */
     public function getTranslator()
     {
@@ -365,9 +367,9 @@ class TreeRouteStack extends SimpleRouteStack implements Translator\TranslatorAw
     }
 
     /**
-     * hasTranslator(): defined by Translator\TranslatorAwareInterface.
+     * hasTranslator(): defined by TranslatorAwareInterface.
      *
-     * @see    Translator\TranslatorAwareInterface::hasTranslator()
+     * @see    TranslatorAwareInterface::hasTranslator()
      * @return boolean
      */
     public function hasTranslator()
@@ -376,9 +378,9 @@ class TreeRouteStack extends SimpleRouteStack implements Translator\TranslatorAw
     }
 
     /**
-     * setTranslatorEnabled(): defined by Translator\TranslatorAwareInterface.
+     * setTranslatorEnabled(): defined by TranslatorAwareInterface.
      *
-     * @see    Translator\TranslatorAwareInterface::setTranslatorEnabled()
+     * @see    TranslatorAwareInterface::setTranslatorEnabled()
      * @param  boolean $enabled
      * @return TreeRouteStack
      */
@@ -389,9 +391,9 @@ class TreeRouteStack extends SimpleRouteStack implements Translator\TranslatorAw
     }
 
     /**
-     * isTranslatorEnabled(): defined by Translator\TranslatorAwareInterface.
+     * isTranslatorEnabled(): defined by TranslatorAwareInterface.
      *
-     * @see    Translator\TranslatorAwareInterface::isTranslatorEnabled()
+     * @see    TranslatorAwareInterface::isTranslatorEnabled()
      * @return boolean
      */
     public function isTranslatorEnabled()
@@ -400,10 +402,10 @@ class TreeRouteStack extends SimpleRouteStack implements Translator\TranslatorAw
     }
 
     /**
-     * setTranslatorTextDomain(): defined by Translator\TranslatorAwareInterface.
+     * setTranslatorTextDomain(): defined by TranslatorAwareInterface.
      *
-     * @see    Translator\TranslatorAwareInterface::setTranslatorTextDomain()
-     * @param string $textDomain
+     * @see    TranslatorAwareInterface::setTranslatorTextDomain()
+     * @param  string $textDomain
      * @return mixed
      */
     public function setTranslatorTextDomain($textDomain = 'default')
@@ -414,9 +416,9 @@ class TreeRouteStack extends SimpleRouteStack implements Translator\TranslatorAw
     }
 
     /**
-     * getTranslatorTextDomain(): defined by Translator\TranslatorAwareInterface.
+     * getTranslatorTextDomain(): defined by TranslatorAwareInterface.
      *
-     * @see    Translator\TranslatorAwareInterface::getTranslatorTextDomain()
+     * @see    TranslatorAwareInterface::getTranslatorTextDomain()
      * @return string
      */
     public function getTranslatorTextDomain()

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -150,22 +150,25 @@ class TreeRouteStack extends SimpleRouteStack
 
         if ($baseUrlLength !== null) {
             $pathLength = strlen($uri->getPath()) - $baseUrlLength;
-
-            foreach ($this->routes as $name => $route) {
-                if (($match = $route->match($request, $baseUrlLength, $options)) instanceof RouteMatch && $match->getLength() === $pathLength) {
-                    $match->setMatchedRouteName($name);
-
-                    foreach ($this->defaultParams as $paramName => $value) {
-                        if ($match->getParam($paramName) === null) {
-                            $match->setParam($paramName, $value);
-                        }
-                    }
-
-                    return $match;
-                }
-            }
         } else {
-            return parent::match($request);
+            $pathLength = null;
+        }
+
+        foreach ($this->routes as $name => $route) {
+            if (
+                ($match = $route->match($request, $baseUrlLength, $options)) instanceof RouteMatch
+                && ($pathLength === null || $match->getLength() === $pathLength)
+            ) {
+                $match->setMatchedRouteName($name);
+
+                foreach ($this->defaultParams as $paramName => $value) {
+                    if ($match->getParam($paramName) === null) {
+                        $match->setParam($paramName, $value);
+                    }
+                }
+
+                return $match;
+            }
         }
 
         return null;

--- a/library/Zend/Mvc/Router/Http/Wildcard.php
+++ b/library/Zend/Mvc/Router/Http/Wildcard.php
@@ -16,8 +16,6 @@ use Zend\Stdlib\RequestInterface as Request;
 
 /**
  * Wildcard route.
- *
- * @see        http://guides.rubyonrails.org/routing.html
  */
 class Wildcard implements RouteInterface
 {
@@ -68,8 +66,8 @@ class Wildcard implements RouteInterface
      *
      * @see    \Zend\Mvc\Router\RouteInterface::factory()
      * @param  array|Traversable $options
-     * @throws \Zend\Mvc\Router\Exception\InvalidArgumentException
      * @return Wildcard
+     * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = array())
     {
@@ -98,9 +96,9 @@ class Wildcard implements RouteInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    \Zend\Mvc\Router\RouteInterface::match()
-     * @param  Request $request
-     * @param  int|null $pathOffset
-     * @return RouteMatch
+     * @param  Request      $request
+     * @param  integer|null $pathOffset
+     * @return RouteMatch|null
      */
     public function match(Request $request, $pathOffset = null)
     {

--- a/library/Zend/Mvc/Router/PriorityList.php
+++ b/library/Zend/Mvc/Router/PriorityList.php
@@ -14,8 +14,7 @@ use Iterator;
 
 /**
  * Priority list
- *
-  */
+ */
 class PriorityList implements Iterator, Countable
 {
     /**

--- a/library/Zend/Mvc/Router/RouteInterface.php
+++ b/library/Zend/Mvc/Router/RouteInterface.php
@@ -35,7 +35,7 @@ interface RouteInterface
      * Match a given request.
      *
      * @param  Request $request
-     * @return RouteMatch
+     * @return RouteMatch|null
      */
     public function match(Request $request);
 

--- a/library/Zend/Mvc/Router/RouteMatch.php
+++ b/library/Zend/Mvc/Router/RouteMatch.php
@@ -87,7 +87,7 @@ class RouteMatch
      * Get a specific parameter.
      *
      * @param  string $name
-     * @param  mixed $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function getParam($name, $default = null)

--- a/library/Zend/Mvc/Router/RoutePluginManager.php
+++ b/library/Zend/Mvc/Router/RoutePluginManager.php
@@ -22,20 +22,22 @@ use Zend\ServiceManager\AbstractPluginManager;
 class RoutePluginManager extends AbstractPluginManager
 {
     /**
-     * @var bool Do not share instances
+     * Do not share instances.
+     *
+     * @var boolean
      */
     protected $shareByDefault = false;
 
     /**
-     * Override setInvokableClass()
+     * Override setInvokableClass().
      *
      * Performs normal operation, but also auto-aliases the class name to the
      * service name. This ensures that providing the FQCN does not trigger an
      * abstract factory later.
      *
-     * @param  string $name
-     * @param  string $invokableClass
-     * @param  null|bool $shared
+     * @param  string       $name
+     * @param  string       $invokableClass
+     * @param  null|boolean $shared
      * @return RoutePluginManager
      */
     public function setInvokableClass($name, $invokableClass, $shared = null)
@@ -48,7 +50,7 @@ class RoutePluginManager extends AbstractPluginManager
     }
 
     /**
-     * Validate the plugin
+     * Validate the plugin.
      *
      * Checks that the filter loaded is either a valid callback or an instance
      * of FilterInterface.
@@ -72,7 +74,7 @@ class RoutePluginManager extends AbstractPluginManager
     }
 
     /**
-     * Attempt to create an instance via an invokable class
+     * Attempt to create an instance via an invokable class.
      *
      * Overrides parent implementation by invoking the route factory,
      * passing $creationOptions as the argument.

--- a/library/Zend/Mvc/Router/SimpleRouteStack.php
+++ b/library/Zend/Mvc/Router/SimpleRouteStack.php
@@ -170,7 +170,7 @@ class SimpleRouteStack implements RouteStackInterface
      * removeRoute(): defined by RouteStackInterface interface.
      *
      * @see    RouteStackInterface::removeRoute()
-     * @param  string  $name
+     * @param  string $name
      * @return SimpleRouteStack
      */
     public function removeRoute($name)
@@ -205,7 +205,7 @@ class SimpleRouteStack implements RouteStackInterface
     /**
      * Check if a route with a specific name exists
      *
-     * @param string $name
+     * @param  string $name
      * @return boolean true if route exists
      */
     public function hasRoute($name)

--- a/library/Zend/Mvc/composer.json
+++ b/library/Zend/Mvc/composer.json
@@ -26,6 +26,9 @@
         "zendframework/zend-text": "self.version",
         "zendframework/zend-view": "self.version"
     },
+    "suggest": {
+        "zendframework/zend-i18n": "Zend\\I18n component for translatable segments"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.1-dev",

--- a/tests/ZendTest/Mvc/Router/Http/SegmentTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/SegmentTest.php
@@ -191,11 +191,6 @@ class SegmentTest extends TestCase
                 'Zend\Mvc\Router\Exception\RuntimeException',
                 'Translated literal missing closing bracket'
             ),
-            'translated-parameter-without-closing-backet' => array(
-                ':{test',
-                'Zend\Mvc\Router\Exception\RuntimeException',
-                'Translated parameter missing closing bracket'
-            ),
         );
     }
 
@@ -267,18 +262,6 @@ class SegmentTest extends TestCase
         $this->setExpectedException('Zend\Mvc\Router\Exception\InvalidArgumentException', 'Missing parameter "foo"');
         $route = new Segment('/:foo');
         $route->assemble();
-    }
-
-    public function testBuildTranslatedLiteral()
-    {
-        $this->setExpectedException('Zend\Mvc\Router\Exception\RuntimeException', 'Translated literals are not implemented yet');
-        $route = new Segment('/{foo}');
-    }
-
-    public function testBuildTranslatedParameter()
-    {
-        $this->setExpectedException('Zend\Mvc\Router\Exception\RuntimeException', 'Translated parameters are not implemented yet');
-        $route = new Segment('/:{foo}');
     }
 
     public function testNoMatchWithoutUriMethod()

--- a/tests/ZendTest/Mvc/Router/Http/SegmentTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/SegmentTest.php
@@ -12,14 +12,32 @@ namespace ZendTest\Mvc\Router\Http;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Http\Request;
+use Zend\I18n\Translator\TextDomain;
+use Zend\I18n\Translator\Translator;
 use Zend\Stdlib\Request as BaseRequest;
 use Zend\Mvc\Router\Http\Segment;
+use ZendTest\I18n\Translator\TestAsset\Loader as TestLoader;
 use ZendTest\Mvc\Router\FactoryTester;
 
 class SegmentTest extends TestCase
 {
     public static function routeProvider()
     {
+        $translator = new Translator();
+        $translator->setLocale('en-US');
+        $enLoader     = new TestLoader();
+        $deLoader     = new TestLoader();
+        $domainLoader = new TestLoader();
+        $enLoader->textDomain     = new TextDomain(array('fw' => 'framework'));
+        $deLoader->textDomain     = new TextDomain(array('fw' => 'baukasten'));
+        $domainLoader->textDomain = new TextDomain(array('fw' => 'fw-alternative'));
+        $translator->getPluginManager()->setService('test-en',     $enLoader);
+        $translator->getPluginManager()->setService('test-de',     $deLoader);
+        $translator->getPluginManager()->setService('test-domain', $domainLoader);
+        $translator->addTranslationFile('test-en', null, 'default', 'en-US');
+        $translator->addTranslationFile('test-de', null, 'default', 'de-DE');
+        $translator->addTranslationFile('test-domain', null, 'alternative', 'en-US');
+
         return array(
             'simple-match' => array(
                 new Segment('/:foo'),
@@ -165,6 +183,34 @@ class SegmentTest extends TestCase
                 null,
                 array('bar' => 'bar', 'baz' => 'baz')
             ),
+            'translate-with-default-locale' => array(
+                new Segment('/{fw}', array(), array()),
+                '/framework',
+                null,
+                array(),
+                array('translator' => $translator)
+            ),
+            'translate-with-specific-locale' => array(
+                new Segment('/{fw}', array(), array()),
+                '/baukasten',
+                null,
+                array(),
+                array('translator' => $translator, 'locale' => 'de-DE')
+            ),
+            'translate-uses-message-id-as-fallback' => array(
+                new Segment('/{fw}', array(), array()),
+                '/fw',
+                null,
+                array(),
+                array('translator' => $translator, 'locale' => 'fr-FR')
+            ),
+            'translate-with-specific-text-domain' => array(
+                new Segment('/{fw}', array(), array()),
+                '/fw-alternative',
+                null,
+                array(),
+                array('translator' => $translator, 'text_domain' => 'alternative')
+            ),
         );
     }
 
@@ -200,12 +246,13 @@ class SegmentTest extends TestCase
      * @param        string  $path
      * @param        integer $offset
      * @param        array   $params
+     * @param        array   $options
      */
-    public function testMatching(Segment $route, $path, $offset, array $params = null)
+    public function testMatching(Segment $route, $path, $offset, array $params = null, array $options = array())
     {
         $request = new Request();
         $request->setUri('http://example.com' . $path);
-        $match = $route->match($request, $offset);
+        $match = $route->match($request, $offset, $options);
 
         if ($params === null) {
             $this->assertNull($match);
@@ -228,15 +275,16 @@ class SegmentTest extends TestCase
      * @param        string  $path
      * @param        integer $offset
      * @param        array   $params
+     * @param        array   $options
      */
-    public function testAssembling(Segment $route, $path, $offset, array $params = null)
+    public function testAssembling(Segment $route, $path, $offset, array $params = null, array $options = array())
     {
         if ($params === null) {
             // Data which will not match are not tested for assembling.
             return;
         }
 
-        $result = $route->assemble($params);
+        $result = $route->assemble($params, $options);
 
         if ($offset !== null) {
             $this->assertEquals($offset, strpos($path, $result, $offset));
@@ -262,6 +310,20 @@ class SegmentTest extends TestCase
         $this->setExpectedException('Zend\Mvc\Router\Exception\InvalidArgumentException', 'Missing parameter "foo"');
         $route = new Segment('/:foo');
         $route->assemble();
+    }
+
+    public function testTranslatedAssemblingThrowsExceptionWithoutTranslator()
+    {
+        $this->setExpectedException('Zend\Mvc\Router\Exception\RuntimeException', 'No translator provided');
+        $route = new Segment('/{foo}');
+        $route->assemble();
+    }
+
+    public function testTranslatedMatchingThrowsExceptionWithoutTranslator()
+    {
+        $this->setExpectedException('Zend\Mvc\Router\Exception\RuntimeException', 'No translator provided');
+        $route = new Segment('/{foo}');
+        $route->match(new Request());
     }
 
     public function testNoMatchWithoutUriMethod()

--- a/tests/ZendTest/Mvc/Router/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/TranslatorAwareTreeRouteStackTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc\Router\Http;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\I18n\Translator\Translator;
+use Zend\Http\Request as Request;
+use Zend\Mvc\Router\Http\TranslatorAwareTreeRouteStack;
+use Zend\Uri\Http as HttpUri;
+
+class TranslatorAwareTreeRouteStackTest extends TestCase
+{
+    public function testTranslatorAwareInterfaceImplementation()
+    {
+        $stack = new TranslatorAwareTreeRouteStack();
+        $this->assertInstanceOf('Zend\I18n\Translator\TranslatorAwareInterface', $stack);
+
+        // Defaults
+        $this->assertNull($stack->getTranslator());
+        $this->assertFalse($stack->hasTranslator());
+        $this->assertEquals('default', $stack->getTranslatorTextDomain());
+        $this->assertTrue($stack->isTranslatorEnabled());
+
+        // Inject translator without text domain
+        $translator = new Translator();
+        $stack->setTranslator($translator);
+        $this->assertSame($translator, $stack->getTranslator());
+        $this->assertEquals('default', $stack->getTranslatorTextDomain());
+        $this->assertTrue($stack->hasTranslator());
+
+        // Reset translator
+        $stack->setTranslator(null);
+        $this->assertNull($stack->getTranslator());
+        $this->assertFalse($stack->hasTranslator());
+
+        // Inject translator with text domain
+        $stack->setTranslator($translator, 'alternative');
+        $this->assertSame($translator, $stack->getTranslator());
+        $this->assertEquals('alternative', $stack->getTranslatorTextDomain());
+
+        // Set text domain
+        $stack->setTranslatorTextDomain('default');
+        $this->assertEquals('default', $stack->getTranslatorTextDomain());
+
+        // Disable translator
+        $stack->setTranslatorEnabled(false);
+        $this->assertFalse($stack->isTranslatorEnabled());
+    }
+
+    public function testTranslatorIsPassedThroughMatchMethod()
+    {
+        $translator = new Translator();
+        $request    = new Request();
+
+        $route = $this->getMock('Zend\Mvc\Router\Http\RouteInterface');
+        $route->expects($this->once())
+              ->method('match')
+              ->with(
+                  $this->equalTo($request),
+                  $this->isNull(),
+                  $this->equalTo(array('translator' => $translator, 'text_domain' => 'default'))
+              );
+
+        $stack = new TranslatorAwareTreeRouteStack();
+        $stack->addRoute('test', $route);
+
+        $stack->match($request, null, array('translator' => $translator));
+    }
+
+    public function testTranslatorIsPassedThroughAssembleMethod()
+    {
+        $translator = new Translator();
+        $uri        = new HttpUri();
+
+        $route = $this->getMock('Zend\Mvc\Router\Http\RouteInterface');
+        $route->expects($this->once())
+              ->method('assemble')
+              ->with(
+                  $this->equalTo(array()),
+                  $this->equalTo(array('translator' => $translator, 'text_domain' => 'default', 'uri' => $uri))
+              );
+
+        $stack = new TranslatorAwareTreeRouteStack();
+        $stack->addRoute('test', $route);
+
+        $stack->assemble(array(), array('name' => 'test', 'translator' => $translator, 'uri' => $uri));
+    }
+}


### PR DESCRIPTION
**Preamble**
This is the initial prototype for the translatable segments. It is considered work in progress, although it should be fully functional. Eventually, only the unit tests are missing.

I already implemented the parsing of translatable segments very early in the beginning, but totally forgot about them until now. This evening I was finally able to make up a good way to implement them.

**Introduction**
So, first of, I completely killed translatable parameters, and only left translatable literals in. This has the reason, that translatable parameters would eventually only serve a very small set of possible values, which can eventually be represented with child-routes and translatable literals. This also makes the implementation a lot easier.

To not force an already configured translator when the router itself is fetched from the service manager the very first time, I decided to move the translation logic completely into the match() and assemble() methods. This also allows to re-use the matching methods with different locales (there may be some use-cases for that, e.g. testing URLs in a CMS).

**New soft dependency**
`Zend\I18n` is now a soft dependency of `Zend\Mvc` and is added as "suggests" in the `composer.json` file. To avoid a hard dependency, a new route stack with the name `Zend\Mvc\Router\Http\TranslatorAwareTreeRouteStack` was implemented. This one has to be used in case you want to use translatable segments. It just extends the normal tree route stack, so it has the same functionality.

The segment route itself is not a problem for this, as it only has a `use Zend\I18n\Translator\Translator` in its head, but only actually uses that class if translatable segments exist.

**Usage**
Eventually, I introduced a few new features here and there, to make the implementation as sane as possible. No BC breaks were done for it, at least as far as I know. All existing unit tests pass (except for the ones which tested for the "not implemented" exceptions, but those were already removed by the initial comit).

To make use of the translatable segments, you first have to inject a translator into the router. This can be done either automatically by the ServiceManager (thanks to the `TranslatorAwareInterface`) or manually through `$router->setTranslator()`.

Optionally you can specify a text domain to use for route translations with `$router->setTranslatorTextDomain()`. If you don't set one, the "default" text domain will be used.

Now you are ready to create translatable segments. Take for instance the following route definition, where the translatable segment is encapsulated in curly brackets:

```
/{bacon}/:id
```

When matching, the `bacon` parameter will be replaced with the translation of the message id "bacon" in the matching regex and then the regex will be evaluated against the request as usual. When assembling, the same thing happens again. This is a much more efficient approach than the one we had in ZF1, where the route had to get **all** translations from the translator.

You also have the possibility to change the translator, the text domain and the locale on-the-fly both for matching and for assembling. For the match() method, a third (non-interface) `array $options = array()` parameter was added after the `$pathOffset` parameter. This allows to pass down "translator", "text_domain" and "locale" down the tree. The same options are also taken into account by the `assemble()` method.

**Sidenote**
I also fixed a few formatting issues and changed some docblocks, nothing to worry about :)
