### PR TITLE
BUGFIX: 'title' attribute of form elements was not translating

### DIFF
--- a/library/Zend/Form/View/Helper/AbstractHelper.php
+++ b/library/Zend/Form/View/Helper/AbstractHelper.php
@@ -42,7 +42,8 @@ abstract class AbstractHelper extends BaseAbstractHelper
      * @var array
      */
     protected $translatableAttributes = array(
-        'placeholder' => true
+        'placeholder' => true,
+        'title'       => true,
     );
 
     /**


### PR DESCRIPTION
Added 'title' to $translatableAttributes of Zend/Form/View/Helper/AbstractHelper.

```
php run-tests.php Form
```

on commit 3a650b3455715d9464598653e915940f4f6905c4 fails w/ error

```
Class 'Locale' not found in /home/nsv/dvl/zf2/library/Zend/I18n/Validator/Float.php on line 65
```

so i cannot test my change, but it works in my job project.

P.S. Oops, sorry for cross-branch and mixing w/ other's commit, don't know how to fix.
