### PR TITLE
Hotfix: Changed array_walk to foreach in Zend\Stdlib\Hydrator\ArraySerializable

### DIFF
--- a/library/Zend/Stdlib/Hydrator/ArraySerializable.php
+++ b/library/Zend/Stdlib/Hydrator/ArraySerializable.php
@@ -31,15 +31,16 @@ class ArraySerializable extends AbstractHydrator
             ));
         }
 
-        $self = $this;
         $data = $object->getArrayCopy();
-        array_walk($data, function (&$value, $name) use ($self, &$data) {
-            if (!$self->getFilter()->filter($name)) {
+
+        foreach ($data as $name => $value) {
+            if (!$this->getFilter()->filter($name)) {
                 unset($data[$name]);
-            } else {
-                $value = $self->extractValue($name, $value);
+                continue;
             }
-        });
+
+            $data[$name] = $this->extractValue($name, $value);
+        }
 
         return $data;
     }


### PR DESCRIPTION
The data array is manipulated while traversing it. This does not work
with array_walk.

http://www.php.net/manual/en/function.array-walk.php

> Only the values of the array may potentially be changed; its structure cannot be altered, i.e., the programmer cannot add, unset or reorder elements. If the callback does not respect this requirement, the behavior of this function is undefined, and unpredictable.

This will fix #4258
