### PR TITLE
Bugfix for redirection handling in Zend\Http\Client

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -533,6 +533,14 @@ class Client implements Stdlib\DispatchableInterface
     }
 
     /**
+     * Clear http authentication
+     */
+    public function clearAuth()
+    {
+        $this->auth = array();
+    }
+
+    /**
      * Set the headers (for the request)
      *
      * @param  Headers|array $headers
@@ -732,13 +740,13 @@ class Client implements Stdlib\DispatchableInterface
      * Reset all the HTTP parameters (auth,cookies,request, response, etc)
      *
      * @param  bool   $clearCookies  Also clear all valid cookies? (defaults to false)
+     * @param  bool   $clearAuth     Also clear http authentication? (defaults to true)
      * @return Client
      */
-    public function resetParameters($clearCookies = false)
+    public function resetParameters($clearCookies = false, $clearAuth = true)
     {
         $uri = $this->getUri();
 
-        $this->auth       = null;
         $this->streamName = null;
         $this->encType    = null;
         $this->request    = null;
@@ -748,6 +756,10 @@ class Client implements Stdlib\DispatchableInterface
 
         if ($clearCookies) {
             $this->clearCookies();
+        }
+        
+        if ($clearAuth) {
+            $this->clearAuth();
         }
 
         return $this;
@@ -897,7 +909,7 @@ class Client implements Stdlib\DispatchableInterface
                    ((! $this->config['strictredirects']) && ($response->getStatusCode() == 302 ||
                        $response->getStatusCode() == 301))) {
 
-                    $this->resetParameters();
+                    $this->resetParameters(false, false);
                     $this->setMethod(Request::METHOD_GET);
                 }
 

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -912,11 +912,20 @@ class Client implements Stdlib\DispatchableInterface
                     $this->resetParameters(false, false);
                     $this->setMethod(Request::METHOD_GET);
                 }
+                
 
                 // If we got a well formed absolute URI
                 if (($scheme = substr($location, 0, 6)) &&
                         ($scheme == 'http:/' || $scheme == 'https:')) {
+                    // remember host of last request
+                    $lastHost = $this->getUri()->getHost();
                     $this->setUri($location);
+                    
+                    // clear authentication for security reasons if host changed
+                    $nextHost = $this->getUri()->getHost();
+                    if (!preg_match('/' . preg_quote($lastHost, '/') . '$/i', $nextHost)) {
+                        $this->clearAuth();
+                    }
                 } else {
 
                     // Split into path and query and set the query

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -933,7 +933,7 @@ class Client implements Stdlib\DispatchableInterface
                 break;
             }
 
-        } while ($this->redirectCounter < $this->config['maxredirects']);
+        } while ($this->redirectCounter <= $this->config['maxredirects']);
 
         $this->response = $response;
         return $response;

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -445,6 +445,35 @@ class Client implements Stdlib\DispatchableInterface
     }
 
     /**
+     * Reset all the HTTP parameters (request, response, etc)
+     *
+     * @param  bool   $clearCookies  Also clear all valid cookies? (defaults to false)
+     * @param  bool   $clearAuth     Also clear http authentication? (defaults to true)
+     * @return Client
+     */
+    public function resetParameters($clearCookies = false, $clearAuth = true)
+    {
+        $uri = $this->getUri();
+
+        $this->streamName = null;
+        $this->encType    = null;
+        $this->request    = null;
+        $this->response   = null;
+
+        $this->setUri($uri);
+
+        if ($clearCookies) {
+            $this->clearCookies();
+        }
+        
+        if ($clearAuth) {
+            $this->clearAuth();
+        }
+
+        return $this;
+    }
+
+    /**
      * Return the current cookies
      *
      * @return array
@@ -530,14 +559,6 @@ class Client implements Stdlib\DispatchableInterface
     public function clearCookies()
     {
         $this->cookies = array();
-    }
-
-    /**
-     * Clear http authentication
-     */
-    public function clearAuth()
-    {
-        $this->auth = array();
     }
 
     /**
@@ -682,6 +703,14 @@ class Client implements Stdlib\DispatchableInterface
     }
 
     /**
+     * Clear http authentication
+     */
+    public function clearAuth()
+    {
+        $this->auth = array();
+    }
+
+    /**
      * Calculate the response value according to the HTTP authentication type
      *
      * @see http://www.faqs.org/rfcs/rfc2617.html
@@ -734,35 +763,6 @@ class Client implements Stdlib\DispatchableInterface
                 break;
         }
         return $response;
-    }
-
-    /**
-     * Reset all the HTTP parameters (auth,cookies,request, response, etc)
-     *
-     * @param  bool   $clearCookies  Also clear all valid cookies? (defaults to false)
-     * @param  bool   $clearAuth     Also clear http authentication? (defaults to true)
-     * @return Client
-     */
-    public function resetParameters($clearCookies = false, $clearAuth = true)
-    {
-        $uri = $this->getUri();
-
-        $this->streamName = null;
-        $this->encType    = null;
-        $this->request    = null;
-        $this->response   = null;
-
-        $this->setUri($uri);
-
-        if ($clearCookies) {
-            $this->clearCookies();
-        }
-        
-        if ($clearAuth) {
-            $this->clearAuth();
-        }
-
-        return $this;
     }
 
     /**

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -455,10 +455,12 @@ class Client implements Stdlib\DispatchableInterface
     {
         $uri = $this->getUri();
 
-        $this->streamName = null;
-        $this->encType    = null;
-        $this->request    = null;
-        $this->response   = null;
+        $this->streamName      = null;
+        $this->encType         = null;
+        $this->request         = null;
+        $this->response        = null;
+        $this->lastRawRequest  = null;
+        $this->lastRawResponse = null;
 
         $this->setUri($uri);
 
@@ -958,6 +960,20 @@ class Client implements Stdlib\DispatchableInterface
 
         $this->response = $response;
         return $response;
+    }
+
+    /**
+     * Fully reset the HTTP client (auth, cookies, request, response, etc.)
+     *
+     * @return Client
+     */
+    public function reset() 
+    {
+       $this->resetParameters();
+       $this->clearAuth();
+       $this->clearCookies();
+       
+       return $this;
     }
 
     /**

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -929,7 +929,7 @@ class Client implements Stdlib\DispatchableInterface
                 // If we got a well formed absolute URI
                 if (($scheme = substr($location, 0, 6)) &&
                         ($scheme == 'http:/' || $scheme == 'https:')) {
-                    # setURI() clears parameters if host changed, see #4215
+                    // setURI() clears parameters if host changed, see #4215
                     $this->setUri($location);
                 } else {
 


### PR DESCRIPTION
When working with Zend\Http\Client today I discovered two issues:
1. Client does not count redirects correctly, so `maxredirects=1` did not follow any redirect, `maxredirects=2` followed 1 redirect.
2. When following a redirect, the client looses the HTTP authentication, if one was set previously, which causes unexpected results when working with websites which are protected by HTTP basic authentication

The first issue is do to a wrong way of counting the redirects, which I fixed in e196bc3. Basically a compare operator was wrong (`<` instead of `<=`). I added a test case for that.

The second issue is due to the fact that the `send()` method makes a call to `resetParameters()` prior to following the redirect. Unfortunatelly this removes the HTTP authentication as well. I added a new method `clearAuth()` (similar to `clearCookies()`) and changed `resetParameters()` to only clear the authentication when the newly introduced second parameter is `true`. To not break backward-compatibilty, this parameter is true by default. All this was done in 954a549, a test case is added as well.
