### PR TITLE
\Zend\Stdlib\ArrayObject::offsetExists() incorrectly returns false if value is null

### DIFF
--- a/library/Zend/Stdlib/ArrayObject/PhpReferenceCompatibility.php
+++ b/library/Zend/Stdlib/ArrayObject/PhpReferenceCompatibility.php
@@ -283,7 +283,7 @@ abstract class PhpReferenceCompatibility implements IteratorAggregate, ArrayAcce
      */
     public function offsetExists($key)
     {
-        return isset($this->storage[$key]);
+        return array_key_exists($key, $this->storage);
     }
 
     /**

--- a/tests/ZendTest/Stdlib/ArrayObjectTest.php
+++ b/tests/ZendTest/Stdlib/ArrayObjectTest.php
@@ -317,6 +317,15 @@ class ArrayObjectTest extends TestCase
         unset($ar['foo']['bar']['baz']);
     }
 
+    public function testOffsetUnsetWithNullValue()
+    {
+        $ar = new ArrayObject();
+        $ar->offsetSet('foo', null);
+        $this->assertTrue($ar->offsetExists('foo'));
+        $ar->offsetUnset('foo');
+        $this->assertFalse($ar->offsetExists('foo'));
+    }
+
     public function testOffsetUnsetThrowsExceptionOnProtectedProperty()
     {
         if (version_compare(PHP_VERSION, '5.3.4') < 0) {
@@ -372,5 +381,4 @@ class ArrayObjectTest extends TestCase
         $ar->uksort($function);
         $this->assertSame($sorted, $ar->getArrayCopy());
     }
-
 }


### PR DESCRIPTION
Fixes https://github.com/zendframework/zf2/issues/4257
