### PR TITLE
Some additional "safe words" for PlatformInterface#quoteIdentifierInFragment(...) call in Zend\Db\Sql\Select#processJoins(...)

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -748,7 +748,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             // note: for Expression objects, pass them to processExpression with a prefix specific to each join (used for named parameters)
             $joinSpecArgArray[$j][] = ($join['on'] instanceof ExpressionInterface)
                 ? $this->processExpression($join['on'], $platform, $driver, $this->processInfo['paramPrefix'] . 'join' . ($j+1) . 'part')
-                : $platform->quoteIdentifierInFragment($join['on'], array('=', 'AND', 'OR', '(', ')', 'BETWEEN', '<', '>')); // on
+                : $platform->quoteIdentifierInFragment($join['on'], array('=', 'AND', 'OR', '(', ')', 'BETWEEN', '<', '>', 'IS', 'NULL', 'NOT', '\'', '\'\'', '"', '""', '!=')); // on
             if ($joinSpecArgArray[$j][2] instanceof StatementContainerInterface) {
                 if ($parameterContainer) {
                     $parameterContainer->merge($joinSpecArgArray[$j][2]->getParameterContainer());


### PR DESCRIPTION
The [list of the safe words](https://github.com/zendframework/zf2/blob/master/library/Zend/Db/Sql/Select.php#L751) passed to (the implementations of) the Zend\Db\Adapter\Platform\PlatformInterface#quoteIdentifierInFragment(...) extended, in order to prevent [issues](http://stackoverflow.com/q/16060679/2019043) with quoting of IS, NULL, single quote(-s), double quote(-s), and != compare operator.
