### PR TITLE
simplify constant usage. FILEINFO_MIME_TYPE is available since PHP 5.3.0

### DIFF
--- a/library/Zend/File/Transfer/Adapter/AbstractAdapter.php
+++ b/library/Zend/File/Transfer/Adapter/AbstractAdapter.php
@@ -1232,7 +1232,7 @@ abstract class AbstractAdapter implements TranslatorAwareInterface
 
             if (empty($mime)) {
                 ErrorHandler::start();
-                $mime = finfo_open($const);
+                $mime = finfo_open(FILEINFO_MIME_TYPE);
                 ErrorHandler::stop();
             }
 

--- a/library/Zend/File/Transfer/Adapter/AbstractAdapter.php
+++ b/library/Zend/File/Transfer/Adapter/AbstractAdapter.php
@@ -1224,10 +1224,9 @@ abstract class AbstractAdapter implements TranslatorAwareInterface
         }
 
         if (class_exists('finfo', false)) {
-            $const = defined('FILEINFO_MIME_TYPE') ? FILEINFO_MIME_TYPE : FILEINFO_MIME;
             if (!empty($value['options']['magicFile'])) {
                 ErrorHandler::start();
-                $mime = finfo_open($const, $value['options']['magicFile']);
+                $mime = finfo_open(FILEINFO_MIME_TYPE, $value['options']['magicFile']);
                 ErrorHandler::stop();
             }
 

--- a/library/Zend/Validator/File/ExcludeMimeType.php
+++ b/library/Zend/Validator/File/ExcludeMimeType.php
@@ -66,7 +66,7 @@ class ExcludeMimeType extends MimeType
             }
 
             if (empty($this->finfo)) {
-                $this->finfo = finfo_open($const);
+                $this->finfo = finfo_open(FILEINFO_MIME_TYPE);
             }
 
             $this->type = null;

--- a/library/Zend/Validator/File/ExcludeMimeType.php
+++ b/library/Zend/Validator/File/ExcludeMimeType.php
@@ -61,9 +61,8 @@ class ExcludeMimeType extends MimeType
 
         $mimefile = $this->getMagicFile();
         if (class_exists('finfo', false)) {
-            $const = defined('FILEINFO_MIME_TYPE') ? FILEINFO_MIME_TYPE : FILEINFO_MIME;
             if (!$this->isMagicFileDisabled() && (!empty($mimefile) && empty($this->finfo))) {
-                $this->finfo = finfo_open($const, $mimefile);
+                $this->finfo = finfo_open(FILEINFO_MIME_TYPE, $mimefile);
             }
 
             if (empty($this->finfo)) {

--- a/library/Zend/Validator/File/MimeType.php
+++ b/library/Zend/Validator/File/MimeType.php
@@ -201,9 +201,8 @@ class MimeType extends AbstractValidator
                 $file
             ));
         } else {
-            $const = defined('FILEINFO_MIME_TYPE') ? FILEINFO_MIME_TYPE : FILEINFO_MIME;
             ErrorHandler::start(E_NOTICE|E_WARNING);
-            $this->finfo = finfo_open($const, $file);
+            $this->finfo = finfo_open(FILEINFO_MIME_TYPE, $file);
             $error       = ErrorHandler::stop();
             if (empty($this->finfo)) {
                 $this->finfo = null;
@@ -376,10 +375,9 @@ class MimeType extends AbstractValidator
 
         $mimefile = $this->getMagicFile();
         if (class_exists('finfo', false)) {
-            $const = defined('FILEINFO_MIME_TYPE') ? FILEINFO_MIME_TYPE : FILEINFO_MIME;
             if (!$this->isMagicFileDisabled() && (!empty($mimefile) && empty($this->finfo))) {
                 ErrorHandler::start(E_NOTICE|E_WARNING);
-                $this->finfo = finfo_open($const, $mimefile);
+                $this->finfo = finfo_open(FILEINFO_MIME_TYPE, $mimefile);
                 ErrorHandler::stop();
             }
 

--- a/library/Zend/Validator/File/MimeType.php
+++ b/library/Zend/Validator/File/MimeType.php
@@ -383,7 +383,7 @@ class MimeType extends AbstractValidator
 
             if (empty($this->finfo)) {
                 ErrorHandler::start(E_NOTICE|E_WARNING);
-                $this->finfo = finfo_open($const);
+                $this->finfo = finfo_open(FILEINFO_MIME_TYPE);
                 ErrorHandler::stop();
             }
 


### PR DESCRIPTION
please see 
http://php.net/manual/en/fileinfo.constants.php
(I think reason is zf1's code remains.)
