### PR TITLE
Allow the event to propagete further. 

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -329,6 +329,7 @@ class Application implements
     {
         $events = $this->getEventManager();
         $event->setTarget($this);
+        $event->stopPropagation(false);
         $events->trigger(MvcEvent::EVENT_RENDER, $event);
         $events->trigger(MvcEvent::EVENT_FINISH, $event);
         return $this;


### PR DESCRIPTION
If you stop the propagation of the event in the dispatch phase you are
able to continue to further phases as render and finish, but after
executing the first listener the other render/finish listeners will not
be called.
