### PR TITLE
Filters priority setting when populating filters in inputfilter factory and not losing it when merging filter chains

### DIFF
--- a/library/Zend/Filter/FilterChain.php
+++ b/library/Zend/Filter/FilterChain.php
@@ -184,8 +184,8 @@ class FilterChain extends AbstractFilter implements Countable
      */
     public function merge(FilterChain $filterChain)
     {
-        foreach ($filterChain->filters as $filter) {
-            $this->attach($filter);
+        foreach ($filterChain->filters->toArray(PriorityQueue::EXTR_BOTH) as $item) {
+            $this->attach($item['data'], $item['priority']);
         }
 
         return $this;

--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -267,11 +267,12 @@ class Factory
                     );
                 }
                 $name = $filter['name'];
+                $priority = isset($filter['priority']) ? $filter['priority'] : FilterChain::DEFAULT_PRIORITY;
                 $options = array();
                 if (isset($filter['options'])) {
                     $options = $filter['options'];
                 }
-                $chain->attachByName($name, $options);
+                $chain->attachByName($name, $options, $priority);
                 continue;
             }
 

--- a/tests/ZendTest/Filter/FilterChainTest.php
+++ b/tests/ZendTest/Filter/FilterChainTest.php
@@ -183,6 +183,38 @@ class FilterChainTest extends \PHPUnit_Framework_TestCase
         $valueExpected = 'abc';
         $this->assertEquals($valueExpected, $unserialized->filter($value));
     }
+    
+    public function testMergingTwoFilterChainsKeepFiltersPriority()
+    {
+        $value         = 'AbC';
+        $valueExpected = 'abc';
+        
+        $chain = new FilterChain();
+        $chain->attach(new StripUpperCase())
+              ->attach(new LowerCase(), 1001);        
+        $this->assertEquals($valueExpected, $chain->filter($value));
+        
+        $chain = new FilterChain();
+        $chain->attach(new LowerCase(), 1001)
+              ->attach(new StripUpperCase());        
+        $this->assertEquals($valueExpected, $chain->filter($value));
+        
+        $chain = new FilterChain();
+        $chain->attach(new LowerCase(), 1001);        
+        $chainToMerge = new FilterChain();
+        $chainToMerge->attach(new StripUpperCase());        
+        $chain->merge($chainToMerge);
+        $this->assertEquals(2, $chain->count());
+        $this->assertEquals($valueExpected, $chain->filter($value));
+        
+        $chain = new FilterChain();
+        $chain->attach(new StripUpperCase());        
+        $chainToMerge = new FilterChain();
+        $chainToMerge->attach(new LowerCase(), 1001);        
+        $chain->merge($chainToMerge);
+        $this->assertEquals(2, $chain->count());
+        $this->assertEquals($valueExpected, $chain->filter($value));        
+    }
 }
 
 

--- a/tests/ZendTest/InputFilter/FactoryTest.php
+++ b/tests/ZendTest/InputFilter/FactoryTest.php
@@ -423,4 +423,47 @@ class FactoryTest extends TestCase
         ));
         $this->assertEquals('My custom error message', $input->getErrorMessage());
     }
+    
+    public function testFactoryWillNotGetPrioritySetting()
+    {
+        //Reminder: Priority at which to enqueue filter; defaults to 1000 (higher executes earlier)
+        $factory = new Factory();
+        $input   = $factory->createInput(array(
+            'name'    => 'foo',
+            'filters' => array(
+                array(
+                    'name'      => 'string_trim',
+                    'priority'  => \Zend\Filter\FilterChain::DEFAULT_PRIORITY - 1 // 999
+                ),
+                array(
+                    'name'      => 'string_to_upper',
+                    'priority'  => \Zend\Filter\FilterChain::DEFAULT_PRIORITY + 1 //1001
+                ),
+                array(
+                    'name'      => 'string_to_lower', // default priority 1000
+                )
+            )
+        ));
+        
+        // We should have 3 filters
+        $this->assertEquals(3, $input->getFilterChain()->count());
+        
+        // Filters should pop in the following order:
+        // string_to_upper (1001), string_to_lower (1000), string_trim (999)
+        $index = 0;
+        foreach($input->getFilterChain()->getFilters() as $filter) {
+            switch($index) {
+                case 0:
+                    $this->assertInstanceOf('Zend\Filter\StringToUpper', $filter);
+                    break;
+                case 1:
+                    $this->assertInstanceOf('Zend\Filter\StringToLower', $filter);
+                    break;
+                case 2:
+                    $this->assertInstanceOf('Zend\Filter\StringTrim', $filter);
+                    break;               
+            }
+            $index++;
+        }
+    }
 }


### PR DESCRIPTION
This PR do two things.

First, we can set the filter priority in the configuration array when creating an input filter through factory.

```
$input->add($factory->createInput(array(
    'name' => 'img_background',
    'required' => true
    'filters' => array(
        array(
            'name' => 'Admin\Filter\Diacritics',
            'priority' => 10000
        ),
    ),
)));
```

It works also for filters set within the form element, here:

```
class Image extends \Zend\Form\File
{
    public function getInputSpecification() {
        $specs = parent::getInputSpecification();
        if (!isset($specs['filters']) || !is_array($specs['filters'])) {
            $specs['filters'] = array();
        }
        $specs['filters'][] = array(
            'name' => '\Admin\Filter\Thumbnail',
            'priority' => 999
        );

        return $specs;
    }
}
```

Second, when merging two filter chains, the filters priority of the merged filter chain are no more lost in the process (reset to the default_priority constant which is 1000 for now).

Keeping my examples above if this two filter chains were related to the same form element then they would be merged and the filters priority of the merged filter chain would be lost (in my example, the merged one is the one with the Diacritics Filter).

With this PR the priority of the Diacritics filter would not be lost when the two filter chains would be merged.

PS: I wanted to make some unit tests but the truth is I don't even know where to start, I'm not even sure it is needed.
