### PR TITLE
Method annotations of Zend\Validator\Hostname constructor

### DIFF
--- a/library/Zend/Validator/Hostname.php
+++ b/library/Zend/Validator/Hostname.php
@@ -304,13 +304,9 @@ class Hostname extends AbstractValidator
     );
 
     /**
-     * Sets validator options
+     * Sets validator options.
      *
-     * @param integer $allow       OPTIONAL Set what types of hostname to allow (default ALLOW_DNS)
-     * @param  bool $validateIdn OPTIONAL Set whether IDN domains are validated (default true)
-     * @param  bool $validateTld OPTIONAL Set whether the TLD element of a hostname is validated (default true)
-     * @param Ip      $ipValidator OPTIONAL
-     * @see http://www.iana.org/cctld/specifications-policies-cctlds-01apr02.htm  Technical Specifications for ccTLDs
+     * @param array $options
      */
     public function __construct($options = array())
     {

--- a/library/Zend/Validator/Hostname.php
+++ b/library/Zend/Validator/Hostname.php
@@ -306,7 +306,11 @@ class Hostname extends AbstractValidator
     /**
      * Sets validator options.
      *
-     * @param array $options
+     * @param int  $allow       OPTIONAL Set what types of hostname to allow (default ALLOW_DNS)
+     * @param bool $useIdnCheck OPTIONAL Set whether IDN domains are validated (default true)
+     * @param bool $useTldCheck Set whether the TLD element of a hostname is validated (default true)
+     * @param Ip   $ipValidator OPTIONAL
+     * @see http://www.iana.org/cctld/specifications-policies-cctlds-01apr02.htm  Technical Specifications for ccTLDs
      */
     public function __construct($options = array())
     {


### PR DESCRIPTION
Method annotations of `Zend\Validator\Hostname` constructor are out of sync.
