### PR TITLE
Update Zend_Validate.php resource

### DIFF
--- a/library/Zend/Validator/CreditCard.php
+++ b/library/Zend/Validator/CreditCard.php
@@ -51,7 +51,7 @@ class CreditCard extends AbstractValidator
         self::INVALID        => "Invalid type given. String expected",
         self::LENGTH         => "The input contains an invalid amount of digits",
         self::PREFIX         => "The input is not from an allowed institute",
-        self::SERVICE        => "The input seems to be an invalid credit card number.",
+        self::SERVICE        => "The input seems to be an invalid credit card number",
         self::SERVICEFAILURE => "An exception has been raised while validating the input",
     );
 

--- a/library/Zend/Validator/Explode.php
+++ b/library/Zend/Validator/Explode.php
@@ -20,7 +20,7 @@ class Explode extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID => "Invalid type given.",
+        self::INVALID => "Invalid type given",
     );
 
     /**

--- a/library/Zend/Validator/File/WordCount.php
+++ b/library/Zend/Validator/File/WordCount.php
@@ -28,8 +28,8 @@ class WordCount extends AbstractValidator
      * @var array Error message templates
      */
     protected $messageTemplates = array(
-        self::TOO_MUCH => "Too many words, maximum '%max%' are allowed but '%count%' were counted.",
-        self::TOO_LESS => "Too less words, minimum '%min%' are expected but '%count%' were counted",
+        self::TOO_MUCH => "Too many words, maximum '%max%' are allowed but '%count%' were counted",
+        self::TOO_LESS => "Too few words, minimum '%min%' are expected but '%count%' were counted",
         self::NOT_FOUND => "File is not readable or does not exist",
     );
 

