### PR TITLE
Update Curl.php

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -500,6 +500,10 @@ class Curl implements HttpAdapter, StreamInterface
      */
     public function readHeader($curl, $header)
     {
+    	if (isset($this->config['curloptions'][CURLOPT_ENCODING]) && strtolower(substr($header, 0, 18)) === 'content-encoding: ') {
+			return strlen($header);
+		}
+        
         $this->response .= $header;
         return strlen($header);
     }


### PR DESCRIPTION
Gzip decoding doesn't work properly with Zend\Http\Client in streaming mode.

In this first example, the file tempfile.txt will be the raw, compressed code but $response->getBody() will be the proper decoded result.

``` php
$client = new Zend\Http\Client('http://www.clickability.com/', array(
    'adapter' => 'Zend\Http\Client\Adapter\Curl',
));
$client->setStream('tempfile.txt');
$response = $client->send();
print_r($response->getBody());
```

When we use Curl to decode the result, Zend\Http\Response will try to decode the already decoded response, resulting in a fatal exception. The output stream will be the expected response

``` php
$client = new Zend\Http\Client('http://www.clickability.com/', array(
    'adapter'     => 'Zend\Http\Client\Adapter\Curl',
    'curloptions' => array(CURLOPT_ENCODING => ''),
));
$client->setStream('tempfile.txt');
$response = $client->send();
print_r($response->getBody());
```

```
Exception thrown:
PHP Fatal error:  Uncaught exception 'ErrorException' with message 'gzinflate(): data error' in /private/curl/vendor/zendframework/zend-http/Zend/Http/Response.php:478
Stack trace:
#0 [internal function]: Zend\Stdlib\ErrorHandler::addError(2, 'gzinflate(): da...', '/private/curl/v...', 478, Array)
#1 /private/curl/vendor/zendframework/zend-http/Zend/Http/Response.php(478): gzinflate('???????????????...')
#2 /private/curl/vendor/zendframework/zend-http/Zend/Http/Response.php(309): Zend\Http\Response->decodeGzip('???????????????...')
#3 /private/curl/vendor/zendframework/zend-http/Zend/Http/Response/Stream.php(234): Zend\Http\Response->getBody()
#4 /private/curl/example.php(20): Zend\Http\Response\Stream->getBody()
#5 {main}

Next exception 'Zend\Http\Exception\RuntimeException' with message 'Error occurred during gzip inflation' in /private/curl/vendor/zendframework/zend-http/Zend/Http/Response.php:481
Stack trace:
#0 /private/curl/vendor/zendframework/zend-http/Zend/Http/Response.php(309): Zend\Http\Response->decodeGzip('????? in /private/curl/vendor/zendframework/zend-http/Zend/Http/Response.php on l
```

With the proposed patch, both the stream and getBody functions return the valid response.

The use case for allowing both functions in stream mode is for authenticated areas. The valid response is the stream. But, when authentication is necessary, it returns text/html and we want to pull some form field values from the response.
