### PR TITLE
View helpers cleanup

### DIFF
--- a/library/Zend/Form/View/Helper/AbstractHelper.php
+++ b/library/Zend/Form/View/Helper/AbstractHelper.php
@@ -157,6 +157,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
     public function setDoctype($doctype)
     {
         $this->getDoctypeHelper()->setDoctype($doctype);
+
         return $this;
     }
 
@@ -179,6 +180,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
     public function setEncoding($encoding)
     {
         $this->getEscapeHtmlHelper()->setEncoding($encoding);
+
         return $this;
     }
 
@@ -203,7 +205,6 @@ abstract class AbstractHelper extends BaseAbstractHelper
     public function createAttributesString(array $attributes)
     {
         $attributes = $this->prepareAttributes($attributes);
-
         $escape     = $this->getEscapeHtmlHelper();
         $strings    = array();
         foreach ($attributes as $key => $value) {
@@ -227,6 +228,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
             //@TODO Escape event attributes like AbstractHtmlElement view helper does in htmlAttribs ??
             $strings[] = sprintf('%s="%s"', $escape($key), $escape($value));
         }
+
         return implode(' ', $strings);
     }
 

--- a/library/Zend/Form/View/Helper/AbstractHelper.php
+++ b/library/Zend/Form/View/Helper/AbstractHelper.php
@@ -157,7 +157,6 @@ abstract class AbstractHelper extends BaseAbstractHelper
     public function setDoctype($doctype)
     {
         $this->getDoctypeHelper()->setDoctype($doctype);
-
         return $this;
     }
 
@@ -180,7 +179,6 @@ abstract class AbstractHelper extends BaseAbstractHelper
     public function setEncoding($encoding)
     {
         $this->getEscapeHtmlHelper()->setEncoding($encoding);
-
         return $this;
     }
 
@@ -228,7 +226,6 @@ abstract class AbstractHelper extends BaseAbstractHelper
             //@TODO Escape event attributes like AbstractHtmlElement view helper does in htmlAttribs ??
             $strings[] = sprintf('%s="%s"', $escape($key), $escape($value));
         }
-
         return implode(' ', $strings);
     }
 

--- a/library/Zend/Form/View/Helper/Captcha/AbstractWord.php
+++ b/library/Zend/Form/View/Helper/Captcha/AbstractWord.php
@@ -30,65 +30,27 @@ abstract class AbstractWord extends FormInput
     protected $captchaPosition = self::CAPTCHA_APPEND;
 
     /**
+     * Separator string for captcha and inputs
+     *
      * @var string
      */
     protected $separator = '';
 
     /**
-     * Set value for captchaPosition
+     * Invoke helper as functor
      *
-     * @param  mixed                              $captchaPosition
-     * @throws Exception\InvalidArgumentException
-     * @return self
+     * Proxies to {@link render()}.
+     *
+     * @param  ElementInterface $element
+     * @return string
      */
-    public function setCaptchaPosition($captchaPosition)
+    public function __invoke(ElementInterface $element = null)
     {
-        $captchaPosition = strtolower($captchaPosition);
-        if (!in_array($captchaPosition, array(self::CAPTCHA_APPEND, self::CAPTCHA_PREPEND))) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects either %s::CAPTCHA_APPEND or %s::CAPTCHA_PREPEND; received "%s"',
-                __METHOD__,
-                __CLASS__,
-                __CLASS__,
-                (string) $captchaPosition
-            ));
+        if (!$element) {
+            return $this;
         }
-        $this->captchaPosition = $captchaPosition;
 
-        return $this;
-    }
-
-    /**
-     * Get position of captcha
-     *
-     * @return string
-     */
-    public function getCaptchaPosition()
-    {
-        return $this->captchaPosition;
-    }
-
-    /**
-     * Set separator string for captcha and inputs
-     *
-     * @param  string       $separator
-     * @return AbstractWord
-     */
-    public function setSeparator($separator)
-    {
-        $this->separator = (string) $separator;
-
-        return $this;
-    }
-
-    /**
-     * Get separator for captcha and inputs
-     *
-     * @return string
-     */
-    public function getSeparator()
-    {
-        return $this->separator;
+        return $this->render($element);
     }
 
     /**
@@ -100,7 +62,7 @@ abstract class AbstractWord extends FormInput
      *
      * More specific renderers will consume this and render it.
      *
-     * @param  ElementInterface          $element
+     * @param  ElementInterface $element
      * @throws Exception\DomainException
      * @return string
      */
@@ -124,27 +86,10 @@ abstract class AbstractWord extends FormInput
             ));
         }
 
-        $hidden    = $this->renderCaptchaHidden($captcha, $attributes);
-        $input     = $this->renderCaptchaInput($captcha, $attributes);
+        $hidden = $this->renderCaptchaHidden($captcha, $attributes);
+        $input  = $this->renderCaptchaInput($captcha, $attributes);
 
         return $hidden . $input;
-    }
-
-    /**
-     * Invoke helper as functor
-     *
-     * Proxies to {@link render()}.
-     *
-     * @param  ElementInterface $element
-     * @return string
-     */
-    public function __invoke(ElementInterface $element = null)
-    {
-        if (!$element) {
-            return $this;
-        }
-
-        return $this->render($element);
     }
 
     /**
@@ -202,5 +147,62 @@ abstract class AbstractWord extends FormInput
         );
 
         return $input;
+    }
+
+    /**
+     * Set value for captchaPosition
+     *
+     * @param  mixed $captchaPosition
+     * @throws Exception\InvalidArgumentException
+     * @return AbstractWord
+     */
+    public function setCaptchaPosition($captchaPosition)
+    {
+        $captchaPosition = strtolower($captchaPosition);
+        if (!in_array($captchaPosition, array(self::CAPTCHA_APPEND, self::CAPTCHA_PREPEND))) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects either %s::CAPTCHA_APPEND or %s::CAPTCHA_PREPEND; received "%s"',
+                __METHOD__,
+                __CLASS__,
+                __CLASS__,
+                (string) $captchaPosition
+            ));
+        }
+        $this->captchaPosition = $captchaPosition;
+
+        return $this;
+    }
+
+    /**
+     * Get position of captcha
+     *
+     * @return string
+     */
+    public function getCaptchaPosition()
+    {
+        return $this->captchaPosition;
+    }
+
+    /**
+     * Set separator string for captcha and inputs
+     *
+     * @param  string $separator
+     * @return AbstractWord
+     */
+    public function setSeparator($separator)
+    {
+        $this->separator = (string) $separator;
+
+        return $this;
+    }
+
+    /**
+     * Get separator for captcha and inputs
+     *
+     * @return string
+     */
+    public function getSeparator()
+    {
+        return $this->separator;
     }
 }

--- a/library/Zend/Form/View/Helper/Captcha/AbstractWord.php
+++ b/library/Zend/Form/View/Helper/Captcha/AbstractWord.php
@@ -192,7 +192,6 @@ abstract class AbstractWord extends FormInput
     public function setSeparator($separator)
     {
         $this->separator = (string) $separator;
-
         return $this;
     }
 

--- a/library/Zend/Form/View/Helper/Captcha/ReCaptcha.php
+++ b/library/Zend/Form/View/Helper/Captcha/ReCaptcha.php
@@ -17,6 +17,23 @@ use Zend\Form\View\Helper\FormInput;
 class ReCaptcha extends FormInput
 {
     /**
+     * Invoke helper as functor
+     *
+     * Proxies to {@link render()}.
+     *
+     * @param  ElementInterface $element
+     * @return string
+     */
+    public function __invoke(ElementInterface $element = null)
+    {
+        if (!$element) {
+            return $this;
+        }
+
+        return $this->render($element);
+    }
+
+    /**
      * Render ReCaptcha form elements
      *
      * @param  ElementInterface $element
@@ -47,23 +64,6 @@ class ReCaptcha extends FormInput
         $js     = $this->renderJsEvents($challengeId, $responseId);
 
         return $hidden . $markup . $js;
-    }
-
-    /**
-     * Invoke helper as functor
-     *
-     * Proxies to {@link render()}.
-     *
-     * @param  ElementInterface $element
-     * @return string
-     */
-    public function __invoke(ElementInterface $element = null)
-    {
-        if (!$element) {
-            return $this;
-        }
-
-        return $this->render($element);
     }
 
     /**

--- a/library/Zend/Form/View/Helper/FormButton.php
+++ b/library/Zend/Form/View/Helper/FormButton.php
@@ -45,6 +45,59 @@ class FormButton extends FormInput
     );
 
     /**
+     * Invoke helper as functor
+     *
+     * Proxies to {@link render()}.
+     *
+     * @param  ElementInterface|null $element
+     * @param  null|string           $buttonContent
+     * @return string|FormButton
+     */
+    public function __invoke(ElementInterface $element = null, $buttonContent = null)
+    {
+        if (!$element) {
+            return $this;
+        }
+
+        return $this->render($element, $buttonContent);
+    }
+
+    /**
+     * Render a form <button> element from the provided $element,
+     * using content from $buttonContent or the element's "label" attribute
+     *
+     * @param  ElementInterface $element
+     * @param  null|string $buttonContent
+     * @throws Exception\DomainException
+     * @return string
+     */
+    public function render(ElementInterface $element, $buttonContent = null)
+    {
+        $openTag = $this->openTag($element);
+
+        if (null === $buttonContent) {
+            $buttonContent = $element->getLabel();
+            if (null === $buttonContent) {
+                throw new Exception\DomainException(sprintf(
+                    '%s expects either button content as the second argument, ' .
+                        'or that the element provided has a label value; neither found',
+                    __METHOD__
+                ));
+            }
+
+            if (null !== ($translator = $this->getTranslator())) {
+                $buttonContent = $translator->translate(
+                    $buttonContent, $this->getTranslatorTextDomain()
+                );
+            }
+        }
+
+        $escape = $this->getEscapeHtmlHelper();
+
+        return $openTag . $escape($buttonContent) . $this->closeTag();
+    }
+
+    /**
      * Generate an opening button tag
      *
      * @param  null|array|ElementInterface $attributesOrElement
@@ -99,59 +152,6 @@ class FormButton extends FormInput
     public function closeTag()
     {
         return '</button>';
-    }
-
-    /**
-     * Render a form <button> element from the provided $element,
-     * using content from $buttonContent or the element's "label" attribute
-     *
-     * @param  ElementInterface $element
-     * @param  null|string $buttonContent
-     * @throws Exception\DomainException
-     * @return string
-     */
-    public function render(ElementInterface $element, $buttonContent = null)
-    {
-        $openTag = $this->openTag($element);
-
-        if (null === $buttonContent) {
-            $buttonContent = $element->getLabel();
-            if (null === $buttonContent) {
-                throw new Exception\DomainException(sprintf(
-                    '%s expects either button content as the second argument, ' .
-                    'or that the element provided has a label value; neither found',
-                    __METHOD__
-                ));
-            }
-
-            if (null !== ($translator = $this->getTranslator())) {
-                $buttonContent = $translator->translate(
-                    $buttonContent, $this->getTranslatorTextDomain()
-                );
-            }
-        }
-
-        $escape = $this->getEscapeHtmlHelper();
-
-        return $openTag . $escape($buttonContent) . $this->closeTag();
-    }
-
-    /**
-     * Invoke helper as functor
-     *
-     * Proxies to {@link render()}.
-     *
-     * @param  ElementInterface|null $element
-     * @param  null|string $buttonContent
-     * @return string|FormButton
-     */
-    public function __invoke(ElementInterface $element = null, $buttonContent = null)
-    {
-        if (!$element) {
-            return $this;
-        }
-
-        return $this->render($element, $buttonContent);
     }
 
     /**

--- a/library/Zend/Form/View/Helper/FormCaptcha.php
+++ b/library/Zend/Form/View/Helper/FormCaptcha.php
@@ -16,11 +16,28 @@ use Zend\Form\Exception;
 class FormCaptcha extends AbstractHelper
 {
     /**
+     * Invoke helper as functor
+     *
+     * Proxies to {@link render()}.
+     *
+     * @param  ElementInterface $element
+     * @return string|FormCaptcha
+     */
+    public function __invoke(ElementInterface $element)
+    {
+        if (!$element) {
+            return $this;
+        }
+
+        return $this->render($element);
+    }
+
+    /**
      * Render a form captcha for an element
      *
      * @param  ElementInterface $element
-     * @return string
      * @throws Exception\DomainException if the element does not compose a captcha, or the renderer does not implement plugin()
+     * @return string
      */
     public function render(ElementInterface $element)
     {
@@ -45,22 +62,5 @@ class FormCaptcha extends AbstractHelper
 
         $helper = $renderer->plugin($helper);
         return $helper($element);
-    }
-
-    /**
-     * Invoke helper as functor
-     *
-     * Proxies to {@link render()}.
-     *
-     * @param  ElementInterface $element
-     * @return string|FormCaptcha
-     */
-    public function __invoke(ElementInterface $element)
-    {
-        if (!$element) {
-            return $this;
-        }
-
-        return $this->render($element);
     }
 }

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -163,7 +163,6 @@ class FormCollection extends AbstractHelper
     public function setShouldWrap($wrap)
     {
         $this->shouldWrap = (bool) $wrap;
-
         return $this;
     }
 
@@ -178,6 +177,18 @@ class FormCollection extends AbstractHelper
     }
 
     /**
+     * Sets the name of the view helper that should be used to render sub elements.
+     *
+     * @param  string $defaultSubHelper The name of the view helper to set.
+     * @return FormCollection
+     */
+    public function setDefaultElementHelper($defaultSubHelper)
+    {
+        $this->defaultElementHelper = $defaultSubHelper;
+        return $this;
+    }
+
+    /**
      * Gets the name of the view helper that should be used to render sub elements.
      *
      * @return string
@@ -188,15 +199,14 @@ class FormCollection extends AbstractHelper
     }
 
     /**
-     * Sets the name of the view helper that should be used to render sub elements.
+     * Sets the element helper that should be used by this collection.
      *
-     * @param  string $defaultSubHelper The name of the view helper to set.
+     * @param  AbstractHelper $elementHelper The element helper to use.
      * @return FormCollection
      */
-    public function setDefaultElementHelper($defaultSubHelper)
+    public function setElementHelper(AbstractHelper $elementHelper)
     {
-        $this->defaultElementHelper = $defaultSubHelper;
-
+        $this->elementHelper = $elementHelper;
         return $this;
     }
 
@@ -225,34 +235,6 @@ class FormCollection extends AbstractHelper
     }
 
     /**
-     * Sets the element helper that should be used by this collection.
-     *
-     * @param  AbstractHelper $elementHelper The element helper to use.
-     * @return FormCollection
-     */
-    public function setElementHelper(AbstractHelper $elementHelper)
-    {
-        $this->elementHelper = $elementHelper;
-
-        return $this;
-    }
-
-    /**
-     * Retrieve the fieldset helper.
-     *
-     * @return AbstractHelper
-     */
-    protected function getFieldsetHelper()
-    {
-        if ($this->fieldsetHelper) {
-            return $this->fieldsetHelper;
-        }
-
-        //if no special fieldset helper was set fall back to FormCollection helper
-        return $this;
-    }
-
-    /**
      * Sets the fieldset helper that should be used by this collection.
      *
      * @param  AbstractHelper $fieldsetHelper The fieldset helper to use.
@@ -261,6 +243,19 @@ class FormCollection extends AbstractHelper
     public function setFieldsetHelper(AbstractHelper $fieldsetHelper)
     {
         $this->fieldsetHelper = $fieldsetHelper;
+        return $this;
+    }
+
+    /**
+     * Retrieve the fieldset helper.
+     *
+     * @return FormCollection
+     */
+    protected function getFieldsetHelper()
+    {
+        if ($this->fieldsetHelper) {
+            return $this->fieldsetHelper;
+        }
 
         return $this;
     }

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -47,6 +47,26 @@ class FormCollection extends AbstractHelper
     protected $fieldsetHelper;
 
     /**
+     * Invoke helper as function
+     *
+     * Proxies to {@link render()}.
+     *
+     * @param  ElementInterface|null $element
+     * @param  bool                  $wrap
+     * @return string|FormCollection
+     */
+    public function __invoke(ElementInterface $element = null, $wrap = true)
+    {
+        if (!$element) {
+            return $this;
+        }
+
+        $this->setShouldWrap($wrap);
+
+        return $this->render($element);
+    }
+
+    /**
      * Render a collection by iterating through all fieldsets and elements
      *
      * @param  ElementInterface $element
@@ -111,7 +131,7 @@ class FormCollection extends AbstractHelper
     /**
      * Only render a template
      *
-     * @param  CollectionElement            $collection
+     * @param  CollectionElement $collection
      * @return string
      */
     public function renderTemplate(CollectionElement $collection)
@@ -135,34 +155,15 @@ class FormCollection extends AbstractHelper
     }
 
     /**
-     * Invoke helper as function
-     *
-     * Proxies to {@link render()}.
-     *
-     * @param  ElementInterface|null $element
-     * @param  bool $wrap
-     * @return string|FormCollection
-     */
-    public function __invoke(ElementInterface $element = null, $wrap = true)
-    {
-        if (!$element) {
-            return $this;
-        }
-
-        $this->setShouldWrap($wrap);
-
-        return $this->render($element);
-    }
-
-    /**
      * If set to true, collections are automatically wrapped around a fieldset
      *
-     * @param bool $wrap
+     * @param  bool $wrap
      * @return FormCollection
      */
     public function setShouldWrap($wrap)
     {
         $this->shouldWrap = (bool) $wrap;
+
         return $this;
     }
 
@@ -189,20 +190,21 @@ class FormCollection extends AbstractHelper
     /**
      * Sets the name of the view helper that should be used to render sub elements.
      *
-     * @param string $defaultSubHelper The name of the view helper to set.
+     * @param  string $defaultSubHelper The name of the view helper to set.
      * @return FormCollection
      */
     public function setDefaultElementHelper($defaultSubHelper)
     {
         $this->defaultElementHelper = $defaultSubHelper;
+
         return $this;
     }
 
     /**
      * Retrieve the element helper.
      *
-     * @throws RuntimeException
      * @return AbstractHelper
+     * @throws RuntimeException
      */
     protected function getElementHelper()
     {
@@ -225,12 +227,13 @@ class FormCollection extends AbstractHelper
     /**
      * Sets the element helper that should be used by this collection.
      *
-     * @param AbstractHelper $elementHelper The element helper to use.
+     * @param  AbstractHelper $elementHelper The element helper to use.
      * @return FormCollection
      */
     public function setElementHelper(AbstractHelper $elementHelper)
     {
         $this->elementHelper = $elementHelper;
+
         return $this;
     }
 
@@ -252,12 +255,13 @@ class FormCollection extends AbstractHelper
     /**
      * Sets the fieldset helper that should be used by this collection.
      *
-     * @param AbstractHelper $fieldsetHelper The fieldset helper to use.
+     * @param  AbstractHelper $fieldsetHelper The fieldset helper to use.
      * @return FormCollection
      */
     public function setFieldsetHelper(AbstractHelper $fieldsetHelper)
     {
         $this->fieldsetHelper = $fieldsetHelper;
+
         return $this;
     }
 }

--- a/library/Zend/Form/View/Helper/FormDateSelect.php
+++ b/library/Zend/Form/View/Helper/FormDateSelect.php
@@ -81,7 +81,7 @@ class FormDateSelect extends FormMonthSelectHelper
     /**
      * Create a key => value options for days
      *
-     * @param string  $pattern Pattern to use for days
+     * @param  string $pattern Pattern to use for days
      * @return array
      */
     protected function getDaysOptions($pattern)

--- a/library/Zend/Form/View/Helper/FormDateTimeSelect.php
+++ b/library/Zend/Form/View/Helper/FormDateTimeSelect.php
@@ -25,14 +25,44 @@ class FormDateTimeSelect extends FormDateSelectHelper
      */
     protected $timeType = IntlDateFormatter::LONG;
 
+    /**
+     * Invoke helper as function
+     *
+     * Proxies to {@link render()}.
+     *
+     * @param ElementInterface $element
+     * @param int              $dateType
+     * @param int|null|string  $timeType
+     * @param null|string      $locale
+     * @return string
+     */
+    public function __invoke(
+        ElementInterface $element = null,
+        $dateType = IntlDateFormatter::LONG,
+        $timeType = IntlDateFormatter::LONG,
+        $locale = null
+    ) {
+        if (!$element) {
+            return $this;
+        }
+
+        $this->setDateType($dateType);
+        $this->setTimeType($timeType);
+
+        if ($locale !== null) {
+            $this->setLocale($locale);
+        }
+
+        return $this->render($element);
+    }
 
     /**
      * Render a date element that is composed of six selects
      *
      * @param  ElementInterface $element
+     * @return string
      * @throws \Zend\Form\Exception\InvalidArgumentException
      * @throws \Zend\Form\Exception\DomainException
-     * @return string
      */
     public function render(ElementInterface $element)
     {
@@ -101,37 +131,6 @@ class FormDateTimeSelect extends FormDateSelectHelper
         }
 
         return $markup;
-    }
-
-    /**
-     * Invoke helper as function
-     *
-     * Proxies to {@link render()}.
-     *
-     * @param \Zend\Form\ElementInterface $element
-     * @param int                         $dateType
-     * @param int|null|string             $timeType
-     * @param null|string                 $locale
-     * @return string
-     */
-    public function __invoke(
-        ElementInterface $element = null,
-        $dateType = IntlDateFormatter::LONG,
-        $timeType = IntlDateFormatter::LONG,
-        $locale = null
-    ) {
-        if (!$element) {
-            return $this;
-        }
-
-        $this->setDateType($dateType);
-        $this->setTimeType($timeType);
-
-        if ($locale !== null) {
-            $this->setLocale($locale);
-        }
-
-        return $this->render($element);
     }
 
     /**
@@ -211,7 +210,7 @@ class FormDateTimeSelect extends FormDateSelectHelper
     /**
      * Create a key => value options for hours
      *
-     * @param string  $pattern Pattern to use for hours
+     * @param  string $pattern Pattern to use for hours
      * @return array
      */
     protected function getHoursOptions($pattern)
@@ -235,7 +234,7 @@ class FormDateTimeSelect extends FormDateSelectHelper
     /**
      * Create a key => value options for minutes
      *
-     * @param string  $pattern Pattern to use for minutes
+     * @param  string $pattern Pattern to use for minutes
      * @return array
      */
     protected function getMinutesOptions($pattern)
@@ -259,7 +258,7 @@ class FormDateTimeSelect extends FormDateSelectHelper
     /**
      * Create a key => value options for seconds
      *
-     * @param string  $pattern Pattern to use for seconds
+     * @param  string $pattern Pattern to use for seconds
      * @return array
      */
     protected function getSecondsOptions($pattern)

--- a/library/Zend/Form/View/Helper/FormElement.php
+++ b/library/Zend/Form/View/Helper/FormElement.php
@@ -16,6 +16,23 @@ use Zend\View\Helper\AbstractHelper as BaseAbstractHelper;
 class FormElement extends BaseAbstractHelper
 {
     /**
+     * Invoke helper as function
+     *
+     * Proxies to {@link render()}.
+     *
+     * @param  ElementInterface|null $element
+     * @return string|FormElement
+     */
+    public function __invoke(ElementInterface $element = null)
+    {
+        if (!$element) {
+            return $this;
+        }
+
+        return $this->render($element);
+    }
+
+    /**
      * Render an element
      *
      * Introspects the element type and attributes to determine which
@@ -196,22 +213,5 @@ class FormElement extends BaseAbstractHelper
 
         $helper = $renderer->plugin('form_input');
         return $helper($element);
-    }
-
-    /**
-     * Invoke helper as function
-     *
-     * Proxies to {@link render()}.
-     *
-     * @param  ElementInterface|null $element
-     * @return string|FormElement
-     */
-    public function __invoke(ElementInterface $element = null)
-    {
-        if (!$element) {
-            return $this;
-        }
-
-        return $this->render($element);
     }
 }

--- a/library/Zend/Form/View/Helper/FormElementErrors.php
+++ b/library/Zend/Form/View/Helper/FormElementErrors.php
@@ -95,6 +95,28 @@ class FormElementErrors extends AbstractHelper
     }
 
     /**
+     * Set the attributes that will go on the message open format
+     *
+     * @param  array $attributes key value pairs of attributes
+     * @return FormElementErrors
+     */
+    public function setAttributes(array $attributes)
+    {
+        $this->attributes = $attributes;
+        return $this;
+    }
+
+    /**
+     * Get the attributes that will go on the message open format
+     *
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
      * Set the string used to close message representation
      *
      * @param  string $messageCloseString
@@ -103,7 +125,6 @@ class FormElementErrors extends AbstractHelper
     public function setMessageCloseString($messageCloseString)
     {
         $this->messageCloseString = (string) $messageCloseString;
-
         return $this;
     }
 
@@ -126,7 +147,6 @@ class FormElementErrors extends AbstractHelper
     public function setMessageOpenFormat($messageOpenFormat)
     {
         $this->messageOpenFormat = (string) $messageOpenFormat;
-
         return $this;
     }
 
@@ -149,7 +169,6 @@ class FormElementErrors extends AbstractHelper
     public function setMessageSeparatorString($messageSeparatorString)
     {
         $this->messageSeparatorString = (string) $messageSeparatorString;
-
         return $this;
     }
 
@@ -161,28 +180,5 @@ class FormElementErrors extends AbstractHelper
     public function getMessageSeparatorString()
     {
         return $this->messageSeparatorString;
-    }
-
-    /**
-     * Set the attributes that will go on the message open format
-     *
-     * @param  array $attributes key value pairs of attributes
-     * @return FormElementErrors
-     */
-    public function setAttributes(array $attributes)
-    {
-        $this->attributes = $attributes;
-
-        return $this;
-    }
-
-    /**
-     * Get the attributes that will go on the message open format
-     *
-     * @return array
-     */
-    public function getAttributes()
-    {
-        return $this->attributes;
     }
 }

--- a/library/Zend/Form/View/Helper/FormElementErrors.php
+++ b/library/Zend/Form/View/Helper/FormElementErrors.php
@@ -29,91 +29,21 @@ class FormElementErrors extends AbstractHelper
     protected $attributes = array();
 
     /**
-     * Set the string used to close message representation
+     * Invoke helper as functor
      *
-     * @param  string $messageCloseString
-     * @return FormElementErrors
+     * Proxies to {@link render()} if an element is passed.
+     *
+     * @param  ElementInterface $element
+     * @param  array            $attributes
+     * @return string|FormElementErrors
      */
-    public function setMessageCloseString($messageCloseString)
+    public function __invoke(ElementInterface $element = null, array $attributes = array())
     {
-        $this->messageCloseString = (string) $messageCloseString;
-        return $this;
-    }
+        if (!$element) {
+            return $this;
+        }
 
-    /**
-     * Get the string used to close message representation
-     *
-     * @return string
-     */
-    public function getMessageCloseString()
-    {
-        return $this->messageCloseString;
-    }
-
-    /**
-     * Set the formatted string used to open message representation
-     *
-     * @param  string $messageOpenFormat
-     * @return FormElementErrors
-     */
-    public function setMessageOpenFormat($messageOpenFormat)
-    {
-        $this->messageOpenFormat = (string) $messageOpenFormat;
-        return $this;
-    }
-
-    /**
-     * Get the formatted string used to open message representation
-     *
-     * @return string
-     */
-    public function getMessageOpenFormat()
-    {
-        return $this->messageOpenFormat;
-    }
-
-    /**
-     * Set the string used to separate messages
-     *
-     * @param  string $messageSeparatorString
-     * @return FormElementErrors
-     */
-    public function setMessageSeparatorString($messageSeparatorString)
-    {
-        $this->messageSeparatorString = (string) $messageSeparatorString;
-        return $this;
-    }
-
-    /**
-     * Get the string used to separate messages
-     *
-     * @return string
-     */
-    public function getMessageSeparatorString()
-    {
-        return $this->messageSeparatorString;
-    }
-
-    /**
-     * Set the attributes that will go on the message open format
-     *
-     * @param array $attributes key value pairs of attributes
-     * @return FormElementErrors
-     */
-    public function setAttributes(array $attributes)
-    {
-        $this->attributes = $attributes;
-        return $this;
-    }
-
-    /**
-     * Get the attributes that will go on the message open format
-     *
-     * @return array
-     */
-    public function getAttributes()
-    {
-        return $this->attributes;
+        return $this->render($element, $attributes);
     }
 
     /**
@@ -149,8 +79,8 @@ class FormElementErrors extends AbstractHelper
         $escapeHtml      = $this->getEscapeHtmlHelper();
         $messagesToPrint = array();
         array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml) {
-            $messagesToPrint[] = $escapeHtml($item);
-        });
+                $messagesToPrint[] = $escapeHtml($item);
+            });
 
         if (empty($messagesToPrint)) {
             return '';
@@ -165,20 +95,94 @@ class FormElementErrors extends AbstractHelper
     }
 
     /**
-     * Invoke helper as functor
+     * Set the string used to close message representation
      *
-     * Proxies to {@link render()} if an element is passed.
-     *
-     * @param  ElementInterface $element
-     * @param  array $attributes
-     * @return string|FormElementErrors
+     * @param  string $messageCloseString
+     * @return FormElementErrors
      */
-    public function __invoke(ElementInterface $element = null, array $attributes = array())
+    public function setMessageCloseString($messageCloseString)
     {
-        if (!$element) {
-            return $this;
-        }
+        $this->messageCloseString = (string) $messageCloseString;
 
-        return $this->render($element, $attributes);
+        return $this;
+    }
+
+    /**
+     * Get the string used to close message representation
+     *
+     * @return string
+     */
+    public function getMessageCloseString()
+    {
+        return $this->messageCloseString;
+    }
+
+    /**
+     * Set the formatted string used to open message representation
+     *
+     * @param  string $messageOpenFormat
+     * @return FormElementErrors
+     */
+    public function setMessageOpenFormat($messageOpenFormat)
+    {
+        $this->messageOpenFormat = (string) $messageOpenFormat;
+
+        return $this;
+    }
+
+    /**
+     * Get the formatted string used to open message representation
+     *
+     * @return string
+     */
+    public function getMessageOpenFormat()
+    {
+        return $this->messageOpenFormat;
+    }
+
+    /**
+     * Set the string used to separate messages
+     *
+     * @param  string $messageSeparatorString
+     * @return FormElementErrors
+     */
+    public function setMessageSeparatorString($messageSeparatorString)
+    {
+        $this->messageSeparatorString = (string) $messageSeparatorString;
+
+        return $this;
+    }
+
+    /**
+     * Get the string used to separate messages
+     *
+     * @return string
+     */
+    public function getMessageSeparatorString()
+    {
+        return $this->messageSeparatorString;
+    }
+
+    /**
+     * Set the attributes that will go on the message open format
+     *
+     * @param  array $attributes key value pairs of attributes
+     * @return FormElementErrors
+     */
+    public function setAttributes(array $attributes)
+    {
+        $this->attributes = $attributes;
+
+        return $this;
+    }
+
+    /**
+     * Get the attributes that will go on the message open format
+     *
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
     }
 }

--- a/library/Zend/Form/View/Helper/FormFile.php
+++ b/library/Zend/Form/View/Helper/FormFile.php
@@ -32,17 +32,6 @@ class FormFile extends FormInput
     );
 
     /**
-     * Determine input type to use
-     *
-     * @param  ElementInterface $element
-     * @return string
-     */
-    protected function getType(ElementInterface $element)
-    {
-        return 'file';
-    }
-
-    /**
      * Render a form <input> element from the provided $element
      *
      * @param  ElementInterface $element
@@ -78,5 +67,16 @@ class FormFile extends FormInput
             $this->createAttributesString($attributes),
             $this->getInlineClosingBracket()
         );
+    }
+
+    /**
+     * Determine input type to use
+     *
+     * @param  ElementInterface $element
+     * @return string
+     */
+    protected function getType(ElementInterface $element)
+    {
+        return 'file';
     }
 }

--- a/library/Zend/Form/View/Helper/FormInput.php
+++ b/library/Zend/Form/View/Helper/FormInput.php
@@ -85,6 +85,23 @@ class FormInput extends AbstractHelper
     );
 
     /**
+     * Invoke helper as functor
+     *
+     * Proxies to {@link render()}.
+     *
+     * @param  ElementInterface|null $element
+     * @return string|FormInput
+     */
+    public function __invoke(ElementInterface $element = null)
+    {
+        if (!$element) {
+            return $this;
+        }
+
+        return $this->render($element);
+    }
+
+    /**
      * Render a form <input> element from the provided $element
      *
      * @param  ElementInterface $element
@@ -111,23 +128,6 @@ class FormInput extends AbstractHelper
             $this->createAttributesString($attributes),
             $this->getInlineClosingBracket()
         );
-    }
-
-    /**
-     * Invoke helper as functor
-     *
-     * Proxies to {@link render()}.
-     *
-     * @param  ElementInterface|null $element
-     * @return string|FormInput
-     */
-    public function __invoke(ElementInterface $element = null)
-    {
-        if (!$element) {
-            return $this;
-        }
-
-        return $this->render($element);
     }
 
     /**

--- a/library/Zend/Form/View/Helper/FormLabel.php
+++ b/library/Zend/Form/View/Helper/FormLabel.php
@@ -28,6 +28,62 @@ class FormLabel extends AbstractHelper
     );
 
     /**
+     * Generate a form label, optionally with content
+     *
+     * Always generates a "for" statement, as we cannot assume the form input
+     * will be provided in the $labelContent.
+     *
+     * @param  ElementInterface $element
+     * @param  null|string      $labelContent
+     * @param  string           $position
+     * @throws Exception\DomainException
+     * @return string|FormLabel
+     */
+    public function __invoke(ElementInterface $element = null, $labelContent = null, $position = null)
+    {
+        if (!$element) {
+            return $this;
+        }
+
+        $openTag = $this->openTag($element);
+        $label   = '';
+        if ($labelContent === null || $position !== null) {
+            $label = $element->getLabel();
+            if (empty($label)) {
+                throw new Exception\DomainException(sprintf(
+                    '%s expects either label content as the second argument, ' .
+                        'or that the element provided has a label attribute; neither found',
+                    __METHOD__
+                ));
+            }
+
+            if (null !== ($translator = $this->getTranslator())) {
+                $label = $translator->translate(
+                    $label, $this->getTranslatorTextDomain()
+                );
+            }
+        }
+
+        if ($label && $labelContent) {
+            switch ($position) {
+                case self::APPEND:
+                    $labelContent .= $label;
+                    break;
+                case self::PREPEND:
+                default:
+                    $labelContent = $label . $labelContent;
+                    break;
+            }
+        }
+
+        if ($label && null === $labelContent) {
+            $labelContent = $label;
+        }
+
+        return $openTag . $labelContent . $this->closeTag();
+    }
+
+    /**
      * Generate an opening label tag
      *
      * @param  null|array|ElementInterface $attributesOrElement
@@ -81,61 +137,5 @@ class FormLabel extends AbstractHelper
     public function closeTag()
     {
         return '</label>';
-    }
-
-    /**
-     * Generate a form label, optionally with content
-     *
-     * Always generates a "for" statement, as we cannot assume the form input
-     * will be provided in the $labelContent.
-     *
-     * @param  ElementInterface $element
-     * @param  null|string $labelContent
-     * @param  string $position
-     * @throws Exception\DomainException
-     * @return string|FormLabel
-     */
-    public function __invoke(ElementInterface $element = null, $labelContent = null, $position = null)
-    {
-        if (!$element) {
-            return $this;
-        }
-
-        $openTag = $this->openTag($element);
-        $label   = '';
-        if ($labelContent === null || $position !== null) {
-            $label = $element->getLabel();
-            if (empty($label)) {
-                throw new Exception\DomainException(sprintf(
-                    '%s expects either label content as the second argument, ' .
-                    'or that the element provided has a label attribute; neither found',
-                    __METHOD__
-                ));
-            }
-
-            if (null !== ($translator = $this->getTranslator())) {
-                $label = $translator->translate(
-                    $label, $this->getTranslatorTextDomain()
-                );
-            }
-        }
-
-        if ($label && $labelContent) {
-            switch ($position) {
-                case self::APPEND:
-                    $labelContent .= $label;
-                    break;
-                case self::PREPEND:
-                default:
-                    $labelContent = $label . $labelContent;
-                    break;
-            }
-        }
-
-        if ($label && null === $labelContent) {
-            $labelContent = $label;
-        }
-
-        return $openTag . $labelContent . $this->closeTag();
     }
 }

--- a/library/Zend/Form/View/Helper/FormMonthSelect.php
+++ b/library/Zend/Form/View/Helper/FormMonthSelect.php
@@ -132,19 +132,6 @@ class FormMonthSelect extends AbstractHelper
     }
 
     /**
-     * @return string
-     */
-    public function getPattern()
-    {
-        if ($this->pattern === null) {
-            $intl           = new IntlDateFormatter($this->getLocale(), $this->dateType, IntlDateFormatter::NONE);
-            $this->pattern  = $intl->getPattern();
-        }
-
-        return $this->pattern;
-    }
-
-    /**
      * Parse the pattern
      *
      * @param  bool $renderDelimiters
@@ -172,6 +159,23 @@ class FormMonthSelect extends AbstractHelper
     }
 
     /**
+     * Retrive pattern to use for Date rendering
+     *
+     * @return string
+     */
+    public function getPattern()
+    {
+        if (null === $this->pattern) {
+            $intl           = new IntlDateFormatter($this->getLocale(), $this->dateType, IntlDateFormatter::NONE);
+            $this->pattern  = $intl->getPattern();
+        }
+
+        return $this->pattern;
+    }
+
+    /**
+     * Set date formatter
+     *
      * @param  int $dateType
      * @return FormDateSelect
      */
@@ -188,6 +192,8 @@ class FormMonthSelect extends AbstractHelper
     }
 
     /**
+     * Get date formatter
+     *
      * @return int
      */
     public function getDateType()
@@ -196,6 +202,8 @@ class FormMonthSelect extends AbstractHelper
     }
 
     /**
+     * Set locale
+     *
      * @param  string $locale
      * @return FormDateSelect
      */
