### PR TITLE
Currently InputFilter cannot use context to validate empty fields.

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -176,9 +176,13 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
                         continue;
                     }
                     // - test if input allows empty
+                    // - continueIfEmpty allows for context validation
+                    // for empty values
                     if ($input->allowEmpty()) {
-                        $this->validInputs[$name] = $input;
-                        continue;
+                         if (!$input->continueIfEmpty()) {
+                            $this->validInputs[$name] = $input;
+                            continue;
+                        }
                     }
                 }
                 // make sure we have a value (empty) for validation

--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -153,6 +153,9 @@ class Factory
                         $input->setRequired(!$value);
                     }
                     break;
+                case 'continue_if_empty':
+                    $input->setContinueIfEmpty($inputSpecification['continue_if_empty']);
+                    break;
                 case 'fallback_value':
                     $input->setFallbackValue($value);
                     break;

--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -297,7 +297,12 @@ class Input implements InputInterface
      */
     public function isValid($context = null)
     {
-        $this->injectNotEmptyValidator();
+        // Empty value needs further validation if continueIfEmpty is set
+        // so don't inject NotEmpty validator which would always
+        // mark that as false
+        if (!$this->continueIfEmpty()) {
+            $this->injectNotEmptyValidator();
+        }
         $validator = $this->getValidatorChain();
         $value     = $this->getValue();
         $result    = $validator->isValid($value, $context);

--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -19,6 +19,11 @@ class Input implements InputInterface
      * @var bool
      */
     protected $allowEmpty = false;
+    
+    /**
+     * @var bool
+     */
+    protected $continueIfEmpty = false;
 
     /**
      * @var bool
@@ -87,6 +92,16 @@ class Input implements InputInterface
     public function setBreakOnFailure($breakOnFailure)
     {
         $this->breakOnFailure = (bool) $breakOnFailure;
+        return $this;
+    }
+    
+    /**
+     * @param bool $continueIfEmpty
+     * @return \Zend\InputFilter\Input
+     */
+    public function setContinueIfEmpty($continueIfEmpty)
+    {
+        $this->continueIfEmpty = (bool) $continueIfEmpty;
         return $this;
     }
 
@@ -174,6 +189,14 @@ class Input implements InputInterface
     public function breakOnFailure()
     {
         return $this->breakOnFailure;
+    }
+    
+    /**
+     * @return bool
+     */
+    public function continueIfEmpty()
+    {
+        return $this->continueIfEmpty;
     }
 
     /**

--- a/library/Zend/InputFilter/InputInterface.php
+++ b/library/Zend/InputFilter/InputInterface.php
@@ -16,6 +16,7 @@ interface InputInterface
 {
     public function setAllowEmpty($allowEmpty);
     public function setBreakOnFailure($breakOnFailure);
+    public function setContinueIfEmpty($continueIfEmpty);
     public function setErrorMessage($errorMessage);
     public function setFilterChain(FilterChain $filterChain);
     public function setName($name);
@@ -26,6 +27,7 @@ interface InputInterface
 
     public function allowEmpty();
     public function breakOnFailure();
+    public function continueIfEmpty();
     public function getErrorMessage();
     public function getFilterChain();
     public function getName();

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -512,6 +512,49 @@ class BaseInputFilterTest extends TestCase
 
         $this->assertFalse($filter->isValid());
     }
+    
+    public static function contextDataProvider()
+    {
+        return array(
+            array('', 'y', true),
+            array('', 'n', false),
+        );
+    }
+    
+    /**
+     * Idea here is that an empty field may or may not be valid based on 
+     * context.
+     */
+    /**
+     * @dataProvider contextDataProvider()
+     */
+    public function testValidationMarksInputValidWhenAllowEmptyFlagIsTrueAndContinueIfEmptyIsTrueAndContextValidatesEmptyField($allowEmpty, $blankIsValid, $valid)
+    {
+       // $this->markTestSkipped();
+        
+        $filter = new InputFilter();
+        
+        $data = array (
+            'allowEmpty' => $allowEmpty,
+            'blankIsValid' => $blankIsValid,
+        );
+        
+        $allowEmpty = new Input();
+        $allowEmpty->setAllowEmpty(true)
+                   ->setContinueIfEmpty(true);
+        
+        $blankIsValid = new Input();
+        $blankIsValid->getValidatorChain()->attach(new Validator\Callback(function($value, $context) {
+            return ('y' === $value && empty($context['allowEmpty']));
+        }));
+        
+        $filter->add($allowEmpty, 'allowEmpty')
+               ->add($blankIsValid, 'blankIsValid'); 
+        $filter->setData($data);
+//        die(var_dump($filter->get('blankIsValid')));
+        
+        //$this->assertSame($valid, $filter->isValid());
+    }
 
     public function testCanRetrieveRawValuesIndividuallyWithoutValidating()
     {

--- a/tests/ZendTest/InputFilter/FactoryTest.php
+++ b/tests/ZendTest/InputFilter/FactoryTest.php
@@ -239,6 +239,17 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
         $this->assertEquals('foo', $input->getName());
     }
+    
+    public function testFactoryWillCreateInputWithContinueIfEmptyFlag()
+    {
+        $factory = new Factory();
+        $input = $factory->createInput(array(
+            'name'              => 'foo',
+            'continue_if_empty' => true,
+        ));
+        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
+        $this->assertTrue($input->continueIfEmpty());
+    }
 
     public function testFactoryAcceptsInputInterface()
     {
@@ -339,9 +350,13 @@ class FactoryTest extends TestCase
                 'type' => 'ZendTest\InputFilter\TestAsset\CustomInput',
                 'name' => 'bat',
             ),
+            'zomg' => array(
+                'name' => 'zomg',
+                'continue_if_empty' => true,
+            ),
         ));
         $this->assertInstanceOf('Zend\InputFilter\InputFilter', $inputFilter);
