### PR TITLE
Added Option to customize the .dat file extension

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/FilesystemOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/FilesystemOptions.php
@@ -104,6 +104,13 @@ class FilesystemOptions extends AdapterOptions
     protected $umask = false;
 
     /**
+     * Allow for custom file extension of cache file
+     *
+     * @var string
+     */
+    protected $fileExtension = '.dat';
+
+    /**
      * Constructor
      *
      * @param  array|Traversable|null $options
@@ -459,5 +466,26 @@ class FilesystemOptions extends AdapterOptions
     public function getUmask()
     {
         return $this->umask;
+    }
+
+    /**
+     * Set a custom file extension for the cache files
+     *
+     * @param string $fileExtension
+     * @return FilesystemOptions
+     */
+    public function setFileExtension($fileExtension) {
+        $this->fileExtension = $fileExtension;
+        return $this;
+    }
+
+    /**
+     * Get the file extension
+     *
+     * @return string
+     */
+    public function getFileExtension()
+    {
+        return $this->fileExtension;
     }
 }

--- a/tests/ZendTest/Cache/Storage/Adapter/FilesystemTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/FilesystemTest.php
@@ -285,4 +285,13 @@ class FilesystemTest extends CommonAdapterTest
         $expectedAtime = fileatime($meta['filespec'] . '.dat');
         $this->assertEquals($expectedAtime, $meta['atime']);
     }
+
+    public function testCustomFileExtension()
+    {
+        $this->_options->setFileExtension('.test');
+        $this->assertTrue($this->_storage->setItem('test', 'v'));
+        $meta = $this->_storage->getMetadata('test');
+        var_dump($meta);
+        $this->assertTrue(file_exists($meta['filespec'] . '.test'));
+    }
 }

--- a/tests/ZendTest/Cache/Storage/Adapter/FilesystemTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/FilesystemTest.php
@@ -291,7 +291,6 @@ class FilesystemTest extends CommonAdapterTest
         $this->_options->setFileExtension('.test');
         $this->assertTrue($this->_storage->setItem('test', 'v'));
         $meta = $this->_storage->getMetadata('test');
-        var_dump($meta);
         $this->assertTrue(file_exists($meta['filespec'] . '.test'));
     }
 }


### PR DESCRIPTION
Setting an '' empty string might lead to trouble, because the getIterator function would return the .tag files as well

I wanted to be able to use the Filesystem cache to write files that can be the same as an original file (i.e. create static .html files) that will be accessed later bypassing ZF2 completly, so I made the file extension of Cache customizable via the config option.
