### PR TITLE
Added translations for form element error messages

### DIFF
--- a/library/Zend/Form/View/Helper/FormElementErrors.php
+++ b/library/Zend/Form/View/Helper/FormElementErrors.php
@@ -149,6 +149,11 @@ class FormElementErrors extends AbstractHelper
         $escapeHtml      = $this->getEscapeHtmlHelper();
         $messagesToPrint = array();
         array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml) {
+            if (null !== ($translator = $this->getTranslator())) {
+                $item = $translator->translate(
+                    $item, $this->getTranslatorTextDomain()
+                );
+            }
             $messagesToPrint[] = $escapeHtml($item);
         });
 

--- a/library/Zend/Form/View/Helper/FormElementErrors.php
+++ b/library/Zend/Form/View/Helper/FormElementErrors.php
@@ -148,11 +148,11 @@ class FormElementErrors extends AbstractHelper
         // Flatten message array
         $escapeHtml      = $this->getEscapeHtmlHelper();
         $messagesToPrint = array();
-        array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml) {
-            if (null !== ($translator = $this->getTranslator())) {
-                $item = $translator->translate(
-                    $item, $this->getTranslatorTextDomain()
-                );
+        $translator      = $this->getTranslator();
+        $textDomain      = $this->getTranslatorTextDomain();
+        array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml, &$translator, &$textDomain) {
+            if (null !== $translator) {
+                $item = $translator->translate($item, $textDomain);
             }
             $messagesToPrint[] = $escapeHtml($item);
         });

--- a/library/Zend/Form/View/Helper/FormElementErrors.php
+++ b/library/Zend/Form/View/Helper/FormElementErrors.php
@@ -148,11 +148,12 @@ class FormElementErrors extends AbstractHelper
         // Flatten message array
         $escapeHtml      = $this->getEscapeHtmlHelper();
         $messagesToPrint = array();
-        $translator      = $this->getTranslator();
-        $textDomain      = $this->getTranslatorTextDomain();
-        array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml, &$translator, &$textDomain) {
-            if (null !== $translator) {
-                $item = $translator->translate($item, $textDomain);
+        $self            = $this;
+        array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml, &$self) {
+            if (null !== ($translator = $self->getTranslator())) {
+                $item = $translator->translate(
+                    $item, $self->getTranslatorTextDomain()
+                );
             }
             $messagesToPrint[] = $escapeHtml($item);
         });

--- a/library/Zend/Form/View/Helper/FormElementErrors.php
+++ b/library/Zend/Form/View/Helper/FormElementErrors.php
@@ -149,7 +149,7 @@ class FormElementErrors extends AbstractHelper
         $escapeHtml      = $this->getEscapeHtmlHelper();
         $messagesToPrint = array();
         $self            = $this;
-        array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml, &$self) {
+        array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml, $self) {
             if (null !== ($translator = $self->getTranslator())) {
                 $item = $translator->translate(
                     $item, $self->getTranslatorTextDomain()


### PR DESCRIPTION
The form element error messages are not translated. This fix solves the issue.
