### PR TITLE
Added dummy cache adapter for short-circuiting.

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/NoCache.php
+++ b/library/Zend/Cache/Storage/Adapter/NoCache.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Cache\Storage\Adapter;
+
+class NoCache extends AbstractAdapter
+{
+    /**
+     * Internal method to get an item.
+     *
+     * @param  string  $normalizedKey
+     * @param  bool $success
+     * @param  mixed   $casToken
+     * @return mixed Data on success, null on failure
+     */
+    protected function internalGetItem(& $normalizedKey, & $success = null,
+        & $casToken = null
+    ) {
+        return null;
+    }
+
+    /**
+     * Internal method to store an item.
+     *
+     * @param  string $normalizedKey
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function internalSetItem(& $normalizedKey, & $value)
+    {
+        return true;
+    }
+
+    /**
+     * Internal method to remove an item.
+     *
+     * @param  string $normalizedKey
+     * @return bool
+     */
+    protected function internalRemoveItem(& $normalizedKey)
+    {
+        return true;
+    }
+}

--- a/library/Zend/Cache/Storage/AdapterPluginManager.php
+++ b/library/Zend/Cache/Storage/AdapterPluginManager.php
@@ -32,6 +32,7 @@ class AdapterPluginManager extends AbstractPluginManager
         'filesystem'     => 'Zend\Cache\Storage\Adapter\Filesystem',
         'memcached'      => 'Zend\Cache\Storage\Adapter\Memcached',
         'memory'         => 'Zend\Cache\Storage\Adapter\Memory',
+        'nocache'        => 'Zend\Cache\Storage\Adapter\NoCache',
         'session'        => 'Zend\Cache\Storage\Adapter\Session',
         'xcache'         => 'Zend\Cache\Storage\Adapter\XCache',
         'wincache'       => 'Zend\Cache\Storage\Adapter\WinCache',

--- a/tests/ZendTest/Cache/Storage/Adapter/NoCacheTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/NoCacheTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Cache
+ */
+
+namespace ZendTest\Cache\Storage\Adapter;
+
+use Zend\Cache\Storage\Adapter\NoCache;
+
+/**
+ * @category   Zend
+ * @package    Zend_Cache
+ * @subpackage UnitTests
+ * @group      Zend_Cache
+ */
+class NoCacheTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test that an item is not stored.
+     *
+     * @return void
+     */
+    public function testHasItemIsFalseAfterSetItem()
+    {
+        $cache = new NoCache();
+        $cache->setItem('key', 'value');
+        $this->assertFalse((boolean)$cache->hasItem('key'));
+    }
+}


### PR DESCRIPTION
Sometimes it is useful to disable a cache by injecting a dummy object; this adapter allows caching to be disabled by implementing a non-functioning version of the cache interface.

(Thank to David Maus for developing the code).
