### PR TITLE
Hotfix for issue #4069

### DIFF
--- a/library/Zend/Db/Sql/Platform/Oracle/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Oracle/SelectDecorator.php
@@ -35,6 +35,15 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
     }
 
     /**
+     * (non-PHPdoc)
+     * @see \Zend\Db\Sql\Select::renderTableAsAlias()
+     */
+    protected function renderTableAsAlias($table, $alias)
+    {
+        return $table . ' ' . $alias;
+    }
+
+	/**
      * @param AdapterInterface $adapter
      * @param StatementContainerInterface $statementContainer
      */

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -552,6 +552,25 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         return $this->tableReadOnly;
     }
 
+    /**
+     * Render table with alias in from/join parts
+     *
+     * @param string $table
+     * @param string $alias
+     */
+    protected function renderTableAsAlias($table, $alias)
+    {
+        return $table . ' AS ' . $alias;
+    }
+
+    /**
+     * Process the select part
+     *
+     * @param PlatformInterface $platform
+     * @param DriverInterface $driver
+     * @param ParameterContainer $parameterContainer
+     * @return null|array
+     */
     protected function processSelect(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         $expr = 1;
@@ -585,7 +604,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
         if ($alias) {
             $fromTable = $platform->quoteIdentifier($alias);
-            $table .= ' AS ' . $fromTable;
+            $table = $this->renderTableAsAlias($table, $fromTable);
         } else {
             $fromTable = $table;
         }

--- a/tests/ZendTest/Db/Sql/Platform/Oracle/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/Oracle/SelectDecoratorTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Db
+ */
+
+namespace ZendTest\Db\Sql\Platform\Oracle;
+
+use Zend\Db\Sql\Platform\Oracle\SelectDecorator;
+use Zend\Db\Sql\Select;
+use Zend\Db\Adapter\ParameterContainer;
+use Zend\Db\Adapter\Platform\Oracle as OraclePlatform;
+
+class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @testdox integration test: Testing SelectDecorator will use Select an internal state to prepare a proper from alias sql statement
+     * @covers Zend\Db\Sql\Platform\Mysql\SelectDecorator::getSqlString
+     * @covers Zend\Db\Sql\Platform\Mysql\SelectDecorator::processLimit
+     * @covers Zend\Db\Sql\Platform\Mysql\SelectDecorator::processOffset
+     * @dataProvider dataProvider
+     */
+    public function testGetSqlString(Select $select, $expectedSql)
+    {
+        $parameterContainer = new ParameterContainer;
+        $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $statement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($parameterContainer));
+
+        $selectDecorator = new SelectDecorator;
+        $selectDecorator->setSubject($select);
+        $this->assertEquals($expectedSql, $selectDecorator->getSqlString(new OraclePlatform));
+    }
+
+    /**
+     * Data provider for testGetSqlString
+     *
+     * @return array
+     */
+    public function dataProvider()
+    {
+        $select0 = new Select;
+        $select0->from(array('x' => 'foo'));
+        $expectedSql0 = 'SELECT "x".* FROM "foo" "x"';
+
+        return array(
+            array($select0, $expectedSql0),
+        );
+    }
+
+}

--- a/tests/ZendTest/Db/Sql/Platform/Oracle/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/Oracle/SelectDecoratorTest.php
@@ -19,9 +19,7 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @testdox integration test: Testing SelectDecorator will use Select an internal state to prepare a proper from alias sql statement
-     * @covers Zend\Db\Sql\Platform\Mysql\SelectDecorator::getSqlString
-     * @covers Zend\Db\Sql\Platform\Mysql\SelectDecorator::processLimit
-     * @covers Zend\Db\Sql\Platform\Mysql\SelectDecorator::processOffset
+     * @covers Zend\Db\Sql\Platform\Oracle\SelectDecorator::getSqlString
      * @dataProvider dataProvider
      */
     public function testGetSqlString(Select $select, $expectedSql)


### PR DESCRIPTION
Oracle renders from table with alias incorrectly with "AS".
- Modified implementation of Sql\Select and oracle specific
  SelectDecorator to reflect the correct behavior
- Added UnitTest to test this implementation

This will resolve #4069
