### PR TITLE
Introduce query parameter for Navigation\Page\Mvc

### DIFF
--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -35,6 +35,13 @@ class Mvc extends AbstractPage
     protected $controller;
 
     /**
+     * URL query part to use when assembling URL
+     *
+     * @var string
+     */
+    protected $query;
+
+    /**
      * Params to use when assembling URL
      *
      * @see getHref()
@@ -212,8 +219,8 @@ class Mvc extends AbstractPage
             $options['fragment'] = $fragment;
         }
 
-        if (isset($params['query'])) {
-            $options['query'] = $params['query'];
+        if (($query = $this->getQuery()) != null) {
+            $options['query'] = $query;
         }
 
         $url = $router->assemble($params, $options);
@@ -287,6 +294,33 @@ class Mvc extends AbstractPage
     public function getController()
     {
         return $this->controller;
+    }
+
+    /**
+     * Sets URL query part to use when assembling URL
+     *
+     * @see getHref()
+     *
+     * @param  array|string|null $query    URL query part
+     * @return self   fluent interface, returns self
+     */
+    public function setQuery($query)
+    {
+        $this->query = $query;
+        $this->hrefCache  = null;
+        return $this;
+    }
+
+    /**
+     * Returns URL query part to use when assembling URL
+     *
+     * @see getHref()
+     *
+     * @return array|string|null  URL query part (as an array or string) or null
+     */
+    public function getQuery()
+    {
+        return $this->query;
     }
 
     /**

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -219,7 +219,7 @@ class Mvc extends AbstractPage
             $options['fragment'] = $fragment;
         }
 
-        if (($query = $this->getQuery()) != null) {
+        if (null !== ($query = $this->getQuery())) {
             $options['query'] = $query;
         }
 
@@ -300,13 +300,12 @@ class Mvc extends AbstractPage
      * Sets URL query part to use when assembling URL
      *
      * @see getHref()
-     *
      * @param  array|string|null $query    URL query part
      * @return self   fluent interface, returns self
      */
     public function setQuery($query)
     {
-        $this->query = $query;
+        $this->query      = $query;
         $this->hrefCache  = null;
         return $this;
     }

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -37,7 +37,7 @@ class Mvc extends AbstractPage
     /**
      * URL query part to use when assembling URL
      *
-     * @var string
+     * @var array|string
      */
     protected $query;
 

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -205,13 +205,18 @@ class Mvc extends AbstractPage
         }
 
         $options = array('name' => $name);
-        $url = $router->assemble($params, $options);
 
         // Add the fragment identifier if it is set
         $fragment = $this->getFragment();
         if (null !== $fragment) {
-            $url .= '#' . $fragment;
+            $options['fragment'] = $fragment;
         }
+
+        if (isset($params['query'])) {
+            $options['query'] = $params['query'];
+        }
+
+        $url = $router->assemble($params, $options);
 
         return $this->hrefCache = $url;
     }

--- a/tests/ZendTest/Navigation/Page/MvcTest.php
+++ b/tests/ZendTest/Navigation/Page/MvcTest.php
@@ -215,6 +215,44 @@ class MvcTest extends TestCase
         $this->assertEquals('/lolcat/myaction/1337#qux', $page->getHref());
     }
 
+    public function testGetHrefPassesQueryPartToRouter()
+    {
+        $page = new Page\Mvc(array(
+            'label'              => 'foo',
+            'query'              => 'foo=bar&baz=qux',
+            'controller'         => 'mycontroller',
+            'action'             => 'myaction',
+            'route'              => 'myroute',
+            'params'             => array(
+                'page' => 1337
+            )
+        ));
+
+        $route = new RegexRoute(
+            '(lolcat/(?<action>[^/]+)/(?<page>\d+))',
+            '/lolcat/%action%/%page%',
+            array(
+                'controller' => 'foobar',
+                'action'     => 'bazbat',
+                'page'       => 1,
+            )
+        );
+        $this->router->addRoute('myroute', $route);
+        $this->routeMatch->setMatchedRouteName('myroute');
+
+        $page->setRouteMatch($this->routeMatch);
+        $page->setRouter($this->router);
+
+        $this->assertEquals('/lolcat/myaction/1337?foo=bar&baz=qux', $page->getHref());
+
+        // Test with array notation
+        $page->setQuery(array(
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ));
+        $this->assertEquals('/lolcat/myaction/1337?foo=bar&baz=qux', $page->getHref());
+    }
+
     public function testIsActiveReturnsTrueOnIdenticalControllerAction()
     {
         $page = new Page\Mvc(array(


### PR DESCRIPTION
Version 2.1.4 has deprecated Query routes, but not updated `Navigation\Page\Mvc` to conform new changes.

This patch introduces `query` parameter for Mvc pages and passes it accordingly into `$router->assemble()` method. Also uses `fragment` option to build URLs as introduced in 2.1.4.
