### PR TITLE
Added FormObjectManager to configure objects via ServiceManager.

### DIFF
--- a/library/Zend/Form/Factory.php
+++ b/library/Zend/Form/Factory.php
@@ -29,6 +29,11 @@ class Factory
     protected $formElementManager;
 
     /**
+     * @var FormObjectManager
+     */
+    protected $formObjectManager;
+
+    /**
      * @param FormElementManager $formElementManager
      */
     public function __construct(FormElementManager $formElementManager = null)
@@ -89,6 +94,27 @@ class Factory
         }
 
         return $this->formElementManager;
+    }
+
+    /**
+     * @param FormObjectManager $formObjectManager
+     * @return \Zend\Form\Factory
+     */
+    public function setFormObjectManager(FormObjectManager $formObjectManager)
+    {
+        $this->formObjectManager = $formObjectManager;
+        return $this;
+    }
+
+    /**
+     * @return \Zend\Form\FormObjectManager
+     */
+    public function getFormObjectManager()
+    {
+        if (null === $this->formObjectManager) {
+            $this->setFormObjectManager(new FormObjectManager());
+        }
+        return $this->formObjectManager;
     }
 
     /**
@@ -387,15 +413,7 @@ class Factory
             ));
         }
 
-        if (!class_exists($objectName)) {
-            throw new Exception\DomainException(sprintf(
-                '%s expects string class name to be a valid class name; received "%s"',
-                $method,
-                $objectName
-            ));
-        }
-
-        $fieldset->setObject(new $objectName);
+        $fieldset->setObject($this->getFormObjectManager()->get($objectName));
     }
 
     /**

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -800,4 +800,20 @@ class Form extends Fieldset implements FormInterface
 
         return $values;
     }
+
+    /**
+     * Rebind an object to the form.
+     *
+     * @return \Zend\Form\Form
+     * @throws \Zend\Form\Exception\DomainException
+     */
+    public function rebind()
+    {
+        if (null === $this->object) {
+            throw new Exception\DomainException('Object not binded with form.');
+        }
+
+        $this->extract();
+        return $this;
+    }
 }

--- a/library/Zend/Form/FormObjectManager.php
+++ b/library/Zend/Form/FormObjectManager.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Form;
+
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\Form\Exception;
+
+/**
+ * Plugin manager implementation for binded form objects.
+ *
+ * Validates objects for *object* type.
+ */
+class FormObjectManager extends AbstractPluginManager
+{
+    /**
+     * @see \Zend\ServiceManager\AbstractPluginManager::validatePlugin()
+     */
+    public function validatePlugin ($plugin)
+    {
+        if (!is_object($plugin)) { 
+            throw new Exception\InvalidElementException(
+                sprintf('Expected object, "%s" actual', gettype($plugin)));
+        }
+    }
+}

--- a/tests/ZendTest/Form/TestAsset/ElementCustomTextfield.php
+++ b/tests/ZendTest/Form/TestAsset/ElementCustomTextfield.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Form\Element;
+
+/**
+ *
+ */
+class ElementCustomTextfield extends Element\Text
+{
+}


### PR DESCRIPTION
Would like to propose configuration for FormElementManager and FormObjectManager

``` php
array(
            'form' => array(
                'Frontend\Form\FooBar' => array(
                    'object' => 'foobar',
                    'attributes' => array(
                        'action' => '/path/to/controller',
                        'method' => 'POST'
                    ),
                    'elements' => array(
                        array(
                            'spec' => array(
                                'name' => 'foo',
                                'type' => 'text',
                            ),
                        ),
                        array(
                            'spec' => array(
                                'name' => 'bar',
                                'type' => 'text',
                            ),
                        ),
                        array(
                            'spec' => array(
                                'name' => 'foobar',
                                'type' => 'foobar',
                            ),
                        ),
                    ),
                ),

                'element_manager' => array(
                    'invokables' => array(
                        'foobar' => 'ZendTest\Form\TestAsset\ElementCustomTextfield',
                    ),
                ),

                'object_manager' => array(
                    'invokables' => array(
                        'foobar' => 'ZendTest\Form\TestAsset\Model',
                    ),
                ),
            ),
),
```
