### PR TITLE
Auto-upgrading and then displaying composer version

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -16,11 +16,19 @@
     </target>
 
     <target name="composer-install" description="Installs dependencies via composer install">
-        <exec executable="composer" failonerror="true">
-            <arg value="install" />
-            <arg value="--dev" />
-            <arg value="--prefer-source" />
-        </exec>
+        <sequential>
+            <exec executable="composer" failonerror="true">
+                <arg value="self-update" />
+            </exec>
+            <exec executable="composer" failonerror="true">
+                <arg value="--version" />
+            </exec>
+            <exec executable="composer" failonerror="true">
+                <arg value="install" />
+                <arg value="--dev" />
+                <arg value="--prefer-source" />
+            </exec>
+        </sequential>
     </target>
 
     <target
@@ -102,12 +110,12 @@
 
             </echo>
             <exec
-                    executable="${basedir}/vendor/bin/phpunit"
-                    output="${basedir}/build/test-results/@{component}.log"
-                    error="${basedir}/build/test-results/@{component}.log"
-                    failonerror="true"
-                    append="true"
-                    >
+                executable="${basedir}/vendor/bin/phpunit"
+                output="${basedir}/build/test-results/@{component}.log"
+                error="${basedir}/build/test-results/@{component}.log"
+                failonerror="true"
+                append="true"
+            >
                 <arg value="-c" />
                 <arg value="${basedir}/tests/phpunit.xml.dist" />
                 <arg value="${basedir}/tests/ZendTest/@{component}" />


### PR DESCRIPTION
Because of the frequent problems with the installer, and without any way of being certain that travis boxes are updated, I added a `composer self-update` command to the build steps.
