### PR TITLE
Allow passing objects to the url helper

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/Redirect.php
+++ b/library/Zend/Mvc/Controller/Plugin/Redirect.php
@@ -33,7 +33,7 @@ class Redirect extends AbstractPlugin
      * @throws Exception\DomainException if composed controller does not implement InjectApplicationEventInterface, or
      *         router cannot be found in controller event
      */
-    public function toRoute($route = null, array $params = array(), $options = array(), $reuseMatchedParams = false)
+    public function toRoute($route = null, $params = array(), $options = array(), $reuseMatchedParams = false)
     {
         $controller = $this->getController();
         if (!$controller || !method_exists($controller, 'plugin')) {

--- a/library/Zend/Mvc/Controller/Plugin/Url.php
+++ b/library/Zend/Mvc/Controller/Plugin/Url.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Mvc\Controller\Plugin;
 
+use Traversable;
 use Zend\EventManager\EventInterface;
 use Zend\Mvc\Exception;
 use Zend\Mvc\InjectApplicationEventInterface;
@@ -22,7 +23,7 @@ class Url extends AbstractPlugin
      * Generates a URL based on a route
      *
      * @param  string             $route              RouteInterface name
-     * @param  array|\Traversable $params             Parameters to use in url generation, if any
+     * @param  array|Traversable $params             Parameters to use in url generation, if any
      * @param  array|bool         $options            RouteInterface-specific options to use in url generation, if any.
      *                                                If boolean, and no fourth argument, used as $reuseMatchedParams.
      * @param  bool               $reuseMatchedParams Whether to reuse matched parameters
@@ -39,16 +40,12 @@ class Url extends AbstractPlugin
             throw new Exception\DomainException('Url plugin requires a controller that implements InjectApplicationEventInterface');
         }
 
-        if (! is_array($params)) {
-
-            if (! $params instanceof \Traversable) {
-
+        if (!is_array($params)) {
+            if (!$params instanceof Traversable) {
                 throw new Exception\InvalidArgumentException(
                     'Params is expected to be an array of a Traversable object'
                 );
-
             } else {
-
                 $params = iterator_to_array($params);
             }
         }

--- a/library/Zend/Mvc/Controller/Plugin/Url.php
+++ b/library/Zend/Mvc/Controller/Plugin/Url.php
@@ -21,20 +21,36 @@ class Url extends AbstractPlugin
     /**
      * Generates a URL based on a route
      *
-     * @param  string $route RouteInterface name
-     * @param  array $params Parameters to use in url generation, if any
-     * @param  array|bool $options RouteInterface-specific options to use in url generation, if any. If boolean, and no fourth argument, used as $reuseMatchedParams
-     * @param  bool $reuseMatchedParams Whether to reuse matched parameters
+     * @param  string             $route              RouteInterface name
+     * @param  array|\Traversable $params             Parameters to use in url generation, if any
+     * @param  array|bool         $options            RouteInterface-specific options to use in url generation, if any.
+     *                                                If boolean, and no fourth argument, used as $reuseMatchedParams.
+     * @param  bool               $reuseMatchedParams Whether to reuse matched parameters
+     *
+     * @throws \Zend\Mvc\Exception\RuntimeException
+     * @throws \Zend\Mvc\Exception\InvalidArgumentException
+     * @throws \Zend\Mvc\Exception\DomainException
      * @return string
-     * @throws Exception\DomainException if composed controller does not implement InjectApplicationEventInterface, or
-     *         router cannot be found in controller event
-     * @throws Exception\RuntimeException if no RouteMatch instance or no matched route name present
      */
-    public function fromRoute($route = null, array $params = array(), $options = array(), $reuseMatchedParams = false)
+    public function fromRoute($route = null, $params = array(), $options = array(), $reuseMatchedParams = false)
     {
         $controller = $this->getController();
         if (!$controller instanceof InjectApplicationEventInterface) {
             throw new Exception\DomainException('Url plugin requires a controller that implements InjectApplicationEventInterface');
+        }
+
+        if (! is_array($params)) {
+
+            if (! $params instanceof \Traversable) {
+
+                throw new Exception\InvalidArgumentException(
+                    'Params is expected to be an array of a Traversable object'
+                );
+
+            } else {
+
+                $params = iterator_to_array($params);
+            }
         }
 
         $event   = $controller->getEvent();

--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -12,6 +12,7 @@ namespace Zend\View\Helper;
 use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\Router\RouteStackInterface;
+use Zend\Stdlib\ArrayUtils;
 use Zend\View\Exception;
 
 /**
@@ -61,16 +62,16 @@ class Url extends AbstractHelper
      * Generates an url given the name of a route.
      *
      * @see    Zend\Mvc\Router\RouteInterface::assemble()
-     * @param  string  $name               Name of the route
-     * @param  array   $params             Parameters for the link
-     * @param  array   $options            Options for the route
-     * @param  bool $reuseMatchedParams Whether to reuse matched parameters
+     * @param  string               $name               Name of the route
+     * @param  array                $params             Parameters for the link
+     * @param  array|\Traversable   $options            Options for the route
+     * @param  bool                 $reuseMatchedParams Whether to reuse matched parameters
      * @return string Url                  For the link href attribute
      * @throws Exception\RuntimeException  If no RouteStackInterface was provided
      * @throws Exception\RuntimeException  If no RouteMatch was provided
      * @throws Exception\RuntimeException  If RouteMatch didn't contain a matched route name
      */
-    public function __invoke($name = null, array $params = array(), $options = array(), $reuseMatchedParams = false)
+    public function __invoke($name = null, $params = array(), $options = array(), $reuseMatchedParams = false)
     {
         if (null === $this->router) {
             throw new Exception\RuntimeException('No RouteStackInterface instance provided');
@@ -92,6 +93,8 @@ class Url extends AbstractHelper
                 throw new Exception\RuntimeException('RouteMatch does not contain a matched route name');
             }
         }
+
+        $params = ArrayUtils::iteratorToArray($params, false);
 
         if ($reuseMatchedParams && $this->routeMatch !== null) {
             $routeMatchParams = $this->routeMatch->getParams();

--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -9,6 +9,7 @@
 
 namespace Zend\View\Helper;
 
+use Traversable;
 use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\Router\RouteStackInterface;
@@ -65,7 +66,7 @@ class Url extends AbstractHelper
      * @see    Zend\Mvc\Router\RouteInterface::assemble()
      * @param  string               $name               Name of the route
      * @param  array                $params             Parameters for the link
-     * @param  array|\Traversable   $options            Options for the route
+     * @param  array|Traversable   $options            Options for the route
      * @param  bool                 $reuseMatchedParams Whether to reuse matched parameters
      * @return string Url                         For the link href attribute
      * @throws Exception\RuntimeException         If no RouteStackInterface was provided
@@ -96,16 +97,12 @@ class Url extends AbstractHelper
             }
         }
 
-        if (! is_array($params)) {
-
-            if (! $params instanceof \Traversable) {
-
+        if (!is_array($params)) {
+            if (!$params instanceof Traversable) {
                 throw new Exception\InvalidArgumentException(
                     'Params is expected to be an array of a Traversable object'
                 );
-
             } else {
-
                 $params = iterator_to_array($params);
             }
         }

--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -14,6 +14,7 @@ use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\Router\RouteStackInterface;
 use Zend\Stdlib\ArrayUtils;
 use Zend\View\Exception;
+use Zend\Stdlib\Exception as StdlibException;
 
 /**
  * Helper for making easy links and getting urls that depend on the routes and router.
@@ -66,10 +67,11 @@ class Url extends AbstractHelper
      * @param  array                $params             Parameters for the link
      * @param  array|\Traversable   $options            Options for the route
      * @param  bool                 $reuseMatchedParams Whether to reuse matched parameters
-     * @return string Url                  For the link href attribute
-     * @throws Exception\RuntimeException  If no RouteStackInterface was provided
-     * @throws Exception\RuntimeException  If no RouteMatch was provided
-     * @throws Exception\RuntimeException  If RouteMatch didn't contain a matched route name
+     * @return string Url                         For the link href attribute
+     * @throws Exception\RuntimeException         If no RouteStackInterface was provided
+     * @throws Exception\RuntimeException         If no RouteMatch was provided
+     * @throws Exception\RuntimeException         If RouteMatch didn't contain a matched route name
+     * @throws Exception\InvalidArgumentException If the params object was not an array or \Traversable object
      */
     public function __invoke($name = null, $params = array(), $options = array(), $reuseMatchedParams = false)
     {
@@ -94,7 +96,14 @@ class Url extends AbstractHelper
             }
         }
 
-        $params = ArrayUtils::iteratorToArray($params, false);
+        try {
+
+            $params = ArrayUtils::iteratorToArray($params, false);
+
+        } catch(StdlibException\InvalidArgumentException $e) {
+
+            throw new Exception\InvalidArgumentException('Params is expected to be an array of a Traversable object');
+        }
 
         if ($reuseMatchedParams && $this->routeMatch !== null) {
             $routeMatchParams = $this->routeMatch->getParams();

--- a/library/Zend/View/Helper/Url.php
+++ b/library/Zend/View/Helper/Url.php
@@ -96,13 +96,18 @@ class Url extends AbstractHelper
             }
         }
 
-        try {
+        if (! is_array($params)) {
 
-            $params = ArrayUtils::iteratorToArray($params, false);
+            if (! $params instanceof \Traversable) {
 
-        } catch(StdlibException\InvalidArgumentException $e) {
+                throw new Exception\InvalidArgumentException(
+                    'Params is expected to be an array of a Traversable object'
+                );
 
-            throw new Exception\InvalidArgumentException('Params is expected to be an array of a Traversable object');
+            } else {
+
+                $params = iterator_to_array($params);
+            }
         }
 
         if ($reuseMatchedParams && $this->routeMatch !== null) {

--- a/tests/ZendTest/Mvc/Controller/Plugin/UrlTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/UrlTest.php
@@ -31,6 +31,12 @@ class UrlTest extends TestCase
                 'controller' => 'ZendTest\Mvc\Controller\TestAsset\SampleController',
             ),
         )));
+        $router->addRoute('default', array(
+            'type' => 'Zend\Mvc\Router\Http\Segment',
+            'options' => array(
+                'route' => '/:controller[/:action]',
+            )
+        ));
         $this->router = $router;
 
         $event = new MvcEvent();
@@ -46,6 +52,14 @@ class UrlTest extends TestCase
     {
         $url = $this->plugin->fromRoute('home');
         $this->assertEquals('/', $url);
+    }
+
+    public function testModel()
+    {
+        $it = new \ArrayIterator(array('controller' => 'ctrl', 'action' => 'act'));
+
+        $url = $this->plugin->fromRoute('default', $it);
+        $this->assertEquals('/ctrl/act', $url);
     }
 
     public function testPluginWithoutControllerRaisesDomainException()

--- a/tests/ZendTest/View/Helper/UrlTest.php
+++ b/tests/ZendTest/View/Helper/UrlTest.php
@@ -73,6 +73,14 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/ctrl/act', $url);
     }
 
