### PR TITLE
Multiple assertions on the same rule set

### DIFF
--- a/tests/ZendTest/Permissions/Acl/AclTest.php
+++ b/tests/ZendTest/Permissions/Acl/AclTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Zend Framework (http://framework.zend.com/)
  *
@@ -20,8 +21,8 @@ use Zend\Permissions\Acl\Resource;
  * @subpackage UnitTests
  * @group      Zend_Acl
  */
-class AclTest extends \PHPUnit_Framework_TestCase
-{
+class AclTest extends \PHPUnit_Framework_TestCase {
+
     /**
      * ACL object for each test method
      *
@@ -34,8 +35,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function setUp()
-    {
+    public function setUp() {
         $this->_acl = new Acl\Acl();
     }
 
@@ -44,12 +44,11 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleRegistryAddAndGetOne()
-    {
+    public function testRoleRegistryAddAndGetOne() {
         $roleGuest = new Role\GenericRole('guest');
 
         $role = $this->_acl->addRole($roleGuest)
-                          ->getRole($roleGuest->getRoleId());
+                ->getRole($roleGuest->getRoleId());
         $this->assertTrue($roleGuest === $role);
         $role = $this->_acl->getRole($roleGuest);
         $this->assertTrue($roleGuest === $role);
@@ -58,10 +57,9 @@ class AclTest extends \PHPUnit_Framework_TestCase
     /**
      * Ensures that basic addition and retrieval of a single Resource works
      */
-    public function testRoleAddAndGetOneByString()
-    {
+    public function testRoleAddAndGetOneByString() {
         $role = $this->_acl->addRole('area')
-                           ->getRole('area');
+                ->getRole('area');
         $this->assertInstanceOf('Zend\Permissions\Acl\Role\RoleInterface', $role);
         $this->assertEquals('area', $role->getRoleId());
     }
@@ -71,11 +69,10 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleRegistryRemoveOne()
-    {
+    public function testRoleRegistryRemoveOne() {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                   ->removeRole($roleGuest);
+                ->removeRole($roleGuest);
         $this->assertFalse($this->_acl->hasRole($roleGuest));
     }
 
@@ -84,8 +81,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleRegistryRemoveOneNonExistent()
-    {
+    public function testRoleRegistryRemoveOneNonExistent() {
         $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException', 'not found');
         $this->_acl->removeRole('nonexistent');
     }
@@ -95,11 +91,10 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleRegistryRemoveAll()
-    {
+    public function testRoleRegistryRemoveAll() {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                   ->removeRoleAll();
+                ->removeRoleAll();
         $this->assertFalse($this->_acl->hasRole($roleGuest));
     }
 
@@ -108,8 +103,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleRegistryAddInheritsNonExistent()
-    {
+    public function testRoleRegistryAddInheritsNonExistent() {
         $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException');
         $this->_acl->addRole(new Role\GenericRole('guest'), 'nonexistent');
     }
@@ -119,10 +113,8 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleRegistryAddNotRole()
-    {
-        $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException',
-                                    'addRole() expects $role to be of type Zend\Permissions\Acl\Role');
+    public function testRoleRegistryAddNotRole() {
+        $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException', 'addRole() expects $role to be of type Zend\Permissions\Acl\Role');
         $this->_acl->addRole(new \stdClass, 'guest');
     }
 
@@ -131,8 +123,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleRegistryInheritsNonExistent()
-    {
+    public function testRoleRegistryInheritsNonExistent() {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest);
         try {
@@ -154,15 +145,14 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleRegistryInherits()
-    {
-        $roleGuest  = new Role\GenericRole('guest');
+    public function testRoleRegistryInherits() {
+        $roleGuest = new Role\GenericRole('guest');
         $roleMember = new Role\GenericRole('member');
         $roleEditor = new Role\GenericRole('editor');
         $roleRegistry = new Role\Registry();
         $roleRegistry->add($roleGuest)
-                     ->add($roleMember, $roleGuest->getRoleId())
-                     ->add($roleEditor, $roleMember);
+                ->add($roleMember, $roleGuest->getRoleId())
+                ->add($roleEditor, $roleMember);
         $this->assertTrue(0 === count($roleRegistry->getParents($roleGuest)));
         $roleMemberParents = $roleRegistry->getParents($roleMember);
         $this->assertTrue(1 === count($roleMemberParents));
@@ -186,15 +176,14 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleRegistryInheritsMultipleArray()
-    {
+    public function testRoleRegistryInheritsMultipleArray() {
         $roleParent1 = new Role\GenericRole('parent1');
         $roleParent2 = new Role\GenericRole('parent2');
-        $roleChild   = new Role\GenericRole('child');
+        $roleChild = new Role\GenericRole('child');
         $roleRegistry = new Role\Registry();
         $roleRegistry->add($roleParent1)
-                     ->add($roleParent2)
-                     ->add($roleChild, array($roleParent1, $roleParent2));
+                ->add($roleParent2)
+                ->add($roleChild, array($roleParent1, $roleParent2));
         $roleChildParents = $roleRegistry->getParents($roleChild);
         $this->assertTrue(2 === count($roleChildParents));
         $i = 1;
@@ -216,18 +205,16 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleRegistryInheritsMultipleTraversable()
-    {
+    public function testRoleRegistryInheritsMultipleTraversable() {
         $roleParent1 = new Role\GenericRole('parent1');
         $roleParent2 = new Role\GenericRole('parent2');
-        $roleChild   = new Role\GenericRole('child');
+        $roleChild = new Role\GenericRole('child');
         $roleRegistry = new Role\Registry();
         $roleRegistry->add($roleParent1)
-            ->add($roleParent2)
-            ->add(
-                $roleChild,
-                new \ArrayIterator(array($roleParent1, $roleParent2))
-            );
+                ->add($roleParent2)
+                ->add(
+                        $roleChild, new \ArrayIterator(array($roleParent1, $roleParent2))
+        );
         $roleChildParents = $roleRegistry->getParents($roleChild);
         $this->assertTrue(2 === count($roleChildParents));
         $i = 1;
@@ -249,13 +236,12 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleRegistryDuplicate()
-    {
+    public function testRoleRegistryDuplicate() {
         $roleGuest = new Role\GenericRole('guest');
         $roleRegistry = new Role\Registry();
         $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException', 'already exists');
         $roleRegistry->add($roleGuest)
-                     ->add($roleGuest);
+                ->add($roleGuest);
     }
 
     /**
@@ -263,14 +249,13 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleRegistryDuplicateId()
-    {
+    public function testRoleRegistryDuplicateId() {
         $roleGuest1 = new Role\GenericRole('guest');
         $roleGuest2 = new Role\GenericRole('guest');
         $roleRegistry = new Role\Registry();
         $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException', 'already exists');
         $roleRegistry->add($roleGuest1)
-                     ->add($roleGuest2);
+                ->add($roleGuest2);
     }
 
     /**
@@ -278,11 +263,10 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testResourceAddAndGetOne()
-    {
+    public function testResourceAddAndGetOne() {
         $resourceArea = new Resource\GenericResource('area');
         $resource = $this->_acl->addResource($resourceArea)
-                          ->getResource($resourceArea->getResourceId());
+                ->getResource($resourceArea->getResourceId());
         $this->assertTrue($resourceArea === $resource);
         $resource = $this->_acl->getResource($resourceArea);
         $this->assertTrue($resourceArea === $resource);
@@ -291,10 +275,9 @@ class AclTest extends \PHPUnit_Framework_TestCase
     /**
      * Ensures that basic addition and retrieval of a single Resource works
      */
-    public function testResourceAddAndGetOneByString()
-    {
+    public function testResourceAddAndGetOneByString() {
         $resource = $this->_acl->addResource('area')
-                          ->getResource('area');
+                ->getResource('area');
         $this->assertInstanceOf('Zend\Permissions\Acl\Resource\ResourceInterface', $resource);
         $this->assertEquals('area', $resource->getResourceId());
     }
@@ -304,11 +287,10 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @group ZF-1167
      */
-    public function testResourceAddAndGetOneWithAddResourceMethod()
-    {
+    public function testResourceAddAndGetOneWithAddResourceMethod() {
         $resourceArea = new Resource\GenericResource('area');
         $resource = $this->_acl->addResource($resourceArea)
-                               ->getResource($resourceArea->getResourceId());
+                ->getResource($resourceArea->getResourceId());
         $this->assertTrue($resourceArea === $resource);
         $resource = $this->_acl->getResource($resourceArea);
         $this->assertTrue($resourceArea === $resource);
@@ -319,11 +301,10 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testResourceRemoveOne()
-    {
+    public function testResourceRemoveOne() {
         $resourceArea = new Resource\GenericResource('area');
         $this->_acl->addResource($resourceArea)
-                   ->removeResource($resourceArea);
+                ->removeResource($resourceArea);
         $this->assertFalse($this->_acl->hasResource($resourceArea));
     }
 
@@ -332,8 +313,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testResourceRemoveOneNonExistent()
-    {
+    public function testResourceRemoveOneNonExistent() {
         $this->setExpectedException('Zend\Permissions\Acl\Exception\ExceptionInterface', 'not found');
         $this->_acl->removeResource('nonexistent');
     }
@@ -343,11 +323,10 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testResourceRemoveAll()
-    {
+    public function testResourceRemoveAll() {
         $resourceArea = new Resource\GenericResource('area');
         $this->_acl->addResource($resourceArea)
-                   ->removeResourceAll();
+                ->removeResourceAll();
         $this->assertFalse($this->_acl->hasResource($resourceArea));
     }
 
@@ -356,8 +335,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testResourceAddInheritsNonExistent()
-    {
+    public function testResourceAddInheritsNonExistent() {
         $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException', 'does not exist');
         $this->_acl->addResource(new Resource\GenericResource('area'), 'nonexistent');
     }
@@ -367,10 +345,8 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testResourceRegistryAddNotResource()
-    {
-        $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException',
-                                    'addResource() expects $resource to be of type Zend\Permissions\Acl\Resource');
+    public function testResourceRegistryAddNotResource() {
+        $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException', 'addResource() expects $resource to be of type Zend\Permissions\Acl\Resource');
         $this->_acl->addResource(new \stdClass);
     }
 
@@ -379,8 +355,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testResourceInheritsNonExistent()
-    {
+    public function testResourceInheritsNonExistent() {
         $resourceArea = new Resource\GenericResource('area');
         $this->_acl->addResource($resourceArea);
         try {
@@ -402,14 +377,13 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testResourceInherits()
-    {
-        $resourceCity     = new Resource\GenericResource('city');
+    public function testResourceInherits() {
+        $resourceCity = new Resource\GenericResource('city');
         $resourceBuilding = new Resource\GenericResource('building');
-        $resourceRoom     = new Resource\GenericResource('room');
+        $resourceRoom = new Resource\GenericResource('room');
         $this->_acl->addResource($resourceCity)
-                   ->addResource($resourceBuilding, $resourceCity->getResourceId())
-                   ->addResource($resourceRoom, $resourceBuilding);
+                ->addResource($resourceBuilding, $resourceCity->getResourceId())
+                ->addResource($resourceRoom, $resourceBuilding);
         $this->assertTrue($this->_acl->inheritsResource($resourceBuilding, $resourceCity, true));
         $this->assertTrue($this->_acl->inheritsResource($resourceRoom, $resourceBuilding, true));
         $this->assertTrue($this->_acl->inheritsResource($resourceRoom, $resourceCity));
@@ -425,12 +399,11 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testResourceDuplicate()
-    {
+    public function testResourceDuplicate() {
         $this->setExpectedException('Zend\Permissions\Acl\Exception\ExceptionInterface', 'already exists');
         $resourceArea = new Resource\GenericResource('area');
         $this->_acl->addResource($resourceArea)
-                   ->addResource($resourceArea);
+                ->addResource($resourceArea);
     }
 
     /**
@@ -438,13 +411,12 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testResourceDuplicateId()
-    {
+    public function testResourceDuplicateId() {
         $this->setExpectedException('Zend\Permissions\Acl\Exception\ExceptionInterface', 'already exists');
         $resourceArea1 = new Resource\GenericResource('area');
         $resourceArea2 = new Resource\GenericResource('area');
         $this->_acl->addResource($resourceArea1)
-                   ->addResource($resourceArea2);
+                ->addResource($resourceArea2);
     }
 
     /**
@@ -452,8 +424,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testIsAllowedNonExistent()
-    {
+    public function testIsAllowedNonExistent() {
         try {
             $this->_acl->isAllowed('nonexistent');
             $this->fail('Expected Zend\Permissions\Acl\Role\Exception\ExceptionInterface not thrown upon non-existent Role');
@@ -473,8 +444,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testDefaultDeny()
-    {
+    public function testDefaultDeny() {
         $this->assertFalse($this->_acl->isAllowed());
     }
 
@@ -483,8 +453,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testDefaultAssert()
-    {
+    public function testDefaultAssert() {
         $this->_acl->deny(null, null, null, new TestAsset\MockAssertion(false));
         $this->assertTrue($this->_acl->isAllowed());
         $this->assertTrue($this->_acl->isAllowed(null, null, 'somePrivilege'));
@@ -495,8 +464,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testDefaultRuleSet()
-    {
+    public function testDefaultRuleSet() {
         $this->_acl->allow();
         $this->assertTrue($this->_acl->isAllowed());
         $this->_acl->deny();
@@ -508,8 +476,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testDefaultPrivilegeDeny()
-    {
+    public function testDefaultPrivilegeDeny() {
         $this->assertFalse($this->_acl->isAllowed(null, null, 'somePrivilege'));
     }
 
@@ -518,8 +485,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testDefaultRuleSetPrivilege()
-    {
+    public function testDefaultRuleSetPrivilege() {
         $this->_acl->allow();
         $this->assertTrue($this->_acl->isAllowed(null, null, 'somePrivilege'));
         $this->_acl->deny();
@@ -531,8 +497,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testPrivilegeAllow()
-    {
+    public function testPrivilegeAllow() {
         $this->_acl->allow(null, null, 'somePrivilege');
         $this->assertTrue($this->_acl->isAllowed(null, null, 'somePrivilege'));
     }
@@ -542,8 +507,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testPrivilegeDeny()
-    {
+    public function testPrivilegeDeny() {
         $this->_acl->allow();
         $this->_acl->deny(null, null, 'somePrivilege');
         $this->assertFalse($this->_acl->isAllowed(null, null, 'somePrivilege'));
@@ -554,8 +518,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testPrivileges()
-    {
+    public function testPrivileges() {
         $this->_acl->allow(null, null, array('p1', 'p2', 'p3'));
         $this->assertTrue($this->_acl->isAllowed(null, null, 'p1'));
         $this->assertTrue($this->_acl->isAllowed(null, null, 'p2'));
@@ -573,8 +536,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testPrivilegeAssert()
-    {
+    public function testPrivilegeAssert() {
         $this->_acl->allow(null, null, 'somePrivilege', new TestAsset\MockAssertion(true));
         $this->assertTrue($this->_acl->isAllowed(null, null, 'somePrivilege'));
         $this->_acl->allow(null, null, 'somePrivilege', new TestAsset\MockAssertion(false));
@@ -586,8 +548,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleDefaultDeny()
-    {
+    public function testRoleDefaultDeny() {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest);
         $this->assertFalse($this->_acl->isAllowed($roleGuest));
@@ -598,11 +559,10 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleDefaultRuleSet()
-    {
+    public function testRoleDefaultRuleSet() {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                   ->allow($roleGuest);
+                ->allow($roleGuest);
         $this->assertTrue($this->_acl->isAllowed($roleGuest));
         $this->_acl->deny($roleGuest);
         $this->assertFalse($this->_acl->isAllowed($roleGuest));
@@ -613,8 +573,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleDefaultPrivilegeDeny()
-    {
+    public function testRoleDefaultPrivilegeDeny() {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest);
         $this->assertFalse($this->_acl->isAllowed($roleGuest, null, 'somePrivilege'));
@@ -625,11 +584,10 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleDefaultRuleSetPrivilege()
-    {
+    public function testRoleDefaultRuleSetPrivilege() {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                   ->allow($roleGuest);
+                ->allow($roleGuest);
         $this->assertTrue($this->_acl->isAllowed($roleGuest, null, 'somePrivilege'));
         $this->_acl->deny($roleGuest);
         $this->assertFalse($this->_acl->isAllowed($roleGuest, null, 'somePrivilege'));
@@ -640,11 +598,10 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRolePrivilegeAllow()
-    {
+    public function testRolePrivilegeAllow() {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                   ->allow($roleGuest, null, 'somePrivilege');
+                ->allow($roleGuest, null, 'somePrivilege');
         $this->assertTrue($this->_acl->isAllowed($roleGuest, null, 'somePrivilege'));
     }
 
@@ -653,12 +610,11 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRolePrivilegeDeny()
-    {
+    public function testRolePrivilegeDeny() {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                   ->allow($roleGuest)
-                   ->deny($roleGuest, null, 'somePrivilege');
+                ->allow($roleGuest)
+                ->deny($roleGuest, null, 'somePrivilege');
         $this->assertFalse($this->_acl->isAllowed($roleGuest, null, 'somePrivilege'));
     }
 
@@ -667,11 +623,10 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRolePrivileges()
-    {
+    public function testRolePrivileges() {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                   ->allow($roleGuest, null, array('p1', 'p2', 'p3'));
+                ->allow($roleGuest, null, array('p1', 'p2', 'p3'));
         $this->assertTrue($this->_acl->isAllowed($roleGuest, null, 'p1'));
         $this->assertTrue($this->_acl->isAllowed($roleGuest, null, 'p2'));
         $this->assertTrue($this->_acl->isAllowed($roleGuest, null, 'p3'));
@@ -688,11 +643,10 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRolePrivilegeAssert()
-    {
+    public function testRolePrivilegeAssert() {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                   ->allow($roleGuest, null, 'somePrivilege', new TestAsset\MockAssertion(true));
+                ->allow($roleGuest, null, 'somePrivilege', new TestAsset\MockAssertion(true));
         $this->assertTrue($this->_acl->isAllowed($roleGuest, null, 'somePrivilege'));
         $this->_acl->allow($roleGuest, null, 'somePrivilege', new TestAsset\MockAssertion(false));
         $this->assertFalse($this->_acl->isAllowed($roleGuest, null, 'somePrivilege'));
@@ -703,8 +657,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRemoveDefaultDeny()
-    {
+    public function testRemoveDefaultDeny() {
         $this->assertFalse($this->_acl->isAllowed());
         $this->_acl->removeDeny();
         $this->assertFalse($this->_acl->isAllowed());
@@ -715,8 +668,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRemoveDefaultDenyAssert()
-    {
+    public function testRemoveDefaultDenyAssert() {
         $this->_acl->deny(null, null, null, new TestAsset\MockAssertion(false));
         $this->assertTrue($this->_acl->isAllowed());
         $this->_acl->removeDeny();
@@ -728,8 +680,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRemoveDefaultAllow()
-    {
+    public function testRemoveDefaultAllow() {
         $this->_acl->allow();
         $this->assertTrue($this->_acl->isAllowed());
         $this->_acl->removeAllow();
@@ -741,8 +692,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRemoveDefaultAllowNonExistent()
-    {
+    public function testRemoveDefaultAllowNonExistent() {
         $this->_acl->removeAllow();
         $this->assertFalse($this->_acl->isAllowed());
     }
@@ -752,10 +702,9 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRemoveDefaultDenyNonExistent()
-    {
+    public function testRemoveDefaultDenyNonExistent() {
         $this->_acl->allow()
-                   ->removeDeny();
+                ->removeDeny();
         $this->assertTrue($this->_acl->isAllowed());
     }
 
@@ -765,15 +714,14 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleDefaultAllowRuleWithResourceDenyRule()
-    {
+    public function testRoleDefaultAllowRuleWithResourceDenyRule() {
         $this->_acl->addRole(new Role\GenericRole('guest'))
-                   ->addRole(new Role\GenericRole('staff'), 'guest')
-                   ->addResource(new Resource\GenericResource('area1'))
-                   ->addResource(new Resource\GenericResource('area2'))
-                   ->deny()
-                   ->allow('staff')
-                   ->deny('staff', array('area1', 'area2'));
+                ->addRole(new Role\GenericRole('staff'), 'guest')
+                ->addResource(new Resource\GenericResource('area1'))
+                ->addResource(new Resource\GenericResource('area2'))
+                ->deny()
+                ->allow('staff')
+                ->deny('staff', array('area1', 'area2'));
         $this->assertFalse($this->_acl->isAllowed('staff', 'area1'));
     }
 
@@ -783,13 +731,12 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRoleDefaultAllowRuleWithPrivilegeDenyRule()
-    {
+    public function testRoleDefaultAllowRuleWithPrivilegeDenyRule() {
         $this->_acl->addRole(new Role\GenericRole('guest'))
-                   ->addRole(new Role\GenericRole('staff'), 'guest')
-                   ->deny()
-                   ->allow('staff')
-                   ->deny('staff', null, array('privilege1', 'privilege2'));
+                ->addRole(new Role\GenericRole('staff'), 'guest')
+                ->deny()
+                ->allow('staff')
+                ->deny('staff', null, array('privilege1', 'privilege2'));
         $this->assertFalse($this->_acl->isAllowed('staff', null, 'privilege1'));
     }
 
@@ -798,8 +745,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRulesRemove()
-    {
+    public function testRulesRemove() {
         $this->_acl->allow(null, null, array('privilege1', 'privilege2'));
         $this->assertFalse($this->_acl->isAllowed());
         $this->assertTrue($this->_acl->isAllowed(null, null, 'privilege1'));
@@ -814,10 +760,9 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRuleRoleRemove()
-    {
+    public function testRuleRoleRemove() {
         $this->_acl->addRole(new Role\GenericRole('guest'))
-                   ->allow('guest');
+                ->allow('guest');
         $this->assertTrue($this->_acl->isAllowed('guest'));
         $this->_acl->removeRole('guest');
         try {
@@ -835,10 +780,9 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRuleRoleRemoveAll()
-    {
+    public function testRuleRoleRemoveAll() {
         $this->_acl->addRole(new Role\GenericRole('guest'))
-                   ->allow('guest');
+                ->allow('guest');
         $this->assertTrue($this->_acl->isAllowed('guest'));
         $this->_acl->removeRoleAll();
         try {
@@ -856,10 +800,9 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRulesResourceRemove()
-    {
+    public function testRulesResourceRemove() {
         $this->_acl->addResource(new Resource\GenericResource('area'))
-                   ->allow(null, 'area');
+                ->allow(null, 'area');
         $this->assertTrue($this->_acl->isAllowed(null, 'area'));
         $this->_acl->removeResource('area');
         try {
@@ -877,10 +820,9 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRulesResourceRemoveAll()
-    {
+    public function testRulesResourceRemoveAll() {
         $this->_acl->addResource(new Resource\GenericResource('area'))
-                   ->allow(null, 'area');
+                ->allow(null, 'area');
         $this->assertTrue($this->_acl->isAllowed(null, 'area'));
         $this->_acl->removeResourceAll();
         try {
@@ -898,13 +840,12 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testCMSExample()
-    {
+    public function testCMSExample() {
         // Add some roles to the Role registry
         $this->_acl->addRole(new Role\GenericRole('guest'))
-                   ->addRole(new Role\GenericRole('staff'), 'guest')  // staff inherits permissions from guest
-                   ->addRole(new Role\GenericRole('editor'), 'staff') // editor inherits permissions from staff
-                   ->addRole(new Role\GenericRole('administrator'));
+                ->addRole(new Role\GenericRole('staff'), 'guest')  // staff inherits permissions from guest
+                ->addRole(new Role\GenericRole('editor'), 'staff') // editor inherits permissions from staff
+                ->addRole(new Role\GenericRole('administrator'));
 
         // Guest may only view content
         $this->_acl->allow('guest', null, 'view');
@@ -962,11 +903,11 @@ class AclTest extends \PHPUnit_Framework_TestCase
 
         // Some checks on specific areas, which inherit access controls from the root ACL node
         $this->_acl->addResource(new Resource\GenericResource('newsletter'))
-                   ->addResource(new Resource\GenericResource('pending'), 'newsletter')
-                   ->addResource(new Resource\GenericResource('gallery'))
-                   ->addResource(new Resource\GenericResource('profiles', 'gallery'))
-                   ->addResource(new Resource\GenericResource('config'))
-                   ->addResource(new Resource\GenericResource('hosts'), 'config');
+                ->addResource(new Resource\GenericResource('pending'), 'newsletter')
+                ->addResource(new Resource\GenericResource('gallery'))
+                ->addResource(new Resource\GenericResource('profiles', 'gallery'))
+                ->addResource(new Resource\GenericResource('config'))
+                ->addResource(new Resource\GenericResource('hosts'), 'config');
         $this->assertTrue($this->_acl->isAllowed('guest', 'pending', 'view'));
         $this->assertTrue($this->_acl->isAllowed('staff', 'profiles', 'revise'));
         $this->assertTrue($this->_acl->isAllowed('staff', 'pending', 'view'));
@@ -980,13 +921,12 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->_acl->addRole(new Role\GenericRole('marketing'), 'staff');
 
         // Refine the privilege sets for more specific needs
-
         // Allow marketing to publish and archive newsletters
         $this->_acl->allow('marketing', 'newsletter', array('publish', 'archive'));
 
         // Allow marketing to publish and archive latest news
         $this->_acl->addResource(new Resource\GenericResource('news'))
-                   ->addResource(new Resource\GenericResource('latest'), 'news');
+                ->addResource(new Resource\GenericResource('latest'), 'news');
         $this->_acl->allow('marketing', 'latest', array('publish', 'archive'));
 
         // Deny staff (and marketing, by inheritance) rights to revise latest news
@@ -1029,7 +969,6 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->_acl->isAllowed('editor', 'announcement', 'archive'));
 
         // Remove some previous permission specifications
-
         // Marketing can no longer publish and archive newsletters
         $this->_acl->removeAllow('marketing', 'newsletter', array('publish', 'archive'));
 
@@ -1057,7 +996,6 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->_acl->isAllowed('marketing', 'latest', 'publish'));
         $this->assertTrue($this->_acl->isAllowed('marketing', 'latest', 'edit'));
         $this->assertTrue($this->_acl->isAllowed('marketing', 'latest'));
-
     }
 
     /**
@@ -1066,11 +1004,10 @@ class AclTest extends \PHPUnit_Framework_TestCase
      * @return void
      * @group  ZF-2502
      */
-    public function testRoleInheritanceSupportsCheckingOnlyParents()
-    {
+    public function testRoleInheritanceSupportsCheckingOnlyParents() {
         $this->_acl->addRole(new Role\GenericRole('grandparent'))
-                   ->addRole(new Role\GenericRole('parent'), 'grandparent')
-                   ->addRole(new Role\GenericRole('child'), 'parent');
+                ->addRole(new Role\GenericRole('parent'), 'grandparent')
+                ->addRole(new Role\GenericRole('child'), 'parent');
         $this->assertFalse($this->_acl->inheritsRole('child', 'grandparent', true));
     }
 
@@ -1080,18 +1017,17 @@ class AclTest extends \PHPUnit_Framework_TestCase
      * @return void
      * @group  ZF-2234
      */
-    public function testAclInternalDFSMethodsBehaveProperly()
-    {
+    public function testAclInternalDFSMethodsBehaveProperly() {
         $acl = new TestAsset\ExtendedAclZF2234();
 
         $someResource = new Resource\GenericResource('someResource');
-        $someRole     = new Role\GenericRole('someRole');
+        $someRole = new Role\GenericRole('someRole');
 
         $acl->addResource($someResource)
-            ->addRole($someRole);
+                ->addRole($someRole);
 
-        $nullValue     = null;
-        $nullReference =& $nullValue;
+        $nullValue = null;
+        $nullReference = & $nullValue;
 
         try {
             $acl->exroleDFSVisitAllPrivileges($someRole, $someResource, $nullReference);
@@ -1122,12 +1058,10 @@ class AclTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-
     /**
      * @group ZF-1721
      */
-    public function testAclAssertionsGetProperRoleWhenInheritenceIsUsed()
-    {
+    public function testAclAssertionsGetProperRoleWhenInheritenceIsUsed() {
         $acl = $this->_loadUseCase1();
 
         $user = new Role\GenericRole('publisher');
@@ -1141,18 +1075,16 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($acl->isAllowed($user, $blogPost, 'modify'));
 
         $this->assertEquals('publisher', $assertion->lastAssertRole->getRoleId());
-
     }
 
     /**
      *
      * @group ZF-1722
      */
-    public function testAclAssertionsGetOriginalIsAllowedObjects()
-    {
+    public function testAclAssertionsGetOriginalIsAllowedObjects() {
         $acl = $this->_loadUseCase1();
 
-        $user     = new TestAsset\UseCase1\User();
+        $user = new TestAsset\UseCase1\User();
         $blogPost = new TestAsset\UseCase1\BlogPost();
 
         $this->assertTrue($acl->isAllowed($user, $blogPost, 'view'));
@@ -1171,15 +1103,13 @@ class AclTest extends \PHPUnit_Framework_TestCase
         // check to see if the last assertion has the proper objets
         $this->assertInstanceOf('ZendTest\Permissions\Acl\TestAsset\UseCase1\User', $assertion->lastAssertRole, 'Assertion did not receive proper role object');
         $this->assertInstanceOf('ZendTest\Permissions\Acl\TestAsset\UseCase1\BlogPost', $assertion->lastAssertResource, 'Assertion did not receive proper resource object');
-
     }
 
     /**
      *
      * @return Zend_Acl_UseCase1_Acl
      */
-    protected function _loadUseCase1()
-    {
+    protected function _loadUseCase1() {
         return new TestAsset\UseCase1\Acl();
     }
 
@@ -1189,15 +1119,14 @@ class AclTest extends \PHPUnit_Framework_TestCase
      *
      * @group ZF-5700
      */
-    public function testRemovingRoleAfterItWasAllowedAccessToAllResourcesGivesError()
-    {
+    public function testRemovingRoleAfterItWasAllowedAccessToAllResourcesGivesError() {
         $acl = new Acl\Acl();
         $acl->addRole(new Role\GenericRole('test0'));
         $acl->addRole(new Role\GenericRole('test1'));
         $acl->addRole(new Role\GenericRole('test2'));
         $acl->addResource(new Resource\GenericResource('Test'));
 
-        $acl->allow(null,'Test','xxx');
+        $acl->allow(null, 'Test', 'xxx');
 
         // error test
         $acl->removeRole('test0');
@@ -1212,8 +1141,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
      * Meant to test for the (in)existance of this notice:
      * "Notice: Undefined index: allPrivileges in lib/Zend/Acl.php on line 682"
      */
-    public function testMethodRemoveAllowDoesNotThrowNotice()
-    {
+    public function testMethodRemoveAllowDoesNotThrowNotice() {
         $acl = new Acl\Acl();
         $acl->addRole('admin');
         $acl->addResource('blog');
@@ -1221,30 +1149,27 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $acl->removeAllow(array('admin'), array('blog'), null);
     }
 
-    public function testRoleObjectImplementsToString()
-    {
+    public function testRoleObjectImplementsToString() {
         $role = new Role\GenericRole('_fooBar_');
-        $this->assertEquals('_fooBar_',(string)$role);
+        $this->assertEquals('_fooBar_', (string) $role);
     }
 
-    public function testResourceObjectImplementsToString()
-    {
+    public function testResourceObjectImplementsToString() {
         $resource = new Resource\GenericResource('_fooBar_');
-        $this->assertEquals('_fooBar_',(string)$resource);
+        $this->assertEquals('_fooBar_', (string) $resource);
     }
 
     /**
      * @group ZF-7973
      */
-    public function testAclPassesPrivilegeToAssertClass()
-    {
+    public function testAclPassesPrivilegeToAssertClass() {
         $assertion = new TestAsset\AssertionZF7973();
 
         $acl = new Acl\Acl();
         $acl->addRole('role');
         $acl->addResource('resource');
         $acl->allow('role', null, null, $assertion);
-        $allowed = $acl->isAllowed('role','resource','privilege', $assertion);
+        $allowed = $acl->isAllowed('role', 'resource', 'privilege', $assertion);
 
         $this->assertTrue($allowed);
     }
@@ -1252,8 +1177,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
     /**
      * @group ZF-8468
      */
-    public function testgetRoles()
-    {
+    public function testgetRoles() {
         $this->assertEquals(array(), $this->_acl->getRoles());
 
         $roleGuest = new Role\GenericRole('guest');
@@ -1262,15 +1186,14 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->_acl->addRole(new Role\GenericRole('editor'), 'staff');
         $this->_acl->addRole(new Role\GenericRole('administrator'));
 
-        $expected = array('guest', 'staff','editor','administrator');
+        $expected = array('guest', 'staff', 'editor', 'administrator');
         $this->assertEquals($expected, $this->_acl->getRoles());
     }
 
     /**
      * @group ZF-8468
      */
-    public function testgetResources()
-    {
+    public function testgetResources() {
         $this->assertEquals(array(), $this->_acl->getResources());
 
         $this->_acl->addResource(new Resource\GenericResource('someResource'));
@@ -1283,8 +1206,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
     /**
      * @group ZF-9643
      */
-    public function testRemoveAllowWithNullResourceAppliesToAllResources()
-    {
+    public function testRemoveAllowWithNullResourceAppliesToAllResources() {
         $this->_acl->addRole('guest');
         $this->_acl->addResource('blogpost');
         $this->_acl->addResource('newsletter');
@@ -1310,8 +1232,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
     /**
      * @group ZF-9643
      */
-    public function testRemoveDenyWithNullResourceAppliesToAllResources()
-    {
+    public function testRemoveDenyWithNullResourceAppliesToAllResources() {
         $this->_acl->addRole('guest');
         $this->_acl->addResource('blogpost');
         $this->_acl->addResource('newsletter');
@@ -1339,8 +1260,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
     /**
      * @group ZF2-3454
      */
-    public function testAclResourcePermissionsAreInheritedWithMultilevelResourcesAndDenyPolicy()
-    {
+    public function testAclResourcePermissionsAreInheritedWithMultilevelResourcesAndDenyPolicy() {
         $this->_acl->addRole('guest');
         $this->_acl->addResource('blogposts');
         $this->_acl->addResource('feature', 'blogposts');
@@ -1362,8 +1282,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->_acl->isAllowed('guest', 'post_2', 'comment'));
     }
 
-    public function testSetRuleWorksWithResourceInterface()
-    {
+    public function testSetRuleWorksWithResourceInterface() {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest);
 
@@ -1376,11 +1295,20 @@ class AclTest extends \PHPUnit_Framework_TestCase
     /**
      * @group 4226
      */
-    public function testAllowNullPermissionAfterResourcesExistShouldAllowAllPermissionsForRole()
-    {
+    public function testAllowNullPermissionAfterResourcesExistShouldAllowAllPermissionsForRole() {
         $this->_acl->addRole('admin');
         $this->_acl->addResource('newsletter');
         $this->_acl->allow('admin');
         $this->assertTrue($this->_acl->isAllowed('admin'));
     }
+
+    public function testMultipleAssertionRulesWithMatchingRoleResourceAndPrivilege() {
+        $this->_acl->addRole('admin');
+        $this->_acl->addResource('newsletter');
+        $this->_acl->allow('admin', 'newsletter', 'view', new TestAsset\MockAssertion(true));
+        $this->_acl->allow('admin', 'newsletter', 'view', new TestAsset\MockAssertion(false));
+
+        $this->assertTrue($this->_acl->isAllowed('admin', 'newsletter', 'view'));
+    }
+
 }

--- a/tests/ZendTest/Permissions/Acl/AclTest.php
+++ b/tests/ZendTest/Permissions/Acl/AclTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework (http://framework.zend.com/)
  *
@@ -21,8 +20,8 @@ use Zend\Permissions\Acl\Resource;
  * @subpackage UnitTests
  * @group      Zend_Acl
  */
-class AclTest extends \PHPUnit_Framework_TestCase {
-
+class AclTest extends \PHPUnit_Framework_TestCase
+{
     /**
      * ACL object for each test method
      *
@@ -35,7 +34,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp()
+    {
         $this->_acl = new Acl\Acl();
     }
 
@@ -44,11 +44,12 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleRegistryAddAndGetOne() {
+    public function testRoleRegistryAddAndGetOne()
+    {
         $roleGuest = new Role\GenericRole('guest');
 
         $role = $this->_acl->addRole($roleGuest)
-                ->getRole($roleGuest->getRoleId());
+                          ->getRole($roleGuest->getRoleId());
         $this->assertTrue($roleGuest === $role);
         $role = $this->_acl->getRole($roleGuest);
         $this->assertTrue($roleGuest === $role);
@@ -57,9 +58,10 @@ class AclTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensures that basic addition and retrieval of a single Resource works
      */
-    public function testRoleAddAndGetOneByString() {
+    public function testRoleAddAndGetOneByString()
+    {
         $role = $this->_acl->addRole('area')
-                ->getRole('area');
+                           ->getRole('area');
         $this->assertInstanceOf('Zend\Permissions\Acl\Role\RoleInterface', $role);
         $this->assertEquals('area', $role->getRoleId());
     }
@@ -69,10 +71,11 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleRegistryRemoveOne() {
+    public function testRoleRegistryRemoveOne()
+    {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                ->removeRole($roleGuest);
+                   ->removeRole($roleGuest);
         $this->assertFalse($this->_acl->hasRole($roleGuest));
     }
 
@@ -81,7 +84,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleRegistryRemoveOneNonExistent() {
+    public function testRoleRegistryRemoveOneNonExistent()
+    {
         $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException', 'not found');
         $this->_acl->removeRole('nonexistent');
     }
@@ -91,10 +95,11 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleRegistryRemoveAll() {
+    public function testRoleRegistryRemoveAll()
+    {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                ->removeRoleAll();
+                   ->removeRoleAll();
         $this->assertFalse($this->_acl->hasRole($roleGuest));
     }
 
@@ -103,7 +108,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleRegistryAddInheritsNonExistent() {
+    public function testRoleRegistryAddInheritsNonExistent()
+    {
         $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException');
         $this->_acl->addRole(new Role\GenericRole('guest'), 'nonexistent');
     }
@@ -113,8 +119,10 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleRegistryAddNotRole() {
-        $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException', 'addRole() expects $role to be of type Zend\Permissions\Acl\Role');
+    public function testRoleRegistryAddNotRole()
+    {
+        $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException',
+                                    'addRole() expects $role to be of type Zend\Permissions\Acl\Role');
         $this->_acl->addRole(new \stdClass, 'guest');
     }
 
@@ -123,7 +131,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleRegistryInheritsNonExistent() {
+    public function testRoleRegistryInheritsNonExistent()
+    {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest);
         try {
@@ -145,14 +154,15 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleRegistryInherits() {
-        $roleGuest = new Role\GenericRole('guest');
+    public function testRoleRegistryInherits()
+    {
+        $roleGuest  = new Role\GenericRole('guest');
         $roleMember = new Role\GenericRole('member');
         $roleEditor = new Role\GenericRole('editor');
         $roleRegistry = new Role\Registry();
         $roleRegistry->add($roleGuest)
-                ->add($roleMember, $roleGuest->getRoleId())
-                ->add($roleEditor, $roleMember);
+                     ->add($roleMember, $roleGuest->getRoleId())
+                     ->add($roleEditor, $roleMember);
         $this->assertTrue(0 === count($roleRegistry->getParents($roleGuest)));
         $roleMemberParents = $roleRegistry->getParents($roleMember);
         $this->assertTrue(1 === count($roleMemberParents));
@@ -176,14 +186,15 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleRegistryInheritsMultipleArray() {
+    public function testRoleRegistryInheritsMultipleArray()
+    {
         $roleParent1 = new Role\GenericRole('parent1');
         $roleParent2 = new Role\GenericRole('parent2');
-        $roleChild = new Role\GenericRole('child');
+        $roleChild   = new Role\GenericRole('child');
         $roleRegistry = new Role\Registry();
         $roleRegistry->add($roleParent1)
-                ->add($roleParent2)
-                ->add($roleChild, array($roleParent1, $roleParent2));
+                     ->add($roleParent2)
+                     ->add($roleChild, array($roleParent1, $roleParent2));
         $roleChildParents = $roleRegistry->getParents($roleChild);
         $this->assertTrue(2 === count($roleChildParents));
         $i = 1;
@@ -205,16 +216,18 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleRegistryInheritsMultipleTraversable() {
+    public function testRoleRegistryInheritsMultipleTraversable()
+    {
         $roleParent1 = new Role\GenericRole('parent1');
         $roleParent2 = new Role\GenericRole('parent2');
-        $roleChild = new Role\GenericRole('child');
+        $roleChild   = new Role\GenericRole('child');
         $roleRegistry = new Role\Registry();
         $roleRegistry->add($roleParent1)
-                ->add($roleParent2)
-                ->add(
-                        $roleChild, new \ArrayIterator(array($roleParent1, $roleParent2))
-        );
+            ->add($roleParent2)
+            ->add(
+                $roleChild,
+                new \ArrayIterator(array($roleParent1, $roleParent2))
+            );
         $roleChildParents = $roleRegistry->getParents($roleChild);
         $this->assertTrue(2 === count($roleChildParents));
         $i = 1;
@@ -236,12 +249,13 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleRegistryDuplicate() {
+    public function testRoleRegistryDuplicate()
+    {
         $roleGuest = new Role\GenericRole('guest');
         $roleRegistry = new Role\Registry();
         $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException', 'already exists');
         $roleRegistry->add($roleGuest)
-                ->add($roleGuest);
+                     ->add($roleGuest);
     }
 
     /**
@@ -249,13 +263,14 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleRegistryDuplicateId() {
+    public function testRoleRegistryDuplicateId()
+    {
         $roleGuest1 = new Role\GenericRole('guest');
         $roleGuest2 = new Role\GenericRole('guest');
         $roleRegistry = new Role\Registry();
         $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException', 'already exists');
         $roleRegistry->add($roleGuest1)
-                ->add($roleGuest2);
+                     ->add($roleGuest2);
     }
 
     /**
@@ -263,10 +278,11 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testResourceAddAndGetOne() {
+    public function testResourceAddAndGetOne()
+    {
         $resourceArea = new Resource\GenericResource('area');
         $resource = $this->_acl->addResource($resourceArea)
-                ->getResource($resourceArea->getResourceId());
+                          ->getResource($resourceArea->getResourceId());
         $this->assertTrue($resourceArea === $resource);
         $resource = $this->_acl->getResource($resourceArea);
         $this->assertTrue($resourceArea === $resource);
@@ -275,9 +291,10 @@ class AclTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensures that basic addition and retrieval of a single Resource works
      */
-    public function testResourceAddAndGetOneByString() {
+    public function testResourceAddAndGetOneByString()
+    {
         $resource = $this->_acl->addResource('area')
-                ->getResource('area');
+                          ->getResource('area');
         $this->assertInstanceOf('Zend\Permissions\Acl\Resource\ResourceInterface', $resource);
         $this->assertEquals('area', $resource->getResourceId());
     }
@@ -287,10 +304,11 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @group ZF-1167
      */
-    public function testResourceAddAndGetOneWithAddResourceMethod() {
+    public function testResourceAddAndGetOneWithAddResourceMethod()
+    {
         $resourceArea = new Resource\GenericResource('area');
         $resource = $this->_acl->addResource($resourceArea)
-                ->getResource($resourceArea->getResourceId());
+                               ->getResource($resourceArea->getResourceId());
         $this->assertTrue($resourceArea === $resource);
         $resource = $this->_acl->getResource($resourceArea);
         $this->assertTrue($resourceArea === $resource);
@@ -301,10 +319,11 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testResourceRemoveOne() {
+    public function testResourceRemoveOne()
+    {
         $resourceArea = new Resource\GenericResource('area');
         $this->_acl->addResource($resourceArea)
-                ->removeResource($resourceArea);
+                   ->removeResource($resourceArea);
         $this->assertFalse($this->_acl->hasResource($resourceArea));
     }
 
@@ -313,7 +332,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testResourceRemoveOneNonExistent() {
+    public function testResourceRemoveOneNonExistent()
+    {
         $this->setExpectedException('Zend\Permissions\Acl\Exception\ExceptionInterface', 'not found');
         $this->_acl->removeResource('nonexistent');
     }
@@ -323,10 +343,11 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testResourceRemoveAll() {
+    public function testResourceRemoveAll()
+    {
         $resourceArea = new Resource\GenericResource('area');
         $this->_acl->addResource($resourceArea)
-                ->removeResourceAll();
+                   ->removeResourceAll();
         $this->assertFalse($this->_acl->hasResource($resourceArea));
     }
 
@@ -335,7 +356,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testResourceAddInheritsNonExistent() {
+    public function testResourceAddInheritsNonExistent()
+    {
         $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException', 'does not exist');
         $this->_acl->addResource(new Resource\GenericResource('area'), 'nonexistent');
     }
@@ -345,8 +367,10 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testResourceRegistryAddNotResource() {
-        $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException', 'addResource() expects $resource to be of type Zend\Permissions\Acl\Resource');
+    public function testResourceRegistryAddNotResource()
+    {
+        $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException',
+                                    'addResource() expects $resource to be of type Zend\Permissions\Acl\Resource');
         $this->_acl->addResource(new \stdClass);
     }
 
@@ -355,7 +379,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testResourceInheritsNonExistent() {
+    public function testResourceInheritsNonExistent()
+    {
         $resourceArea = new Resource\GenericResource('area');
         $this->_acl->addResource($resourceArea);
         try {
@@ -377,13 +402,14 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testResourceInherits() {
-        $resourceCity = new Resource\GenericResource('city');
+    public function testResourceInherits()
+    {
+        $resourceCity     = new Resource\GenericResource('city');
         $resourceBuilding = new Resource\GenericResource('building');
-        $resourceRoom = new Resource\GenericResource('room');
+        $resourceRoom     = new Resource\GenericResource('room');
         $this->_acl->addResource($resourceCity)
-                ->addResource($resourceBuilding, $resourceCity->getResourceId())
-                ->addResource($resourceRoom, $resourceBuilding);
+                   ->addResource($resourceBuilding, $resourceCity->getResourceId())
+                   ->addResource($resourceRoom, $resourceBuilding);
         $this->assertTrue($this->_acl->inheritsResource($resourceBuilding, $resourceCity, true));
         $this->assertTrue($this->_acl->inheritsResource($resourceRoom, $resourceBuilding, true));
         $this->assertTrue($this->_acl->inheritsResource($resourceRoom, $resourceCity));
@@ -399,11 +425,12 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testResourceDuplicate() {
+    public function testResourceDuplicate()
+    {
         $this->setExpectedException('Zend\Permissions\Acl\Exception\ExceptionInterface', 'already exists');
         $resourceArea = new Resource\GenericResource('area');
         $this->_acl->addResource($resourceArea)
-                ->addResource($resourceArea);
+                   ->addResource($resourceArea);
     }
 
     /**
@@ -411,12 +438,13 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testResourceDuplicateId() {
+    public function testResourceDuplicateId()
+    {
         $this->setExpectedException('Zend\Permissions\Acl\Exception\ExceptionInterface', 'already exists');
         $resourceArea1 = new Resource\GenericResource('area');
         $resourceArea2 = new Resource\GenericResource('area');
         $this->_acl->addResource($resourceArea1)
-                ->addResource($resourceArea2);
+                   ->addResource($resourceArea2);
     }
 
     /**
@@ -424,7 +452,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testIsAllowedNonExistent() {
+    public function testIsAllowedNonExistent()
+    {
         try {
             $this->_acl->isAllowed('nonexistent');
             $this->fail('Expected Zend\Permissions\Acl\Role\Exception\ExceptionInterface not thrown upon non-existent Role');
@@ -444,7 +473,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testDefaultDeny() {
+    public function testDefaultDeny()
+    {
         $this->assertFalse($this->_acl->isAllowed());
     }
 
@@ -453,7 +483,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testDefaultAssert() {
+    public function testDefaultAssert()
+    {
         $this->_acl->deny(null, null, null, new TestAsset\MockAssertion(false));
         $this->assertTrue($this->_acl->isAllowed());
         $this->assertTrue($this->_acl->isAllowed(null, null, 'somePrivilege'));
@@ -464,7 +495,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testDefaultRuleSet() {
+    public function testDefaultRuleSet()
+    {
         $this->_acl->allow();
         $this->assertTrue($this->_acl->isAllowed());
         $this->_acl->deny();
@@ -476,7 +508,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testDefaultPrivilegeDeny() {
+    public function testDefaultPrivilegeDeny()
+    {
         $this->assertFalse($this->_acl->isAllowed(null, null, 'somePrivilege'));
     }
 
@@ -485,7 +518,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testDefaultRuleSetPrivilege() {
+    public function testDefaultRuleSetPrivilege()
+    {
         $this->_acl->allow();
         $this->assertTrue($this->_acl->isAllowed(null, null, 'somePrivilege'));
         $this->_acl->deny();
@@ -497,7 +531,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testPrivilegeAllow() {
+    public function testPrivilegeAllow()
+    {
         $this->_acl->allow(null, null, 'somePrivilege');
         $this->assertTrue($this->_acl->isAllowed(null, null, 'somePrivilege'));
     }
@@ -507,7 +542,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testPrivilegeDeny() {
+    public function testPrivilegeDeny()
+    {
         $this->_acl->allow();
         $this->_acl->deny(null, null, 'somePrivilege');
         $this->assertFalse($this->_acl->isAllowed(null, null, 'somePrivilege'));
@@ -518,7 +554,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testPrivileges() {
+    public function testPrivileges()
+    {
         $this->_acl->allow(null, null, array('p1', 'p2', 'p3'));
         $this->assertTrue($this->_acl->isAllowed(null, null, 'p1'));
         $this->assertTrue($this->_acl->isAllowed(null, null, 'p2'));
@@ -536,7 +573,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testPrivilegeAssert() {
+    public function testPrivilegeAssert()
+    {
         $this->_acl->allow(null, null, 'somePrivilege', new TestAsset\MockAssertion(true));
         $this->assertTrue($this->_acl->isAllowed(null, null, 'somePrivilege'));
         $this->_acl->allow(null, null, 'somePrivilege', new TestAsset\MockAssertion(false));
@@ -548,7 +586,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleDefaultDeny() {
+    public function testRoleDefaultDeny()
+    {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest);
         $this->assertFalse($this->_acl->isAllowed($roleGuest));
@@ -559,10 +598,11 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleDefaultRuleSet() {
+    public function testRoleDefaultRuleSet()
+    {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                ->allow($roleGuest);
+                   ->allow($roleGuest);
         $this->assertTrue($this->_acl->isAllowed($roleGuest));
         $this->_acl->deny($roleGuest);
         $this->assertFalse($this->_acl->isAllowed($roleGuest));
@@ -573,7 +613,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleDefaultPrivilegeDeny() {
+    public function testRoleDefaultPrivilegeDeny()
+    {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest);
         $this->assertFalse($this->_acl->isAllowed($roleGuest, null, 'somePrivilege'));
@@ -584,10 +625,11 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleDefaultRuleSetPrivilege() {
+    public function testRoleDefaultRuleSetPrivilege()
+    {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                ->allow($roleGuest);
+                   ->allow($roleGuest);
         $this->assertTrue($this->_acl->isAllowed($roleGuest, null, 'somePrivilege'));
         $this->_acl->deny($roleGuest);
         $this->assertFalse($this->_acl->isAllowed($roleGuest, null, 'somePrivilege'));
@@ -598,10 +640,11 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRolePrivilegeAllow() {
+    public function testRolePrivilegeAllow()
+    {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                ->allow($roleGuest, null, 'somePrivilege');
+                   ->allow($roleGuest, null, 'somePrivilege');
         $this->assertTrue($this->_acl->isAllowed($roleGuest, null, 'somePrivilege'));
     }
 
@@ -610,11 +653,12 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRolePrivilegeDeny() {
+    public function testRolePrivilegeDeny()
+    {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                ->allow($roleGuest)
-                ->deny($roleGuest, null, 'somePrivilege');
+                   ->allow($roleGuest)
+                   ->deny($roleGuest, null, 'somePrivilege');
         $this->assertFalse($this->_acl->isAllowed($roleGuest, null, 'somePrivilege'));
     }
 
@@ -623,10 +667,11 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRolePrivileges() {
+    public function testRolePrivileges()
+    {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                ->allow($roleGuest, null, array('p1', 'p2', 'p3'));
+                   ->allow($roleGuest, null, array('p1', 'p2', 'p3'));
         $this->assertTrue($this->_acl->isAllowed($roleGuest, null, 'p1'));
         $this->assertTrue($this->_acl->isAllowed($roleGuest, null, 'p2'));
         $this->assertTrue($this->_acl->isAllowed($roleGuest, null, 'p3'));
@@ -643,10 +688,11 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRolePrivilegeAssert() {
+    public function testRolePrivilegeAssert()
+    {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest)
-                ->allow($roleGuest, null, 'somePrivilege', new TestAsset\MockAssertion(true));
+                   ->allow($roleGuest, null, 'somePrivilege', new TestAsset\MockAssertion(true));
         $this->assertTrue($this->_acl->isAllowed($roleGuest, null, 'somePrivilege'));
         $this->_acl->allow($roleGuest, null, 'somePrivilege', new TestAsset\MockAssertion(false));
         $this->assertFalse($this->_acl->isAllowed($roleGuest, null, 'somePrivilege'));
@@ -657,7 +703,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRemoveDefaultDeny() {
+    public function testRemoveDefaultDeny()
+    {
         $this->assertFalse($this->_acl->isAllowed());
         $this->_acl->removeDeny();
         $this->assertFalse($this->_acl->isAllowed());
@@ -668,7 +715,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRemoveDefaultDenyAssert() {
+    public function testRemoveDefaultDenyAssert()
+    {
         $this->_acl->deny(null, null, null, new TestAsset\MockAssertion(false));
         $this->assertTrue($this->_acl->isAllowed());
         $this->_acl->removeDeny();
@@ -680,7 +728,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRemoveDefaultAllow() {
+    public function testRemoveDefaultAllow()
+    {
         $this->_acl->allow();
         $this->assertTrue($this->_acl->isAllowed());
         $this->_acl->removeAllow();
@@ -692,7 +741,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRemoveDefaultAllowNonExistent() {
+    public function testRemoveDefaultAllowNonExistent()
+    {
         $this->_acl->removeAllow();
         $this->assertFalse($this->_acl->isAllowed());
     }
@@ -702,9 +752,10 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRemoveDefaultDenyNonExistent() {
+    public function testRemoveDefaultDenyNonExistent()
+    {
         $this->_acl->allow()
-                ->removeDeny();
+                   ->removeDeny();
         $this->assertTrue($this->_acl->isAllowed());
     }
 
@@ -714,14 +765,15 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleDefaultAllowRuleWithResourceDenyRule() {
+    public function testRoleDefaultAllowRuleWithResourceDenyRule()
+    {
         $this->_acl->addRole(new Role\GenericRole('guest'))
-                ->addRole(new Role\GenericRole('staff'), 'guest')
-                ->addResource(new Resource\GenericResource('area1'))
-                ->addResource(new Resource\GenericResource('area2'))
-                ->deny()
-                ->allow('staff')
-                ->deny('staff', array('area1', 'area2'));
+                   ->addRole(new Role\GenericRole('staff'), 'guest')
+                   ->addResource(new Resource\GenericResource('area1'))
+                   ->addResource(new Resource\GenericResource('area2'))
+                   ->deny()
+                   ->allow('staff')
+                   ->deny('staff', array('area1', 'area2'));
         $this->assertFalse($this->_acl->isAllowed('staff', 'area1'));
     }
 
@@ -731,12 +783,13 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRoleDefaultAllowRuleWithPrivilegeDenyRule() {
+    public function testRoleDefaultAllowRuleWithPrivilegeDenyRule()
+    {
         $this->_acl->addRole(new Role\GenericRole('guest'))
-                ->addRole(new Role\GenericRole('staff'), 'guest')
-                ->deny()
-                ->allow('staff')
-                ->deny('staff', null, array('privilege1', 'privilege2'));
+                   ->addRole(new Role\GenericRole('staff'), 'guest')
+                   ->deny()
+                   ->allow('staff')
+                   ->deny('staff', null, array('privilege1', 'privilege2'));
         $this->assertFalse($this->_acl->isAllowed('staff', null, 'privilege1'));
     }
 
@@ -745,7 +798,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRulesRemove() {
+    public function testRulesRemove()
+    {
         $this->_acl->allow(null, null, array('privilege1', 'privilege2'));
         $this->assertFalse($this->_acl->isAllowed());
         $this->assertTrue($this->_acl->isAllowed(null, null, 'privilege1'));
@@ -760,9 +814,10 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRuleRoleRemove() {
+    public function testRuleRoleRemove()
+    {
         $this->_acl->addRole(new Role\GenericRole('guest'))
-                ->allow('guest');
+                   ->allow('guest');
         $this->assertTrue($this->_acl->isAllowed('guest'));
         $this->_acl->removeRole('guest');
         try {
@@ -780,9 +835,10 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRuleRoleRemoveAll() {
+    public function testRuleRoleRemoveAll()
+    {
         $this->_acl->addRole(new Role\GenericRole('guest'))
-                ->allow('guest');
+                   ->allow('guest');
         $this->assertTrue($this->_acl->isAllowed('guest'));
         $this->_acl->removeRoleAll();
         try {
@@ -800,9 +856,10 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRulesResourceRemove() {
+    public function testRulesResourceRemove()
+    {
         $this->_acl->addResource(new Resource\GenericResource('area'))
-                ->allow(null, 'area');
+                   ->allow(null, 'area');
         $this->assertTrue($this->_acl->isAllowed(null, 'area'));
         $this->_acl->removeResource('area');
         try {
@@ -820,9 +877,10 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testRulesResourceRemoveAll() {
+    public function testRulesResourceRemoveAll()
+    {
         $this->_acl->addResource(new Resource\GenericResource('area'))
-                ->allow(null, 'area');
+                   ->allow(null, 'area');
         $this->assertTrue($this->_acl->isAllowed(null, 'area'));
         $this->_acl->removeResourceAll();
         try {
@@ -840,12 +898,13 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testCMSExample() {
+    public function testCMSExample()
+    {
         // Add some roles to the Role registry
         $this->_acl->addRole(new Role\GenericRole('guest'))
-                ->addRole(new Role\GenericRole('staff'), 'guest')  // staff inherits permissions from guest
-                ->addRole(new Role\GenericRole('editor'), 'staff') // editor inherits permissions from staff
-                ->addRole(new Role\GenericRole('administrator'));
+                   ->addRole(new Role\GenericRole('staff'), 'guest')  // staff inherits permissions from guest
+                   ->addRole(new Role\GenericRole('editor'), 'staff') // editor inherits permissions from staff
+                   ->addRole(new Role\GenericRole('administrator'));
 
         // Guest may only view content
         $this->_acl->allow('guest', null, 'view');
@@ -903,11 +962,11 @@ class AclTest extends \PHPUnit_Framework_TestCase {
 
         // Some checks on specific areas, which inherit access controls from the root ACL node
         $this->_acl->addResource(new Resource\GenericResource('newsletter'))
-                ->addResource(new Resource\GenericResource('pending'), 'newsletter')
-                ->addResource(new Resource\GenericResource('gallery'))
-                ->addResource(new Resource\GenericResource('profiles', 'gallery'))
-                ->addResource(new Resource\GenericResource('config'))
-                ->addResource(new Resource\GenericResource('hosts'), 'config');
+                   ->addResource(new Resource\GenericResource('pending'), 'newsletter')
+                   ->addResource(new Resource\GenericResource('gallery'))
+                   ->addResource(new Resource\GenericResource('profiles', 'gallery'))
+                   ->addResource(new Resource\GenericResource('config'))
+                   ->addResource(new Resource\GenericResource('hosts'), 'config');
         $this->assertTrue($this->_acl->isAllowed('guest', 'pending', 'view'));
         $this->assertTrue($this->_acl->isAllowed('staff', 'profiles', 'revise'));
         $this->assertTrue($this->_acl->isAllowed('staff', 'pending', 'view'));
@@ -921,12 +980,13 @@ class AclTest extends \PHPUnit_Framework_TestCase {
         $this->_acl->addRole(new Role\GenericRole('marketing'), 'staff');
 
         // Refine the privilege sets for more specific needs
+
         // Allow marketing to publish and archive newsletters
         $this->_acl->allow('marketing', 'newsletter', array('publish', 'archive'));
 
         // Allow marketing to publish and archive latest news
         $this->_acl->addResource(new Resource\GenericResource('news'))
-                ->addResource(new Resource\GenericResource('latest'), 'news');
+                   ->addResource(new Resource\GenericResource('latest'), 'news');
         $this->_acl->allow('marketing', 'latest', array('publish', 'archive'));
 
         // Deny staff (and marketing, by inheritance) rights to revise latest news
@@ -969,6 +1029,7 @@ class AclTest extends \PHPUnit_Framework_TestCase {
         $this->assertFalse($this->_acl->isAllowed('editor', 'announcement', 'archive'));
 
         // Remove some previous permission specifications
+
         // Marketing can no longer publish and archive newsletters
         $this->_acl->removeAllow('marketing', 'newsletter', array('publish', 'archive'));
 
@@ -996,6 +1057,7 @@ class AclTest extends \PHPUnit_Framework_TestCase {
         $this->assertTrue($this->_acl->isAllowed('marketing', 'latest', 'publish'));
         $this->assertTrue($this->_acl->isAllowed('marketing', 'latest', 'edit'));
         $this->assertTrue($this->_acl->isAllowed('marketing', 'latest'));
+
     }
 
     /**
@@ -1004,10 +1066,11 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      * @return void
      * @group  ZF-2502
      */
-    public function testRoleInheritanceSupportsCheckingOnlyParents() {
+    public function testRoleInheritanceSupportsCheckingOnlyParents()
+    {
         $this->_acl->addRole(new Role\GenericRole('grandparent'))
-                ->addRole(new Role\GenericRole('parent'), 'grandparent')
-                ->addRole(new Role\GenericRole('child'), 'parent');
+                   ->addRole(new Role\GenericRole('parent'), 'grandparent')
+                   ->addRole(new Role\GenericRole('child'), 'parent');
         $this->assertFalse($this->_acl->inheritsRole('child', 'grandparent', true));
     }
 
@@ -1017,17 +1080,18 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      * @return void
      * @group  ZF-2234
      */
-    public function testAclInternalDFSMethodsBehaveProperly() {
+    public function testAclInternalDFSMethodsBehaveProperly()
+    {
         $acl = new TestAsset\ExtendedAclZF2234();
 
         $someResource = new Resource\GenericResource('someResource');
-        $someRole = new Role\GenericRole('someRole');
+        $someRole     = new Role\GenericRole('someRole');
 
         $acl->addResource($someResource)
-                ->addRole($someRole);
+            ->addRole($someRole);
 
-        $nullValue = null;
-        $nullReference = & $nullValue;
+        $nullValue     = null;
+        $nullReference =& $nullValue;
 
         try {
             $acl->exroleDFSVisitAllPrivileges($someRole, $someResource, $nullReference);
@@ -1058,10 +1122,12 @@ class AclTest extends \PHPUnit_Framework_TestCase {
         }
     }
 
+
     /**
      * @group ZF-1721
      */
-    public function testAclAssertionsGetProperRoleWhenInheritenceIsUsed() {
+    public function testAclAssertionsGetProperRoleWhenInheritenceIsUsed()
+    {
         $acl = $this->_loadUseCase1();
 
         $user = new Role\GenericRole('publisher');
@@ -1075,16 +1141,18 @@ class AclTest extends \PHPUnit_Framework_TestCase {
         $this->assertTrue($acl->isAllowed($user, $blogPost, 'modify'));
 
         $this->assertEquals('publisher', $assertion->lastAssertRole->getRoleId());
+
     }
 
     /**
      *
      * @group ZF-1722
      */
-    public function testAclAssertionsGetOriginalIsAllowedObjects() {
+    public function testAclAssertionsGetOriginalIsAllowedObjects()
+    {
         $acl = $this->_loadUseCase1();
 
-        $user = new TestAsset\UseCase1\User();
+        $user     = new TestAsset\UseCase1\User();
         $blogPost = new TestAsset\UseCase1\BlogPost();
 
         $this->assertTrue($acl->isAllowed($user, $blogPost, 'view'));
@@ -1103,13 +1171,15 @@ class AclTest extends \PHPUnit_Framework_TestCase {
         // check to see if the last assertion has the proper objets
         $this->assertInstanceOf('ZendTest\Permissions\Acl\TestAsset\UseCase1\User', $assertion->lastAssertRole, 'Assertion did not receive proper role object');
         $this->assertInstanceOf('ZendTest\Permissions\Acl\TestAsset\UseCase1\BlogPost', $assertion->lastAssertResource, 'Assertion did not receive proper resource object');
+
     }
 
     /**
      *
      * @return Zend_Acl_UseCase1_Acl
      */
-    protected function _loadUseCase1() {
+    protected function _loadUseCase1()
+    {
         return new TestAsset\UseCase1\Acl();
     }
 
@@ -1119,14 +1189,15 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      *
      * @group ZF-5700
      */
-    public function testRemovingRoleAfterItWasAllowedAccessToAllResourcesGivesError() {
+    public function testRemovingRoleAfterItWasAllowedAccessToAllResourcesGivesError()
+    {
         $acl = new Acl\Acl();
         $acl->addRole(new Role\GenericRole('test0'));
         $acl->addRole(new Role\GenericRole('test1'));
         $acl->addRole(new Role\GenericRole('test2'));
         $acl->addResource(new Resource\GenericResource('Test'));
 
-        $acl->allow(null, 'Test', 'xxx');
+        $acl->allow(null,'Test','xxx');
 
         // error test
         $acl->removeRole('test0');
@@ -1141,7 +1212,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
      * Meant to test for the (in)existance of this notice:
      * "Notice: Undefined index: allPrivileges in lib/Zend/Acl.php on line 682"
      */
-    public function testMethodRemoveAllowDoesNotThrowNotice() {
+    public function testMethodRemoveAllowDoesNotThrowNotice()
+    {
         $acl = new Acl\Acl();
         $acl->addRole('admin');
         $acl->addResource('blog');
@@ -1149,27 +1221,30 @@ class AclTest extends \PHPUnit_Framework_TestCase {
         $acl->removeAllow(array('admin'), array('blog'), null);
     }
 
-    public function testRoleObjectImplementsToString() {
+    public function testRoleObjectImplementsToString()
+    {
         $role = new Role\GenericRole('_fooBar_');
-        $this->assertEquals('_fooBar_', (string) $role);
+        $this->assertEquals('_fooBar_',(string)$role);
     }
 
-    public function testResourceObjectImplementsToString() {
+    public function testResourceObjectImplementsToString()
+    {
         $resource = new Resource\GenericResource('_fooBar_');
-        $this->assertEquals('_fooBar_', (string) $resource);
+        $this->assertEquals('_fooBar_',(string)$resource);
     }
 
     /**
      * @group ZF-7973
      */
-    public function testAclPassesPrivilegeToAssertClass() {
+    public function testAclPassesPrivilegeToAssertClass()
+    {
         $assertion = new TestAsset\AssertionZF7973();
 
         $acl = new Acl\Acl();
         $acl->addRole('role');
         $acl->addResource('resource');
         $acl->allow('role', null, null, $assertion);
-        $allowed = $acl->isAllowed('role', 'resource', 'privilege', $assertion);
+        $allowed = $acl->isAllowed('role','resource','privilege', $assertion);
 
         $this->assertTrue($allowed);
     }
@@ -1177,7 +1252,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
     /**
      * @group ZF-8468
      */
-    public function testgetRoles() {
+    public function testgetRoles()
+    {
         $this->assertEquals(array(), $this->_acl->getRoles());
 
         $roleGuest = new Role\GenericRole('guest');
@@ -1186,14 +1262,15 @@ class AclTest extends \PHPUnit_Framework_TestCase {
         $this->_acl->addRole(new Role\GenericRole('editor'), 'staff');
         $this->_acl->addRole(new Role\GenericRole('administrator'));
 
-        $expected = array('guest', 'staff', 'editor', 'administrator');
+        $expected = array('guest', 'staff','editor','administrator');
         $this->assertEquals($expected, $this->_acl->getRoles());
     }
 
     /**
      * @group ZF-8468
      */
-    public function testgetResources() {
+    public function testgetResources()
+    {
         $this->assertEquals(array(), $this->_acl->getResources());
 
         $this->_acl->addResource(new Resource\GenericResource('someResource'));
@@ -1206,7 +1283,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
     /**
      * @group ZF-9643
      */
-    public function testRemoveAllowWithNullResourceAppliesToAllResources() {
+    public function testRemoveAllowWithNullResourceAppliesToAllResources()
+    {
         $this->_acl->addRole('guest');
         $this->_acl->addResource('blogpost');
         $this->_acl->addResource('newsletter');
@@ -1232,7 +1310,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
     /**
      * @group ZF-9643
      */
-    public function testRemoveDenyWithNullResourceAppliesToAllResources() {
+    public function testRemoveDenyWithNullResourceAppliesToAllResources()
+    {
         $this->_acl->addRole('guest');
         $this->_acl->addResource('blogpost');
         $this->_acl->addResource('newsletter');
@@ -1260,7 +1339,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
     /**
      * @group ZF2-3454
      */
-    public function testAclResourcePermissionsAreInheritedWithMultilevelResourcesAndDenyPolicy() {
+    public function testAclResourcePermissionsAreInheritedWithMultilevelResourcesAndDenyPolicy()
+    {
         $this->_acl->addRole('guest');
         $this->_acl->addResource('blogposts');
         $this->_acl->addResource('feature', 'blogposts');
@@ -1282,7 +1362,8 @@ class AclTest extends \PHPUnit_Framework_TestCase {
         $this->assertFalse($this->_acl->isAllowed('guest', 'post_2', 'comment'));
     }
 
-    public function testSetRuleWorksWithResourceInterface() {
+    public function testSetRuleWorksWithResourceInterface()
+    {
         $roleGuest = new Role\GenericRole('guest');
         $this->_acl->addRole($roleGuest);
 
@@ -1295,14 +1376,16 @@ class AclTest extends \PHPUnit_Framework_TestCase {
     /**
      * @group 4226
      */
-    public function testAllowNullPermissionAfterResourcesExistShouldAllowAllPermissionsForRole() {
+    public function testAllowNullPermissionAfterResourcesExistShouldAllowAllPermissionsForRole()
+    {
         $this->_acl->addRole('admin');
         $this->_acl->addResource('newsletter');
         $this->_acl->allow('admin');
         $this->assertTrue($this->_acl->isAllowed('admin'));
     }
-
-    public function testMultipleAssertionRulesWithMatchingRoleResourceAndPrivilege() {
+    
+    public function testMultipleAssertionRulesWithMatchingRoleResourceAndPrivilege()
+    {
         $this->_acl->addRole('admin');
         $this->_acl->addResource('newsletter');
         $this->_acl->allow('admin', 'newsletter', 'view', new TestAsset\MockAssertion(true));
@@ -1310,5 +1393,4 @@ class AclTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertTrue($this->_acl->isAllowed('admin', 'newsletter', 'view'));
     }
-
 }


### PR DESCRIPTION
I've written a test (that fails) to explain what I mean, but I can't work out whether this is a bug or intended behaviour?

I often want to add two allow rules with the same role, resource and privilege settings but different assertions. When doing this, the second allow rule always overwrites the first.

Am I doing it wrong, or should the Acl keep both rules? I can work around this by implementing a "MultiAssertion" class, or perhaps grouping things better, but happy to attempt a fix if anyone agrees?

Update: This is what I could find in the manual: "... it should be understood that in all other cases (i.e., where a specific role, resource, or privilege is specified for the rule), a failed assertion results in the rule not applying, and other rules would be used to determine whether access is allowed or denied."
