### PR TITLE
fix getHref strategy in PageMvc

### DIFF
--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -190,7 +190,7 @@ class Mvc extends AbstractPage
             );
         }
 
-        if ($this->get(useRouteMatch) && $this->getRouteMatch() !== null) {
+        if ($this->get('useRouteMatch') && $this->getRouteMatch() !== null) {
             $rmParams = $this->getRouteMatch()->getParams();
 
             if (isset($rmParams[ModuleRouteListener::ORIGINAL_CONTROLLER])) {

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -454,6 +454,7 @@ class Mvc extends AbstractPage
     public function setUseRouteMatch($useRoteMatch = true)
     {
         $this->useRouteMatch = (bool) $useRoteMatch;
+        $this->hrefCache = null;
         return $this;
     }
 

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -76,6 +76,13 @@ class Mvc extends AbstractPage
     protected $routeMatch;
 
     /**
+     * If true and set routeMatch than getHref will use routeMatch params
+     * to assemble uri
+     * @var bool
+     */
+    protected $useRouteMatch = false;
+
+    /**
      * Router for assembling URLs
      *
      * @see getHref()
@@ -190,7 +197,7 @@ class Mvc extends AbstractPage
             );
         }
 
-        if ($this->get('useRouteMatch') && $this->getRouteMatch() !== null) {
+        if ($this->getUseRouteMatch() && $this->getRouteMatch() !== null) {
             $rmParams = $this->getRouteMatch()->getParams();
 
             if (isset($rmParams[ModuleRouteListener::ORIGINAL_CONTROLLER])) {
@@ -424,6 +431,29 @@ class Mvc extends AbstractPage
     public function setRouteMatch(RouteMatch $matches)
     {
         $this->routeMatch = $matches;
+        return $this;
+    }
+
+    /**
+     * Get the useRouteMatch
+     *
+     * @return bool
+     */
+    public function getUseRouteMatch()
+    {
+        return $this->useRouteMatch;
+    }
+
+    /**
+     * Set whether the page should use route match params for assembling link uri
+     *
+     * @see getHref()
+     * @param bool $useRoteMatch [optional]
+     * @return Mvc
+     */
+    public function setUseRouteMatch($useRoteMatch = true)
+    {
+        $this->useRouteMatch = (bool) $useRoteMatch;
         return $this;
     }
 

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -190,7 +190,7 @@ class Mvc extends AbstractPage
             );
         }
 
-        if ($this->getRouteMatch() !== null) {
+        if ($this->get(useRouteMatch) && $this->getRouteMatch() !== null) {
             $rmParams = $this->getRouteMatch()->getParams();
 
             if (isset($rmParams[ModuleRouteListener::ORIGINAL_CONTROLLER])) {

--- a/tests/ZendTest/Navigation/Page/MvcTest.php
+++ b/tests/ZendTest/Navigation/Page/MvcTest.php
@@ -542,7 +542,8 @@ class MvcTest extends TestCase
     {
         $page = new Page\Mvc(array(
             'label' => 'lollerblades',
-            'route' => 'lollerblades'
+            'route' => 'lollerblades',
+            'useRouteMatch' => true
         ));
 
         $route = new SegmentRoute('/lollerblades/view/:serialNumber');
@@ -565,7 +566,8 @@ class MvcTest extends TestCase
     {
         $page = new Page\Mvc(array(
             'label' => 'mpinkstonwashere',
-            'route' => 'lmaoplane'
+            'route' => 'lmaoplane',
+            'useRouteMatch' => true
         ));
 
         $route = new SegmentRoute('/lmaoplane/:controller');

--- a/tests/ZendTest/Navigation/Page/MvcTest.php
+++ b/tests/ZendTest/Navigation/Page/MvcTest.php
@@ -538,12 +538,31 @@ class MvcTest extends TestCase
         $page->setDefaultRouter(null);
     }
 
+    public function testBoolSetAndGetUseRouteMatch()
+    {
+        $page = new Page\Mvc(array(
+            'useRouteMatch' => 2,
+        ));
+        $this->assertSame(true, $page->getUseRouteMatch());
+
+        $page->setUseRouteMatch(null);
+        $this->assertSame(false, $page->getUseRouteMatch());
+
+        $page->setUseRouteMatch(false);
+        $this->assertSame(false, $page->getUseRouteMatch());
+
+        $page->setUseRouteMatch(true);
+        $this->assertSame(true, $page->getUseRouteMatch());
+
+        $page->setUseRouteMatch();
+        $this->assertSame(true, $page->getUseRouteMatch());
+    }
+
     public function testMvcPageParamsInheritRouteMatchParams()
     {
         $page = new Page\Mvc(array(
             'label' => 'lollerblades',
             'route' => 'lollerblades',
-            'useRouteMatch' => true
         ));
 
         $route = new SegmentRoute('/lollerblades/view/:serialNumber');
@@ -559,6 +578,9 @@ class MvcTest extends TestCase
         $page->setRouter($router);
         $page->setRouteMatch($routeMatch);
 
+        $this->assertEquals('/lollerblades/view/', $page->getHref());
+
+        $page->setUseRouteMatch(true);
         $this->assertEquals('/lollerblades/view/23', $page->getHref());
     }
 
@@ -567,7 +589,6 @@ class MvcTest extends TestCase
         $page = new Page\Mvc(array(
             'label' => 'mpinkstonwashere',
             'route' => 'lmaoplane',
-            'useRouteMatch' => true
         ));
 
         $route = new SegmentRoute('/lmaoplane/:controller');
@@ -591,6 +612,9 @@ class MvcTest extends TestCase
         $page->setRouter($event->getRouter());
         $page->setRouteMatch($event->getRouteMatch());
 
+        $this->assertEquals('/lmaoplane/', $page->getHref());
+
+        $page->setUseRouteMatch(true);
         $this->assertEquals('/lmaoplane/index', $page->getHref());
     }
 }

--- a/tests/ZendTest/Navigation/Page/MvcTest.php
+++ b/tests/ZendTest/Navigation/Page/MvcTest.php
@@ -565,7 +565,7 @@ class MvcTest extends TestCase
             'route' => 'lollerblades',
         ));
 
-        $route = new SegmentRoute('/lollerblades/view/:serialNumber');
+        $route = new SegmentRoute('/lollerblades/view[/:serialNumber]');
 
         $router = new TreeRouteStack;
         $router->addRoute('lollerblades', $route);
@@ -578,7 +578,7 @@ class MvcTest extends TestCase
         $page->setRouter($router);
         $page->setRouteMatch($routeMatch);
 
-        $this->assertEquals('/lollerblades/view/', $page->getHref());
+        $this->assertEquals('/lollerblades/view', $page->getHref());
 
         $page->setUseRouteMatch(true);
         $this->assertEquals('/lollerblades/view/23', $page->getHref());
@@ -591,7 +591,7 @@ class MvcTest extends TestCase
             'route' => 'lmaoplane',
         ));
 
-        $route = new SegmentRoute('/lmaoplane/:controller');
+        $route = new SegmentRoute('/lmaoplane[/:controller]');
 
         $router = new TreeRouteStack;
         $router->addRoute('lmaoplane', $route);
@@ -612,7 +612,7 @@ class MvcTest extends TestCase
         $page->setRouter($event->getRouter());
         $page->setRouteMatch($event->getRouteMatch());
 
-        $this->assertEquals('/lmaoplane/', $page->getHref());
+        $this->assertEquals('/lmaoplane', $page->getHref());
 
         $page->setUseRouteMatch(true);
         $this->assertEquals('/lmaoplane/index', $page->getHref());


### PR DESCRIPTION
I was caused by problem which breaks menu link dependent from which page it was generated.

As example in one router I have default action 'list' in another - 'view'. Current getHref function replace proper default action parameter with broken from route match.
Also if I will add some new defaults then I should has to fix all entrances in navigation array.
