### PR TITLE
[InputFilter] Allow specification of error message via Factory

### DIFF
--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -153,6 +153,9 @@ class Factory
                         $input->setRequired(!$value);
                     }
                     break;
+                case 'error_message':
+                    $input->setErrorMessage($value);
+                    break;
                 case 'fallback_value':
                     $input->setFallbackValue($value);
                     break;

--- a/tests/ZendTest/InputFilter/FactoryTest.php
+++ b/tests/ZendTest/InputFilter/FactoryTest.php
@@ -428,4 +428,14 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('Zend\InputFilter\InputFilter', $inputFilter->getInputFilter());
         $this->assertEquals(3, $inputFilter->getCount());
     }
+
+    public function testFactoryWillCreateInputWithErrorMessage()
+    {
+        $factory = new Factory();
+        $input   = $factory->createInput(array(
+            'name'          => 'foo',
+            'error_message' => 'My custom error message',
+        ));
+        $this->assertEquals('My custom error message', $input->getErrorMessage());
+    }
 }


### PR DESCRIPTION
One might want to stop the 'Email' validator (for example) from returning all of the multiple errors about hostname, parts, etc. This is already supported by `\Zend\InputFilter\Input` via the `setErrorMessage()` method.

This PR simply adds the ability to specify this via the factory as `error_message`.

```
$this->add(array(
    'name' => 'email',
    'required' => false,
    'error_message' => 'This is not a valid email address',
    'validators' => array(
        array(
            'name' => 'EmailAddress',
        )
    )
));
```
