### PR TITLE
Zend\Stdlib\Hydrator\ClassMethods::hydrate() - support for __call() magic method

### DIFF
--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -177,7 +177,7 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
             if ($this->underscoreSeparatedKeys) {
                 $method = preg_replace_callback('/(_[a-z])/', $transform, $method);
             }
-            if (method_exists($object, $method)) {
+            if (is_callable(array($object, $method))) {
                 $value = $this->hydrateValue($property, $value);
 
                 $object->$method($value);

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -17,6 +17,8 @@ use Zend\Stdlib\Hydrator\ArraySerializable;
 use Zend\Stdlib\Hydrator\Filter\FilterComposite;
 use ZendTest\Stdlib\TestAsset\ClassMethodsCamelCase;
 use ZendTest\Stdlib\TestAsset\ClassMethodsFilterProviderInterface;
+use ZendTest\Stdlib\TestAsset\ClassMethodsMagicMethodSetter;
+use ZendTest\Stdlib\TestAsset\ClassMethodsProtectedSetter;
 use ZendTest\Stdlib\TestAsset\ClassMethodsUnderscore;
 use ZendTest\Stdlib\TestAsset\ClassMethodsCamelCaseMissing;
 use ZendTest\Stdlib\TestAsset\ClassMethodsInvalidParameter;
@@ -396,5 +398,25 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(array_key_exists("filter", $data));
         $this->assertSame("bar", $data["foo"]);
         $this->assertSame("foo", $data["bar"]);
+    }
+
+    public function testHydratorClassMethodsWithProtectedSetter()
+    {
+        $hydrator = new ClassMethods(false);
+        $object = new ClassMethodsProtectedSetter();
+        $hydrator->hydrate(array('foo' => 'bar', 'bar' => 'BAR'), $object);
+        $data = $hydrator->extract($object);
+
+        $this->assertEquals($data['bar'], 'BAR');
+    }
+
+    public function testHydratorClassMethodsWithMagicMethodSetter()
+    {
+        $hydrator = new ClassMethods(false);
+        $object = new ClassMethodsMagicMethodSetter();
+        $hydrator->hydrate(array('foo' => 'bar'), $object);
+        $data = $hydrator->extract($object);
+
+        $this->assertEquals($data['foo'], 'bar');
     }
 }

--- a/tests/ZendTest/Stdlib/TestAsset/ClassMethodsMagicMethodSetter.php
+++ b/tests/ZendTest/Stdlib/TestAsset/ClassMethodsMagicMethodSetter.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+namespace ZendTest\Stdlib\TestAsset;
+
+class ClassMethodsMagicMethodSetter
+{
+    protected $foo;
+
+    public function __call($method, $args)
+    {
+        if(strlen($method) > 3 && strtolower(substr($method, 3)) == 'foo')
+        {
+            $this->foo = $args[0];
+        }
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+}

--- a/tests/ZendTest/Stdlib/TestAsset/ClassMethodsProtectedSetter.php
+++ b/tests/ZendTest/Stdlib/TestAsset/ClassMethodsProtectedSetter.php
@@ -24,11 +24,6 @@ class ClassMethodsProtectedSetter
         $this->bar = $bar;
     }
 
-    public function getFoo()
-    {
-        return $this->foo;
-    }
-
     public function getBar()
     {
         return $this->bar;

--- a/tests/ZendTest/Stdlib/TestAsset/ClassMethodsProtectedSetter.php
+++ b/tests/ZendTest/Stdlib/TestAsset/ClassMethodsProtectedSetter.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+namespace ZendTest\Stdlib\TestAsset;
+
+class ClassMethodsProtectedSetter
+{
+    protected $foo;
+    protected $bar;
+
+    protected function setFoo($foo)
+    {
+        $this->foo = $foo;
+    }
+
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+}


### PR DESCRIPTION
I've noticed that the hydrate() method checks if a method exists, in the target object, using the method_exists() function. Wouldn't it be better to use is_callable() instead so it would be possible to use the __call() magic method?
