### PR TITLE
Fixed failure when implementing custom rbac roles

### DIFF
--- a/library/Zend/Permissions/Rbac/AbstractIterator.php
+++ b/library/Zend/Permissions/Rbac/AbstractIterator.php
@@ -80,7 +80,11 @@ abstract class AbstractIterator implements RecursiveIterator
      */
     public function hasChildren()
     {
-        return count($this->children) > 0;
+        if ($this->valid() && ($this->current() instanceof RecursiveIterator)) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/library/Zend/Permissions/Rbac/Rbac.php
+++ b/library/Zend/Permissions/Rbac/Rbac.php
@@ -45,7 +45,7 @@ class Rbac extends AbstractIterator
      *
      * @param  string|RoleInterface               $child
      * @param  array|RoleInterface|null           $parents
-     * @return RoleInterface
+     * @return \Zend\Permissions\Rbac\Rbac
      * @throws Exception\InvalidArgumentException
      */
     public function addRole($child, $parents = null)

--- a/tests/ZendTest/Permissions/Rbac/RbacTest.php
+++ b/tests/ZendTest/Permissions/Rbac/RbacTest.php
@@ -141,4 +141,24 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($bar->getParent(), $foo);
         $this->assertEquals(1, count($foo->getChildren()));
     }
+
+    /**
+     * @tesdox Test adding custom child roles works
+     */
+    public function testAddCustomChildRole()
+    {
+        $role = $this->getMockForAbstractClass('\Zend\Permissions\Rbac\RoleInterface');
+        $this->rbac->setCreateMissingRoles(true)->addRole($role, array('parent'));
+
+        $role->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('customchild'));
+
+        $role->expects($this->once())
+            ->method('hasPermission')
+            ->with('test')
+            ->will($this->returnValue(true));
+
+        $this->assertTrue($this->rbac->isGranted('parent', 'test'));
+    }
 }

--- a/tests/ZendTest/Permissions/Rbac/RbacTest.php
+++ b/tests/ZendTest/Permissions/Rbac/RbacTest.php
@@ -147,7 +147,7 @@ class RbacTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddCustomChildRole()
     {
-        $role = $this->getMockForAbstractClass('\Zend\Permissions\Rbac\RoleInterface');
+        $role = $this->getMockForAbstractClass('Zend\Permissions\Rbac\RoleInterface');
         $this->rbac->setCreateMissingRoles(true)->addRole($role, array('parent'));
 
         $role->expects($this->any())


### PR DESCRIPTION
`Zend\Permissions\Rbac\Rbac::isGranted()` will faill, when implementing the interface `Zend\Permissions\Rbac\RoleInterface` with a custom role and adding it to a `Zend\Permissions\Rbac\Rbac` instance with parents (due to missing implementation of RecursiveIterator on the custom role).

``` php
$custom = new MyCustomRole();
$rbac->addRole($custom, 'foo');
$rbac->isGranted('foo', 'something'); // <- failure
```

This example will throw an UnexpectedValueException ("Objects returned by RecursiveIterator::getChildren() must implement RecursiveIterator").
- Added a unit test to reflect this behavior
- Implemented a fix by improving the hasChildren() implementation in
  `Zend\Permissions\Rbac\AbstractIterator`
