### PR TITLE
Improve the output of PhpArray Writer to more human code standard.

### DIFF
--- a/library/Zend/Config/Writer/PhpArray.php
+++ b/library/Zend/Config/Writer/PhpArray.php
@@ -22,7 +22,13 @@ class PhpArray extends AbstractWriter
         $arrayString = "<?php\n"
                      . "return " . var_export($config, true) . ";\n";
         $arrayString = preg_replace("/=> \n + array/", '=> array', $arrayString);
-        $arrayString = str_replace("  ", '    ', $arrayString);
+        $arrayString = preg_replace_callback(
+            '/^(  )+/m',
+            function ($m) {
+                return str_repeat($m[0], 2);
+            },
+            $arrayString
+        );
 
         return $arrayString;
     }

--- a/library/Zend/Config/Writer/PhpArray.php
+++ b/library/Zend/Config/Writer/PhpArray.php
@@ -21,6 +21,8 @@ class PhpArray extends AbstractWriter
     {
         $arrayString = "<?php\n"
                      . "return " . var_export($config, true) . ";\n";
+        $arrayString = preg_replace("/=> \n + array/", '=> array', $arrayString);
+        $arrayString = str_replace("  ", '    ', $arrayString);
 
         return $arrayString;
     }

--- a/tests/ZendTest/Config/FactoryTest.php
+++ b/tests/ZendTest/Config/FactoryTest.php
@@ -182,12 +182,11 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         // build string line by line as we are trailing-whitespace sensitive.
         $expected = "<?php\n";
         $expected .= "return array (\n";
-        $expected .= "  'test' => 'foo',\n";
-        $expected .= "  'bar' => \n";
-        $expected .= "  array (\n";
-        $expected .= "    0 => 'baz',\n";
-        $expected .= "    1 => 'foo',\n";
-        $expected .= "  ),\n";
+        $expected .= "    'test' => 'foo',\n";
+        $expected .= "    'bar' => array (\n";
+        $expected .= "        0 => 'baz',\n";
+        $expected .= "        1 => 'foo',\n";
+        $expected .= "    ),\n";
         $expected .= ");\n";
 
         $this->assertEquals(true, $result);

--- a/tests/ZendTest/Config/Writer/PhpArrayTest.php
+++ b/tests/ZendTest/Config/Writer/PhpArrayTest.php
@@ -35,20 +35,39 @@ class PhpArrayTest extends AbstractWriterTestCase
      */
     public function testRender()
     {
-        $config = new Config(array('test' => 'foo', 'bar' => array(0 => 'baz', 1 => 'foo')));
-
-        $configString = $this->writer->toString($config);
+        $array = array(
+            'test' => 'foo',
+            'with 2 spaces' => 'foo  bar',
+            'with 4 spaces' => 'foo    bar',
+            'bar' => array(
+                0 => 'baz',
+                1 => 'foo',
+                'sub-sub' => array(
+                    'foo' => 'bar'
+                )
+            )
+        );
+        $config = new Config($array);
 
         // build string line by line as we are trailing-whitespace sensitive.
         $expected = "<?php\n";
         $expected .= "return array (\n";
         $expected .= "    'test' => 'foo',\n";
+        $expected .= "    'with 2 spaces' => 'foo  bar',\n";
+        $expected .= "    'with 4 spaces' => 'foo    bar',\n";
         $expected .= "    'bar' => array (\n";
         $expected .= "        0 => 'baz',\n";
         $expected .= "        1 => 'foo',\n";
+        $expected .= "        'sub-sub' => array (\n";
+        $expected .= "            'foo' => 'bar',\n";
+        $expected .= "        ),\n";
         $expected .= "    ),\n";
         $expected .= ");\n";
 
+        $arrayString = $this->writer->toString($array);
+        $configString = $this->writer->toString($config);
+
         $this->assertEquals($expected, $configString);
+        $this->assertEquals($expected, $arrayString);
     }
 }

--- a/tests/ZendTest/Config/Writer/PhpArrayTest.php
+++ b/tests/ZendTest/Config/Writer/PhpArrayTest.php
@@ -42,12 +42,11 @@ class PhpArrayTest extends AbstractWriterTestCase
         // build string line by line as we are trailing-whitespace sensitive.
         $expected = "<?php\n";
         $expected .= "return array (\n";
-        $expected .= "  'test' => 'foo',\n";
-        $expected .= "  'bar' => \n";
-        $expected .= "  array (\n";
-        $expected .= "    0 => 'baz',\n";
-        $expected .= "    1 => 'foo',\n";
-        $expected .= "  ),\n";
+        $expected .= "    'test' => 'foo',\n";
+        $expected .= "    'bar' => array (\n";
+        $expected .= "        0 => 'baz',\n";
+        $expected .= "        1 => 'foo',\n";
+        $expected .= "    ),\n";
         $expected .= ");\n";
 
         $this->assertEquals($expected, $configString);


### PR DESCRIPTION
Expand intedation to 4 spaces. Move beginning of array to one line.

It become looks like typed code.
