### PR TITLE
Better fix for #4284

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
-        "ext-intl": "*"
+        "php": ">=5.3.3"
     },
     "require-dev": {
         "doctrine/common": ">=2.1",
@@ -19,6 +18,7 @@
         "phpunit/PHPUnit": "3.7.*"
     },
     "suggest": {
+        "ext-intl": "ext/intl for i18n features (included in default builds of PHP)",
         "doctrine/common": "Doctrine\\Common >=2.1 for annotation features",
         "ircmaxell/random-lib": "Fallback random byte generator for Zend\\Math\\Rand if OpenSSL/Mcrypt extensions are unavailable",
         "pecl-weakref": "Implementation of weak references for Zend\\Stdlib\\CallbackHandler",

--- a/library/Zend/I18n/Exception/ExtensionNotLoadedException.php
+++ b/library/Zend/I18n/Exception/ExtensionNotLoadedException.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\I18n\Exception;
+
+use DomainException;
+
+class ExtensionNotLoadedException extends DomainException implements
+    ExceptionInterface
+{}

--- a/library/Zend/I18n/Filter/AbstractLocale.php
+++ b/library/Zend/I18n/Filter/AbstractLocale.php
@@ -16,7 +16,7 @@ use Zend\I18n\Exception;
 abstract class AbstractLocale extends AbstractFilter
 {
     /**
-     * @throws Exception\InvalidArgumentException if ext/intl is not present
+     * @throws Exception\ExtensionNotLoadedException if ext/intl is not present
      */
     public function __construct()
     {

--- a/library/Zend/I18n/Filter/AbstractLocale.php
+++ b/library/Zend/I18n/Filter/AbstractLocale.php
@@ -11,9 +11,23 @@ namespace Zend\I18n\Filter;
 
 use Locale;
 use Zend\Filter\AbstractFilter;
+use Zend\I18n\Exception;
 
 abstract class AbstractLocale extends AbstractFilter
 {
+    /**
+     * @throws Exception\InvalidArgumentException if ext/intl is not present
+     */
+    public function __construct()
+    {
+        if (!extension_loaded('intl')) {
+            throw new Exception\ExtensionNotLoadedException(sprintf(
+                '%s component requires the intl PHP extension',
+                __NAMESPACE__
+            ));
+        }
+    }
+
     /**
      * Sets the locale option
      *

--- a/library/Zend/I18n/Filter/Alnum.php
+++ b/library/Zend/I18n/Filter/Alnum.php
@@ -30,6 +30,7 @@ class Alnum extends AbstractLocale
      */
     public function __construct($allowWhiteSpaceOrOptions = null, $locale = null)
     {
+        parent::__construct();
         if ($allowWhiteSpaceOrOptions !== null) {
             if (static::isOptions($allowWhiteSpaceOrOptions)) {
                 $this->setOptions($allowWhiteSpaceOrOptions);

--- a/library/Zend/I18n/Filter/NumberFormat.php
+++ b/library/Zend/I18n/Filter/NumberFormat.php
@@ -37,6 +37,7 @@ class NumberFormat extends AbstractLocale
         $style = NumberFormatter::DEFAULT_STYLE,
         $type = NumberFormatter::TYPE_DOUBLE)
     {
+        parent::__construct();
         if ($localeOrOptions !== null) {
             if ($localeOrOptions instanceof Traversable) {
                 $localeOrOptions = iterator_to_array($localeOrOptions);

--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -80,19 +80,6 @@ class Translator
     protected $pluginManager;
 
     /**
-     * @throws Exception\ExtensionNotLoadedException if ext/intl is not present
-     */
-    public function __construct()
-    {
-        if (!extension_loaded('intl')) {
-            throw new Exception\ExtensionNotLoadedException(sprintf(
-                '%s component requires the intl PHP extension',
-                __NAMESPACE__
-            ));
-        }
-    }
-
-    /**
      * Instantiate a translator
      *
      * @param  array|Traversable                  $options
@@ -230,10 +217,17 @@ class Translator
      * Get the default locale.
      *
      * @return string
+     * @throws Exception\ExtensionNotLoadedException if ext/intl is not present and no locale set
      */
     public function getLocale()
     {
         if ($this->locale === null) {
+            if (!extension_loaded('intl')) {
+                throw new Exception\ExtensionNotLoadedException(sprintf(
+                    '%s component requires the intl PHP extension',
+                    __NAMESPACE__
+                ));
+            }
             $this->locale = Locale::getDefault();
         }
 

--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -84,10 +84,18 @@ class Translator
      *
      * @param  array|Traversable                  $options
      * @return Translator
+     * @throws Exception\ExtensionNotLoadedException if ext/intl is not present
      * @throws Exception\InvalidArgumentException
      */
     public static function factory($options)
     {
+        if (!extension_loaded('intl')) {
+            throw new Exception\ExtensionNotLoadedException(sprintf(
+                '%s component requires the intl PHP extension',
+                __NAMESPACE__
+            ));
+        }
+
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         } elseif (!is_array($options)) {

--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -80,14 +80,9 @@ class Translator
     protected $pluginManager;
 
     /**
-     * Instantiate a translator
-     *
-     * @param  array|Traversable                  $options
-     * @return Translator
      * @throws Exception\ExtensionNotLoadedException if ext/intl is not present
-     * @throws Exception\InvalidArgumentException
      */
-    public static function factory($options)
+    public function __construct()
     {
         if (!extension_loaded('intl')) {
             throw new Exception\ExtensionNotLoadedException(sprintf(
@@ -95,7 +90,17 @@ class Translator
                 __NAMESPACE__
             ));
         }
+    }
 
+    /**
+     * Instantiate a translator
+     *
+     * @param  array|Traversable                  $options
+     * @return Translator
+     * @throws Exception\InvalidArgumentException
+     */
+    public static function factory($options)
+    {
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         } elseif (!is_array($options)) {

--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -12,6 +12,7 @@ namespace Zend\I18n\Validator;
 use Locale;
 use NumberFormatter;
 use Traversable;
+use Zend\I18n\Exception as I18nException;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\Exception;
@@ -40,9 +41,17 @@ class Float extends AbstractValidator
      * Constructor for the integer validator
      *
      * @param array|Traversable $options
+     * @throws Exception\ExtensionNotLoadedException if ext/intl is not present
      */
     public function __construct($options = array())
     {
+        if (!extension_loaded('intl')) {
+            throw new I18nException\ExtensionNotLoadedException(sprintf(
+                '%s component requires the intl PHP extension',
+                __NAMESPACE__
+            ));
+        }
+
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         }

--- a/library/Zend/I18n/Validator/Int.php
+++ b/library/Zend/I18n/Validator/Int.php
@@ -12,6 +12,7 @@ namespace Zend\I18n\Validator;
 use Locale;
 use NumberFormatter;
 use Traversable;
+use Zend\I18n\Exception as I18nException;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\Exception;
@@ -40,9 +41,17 @@ class Int extends AbstractValidator
      * Constructor for the integer validator
      *
      * @param  array|Traversable $options
+     * @throws Exception\ExtensionNotLoadedException if ext/intl is not present
      */
     public function __construct($options = array())
     {
+        if (!extension_loaded('intl')) {
+            throw new I18nException\ExtensionNotLoadedException(sprintf(
+                '%s component requires the intl PHP extension',
+                __NAMESPACE__
+            ));
+        }
+
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         }

--- a/library/Zend/I18n/Validator/PostCode.php
+++ b/library/Zend/I18n/Validator/PostCode.php
@@ -11,6 +11,7 @@ namespace Zend\I18n\Validator;
 
 use Locale;
 use Traversable;
+use Zend\I18n\Exception as I18nException;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\Callback;
@@ -226,9 +227,17 @@ class PostCode extends AbstractValidator
      * Accepts a string locale and/or "format".
      *
      * @param  array|Traversable $options
+     * @throws Exception\ExtensionNotLoadedException if ext/intl is not present
      */
     public function __construct($options = array())
     {
+        if (!extension_loaded('intl')) {
+            throw new I18nException\ExtensionNotLoadedException(sprintf(
+                '%s component requires the intl PHP extension',
+                __NAMESPACE__
+            ));
+        }
+
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         }

--- a/library/Zend/I18n/View/Helper/AbstractTranslatorHelper.php
+++ b/library/Zend/I18n/View/Helper/AbstractTranslatorHelper.php
@@ -9,6 +9,7 @@
 
 namespace Zend\I18n\View\Helper;
 
+use Zend\I18n\Exception;
 use Zend\I18n\Translator\Translator;
 use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\View\Helper\AbstractHelper;
@@ -29,6 +30,19 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
      * @var string
      */
     protected $translatorTextDomain = 'default';
+
+    /**
+     * @throws Exception\InvalidArgumentException if ext/intl is not present
+     */
+    public function __construct()
+    {
+        if (!extension_loaded('intl')) {
+            throw new Exception\ExtensionNotLoadedException(sprintf(
+                '%s component requires the intl PHP extension',
+                __NAMESPACE__
+            ));
+        }
+    }
 
     /**
      * Whether translator should be used

--- a/library/Zend/I18n/View/Helper/AbstractTranslatorHelper.php
+++ b/library/Zend/I18n/View/Helper/AbstractTranslatorHelper.php
@@ -32,7 +32,7 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
     protected $translatorTextDomain = 'default';
 
     /**
-     * @throws Exception\InvalidArgumentException if ext/intl is not present
+     * @throws Exception\ExtensionsNotLoadedException if ext/intl is not present
      */
     public function __construct()
     {

--- a/library/Zend/I18n/View/Helper/CurrencyFormat.php
+++ b/library/Zend/I18n/View/Helper/CurrencyFormat.php
@@ -48,7 +48,7 @@ class CurrencyFormat extends AbstractHelper
     protected $formatters = array();
 
     /**
-     * @throws Exception\InvalidArgumentException if ext/intl is not present
+     * @throws Exception\ExtensionNotLoadedException if ext/intl is not present
      */
     public function __construct()
     {

--- a/library/Zend/I18n/View/Helper/CurrencyFormat.php
+++ b/library/Zend/I18n/View/Helper/CurrencyFormat.php
@@ -11,6 +11,7 @@ namespace Zend\I18n\View\Helper;
 
 use Locale;
 use NumberFormatter;
+use Zend\I18n\Exception;
 use Zend\View\Helper\AbstractHelper;
 
 /**
@@ -45,6 +46,19 @@ class CurrencyFormat extends AbstractHelper
      * @var array
      */
     protected $formatters = array();
+
+    /**
+     * @throws Exception\InvalidArgumentException if ext/intl is not present
+     */
+    public function __construct()
+    {
+        if (!extension_loaded('intl')) {
+            throw new Exception\ExtensionNotLoadedException(sprintf(
+                '%s component requires the intl PHP extension',
+                __NAMESPACE__
+            ));
+        }
+    }
 
     /**
      * The 3-letter ISO 4217 currency code indicating the currency to use.

--- a/library/Zend/I18n/View/Helper/DateFormat.php
+++ b/library/Zend/I18n/View/Helper/DateFormat.php
@@ -42,7 +42,7 @@ class DateFormat extends AbstractHelper
     protected $formatters = array();
 
     /**
-     * @throws Exception\InvalidArgumentException if ext/intl is not present
+     * @throws Exception\ExtensionNotLoadedException if ext/intl is not present
      */
     public function __construct()
     {

--- a/library/Zend/I18n/View/Helper/DateFormat.php
+++ b/library/Zend/I18n/View/Helper/DateFormat.php
@@ -42,6 +42,19 @@ class DateFormat extends AbstractHelper
     protected $formatters = array();
 
     /**
+     * @throws Exception\InvalidArgumentException if ext/intl is not present
+     */
+    public function __construct()
+    {
+        if (!extension_loaded('intl')) {
+            throw new Exception\ExtensionNotLoadedException(sprintf(
+                '%s component requires the intl PHP extension',
+                __NAMESPACE__
+            ));
+        }
+    }
+
+    /**
      * Set timezone to use instead of the default.
      *
      * @param string $timezone

--- a/library/Zend/I18n/View/Helper/NumberFormat.php
+++ b/library/Zend/I18n/View/Helper/NumberFormat.php
@@ -11,6 +11,7 @@ namespace Zend\I18n\View\Helper;
 
 use Locale;
 use NumberFormatter;
+use Zend\I18n\Exception;
 use Zend\View\Helper\AbstractHelper;
 
 /**
@@ -45,6 +46,19 @@ class NumberFormat extends AbstractHelper
      * @var array
      */
     protected $formatters = array();
+
+    /**
+     * @throws Exception\InvalidArgumentException if ext/intl is not present
+     */
+    public function __construct()
+    {
+        if (!extension_loaded('intl')) {
+            throw new Exception\ExtensionNotLoadedException(sprintf(
+                '%s component requires the intl PHP extension',
+                __NAMESPACE__
+            ));
+        }
+    }
 
     /**
      * Set format style to use instead of the default.

--- a/library/Zend/I18n/View/Helper/NumberFormat.php
+++ b/library/Zend/I18n/View/Helper/NumberFormat.php
@@ -48,7 +48,7 @@ class NumberFormat extends AbstractHelper
     protected $formatters = array();
 
     /**
-     * @throws Exception\InvalidArgumentException if ext/intl is not present
+     * @throws Exception\ExtensionNotLoadedException if ext/intl is not present
      */
     public function __construct()
     {

--- a/library/Zend/I18n/View/Helper/Plural.php
+++ b/library/Zend/I18n/View/Helper/Plural.php
@@ -35,7 +35,7 @@ class Plural extends AbstractHelper
     protected $rule;
 
     /**
-     * @throws Exception\InvalidArgumentException if ext/intl is not present
+     * @throws Exception\ExtensionNotLoadedException if ext/intl is not present
      */
     public function __construct()
     {

--- a/library/Zend/I18n/View/Helper/Plural.php
+++ b/library/Zend/I18n/View/Helper/Plural.php
@@ -35,6 +35,19 @@ class Plural extends AbstractHelper
     protected $rule;
 
     /**
+     * @throws Exception\InvalidArgumentException if ext/intl is not present
+     */
+    public function __construct()
+    {
+        if (!extension_loaded('intl')) {
+            throw new Exception\ExtensionNotLoadedException(sprintf(
+                '%s component requires the intl PHP extension',
+                __NAMESPACE__
+            ));
+        }
+    }
+
+    /**
      * Set the plural rule to use
      *
      * @param  PluralRule|string $pluralRule

--- a/library/Zend/I18n/composer.json
+++ b/library/Zend/I18n/composer.json
@@ -14,10 +14,10 @@
     "target-dir": "Zend/I18n",
     "require": {
         "php": ">=5.3.3",
-        "ext-intl": "*",
         "zendframework/zend-stdlib": "self.version"
     },
     "suggest": {
+        "ext-intl": "Required for most features of Zend\\I18n; included in default builds of PHP",
         "zendframework/zend-filter": "You should install this package to use the provided filters",
         "zendframework/zend-validator": "You should install this package to use the provided validators",
         "zendframework/zend-view": "You should install this package to use the provided view helpers"


### PR DESCRIPTION
This commit provides a better fix for #4284 by making `ext/intl` an _optional_ dependency, but enforcing its requirement via tests to `extension_loaded` and raising an `ExtensionNotLoadedException` when not found.
