### PR TITLE
Zend\Test - set the request's requestUri to the dispatched url

### DIFF
--- a/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -233,6 +233,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
         $request->setQuery(new Parameters($query));
         $request->setPost(new Parameters($post));
         $request->setUri($uri);
+        $request->setRequestUri($uri->getPath());
 
         return $this;
     }

--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -233,4 +233,10 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertEquals(true, $result->stopped());
         $this->assertEquals(Application::ERROR_ROUTER_NO_MATCH, $this->getApplication()->getMvcEvent()->getError());
     }
+
+    public function testDispatchRequestUri()
+    {
+        $this->dispatch('/tests');
+        $this->assertEquals('/tests', $this->getApplication()->getRequest()->getRequestUri());
+    }
 }


### PR DESCRIPTION
When dispatching a url in a controller test (e.g. $this->dispatch('/foo');), the request's uri object's path is set to the dispatched url, but the request's requestUri is not.  It is always set to '/'.  This causes problems for any module or controller code that looks at the request's requestUri.  This pull request fixes this problem.