--- a/resources/languages/ar/Zend_Validate.php
+++ b/resources/languages/ar/Zend_Validate.php
@@ -172,7 +172,7 @@ return array(
 
     // Zend_Validate_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "'%count%' كلمات أكثر من العدد الأقصى المسموح به وهو '%max%' كلمات",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "'%count%' كلمات أقل من العدد الأدنى المسموح وهو '%min%' كلمات",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "'%count%' كلمات أقل من العدد الأدنى المسموح وهو '%min%' كلمات",
     "File '%value%' is not readable or does not exist" => "الملف '%value%' لا يمكن قراءته أو أنه غير موجود",
 
     // Zend_Validate_Float

--- a/resources/languages/bg/Zend_Validate.php
+++ b/resources/languages/bg/Zend_Validate.php
@@ -187,7 +187,7 @@ return array(
 
     // Zend_Validator_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Твърде много думи, очакват се максимум '%max%', но '%count%' бяха открити",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Твърде малко думи, очакват се минимум '%min%' но само '%count%' бяха открити",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Твърде малко думи, очакват се минимум '%min%' но само '%count%' бяха открити",
     "File '%value%' is not readable or does not exist" => "Файлът '%value%' не може да бъде прочетен или не съществува",
 
     // Zend_Validator_GreaterThan

--- a/resources/languages/ca/Zend_Validate.php
+++ b/resources/languages/ca/Zend_Validate.php
@@ -199,7 +199,7 @@ return array(
 
     // Zend_Validator_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Excés de paraules, màxim '%max%' es permeten però s'han comptat '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Falten paraules, mínim '%min%' es permeten però s'han comptat '%count%'",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Falten paraules, mínim '%min%' es permeten però s'han comptat '%count%'",
     "File '%value%' is not readable or does not exist" => "L'arxiu '%value%' no és llegible o no existeix",
 
     // Zend_Validator_GreaterThan

--- a/resources/languages/cs/Zend_Validate.php
+++ b/resources/languages/cs/Zend_Validate.php
@@ -197,7 +197,7 @@ return array(
 
     // Zend_Validator_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Příliš mnoho slov. Je jich dovoleno maximálně '%max%', ale bylo zadáno '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Příliš málo slov. Musí jich být alespoň '%min%', ale bylo zadáno jen '%count%'",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Příliš málo slov. Musí jich být alespoň '%min%', ale bylo zadáno jen '%count%'",
     "File is not readable or does not exist" => "Soubor není čitelný nebo neexistuje",
 
     // Zend_Validator_GreaterThan

--- a/resources/languages/de/Zend_Validate.php
+++ b/resources/languages/de/Zend_Validate.php
@@ -186,7 +186,7 @@ return array(
 
     // Zend_Validator_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted"                                                    => "Zu viele Wörter. Maximal '%max%' sind erlaubt, aber '%count%' wurden gezählt",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted"                                                   => "Zu wenige Wörter. Mindestens '%min%' wurden erwartet, aber '%count%' wurden gezählt",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted"                                                   => "Zu wenige Wörter. Mindestens '%min%' wurden erwartet, aber '%count%' wurden gezählt",
     "File '%value%' is not readable or does not exist"                                                                          => "Die Datei '%value%' konnte nicht gelesen werden oder existiert nicht",
 
     // Zend_Validator_GreaterThan

--- a/resources/languages/en/Zend_Captcha.php
+++ b/resources/languages/en/Zend_Captcha.php
@@ -20,12 +20,12 @@
  * EN-Revision: 30.Jul.2011
  */
 return array(
-    // Zend_Captcha_ReCaptcha
+    // Zend\Captcha\ReCaptcha
     "Missing captcha fields" => "Missing captcha fields",
     "Failed to validate captcha" => "Failed to validate captcha",
     "Captcha value is wrong: %value%" => "Captcha value is wrong: %value%",
 
-    // Zend_Captcha_Word
+    // Zend\Captcha\Word
     "Empty captcha value" => "Empty captcha value",
     "Captcha ID field is missing" => "Captcha ID field is missing",
     "Captcha value is wrong" => "Captcha value is wrong",

--- a/resources/languages/en/Zend_Validate.php
+++ b/resources/languages/en/Zend_Validate.php
@@ -17,78 +17,76 @@
  */
 
 /**
- * EN-Revision: 09.Sept.2012
+ * EN-Revision: 04.Apr.2013
  */
 return array(
-    // Zend_I18n_Validator_Alnum
+    // Zend\I18n\Validator\Alnum
     "Invalid type given. String, integer or float expected" => "Invalid type given. String, integer or float expected",
     "The input contains characters which are non alphabetic and no digits" => "The input contains characters which are non alphabetic and no digits",
     "The input is an empty string" => "The input is an empty string",
 
-    // Zend_I18n_Validator_Alpha
+    // Zend\I18n\Validator\Alpha
     "Invalid type given. String expected" => "Invalid type given. String expected",
     "The input contains non alphabetic characters" => "The input contains non alphabetic characters",
     "The input is an empty string" => "The input is an empty string",
 
-    // Zend_I18n_Validator_Float
+    // Zend\I18n\Validator\Float
     "Invalid type given. String, integer or float expected" => "Invalid type given. String, integer or float expected",
     "The input does not appear to be a float" => "The input does not appear to be a float",
 
-    // Zend_I18n_Validator_Int
+    // Zend\I18n\Validator\Int
     "Invalid type given. String or integer expected" => "Invalid type given. String or integer expected",
     "The input does not appear to be an integer" => "The input does not appear to be an integer",
 
-    // Zend_I18n_Validator_PostCode
+    // Zend\I18n\Validator\PostCode
     "Invalid type given. String or integer expected" => "Invalid type given. String or integer expected",
     "The input does not appear to be a postal code" => "The input does not appear to be a postal code",
     "An exception has been raised while validating the input" => "An exception has been raised while validating the input",
 
-    // Zend_Validator_Barcode
+    // Zend\Validator\Barcode
     "The input failed checksum validation" => "The input failed checksum validation",
     "The input contains invalid characters" => "The input contains invalid characters",
     "The input should have a length of %length% characters" => "The input should have a length of %length% characters",
     "Invalid type given. String expected" => "Invalid type given. String expected",
 
-    // Zend_Validator_Between
+    // Zend\Validator\Between
     "The input is not between '%min%' and '%max%', inclusively" => "The input is not between '%min%' and '%max%', inclusively",
     "The input is not strictly between '%min%' and '%max%'" => "The input is not strictly between '%min%' and '%max%'",
 
-    // Zend_Validator_Callback
+    // Zend\Validator\Callback
     "The input is not valid" => "The input is not valid",
     "An exception has been raised within the callback" => "An exception has been raised within the callback",
 
-    // Zend_Validator_CreditCard
+    // Zend\Validator\CreditCard
     "The input seems to contain an invalid checksum" => "The input seems to contain an invalid checksum",
     "The input must contain only digits" => "The input must contain only digits",
     "Invalid type given. String expected" => "Invalid type given. String expected",
     "The input contains an invalid amount of digits" => "The input contains an invalid amount of digits",
     "The input is not from an allowed institute" => "The input is not from an allowed institute",
-    "The input seems to be an invalid creditcard number" => "The input seems to be an invalid creditcard number",
+    "The input seems to be an invalid credit card number" => "The input seems to be an invalid credit card number",
     "An exception has been raised while validating the input" => "An exception has been raised while validating the input",
 
-    // Zend_Validator_Csrf
+    // Zend\Validator\Csrf
     "The form submitted did not originate from the expected site" => "The form submitted did not originate from the expected site",
 
-    // Zend_Validator_Date
+    // Zend\Validator\Date
     "Invalid type given. String, integer, array or DateTime expected" => "Invalid type given. String, integer, array or DateTime expected",
     "The input does not appear to be a valid date" => "The input does not appear to be a valid date",
     "The input does not fit the date format '%format%'" => "The input does not fit the date format '%format%'",
 
-    // Zend_Validator_DateStep
-    "Invalid type given. String, integer, array or DateTime expected" => "Invalid type given. String, integer, array or DateTime expected",
-    "The input does not appear to be a valid date" => "The input does not appear to be a valid date",
+    // Zend\Validator\DateStep
     "The input is not a valid step" => "The input is not a valid step",
 
-    // Zend_Validator_Db_AbstractDb
+    // Zend\Validator\Db\AbstractDb
     "No record matching the input was found" => "No record matching the input was found",
     "A record matching the input was found" => "A record matching the input was found",
 
-    // Zend_Validator_Digits
+    // Zend\Validator\Digits
     "The input must contain only digits" => "The input must contain only digits",
     "The input is an empty string" => "The input is an empty string",
     "Invalid type given. String, integer or float expected" => "Invalid type given. String, integer or float expected",
 
-    // Zend_Validator_EmailAddress
+    // Zend\Validator\EmailAddress
     "Invalid type given. String expected" => "Invalid type given. String expected",
     "The input is not a valid email address. Use the basic format local-part@hostname" => "The input is not a valid email address. Use the basic format local-part@hostname",
     "'%hostname%' is not a valid hostname for the email address" => "'%hostname%' is not a valid hostname for the email address",
@@ -99,81 +97,81 @@ return array(
     "'%localPart%' is not a valid local part for the email address" => "'%localPart%' is not a valid local part for the email address",
     "The input exceeds the allowed length" => "The input exceeds the allowed length",
 
-    // Zend_Validator_Explode
-    "Invalid type given. String expected" => "Invalid type given. String expected",
+    // Zend\Validator\Explode
+    "Invalid type given" => "Invalid type given",
 
-    // Zend_Validator_File_Count
+    // Zend\Validator\File\Count
     "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Too many files, maximum '%max%' are allowed but '%count%' are given",
     "Too few files, minimum '%min%' are expected but '%count%' are given" => "Too few files, minimum '%min%' are expected but '%count%' are given",
 
-    // Zend_Validator_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "File '%value%' does not match the given crc32 hashes",
+    // Zend\Validator\File\Crc32
+    "File does not match the given crc32 hashes" => "File does not match the given crc32 hashes",
     "A crc32 hash could not be evaluated for the given file" => "A crc32 hash could not be evaluated for the given file",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "File is not readable or does not exist" => "File is not readable or does not exist",
 
-    // Zend_Validator_File_ExcludeExtension
-    "File '%value%' has a false extension" => "File '%value%' has a false extension",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    // Zend\Validator\File\ExcludeExtension
+    "File has an incorrect extension" => "File has an incorrect extension",
+    "File is not readable or does not exist" => "File is not readable or does not exist",
 
-    // Zend_Validator_File_Exists
-    "File '%value%' does not exist" => "File '%value%' does not exist",
+    // Zend\Validator\File\Exists
+    "File does not exist" => "File does not exist",
 
-    // Zend_Validator_File_Extension
-    "File '%value%' has a false extension" => "File '%value%' has a false extension",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    // Zend\Validator\File\Extension
+    "File has an incorrect extension" => "File has an incorrect extension",
+    "File is not readable or does not exist" => "File is not readable or does not exist",
 
-    // Zend_Validator_File_FilesSize
+    // Zend\Validator\File\FilesSize
     "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "All files in sum should have a maximum size of '%max%' but '%size%' were detected",
     "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "All files in sum should have a minimum size of '%min%' but '%size%' were detected",
     "One or more files can not be read" => "One or more files can not be read",
 
-    // Zend_Validator_File_Hash
-    "File '%value%' does not match the given hashes" => "File '%value%' does not match the given hashes",
+    // Zend\Validator\File\Hash
+    "File does not match the given hashes" => "File does not match the given hashes",
     "A hash could not be evaluated for the given file" => "A hash could not be evaluated for the given file",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "File is not readable or does not exist" => "File is not readable or does not exist",
 
-    // Zend_Validator_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected",
-    "The size of image '%value%' could not be detected" => "The size of image '%value%' could not be detected",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    // Zend\Validator\File\ImageSize
+    "Maximum allowed width for image should be '%maxwidth%' but '%width%' detected" => "Maximum allowed width for image should be '%maxwidth%' but '%width%' detected",
+    "Minimum expected width for image should be '%minwidth%' but '%width%' detected" => "Minimum expected width for image should be '%minwidth%' but '%width%' detected",
+    "Maximum allowed height for image should be '%maxheight%' but '%height%' detected" => "Maximum allowed height for image should be '%maxheight%' but '%height%' detected",
+    "Minimum expected height for image should be '%minheight%' but '%height%' detected" => "Minimum expected height for image should be '%minheight%' but '%height%' detected",
+    "The size of image could not be detected" => "The size of image could not be detected",
+    "File is not readable or does not exist" => "File is not readable or does not exist",
 
-    // Zend_Validator_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "File '%value%' is not compressed, '%type%' detected",
-    "The mimetype of file '%value%' could not be detected" => "The mimetype of file '%value%' could not be detected",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    // Zend\Validator\File\IsCompressed
+    "File is not compressed, '%type%' detected" => "File is not compressed, '%type%' detected",
+    "The mimetype could not be detected from the file" => "The mimetype could not be detected from the file",
+    "File is not readable or does not exist" => "File is not readable or does not exist",
 
-    // Zend_Validator_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "File '%value%' is no image, '%type%' detected",
-    "The mimetype of file '%value%' could not be detected" => "The mimetype of file '%value%' could not be detected",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    // Zend\Validator\File\IsImage
+    "File is no image, '%type%' detected" => "File is no image, '%type%' detected",
+    "The mimetype could not be detected from the file" => "The mimetype could not be detected from the file",
+    "File is not readable or does not exist" => "File is not readable or does not exist",
 
-    // Zend_Validator_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "File '%value%' does not match the given md5 hashes",
-    "A md5 hash could not be evaluated for the given file" => "A md5 hash could not be evaluated for the given file",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    // Zend\Validator\File\Md5
+    "File does not match the given md5 hashes" => "File does not match the given md5 hashes",
+    "An md5 hash could not be evaluated for the given file" => "An md5 hash could not be evaluated for the given file",
+    "File is not readable or does not exist" => "File is not readable or does not exist",
 
-    // Zend_Validator_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "File '%value%' has a false mimetype of '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "The mimetype of file '%value%' could not be detected",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    // Zend\Validator\File\MimeType
+    "File has an incorrect mimetype of '%type%'" => "File has an incorrect mimetype of '%type%'",
+    "The mimetype could not be detected from the file" => "The mimetype could not be detected from the file",
+    "File is not readable or does not exist" => "File is not readable or does not exist",
 
-    // Zend_Validator_File_NotExists
-    "File '%value%' exists" => "File '%value%' exists",
+    // Zend\Validator\File\NotExists
+    "File exists" => "File exists",
 
-    // Zend_Validator_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "File '%value%' does not match the given sha1 hashes",
+    // Zend\Validator\File\Sha1
+    "File does not match the given sha1 hashes" => "File does not match the given sha1 hashes",
     "A sha1 hash could not be evaluated for the given file" => "A sha1 hash could not be evaluated for the given file",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    "File is not readable or does not exist" => "File is not readable or does not exist",
 
-    // Zend_Validator_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "Minimum expected size for file '%value%' is '%min%' but '%size%' detected",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    // Zend\Validator\File\Size
+    "Maximum allowed size for file is '%max%' but '%size%' detected" => "Maximum allowed size for file is '%max%' but '%size%' detected",
+    "Minimum expected size for file is '%min%' but '%size%' detected" => "Minimum expected size for file is '%min%' but '%size%' detected",
+    "File is not readable or does not exist" => "File is not readable or does not exist",
 
-    // Zend_Validator_File_Upload
+    // Zend\Validator\File\Upload
     "File '%value%' exceeds the defined ini size" => "File '%value%' exceeds the defined ini size",
     "File '%value%' exceeds the defined form size" => "File '%value%' exceeds the defined form size",
     "File '%value%' was only partially uploaded" => "File '%value%' was only partially uploaded",
@@ -185,7 +183,7 @@ return array(
     "File '%value%' was not found" => "File '%value%' was not found",
     "Unknown error while uploading file '%value%'" => "Unknown error while uploading file '%value%'",
 
-    // Zend_Validator_File_UploadFile
+    // Zend\Validator\File\UploadFile
     "File exceeds the defined ini size" => "File exceeds the defined ini size",
     "File exceeds the defined form size" => "File exceeds the defined form size",
     "File was only partially uploaded" => "File was only partially uploaded",
@@ -197,20 +195,20 @@ return array(
     "File was not found" => "File was not found",
     "Unknown error while uploading file" => "Unknown error while uploading file",
 
-    // Zend_Validator_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Too much words, maximum '%max%' are allowed but '%count%' were counted",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Too less words, minimum '%min%' are expected but '%count%' were counted",
-    "File '%value%' is not readable or does not exist" => "File '%value%' is not readable or does not exist",
+    // Zend\Validator\File\WordCount
+    "Too many words, maximum '%max%' are allowed but '%count%' were counted" => "Too many words, maximum '%max%' are allowed but '%count%' were counted",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Too few words, minimum '%min%' are expected but '%count%' were counted",
+    "File is not readable or does not exist" => "File is not readable or does not exist",
 
-    // Zend_Validator_GreaterThan
+    // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "The input is not greater than '%min%'",
     "The input is not greater or equal than '%min%'" => "The input is not greater or equal than '%min%'",
 
-    // Zend_Validator_Hex
+    // Zend\Validator\Hex
     "Invalid type given. String expected" => "Invalid type given. String expected",
     "The input contains non-hexadecimal characters" => "The input contains non-hexadecimal characters",
 
-    // Zend_Validator_Hostname
+    // Zend\Validator\Hostname
     "The input appears to be a DNS hostname but the given punycode notation cannot be decoded" => "The input appears to be a DNS hostname but the given punycode notation cannot be decoded",
     "Invalid type given. String expected" => "Invalid type given. String expected",
     "The input appears to be a DNS hostname but contains a dash in an invalid position" => "The input appears to be a DNS hostname but contains a dash in an invalid position",
@@ -223,66 +221,69 @@ return array(
     "The input appears to be a DNS hostname but cannot extract TLD part" => "The input appears to be a DNS hostname but cannot extract TLD part",
     "The input appears to be a DNS hostname but cannot match TLD against known list" => "The input appears to be a DNS hostname but cannot match TLD against known list",
 
-    // Zend_Validator_Iban
+    // Zend\Validator\Iban
     "Unknown country within the IBAN" => "Unknown country within the IBAN",
     "Countries outside the Single Euro Payments Area (SEPA) are not supported" => "Countries outside the Single Euro Payments Area (SEPA) are not supported",
     "The input has a false IBAN format" => "The input has a false IBAN format",
     "The input has failed the IBAN check" => "The input has failed the IBAN check",
 
-    // Zend_Validator_Identical
+    // Zend\Validator\Identical
     "The two given tokens do not match" => "The two given tokens do not match",
     "No token was provided to match against" => "No token was provided to match against",
 
-    // Zend_Validator_InArray
+    // Zend\Validator\InArray
     "The input was not found in the haystack" => "The input was not found in the haystack",
 
-    // Zend_Validator_Ip
+    // Zend\Validator\Ip
     "Invalid type given. String expected" => "Invalid type given. String expected",
     "The input does not appear to be a valid IP address" => "The input does not appear to be a valid IP address",
 
-    // Zend_Validator_Isbn
+    // Zend\Validator\IsInstanceOf
+    "The input is not an instance of '%className%'" => "The input is not an instance of '%className%'",
+
+    // Zend\Validator\Isbn
     "Invalid type given. String or integer expected" => "Invalid type given. String or integer expected",
     "The input is not a valid ISBN number" => "The input is not a valid ISBN number",
 
-    // Zend_Validator_LessThan
+    // Zend\Validator\LessThan
     "The input is not less than '%max%'" => "The input is not less than '%max%'",
     "The input is not less or equal than '%max%'" => "The input is not less or equal than '%max%'",
 
-    // Zend_Validator_NotEmpty
+    // Zend\Validator\NotEmpty
     "Value is required and can't be empty" => "Value is required and can't be empty",
     "Invalid type given. String, integer, float, boolean or array expected" => "Invalid type given. String, integer, float, boolean or array expected",
 
-    // Zend_Validator_Regex
+    // Zend\Validator\Regex
     "Invalid type given. String, integer or float expected" => "Invalid type given. String, integer or float expected",
     "The input does not match against pattern '%pattern%'" => "The input does not match against pattern '%pattern%'",
     "There was an internal error while using the pattern '%pattern%'" => "There was an internal error while using the pattern '%pattern%'",
 
-    // Zend_Validator_Sitemap_Changefreq
+    // Zend\Validator\Sitemap\Changefreq
     "The input is not a valid sitemap changefreq" => "The input is not a valid sitemap changefreq",
     "Invalid type given. String expected" => "Invalid type given. String expected",
 
-    // Zend_Validator_Sitemap_Lastmod
+    // Zend\Validator\Sitemap\Lastmod
     "The input is not a valid sitemap lastmod" => "The input is not a valid sitemap lastmod",
     "Invalid type given. String expected" => "Invalid type given. String expected",
 
-    // Zend_Validator_Sitemap_Loc
+    // Zend\Validator\Sitemap\Loc
     "The input is not a valid sitemap location" => "The input is not a valid sitemap location",
     "Invalid type given. String expected" => "Invalid type given. String expected",
 
-    // Zend_Validator_Sitemap_Priority
+    // Zend\Validator\Sitemap\Priority
     "The input is not a valid sitemap priority" => "The input is not a valid sitemap priority",
     "Invalid type given. Numeric string, integer or float expected" => "Invalid type given. Numeric string, integer or float expected",
 
-    // Zend_Validator_Step
+    // Zend\Validator\Step
     "Invalid value given. Scalar expected" => "Invalid value given. Scalar expected",
     "The input is not a valid step" => "The input is not a valid step",
 
-    // Zend_Validator_StringLength
+    // Zend\Validator\StringLength
     "Invalid type given. String expected" => "Invalid type given. String expected",
     "The input is less than %min% characters long" => "The input is less than %min% characters long",
     "The input is more than %max% characters long" => "The input is more than %max% characters long",
 
-    // Zend_Validator_Uri
+    // Zend\Validator\Uri
     "Invalid type given. String expected" => "Invalid type given. String expected",
     "The input does not appear to be a valid Uri" => "The input does not appear to be a valid Uri",
 );

--- a/resources/languages/es/Zend_Validate.php
+++ b/resources/languages/es/Zend_Validate.php
@@ -172,7 +172,7 @@ return array(
 
     // Zend_Validate_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Demasiadas palabras, sólo se permiten '%max%' pero se han contado '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Demasiado pocas palabras, se esperaban al menos '%min%' pero se han contado '%count%'",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Demasiado pocas palabras, se esperaban al menos '%min%' pero se han contado '%count%'",
     "File '%value%' could not be found" => "No se ha podido encontrar el archivo '%value%'",
 
     // Zend_Validate_Float

--- a/resources/languages/fi/Zend_Validate.php
+++ b/resources/languages/fi/Zend_Validate.php
@@ -172,7 +172,7 @@ return array(
 
     // Zend_Validate_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Virheellinen määrä sanoja, maksimäärä on '%max%', annettu '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Virheellinen määrä sanoja, minimimäärä on '%min%', annettu '%count%'",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Virheellinen määrä sanoja, minimimäärä on '%min%', annettu '%count%'",
     "File '%value%' is not readable or does not exist" => "Tiedostoa '%value%' ei voida lukea tai sitä ei ole",
 
     // Zend_Validate_Float

--- a/resources/languages/fr/Zend_Validate.php
+++ b/resources/languages/fr/Zend_Validate.php
@@ -188,7 +188,7 @@ return array(
 
     // Zend_Validator_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Trop de mots. '%max%' sont autorisés, '%count%' comptés",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Pas assez de mots. '%min%' sont attendus, '%count%' comptés",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Pas assez de mots. '%min%' sont attendus, '%count%' comptés",
     "File '%value%' is not readable or does not exist" => "Le fichier '%value%' n'est pas lisible ou n'existe pas",
 
     // Zend_Validator_GreaterThan

--- a/resources/languages/hr/Zend_Validate.php
+++ b/resources/languages/hr/Zend_Validate.php
@@ -172,7 +172,7 @@ return array(
 
     // Zend_Validate_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Previše riječi, maksimalno '%max%' riječi je dozvoljeno, a ima ih '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Premalo riječi, očekuje se minimalno '%min%' riječi, a ima ih '%count%' ",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Premalo riječi, očekuje se minimalno '%min%' riječi, a ima ih '%count%' ",
     "File '%value%' could not be found" => "Datoteku '%value%' nije moguće pronaći",
 
     // Zend_Validate_Float

--- a/resources/languages/it/Zend_Captcha.php
+++ b/resources/languages/it/Zend_Captcha.php
@@ -20,12 +20,12 @@
  * EN-Revision: 30.Jul.2011
  */
 return array(
-    // Zend_Captcha_ReCaptcha
+    // Zend\Captcha\ReCaptcha
     "Missing captcha fields" => "Campi captcha mancanti",
     "Failed to validate captcha" => "Validazione del captcha fallito",
     "Captcha value is wrong: %value%" => "Il valore del Captcha è sbagliato: %value%",
 
-    // Zend_Captcha_Word
+    // Zend\Captcha\Word
     "Empty captcha value" => "Valore del captcha vuoto",
     "Captcha ID field is missing" => "Manca il campo Captcha ID",
     "Captcha value is wrong" => "Il valore del Captcha è sbagliato",

--- a/resources/languages/it/Zend_Validate.php
+++ b/resources/languages/it/Zend_Validate.php
@@ -17,163 +17,161 @@
  */
 
 /**
- * EN-Revision: 09.Sept.2012
+ * IT-Revision: 04.Apr.2013
  */
 return array(
-    // Zend_I18n_Validator_Alnum
+    // Zend\I18n\Validator\Alnum
     "Invalid type given. String, integer or float expected" => "Tipo di dato non valido. Era atteso un dato di tipo string, float o integer",
     "The input contains characters which are non alphabetic and no digits" => "L'input contiene caratteri che non sono alfanumerici",
     "The input is an empty string" => "L'input è una stringa vuota",
 
-    // Zend_I18n_Validator_Alpha
+    // Zend\I18n\Validator\Alpha
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input contains non alphabetic characters" => "L'input contiene caratteri non alfabetici",
     "The input is an empty string" => "L'input è una stringa vuota",
 
-    // Zend_I18n_Validator_Float
+    // Zend\I18n\Validator\Float
     "Invalid type given. String, integer or float expected" => "Tipo di dato non valido. Era atteso un dato di tipo string, float o integer",
     "The input does not appear to be a float" => "L'input non sembra essere un dato di tipo float",
 
-    // Zend_I18n_Validator_Int
+    // Zend\I18n\Validator\Int
     "Invalid type given. String or integer expected" => "Tipo di dato non valido. Era atteso un dato di tipo string o integer",
     "The input does not appear to be an integer" => "L'input non sembra essere un intero",
 
-    // Zend_I18n_Validator_PostCode
+    // Zend\I18n\Validator\PostCode
     "Invalid type given. String or integer expected" => "Tipo di dato non valido. Era atteso un dato di tipo string o integer",
     "The input does not appear to be a postal code" => "L'input non sembra essere un codice postale",
     "An exception has been raised while validating the input" => "Un'eccezione è stata sollevada durante la validazione dell'input",
 
-    // Zend_Validator_Barcode
+    // Zend\Validator\Barcode
     "The input failed checksum validation" => "L'input non ha un checksum valido",
     "The input contains invalid characters" => "L'input contiene caratteri non permessi",
     "The input should have a length of %length% characters" => "L'input non ha la lunghezza corretta di %length% caratteri",
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
 
-    // Zend_Validator_Between
+    // Zend\Validator\Between
     "The input is not between '%min%' and '%max%', inclusively" => "L'input non è compreso tra '%min%' e '%max%', inclusi",
     "The input is not strictly between '%min%' and '%max%'" => "L'input non è strettamente compreso tra '%min%' e '%max%'",
 
-    // Zend_Validator_Callback
+    // Zend\Validator\Callback
     "The input is not valid" => "L'input non è valido",
     "An exception has been raised within the callback" => "Un'eccezione è stata sollevata all'interno della callback",
 
-    // Zend_Validator_CreditCard
+    // Zend\Validator\CreditCard
     "The input seems to contain an invalid checksum" => "L'input sembra avere un checksum non valido",
     "The input must contain only digits" => "L'input deve contenere solo cifre",
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input contains an invalid amount of digits" => "L'input contiene un numero non valido di cifre",
     "The input is not from an allowed institute" => "L'input proviene da un istituto non supportato",
-    "The input seems to be an invalid creditcard number" => "L'input sembra essere un numero di carta di credito non valido",
+    "The input seems to be an invalid credit card number" => "L'input sembra essere un numero di carta di credito non valido",
     "An exception has been raised while validating the input" => "Un'eccezione è stata sollevada durante la validazione dell'input",
 
-    // Zend_Validator_Csrf
+    // Zend\Validator\Csrf
     "The form submitted did not originate from the expected site" => "La form inviata non ha avuto origine dal luogo previsto",
 
-    // Zend_Validator_Date
+    // Zend\Validator\Date
     "Invalid type given. String, integer, array or DateTime expected" => "Tipo di dato non valido. Era atteso un dato di tipo string, integer, array o DateTime",
     "The input does not appear to be a valid date" => "L'input non sembra essere una data valida",
     "The input does not fit the date format '%format%'" => "L'input non corrisponde al formato data '%format%'",
 
-    // Zend_Validator_DateStep
-    "Invalid type given. String, integer, array or DateTime expected" => "Tipo di dato non valido. Era atteso un dato di tipo string, integer, array o DateTime",
-    "The input does not appear to be a valid date" => "L'input non sembra essere una data valida",
+    // Zend\Validator\DateStep
     "The input is not a valid step" => "L'input non è uno step valido",
 
-    // Zend_Validator_Db_AbstractDb
+    // Zend\Validator\Db\AbstractDb
     "No record matching the input was found" => "Non è stata trovata nessuna riga corrispondente all'input",
     "A record matching the input was found" => "E' già stata trovata una riga corrispondente all'input",
 
-    // Zend_Validator_Digits
+    // Zend\Validator\Digits
     "The input must contain only digits" => "L'input deve contenere solo cifre",
     "The input is an empty string" => "L'input è una stringa vuota",
     "Invalid type given. String, integer or float expected" => "Tipo di dato non valido. Era atteso un dato di tipo string, float o integer",
 
-    // Zend_Validator_EmailAddress
+    // Zend\Validator\EmailAddress
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input is not a valid email address. Use the basic format local-part@hostname" => "L'input non è un indirizzo email valido nel formato base local-part@hostname",
     "'%hostname%' is not a valid hostname for the email address" => "'%hostname%' non è un hostname valido nell'indirizzo email",
     "'%hostname%' does not appear to have any valid MX or A records for the email address" => "'%hostname%' non sembra avere un record MX o A valido nell'indirizzo email",
-    "'%hostname%' is not in a routable network segment. The email address should not be resolved from public network" => "'%hostname%' non è in un segmento di rete instradabile. L'indirizzo email non può essere risolto nella rete pubblica.",
+    "'%hostname%' is not in a routable network segment. The email address should not be resolved from public network" => "'%hostname%' non è in un segmento di rete instradabile. L'indirizzo email non può essere risolto nella rete pubblica",
     "'%localPart%' can not be matched against dot-atom format" => "'%localPart%' non può essere validato nel formato dot-atom",
     "'%localPart%' can not be matched against quoted-string format" => "'%localPart%' non può essere validato nel formato quoted-string",
     "'%localPart%' is not a valid local part for the email address" => "'%localPart%' non è una local part valida nell'indirizzo email",
     "The input exceeds the allowed length" => "L'input supera la lunghezza consentita",
 
-    // Zend_Validator_Explode
-    "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
+    // Zend\Validator\Explode
+    "Invalid type given" => "Tipo di dato non valido",
 
-    // Zend_Validator_File_Count
+    // Zend\Validator\File\Count
     "Too many files, maximum '%max%' are allowed but '%count%' are given" => "Troppi file, sono consentiti massimo '%max%' file ma ne sono stati passati '%count%'",
     "Too few files, minimum '%min%' are expected but '%count%' are given" => "Troppi pochi file, sono attesi minimo '%min%' file ma ne sono stato passati solo '%count%'",
 
-    // Zend_Validator_File_Crc32
-    "File '%value%' does not match the given crc32 hashes" => "Il file '%value%' non ha un hash crc32 tra quelli consentiti",
+    // Zend\Validator\File\Crc32
+    "File does not match the given crc32 hashes" => "Il file non ha un hash crc32 tra quelli consentiti",
     "A crc32 hash could not be evaluated for the given file" => "L'hash crc32 non può essere calcolato per il file dato",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "File is not readable or does not exist" => "Il file non è leggibile o non esiste",
 
-    // Zend_Validator_File_ExcludeExtension
-    "File '%value%' has a false extension" => "Il file '%value%' ha un'estensione invalida",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    // Zend\Validator\File\ExcludeExtension
+    "File has an incorrect extension" => "Il file ha un'estensione invalida",
+    "File is not readable or does not exist" => "Il file non è leggibile o non esiste",
 
-    // Zend_Validator_File_Exists
-    "File '%value%' does not exist" => "Il file '%value%' non esiste",
+    // Zend\Validator\File\Exists
+    "File does not exist" => "Il file non esiste",
 
-    // Zend_Validator_File_Extension
-    "File '%value%' has a false extension" => "Il file '%value%' ha un'estensione invalida",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    // Zend\Validator\File\Extension
+    "File has an incorrect extension" => "Il file ha un'estensione invalida",
+    "File is not readable or does not exist" => "Il file non è leggibile o non esiste",
 
-    // Zend_Validator_File_FilesSize
+    // Zend\Validator\File\FilesSize
     "All files in sum should have a maximum size of '%max%' but '%size%' were detected" => "I file devono avere in totale una dimensione massima di '%max%' ma è stata rilevata una dimensione di '%size%'",
     "All files in sum should have a minimum size of '%min%' but '%size%' were detected" => "I file devono avere in totale una dimensione minima di '%min%' ma è stata rilevata una dimensione di '%size%'",
     "One or more files can not be read" => "Uno o più file non possono essere letti",
 
-    // Zend_Validator_File_Hash
-    "File '%value%' does not match the given hashes" => "I file '%value%' non corrisponde agli hash dati",
+    // Zend\Validator\File\Hash
+    "File does not match the given hashes" => "I file non corrisponde agli hash dati",
     "A hash could not be evaluated for the given file" => "Un hash non può essere valutato per il file dato",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "File is not readable or does not exist" => "Il file non è leggibile o non esiste",
 
-    // Zend_Validator_File_ImageSize
-    "Maximum allowed width for image '%value%' should be '%maxwidth%' but '%width%' detected" => "La larghezza massima consentita per l'immagine '%value%' è '%maxwidth%' ma è stata rilevata una larghezza di '%width%'",
-    "Minimum expected width for image '%value%' should be '%minwidth%' but '%width%' detected" => "La larghezza minima consentita per l'immagine '%value%' è '%minwidth%' ma è stata rilevata una larghezza di '%width%'",
-    "Maximum allowed height for image '%value%' should be '%maxheight%' but '%height%' detected" => "L'altezza massima consentita per l'immagine '%value%' è '%maxheight%' ma è stata rilevata un'altezza di '%height%'",
-    "Minimum expected height for image '%value%' should be '%minheight%' but '%height%' detected" => "L'altezza minima consentita per l'immagine '%value%' è '%minheight%' ma è stata rilevata un'altezza di '%height%'",
-    "The size of image '%value%' could not be detected" => "Le dimensioni dell'immagine '%value%' non possono essere rilevate",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    // Zend\Validator\File\ImageSize
+    "Maximum allowed width for image should be '%maxwidth%' but '%width%' detected" => "La larghezza massima consentita per l'immagine è '%maxwidth%' ma è stata rilevata una larghezza di '%width%'",
+    "Minimum expected width for image should be '%minwidth%' but '%width%' detected" => "La larghezza minima consentita per l'immagine è '%minwidth%' ma è stata rilevata una larghezza di '%width%'",
+    "Maximum allowed height for image should be '%maxheight%' but '%height%' detected" => "L'altezza massima consentita per l'immagine è '%maxheight%' ma è stata rilevata un'altezza di '%height%'",
+    "Minimum expected height for image should be '%minheight%' but '%height%' detected" => "L'altezza minima consentita per l'immagine è '%minheight%' ma è stata rilevata un'altezza di '%height%'",
+    "The size of image could not be detected" => "Le dimensioni dell'immagine non possono essere rilevate",
+    "File is not readable or does not exist" => "Il file non è leggibile o non esiste",
 
-    // Zend_Validator_File_IsCompressed
-    "File '%value%' is not compressed, '%type%' detected" => "Il file '%value%' non è un file compresso, ma un file di tipo '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Il mimetype del file '%value%' non può essere rilevato",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    // Zend\Validator\File\IsCompressed
+    "File is not compressed, '%type%' detected" => "Il file non è un file compresso, ma un file di tipo '%type%'",
+    "The mimetype could not be detected from the file" => "Il mimetype del file non può essere rilevato",
+    "File is not readable or does not exist" => "Il file non è leggibile o non esiste",
 
-    // Zend_Validator_File_IsImage
-    "File '%value%' is no image, '%type%' detected" => "Il file '%value%' non è un'immagine, ma un file di tipo '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Il mimetype del file '%value%' non può essere rilevato",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    // Zend\Validator\File\IsImage
+    "File is no image, '%type%' detected" => "Il file non è un'immagine, ma un file di tipo '%type%'",
+    "The mimetype could not be detected from the file" => "Il mimetype del file non può essere rilevato",
+    "File is not readable or does not exist" => "Il file non è leggibile o non esiste",
 
-    // Zend_Validator_File_Md5
-    "File '%value%' does not match the given md5 hashes" => "Il file '%value%' non corrisponde agli hash md5 dati",
-    "A md5 hash could not be evaluated for the given file" => "Un hash md5 non può essere valutato per il file dato",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    // Zend\Validator\File\Md5
+    "File does not match the given md5 hashes" => "Il file non corrisponde agli hash md5 dati",
+    "An md5 hash could not be evaluated for the given file" => "Un hash md5 non può essere valutato per il file dato",
+    "File is not readable or does not exist" => "Il file non è leggibile o non esiste",
 
-    // Zend_Validator_File_MimeType
-    "File '%value%' has a false mimetype of '%type%'" => "Il file '%value%' ha un mimetype invalido: '%type%'",
-    "The mimetype of file '%value%' could not be detected" => "Il mimetype del file '%value%' non può essere rilevato",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    // Zend\Validator\File\MimeType
+    "File has an incorrect mimetype of '%type%'" => "Il file ha un mimetype invalido: '%type%'",
+    "The mimetype could not be detected from the file" => "Il mimetype del file non può essere rilevato",
+    "File is not readable or does not exist" => "Il file non è leggibile o non esiste",
 
-    // Zend_Validator_File_NotExists
-    "File '%value%' exists" => "Il file '%value%' esiste già",
+    // Zend\Validator\File\NotExists
+    "File exists" => "Il file esiste già",
 
-    // Zend_Validator_File_Sha1
-    "File '%value%' does not match the given sha1 hashes" => "Il file '%value%' non corrisponde agli hash sha1 dati",
+    // Zend\Validator\File\Sha1
+    "File does not match the given sha1 hashes" => "Il file non corrisponde agli hash sha1 dati",
     "A sha1 hash could not be evaluated for the given file" => "Un hash sha1 non può essere valutato per il file dato",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    "File is not readable or does not exist" => "Il file non è leggibile o non esiste",
 
-    // Zend_Validator_File_Size
-    "Maximum allowed size for file '%value%' is '%max%' but '%size%' detected" => "La dimensione massima consentita per il file '%value%' è '%max%' ma è stata rilevata una dimensione di '%size%'",
-    "Minimum expected size for file '%value%' is '%min%' but '%size%' detected" => "La dimensione minima consentita per il file '%value%' è '%min%' ma è stata rilevata una dimensione di '%size%'",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    // Zend\Validator\File\Size
+    "Maximum allowed size for file is '%max%' but '%size%' detected" => "La dimensione massima consentita per il file è '%max%' ma è stata rilevata una dimensione di '%size%'",
+    "Minimum expected size for file is '%min%' but '%size%' detected" => "La dimensione minima consentita per il file è '%min%' ma è stata rilevata una dimensione di '%size%'",
+    "File is not readable or does not exist" => "Il file non è leggibile o non esiste",
 
-    // Zend_Validator_File_Upload
+    // Zend\Validator\File\Upload
     "File '%value%' exceeds the defined ini size" => "Il file '%value%' eccede la dimensione definita nell'ini",
     "File '%value%' exceeds the defined form size" => "Il file '%value%' eccede la dimensione definita nella form",
     "File '%value%' was only partially uploaded" => "Il file '%value%' è stato caricato solo parzialmente",
@@ -185,7 +183,7 @@ return array(
     "File '%value%' was not found" => "Il file '%value%' non è stato trovato",
     "Unknown error while uploading file '%value%'" => "Errore sconosciuto durante il caricamento del file '%value%'",
 
-    // Zend_Validator_File_UploadFile
+    // Zend\Validator\File\UploadFile
     "File exceeds the defined ini size" => "Il file eccede la dimensione definita nell'ini",
     "File exceeds the defined form size" => "Il file eccede la dimensione definita nella form",
     "File was only partially uploaded" => "Il file è stato caricato solo parzialmente",
@@ -197,20 +195,20 @@ return array(
     "File was not found" => "Il file non è stato trovato",
     "Unknown error while uploading file" => "Errore sconosciuto durante il caricamento del file",
 
-    // Zend_Validator_File_WordCount
-    "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Il file contiene troppe parole, ne sono consentite massimo '%max%' ma ne sono state contate '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Il file contiene troppe poche parole, ne sono consentite minimo '%min%' ma ne sono state contate '%count%'",
-    "File '%value%' is not readable or does not exist" => "Il file '%value%' non è leggibile o non esiste",
+    // Zend\Validator\File\WordCount
+    "Too many words, maximum '%max%' are allowed but '%count%' were counted" => "Il file contiene troppe parole, ne sono consentite massimo '%max%' ma ne sono state contate '%count%'",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Il file contiene troppe poche parole, ne sono consentite minimo '%min%' ma ne sono state contate '%count%'",
+    "File is not readable or does not exist" => "Il file non è leggibile o non esiste",
 
-    // Zend_Validator_GreaterThan
+    // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "L'input non è maggiore di '%min%'",
     "The input is not greater or equal than '%min%'" => "L'input non è maggiore o uguale a '%min%'",
 
-    // Zend_Validator_Hex
+    // Zend\Validator\Hex
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input contains non-hexadecimal characters" => "L'input non è composto solo da caratteri esadecimali",
 
-    // Zend_Validator_Hostname
+    // Zend\Validator\Hostname
     "The input appears to be a DNS hostname but the given punycode notation cannot be decoded" => "L'input sembra essere un hostname DNS ma la notazione punycode data non può essere decodificata",
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input appears to be a DNS hostname but contains a dash in an invalid position" => "L'input sembra essere un hostname DNS ma contiene un trattino in una posizione non valida",
@@ -223,66 +221,69 @@ return array(
     "The input appears to be a DNS hostname but cannot extract TLD part" => "L'input sembra essere un hostname DNS ma non è possibile estrarne il TLD",
     "The input appears to be a DNS hostname but cannot match TLD against known list" => "L'input sembra essere un hostname DNS ma il suo TLD è sconosciuto",
 
-    // Zend_Validator_Iban
+    // Zend\Validator\Iban
     "Unknown country within the IBAN" => "Codice paese sconosciuto nell'IBAN fornito",
     "Countries outside the Single Euro Payments Area (SEPA) are not supported" => "I paesi fuori dall'Area unica dei pagamenti in euro (SEPA) non sono supportati",
     "The input has a false IBAN format" => "L'input ha un formato IBAN non valido",
     "The input has failed the IBAN check" => "L'input ha fallito il controllo IBAN",
 
-    // Zend_Validator_Identical
+    // Zend\Validator\Identical
     "The two given tokens do not match" => "I due token dati non corrispondono",
     "No token was provided to match against" => "Non è stato dato nessun token per il confronto",
 
-    // Zend_Validator_InArray
+    // Zend\Validator\InArray
     "The input was not found in the haystack" => "L'input non è stato trovato nell'array",
 
-    // Zend_Validator_Ip
+    // Zend\Validator\Ip
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input does not appear to be a valid IP address" => "L'input non sembra essere un indirizzo IP valido",
 
-    // Zend_Validator_Isbn
+    // Zend\Validator\IsInstanceOf
+    "The input is not an instance of '%className%'" => "L'input non è un'istanza di '%className%'",
+
+    // Zend\Validator\Isbn
     "Invalid type given. String or integer expected" => "Tipo di dato non valido. Era atteso un dato di tipo string o integer",
     "The input is not a valid ISBN number" => "L'input non è un numero ISBN valido",
 
-    // Zend_Validator_LessThan
+    // Zend\Validator\LessThan
     "The input is not less than '%max%'" => "L'input non è minore di '%max%'",
     "The input is not less or equal than '%max%'" => "L'input non è minore o uguale a '%max%'",
 
-    // Zend_Validator_NotEmpty
+    // Zend\Validator\NotEmpty
     "Value is required and can't be empty" => "Il dato è richiesto e non può essere vuoto",
     "Invalid type given. String, integer, float, boolean or array expected" => "Tipo di dato non valido. Era atteso un dato di tipo string, integer, float, boolean o array",
 
-    // Zend_Validator_Regex
+    // Zend\Validator\Regex
     "Invalid type given. String, integer or float expected" => "Tipo di dato non valido. Era atteso un dato di tipo string, float o integer",
     "The input does not match against pattern '%pattern%'" => "L'input non corrisponde al pattern '%pattern%'",
     "There was an internal error while using the pattern '%pattern%'" => "Si è verificato un errore interno usando il pattern '%pattern%'",
 
-    // Zend_Validator_Sitemap_Changefreq
+    // Zend\Validator\Sitemap\Changefreq
     "The input is not a valid sitemap changefreq" => "L'input non è una sitemap changefreq valida",
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
 
-    // Zend_Validator_Sitemap_Lastmod
+    // Zend\Validator\Sitemap\Lastmod
     "The input is not a valid sitemap lastmod" => "L'input non è un sitemap lastmod valido",
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
 
-    // Zend_Validator_Sitemap_Loc
+    // Zend\Validator\Sitemap\Loc
     "The input is not a valid sitemap location" => "L'input non è una sitemap location valida",
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
 
-    // Zend_Validator_Sitemap_Priority
+    // Zend\Validator\Sitemap\Priority
     "The input is not a valid sitemap priority" => "L'input non è una sitemap priority valida",
     "Invalid type given. Numeric string, integer or float expected" => "Tipo di dato non valido. Era atteso un dato di tipo stringa numerica, float o integer",
 
-    // Zend_Validator_Step
+    // Zend\Validator\Step
     "Invalid value given. Scalar expected" => "Tipo di dato non valido. Era attesto un dato di tipo scalare",
     "The input is not a valid step" => "L'input non è uno step valido",
 
-    // Zend_Validator_StringLength
+    // Zend\Validator\StringLength
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input is less than %min% characters long" => "L'input è meno lungo di %min% caratteri",
     "The input is more than %max% characters long" => "L'input è più lungo di %max% caratteri",
 
-    // Zend_Validator_Uri
+    // Zend\Validator\Uri
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",
     "The input does not appear to be a valid Uri" => "L'input non sembra essere un indirizzo URI valido",
 );

--- a/resources/languages/ja/Zend_Validate.php
+++ b/resources/languages/ja/Zend_Validate.php
@@ -187,7 +187,7 @@ return array(
 
     // Zend_Validator_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "単語数 '%count%' が多過ぎます。最大で '%max%' 個が許されます",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "単語数 '%count%' が少な過ぎます。少なくとも '%min%' 個必要です",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "単語数 '%count%' が少な過ぎます。少なくとも '%min%' 個必要です",
     "File '%value%' is not readable or does not exist" => "ファイル '%value%' は読み込めないかもしくは存在しません",
 
     // Zend_Validator_GreaterThan

--- a/resources/languages/nl/Zend_Validate.php
+++ b/resources/languages/nl/Zend_Validate.php
@@ -187,7 +187,7 @@ return array(
 
     // Zend_Validator_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Te veel woorden, er is een maximum van '%max%', maar er waren '%count%' geteld",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Te weinig worden, er is een minimum van '%min%' maar er waren '%count%' getelc",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Te weinig worden, er is een minimum van '%min%' maar er waren '%count%' getelc",
     "File '%value%' is not readable or does not exist" => "Het bestand '%value%' kon niet worden gevonden",
 
     // Zend_Validator_GreaterThan

--- a/resources/languages/no/Zend_Validate.php
+++ b/resources/languages/no/Zend_Validate.php
@@ -172,7 +172,7 @@ return array(
 
     // Zend_Validate_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "For mange ord, maksimum '%max%' er tillatt, men '%count%' ble telt",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "For få ord, minimum '%min%' er forventet, men '%count%' ble telt",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "For få ord, minimum '%min%' er forventet, men '%count%' ble telt",
     "File '%value%' is not readable or does not exist" => "Filen '%value%' er ikke lesbar eller finnes ikke",
 
     // Zend_Validate_Float

--- a/resources/languages/pl/Zend_Validate.php
+++ b/resources/languages/pl/Zend_Validate.php
@@ -172,7 +172,7 @@ return array(
 
     // Zend_Validate_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Podano '%count%' słów. Maksymalna liczba słów to '%max%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Podano '%count%' słów. Minimalna liczba słów to '%min%'",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Podano '%count%' słów. Minimalna liczba słów to '%min%'",
     "File '%value%' is not readable or does not exist" => "Plik '%value%' nie istnieje lub nie można go odczytać",
 
     // Zend_Validate_Float

--- a/resources/languages/pt_BR/Zend_Validate.php
+++ b/resources/languages/pt_BR/Zend_Validate.php
@@ -199,7 +199,7 @@ return array(
 
     // Zend_Validator_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Há muitas palavras, são permitidas no máximo '%max%', mas '%count%' foram contadas",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Há poucas palavras, são esperadas no mínimo '%min%', mas '%count%' foram contadas",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Há poucas palavras, são esperadas no mínimo '%min%', mas '%count%' foram contadas",
     "File '%value%' is not readable or does not exist" => "O arquivo '%value%' não pode ser lido ou não existe",
 
     // Zend_Validator_GreaterThan

--- a/resources/languages/ru/Zend_Validate.php
+++ b/resources/languages/ru/Zend_Validate.php
@@ -172,7 +172,7 @@ return array(
 
     // Zend_Validate_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Слишком много слов, разрешено максимум '%max%' слов, но сейчас - '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Слишком мало слов, разрешено минимум '%min%' слов, но сейчас - '%count%'",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Слишком мало слов, разрешено минимум '%min%' слов, но сейчас - '%count%'",
     "File '%value%' could not be found" => "Файл '%value%' не найден",
 
     // Zend_Validate_Float

--- a/resources/languages/se/Zend_Validate.php
+++ b/resources/languages/se/Zend_Validate.php
@@ -199,7 +199,7 @@ return array(
 
     // Zend_Validator_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "För många ord, maximalt '%max%' är tillåtna men '%count%' räknades",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "För få ord, minimalt '%min%' förväntas men '%count%' räknades",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "För få ord, minimalt '%min%' förväntas men '%count%' räknades",
     "File '%value%' is not readable or does not exist" => "Filen '%value%' är inte läsbar eller existerar inte",
 
     // Zend_Validator_GreaterThan

--- a/resources/languages/sk/Zend_Validate.php
+++ b/resources/languages/sk/Zend_Validate.php
@@ -172,7 +172,7 @@ return array(
 
     // Zend_Validate_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Príliš veľa slov. Maximálne je ich dovolených '%max%', ale bolo zadaných '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Príliš málo slov. Musí ich byť aspoň '%min%', ale bolo zadaných len '%count%'",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Príliš málo slov. Musí ich byť aspoň '%min%', ale bolo zadaných len '%count%'",
     "File '%value%' is not readable or does not exist" => "Súbor '%value%' buď nie je čitateľný, alebo neexistuje",
 
     // Zend_Validate_Float

--- a/resources/languages/sl/Zend_Validate.php
+++ b/resources/languages/sl/Zend_Validate.php
@@ -172,7 +172,7 @@ return array(
 
     // Zend_Validate_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Preveč besed, največ '%max%' je dovoljenih vendar preštetih je bilo '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Premalo besed, vsaj '%min%' je predvidenih vendar preštetih je bilo '%count%'",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Premalo besed, vsaj '%min%' je predvidenih vendar preštetih je bilo '%count%'",
     "File '%value%' is not readable or does not exist" => "Datoteke '%value%' ni mogoče brati ali pa ne obstaja",
 
     // Zend_Validate_Float

--- a/resources/languages/sr/Zend_Validate.php
+++ b/resources/languages/sr/Zend_Validate.php
@@ -173,7 +173,7 @@ return array(
 
     // Zend_Validate_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Previše reči, maksimalno '%max%' je dozvoljeno, '%count%' je izbrojano",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Premalo reči, minimalno '%min%' je očekivano, '%count%' je izbrojano",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Premalo reči, minimalno '%min%' je očekivano, '%count%' je izbrojano",
     "File '%value%' could not be found" => "Fajl '%value%' ne može biti pronađen",
 
     // Zend_Validate_Float

--- a/resources/languages/tr/Zend_Validate.php
+++ b/resources/languages/tr/Zend_Validate.php
@@ -187,7 +187,7 @@ return array(
 
     // Zend_Validator_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Çok fazla kelime, en fazla '%max%' kelimeye izin veriliyor fakat '%count%' sayıldı",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Çok az kelime, en az '%min%' kelimeye izin veriliyor fakat '%count%' sayıldı",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Çok az kelime, en az '%min%' kelimeye izin veriliyor fakat '%count%' sayıldı",
     "File '%value%' is not readable or does not exist" => "'%value%' dosyası okunamıyor ya da yok",
 
     // Zend_Validator_GreaterThan

--- a/resources/languages/uk/Zend_Validate.php
+++ b/resources/languages/uk/Zend_Validate.php
@@ -172,7 +172,7 @@ return array(
 
     // Zend_Validate_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "Занадто багато слів, дозволено максимум '%max%' слів, зараз - '%count%'",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "Занадто мало слів, дозволено мінімум '%min%' слів, зараз - '%count%'",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "Занадто мало слів, дозволено мінімум '%min%' слів, зараз - '%count%'",
     "File '%value%' could not be found" => "Файл '%value%' не знайдено",
 
     // Zend_Validate_Float

--- a/resources/languages/zh/Zend_Validate.php
+++ b/resources/languages/zh/Zend_Validate.php
@@ -187,7 +187,7 @@ return array(
 
     // Zend_Validator_File_WordCount
     "Too much words, maximum '%max%' are allowed but '%count%' were counted" => "输入的单词过多，最多允许'%max%'个单词，输入了'%count%'个",
-    "Too less words, minimum '%min%' are expected but '%count%' were counted" => "输入的单词过少，至少需要'%min%'个单词，输入了'%count%'个",
+    "Too few words, minimum '%min%' are expected but '%count%' were counted" => "输入的单词过少，至少需要'%min%'个单词，输入了'%count%'个",
     "File '%value%' is not readable or does not exist" => "文件'%value%'无法读取或不存在",
 
     // Zend_Validator_GreaterThan


### PR DESCRIPTION
The current status of `Zend_Validate.php` resource is plain broken in pretty much every language.
This is an attempt to quickly fix the current state (#2536), ignoring the proposal of adding full stops a the end of each message which, as discussed in #2984, has raised some BC concerns.

At the moment this PR completely fixes EN and IT languages only, but I'll try to fix the other languages too, at least the message keys.
