### PR TITLE
Composer: Suggest the ServiceManager for the filters and validators

### DIFF
--- a/library/Zend/Filter/composer.json
+++ b/library/Zend/Filter/composer.json
@@ -20,6 +20,7 @@
         "zendframework/zend-crypt": "self.version"
     },
     "suggest": {
+        "zendframework/zend-servicemanager": "Zend\\ServiceManager component to use the FilterPluginManager",
         "zendframework/zend-i18n": "Zend\\I18n component",
         "zendframework/zend-uri": "Zend\\Uri component for UriNormalize filter",
         "zendframework/zend-validator": "Zend\\Validator component",

--- a/library/Zend/Validator/composer.json
+++ b/library/Zend/Validator/composer.json
@@ -15,13 +15,13 @@
     "require": {
         "php": ">=5.3.3",
         "zendframework/zend-i18n": "self.version",
-        "zendframework/zend-servicemanager": "self.version",
         "zendframework/zend-stdlib": "self.version"
     },
     "require-dev": {
         "zendframework/zend-math": "self.version"
     },
     "suggest": {
+        "zendframework/zend-servicemanager": "Zend\\ServiceManager component to use the ValidatorPluginManager",
         "zendframework/zend-db": "Zend\\Db component",
         "zendframework/zend-math": "Zend\\Math component"
     },


### PR DESCRIPTION
Since the ServiceManager component is only required for the `FilterPluginManager`/`ValidatorPluginManager` (and thus `FilterChain`/`ValidatorChain` and `StaticFilter`/`StaticValidator` as well, as they use the managers) it may be a good idea to suggest the ServiceManager component rather than require it (Zend\Validator) or not mention it at all (Zend\Filter).

This would allow to use the filters and validators as standalone (e.g. by directly instantiating the classes) without having to download the ServiceManager component. 
