### PR TITLE
Mail\Headers.php: Adjust regex for field name to RFC 5322

### DIFF
--- a/library/Zend/Mail/Header/GenericHeader.php
+++ b/library/Zend/Mail/Header/GenericHeader.php
@@ -76,9 +76,9 @@ class GenericHeader implements HeaderInterface, UnstructuredInterface
         $fieldName = str_replace(' ', '-', ucwords(str_replace(array('_', '-'), ' ', $fieldName)));
 
         // Validate what we have
-        if (!preg_match('/^[a-z][a-z0-9-]*$/i', $fieldName)) {
+        if (!preg_match('/^[\x21-\x39\x3B-\x7E]*$/i', $fieldName)) {
             throw new Exception\InvalidArgumentException(
-                'Header name must start with a letter, and consist of only letters, numbers and dashes.'
+                'Header name must be composed of printable US-ASCII characters, except colon.'
             );
         }
 

--- a/library/Zend/Mail/Headers.php
+++ b/library/Zend/Mail/Headers.php
@@ -70,7 +70,7 @@ class Headers implements Countable, Iterator
         // iterate the header lines, some might be continuations
         foreach (explode($EOL, $string) as $line) {
             // check if a header name is present
-            if (preg_match('/^(?P<name>[^()><@,;:\"\\/\[\]?=}{ \t]+):.*$/', $line, $matches)) {
+            if (preg_match('/^(?P<name>[\x21-\x39\x3B-\x7E]+):.*$/', $line, $matches)) {
                 if ($currentLine) {
                     // a header name was present, then store the current complete line
                     $headers->addHeaderLine($currentLine);


### PR DESCRIPTION
According to RFC 5322 (http://tools.ietf.org/html/rfc5322#section-2.2), a field name may contain "printable US-ASCII characters (i.e., characters that have values between 33 and 126, inclusive), except colon".
