### PR TITLE
Fix for a problem with Service Manager and Abstract Factories

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -56,12 +56,12 @@ class ServiceManager implements ServiceLocatorInterface
     /**
      * @var string
      */
-    public $lastAbstractFactoryUsed = null;
+    protected $lastAbstractFactoryUsed = null;
 
     /**
      * @var string
      */
-    public $lastCanonicalNameUsed   = null;
+    protected $lastCanonicalNameUsed   = null;
 
     /**
      * @var array

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -54,6 +54,16 @@ class ServiceManager implements ServiceLocatorInterface
     protected $pendingAbstractFactoryRequests = array();
 
     /**
+     * @var string
+     */
+    public $lastAbstractFactoryUsed = null;
+
+    /**
+     * @var string
+     */
+    public $lastCanonicalNameUsed   = null;
+
+    /**
      * @var array
      */
     protected $shared = array();
@@ -608,7 +618,18 @@ class ServiceManager implements ServiceLocatorInterface
                 return false;
             }
 
+            $objectHash = spl_object_hash($abstractFactory);
+
+            if ($this->lastAbstractFactoryUsed === $objectHash && $this->lastCanonicalNameUsed === $cName) {
+                $this->lastAbstractFactoryUsed = $this->lastCanonicalNameUsed = null;
+                return false;
+            }
+
+            $this->lastAbstractFactoryUsed = $objectHash;
+            $this->lastCanonicalNameUsed   = $cName;
+
             if ($abstractFactory->canCreateServiceWithName($this, $cName, $rName)) {
+                $this->lastAbstractFactoryUsed = $this->lastCanonicalNameUsed = null;
                 return true;
             }
         }

--- a/tests/ZendTest/ServiceManager/Di/DiAbstractServiceFactoryTest.php
+++ b/tests/ZendTest/ServiceManager/Di/DiAbstractServiceFactoryTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\Di;
@@ -13,6 +12,9 @@ namespace ZendTest\ServiceManager\Di;
 use Zend\ServiceManager\Di\DiAbstractServiceFactory;
 use Zend\ServiceManager\ServiceManager;
 
