### PR TITLE
Update to ServiceManager to provide more precise error messages

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -148,7 +148,7 @@ class ServiceManager implements ServiceLocatorInterface
         if ($this->allowOverride === false) {
             throw new Exception\RuntimeException(sprintf(
                 '%s: cannot alter default shared service setting; container is marked immutable (allow_override is false)',
-                str_replace(__CLASS__, get_called_class(), __METHOD__)
+                get_called_class() . '::' . __FUNCTION__
             ));
         }
         $this->shareByDefault = (bool) $shareByDefault;
@@ -362,7 +362,7 @@ class ServiceManager implements ServiceLocatorInterface
             if ($this->allowOverride === false) {
                 throw new Exception\InvalidServiceNameException(sprintf(
                     '%s: A service by the name "%s" or alias already exists and cannot be overridden, please use an alternate name.',
-                    str_replace(__CLASS__, get_called_class(), __METHOD__),
+                    get_called_class() . '::' . __FUNCTION__,
                     $name
                 ));
             }
@@ -391,7 +391,7 @@ class ServiceManager implements ServiceLocatorInterface
         ) {
             throw new Exception\ServiceNotFoundException(sprintf(
                 '%s: A service by the name "%s" was not found and could not be marked as shared',
-                str_replace(__CLASS__, get_called_class(), __METHOD__),
+                get_called_class() . '::' . __FUNCTION__,
                 $name
             ));
         }
@@ -455,7 +455,7 @@ class ServiceManager implements ServiceLocatorInterface
 
             throw new Exception\ServiceNotFoundException(sprintf(
                 '%s was unable to fetch or create an instance for %s',
-                str_replace(__CLASS__, get_called_class(), __METHOD__),
+                get_called_class() . '::' . __FUNCTION__,
                 $name
             ));
         }
@@ -838,7 +838,7 @@ class ServiceManager implements ServiceLocatorInterface
         if (!class_exists($invokable)) {
             throw new Exception\ServiceNotFoundException(sprintf(
                 '%s: failed retrieving "%s%s" via invokable class "%s"; class does not exist',
-                str_replace(__CLASS__, get_called_class(), __METHOD__),
+                get_called_class() . '::' . __FUNCTION__,
                 $canonicalName,
                 ($requestedName ? '(alias: ' . $requestedName . ')' : ''),
                 $invokable

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -148,7 +148,7 @@ class ServiceManager implements ServiceLocatorInterface
         if ($this->allowOverride === false) {
             throw new Exception\RuntimeException(sprintf(
                 '%s: cannot alter default shared service setting; container is marked immutable (allow_override is false)',
-                __METHOD__
+                str_replace(__CLASS__, get_called_class(), __METHOD__)
             ));
         }
         $this->shareByDefault = (bool) $shareByDefault;
@@ -362,7 +362,7 @@ class ServiceManager implements ServiceLocatorInterface
             if ($this->allowOverride === false) {
                 throw new Exception\InvalidServiceNameException(sprintf(
                     '%s: A service by the name "%s" or alias already exists and cannot be overridden, please use an alternate name.',
-                    __METHOD__,
+                    str_replace(__CLASS__, get_called_class(), __METHOD__),
                     $name
                 ));
             }
@@ -391,7 +391,7 @@ class ServiceManager implements ServiceLocatorInterface
         ) {
             throw new Exception\ServiceNotFoundException(sprintf(
                 '%s: A service by the name "%s" was not found and could not be marked as shared',
-                __METHOD__,
+                str_replace(__CLASS__, get_called_class(), __METHOD__),
                 $name
             ));
         }
@@ -455,7 +455,7 @@ class ServiceManager implements ServiceLocatorInterface
 
             throw new Exception\ServiceNotFoundException(sprintf(
                 '%s was unable to fetch or create an instance for %s',
-                __METHOD__,
+                str_replace(__CLASS__, get_called_class(), __METHOD__),
                 $name
             ));
         }
@@ -838,7 +838,7 @@ class ServiceManager implements ServiceLocatorInterface
         if (!class_exists($invokable)) {
             throw new Exception\ServiceNotFoundException(sprintf(
                 '%s: failed retrieving "%s%s" via invokable class "%s"; class does not exist',
-                __METHOD__,
+                str_replace(__CLASS__, get_called_class(), __METHOD__),
                 $canonicalName,
                 ($requestedName ? '(alias: ' . $requestedName . ')' : ''),
                 $invokable


### PR DESCRIPTION
When using any of the Plugin Managers, these all use the Abstract for get. Unfortunately this uses 
__ METHOD __ to display when it can't find a service,

This leads to major confusion as the service manager may have that service set, but the child or plugin manager might not.

This updates to replace the Service manager name with the called class name so that instead of 

> Zend\ServiceManager\ServiceManager::get was unable to fetch or create an instance for ServiceRequested

you get 

> Zend\Form\FormElementManager::get was unable to fetch or create an instance for ServiceRequested