@@ -206,11 +214,13 @@ class FormMonthSelect extends AbstractHelper
     }
 
     /**
+     * Get locale
+     *
      * @return string
      */
     public function getLocale()
     {
-        if ($this->locale === null) {
+        if (null === $this->locale) {
             $this->locale = Locale::getDefault();
         }
 
@@ -263,7 +273,7 @@ class FormMonthSelect extends AbstractHelper
     /**
      * Retrieve the FormSelect helper
      *
-     * @return FormRow
+     * @return FormSelect
      */
     protected function getSelectElementHelper()
     {

--- a/library/Zend/Form/View/Helper/FormMonthSelect.php
+++ b/library/Zend/Form/View/Helper/FormMonthSelect.php
@@ -46,11 +46,35 @@ class FormMonthSelect extends AbstractHelper
      */
     protected $locale;
 
+    /**
+     * Invoke helper as function
+     *
+     * Proxies to {@link render()}.
+     *
+     * @param  ElementInterface $element
+     * @param  int              $dateType
+     * @param  null|string      $locale
+     * @return FormDateSelect
+     */
+    public function __invoke(ElementInterface $element = null, $dateType = IntlDateFormatter::LONG, $locale = null)
+    {
+        if (!$element) {
+            return $this;
+        }
+
+        $this->setDateType($dateType);
+
+        if ($locale !== null) {
+            $this->setLocale($locale);
+        }
+
+        return $this->render($element);
+    }
 
     /**
      * Render a month element that is composed of two selects
      *
-     * @param \Zend\Form\ElementInterface $element
+     * @param  \Zend\Form\ElementInterface $element
      * @throws \Zend\Form\Exception\InvalidArgumentException
      * @throws \Zend\Form\Exception\DomainException
      * @return string
@@ -105,31 +129,6 @@ class FormMonthSelect extends AbstractHelper
         }
 
         return $markup;
-    }
-
-    /**
-     * Invoke helper as function
-     *
-     * Proxies to {@link render()}.
-     *
-     * @param \Zend\Form\ElementInterface $element
-     * @param int                         $dateType
-     * @param null|string                 $locale
-     * @return FormDateSelect
-     */
-    public function __invoke(ElementInterface $element = null, $dateType = IntlDateFormatter::LONG, $locale = null)
-    {
-        if (!$element) {
-            return $this;
-        }
-
-        $this->setDateType($dateType);
-
-        if ($locale !== null) {
-            $this->setLocale($locale);
-        }
-
-        return $this->render($element);
     }
 
     /**

--- a/library/Zend/Form/View/Helper/FormMultiCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormMultiCheckbox.php
@@ -54,127 +54,25 @@ class FormMultiCheckbox extends FormInput
     protected $separator = '';
 
     /**
-     * Set value for labelPosition
+     * Invoke helper as functor
      *
-     * @param  mixed $labelPosition
-     * @throws Exception\InvalidArgumentException
-     * @return FormMultiCheckbox
+     * Proxies to {@link render()}.
+     *
+     * @param  ElementInterface|null $element
+     * @param  null|string           $labelPosition
+     * @return string|FormMultiCheckbox
      */
-    public function setLabelPosition($labelPosition)
+    public function __invoke(ElementInterface $element = null, $labelPosition = null)
     {
-        $labelPosition = strtolower($labelPosition);
-        if (!in_array($labelPosition, array(self::LABEL_APPEND, self::LABEL_PREPEND))) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects either %s::LABEL_APPEND or %s::LABEL_PREPEND; received "%s"',
-                __METHOD__,
-                __CLASS__,
-                __CLASS__,
-                (string) $labelPosition
-            ));
+        if (!$element) {
+            return $this;
         }
-        $this->labelPosition = $labelPosition;
 
-        return $this;
-    }
+        if ($labelPosition !== null) {
+            $this->setLabelPosition($labelPosition);
+        }
 
-    /**
-     * Get position of label
-     *
-     * @return string
-     */
-    public function getLabelPosition()
-    {
-        return $this->labelPosition;
-    }
-
-    /**
-     * Set separator string for checkbox elements
-     *
-     * @param  string $separator
-     * @return FormMultiCheckbox
-     */
-    public function setSeparator($separator)
-    {
-        $this->separator = (string) $separator;
-        return $this;
-    }
-
-    /**
-     * Get separator for checkbox elements
-     *
-     * @return string
-     */
-    public function getSeparator()
-    {
-        return $this->separator;
-    }
-
-    /**
-     * Sets the attributes applied to option label.
-     *
-     * @param  array|null $attributes
-     * @return FormMultiCheckbox
-     */
-    public function setLabelAttributes($attributes)
-    {
-        $this->labelAttributes = $attributes;
-        return $this;
-    }
-
-    /**
-     * Returns the attributes applied to each option label.
-     *
-     * @return array|null
-     */
-    public function getLabelAttributes()
-    {
-        return $this->labelAttributes;
-    }
-
-    /**
-     * Returns the option for prefixing the element with a hidden element
-     * for the unset value.
-     *
-     * @return bool
-     */
-    public function getUseHiddenElement()
-    {
-        return $this->useHiddenElement;
-    }
-
-    /**
-     * Sets the option for prefixing the element with a hidden element
-     * for the unset value.
-     *
-     * @param  bool $useHiddenElement
-     * @return FormMultiCheckbox
-     */
-    public function setUseHiddenElement($useHiddenElement)
-    {
-        $this->useHiddenElement = (bool) $useHiddenElement;
-        return $this;
-    }
-
-    /**
-     * Returns the unchecked value used when "UseHiddenElement" is turned on.
-     *
-     * @return string
-     */
-    public function getUncheckedValue()
-    {
-        return $this->uncheckedValue;
-    }
-
-    /**
-     * Sets the unchecked value used when "UseHiddenElement" is turned on.
-     *
-     * @param  bool $value
-     * @return FormMultiCheckbox
-     */
-    public function setUncheckedValue($value)
-    {
-        $this->uncheckedValue = $value;
-        return $this;
+        return $this->render($element);
     }
 
     /**
@@ -226,14 +124,14 @@ class FormMultiCheckbox extends FormInput
     /**
      * Render options
      *
-     * @param MultiCheckboxElement $element
-     * @param array                $options
-     * @param array                $selectedOptions
-     * @param array                $attributes
+     * @param  MultiCheckboxElement $element
+     * @param  array                $options
+     * @param  array                $selectedOptions
+     * @param  array                $attributes
      * @return string
      */
     protected function renderOptions(MultiCheckboxElement $element, array $options, array $selectedOptions,
-                                     array $attributes)
+        array $attributes)
     {
         $escapeHtmlHelper = $this->getEscapeHtmlHelper();
         $labelHelper      = $this->getLabelHelper();
@@ -341,8 +239,8 @@ class FormMultiCheckbox extends FormInput
         $closingBracket = $this->getInlineClosingBracket();
 
         $uncheckedValue = $element->getUncheckedValue()
-                ? $element->getUncheckedValue()
-                : $this->uncheckedValue;
+            ? $element->getUncheckedValue()
+            : $this->uncheckedValue;
 
         $hiddenAttributes = array(
             'name'  => $element->getName(),
@@ -357,25 +255,131 @@ class FormMultiCheckbox extends FormInput
     }
 
     /**
-     * Invoke helper as functor
+     * Set value for labelPosition
      *
-     * Proxies to {@link render()}.
-     *
-     * @param  ElementInterface|null $element
-     * @param  null|string           $labelPosition
-     * @return string|FormMultiCheckbox
+     * @param  mixed $labelPosition
+     * @throws Exception\InvalidArgumentException
+     * @return FormMultiCheckbox
      */
-    public function __invoke(ElementInterface $element = null, $labelPosition = null)
+    public function setLabelPosition($labelPosition)
     {
-        if (!$element) {
-            return $this;
+        $labelPosition = strtolower($labelPosition);
+        if (!in_array($labelPosition, array(self::LABEL_APPEND, self::LABEL_PREPEND))) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects either %s::LABEL_APPEND or %s::LABEL_PREPEND; received "%s"',
+                __METHOD__,
+                __CLASS__,
+                __CLASS__,
+                (string) $labelPosition
+            ));
         }
+        $this->labelPosition = $labelPosition;
 
-        if ($labelPosition !== null) {
-            $this->setLabelPosition($labelPosition);
-        }
+        return $this;
+    }
 
-        return $this->render($element);
+    /**
+     * Get position of label
+     *
+     * @return string
+     */
+    public function getLabelPosition()
+    {
+        return $this->labelPosition;
+    }
+
+    /**
+     * Set separator string for checkbox elements
+     *
+     * @param  string $separator
+     * @return FormMultiCheckbox
+     */
+    public function setSeparator($separator)
+    {
+        $this->separator = (string) $separator;
+
+        return $this;
+    }
+
+    /**
+     * Get separator for checkbox elements
+     *
+     * @return string
+     */
+    public function getSeparator()
+    {
+        return $this->separator;
+    }
+
+    /**
+     * Sets the attributes applied to option label.
+     *
+     * @param  array|null $attributes
+     * @return FormMultiCheckbox
+     */
+    public function setLabelAttributes($attributes)
+    {
+        $this->labelAttributes = $attributes;
+
+        return $this;
+    }
+
+    /**
+     * Returns the attributes applied to each option label.
+     *
+     * @return array|null
+     */
+    public function getLabelAttributes()
+    {
+        return $this->labelAttributes;
+    }
+
+    /**
+     * Returns the option for prefixing the element with a hidden element
+     * for the unset value.
+     *
+     * @return bool
+     */
+    public function getUseHiddenElement()
+    {
+        return $this->useHiddenElement;
+    }
+
+    /**
+     * Sets the option for prefixing the element with a hidden element
+     * for the unset value.
+     *
+     * @param  bool $useHiddenElement
+     * @return FormMultiCheckbox
+     */
+    public function setUseHiddenElement($useHiddenElement)
+    {
+        $this->useHiddenElement = (bool) $useHiddenElement;
+
+        return $this;
+    }
+
+    /**
+     * Returns the unchecked value used when "UseHiddenElement" is turned on.
+     *
+     * @return string
+     */
+    public function getUncheckedValue()
+    {
+        return $this->uncheckedValue;
+    }
+
+    /**
+     * Sets the unchecked value used when "UseHiddenElement" is turned on.
+     *
+     * @param  bool $value
+     * @return FormMultiCheckbox
+     */
+    public function setUncheckedValue($value)
+    {
+        $this->uncheckedValue = $value;
+
+        return $this;
     }
 
     /**

--- a/library/Zend/Form/View/Helper/FormMultiCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormMultiCheckbox.php
@@ -19,39 +19,53 @@ class FormMultiCheckbox extends FormInput
     const LABEL_PREPEND = 'prepend';
 
     /**
-     * @var bool
-     */
-    protected $useHiddenElement = false;
-
-    /**
-     * @var string
-     */
-    protected $uncheckedValue = '';
-
-    /**
-     * @var FormInput
-     */
-    protected $inputHelper;
-
-    /**
-     * @var FormLabel
-     */
-    protected $labelHelper;
-
-    /**
-     * @var string
-     */
-    protected $labelPosition = self::LABEL_APPEND;
-
-    /**
+     * The attributes applied to option label
+     *
      * @var array
      */
     protected $labelAttributes;
 
     /**
+     * Where will be label rendered?
+     *
+     * @var string
+     */
+    protected $labelPosition = self::LABEL_APPEND;
+
+    /**
+     * Separator for checkbox elements
+     *
      * @var string
      */
     protected $separator = '';
+
+    /**
+     * Prefixing the element with a hidden element for the unset value?
+     *
+     * @var bool
+     */
+    protected $useHiddenElement = false;
+
+    /**
+     * The unchecked value used when "UseHiddenElement" is turned on
+     *
+     * @var string
+     */
+    protected $uncheckedValue = '';
+
+    /**
+     * Form input helper instance
+     *
+     * @var FormInput
+     */
+    protected $inputHelper;
+
+    /**
+     * Form label helper instance
+     *
+     * @var FormLabel
+     */
+    protected $labelHelper;
 
     /**
      * Invoke helper as functor
@@ -255,6 +269,28 @@ class FormMultiCheckbox extends FormInput
     }
 
     /**
+     * Sets the attributes applied to option label.
+     *
+     * @param  array|null $attributes
+     * @return FormMultiCheckbox
+     */
+    public function setLabelAttributes($attributes)
+    {
+        $this->labelAttributes = $attributes;
+        return $this;
+    }
+
+    /**
+     * Returns the attributes applied to each option label.
+     *
+     * @return array|null
+     */
+    public function getLabelAttributes()
+    {
+        return $this->labelAttributes;
+    }
+
+    /**
      * Set value for labelPosition
      *
      * @param  mixed $labelPosition
@@ -297,7 +333,6 @@ class FormMultiCheckbox extends FormInput
     public function setSeparator($separator)
     {
         $this->separator = (string) $separator;
-
         return $this;
     }
 
@@ -312,26 +347,16 @@ class FormMultiCheckbox extends FormInput
     }
 
     /**
-     * Sets the attributes applied to option label.
+     * Sets the option for prefixing the element with a hidden element
+     * for the unset value.
      *
-     * @param  array|null $attributes
+     * @param  bool $useHiddenElement
      * @return FormMultiCheckbox
      */
-    public function setLabelAttributes($attributes)
+    public function setUseHiddenElement($useHiddenElement)
     {
-        $this->labelAttributes = $attributes;
-
+        $this->useHiddenElement = (bool) $useHiddenElement;
         return $this;
-    }
-
-    /**
-     * Returns the attributes applied to each option label.
-     *
-     * @return array|null
-     */
-    public function getLabelAttributes()
-    {
-        return $this->labelAttributes;
     }
 
     /**
@@ -346,16 +371,14 @@ class FormMultiCheckbox extends FormInput
     }
 
     /**
-     * Sets the option for prefixing the element with a hidden element
-     * for the unset value.
+     * Sets the unchecked value used when "UseHiddenElement" is turned on.
      *
-     * @param  bool $useHiddenElement
+     * @param  bool $value
      * @return FormMultiCheckbox
      */
-    public function setUseHiddenElement($useHiddenElement)
+    public function setUncheckedValue($value)
     {
-        $this->useHiddenElement = (bool) $useHiddenElement;
-
+        $this->uncheckedValue = $value;
         return $this;
     }
 
@@ -370,19 +393,6 @@ class FormMultiCheckbox extends FormInput
     }
 
     /**
-     * Sets the unchecked value used when "UseHiddenElement" is turned on.
-     *
-     * @param  bool $value
-     * @return FormMultiCheckbox
-     */
-    public function setUncheckedValue($value)
-    {
-        $this->uncheckedValue = $value;
-
-        return $this;
-    }
-
-    /**
      * Return input type
      *
      * @return string
@@ -390,6 +400,25 @@ class FormMultiCheckbox extends FormInput
     protected function getInputType()
     {
         return 'checkbox';
+    }
+
+    /**
+     * Get element name
+     *
+     * @param  ElementInterface $element
+     * @throws Exception\DomainException
+     * @return string
+     */
+    protected static function getName(ElementInterface $element)
+    {
+        $name = $element->getName();
+        if ($name === null || $name === '') {
+            throw new Exception\DomainException(sprintf(
+                '%s requires that the element has an assigned name; none discovered',
+                __METHOD__
+            ));
+        }
+        return $name . '[]';
     }
 
     /**
@@ -434,24 +463,5 @@ class FormMultiCheckbox extends FormInput
         }
 
         return $this->labelHelper;
-    }
-
-    /**
-     * Get element name
-     *
-     * @param  ElementInterface $element
-     * @throws Exception\DomainException
-     * @return string
-     */
-    protected static function getName(ElementInterface $element)
-    {
-        $name = $element->getName();
-        if ($name === null || $name === '') {
-            throw new Exception\DomainException(sprintf(
-                '%s requires that the element has an assigned name; none discovered',
-                __METHOD__
-            ));
-        }
-        return $name . '[]';
     }
 }

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -53,13 +53,39 @@ class FormRow extends AbstractHelper
      */
     protected $elementErrorsHelper;
 
+    /**
+     * Invoke helper as functor
+     *
+     * Proxies to {@link render()}.
+     *
+     * @param  null|ElementInterface $element
+     * @param  null|string           $labelPosition
+     * @param  bool                  $renderErrors
+     * @return string|FormRow
+     */
+    public function __invoke(ElementInterface $element = null, $labelPosition = null, $renderErrors = null)
+    {
+        if (!$element) {
+            return $this;
+        }
+
+        if ($labelPosition !== null) {
+            $this->setLabelPosition($labelPosition);
+        }
+
+        if ($renderErrors !== null){
+            $this->setRenderErrors($renderErrors);
+        }
+
+        return $this->render($element);
+    }
 
     /**
      * Utility form helper that renders a label (if it exists), an element and errors
      *
-     * @param ElementInterface $element
-     * @return string
+     * @param  ElementInterface $element
      * @throws \Zend\Form\Exception\DomainException
+     * @return string
      */
     public function render(ElementInterface $element)
     {
@@ -145,38 +171,11 @@ class FormRow extends AbstractHelper
     }
 
     /**
-     * Invoke helper as functor
-     *
-     * Proxies to {@link render()}.
-     *
-     * @param null|ElementInterface $element
-     * @param null|string           $labelPosition
-     * @param bool                  $renderErrors
-     * @return string|FormRow
-     */
-    public function __invoke(ElementInterface $element = null, $labelPosition = null, $renderErrors = null)
-    {
-        if (!$element) {
-            return $this;
-        }
-
-        if ($labelPosition !== null) {
-            $this->setLabelPosition($labelPosition);
-        }
-
-        if ($renderErrors !== null){
-            $this->setRenderErrors($renderErrors);
-        }
-
-        return $this->render($element);
-    }
-
-    /**
      * Set the label position
      *
-     * @param $labelPosition
-     * @return FormRow
+     * @param  string $labelPosition
      * @throws \Zend\Form\Exception\InvalidArgumentException
+     * @return FormRow
      */
     public function setLabelPosition($labelPosition)
     {
@@ -214,6 +213,7 @@ class FormRow extends AbstractHelper
     public function setRenderErrors($renderErrors)
     {
         $this->renderErrors = (bool) $renderErrors;
+
         return $this;
     }
 
@@ -234,6 +234,7 @@ class FormRow extends AbstractHelper
     public function setLabelAttributes($labelAttributes)
     {
         $this->labelAttributes = $labelAttributes;
+
         return $this;
     }
 
@@ -256,6 +257,7 @@ class FormRow extends AbstractHelper
     public function setInputErrorClass($inputErrorClass)
     {
         $this->inputErrorClass = $inputErrorClass;
+
         return $this;
     }
 

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -19,36 +19,50 @@ class FormRow extends AbstractHelper
     const LABEL_PREPEND = 'prepend';
 
     /**
-     * @var string
-     */
-    protected $labelPosition = self::LABEL_PREPEND;
-
-    /**
-     * @var bool
-     */
-    protected $renderErrors = true;
-
-    /**
-     * @var array
-     */
-    protected $labelAttributes;
-
-    /**
+     * The class that is added to element that have errors
+     *
      * @var string
      */
     protected $inputErrorClass = 'input-error';
 
     /**
+     * The attributes for the row label
+     *
+     * @var array
+     */
+    protected $labelAttributes;
+
+    /**
+     * Where will be label rendered?
+     *
+     * @var string
+     */
+    protected $labelPosition = self::LABEL_PREPEND;
+
+    /**
+     * Are the errors are rendered by this helper?
+     *
+     * @var bool
+     */
+    protected $renderErrors = true;
+
+    /**
+     * Form label helper instance
+     *
      * @var FormLabel
      */
     protected $labelHelper;
 
     /**
+     * Form element helper instance
+     *
      * @var FormElement
      */
     protected $elementHelper;
 
     /**
+     * Form element errors helper instance
+     *
      * @var FormElementErrors
      */
     protected $elementErrorsHelper;
@@ -171,6 +185,50 @@ class FormRow extends AbstractHelper
     }
 
     /**
+     * Set the class that is added to element that have errors
+     *
+     * @param  string $inputErrorClass
+     * @return FormRow
+     */
+    public function setInputErrorClass($inputErrorClass)
+    {
+        $this->inputErrorClass = $inputErrorClass;
+        return $this;
+    }
+
+    /**
+     * Get the class that is added to element that have errors
+     *
+     * @return string
+     */
+    public function getInputErrorClass()
+    {
+        return $this->inputErrorClass;
+    }
+
+    /**
+     * Set the attributes for the row label
+     *
+     * @param  array $labelAttributes
+     * @return FormRow
+     */
+    public function setLabelAttributes($labelAttributes)
+    {
+        $this->labelAttributes = $labelAttributes;
+        return $this;
+    }
+
+    /**
+     * Get the attributes for the row label
+     *
+     * @return array
+     */
+    public function getLabelAttributes()
+    {
+        return $this->labelAttributes;
+    }
+
+    /**
      * Set the label position
      *
      * @param  string $labelPosition
@@ -205,7 +263,7 @@ class FormRow extends AbstractHelper
     }
 
     /**
-     * Are the errors rendered by this helper ?
+     * Set if the errors are rendered by this helper
      *
      * @param  bool $renderErrors
      * @return FormRow
@@ -213,62 +271,17 @@ class FormRow extends AbstractHelper
     public function setRenderErrors($renderErrors)
     {
         $this->renderErrors = (bool) $renderErrors;
-
         return $this;
     }
 
     /**
+     * Retrive if the errors are rendered by this helper
+     *
      * @return bool
      */
     public function getRenderErrors()
     {
         return $this->renderErrors;
-    }
-
-    /**
-     * Set the attributes for the row label
-     *
-     * @param  array $labelAttributes
-     * @return FormRow
-     */
-    public function setLabelAttributes($labelAttributes)
-    {
-        $this->labelAttributes = $labelAttributes;
-
-        return $this;
-    }
-
-    /**
-     * Get the attributes for the row label
-     *
-     * @return array
-     */
-    public function getLabelAttributes()
-    {
-        return $this->labelAttributes;
-    }
-
-    /**
-     * Set the class that is added to element that have errors
-     *
-     * @param  string $inputErrorClass
-     * @return FormRow
-     */
-    public function setInputErrorClass($inputErrorClass)
-    {
-        $this->inputErrorClass = $inputErrorClass;
-
-        return $this;
-    }
-
-    /**
-     * Get the class that is added to element that have errors
-     *
-     * @return string
-     */
-    public function getInputErrorClass()
-    {
-        return $this->inputErrorClass;
     }
 
     /**

--- a/library/Zend/Form/View/Helper/FormSelect.php
+++ b/library/Zend/Form/View/Helper/FormSelect.php
@@ -25,6 +25,9 @@ class FormSelect extends AbstractHelper
      */
     protected $validTagAttributes;
 
+    /**
+     * @var array
+     */
     protected $validSelectAttributes = array(
         'name'      => true,
         'autofocus' => true,
@@ -35,6 +38,9 @@ class FormSelect extends AbstractHelper
         'size'      => true
     );
 
+    /**
+     * @var array
+     */
     protected $validOptionAttributes = array(
         'disabled' => true,
         'selected' => true,
@@ -42,10 +48,30 @@ class FormSelect extends AbstractHelper
         'value'    => true,
     );
 
+    /**
+     * @var array
+     */
     protected $validOptgroupAttributes = array(
         'disabled' => true,
         'label'    => true,
     );
+
+    /**
+     * Invoke helper as functor
+     *
+     * Proxies to {@link render()}.
+     *
+     * @param  ElementInterface|null $element
+     * @return string|FormSelect
+     */
+    public function __invoke(ElementInterface $element = null)
+    {
+        if (!$element) {
+            return $this;
+        }
+
+        return $this->render($element);
+    }
 
     /**
      * Render a form <select> element from the provided $element
@@ -203,23 +229,6 @@ class FormSelect extends AbstractHelper
             $attributes,
             $this->renderOptions($options, $selectedOptions)
         );
-    }
-
-    /**
-     * Invoke helper as functor
-     *
-     * Proxies to {@link render()}.
-     *
-     * @param  ElementInterface|null $element
-     * @return string|FormSelect
-     */
-    public function __invoke(ElementInterface $element = null)
-    {
-        if (!$element) {
-            return $this;
-        }
-
-        return $this->render($element);
     }
 
     /**

--- a/library/Zend/Form/View/Helper/FormSelect.php
+++ b/library/Zend/Form/View/Helper/FormSelect.php
@@ -26,6 +26,8 @@ class FormSelect extends AbstractHelper
     protected $validTagAttributes;
 
     /**
+     * Attributes valid for select
+     *
      * @var array
      */
     protected $validSelectAttributes = array(
@@ -39,6 +41,8 @@ class FormSelect extends AbstractHelper
     );
 
     /**
+     * Attributes valid for options
+     *
      * @var array
      */
     protected $validOptionAttributes = array(
@@ -49,6 +53,8 @@ class FormSelect extends AbstractHelper
     );
 
     /**
+     * Attributes valid for option groups
+     *
      * @var array
      */
     protected $validOptgroupAttributes = array(

--- a/library/Zend/Form/View/Helper/FormTextarea.php
+++ b/library/Zend/Form/View/Helper/FormTextarea.php
@@ -35,6 +35,23 @@ class FormTextarea extends AbstractHelper
     );
 
     /**
+     * Invoke helper as functor
+     *
+     * Proxies to {@link render()}.
+     *
+     * @param  ElementInterface|null $element
+     * @return string|FormTextarea
+     */
+    public function __invoke(ElementInterface $element = null)
+    {
+        if (!$element) {
+            return $this;
+        }
+
+        return $this->render($element);
+    }
+
+    /**
      * Render a form <textarea> element from the provided $element
      *
      * @param  ElementInterface $element
@@ -61,22 +78,5 @@ class FormTextarea extends AbstractHelper
             $this->createAttributesString($attributes),
             $escapeHtml($content)
         );
-    }
-
-    /**
-     * Invoke helper as functor
-     *
-     * Proxies to {@link render()}.
-     *
-     * @param  ElementInterface|null $element
-     * @return string|FormTextarea
-     */
-    public function __invoke(ElementInterface $element = null)
-    {
-        if (!$element) {
-            return $this;
-        }
-
-        return $this->render($element);
     }
 }

--- a/library/Zend/Form/View/HelperConfig.php
+++ b/library/Zend/Form/View/HelperConfig.php
@@ -18,7 +18,9 @@ use Zend\ServiceManager\ServiceManager;
 class HelperConfig implements ConfigInterface
 {
     /**
-     * @var array Pre-aliased view helpers
+     * Pre-aliased view helpers
+     *
+     * @var array
      */
     protected $invokables = array(
         'form'                    => 'Zend\Form\View\Helper\Form',

--- a/library/Zend/I18n/View/Helper/AbstractTranslatorHelper.php
+++ b/library/Zend/I18n/View/Helper/AbstractTranslatorHelper.php
@@ -89,7 +89,6 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
     public function setTranslatorEnabled($enabled = true)
     {
         $this->translatorEnabled = (bool) $enabled;
-
         return $this;
     }
 
@@ -112,7 +111,6 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
     public function setTranslatorTextDomain($textDomain = 'default')
     {
         $this->translatorTextDomain = $textDomain;
-
         return $this;
     }
 

--- a/library/Zend/I18n/View/Helper/AbstractTranslatorHelper.php
+++ b/library/Zend/I18n/View/Helper/AbstractTranslatorHelper.php
@@ -52,6 +52,7 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
         if (null !== $textDomain) {
             $this->setTranslatorTextDomain($textDomain);
         }
+
         return $this;
     }
 
@@ -82,13 +83,13 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
     /**
      * Sets whether translator is enabled and should be used
      *
-     * @param  bool $enabled [optional] whether translator should be used.
-     *                       Default is true.
+     * @param  bool $enabled
      * @return AbstractTranslatorHelper
      */
     public function setTranslatorEnabled($enabled = true)
     {
         $this->translatorEnabled = (bool) $enabled;
+
         return $this;
     }
 
@@ -111,6 +112,7 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
     public function setTranslatorTextDomain($textDomain = 'default')
     {
         $this->translatorTextDomain = $textDomain;
+
         return $this;
     }
 

--- a/library/Zend/I18n/View/Helper/CurrencyFormat.php
+++ b/library/Zend/I18n/View/Helper/CurrencyFormat.php
@@ -47,76 +47,6 @@ class CurrencyFormat extends AbstractHelper
     protected $formatters = array();
 
     /**
-     * The 3-letter ISO 4217 currency code indicating the currency to use.
-     *
-     * @param  string $currencyCode
-     * @return CurrencyFormat
-     */
-    public function setCurrencyCode($currencyCode)
-    {
-        $this->currencyCode = $currencyCode;
-        return $this;
-    }
-
-    /**
-     * Get the 3-letter ISO 4217 currency code indicating the currency to use.
-     *
-     * @return string
-     */
-    public function getCurrencyCode()
-    {
-        return $this->currencyCode;
-    }
-
-    /**
-     * Set if the view helper should show two decimals
-     *
-     * @param  bool $showDecimals
-     * @return CurrencyFormat
-     */
-    public function setShouldShowDecimals($showDecimals)
-    {
-        $this->showDecimals = (bool) $showDecimals;
-        return $this;
-    }
-
-    /**
-     * Get if the view helper should show two decimals
-     *
-     * @return bool
-     */
-    public function shouldShowDecimals()
-    {
-        return $this->showDecimals;
-    }
-
-    /**
-     * Set locale to use instead of the default.
-     *
-     * @param  string $locale
-     * @return CurrencyFormat
-     */
-    public function setLocale($locale)
-    {
-        $this->locale = (string) $locale;
-        return $this;
-    }
-
-    /**
-     * Get the locale to use.
-     *
-     * @return string|null
-     */
-    public function getLocale()
-    {
-        if ($this->locale === null) {
-            $this->locale = Locale::getDefault();
-        }
-
-        return $this->locale;
-    }
-
-    /**
      * Format a number.
      *
      * @param  float  $number
@@ -159,5 +89,78 @@ class CurrencyFormat extends AbstractHelper
         return $this->formatters[$formatterId]->formatCurrency(
             $number, $currencyCode
         );
+    }
+
+    /**
+     * The 3-letter ISO 4217 currency code indicating the currency to use.
+     *
+     * @param  string $currencyCode
+     * @return CurrencyFormat
+     */
+    public function setCurrencyCode($currencyCode)
+    {
+        $this->currencyCode = $currencyCode;
+
+        return $this;
+    }
+
+    /**
+     * Get the 3-letter ISO 4217 currency code indicating the currency to use.
+     *
+     * @return string
+     */
+    public function getCurrencyCode()
+    {
+        return $this->currencyCode;
+    }
+
+    /**
+     * Set if the view helper should show two decimals
+     *
+     * @param  bool $showDecimals
+     * @return CurrencyFormat
+     */
+    public function setShouldShowDecimals($showDecimals)
+    {
+        $this->showDecimals = (bool) $showDecimals;
+
+        return $this;
+    }
+
+    /**
+     * Get if the view helper should show two decimals
+     *
+     * @return bool
+     */
+    public function shouldShowDecimals()
+    {
+        return $this->showDecimals;
+    }
+
+    /**
+     * Set locale to use instead of the default.
+     *
+     * @param  string $locale
+     * @return CurrencyFormat
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = (string) $locale;
+
+        return $this;
+    }
+
+    /**
+     * Get the locale to use.
+     *
+     * @return string|null
+     */
+    public function getLocale()
+    {
+        if ($this->locale === null) {
+            $this->locale = Locale::getDefault();
+        }
+
+        return $this->locale;
     }
 }

--- a/library/Zend/I18n/View/Helper/CurrencyFormat.php
+++ b/library/Zend/I18n/View/Helper/CurrencyFormat.php
@@ -19,18 +19,25 @@ use Zend\View\Helper\AbstractHelper;
 class CurrencyFormat extends AbstractHelper
 {
     /**
-     * Locale to use instead of the default.
-     *
-     * @var string
-     */
-    protected $locale;
-
-    /**
-     * The 3-letter ISO 4217 currency code indicating the currency to use.
+     * The 3-letter ISO 4217 currency code indicating the currency to use
      *
      * @var string
      */
     protected $currencyCode;
+
+    /**
+     * Formatter instances
+     *
+     * @var array
+     */
+    protected $formatters = array();
+
+    /**
+     * Locale to use instead of the default
+     *
+     * @var string
+     */
+    protected $locale;
 
     /**
      * If set to true, the currency will be returned with two decimals
@@ -40,14 +47,7 @@ class CurrencyFormat extends AbstractHelper
     protected $showDecimals = true;
 
     /**
-     * Formatter instances.
-     *
-     * @var array
-     */
-    protected $formatters = array();
-
-    /**
-     * Format a number.
+     * Format a number
      *
      * @param  float  $number
      * @param  string $currencyCode
@@ -92,7 +92,7 @@ class CurrencyFormat extends AbstractHelper
     }
 
     /**
-     * The 3-letter ISO 4217 currency code indicating the currency to use.
+     * The 3-letter ISO 4217 currency code indicating the currency to use
      *
      * @param  string $currencyCode
      * @return CurrencyFormat
@@ -100,18 +100,43 @@ class CurrencyFormat extends AbstractHelper
     public function setCurrencyCode($currencyCode)
     {
         $this->currencyCode = $currencyCode;
-
         return $this;
     }
 
     /**
-     * Get the 3-letter ISO 4217 currency code indicating the currency to use.
+     * Get the 3-letter ISO 4217 currency code indicating the currency to use
      *
      * @return string
      */
     public function getCurrencyCode()
     {
         return $this->currencyCode;
+    }
+
+    /**
+     * Set locale to use instead of the default
+     *
+     * @param  string $locale
+     * @return CurrencyFormat
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = (string) $locale;
+        return $this;
+    }
+
+    /**
+     * Get the locale to use
+     *
+     * @return string|null
+     */
+    public function getLocale()
+    {
+        if ($this->locale === null) {
+            $this->locale = Locale::getDefault();
+        }
+
+        return $this->locale;
     }
 
     /**
@@ -123,7 +148,6 @@ class CurrencyFormat extends AbstractHelper
     public function setShouldShowDecimals($showDecimals)
     {
         $this->showDecimals = (bool) $showDecimals;
-
         return $this;
     }
 
@@ -135,32 +159,5 @@ class CurrencyFormat extends AbstractHelper
     public function shouldShowDecimals()
     {
         return $this->showDecimals;
-    }
-
-    /**
-     * Set locale to use instead of the default.
-     *
-     * @param  string $locale
-     * @return CurrencyFormat
-     */
-    public function setLocale($locale)
-    {
-        $this->locale = (string) $locale;
-
-        return $this;
-    }
-
-    /**
-     * Get the locale to use.
-     *
-     * @return string|null
-     */
-    public function getLocale()
-    {
-        if ($this->locale === null) {
-            $this->locale = Locale::getDefault();
-        }
-
-        return $this->locale;
     }
 }

--- a/library/Zend/I18n/View/Helper/DateFormat.php
+++ b/library/Zend/I18n/View/Helper/DateFormat.php
@@ -21,28 +21,28 @@ use Zend\View\Helper\AbstractHelper;
 class DateFormat extends AbstractHelper
 {
     /**
-     * Locale to use instead of the default.
+     * Locale to use instead of the default
      *
      * @var string
      */
     protected $locale;
 
     /**
-     * Timezone to use.
+     * Timezone to use
      *
      * @var string
      */
     protected $timezone;
 
     /**
-     * Formatter instances.
+     * Formatter instances
      *
      * @var array
      */
     protected $formatters = array();
 
     /**
-     * Format a date.
+     * Format a date
      *
      * @param  DateTime|integer|array $date
      * @param  int                    $dateType
@@ -85,7 +85,33 @@ class DateFormat extends AbstractHelper
     }
 
     /**
-     * Set timezone to use instead of the default.
+     * Set locale to use instead of the default
+     *
+     * @param  string $locale
+     * @return DateFormat
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = (string) $locale;
+        return $this;
+    }
+
+    /**
+     * Get the locale to use
+     *
+     * @return string|null
+     */
+    public function getLocale()
+    {
+        if ($this->locale === null) {
+            $this->locale = Locale::getDefault();
+        }
+
+        return $this->locale;
+    }
+
+    /**
+     * Set timezone to use instead of the default
      *
      * @param  string $timezone
      * @return DateFormat
@@ -102,7 +128,7 @@ class DateFormat extends AbstractHelper
     }
 
     /**
-     * Get the timezone to use.
+     * Get the timezone to use
      *
      * @return string|null
      */
@@ -113,32 +139,5 @@ class DateFormat extends AbstractHelper
         }
 
         return $this->timezone;
-    }
-
-    /**
-     * Set locale to use instead of the default.
-     *
-     * @param  string $locale
-     * @return DateFormat
-     */
-    public function setLocale($locale)
-    {
-        $this->locale = (string) $locale;
-
-        return $this;
-    }
-
-    /**
-     * Get the locale to use.
-     *
-     * @return string|null
-     */
-    public function getLocale()
-    {
-        if ($this->locale === null) {
-            $this->locale = Locale::getDefault();
-        }
-
-        return $this->locale;
     }
 }

