### PR TITLE
Remove SM-Aware requirement from Forward plugin

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/Forward.php
+++ b/library/Zend/Mvc/Controller/Plugin/Forward.php
@@ -45,6 +45,14 @@ class Forward extends AbstractPlugin
     protected $listenersToDetach = null;
 
     /**
+     * @param ControllerManager $locator
+     */
+    public function __construct(ControllerManager $locator)
+    {
+        $this->setLocator($locator);
+    }
+
+    /**
      * Set maximum number of nested forwards allowed
      *
      * @param  int $maxNestedForwards
@@ -129,12 +137,6 @@ class Forward extends AbstractPlugin
     {
         $event   = clone($this->getEvent());
         $locator = $this->getLocator();
-        if (!$locator instanceof ControllerManager) {
-            throw new Exception\DomainException(sprintf(
-                '%s requires that Zend\Mvc\Controller\ControllerManager is injected via setLocator(); no manager found',
-                __METHOD__
-            ));
-        }
 
         $controller = $locator->get($name);
         if ($controller instanceof InjectApplicationEventInterface) {

--- a/library/Zend/Mvc/Controller/Plugin/Forward.php
+++ b/library/Zend/Mvc/Controller/Plugin/Forward.php
@@ -15,19 +15,18 @@ use Zend\Mvc\Exception;
 use Zend\Mvc\InjectApplicationEventInterface;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;
-use Zend\ServiceManager\ServiceLocatorInterface;
 
 class Forward extends AbstractPlugin
 {
     /**
+     * @var ControllerManager
+     */
+    protected $controllers;
+
+    /**
      * @var MvcEvent
      */
     protected $event;
-
-    /**
-     * @var ServiceLocatorInterface
-     */
-    protected $locator;
 
     /**
      * @var int
@@ -45,11 +44,11 @@ class Forward extends AbstractPlugin
     protected $listenersToDetach = null;
 
     /**
-     * @param ControllerManager $locator
+     * @param ControllerManager $controllers
      */
-    public function __construct(ControllerManager $locator)
+    public function __construct(ControllerManager $controllers)
     {
-        $this->setLocator($locator);
+        $this->controllers = $controllers;
     }
 
     /**
@@ -103,31 +102,9 @@ class Forward extends AbstractPlugin
     }
 
     /**
-     * Set the service locator for controllers
-     *
-     * @param  ControllerManager $locator
-     * @return self
-     */
-    public function setLocator(ControllerManager $locator)
-    {
-        $this->locator = $locator;
-        return $this;
-    }
-
-    /**
-     * Get the service locator for controllers
-     *
-     * @return ControllerManager
-     */
-    public function getLocator()
-    {
-        return $this->locator;
-    }
-
-    /**
      * Dispatch another controller
      *
-     * @param  string $name Controller name; either a class name or an alias used in the DI container or service locator
+     * @param  string $name Controller name; either a class name or an alias used in the controller manager
      * @param  null|array $params Parameters with which to seed a custom RouteMatch object for the new controller
      * @return mixed
      * @throws Exception\DomainException if composed controller does not define InjectApplicationEventInterface
@@ -136,9 +113,8 @@ class Forward extends AbstractPlugin
     public function dispatch($name, array $params = null)
     {
         $event   = clone($this->getEvent());
-        $locator = $this->getLocator();
 
-        $controller = $locator->get($name);
+        $controller = $this->controllers->get($name);
         if ($controller instanceof InjectApplicationEventInterface) {
             $controller->setEvent($event);
         }

--- a/library/Zend/Mvc/Controller/Plugin/Service/ForwardFactory.php
+++ b/library/Zend/Mvc/Controller/Plugin/Service/ForwardFactory.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Controller\Plugin\Service;
+
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\Mvc\Controller\Plugin\Forward;
+
+class ForwardFactory implements FactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return Forward
+     * @throws ServiceNotCreatedException if ControllerLoader service is not found in application service locator
+     */
+    public function createService(ServiceLocatorInterface $plugins)
+    {
+        $services = $plugins->getServiceLocator();
+        if (!$services instanceof ServiceLocatorInterface) {
+            throw new ServiceNotCreatedException(sprintf(
+                '%s requires that the application service manager has been injected; none found',
+                __CLASS__
+            ));
+        }
+
+        if (!$services->has('ControllerLoader')) {
+            throw new ServiceNotCreatedException(sprintf(
+                '%s requires that the application service manager contains a "%s" service; none found',
+                __CLASS__,
+                'ControllerLoader'
+            ));
+        }
+        $controllers = $services->get('ControllerLoader');
+
+        $helper = new Forward();
+        $helper->setLocator($controllers);
+        return $helper;
+    }
+}

