### PR TITLE
ZF2013-03: Pdo\Connection getResource -> missing connect()

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -186,6 +186,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      */
     public function getResource()
     {
+        $this->connect();
         return $this->resource;
     }
 


### PR DESCRIPTION
Hello,

through the fix related to: http://framework.zend.com/security/advisory/ZF2013-03

Always the trigger_error get's raised in Adapter/Platform/Mysql::quoteValue

Now Pdo\Connection get's connected when getting the resource.
Like in Mysql\Conneciton already done.

Maybe the other Driver are also affected....