--- a/library/Zend/I18n/View/Helper/DateFormat.php
+++ b/library/Zend/I18n/View/Helper/DateFormat.php
@@ -42,69 +42,13 @@ class DateFormat extends AbstractHelper
     protected $formatters = array();
 
     /**
-     * Set timezone to use instead of the default.
-     *
-     * @param string $timezone
-     * @return DateFormat
-     */
-    public function setTimezone($timezone)
-    {
-        $this->timezone = (string) $timezone;
-
-        foreach ($this->formatters as $formatter) {
-            $formatter->setTimeZoneId($this->timezone);
-        }
-        return $this;
-    }
-
-    /**
-     * Get the timezone to use.
-     *
-     * @return string|null
-     */
-    public function getTimezone()
-    {
-        if (!$this->timezone) {
-            return date_default_timezone_get();
-        }
-
-        return $this->timezone;
-    }
-
-    /**
-     * Set locale to use instead of the default.
-     *
-     * @param  string $locale
-     * @return DateFormat
-     */
-    public function setLocale($locale)
-    {
-        $this->locale = (string) $locale;
-        return $this;
-    }
-
-    /**
-     * Get the locale to use.
-     *
-     * @return string|null
-     */
-    public function getLocale()
-    {
-        if ($this->locale === null) {
-            $this->locale = Locale::getDefault();
-        }
-
-        return $this->locale;
-    }
-
-    /**
      * Format a date.
      *
-     * @param  DateTime|integer|array  $date
-     * @param  int                     $dateType
-     * @param  int                     $timeType
-     * @param  string                  $locale
-     * @param  string|null             $pattern
+     * @param  DateTime|integer|array $date
+     * @param  int                    $dateType
+     * @param  int                    $timeType
+     * @param  string                 $locale
+     * @param  string|null            $pattern
      * @return string
      */
     public function __invoke(
@@ -138,5 +82,63 @@ class DateFormat extends AbstractHelper
         }
 
         return $this->formatters[$formatterId]->format($date);
+    }
+
+    /**
+     * Set timezone to use instead of the default.
+     *
+     * @param  string $timezone
+     * @return DateFormat
+     */
+    public function setTimezone($timezone)
+    {
+        $this->timezone = (string) $timezone;
+
+        foreach ($this->formatters as $formatter) {
+            $formatter->setTimeZoneId($this->timezone);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the timezone to use.
+     *
+     * @return string|null
+     */
+    public function getTimezone()
+    {
+        if (!$this->timezone) {
+            return date_default_timezone_get();
+        }
+
+        return $this->timezone;
+    }
+
+    /**
+     * Set locale to use instead of the default.
+     *
+     * @param  string $locale
+     * @return DateFormat
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = (string) $locale;
+
+        return $this;
+    }
+
+    /**
+     * Get the locale to use.
+     *
+     * @return string|null
+     */
+    public function getLocale()
+    {
+        if ($this->locale === null) {
+            $this->locale = Locale::getDefault();
+        }
+
+        return $this->locale;
     }
 }

--- a/library/Zend/I18n/View/Helper/NumberFormat.php
+++ b/library/Zend/I18n/View/Helper/NumberFormat.php
@@ -47,88 +47,12 @@ class NumberFormat extends AbstractHelper
     protected $formatters = array();
 
     /**
-     * Set format style to use instead of the default.
-     *
-     * @param  integer $formatStyle
-     * @return NumberFormat
-     */
-    public function setFormatStyle($formatStyle)
-    {
-        $this->formatStyle = (int) $formatStyle;
-        return $this;
-    }
-
-    /**
-     * Get the format style to use.
-     *
-     * @return integer
-     */
-    public function getFormatStyle()
-    {
-        if (null === $this->formatStyle) {
-            $this->formatStyle = NumberFormatter::DECIMAL;
-        }
-        return $this->formatStyle;
-    }
-
-    /**
-     * Set format type to use instead of the default.
-     *
-     * @param  integer $formatType
-     * @return NumberFormat
-     */
-    public function setFormatType($formatType)
-    {
-        $this->formatType = (int) $formatType;
-        return $this;
-    }
-
-    /**
-     * Get the format type to use.
-     *
-     * @return integer
-     */
-    public function getFormatType()
-    {
-        if (null === $this->formatType) {
-            $this->formatType = NumberFormatter::TYPE_DEFAULT;
-        }
-        return $this->formatType;
-    }
-
-    /**
-     * Set locale to use instead of the default.
-     *
-     * @param string $locale
-     * @return NumberFormat
-     */
-    public function setLocale($locale)
-    {
-        $this->locale = (string) $locale;
-        return $this;
-    }
-
-    /**
-     * Get the locale to use.
-     *
-     * @return string|null
-     */
-    public function getLocale()
-    {
-        if ($this->locale === null) {
-            $this->locale = Locale::getDefault();
-        }
-
-        return $this->locale;
-    }
-
-    /**
      * Format a number.
      *
-     * @param  integer|float $number
-     * @param  integer       $formatStyle
-     * @param  integer       $formatType
-     * @param  string        $locale
+     * @param  int|float $number
+     * @param  int       $formatStyle
+     * @param  int       $formatType
+     * @param  string    $locale
      * @return string
      */
     public function __invoke(
@@ -157,5 +81,85 @@ class NumberFormat extends AbstractHelper
         }
 
         return $this->formatters[$formatterId]->format($number, $formatType);
+    }
+
+    /**
+     * Set format style to use instead of the default.
+     *
+     * @param  int $formatStyle
+     * @return NumberFormat
+     */
+    public function setFormatStyle($formatStyle)
+    {
+        $this->formatStyle = (int) $formatStyle;
+
+        return $this;
+    }
+
+    /**
+     * Get the format style to use.
+     *
+     * @return int
+     */
+    public function getFormatStyle()
+    {
+        if (null === $this->formatStyle) {
+            $this->formatStyle = NumberFormatter::DECIMAL;
+        }
+
+        return $this->formatStyle;
+    }
+
+    /**
+     * Set format type to use instead of the default.
+     *
+     * @param  int $formatType
+     * @return NumberFormat
+     */
+    public function setFormatType($formatType)
+    {
+        $this->formatType = (int) $formatType;
+
+        return $this;
+    }
+
+    /**
+     * Get the format type to use.
+     *
+     * @return int
+     */
+    public function getFormatType()
+    {
+        if (null === $this->formatType) {
+            $this->formatType = NumberFormatter::TYPE_DEFAULT;
+        }
+        return $this->formatType;
+    }
+
+    /**
+     * Set locale to use instead of the default.
+     *
+     * @param  string $locale
+     * @return NumberFormat
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = (string) $locale;
+
+        return $this;
+    }
+
+    /**
+     * Get the locale to use.
+     *
+     * @return string|null
+     */
+    public function getLocale()
+    {
+        if ($this->locale === null) {
+            $this->locale = Locale::getDefault();
+        }
+
+        return $this->locale;
     }
 }

--- a/library/Zend/I18n/View/Helper/NumberFormat.php
+++ b/library/Zend/I18n/View/Helper/NumberFormat.php
@@ -19,35 +19,35 @@ use Zend\View\Helper\AbstractHelper;
 class NumberFormat extends AbstractHelper
 {
     /**
-     * Locale to use instead of the default.
-     *
-     * @var string
-     */
-    protected $locale;
-
-    /**
-     * NumberFormat style to use.
+     * NumberFormat style to use
      *
      * @var integer
      */
     protected $formatStyle;
 
     /**
-     * NumberFormat type to use.
+     * NumberFormat type to use
      *
      * @var integer
      */
     protected $formatType;
 
     /**
-     * Formatter instances.
+     * Formatter instances
      *
      * @var array
      */
     protected $formatters = array();
 
     /**
-     * Format a number.
+     * Locale to use instead of the default
+     *
+     * @var string
+     */
+    protected $locale;
+
+    /**
+     * Format a number
      *
      * @param  int|float $number
      * @param  int       $formatStyle
@@ -84,7 +84,7 @@ class NumberFormat extends AbstractHelper
     }
 
     /**
-     * Set format style to use instead of the default.
+     * Set format style to use instead of the default
      *
      * @param  int $formatStyle
      * @return NumberFormat
@@ -92,12 +92,11 @@ class NumberFormat extends AbstractHelper
     public function setFormatStyle($formatStyle)
     {
         $this->formatStyle = (int) $formatStyle;
-
         return $this;
     }
 
     /**
-     * Get the format style to use.
+     * Get the format style to use
      *
      * @return int
      */
@@ -111,7 +110,7 @@ class NumberFormat extends AbstractHelper
     }
 
     /**
-     * Set format type to use instead of the default.
+     * Set format type to use instead of the default
      *
      * @param  int $formatType
      * @return NumberFormat
@@ -119,12 +118,11 @@ class NumberFormat extends AbstractHelper
     public function setFormatType($formatType)
     {
         $this->formatType = (int) $formatType;
-
         return $this;
     }
 
     /**
-     * Get the format type to use.
+     * Get the format type to use
      *
      * @return int
      */
@@ -137,7 +135,7 @@ class NumberFormat extends AbstractHelper
     }
 
     /**
-     * Set locale to use instead of the default.
+     * Set locale to use instead of the default
      *
      * @param  string $locale
      * @return NumberFormat
@@ -145,12 +143,11 @@ class NumberFormat extends AbstractHelper
     public function setLocale($locale)
     {
         $this->locale = (string) $locale;
-
         return $this;
     }
 
     /**
-     * Get the locale to use.
+     * Get the locale to use
      *
      * @return string|null
      */

--- a/library/Zend/I18n/View/Helper/Plural.php
+++ b/library/Zend/I18n/View/Helper/Plural.php
@@ -28,7 +28,7 @@ use Zend\View\Helper\AbstractHelper;
 class Plural extends AbstractHelper
 {
     /**
-     * Rule to use
+     * Plural rule to use
      *
      * @var PluralRule
      */
@@ -45,7 +45,7 @@ class Plural extends AbstractHelper
      */
     public function __invoke($strings, $number)
     {
-        if ($this->rule === null) {
+        if (null === $this->getPluralRule()) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'No plural rule was set'
             ));
@@ -55,7 +55,7 @@ class Plural extends AbstractHelper
             $strings = (array) $strings;
         }
 
-        $pluralIndex = $this->rule->evaluate($number);
+        $pluralIndex = $this->getPluralRule()->evaluate($number);
 
         return $strings[$pluralIndex];
     }
@@ -75,5 +75,15 @@ class Plural extends AbstractHelper
         $this->rule = $pluralRule;
 
         return $this;
+    }
+
+    /**
+     * Get the plural rule to  use
+     *
+     * @return PluralRule
+     */
+    public function getPluralRule()
+    {
+        return $this->rule;
     }
 }

--- a/library/Zend/I18n/View/Helper/Plural.php
+++ b/library/Zend/I18n/View/Helper/Plural.php
@@ -35,23 +35,6 @@ class Plural extends AbstractHelper
     protected $rule;
 
     /**
-     * Set the plural rule to use
-     *
-     * @param  PluralRule|string $pluralRule
-     * @return Plural
-     */
-    public function setPluralRule($pluralRule)
-    {
-        if (!$pluralRule instanceof PluralRule) {
-            $pluralRule = PluralRule::fromString($pluralRule);
-        }
-
-        $this->rule = $pluralRule;
-
-        return $this;
-    }
-
-    /**
      * Given an array of strings, a number and, if wanted, an optional locale (the default one is used
      * otherwise), this picks the right string according to plural rules of the locale
      *
@@ -75,5 +58,22 @@ class Plural extends AbstractHelper
         $pluralIndex = $this->rule->evaluate($number);
 
         return $strings[$pluralIndex];
+    }
+
+    /**
+     * Set the plural rule to use
+     *
+     * @param  PluralRule|string $pluralRule
+     * @return Plural
+     */
+    public function setPluralRule($pluralRule)
+    {
+        if (!$pluralRule instanceof PluralRule) {
+            $pluralRule = PluralRule::fromString($pluralRule);
+        }
+
+        $this->rule = $pluralRule;
+
+        return $this;
     }
 }

--- a/library/Zend/I18n/View/Helper/Translate.php
+++ b/library/Zend/I18n/View/Helper/Translate.php
@@ -17,13 +17,13 @@ use Zend\I18n\Exception;
 class Translate extends AbstractTranslatorHelper
 {
     /**
-     * Translate a message.
+     * Translate a message
      *
      * @param  string $message
      * @param  string $textDomain
      * @param  string $locale
-     * @return string
      * @throws Exception\RuntimeException
+     * @return string
      */
     public function __invoke($message, $textDomain = null, $locale = null)
     {
@@ -34,6 +34,7 @@ class Translate extends AbstractTranslatorHelper
         if (null === $textDomain) {
             $textDomain = $this->getTranslatorTextDomain();
         }
+
         return $translator->translate($message, $textDomain, $locale);
     }
 }

--- a/library/Zend/I18n/View/Helper/TranslatePlural.php
+++ b/library/Zend/I18n/View/Helper/TranslatePlural.php
@@ -17,15 +17,15 @@ use Zend\I18n\Exception;
 class TranslatePlural extends AbstractTranslatorHelper
 {
     /**
-     * Translate a plural message.
+     * Translate a plural message
      *
      * @param  string  $singular
      * @param  string  $plural
      * @param  integer $number
      * @param  string  $textDomain
      * @param  string  $locale
-     * @return string
      * @throws Exception\RuntimeException
+     * @return string
      */
     public function __invoke(
         $singular,
@@ -42,6 +42,7 @@ class TranslatePlural extends AbstractTranslatorHelper
         if (null === $textDomain) {
             $textDomain = $this->getTranslatorTextDomain();
         }
+
         return $translator->translatePlural($singular, $plural, $number, $textDomain, $locale);
     }
 }

--- a/library/Zend/I18n/View/HelperConfig.php
+++ b/library/Zend/I18n/View/HelperConfig.php
@@ -18,7 +18,9 @@ use Zend\ServiceManager\ServiceManager;
 class HelperConfig implements ConfigInterface
 {
     /**
-     * @var array Pre-aliased view helpers
+     * Pre-aliased view helpers
+     *
+     * @var array
      */
     protected $invokables = array(
         'currencyformat'  => 'Zend\I18n\View\Helper\CurrencyFormat',

--- a/library/Zend/View/Helper/AbstractHelper.php
+++ b/library/Zend/View/Helper/AbstractHelper.php
@@ -30,6 +30,7 @@ abstract class AbstractHelper implements HelperInterface
     public function setView(Renderer $view)
     {
         $this->view = $view;
+
         return $this;
     }
 

--- a/library/Zend/View/Helper/AbstractHelper.php
+++ b/library/Zend/View/Helper/AbstractHelper.php
@@ -15,7 +15,7 @@ use Zend\View\Renderer\RendererInterface as Renderer;
 abstract class AbstractHelper implements HelperInterface
 {
     /**
-     * View object
+     * View object instance
      *
      * @var Renderer
      */
@@ -30,7 +30,6 @@ abstract class AbstractHelper implements HelperInterface
     public function setView(Renderer $view)
     {
         $this->view = $view;
-
         return $this;
     }
 

--- a/library/Zend/View/Helper/AbstractHtmlElement.php
+++ b/library/Zend/View/Helper/AbstractHtmlElement.php
@@ -64,7 +64,7 @@ abstract class AbstractHtmlElement extends AbstractHelper
     protected function htmlAttribs($attribs)
     {
         $xhtml   = '';
-        $escaper = $this->view->plugin('escapehtml');
+        $escaper = $this->getView()->plugin('escapehtml');
 
         foreach ((array) $attribs as $key => $val) {
             $key = $escaper($key);

--- a/library/Zend/View/Helper/AbstractHtmlElement.php
+++ b/library/Zend/View/Helper/AbstractHtmlElement.php
@@ -48,8 +48,7 @@ abstract class AbstractHtmlElement extends AbstractHelper
      */
     protected function isXhtml()
     {
-        $doctype = $this->view->plugin('doctype');
-        return $doctype->isXhtml();
+        return $this->getView()->plugin('doctype')->isXhtml();
     }
 
     /**
@@ -66,6 +65,7 @@ abstract class AbstractHtmlElement extends AbstractHelper
     {
         $xhtml   = '';
         $escaper = $this->view->plugin('escapehtml');
+
         foreach ((array) $attribs as $key => $val) {
             $key = $escaper($key);
 
@@ -96,8 +96,8 @@ abstract class AbstractHtmlElement extends AbstractHelper
             } else {
                 $xhtml .= " $key=\"$val\"";
             }
-
         }
+
         return $xhtml;
     }
 
@@ -117,6 +117,7 @@ abstract class AbstractHtmlElement extends AbstractHelper
             $value = str_replace('][', '-', $value);
             $value = str_replace('[', '-', $value);
         }
+
         return $value;
     }
 }

--- a/library/Zend/View/Helper/BasePath.php
+++ b/library/Zend/View/Helper/BasePath.php
@@ -54,6 +54,7 @@ class BasePath extends AbstractHelper
     public function setBasePath($basePath)
     {
         $this->basePath = rtrim($basePath, '/');
+
         return $this;
     }
 }

--- a/library/Zend/View/Helper/BasePath.php
+++ b/library/Zend/View/Helper/BasePath.php
@@ -17,7 +17,7 @@ use Zend\View\Exception;
 class BasePath extends AbstractHelper
 {
     /**
-     * Base path.
+     * Base path
      *
      * @var string
      */
@@ -54,7 +54,6 @@ class BasePath extends AbstractHelper
     public function setBasePath($basePath)
     {
         $this->basePath = rtrim($basePath, '/');
-
         return $this;
     }
 }

--- a/library/Zend/View/Helper/Cycle.php
+++ b/library/Zend/View/Helper/Cycle.php
@@ -14,7 +14,6 @@ namespace Zend\View\Helper;
  */
 class Cycle extends AbstractHelper implements \Iterator
 {
-
     /**
      * Default name
      * @var string
@@ -45,49 +44,54 @@ class Cycle extends AbstractHelper implements \Iterator
     /**
      * Add elements to alternate
      *
-     * @param array $data
-     * @param string $name
-     * @return \Zend\View\Helper\Cycle
+     * @param  array $data
+     * @param  string $name
+     * @return Cycle
      */
     public function __invoke(array $data = array(), $name = self::DEFAULT_NAME)
     {
-        if (!empty($data))
+        if (!empty($data)) {
            $this->data[$name] = $data;
+        }
 
         $this->setName($name);
+
         return $this;
     }
 
     /**
      * Add elements to alternate
      *
-     * @param array $data
-     * @param string $name
-     * @return \Zend\View\Helper\Cycle
+     * @param  array $data
+     * @param  string $name
+     * @return Cycle
      */
     public function assign(Array $data , $name = self::DEFAULT_NAME)
     {
         $this->setName($name);
         $this->data[$name] = $data;
         $this->rewind();
+
         return $this;
     }
 
     /**
      * Sets actual name of cycle
      *
-     * @param $name
-     * @return \Zend\View\Helper\Cycle
+     * @param  $name
+     * @return Cycle
      */
     public function setName($name = self::DEFAULT_NAME)
     {
        $this->name = $name;
 
-       if (!isset($this->data[$this->name]))
-         $this->data[$this->name] = array();
+       if (!isset($this->data[$this->name])) {
+           $this->data[$this->name] = array();
+       }
 
-       if (!isset($this->pointers[$this->name]))
-         $this->rewind();
+       if (!isset($this->pointers[$this->name])) {
+           $this->rewind();
+       }
 
        return $this;
     }
@@ -114,52 +118,38 @@ class Cycle extends AbstractHelper implements \Iterator
     }
 
     /**
-     * Turn helper into string
-     *
-     * @return string
-     */
-    public function toString()
-    {
-        return (string) $this->data[$this->name][$this->key()];
-    }
-
-    /**
-     * Cast to string
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return $this->toString();
-    }
-
-    /**
      * Move to next value
      *
-     * @return \Zend\View\Helper\Cycle
+     * @return Cycle
      */
     public function next()
     {
         $count = count($this->data[$this->name]);
-        if ($this->pointers[$this->name] == ($count - 1))
+
+        if ($this->pointers[$this->name] == ($count - 1)) {
             $this->pointers[$this->name] = 0;
-        else
+        } else {
             $this->pointers[$this->name] = ++$this->pointers[$this->name];
+        }
+
         return $this;
     }
 
     /**
      * Move to previous value
      *
-     * @return \Zend\View\Helper\Cycle
+     * @return Cycle
      */
     public function prev()
     {
         $count = count($this->data[$this->name]);
-        if ($this->pointers[$this->name] <= 0)
+
+        if ($this->pointers[$this->name] <= 0) {
             $this->pointers[$this->name] = $count - 1;
-        else
+        } else {
             $this->pointers[$this->name] = --$this->pointers[$this->name];
+        }
+
         return $this;
     }
 
@@ -170,20 +160,22 @@ class Cycle extends AbstractHelper implements \Iterator
      */
     public function key()
     {
-        if ($this->pointers[$this->name] < 0)
+        if ($this->pointers[$this->name] < 0) {
             return 0;
-        else
+        } else {
             return $this->pointers[$this->name];
+        }
     }
 
     /**
      * Rewind pointer
      *
-     * @return \Zend\View\Helper\Cycle
+     * @return Cycle
      */
     public function rewind()
     {
         $this->pointers[$this->name] = -1;
+
         return $this;
     }
 
@@ -205,5 +197,25 @@ class Cycle extends AbstractHelper implements \Iterator
     public function current()
     {
         return $this->data[$this->name][$this->key()];
+    }
+
+    /**
+     * Turn helper into string
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return (string) $this->data[$this->name][$this->key()];
+    }
+
+    /**
+     * Cast to string
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toString();
     }
 }

--- a/library/Zend/View/Helper/Cycle.php
+++ b/library/Zend/View/Helper/Cycle.php
@@ -21,13 +21,6 @@ class Cycle extends AbstractHelper implements \Iterator
     const DEFAULT_NAME = 'default';
 
     /**
-     * Pointers
-     *
-     * @var array
-     */
-    protected $pointers = array(self::DEFAULT_NAME =>-1);
-
-    /**
      * Array of values
      *
      * @var array
@@ -40,6 +33,13 @@ class Cycle extends AbstractHelper implements \Iterator
      * @var string
      */
     protected $name = self::DEFAULT_NAME;
+
+    /**
+     * Pointers
+     *
+     * @var array
+     */
+    protected $pointers = array(self::DEFAULT_NAME =>-1);
 
     /**
      * Add elements to alternate
@@ -55,8 +55,27 @@ class Cycle extends AbstractHelper implements \Iterator
         }
 
         $this->setName($name);
-
         return $this;
+    }
+
+    /**
+     * Cast to string
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toString();
+    }
+
+    /**
+     * Turn helper into string
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return (string) $this->data[$this->name][$this->key()];
     }
 
     /**
@@ -71,7 +90,6 @@ class Cycle extends AbstractHelper implements \Iterator
         $this->setName($name);
         $this->data[$name] = $data;
         $this->rewind();
-
         return $this;
     }
 
@@ -175,7 +193,6 @@ class Cycle extends AbstractHelper implements \Iterator
     public function rewind()
     {
         $this->pointers[$this->name] = -1;
-
         return $this;
     }
 
@@ -197,25 +214,5 @@ class Cycle extends AbstractHelper implements \Iterator
     public function current()
     {
         return $this->data[$this->name][$this->key()];
-    }
-
-    /**
-     * Turn helper into string
-     *
-     * @return string
-     */
-    public function toString()
-    {
-        return (string) $this->data[$this->name][$this->key()];
-    }
-
-    /**
-     * Cast to string
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return $this->toString();
     }
 }

--- a/library/Zend/View/Helper/DeclareVars.php
+++ b/library/Zend/View/Helper/DeclareVars.php
@@ -16,6 +16,7 @@ class DeclareVars extends AbstractHelper
 {
     /**
      * The view object that created this helper object.
+     *
      * @var \Zend\View\View
      */
     public $view;

--- a/library/Zend/View/Helper/Doctype.php
+++ b/library/Zend/View/Helper/Doctype.php
@@ -37,11 +37,6 @@ class Doctype extends AbstractHelper
     /**#@-*/
 
     /**
-     * @var ArrayObject Shared doctypes to use throughout all instances
-     */
-    protected static $registeredDoctypes;
-
-    /**
      * Default DocType
      *
      * @var string
@@ -54,6 +49,11 @@ class Doctype extends AbstractHelper
      * @var ArrayObject
      */
     protected $registry;
+
+    /**
+     * @var ArrayObject Shared doctypes to use throughout all instances
+     */
+    protected static $registeredDoctypes;
 
     /**
      * Constructor
@@ -113,6 +113,18 @@ class Doctype extends AbstractHelper
     }
 
     /**
+     * String representation of doctype
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $doctypes = $this->getDoctypes();
+
+        return $doctypes[$this->getDoctype()];
+    }
+
+    /**
      * Register the default doctypes we understand
      *
      * @return void
@@ -159,7 +171,6 @@ class Doctype extends AbstractHelper
     public function setDoctype($doctype)
     {
         $this->registry['doctype'] = $doctype;
-
         return $this;
     }
 
@@ -215,17 +226,5 @@ class Doctype extends AbstractHelper
     public function isRdfa()
     {
         return ($this->isHtml5() || stristr($this->getDoctype(), 'rdfa') ? true : false);
-    }
-
-    /**
-     * String representation of doctype
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        $doctypes = $this->getDoctypes();
-
-        return $doctypes[$this->getDoctype()];
     }
 }

--- a/library/Zend/View/Helper/Doctype.php
+++ b/library/Zend/View/Helper/Doctype.php
@@ -43,15 +43,74 @@ class Doctype extends AbstractHelper
 
     /**
      * Default DocType
+     *
      * @var string
      */
     protected $defaultDoctype = self::HTML4_LOOSE;
 
     /**
      * Registry containing current doctype and mappings
+     *
      * @var ArrayObject
      */
     protected $registry;
+
+    /**
+     * Constructor
+     *
+     * Map constants to doctype strings, and set default doctype
+     */
+    public function __construct()
+    {
+        if (null === static::$registeredDoctypes) {
+            static::registerDefaultDoctypes();
+            $this->setDoctype($this->defaultDoctype);
+        }
+        $this->registry = static::$registeredDoctypes;
+    }
+
+    /**
+     * Set or retrieve doctype
+     *
+     * @param  string $doctype
+     * @throws Exception\DomainException
+     * @return Doctype
+     */
+    public function __invoke($doctype = null)
+    {
+        if (null !== $doctype) {
+            switch ($doctype) {
+                case self::XHTML11:
+                case self::XHTML1_STRICT:
+                case self::XHTML1_TRANSITIONAL:
+                case self::XHTML1_FRAMESET:
+                case self::XHTML_BASIC1:
+                case self::XHTML1_RDFA:
+                case self::XHTML1_RDFA11:
+                case self::XHTML5:
+                case self::HTML4_STRICT:
+                case self::HTML4_LOOSE:
+                case self::HTML4_FRAMESET:
+                case self::HTML5:
+                    $this->setDoctype($doctype);
+                    break;
+                default:
+                    if (substr($doctype, 0, 9) != '<!DOCTYPE') {
+                        throw new Exception\DomainException('The specified doctype is malformed');
+                    }
+                    if (stristr($doctype, 'xhtml')) {
+                        $type = self::CUSTOM_XHTML;
+                    } else {
+                        $type = self::CUSTOM;
+                    }
+                    $this->setDoctype($type);
+                    $this->registry['doctypes'][$type] = $doctype;
+                    break;
+            }
+        }
+
+        return $this;
+    }
 
     /**
      * Register the default doctypes we understand
@@ -92,63 +151,6 @@ class Doctype extends AbstractHelper
     }
 
     /**
-     * Constructor
-     *
-     * Map constants to doctype strings, and set default doctype
-     */
-    public function __construct()
-    {
-        if (null === static::$registeredDoctypes) {
-            static::registerDefaultDoctypes();
-            $this->setDoctype($this->defaultDoctype);
-        }
-        $this->registry = static::$registeredDoctypes;
-    }
-
-    /**
-     * Set or retrieve doctype
-     *
-     * @param  string $doctype
-     * @return Doctype Provides a fluent interface
-     * @throws Exception\DomainException
-     */
-    public function __invoke($doctype = null)
-    {
-        if (null !== $doctype) {
-            switch ($doctype) {
-                case self::XHTML11:
-                case self::XHTML1_STRICT:
-                case self::XHTML1_TRANSITIONAL:
-                case self::XHTML1_FRAMESET:
-                case self::XHTML_BASIC1:
-                case self::XHTML1_RDFA:
-                case self::XHTML1_RDFA11:
-                case self::XHTML5:
-                case self::HTML4_STRICT:
-                case self::HTML4_LOOSE:
-                case self::HTML4_FRAMESET:
-                case self::HTML5:
-                    $this->setDoctype($doctype);
-                    break;
-                default:
-                    if (substr($doctype, 0, 9) != '<!DOCTYPE') {
-                        throw new Exception\DomainException('The specified doctype is malformed');
-                    }
-                    if (stristr($doctype, 'xhtml')) {
-                        $type = self::CUSTOM_XHTML;
-                    } else {
-                        $type = self::CUSTOM;
-                    }
-                    $this->setDoctype($type);
-                    $this->registry['doctypes'][$type] = $doctype;
-                    break;
-            }
-        }
-
-        return $this;
-    }
-
-    /**
      * Set doctype
      *
      * @param  string $doctype
@@ -157,6 +159,7 @@ class Doctype extends AbstractHelper
     public function setDoctype($doctype)
     {
         $this->registry['doctype'] = $doctype;
+
         return $this;
     }
 
@@ -170,6 +173,7 @@ class Doctype extends AbstractHelper
         if (!isset($this->registry['doctype'])) {
             $this->setDoctype($this->defaultDoctype);
         }
+
         return $this->registry['doctype'];
     }
 
@@ -221,6 +225,7 @@ class Doctype extends AbstractHelper
     public function __toString()
     {
         $doctypes = $this->getDoctypes();
+
         return $doctypes[$this->getDoctype()];
     }
 }

--- a/library/Zend/View/Helper/EscapeCss.php
+++ b/library/Zend/View/Helper/EscapeCss.php
@@ -16,11 +16,10 @@ use Zend\View\Helper\Escaper;
  */
 class EscapeCss extends Escaper\AbstractHelper
 {
-
     /**
      * Escape a value for current escaping strategy
      *
-     * @param string $value
+     * @param  string $value
      * @return string
      */
     protected function escape($value)

--- a/library/Zend/View/Helper/EscapeHtml.php
+++ b/library/Zend/View/Helper/EscapeHtml.php
@@ -16,11 +16,10 @@ use Zend\View\Helper\Escaper;
  */
 class EscapeHtml extends Escaper\AbstractHelper
 {
-
     /**
      * Escape a value for current escaping strategy
      *
-     * @param string $value
+     * @param  string $value
      * @return string
      */
     protected function escape($value)

--- a/library/Zend/View/Helper/EscapeHtmlAttr.php
+++ b/library/Zend/View/Helper/EscapeHtmlAttr.php
@@ -16,11 +16,10 @@ use Zend\View\Helper\Escaper;
  */
 class EscapeHtmlAttr extends Escaper\AbstractHelper
 {
-
     /**
      * Escape a value for current escaping strategy
      *
-     * @param string $value
+     * @param  string $value
      * @return string
      */
     protected function escape($value)

--- a/library/Zend/View/Helper/EscapeJs.php
+++ b/library/Zend/View/Helper/EscapeJs.php
@@ -16,11 +16,10 @@ use Zend\View\Helper\Escaper;
  */
 class EscapeJs extends Escaper\AbstractHelper
 {
-
     /**
      * Escape a value for current escaping strategy
      *
-     * @param string $value
+     * @param  string $value
      * @return string
      */
     protected function escape($value)

--- a/library/Zend/View/Helper/EscapeUrl.php
+++ b/library/Zend/View/Helper/EscapeUrl.php
@@ -16,11 +16,10 @@ use Zend\View\Helper\Escaper;
  */
 class EscapeUrl extends Escaper\AbstractHelper
 {
-
     /**
      * Escape a value for current escaping strategy
      *
-     * @param string $value
+     * @param  string $value
      * @return string
      */
     protected function escape($value)

--- a/library/Zend/View/Helper/Escaper/AbstractHelper.php
+++ b/library/Zend/View/Helper/Escaper/AbstractHelper.php
@@ -26,14 +26,14 @@ abstract class AbstractHelper extends Helper\AbstractHelper
     const RECURSE_OBJECT = 0x02;
 
     /**
-     * @var Escaper\Escaper
-     */
-    protected $escaper = null;
-
-    /**
      * @var string Encoding
      */
     protected $encoding = 'UTF-8';
+
+    /**
+     * @var Escaper\Escaper
+     */
+    protected $escaper = null;
 
     /**
      * Invoke this helper: escape a value
@@ -77,37 +77,16 @@ abstract class AbstractHelper extends Helper\AbstractHelper
             return $this->__invoke((array) $value, $recurse | self::RECURSE_ARRAY);
         }
 
-        // At this point, we have a scalar; simply return it
         return $value;
     }
 
     /**
-     * Set instance of Escaper
+     * Escape a value for current escaping strategy
      *
-     * @param  Escaper\Escaper $escaper
-     * @return AbstractHelper
+     * @param  string $value
+     * @return string
      */
-    public function setEscaper(Escaper\Escaper $escaper)
-    {
-        $this->escaper = $escaper;
-        $this->encoding = $escaper->getEncoding();
-
-        return $this;
-    }
-
-    /**
-     * Get instance of Escaper
-     *
-     * @return null|Escaper\Escaper
-     */
-    public function getEscaper()
-    {
-        if (null === $this->escaper) {
-            $this->setEscaper(new Escaper\Escaper($this->getEncoding()));
-        }
-
-        return $this->escaper;
-    }
+    abstract protected function escape($value);
 
     /**
      * Set the encoding to use for escape operations
@@ -121,7 +100,7 @@ abstract class AbstractHelper extends Helper\AbstractHelper
         if (null !== $this->escaper) {
             throw new Exception\InvalidArgumentException(
                 'Character encoding settings cannot be changed once the Helper has been used or '
-                . ' if a Zend\Escaper\Escaper object (with preset encoding option) is set.'
+                    . ' if a Zend\Escaper\Escaper object (with preset encoding option) is set.'
             );
         }
 
@@ -141,10 +120,30 @@ abstract class AbstractHelper extends Helper\AbstractHelper
     }
 
     /**
-     * Escape a value for current escaping strategy
+     * Set instance of Escaper
      *
-     * @param  string $value
-     * @return string
+     * @param  Escaper\Escaper $escaper
+     * @return AbstractHelper
      */
-    abstract protected function escape($value);
+    public function setEscaper(Escaper\Escaper $escaper)
+    {
+        $this->escaper  = $escaper;
+        $this->encoding = $escaper->getEncoding();
+
+        return $this;
+    }
+
+    /**
+     * Get instance of Escaper
+     *
+     * @return null|Escaper\Escaper
+     */
+    public function getEscaper()
+    {
+        if (null === $this->escaper) {
+            $this->setEscaper(new Escaper\Escaper($this->getEncoding()));
+        }
+
+        return $this->escaper;
+    }
 }

--- a/library/Zend/View/Helper/Escaper/AbstractHelper.php
+++ b/library/Zend/View/Helper/Escaper/AbstractHelper.php
@@ -18,14 +18,12 @@ use Zend\View\Helper;
  */
 abstract class AbstractHelper extends Helper\AbstractHelper
 {
-
-    /**@+
+    /**
      * @const Recursion constants
      */
     const RECURSE_NONE   = 0x00;
     const RECURSE_ARRAY  = 0x01;
     const RECURSE_OBJECT = 0x02;
-    /**@-*/
 
     /**
      * @var Escaper\Escaper
@@ -37,18 +35,77 @@ abstract class AbstractHelper extends Helper\AbstractHelper
      */
     protected $encoding = 'UTF-8';
 
+    /**
+     * Invoke this helper: escape a value
+     *
+     * @param  mixed $value
+     * @param  int   $recurse Expects one of the recursion constants; used to decide whether or not to recurse the given value when escaping
+     * @throws Exception\InvalidArgumentException
+     * @return mixed Given a scalar, a scalar value is returned. Given an object, with the $recurse flag not allowing object recursion, returns a string. Otherwise, returns an array.
+     */
+    public function __invoke($value, $recurse = self::RECURSE_NONE)
+    {
+        if (is_string($value)) {
+            return $this->escape($value);
+        }
+
+        if (is_array($value)) {
+            if (!(self::RECURSE_ARRAY & $recurse)) {
+                throw new Exception\InvalidArgumentException(
+                    'Array provided to Escape helper, but flags do not allow recursion'
+                );
+            }
+            foreach ($value as $k => $v) {
+                $value[$k] = $this->__invoke($v, $recurse);
+            }
+            return $value;
+        }
+
+        if (is_object($value)) {
+            if (!(self::RECURSE_OBJECT & $recurse)) {
+                // Attempt to cast it to a string
+                if (method_exists($value, '__toString')) {
+                    return $this->escape((string) $value);
+                }
+                throw new Exception\InvalidArgumentException(
+                    'Object provided to Escape helper, but flags do not allow recursion'
+                );
+            }
+            if (method_exists($value, 'toArray')) {
+                return $this->__invoke($value->toArray(), $recurse | self::RECURSE_ARRAY);
+            }
+            return $this->__invoke((array) $value, $recurse | self::RECURSE_ARRAY);
+        }
+
+        // At this point, we have a scalar; simply return it
+        return $value;
+    }
+
+    /**
+     * Set instance of Escaper
+     *
+     * @param  Escaper\Escaper $escaper
+     * @return AbstractHelper
+     */
     public function setEscaper(Escaper\Escaper $escaper)
     {
         $this->escaper = $escaper;
         $this->encoding = $escaper->getEncoding();
+
         return $this;
     }
 
+    /**
+     * Get instance of Escaper
+     *
+     * @return null|Escaper\Escaper
+     */
     public function getEscaper()
     {
         if (null === $this->escaper) {
             $this->setEscaper(new Escaper\Escaper($this->getEncoding()));
         }
+
         return $this->escaper;
     }
 
@@ -67,7 +124,9 @@ abstract class AbstractHelper extends Helper\AbstractHelper
                 . ' if a Zend\Escaper\Escaper object (with preset encoding option) is set.'
             );
         }
+
         $this->encoding = $encoding;
+
         return $this;
     }
 
@@ -82,54 +141,10 @@ abstract class AbstractHelper extends Helper\AbstractHelper
     }
 
     /**
-     * Invoke this helper: escape a value
-     *
-     * @param  mixed $value
-     * @param  int $recurse Expects one of the recursion constants; used to decide whether or not to recurse the given value when escaping
-     * @return mixed Given a scalar, a scalar value is returned. Given an object, with the $recurse flag not allowing object recursion, returns a string. Otherwise, returns an array.
-     * @throws Exception\InvalidArgumentException
-     */
-    public function __invoke($value, $recurse = self::RECURSE_NONE)
-    {
-        if (is_string($value)) {
-            return $this->escape($value);
-        }
-        if (is_array($value)) {
-            if (!(self::RECURSE_ARRAY & $recurse)) {
-                throw new Exception\InvalidArgumentException(
-                    'Array provided to Escape helper, but flags do not allow recursion'
-                );
-            }
-            foreach ($value as $k => $v) {
-                $value[$k] = $this->__invoke($v, $recurse);
-            }
-            return $value;
-        }
-        if (is_object($value)) {
-            if (!(self::RECURSE_OBJECT & $recurse)) {
-                // Attempt to cast it to a string
-                if (method_exists($value, '__toString')) {
-                    return $this->escape((string) $value);
-                }
-                throw new Exception\InvalidArgumentException(
-                    'Object provided to Escape helper, but flags do not allow recursion'
-                );
-            }
-            if (method_exists($value, 'toArray')) {
-                return $this->__invoke($value->toArray(), $recurse | self::RECURSE_ARRAY);
-            }
-            return $this->__invoke((array) $value, $recurse | self::RECURSE_ARRAY);
-        }
-        // At this point, we have a scalar; simply return it
-        return $value;
-    }
-
-    /**
      * Escape a value for current escaping strategy
      *
-     * @param string $value
+     * @param  string $value
      * @return string
      */
     abstract protected function escape($value);
-
 }

--- a/library/Zend/View/Helper/FlashMessenger.php
+++ b/library/Zend/View/Helper/FlashMessenger.php
@@ -9,7 +9,7 @@
 
 namespace Zend\View\Helper;
 
-use Zend\Mvc\Controller\Plugin\FlashMessenger as PluginFlashMessenger;
+use Zend\Mvc\Controller\Plugin\FlashMessenger as FlashMessengerPlugin;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\View\Helper\AbstractHelper;
@@ -27,10 +27,10 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
      * @var array
      */
     protected $classMessages = array(
-        PluginFlashMessenger::NAMESPACE_INFO => 'info',
-        PluginFlashMessenger::NAMESPACE_ERROR => 'error',
-        PluginFlashMessenger::NAMESPACE_SUCCESS => 'success',
-        PluginFlashMessenger::NAMESPACE_DEFAULT => 'default',
+        FlashMessengerPlugin::NAMESPACE_INFO => 'info',
+        FlashMessengerPlugin::NAMESPACE_ERROR => 'error',
+        FlashMessengerPlugin::NAMESPACE_SUCCESS => 'success',
+        FlashMessengerPlugin::NAMESPACE_DEFAULT => 'default',
     );
 
     /**
@@ -52,9 +52,9 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     /**
      * Flash messenger plugin
      *
-     * @var PluginFlashMessenger
+     * @var FlashMessengerPlugin
      */
-    protected $pluginFlashMessenger;
+    protected $flashMessengerPlugin;
 
     /**
      * Service locator
@@ -67,14 +67,14 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
      * Returns the flash messenger plugin controller
      *
      * @param  string|null $namespace
-     * @return FlashMessenger|PluginFlashMessenger
+     * @return FlashMessenger|FlashMessengerPlugin
      */
     public function __invoke($namespace = null)
     {
         if (null === $namespace) {
             return $this;
         }
-        $flashMessenger = $this->getPluginFlashMessenger();
+        $flashMessenger = $this->getFlashMessengerPlugin();
 
         return $flashMessenger->getMessagesFromNamespace($namespace);
     }
@@ -88,8 +88,7 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
      */
     public function __call($method, $argv)
     {
-        $flashMessenger = $this->getPluginFlashMessenger();
-
+        $flashMessenger = $this->getFlashMessengerPlugin();
         return call_user_func_array(array($flashMessenger, $method), $argv);
     }
 
@@ -100,15 +99,15 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
      * @param  array  $classes
      * @return string
      */
-    public function render($namespace = PluginFlashMessenger::NAMESPACE_DEFAULT, array $classes = array())
+    public function render($namespace = FlashMessengerPlugin::NAMESPACE_DEFAULT, array $classes = array())
     {
-        $flashMessenger = $this->getPluginFlashMessenger();
+        $flashMessenger = $this->getFlashMessengerPlugin();
         $messages = $flashMessenger->getMessagesFromNamespace($namespace);
 
         // Prepare classes for opening tag
         if (empty($classes)) {
             $classes = isset($this->classMessages[$namespace]) ?
-                $this->classMessages[$namespace] : $this->classMessages[PluginFlashMessenger::NAMESPACE_DEFAULT];
+                $this->classMessages[$namespace] : $this->classMessages[FlashMessengerPlugin::NAMESPACE_DEFAULT];
             $classes = array($classes);
         }
 
@@ -141,6 +140,32 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     }
 
     /**
+     * Set the flash messenger plugin
+     *
+     * @param  FlashMessengerPlugin $flashMessengerPlugin
+     * @return FlashMessenger
+     */
+    public function setFlashMessengerPlugin(FlashMessengerPlugin $flashMessengerPlugin)
+    {
+        $this->flashMessengerPlugin = $flashMessengerPlugin;
+        return $this;
+    }
+
+    /**
+     * Get the flash messenger plugin
+     *
+     * @return FlashMessengerPlugin
+     */
+    public function getFlashMessengerPlugin()
+    {
+        if (null === $this->flashMessengerPlugin) {
+            $this->setFlashMessengerPlugin(new FlashMessengerPlugin());
+        }
+
+        return $this->flashMessengerPlugin;
+    }
+
+    /**
      * Set the string used to close message representation
      *
      * @param  string $messageCloseString
@@ -149,7 +174,6 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     public function setMessageCloseString($messageCloseString)
     {
         $this->messageCloseString = (string) $messageCloseString;
-
         return $this;
     }
 
@@ -172,7 +196,6 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     public function setMessageOpenFormat($messageOpenFormat)
     {
         $this->messageOpenFormat = (string) $messageOpenFormat;
-
         return $this;
     }
 
@@ -195,7 +218,6 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     public function setMessageSeparatorString($messageSeparatorString)
     {
         $this->messageSeparatorString = (string) $messageSeparatorString;
-
         return $this;
     }
 
@@ -210,55 +232,6 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     }
 
     /**
-     * Retrieve the escapeHtml helper
-     *
-     * @return EscapeHtml
-     */
-    protected function getEscapeHtmlHelper()
-    {
-        if ($this->escapeHtmlHelper) {
-            return $this->escapeHtmlHelper;
-        }
-
-        if (method_exists($this->view, 'plugin')) {
-            $this->escapeHtmlHelper = $this->view->plugin('escapehtml');
-        }
-
-        if (!$this->escapeHtmlHelper instanceof EscapeHtml) {
-            $this->escapeHtmlHelper = new EscapeHtml();
-        }
-
-        return $this->escapeHtmlHelper;
-    }
-
-    /**
-     * Get the flash messenger plugin
-     *
-     * @return PluginFlashMessenger
-     */
-    public function getPluginFlashMessenger()
-    {
-        if (null === $this->pluginFlashMessenger) {
-            $this->setPluginFlashMessenger(new PluginFlashMessenger());
-        }
-
-        return $this->pluginFlashMessenger;
-    }
-
-    /**
-     * Set the flash messenger plugin
-     *
-     * @param  PluginFlashMessenger $pluginFlashMessenger
-     * @return FlashMessenger
-     */
-    public function setPluginFlashMessenger(PluginFlashMessenger $pluginFlashMessenger)
-    {
-        $this->pluginFlashMessenger = $pluginFlashMessenger;
-
-        return $this;
-    }
-
-    /**
      * Set the service locator.
      *
      * @param  ServiceLocatorInterface $serviceLocator
@@ -267,7 +240,6 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
     {
         $this->serviceLocator = $serviceLocator;
-
         return $this;
     }
 
@@ -279,5 +251,27 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     public function getServiceLocator()
     {
         return $this->serviceLocator;
+    }
+
+    /**
+     * Retrieve the escapeHtml helper
+     *
+     * @return EscapeHtml
+     */
+    protected function getEscapeHtmlHelper()
+    {
+        if ($this->escapeHtmlHelper) {
+            return $this->escapeHtmlHelper;
+        }
+
+        if (method_exists($this->getView(), 'plugin')) {
+            $this->escapeHtmlHelper = $this->view->plugin('escapehtml');
+        }
+
+        if (!$this->escapeHtmlHelper instanceof EscapeHtml) {
+            $this->escapeHtmlHelper = new EscapeHtml();
+        }
+
+        return $this->escapeHtmlHelper;
     }
 }

--- a/library/Zend/View/Helper/FlashMessenger.php
+++ b/library/Zend/View/Helper/FlashMessenger.php
@@ -22,29 +22,9 @@ use Zend\I18n\View\Helper\AbstractTranslatorHelper;
 class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorAwareInterface
 {
     /**
-     * @var ServiceLocatorInterface
-     */
-    protected $serviceLocator;
-
-    /**
-     * @var string Templates for the open/close/separators for message tags
-     */
-    protected $messageCloseString     = '</li></ul>';
-    protected $messageOpenFormat      = '<ul%s><li>';
-    protected $messageSeparatorString = '</li><li>';
-
-    /**
-     * @var EscapeHtml
-     */
-    protected $escapeHtmlHelper;
-
-    /**
-     * @var PluginFlashMessenger
-     */
-    protected $pluginFlashMessenger;
-
-    /**
-     * @var array Default attributes for the open format tag
+     * Default attributes for the open format tag
+     *
+     * @var array
      */
     protected $classMessages = array(
         PluginFlashMessenger::NAMESPACE_INFO => 'info',
@@ -52,6 +32,36 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
         PluginFlashMessenger::NAMESPACE_SUCCESS => 'success',
         PluginFlashMessenger::NAMESPACE_DEFAULT => 'default',
     );
+
+    /**
+     * Templates for the open/close/separators for message tags
+     *
+     * @var string
+     */
+    protected $messageCloseString     = '</li></ul>';
+    protected $messageOpenFormat      = '<ul%s><li>';
+    protected $messageSeparatorString = '</li><li>';
+
+    /**
+     * Html escape helper
+     *
+     * @var EscapeHtml
+     */
+    protected $escapeHtmlHelper;
+
+    /**
+     * Flash messenger plugin
+     *
+     * @var PluginFlashMessenger
+     */
+    protected $pluginFlashMessenger;
+
+    /**
+     * Service locator
+     *
+     * @var ServiceLocatorInterface
+     */
+    protected $serviceLocator;
 
     /**
      * Returns the flash messenger plugin controller
@@ -133,7 +143,7 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     /**
      * Set the string used to close message representation
      *
-     * @param  string         $messageCloseString
+     * @param  string $messageCloseString
      * @return FlashMessenger
      */
     public function setMessageCloseString($messageCloseString)
@@ -156,7 +166,7 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     /**
      * Set the formatted string used to open message representation
      *
-     * @param  string         $messageOpenFormat
+     * @param  string $messageOpenFormat
      * @return FlashMessenger
      */
     public function setMessageOpenFormat($messageOpenFormat)
@@ -179,7 +189,7 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     /**
      * Set the string used to separate messages
      *
-     * @param  string         $messageSeparatorString
+     * @param  string $messageSeparatorString
      * @return FlashMessenger
      */
     public function setMessageSeparatorString($messageSeparatorString)

--- a/library/Zend/View/Helper/FlashMessenger.php
+++ b/library/Zend/View/Helper/FlashMessenger.php
@@ -9,7 +9,7 @@
 
 namespace Zend\View\Helper;
 
-use Zend\Mvc\Controller\Plugin\FlashMessenger as FlashMessengerPlugin;
+use Zend\Mvc\Controller\Plugin\FlashMessenger as PluginFlashMessenger;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\View\Helper\AbstractHelper;
@@ -27,10 +27,10 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
      * @var array
      */
     protected $classMessages = array(
-        FlashMessengerPlugin::NAMESPACE_INFO => 'info',
-        FlashMessengerPlugin::NAMESPACE_ERROR => 'error',
-        FlashMessengerPlugin::NAMESPACE_SUCCESS => 'success',
-        FlashMessengerPlugin::NAMESPACE_DEFAULT => 'default',
+        PluginFlashMessenger::NAMESPACE_INFO => 'info',
+        PluginFlashMessenger::NAMESPACE_ERROR => 'error',
+        PluginFlashMessenger::NAMESPACE_SUCCESS => 'success',
+        PluginFlashMessenger::NAMESPACE_DEFAULT => 'default',
     );
 
     /**
@@ -52,9 +52,9 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     /**
      * Flash messenger plugin
      *
-     * @var FlashMessengerPlugin
+     * @var PluginFlashMessenger
      */
-    protected $flashMessengerPlugin;
+    protected $pluginFlashMessenger;
 
     /**
      * Service locator
@@ -67,14 +67,14 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
      * Returns the flash messenger plugin controller
      *
      * @param  string|null $namespace
-     * @return FlashMessenger|FlashMessengerPlugin
+     * @return FlashMessenger|PluginFlashMessenger
      */
     public function __invoke($namespace = null)
     {
         if (null === $namespace) {
             return $this;
         }
-        $flashMessenger = $this->getFlashMessengerPlugin();
+        $flashMessenger = $this->getPluginFlashMessenger();
 
         return $flashMessenger->getMessagesFromNamespace($namespace);
     }
@@ -88,7 +88,7 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
      */
     public function __call($method, $argv)
     {
-        $flashMessenger = $this->getFlashMessengerPlugin();
+        $flashMessenger = $this->getPluginFlashMessenger();
         return call_user_func_array(array($flashMessenger, $method), $argv);
     }
 
@@ -99,15 +99,15 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
      * @param  array  $classes
      * @return string
      */
-    public function render($namespace = FlashMessengerPlugin::NAMESPACE_DEFAULT, array $classes = array())
+    public function render($namespace = PluginFlashMessenger::NAMESPACE_DEFAULT, array $classes = array())
     {
-        $flashMessenger = $this->getFlashMessengerPlugin();
+        $flashMessenger = $this->getPluginFlashMessenger();
         $messages = $flashMessenger->getMessagesFromNamespace($namespace);
 
         // Prepare classes for opening tag
         if (empty($classes)) {
             $classes = isset($this->classMessages[$namespace]) ?
-                $this->classMessages[$namespace] : $this->classMessages[FlashMessengerPlugin::NAMESPACE_DEFAULT];
+                $this->classMessages[$namespace] : $this->classMessages[PluginFlashMessenger::NAMESPACE_DEFAULT];
             $classes = array($classes);
         }
 
@@ -137,32 +137,6 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
         $markup .= $this->getMessageCloseString();
 
         return $markup;
-    }
-
-    /**
-     * Set the flash messenger plugin
-     *
-     * @param  FlashMessengerPlugin $flashMessengerPlugin
-     * @return FlashMessenger
-     */
-    public function setFlashMessengerPlugin(FlashMessengerPlugin $flashMessengerPlugin)
-    {
-        $this->flashMessengerPlugin = $flashMessengerPlugin;
-        return $this;
-    }
-
-    /**
-     * Get the flash messenger plugin
-     *
-     * @return FlashMessengerPlugin
-     */
-    public function getFlashMessengerPlugin()
-    {
-        if (null === $this->flashMessengerPlugin) {
-            $this->setFlashMessengerPlugin(new FlashMessengerPlugin());
-        }
-
-        return $this->flashMessengerPlugin;
     }
 
     /**
@@ -229,6 +203,32 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     public function getMessageSeparatorString()
     {
         return $this->messageSeparatorString;
+    }
+
+    /**
+     * Set the flash messenger plugin
+     *
+     * @param  PluginFlashMessenger $pluginFlashMessenger
+     * @return FlashMessenger
+     */
+    public function setPluginFlashMessenger(PluginFlashMessenger $pluginFlashMessenger)
+    {
+        $this->pluginFlashMessenger = $pluginFlashMessenger;
+        return $this;
+    }
+
+    /**
+     * Get the flash messenger plugin
+     *
+     * @return PluginFlashMessenger
+     */
+    public function getPluginFlashMessenger()
+    {
+        if (null === $this->pluginFlashMessenger) {
+            $this->setPluginFlashMessenger(new PluginFlashMessenger());
+        }
+
+        return $this->pluginFlashMessenger;
     }
 
     /**

--- a/library/Zend/View/Helper/Gravatar.php
+++ b/library/Zend/View/Helper/Gravatar.php
@@ -43,6 +43,20 @@ class Gravatar extends AbstractHtmlElement
     const DEFAULT_WAVATAR   = 'wavatar';
 
     /**
+     * Attributes for HTML image tag
+     *
+     * @var array
+     */
+    protected $attribs;
+
+    /**
+     * Email Address
+     *
+     * @var string
+     */
+    protected $email;
+
+    /**
      * Options
      *
      * @var array
@@ -53,20 +67,6 @@ class Gravatar extends AbstractHtmlElement
         'rating'      => self::RATING_G,
         'secure'      => null,
     );
-
-    /**
-     * Email Address
-     *
-     * @var string
-     */
-    protected $email;
-
-    /**
-     * Attributes for HTML image tag
-     *
-     * @var array
-     */
-    protected $attribs;
 
     /**
      * Returns an avatar from gravatar's service.
@@ -100,6 +100,16 @@ class Gravatar extends AbstractHtmlElement
     }
 
     /**
+     * Return valid image tag
+     *
+     * @return string
+     */
+    public function  __toString()
+    {
+        return $this->getImgTag();
+    }
+
+    /**
      * Configure state
      *
      * @param  array $options
@@ -118,36 +128,74 @@ class Gravatar extends AbstractHtmlElement
     }
 
     /**
-     * Get img size
+     * Get avatar url (including size, rating and default image options)
      *
-     * @return int The img size
+     * @return string
      */
-    public function getImgSize()
+    protected function getAvatarUrl()
     {
-        return $this->options['img_size'];
+        $src = $this->getGravatarUrl()
+            . '/'   . md5($this->getEmail())
+            . '?s=' . $this->getImgSize()
+            . '&d=' . $this->getDefaultImg()
+            . '&r=' . $this->getRating();
+        return $src;
     }
 
     /**
-     * Set img size in pixels
+     * Get URL to gravatar's service.
      *
-     * @param  int $imgSize Size of img must be between 1 and 512
+     * @return string URL
+     */
+    protected function getGravatarUrl()
+    {
+        return ($this->getSecure() === false) ? self::GRAVATAR_URL : self::GRAVATAR_URL_SECURE;
+    }
+
+    /**
+     * Return valid image tag
+     *
+     * @return string
+     */
+    public function getImgTag()
+    {
+        $this->setSrcAttribForImg();
+        $html = '<img'
+            . $this->htmlAttribs($this->getAttribs())
+            . $this->getClosingBracket();
+
+        return $html;
+    }
+
+    /**
+     * Set attribs for image tag
+     *
+     * Warning! You shouldn't set src attrib for image tag.
+     * This attrib is overwritten in protected method setSrcAttribForImg().
+     * This method(_setSrcAttribForImg) is called in public method getImgTag().
+     *
+     * @param  array $attribs
      * @return Gravatar
      */
-    public function setImgSize($imgSize)
+    public function setAttribs(array $attribs)
     {
-        $this->options['img_size'] = (int) $imgSize;
-
+        $this->attribs = $attribs;
         return $this;
     }
 
     /**
-     * Get default img
+     * Get attribs of image
      *
-     * @return string
+     * Warning!
+     * If you set src attrib, you get it, but this value will be overwritten in
+     * protected method setSrcAttribForImg(). And finally your get other src
+     * value!
+     *
+     * @return array
      */
-    public function getDefaultImg()
+    public function getAttribs()
     {
-        return $this->options['default_img'];
+        return $this->attribs;
     }
 
     /**
@@ -162,8 +210,61 @@ class Gravatar extends AbstractHtmlElement
     public function setDefaultImg($defaultImg)
     {
         $this->options['default_img'] = urlencode($defaultImg);
-
         return $this;
+    }
+
+    /**
+     * Get default img
+     *
+     * @return string
+     */
+    public function getDefaultImg()
+    {
+        return $this->options['default_img'];
+    }
+
+    /**
+     * Set email address
+     *
+     * @param  string $email
+     * @return Gravatar
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    /**
+     * Get email address
+     *
+     * @return string
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * Set img size in pixels
+     *
+     * @param  int $imgSize Size of img must be between 1 and 512
+     * @return Gravatar
+     */
+    public function setImgSize($imgSize)
+    {
+        $this->options['img_size'] = (int) $imgSize;
+        return $this;
+    }
+
+    /**
+     * Get img size
+     *
+     * @return int The img size
+     */
+    public function getImgSize()
+    {
+        return $this->options['img_size'];
     }
 
     /**
@@ -206,29 +307,6 @@ class Gravatar extends AbstractHtmlElement
     }
 
     /**
-     * Set email address
-     *
-     * @param  string $email
-     * @return Gravatar
-     */
-    public function setEmail( $email )
-    {
-        $this->email = $email;
-
-        return $this;
-    }
-
-    /**
-     * Get email address
-     *
-     * @return string
-     */
-    public function getEmail()
-    {
-        return $this->email;
-    }
-
-    /**
      * Load from an SSL or No-SSL location?
      *
      * @param  bool $flag
@@ -237,7 +315,6 @@ class Gravatar extends AbstractHtmlElement
     public function setSecure($flag)
     {
         $this->options['secure'] = ($flag === null) ? null : (bool) $flag;
-
         return $this;
     }
 
@@ -256,63 +333,6 @@ class Gravatar extends AbstractHtmlElement
     }
 
     /**
-     * Get attribs of image
-     *
-     * Warning!
-     * If you set src attrib, you get it, but this value will be overwritten in
-     * protected method setSrcAttribForImg(). And finally your get other src
-     * value!
-     *
-     * @return array
-     */
-    public function getAttribs()
-    {
-        return $this->attribs;
-    }
-
-    /**
-     * Set attribs for image tag
-     *
-     * Warning! You shouldn't set src attrib for image tag.
-     * This attrib is overwritten in protected method setSrcAttribForImg().
-     * This method(_setSrcAttribForImg) is called in public method getImgTag().
-     *
-     * @param  array $attribs
-     * @return Gravatar
-     */
-    public function setAttribs(array $attribs)
-    {
-        $this->attribs = $attribs;
-
-        return $this;
-    }
-
-    /**
-     * Get URL to gravatar's service.
-     *
-     * @return string URL
-     */
-    protected function getGravatarUrl()
-    {
-        return ($this->getSecure() === false) ? self::GRAVATAR_URL : self::GRAVATAR_URL_SECURE;
-    }
-
-    /**
-     * Get avatar url (including size, rating and default image options)
-     *
-     * @return string
-     */
-    protected function getAvatarUrl()
-    {
-        $src = $this->getGravatarUrl()
-             . '/'   . md5($this->getEmail())
-             . '?s=' . $this->getImgSize()
-             . '&d=' . $this->getDefaultImg()
-             . '&r=' . $this->getRating();
-        return $src;
-    }
-
-    /**
      * Set src attrib for image.
      *
      * You shouldn't set a own url value!
@@ -327,30 +347,5 @@ class Gravatar extends AbstractHtmlElement
         $attribs        = $this->getAttribs();
         $attribs['src'] = $this->getAvatarUrl();
         $this->setAttribs($attribs);
-    }
-
-    /**
-     * Return valid image tag
-     *
-     * @return string
-     */
-    public function getImgTag()
-    {
-        $this->setSrcAttribForImg();
-        $html = '<img'
-              . $this->htmlAttribs($this->getAttribs())
-              . $this->getClosingBracket();
-
-        return $html;
-    }
-
-    /**
-     * Return valid image tag
-     *
-     * @return string
-     */
-    public function  __toString()
-    {
-        return $this->getImgTag();
     }
 }

--- a/library/Zend/View/Helper/Gravatar.php
+++ b/library/Zend/View/Helper/Gravatar.php
@@ -79,9 +79,9 @@ class Gravatar extends AbstractHtmlElement
      *
      * @see    http://pl.gravatar.com/site/implement/url
      * @see    http://pl.gravatar.com/site/implement/url More information about gravatar's service.
-     * @param  string|null $email Email address.
-     * @param  null|array $options Options
-     * @param  array $attribs Attributes for image tag (title, alt etc.)
+     * @param  string|null $email   Email address.
+     * @param  null|array  $options Options
+     * @param  array       $attribs Attributes for image tag (title, alt etc.)
      * @return Gravatar
      */
     public function __invoke($email = "", $options = array(), $attribs = array())
@@ -95,6 +95,7 @@ class Gravatar extends AbstractHtmlElement
         if (!empty($attribs)) {
             $this->setAttribs($attribs);
         }
+
         return $this;
     }
 
@@ -112,6 +113,7 @@ class Gravatar extends AbstractHtmlElement
                 $this->{$method}($value);
             }
         }
