### PR TITLE
ValueGenerator constant detection

### DIFF
--- a/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
@@ -72,12 +72,15 @@ class ValueGeneratorTest extends \PHPUnit_Framework_TestCase
             5,
             'one' => 1,
             'two' => '2',
+            'constant1' => '__DIR__ . \'/anydir1/anydir2\'',
             array(
+                'baz' => true,
                 'foo',
                 'bar',
                 array(
                     'baz1',
                     'baz2',
+                    'constant2' => 'ArrayObject::STD_PROP_LIST',
                 )
             ),
             new ValueGenerator('PHP_EOL', 'constant')
@@ -88,12 +91,15 @@ array(
         5,
         'one' => 1,
         'two' => '2',
+        'constant1' => __DIR__ . '/anydir1/anydir2',
         array(
+            'baz' => true,
             'foo',
             'bar',
             array(
                 'baz1',
-                'baz2'
+                'baz2',
+                'constant2' => ArrayObject::STD_PROP_LIST
                 )
             ),
         PHP_EOL
@@ -101,6 +107,7 @@ array(
 EOS;
 
         $valueGenerator = new ValueGenerator();
+        $valueGenerator->initEnvironmentConstants();
         $valueGenerator->setValue($targetValue);
         $generatedTargetSource = $valueGenerator->generate();
         $this->assertEquals($expectedSource, $generatedTargetSource);


### PR DESCRIPTION
For example, we need to get a file like this:

```
<?php
return array(
    'module' => array(
        'moduleDir' => __DIR__ . '/../module'
    )
);
```

but we cant pass argument `__DIR__`, because this constant will be parsed and replaced to value, and we must quote it '**DIR**' . And finally, after generation, we will not get this:

```
        'moduleDir' => __DIR__ . '/../module'
```

generated value will be like it:

```
        'moduleDir' => '__DIR__ . \'/../module\''
```

Changes:
Add ability to define environment constants by method

```
public function initEnvironmentConstants();
```

Also add ability to define custom constants by methods

```
public function addConstant($constant);
public function deleteConstant($constant)
```

property `$constants` must be type of `ArrayObject` for memory saving when pass it as argument for recursive generation by reference.
