### PR TITLE
Minor performance optimization on stdlib

### DIFF
--- a/library/Zend/Stdlib/ArrayUtils.php
+++ b/library/Zend/Stdlib/ArrayUtils.php
@@ -258,9 +258,9 @@ abstract class ArrayUtils
     {
         foreach ($b as $key => $value) {
             if (array_key_exists($key, $a)) {
-                if (is_int($key)) {
+                if ($key === (int) $key) {
                     $a[] = $value;
-                } elseif (is_array($value) && is_array($a[$key])) {
+                } elseif (($value === (array) $value) && $a[$key] === (array) $a[$key]) {
                     $a[$key] = static::merge($a[$key], $value);
                 } else {
                     $a[$key] = $value;

--- a/library/Zend/Stdlib/SplPriorityQueue.php
+++ b/library/Zend/Stdlib/SplPriorityQueue.php
@@ -36,9 +36,10 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
      */
     public function insert($datum, $priority)
     {
-        if (!is_array($priority)) {
+        if ($priority !== (array) $priority) {
             $priority = array($priority, $this->serial--);
         }
+
         parent::insert($datum, $priority);
     }
 


### PR DESCRIPTION
Some more hidden pearls I didn't really know of: taken from http://stackoverflow.com/a/3471356/347063

I don't know if it's really worth it, but `ArrayUtils::merge` and `PriorityQueue` are quite final, and they're used quite a lot, recursively, causing hundreds of calls to `is_array`. Also, `ArrayUtils::merge` is almost never used with objects (not in a typical ZF2 app), so I went on and applied this one after checking kcachegrind with a skeleton application first
