### PR TITLE
POP3 protocol "return;" is needed after APOP request

### DIFF
--- a/library/Zend/Mail/Protocol/Pop3.php
+++ b/library/Zend/Mail/Protocol/Pop3.php
@@ -245,6 +245,7 @@ class Pop3
         if ($tryApop && $this->timestamp) {
             try {
                 $this->request("APOP $user " . md5($this->timestamp . $password));
+                return;
             } catch (Exception\ExceptionInterface $e) {
                 // ignore
             }


### PR DESCRIPTION
"return;" existed before Apr 30, 2012(not inclusive). However, "return;" was erased in Apr 30, 2012. I think it is human error. "return;" is needed in POP3 protocol.
