### PR TITLE
Allow GenericHeader to accept empty values

### DIFF
--- a/library/Zend/Http/Header/GenericHeader.php
+++ b/library/Zend/Http/Header/GenericHeader.php
@@ -47,11 +47,11 @@ class GenericHeader implements HeaderInterface
      */
     public function __construct($fieldName = null, $fieldValue = null)
     {
-        if ($fieldName) {
+        if ($fieldName !== null) {
             $this->setFieldName($fieldName);
         }
 
-        if ($fieldValue) {
+        if ($fieldValue !== null) {
             $this->setFieldValue($fieldValue);
         }
     }

--- a/library/Zend/Mail/Header/GenericHeader.php
+++ b/library/Zend/Mail/Header/GenericHeader.php
@@ -50,11 +50,11 @@ class GenericHeader implements HeaderInterface, UnstructuredInterface
      */
     public function __construct($fieldName = null, $fieldValue = null)
     {
-        if ($fieldName) {
+        if ($fieldName !== null) {
             $this->setFieldName($fieldName);
         }
 
-        if ($fieldValue) {
+        if ($fieldValue !== null) {
             $this->setFieldValue($fieldValue);
         }
     }


### PR DESCRIPTION
Currently if you try to parse line like this:
  X-Custom-Header: 0
it will not parse value as string "0" casts to false.
