### PR TITLE
Allow status code in Redirect::toUrl()

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/Redirect.php
+++ b/library/Zend/Mvc/Controller/Plugin/Redirect.php
@@ -45,11 +45,11 @@ class Redirect extends AbstractPlugin
      * @param  string $url
      * @return Response
      */
-    public function toUrl($url)
+    public function toUrl($url, $code = 302)
     {
         $response = $this->getResponse();
         $response->headers()->addHeaderLine('Location', $url);
-        $response->setStatusCode(302);
+        $response->setStatusCode($code);
         return $response;
     }
 

--- a/tests/Zend/Mvc/Controller/Plugin/RedirectTest.php
+++ b/tests/Zend/Mvc/Controller/Plugin/RedirectTest.php
@@ -52,6 +52,26 @@ class RedirectTest extends TestCase
         $this->assertEquals('/foo', $location->getFieldValue());
     }
 
+    public function testPluginCanRedirectToUrlWhenProperlyConfiguredWithDefaultStatus()
+    {
+        $response = $this->plugin->toUrl('/foo');
+        $this->assertTrue($response->isRedirect());
+        $this->assertEquals(302, $response->getStatusCode());
+        $headers = $response->headers();
+        $location = $headers->get('Location');
+        $this->assertEquals('/foo', $location->getFieldValue());
+    }
+
+    public function testPluginCanRedirectToUrlWhenProperlyConfiguredWithCustomStatus()
+    {
+        $response = $this->plugin->toUrl('/foo', 301);
+        $this->assertTrue($response->isRedirect());
+        $this->assertEquals(301, $response->getStatusCode());
+        $headers = $response->headers();
+        $location = $headers->get('Location');
+        $this->assertEquals('/foo', $location->getFieldValue());
+    }
+
     public function testPluginWithoutControllerRaisesDomainException()
     {
         $plugin = new RedirectPlugin();


### PR DESCRIPTION
The implementation of the method `Zend\Mvc\Controller\Plugin\Redirect::toUrl()` contains:

``` php
public function toUrl($url)
{
    $response = $this->getResponse();
    $response->headers()->addHeaderLine('Location', $url);
    $response->setStatusCode(302);
    return $response;
}
```

Sometimes you want a 301 status. So why not make the signature:

```
public function toUrl($url, $code = 302)
```

This PR makes this change and adds unit-tests for default code and custom code setting.
