### PR TITLE
Fix name of variable used for capturing output when executing shell command

### DIFF
--- a/README-GIT.md
+++ b/README-GIT.md
@@ -130,7 +130,7 @@ foreach ($output as $file) {
 
     if ($return != 0) {
         echo "PHP file fails to parse: " . $fileName . ":" . PHP_EOL;
-        echo implode(PHP_EOL, $lintOutput) . PHP_EOL;
+        echo implode(PHP_EOL, $output) . PHP_EOL;
         $exit = 1;
         continue;
     }


### PR DESCRIPTION
The name of the variable used for capturing output of the execution of a shell command is `$output`, but the variable that is later used for rendering is named `$lintOutput` and remains undefined.
