### PR TITLE
Use prefix in Logger abstract factory

### DIFF
--- a/library/Zend/Cache/Service/StorageCacheAbstractFactory.php
+++ b/library/Zend/Cache/Service/StorageCacheAbstractFactory.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Cache\Service;
+
+use Zend\Cache\StorageFactory;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Storage cache factory for multiple caches.
+ */
+class StorageCacheAbstractFactory implements AbstractFactoryInterface
+{
+    /**
+     * @param ServiceLocatorInterface $serviceLocator
+     * @param string $name
+     * @param string $requestedName
+     * @return bool
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        if ('cache\\' !== substr(strtolower($requestedName), 0, 6)) {
+            return false;
+        }
+
+        $config  = $serviceLocator->get('Config');
+        if (!isset($config['caches'])) {
+            return false;
+        }
+
+        $config  = array_change_key_case($config['caches']);
+        $service = substr(strtolower($requestedName), 6);
+        return isset($config[$service]) && is_array($config[$service]);
+    }
+
+    /**
+     * @param ServiceLocatorInterface $serviceLocator
+     * @param string $name
+     * @param string $requestedName
+     * @return \Zend\Cache\Storage\StorageInterface
+     */
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        $config      = $serviceLocator->get('Config');
+        $config      = array_change_key_case($config['caches']);
+        $service     = substr(strtolower($requestedName), 6);
+        $cacheConfig = $config[$service];
+        return StorageFactory::factory($cacheConfig);
+    }
+}

--- a/library/Zend/Log/LoggerAbstractServiceFactory.php
+++ b/library/Zend/Log/LoggerAbstractServiceFactory.php
@@ -27,8 +27,18 @@ class LoggerAbstractServiceFactory implements AbstractFactoryInterface
      */
     public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
-        $config = $serviceLocator->get('Config');
-        return isset($config['log'][$requestedName]);
+        if ('logger\\' != substr(strtolower($requestedName), 0, 7)) {
+            return false;
+        }
+
+        $config  = $serviceLocator->get('Config');
+        if (!isset($config['log'])) {
+            return false;
+        }
+
+        $config  = array_change_key_case($config['log']);
+        $service = substr(strtolower($requestedName), 7);
+        return isset($config[$service]);
     }
 
     /**
@@ -39,7 +49,9 @@ class LoggerAbstractServiceFactory implements AbstractFactoryInterface
      */
     public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
-        $config = $serviceLocator->get('Config');
-        return new Logger($config['log'][$requestedName]);
+        $config  = $serviceLocator->get('Config');
+        $config  = array_change_key_case($config['log']);
+        $service = substr(strtolower($requestedName), 7);
+        return new Logger($config[$service]);
     }
 }

--- a/tests/ZendTest/Cache/Service/StorageCacheAbstractFactoryTest.php
+++ b/tests/ZendTest/Cache/Service/StorageCacheAbstractFactoryTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Cache
  */
 
 namespace ZendTest\Cache\Service;
@@ -14,9 +13,6 @@ use Zend\Cache;
 use Zend\ServiceManager\ServiceManager;
 
 /**
- * @category   Zend
- * @package    Zend_Cache
- * @subpackage UnitTests
  * @group      Zend_Cache
  */
 class StorageCacheAbstractFactoryTest extends \PHPUnit_Framework_TestCase

--- a/tests/ZendTest/Cache/Service/StorageCacheAbstractFactoryTest.php
+++ b/tests/ZendTest/Cache/Service/StorageCacheAbstractFactoryTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Cache
+ */
+
+namespace ZendTest\Cache\Service;
+
+use Zend\Cache;
+use Zend\ServiceManager\ServiceManager;
+
+/**
+ * @category   Zend
+ * @package    Zend_Cache
+ * @subpackage UnitTests
+ * @group      Zend_Cache
+ */
+class StorageCacheAbstractFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    protected $sm;
+
+    public function setUp()
+    {
+        Cache\StorageFactory::resetAdapterPluginManager();
+        Cache\StorageFactory::resetPluginManager();
+        $this->sm = new ServiceManager();
+        $this->sm->setService('Config', array('caches' => array(
+            'Memory' => array(
+                'adapter' => 'Memory',
+                'plugins' => array('Serializer', 'ClearExpiredByFactor'),
+            ),
+            'invalid' => array(
+                'adapter' => 'Memory',
+                'plugins' => array('Serializer', 'ClearExpiredByFactor'),
+            ),
+            'Foo' => array(
+                'adapter' => 'Memory',
+                'plugins' => array('Serializer', 'ClearExpiredByFactor'),
+            ),
+        )));
+        $this->sm->addAbstractFactory('Zend\Cache\Service\StorageCacheAbstractFactory');
+    }
+
+    public function tearDown()
+    {
+        Cache\StorageFactory::resetAdapterPluginManager();
+        Cache\StorageFactory::resetPluginManager();
+    }
+
+    public function testCanLookupCacheByName()
+    {
+        $this->assertTrue($this->sm->has('Cache\Memory'));
+        $this->assertTrue($this->sm->has('Cache\Foo'));
+    }
+
+    public function testCanRetrieveCacheByName()
+    {
+        $cacheA = $this->sm->get('Cache\Memory');
+        $this->assertInstanceOf('Zend\Cache\Storage\Adapter\Memory', $cacheA);
+
+        $cacheB = $this->sm->get('Cache\Foo');
+        $this->assertInstanceOf('Zend\Cache\Storage\Adapter\Memory', $cacheB);
+
+        $this->assertNotSame($cacheA, $cacheB);
+    }
+
+    public function testInvalidCacheServiceNameWillBeIgnored()
+    {
+        $this->assertFalse($this->sm->has('invalid'));
+    }
+}

--- a/tests/ZendTest/Log/LoggerAbstractServiceFactoryTest.php
+++ b/tests/ZendTest/Log/LoggerAbstractServiceFactoryTest.php
@@ -39,8 +39,8 @@ class LoggerAbstractServiceFactoryTeset extends \PHPUnit_Framework_TestCase
 
         $this->serviceManager->setService('Config', array(
             'log' => array(
-                'Application\Frontend\Logger' => array(),
-                'Application\Backend\Logger' => array(),
+                'Application\Frontend' => array(),
+                'Application\Backend'  => array(),
             ),
         ));
     }
@@ -51,8 +51,8 @@ class LoggerAbstractServiceFactoryTeset extends \PHPUnit_Framework_TestCase
     public function providerValidLoggerService()
     {
         return array(
-            array('Application\Frontend\Logger'),
-            array('Application\Backend\Logger'),
+            array('Logger\Application\Frontend'),
+            array('Logger\Application\Backend'),
         );
     }
 
@@ -62,7 +62,9 @@ class LoggerAbstractServiceFactoryTeset extends \PHPUnit_Framework_TestCase
     public function providerInvalidLoggerService()
     {
         return array(
-            array('Application\Unknown\Logger'),
+            array('Logger\Application\Unknown'),
+            array('Application\Frontend'),
+            array('Application\Backend'),
         );
     }
 


### PR DESCRIPTION
Force service prefix in LoggerAbstractServiceFactory
- To prevent collisions with other abstract factories, the logger
  abstract factory should require that, when requesting a service, the
  service name be prefixed. I chose "Logger", as that's the service type
  being requested.
- This complements the approach in zendframework/zf2#4253 for cache
  objects.
- Not a BC break, as the LoggerAbstractServiceFactory has not yet been
  released.
