### PR TITLE
Updated Page\Mvc::getHref to grab correct controller name from routeMatc...

### DIFF
--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -191,7 +191,18 @@ class Mvc extends AbstractPage
         }
 
         if ($this->getRouteMatch() !== null) {
-            $params = array_merge($this->getRouteMatch()->getParams(), $this->getParams());
+            $rmParams = $this->getRouteMatch()->getParams();
+
+            if (isset($rmParams[ModuleRouteListener::ORIGINAL_CONTROLLER])) {
+                $rmParams['controller'] = $rmParams[ModuleRouteListener::ORIGINAL_CONTROLLER];
+                unset($rmParams[ModuleRouteListener::ORIGINAL_CONTROLLER]);
+            }
+
+            if (isset($rmParams[ModuleRouteListener::MODULE_NAMESPACE])) {
+                unset($rmParams[ModuleRouteListener::MODULE_NAMESPACE]);
+            }
+
+            $params = array_merge($rmParams, $this->getParams());
         } else {
             $params = $this->getParams();
         }

--- a/tests/ZendTest/Navigation/Page/MvcTest.php
+++ b/tests/ZendTest/Navigation/Page/MvcTest.php
@@ -561,5 +561,34 @@ class MvcTest extends TestCase
         $this->assertEquals('/lollerblades/view/23', $page->getHref());
     }
 
+    public function testInheritedRouteMatchParamsWorkWithModuleRouteListener()
+    {
+        $page = new Page\Mvc(array(
+            'label' => 'mpinkstonwashere',
+            'route' => 'lmaoplane'
+        ));
 
+        $route = new SegmentRoute('/lmaoplane/:controller');
+
+        $router = new TreeRouteStack;
+        $router->addRoute('lmaoplane', $route);
+
+        $routeMatch = new RouteMatch(array(
+            ModuleRouteListener::MODULE_NAMESPACE => 'Application\Controller',
+            'controller' => 'index'
+        ));
+        $routeMatch->setMatchedRouteName('lmaoplane');
+
+        $event = new MvcEvent();
+        $event->setRouter($router)
+            ->setRouteMatch($routeMatch);
+
+        $moduleRouteListener = new ModuleRouteListener();
+        $moduleRouteListener->onRoute($event);
+
+        $page->setRouter($event->getRouter());
+        $page->setRouteMatch($event->getRouteMatch());
+
+        $this->assertEquals('/lmaoplane/index', $page->getHref());
+    }
 }


### PR DESCRIPTION
...h when using ModuleRouteListener

If the controller param was being inherited from the routeMatch when ModuleRouteListener is used, the wrong name was being returned. This also removes ModuleRouteListener specific params from being assembled and returned for routes such as wildcard.
