### PR TITLE
Remove needless is_object check

### DIFF
--- a/library/Zend/Form/Factory.php
+++ b/library/Zend/Form/Factory.php
@@ -413,7 +413,7 @@ class Factory
      */
     protected function prepareAndInjectHydrator($hydratorOrName, FieldsetInterface $fieldset, $method)
     {
-        if (is_object($hydratorOrName) && $hydratorOrName instanceof Hydrator\HydratorInterface) {
+        if ($hydratorOrName instanceof Hydrator\HydratorInterface) {
             $fieldset->setHydrator($hydratorOrName);
             return;
         }


### PR DESCRIPTION
If `$hydratorOrName` is instance of `Hydrator\HydratorInterface`, of course this is an object (:
