### PR TITLE
Hotfix - FQCN in `extends` and `implements`

### DIFF
--- a/library/Zend/Code/Generator/ClassGenerator.php
+++ b/library/Zend/Code/Generator/ClassGenerator.php
@@ -697,11 +697,16 @@ class ClassGenerator extends AbstractGenerator
         $output .= 'class ' . $this->getName();
 
         if (!empty($this->extendedClass)) {
-            $output .= ' extends ' . $this->extendedClass;
+            $output .= ' extends \\' . trim($this->extendedClass, '\\');
         }
 
         $implemented = $this->getImplementedInterfaces();
+
         if (!empty($implemented)) {
+            foreach ($implemented as & $interface) {
+                $interface = '\\' . trim($interface, '\\');
+            }
+
             $output .= ' implements ' . implode(', ', $implemented);
         }
 

--- a/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
@@ -200,7 +200,7 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
         ));
 
         $expectedOutput = <<<EOS
-abstract class SampleClass extends ExtendedClassName implements Iterator, Traversable
+abstract class SampleClass extends \ExtendedClassName implements \Iterator, \Traversable
 {
 
     public \$foo = null;
@@ -233,8 +233,8 @@ EOS;
         $code = $classGenerator->generate();
 
         $expectedClassDef = 'class ClassWithInterface'
-            . ' implements ZendTest\Code\Generator\TestAsset\OneInterface'
-            . ', ZendTest\Code\Generator\TestAsset\TwoInterface';
+            . ' implements \ZendTest\Code\Generator\TestAsset\OneInterface'
+            . ', \ZendTest\Code\Generator\TestAsset\TwoInterface';
         $this->assertContains($expectedClassDef, $code);
     }
 
@@ -251,8 +251,8 @@ EOS;
         $code = $classGenerator->generate();
 
         $expectedClassDef = 'class NewClassWithInterface'
-            . ' extends ZendTest\Code\Generator\TestAsset\ClassWithInterface'
-            . ' implements ZendTest\Code\Generator\TestAsset\ThreeInterface';
+            . ' extends \ZendTest\Code\Generator\TestAsset\ClassWithInterface'
+            . ' implements \ZendTest\Code\Generator\TestAsset\ThreeInterface';
         $this->assertContains($expectedClassDef, $code);
     }
 
@@ -288,7 +288,7 @@ CODE;
             ->setExtendedClass('ParentClass');
 
         $expected = <<<CODE
-class MyClass extends ParentClass
+class MyClass extends \ParentClass
 {
 
 

--- a/tests/ZendTest/Code/Generator/FileGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/FileGeneratorTest.php
@@ -66,7 +66,7 @@ class FileGeneratorTest extends \PHPUnit_Framework_TestCase
 
 require_once 'SampleClass.php';
 
-abstract class SampleClass extends ExtendedClassName implements Iterator, Traversable
+abstract class SampleClass extends \ExtendedClassName implements \Iterator, \Traversable
 {
 
 


### PR DESCRIPTION
This PR is a BC break. 

Similar to #4149, it is currently problematic to generate multiple classes into the same file. 

This PR introduces fully qualified class names for the `extends` and `implements` clauses in generated code.

Before

``` php
class Foo extends Bar implements Baz {}
```

After

``` php
class Foo extends \Bar implements \Baz {}
```
