### PR TITLE
Resource object of connection and platform not synchronized in DB Adapter

### DIFF
--- a/library/Zend/Db/Metadata/Source/MysqlMetadata.php
+++ b/library/Zend/Db/Metadata/Source/MysqlMetadata.php
@@ -98,6 +98,9 @@ class MysqlMetadata extends AbstractSource
         }
         $this->prepareDataHierarchy('columns', $schema, $table);
         $p = $this->adapter->getPlatform();
+        // if the platform's resource is not synchronized, try to fetch it
+        // from connection object
+        $p->setDriver($this->adapter->getDriver());
 
         $isColumns = array(
             array('C','ORDINAL_POSITION'),

--- a/library/Zend/Form/View/Helper/FormSelect.php
+++ b/library/Zend/Form/View/Helper/FormSelect.php
@@ -237,7 +237,11 @@ class FormSelect extends AbstractHelper
      */
     protected function validateMultiValue($value, array $attributes)
     {
-        if (empty($value)) {
+        if (null === $value) {
+            return array();
+        }
+        
+        if (is_array($value) && empty($value)) {
             return array();
         }
 

--- a/library/Zend/Form/View/Helper/FormSelect.php
+++ b/library/Zend/Form/View/Helper/FormSelect.php
@@ -237,7 +237,7 @@ class FormSelect extends AbstractHelper
      */
     protected function validateMultiValue($value, array $attributes)
     {
-        if (null === $value) {
+        if (empty($value)) {
             return array();
         }
 


### PR DESCRIPTION
See:
https://github.com/zendframework/zf2/issues/4042

This is just kind of a hack becouse it shoud be the responsabily of the DB adapter to have all its dependencies synchronized (in thsi case the resource object of the connection and the resurce object of the platform) 
