### PR TITLE
Update Stream.php

### DIFF
--- a/library/Zend/Http/Response/Stream.php
+++ b/library/Zend/Http/Response/Stream.php
@@ -195,8 +195,8 @@ class Stream extends Response
             $response->content = implode("\n", $responseArray);
         }
 
-        $headers = $response->getHeaders();
-        foreach ($headers as $header) {
+        $this->headers = $response->getHeaders();
+        foreach ($this->headers as $header) {
             if ($header instanceof \Zend\Http\Header\ContentLength) {
                 $response->setContentLength((int) $header->getFieldValue());
                 $contentLength = $response->getContentLength();


### PR DESCRIPTION
When using $client->setStream(true), $response->getHeaders() doesn't return any data. Since Zend\Http\Response\Stream extends Zend\Http\Response, and even uses it for header parsing, we can simply pass through the headers.
