### PR TITLE
[WIP] Fix Rbac consistency

### DIFF
--- a/library/Zend/Permissions/Rbac/AbstractRole.php
+++ b/library/Zend/Permissions/Rbac/AbstractRole.php
@@ -16,7 +16,7 @@ abstract class AbstractRole extends AbstractIterator implements RoleInterface
     /**
      * @var null|RoleInterface
      */
-    protected $parent;
+    protected $parents;
 
     /**
      * @var string
@@ -101,18 +101,76 @@ abstract class AbstractRole extends AbstractIterator implements RoleInterface
      * @param  RoleInterface $parent
      * @return RoleInterface
      */
-    public function setParent($parent)
+    public function setParent(RoleInterface $parent)
     {
-        $this->parent = $parent;
-
+        $this->parents[$parent->getName()] = $parent;
         return $this;
     }
 
     /**
+     * @param RoleInterface|string|null $name
      * @return null|RoleInterface
      */
-    public function getParent()
+    public function getParent($name = null)
     {
-        return $this->parent;
+        if ($name === null) {
+            return reset($this->parents);
+        }
+
+        if (!$this->hasParent($name)) {
+            return null;
+        }
+
+        return $this->parents[$name];
+    }
+
+    /**
+     * @see \Zend\Permissions\Rbac\RoleInterface::addParent()
+     * @param string|RoleInterface
+     * @return self
+     */
+    public function addParent($parent)
+    {
+        if (is_string($parent)) {
+            if (isset($this->parents[$parent])) {
+                $parent = $this->parents[$parent];
+            } else {
+                $parent = new Role($parent);
+            }
+        }
+
+        if (!$parent instanceof RoleInterface) {
+            throw new Exception\InvalidArgumentException(
+                'Parent must be a string or implement Zend\Permissions\Rbac\RoleInterface'
+            );
+        }
+
+        $this->parents[$parent->getName()] = $parent;
+        $parent->addChild($this);
+
+        return $this;
+    }
+
+	/**
+     * @see \Zend\Permissions\Rbac\RoleInterface::getParents()
+     * @return array|\Traversable
+     */
+    public function getParents()
+    {
+        return $this->parents;
+    }
+
+	/**
+     * @see \Zend\Permissions\Rbac\RoleInterface::hasParent()
+     * @param string|RoleInterface $name
+     * @return bool
+     */
+    public function hasParent($name)
+    {
+        if ($name instanceof RoleInterface) {
+            $name = $name->getName();
+        }
+
+        return isset($this->parents[$name]);
     }
 }

--- a/library/Zend/Permissions/Rbac/AbstractRole.php
+++ b/library/Zend/Permissions/Rbac/AbstractRole.php
@@ -151,7 +151,7 @@ abstract class AbstractRole extends AbstractIterator implements RoleInterface
         return $this;
     }
 
-	/**
+    /**
      * @see \Zend\Permissions\Rbac\RoleInterface::getParents()
      * @return array|\Traversable
      */
@@ -160,7 +160,7 @@ abstract class AbstractRole extends AbstractIterator implements RoleInterface
         return $this->parents;
     }
 
-	/**
+    /**
      * @see \Zend\Permissions\Rbac\RoleInterface::hasParent()
      * @param string|RoleInterface $name
      * @return bool

--- a/library/Zend/Permissions/Rbac/Exception/RoleNotFoundException.php
+++ b/library/Zend/Permissions/Rbac/Exception/RoleNotFoundException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Permissions\Rbac\Exception;
+
+/**
+ * Exception for undefined roles
+ */
+class RoleNotFoundException extends InvalidArgumentException
+{
+}

