### PR TITLE
Fix DB connection get resource, needed for escaping

### DIFF
--- a/library/Zend/Db/Adapter/Driver/IbmDb2/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/IbmDb2/Connection.php
@@ -135,7 +135,6 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      */
     public function getResource()
     {
-        $this->connect();
         return $this->resource;
     }
 

--- a/library/Zend/Db/Adapter/Driver/IbmDb2/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/IbmDb2/Connection.php
@@ -135,6 +135,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      */
     public function getResource()
     {
+        $this->connect();
         return $this->resource;
     }
 

--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -186,6 +186,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      */
     public function getResource()
     {
+        $this->connect();
         return $this->resource;
     }
 

--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -186,7 +186,9 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      */
     public function getResource()
     {
-        $this->connect();
+        if (!$this->isConnected()) {
+            $this->connect();
+        }
         return $this->resource;
     }
 

--- a/library/Zend/Db/Adapter/Driver/Pgsql/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pgsql/Connection.php
@@ -137,6 +137,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      */
     public function getResource()
     {
+        $this->connect();
         return $this->resource;
     }
 

--- a/library/Zend/Db/Adapter/Driver/Pgsql/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pgsql/Connection.php
@@ -137,7 +137,9 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      */
     public function getResource()
     {
-        $this->connect();
+        if (!$this->isConnected()) {
+            $this->connect();
+        }
         return $this->resource;
     }
 

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Connection.php
@@ -44,7 +44,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     /**
      * Constructor
      *
-g     * @param array|resource $connectionInfo
+     * @param array|resource $connectionInfo
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
      */
     public function __construct($connectionInfo)

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Connection.php
@@ -147,6 +147,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      */
     public function getResource()
     {
+        $this->connect();
         return $this->resource;
     }
 

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Connection.php
@@ -44,7 +44,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     /**
      * Constructor
      *
-     * @param array|resource $connectionInfo
+g     * @param array|resource $connectionInfo
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
      */
     public function __construct($connectionInfo)
@@ -147,7 +147,9 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      */
     public function getResource()
     {
-        $this->connect();
+        if (!$this->isConnected()) {
+            $this->connect();
+        }
         return $this->resource;
     }
 

--- a/tests/ZendTest/Db/Adapter/Driver/Pdo/ConnectionTest.php
+++ b/tests/ZendTest/Db/Adapter/Driver/Pdo/ConnectionTest.php
@@ -3,7 +3,7 @@ namespace ZendTest\Db\Adapter\Driver\Pdo;
 
 use Zend\Db\Adapter\Driver\Pdo\Connection;
 
-class PgsqlTest extends \PHPUnit_Framework_TestCase
+class ConnectionTest extends \PHPUnit_Framework_TestCase
 {
 
     /**

--- a/tests/ZendTest/Db/Adapter/Driver/Pdo/ConnectionTest.php
+++ b/tests/ZendTest/Db/Adapter/Driver/Pdo/ConnectionTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace ZendTest\Db\Adapter\Driver\Pdo;
+
+use Zend\Db\Adapter\Driver\Pdo\Connection;
+
+class PgsqlTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var Connection
+     */
+    protected $connection = null;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->connection = new Connection();
+    }
+
+    /**
+     * Test getResource method tries to connect to  the database, it should never return null
+     *
+     * @covers Zend\Db\Adapter\Driver\Pdo\Connection::getResource
+     */
+    public function testResource()
+    {
+        $this->setExpectedException('Zend\Db\Adapter\Exception\InvalidConnectionParametersException');
+        $this->connection->getResource();
+    }
+}

--- a/tests/ZendTest/Db/Adapter/Driver/Pgsql/ConnectionTest.php
+++ b/tests/ZendTest/Db/Adapter/Driver/Pgsql/ConnectionTest.php
@@ -28,9 +28,16 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
     public function testResource()
     {
         if (extension_loaded('pgsql')) {
-            $this->setExpectedException('Zend\Db\Adapter\Exception\RuntimeException');
-            // Error supressing needed else pg_connect will fatal
-            @$this->connection->getResource();
+            try {
+                // Error supressing needed else pg_connect will fatal
+                $resource = @$this->connection->getResource();
+                // pg_connect allows to connect with an empty string
+                $this->assertTrue(is_resource($resource));
+            } catch (\Zend\Db\Adapter\Exception\RuntimeException $exc) {
+                // If it throws an exception it has failed to connect
+                $this->setExpectedException('Zend\Db\Adapter\Exception\RuntimeException');
+                throw $exc;
+            }
         } else {
             $this->markTestSkipped('pgsql extension not loaded');
         }

--- a/tests/ZendTest/Db/Adapter/Driver/Pgsql/ConnectionTest.php
+++ b/tests/ZendTest/Db/Adapter/Driver/Pgsql/ConnectionTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace ZendTest\Db\Adapter\Driver\Pgsql;
+
+use Zend\Db\Adapter\Driver\Pgsql\Connection;
+
+class ConnectionTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var Connection
+     */
+    protected $connection = null;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->connection = new Connection();
+    }
+
+    /**
+     * Test getResource method if it tries to connect to the database.
+     *
+     * @covers Zend\Db\Adapter\Driver\Pgsql\Connection::getResource
+     */
+    public function testResource()
+    {
+        if (extension_loaded('pgsql')) {
+            $this->setExpectedException('Zend\Db\Adapter\Exception\RuntimeException');
+            // Error supressing needed else pg_connect will fatal
+            @$this->connection->getResource();
+        } else {
+            $this->markTestSkipped('pgsql extension not loaded');
+        }
+    }
+}


### PR DESCRIPTION
Some connection returned null as resource if the database was not connected yet. This gives problems when escaping these as it check the required resource e.g pdo  / pgsql etc to use the correct escaping.

It would always trigger notices when trying to build a query before database connection.
only IBM didn't needed this as it checks for a function not pdo.

``` php
    /**
     * Quote value
     *
     * @param  string $value
     * @return string
     */
    public function quoteValue($value)
    {
        if (is_resource($this->resource)) {
            return '\'' . pg_escape_string($this->resource, $value) . '\'';
        }
        if ($this->resource instanceof \PDO) {
            return $this->resource->quote($value);
        }
        trigger_error(
            'Attempting to quote a value in ' . __CLASS__ . ' without extension/driver support '
                . 'can introduce security vulnerabilities in a production environment.'
        );
        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
    }
```
