### PR TITLE
ZF2 ACL full access

### DIFF
--- a/library/Zend/Permissions/Acl/Acl.php
+++ b/library/Zend/Permissions/Acl/Acl.php
@@ -556,6 +556,10 @@ class Acl implements AclInterface
         if (!is_array($resources)) {
             if (null === $resources && count($this->resources) > 0) {
                 $resources = array_keys($this->resources);
+                // Passing a null resource; make sure "global" permission is also set!
+                if (!in_array(null, $resources)) {
+                    array_unshift($resources, null);
+                }
             } else {
                 $resources = array($resources);
             }

--- a/tests/ZendTest/Permissions/Acl/AclTest.php
+++ b/tests/ZendTest/Permissions/Acl/AclTest.php
@@ -1372,4 +1372,12 @@ class AclTest extends \PHPUnit_Framework_TestCase
 
         $this->_acl->setRule(Acl\Acl::OP_ADD, Acl\Acl::TYPE_ALLOW, $roleGuest, $resourceFoo);
     }
+
+    public function testAllowNullPermissionAfterResourcesExistShouldAllowAllPermissionsForRole()
+    {
+        $this->_acl->addRole('admin');
+        $this->_acl->addResource('newsletter');
+        $this->_acl->allow('admin');
+        $this->assertTrue($this->_acl->isAllowed('admin'));
+    }
 }

--- a/tests/ZendTest/Permissions/Acl/AclTest.php
+++ b/tests/ZendTest/Permissions/Acl/AclTest.php
@@ -1373,6 +1373,9 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->_acl->setRule(Acl\Acl::OP_ADD, Acl\Acl::TYPE_ALLOW, $roleGuest, $resourceFoo);
     }
 
+    /**
+     * @group 4226
+     */
     public function testAllowNullPermissionAfterResourcesExistShouldAllowAllPermissionsForRole()
     {
         $this->_acl->addRole('admin');


### PR DESCRIPTION
Hello, I want to check if role has full access in ZF2 ACL, but I can't

$acl->allow('admin_role'); // set full access
$isAllowed = $acl->isAllowed('admin_role'); // check if role has full access
//$isAllowed equals false
