### PR TITLE
Make identifier name configurable for AbstractRestfulController

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -39,6 +39,13 @@ abstract class AbstractRestfulController extends AbstractController
     );
 
     /**
+     * Name of request or query parameter containing identifier
+     * 
+     * @var string
+     */
+    protected $identifierName = 'id';
+
+    /**
      * @var int From Zend\Json\Json
      */
     protected $jsonDecodeType = Json::TYPE_ARRAY;
@@ -49,6 +56,28 @@ abstract class AbstractRestfulController extends AbstractController
      * @var array
      */
     protected $customHttpMethodsMap = array();
+
+    /**
+     * Set the route match/query parameter name containing the identifier
+     * 
+     * @param  string $name 
+     * @return self
+     */
+    public function setIdentifierName($name)
+    {
+        $this->identifierName = (string) $name;
+        return $this;
+    }
+
+    /**
+     * Retrieve the route match/query parameter name containing the identifier
+     * 
+     * @return string
+     */
+    public function getIdentifierName()
+    {
+        return $this->identifierName;
+    }
 
     /**
      * Create a new resource
@@ -439,12 +468,13 @@ abstract class AbstractRestfulController extends AbstractController
      */
     protected function getIdentifier($routeMatch, $request)
     {
-        $id = $routeMatch->getParam('id', false);
+        $identifier = $this->getIdentifierName();
+        $id = $routeMatch->getParam($identifier, false);
         if ($id) {
             return $id;
         }
 
-        $id = $request->getQuery()->get('id', false);
+        $id = $request->getQuery()->get($identifier, false);
         if ($id) {
             return $id;
         }

--- a/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
+++ b/tests/ZendTest/Mvc/Controller/RestfulControllerTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Mvc\Controller;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionObject;
 use stdClass;
 use Zend\EventManager\SharedEventManager;
 use Zend\Http\Response;
@@ -393,5 +394,34 @@ class RestfulControllerTest extends TestCase
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertInstanceOf('Zend\Http\Response', $result);
         $this->assertEquals(405, $result->getStatusCode());
+    }
+
+    public function testIdentifierNameDefaultsToId()
+    {
+        $this->assertEquals('id', $this->controller->getIdentifierName());
+    }
+
+    public function testCanSetIdentifierName()
+    {
+        $this->controller->setIdentifierName('name');
+        $this->assertEquals('name', $this->controller->getIdentifierName());
+    }
+
+    public function testUsesConfiguredIdentifierNameToGetIdentifier()
+    {
+        $r = new ReflectionObject($this->controller);
+        $getIdentifier = $r->getMethod('getIdentifier');
+        $getIdentifier->setAccessible(true);
+
+        $this->controller->setIdentifierName('name');
+
+        $this->routeMatch->setParam('name', 'foo');
+        $result = $getIdentifier->invoke($this->controller, $this->routeMatch, $this->request);
+        $this->assertEquals('foo', $result);
+
+        $this->routeMatch->setParam('name', false);
+        $this->request->getQuery()->set('name', 'bar');
+        $result = $getIdentifier->invoke($this->controller, $this->routeMatch, $this->request);
+        $this->assertEquals('bar', $result);
     }
 }


### PR DESCRIPTION
Currently, `AbstractRestfulController::getIdentifier()` hard codes a lookup on an `id` parameter in either the route matches or the query string. This is not optimal in the case of child resources, as it forces the creation of additional routes to ensure that the `:id` segment is specific to the given child resource:

``` php
'parent' => array(
    'type' => 'Segment',
    'options' => array(
        'route' => '/api/parent[/:id]',
    ),
),
'child' => array(
    'type' => 'Segment',
    'options' => array(
        'route' => '/api/parent/:parent/child[/:id]',
    ),
),
```

versus the more semantic:

``` php
'parent' => array(
    'type' => 'Segment',
    'options' => array(
        'route' => '/api/parent[/:parent]',
    ),
    'may_terminate' => true,
    'child_routes' => array(
        'child' => array(
            'type' => 'Segment',
            'options' => array(
                'route' => '/child[/:child]',
            ),
        ),
    ),
),
```

This PR makes the identifier name configurable. BC is retained, as it still defaults to "id"; however, new methods allow you to inject an alternate identifier name, and that name will be used by `getIdentifier()` in order to look up the resource ID.
