### PR TITLE
Fixed issue with invalid @cover annotations, pointed to not existed class

### DIFF
--- a/tests/ZendTest/Navigation/ServiceFactoryTest.php
+++ b/tests/ZendTest/Navigation/ServiceFactoryTest.php
@@ -103,7 +103,7 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Zend\Navigation\MvcNavigationFactory
+     * @covers \Zend\Navigation\Service\AbstractNavigationFactory
      */
     public function testDefaultFactoryAcceptsFileString()
     {
@@ -112,7 +112,7 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Zend\Navigation\MvcNavigationFactory
+     * @covers \Zend\Navigation\Service\DefaultNavigationFactory
      */
     public function testMvcPagesGetInjectedWithComponents()
     {
@@ -133,7 +133,7 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Zend\Navigation\MvcNavigationFactory
+     * @covers \Zend\Navigation\Service\DefaultNavigationFactory
      */
     public function testDefaultFactory()
     {
@@ -144,7 +144,7 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Zend\Navigation\MvcNavigationFactory
+     * @covers \Zend\Navigation\Service\ConstructedNavigationFactory
      */
     public function testConstructedFromArray()
     {
@@ -171,7 +171,7 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Zend\Navigation\MvcNavigationFactory
+     * @covers \Zend\Navigation\Service\ConstructedNavigationFactory
      */
     public function testConstructedFromFileString()
     {
@@ -184,7 +184,7 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Zend\Navigation\MvcNavigationFactory
+     * @covers \Zend\Navigation\Service\ConstructedNavigationFactory
      */
     public function testConstructedFromConfig()
     {


### PR DESCRIPTION
Was impossible to run phpunit with coverage for module Zend/Navigation because error in @cover annotations.