--- a/library/Zend/Mvc/Controller/Plugin/Service/ForwardFactory.php
+++ b/library/Zend/Mvc/Controller/Plugin/Service/ForwardFactory.php
@@ -41,8 +41,6 @@ class ForwardFactory implements FactoryInterface
         }
         $controllers = $services->get('ControllerLoader');
 
-        $helper = new Forward();
-        $helper->setLocator($controllers);
-        return $helper;
+        return new Forward($controllers);
     }
 }

--- a/library/Zend/Mvc/Controller/PluginManager.php
+++ b/library/Zend/Mvc/Controller/PluginManager.php
@@ -28,6 +28,7 @@ class PluginManager extends AbstractPluginManager
      * @var array
      */
     protected $factories = array(
+        'forward'  => 'Zend\Mvc\Controller\Plugin\Service\ForwardFactory',
         'identity' => 'Zend\Mvc\Controller\Plugin\Service\IdentityFactory',
     );
 
@@ -40,7 +41,6 @@ class PluginManager extends AbstractPluginManager
         'acceptableviewmodelselector' => 'Zend\Mvc\Controller\Plugin\AcceptableViewModelSelector',
         'filepostredirectget'         => 'Zend\Mvc\Controller\Plugin\FilePostRedirectGet',
         'flashmessenger'              => 'Zend\Mvc\Controller\Plugin\FlashMessenger',
-        'forward'                     => 'Zend\Mvc\Controller\Plugin\Forward',
         'layout'                      => 'Zend\Mvc\Controller\Plugin\Layout',
         'params'                      => 'Zend\Mvc\Controller\Plugin\Params',
         'postredirectget'             => 'Zend\Mvc\Controller\Plugin\PostRedirectGet',

--- a/tests/ZendTest/Mvc/Controller/Plugin/ForwardTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/ForwardTest.php
@@ -15,6 +15,8 @@ use stdClass;
 use Zend\EventManager\StaticEventManager;
 use Zend\Http\Request;
 use Zend\Http\Response;
+use Zend\Mvc\Controller\ControllerManager;
+use Zend\Mvc\Controller\PluginManager;
 use Zend\Mvc\Controller\Plugin\Forward as ForwardPlugin;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;
@@ -46,14 +48,37 @@ class ForwardTest extends TestCase
         $routeMatch->setMatchedRouteName('some-route');
         $event->setRouteMatch($routeMatch);
 
