### PR TITLE
Fix #4167 - Console posix adapter writeLine() background color bleeding through to the next line.

### DIFF
--- a/library/Zend/Console/Adapter/Posix.php
+++ b/library/Zend/Console/Adapter/Posix.php
@@ -93,6 +93,24 @@ class Posix extends AbstractAdapter
     protected $lastTTYMode = null;
 
     /**
+     * Write a single line of text to console and advance cursor to the next line.
+     *
+     * This override works around a bug in some terminals that cause the background color
+     * to fill the next line after EOL. To remedy this, we are sending the colored string with
+     * appropriate color reset sequences before sending EOL character.
+     *
+     * @link https://github.com/zendframework/zf2/issues/4167
+     * @param string   $text
+     * @param null|int $color
+     * @param null|int $bgColor
+     */
+    public function writeLine($text = "", $color = null, $bgColor = null)
+    {
+        $this->write($text, $color, $bgColor);
+        $this->write(PHP_EOL);
+    }
+
+    /**
      * Determine and return current console width.
      *
      * @return int


### PR DESCRIPTION
Fixes https://github.com/zendframework/zf2/issues/4167.
