### PR TITLE
Add create sql to db adapter

### DIFF
--- a/library/Zend/Db/Adapter/Adapter.php
+++ b/library/Zend/Db/Adapter/Adapter.php
@@ -10,6 +10,7 @@
 namespace Zend\Db\Adapter;
 
 use Zend\Db\ResultSet;
+use Zend\Db\Sql\Sql;
 
 /**
  * @property Driver\DriverInterface $driver
@@ -248,6 +249,16 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface
                 throw new Exception\InvalidArgumentException('Invalid magic property on adapter');
         }
 
+    }
+
+    /**
+     * Create a new Sql object already populated with this adapter.
+     *
+     * @return Sql
+     */
+    public function createSql()
+    {
+        return new Sql($this);
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/AdapterTest.php
+++ b/tests/ZendTest/Db/Adapter/AdapterTest.php
@@ -298,4 +298,18 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('InvalidArgumentException', 'Invalid magic');
         $this->adapter->foo;
     }
+
+    /**
+     * Test that create sql returns an instance of the Sql object populated with the adapter
+     *
+     * @testdox unit test: Test that it returns an instance of a Sql object which is populated with the adapter
+     * @covers Zend\Db\Adapter\Adapter::createSql
+     */
+    public function testCreateSqlReturnsInstanceOfSqlObjectWithAdapter()
+    {
+        $sql = $this->adapter->createSql();
+
+        $this->assertInstanceOf('Zend\Db\Sql\Sql', $sql);
+        $this->assertSame($this->adapter, $sql->getAdapter());
+    }
 }


### PR DESCRIPTION
Added the createSql method to the Zend\Db\Adapter\Adapter for convenience and so that it can be mocked out for other tests.
