### PR TITLE
Normalize console usage

### DIFF
--- a/library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php
@@ -221,7 +221,8 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
                     continue; // this module does not provide a banner
                 }
 
-                $banners[] = $module->getConsoleBanner($console);
+                // We colorize each banners in blue for visually splitting everything
+                $banners[] = $console->colorize($module->getConsoleBanner($console), ColorInterface::BLUE);
             }
         }
 
@@ -267,13 +268,24 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
                     continue; // this module does not provide usage info
                 }
 
+                // We prepend the usage by the module name (printed in red), so that each module is
+                // clearly visible by the user
+                $moduleName = sprintf("%s\n%s\n%s\n",
+                    str_repeat('-', $console->getWidth()),
+                    $name,
+                    str_repeat('-', $console->getWidth())
+                );
+
+                $moduleName = $console->colorize($moduleName, ColorInterface::RED);
+
                 $usage = $module->getConsoleUsage($console);
 
                 // Normalize what we got from the module or discard
                 if (is_array($usage)) {
+                    array_unshift($usage, $moduleName);
                     $usageInfo[$name] = $usage;
                 } elseif (is_string($usage)) {
-                    $usageInfo[$name] = array($usage);
+                    $usageInfo[$name] = array($moduleName, $usage);
                 }
             }
         }


### PR DESCRIPTION
Hi,

This is a PR that attempt to answer a problem that I outlined here: https://github.com/zendframework/zf2/issues/3731

Basically, I'm using a few modules that have console commands. The problem that arised is that it quickly becomes a mess for three main reasons:
1. There are no colors by default that help me to separate each module.
2. Each module owner have their own conventions for banner...
3. The getConsoleBanner was misused by me (and a lot of other people too).

What I thought first is that getConsoleBanner was used to tell the name of the module, so that the following logic were used: banner 1, usage 1, banner 2, usage 2... However, as @Thinkscape outlined to me, banners are all appended at the beginning and should remain short (name of the module and version).

My idea is to automatically generate module name separators, with some pre-defined colors that visually separate each module. We would also need to update the doc so that people are encouraged to follow the same conventions:
1. getConsoleBanner should return a ONE-LINE only with name of module + version of module. This way, all modules are clearly shown at the beginning of the console.
2. getConsoleUsage SHOULD NOT return the name of the module as this is automatically done now by the Console component itself. This one should only return... well.. usage. This is not a BC. At worst, people that wrote the module name in the usage, it will just write it twice (the user one and the automatically generated one).

For those who want to see the result, here it is (I'm open to discuss about color choices):

http://cl.ly/image/47203A0c0i1c

As you can see, the module names are all appended at the beginning in blue, while each module are separated by the module name wrapped around dashes (those take the whole console width).

What do you think ?
