### PR TITLE
Fix weird verbalization

### DIFF
--- a/README-GIT.md
+++ b/README-GIT.md
@@ -142,7 +142,7 @@ foreach ($output as $file) {
     $return = null;
     exec("php-cs-fixer fix --dry-run --level=psr2 " . escapeshellarg($fileName), $output, $return);
     if ($return != 0 || !empty($output)) {
-        echo "PHP file fails contains CS issues: " . $fileName . ":" . PHP_EOL;
+        echo "PHP file contains CS issues: " . $fileName . ":" . PHP_EOL;
         echo implode(PHP_EOL, $output) . PHP_EOL;
         $exit = 1;
         continue;


### PR DESCRIPTION
`PHP file fails contains CS issues` should probably be `PHP file contains CS issues`.