-        $locator = new Locator;
-        $locator->add('forward', function () {
-            return new ForwardController();
+        $services    = new Locator();
+        $plugins     = $this->plugins = new PluginManager();
+        $plugins->setServiceLocator($services);
+
+        $controllers = $this->controllers = new ControllerManager();
+        $controllers->setFactory('forward', function () use ($plugins) {
+            $controller = new ForwardController();
+            $controller->setPluginManager($plugins);
+            return $controller;
+        });
+        $controllers->setServiceLocator($services);
+        $services->add('ControllerLoader', function () use ($controllers) {
+            return $controllers;
+        });
+        $services->add('ControllerPluginManager', function () use ($plugins) {
+            return $plugins;
+        });
+        $services->add('Zend\ServiceManager\ServiceLocatorInterface', function () use ($services) {
+            return $services;
+        });
+        $services->add('EventManager', function () use ($mockEventManager) {
+            return $mockEventManager;
+        });
+        $services->add('SharedEventManager', function () use ($mockSharedEventManager) {
+            return $mockSharedEventManager;
         });
 
         $this->controller = new SampleController();
         $this->controller->setEvent($event);
-        $this->controller->setServiceLocator($locator);
+        $this->controller->setServiceLocator($services);
+        $this->controller->setPluginManager($plugins);
 
         $this->plugin = $this->controller->plugin('forward');
     }
@@ -78,16 +103,15 @@ class ForwardTest extends TestCase
         $controller->setEvent($this->controller->getEvent());
         $plugin     = new ForwardPlugin();
         $plugin->setController($controller);
-        $this->setExpectedException('Zend\Mvc\Exception\DomainException', 'implements ServiceLocatorAwareInterface');
+        $this->setExpectedException('Zend\Mvc\Exception\DomainException');
         $plugin->dispatch('forward');
     }
 
-    public function testPluginWithoutControllerLocatorRaisesDomainException()
+    public function testPluginWithoutControllerLocatorRaisesServiceNotCreatedException()
     {
         $controller = new SampleController();
+        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotCreatedException');
         $plugin     = $controller->plugin('forward');
-        $this->setExpectedException('Zend\Mvc\Exception\DomainException', 'composes Locator');
-        $plugin->dispatch('forward');
     }
 
     public function testDispatchRaisesDomainExceptionIfDiscoveredControllerIsNotDispatchable()
@@ -96,7 +120,7 @@ class ForwardTest extends TestCase
         $locator->add('bogus', function () {
             return new stdClass;
         });
-        $this->setExpectedException('Zend\Mvc\Exception\DomainException', 'DispatchableInterface');
+        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotFoundException');
         $this->plugin->dispatch('bogus');
     }
 
@@ -104,9 +128,7 @@ class ForwardTest extends TestCase
     {
         $this->setExpectedException('Zend\Mvc\Exception\DomainException', 'Circular forwarding');
         $sampleController = $this->controller;
-        $sampleController->getServiceLocator()->add('sample', function () use ($sampleController) {
-            return $sampleController;
-        });
+        $this->controllers->setService('sample', $sampleController);
         $this->plugin->dispatch('sample', array('action' => 'test-circular'));
     }
 

--- a/tests/ZendTest/Mvc/Controller/Plugin/ForwardTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/ForwardTest.php
@@ -91,19 +91,9 @@ class ForwardTest extends TestCase
     public function testPluginWithoutEventAwareControllerRaisesDomainException()
     {
         $controller = new UneventfulController();
-        $plugin     = new ForwardPlugin();
+        $plugin     = new ForwardPlugin($this->controllers);
         $plugin->setController($controller);
         $this->setExpectedException('Zend\Mvc\Exception\DomainException', 'InjectApplicationEventInterface');
-        $plugin->dispatch('forward');
-    }
-
-    public function testPluginWithoutLocatorAwareControllerRaisesDomainException()
-    {
-        $controller = new UnlocatableEventfulController();
-        $controller->setEvent($this->controller->getEvent());
-        $plugin     = new ForwardPlugin();
-        $plugin->setController($controller);
-        $this->setExpectedException('Zend\Mvc\Exception\DomainException');
         $plugin->dispatch('forward');
     }
 


### PR DESCRIPTION
This is based on discussions in #4314 - essentially, the main reason that controllers are ServiceManagerAware is because it was the only way to have workflow-aware plugins such as the Forward plugin. Or so we thought.

On analysis, it's far simpler and easier to inject the ControllerManager instance directly into the Forward plugin on creation, as it allows us to remove quite some code, and remove the requirement that controllers be ServiceManagerAware in order to forward.

This PR modifies the Forward plugin to accept a ControllerManager instance via a setter, and adds a ForwardFactory that does this. Tests have been modified as the internal workflow was able to change and be simplified (much of the work done was validating the controller, and this is handled by the ControllerManager now).
