### PR TITLE
[ZF3] FQCN in parameter type hints

### DIFF
--- a/library/Zend/Code/Generator/ParameterGenerator.php
+++ b/library/Zend/Code/Generator/ParameterGenerator.php
@@ -261,7 +261,13 @@ class ParameterGenerator extends AbstractGenerator
         $output = '';
 
         if ($this->type && !in_array($this->type, static::$simple)) {
-            $output .= $this->type . ' ';
+            $type = strtolower($this->type);
+
+            if ($type === 'array' || $type === 'callable') {
+                $output .= $type . ' ';
+            } else {
+                $output .= '\\' . trim($this->type, '\\') . ' ';
+            }
         }
 
         if (true === $this->passedByReference) {

--- a/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
@@ -67,6 +67,9 @@ class ParameterGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $parameterGenerator->setType('array');
         $this->assertEquals('array $bar = \'foo\'', $parameterGenerator->generate());
+
+        $parameterGenerator->setType('callable');
+        $this->assertEquals('callable $bar = \'foo\'', $parameterGenerator->generate());
     }
 
     public function testFromReflectionGetParameterName()

--- a/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
@@ -60,10 +60,13 @@ class ParameterGeneratorTest extends \PHPUnit_Framework_TestCase
         $parameterGenerator->setType('Foo');
         $parameterGenerator->setName('bar');
         $parameterGenerator->setDefaultValue(15);
-        $this->assertEquals('Foo $bar = 15', $parameterGenerator->generate());
+        $this->assertEquals('\Foo $bar = 15', $parameterGenerator->generate());
 
         $parameterGenerator->setDefaultValue('foo');
-        $this->assertEquals('Foo $bar = \'foo\'', $parameterGenerator->generate());
+        $this->assertEquals('\Foo $bar = \'foo\'', $parameterGenerator->generate());
+
+        $parameterGenerator->setType('array');
+        $this->assertEquals('array $bar = \'foo\'', $parameterGenerator->generate());
     }
 
     public function testFromReflectionGetParameterName()

--- a/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
@@ -139,7 +139,7 @@ class ParameterGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('name', '$param'),
-            array('type', 'stdClass $bar'),
+            array('type', '\stdClass $bar'),
             array('reference', '&$baz'),
             array('defaultValue', '$value = \'foo\''),
             array('defaultNull', '$value = null'),


### PR DESCRIPTION
This PR introduces FQCNs for type-hints in generated method signatures. This is a BC break, but it is necessary to use the code generator when the generated code is not placed on a dedicated file.

Before:

``` php
public function doFoo(Foo $foo) {}
```

After

``` php
public function doFoo(\Foo $foo) {}
```

This PR also takes into account the new PHP 5.4 `callable` data type when generating code.
