### PR TITLE
[Curl] setOptions should merge config items that can be arrays

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -134,6 +134,9 @@ class Curl implements HttpAdapter, StreamInterface
                     $this->setCurlOption(CURLOPT_PROXYPORT, $v);
                     break;
                 default:
+                    if (is_array($v) && isset($this->config[$option]) && is_array($this->config[$option])) {
+                        $v = ArrayUtils::merge($this->config[$option], $v);
+                    }
                     $this->config[$option] = $v;
                     break;
             }

--- a/tests/ZendTest/Http/Client/CurlTest.php
+++ b/tests/ZendTest/Http/Client/CurlTest.php
@@ -254,6 +254,27 @@ class CurlTest extends CommonHttpTests
         );
     }
 
+    public function testSetOptionsMergesCurlOptions()
+    {
+        $adapter = new Adapter\Curl();
+
+        $adapter->setOptions(array(
+            'curloptions' => array(
+                'foo' => 'bar',
+            ),
+        ));
+        $adapter->setOptions(array(
+            'curloptions' => array(
+                'bar' => 'baz',
+            ),
+        ));
+
+        $this->assertEquals(
+            array('curloptions' => array('foo' => 'bar', 'bar' => 'baz')),
+            $this->readAttribute($adapter, 'config')
+        );
+    }
+
     public function testWorkWithProxyConfiguration()
     {
         $adapter = new Adapter\Curl();


### PR DESCRIPTION
Right now calling setOptions with a config item that is an array will completely overwrite the existing config option. Instead the two should be merged if they both happen to be arrays.
