### PR TITLE
Create AbstractFactory for Cache

### DIFF
--- a/library/Zend/Cache/Service/StorageCacheAbstractFactory.php
+++ b/library/Zend/Cache/Service/StorageCacheAbstractFactory.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Cache\Service;
+
+use Zend\Cache\StorageFactory;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Storage cache factory for multiple caches.
+ */
+class StorageCacheAbstractFactory implements AbstractFactoryInterface
+{
+    /**
+     * @param ServiceLocatorInterface $serviceLocator
+     * @param string $name
+     * @param string $requestedName
+     * @return bool
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        if ('cache\\' !== substr(strtolower($requestedName), 0, 6)) {
+            return false;
+        }
+
+        $config  = $serviceLocator->get('Config');
+        if (!isset($config['caches'])) {
+            return false;
+        }
+
+        $config  = array_change_key_case($config['caches']);
+        $service = substr(strtolower($requestedName), 6);
+        return isset($config[$service]) && is_array($config[$service]);
+    }
+
+    /**
+     * @param ServiceLocatorInterface $serviceLocator
+     * @param string $name
+     * @param string $requestedName
+     * @return \Zend\Cache\Storage\StorageInterface
+     */
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        $config      = $serviceLocator->get('Config');
+        $config      = array_change_key_case($config['caches']);
+        $service     = substr(strtolower($requestedName), 6);
+        $cacheConfig = $config[$service];
+        return StorageFactory::factory($cacheConfig);
+    }
+}

--- a/tests/ZendTest/Cache/Service/StorageCacheAbstractFactoryTest.php
+++ b/tests/ZendTest/Cache/Service/StorageCacheAbstractFactoryTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Cache
+ */
+
+namespace ZendTest\Cache\Service;
+
+use Zend\Cache;
+use Zend\ServiceManager\ServiceManager;
+
+/**
+ * @category   Zend
+ * @package    Zend_Cache
+ * @subpackage UnitTests
+ * @group      Zend_Cache
+ */
+class StorageCacheAbstractFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    protected $sm;
+
+    public function setUp()
+    {
+        Cache\StorageFactory::resetAdapterPluginManager();
+        Cache\StorageFactory::resetPluginManager();
+        $this->sm = new ServiceManager();
+        $this->sm->setService('Config', array('caches' => array(
+            'Memory' => array(
+                'adapter' => 'Memory',
+                'plugins' => array('Serializer', 'ClearExpiredByFactor'),
+            ),
+            'invalid' => array(
+                'adapter' => 'Memory',
+                'plugins' => array('Serializer', 'ClearExpiredByFactor'),
+            ),
+            'Foo' => array(
+                'adapter' => 'Memory',
+                'plugins' => array('Serializer', 'ClearExpiredByFactor'),
+            ),
+        )));
+        $this->sm->addAbstractFactory('Zend\Cache\Service\StorageCacheAbstractFactory');
+    }
+
+    public function tearDown()
+    {
+        Cache\StorageFactory::resetAdapterPluginManager();
+        Cache\StorageFactory::resetPluginManager();
+    }
+
+    public function testCanLookupCacheByName()
+    {
+        $this->assertTrue($this->sm->has('Cache\Memory'));
+        $this->assertTrue($this->sm->has('Cache\Foo'));
+    }
+
+    public function testCanRetrieveCacheByName()
+    {
+        $cacheA = $this->sm->get('Cache\Memory');
+        $this->assertInstanceOf('Zend\Cache\Storage\Adapter\Memory', $cacheA);
+
+        $cacheB = $this->sm->get('Cache\Foo');
+        $this->assertInstanceOf('Zend\Cache\Storage\Adapter\Memory', $cacheB);
+
+        $this->assertNotSame($cacheA, $cacheB);
+    }
+
+    public function testInvalidCacheServiceNameWillBeIgnored()
+    {
+        $this->assertFalse($this->sm->has('invalid'));
+    }
+}


### PR DESCRIPTION
We already have `Zend\Cache\Service\StorageCacheFactory`. However, that is limited to a single cache object based on a single configuration value.

This PR creates `Zend\Cache\Service\StorageCacheAbstractFactory`, which allows defining configuration for multiple named cache objects:

``` php
'caches' => array(
    'Memory' => array(
        'adapter' => 'Memory',
        'plugins' => array('Serializer', 'ClearExpiredByFactor'),
    ),
    'Apc' => array(
        'adapter' => 'apc',
        'plugins' => array(
            'exception_handler' => array('throw_exceptions' => false),
        ),
    ),
),
```

Cache services are then requested using the prefix 'Cache\' and the appropriate configuration key: `Cache\Memory`, 'Cache\Apc`. (Using a prefix prevents the possibility of naming collisions with other abstract factories.)

This abstract factory:
- does not conflict with the current factory, as it uses a different configuration key (`cache` vs `caches`)
- is opt-in only (you have to tell your application to use the abstract factory; it is not automatically registered by the MVC)
- follows the same paradigm as the `LoggerAbstractServiceFactory`
