### PR TITLE
Fetch model from event parameter

### DIFF
--- a/library/Zend/View/View.php
+++ b/library/Zend/View/View.php
@@ -184,6 +184,10 @@ class View implements EventManagerAwareInterface
         $event->setRenderer($renderer);
         $results = $events->trigger(ViewEvent::EVENT_RENDERER_POST, $event);
 
+        // If EVENT_RENDERER or EVENT_RENDERER_POST changed the model, make sure
+        // we use this new model instead of the current $model
+        $model   = $event->getModel();
+
         // If we have children, render them first, but only if:
         // a) the renderer does not implement TreeRendererInterface, or
         // b) it does, but canRenderTrees() returns false


### PR DESCRIPTION
The model used for rendering can be modified during the EVENT_RENDERER and EVENT_RENDERER events. If only attributes (like the template) are modified, the current behaviour does not raise problems. However, when the entire view model is swapped out, the current behaviour does raise a problem.
### Use Case

A use case for swapping out view models is the principle of a three step view pattern. The `<html>`, `<head>` and contents of the `<head>` is usually the same for every layout you use. If you want to abstract that contents into a "wrapper" layout, you create a new view model, grab the model from the event and use the model from the event as a child. In code:

```
$model = $e->getModel();

$wrapper = new ViewModel;
$wrapper->setTemplate('layout/bar');
$wrapper->addChild($model);

$e->setModel($wrapper);
```

An example wrapper:

```
<?= $this->doctype() ?>

<html lang="en">
<head>
    <meta charset="utf-8">
    <?= $this->headTitle() ?>
    <?= $this->headMeta() ?>
    <?= $this->headLink() ?>
    <?= $this->headScript() ?>
</head>

<body>
    <?= $this->content ?>
    <?= $this->inlineScript() ?>
</body>
</html>
```

The layout becomes then simpler:

```
<?php
$this->headTitle('My Website')
     ->setSeparator(' &middot; ')
     ->setAutoEscape(false);

$this->headLink()
     ->appendStylesheet($this->basePath() . '/styles/css/styles.css');

$this->inlineScript()
     ->prependFile('https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js');
?>

<header><img src="logo.png"></header>

<nav><?= $this->navigation()->menu() ?></nav>

<section>
  <?= $this->content ?>
</section>

<footer>
    Copyright 2013 ACME
</footer>
```
### This PR

You simply cannot accomplish this or perform any other logic with the view model when the new model is not taken from the event. The simple addition makes it all possible :-)
