### PR TITLE
Update EM->trigerUntil to be an alias of trigger

### DIFF
--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -220,30 +220,7 @@ class EventManager implements EventManagerInterface
      */
     public function triggerUntil($event, $target, $argv = null, $callback = null)
     {
-        if ($event instanceof EventInterface) {
-            $e        = $event;
-            $event    = $e->getName();
-            $callback = $target;
-        } elseif ($target instanceof EventInterface) {
-            $e = $target;
-            $e->setName($event);
-            $callback = $argv;
-        } elseif ($argv instanceof EventInterface) {
-            $e = $argv;
-            $e->setName($event);
-            $e->setTarget($target);
-        } else {
-            $e = new $this->eventClass();
-            $e->setName($event);
-            $e->setTarget($target);
-            $e->setParams($argv);
-        }
-
-        if (!is_callable($callback)) {
-            throw new Exception\InvalidCallbackException('Invalid callback provided');
-        }
-
-        return $this->triggerListeners($event, $e, $callback);
+        return $this->trigger($event, $target, $argv, $callback);
     }
 
     /**

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -216,10 +216,16 @@ class EventManager implements EventManagerInterface
      * @param  array|ArrayAccess $argv Array of arguments; typically, should be associative
      * @param  callable $callback
      * @return ResponseCollection
+     * @deprecated Please use trigger()
      * @throws Exception\InvalidCallbackException if invalid callable provided
      */
     public function triggerUntil($event, $target, $argv = null, $callback = null)
     {
+        trigger_error(
+            'This method is deprecated and will be removed in the future. ' .
+            'Please use trigger() instead.',
+            E_USER_DEPRECATED
+        );
         return $this->trigger($event, $target, $argv, $callback);
     }
 


### PR DESCRIPTION
They contained the exact same code/logic. The only difference was the
conditional around checking if the callback was valid, but the outcome
is the same for both. This simply reduces duplicate code and causes no
change in behavior at all.
