### PR TITLE
Zend\Navigation\Page\Mvc::getHref does not use RouteMatch parameters

### DIFF
--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -183,7 +183,12 @@ class Mvc extends AbstractPage
             );
         }
 
-        $params = $this->getParams();
+        if ($this->getRouteMatch() !== null) {
+            $params = array_merge($this->getRouteMatch()->getParams(), $this->getParams());
+        } else {
+            $params = $this->getParams();
+        }
+
 
         if (($param = $this->getController()) != null) {
             $params['controller'] = $param;

--- a/tests/ZendTest/Navigation/Page/MvcTest.php
+++ b/tests/ZendTest/Navigation/Page/MvcTest.php
@@ -14,6 +14,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\Router\Http\Regex as RegexRoute;
 use Zend\Mvc\Router\Http\Literal as LiteralRoute;
+use Zend\Mvc\Router\Http\Segment as SegmentRoute;
 use Zend\Mvc\Router\Http\TreeRouteStack;
 use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\MvcEvent;
@@ -498,4 +499,29 @@ class MvcTest extends TestCase
         $page->getHref();
         $page->setDefaultRouter(null);
     }
+
+    public function testMvcPageParamsInheritRouteMatchParams()
+    {
+        $page = new Page\Mvc(array(
+            'label' => 'lollerblades',
+            'route' => 'lollerblades'
+        ));
+
+        $route = new SegmentRoute('/lollerblades/view/:serialNumber');
+
+        $router = new TreeRouteStack;
+        $router->addRoute('lollerblades', $route);
+
+        $routeMatch = new RouteMatch(array(
+            'serialNumber' => 23,
+        ));
+        $routeMatch->setMatchedRouteName('lollerblades');
+
+        $page->setRouter($router);
+        $page->setRouteMatch($routeMatch);
+
+        $this->assertEquals('/lollerblades/view/23', $page->getHref());
+    }
+
+
 }


### PR DESCRIPTION
The MVC page type in Navigation does not pull matched parameters from the provided RouteMatch object, which results in an error when using the breadcrumbs view helper:

```
Fatal error: Zend\Mvc\Router\Exception\InvalidArgumentException: Missing parameter "school" in <zf>/library/Zend/View/Helper/Navigation/AbstractHelper.php on line 466
```

My route hierarchy:

```
'router' => array(
    'routes' => array(
        'registration' => array(
            'type' => 'Literal',
            'options' => array(
                'route' => '/registration',
                'defaults' => array(
                    'controller' => 'CdliPortal\Controller\Registration\Dashboard',
                    'action' => 'index',
                ),
            ),
            'may_terminate' => true,
            'child_routes' => array(
                'school' => array(
                    'type' => 'Segment',
                    'options' => array(
                        'route' => '/school/:school',   
                        'constraints' => array(
                            'school' => '[0-9]+',
                        ),
                        'defaults' => array(
                            'controller' => 'CdliPortal\Controller\Registration\School\Dashboard',
                            'action'     => 'index',
                        ),
                    ),
                ),
            ),
        ),
    ),
),
```

The simplest fix i've found is to change `Zend\Navigation\Page\Mvc::getHref` to use the parameters from the RouteMatch object (if they are set) as the defaults and then merge the parameters set directly on the `Zend\Navigation\Page\Mvc` into that:

```
if ($this->getRouteMatch() !== null) {
    $params = array_merge($this->getRouteMatch()->getParams(), $this->getParams());
} else {
    $params = $this->getParams();
}
```

Though I am not 100% certain this is a comprehensive fix, or that it doesn't break / cause unexpected results with the other navigation view helpers (my application only uses bredcrumbs currently)
