### PR TITLE
EventManager or Stdlib\CallbackHandler can't handle WeakRef enough.

### DIFF
--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -461,9 +461,15 @@ class EventManager implements EventManagerInterface
         }
 
         foreach ($listeners as $listener) {
+            $listenerCallback = $listener->getCallback();
+            if (!$listenerCallback) {
+                $this->detach($listener);
+                continue;
+            }
+
             // Trigger the listener's callback, and push its result onto the
             // response collection
-            $responses->push(call_user_func($listener->getCallback(), $e));
+            $responses->push(call_user_func($listenerCallback, $e));
 
             // If the event was asked to stop propagating, do so
             if ($e->propagationIsStopped()) {


### PR DESCRIPTION
In develop branch,
I got this error.

```
$ php -d extension=weakref.so /usr/bin/phpunit ZendTest/EventManager
PHPUnit 3.7.14 by Sebastian Bergmann.

Configuration read from /home/sasezaki/zf2/tests/phpunit.xml.dist

.....................................E........................... 65 / 86 ( 75%)
.....................

Time: 0 seconds, Memory: 3.25Mb

There was 1 error:

1) ZendTest\EventManager\EventManagerTest::testWeakRefsAreHonoredWhenTriggering
call_user_func() expects parameter 1 to be a valid callback, no array or string given

/home/sasezaki/zf2/library/Zend/EventManager/EventManager.php:460
/home/sasezaki/zf2/library/Zend/EventManager/EventManager.php:204
/home/sasezaki/zf2/tests/ZendTest/EventManager/EventManagerTest.php:560

FAILURES!
Tests: 86, Assertions: 224, Errors: 1.
```

I did run under environment.

```
$ php -v
PHP 5.4.11-1~precise+1 (cli) (built: Jan 24 2013 15:22:16) 
Copyright (c) 1997-2013 The PHP Group
Zend Engine v2.4.0, Copyright (c) 1998-2013 Zend Technologies
    with Xdebug v2.2.1, Copyright (c) 2002-2012, by Derick Rethans
```

(When turn off xdebug or -d apc.enabled=0, I got same error).

This WeakRef issue occurs ZendSkeletonApplication can't run.
