### PR TITLE
Hotfix/db profiler executed sql

### DIFF
--- a/library/Zend/Db/Adapter/Profiler/Profiler.php
+++ b/library/Zend/Db/Adapter/Profiler/Profiler.php
@@ -26,16 +26,24 @@ class Profiler implements ProfilerInterface
     {
         $profileInformation = array(
             'sql' => '',
+            'executed_sql' => '',
             'parameters' => null,
             'start' => microtime(true),
             'end' => null,
             'elapse' => null
         );
         if ($target instanceof StatementContainerInterface) {
-            $profileInformation['sql'] = $target->getSql();
-            $profileInformation['parameters'] = clone $target->getParameterContainer();
+            $prepStmt                           = $target->getSql();
+            $profileInformation['sql']          = $prepStmt;
+            $profileInformation['executed_sql'] = $prepStmt;
+            $profileInformation['parameters']   = clone $target->getParameterContainer();
+            // Populates the prepared statement with parameters (if any)
+            foreach ($profileInformation['parameters'] as $pName => $pValue) {
+                $profileInformation['executed_sql'] = str_replace("{$pName}", "{$pValue}", $profileInformation['executed_sql']);
+            }
         } elseif (is_string($target)) {
             $profileInformation['sql'] = $target;
+            $profileInformation['executed_sql'] = $target;
         } else {
             throw new Exception\InvalidArgumentException(__FUNCTION__ . ' takes either a StatementContainer or a string');
         }

--- a/tests/ZendTest/Db/Adapter/Profiler/ProfilerTest.php
+++ b/tests/ZendTest/Db/Adapter/Profiler/ProfilerTest.php
@@ -38,7 +38,24 @@ class ProfilerTest extends \PHPUnit_Framework_TestCase
         $this->profiler->profilerStart(5);
     }
     
-
+    /**
+     * @covers Zend\Db\Adapter\Profiler\Profiler::profilerStart
+     */
+    public function testProfilerExecutedSql()
+    {
+        $prepSql = "SELECT * FROM foo WHERE bar = ':where1'";
+        $prepParams = new ParameterContainer(array(':where1' => 'baz'));
+        $stmt = new StatementContainer($prepSql, $prepParams);
+        $profiler = $this->profiler->profilerStart($stmt);
+        $profiles = $profiler->getProfiles();
+        $profile = array_shift($profiles);
+        $this->assertArrayHasKey('executed_sql', $profile, 
+                                 'executed_sql key not set in a profile');
+        
+        $expectedExecedSlq = "SELECT * FROM foo WHERE bar = 'baz'";
+        $this->assertEquals($expectedExecedSlq, $profile['executed_sql'], 
+                            "Profile's executed_sql key returns unexpected result");
+    }
    
     /**
      * @covers Zend\Db\Adapter\Profiler\Profiler::profilerFinish

--- a/tests/ZendTest/Db/Adapter/Profiler/ProfilerTest.php
+++ b/tests/ZendTest/Db/Adapter/Profiler/ProfilerTest.php
@@ -3,6 +3,7 @@ namespace ZendTest\Db\Adapter\Profiler;
 
 use Zend\Db\Adapter\Profiler\Profiler;
 use Zend\Db\Adapter\StatementContainer;
+use Zend\Db\Adapter\ParameterContainer;
 
 class ProfilerTest extends \PHPUnit_Framework_TestCase
 {
@@ -36,7 +37,9 @@ class ProfilerTest extends \PHPUnit_Framework_TestCase
         );
         $this->profiler->profilerStart(5);
     }
+    
 
+   
     /**
      * @covers Zend\Db\Adapter\Profiler\Profiler::profilerFinish
      */


### PR DESCRIPTION
Hi,

The current Db adapter profiler return array profiles that include 'sql' key. The value of this key is the Sql statement. However, the sql statements are sometimes displayed with the placeholders instead of the binded values.

I edited a bit <code>\Zend\Db\Adapter\Profiler\Profiler::profilerStart()</code> and now the arrays returned by  \Zend\Db\Adapter\Profiler\Profiler::getProfiles()</code> has an extra key 'executed_sql' with value of the populated sql statement including the binded parameters (if any).
