### PR TITLE
[WIP] PHP 5.3.23 and PHP 5.4.13 should use Zend\Stdlib\ArrayObject\PhpLegacyCompatibility

### DIFF
--- a/library/Zend/Stdlib/ArrayObject.php
+++ b/library/Zend/Stdlib/ArrayObject.php
@@ -18,7 +18,10 @@ namespace Zend\Stdlib;
  * class_alias is a global construct, so we can alias either one to Zend\Stdlib\ArrayObject,
  * and from this point forward, that alias will be used.
  */
-if (version_compare(PHP_VERSION, '5.3.4', 'lt')) {
+if (PHP_VERSION_ID <= 50303 || // specific check for 5.3.3 and less
+    (PHP_VERSION_ID >= 50323 && PHP_VERSION_ID <= 50399) || // check for 5.3
+    PHP_VERSION_ID >= 50413) // check for 5.4 versions
+{
     class_alias('Zend\Stdlib\ArrayObject\PhpLegacyCompatibility', 'Zend\Stdlib\AbstractArrayObject');
 } else {
     class_alias('Zend\Stdlib\ArrayObject\PhpReferenceCompatibility', 'Zend\Stdlib\AbstractArrayObject');

--- a/tests/ZendTest/Stdlib/ArrayObjectTest.php
+++ b/tests/ZendTest/Stdlib/ArrayObjectTest.php
@@ -12,6 +12,8 @@ namespace ZendTest\Stdlib;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Stdlib\ArrayObject;
+use Zend\Stdlib\ArrayObject\PhpLegacyCompatibility;
+use Zend\Stdlib\ArrayObject\PhpReferenceCompatibility;
 
 class ArrayObjectTest extends TestCase
 {
@@ -53,8 +55,8 @@ class ArrayObjectTest extends TestCase
 
     public function testStdPropListCannotAccessObjectVars()
     {
-        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
-            $this->markTestSkipped('Behavior is for overwritten ArrayObject in greater than 5.3.3');
+        if (PHP_VERSION_ID <= 50303 || (PHP_VERSION_ID >= 50323 && PHP_VERSION_ID <= 50399) || PHP_VERSION_ID >= 50413) {
+            $this->markTestSkipped('Behavior is for overwritten ArrayObject in PHP 5.3.4 - 5.3.22 OR PHP 5.4.0 - 5.4.12');
         }
         $this->setExpectedException('InvalidArgumentException');
         $ar = new ArrayObject();
@@ -207,8 +209,8 @@ class ArrayObjectTest extends TestCase
 
     public function testInvalidIteratorClassThrowsInvalidArgumentException()
     {
-        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
-            $this->markTestSkipped('Behavior is for overwritten ArrayObject in greater than 5.3.3');
+        if (PHP_VERSION_ID <= 50303 || (PHP_VERSION_ID >= 50323 && PHP_VERSION_ID <= 50399) || PHP_VERSION_ID >= 50413) {
+            $this->markTestSkipped('Behavior is for overwritten ArrayObject in PHP 5.3.4 - 5.3.22 OR PHP 5.4.0 - 5.4.12');
         }
         $this->setExpectedException('InvalidArgumentException');
         $ar = new ArrayObject(array(), ArrayObject::STD_PROP_LIST, 'InvalidArrayIterator');
@@ -255,8 +257,8 @@ class ArrayObjectTest extends TestCase
 
     public function testOffsetExistsThrowsExceptionOnProtectedProperty()
     {
-        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
-            $this->markTestSkipped('Behavior is for overwritten ArrayObject in greater than 5.3.3');
+        if (PHP_VERSION_ID <= 50303 || (PHP_VERSION_ID >= 50323 && PHP_VERSION_ID <= 50399) || PHP_VERSION_ID >= 50413) {
+            $this->markTestSkipped('Behavior is for overwritten ArrayObject in PHP 5.3.4 - 5.3.22 OR PHP 5.4.0 - 5.4.12');
         }
         $this->setExpectedException('InvalidArgumentException');
         $ar = new ArrayObject();
@@ -277,8 +279,8 @@ class ArrayObjectTest extends TestCase
 
     public function testOffsetGetThrowsExceptionOnProtectedProperty()
     {
-        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
-            $this->markTestSkipped('Behavior is for overwritten ArrayObject in greater than 5.3.3');
+        if (PHP_VERSION_ID <= 50303 || (PHP_VERSION_ID >= 50323 && PHP_VERSION_ID <= 50399) || PHP_VERSION_ID >= 50413) {
+            $this->markTestSkipped('Behavior is for overwritten ArrayObject in PHP 5.3.4 - 5.3.22 OR PHP 5.4.0 - 5.4.12');
         }
         $this->setExpectedException('InvalidArgumentException');
         $ar = new ArrayObject();
@@ -287,8 +289,8 @@ class ArrayObjectTest extends TestCase
 
     public function testOffsetSetThrowsExceptionOnProtectedProperty()
     {
-        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
-            $this->markTestSkipped('Behavior is for overwritten ArrayObject in greater than 5.3.3');
+        if (PHP_VERSION_ID <= 50303 || (PHP_VERSION_ID >= 50323 && PHP_VERSION_ID <= 50399) || PHP_VERSION_ID >= 50413) {
+            $this->markTestSkipped('Behavior is for overwritten ArrayObject in PHP 5.3.4 - 5.3.22 OR PHP 5.4.0 - 5.4.12');
         }
         $this->setExpectedException('InvalidArgumentException');
         $ar = new ArrayObject();
@@ -309,8 +311,8 @@ class ArrayObjectTest extends TestCase
 
     public function testOffsetUnsetMultidimensional()
     {
-        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
-            $this->markTestSkipped('Behavior is for overwritten ArrayObject in greater than 5.3.3');
+        if (PHP_VERSION_ID <= 50303) {
+            $this->markTestSkipped('Behavior can only be tested on PHP > 5.3.3');
         }
         $ar = new ArrayObject();
         $ar['foo'] = array('bar' => array('baz' => 'boo'));
@@ -319,8 +321,8 @@ class ArrayObjectTest extends TestCase
 
     public function testOffsetUnsetThrowsExceptionOnProtectedProperty()
     {
-        if (version_compare(PHP_VERSION, '5.3.4') < 0) {
-            $this->markTestSkipped('Behavior is for overwritten ArrayObject in greater than 5.3.3');
+        if (PHP_VERSION_ID <= 50303 || (PHP_VERSION_ID >= 50323 && PHP_VERSION_ID <= 50399) || PHP_VERSION_ID >= 50413) {
+            $this->markTestSkipped('Behavior is for overwritten ArrayObject in PHP 5.3.4 - 5.3.22 OR PHP 5.4.0 - 5.4.12');
         }
         $this->setExpectedException('InvalidArgumentException');
         $ar = new ArrayObject();
@@ -371,6 +373,19 @@ class ArrayObjectTest extends TestCase
         uksort($sorted, $function);
         $ar->uksort($function);
         $this->assertSame($sorted, $ar->getArrayCopy());
+    }
+
+    public function testPhpVersionProvidesProperInstance()
+    {
+        if (PHP_VERSION_ID <= 50303) {
+            $this->assertInstanceOf('\Zend\Stdlib\ArrayObject\PhpLegacyCompatibility', new ArrayObject());
+        } elseif (PHP_VERSION_ID >= 50323 && PHP_VERSION_ID <= 50399) {
+            $this->assertInstanceOf('\Zend\Stdlib\ArrayObject\PhpLegacyCompatibility', new ArrayObject());
+        } elseif (PHP_VERSION_ID >= 50413) {
+            $this->assertInstanceOf('\Zend\Stdlib\ArrayObject\PhpLegacyCompatibility', new ArrayObject());
+        } else {
+            $this->assertInstanceOf('\Zend\Stdlib\ArrayObject\PhpReferenceCompatibility', new ArrayObject());
+        }
     }
 
 }


### PR DESCRIPTION
With PHP 5.3.23 and PHP 5.4.13 being released (http://www.php.net/ChangeLog-5.php) it contains a fix for being able to unset multi-dimensional arrays (JOY!) in an ArrayObject so it does not freak out with wonderful error messages.  More on the bug: https://bugs.php.net/bug.php?id=52861

Anyhow, since this is now resolved the polyfill needs to be updated so we don't randomly leave people with references.  This also resolves #3961 where you would receive a reference if your version was greater than 5.3.3 (your PHP version must be 5.3.23 OR 5.4.13 to not receive a reference).