+
         return $this;
     }
 
@@ -128,12 +130,13 @@ class Gravatar extends AbstractHtmlElement
     /**
      * Set img size in pixels
      *
-     * @param int $imgSize Size of img must be between 1 and 512
+     * @param  int $imgSize Size of img must be between 1 and 512
      * @return Gravatar
      */
     public function setImgSize($imgSize)
     {
         $this->options['img_size'] = (int) $imgSize;
+
         return $this;
     }
 
@@ -159,6 +162,7 @@ class Gravatar extends AbstractHtmlElement
     public function setDefaultImg($defaultImg)
     {
         $this->options['default_img'] = urlencode($defaultImg);
+
         return $this;
     }
 
@@ -187,6 +191,7 @@ class Gravatar extends AbstractHtmlElement
                     $rating
                 ));
         }
+
         return $this;
     }
 
@@ -203,12 +208,13 @@ class Gravatar extends AbstractHtmlElement
     /**
      * Set email address
      *
-     * @param string $email
+     * @param  string $email
      * @return Gravatar
      */
     public function setEmail( $email )
     {
         $this->email = $email;
+
         return $this;
     }
 
@@ -225,12 +231,13 @@ class Gravatar extends AbstractHtmlElement
     /**
      * Load from an SSL or No-SSL location?
      *
-     * @param bool $flag
+     * @param  bool $flag
      * @return Gravatar
      */
     public function setSecure($flag)
     {
         $this->options['secure'] = ($flag === null) ? null : (bool) $flag;
+
         return $this;
     }
 
@@ -244,6 +251,7 @@ class Gravatar extends AbstractHtmlElement
         if ($this->options['secure'] === null) {
             return (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
         }
+
         return $this->options['secure'];
     }
 
@@ -275,6 +283,7 @@ class Gravatar extends AbstractHtmlElement
     public function setAttribs(array $attribs)
     {
         $this->attribs = $attribs;
+
         return $this;
     }
 

--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -16,19 +16,21 @@ use Zend\View\Exception;
 /**
  * Zend_Layout_View_Helper_HeadLink
  *
- * @see        http://www.w3.org/TR/xhtml1/dtds.html
+ * @see http://www.w3.org/TR/xhtml1/dtds.html
  */
 class HeadLink extends Placeholder\Container\AbstractStandalone
 {
     /**
-     * $validAttributes
+     * Allowed attributes
      *
      * @var array
      */
     protected $itemKeys = array('charset', 'href', 'hreflang', 'id', 'media', 'rel', 'rev', 'type', 'title', 'extras');
 
     /**
-     * @var string registry key
+     * Registry key for placeholder
+     *
+     * @var string
      */
     protected $regKey = 'Zend_View_Helper_HeadLink';
 
@@ -36,11 +38,11 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      * Constructor
      *
      * Use PHP_EOL as separator
-     *
      */
     public function __construct()
     {
         parent::__construct();
+
         $this->setSeparator(PHP_EOL);
     }
 
@@ -50,9 +52,9 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      * Returns current object instance. Optionally, allows passing array of
      * values to build link.
      *
-     * @param array $attributes
-     * @param string $placement
-     * @return \Zend\View\Helper\HeadLink
+     * @param  array  $attributes
+     * @param  string $placement
+     * @return HeadLink
      */
     public function __invoke(array $attributes = null, $placement = Placeholder\Container\AbstractContainer::APPEND)
     {
@@ -71,6 +73,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
                     break;
             }
         }
+
         return $this;
     }
 
@@ -105,10 +108,10 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      *   - public function appendSection()
      *   - public function appendSubsection()
      *
-     * @param mixed $method
-     * @param mixed $args
-     * @return void
+     * @param  mixed $method
+     * @param  mixed $args
      * @throws Exception\BadMethodCallException
