### PR TITLE
Fix BC break in 2.1.5dev - Revert to previous isRequired behavior for file upload inputs

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -159,14 +159,6 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
         $inputs = $this->validationGroup ?: array_keys($this->inputs);
         foreach ($inputs as $name) {
             $input = $this->inputs[$name];
-            if ((!array_key_exists($name, $this->data)
-                    || (null === $this->data[$name]))
-                && $input instanceof InputInterface
-                && !$input->isRequired()
-            ) {
-                $this->validInputs[$name] = $input;
-                continue;
-            }
             if (!array_key_exists($name, $this->data)
                 || (null === $this->data[$name])
                 || (is_string($this->data[$name]) && strlen($this->data[$name]) === 0)
@@ -178,6 +170,14 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
                     && isset($this->data[$name][0]['error']) && $this->data[$name][0]['error'] === UPLOAD_ERR_NO_FILE)
             ) {
                 if ($input instanceof InputInterface) {
+                    // - test if input is required
+                    if (!$input->isRequired()
+                        // Do not mark valid for isRequired setting if value exists and is empty string
+                        && !(array_key_exists($name, $this->data) && is_string($this->data[$name]) && strlen($this->data[$name]) === 0)
+                    ) {
+                        $this->validInputs[$name] = $input;
+                        continue;
+                    }
                     // - test if input allows empty
                     if ($input->allowEmpty()) {
                         $this->validInputs[$name] = $input;

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -172,8 +172,8 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
                 if ($input instanceof InputInterface) {
                     // - test if input is required
                     if (!$input->isRequired()
-                        // Do not mark valid for isRequired setting if value exists and is empty string
-                        && !(array_key_exists($name, $this->data) && is_string($this->data[$name]) && strlen($this->data[$name]) === 0)
+                        // "Not required" should not apply to empty strings (#3983)
+                        && !(array_key_exists($name, $this->data) && is_string($this->data[$name]))
                     ) {
                         $this->validInputs[$name] = $input;
                         continue;

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -450,13 +450,13 @@ class BaseInputFilterTest extends TestCase
         $this->assertTrue($filter->isValid());
     }
 
-    public function testValidationSkipsFileInputsMarkedAllowEmptyWhenNoFileDataIsPresent()
+    public function testValidationSkipsFileInputsMarkedNotRequiredWhenNoFileDataIsPresent()
     {
         $filter = new InputFilter();
 
         $foo   = new FileInput();
         $foo->getValidatorChain()->attach(new Validator\File\UploadFile());
-        $foo->setAllowEmpty(true);
+        $foo->setRequired(false);
 
         $filter->add($foo, 'foo');
 
@@ -473,16 +473,16 @@ class BaseInputFilterTest extends TestCase
         $this->assertTrue($filter->isValid());
 
         // Negative test
-        $foo->setAllowEmpty(false);
+        $foo->setRequired(true);
         $filter->setData($data);
         $this->assertFalse($filter->isValid());
     }
 
-    public function testValidationSkipsFileInputsMarkedAllowEmptyWhenNoMultiFileDataIsPresent()
+    public function testValidationSkipsFileInputsMarkedNotRequiredWhenNoMultiFileDataIsPresent()
     {
         $filter = new InputFilter();
         $foo    = new FileInput();
-        $foo->setAllowEmpty(true);
+        $foo->setRequired(false);
         $filter->add($foo, 'foo');
 
         $data = array(
@@ -498,7 +498,7 @@ class BaseInputFilterTest extends TestCase
         $this->assertTrue($filter->isValid());
 
         // Negative test
-        $foo->setAllowEmpty(false);
+        $foo->setRequired(true);
         $filter->setData($data);
         $this->assertFalse($filter->isValid());
     }


### PR DESCRIPTION
#3983 causes BC breaks for FilePostRedirectGet Plugin, and in existing projects using File Inputs with changed isRequired settings.

To reproduce, install https://github.com/cgmartin/ZF2FileUploadExamples and test the following examples:
- "Single File Upload with partial validation"
- "Post-Redirect-Get Plugin Example"
- "FilePRG Plugin Example with nested Fieldset"

With ZF2.1.4, the examples work correctly.
With ZF2.1.5dev, the examples fail.

Reported via email by @leup (Thanks!)
