### PR TITLE
[WIP] 'Zend\Form\FormManager' implementation and 'EventManager' integration

### DIFF
--- a/library/Zend/Form/Factory.php
+++ b/library/Zend/Form/Factory.php
@@ -16,6 +16,9 @@ use Zend\InputFilter\InputFilterInterface;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\Hydrator;
 
+/**
+ * @deprecated <i>Zend\Form\Factory</i> has been replaced by <i>Zend\Form\FormFactory</i> as of 2.2.0
+ */
 class Factory
 {
     /**
@@ -33,7 +36,12 @@ class Factory
      */
     public function __construct(FormElementManager $formElementManager = null)
     {
-        if ($formElementManager) {
+        trigger_error(
+            'Zend\Form\Factory has been deprecated in ZF as of 2.2.0, use Zend\Form\FormFactory instead',
+            E_USER_DEPRECATED
+        );
+
+        if ($formElementManager !== null) {
             $this->setFormElementManager($formElementManager);
         }
     }

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -19,28 +19,34 @@ class Fieldset extends Element implements FieldsetInterface
 {
     /**
      * @var Factory
+     * @deprecated As of 2.2.0 Form Factory should be retrieved via the Form Manager
      */
-    protected $factory;
+    protected $factory     = null;
+
+    /**
+     * @var FormManager
+     */
+    protected $formManager = null;
 
     /**
      * @var array
      */
-    protected $byName    = array();
+    protected $byName      = array();
 
     /**
      * @var array
      */
-    protected $elements  = array();
+    protected $elements    = array();
 
     /**
      * @var array
      */
-    protected $fieldsets = array();
+    protected $fieldsets   = array();
 
     /**
      * @var array
      */
-    protected $messages  = array();
+    protected $messages    = array();
 
     /**
      * @var PriorityQueue
@@ -100,29 +106,55 @@ class Fieldset extends Element implements FieldsetInterface
     /**
      * Compose a form factory to use when calling add() with a non-element/fieldset
      *
-     * @param  Factory $factory
-     * @return Form
+     * @deprecated As of 2.2.0 <b>Form Factory</b> should be set through <b>Form Manager</b>
+     * @param      Factory $factory
+     * @return     self
      */
     public function setFormFactory(Factory $factory)
     {
-        $this->factory = $factory;
+        $this->getFormManager()->setFormFactory($factory);
         return $this;
     }
 
     /**
      * Retrieve composed form factory
      *
-     * Lazy-loads one if none present.
+     * Pulls the instance from <b>Form Manager</b> if none is set
      *
-     * @return Factory
+     * @deprecated As of 2.2.0 <b>Form Factory</b> should be retrieved via <b>Form Manager</b>
+     * @return     Factory
      */
     public function getFormFactory()
     {
-        if (null === $this->factory) {
-            $this->setFormFactory(new Factory());
+        return $this->getFormManager()->getFormFactory();
+    }
+
+    /**
+     * Set <b>Form Manager</b>
+     *
+     * @param  FormManager $formManager
+     * @return self
+     */
+    public function setFormManager(FormManager $formManager)
+    {
+        $this->formManager = $formManager;
+        return $this;
+    }
+
+    /**
+     * Get <b>Form Manager</b>
+     *
+     * Lazy load a <b>Form Manager</b> instance if none is set
+     *
+     * @return FormManager
+     */
+    public function getFormManager()
+    {
+        if ($this->formManager === null) {
+            $this->setFormManager(new FormManager);
         }
 
-        return $this->factory;
+        return $this->formManager;
     }
 
     /**
@@ -142,7 +174,7 @@ class Fieldset extends Element implements FieldsetInterface
         if (is_array($elementOrFieldset)
             || ($elementOrFieldset instanceof Traversable && !$elementOrFieldset instanceof ElementInterface)
         ) {
-            $factory = $this->getFormFactory();
+            $factory = $this->getFormManager()->getFormFactory();
             $elementOrFieldset = $factory->create($elementOrFieldset);
         }
 

--- a/library/Zend/Form/FieldsetInterface.php
+++ b/library/Zend/Form/FieldsetInterface.php
@@ -18,7 +18,10 @@ interface FieldsetInterface extends
     IteratorAggregate,
     ElementInterface,
     ElementPrepareAwareInterface,
-    FormFactoryAwareInterface
+    // @deprecated As of 2.2.0 Form Factory should be retrieved via Form Manager by implementing
+    // FormManagerAwareInterface
+    FormFactoryAwareInterface,
+    FormManagerAwareInterface
 {
     /**
      * Add an element or fieldset

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -142,7 +142,7 @@ class Form extends Fieldset implements FormInterface
         if (is_array($elementOrFieldset)
             || ($elementOrFieldset instanceof Traversable && !$elementOrFieldset instanceof ElementInterface)
         ) {
-            $factory = $this->getFormFactory();
+            $factory           = $this->getFormManager()->getFormFactory();
             $elementOrFieldset = $factory->create($elementOrFieldset);
         }
 
@@ -689,8 +689,8 @@ class Form extends Fieldset implements FormInterface
      */
     public function attachInputFilterDefaults(InputFilterInterface $inputFilter, FieldsetInterface $fieldset)
     {
-        $formFactory  = $this->getFormFactory();
-        $inputFactory = $formFactory->getInputFilterFactory();
+        $formManager  = $this->getFormManager();
+        $inputFactory = $formManager->getInputFilterFactory();
 
         if ($this instanceof InputFilterProviderInterface) {
             foreach ($this->getInputFilterSpecification() as $name => $spec) {

--- a/library/Zend/Form/FormElementManager.php
+++ b/library/Zend/Form/FormElementManager.php
@@ -74,18 +74,40 @@ class FormElementManager extends AbstractPluginManager
     {
         parent::__construct($configuration);
 
-        $this->addInitializer(array($this, 'injectFactory'));
+        // Form Manager must be injected first so when calling $element->getFormManager()->getFormFactory()
+        // returns the same instance as $element->getFormFactory();
+        $this->addInitializer(array($this, 'injectFactory'), false);
+        $this->addInitializer(array($this, 'injectFormManager'));
     }
 
     /**
-     * Inject the factory to any element that implements FormFactoryAwareInterface
+     * Inject the factory to any element that implements <i>FormFactoryAwareInterface</i>
      *
-     * @param $element
+     * @deprecated As of 2.2.0 <b>Form Factory</b> should be retrieved via <b>Form Manager</b>
+     * @param ElementInterface $element
      */
     public function injectFactory($element)
     {
         if ($element instanceof FormFactoryAwareInterface) {
             $element->getFormFactory()->setFormElementManager($this);
+        }
+    }
+
+    /**
+     * Inject the <b>Form Manager</b> to any element that implements <i>FormManagerAwareInterface</i>
+     *
+     * @param ElementInterface $element
+     */
+    public function injectFormManager($element)
+    {
+        if (
+            $element instanceof FormManagerAwareInterface
+            && $this->getServiceLocator() !== null
+            && $this->getServiceLocator()->has('FormManager')
+        ) {
+            $formManager = $this->getServiceLocator()->get('FormManager');
+            $formManager->setFormElementManager($this);
+            $element->setFormManager($formManager);
         }
     }
 

--- a/library/Zend/Form/FormFactory.php
+++ b/library/Zend/Form/FormFactory.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Form;
+
+use Zend\InputFilter\Factory as InputFilterFactory;
+
+/**
+ * This class extends the deprecated Factory to keep Backwards Compatibility
+ */
+class FormFactory extends Factory implements FormManagerAwareInterface
+{
+    /**
+     * @var FormManager
+     */
+    protected $formManager = null;
+
+    /**
+     * @param FormManager $formManager
+     */
+    public function __construct(FormManager $formManager = null)
+    {
+        if ($formManager !== null) {
+            $this->setFormManager($formManager);
+        }
+    }
+
+    /**
+     * Get <b>Form Element Manager</b>
+     *
+     * @deprecated Should grab <b>Form Element Manager</b> via <b>Form Manager</b>:
+     * <code>$this->getFormManager()->getFormElementManager()</code>
+     *
+     * @return FormElementManager
+     */
+    public function getFormElementManager()
+    {
+        if ($this->formElementManager === null) {
+            $this->setFormElementManager($this->getFormManager()->getFormElementManager());
+        }
+
+        return $this->formElementManager;
+    }
+
+    /**
+     * Set <b>Form Manager</b>
+     *
+     * @param  FormManager $formManager
+     * @return self
+     */
+    public function setFormManager(FormManager $formManager)
+    {
+        $this->formManager = $formManager;
+        return $this;
+    }
+
+    /**
+     * Get <b>Form Manager</b>
+     *
+     * Lazy load a <b>Form Manager</b> if none is set
+     *
+     * @return FormManager
+     */
+    public function getFormManager()
+    {
+        if ($this->formManager === null) {
+            $this->setFormManager(new FormManager);
+        }
+
+        return $this->formManager;
+    }
+
+    /**
+     * Get current <b>Input Filter Factory</b>
+     *
+     * If none provided, grabs one from <b>Form Manager</b>.
+     *
+     * @deprecated Should grab <b>Input Filter Factory</b> directly via <b>Form Manager</b>:
+     * <code>$this->getFormManager()->getInputFilterFactory()</code>
+     *
+     * @return InputFilterFactory
+     */
+    public function getInputFilterFactory()
+    {
+        if ($this->inputFilterFactory === null) {
+            $this->setInputFilterFactory($this->getFormManager()->getInputFilterFactory());
+        }
+        return $this->inputFilterFactory;
+    }
+}

--- a/library/Zend/Form/FormFactoryAwareTrait.php
+++ b/library/Zend/Form/FormFactoryAwareTrait.php
@@ -9,8 +9,10 @@
 
 namespace Zend\Form;
 
-use \Zend\Form\Factory;
-
+/**
+ * @deprecated As of 2.2.0 <b>Form Factory</b> should be retrieved via <b>Form Manager</b> by implementing
+ *             <i>FormManagerAwareInterface</i>
+ */
 trait FormFactoryAwareTrait
 {
     /**

--- a/library/Zend/Form/FormManager.php
+++ b/library/Zend/Form/FormManager.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Form;
+
+use Zend\InputFilter\Factory as InputFilterFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+
+class FormManager implements ServiceLocatorAwareInterface
+{
+    /**
+     * @var FormElementManager
+     */
+    protected $formElementManager = null;
+
+    /**
+     * @var FormFactory
+     */
+    protected $formFactory        = null;
+
+    /**
+     * @var InputFilterFactory
+     */
+    protected $inputFilterFactory = null;
+
+    /**
+     * @var ServiceLocatorInterface
+     */
+    protected $serviceLocator     = null;
+
+    /**
+     * Set <b>Form Element Manager</b>
+     *
+     * @param  FormElementManager $formElementManager
+     * @return self
+     */
+    public function setFormElementManager(FormElementManager $formElementManager)
+    {
+        $this->formElementManager = $formElementManager;
+
+        return $this;
+    }
+
+    /**
+     * Get <b>Form Element Manager</b>
+     *
+     * Lazy loads an instance if none is set.
+     *
+     * @return FormElementManager
+     */
+    public function getFormElementManager()
+    {
+        if ($this->formElementManager === null) {
+            $this->setFormElementManager(new FormElementManager());
+        }
+
+        return $this->formElementManager;
+    }
+
+    /**
+     * Set Form Factory
+     *
+     * @param  Factory $formFactory
+     * @return self
+     */
+    public function setFormFactory(FormFactory $formFactory)
+    {
+        $formFactory->setFormManager($this);
+        $this->formFactory = $formFactory;
+
+        return $this;
+    }
+
+    /**
+     * Get Form Factory
+     *
+     * Lazy loads an instance if none is set.
+     *
+     * @return FormFactory
+     */
+    public function getFormFactory()
+    {
+        if ($this->formFactory === null) {
+            $this->setFormFactory(new FormFactory());
+        }
+
+        return $this->formFactory;
+    }
+
+
+    /**
+     * Set input filter factory to use when creating forms
+     *
+     * @param  InputFilterFactory $inputFilterFactory
+     * @return Factory
+     */
+    public function setInputFilterFactory(InputFilterFactory $inputFilterFactory)
+    {
+        $this->inputFilterFactory = $inputFilterFactory;
+        return $this;
+    }
+
+    /**
+     * Get current input filter factory
+     *
+     * Lazy loads an instance if none is set.
+     *
+     * @return InputFilterFactory
+     */
+    public function getInputFilterFactory()
+    {
+        if ($this->inputFilterFactory === null) {
+            $this->setInputFilterFactory(new InputFilterFactory());
+        }
+        return $this->inputFilterFactory;
+    }
+
+    /**
+     * Set service locator
+     *
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @return self
+     */
+    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+        return $this;
+    }
+
+    /**
+     * Get service locator
+     *
+     * @return ServiceLocatorInterface
+     */
+    public function getServiceLocator()
+    {
+        return $this->serviceLocator;
+    }
+}

--- a/library/Zend/Form/FormManagerAwareInterface.php
+++ b/library/Zend/Form/FormManagerAwareInterface.php
@@ -9,16 +9,19 @@
 
 namespace Zend\Form;
 
-/**
- * @deprecated As of 2.2.0 <b>Form Factory</b> should be retrieved via <b>Form Manager</b> by implementing
- *             <i>FormManagerAwareInterface</i>
- */
-interface FormFactoryAwareInterface
+interface FormManagerAwareInterface
 {
     /**
-     * Compose a form factory into the object
+     * Set <b>Form Manager</b>
      *
-     * @param Factory $factory
+     * @param FormManager $formManager
      */
-    public function setFormFactory(Factory $factory);
+    public function setFormManager(FormManager $formManager);
+
+    /**
+     * Get <b>Form Manager</b>
+     *
+     * @return FormManager
+     */
+    public function getFormManager();
 }

--- a/library/Zend/Form/FormManagerAwareTrait.php
+++ b/library/Zend/Form/FormManagerAwareTrait.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Form;
+
+trait FormManagerAwareTrait
+{
+    /**
+     * @var FormManager
+     */
+    protected $formManager = null;
+
+    /**
+     * Set <b>Form Manager</b>
+     *
+     * @param  FormManager $formManager
+     * @return mixed
+     */
+    public function setFormManager(FormManager $formManager)
+    {
+        $this->formManager = $formManager;
+        return $this;
+    }
+
+    /**
+     * Get <b>Form Manager</b>
+     *
+     * Lazy load a <b>Form Manager</b> if none is set
+     *
+     * @return FormManager
+     */
+    public function getFormManager()
+    {
+        if ($this->formManager === null) {
+            $this->formManager = new FormManager;
+        }
+        return $this->formManager;
+    }
+}

--- a/library/Zend/Mvc/Service/FormManagerFactory.php
+++ b/library/Zend/Mvc/Service/FormManagerFactory.php
@@ -9,22 +9,25 @@
 
 namespace Zend\Mvc\Service;
 
-use Zend\Form\FormElementManager;
+use Zend\Form\FormManager;
+use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
-class FormElementManagerFactory extends AbstractPluginManagerFactory
+class FormManagerFactory implements FactoryInterface
 {
-    const PLUGIN_MANAGER_CLASS = 'Zend\Form\FormElementManager';
 
     /**
-     * Create and return the <b>Form Element Manager</b>
+     * Create and return the <b>Form Manager</b>
      *
      * @param  ServiceLocatorInterface $serviceLocator
-     * @return FormElementManager
+     * @return FormManager
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $plugins = parent::createService($serviceLocator);
-        return $plugins;
+        $formManager = new FormManager;
+
+        $formManager->setFormElementManager($serviceLocator->get('FormElementManager'));
+
+        return $formManager;
     }
 }

--- a/library/Zend/Mvc/Service/ServiceListenerFactory.php
+++ b/library/Zend/Mvc/Service/ServiceListenerFactory.php
@@ -52,6 +52,7 @@ class ServiceListenerFactory implements FactoryInterface
             'DiStrictAbstractServiceFactory' => 'Zend\Mvc\Service\DiStrictAbstractServiceFactoryFactory',
             'FilterManager'                  => 'Zend\Mvc\Service\FilterManagerFactory',
             'FormElementManager'             => 'Zend\Mvc\Service\FormElementManagerFactory',
+            'FormManager'                    => 'Zend\Mvc\Service\FormManagerFactory',
             'HttpRouter'                     => 'Zend\Mvc\Service\RouterFactory',
             'PaginatorPluginManager'         => 'Zend\Mvc\Service\PaginatorPluginManagerFactory',
             'Request'                        => 'Zend\Mvc\Service\RequestFactory',

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -12,6 +12,7 @@
  * Set error reporting to the level to which Zend Framework code must comply.
  */
 error_reporting( E_ALL | E_STRICT );
+date_default_timezone_set('UTC');
 
 if (class_exists('PHPUnit_Runner_Version', true)) {
     $phpUnitVersion = PHPUnit_Runner_Version::id();

--- a/tests/ZendTest/Form/Element/CaptchaTest.php
+++ b/tests/ZendTest/Form/Element/CaptchaTest.php
@@ -15,7 +15,7 @@ use ArrayIterator;
 use ArrayObject;
 use Zend\Captcha;
 use Zend\Form\Element\Captcha as CaptchaElement;
-use Zend\Form\Factory;
+use Zend\Form\FormFactory;
 use ZendTest\Form\TestAsset;
 
 class CaptchaTest extends TestCase
@@ -77,7 +77,7 @@ class CaptchaTest extends TestCase
 
     public function testCreatingCaptchaElementViaFormFactoryWillCreateCaptcha()
     {
-        $factory = new Factory();
+        $factory = new FormFactory();
         $element = $factory->createElement(array(
             'type'       => 'Zend\Form\Element\Captcha',
             'name'       => 'foo',

--- a/tests/ZendTest/Form/ElementTest.php
+++ b/tests/ZendTest/Form/ElementTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Form
  */
 
 namespace ZendTest\Form;

--- a/tests/ZendTest/Form/ElementTest.php
+++ b/tests/ZendTest/Form/ElementTest.php
@@ -14,9 +14,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element;
 
 /**
- * @category   Zend
- * @package    Zend_Form
- * @subpackage UnitTest
+ * @group Zend_Form
  */
 class ElementTest extends TestCase
 {

--- a/tests/ZendTest/Form/FactoryTest.php
+++ b/tests/ZendTest/Form/FactoryTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Form
  */
 
 namespace ZendTest\Form;

--- a/tests/ZendTest/Form/FactoryTest.php
+++ b/tests/ZendTest/Form/FactoryTest.php
@@ -14,14 +14,15 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Filter;
 use Zend\Form;
 use Zend\Form\FormElementManager;
-use Zend\Form\Factory as FormFactory;
+use Zend\Form\FormFactory;
+use Zend\Form\FormManager;
 use Zend\InputFilter;
 use Zend\ServiceManager\ServiceManager;
 
 /**
- * @category   Zend
- * @package    Zend_Form
- * @subpackage UnitTest
+ * Zend\Form\Factory was replaced by Zend\Form\FormFactory as of 2.2.0
+ *
+ * @group Zend_Form
  */
 class FactoryTest extends TestCase
 {
@@ -32,9 +33,15 @@ class FactoryTest extends TestCase
 
     public function setUp()
     {
-        $elementManager = new FormElementManager();
-        $elementManager->setServiceLocator(new ServiceManager());
-        $this->factory = new FormFactory($elementManager);
+        $formManager        = new FormManager;
+        $formElementManager = new FormElementManager;
+        $serviceManager     = new ServiceManager;
+
+        $formElementManager->setServiceLocator($serviceManager);
+        $formManager->setServiceLocator($serviceManager);
+        $formManager->setFormElementManager($formElementManager);
+
+        $this->factory      = new FormFactory($formManager);
     }
 
     public function testCanCreateElements()
@@ -595,10 +602,34 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('Zend\Stdlib\Hydrator\ObjectProperty', $fieldset->getHydrator());
     }
 
-    public function testCreatedFieldsetsHaveFactoryAndFormElementManagerInjected()
+    public function testCreatedFieldsetsHaveFormManagerAndFormElementManagerInjected()
     {
         $fieldset = $this->factory->createFieldset(array('name' => 'myFieldset'));
-        $this->assertAttributeInstanceOf('Zend\Form\Factory', 'factory', $fieldset);
+        $this->assertAttributeInstanceOf('Zend\Form\FormManager', 'formManager', $fieldset);
         $this->assertSame($fieldset->getFormFactory()->getFormElementManager(), $this->factory->getFormElementManager());
+    }
+
+    /**
+     * This test should be removed when refactoring Zend\Form\FormFactory for ZF3
+     *
+     * @covers FormFactory::getFormElementManager()
+     */
+    public function testFormElementManagerFromFormFactoryIsOverwroteByTheOneFromFormManager()
+    {
+        $fromFormManager = $this->factory->getFormManager()->getFormElementManager();
+        $fromFormFactory = $this->factory->getFormElementManager();
+        $this->assertSame($fromFormManager, $fromFormFactory);
+    }
+
+    /**
+     * This test should be removed when refactoring Zend\Form\FormFactory for ZF3
+     *
+     * @covers FormFactory::getInputFilterFactory()
+     */
+    public function testInputFilterFactoryFromFormFactoryIsOverwroteByTheOneFromFormManager()
+    {
+        $fromFormManager = $this->factory->getFormManager()->getInputFilterFactory();
+        $fromFormFactory = $this->factory->getInputFilterFactory();
+        $this->assertSame($fromFormManager, $fromFormFactory);
     }
 }

--- a/tests/ZendTest/Form/FieldsetTest.php
+++ b/tests/ZendTest/Form/FieldsetTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Form
  */
 
 namespace ZendTest\Form;

--- a/tests/ZendTest/Form/FieldsetTest.php
+++ b/tests/ZendTest/Form/FieldsetTest.php
@@ -12,14 +12,13 @@ namespace ZendTest\Form;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element;
-use Zend\Form\Form;
 use Zend\Form\Fieldset;
+use Zend\Form\Form;
+use Zend\Form\FormFactory;
 use Zend\InputFilter\InputFilter;
 
 /**
- * @category   Zend
- * @package    Zend_Form
- * @subpackage UnitTest
+ * @group Zend_Form
  */
 class FieldsetTest extends TestCase
 {
@@ -459,5 +458,19 @@ class FieldsetTest extends TestCase
     {
         $this->setExpectedException('Zend\Form\Exception\InvalidArgumentException');
         $this->fieldset->setObject('foo');
+    }
+
+    public function testCallingGetFormFactoryReturnsTheInstanceFromFormManager()
+    {
+        // By Lazy Instantiation
+        $fromFormFactory = $this->fieldset->getFormFactory();
+        $fromFormManager = $this->fieldset->getFormManager()->getFormFactory();
+        $this->assertSame($fromFormFactory, $fromFormManager);
+
+        // By Setting a new FormFactory instance
+        $this->fieldset->getFormManager()->setFormFactory(new FormFactory);
+        $fromFormFactory = $this->fieldset->getFormFactory();
+        $fromFormManager = $this->fieldset->getFormManager()->getFormFactory();
+        $this->assertSame($fromFormFactory, $fromFormManager);
     }
 }

--- a/tests/ZendTest/Form/FormAbstractServiceFactoryTest.php
+++ b/tests/ZendTest/Form/FormAbstractServiceFactoryTest.php
@@ -9,22 +9,24 @@
  */
 namespace ZendTest\Form;
 
+use PHPUnit_Framework_TestCase as TestCase;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Mvc\Service\ServiceManagerConfig;
 
-class FormAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
+/**
+ * @group Zend_Form
+ */
+class FormAbstractServiceFactoryTest extends TestCase
 {
-
     /**
-     *
-     * @var \Zend\ServiceManager\ServiceManager
+     * @var ServiceManager
      */
     private $serviceManager;
 
     /**
      * Set up service manager and form specification.
      */
-    protected function setUp ()
+    protected function setUp()
     {
         $this->serviceManager = new ServiceManager(new ServiceManagerConfig(array(
             'abstract_factories' => array(
@@ -111,10 +113,9 @@ class FormAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     *
      * @return array
      */
-    public function providerValidService ()
+    public function providerValidService()
     {
         return array(
             array(
@@ -124,10 +125,9 @@ class FormAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     *
      * @return array
      */
-    public function providerInvalidService ()
+    public function providerInvalidService()
     {
         return array(
             array(
@@ -137,23 +137,21 @@ class FormAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     *
      * @param string $service
-     *            @dataProvider providerValidService
+     * @dataProvider providerValidService
      */
-    public function testValidService ($service)
+    public function testValidService($service)
     {
         $actual = $this->serviceManager->get($service);
         $this->assertInstanceOf('Zend\Form\Form', $actual);
     }
 
     /**
-     *
      * @param string $service
-     *            @dataProvider providerInvalidService
-     *            @expectedException Zend\ServiceManager\Exception\ServiceNotFoundException
+     * @dataProvider providerInvalidService
+     * @expectedException Zend\ServiceManager\Exception\ServiceNotFoundException
      */
-    public function testInvalidService ($service)
+    public function testInvalidService($service)
     {
         $actual = $this->serviceManager->get($service);
     }

--- a/tests/ZendTest/Form/FormAbstractServiceFactoryTest.php
+++ b/tests/ZendTest/Form/FormAbstractServiceFactoryTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Form
  */
 namespace ZendTest\Form;
 

--- a/tests/ZendTest/Form/FormElementManagerTest.php
+++ b/tests/ZendTest/Form/FormElementManagerTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Form
  */
 
 namespace ZendTest\Form;

--- a/tests/ZendTest/Form/FormElementManagerTest.php
+++ b/tests/ZendTest/Form/FormElementManagerTest.php
@@ -10,27 +10,42 @@
 
 namespace ZendTest\Form;
 
-use Zend\ServiceManager\ServiceManager;
-use Zend\Form\Factory;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\FormFactory;
 use Zend\Form\Form;
 use Zend\Form\FormElementManager;
+use Zend\Form\FormManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
- * @category   Zend
- * @package    Zend_Form
- * @subpackage UnitTests
- * @group      Zend_Form
+ * @group Zend_Form
  */
-class FormElementManagerTest extends \PHPUnit_Framework_TestCase
+class FormElementManagerTest extends TestCase
 {
     /**
      * @var FormElementManager
      */
     protected $manager;
 
+    /**
+     * @var ServiceLocatorInterface
+     */
+    protected $serviceLocator;
+
+    /**
+     * @var FormManager
+     */
+    protected $formManager;
+
     public function setUp()
     {
-        $this->manager = new FormElementManager();
+        $this->manager        = new FormElementManager();
+        $this->serviceLocator = new ServiceManager;
+        $this->formManager    = new FormManager;
+        // The service manager must have a 'FormManager' service registered
+        // to be able to inject it into any element implementing FormManagerAwareInterface
+        $this->serviceLocator->setService('FormManager', $this->formManager);
     }
 
     public function testInjectToFormFactoryAware()
@@ -39,12 +54,20 @@ class FormElementManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->manager, $form->getFormFactory()->getFormElementManager());
     }
 
+    public function testInjectToFormManagerAware()
+    {
+        $this->manager->setServiceLocator($this->serviceLocator);
+
+        $form = $this->manager->get('Form');
+        $this->assertSame($this->formManager, $form->getFormManager());
+    }
+
     /**
      * @group 3735
      */
     public function testInjectsFormElementManagerToFormComposedByFormFactoryAwareElement()
     {
-        $factory = new Factory();
+        $factory = new FormFactory();
         $this->manager->setFactory('my-form', function ($elements) use ($factory) {
             $form = new Form();
             $form->setFormFactory($factory);
@@ -66,5 +89,31 @@ class FormElementManagerTest extends \PHPUnit_Framework_TestCase
         $this->manager->setInvokableClass('test', get_class($this));
         $this->setExpectedException('Zend\Form\Exception\InvalidElementException');
         $this->manager->get('test');
+    }
+
+    /**
+     * Tests if an element implementing FormManagerAwareInterface and FormFactoryAwareInterface
+     * returns the same instance of a factory via $element->getFormManager()->getFormFactory() and
+     * $element->getFormFactory()
+     */
+    public function testElementFormFactoryAndFormManagerAwareShareTheSameInstanceOfFormFactoryObject()
+    {
+        $element = $this->manager->get('form');
+        $this->assertSame($element->getFormManager()->getFormFactory(), $element->getFormFactory());
+    }
+
+    /**
+     * Tests if an element implementing FormManagerAwareInterface and FormFactoryAwareInterface
+     * returns the same instance of a form element manager via $element->getFormManager()->getFormElementManager()
+     * and $element->getFormElementManager()
+     */
+    public function testElementFormFactoryAndFormManagerAwareShareTheSameInstanceOfFormElementManagerObject()
+    {
+        $this->manager->setServiceLocator($this->serviceLocator);
+
+        $element         = $this->manager->get('form');
+        $fromFormManager = $element->getFormManager()->getFormElementManager();
+        $fromFormFactory = $element->getFormFactory()->getFormElementManager();
+        $this->assertSame($fromFormManager, $fromFormFactory);
     }
 }

--- a/tests/ZendTest/Form/FormFactoryAwareTraitTest.php
+++ b/tests/ZendTest/Form/FormFactoryAwareTraitTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Form
  */
 
 namespace ZendTest\Form;
@@ -15,9 +14,8 @@ use Zend\Form\Factory;
 
 /**
  * @deprecated As of 2.2.0 <b>Form Factory</b> should be set/get via <b>Form Manager</b>
- * @requires PHP 5.4
- *
- * @group Zend_Form
+ * @group      Zend_Form
+ * @requires   PHP 5.4
  */
 class FormFactoryAwareTraitTest extends TestCase
 {

--- a/tests/ZendTest/Form/FormFactoryAwareTraitTest.php
+++ b/tests/ZendTest/Form/FormFactoryAwareTraitTest.php
@@ -10,24 +10,21 @@
 
 namespace ZendTest\Form;
 
-use \PHPUnit_Framework_TestCase as TestCase;
-use \Zend\Form\Factory;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Factory;
 
 /**
+ * @deprecated As of 2.2.0 <b>Form Factory</b> should be set/get via <b>Form Manager</b>
  * @requires PHP 5.4
+ *
+ * @group Zend_Form
  */
 class FormFactoryAwareTraitTest extends TestCase
 {
     public function testSetFormFactory()
     {
-        $object = $this->getObjectForTrait('\Zend\Form\FormFactoryAwareTrait');
-
-        $this->assertAttributeEquals(null, 'factory', $object);
-
-        $factory = new Factory;
-
-        $object->setFormFactory($factory);
-
-        $this->assertAttributeEquals($factory, 'factory', $object);
+        $this->markTestSkipped(
+            'Zend\Form\Factory has been deprecated in ZF as of 2.2.0, use Zend\Form\FormFactory instead'
+        );
     }
 }

--- a/tests/ZendTest/Form/FormManagerAwareTraitTest.php
+++ b/tests/ZendTest/Form/FormManagerAwareTraitTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Form
  */
 
 namespace ZendTest\Form;

--- a/tests/ZendTest/Form/FormManagerAwareTraitTest.php
+++ b/tests/ZendTest/Form/FormManagerAwareTraitTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace ZendTest\Form;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\FormManager;
+
+/**
+ * @group    Zend_Form
+ * @requires PHP 5.4
+ */
+class FormManagerAwareTraitTest extends TestCase
+{
+    public function testSetFormManager()
+    {
+        $object = $this->getObjectForTrait('\Zend\Form\FormManagerAwareTrait');
+
+        $this->assertAttributeEquals(null, 'formManager', $object);
+
+        $formManager = new FormManager;
+
+        $object->setFormManager($formManager);
+
+        $this->assertAttributeEquals($formManager, 'formManager', $object);
+    }
+
+    public function testGetFormManager()
+    {
+        $object = $this->getObjectForTrait('\Zend\Form\FormManagerAwareTrait');
+
+        // The instance is lazy loaded
+        $this->assertInstanceOf('Zend\Form\FormManager', $object->getFormManager());
+
+        $formManager = new FormManager;
+
+        $object->setFormManager($formManager);
+
+        $this->assertEquals($formManager, $object->getFormManager());
+    }
+}

--- a/tests/ZendTest/Form/FormManagerTest.php
+++ b/tests/ZendTest/Form/FormManagerTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Form
  */
 
 namespace ZendTest\Form;

--- a/tests/ZendTest/Form/FormManagerTest.php
+++ b/tests/ZendTest/Form/FormManagerTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace ZendTest\Form;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\FormFactory;
+use Zend\Form\FormManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * @group Zend_Form
+ */
+class FormManagerTest extends TestCase
+{
+    /**
+     * @var FormFactory
+     */
+    protected $formFactory;
+
+    /**
+     * @var FormManager
+     */
+    protected $formManager;
+
+    public function setUp()
+    {
+        $this->formManager = new FormManager;
+        $this->formManager->setServiceLocator(new ServiceManager);
+    }
+
+    public function testFormManagerInjectsItselfIntoFormFactoryOnLazyInstantiation()
+    {
+        $formManager = $this->formManager;
+        // Lazy loads a FormFactory instance
+        $formFactory = $formManager->getFormFactory();
+        $this->assertSame($formManager, $formFactory->getFormManager());
+    }
+
+    public function testFormManagerInjectsItselfIntoFormFactoryOnSetting()
+    {
+        $formManager = $this->formManager;
+        $formFactory = new FormFactory;
+        $formManager->setFormFactory($formFactory);
+        $this->assertSame($formManager, $formFactory->getFormManager());
+    }
+}

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Form
  */
 
 namespace ZendTest\Form;

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -16,12 +16,16 @@ use Zend\Form\Element;
 use Zend\Form\Factory;
 use Zend\Form\Fieldset;
 use Zend\Form\Form;
+use Zend\Form\FormManager;
 use Zend\InputFilter\InputFilter;
 use Zend\InputFilter\Factory as InputFilterFactory;
 use Zend\Stdlib\Hydrator;
 use ZendTest\Form\TestAsset\Entity;
 use ZendTest\Form\TestAsset\HydratorAwareModel;
 
+/**
+ * @group Zend_Form
+ */
 class FormTest extends TestCase
 {
     /**
@@ -682,17 +686,17 @@ class FormTest extends TestCase
         ), $model->foobar);
     }
 
-    public function testHasFactoryComposedByDefault()
+    public function testHasFormManagerComposedByDefault()
     {
-        $factory = $this->form->getFormFactory();
-        $this->assertInstanceOf('Zend\Form\Factory', $factory);
+        $formManager = $this->form->getFormManager();
+        $this->assertInstanceOf('Zend\Form\FormManager', $formManager);
     }
 
-    public function testCanComposeFactory()
+    public function testCanComposeFormManager()
     {
-        $factory = new Factory();
-        $this->form->setFormFactory($factory);
-        $this->assertSame($factory, $this->form->getFormFactory());
+        $formManager = new FormManager();
+        $this->form->setFormManager($formManager);
+        $this->assertSame($formManager, $this->form->getFormManager());
     }
 
     public function testCanAddElementsUsingSpecs()


### PR DESCRIPTION
I opened an issue (#4228) to discuss some ideas I had, and now I have some code I wrote. This PR is supposed to provide the following:
- [x] Implementation of `Zend\Form\FormManager`:
  This class will manage anything related to `Zend\Form`, like `FormElementManager`, `FormFactory`, `InputFilterFactory` and possibly `FormObjectManager` - see #4100.
- [x] Creation of `Zend\Form\FormFactory` to replace `Zend\Form\Factory`:
  The intention of this is that the factory would use `FormManager` to retrieve its dependencies. The `Zend\Form\Factory` would be deprecated.
- [ ] Create a `ModuleManager` listener:
  We would deprecate `form_elements` key and `getFormElementConfig` method and provide a `form_manager` key (similar with the one presented by @stephanoff in #4100), and a method `getFormConfig()`.
  
  ``` PHP
  public function getFormConfig()
  {
      return array(
          'forms' => ( /* Especifications for Zend\Form\FormAbstractServiceFactory */ ),
          'element_manager' => (),
          'object_manager'  => (), // plz refer to #4100
      );
  }
  ```
  
  Or in a config file:
  
  ``` PHP
  return array(
      'form_manager' => array(
          'forms' => (),
          'elements' => (), // instead of 'element_manager'
          'objects'  => (), // instead of 'object_manager'
      ),
  );
  ```
  
  Something like this, let me know if you have suggestions.
- [ ] Implementation of a `Zend\EventManager` integration:
  This integration would be added as a **soft** dependency that could be activated via a key in the configuration (similar with the one presented by @DASPRiD in #4187):
  
  ``` PHP
  return array(
      'form_manager' => array(
          'event_manager_enabled' => true,
      ),
  );
  ```
  
  The idea of this integration is to provide something like the following examples:
  
  ``` PHP
  // In a 'product' fieldset
  $this->add(array(
      'name' => 'isSale',
      'type' => 'Checkbox',
  ));
  
  $this->add(array(
      'name' => 'salePrice',
      'event_listeners' => array( // array of events to be attached to the EventManager
          array(
              'event'    => 'validate', // Would be triggered when isValid() gets called
              'callback' => function ($e) {
                  $form = $e->getForm();
  
                  // If 'isSale' is NOT checked 'salePrice' should not be requiered
                  if (!$form->get('product')->get('isSale')->isChecked()) {
                      $form->getInputFilter()->get('product')->get('salePrice')->setRequired(false);
                  }
              },
              'priority' => 25,
          ),
          array(
              'event'    => 'prepare', // Would be triggered when prepare() gets called
              'callback' => function ($e) {
                  $form = $e->getForm();
  
                  if (!$form->get('product')->get('isSale')->isChecked()) {
                      // This could be done in the 'validate' event, but it's here just for demonstration
                      $form->get('product')->get('salePrice')->setAttribute('disabled', 'disabled');
                  }
              },
          ),
      ),
  ));
  ```
  
  **Note: _The `EventManager` Integration should probably go in another PR, but I'm just showing where all this came from_**
