### PR TITLE
Docblocks do not match

### DIFF
--- a/library/Zend/Authentication/Adapter/DbTable/CallbackCheckAdapter.php
+++ b/library/Zend/Authentication/Adapter/DbTable/CallbackCheckAdapter.php
@@ -27,12 +27,11 @@ class CallbackCheckAdapter extends AbstractAdapter
     /**
      * __construct() - Sets configuration options
      *
-     * @param  DbAdapter $zendDb
-     * @param  string    $tableName           Optional
-     * @param  string    $identityColumn      Optional
-     * @param  string    $credentialColumn    Optional
-     * @param  callable  $credentialValidationCallback   Optional
-     * @return \Zend\Authentication\Adapter\DbTable
+     * @param DbAdapter $zendDb
+     * @param string    $tableName                    Optional
+     * @param string    $identityColumn               Optional
+     * @param string    $credentialColumn             Optional
+     * @param callable  $credentialValidationCallback Optional
      */
     public function __construct(
         DbAdapter $zendDb,

--- a/library/Zend/Authentication/Adapter/DbTable/CredentialTreatmentAdapter.php
+++ b/library/Zend/Authentication/Adapter/DbTable/CredentialTreatmentAdapter.php
@@ -27,12 +27,11 @@ class CredentialTreatmentAdapter extends AbstractAdapter
     /**
      * __construct() - Sets configuration options
      *
-     * @param  DbAdapter $zendDb
-     * @param  string    $tableName           Optional
-     * @param  string    $identityColumn      Optional
-     * @param  string    $credentialColumn    Optional
-     * @param  string    $credentialTreatment Optional
-     * @return \Zend\Authentication\Adapter\DbTable
+     * @param DbAdapter $zendDb
+     * @param string    $tableName           Optional
+     * @param string    $identityColumn      Optional
+     * @param string    $credentialColumn    Optional
+     * @param string    $credentialTreatment Optional
      */
     public function __construct(
         DbAdapter $zendDb,

--- a/library/Zend/Barcode/Renderer/Pdf.php
+++ b/library/Zend/Barcode/Renderer/Pdf.php
@@ -138,13 +138,13 @@ class Pdf extends AbstractRenderer
 
     /**
      * Draw a polygon in the rendering resource
-     * @param string $text
-     * @param float $size
-     * @param array $position
-     * @param string $font
+     * @param string  $text
+     * @param float   $size
+     * @param array   $position
+     * @param string  $font
      * @param integer $color
-     * @param string $alignment
-     * @param float $orientation
+     * @param string  $alignment
+     * @param float   $orientation
      */
     protected function drawText(
         $text,

--- a/library/Zend/Cache/Storage/Adapter/SessionOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/SessionOptions.php
@@ -27,7 +27,7 @@ class SessionOptions extends AdapterOptions
     /**
      * Set the session container
      *
-     * @param  null|SessionContainer $memoryLimit
+     * @param  null|SessionContainer $sessionContainer
      * @return SessionOptions
      */
     public function setSessionContainer(SessionContainer $sessionContainer = null)

--- a/library/Zend/Console/Color/Xterm256.php
+++ b/library/Zend/Console/Color/Xterm256.php
@@ -30,7 +30,6 @@ class Xterm256
      * Populate color property with X11-formatted equivalent
      *
      * @param mixed $color
-     * @return void
      */
     protected function __construct($color = null)
     {

--- a/library/Zend/Db/Adapter/Driver/IbmDb2/IbmDb2.php
+++ b/library/Zend/Db/Adapter/Driver/IbmDb2/IbmDb2.php
@@ -33,9 +33,8 @@ class IbmDb2 implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param array|Connection|resource $connection
-     * @param null|Statement $statementPrototype
-     * @param null|Result $resultPrototype
-     * @param string $features
+     * @param null|Statement            $statementPrototype
+     * @param null|Result               $resultPrototype
      */
     public function __construct($connection, Statement $statementPrototype = null, Result $resultPrototype = null)
     {

--- a/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
@@ -132,7 +132,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     /**
      * Set resource
      *
-     * @param  mysqli $resource
+     * @param  \mysqli $resource
      * @return Connection
      */
     public function setResource(\mysqli $resource)

--- a/library/Zend/Db/Adapter/Driver/Oci8/Oci8.php
+++ b/library/Zend/Db/Adapter/Driver/Oci8/Oci8.php
@@ -195,7 +195,8 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @param resource $resource
+     * @param  resource $resource
+     * @param  null     $isBuffered
      * @return Result
      */
     public function createResult($resource, $isBuffered = null)

--- a/library/Zend/Db/Adapter/Platform/PlatformInterface.php
+++ b/library/Zend/Db/Adapter/Platform/PlatformInterface.php
@@ -87,7 +87,7 @@ interface PlatformInterface
      * Quote identifier in fragment
      *
      * @param  string $identifier
-     * @param  array $safeWords
+     * @param  array $additionalSafeWords
      * @return string
      */
     public function quoteIdentifierInFragment($identifier, array $additionalSafeWords = array());

--- a/library/Zend/Dom/NodeList.php
+++ b/library/Zend/Dom/NodeList.php
@@ -52,11 +52,10 @@ class NodeList implements Iterator, Countable, ArrayAccess
     /**
      * Constructor
      *
-     * @param  string       $cssQuery
-     * @param  string|array $xpathQuery
-     * @param  DOMDocument  $document
-     * @param  DOMNodeList  $nodeList
-     * @return void
+     * @param string       $cssQuery
+     * @param string|array $xpathQuery
+     * @param DOMDocument  $document
+     * @param DOMNodeList  $nodeList
      */
     public function  __construct($cssQuery, $xpathQuery, DOMDocument $document, DOMNodeList $nodeList)
     {
@@ -192,7 +191,8 @@ class NodeList implements Iterator, Countable, ArrayAccess
     /**
      * ArrayAccess: set offset
      *
-     * @return void
+     * @param  mixed $key
+     * @param  mixed $value
      * @throws Exception\BadMethodCallException when attemptingn to write to a read-only item
      */
     public function offsetSet($key, $value)
@@ -203,7 +203,7 @@ class NodeList implements Iterator, Countable, ArrayAccess
     /**
      * ArrayAccess: unset offset
      *
-     * @return void
+     * @param  mixed $key
      * @throws Exception\BadMethodCallException when attemptingn to unset a read-only item
      */
     public function offsetUnset($key)

--- a/library/Zend/EventManager/StaticEventManager.php
+++ b/library/Zend/EventManager/StaticEventManager.php
@@ -22,8 +22,6 @@ class StaticEventManager extends SharedEventManager
 
     /**
      * Singleton
-     *
-     * @return void
      */
     protected function __construct()
     {

--- a/library/Zend/Filter/UriNormalize.php
+++ b/library/Zend/Filter/UriNormalize.php
@@ -34,8 +34,7 @@ class UriNormalize extends AbstractFilter
     /**
      * Sets filter options
      *
-     * @param  array|\Traversable|null $options
-     * @return void
+     * @param array|\Traversable|null $options
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Form/FormAbstractServiceFactory.php
+++ b/library/Zend/Form/FormAbstractServiceFactory.php
@@ -47,8 +47,9 @@ class FormAbstractServiceFactory implements AbstractFactoryInterface
     }
 
     /**
-     * @param array $spec
-     * @return \Zend\Form\FormInterface
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @param  array $spec
+     * @return ElementInterface
      */
     public function createForm(ServiceLocatorInterface $serviceLocator, $spec = array())
     {
@@ -68,7 +69,8 @@ class FormAbstractServiceFactory implements AbstractFactoryInterface
     }
 
     /**
-     * @return \Zend\Form\Factory
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @return Factory
      */
     public function getFormFactory(ServiceLocatorInterface $serviceLocator)
     {

--- a/library/Zend/Json/Decoder.php
+++ b/library/Zend/Json/Decoder.php
@@ -78,12 +78,11 @@ class Decoder
     /**
      * Constructor
      *
-     * @param string $source String source to decode
-     * @param int $decodeType How objects should be decoded -- see
+     * @param string $source     String source to decode
+     * @param int    $decodeType How objects should be decoded -- see
      * {@link Zend\Json\Json::TYPE_ARRAY} and {@link Zend\Json\Json::TYPE_OBJECT} for
      * valid values
      * @throws InvalidArgumentException
-     * @return void
      */
     protected function __construct($source, $decodeType)
     {

--- a/library/Zend/Json/Server/Server.php
+++ b/library/Zend/Json/Server/Server.php
@@ -155,8 +155,8 @@ class Server extends AbstractServer
      * Handle request
      *
      * @param  Request $request
-     * @throws Exception\InvalidArgumentException
      * @return null|Response
+     * @throws Exception\InvalidArgumentException
      */
     public function handle($request = false)
     {

--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -168,7 +168,8 @@ abstract class AbstractRestfulController extends AbstractController
      * Not marked as abstract, as that would introduce a BC break
      * (introduced in 2.1.0); instead, raises an exception if not implemented.
      *
-     * @return mixed
+     * @param  $id
+     * @param  $data
      * @throws Exception\RuntimeException
      */
     public function patch($id, $data)

--- a/library/Zend/Paginator/Adapter/DbTableGateway.php
+++ b/library/Zend/Paginator/Adapter/DbTableGateway.php
@@ -9,16 +9,18 @@
 
 namespace Zend\Paginator\Adapter;
 
-use Zend\Paginator\Adapter\DbSelect;
+use Zend\Db\Sql\Where;
 use Zend\Db\TableGateway\TableGateway;
+use Zend\Paginator\Adapter\DbSelect;
 
 class DbTableGateway extends DbSelect
 {
     /**
-     * Construnct
+     * Constructs instance.
      *
      * @param TableGateway                $tableGateway
      * @param Where|\Closure|string|array $where
+     * @param null                        $order
      */
     public function __construct(TableGateway $tableGateway, $where = null, $order = null)
     {

--- a/library/Zend/Soap/AutoDiscover.php
+++ b/library/Zend/Soap/AutoDiscover.php
@@ -150,8 +150,9 @@ class AutoDiscover
     /**
      * Set the class map of php to wsdl qname types.
      *
-     * @param array $classmap
+     * @param  array $classmap
      * @return AutoDiscover
+     * @throws Exception\InvalidArgumentException
      */
     public function setClassMap($classMap)
     {

--- a/library/Zend/Stdlib/ArrayObject/PhpLegacyCompatibility.php
+++ b/library/Zend/Stdlib/ArrayObject/PhpLegacyCompatibility.php
@@ -24,10 +24,9 @@ abstract class PhpLegacyCompatibility extends PhpArrayObject
     /**
      * Constructor
      *
-     * @param  array       $input
-     * @param  int         $flags
-     * @param  string      $iteratorClass
-     * @return ArrayObject
+     * @param array  $input
+     * @param int    $flags
+     * @param string $iteratorClass
      */
     public function __construct($input = array(), $flags = self::STD_PROP_LIST, $iteratorClass = 'ArrayIterator')
     {

--- a/library/Zend/Stdlib/ArrayObject/PhpReferenceCompatibility.php
+++ b/library/Zend/Stdlib/ArrayObject/PhpReferenceCompatibility.php
@@ -59,10 +59,9 @@ abstract class PhpReferenceCompatibility implements IteratorAggregate, ArrayAcce
     /**
      * Constructor
      *
-     * @param  array       $input
-     * @param  int         $flags
-     * @param  string      $iteratorClass
-     * @return ArrayObject
+     * @param array  $input
+     * @param int    $flags
+     * @param string $iteratorClass
      */
     public function __construct($input = array(), $flags = self::STD_PROP_LIST, $iteratorClass = 'ArrayIterator')
     {

--- a/library/Zend/Stdlib/Hydrator/AbstractHydrator.php
+++ b/library/Zend/Stdlib/Hydrator/AbstractHydrator.php
@@ -102,9 +102,9 @@ abstract class AbstractHydrator implements HydratorInterface, StrategyEnabledInt
     /**
      * Converts a value for extraction. If no strategy exists the plain value is returned.
      *
-     * @param string $name The name of the strategy to use.
-     * @param mixed $value The value that should be converted.
-     * @param array $data The object is optionally provided as context.
+     * @param  string $name  The name of the strategy to use.
+     * @param  mixed  $value  The value that should be converted.
+     * @param  array  $object The object is optionally provided as context.
      * @return mixed
      */
     public function extractValue($name, $value, $object = null)

--- a/library/Zend/Test/Util/ModuleLoader.php
+++ b/library/Zend/Test/Util/ModuleLoader.php
@@ -20,7 +20,8 @@ class ModuleLoader
 
     /**
      * Load list of modules or application configuration
-     * @param array $modules
+     *
+     * @param array $configuration
      */
     public function __construct(array $configuration)
     {
@@ -50,6 +51,7 @@ class ModuleLoader
 
     /**
      * Get the application
+     *
      * @return Zend\Mvc\Application
      */
     public function getApplication()
@@ -59,6 +61,7 @@ class ModuleLoader
 
     /**
      * Get the module manager
+     *
      * @return Zend\ModuleManager\ModuleManager
      */
     public function getModuleManager()
@@ -68,6 +71,7 @@ class ModuleLoader
 
     /**
      * Get module
+     *
      * @return mixed
      */
     public function getModule($moduleName)
@@ -77,6 +81,7 @@ class ModuleLoader
 
     /**
      * Get the service manager
+     *
      * @var ServiceManager
      */
     public function getServiceManager()

--- a/library/Zend/View/Helper/Navigation/Listener/AclListener.php
+++ b/library/Zend/View/Helper/Navigation/Listener/AclListener.php
@@ -27,8 +27,8 @@ class AclListener
      *      - Page is accepted if it has no resource or privilege.
      *      - Page is accepted if ACL allows page's resource or privilege.
      *
-     * @param   MvcEvent    $event
-     * @return  boolean
+     * @param  Event    $event
+     * @return bool
      */
     public static function accept(Event $event)
     {

--- a/library/Zend/View/Stream.php
+++ b/library/Zend/View/Stream.php
@@ -48,6 +48,10 @@ class Stream
     /**
      * Opens the script file and converts markup.
      *
+     * @param  string $path
+     * @param         $mode
+     * @param         $options
+     * @param         $opened_path
      * @return bool
      */
     public function stream_open($path, $mode, $options, &$opened_path)
@@ -95,7 +99,8 @@ class Stream
     /**
      * Reads from the stream.
      *
-     * @return string|false
+     * @param  int $count
+     * @return string
      */
     public function stream_read($count)
     {
@@ -141,6 +146,8 @@ class Stream
     /**
      * Seek to a specific point in the stream.
      *
+     * @param  $offset
+     * @param  $whence
      * @return bool
      */
     public function stream_seek($offset, $whence)


### PR DESCRIPTION
In a few classes I came across some issues with method doc-blocks not matching the actual method declarations. Also, some constructors have got `@return` annotations.

This PR fixes some of these mis-matches.
