### PR TITLE
Fixed console routes when using same name for group and parameter

### DIFF
--- a/library/Zend/Mvc/Router/Console/Simple.php
+++ b/library/Zend/Mvc/Router/Console/Simple.php
@@ -692,17 +692,17 @@ class Simple implements RouteInterface
             if (isset($part['alternatives'])) {
                 if ($part['hasValue']) {
                     foreach ($part['alternatives'] as $alt) {
-                        if ($alt == $matchedName) {
+                        if ($alt === $matchedName && !isset($matches[$alt])) {
                             $matches[$alt] = $value;
-                        } else {
+                        } elseif (!isset($matches[$alt])) {
                             $matches[$alt] = null;
                         }
                     }
                 } else {
                     foreach ($part['alternatives'] as $alt) {
-                        if ($alt == $matchedName) {
+                        if ($alt === $matchedName && !isset($matches[$alt])) {
                             $matches[$alt] = true;
-                        } else {
+                        } elseif (!isset($matches[$alt])) {
                             $matches[$alt] = false;
                         }
                     }

--- a/tests/ZendTest/Mvc/Router/Console/SimpleTest.php
+++ b/tests/ZendTest/Mvc/Router/Console/SimpleTest.php
@@ -628,6 +628,46 @@ class SimpleTestTest extends TestCase
                     'test' => true,
                 )
             ),
+            'group-5' => array(
+                'group (-t | --test ):test',
+                array('group', '--test'),
+                array(
+                    'group' => true,
+                    'test' => true,
+                ),
+            ),
+            'group-6' => array(
+                'group (-t | --test ):test',
+                array('group', '-t'),
+                array(
+                    'group' => true,
+                    'test' => true,
+                ),
+            ),
+            'group-7' => array(
+                'group [-x|-y|-z]:test',
+                array('group', '-y'),
+                array(
+                    'group' => true,
+                    'test' => true,
+                ),
+            ),
+            'group-8' => array(
+                'group [--foo|--bar|--baz]:test',
+                array('group', '--foo'),
+                array(
+                    'group' => true,
+                    'test' => true,
+                ),
+            ),
+            'group-9' => array(
+                'group (--foo|--bar|--baz):test',
+                array('group', '--foo'),
+                array(
+                    'group' => true,
+                    'test' => true,
+                ),
+            ),
 
             /*'combined-2' => array(
                 '--foo --bar',

--- a/tests/ZendTest/Mvc/Router/Console/SimpleTest.php
+++ b/tests/ZendTest/Mvc/Router/Console/SimpleTest.php
@@ -592,6 +592,43 @@ class SimpleTestTest extends TestCase
                     'baz' => true
                 )
             ),
+            // group with group name diferent than options (short)
+            'group-1' => array(
+                'group [-t|--test]:testgroup',
+                array('group', '-t'),
+                array(
+                    'group' => true,
+                    'testgroup' => true,
+                )
+            ),
+            // group with group name diferent than options (long)
+            'group-2' => array(
+                'group [-t|--test]:testgroup',
+                array('group', '--test'),
+                array(
+                    'group' => true,
+                    'testgroup' => true,
+                )
+            ),
+            // group with same name as option (short)
+            'group-3' => array(
+                'group [-t|--test]:test',
+                array('group', '-t'),
+                array(
+                    'group' => true,
+                    'test' => true,
+                )
+            ),
+            // group with same name as option (long)
+            'group-4' => array(
+                'group [-t|--test]:test',
+                array('group', '--test'),
+                array(
+                    'group' => true,
+                    'test' => true,
+                )
+            ),
+
             /*'combined-2' => array(
                 '--foo --bar',
                 array('a','b', 'c', '--foo', '--bar'),


### PR DESCRIPTION
When using console routes with groups where the name of the group matched a parameter name, like:

``` php
'route'    => 'test [-t|--test]:test'
```

the obtained parameters were incorrect.
