### PR TITLE
Use is_int() instead of is_integer()

### DIFF
--- a/library/Zend/Authentication/Adapter/DbTable/AbstractAdapter.php
+++ b/library/Zend/Authentication/Adapter/DbTable/AbstractAdapter.php
@@ -149,7 +149,7 @@ abstract class AbstractAdapter extends BaseAdapter
      */
     public function setAmbiguityIdentity($flag)
     {
-        if (is_integer($flag)) {
+        if (is_int($flag)) {
             $this->ambiguityIdentity = (1 === $flag ? true : false);
         } elseif (is_bool($flag)) {
             $this->ambiguityIdentity = $flag;

--- a/library/Zend/Config/Writer/Ini.php
+++ b/library/Zend/Config/Writer/Ini.php
@@ -143,7 +143,7 @@ class Ini extends AbstractWriter
      */
     protected function prepareValue($value)
     {
-        if (is_integer($value) || is_float($value)) {
+        if (is_int($value) || is_float($value)) {
             return $value;
         } elseif (is_bool($value)) {
             return ($value ? 'true' : 'false');

--- a/library/Zend/ProgressBar/Adapter/Console.php
+++ b/library/Zend/ProgressBar/Adapter/Console.php
@@ -209,7 +209,7 @@ class Console extends AbstractAdapter
      */
     public function setWidth($width = null)
     {
-        if ($width === null || !is_integer($width)) {
+        if ($width === null || !is_int($width)) {
             if (substr(PHP_OS, 0, 3) === 'WIN') {
                 // We have to default to 79 on windows, because the windows
                 // terminal always has a fixed width of 80 characters and the


### PR DESCRIPTION
`is_integer()` aliases `is_int()`, but `is_int()` is used more often throughout the code base.

On a separate note, I feel usage of methods, coding **and** documentation style should be as consistent as possible throughout a project.
