### PR TITLE
Form\Collection: allow create new objects

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -69,6 +69,13 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
     protected $templatePlaceholder = self::DEFAULT_TEMPLATE_PLACEHOLDER;
 
     /**
+     * Whether or not to create new objects during modify
+     *
+     * @var bool
+     */
+    protected $createNewObjects = false;
+
+    /**
      * Element used as a template
      *
      * @var ElementInterface|FieldsetInterface
@@ -113,6 +120,10 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
 
         if (isset($options['template_placeholder'])) {
             $this->setTemplatePlaceholder($options['template_placeholder']);
+        }
+
+        if (isset($options['create_new_objects'])) {
+            $this->setCreateNewObjects($options['create_new_objects']);
         }
 
         return $this;
@@ -420,6 +431,24 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
     }
 
     /**
+     * @param bool $createNewObjects
+     * @return Collection
+     */
+    public function setCreateNewObjects($createNewObjects)
+    {
+        $this->createNewObjects = (bool) $createNewObjects;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function createNewObjects()
+    {
+        return $this->createNewObjects;
+    }
+
+    /**
      * Get a template element used for rendering purposes only
      *
      * @return null|ElementInterface|FieldsetInterface
@@ -479,7 +508,7 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
                 $targetElement = clone $this->targetElement;
                 $targetElement->object = $value;
                 $values[$key] = $targetElement->extract();
-                if ($this->has($key)) {
+                if (! $this->createNewObjects() && $this->has($key)) {
                     $fieldset = $this->get($key);
                     if ($fieldset instanceof Fieldset && $fieldset->allowObjectBinding($value)) {
                         $fieldset->setObject($value);

--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -245,7 +245,9 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
             );
         }
 
-        $this->replaceTemplateObjects();
+        if (! $this->createNewObjects()) {
+            $this->replaceTemplateObjects();
+        }
     }
 
     /**

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -322,6 +322,49 @@ class CollectionTest extends TestCase
         $this->assertSame($categories[1], $cat2);
     }
 
+    public function testCreatesNewObjectsIfSpecified()
+    {
+        $this->productFieldset->setUseAsBaseFieldset(true);
+        $categories = $this->productFieldset->get('categories');
+        $categories->setOptions(array(
+            'create_new_objects' => true,
+        ));
+
+        $form = new \Zend\Form\Form();
+        $form->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
+        $form->add($this->productFieldset);
+
+        $product = new Product();
+        $product->setName("foo");
+        $product->setPrice(42);
+        $cat1 = new \ZendTest\Form\TestAsset\Entity\Category();
+        $cat1->setName("bar");
+        $cat2 = new \ZendTest\Form\TestAsset\Entity\Category();
+        $cat2->setName("bar2");
+
+        $product->setCategories(array($cat1,$cat2));
+
+        $form->bind($product);
+
+        $form->setData(
+            array("product"=>
+                array(
+                    "name" => "franz",
+                    "price" => 13,
+                    "categories" => array(
+                        array("name" => "sepp"),
+                        array("name" => "herbert")
+                    )
+                )
+            )
+        );
+        $form->isValid();
+
+        $categories = $product->getCategories();
+        $this->assertNotSame($categories[0], $cat1);
+        $this->assertNotSame($categories[1], $cat2);
+    }
+
     public function testExtractDefaultIsEmptyArray()
     {
         $collection = $this->form->get('fieldsets');


### PR DESCRIPTION
The commit https://github.com/zendframework/zf2/commit/b0c03a331565960599de338311cc56cb940c4655 , merged in 2.1.4, introduced a compatibility break: before that commit, the behaviour of collection was totally different. If you expecially used collections with Doctrine Entities, this is a huge change.

This PR reintroduce the ability to create new objects if requested, and leave the new behaviour by default.
