### PR TITLE
Hotfix - `callable` type introspection for method parameters

### DIFF
--- a/library/Zend/Code/Generator/ParameterGenerator.php
+++ b/library/Zend/Code/Generator/ParameterGenerator.php
@@ -56,6 +56,8 @@ class ParameterGenerator extends AbstractGenerator
 
         if ($reflectionParameter->isArray()) {
             $param->setType('array');
+        } elseif (method_exists($reflectionParameter, 'isCallable') && $reflectionParameter->isCallable()) {
+            $param->setType('callable');
         } else {
             $typeClass = $reflectionParameter->getClass();
             if ($typeClass) {

--- a/library/Zend/Code/Reflection/ParameterReflection.php
+++ b/library/Zend/Code/Reflection/ParameterReflection.php
@@ -77,6 +77,8 @@ class ParameterReflection extends ReflectionParameter implements ReflectionInter
     {
         if ($this->isArray()) {
             return 'array';
+        } elseif (method_exists($this, 'isCallable') && $this->isCallable()) {
+            return 'callable';
         }
 
         if (($class = $this->getClass()) instanceof \ReflectionClass) {

--- a/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Code\Generator;
 
 use Zend\Code\Generator\ParameterGenerator;
 use Zend\Code\Generator\ValueGenerator;
+use Zend\Code\Reflection\ParameterReflection;
 
 /**
  * @category   Zend
@@ -114,6 +115,19 @@ class ParameterGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEquals('int', $codeGenParam->getType());
         $this->assertEquals('', $codeGenParam->getType());
+    }
+
+    public function testCallableTypeHint()
+    {
+        if (PHP_VERSION_ID < 50400) {
+            $this->markTestSkipped('`callable` is only supported in PHP >=5.4.0');
+        }
+
+        $parameter = ParameterGenerator::fromReflection(
+            new ParameterReflection(array('ZendTest\Code\Generator\TestAsset\CallableTypeHintClass', 'foo'), 'bar')
+        );
+
+        $this->assertEquals('callable', $parameter->getType());
     }
 
     /**

--- a/tests/ZendTest/Code/Generator/TestAsset/CallableTypeHintClass.php
+++ b/tests/ZendTest/Code/Generator/TestAsset/CallableTypeHintClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ZendTest\Code\Generator\TestAsset;
+
+class CallableTypeHintClass
+{
+    public function foo(callable $bar)
+    {
+    }
+}

--- a/tests/ZendTest/Code/Reflection/ParameterReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/ParameterReflectionTest.php
@@ -48,6 +48,17 @@ class ParameterReflectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($type, $parameter->getType());
     }
 
+    public function testCallableTypeHint()
+    {
+        if (PHP_VERSION_ID < 50400) {
+            $this->markTestSkipped('`callable` is only supported in PHP >=5.4.0');
+        }
+
+        $parameter = new Reflection\ParameterReflection(array('ZendTest\Code\Reflection\TestAsset\CallableTypeHintClass', 'foo'), 'bar');
+
+        $this->assertEquals('callable', $parameter->getType());
+    }
+
     public function paramTypeTestProvider()
     {
         return array(

--- a/tests/ZendTest/Code/Reflection/TestAsset/CallableTypeHintClass.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/CallableTypeHintClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ZendTest\Code\Reflection\TestAsset;
+
+class CallableTypeHintClass
+{
+    public function foo(callable $bar)
+    {
+    }
+}


### PR DESCRIPTION
This PR introduces a fix that allows `Zend\Code` to recognize the `callable` type hint on method parameters.

This PR is BC.
