### PR TITLE
Fix Collection form element replacing bound objects with dummies upon form validation

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -233,6 +233,8 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
                 )
             );
         }
+
+        $this->replaceTemplateObjects();
     }
 
     /**
@@ -535,5 +537,27 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
         $elementOrFieldset->setName($this->templatePlaceholder);
 
         return $elementOrFieldset;
+    }
+
+    /**
+     * Replaces the default template object of a sub element with the corresponding
+     * real entity so that all properties are preserved.
+     *
+     * @return void
+     */
+    protected function replaceTemplateObjects()
+    {
+        $fieldsets = $this->getFieldsets();
+
+        if (!count($fieldsets) || !$this->object) {
+            return;
+        }
+
+        foreach ($fieldsets as $fieldset) {
+            $i = $fieldset->getName();
+            if (isset($this->object[$i])) {
+                $fieldset->setObject($this->object[$i]);
+            }
+        }
     }
 }

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1357,4 +1357,47 @@ class FormTest extends TestCase
     {
         $this->assertNull($this->form->getValidationGroup());
     }
+
+    public function testPreserveEntitiesBoundToCollectionAfterValidation() {
+        $this->form->setInputFilter(new \Zend\InputFilter\InputFilter());
+        $fieldset = new TestAsset\ProductCategoriesFieldset();
+        $fieldset->setUseAsBaseFieldset(true);
+
+        $product = new Entity\Product();
+        $product->setName('Foobar');
+        $product->setPrice(100);
+
+        $c1 = new Entity\Category();
+        $c1->setId(1);
+        $c1->setName('First Category');
+
+        $c2 = new Entity\Category();
+        $c2->setId(2);
+        $c2->setName('Second Category');
+
+        $product->setCategories(array($c1, $c2));
+
+        $this->form->add($fieldset);
+        $this->form->bind($product);
+
+        $data = array(
+            'product' => array(
+                'name' => 'Barbar',
+                'price' => 200,
+                'categories' => array(
+                    array('name' => 'Something else'),
+                    array('name' => 'Totally different'),
+                ),
+            ),
+        );
+
+        $hash1 = spl_object_hash($this->form->getObject()->getCategory(0));
+        $this->form->setData($data);
+        $this->form->isValid();
+        $hash2 = spl_object_hash($this->form->getObject()->getCategory(0));
+
+        // Returned object has to be the same as when binding or properties
+        // will be lost. (For example entity IDs.)
+        $this->assertTrue($hash1 == $hash2);
+    }
 }

--- a/tests/ZendTest/Form/TestAsset/Entity/Category.php
+++ b/tests/ZendTest/Form/TestAsset/Entity/Category.php
@@ -13,6 +13,11 @@ namespace ZendTest\Form\TestAsset\Entity;
 class Category
 {
     /**
+     * @var int
+     */
+    protected $id;
+
+    /**
      * @var string
      */
     protected $name;
@@ -33,5 +38,22 @@ class Category
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @param int $id
+     * @return Product
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId() {
+        return $this->id;
     }
 }

--- a/tests/ZendTest/Form/TestAsset/Entity/Product.php
+++ b/tests/ZendTest/Form/TestAsset/Entity/Product.php
@@ -80,4 +80,24 @@ class Product
     {
         return $this->price;
     }
+
+    /**
+     * Return category from index
+     *
+     * @param int $i
+     */
+    public function getCategory($i)
+    {
+        return $this->categories[$i];
+    }
+
+    /**
+     * Required when binding to a form
+     *
+     * @return array
+     */
+    public function getArrayCopy()
+    {
+        return get_object_vars($this);
+    }
 }

--- a/tests/ZendTest/Form/TestAsset/ProductCategoriesFieldset.php
+++ b/tests/ZendTest/Form/TestAsset/ProductCategoriesFieldset.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ZendTest\Form\TestAsset;
+
+class ProductCategoriesFieldset extends ProductFieldset
+{
+    public function __construct() {
+        parent::__construct();
+
+        $template = new CategoryFieldset();
+
+        $this->add(array(
+            'name' => 'categories',
+            'type' => 'collection',
+            'options' => array(
+                'label' => 'Categories',
+                'should_create_template' => true,
+                'allow_add' => true,
+                'count' => 0,
+                'target_element' => $template,
+            ),
+        ));
+    }
+}


### PR DESCRIPTION
Currently the Zend\Form\Element\Collection will discard bound objects and replace them with clones of its dummy template when the form is validated. This will result in loss of all properties that do not have a field in the Collection's target element (fieldset). 

Also the returned object instances have to be the same that were passed to the form originally or it will cause corruption.