+    public function testModel()
+    {
+        $it = new \ArrayIterator(array('controller' => 'ctrl', 'action' => 'act'));
+
+        $url = $this->url->__invoke('default', $it);
+        $this->assertEquals('/ctrl/act', $url);
+    }
+
     public function testPluginWithoutRouteMatchesInEventRaisesExceptionWhenNoRouteProvided()
     {
         $this->setExpectedException('Zend\View\Exception\RuntimeException', 'RouteMatch');

--- a/tests/ZendTest/View/Helper/UrlTest.php
+++ b/tests/ZendTest/View/Helper/UrlTest.php
@@ -81,6 +81,14 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/ctrl/act', $url);
     }
 
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     */
+    public function testThrowsExceptionOnInvalidParams()
+    {
+        $this->url->__invoke('default', 'invalid params');
+    }
+
     public function testPluginWithoutRouteMatchesInEventRaisesExceptionWhenNoRouteProvided()
     {
         $this->setExpectedException('Zend\View\Exception\RuntimeException', 'RouteMatch');


### PR DESCRIPTION
Heya peeeps!

I can't be the only person that hates doing

``` php
echo $this->url('route', array('id' => $model->getId(), 'slug' => $model->getSlug()));
```

since they map directly it would be nice to just do

``` php
echo $this->url('route', $model);
```

An idea would also be to check if the model/entity has a toArray method if the ArrayUtils fails. 