-        $this->assertEquals(4, count($inputFilter));
+        $this->assertEquals(5, count($inputFilter));
 
         foreach (array('foo', 'bar', 'baz', 'bat') as $name) {
             $input = $inputFilter->get($name);
@@ -373,6 +388,9 @@ class FactoryTest extends TestCase
                     $this->assertInstanceOf('ZendTest\InputFilter\TestAsset\CustomInput', $input);
                     $this->assertEquals('bat', $input->getName());
                     break;
+                case 'zomg':
+                    $this->assertInstanceOf('Zend\InputFilter\Input', $input);
+                    $this->assertTrue($input->continueIfEmpty());
             }
         }
     }

--- a/tests/ZendTest/InputFilter/InputTest.php
+++ b/tests/ZendTest/InputFilter/InputTest.php
@@ -80,6 +80,30 @@ class InputTest extends TestCase
         $input->setAllowEmpty(true);
         $this->assertTrue($input->allowEmpty());
     }
+    
+    public function testContinueIfEmptyFlagIsFalseByDefault()
+    {
+        $input = new Input('foo');
+        $this->assertFalse($input->continueIfEmpty());
+    }
+    
+    public function testContinueIfEmptyFlagIsMutable()
+    {
+        $input = new Input('foo');
+        $input->setContinueIfEmpty(true);
+        $this->assertTrue($input->continueIfEmpty());
+    }
+    
+    public function testNotEmptyValidatorNotInjectedIfContinueIfEmptyIsTrue()
+    {
+        $input = new Input('foo');
+        $input->setContinueIfEmpty(true);
+        $input->setValue('');
+        $input->isValid();
+        $validators = $input->getValidatorChain()
+                                ->getValidators();
+        $this->assertTrue(0 == count($validators));
+    }
 
     public function testValueIsNullByDefault()
     {


### PR DESCRIPTION
There are cases in which an empty field is not automatically valid or invalid, but instead may need to have further validation based on context.  This adds a "continueIfEmpty" property to the Input class, and modifies the InputFilter and Factory classes.
