### PR TITLE
Suggestion: Don't render empty module console information

### DIFF
--- a/library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php
@@ -221,8 +221,14 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
                     continue; // this module does not provide a banner
                 }
 
+                // Don't render empty completely empty lines
+                $banner = $module->getConsoleBanner($console);
+                if ($banner == '') {
+                    continue;
+                }
+
                 // We colorize each banners in blue for visual emphasis
-                $banners[] = $console->colorize($module->getConsoleBanner($console), ColorInterface::BLUE);
+                $banners[] = $console->colorize($banner, ColorInterface::BLUE);
             }
         }
 

--- a/library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php
@@ -281,10 +281,10 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
                 $usage = $module->getConsoleUsage($console);
 
                 // Normalize what we got from the module or discard
-                if (is_array($usage)) {
+                if (is_array($usage) && !empty($usage)) {
                     array_unshift($usage, $moduleName);
                     $usageInfo[$name] = $usage;
-                } elseif (is_string($usage)) {
+                } elseif (is_string($usage) && ($usage != '')) {
                     $usageInfo[$name] = array($moduleName, $usage);
                 }
             }


### PR DESCRIPTION
This change will allow modules to provide the console usage and banner
information dynamically and returning an empty array/string when nothing
should be rendered. 

A module can now check the environment and capabilities before returning
the information.
