### PR TITLE
Fixes matched routes from bubbling over to other segment routes. 

### DIFF
--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -197,23 +197,7 @@ class Mvc extends AbstractPage
             );
         }
 
-        if ($this->useRouteMatch()) {
-            $rmParams = $this->getRouteMatch()->getParams();
-
-            if (isset($rmParams[ModuleRouteListener::ORIGINAL_CONTROLLER])) {
-                $rmParams['controller'] = $rmParams[ModuleRouteListener::ORIGINAL_CONTROLLER];
-                unset($rmParams[ModuleRouteListener::ORIGINAL_CONTROLLER]);
-            }
-
-            if (isset($rmParams[ModuleRouteListener::MODULE_NAMESPACE])) {
-                unset($rmParams[ModuleRouteListener::MODULE_NAMESPACE]);
-            }
-
-            $params = array_merge($rmParams, $this->getParams());
-        } else {
-            $params = $this->getParams();
-        }
-
+        $params = ($this->getRouteMatch() !== null) ? array() : $this->getParams();
 
         if (($param = $this->getController()) != null) {
             $params['controller'] = $param;


### PR DESCRIPTION
This PR is an attempt to fix #4333 matched routes from bubbling over to other segment routes by assembling the url based on the matched route. 
