### PR TITLE
[#4249] Override 'ServiceManager::has' to do not use peering service managers

### DIFF
--- a/library/Zend/Mvc/Controller/ControllerManager.php
+++ b/library/Zend/Mvc/Controller/ControllerManager.php
@@ -108,7 +108,20 @@ class ControllerManager extends AbstractPluginManager
     }
 
     /**
-     * Override: do not use peering service manager to retrieve controller
+     * Override: do not use peering service managers
+     *
+     * @param  string|array $name
+     * @param  bool         $checkAbstractFactories
+     * @param  bool         $usePeeringServiceManagers
+     * @return bool
+     */
+    public function has($name, $checkAbstractFactories = true, $usePeeringServiceManagers = false)
+    {
+        return parent::has($name, $checkAbstractFactories, $usePeeringServiceManagers);
+    }
+
+    /**
+     * Override: do not use peering service managers
      *
      * @param  string $name
      * @param  array $options

--- a/tests/ZendTest/Mvc/Controller/ControllerManagerTest.php
+++ b/tests/ZendTest/Mvc/Controller/ControllerManagerTest.php
@@ -62,13 +62,13 @@ class ControllerManagerTest extends TestCase
     }
 
     /**
-     * @covers            ControllerManager::has
-     * @covers            ControllerManager::get
-     * @expectedException Zend\ServiceManager\Exception\ServiceNotFoundException
+     * @covers ControllerManager::has
+     * @covers ControllerManager::get
      */
     public function testDoNotUsePeeringServiceManagers()
     {
         $this->assertFalse($this->controllers->has('EventManager'));
+        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotFoundException');
         $this->controllers->get('EventManager');
     }
 }

--- a/tests/ZendTest/Mvc/Controller/ControllerManagerTest.php
+++ b/tests/ZendTest/Mvc/Controller/ControllerManagerTest.php
@@ -33,6 +33,7 @@ class ControllerManagerTest extends TestCase
 
         $this->controllers = new ControllerManager();
         $this->controllers->setServiceLocator($this->services);
+        $this->controllers->addPeeringServiceManager($this->services);
     }
 
     public function testInjectControllerDependenciesInjectsExpectedDependencies()
@@ -58,5 +59,16 @@ class ControllerManagerTest extends TestCase
         $this->controllers->injectControllerDependencies($controller, $this->controllers);
         $this->assertSame($events, $controller->getEventManager());
         $this->assertSame($this->sharedEvents, $events->getSharedManager());
+    }
+
+    /**
+     * @covers            ControllerManager::has
+     * @covers            ControllerManager::get
+     * @expectedException Zend\ServiceManager\Exception\ServiceNotFoundException
+     */
+    public function testDoNotUsePeeringServiceManagers()
+    {
+        $this->assertFalse($this->controllers->has('EventManager'));
+        $this->controllers->get('EventManager');
     }
 }


### PR DESCRIPTION
Maybe this breaks BC, tell me if I need to reopen this PR against develop