+/**
+ * @group Zend_ServiceManager
+ */
 class DiAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
 {
 

--- a/tests/ZendTest/ServiceManager/Di/DiServiceFactoryTest.php
+++ b/tests/ZendTest/ServiceManager/Di/DiServiceFactoryTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\Di;
@@ -14,6 +13,9 @@ use Zend\Di\Di;
 use Zend\ServiceManager\Di\DiServiceFactory;
 use Zend\ServiceManager\ServiceManager;
 
+/**
+ * @group Zend_ServiceManager
+ */
 class DiServiceFactoryTest extends \PHPUnit_Framework_TestCase
 {
 

--- a/tests/ZendTest/ServiceManager/Di/DiServiceInitializerTest.php
+++ b/tests/ZendTest/ServiceManager/Di/DiServiceInitializerTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\Di;
@@ -13,6 +12,9 @@ namespace ZendTest\ServiceManager\Di;
 use Zend\ServiceManager\Di\DiServiceInitializer;
 use Zend\ServiceManager\Di\DiInstanceManagerProxy;
 
+/**
+ * @group Zend_ServiceManager
+ */
 class DiServiceInitializerTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/ZendTest/ServiceManager/ServiceLocatorAwareTraitTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceLocatorAwareTraitTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager;
@@ -15,6 +14,7 @@ use \Zend\ServiceManager\ServiceManager;
 
 /**
  * @requires PHP 5.4
+ * @group    Zend_ServiceManager
  */
 class ServiceLocatorAwareTraitTest extends TestCase
 {

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager;
@@ -20,6 +19,9 @@ use Zend\ServiceManager\Config;
 
 use ZendTest\ServiceManager\TestAsset\FooCounterAbstractFactory;
 
+/**
+ * @group Zend_ServiceManager
+ */
 class ServiceManagerTest extends TestCase
 {
 

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\ServiceManager;
 
+use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Di\Di;
 use Zend\Mvc\Service\DiFactory;
 use Zend\ServiceManager\Di\DiAbstractServiceFactory;
@@ -19,7 +20,7 @@ use Zend\ServiceManager\Config;
 
 use ZendTest\ServiceManager\TestAsset\FooCounterAbstractFactory;
 
-class ServiceManagerTest extends \PHPUnit_Framework_TestCase
+class ServiceManagerTest extends TestCase
 {
 
     /**
@@ -546,6 +547,24 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
         $sm->addAbstractFactory($abstractFactory);
         $foo = $sm->get('foo');
         $this->assertSame($abstractFactory->expectedInstance, $foo);
+    }
+
+    /**
+     * When failing, this test will trigger a fatal error: Allowed memory size of # bytes exhausted
+     */
+    public function testCallingANonExistingServiceFromAnAbstractServiceDoesNotMakeTheServerExhaustTheAllowedMemoryByCallingItselfForTheGivenService()
+    {
+        $abstractFactory = new TestAsset\TrollAbstractFactory;
+        $this->serviceManager->addAbstractFactory($abstractFactory);
+
+        $this->assertSame($abstractFactory->inexistingServiceCheckResult, null);
+
+        // By doing this the Service Manager will rely on the Abstract Service Factory
+        $service = $this->serviceManager->get('SomethingThatCanBeCreated');
+
+        $this->assertSame(false, $abstractFactory->inexistingServiceCheckResult);
+
+        $this->assertInstanceOf('stdClass', $service);
     }
 
     public function testShouldAllowAddingInitializersAsClassNames()

--- a/tests/ZendTest/ServiceManager/TestAsset/Bar.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/Bar.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\TestAsset;

--- a/tests/ZendTest/ServiceManager/TestAsset/BarAbstractFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/BarAbstractFactory.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\TestAsset;

--- a/tests/ZendTest/ServiceManager/TestAsset/CircularDependencyAbstractFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/CircularDependencyAbstractFactory.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\TestAsset;

--- a/tests/ZendTest/ServiceManager/TestAsset/ExceptionThrowingFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/ExceptionThrowingFactory.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\TestAsset;

--- a/tests/ZendTest/ServiceManager/TestAsset/Foo.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/Foo.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\TestAsset;

--- a/tests/ZendTest/ServiceManager/TestAsset/FooAbstractFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/FooAbstractFactory.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\TestAsset;

--- a/tests/ZendTest/ServiceManager/TestAsset/FooCounterAbstractFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/FooCounterAbstractFactory.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\TestAsset;

--- a/tests/ZendTest/ServiceManager/TestAsset/FooException.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/FooException.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\TestAsset;

--- a/tests/ZendTest/ServiceManager/TestAsset/FooFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/FooFactory.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\TestAsset;

--- a/tests/ZendTest/ServiceManager/TestAsset/FooInitializer.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/FooInitializer.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\TestAsset;

--- a/tests/ZendTest/ServiceManager/TestAsset/GlobIteratorService.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/GlobIteratorService.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\TestAsset;

--- a/tests/ZendTest/ServiceManager/TestAsset/TrollAbstractFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/TrollAbstractFactory.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_ServiceManager
  */
 
 namespace ZendTest\ServiceManager\TestAsset;

--- a/tests/ZendTest/ServiceManager/TestAsset/TrollAbstractFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/TrollAbstractFactory.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_ServiceManager
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use stdClass;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class TrollAbstractFactory implements AbstractFactoryInterface
+{
+    public $inexistingServiceCheckResult = null;
+
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        // Check if a non-existing service exists
+        $this->inexistingServiceCheckResult = $serviceLocator->has('NonExistingService');
+
+        if ($requestedName === 'SomethingThatCanBeCreated') {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        return new stdClass;
+    }
+}


### PR DESCRIPTION
When a abstract factory, inside the method `canCreateServiceWithName()`, try to check or retrieve a service that doesn't exists, a loop is created between the service manager and the given factory - see the test to get a better idea.

I'm not sure if my fix is a good one, but that's everything I can do. If someone else have a better approach to solve this, please feel free to fix it. :)

My idea was to skip the abstract factory when it, coupled with the canonical name, was the last one to be used.