--- a/library/Zend/Permissions/Rbac/Rbac.php
+++ b/library/Zend/Permissions/Rbac/Rbac.php
@@ -14,64 +14,36 @@ use RecursiveIteratorIterator;
 class Rbac extends AbstractIterator
 {
     /**
-     * flag: whether or not to create roles automatically if
-     * they do not exist.
-     *
-     * @var bool
-     */
-    protected $createMissingRoles = false;
-
-    /**
-     * @param  bool                     $createMissingRoles
-     * @return \Zend\Permissions\Rbac\Rbac
-     */
-    public function setCreateMissingRoles($createMissingRoles)
-    {
-        $this->createMissingRoles = $createMissingRoles;
-
-        return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getCreateMissingRoles()
-    {
-        return $this->createMissingRoles;
-    }
-
-    /**
      * Add a child.
      *
-     * @param  string|RoleInterface               $child
-     * @param  array|RoleInterface|null           $parents
+     * @param  string|RoleInterface               $role
+     * @param  array|RoleInterface|null           $childs
      * @return self
      * @throws Exception\InvalidArgumentException
      */
-    public function addRole($child, $parents = null)
+    public function addRole($role, $childs = null)
     {
-        if (is_string($child)) {
-            $child = new Role($child);
+        if (is_string($role)) {
+            $role = new Role($role);
         }
-        if (!$child instanceof RoleInterface) {
+
+        if (!$role instanceof RoleInterface) {
             throw new Exception\InvalidArgumentException(
                 'Child must be a string or implement Zend\Permissions\Rbac\RoleInterface'
             );
         }
 
-        if ($parents) {
-            if (!is_array($parents)) {
-                $parents = array($parents);
+        if ($childs) {
+            if (!is_array($childs)) {
+                $childs = array($childs);
             }
-            foreach ($parents as $parent) {
-                if ($this->createMissingRoles && !$this->hasRole($parent)) {
-                    $this->addRole($parent);
-                }
-                $this->getRole($parent)->addChild($child);
+
+            foreach ($childs as $child) {
+                $role->addChild($child);
             }
         }
 
-        $this->children[] = $child;
+        $this->children[] = $role;
 
         return $this;
     }
@@ -115,10 +87,12 @@ class Rbac extends AbstractIterator
             }
         }
 
-        throw new Exception\InvalidArgumentException(sprintf(
-            'No child with name "%s" could be found',
-            is_object($objectOrName) ? $objectOrName->getName() : $objectOrName
-        ));
+        throw new Exception\InvalidArgumentException(
+            sprintf(
+                'No child with name "%s" could be found',
+                is_object($objectOrName) ? $objectOrName->getName() : $objectOrName
+            )
+        );
     }
 
     /**

--- a/library/Zend/Permissions/Rbac/Rbac.php
+++ b/library/Zend/Permissions/Rbac/Rbac.php
@@ -15,6 +15,16 @@ use Traversable;
 class Rbac extends AbstractIterator
 {
     /**
+     * flag: whether or not to create roles automatically if
+     * they do not exist.
+     *
+     * @var        bool
+     * @deprecated 2.2.0 This is needless, since hasRole(), getRole() and IsGranted()
+     *             will look for roles recursively in children's children
+     */
+    protected $createMissingRoles = false;
+
+    /**
      * Add a child role.
      *
      * @deprecated 2.2.0
@@ -209,16 +219,6 @@ class Rbac extends AbstractIterator
 
         return false;
     }
-
-    /**
-     * flag: whether or not to create roles automatically if
-     * they do not exist.
-     *
-     * @var        bool
-     * @deprecated 2.2.0 This is needless, since hasRole(), getRole() and IsGranted()
-     *             will look for roles recursively in children's children
-     */
-    protected $createMissingRoles = false;
 
     /**
      * @param      boolean                     $createMissingRoles

--- a/library/Zend/Permissions/Rbac/Rbac.php
+++ b/library/Zend/Permissions/Rbac/Rbac.php
@@ -166,7 +166,7 @@ class Rbac extends AbstractIterator
 
         $it = new RecursiveIteratorIterator($this, RecursiveIteratorIterator::CHILD_FIRST);
         foreach ($it as $leaf) {
-            if ((is_string($objectOrName) && $leaf->getName() == $objectOrName) || $leaf == $objectOrName) {
+            if ((is_string($objectOrName) && $leaf->getName() == $objectOrName) || $leaf === $objectOrName) {
                 return $leaf;
             }
         }

--- a/library/Zend/Permissions/Rbac/Rbac.php
+++ b/library/Zend/Permissions/Rbac/Rbac.php
@@ -127,4 +127,45 @@ class Rbac extends AbstractIterator
 
         return false;
     }
+
+    /**
+     * flag: whether or not to create roles automatically if
+     * they do not exist.
+     *
+     * @var        bool
+     * @deprecated 2.2.0 This is needless, since hasRole(), getRole() and IsGranted()
+     *             will look for roles recursively in children's children
+     */
+    protected $createMissingRoles = false;
+
+    /**
+     * @param      boolean                     $createMissingRoles
+     * @return     \Zend\Permissions\Rbac\Rbac
+     * @deprecated 2.2.0
+     */
+    public function setCreateMissingRoles($createMissingRoles)
+    {
+        trigger_error(
+            'This method does not make any effect and will be removed in the future.',
+            E_USER_DEPRECATED
+        );
+
+        $this->createMissingRoles = $createMissingRoles;
+
+        return $this;
+    }
+
+    /**
+     * @return     boolean
+     * @deprecated 2.2.0
+     */
+    public function getCreateMissingRoles()
+    {
+        trigger_error(
+            'This method does not make any effect and will be removed in the future.',
+            E_USER_DEPRECATED
+        );
+
+        return $this->createMissingRoles;
+    }
 }

--- a/library/Zend/Permissions/Rbac/RoleInterface.php
+++ b/library/Zend/Permissions/Rbac/RoleInterface.php
@@ -57,7 +57,7 @@ interface RoleInterface
     /**
      * @return null|RoleInterface
      */
-    public function getParent($name);
+    public function getParent($name = null);
 
     /**
      * Return all parent roles

--- a/library/Zend/Permissions/Rbac/RoleInterface.php
+++ b/library/Zend/Permissions/Rbac/RoleInterface.php
@@ -43,13 +43,34 @@ interface RoleInterface
     public function addChild($child);
 
     /**
-     * @param  RoleInterface $parent
-     * @return RoleInterface
+     * @param RoleInterface|string $parent
+     * @return self
      */
-    public function setParent($parent);
+    public function addParent($parent);
+
+    /**
+     * @param  RoleInterface $parent
+     * @return self
+     */
+    public function setParent(RoleInterface $parent);
 
     /**
      * @return null|RoleInterface
      */
-    public function getParent();
+    public function getParent($name);
+
+    /**
+     * Return all parent roles
+     *
+     * @return array|\Traversable
+     */
+    public function getParents();
+
+    /**
+     * Check for the existence of a parent role
+     *
+     * @param string $name
+     * @return bool
+     */
+    public function hasParent($name);
 }

--- a/tests/ZendTest/Permissions/Rbac/RbacTest.php
+++ b/tests/ZendTest/Permissions/Rbac/RbacTest.php
@@ -45,8 +45,8 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $foo->addPermission('can.foo');
         $bar->addPermission('can.bar');
 
-        $this->rbac->addRole($foo);
-        $this->rbac->addRole($bar);
+        $this->rbac->addRoleWithChildren($foo);
+        $this->rbac->addRoleWithChildren($bar);
 
         $this->assertEquals(true, $this->rbac->isGranted($foo, 'can.foo', $true));
         $this->assertEquals(false, $this->rbac->isGranted($bar, 'can.bar', $false));
@@ -62,7 +62,7 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $foo = new Rbac\Role('foo');
         $foo->addPermission('can.foo');
 
-        $this->rbac->addRole($foo);
+        $this->rbac->addRoleWithChildren($foo);
 
         $this->assertTrue($this->rbac->isGranted('foo', 'can.foo'));
         $this->assertFalse($this->rbac->isGranted('foo', 'can.bar'));
@@ -76,8 +76,8 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $foo->addPermission('can.foo');
         $bar->addPermission('can.bar');
 
-        $this->rbac->addRole($bar);
-        $this->rbac->addRole($foo, $bar);
+        $this->rbac->addRoleWithChildren($bar);
+        $this->rbac->addRoleWithChildren($foo, $bar);
 
         $this->assertTrue($this->rbac->isGranted('foo', 'can.foo'));
         $this->assertTrue($this->rbac->isGranted('foo', 'can.bar'));
@@ -92,8 +92,8 @@ class RbacTest extends \PHPUnit_Framework_TestCase
     {
         $foo = new Rbac\Role('foo');
 
-        $this->rbac->addRole($foo);
-        $this->rbac->addRole('bar');
+        $this->rbac->addRoleWithChildren($foo);
+        $this->rbac->addRoleWithChildren('bar');
 
         $this->assertTrue($this->rbac->hasRole($foo));
         $this->assertTrue($this->rbac->hasRole('bar'));
@@ -102,7 +102,7 @@ class RbacTest extends \PHPUnit_Framework_TestCase
 
     public function testAddRoleFromString()
     {
-        $this->rbac->addRole('foo');
+        $this->rbac->addRoleWithChildren('foo');
 
         $foo = $this->rbac->getRole('foo');
 
@@ -113,7 +113,7 @@ class RbacTest extends \PHPUnit_Framework_TestCase
     {
         $foo = new Rbac\Role('foo');
 
-        $this->rbac->addRole($foo);
+        $this->rbac->addRoleWithChildren($foo);
 
         $this->assertSame($foo, $this->rbac->getRole('foo'));
     }
@@ -123,7 +123,7 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $foo = new Rbac\Role('foo');
         $bar = new Rbac\Role('bar');
 
-        $this->rbac->addRole($bar, $foo);
+        $this->rbac->addRoleWithChildren($bar, $foo);
 
         $this->assertTrue($bar->hasChildren($foo));
         $this->assertSame($bar, $foo->getParent());
@@ -133,7 +133,7 @@ class RbacTest extends \PHPUnit_Framework_TestCase
     {
         $role = $this->getMockForAbstractClass('Zend\Permissions\Rbac\RoleInterface');
 
-        $this->rbac->addRole('parent', $role);
+        $this->rbac->addRoleWithChildren('parent', $role);
 
         $role->expects($this->any())
             ->method('getName')


### PR DESCRIPTION
This is scheduled for 2.3
- [ ] Deprecate parent relationship (we should have only children relationship).
- [ ] Make `IsGranted()` returns `false` when assertion is `true` but the role doesn't have the needed permission.
- [ ] Disallow multiple roles with the same name.
- [ ] Deprecate role instantiation in `AbstractRole`.
- [ ] Move `hasPermission()` logic from `AbstractRole` to `Rbac`
- [ ] Move assertion logic to a specific method.
- [x] Make a role can have multiple children.
- [x] Deprecate `createMissingRoles`.
- [x] Add `RoleNotFoundException` to replace `InvalidArgumentException` in `Rbac::getRole()`.
- [x] Use properly PHPUnit assertions in tests.
- [ ] Update docs

Note that **ZfcRbac** need to be updated before this merge.

Ping @spiffyjr
