### PR TITLE
Fixed error in adapter paginator DbTableGateway

### DIFF
--- a/library/Zend/Paginator/Adapter/DbTableGateway.php
+++ b/library/Zend/Paginator/Adapter/DbTableGateway.php
@@ -20,9 +20,12 @@ class DbTableGateway extends DbSelect
      * @param TableGateway                $tableGateway
      * @param Where|\Closure|string|array $where
      */
-    public function __construct(TableGateway $tableGateway, $where = null)
+    public function __construct(TableGateway $tableGateway, $where = null, $order = null)
     {
-        $select             = $tableGateway->getSql()->select($where);
+        $select = $tableGateway->getSql()->select();
+        if ($where) $select->where($where);
+        if ($order) $select->order($order);
+        
         $dbAdapter          = $tableGateway->getAdapter();
         $resultSetPrototype = $tableGateway->getResultSetPrototype();
 

--- a/tests/ZendTest/Paginator/Adapter/DbTableGatewayTest.php
+++ b/tests/ZendTest/Paginator/Adapter/DbTableGatewayTest.php
@@ -24,7 +24,9 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
 
     /** @var DbTableGateway */
     protected $dbTableGateway;
-
+    
+    protected $mockTableGateway;
+    
     public function setup()
     {
         $mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
@@ -48,11 +50,14 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->mockStatement = $mockStatement;
-        $this->dbTableGateway = new DbTableGateway($mockTableGateway);
+        
+        $this->mockTableGateway = $mockTableGateway;
     }
 
     public function testGetItems()
     {
+        $this->dbTableGateway = new DbTableGateway($this->mockTableGateway);
+        
         $mockResult = $this->getMock('Zend\Db\Adapter\Driver\ResultInterface');
         $this->mockStatement
              ->expects($this->any())
@@ -65,6 +70,8 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
 
     public function testCount()
     {
+        $this->dbTableGateway = new DbTableGateway($this->mockTableGateway);
+        
         $mockResult = $this->getMock('Zend\Db\Adapter\Driver\ResultInterface');
         $mockResult->expects($this->any())
                    ->method('current')
@@ -76,5 +83,21 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
 
         $count = $this->dbTableGateway->count();
         $this->assertEquals(10, $count);
+    }
+    
+    public function testGetItemsWithWhereAndOrder()
+    {
+        $where = "foo = bar";
+        $order = "foo";
+        $this->dbTableGateway = new DbTableGateway($this->mockTableGateway, $where, $order);
+        
+        $mockResult = $this->getMock('Zend\Db\Adapter\Driver\ResultInterface');
+        $this->mockStatement
+             ->expects($this->any())
+             ->method('execute')
+             ->will($this->returnValue($mockResult));
+        
+        $items = $this->dbTableGateway->getItems(2, 10);
+        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
     }
 }


### PR DESCRIPTION
Fixed error in paging adapter DbTableGateway because the condition was being added as the table name.

I added a third parameter to the ordination
