### PR TITLE
illegal usage of array_walk in ObjectProperty, ClassMapAutoloader

### DIFF
--- a/library/Zend/Stdlib/Hydrator/ObjectProperty.php
+++ b/library/Zend/Stdlib/Hydrator/ObjectProperty.php
@@ -33,16 +33,15 @@ class ObjectProperty extends AbstractHydrator
         $data = get_object_vars($object);
 
         $filter = $this->getFilter();
-        foreach (array_keys($data) as $name) {
+        foreach ($data as $name => $value) {
+            // Filter keys, removing any we don't want
             if (!$filter->filter($name)) {
                 unset($data[$name]);
+                continue;
             }
+            // Extract data
+            $data[$name] = $this->extractValue($name, $value);
         }
-
-        $self = $this;
-        array_walk($data, function (&$value, $name) use ($self) {
-            $value = $self->extractValue($name, $value);
-        });
 
         return $data;
     }

--- a/library/Zend/Stdlib/Hydrator/ObjectProperty.php
+++ b/library/Zend/Stdlib/Hydrator/ObjectProperty.php
@@ -30,15 +30,20 @@ class ObjectProperty extends AbstractHydrator
             ));
         }
 
-        $self = $this;
         $data = get_object_vars($object);
-        array_walk($data, function (&$value, $name) use ($self, &$data) {
-            if (!$self->getFilter()->filter($name)) {
+
+        $filter = $this->getFilter();
+        foreach (array_keys($data) as $name) {
+            if (!$filter->filter($name)) {
                 unset($data[$name]);
-            } else {
-                $value = $self->extractValue($name, $value);
             }
+        }
+
+        $self = $this;
+        array_walk($data, function (&$value, $name) use ($self) {
+            $value = $self->extractValue($name, $value);
         });
+
         return $data;
     }
 

--- a/tests/ZendTest/Stdlib/HydratorObjectPropertyTest.php
+++ b/tests/ZendTest/Stdlib/HydratorObjectPropertyTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+
+namespace ZendTest\Stdlib;
+
+use Zend\Stdlib\Hydrator\ObjectProperty;
+
+class HydratorObjectPropertyTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->hydrator = new ObjectProperty();
+    }
+
+    public function testMultipleInvocationsWithDifferentFiltersFindsAllProperties()
+    {
+        $instance = (object) array();
+
+        $instance->id         = 4;
+        $instance->array      = array(4, 3, 5, 6);
+        $instance->object     = (object) array();
+        $instance->object->id = 4;
+
+        $this->hydrator->addFilter('values', function ($property) {
+            return true;
+        });
+        $result = $this->hydrator->extract($instance);
+        $this->assertArrayHasKey('id', $result);
+        $this->assertEquals($instance->id, $result['id']);
+        $this->assertArrayHasKey('array', $result);
+        $this->assertEquals($instance->array, $result['array']);
+        $this->assertArrayHasKey('object', $result);
+        $this->assertSame($instance->object, $result['object']);
+
+        $this->hydrator->removeFilter('values');
+        $this->hydrator->addFilter('complex', function ($property) {
+            switch ($property) {
+                case 'array':
+                case 'object':
+                    return false;
+                default:
+                    return true;
+            }
+        });
+        $result = $this->hydrator->extract($instance);
+        $this->assertArrayHasKey('id', $result);
+        $this->assertEquals($instance->id, $result['id']);
+        $this->assertArrayNotHasKey('array', $result);
+        $this->assertArrayNotHasKey('object', $result);
+    }
+}


### PR DESCRIPTION
Per definition of array_walk: http://php.net/manual/en/function.array-walk.php it's not allowed to change the referenced array in the process of array_walk. 

e.g. on extraction ObjectProperty does not correctly apply filters. http://pastie.org/7684226
