### PR TITLE
Add event manager as soft dependency to translator

### DIFF
--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -213,6 +213,11 @@ class Translator
             }
         }
 
+        // event manager enabled
+        if (isset($options['event_manager_enabled']) && $options['event_manager_enabled']) {
+            $translator->enableEventManager();
+        }
+
         return $translator;
     }
 

--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -26,6 +26,16 @@ use Zend\Stdlib\ArrayUtils;
 class Translator
 {
     /**
+     * Event fired when the translation for a message is missing.
+     */
+    const EVENT_MISSING_TRANSLATION = 'missingTranslation';
+
+    /**
+     * Event fired when no messages were loaded for a locale/text-domain combination.
+     */
+    const EVENT_NO_MESSAGES_LOADED = 'noMessagesLoaded';
+
+    /**
      * Messages loaded by the translator.
      *
      * @var array
@@ -427,7 +437,7 @@ class Translator
 
         if ($this->isEventManagerEnabled()) {
             $this->getEventManager()->trigger(
-                'getTranslatedMessage.missing-translation',
+                self::EVENT_MISSING_TRANSLATION,
                 $this,
                 array(
                     'message'     => $message,
@@ -548,7 +558,7 @@ class Translator
         if (!$messagesLoaded) {
             if ($this->isEventManagerEnabled()) {
                 $this->getEventManager()->trigger(
-                    'loadMessages.no-messages-loaded',
+                    self::EVENT_NO_MESSAGES_LOADED,
                     $this,
                     array(
                         'locale'      => $locale,
@@ -696,8 +706,8 @@ class Translator
     {
         $events->setIdentifiers(array(
             __CLASS__,
-            get_called_class(),
-            'module_manager',
+            get_class($this),
+            'translator',
         ));
         $this->events = $events;
         return $this;

--- a/library/Zend/I18n/composer.json
+++ b/library/Zend/I18n/composer.json
@@ -18,6 +18,7 @@
     },
     "suggest": {
         "ext-intl": "ext/intl for i18n features",
+        "zendframework/zend-eventmanager": "You should install this package to use the events in the translator",
         "zendframework/zend-filter": "You should install this package to use the provided filters",
         "zendframework/zend-validator": "You should install this package to use the provided validators",
         "zendframework/zend-view": "You should install this package to use the provided view helpers"

--- a/tests/ZendTest/I18n/Translator/TranslatorTest.php
+++ b/tests/ZendTest/I18n/Translator/TranslatorTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\I18n\Translator;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Locale;
+use Zend\EventManager\EventInterface;
 use Zend\I18n\Translator\Translator;
 use Zend\I18n\Translator\TextDomain;
 use ZendTest\I18n\Translator\TestAsset\Loader as TestLoader;
@@ -233,5 +234,71 @@ class TranslatorTest extends TestCase
 
         $this->assertEquals('Message 1', $this->translator->translate('Message 1'));
         $this->assertEquals('Message 9', $this->translator->translate('Message 9'));
+    }
+
+    public function testEnableDisableEventManger()
+    {
+        $this->assertFalse($this->translator->isEventManagerEnabled(), 'Default value');
+
+        $this->translator->enableEventManager();
+        $this->assertTrue($this->translator->isEventManagerEnabled());
+
+        $this->translator->disableEventManager();
+        $this->assertFalse($this->translator->isEventManagerEnabled());
+    }
+
+    public function testMissingTranslationEvent()
+    {
+        $actualEvent = null;
+
+        $this->translator->enableEventManager();
+        $this->translator->getEventManager()->attach('getTranslatedMessage.missing-translation', function(EventInterface $event) use (&$actualEvent) {
+            $actualEvent = $event;
+        });
+
+        $this->translator->translate('foo', 'bar', 'baz');
+
+        $this->assertInstanceOf('Zend\EventManager\Event', $actualEvent);
+        $this->assertEquals(
+            array(
+                'message'     => 'foo',
+                'locale'      => 'baz',
+                'text_domain' => 'bar',
+            ),
+            $actualEvent->getParams()
+        );
+
+        // But fire no event when disabled
+        $actualEvent = null;
+        $this->translator->disableEventManager();
+        $this->translator->translate('foo', 'bar', 'baz');
+        $this->assertNull($actualEvent);
+    }
+
+    public function testNoMessagesLoadedEvent()
+    {
+        $actualEvent = null;
+
+        $this->translator->enableEventManager();
+        $this->translator->getEventManager()->attach('loadMessages.no-messages-loaded', function(EventInterface $event) use (&$actualEvent) {
+            $actualEvent = $event;
+        });
+
+        $this->translator->translate('foo', 'bar', 'baz');
+
+        $this->assertInstanceOf('Zend\EventManager\Event', $actualEvent);
+        $this->assertEquals(
+            array(
+                'locale'      => 'baz',
+                'text_domain' => 'bar',
+            ),
+            $actualEvent->getParams()
+        );
+
+        // But fire no event when disabled
+        $actualEvent = null;
+        $this->translator->disableEventManager();
+        $this->translator->translate('foo', 'bar', 'baz');
+        $this->assertNull($actualEvent);
     }
 }

--- a/tests/ZendTest/I18n/Translator/TranslatorTest.php
+++ b/tests/ZendTest/I18n/Translator/TranslatorTest.php
@@ -247,6 +247,17 @@ class TranslatorTest extends TestCase
         $this->assertFalse($this->translator->isEventManagerEnabled());
     }
 
+    public function testEnableEventMangerViaFactory()
+    {
+        $translator = Translator::factory(array(
+            'event_manager_enabled' => true
+        ));
+        $this->assertTrue($translator->isEventManagerEnabled());
+
+        $translator = Translator::factory(array());
+        $this->assertFalse($translator->isEventManagerEnabled());
+    }
+
     public function testMissingTranslationEvent()
     {
         $actualEvent = null;

--- a/tests/ZendTest/I18n/Translator/TranslatorTest.php
+++ b/tests/ZendTest/I18n/Translator/TranslatorTest.php
@@ -263,7 +263,7 @@ class TranslatorTest extends TestCase
         $actualEvent = null;
 
         $this->translator->enableEventManager();
-        $this->translator->getEventManager()->attach('getTranslatedMessage.missing-translation', function(EventInterface $event) use (&$actualEvent) {
+        $this->translator->getEventManager()->attach(Translator::EVENT_MISSING_TRANSLATION, function(EventInterface $event) use (&$actualEvent) {
             $actualEvent = $event;
         });
 
@@ -291,7 +291,7 @@ class TranslatorTest extends TestCase
         $actualEvent = null;
 
         $this->translator->enableEventManager();
-        $this->translator->getEventManager()->attach('loadMessages.no-messages-loaded', function(EventInterface $event) use (&$actualEvent) {
+        $this->translator->getEventManager()->attach(Translator::EVENT_NO_MESSAGES_LOADED, function(EventInterface $event) use (&$actualEvent) {
             $actualEvent = $event;
         });
 


### PR DESCRIPTION
This PR allows users to attach to two new events in the translator:
- loadMessages.no-messages-loaded which will always fire when messages for a specific locale/text-domain combination could not be loaded
- getTranslatedMessage.missing-translation which will always fire when a message in a specific locale/text-domain could not be found

By default, events are disabled, and the translator will not try to create an event manager instance. This makes it a rather nice soft dependency, without having it as requirement.
