### PR TITLE
Remove superfluous indentation from one line of code

### DIFF
--- a/library/Zend/Validator/File/MimeType.php
+++ b/library/Zend/Validator/File/MimeType.php
@@ -395,7 +395,7 @@ class MimeType extends AbstractValidator
 
         if (empty($this->type) &&
             (function_exists('mime_content_type') && ini_get('mime_magic.magicfile'))) {
-                $this->type = mime_content_type($file);
+            $this->type = mime_content_type($file);
         }
 
         if (empty($this->type) && $this->getHeaderCheck()) {


### PR DESCRIPTION
This line is indented by one too many levels. It's been indented relative to the
part of the if statement that's been broken onto a second line, rather than
relative to the previous indentation level itself. This makes it look like two
nested if statements instead of the one that's actually there.
