### PR TITLE
Reset stop-propagation flag when triggering event

### DIFF
--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -201,6 +201,9 @@ class EventManager implements EventManagerInterface
             throw new Exception\InvalidCallbackException('Invalid callback provided');
         }
 
+        // Initial value of stop propagation flag should be false
+        $e->stopPropagation(false);
+
         return $this->triggerListeners($event, $e, $callback);
     }
 
@@ -242,6 +245,9 @@ class EventManager implements EventManagerInterface
         if (!is_callable($callback)) {
             throw new Exception\InvalidCallbackException('Invalid callback provided');
         }
+
+        // Initial value of stop propagation flag should be false
+        $e->stopPropagation(false);
 
         return $this->triggerListeners($event, $e, $callback);
     }

--- a/tests/ZendTest/EventManager/EventManagerTest.php
+++ b/tests/ZendTest/EventManager/EventManagerTest.php
@@ -657,4 +657,37 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         StaticEventManager::resetInstance();
         $this->assertFalse($this->events->getSharedManager());
     }
+
+    public function testTriggerSetsStopPropagationFlagToFalse()
+    {
+        $marker = (object) array('propagationIsStopped' => true);
+        $this->events->attach('foo', function ($e) use ($marker) {
+            $marker->propagationIsStopped = $e->propagationIsStopped();
+        });
+
+        $event = new Event();
+        $event->stopPropagation(true);
+        $this->events->trigger('foo', $event);
+
+        $this->assertFalse($marker->propagationIsStopped);
+        $this->assertFalse($event->propagationIsStopped());
+    }
+
+    public function testTriggerUntilSetsStopPropagationFlagToFalse()
+    {
+        $marker = (object) array('propagationIsStopped' => true);
+        $this->events->attach('foo', function ($e) use ($marker) {
+            $marker->propagationIsStopped = $e->propagationIsStopped();
+        });
+
+        $criteria = function ($r) {
+            return false;
+        };
+        $event = new Event();
+        $event->stopPropagation(true);
+        $this->events->triggerUntil('foo', $event, $criteria);
+
+        $this->assertFalse($marker->propagationIsStopped);
+        $this->assertFalse($event->propagationIsStopped());
+    }
 }


### PR DESCRIPTION
@macnibblet noticed that if an event listener on, say, the dispatch event called `stopPropagation` on the event, nothing was rendered in the response. On investigation, I discovered that the "stop propagation" flag on the `MvcEvent` was not being reset between different events that were being triggered. When triggering events in sequence, using the same event object, this is problematic, as the first listener in a subsequent trigger will be executed normally, but no others will be.

The solution is to reset the flag at the start of `trigger` (and `triggerUntil`). This PR does that, providing unit tests for the `EventManager`, and integration tests for the `Application` object. 
