### PR TITLE
Main framework composer.json is incorrectly configured

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "ext-intl": "*"
     },
     "require-dev": {
         "doctrine/common": ">=2.1",
@@ -19,7 +20,6 @@
     },
     "suggest": {
         "doctrine/common": "Doctrine\\Common >=2.1 for annotation features",
-        "ext-intl": "ext/intl for i18n features",
         "ircmaxell/random-lib": "Fallback random byte generator for Zend\\Math\\Rand if OpenSSL/Mcrypt extensions are unavailable",
         "pecl-weakref": "Implementation of weak references for Zend\\Stdlib\\CallbackHandler",
         "zendframework/zendpdf": "ZendPdf for creating PDF representations of barcodes",


### PR DESCRIPTION
The I18n component's composer.json specifies [a requirement for the intl extension](https://github.com/zendframework/zf2/blob/master/library/Zend/I18n/composer.json#L17) to be installed. The main framework composer.json only specifies the intl extension [as a suggestion](https://github.com/zendframework/zf2/blob/master/composer.json#L22), but simultaneously [claims to replace the I18n component](https://github.com/zendframework/zf2/blob/master/composer.json#L57).

The upshot of this is that anybody who tries to install _any_ Zend component with a dependency on the I18n component through Composer will receive the _entire_ Zend framework rather than just the dependency they requested, unless they have the PHP intl extension installed on their machine.

The reason for this is that the Composer solver sees the framework as a way to get zend-i18n without the requirement for the intl extension to be installed. A quick search reveals that many have been caught out by this behaviour:
- composer/composer#1587
- [StackOverflow question 1](http://stackoverflow.com/questions/11747962/zend-framework-composer-packages)
- [StackOverflow question 2](http://stackoverflow.com/questions/14356318/install-component-zf2-using-composer)
- [StackOverflow question 3](http://stackoverflow.com/questions/15349935/is-it-normal-that-zendframework-zend-http-package-requires-49-components)
- [composer-dev mailing list discussion](https://groups.google.com/d/topic/composer-dev/yT33S9A9x1o/discussion)

This PR adds a requirement for the intl extension to the main framework composer.json, which will stop these type of issues from occurring.

Note, I am assuming that zend-i18n does in fact have a concrete requirement on the intl extension and cannot function without it. In which case, since the framework includes the zend-i18n code, this concrete requirement extends to the main framework also.