+     * @return void
      */
     public function __call($method, $args)
     {
@@ -179,8 +182,8 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      * append()
      *
      * @param  array $value
-     * @return void
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function append($value)
     {
@@ -197,9 +200,9 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      * offsetSet()
      *
      * @param  string|int $index
-     * @param  array $value
-     * @return void
+     * @param  array      $value
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function offsetSet($index, $value)
     {
@@ -216,8 +219,8 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      * prepend()
      *
      * @param  array $value
-     * @return HeadLink
      * @throws Exception\InvalidArgumentException
+     * @return HeadLink
      */
     public function prepend($value)
     {
@@ -234,8 +237,8 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      * set()
      *
      * @param  array $value
-     * @return HeadLink
      * @throws Exception\InvalidArgumentException
+     * @return HeadLink
      */
     public function set($value)
     {
@@ -321,8 +324,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      */
     public function createData(array $attributes)
     {
-        $data = (object) $attributes;
-        return $data;
+        return (object) $attributes;
     }
 
     /**
@@ -366,6 +368,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         }
 
         $attributes = compact('rel', 'type', 'href', 'media', 'conditionalStylesheet', 'extras');
+
         return $this->createData($attributes);
     }
 
@@ -382,6 +385,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
                 return true;
             }
         }
+
         return false;
     }
 
@@ -389,8 +393,8 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      * Create item for alternate link item
      *
      * @param  array $args
-     * @return stdClass
      * @throws Exception\InvalidArgumentException
+     * @return stdClass
      */
     public function createDataAlternate(array $args)
     {
@@ -420,13 +424,14 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         $title = (string) $title;
 
         $attributes = compact('rel', 'href', 'type', 'title', 'extras');
+
         return $this->createData($attributes);
     }
 
     /**
      * Create item for a prev relationship (mainly used for pagination)
      *
-     * @param array $args
+     * @param  array $args
      * @return stdClass
      */
     public function createDataPrev(array $args)
@@ -435,13 +440,14 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         $href = (string) array_shift($args);
 
         $attributes = compact('rel', 'href');
+
         return $this->createData($attributes);
     }
 
     /**
      * Create item for a prev relationship (mainly used for pagination)
      *
-     * @param array $args
+     * @param  array $args
      * @return stdClass
      */
     public function createDataNext(array $args)
@@ -450,6 +456,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         $href = (string) array_shift($args);
 
         $attributes = compact('rel', 'href');
+
         return $this->createData($attributes);
     }
 }

--- a/library/Zend/View/Helper/HeadMeta.php
+++ b/library/Zend/View/Helper/HeadMeta.php
@@ -16,20 +16,35 @@ use Zend\View\Exception;
 /**
  * Zend_Layout_View_Helper_HeadMeta
  *
- * @see        http://www.w3.org/TR/xhtml1/dtds.html
+ * @see http://www.w3.org/TR/xhtml1/dtds.html
  */
 class HeadMeta extends Placeholder\Container\AbstractStandalone
 {
     /**
-     * Types of attributes
+     * Allowed key types
+     *
      * @var array
      */
-    protected $typeKeys     = array('name', 'http-equiv', 'charset', 'property');
+    protected $typeKeys  = array('name', 'http-equiv', 'charset', 'property');
+
+    /**
+     * Required attributes for meta tag
+     *
+     * @var array
+     */
     protected $requiredKeys = array('content');
+
+    /**
+     * Allowed modifier keys
+     *
+     * @var array
+     */
     protected $modifierKeys = array('lang', 'scheme');
 
     /**
-     * @var string registry key
+     * Registry key for placeholder
+     *
+     * @var string
      */
     protected $regKey = 'Zend_View_Helper_HeadMeta';
 
@@ -42,6 +57,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
     public function __construct()
     {
         parent::__construct();
+
         $this->setSeparator(PHP_EOL);
     }
 
@@ -51,9 +67,9 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      * @param  string $content
      * @param  string $keyValue
      * @param  string $keyType
-     * @param  array $modifiers
+     * @param  array  $modifiers
      * @param  string $placement
-     * @return \Zend\View\Helper\HeadMeta
+     * @return HeadMeta
      */
     public function __invoke($content = null, $keyValue = null, $keyType = 'name', $modifiers = array(), $placement = Placeholder\Container\AbstractContainer::APPEND)
     {
@@ -76,30 +92,6 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
     }
 
     /**
-     * Normalize type attribute of meta
-     *
-     * @param string $type type in CamelCase
-     * @return string
-     * @throws Exception\DomainException
-     */
-    protected function normalizeType($type)
-    {
-        switch ($type) {
-            case 'Name':
-                return 'name';
-            case 'HttpEquiv':
-                return 'http-equiv';
-            case 'Property':
-                return 'property';
-            default:
-                throw new Exception\DomainException(sprintf(
-                    'Invalid type "%s" passed to normalizeType',
-                    $type
-                ));
-        }
-    }
-
-    /**
      * Overload method access
      *
      * Allows the following 'virtual' methods:
@@ -117,9 +109,9 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      * - setProperty($keyValue, $content, $modifiers = array())
      *
      * @param  string $method
-     * @param  array $args
-     * @return \Zend\View\Helper\HeadMeta
+     * @param  array  $args
      * @throws Exception\BadMethodCallException
+     * @return HeadMeta
      */
     public function __call($method, $args)
     {
@@ -153,6 +145,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
             }
 
             $this->$action($item);
+
             return $this;
         }
 
@@ -160,12 +153,36 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
     }
 
     /**
+     * Normalize type attribute of meta
+     *
+     * @param  string $type type in CamelCase
+     * @throws Exception\DomainException
+     * @return string
+     */
+    protected function normalizeType($type)
+    {
+        switch ($type) {
+            case 'Name':
+                return 'name';
+            case 'HttpEquiv':
+                return 'http-equiv';
+            case 'Property':
+                return 'property';
+            default:
+                throw new Exception\DomainException(sprintf(
+                    'Invalid type "%s" passed to normalizeType',
+                    $type
+                ));
+        }
+    }
+
+    /**
      * Create an HTML5-style meta charset tag. Something like <meta charset="utf-8">
      *
      * Not valid in a non-HTML5 doctype
      *
-     * @param string $charset
-     * @return \Zend\View\Helper\HeadMeta Provides a fluent interface
+     * @param  string $charset
+     * @return HeadMeta Provides a fluent interface
      */
     public function setCharset($charset)
     {
@@ -175,6 +192,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
         $item->content = null;
         $item->modifiers = array();
         $this->set($item);
+
         return $this;
     }
 
@@ -230,9 +248,9 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      * OffsetSet
      *
      * @param  string|int $index
-     * @param  string $value
-     * @return void
+     * @param  string     $value
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function offsetSet($index, $value)
     {
@@ -249,8 +267,8 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      * OffsetUnset
      *
      * @param  string|int $index
-     * @return void
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function offsetUnset($index)
     {
@@ -265,8 +283,8 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      * Prepend
      *
      * @param  string $value
-     * @return void
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function prepend($value)
     {
@@ -283,8 +301,8 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      * Set
      *
      * @param  string $value
-     * @return void
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function set($value)
     {
@@ -388,6 +406,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
 
         $items = array();
         $this->getContainer()->ksort();
+
         try {
             foreach ($this as $item) {
                 $items[] = $this->itemToString($item);
@@ -396,6 +415,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
             trigger_error($e->getMessage(), E_USER_WARNING);
             return '';
         }
+
         return $indent . implode($this->escape($this->getSeparator()) . $indent, $items);
     }
 
@@ -405,7 +425,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      * @param  string $type
      * @param  string $typeValue
      * @param  string $content
-     * @param  array $modifiers
+     * @param  array  $modifiers
      * @return stdClass
      */
     public function createData($type, $typeValue, $content, array $modifiers)
@@ -415,6 +435,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
         $data->$type     = $typeValue;
         $data->content   = $content;
         $data->modifiers = $modifiers;
+
         return $data;
     }
 }

--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -18,46 +18,66 @@ use Zend\View\Exception;
  */
 class HeadScript extends Placeholder\Container\AbstractStandalone
 {
-    /**#@+
+    /**
      * Script type constants
+     *
      * @const string
      */
     const FILE   = 'FILE';
     const SCRIPT = 'SCRIPT';
-    /**#@-*/
 
     /**
      * Registry key for placeholder
+     *
      * @var string
      */
     protected $regKey = 'Zend_View_Helper_HeadScript';
 
     /**
      * Are arbitrary attributes allowed?
+     *
      * @var bool
      */
     protected $arbitraryAttributes = false;
 
-    /**#@+
-     * Capture type and/or attributes (used for hinting during capture)
-     * @var string
+    /**
+     * Is capture lock?
+     *
+     * @var bool
      */
     protected $captureLock;
-    protected $captureScriptType  = null;
+
+    /**
+     * Capture type
+     *
+     * @var string
+     */
+    protected $captureScriptType;
+
+    /**
+     * Capture attributes
+     *
+     * @var null|array
+     */
     protected $captureScriptAttrs = null;
+
+    /**
+     * Capture type (append, prepend, set)
+     *
+     * @var string
+     */
     protected $captureType;
-    /**#@-*/
 
     /**
      * Optional allowed attributes for script tag
+     *
      * @var array
      */
-    protected $optionalAttributes = array(
-        'charset', 'defer', 'language', 'src'
-    );
+    protected $optionalAttributes = array('charset', 'defer', 'language', 'src');
 
     /**
      * Required attributes for script tag
+     *
      * @var string
      */
     protected $requiredAttributes = array('type');
@@ -65,6 +85,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
     /**
      * Whether or not to format scripts using CDATA; used only if doctype
      * helper is not accessible
+     *
      * @var bool
      */
     public $useCdata = false;
@@ -73,11 +94,11 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * Constructor
      *
      * Set separator to PHP_EOL.
-     *
      */
     public function __construct()
     {
         parent::__construct();
+
         $this->setSeparator(PHP_EOL);
     }
 
@@ -92,7 +113,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * @param  string $placement Append, prepend, or set
      * @param  array  $attrs     Array of script attributes
      * @param  string $type      Script type and/or array of script attributes
-     * @return \Zend\View\Helper\HeadScript
+     * @return HeadScript
      */
     public function __invoke($mode = HeadScript::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
     {
@@ -121,8 +142,8 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * @param  mixed  $captureType Type of capture
      * @param  string $type        Type of script
      * @param  array  $attrs       Attributes of capture
-     * @return void
      * @throws Exception\RuntimeException
+     * @return void
      */
     public function captureStart($captureType = Placeholder\Container\AbstractContainer::APPEND, $type = 'text/javascript', $attrs = array())
     {
@@ -144,9 +165,9 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      */
     public function captureEnd()
     {
-        $content                   = ob_get_clean();
-        $type                      = $this->captureScriptType;
-        $attrs                     = $this->captureScriptAttrs;
+        $content                  = ob_get_clean();
+        $type                     = $this->captureScriptType;
+        $attrs                    = $this->captureScriptAttrs;
         $this->captureScriptType  = null;
         $this->captureScriptAttrs = null;
         $this->captureLock        = false;
@@ -161,6 +182,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
                 $action = 'appendScript';
                 break;
         }
+
         $this->$action($content, $type, $attrs);
     }
 
@@ -179,8 +201,8 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      *
      * @param  string $method Method to call
      * @param  array  $args   Arguments of method
-     * @return \Zend\View\Helper\HeadScript
      * @throws Exception\BadMethodCallException if too few arguments or invalid method
+     * @return HeadScript
      */
     public function __call($method, $args)
     {
@@ -261,6 +283,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
                 return true;
             }
         }
+
         return false;
     }
 
@@ -286,8 +309,8 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * Override append
      *
      * @param  string $value Append script or file
-     * @return void
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function append($value)
     {
@@ -304,8 +327,8 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * Override prepend
      *
      * @param  string $value Prepend script or file
-     * @return void
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function prepend($value)
     {
@@ -322,8 +345,8 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * Override set
      *
      * @param  string $value Set script or file
-     * @return void
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function set($value)
     {
@@ -341,8 +364,8 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      *
      * @param  string|int $index Set script of file offset
      * @param  mixed      $value
-     * @return void
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function offsetSet($index, $value)
     {
@@ -359,11 +382,12 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * Set flag indicating if arbitrary attributes are allowed
      *
      * @param  bool $flag Set flag
-     * @return \Zend\View\Helper\HeadScript
+     * @return HeadScript
      */
     public function setAllowArbitraryAttributes($flag)
     {
         $this->arbitraryAttributes = (bool) $flag;
+
         return $this;
     }
 
@@ -402,7 +426,6 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
                 $attrString .= sprintf(' %s="%s"', $key, ($this->autoEscape) ? $this->escape($value) : $value);
             }
         }
-
 
         $addScriptEscape = !(isset($item->attributes['noescape']) && filter_var($item->attributes['noescape'], FILTER_VALIDATE_BOOLEAN));
 
@@ -468,8 +491,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
             $items[] = $this->itemToString($item, $indent, $escapeStart, $escapeEnd);
         }
 
-        $return = implode($this->getSeparator(), $items);
-        return $return;
+        return implode($this->getSeparator(), $items);
     }
 
     /**
@@ -486,6 +508,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
         $data->type       = $type;
         $data->attributes = $attributes;
         $data->source     = $content;
+
         return $data;
     }
 }

--- a/library/Zend/View/Helper/HeadStyle.php
+++ b/library/Zend/View/Helper/HeadStyle.php
@@ -20,18 +20,21 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
 {
     /**
      * Registry key for placeholder
+     *
      * @var string
      */
     protected $regKey = 'Zend_View_Helper_HeadStyle';
 
     /**
      * Allowed optional attributes
+     *
      * @var array
      */
     protected $optionalAttributes = array('lang', 'title', 'media', 'dir');
 
     /**
      * Allowed media types
+     *
      * @var array
      */
     protected $mediaTypes = array(
@@ -41,18 +44,21 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
 
     /**
      * Capture type and/or attributes (used for hinting during capture)
+     *
      * @var string
      */
     protected $captureAttrs = null;
 
     /**
      * Capture lock
+     *
      * @var bool
      */
     protected $captureLock;
 
     /**
      * Capture type (append, prepend, set)
+     *
      * @var string
      */
     protected $captureType;
@@ -61,11 +67,11 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      * Constructor
      *
      * Set separator to PHP_EOL.
-     *
      */
     public function __construct()
     {
         parent::__construct();
+
         $this->setSeparator(PHP_EOL);
     }
 
@@ -74,10 +80,10 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      *
      * Returns headStyle helper object; optionally, allows specifying
      *
-     * @param  string $content Stylesheet contents
-     * @param  string $placement Append, prepend, or set
+     * @param  string       $content    Stylesheet contents
+     * @param  string       $placement  Append, prepend, or set
      * @param  string|array $attributes Optional attributes to utilize
-     * @return \Zend\View\Helper\HeadStyle
+     * @return HeadStyle
      */
     public function __invoke($content = null, $placement = 'APPEND', $attributes = array())
     {
@@ -110,9 +116,9 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      * - setStyle($content, $attributes = array())
      *
      * @param  string $method
-     * @param  array $args
-     * @return void
+     * @param  array  $args
      * @throws Exception\BadMethodCallException When no $content provided or invalid method
+     * @return void
      */
     public function __call($method, $args)
     {
@@ -177,8 +183,8 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      * Override append to enforce style creation
      *
      * @param  mixed $value
-     * @return void
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function append($value)
     {
@@ -195,9 +201,9 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      * Override offsetSet to enforce style creation
      *
      * @param  string|int $index
-     * @param  mixed $value
-     * @return void
+     * @param  mixed      $value
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function offsetSet($index, $value)
     {
@@ -214,8 +220,8 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      * Override prepend to enforce style creation
      *
      * @param  mixed $value
-     * @return void
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function prepend($value)
     {
@@ -232,8 +238,8 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      * Override set to enforce style creation
      *
      * @param  mixed $value
-     * @return void
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function set($value)
     {
@@ -247,10 +253,10 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
     /**
      * Start capture action
      *
-     * @param string $type
-     * @param string $attrs
-     * @return void
+     * @param  string $type
+     * @param  string $attrs
      * @throws Exception\RuntimeException
+     * @return void
      */
     public function captureStart($type = Placeholder\Container\AbstractContainer::APPEND, $attrs = null)
     {
@@ -293,8 +299,8 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
     /**
      * Convert content and attributes into valid style tag
      *
-     * @param  stdClass $item Item to render
-     * @param  string $indent Indentation to use
+     * @param  stdClass $item   Item to render
+     * @param  string   $indent Indentation to use
      * @return string
      */
     public function itemToString(stdClass $item, $indent)
@@ -378,6 +384,7 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
 
         $return = $indent . implode($this->getSeparator() . $indent, $items);
         $return = preg_replace("/(\r\n?|\n)/", '$1' . $indent, $return);
+
         return $return;
     }
 
@@ -385,7 +392,7 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      * Create data item for use in stack
      *
      * @param  string $content
-     * @param  array $attributes
+     * @param  array  $attributes
      * @return stdClass
      */
     public function createData($content, array $attributes)

--- a/library/Zend/View/Helper/HeadTitle.php
+++ b/library/Zend/View/Helper/HeadTitle.php
@@ -84,39 +84,6 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
     }
 
     /**
-     * Set a default order to add titles
-     *
-     * @param  string $setType
-     * @throws Exception\DomainException
-     * @return HeadTitle
-     */
-    public function setDefaultAttachOrder($setType)
-    {
-        if (!in_array($setType, array(
-            Placeholder\Container\AbstractContainer::APPEND,
-            Placeholder\Container\AbstractContainer::SET,
-            Placeholder\Container\AbstractContainer::PREPEND
-        ))) {
-            throw new Exception\DomainException(
-                "You must use a valid attach order: 'PREPEND', 'APPEND' or 'SET'"
-            );
-        }
-        $this->defaultAttachOrder = $setType;
-
-        return $this;
-    }
-
-    /**
-     * Get the default attach order, if any.
-     *
-     * @return mixed
-     */
-    public function getDefaultAttachOrder()
-    {
-        return $this->defaultAttachOrder;
-    }
-
-    /**
      * Turn helper into string
      *
      * @param  string|null $indent
@@ -160,6 +127,39 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
         $output = ($this->autoEscape) ? $this->escape($output) : $output;
 
         return $indent . '<title>' . $output . '</title>';
+    }
+
+    /**
+     * Set a default order to add titles
+     *
+     * @param  string $setType
+     * @throws Exception\DomainException
+     * @return HeadTitle
+     */
+    public function setDefaultAttachOrder($setType)
+    {
+        if (!in_array($setType, array(
+            Placeholder\Container\AbstractContainer::APPEND,
+            Placeholder\Container\AbstractContainer::SET,
+            Placeholder\Container\AbstractContainer::PREPEND
+        ))) {
+            throw new Exception\DomainException(
+                "You must use a valid attach order: 'PREPEND', 'APPEND' or 'SET'"
+            );
+        }
+        $this->defaultAttachOrder = $setType;
+
+        return $this;
+    }
+
+    /**
+     * Get the default attach order, if any.
+     *
+     * @return mixed
+     */
+    public function getDefaultAttachOrder()
+    {
+        return $this->defaultAttachOrder;
     }
 
     // Translator methods - Good candidate to refactor as a trait with PHP 5.4
@@ -216,7 +216,6 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
     public function setTranslatorEnabled($enabled = true)
     {
         $this->translatorEnabled = (bool) $enabled;
-
         return $this;
     }
 
@@ -239,7 +238,6 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
     public function setTranslatorTextDomain($textDomain = 'default')
     {
         $this->translatorTextDomain = $textDomain;
-
         return $this;
     }
 

--- a/library/Zend/View/Helper/HeadTitle.php
+++ b/library/Zend/View/Helper/HeadTitle.php
@@ -21,6 +21,7 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
 {
     /**
      * Registry key for placeholder
+     *
      * @var string
      */
     protected $regKey = 'Zend_View_Helper_HeadTitle';
@@ -58,7 +59,7 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
      *
      * @param  string $title
      * @param  string $setType
-     * @return \Zend\View\Helper\HeadTitle
+     * @return HeadTitle
      */
     public function __invoke($title = null, $setType = null)
     {
@@ -85,9 +86,9 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
     /**
      * Set a default order to add titles
      *
-     * @param string $setType
-     * @return HeadTitle
+     * @param  string $setType
      * @throws Exception\DomainException
+     * @return HeadTitle
      */
     public function setDefaultAttachOrder($setType)
     {
@@ -215,6 +216,7 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
     public function setTranslatorEnabled($enabled = true)
     {
         $this->translatorEnabled = (bool) $enabled;
+
         return $this;
     }
 
@@ -237,6 +239,7 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
     public function setTranslatorTextDomain($textDomain = 'default')
     {
         $this->translatorTextDomain = $textDomain;
+
         return $this;
     }
 

--- a/library/Zend/View/Helper/HtmlFlash.php
+++ b/library/Zend/View/Helper/HtmlFlash.php
@@ -13,24 +13,21 @@ class HtmlFlash extends AbstractHtmlElement
 {
     /**
      * Default file type for a flash applet
-     *
      */
     const TYPE = 'application/x-shockwave-flash';
 
     /**
      * Output a flash movie object tag
      *
-     * @param string $data The flash file
-     * @param array  $attribs Attribs for the object tag
-     * @param array  $params Params for in the object tag
-     * @param string $content Alternative content
+     * @param  string $data    The flash file
+     * @param  array  $attribs Attribs for the object tag
+     * @param  array  $params  Params for in the object tag
+     * @param  string $content Alternative content
      * @return string
      */
     public function __invoke($data, array $attribs = array(), array $params = array(), $content = null)
     {
-        // Params
-        $params = array_merge(array('movie'   => $data,
-                                    'quality' => 'high'), $params);
+        $params = array_merge(array('movie' => $data, 'quality' => 'high'), $params);
 
         $htmlObject = $this->getView()->plugin('htmlObject');
         return $htmlObject($data, self::TYPE, $attribs, $params, $content);

--- a/library/Zend/View/Helper/HtmlList.php
+++ b/library/Zend/View/Helper/HtmlList.php
@@ -17,10 +17,10 @@ class HtmlList extends AbstractHtmlElement
     /**
      * Generates a 'List' element.
      *
-     * @param array   $items   Array with the elements of the list
-     * @param  bool $ordered Specifies ordered/unordered list; default unordered
-     * @param array   $attribs Attributes for the ol/ul tag.
-     * @param  bool $escape Escape the items.
+     * @param  array $items   Array with the elements of the list
+     * @param  bool  $ordered Specifies ordered/unordered list; default unordered
+     * @param  array $attribs Attributes for the ol/ul tag.
+     * @param  bool  $escape  Escape the items.
      * @return string The list XHTML.
      */
     public function __invoke(array $items, $ordered = false, $attribs = false, $escape = true)
@@ -30,7 +30,7 @@ class HtmlList extends AbstractHtmlElement
         foreach ($items as $item) {
             if (!is_array($item)) {
                 if ($escape) {
-                    $escaper = $this->view->plugin('escapeHtml');
+                    $escaper = $this->getView()->plugin('escapeHtml');
                     $item    = $escaper($item);
                 }
                 $list .= '<li>' . $item . '</li>' . self::EOL;

--- a/library/Zend/View/Helper/HtmlObject.php
+++ b/library/Zend/View/Helper/HtmlObject.php
@@ -16,13 +16,13 @@ class HtmlObject extends AbstractHtmlElement
     /**
      * Output an object set
      *
-     * @param string $data The data file
-     * @param string $type Data file type
-     * @param array  $attribs Attribs for the object tag
-     * @param array  $params Params for in the object tag
-     * @param string $content Alternative content for object
-     * @return string
+     * @param  string $data    The data file
+     * @param  string $type    Data file type
+     * @param  array  $attribs Attribs for the object tag
+     * @param  array  $params  Params for in the object tag
+     * @param  string $content Alternative content for object
      * @throws InvalidArgumentException
+     * @return string
      */
     public function __invoke($data = null, $type = null, array $attribs = array(), array $params = array(), $content = null)
     {
@@ -31,8 +31,7 @@ class HtmlObject extends AbstractHtmlElement
         }
 
         // Merge data and type
-        $attribs = array_merge(array('data' => $data,
-                                     'type' => $type), $attribs);
+        $attribs = array_merge(array('data' => $data, 'type' => $type), $attribs);
 
         // Params
         $paramHtml = array();

--- a/library/Zend/View/Helper/HtmlPage.php
+++ b/library/Zend/View/Helper/HtmlPage.php
@@ -13,13 +13,11 @@ class HtmlPage extends AbstractHtmlElement
 {
     /**
      * Default file type for html
-     *
      */
     const TYPE = 'text/html';
 
     /**
      * Object classid
-     *
      */
     const ATTRIB_CLASSID  = 'clsid:25336920-03F9-11CF-8FD0-00AA00686F13';
 
@@ -33,15 +31,15 @@ class HtmlPage extends AbstractHtmlElement
     /**
      * Output a html object tag
      *
-     * @param string $data The html url
-     * @param array  $attribs Attribs for the object tag
-     * @param array  $params Params for in the object tag
-     * @param string $content Alternative content
+     * @param  string $data    The html url
+     * @param  array  $attribs Attribs for the object tag
+     * @param  array  $params  Params for in the object tag
+     * @param  string $content Alternative content
      * @return string
      */
     public function __invoke($data, array $attribs = array(), array $params = array(), $content = null)
     {
-        // Attrs
+        // Attribs
         $attribs = array_merge($this->attribs, $attribs);
 
         // Params

--- a/library/Zend/View/Helper/HtmlQuicktime.php
+++ b/library/Zend/View/Helper/HtmlQuicktime.php
@@ -13,19 +13,16 @@ class HtmlQuicktime extends AbstractHtmlElement
 {
     /**
      * Default file type for a movie applet
-     *
      */
     const TYPE = 'video/quicktime';
 
     /**
      * Object classid
-     *
      */
     const ATTRIB_CLASSID  = 'clsid:02BF25D5-8C17-4B23-BC80-D3488ABDDC6B';
 
     /**
      * Object Codebase
-     *
      */
     const ATTRIB_CODEBASE = 'http://www.apple.com/qtactivex/qtplugin.cab';
 
@@ -34,16 +31,15 @@ class HtmlQuicktime extends AbstractHtmlElement
      *
      * @var array
      */
-    protected $attribs = array('classid'  => self::ATTRIB_CLASSID,
-                                'codebase' => self::ATTRIB_CODEBASE);
+    protected $attribs = array('classid' => self::ATTRIB_CLASSID, 'codebase' => self::ATTRIB_CODEBASE);
 
     /**
      * Output a quicktime movie object tag
      *
-     * @param string $data The quicktime file
-     * @param array  $attribs Attribs for the object tag
-     * @param array  $params Params for in the object tag
-     * @param string $content Alternative content
+     * @param  string $data    The quicktime file
+     * @param  array  $attribs Attribs for the object tag
+     * @param  array  $params  Params for in the object tag
+     * @param  string $content Alternative content
      * @return string
      */
     public function __invoke($data, array $attribs = array(), array $params = array(), $content = null)

--- a/library/Zend/View/Helper/Identity.php
+++ b/library/Zend/View/Helper/Identity.php
@@ -18,33 +18,19 @@ use Zend\View\Exception;
 class Identity extends AbstractHelper
 {
     /**
+     * AuthenticationService instance
+     *
      * @var AuthenticationService
      */
     protected $authenticationService;
-
-    /**
-     * @return AuthenticationService
-     */
-    public function getAuthenticationService()
-    {
-        return $this->authenticationService;
-    }
-
-    /**
-     * @param AuthenticationService $authenticationService
-     */
-    public function setAuthenticationService(AuthenticationService $authenticationService)
-    {
-        $this->authenticationService = $authenticationService;
-    }
 
     /**
      * Retrieve the current identity, if any.
      *
      * If none available, returns null.
      *
-     * @return mixed|null
      * @throws Exception\RuntimeException
+     * @return mixed|null
      */
     public function __invoke()
     {
@@ -55,6 +41,30 @@ class Identity extends AbstractHelper
         if (!$this->authenticationService->hasIdentity()) {
             return null;
         }
+
         return $this->authenticationService->getIdentity();
+    }
+
+    /**
+     * Set AuthenticationService instance
+     *
+     * @param AuthenticationService $authenticationService
+     * @return Identity
+     */
+    public function setAuthenticationService(AuthenticationService $authenticationService)
+    {
+        $this->authenticationService = $authenticationService;
+
+        return $this;
+    }
+
+    /**
+     * Get AuthenticationService instance
+     *
+     * @return AuthenticationService
+     */
+    public function getAuthenticationService()
+    {
+        return $this->authenticationService;
     }
 }

--- a/library/Zend/View/Helper/Identity.php
+++ b/library/Zend/View/Helper/Identity.php
@@ -54,7 +54,6 @@ class Identity extends AbstractHelper
     public function setAuthenticationService(AuthenticationService $authenticationService)
     {
         $this->authenticationService = $authenticationService;
-
         return $this;
     }
 

--- a/library/Zend/View/Helper/InlineScript.php
+++ b/library/Zend/View/Helper/InlineScript.php
@@ -17,6 +17,7 @@ class InlineScript extends HeadScript
 {
     /**
      * Registry key for placeholder
+     *
      * @var string
      */
     protected $regKey = 'Zend_View_Helper_InlineScript';
@@ -27,12 +28,12 @@ class InlineScript extends HeadScript
      * Returns InlineScript helper object; optionally, allows specifying a
      * script or script file to include.
      *
-     * @param  string $mode Script or file
-     * @param  string $spec Script/url
+     * @param  string $mode      Script or file
+     * @param  string $spec      Script/url
      * @param  string $placement Append, prepend, or set
-     * @param  array $attrs Array of script attributes
-     * @param  string $type Script type and/or array of script attributes
-     * @return \Zend\View\Helper\InlineScript
+     * @param  array  $attrs     Array of script attributes
+     * @param  string $type      Script type and/or array of script attributes
+     * @return InlineScript
      */
     public function __invoke($mode = HeadScript::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
     {

--- a/library/Zend/View/Helper/Json.php
+++ b/library/Zend/View/Helper/Json.php
@@ -50,7 +50,6 @@ class Json extends AbstractHelper
     public function setResponse(Response $response)
     {
         $this->response = $response;
-
         return $this;
     }
 }

--- a/library/Zend/View/Helper/Json.php
+++ b/library/Zend/View/Helper/Json.php
@@ -23,18 +23,6 @@ class Json extends AbstractHelper
     protected $response;
 
     /**
-     * Set the response object
-     *
-     * @param  Response $response
-     * @return Json
-     */
-    public function setResponse(Response $response)
-    {
-        $this->response = $response;
-        return $this;
-    }
-
-    /**
      * Encode data as JSON and set response header
      *
      * @param  mixed $data
@@ -51,5 +39,18 @@ class Json extends AbstractHelper
         }
 
         return $data;
+    }
+
+    /**
+     * Set the response object
+     *
+     * @param  Response $response
+     * @return Json
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+
+        return $this;
     }
 }

--- a/library/Zend/View/Helper/Layout.php
+++ b/library/Zend/View/Helper/Layout.php
@@ -23,30 +23,6 @@ class Layout extends AbstractHelper
     protected $viewModelHelper;
 
     /**
-     * Get layout template
-     *
-     * @return string
-     */
-    public function getLayout()
-    {
-        $model = $this->getRoot();
-        return $model->getTemplate();
-    }
-
-    /**
-     * Set layout template
-     *
-     * @param  string $template
-     * @return Layout
-     */
-    public function setTemplate($template)
-    {
-        $model = $this->getRoot();
-        $model->setTemplate((string) $template);
-        return $this;
-    }
-
-    /**
      * Set layout template or retrieve "layout" view model
      *
      * If no arguments are given, grabs the "root" or "layout" view model.
@@ -60,7 +36,31 @@ class Layout extends AbstractHelper
         if (null === $template) {
             return $this->getRoot();
         }
+
         return $this->setTemplate($template);
+    }
+
+    /**
+     * Get layout template
+     *
+     * @return string
+     */
+    public function getLayout()
+    {
+        return $this->getRoot()->getTemplate();
+    }
+
+    /**
+     * Set layout template
+     *
+     * @param  string $template
+     * @return Layout
+     */
+    public function setTemplate($template)
+    {
+        $this->getRoot()->setTemplate((string) $template);
+
+        return $this;
     }
 
     /**
@@ -72,12 +72,14 @@ class Layout extends AbstractHelper
     protected function getRoot()
     {
         $helper = $this->getViewModelHelper();
+
         if (!$helper->hasRoot()) {
             throw new Exception\RuntimeException(sprintf(
                 '%s: no view model currently registered as root in renderer',
                 __METHOD__
             ));
         }
+
         return $helper->getRoot();
     }
 
@@ -88,11 +90,10 @@ class Layout extends AbstractHelper
      */
     protected function getViewModelHelper()
     {
-        if ($this->viewModelHelper) {
-            return $this->viewModelHelper;
+        if(null === $this->viewModelHelper) {
+            $this->viewModelHelper = $this->getView()->plugin('view_model');
         }
-        $view = $this->getView();
-        $this->viewModelHelper = $view->plugin('view_model');
+
         return $this->viewModelHelper;
     }
 }

--- a/library/Zend/View/Helper/Layout.php
+++ b/library/Zend/View/Helper/Layout.php
@@ -51,19 +51,6 @@ class Layout extends AbstractHelper
     }
 
     /**
-     * Set layout template
-     *
-     * @param  string $template
-     * @return Layout
-     */
-    public function setTemplate($template)
-    {
-        $this->getRoot()->setTemplate((string) $template);
-
-        return $this;
-    }
-
-    /**
      * Get the root view model
      *
      * @throws Exception\RuntimeException
@@ -81,6 +68,18 @@ class Layout extends AbstractHelper
         }
 
         return $helper->getRoot();
+    }
+
+    /**
+     * Set layout template
+     *
+     * @param  string $template
+     * @return Layout
+     */
+    public function setTemplate($template)
+    {
+        $this->getRoot()->setTemplate((string) $template);
+        return $this;
     }
 
     /**

--- a/library/Zend/View/Helper/Navigation.php
+++ b/library/Zend/View/Helper/Navigation.php
@@ -28,11 +28,6 @@ class Navigation extends AbstractNavigationHelper
     const NS = 'Zend\View\Helper\Navigation';
 
     /**
-     * @var Navigation\PluginManager
-     */
-    protected $plugins;
-
-    /**
      * Default proxy to use in {@link render()}
      *
      * @var string
@@ -47,13 +42,6 @@ class Navigation extends AbstractNavigationHelper
     protected $injected = array();
 
     /**
-     * Whether container should be injected when proxying
-     *
-     * @var bool
-     */
-    protected $injectContainer = true;
-
-    /**
      * Whether ACL should be injected when proxying
      *
      * @var bool
@@ -61,11 +49,23 @@ class Navigation extends AbstractNavigationHelper
     protected $injectAcl = true;
 
     /**
+     * Whether container should be injected when proxying
+     *
+     * @var bool
+     */
+    protected $injectContainer = true;
+
+    /**
      * Whether translator should be injected when proxying
      *
      * @var bool
      */
     protected $injectTranslator = true;
+
+    /**
+     * @var Navigation\PluginManager
+     */
+    protected $plugins;
 
     /**
      * Helper entry point
@@ -130,43 +130,7 @@ class Navigation extends AbstractNavigationHelper
      */
     public function render($container = null)
     {
-        $helper = $this->findHelper($this->getDefaultProxy());
-
-        return $helper->render($container);
-    }
-
-    /**
-     * Set manager for retrieving navigation helpers
-     *
-     * @param  Navigation\PluginManager $plugins
-     * @return Navigation
-     */
-    public function setPluginManager(Navigation\PluginManager $plugins)
-    {
-        $renderer = $this->getView();
-        if ($renderer) {
-            $plugins->setRenderer($renderer);
-        }
-        $this->plugins = $plugins;
-
-        return $this;
-    }
-
-    /**
-     * Retrieve plugin loader for navigation helpers
-     *
-     * Lazy-loads an instance of Navigation\HelperLoader if none currently
-     * registered.
-     *
-     * @return Navigation\PluginManager
-     */
-    public function getPluginManager()
-    {
-        if (null === $this->plugins) {
-            $this->setPluginManager(new Navigation\PluginManager());
-        }
-
-        return $this->plugins;
+        return $this->findHelper($this->getDefaultProxy())->render($container);
     }
 
     /**
@@ -237,8 +201,6 @@ class Navigation extends AbstractNavigationHelper
         }
     }
 
-    // Accessors:
-
     /**
      * Sets the default proxy to use in {@link render()}
      *
@@ -248,7 +210,6 @@ class Navigation extends AbstractNavigationHelper
     public function setDefaultProxy($proxy)
     {
         $this->defaultProxy = (string) $proxy;
-
         return $this;
     }
 
@@ -265,20 +226,19 @@ class Navigation extends AbstractNavigationHelper
     /**
      * Sets whether container should be injected when proxying
      *
-     * @param  bool $injectContainer [optional] whether container should be injected when proxying.
+     * @param  bool $injectContainer
      * @return Navigation
      */
     public function setInjectContainer($injectContainer = true)
     {
         $this->injectContainer = (bool) $injectContainer;
-
         return $this;
     }
 
     /**
      * Returns whether container should be injected when proxying
      *
-     * @return bool whether container should be injected when proxying
+     * @return bool
      */
     public function getInjectContainer()
     {
@@ -288,20 +248,19 @@ class Navigation extends AbstractNavigationHelper
     /**
      * Sets whether ACL should be injected when proxying
      *
-     * @param  bool $injectAcl [optional] whether ACL should be injected when proxying.
+     * @param  bool $injectAcl
      * @return Navigation
      */
     public function setInjectAcl($injectAcl = true)
     {
         $this->injectAcl = (bool) $injectAcl;
-
         return $this;
     }
 
     /**
      * Returns whether ACL should be injected when proxying
      *
-     * @return bool  whether ACL should be injected when proxying
+     * @return bool
      */
     public function getInjectAcl()
     {
@@ -311,23 +270,56 @@ class Navigation extends AbstractNavigationHelper
     /**
      * Sets whether translator should be injected when proxying
      *
-     * @param  bool $injectTranslator [optional] whether translator should be injected when proxying.
+     * @param  bool $injectTranslator
      * @return Navigation
      */
     public function setInjectTranslator($injectTranslator = true)
     {
         $this->injectTranslator = (bool) $injectTranslator;
-
         return $this;
     }
 
     /**
      * Returns whether translator should be injected when proxying
      *
-     * @return bool  whether translator should be injected when proxying
+     * @return bool
      */
     public function getInjectTranslator()
     {
         return $this->injectTranslator;
+    }
+
+    /**
+     * Set manager for retrieving navigation helpers
+     *
+     * @param  Navigation\PluginManager $plugins
+     * @return Navigation
+     */
+    public function setPluginManager(Navigation\PluginManager $plugins)
+    {
+        $renderer = $this->getView();
+        if ($renderer) {
+            $plugins->setRenderer($renderer);
+        }
+        $this->plugins = $plugins;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve plugin loader for navigation helpers
+     *
+     * Lazy-loads an instance of Navigation\HelperLoader if none currently
+     * registered.
+     *
+     * @return Navigation\PluginManager
+     */
+    public function getPluginManager()
+    {
+        if (null === $this->plugins) {
+            $this->setPluginManager(new Navigation\PluginManager());
+        }
+
+        return $this->plugins;
     }
 }

--- a/library/Zend/View/Helper/Navigation.php
+++ b/library/Zend/View/Helper/Navigation.php
@@ -97,15 +97,14 @@ class Navigation extends AbstractNavigationHelper
      * $blogPages = $this->navigation()->findAllByRoute('blog');
      * </code>
      *
-     * @param  string $method             helper name or method name in
-     *                                    container
+     * @param  string $method             helper name or method name in container
      * @param  array  $arguments          [optional] arguments to pass
-     * @return mixed                      returns what the proxied call returns
      * @throws \Zend\View\Exception\ExceptionInterface        if proxying to a helper, and the
      *                                    helper is not an instance of the
      *                                    interface specified in
      *                                    {@link findHelper()}
      * @throws \Zend\Navigation\Exception\ExceptionInterface  if method does not exist in container
+     * @return mixed                      returns what the proxied call returns
      */
     public function __call($method, array $arguments = array())
     {
@@ -123,6 +122,20 @@ class Navigation extends AbstractNavigationHelper
     }
 
     /**
+     * Renders helper
+     *
+     * @param  AbstractContainer $container
+     * @return string
+     * @throws Exception\RuntimeException
+     */
+    public function render($container = null)
+    {
+        $helper = $this->findHelper($this->getDefaultProxy());
+
+        return $helper->render($container);
+    }
+
+    /**
      * Set manager for retrieving navigation helpers
      *
      * @param  Navigation\PluginManager $plugins
@@ -135,6 +148,7 @@ class Navigation extends AbstractNavigationHelper
             $plugins->setRenderer($renderer);
         }
         $this->plugins = $plugins;
+
         return $this;
     }
 
@@ -151,6 +165,7 @@ class Navigation extends AbstractNavigationHelper
         if (null === $this->plugins) {
             $this->setPluginManager(new Navigation\PluginManager());
         }
+
         return $this->plugins;
     }
 
@@ -160,14 +175,12 @@ class Navigation extends AbstractNavigationHelper
      * The helper must implement the interface
      * {@link Zend\View\Helper\Navigation\Helper}.
      *
-     * @param string $proxy                        helper name
-     * @param bool   $strict                       [optional] whether
-     *                                             exceptions should be
-     *                                             thrown if something goes
-     *                                             wrong. Default is true.
+     * @param string $proxy  helper name
+     * @param bool   $strict [optional] whether exceptions should be
+     *                                  thrown if something goes
+     *                                  wrong. Default is true.
+     * @throws Exception\RuntimeException if $strict is true and helper cannot be found
      * @return \Zend\View\Helper\Navigation\HelperInterface  helper instance
-     * @throws Exception\RuntimeException if $strict is true and
-     *         helper cannot be found
      */
     public function findHelper($proxy, $strict = true)
     {
@@ -199,7 +212,7 @@ class Navigation extends AbstractNavigationHelper
      * Injects container, ACL, and translator to the given $helper if this
      * helper is configured to do so
      *
-     * @param  NavigationHelper $helper  helper instance
+     * @param  NavigationHelper $helper helper instance
      * @return void
      */
     protected function inject(NavigationHelper $helper)
@@ -229,19 +242,20 @@ class Navigation extends AbstractNavigationHelper
     /**
      * Sets the default proxy to use in {@link render()}
      *
-     * @param  string $proxy                default proxy
-     * @return \Zend\View\Helper\Navigation  fluent interface, returns self
+     * @param  string $proxy default proxy
+     * @return Navigation
      */
     public function setDefaultProxy($proxy)
     {
         $this->defaultProxy = (string) $proxy;
+
         return $this;
     }
 
     /**
      * Returns the default proxy to use in {@link render()}
      *
-     * @return string  the default proxy to use in {@link render()}
+     * @return string
      */
     public function getDefaultProxy()
     {
@@ -251,21 +265,20 @@ class Navigation extends AbstractNavigationHelper
     /**
      * Sets whether container should be injected when proxying
      *
-     * @param bool $injectContainer         [optional] whether container should
-     *                                      be injected when proxying. Default
-     *                                      is true.
-     * @return \Zend\View\Helper\Navigation  fluent interface, returns self
+     * @param  bool $injectContainer [optional] whether container should be injected when proxying.
+     * @return Navigation
      */
     public function setInjectContainer($injectContainer = true)
     {
         $this->injectContainer = (bool) $injectContainer;
+
         return $this;
     }
 
     /**
      * Returns whether container should be injected when proxying
      *
-     * @return bool  whether container should be injected when proxying
+     * @return bool whether container should be injected when proxying
      */
     public function getInjectContainer()
     {
@@ -275,14 +288,13 @@ class Navigation extends AbstractNavigationHelper
     /**
      * Sets whether ACL should be injected when proxying
      *
-     * @param  bool $injectAcl              [optional] whether ACL should be
-     *                                      injected when proxying. Default is
-     *                                      true.
-     * @return \Zend\View\Helper\Navigation  fluent interface, returns self
+     * @param  bool $injectAcl [optional] whether ACL should be injected when proxying.
+     * @return Navigation
      */
     public function setInjectAcl($injectAcl = true)
     {
         $this->injectAcl = (bool) $injectAcl;
+
         return $this;
     }
 
@@ -299,14 +311,13 @@ class Navigation extends AbstractNavigationHelper
     /**
      * Sets whether translator should be injected when proxying
      *
-     * @param  bool $injectTranslator       [optional] whether translator should
-     *                                      be injected when proxying. Default
-     *                                      is true.
-     * @return Navigation  fluent interface, returns self
+     * @param  bool $injectTranslator [optional] whether translator should be injected when proxying.
+     * @return Navigation
      */
     public function setInjectTranslator($injectTranslator = true)
     {
         $this->injectTranslator = (bool) $injectTranslator;
+
         return $this;
     }
 
@@ -318,23 +329,5 @@ class Navigation extends AbstractNavigationHelper
     public function getInjectTranslator()
     {
         return $this->injectTranslator;
-    }
-
-    // Zend\View\Helper\Navigation\Helper:
-
-    /**
-     * Renders helper
-     *
-     * @param  \Zend\Navigation\AbstractContainer $container  [optional] container to
-     *                                               render. Default is to
-     *                                               render the container
-     *                                               registered in the helper.
-     * @return string helper output
-     * @throws Exception\RuntimeException if helper cannot be found
-     */
-    public function render($container = null)
-    {
-        $helper = $this->findHelper($this->getDefaultProxy());
-        return $helper->render($container);
     }
 }

--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -129,19 +129,20 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     /**
      * Set the service locator.
      *
-     * @param ServiceLocatorInterface $serviceLocator
+     * @param  ServiceLocatorInterface $serviceLocator
      * @return AbstractHelper
      */
     public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
     {
         $this->serviceLocator = $serviceLocator;
+
         return $this;
     }
 
     /**
      * Get the service locator.
      *
-     * @return \Zend\ServiceManager\ServiceLocatorInterface
+     * @return ServiceLocatorInterface
      */
     public function getServiceLocator()
     {
@@ -153,14 +154,14 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      *
      * Implements {@link HelperInterface::setContainer()}.
      *
-     * @param  string|Navigation\AbstractContainer $container [optional] container to operate on.
-     *                                                        Default is null, meaning container will be reset.
-     * @return AbstractHelper  fluent interface, returns self
+     * @param  string|Navigation\AbstractContainer $container Default is null, meaning container will be reset.
+     * @return AbstractHelper
      */
     public function setContainer($container = null)
     {
         $this->parseContainer($container);
         $this->container = $container;
+
         return $this;
     }
 
@@ -229,9 +230,8 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     /**
      * Sets the minimum depth a page must have to be included when rendering
      *
-     * @param  int $minDepth [optional] minimum depth. Default is null, which
-     *                       sets no minimum depth.
-     * @return AbstractHelper fluent interface, returns self
+     * @param  int $minDepth Default is null, which sets no minimum depth.
+     * @return AbstractHelper
      */
     public function setMinDepth($minDepth = null)
     {
@@ -240,28 +240,29 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
         } else {
             $this->minDepth = (int) $minDepth;
         }
+
         return $this;
     }
 
     /**
      * Returns minimum depth a page must have to be included when rendering
      *
-     * @return int|null  minimum depth or null
+     * @return int|null
      */
     public function getMinDepth()
     {
         if (!is_int($this->minDepth) || $this->minDepth < 0) {
             return 0;
         }
+
         return $this->minDepth;
     }
 
     /**
      * Sets the maximum depth a page can have to be included when rendering
      *
-     * @param  int $maxDepth [optional] maximum depth. Default is null, which
-     *                       sets no maximum depth.
-     * @return AbstractHelper fluent interface, returns self
+     * @param  int $maxDepth Default is null, which sets no maximum depth.
+     * @return AbstractHelper
      */
     public function setMaxDepth($maxDepth = null)
     {
@@ -270,13 +271,14 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
         } else {
             $this->maxDepth = (int) $maxDepth;
         }
+
         return $this;
     }
 
     /**
      * Returns maximum depth a page can have to be included when rendering
      *
-     * @return int|null  maximum depth or null
+     * @return int|null
      */
     public function getMaxDepth()
     {
@@ -287,12 +289,13 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      * Set the indentation string for using in {@link render()}, optionally a
      * number of spaces to indent with
      *
-     * @param  string|int $indent indentation string or number of spaces
-     * @return AbstractHelper  fluent interface, returns self
+     * @param  string|int $indent
+     * @return AbstractHelper
      */
     public function setIndent($indent)
     {
         $this->indent = $this->getWhitespace($indent);
+
         return $this;
     }
 
@@ -311,12 +314,13 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      *
      * Implements {@link HelperInterface::setAcl()}.
      *
-     * @param  Acl\AclInterface $acl [optional] ACL object.  Default is null.
-     * @return AbstractHelper  fluent interface, returns self
+     * @param  Acl\AclInterface $acl ACL object.
+     * @return AbstractHelper
      */
     public function setAcl(Acl\AclInterface $acl = null)
     {
         $this->acl = $acl;
+
         return $this;
     }
 
@@ -345,8 +349,8 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      * @param  mixed $role [optional] role to set. Expects a string, an
      *                     instance of type {@link Acl\Role\RoleInterface}, or null. Default
      *                     is null, which will set no role.
-     * @return AbstractHelper  fluent interface, returns self
-     * @throws Exception\InvalidArgumentException if $role is invalid
+     * @return AbstractHelper
+     * @throws Exception\InvalidArgumentException
      */
     public function setRole($role = null)
     {
@@ -371,7 +375,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      *
      * Implements {@link HelperInterface::getRole()}.
      *
-     * @return string|Acl\Role\RoleInterface|null  role or null
+     * @return string|Acl\Role\RoleInterface|null
      */
     public function getRole()
     {
@@ -387,12 +391,13 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      *
      * Implements {@link HelperInterface::setUseAcl()}.
      *
-     * @param  bool $useAcl [optional] whether ACL should be used.  Default is true.
-     * @return AbstractHelper  fluent interface, returns self
+     * @param  bool $useAcl Whether ACL should be used.
+     * @return AbstractHelper
      */
     public function setUseAcl($useAcl = true)
     {
         $this->useAcl = (bool) $useAcl;
+
         return $this;
     }
 
@@ -401,7 +406,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      *
      * Implements {@link HelperInterface::getUseAcl()}.
      *
-     * @return bool  whether ACL should be used
+     * @return bool
      */
     public function getUseAcl()
     {
@@ -421,12 +426,13 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     /**
      * Render invisible items?
      *
-     * @param  bool $renderInvisible [optional] boolean flag
-     * @return AbstractHelper  fluent interface returns self
+     * @param  bool $renderInvisible
+     * @return AbstractHelper
      */
     public function setRenderInvisible($renderInvisible = true)
     {
         $this->renderInvisible = (bool) $renderInvisible;
+
         return $this;
     }
 
@@ -435,10 +441,10 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     /**
      * Magic overload: Proxy calls to the navigation container
      *
-     * @param  string $method             method name in container
-     * @param  array  $arguments          [optional] arguments to pass
-     * @return mixed                      returns what the container returns
-     * @throws Navigation\Exception\ExceptionInterface  if method does not exist in container
+     * @param  string $method    method name in container
+     * @param  array  $arguments rguments to pass
+     * @return mixed
+     * @throws Navigation\Exception\ExceptionInterface
      */
     public function __call($method, array $arguments = array())
     {
@@ -546,7 +552,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      *
      * Implements {@link HelperInterface::hasContainer()}.
      *
-     * @return bool  whether the helper has a container or not
+     * @return bool
      */
     public function hasContainer()
     {
@@ -558,7 +564,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      *
      * Implements {@link HelperInterface::hasAcl()}.
      *
-     * @return bool  whether the helper has a an ACL instance or not
+     * @return bool
      */
     public function hasAcl()
     {
@@ -576,7 +582,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      *
      * Implements {@link HelperInterface::hasRole()}.
      *
-     * @return bool  whether the helper has a an ACL role or not
+     * @return bool
      */
     public function hasRole()
     {
@@ -595,7 +601,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      * Returns an HTML string containing an 'a' element for the given page
      *
      * @param  AbstractPage $page  page to generate HTML for
-     * @return string                      HTML string for the given page
+     * @return string
      */
     public function htmlify(AbstractPage $page)
     {
@@ -624,9 +630,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
 
         $escaper = $this->view->plugin('escapeHtml');
 
-        return '<a' . $this->htmlAttribs($attribs) . '>'
-             . $escaper($label)
-             . '</a>';
+        return '<a' . $this->htmlAttribs($attribs) . '>' . $escaper($label) . '</a>';
     }
 
     // Translator methods - Good candidate to refactor as a trait with PHP 5.4
@@ -646,6 +650,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
         if (null !== $textDomain) {
             $this->setTranslatorTextDomain($textDomain);
         }
+
         return $this;
     }
 
@@ -676,13 +681,13 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     /**
      * Sets whether translator is enabled and should be used
      *
-     * @param  bool $enabled [optional] whether translator should be used.
-     *                       Default is true.
+     * @param  bool $enabled
      * @return AbstractHelper
      */
     public function setTranslatorEnabled($enabled = true)
     {
         $this->translatorEnabled = (bool) $enabled;
+
         return $this;
     }
 
@@ -705,6 +710,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     public function setTranslatorTextDomain($textDomain = 'default')
     {
         $this->translatorTextDomain = $textDomain;
+
         return $this;
     }
 
@@ -738,7 +744,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      * @param  bool         $recursive [optional] if true, page will not be
      *                                 accepted if it is the descendant of a
      *                                 page that is not accepted. Default is true.
-     * @return bool                    whether page should be accepted
+     * @return bool
      */
     public function accept(AbstractPage $page, $recursive = true)
     {
@@ -773,7 +779,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      * - If page has no resource or privilege, page is accepted
      *
      * @param  AbstractPage $page  page to check
-     * @return bool                whether page is accepted by ACL
+     * @return bool
      */
     protected function acceptAcl(AbstractPage $page)
     {
@@ -818,7 +824,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      *
      * @param  array $attribs  an array where each key-value pair is converted
      *                         to an attribute name and value
-     * @return string          an attribute string
+     * @return string
      */
     protected function htmlAttribs($attribs)
     {

--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -127,318 +127,6 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     protected static $defaultRole;
 
     /**
-     * Set the service locator.
-     *
-     * @param  ServiceLocatorInterface $serviceLocator
-     * @return AbstractHelper
-     */
-    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
-    {
-        $this->serviceLocator = $serviceLocator;
-
-        return $this;
-    }
-
-    /**
-     * Get the service locator.
-     *
-     * @return ServiceLocatorInterface
-     */
-    public function getServiceLocator()
-    {
-        return $this->serviceLocator;
-    }
-
-    /**
-     * Sets navigation container the helper operates on by default
-     *
-     * Implements {@link HelperInterface::setContainer()}.
-     *
-     * @param  string|Navigation\AbstractContainer $container Default is null, meaning container will be reset.
-     * @return AbstractHelper
-     */
-    public function setContainer($container = null)
-    {
-        $this->parseContainer($container);
-        $this->container = $container;
-
-        return $this;
-    }
-
-    /**
-     * Returns the navigation container helper operates on by default
-     *
-     * Implements {@link HelperInterface::getContainer()}.
-     *
-     * If no container is set, a new container will be instantiated and
-     * stored in the helper.
-     *
-     * @return Navigation\AbstractContainer  navigation container
-     */
-    public function getContainer()
-    {
-        if (null === $this->container) {
-            $this->container = new Navigation\Navigation();
-        }
-
-        return $this->container;
-    }
-
-    /**
-     * Verifies container and eventually fetches it from service locator if it is a string
-     *
-     * @param  Navigation\AbstractContainer|string|null $container
-     * @throws Exception\InvalidArgumentException
-     */
-    protected function parseContainer(&$container = null)
-    {
-        if (null === $container) {
-            return;
-        }
-
-        if (is_string($container)) {
-            if (!$this->getServiceLocator()) {
-                throw new Exception\InvalidArgumentException(sprintf(
-                    'Attempted to set container with alias "%s" but no ServiceLocator was set',
-                    $container
-                ));
-            }
-
-            /**
-             * Load the navigation container from the root service locator
-             *
-             * The navigation container is probably located in Zend\ServiceManager\ServiceManager
-             * and not in the View\HelperPluginManager. If the set service locator is a
-             * HelperPluginManager, access the navigation container via the main service locator.
-             */
-            $sl = $this->getServiceLocator();
-            if ($sl instanceof View\HelperPluginManager) {
-                $sl = $sl->getServiceLocator();
-            }
-            $container = $sl->get($container);
-            return;
-        }
-
-        if (!$container instanceof Navigation\AbstractContainer) {
-            throw new  Exception\InvalidArgumentException(
-                'Container must be a string alias or an instance of ' .
-                    'Zend\Navigation\AbstractContainer'
-            );
-        }
-    }
-
-    /**
-     * Sets the minimum depth a page must have to be included when rendering
-     *
-     * @param  int $minDepth Default is null, which sets no minimum depth.
-     * @return AbstractHelper
-     */
-    public function setMinDepth($minDepth = null)
-    {
-        if (null === $minDepth || is_int($minDepth)) {
-            $this->minDepth = $minDepth;
-        } else {
-            $this->minDepth = (int) $minDepth;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Returns minimum depth a page must have to be included when rendering
-     *
-     * @return int|null
-     */
-    public function getMinDepth()
-    {
-        if (!is_int($this->minDepth) || $this->minDepth < 0) {
-            return 0;
-        }
-
-        return $this->minDepth;
-    }
-
-    /**
-     * Sets the maximum depth a page can have to be included when rendering
-     *
-     * @param  int $maxDepth Default is null, which sets no maximum depth.
-     * @return AbstractHelper
-     */
-    public function setMaxDepth($maxDepth = null)
-    {
-        if (null === $maxDepth || is_int($maxDepth)) {
-            $this->maxDepth = $maxDepth;
-        } else {
-            $this->maxDepth = (int) $maxDepth;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Returns maximum depth a page can have to be included when rendering
-     *
-     * @return int|null
-     */
-    public function getMaxDepth()
-    {
-        return $this->maxDepth;
-    }
-
-    /**
-     * Set the indentation string for using in {@link render()}, optionally a
-     * number of spaces to indent with
-     *
-     * @param  string|int $indent
-     * @return AbstractHelper
-     */
-    public function setIndent($indent)
-    {
-        $this->indent = $this->getWhitespace($indent);
-
-        return $this;
-    }
-
-    /**
-     * Returns indentation
-     *
-     * @return string
-     */
-    public function getIndent()
-    {
-        return $this->indent;
-    }
-
-    /**
-     * Sets ACL to use when iterating pages
-     *
-     * Implements {@link HelperInterface::setAcl()}.
-     *
-     * @param  Acl\AclInterface $acl ACL object.
-     * @return AbstractHelper
-     */
-    public function setAcl(Acl\AclInterface $acl = null)
-    {
-        $this->acl = $acl;
-
-        return $this;
-    }
-
-    /**
-     * Returns ACL or null if it isn't set using {@link setAcl()} or
-     * {@link setDefaultAcl()}
-     *
-     * Implements {@link HelperInterface::getAcl()}.
-     *
-     * @return Acl\AclInterface|null  ACL object or null
-     */
-    public function getAcl()
-    {
-        if ($this->acl === null && static::$defaultAcl !== null) {
-            return static::$defaultAcl;
-        }
-
-        return $this->acl;
-    }
-
-    /**
-     * Sets ACL role(s) to use when iterating pages
-     *
-     * Implements {@link HelperInterface::setRole()}.
-     *
-     * @param  mixed $role [optional] role to set. Expects a string, an
-     *                     instance of type {@link Acl\Role\RoleInterface}, or null. Default
-     *                     is null, which will set no role.
-     * @return AbstractHelper
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setRole($role = null)
-    {
-        if (null === $role || is_string($role) ||
-            $role instanceof Acl\Role\RoleInterface
-        ) {
-            $this->role = $role;
-        } else {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '$role must be a string, null, or an instance of '
-                .  'Zend\Permissions\Role\RoleInterface; %s given',
-                (is_object($role) ? get_class($role) : gettype($role))
-            ));
-        }
-
-        return $this;
-    }
-
-    /**
-     * Returns ACL role to use when iterating pages, or null if it isn't set
-     * using {@link setRole()} or {@link setDefaultRole()}
-     *
-     * Implements {@link HelperInterface::getRole()}.
-     *
-     * @return string|Acl\Role\RoleInterface|null
-     */
-    public function getRole()
-    {
-        if ($this->role === null && static::$defaultRole !== null) {
-            return static::$defaultRole;
-        }
-
-        return $this->role;
-    }
-
-    /**
-     * Sets whether ACL should be used
-     *
-     * Implements {@link HelperInterface::setUseAcl()}.
-     *
-     * @param  bool $useAcl Whether ACL should be used.
-     * @return AbstractHelper
-     */
-    public function setUseAcl($useAcl = true)
-    {
-        $this->useAcl = (bool) $useAcl;
-
-        return $this;
-    }
-
-    /**
-     * Returns whether ACL should be used
-     *
-     * Implements {@link HelperInterface::getUseAcl()}.
-     *
-     * @return bool
-     */
-    public function getUseAcl()
-    {
-        return $this->useAcl;
-    }
-
-    /**
-     * Return renderInvisible flag
-     *
-     * @return bool
-     */
-    public function getRenderInvisible()
-    {
-        return $this->renderInvisible;
-    }
-
-    /**
-     * Render invisible items?
-     *
-     * @param  bool $renderInvisible
-     * @return AbstractHelper
-     */
-    public function setRenderInvisible($renderInvisible = true)
-    {
-        $this->renderInvisible = (bool) $renderInvisible;
-
-        return $this;
-    }
-
-    // Magic overloads:
-
-    /**
      * Magic overload: Proxy calls to the navigation container
      *
      * @param  string $method    method name in container
@@ -449,8 +137,8 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     public function __call($method, array $arguments = array())
     {
         return call_user_func_array(
-                array($this->getContainer(), $method),
-                $arguments);
+            array($this->getContainer(), $method),
+            $arguments);
     }
 
     /**
@@ -473,8 +161,6 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
             return '';
         }
     }
-
-    // Public methods:
 
     /**
      * Finds the deepest active page in the given container
@@ -548,180 +234,46 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     }
 
     /**
-     * Checks if the helper has a container
+     * Verifies container and eventually fetches it from service locator if it is a string
      *
-     * Implements {@link HelperInterface::hasContainer()}.
-     *
-     * @return bool
+     * @param  Navigation\AbstractContainer|string|null $container
+     * @throws Exception\InvalidArgumentException
      */
-    public function hasContainer()
+    protected function parseContainer(&$container = null)
     {
-        return null !== $this->container;
-    }
-
-    /**
-     * Checks if the helper has an ACL instance
-     *
-     * Implements {@link HelperInterface::hasAcl()}.
-     *
-     * @return bool
-     */
-    public function hasAcl()
-    {
-        if ($this->acl instanceof Acl\Acl
-            || static::$defaultAcl instanceof Acl\Acl
-        ) {
-            return true;
+        if (null === $container) {
+            return;
         }
 
-        return false;
-    }
-
-    /**
-     * Checks if the helper has an ACL role
-     *
-     * Implements {@link HelperInterface::hasRole()}.
-     *
-     * @return bool
-     */
-    public function hasRole()
-    {
-        if ($this->role instanceof Acl\Role\RoleInterface
-            || is_string($this->role)
-            || static::$defaultRole instanceof Acl\Role\RoleInterface
-            || is_string(static::$defaultRole)
-        ) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Returns an HTML string containing an 'a' element for the given page
-     *
-     * @param  AbstractPage $page  page to generate HTML for
-     * @return string
-     */
-    public function htmlify(AbstractPage $page)
-    {
-        // get label and title for translating
-        $label = $page->getLabel();
-        $title = $page->getTitle();
-
-        if (null !== ($translator = $this->getTranslator())) {
-            $textDomain = $this->getTranslatorTextDomain();
-            if (is_string($label) && !empty($label)) {
-                $label = $translator->translate($label, $textDomain);
+        if (is_string($container)) {
+            if (!$this->getServiceLocator()) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Attempted to set container with alias "%s" but no ServiceLocator was set',
+                    $container
+                ));
             }
-            if (is_string($title) && !empty($title)) {
-                $title = $translator->translate($title, $textDomain);
+
+            /**
+             * Load the navigation container from the root service locator
+             *
+             * The navigation container is probably located in Zend\ServiceManager\ServiceManager
+             * and not in the View\HelperPluginManager. If the set service locator is a
+             * HelperPluginManager, access the navigation container via the main service locator.
+             */
+            $sl = $this->getServiceLocator();
+            if ($sl instanceof View\HelperPluginManager) {
+                $sl = $sl->getServiceLocator();
             }
+            $container = $sl->get($container);
+            return;
         }
 
-        // get attribs for anchor element
-        $attribs = array(
-            'id'     => $page->getId(),
-            'title'  => $title,
-            'class'  => $page->getClass(),
-            'href'   => $page->getHref(),
-            'target' => $page->getTarget()
-        );
-
-        $escaper = $this->view->plugin('escapeHtml');
-
-        return '<a' . $this->htmlAttribs($attribs) . '>' . $escaper($label) . '</a>';
-    }
-
-    // Translator methods - Good candidate to refactor as a trait with PHP 5.4
-
-    /**
-     * Sets translator to use in helper
-     *
-     * @param  Translator $translator  [optional] translator.
-     *                                 Default is null, which sets no translator.
-     * @param  string     $textDomain  [optional] text domain
-     *                                 Default is null, which skips setTranslatorTextDomain
-     * @return AbstractHelper
-     */
-    public function setTranslator(Translator $translator = null, $textDomain = null)
-    {
-        $this->translator = $translator;
-        if (null !== $textDomain) {
-            $this->setTranslatorTextDomain($textDomain);
+        if (!$container instanceof Navigation\AbstractContainer) {
+            throw new  Exception\InvalidArgumentException(
+                'Container must be a string alias or an instance of ' .
+                    'Zend\Navigation\AbstractContainer'
+            );
         }
-
-        return $this;
-    }
-
-    /**
-     * Returns translator used in helper
-     *
-     * @return Translator|null
-     */
-    public function getTranslator()
-    {
-        if (! $this->isTranslatorEnabled()) {
-            return null;
-        }
-
-        return $this->translator;
-    }
-
-    /**
-     * Checks if the helper has a translator
-     *
-     * @return bool
-     */
-    public function hasTranslator()
-    {
-        return (bool) $this->getTranslator();
-    }
-
-    /**
-     * Sets whether translator is enabled and should be used
-     *
-     * @param  bool $enabled
-     * @return AbstractHelper
-     */
-    public function setTranslatorEnabled($enabled = true)
-    {
-        $this->translatorEnabled = (bool) $enabled;
-
-        return $this;
-    }
-
-    /**
-     * Returns whether translator is enabled and should be used
-     *
-     * @return bool
-     */
-    public function isTranslatorEnabled()
-    {
-        return $this->translatorEnabled;
-    }
-
-    /**
-     * Set translation text domain
-     *
-     * @param  string $textDomain
-     * @return AbstractHelper
-     */
-    public function setTranslatorTextDomain($textDomain = 'default')
-    {
-        $this->translatorTextDomain = $textDomain;
-
-        return $this;
-    }
-
-    /**
-     * Return the translation text domain
-     *
-     * @return string
-     */
-    public function getTranslatorTextDomain()
-    {
-        return $this->translatorTextDomain;
     }
 
     // Iterator filter methods:
@@ -839,6 +391,42 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     }
 
     /**
+     * Returns an HTML string containing an 'a' element for the given page
+     *
+     * @param  AbstractPage $page  page to generate HTML for
+     * @return string
+     */
+    public function htmlify(AbstractPage $page)
+    {
+        // get label and title for translating
+        $label = $page->getLabel();
+        $title = $page->getTitle();
+
+        if (null !== ($translator = $this->getTranslator())) {
+            $textDomain = $this->getTranslatorTextDomain();
+            if (is_string($label) && !empty($label)) {
+                $label = $translator->translate($label, $textDomain);
+            }
+            if (is_string($title) && !empty($title)) {
+                $title = $translator->translate($title, $textDomain);
+            }
+        }
+
+        // get attribs for anchor element
+        $attribs = array(
+            'id'     => $page->getId(),
+            'title'  => $title,
+            'class'  => $page->getClass(),
+            'href'   => $page->getHref(),
+            'target' => $page->getTarget()
+        );
+
+        $escaper = $this->view->plugin('escapeHtml');
+
+        return '<a' . $this->htmlAttribs($attribs) . '>' . $escaper($label) . '</a>';
+    }
+
+    /**
      * Normalize an ID
      *
      * Overrides {@link View\Helper\AbstractHtmlElement::normalizeId()}.
@@ -852,6 +440,407 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
         $prefix = strtolower(trim(substr($prefix, strrpos($prefix, '\\')), '\\'));
 
         return $prefix . '-' . $value;
+    }
+
+    /**
+     * Sets ACL to use when iterating pages
+     *
+     * Implements {@link HelperInterface::setAcl()}.
+     *
+     * @param  Acl\AclInterface $acl ACL object.
+     * @return AbstractHelper
+     */
+    public function setAcl(Acl\AclInterface $acl = null)
+    {
+        $this->acl = $acl;
+        return $this;
+    }
+
+    /**
+     * Returns ACL or null if it isn't set using {@link setAcl()} or
+     * {@link setDefaultAcl()}
+     *
+     * Implements {@link HelperInterface::getAcl()}.
+     *
+     * @return Acl\AclInterface|null  ACL object or null
+     */
+    public function getAcl()
+    {
+        if ($this->acl === null && static::$defaultAcl !== null) {
+            return static::$defaultAcl;
+        }
+
+        return $this->acl;
+    }
+
+    /**
+     * Checks if the helper has an ACL instance
+     *
+     * Implements {@link HelperInterface::hasAcl()}.
+     *
+     * @return bool
+     */
+    public function hasAcl()
+    {
+        if ($this->acl instanceof Acl\Acl
+            || static::$defaultAcl instanceof Acl\Acl
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Sets navigation container the helper operates on by default
+     *
+     * Implements {@link HelperInterface::setContainer()}.
+     *
+     * @param  string|Navigation\AbstractContainer $container Default is null, meaning container will be reset.
+     * @return AbstractHelper
+     */
+    public function setContainer($container = null)
+    {
+        $this->parseContainer($container);
+        $this->container = $container;
+
+        return $this;
+    }
+
+    /**
+     * Returns the navigation container helper operates on by default
+     *
+     * Implements {@link HelperInterface::getContainer()}.
+     *
+     * If no container is set, a new container will be instantiated and
+     * stored in the helper.
+     *
+     * @return Navigation\AbstractContainer  navigation container
+     */
+    public function getContainer()
+    {
+        if (null === $this->container) {
+            $this->container = new Navigation\Navigation();
+        }
+
+        return $this->container;
+    }
+
+    /**
+     * Checks if the helper has a container
+     *
+     * Implements {@link HelperInterface::hasContainer()}.
+     *
+     * @return bool
+     */
+    public function hasContainer()
+    {
+        return null !== $this->container;
+    }
+
+    /**
+     * Set the indentation string for using in {@link render()}, optionally a
+     * number of spaces to indent with
+     *
+     * @param  string|int $indent
+     * @return AbstractHelper
+     */
+    public function setIndent($indent)
+    {
+        $this->indent = $this->getWhitespace($indent);
+        return $this;
+    }
+
+    /**
+     * Returns indentation
+     *
+     * @return string
+     */
+    public function getIndent()
+    {
+        return $this->indent;
+    }
+
+    /**
+     * Sets the maximum depth a page can have to be included when rendering
+     *
+     * @param  int $maxDepth Default is null, which sets no maximum depth.
+     * @return AbstractHelper
+     */
+    public function setMaxDepth($maxDepth = null)
+    {
+        if (null === $maxDepth || is_int($maxDepth)) {
+            $this->maxDepth = $maxDepth;
+        } else {
+            $this->maxDepth = (int) $maxDepth;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns maximum depth a page can have to be included when rendering
+     *
+     * @return int|null
+     */
+    public function getMaxDepth()
+    {
+        return $this->maxDepth;
+    }
+
+    /**
+     * Sets the minimum depth a page must have to be included when rendering
+     *
+     * @param  int $minDepth Default is null, which sets no minimum depth.
+     * @return AbstractHelper
+     */
+    public function setMinDepth($minDepth = null)
+    {
+        if (null === $minDepth || is_int($minDepth)) {
+            $this->minDepth = $minDepth;
+        } else {
+            $this->minDepth = (int) $minDepth;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns minimum depth a page must have to be included when rendering
+     *
+     * @return int|null
+     */
+    public function getMinDepth()
+    {
+        if (!is_int($this->minDepth) || $this->minDepth < 0) {
+            return 0;
+        }
+
+        return $this->minDepth;
+    }
+
+    /**
+     * Render invisible items?
+     *
+     * @param  bool $renderInvisible
+     * @return AbstractHelper
+     */
+    public function setRenderInvisible($renderInvisible = true)
+    {
+        $this->renderInvisible = (bool) $renderInvisible;
+        return $this;
+    }
+
+    /**
+     * Return renderInvisible flag
+     *
+     * @return bool
+     */
+    public function getRenderInvisible()
+    {
+        return $this->renderInvisible;
+    }
+
+    /**
+     * Sets ACL role(s) to use when iterating pages
+     *
+     * Implements {@link HelperInterface::setRole()}.
+     *
+     * @param  mixed $role [optional] role to set. Expects a string, an
+     *                     instance of type {@link Acl\Role\RoleInterface}, or null. Default
+     *                     is null, which will set no role.
+     * @return AbstractHelper
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setRole($role = null)
+    {
+        if (null === $role || is_string($role) ||
+            $role instanceof Acl\Role\RoleInterface
+        ) {
+            $this->role = $role;
+        } else {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '$role must be a string, null, or an instance of '
+                    .  'Zend\Permissions\Role\RoleInterface; %s given',
+                (is_object($role) ? get_class($role) : gettype($role))
+            ));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns ACL role to use when iterating pages, or null if it isn't set
+     * using {@link setRole()} or {@link setDefaultRole()}
+     *
+     * Implements {@link HelperInterface::getRole()}.
+     *
+     * @return string|Acl\Role\RoleInterface|null
+     */
+    public function getRole()
+    {
+        if ($this->role === null && static::$defaultRole !== null) {
+            return static::$defaultRole;
+        }
+
+        return $this->role;
+    }
+
+    /**
+     * Checks if the helper has an ACL role
+     *
+     * Implements {@link HelperInterface::hasRole()}.
+     *
+     * @return bool
+     */
+    public function hasRole()
+    {
+        if ($this->role instanceof Acl\Role\RoleInterface
+            || is_string($this->role)
+            || static::$defaultRole instanceof Acl\Role\RoleInterface
+            || is_string(static::$defaultRole)
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Set the service locator.
+     *
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @return AbstractHelper
+     */
+    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+        return $this;
+    }
+
+    /**
+     * Get the service locator.
+     *
+     * @return ServiceLocatorInterface
+     */
+    public function getServiceLocator()
+    {
+        return $this->serviceLocator;
+    }
+
+    // Translator methods - Good candidate to refactor as a trait with PHP 5.4
+
+    /**
+     * Sets translator to use in helper
+     *
+     * @param  Translator $translator  [optional] translator.
+     *                                 Default is null, which sets no translator.
+     * @param  string     $textDomain  [optional] text domain
+     *                                 Default is null, which skips setTranslatorTextDomain
+     * @return AbstractHelper
+     */
+    public function setTranslator(Translator $translator = null, $textDomain = null)
+    {
+        $this->translator = $translator;
+        if (null !== $textDomain) {
+            $this->setTranslatorTextDomain($textDomain);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns translator used in helper
+     *
+     * @return Translator|null
+     */
+    public function getTranslator()
+    {
+        if (! $this->isTranslatorEnabled()) {
+            return null;
+        }
+
+        return $this->translator;
+    }
+
+    /**
+     * Checks if the helper has a translator
+     *
+     * @return bool
+     */
+    public function hasTranslator()
+    {
+        return (bool) $this->getTranslator();
+    }
+
+    /**
+     * Sets whether translator is enabled and should be used
+     *
+     * @param  bool $enabled
+     * @return AbstractHelper
+     */
+    public function setTranslatorEnabled($enabled = true)
+    {
+        $this->translatorEnabled = (bool) $enabled;
+        return $this;
+    }
+
+    /**
+     * Returns whether translator is enabled and should be used
+     *
+     * @return bool
+     */
+    public function isTranslatorEnabled()
+    {
+        return $this->translatorEnabled;
+    }
+
+    /**
+     * Set translation text domain
+     *
+     * @param  string $textDomain
+     * @return AbstractHelper
+     */
+    public function setTranslatorTextDomain($textDomain = 'default')
+    {
+        $this->translatorTextDomain = $textDomain;
+        return $this;
+    }
+
+    /**
+     * Return the translation text domain
+     *
+     * @return string
+     */
+    public function getTranslatorTextDomain()
+    {
+        return $this->translatorTextDomain;
+    }
+
+    /**
+     * Sets whether ACL should be used
+     *
+     * Implements {@link HelperInterface::setUseAcl()}.
+     *
+     * @param  bool $useAcl
+     * @return AbstractHelper
+     */
+    public function setUseAcl($useAcl = true)
+    {
+        $this->useAcl = (bool) $useAcl;
+        return $this;
+    }
+
+    /**
+     * Returns whether ACL should be used
+     *
+     * Implements {@link HelperInterface::getUseAcl()}.
+     *
+     * @return bool
+     */
+    public function getUseAcl()
+    {
+        return $this->useAcl;
     }
 
     // Static methods:

--- a/library/Zend/View/Helper/Navigation/Breadcrumbs.php
+++ b/library/Zend/View/Helper/Navigation/Breadcrumbs.php
@@ -66,7 +66,7 @@ class Breadcrumbs extends AbstractHelper
      * Sets breadcrumb separator
      *
      * @param  string $separator separator string
-     * @return Breadcrumbs fluent interface, returns self
+     * @return Breadcrumbs
      */
     public function setSeparator($separator)
     {
@@ -91,7 +91,7 @@ class Breadcrumbs extends AbstractHelper
      * Sets whether last page in breadcrumbs should be hyperlinked
      *
      * @param  bool $linkLast whether last page should be hyperlinked
-     * @return Breadcrumbs fluent interface, returns self
+     * @return Breadcrumbs
      */
     public function setLinkLast($linkLast)
     {
@@ -102,7 +102,7 @@ class Breadcrumbs extends AbstractHelper
     /**
      * Returns whether last page in breadcrumbs should be hyperlinked
      *
-     * @return bool  whether last page in breadcrumbs should be hyperlinked
+     * @return bool
      */
     public function getLinkLast()
     {
@@ -117,7 +117,7 @@ class Breadcrumbs extends AbstractHelper
      *                               values; the partial view script to use,
      *                               and the module where the script can be
      *                               found.
-     * @return Breadcrumbs fluent interface, returns self
+     * @return Breadcrumbs
      */
     public function setPartial($partial)
     {
@@ -146,7 +146,7 @@ class Breadcrumbs extends AbstractHelper
      *
      * @param  AbstractContainer $container [optional] container to render. Default is
      *                              to render the container registered in the helper.
-     * @return string               helper output
+     * @return string
      */
     public function renderStraight($container = null)
     {
@@ -279,7 +279,7 @@ class Breadcrumbs extends AbstractHelper
      *
      * @param  AbstractContainer $container [optional] container to render. Default is
      *                              to render the container registered in the helper.
-     * @return string               helper output
+     * @return string
      */
     public function render($container = null)
     {

--- a/library/Zend/View/Helper/Navigation/HelperInterface.php
+++ b/library/Zend/View/Helper/Navigation/HelperInterface.php
@@ -19,6 +19,49 @@ use Zend\View\Helper\HelperInterface as BaseHelperInterface;
 interface HelperInterface extends BaseHelperInterface
 {
     /**
+     * Magic overload: Should proxy to {@link render()}.
+     *
+     * @return string
+     */
+    public function __toString();
+
+    /**
+     * Renders helper
+     *
+     * @param  string|Navigation\AbstractContainer $container [optional] container to render.
+     *                                         Default is null, which indicates
+     *                                         that the helper should render
+     *                                         the container returned by {@link
+     *                                         getContainer()}.
+     * @return string helper output
+     * @throws \Zend\View\Exception\ExceptionInterface
+     */
+    public function render($container = null);
+
+    /**
+     * Sets ACL to use when iterating pages
+     *
+     * @param  Acl\AclInterface $acl [optional] ACL instance
+     * @return HelperInterface
+     */
+    public function setAcl(Acl\AclInterface $acl = null);
+
+    /**
+     * Returns ACL or null if it isn't set using {@link setAcl()} or
+     * {@link setDefaultAcl()}
+     *
+     * @return Acl\AclInterface|null
+     */
+    public function getAcl();
+
+    /**
+     * Checks if the helper has an ACL instance
+     *
+     * @return bool
+     */
+    public function hasAcl();
+
+    /**
      * Sets navigation container the helper should operate on by default
      *
      * @param  string|Navigation\AbstractContainer $container [optional] container to operate
@@ -37,20 +80,26 @@ interface HelperInterface extends BaseHelperInterface
     public function getContainer();
 
     /**
-     * Sets ACL to use when iterating pages
+     * Checks if the helper has a container
      *
-     * @param  Acl\AclInterface $acl [optional] ACL instance
-     * @return HelperInterface
+     * @return bool
      */
-    public function setAcl(Acl\AclInterface $acl = null);
+    public function hasContainer();
 
     /**
-     * Returns ACL or null if it isn't set using {@link setAcl()} or
-     * {@link setDefaultAcl()}
+     * Render invisible items?
      *
-     * @return Acl\AclInterface|null
+     * @param  bool $renderInvisible [optional] boolean flag
+     * @return HelperInterface
      */
-    public function getAcl();
+    public function setRenderInvisible($renderInvisible = true);
+
+    /**
+     * Return renderInvisible flag
+     *
+     * @return bool
+     */
+    public function getRenderInvisible();
 
     /**
      * Sets ACL role to use when iterating pages
@@ -71,6 +120,13 @@ interface HelperInterface extends BaseHelperInterface
     public function getRole();
 
     /**
+     * Checks if the helper has an ACL role
+     *
+     * @return bool
+     */
+    public function hasRole();
+
+    /**
      * Sets whether ACL should be used
      *
      * @param  bool $useAcl [optional] whether ACL should be used. Default is true.
@@ -84,60 +140,4 @@ interface HelperInterface extends BaseHelperInterface
      * @return bool
      */
     public function getUseAcl();
-
-    /**
-     * Return renderInvisible flag
-     *
-     * @return bool
-     */
-    public function getRenderInvisible();
-
-    /**
-     * Render invisible items?
-     *
-     * @param  bool $renderInvisible [optional] boolean flag
-     * @return HelperInterface
-     */
-    public function setRenderInvisible($renderInvisible = true);
-
-    /**
-     * Checks if the helper has a container
-     *
-     * @return bool
-     */
-    public function hasContainer();
-
-    /**
-     * Checks if the helper has an ACL instance
-     *
-     * @return bool
-     */
-    public function hasAcl();
-
-    /**
-     * Checks if the helper has an ACL role
-     *
-     * @return bool
-     */
-    public function hasRole();
-
-    /**
-     * Magic overload: Should proxy to {@link render()}.
-     *
-     * @return string
-     */
-    public function __toString();
-
-    /**
-     * Renders helper
-     *
-     * @param  string|Navigation\AbstractContainer $container [optional] container to render.
-     *                                         Default is null, which indicates
-     *                                         that the helper should render
-     *                                         the container returned by {@link
-     *                                         getContainer()}.
-     * @return string helper output
-     * @throws \Zend\View\Exception\ExceptionInterface
-     */
-    public function render($container = null);
 }

--- a/library/Zend/View/Helper/Navigation/HelperInterface.php
+++ b/library/Zend/View/Helper/Navigation/HelperInterface.php
@@ -25,7 +25,7 @@ interface HelperInterface extends BaseHelperInterface
      *                                         on. Default is null, which
      *                                         indicates that the container
      *                                         should be reset.
-     * @return HelperInterface fluent interface, returns self
+     * @return HelperInterface
      */
     public function setContainer($container = null);
 
@@ -40,7 +40,7 @@ interface HelperInterface extends BaseHelperInterface
      * Sets ACL to use when iterating pages
      *
      * @param  Acl\AclInterface $acl [optional] ACL instance
-     * @return HelperInterface  fluent interface, returns self
+     * @return HelperInterface
      */
     public function setAcl(Acl\AclInterface $acl = null);
 
@@ -48,7 +48,7 @@ interface HelperInterface extends BaseHelperInterface
      * Returns ACL or null if it isn't set using {@link setAcl()} or
      * {@link setDefaultAcl()}
      *
-     * @return Acl\AclInterface|null  ACL object or null
+     * @return Acl\AclInterface|null
      */
     public function getAcl();
 
@@ -59,15 +59,14 @@ interface HelperInterface extends BaseHelperInterface
      *                     instance of type {@link Acl\Role}, or null. Default
      *                     is null.
      * @throws \Zend\View\Exception\ExceptionInterface if $role is invalid
-     * @return HelperInterface fluent interface, returns
-     *                                             self
+     * @return HelperInterface
      */
     public function setRole($role = null);
 
     /**
      * Returns ACL role to use when iterating pages, or null if it isn't set
      *
-     * @return string|Acl\Role\RoleInterface|null  role or null
+     * @return string|Acl\Role\RoleInterface|null
      */
     public function getRole();
 
@@ -75,14 +74,14 @@ interface HelperInterface extends BaseHelperInterface
      * Sets whether ACL should be used
      *
      * @param  bool $useAcl [optional] whether ACL should be used. Default is true.
-     * @return HelperInterface  fluent interface, returns self
+     * @return HelperInterface
      */
     public function setUseAcl($useAcl = true);
 
     /**
      * Returns whether ACL should be used
      *
-     * @return bool  whether ACL should be used
+     * @return bool
      */
     public function getUseAcl();
 
@@ -97,28 +96,28 @@ interface HelperInterface extends BaseHelperInterface
      * Render invisible items?
      *
      * @param  bool $renderInvisible [optional] boolean flag
-     * @return HelperInterface  fluent interface returns self
+     * @return HelperInterface
      */
     public function setRenderInvisible($renderInvisible = true);
 
     /**
      * Checks if the helper has a container
      *
-     * @return bool  whether the helper has a container or not
+     * @return bool
      */
     public function hasContainer();
 
     /**
      * Checks if the helper has an ACL instance
      *
-     * @return bool  whether the helper has a an ACL instance or not
+     * @return bool
      */
     public function hasAcl();
 
     /**
      * Checks if the helper has an ACL role
      *
-     * @return bool  whether the helper has a an ACL role or not
+     * @return bool
      */
     public function hasRole();
 
@@ -138,7 +137,7 @@ interface HelperInterface extends BaseHelperInterface
      *                                         the container returned by {@link
      *                                         getContainer()}.
      * @return string helper output
-     * @throws \Zend\View\Exception\ExceptionInterface if unable to render
+     * @throws \Zend\View\Exception\ExceptionInterface
      */
     public function render($container = null);
 }

--- a/library/Zend/View/Helper/Navigation/Links.php
+++ b/library/Zend/View/Helper/Navigation/Links.php
@@ -23,7 +23,7 @@ use Zend\View\Exception;
  */
 class Links extends AbstractHelper
 {
-    /**#@+
+    /**
      * Constants used for specifying which link types to find and render
      *
      * @var int
@@ -45,7 +45,6 @@ class Links extends AbstractHelper
     const RENDER_BOOKMARK   = 0x4000;
     const RENDER_CUSTOM     = 0x8000;
     const RENDER_ALL        = 0xffff;
-    /**#@+**/
 
     /**
      * Maps render constants to W3C link types
@@ -86,7 +85,6 @@ class Links extends AbstractHelper
      * the {@link render()} method.
      *
      * @see _findRoot()
-     *
      * @var AbstractContainer
      */
     protected $root;
@@ -117,10 +115,10 @@ class Links extends AbstractHelper
      * $h->findRelFoo($page);     // $h->findRelation($page, 'rel', 'foo');
      * </code>
      *
-     * @param  string $method             method name
-     * @param  array  $arguments          method arguments
+     * @param  string $method
+     * @param  array  $arguments
      * @return mixed
-     * @throws Exception\ExceptionInterface  if method does not exist in container
+     * @throws Exception\ExceptionInterface
      */
     public function __call($method, array $arguments = array())
     {
@@ -161,19 +159,20 @@ class Links extends AbstractHelper
      * Note that custom relations can also be rendered directly using the
      * {@link renderLink()} method.
      *
-     * @param  int $renderFlag render flag
-     * @return Links  fluent interface, returns self
+     * @param  int $renderFlag
+     * @return Links
      */
     public function setRenderFlag($renderFlag)
     {
         $this->renderFlag = (int) $renderFlag;
+
         return $this;
     }
 
     /**
      * Returns the helper's render flag
      *
-     * @return int  render flag
+     * @return int
      */
     public function getRenderFlag()
     {
@@ -203,8 +202,8 @@ class Links extends AbstractHelper
      * </code>
      *
      * @param  AbstractPage $page  page to find links for
-     * @param null|int $flag
-     * @return array related pages
+     * @param  null|int
+     * @return array
      */
     public function findAllRelations(AbstractPage $page, $flag = null)
     {
@@ -246,10 +245,10 @@ class Links extends AbstractHelper
      * This method will first look for relations in the page instance, then
      * by searching the root container if nothing was found in the page.
      *
-     * @param  AbstractPage        $page        page to find relations for
-     * @param  string              $rel         relation, "rel" or "rev"
-     * @param  string              $type        link type, e.g. 'start', 'next'
-     * @return AbstractPage|array|null  page(s), or null if not found
+     * @param  AbstractPage $page page to find relations for
+     * @param  string       $rel  relation, "rel" or "rev"
+     * @param  string       $type link type, e.g. 'start', 'next'
+     * @return AbstractPage|array|null
      * @throws Exception\DomainException if $rel is not "rel" or "rev"
      */
     public function findRelation(AbstractPage $page, $rel, $type)
@@ -272,10 +271,10 @@ class Links extends AbstractHelper
      * Finds relations of given $type for $page by checking if the
      * relation is specified as a property of $page
      *
-     * @param  AbstractPage        $page        page to find relations for
-     * @param  string              $rel         relation, 'rel' or 'rev'
-     * @param  string              $type        link type, e.g. 'start', 'next'
-     * @return AbstractPage|array|null  page(s), or null if not found
+     * @param  AbstractPage $page  page to find relations for
+     * @param  string       $rel   relation, 'rel' or 'rev'
+     * @param  string       $type  link type, e.g. 'start', 'next'
+     * @return AbstractPage|array|null
      */
     protected function findFromProperty(AbstractPage $page, $rel, $type)
     {
@@ -305,10 +304,10 @@ class Links extends AbstractHelper
      * Finds relations of given $rel=$type for $page by using the helper to
      * search for the relation in the root container
      *
-     * @param  AbstractPage        $page   page to find relations for
-     * @param  string              $rel    relation, 'rel' or 'rev'
-     * @param  string              $type   link type, e.g. 'start', 'next', etc
-     * @return array|null                  array of pages, or null if not found
+     * @param  AbstractPage $page page to find relations for
+     * @param  string       $rel  relation, 'rel' or 'rev'
+     * @param  string       $type link type, e.g. 'start', 'next', etc
+     * @return array|null
      */
     protected function findFromSearch(AbstractPage $page, $rel, $type)
     {
@@ -333,8 +332,8 @@ class Links extends AbstractHelper
      * tells search engines which document is considered by the author to be the
      * starting point of the collection.
      *
-     * @param  AbstractPage $page  page to find relation for
-     * @return AbstractPage|null   page or null
+     * @param  AbstractPage $page
+     * @return AbstractPage|null
      */
     public function searchRelStart(AbstractPage $page)
     {
@@ -360,8 +359,8 @@ class Links extends AbstractHelper
      * agents may choose to preload the "next" document, to reduce the perceived
      * load time.
      *
-     * @param  AbstractPage $page  page to find relation for
-     * @return AbstractPage|null   page(s) or null
+     * @param  AbstractPage $page
+     * @return AbstractPage|null
      */
     public function searchRelNext(AbstractPage $page)
     {
@@ -393,8 +392,8 @@ class Links extends AbstractHelper
      * Refers to the previous document in an ordered series of documents. Some
      * user agents also support the synonym "Previous".
      *
-     * @param  AbstractPage $page  page to find relation for
-     * @return AbstractPage|null   page or null
+     * @param  AbstractPage $page
+     * @return AbstractPage|null
      */
     public function searchRelPrev(AbstractPage $page)
     {
@@ -425,8 +424,8 @@ class Links extends AbstractHelper
      * From {@link http://www.w3.org/TR/html4/types.html#type-links}:
      * Refers to a document serving as a chapter in a collection of documents.
      *
-     * @param  AbstractPage $page       page to find relation for
-     * @return AbstractPage|array|null  page(s) or null
+     * @param  AbstractPage $page
+     * @return AbstractPage|array|null
      */
     public function searchRelChapter(AbstractPage $page)
     {
@@ -467,8 +466,8 @@ class Links extends AbstractHelper
      * From {@link http://www.w3.org/TR/html4/types.html#type-links}:
      * Refers to a document serving as a section in a collection of documents.
      *
-     * @param  AbstractPage $page       page to find relation for
-     * @return AbstractPage|array|null  page(s) or null
+     * @param  AbstractPage $page
+     * @return AbstractPage|array|null
      */
     public function searchRelSection(AbstractPage $page)
     {
@@ -501,8 +500,8 @@ class Links extends AbstractHelper
      * Refers to a document serving as a subsection in a collection of
      * documents.
      *
-     * @param  AbstractPage $page       page to find relation for
-     * @return AbstractPage|array|null  page(s) or null
+     * @param  AbstractPage $page
+     * @return AbstractPage|array|null
      */
     public function searchRelSubsection(AbstractPage $page)
     {
@@ -539,8 +538,8 @@ class Links extends AbstractHelper
      * From {@link http://www.w3.org/TR/html4/types.html#type-links}:
      * Refers to a document serving as a section in a collection of documents.
      *
-     * @param  AbstractPage $page  page to find relation for
-     * @return AbstractPage|null   page(s) or null
+     * @param  AbstractPage $page
+     * @return AbstractPage|null
      */
     public function searchRevSection(AbstractPage $page)
     {
@@ -564,8 +563,8 @@ class Links extends AbstractHelper
      * Refers to a document serving as a subsection in a collection of
      * documents.
      *
-     * @param  AbstractPage $page  page to find relation for
-     * @return AbstractPage|null   page(s) or null
+     * @param  AbstractPage $page
+     * @return AbstractPage|null
      */
     public function searchRevSubsection(AbstractPage $page)
     {
@@ -596,8 +595,8 @@ class Links extends AbstractHelper
      * makes sure finder methods will not traverse above the container given
      * to the render method.
      *
-     * @param  AbstractPage $page  page to find root for
-     * @return AbstractContainer   the root container of the given page
+     * @param  AbstractPage $page
+     * @return AbstractContainer
      */
     protected function findRoot(AbstractPage $page)
     {
@@ -622,10 +621,10 @@ class Links extends AbstractHelper
     /**
      * Converts a $mixed value to an array of pages
      *
-     * @param  mixed $mixed             mixed value to get page(s) from
-     * @param  bool  $recursive         whether $value should be looped
-     *                                  if it is an array or a config
-     * @return AbstractPage|array|null  empty if unable to convert
+     * @param  mixed $mixed     mixed value to get page(s) from
+     * @param  bool  $recursive whether $value should be looped
+     *                          if it is an array or a config
+     * @return AbstractPage|array|null
      */
     protected function convertToPages($mixed, $recursive = true)
     {
@@ -679,17 +678,17 @@ class Links extends AbstractHelper
     /**
      * Renders the given $page as a link element, with $attrib = $relation
      *
-     * @param  AbstractPage         $page      the page to render the link for
-     * @param  string               $attrib    the attribute to use for $type,
-     *                                         either 'rel' or 'rev'
-     * @param  string               $relation  relation type, muse be one of;
-     *                                         alternate, appendix, bookmark,
-     *                                         chapter, contents, copyright,
-     *                                         glossary, help, home, index, next,
-     *                                         prev, section, start, stylesheet,
-     *                                         subsection
-     * @return string                          rendered link element
-     * @throws Exception\DomainException if $attrib is invalid
+     * @param  AbstractPage $page     the page to render the link for
+     * @param  string       $attrib   the attribute to use for $type,
+     *                                either 'rel' or 'rev'
+     * @param  string       $relation relation type, muse be one of;
+     *                                alternate, appendix, bookmark,
+     *                                chapter, contents, copyright,
+     *                                glossary, help, home, index, next,
+     *                                prev, section, start, stylesheet,
+     *                                subsection
+     * @return string
+     * @throws Exception\DomainException
      */
     public function renderLink(AbstractPage $page, $attrib, $relation)
     {
@@ -728,7 +727,7 @@ class Links extends AbstractHelper
      *                                         Default is to render the
      *                                         container registered in the
      *                                         helper.
-     * @return string                          helper output
+     * @return string
      */
     public function render($container = null)
     {

--- a/library/Zend/View/Helper/Navigation/Links.php
+++ b/library/Zend/View/Helper/Navigation/Links.php
@@ -135,48 +135,92 @@ class Links extends AbstractHelper
     }
 
     /**
-     * Sets the helper's render flag
+     * Renders helper
      *
-     * The helper uses the bitwise '&' operator against the hex values of the
-     * render constants. This means that the flag can is "bitwised" value of
-     * the render constants. Examples:
-     * <code>
-     * // render all links except glossary
-     * $flag = Links:RENDER_ALL ^ Links:RENDER_GLOSSARY;
-     * $helper->setRenderFlag($flag);
+     * Implements {@link HelperInterface::render()}.
      *
-     * // render only chapters and sections
-     * $flag = Links:RENDER_CHAPTER | Links:RENDER_SECTION;
-     * $helper->setRenderFlag($flag);
-     *
-     * // render only relations that are not native W3C relations
-     * $helper->setRenderFlag(Links:RENDER_CUSTOM);
-     *
-     * // render all relations (default)
-     * $helper->setRenderFlag(Links:RENDER_ALL);
-     * </code>
-     *
-     * Note that custom relations can also be rendered directly using the
-     * {@link renderLink()} method.
-     *
-     * @param  int $renderFlag
-     * @return Links
+     * @param  AbstractContainer|string|null $container [optional] container to render.
+     *                                         Default is to render the
+     *                                         container registered in the
+     *                                         helper.
+     * @return string
      */
-    public function setRenderFlag($renderFlag)
+    public function render($container = null)
     {
-        $this->renderFlag = (int) $renderFlag;
+        $this->parseContainer($container);
+        if (null === $container) {
+            $container = $this->getContainer();
+        }
 
-        return $this;
+        $active = $this->findActive($container);
+        if ($active) {
+            $active = $active['page'];
+        } else {
+            // no active page
+            return '';
+        }
+
+        $output = '';
+        $indent = $this->getIndent();
+        $this->root = $container;
+
+        $result = $this->findAllRelations($active, $this->getRenderFlag());
+        foreach ($result as $attrib => $types) {
+            foreach ($types as $relation => $pages) {
+                foreach ($pages as $page) {
+                    $r = $this->renderLink($page, $attrib, $relation);
+                    if ($r) {
+                        $output .= $indent . $r . self::EOL;
+                    }
+                }
+            }
+        }
+
+        $this->root = null;
+
+        // return output (trim last newline by spec)
+        return strlen($output) ? rtrim($output, self::EOL) : '';
     }
 
     /**
-     * Returns the helper's render flag
+     * Renders the given $page as a link element, with $attrib = $relation
      *
-     * @return int
+     * @param  AbstractPage $page     the page to render the link for
+     * @param  string       $attrib   the attribute to use for $type,
+     *                                either 'rel' or 'rev'
+     * @param  string       $relation relation type, muse be one of;
+     *                                alternate, appendix, bookmark,
+     *                                chapter, contents, copyright,
+     *                                glossary, help, home, index, next,
+     *                                prev, section, start, stylesheet,
+     *                                subsection
+     * @return string
+     * @throws Exception\DomainException
      */
-    public function getRenderFlag()
+    public function renderLink(AbstractPage $page, $attrib, $relation)
     {
-        return $this->renderFlag;
+        if (!in_array($attrib, array('rel', 'rev'))) {
+            throw new Exception\DomainException(sprintf(
+                'Invalid relation attribute "%s", must be "rel" or "rev"',
+                $attrib
+            ));
+        }
+
+        if (!$href = $page->getHref()) {
+            return '';
+        }
+
+        // TODO: add more attribs
+        // http://www.w3.org/TR/html401/struct/links.html#h-12.2
+        $attribs = array(
+            $attrib  => $relation,
+            'href'   => $href,
+            'title'  => $page->getLabel()
+        );
+
+        return '<link' .
+            $this->htmlAttribs($attribs) .
+            $this->getClosingBracket();
     }
 
     // Finder methods:
@@ -673,96 +717,48 @@ class Links extends AbstractHelper
         return null;
     }
 
-    // Render methods:
-
     /**
-     * Renders the given $page as a link element, with $attrib = $relation
+     * Sets the helper's render flag
      *
-     * @param  AbstractPage $page     the page to render the link for
-     * @param  string       $attrib   the attribute to use for $type,
-     *                                either 'rel' or 'rev'
-     * @param  string       $relation relation type, muse be one of;
-     *                                alternate, appendix, bookmark,
-     *                                chapter, contents, copyright,
-     *                                glossary, help, home, index, next,
-     *                                prev, section, start, stylesheet,
-     *                                subsection
-     * @return string
-     * @throws Exception\DomainException
+     * The helper uses the bitwise '&' operator against the hex values of the
+     * render constants. This means that the flag can is "bitwised" value of
+     * the render constants. Examples:
+     * <code>
+     * // render all links except glossary
+     * $flag = Links:RENDER_ALL ^ Links:RENDER_GLOSSARY;
+     * $helper->setRenderFlag($flag);
+     *
+     * // render only chapters and sections
+     * $flag = Links:RENDER_CHAPTER | Links:RENDER_SECTION;
+     * $helper->setRenderFlag($flag);
+     *
+     * // render only relations that are not native W3C relations
+     * $helper->setRenderFlag(Links:RENDER_CUSTOM);
+     *
+     * // render all relations (default)
+     * $helper->setRenderFlag(Links:RENDER_ALL);
+     * </code>
+     *
+     * Note that custom relations can also be rendered directly using the
+     * {@link renderLink()} method.
+     *
+     * @param  int $renderFlag
+     * @return Links
      */
-    public function renderLink(AbstractPage $page, $attrib, $relation)
+    public function setRenderFlag($renderFlag)
     {
-        if (!in_array($attrib, array('rel', 'rev'))) {
-            throw new Exception\DomainException(sprintf(
-                'Invalid relation attribute "%s", must be "rel" or "rev"',
-                $attrib
-            ));
-        }
+        $this->renderFlag = (int) $renderFlag;
 
-        if (!$href = $page->getHref()) {
-            return '';
-        }
-
-        // TODO: add more attribs
-        // http://www.w3.org/TR/html401/struct/links.html#h-12.2
-        $attribs = array(
-            $attrib  => $relation,
-            'href'   => $href,
-            'title'  => $page->getLabel()
-        );
-
-        return '<link' .
-               $this->htmlAttribs($attribs) .
-               $this->getClosingBracket();
+        return $this;
     }
 
-    // Zend\View\Helper\Navigation\Helper:
-
     /**
-     * Renders helper
+     * Returns the helper's render flag
      *
-     * Implements {@link HelperInterface::render()}.
-     *
-     * @param  AbstractContainer|string|null $container [optional] container to render.
-     *                                         Default is to render the
-     *                                         container registered in the
-     *                                         helper.
-     * @return string
+     * @return int
      */
-    public function render($container = null)
+    public function getRenderFlag()
     {
-        $this->parseContainer($container);
-        if (null === $container) {
-            $container = $this->getContainer();
-        }
-
-        $active = $this->findActive($container);
-        if ($active) {
-            $active = $active['page'];
-        } else {
-            // no active page
-            return '';
-        }
-
-        $output = '';
-        $indent = $this->getIndent();
-        $this->root = $container;
-
-        $result = $this->findAllRelations($active, $this->getRenderFlag());
-        foreach ($result as $attrib => $types) {
-            foreach ($types as $relation => $pages) {
-                foreach ($pages as $page) {
-                    $r = $this->renderLink($page, $attrib, $relation);
-                    if ($r) {
-                        $output .= $indent . $r . self::EOL;
-                    }
-                }
-            }
-        }
-
-        $this->root = null;
-
-        // return output (trim last newline by spec)
-        return strlen($output) ? rtrim($output, self::EOL) : '';
+        return $this->renderFlag;
     }
 }

--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -60,7 +60,7 @@ class Menu extends AbstractHelper
      * Retrieves helper and optionally sets container to operate on
      *
      * @param  AbstractContainer $container [optional] container to operate on
-     * @return Menu      fluent interface, returns self
+     * @return Menu
      */
     public function __invoke($container = null)
     {
@@ -75,7 +75,7 @@ class Menu extends AbstractHelper
      * Sets CSS class to use for the first 'ul' element when rendering
      *
      * @param  string $ulClass CSS class to set
-     * @return Menu  fluent interface, returns self
+     * @return Menu
      */
     public function setUlClass($ulClass)
     {
@@ -89,7 +89,7 @@ class Menu extends AbstractHelper
     /**
      * Returns CSS class to use for the first 'ul' element when rendering
      *
-     * @return string  CSS class
+     * @return string
      */
     public function getUlClass()
     {
@@ -99,12 +99,13 @@ class Menu extends AbstractHelper
     /**
      * Sets a flag indicating whether only active branch should be rendered
      *
-     * @param  bool $flag [optional] render only active branch. Default is true.
-     * @return Menu  fluent interface, returns self
+     * @param  bool $flag [optional] render only active branch.
+     * @return Menu
      */
     public function setOnlyActiveBranch($flag = true)
     {
         $this->onlyActiveBranch = (bool) $flag;
+
         return $this;
     }
 
@@ -114,7 +115,7 @@ class Menu extends AbstractHelper
      * By default, this value is false, meaning the entire menu will be
      * be rendered.
      *
-     * @return bool  whether only active branch should be rendered
+     * @return bool
      */
     public function getOnlyActiveBranch()
     {
@@ -124,12 +125,13 @@ class Menu extends AbstractHelper
     /**
      * Sets a flag indicating whether labels should be escaped
      *
-     * @param bool $flag [optional] escape labels. Default is true.
-     * @return Menu  fluent interface, returns self
+     * @param bool $flag [optional] escape labels
+     * @return Menu
      */
     public function escapeLabels($flag = true)
     {
         $this->escapeLabels = (bool) $flag;
+
         return $this;
     }
 
@@ -139,12 +141,12 @@ class Menu extends AbstractHelper
      * See {@link setOnlyActiveBranch()} for more information.
      *
      * @param  bool $flag [optional] render parents when rendering active branch.
-     *                    Default is true.
-     * @return Menu  fluent interface, returns self
+     * @return Menu
      */
     public function setRenderParents($flag = true)
     {
         $this->renderParents = (bool) $flag;
+
         return $this;
     }
 
@@ -154,7 +156,7 @@ class Menu extends AbstractHelper
      *
      * By default, this value is true.
      *
-     * @return bool  whether parents should be rendered
+     * @return bool
      */
     public function getRenderParents()
     {
@@ -169,7 +171,7 @@ class Menu extends AbstractHelper
      *                               values; the partial view script to use,
      *                               and the module where the script can be
      *                               found.
-     * @return Menu  fluent interface, returns self
+     * @return Menu
      */
     public function setPartial($partial)
     {
@@ -198,9 +200,9 @@ class Menu extends AbstractHelper
      *
      * Overrides {@link AbstractHelper::htmlify()}.
      *
-     * @param  AbstractPage $page   page to generate HTML for
-     * @param bool $escapeLabel     Whether or not to escape the label
-     * @return string               HTML string for the given page
+     * @param  AbstractPage $page        page to generate HTML for
+     * @param  bool         $escapeLabel Whether or not to escape the label
+     * @return string
      */
     public function htmlify(AbstractPage $page, $escapeLabel = true)
     {
@@ -252,7 +254,7 @@ class Menu extends AbstractHelper
      * Normalizes given render options
      *
      * @param  array $options  [optional] options to normalize
-     * @return array           normalized options
+     * @return array
      */
     protected function normalizeOptions(array $options = array())
     {
@@ -309,13 +311,13 @@ class Menu extends AbstractHelper
      * Renders the deepest active menu within [$minDepth, $maxDepth], (called
      * from {@link renderMenu()})
      *
-     * @param  AbstractContainer         $container    container to render
-     * @param  string                    $ulClass      CSS class for first UL
-     * @param  string                    $indent       initial indentation
-     * @param  int|null                  $minDepth     minimum depth
-     * @param  int|null                  $maxDepth     maximum depth
-     * @param  bool                      $escapeLabels Whether or not to escape the labels
-     * @return string                                  rendered menu
+     * @param  AbstractContainer $container    container to render
+     * @param  string            $ulClass      CSS class for first UL
+     * @param  string            $indent       initial indentation
+     * @param  int|null          $minDepth     minimum depth
+     * @param  int|null          $maxDepth     maximum depth
+     * @param  bool              $escapeLabels Whether or not to escape the labels
+     * @return string
      */
     protected function renderDeepestMenu(AbstractContainer $container,
                                          $ulClass,
@@ -362,13 +364,13 @@ class Menu extends AbstractHelper
     /**
      * Renders a normal menu (called from {@link renderMenu()})
      *
-     * @param  AbstractContainer         $container    container to render
-     * @param  string                    $ulClass      CSS class for first UL
-     * @param  string                    $indent       initial indentation
-     * @param  int|null                  $minDepth     minimum depth
-     * @param  int|null                  $maxDepth     maximum depth
-     * @param  bool                      $onlyActive   render only active branch?
-     * @param  bool                      $escapeLabels Whether or not to escape the labels
+     * @param  AbstractContainer $container    container to render
+     * @param  string            $ulClass      CSS class for first UL
+     * @param  string            $indent       initial indentation
+     * @param  int|null          $minDepth     minimum depth
+     * @param  int|null          $maxDepth     maximum depth
+     * @param  bool              $onlyActive   render only active branch?
+     * @param  bool              $escapeLabels Whether or not to escape the labels
      * @return string
      */
     protected function renderNormalMenu(AbstractContainer $container,
@@ -486,10 +488,10 @@ class Menu extends AbstractHelper
      *
      *
      * @param  AbstractContainer $container [optional] container to create menu from.
-     *                              Default is to use the container retrieved
-     *                              from {@link getContainer()}.
-     * @param  array     $options   [optional] options for controlling rendering
-     * @return string    rendered menu
+     *                                      Default is to use the container retrieved
+     *                                      from {@link getContainer()}.
+     * @param  array             $options   [optional] options for controlling rendering
+     * @return string
      */
     public function renderMenu($container = null, array $options = array())
     {
@@ -536,20 +538,20 @@ class Menu extends AbstractHelper
      * ));
      * </code>
      *
-     * @param  AbstractContainer                 $container  [optional] container to
-     *                                               render. Default is to render
-     *                                               the container registered in
-     *                                               the helper.
-     * @param  string                    $ulClass    [optional] CSS class to
-     *                                               use for UL element. Default
-     *                                               is to use the value from
-     *                                               {@link getUlClass()}.
-     * @param  string|int                $indent     [optional] indentation as
-     *                                               a string or number of
-     *                                               spaces. Default is to use
-     *                                               the value retrieved from
-     *                                               {@link getIndent()}.
-     * @return string                                rendered content
+     * @param  AbstractContainer $container [optional] container to
+     *                                      render. Default is to render
+     *                                      the container registered in
+     *                                      the helper.
+     * @param  string            $ulClass   [optional] CSS class to
+     *                                      use for UL element. Default
+     *                                      is to use the value from
+     *                                      {@link getUlClass()}.
+     * @param  string|int        $indent    [optional] indentation as
+     *                                      a string or number of
+     *                                      spaces. Default is to use
+     *                                      the value retrieved from
+     *                                      {@link getIndent()}.
+     * @return string
      */
     public function renderSubMenu(AbstractContainer $container = null,
                                   $ulClass = null,
@@ -583,7 +585,7 @@ class Menu extends AbstractHelper
      *                                  values; the partial view script to use,
      *                                  and the module where the script can be
      *                                  found.
-     * @return string                   helper output
+     * @return string
      * @throws Exception\RuntimeException if no partial provided
      * @throws Exception\InvalidArgumentException if partial is invalid array
      */
@@ -640,9 +642,8 @@ class Menu extends AbstractHelper
      * @see renderMenu()
      *
      * @param  AbstractContainer $container [optional] container to render. Default is
-     *                              to render the container registered in the
-     *                              helper.
-     * @return string               helper output
+     *                              to render the container registered in the helper.
+     * @return string
      */
     public function render($container = null)
     {
@@ -650,6 +651,7 @@ class Menu extends AbstractHelper
         if ($partial) {
             return $this->renderPartial($container, $partial);
         }
+
         return $this->renderMenu($container);
     }
 }

--- a/library/Zend/View/Helper/Navigation/Sitemap.php
+++ b/library/Zend/View/Helper/Navigation/Sitemap.php
@@ -99,19 +99,20 @@ class Sitemap extends AbstractHelper
     /**
      * Sets whether XML output should be formatted
      *
-     * @param  bool $formatOutput [optional] whether output should be formatted. Default is true.
-     * @return Sitemap  fluent interface, returns self
+     * @param  bool $formatOutput
+     * @return Sitemap
      */
     public function setFormatOutput($formatOutput = true)
     {
         $this->formatOutput = (bool) $formatOutput;
+
         return $this;
     }
 
     /**
      * Returns whether XML output should be formatted
      *
-     * @return bool  whether XML output should be formatted
+     * @return bool
      */
     public function getFormatOutput()
     {
@@ -121,19 +122,20 @@ class Sitemap extends AbstractHelper
     /**
      * Sets whether the XML declaration should be used in output
      *
-     * @param  bool $useXmlDecl whether XML declaration should be rendered
-     * @return Sitemap  fluent interface, returns self
+     * @param  bool $useXmlDecl
+     * @return Sitemap
      */
     public function setUseXmlDeclaration($useXmlDecl)
     {
         $this->useXmlDeclaration = (bool) $useXmlDecl;
+
         return $this;
     }
 
     /**
      * Returns whether the XML declaration should be used in output
      *
-     * @return bool  whether the XML declaration should be used in output
+     * @return bool
      */
     public function getUseXmlDeclaration()
     {
@@ -143,19 +145,20 @@ class Sitemap extends AbstractHelper
     /**
      * Sets whether sitemap should be validated using Zend\Validate\Sitemap_*
      *
-     * @param  bool $useSitemapValidators whether sitemap validators should be used
-     * @return Sitemap  fluent interface, returns self
+     * @param  bool $useSitemapValidators
+     * @return Sitemap
      */
     public function setUseSitemapValidators($useSitemapValidators)
     {
         $this->useSitemapValidators = (bool) $useSitemapValidators;
+
         return $this;
     }
 
     /**
      * Returns whether sitemap should be validated using Zend\Validate\Sitemap_*
      *
-     * @return bool  whether sitemap should be validated using validators
+     * @return bool
      */
     public function getUseSitemapValidators()
     {
@@ -165,12 +168,13 @@ class Sitemap extends AbstractHelper
     /**
      * Sets whether sitemap should be schema validated when generated
      *
-     * @param  bool $schemaValidation whether sitemap should validated using XSD Schema
+     * @param  bool $schemaValidation
      * @return Sitemap
      */
     public function setUseSchemaValidation($schemaValidation)
     {
         $this->useSchemaValidation = (bool) $schemaValidation;
+
         return $this;
     }
 
@@ -189,9 +193,9 @@ class Sitemap extends AbstractHelper
      *
      * E.g. http://www.example.com
      *
-     * @param  string $serverUrl server URL to set (only scheme and host)
-     * @return Sitemap fluent interface, returns self
-     * @throws Exception\InvalidArgumentException if invalid server URL
+     * @param  string $serverUrl
+     * @return Sitemap
+     * @throws Exception\InvalidArgumentException
      */
     public function setServerUrl($serverUrl)
     {
@@ -215,7 +219,7 @@ class Sitemap extends AbstractHelper
     /**
      * Returns server URL
      *
-     * @return string  server URL
+     * @return string
      */
     public function getServerUrl()
     {
@@ -232,8 +236,8 @@ class Sitemap extends AbstractHelper
     /**
      * Escapes string for XML usage
      *
-     * @param  string $string  string to escape
-     * @return string          escaped string
+     * @param  string $string
+     * @return string
      */
     protected function xmlEscape($string)
     {
@@ -246,7 +250,7 @@ class Sitemap extends AbstractHelper
     /**
      * Returns an escaped absolute URL for the given page
      *
-     * @param  AbstractPage $page  page to get URL from
+     * @param  AbstractPage $page
      * @return string
      */
     public function url(AbstractPage $page)
@@ -434,9 +438,8 @@ class Sitemap extends AbstractHelper
      * Implements {@link HelperInterface::render()}.
      *
      * @param  AbstractContainer $container [optional] container to render. Default is
-     *                           to render the container registered in the
-     *                           helper.
-     * @return string            helper output
+     *                           to render the container registered in the helper.
+     * @return string
      */
     public function render($container = null)
     {

--- a/library/Zend/View/Helper/Navigation/Sitemap.php
+++ b/library/Zend/View/Helper/Navigation/Sitemap.php
@@ -47,11 +47,18 @@ class Sitemap extends AbstractHelper
     protected $formatOutput = false;
 
     /**
-     * Whether the XML declaration should be included in XML output
+     * Server url
      *
-     * @var bool
+     * @var string
      */
-    protected $useXmlDeclaration = true;
+    protected $serverUrl;
+
+    /**
+     * List of urls in the sitemap
+     *
+     * @var array
+     */
+    protected $urls = array();
 
     /**
      * Whether sitemap should be validated using Zend\Validate\Sitemap\*
@@ -68,18 +75,11 @@ class Sitemap extends AbstractHelper
     protected $useSchemaValidation = false;
 
     /**
-     * Server url
+     * Whether the XML declaration should be included in XML output
      *
-     * @var string
+     * @var bool
      */
-    protected $serverUrl;
-
-    /**
-     * List of urls in the sitemap
-     *
-     * @var array
-     */
-    protected $urls = array();
+    protected $useXmlDeclaration = true;
 
     /**
      * Helper entry point
@@ -97,192 +97,22 @@ class Sitemap extends AbstractHelper
     }
 
     /**
-     * Sets whether XML output should be formatted
+     * Renders helper
      *
-     * @param  bool $formatOutput
-     * @return Sitemap
-     */
-    public function setFormatOutput($formatOutput = true)
-    {
-        $this->formatOutput = (bool) $formatOutput;
-
-        return $this;
-    }
-
-    /**
-     * Returns whether XML output should be formatted
+     * Implements {@link HelperInterface::render()}.
      *
-     * @return bool
-     */
-    public function getFormatOutput()
-    {
-        return $this->formatOutput;
-    }
-
-    /**
-     * Sets whether the XML declaration should be used in output
-     *
-     * @param  bool $useXmlDecl
-     * @return Sitemap
-     */
-    public function setUseXmlDeclaration($useXmlDecl)
-    {
-        $this->useXmlDeclaration = (bool) $useXmlDecl;
-
-        return $this;
-    }
-
-    /**
-     * Returns whether the XML declaration should be used in output
-     *
-     * @return bool
-     */
-    public function getUseXmlDeclaration()
-    {
-        return $this->useXmlDeclaration;
-    }
-
-    /**
-     * Sets whether sitemap should be validated using Zend\Validate\Sitemap_*
-     *
-     * @param  bool $useSitemapValidators
-     * @return Sitemap
-     */
-    public function setUseSitemapValidators($useSitemapValidators)
-    {
-        $this->useSitemapValidators = (bool) $useSitemapValidators;
-
-        return $this;
-    }
-
-    /**
-     * Returns whether sitemap should be validated using Zend\Validate\Sitemap_*
-     *
-     * @return bool
-     */
-    public function getUseSitemapValidators()
-    {
-        return $this->useSitemapValidators;
-    }
-
-    /**
-     * Sets whether sitemap should be schema validated when generated
-     *
-     * @param  bool $schemaValidation
-     * @return Sitemap
-     */
-    public function setUseSchemaValidation($schemaValidation)
-    {
-        $this->useSchemaValidation = (bool) $schemaValidation;
-
-        return $this;
-    }
-
-    /**
-     * Returns true if sitemap should be schema validated when generated
-     *
-     * @return bool
-     */
-    public function getUseSchemaValidation()
-    {
-        return $this->useSchemaValidation;
-    }
-
-    /**
-     * Sets server url (scheme and host-related stuff without request URI)
-     *
-     * E.g. http://www.example.com
-     *
-     * @param  string $serverUrl
-     * @return Sitemap
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setServerUrl($serverUrl)
-    {
-        $uri = Uri\UriFactory::factory($serverUrl);
-        $uri->setFragment('');
-        $uri->setPath('');
-        $uri->setQuery('');
-
-        if ($uri->isValid()) {
-            $this->serverUrl = $uri->toString();
-        } else {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'Invalid server URL: "%s"',
-                $serverUrl
-            ));
-        }
-
-        return $this;
-    }
-
-    /**
-     * Returns server URL
-     *
+     * @param  AbstractContainer $container [optional] container to render. Default is
+     *                           to render the container registered in the helper.
      * @return string
      */
-    public function getServerUrl()
+    public function render($container = null)
     {
-        if (!isset($this->serverUrl)) {
-            $serverUrlHelper  = $this->getView()->plugin('serverUrl');
-            $this->serverUrl = $serverUrlHelper();
-        }
+        $dom = $this->getDomSitemap($container);
+        $xml = $this->getUseXmlDeclaration() ?
+            $dom->saveXML() :
+            $dom->saveXML($dom->documentElement);
 
-        return $this->serverUrl;
-    }
-
-    // Helper methods:
-
-    /**
-     * Escapes string for XML usage
-     *
-     * @param  string $string
-     * @return string
-     */
-    protected function xmlEscape($string)
-    {
-        $escaper = $this->view->plugin('escapeHtml');
-        return $escaper($string);
-    }
-
-    // Public methods:
-
-    /**
-     * Returns an escaped absolute URL for the given page
-     *
-     * @param  AbstractPage $page
-     * @return string
-     */
-    public function url(AbstractPage $page)
-    {
-        $href = $page->getHref();
-
-        if (!isset($href{0})) {
-            // no href
-            return '';
-        } elseif ($href{0} == '/') {
-            // href is relative to root; use serverUrl helper
-            $url = $this->getServerUrl() . $href;
-        } elseif (preg_match('/^[a-z]+:/im', (string) $href)) {
-            // scheme is given in href; assume absolute URL already
-            $url = (string) $href;
-        } else {
-            // href is relative to current document; use url helpers
-            $basePathHelper = $this->getView()->plugin('basepath');
-            $curDoc         = $basePathHelper();
-            $curDoc         = ('/' == $curDoc) ? '' : trim($curDoc, '/');
-            $url            = rtrim($this->getServerUrl(), '/') . '/'
-                                                                . $curDoc
-                                                                . (empty($curDoc) ? '' : '/') . $href;
-        }
-
-        if (! in_array($url, $this->urls)) {
-
-            $this->urls[] = $url;
-            return $this->xmlEscape($url);
-        }
-
-        return null;
+        return rtrim($xml, PHP_EOL);
     }
 
     /**
@@ -369,7 +199,7 @@ class Sitemap extends AbstractHelper
 
             // put url in 'loc' element
             $urlNode->appendChild($dom->createElementNS(self::SITEMAP_NS,
-                    'loc', $url));
+                'loc', $url));
 
             // add 'lastmod' element if a valid lastmod is set in page
             if (isset($page->lastmod)) {
@@ -430,24 +260,184 @@ class Sitemap extends AbstractHelper
         return $dom;
     }
 
-    // Zend_View_Helper_Navigation_Helper:
-
     /**
-     * Renders helper
+     * Returns an escaped absolute URL for the given page
      *
-     * Implements {@link HelperInterface::render()}.
-     *
-     * @param  AbstractContainer $container [optional] container to render. Default is
-     *                           to render the container registered in the helper.
+     * @param  AbstractPage $page
      * @return string
      */
-    public function render($container = null)
+    public function url(AbstractPage $page)
     {
-        $dom = $this->getDomSitemap($container);
-        $xml = $this->getUseXmlDeclaration() ?
-            $dom->saveXML() :
-            $dom->saveXML($dom->documentElement);
+        $href = $page->getHref();
 
-        return rtrim($xml, PHP_EOL);
+        if (!isset($href{0})) {
+            // no href
+            return '';
+        } elseif ($href{0} == '/') {
+            // href is relative to root; use serverUrl helper
+            $url = $this->getServerUrl() . $href;
+        } elseif (preg_match('/^[a-z]+:/im', (string) $href)) {
+            // scheme is given in href; assume absolute URL already
+            $url = (string) $href;
+        } else {
+            // href is relative to current document; use url helpers
+            $basePathHelper = $this->getView()->plugin('basepath');
+            $curDoc         = $basePathHelper();
+            $curDoc         = ('/' == $curDoc) ? '' : trim($curDoc, '/');
+            $url            = rtrim($this->getServerUrl(), '/') . '/'
+                                                                . $curDoc
+                                                                . (empty($curDoc) ? '' : '/') . $href;
+        }
+
+        if (! in_array($url, $this->urls)) {
+
+            $this->urls[] = $url;
+            return $this->xmlEscape($url);
+        }
+
+        return null;
+    }
+
+    /**
+     * Escapes string for XML usage
+     *
+     * @param  string $string
+     * @return string
+     */
+    protected function xmlEscape($string)
+    {
+        $escaper = $this->view->plugin('escapeHtml');
+        return $escaper($string);
+    }
+
+    /**
+     * Sets whether XML output should be formatted
+     *
+     * @param  bool $formatOutput
+     * @return Sitemap
+     */
+    public function setFormatOutput($formatOutput = true)
+    {
+        $this->formatOutput = (bool) $formatOutput;
+        return $this;
+    }
+
+    /**
+     * Returns whether XML output should be formatted
+     *
+     * @return bool
+     */
+    public function getFormatOutput()
+    {
+        return $this->formatOutput;
+    }
+
+    /**
+     * Sets server url (scheme and host-related stuff without request URI)
+     *
+     * E.g. http://www.example.com
+     *
+     * @param  string $serverUrl
+     * @return Sitemap
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setServerUrl($serverUrl)
+    {
+        $uri = Uri\UriFactory::factory($serverUrl);
+        $uri->setFragment('');
+        $uri->setPath('');
+        $uri->setQuery('');
+
+        if ($uri->isValid()) {
+            $this->serverUrl = $uri->toString();
+        } else {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Invalid server URL: "%s"',
+                $serverUrl
+            ));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns server URL
+     *
+     * @return string
+     */
+    public function getServerUrl()
+    {
+        if (!isset($this->serverUrl)) {
+            $serverUrlHelper  = $this->getView()->plugin('serverUrl');
+            $this->serverUrl = $serverUrlHelper();
+        }
+
+        return $this->serverUrl;
+    }
+
+    /**
+     * Sets whether sitemap should be validated using Zend\Validate\Sitemap_*
+     *
+     * @param  bool $useSitemapValidators
+     * @return Sitemap
+     */
+    public function setUseSitemapValidators($useSitemapValidators)
+    {
+        $this->useSitemapValidators = (bool) $useSitemapValidators;
+        return $this;
+    }
+
+    /**
+     * Returns whether sitemap should be validated using Zend\Validate\Sitemap_*
+     *
+     * @return bool
+     */
+    public function getUseSitemapValidators()
+    {
+        return $this->useSitemapValidators;
+    }
+
+    /**
+     * Sets whether sitemap should be schema validated when generated
+     *
+     * @param  bool $schemaValidation
+     * @return Sitemap
+     */
+    public function setUseSchemaValidation($schemaValidation)
+    {
+        $this->useSchemaValidation = (bool) $schemaValidation;
+        return $this;
+    }
+
+    /**
+     * Returns true if sitemap should be schema validated when generated
+     *
+     * @return bool
+     */
+    public function getUseSchemaValidation()
+    {
+        return $this->useSchemaValidation;
+    }
+
+    /**
+     * Sets whether the XML declaration should be used in output
+     *
+     * @param  bool $useXmlDecl
+     * @return Sitemap
+     */
+    public function setUseXmlDeclaration($useXmlDecl)
+    {
+        $this->useXmlDeclaration = (bool) $useXmlDecl;
+        return $this;
+    }
+
+    /**
+     * Returns whether the XML declaration should be used in output
+     *
+     * @return bool
+     */
+    public function getUseXmlDeclaration()
+    {
+        return $this->useXmlDeclaration;
     }
 }

--- a/library/Zend/View/Helper/PaginationControl.php
+++ b/library/Zend/View/Helper/PaginationControl.php
@@ -16,18 +16,18 @@ use Zend\View\Exception;
 class PaginationControl extends AbstractHelper
 {
     /**
-     * Default view partial
-     *
-     * @var string|array
-     */
-    protected static $defaultViewPartial = null;
-
-    /**
      * Default Scrolling Style
      *
      * @var string
      */
     protected static $defaultScrollingStyle = 'sliding';
+
+    /**
+     * Default view partial
+     *
+     * @var string|array
+     */
+    protected static $defaultViewPartial = null;
 
     /**
      * Render the provided pages.  This checks if $view->paginator is set and,
@@ -90,6 +90,26 @@ class PaginationControl extends AbstractHelper
     }
 
     /**
+     * Sets the default Scrolling Style
+     *
+     * @param string $style string 'all' | 'elastic' | 'sliding' | 'jumping'
+     */
+    public static function setDefaultScrollingStyle($style)
+    {
+        static::$defaultScrollingStyle = $style;
+    }
+
+    /**
+     * Gets the default scrolling style
+     *
+     * @return string
+     */
+    public static function getDefaultScrollingStyle()
+    {
+        return static::$defaultScrollingStyle;
+    }
+
+    /**
      * Sets the default view partial.
      *
      * @param string|array $partial View partial
@@ -107,25 +127,5 @@ class PaginationControl extends AbstractHelper
     public static function getDefaultViewPartial()
     {
         return static::$defaultViewPartial;
-    }
-
-     /**
-     * Gets the default scrolling style
-     *
-     * @return string
-     */
-    public static function getDefaultScrollingStyle()
-    {
-        return static::$defaultScrollingStyle;
-    }
-
-    /**
-     * Sets the default Scrolling Style
-     *
-     * @param string $style string 'all' | 'elastic' | 'sliding' | 'jumping'
-     */
-    public static function setDefaultScrollingStyle($style)
-    {
-        static::$defaultScrollingStyle = $style;
     }
 }

--- a/library/Zend/View/Helper/PaginationControl.php
+++ b/library/Zend/View/Helper/PaginationControl.php
@@ -30,57 +30,17 @@ class PaginationControl extends AbstractHelper
     protected static $defaultScrollingStyle = 'sliding';
 
     /**
-     * Sets the default view partial.
-     *
-     * @param string|array $partial View partial
-     */
-    public static function setDefaultViewPartial($partial)
-    {
-        static::$defaultViewPartial = $partial;
-    }
-
-    /**
-     * Gets the default view partial
-     *
-     * @return string|array
-     */
-    public static function getDefaultViewPartial()
-    {
-        return static::$defaultViewPartial;
-    }
-
-     /**
-     * Gets the default scrolling style
-     *
-     * @return string
-     */
-    public static function getDefaultScrollingStyle()
-    {
-        return static::$defaultScrollingStyle;
-    }
-
-    /**
-     * Sets the default Scrolling Style
-     *
-     * @param string $style string 'all' | 'elastic' | 'sliding' | 'jumping'
-     */
-    public static function setDefaultScrollingStyle($style)
-    {
-        static::$defaultScrollingStyle = $style;
-    }
-
-    /**
      * Render the provided pages.  This checks if $view->paginator is set and,
      * if so, uses that.  Also, if no scrolling style or partial are specified,
      * the defaults will be used (if set).
      *
-     * @param  \Zend\Paginator\Paginator (Optional) $paginator
-     * @param  string $scrollingStyle (Optional) Scrolling style
-     * @param  string $partial (Optional) View partial
-     * @param  array|string $params (Optional) params to pass to the partial
-     * @return string
+     * @param  Paginator\Paginator $paginator      (Optional)
+     * @param  string              $scrollingStyle (Optional) Scrolling style
+     * @param  string              $partial        (Optional) View partial
+     * @param  array|string        $params         (Optional) params to pass to the partial
      * @throws Exception\RuntimeException if no paginator or no view partial provided
      * @throws Exception\InvalidArgumentException if partial is invalid array
+     * @return string
      */
     public function __invoke(Paginator\Paginator $paginator = null, $scrollingStyle = null, $partial = null, $params = null)
     {
@@ -127,5 +87,45 @@ class PaginationControl extends AbstractHelper
 
         $partialHelper = $this->view->plugin('partial');
         return $partialHelper($partial, $pages);
+    }
+
+    /**
+     * Sets the default view partial.
+     *
+     * @param string|array $partial View partial
+     */
+    public static function setDefaultViewPartial($partial)
+    {
+        static::$defaultViewPartial = $partial;
+    }
+
+    /**
+     * Gets the default view partial
+     *
+     * @return string|array
+     */
+    public static function getDefaultViewPartial()
+    {
+        return static::$defaultViewPartial;
+    }
+
+     /**
+     * Gets the default scrolling style
+     *
+     * @return string
+     */
+    public static function getDefaultScrollingStyle()
+    {
+        return static::$defaultScrollingStyle;
+    }
+
+    /**
+     * Sets the default Scrolling Style
+     *
+     * @param string $style string 'all' | 'elastic' | 'sliding' | 'jumping'
+     */
+    public static function setDefaultScrollingStyle($style)
+    {
+        static::$defaultScrollingStyle = $style;
     }
 }

--- a/library/Zend/View/Helper/Partial.php
+++ b/library/Zend/View/Helper/Partial.php
@@ -19,6 +19,7 @@ class Partial extends AbstractHelper
 {
     /**
      * Variable to which object will be assigned
+     *
      * @var string
      */
     protected $objectKey;
@@ -27,10 +28,10 @@ class Partial extends AbstractHelper
      * Renders a template fragment within a variable scope distinct from the
      * calling View object. It proxies to view's render function
      *
-     * @param  string|ModelInterface $name Name of view script, or a view model
-     * @param  array|object $values Variables to populate in the view
-     * @return string|Partial
+     * @param  string|ModelInterface $name   Name of view script, or a view model
+     * @param  array|object          $values Variables to populate in the view
      * @throws Exception\RuntimeException
+     * @return string|Partial
      */
     public function __invoke($name = null, $values = null)
     {
@@ -74,6 +75,7 @@ class Partial extends AbstractHelper
         }
 
         $this->objectKey = (string) $key;
+
         return $this;
     }
 

--- a/library/Zend/View/Helper/PartialLoop.php
+++ b/library/Zend/View/Helper/PartialLoop.php
@@ -33,10 +33,10 @@ class PartialLoop extends Partial
      *
      * If no arguments are provided, returns object instance.
      *
-     * @param  string $name Name of view script
-     * @param  array $values Variables to populate in the view
-     * @return string
+     * @param  string $name   Name of view script
+     * @param  array  $values Variables to populate in the view
      * @throws Exception\InvalidArgumentException
+     * @return string
      */
     public function __invoke($name = null, $values = null)
     {

--- a/library/Zend/View/Helper/Placeholder.php
+++ b/library/Zend/View/Helper/Placeholder.php
@@ -21,12 +21,15 @@ class Placeholder extends AbstractHelper
 {
     /**
      * Placeholder items
+     *
      * @var array
      */
     protected $items = array();
 
     /**
-     * @var \Zend\View\Helper\Placeholder\Registry
+     * Placeholder registry intance
+     *
+     * @var Placeholder\Registry
      */
     protected $registry;
 
@@ -34,7 +37,6 @@ class Placeholder extends AbstractHelper
      * Constructor
      *
      * Retrieve container registry from Placeholder\Registry, or create new one and register it.
-     *
      */
     public function __construct()
     {
@@ -45,8 +47,8 @@ class Placeholder extends AbstractHelper
      * Placeholder helper
      *
      * @param  string $name
-     * @return \Zend\View\Helper\Placeholder\Container\AbstractContainer
      * @throws InvalidArgumentException
+     * @return Placeholder\Container\AbstractContainer
      */
     public function __invoke($name = null)
     {
@@ -54,14 +56,13 @@ class Placeholder extends AbstractHelper
             throw new InvalidArgumentException('Placeholder: missing argument.  $name is required by placeholder($name)');
         }
 
-        $name = (string) $name;
-        return $this->registry->getContainer($name);
+        return $this->getRegistry()->getContainer((string) $name);
     }
 
     /**
      * Retrieve the registry
      *
-     * @return \Zend\View\Helper\Placeholder\Registry
+     * @return Placeholder\Registry
      */
     public function getRegistry()
     {

--- a/library/Zend/View/Helper/Placeholder/Container/AbstractContainer.php
+++ b/library/Zend/View/Helper/Placeholder/Container/AbstractContainer.php
@@ -18,67 +18,76 @@ abstract class AbstractContainer extends \ArrayObject
 {
     /**
      * Whether or not to override all contents of placeholder
+     *
      * @const string
      */
     const SET    = 'SET';
 
     /**
      * Whether or not to append contents to placeholder
+     *
      * @const string
      */
     const APPEND = 'APPEND';
 
     /**
      * Whether or not to prepend contents to placeholder
+     *
      * @const string
      */
     const PREPEND = 'PREPEND';
 
     /**
      * What text to prefix the placeholder with when rendering
+     *
      * @var string
      */
     protected $prefix    = '';
 
     /**
      * What text to append the placeholder with when rendering
+     *
      * @var string
      */
     protected $postfix   = '';
 
     /**
      * What string to use between individual items in the placeholder when rendering
+     *
      * @var string
      */
     protected $separator = '';
 
     /**
      * What string to use as the indentation of output, this will typically be spaces. Eg: '    '
+     *
      * @var string
      */
     protected $indent = '';
 
     /**
      * Whether or not we're already capturing for this given container
+     *
      * @var bool
      */
     protected $captureLock = false;
 
     /**
      * What type of capture (overwrite (set), append, prepend) to use
+     *
      * @var string
      */
     protected $captureType;
 
     /**
      * Key to which to capture content
+     *
      * @var string
      */
     protected $captureKey;
 
     /**
      * Constructor - This is needed so that we can attach a class member as the ArrayObject container
-     *
      */
     public function __construct()
     {
@@ -94,6 +103,7 @@ abstract class AbstractContainer extends \ArrayObject
     public function set($value)
     {
         $this->exchangeArray(array($value));
+
         return $this;
     }
 
@@ -108,6 +118,7 @@ abstract class AbstractContainer extends \ArrayObject
         $values = $this->getArrayCopy();
         array_unshift($values, $value);
         $this->exchangeArray($values);
+
         return $this;
     }
 
@@ -134,11 +145,12 @@ abstract class AbstractContainer extends \ArrayObject
      * Set prefix for __toString() serialization
      *
      * @param  string $prefix
-     * @return \Zend\View\Helper\Placeholder\Container\AbstractContainer
+     * @return AbstractContainer
      */
     public function setPrefix($prefix)
     {
         $this->prefix = (string) $prefix;
+
         return $this;
     }
 
@@ -156,11 +168,12 @@ abstract class AbstractContainer extends \ArrayObject
      * Set postfix for __toString() serialization
      *
      * @param  string $postfix
-     * @return \Zend\View\Helper\Placeholder\Container\AbstractContainer
+     * @return AbstractContainer
      */
     public function setPostfix($postfix)
     {
         $this->postfix = (string) $postfix;
+
         return $this;
     }
 
@@ -180,11 +193,12 @@ abstract class AbstractContainer extends \ArrayObject
      * Used to implode elements in container
      *
      * @param  string $separator
-     * @return \Zend\View\Helper\Placeholder\Container\AbstractContainer
+     * @return AbstractContainer
      */
     public function setSeparator($separator)
     {
         $this->separator = (string) $separator;
+
         return $this;
     }
 
@@ -203,11 +217,12 @@ abstract class AbstractContainer extends \ArrayObject
      * optionally, if a number is passed, it will be the number of spaces
      *
      * @param  string|int $indent
-     * @return \Zend\View\Helper\Placeholder\Container\AbstractContainer
+     * @return AbstractContainer
      */
     public function setIndent($indent)
     {
         $this->indent = $this->getWhitespace($indent);
+
         return $this;
     }
 
@@ -240,9 +255,9 @@ abstract class AbstractContainer extends \ArrayObject
      * Start capturing content to push into placeholder
      *
      * @param  string $type How to capture content into placeholder; append, prepend, or set
-     * @param  mixed $key Key to which to capture content
-     * @return void
+     * @param  mixed  $key  Key to which to capture content
      * @throws Exception\RuntimeException if nested captures detected
+     * @return void
      */
     public function captureStart($type = AbstractContainer::APPEND, $key = null)
     {
@@ -314,13 +329,13 @@ abstract class AbstractContainer extends \ArrayObject
     public function getKeys()
     {
         $array = $this->getArrayCopy();
+
         return array_keys($array);
     }
 
     /**
-     * Next Index
+     * Next Index as defined by the PHP manual
      *
-     * as defined by the PHP manual
      * @return int
      */
     public function nextIndex()
@@ -336,7 +351,7 @@ abstract class AbstractContainer extends \ArrayObject
     /**
      * Render the placeholder
      *
-     * @param null|int|string $indent
+     * @param  null|int|string $indent
      * @return string
      */
     public function toString($indent = null)
@@ -351,6 +366,7 @@ abstract class AbstractContainer extends \ArrayObject
                 . implode($this->getSeparator(), $items)
                 . $this->getPostfix();
         $return = preg_replace("/(\r\n?|\n)/", '$1' . $indent, $return);
+
         return $return;
     }
 

--- a/library/Zend/View/Helper/Placeholder/Container/AbstractStandalone.php
+++ b/library/Zend/View/Helper/Placeholder/Container/AbstractStandalone.php
@@ -22,7 +22,7 @@ abstract class AbstractStandalone
     implements \IteratorAggregate, \Countable, \ArrayAccess
 {
     /**
-     * @var \Zend\View\Helper\Placeholder\Container\AbstractContainer
+     * @var AbstractContainer
      */
     protected $container;
 
@@ -32,12 +32,13 @@ abstract class AbstractStandalone
     protected $escapers = array();
 
     /**
-     * @var \Zend\View\Helper\Placeholder\Registry
+     * @var Registry
      */
     protected $registry;
 
     /**
      * Registry key under which container registers itself
+     *
      * @var string
      */
     protected $regKey;
@@ -45,13 +46,13 @@ abstract class AbstractStandalone
     /**
      * Flag whether to automatically escape output, must also be
      * enforced in the child class if __toString/toString is overridden
+     *
      * @var bool
      */
     protected $autoEscape = true;
 
     /**
      * Constructor
-     *
      */
     public function __construct()
     {
@@ -62,7 +63,7 @@ abstract class AbstractStandalone
     /**
      * Retrieve registry
      *
-     * @return \Zend\View\Helper\Placeholder\Registry
+     * @return Registry
      */
     public function getRegistry()
     {
@@ -72,12 +73,13 @@ abstract class AbstractStandalone
     /**
      * Set registry object
      *
-     * @param  \Zend\View\Helper\Placeholder\Registry $registry
-     * @return \Zend\View\Helper\Placeholder\Container\AbstractStandalone
+     * @param  Registry $registry
+     * @return AbstractStandalone
      */
     public function setRegistry(Registry $registry)
     {
         $this->registry = $registry;
+
         return $this;
     }
 
@@ -91,6 +93,7 @@ abstract class AbstractStandalone
     {
         $encoding = $escaper->getEncoding();
         $this->escapers[$encoding] = $escaper;
+
         return $this;
     }
 
@@ -108,6 +111,7 @@ abstract class AbstractStandalone
         if (!isset($this->escapers[$enc])) {
             $this->setEscaper(new Escaper($enc));
         }
+
         return $this->escapers[$enc];
     }
 
@@ -115,11 +119,12 @@ abstract class AbstractStandalone
      * Set whether or not auto escaping should be used
      *
      * @param  bool $autoEscape whether or not to auto escape output
-     * @return \Zend\View\Helper\Placeholder\Container\AbstractStandalone
+     * @return AbstractStandalone
      */
     public function setAutoEscape($autoEscape = true)
     {
         $this->autoEscape = ($autoEscape) ? true : false;
+
         return $this;
     }
 
@@ -150,25 +155,27 @@ abstract class AbstractStandalone
         }
 
         $escaper = $this->getEscaper();
+
         return $escaper->escapeHtml((string) $string);
     }
 
     /**
      * Set container on which to operate
      *
-     * @param  \Zend\View\Helper\Placeholder\Container\AbstractContainer $container
-     * @return \Zend\View\Helper\Placeholder\Container\AbstractStandalone
+     * @param  AbstractContainer $container
+     * @return AbstractStandalone
      */
     public function setContainer(AbstractContainer $container)
     {
         $this->container = $container;
+
         return $this;
     }
 
     /**
      * Retrieve placeholder container
      *
-     * @return \Zend\View\Helper\Placeholder\Container\AbstractContainer
+     * @return AbstractContainer
      */
     public function getContainer()
     {
@@ -237,8 +244,8 @@ abstract class AbstractStandalone
      *
      * @param  string $method
      * @param  array $args
-     * @return mixed
      * @throws Exception\BadMethodCallException
+     * @return mixed
      */
     public function __call($method, $args)
     {
@@ -283,6 +290,7 @@ abstract class AbstractStandalone
     public function count()
     {
         $container = $this->getContainer();
+
         return count($container);
     }
 

--- a/library/Zend/View/Helper/Placeholder/Registry.php
+++ b/library/Zend/View/Helper/Placeholder/Registry.php
@@ -64,19 +64,18 @@ class Registry
     }
 
     /**
-     * createContainer
+     * Set the container for an item in the registry
      *
-     * @param  string $key
-     * @param  array  $value
-     * @return Container\AbstractContainer
+     * @param  string                      $key
+     * @param  Container\AbstractContainer $container
+     * @return Registry
      */
-    public function createContainer($key, array $value = array())
+    public function setContainer($key, Container\AbstractContainer $container)
     {
         $key = (string) $key;
+        $this->items[$key] = $container;
 
-        $this->items[$key] = new $this->containerClass($value);
-
-        return $this->items[$key];
+        return $this;
     }
 
     /**
@@ -111,18 +110,19 @@ class Registry
     }
 
     /**
-     * Set the container for an item in the registry
+     * createContainer
      *
-     * @param  string                      $key
-     * @param  Container\AbstractContainer $container
-     * @return Registry
+     * @param  string $key
+     * @param  array  $value
+     * @return Container\AbstractContainer
      */
-    public function setContainer($key, Container\AbstractContainer $container)
+    public function createContainer($key, array $value = array())
     {
         $key = (string) $key;
-        $this->items[$key] = $container;
 
-        return $this;
+        $this->items[$key] = new $this->containerClass($value);
+
+        return $this->items[$key];
     }
 
     /**

--- a/library/Zend/View/Helper/Placeholder/Registry.php
+++ b/library/Zend/View/Helper/Placeholder/Registry.php
@@ -17,18 +17,22 @@ use Zend\View\Exception;
 class Registry
 {
     /**
-     * @var Registry Singleton instance
+     * Singleton instance
+     *
+     * @var Registry
      */
     protected static $instance;
 
     /**
      * Default container class
+     *
      * @var string
      */
     protected $containerClass = 'Zend\View\Helper\Placeholder\Container';
 
     /**
      * Placeholder containers
+     *
      * @var array
      */
     protected $items = array();
@@ -63,7 +67,7 @@ class Registry
      * createContainer
      *
      * @param  string $key
-     * @param  array $value
+     * @param  array  $value
      * @return Container\AbstractContainer
      */
     public function createContainer($key, array $value = array())
@@ -71,6 +75,7 @@ class Registry
         $key = (string) $key;
 
         $this->items[$key] = new $this->containerClass($value);
+
         return $this->items[$key];
     }
 
@@ -101,14 +106,14 @@ class Registry
     public function containerExists($key)
     {
         $key = (string) $key;
-        $return =  array_key_exists($key, $this->items);
-        return $return;
+
+        return array_key_exists($key, $this->items);
     }
 
     /**
      * Set the container for an item in the registry
      *
-     * @param  string $key
+     * @param  string                      $key
      * @param  Container\AbstractContainer $container
      * @return Registry
      */
@@ -116,6 +121,7 @@ class Registry
     {
         $key = (string) $key;
         $this->items[$key] = $container;
+
         return $this;
     }
 
@@ -159,6 +165,7 @@ class Registry
         }
 
         $this->containerClass = $name;
+
         return $this;
     }
 

--- a/library/Zend/View/Helper/RenderChildModel.php
+++ b/library/Zend/View/Helper/RenderChildModel.php
@@ -21,11 +21,15 @@ use Zend\View\Model\ModelInterface as Model;
 class RenderChildModel extends AbstractHelper
 {
     /**
-     * @var Model Current view model
+     * Current view model
+     *
+     * @var Model
      */
     protected $current;
 
     /**
+     * View model helper instance
+     *
      * @var ViewModel
      */
     protected $viewModelHelper;
@@ -64,6 +68,7 @@ class RenderChildModel extends AbstractHelper
         $return  = $view->render($model);
         $helper  = $this->getViewModelHelper();
         $helper->setCurrent($current);
+
         return $return;
     }
 
@@ -85,6 +90,7 @@ class RenderChildModel extends AbstractHelper
                 return $childModel;
             }
         }
+
         return false;
     }
 
@@ -103,6 +109,7 @@ class RenderChildModel extends AbstractHelper
                 __METHOD__
             ));
         }
+
         return $helper->getCurrent();
     }
 
@@ -113,11 +120,10 @@ class RenderChildModel extends AbstractHelper
      */
     protected function getViewModelHelper()
     {
-        if ($this->viewModelHelper) {
-            return $this->viewModelHelper;
+        if (null === $this->viewModelHelper) {
+            $this->viewModelHelper = $this->getView()->plugin('view_model');
         }
-        $view = $this->getView();
-        $this->viewModelHelper = $view->plugin('view_model');
+
         return $this->viewModelHelper;
     }
 }

--- a/library/Zend/View/Helper/RenderChildModel.php
+++ b/library/Zend/View/Helper/RenderChildModel.php
@@ -120,8 +120,12 @@ class RenderChildModel extends AbstractHelper
      */
     protected function getViewModelHelper()
     {
-        if (null === $this->viewModelHelper) {
-            $this->viewModelHelper = $this->getView()->plugin('view_model');
+        if ($this->viewModelHelper) {
+            return $this->viewModelHelper;
+        }
+
+        if (method_exists($this->getView(), 'plugin')) {
+            $this->viewModelHelper = $this->view->plugin('view_model');
         }
 
         return $this->viewModelHelper;

--- a/library/Zend/View/Helper/RenderToPlaceholder.php
+++ b/library/Zend/View/Helper/RenderToPlaceholder.php
@@ -21,8 +21,8 @@ class RenderToPlaceholder extends AbstractHelper
      * Renders a template and stores the rendered output as a placeholder
      * variable for later use.
      *
-     * @param string|ModelInterface $script The template script to render
-     * @param string $placeholder The placeholder variable name in which to store the rendered output
+     * @param string|ModelInterface $script      The template script to render
+     * @param string                $placeholder The placeholder variable name in which to store the rendered output
      * @return void
      */
     public function __invoke($script, $placeholder)

--- a/library/Zend/View/Helper/ServerUrl.php
+++ b/library/Zend/View/Helper/ServerUrl.php
@@ -51,7 +51,7 @@ class ServerUrl extends AbstractHelper
      *                                     as a path. If a string is given, it
      *                                     will be appended as a path. Default
      *                                     is to not append any path.
-     * @return string                      server url
+     * @return string
      */
     public function __invoke($requestUri = null)
     {
@@ -69,21 +69,22 @@ class ServerUrl extends AbstractHelper
     /**
      * Returns host
      *
-     * @return string  host
+     * @return string
      */
     public function getHost()
     {
         if (null === $this->host) {
             $this->detectHost();
         }
+
         return $this->host;
     }
 
     /**
      * Sets host
      *
-     * @param  string $host                new host
-     * @return \Zend\View\Helper\ServerUrl  fluent interface, returns self
+     * @param  string $host
+     * @return ServerUrl
      */
     public function setHost($host)
     {
@@ -98,31 +99,34 @@ class ServerUrl extends AbstractHelper
         }
 
         $this->host = $host . ':' . $port;
+
         return $this;
     }
 
     /**
      * Returns scheme (typically http or https)
      *
-     * @return string  scheme (typically http or https)
+     * @return string
      */
     public function getScheme()
     {
         if (null === $this->scheme) {
             $this->detectScheme();
         }
+
         return $this->scheme;
     }
 
     /**
      * Sets scheme (typically http or https)
      *
-     * @param  string $scheme              new scheme (typically http or https)
-     * @return \Zend\View\Helper\ServerUrl  fluent interface, returns self
+     * @param  string $scheme
+     * @return ServerUrl
      */
     public function setScheme($scheme)
     {
         $this->scheme = $scheme;
+
         return $this;
     }
 
@@ -136,6 +140,7 @@ class ServerUrl extends AbstractHelper
         if (null === $this->port) {
             $this->detectPort();
         }
+
         return $this->port;
     }
 
@@ -148,6 +153,7 @@ class ServerUrl extends AbstractHelper
     public function setPort($port)
     {
         $this->port = (int) $port;
+
         return $this;
     }
 
@@ -160,6 +166,7 @@ class ServerUrl extends AbstractHelper
     public function setUseProxy($useProxy = false)
     {
         $this->useProxy = (bool) $useProxy;
+
         return $this;
     }
 
@@ -185,6 +192,7 @@ class ServerUrl extends AbstractHelper
             }
 
             $this->setHost($_SERVER['HTTP_HOST']);
+
             return;
         }
 
@@ -220,6 +228,7 @@ class ServerUrl extends AbstractHelper
             return false;
         }
         $this->setHost($host);
+
         return true;
     }
 
@@ -244,6 +253,7 @@ class ServerUrl extends AbstractHelper
                 $scheme = 'http';
                 break;
         }
+
         $this->setScheme($scheme);
     }
 
@@ -291,7 +301,9 @@ class ServerUrl extends AbstractHelper
         if (empty($scheme)) {
             return false;
         }
+
         $this->setScheme($scheme);
+
         return true;
     }
 
@@ -312,6 +324,7 @@ class ServerUrl extends AbstractHelper
 
         $port = $_SERVER['HTTP_X_FORWARDED_PORT'];
         $this->setPort($port);
+
         return true;
     }
 }

--- a/library/Zend/View/Helper/Service/FlashMessengerFactory.php
+++ b/library/Zend/View/Helper/Service/FlashMessengerFactory.php
@@ -15,6 +15,12 @@ use Zend\View\Helper\FlashMessenger;
 
 class FlashMessengerFactory implements FactoryInterface
 {
+    /**
+     * Create service
+     *
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @return FlashMessenger
+     */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $serviceLocator = $serviceLocator->getServiceLocator();

--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -98,7 +98,6 @@ class Url extends AbstractHelper
     public function setRouter(RouteStackInterface $router)
     {
         $this->router = $router;
-
         return $this;
     }
 
@@ -111,7 +110,6 @@ class Url extends AbstractHelper
     public function setRouteMatch(RouteMatch $routeMatch)
     {
         $this->routeMatch = $routeMatch;
-
         return $this;
     }
 }

--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -34,41 +34,17 @@ class Url extends AbstractHelper
     protected $routeMatch;
 
     /**
-     * Set the router to use for assembling.
-     *
-     * @param RouteStackInterface $router
-     * @return Url
-     */
-    public function setRouter(RouteStackInterface $router)
-    {
-        $this->router = $router;
-        return $this;
-    }
-
-    /**
-     * Set route match returned by the router.
-     *
-     * @param  RouteMatch $routeMatch
-     * @return self
-     */
-    public function setRouteMatch(RouteMatch $routeMatch)
-    {
-        $this->routeMatch = $routeMatch;
-        return $this;
-    }
-
-    /**
      * Generates an url given the name of a route.
      *
      * @see    Zend\Mvc\Router\RouteInterface::assemble()
-     * @param  string  $name               Name of the route
-     * @param  array   $params             Parameters for the link
-     * @param  array   $options            Options for the route
-     * @param  bool $reuseMatchedParams Whether to reuse matched parameters
-     * @return string Url                  For the link href attribute
-     * @throws Exception\RuntimeException  If no RouteStackInterface was provided
-     * @throws Exception\RuntimeException  If no RouteMatch was provided
-     * @throws Exception\RuntimeException  If RouteMatch didn't contain a matched route name
+     * @param  string $name               Name of the route
+     * @param  array  $params             Parameters for the link
+     * @param  array  $options            Options for the route
+     * @param  bool   $reuseMatchedParams Whether to reuse matched parameters
+     * @throws Exception\RuntimeException If no RouteStackInterface was provided
+     * @throws Exception\RuntimeException If no RouteMatch was provided
+     * @throws Exception\RuntimeException If RouteMatch didn't contain a matched route name
+     * @return string Url                 For the link href attribute
      */
     public function __invoke($name = null, array $params = array(), $options = array(), $reuseMatchedParams = false)
     {
@@ -111,5 +87,31 @@ class Url extends AbstractHelper
         $options['name'] = $name;
 
         return $this->router->assemble($params, $options);
+    }
+
+    /**
+     * Set the router to use for assembling.
+     *
+     * @param RouteStackInterface $router
+     * @return Url
+     */
+    public function setRouter(RouteStackInterface $router)
+    {
+        $this->router = $router;
+
+        return $this;
+    }
+
+    /**
+     * Set route match returned by the router.
+     *
+     * @param  RouteMatch $routeMatch
+     * @return Url
+     */
+    public function setRouteMatch(RouteMatch $routeMatch)
+    {
+        $this->routeMatch = $routeMatch;
+
+        return $this;
     }
 }

--- a/library/Zend/View/Helper/ViewModel.php
+++ b/library/Zend/View/Helper/ViewModel.php
@@ -27,23 +27,15 @@ class ViewModel extends AbstractHelper
     protected $root;
 
     /**
-     * Get the root view model
+     * Set the current view model
      *
-     * @return null|Model
+     * @param  Model $model
+     * @return ViewModel
      */
-    public function getRoot()
+    public function setCurrent(Model $model)
     {
-        return $this->root;
-    }
-
-    /**
-     * Is a root view model composed?
-     *
-     * @return bool
-     */
-    public function hasRoot()
-    {
-        return ($this->root instanceof Model);
+        $this->current = $model;
+        return $this;
     }
 
     /**
@@ -75,20 +67,26 @@ class ViewModel extends AbstractHelper
     public function setRoot(Model $model)
     {
         $this->root = $model;
-
         return $this;
     }
 
     /**
-     * Set the current view model
+     * Get the root view model
      *
-     * @param  Model $model
-     * @return ViewModel
+     * @return null|Model
      */
-    public function setCurrent(Model $model)
+    public function getRoot()
     {
-        $this->current = $model;
+        return $this->root;
+    }
 
-        return $this;
+    /**
+     * Is a root view model composed?
+     *
+     * @return bool
+     */
+    public function hasRoot()
+    {
+        return ($this->root instanceof Model);
     }
 }

--- a/library/Zend/View/Helper/ViewModel.php
+++ b/library/Zend/View/Helper/ViewModel.php
@@ -75,6 +75,7 @@ class ViewModel extends AbstractHelper
     public function setRoot(Model $model)
     {
         $this->root = $model;
+
         return $this;
     }
 
@@ -87,6 +88,7 @@ class ViewModel extends AbstractHelper
     public function setCurrent(Model $model)
     {
         $this->current = $model;
+
         return $this;
     }
 }


### PR DESCRIPTION
**Overview:**
- Comments cleanup
- CS cleanup
- Add some missing docblocks and comments
- Properties are sorted alphabetically
- Methods in blocks are sorted alphabetically
- All helpers now follow this structure set_, get_, has*
- Some minor changes

**Every helper now follow this structure:**

> __construct()
> __invoke()
> __call()
> __toString()
> render()
> toString()
> ...
> set_()
> get_()
> has*()
