### PR TITLE
Add missing file level doc-block

### DIFF
--- a/library/Zend/Config/WriterPluginManager.php
+++ b/library/Zend/Config/WriterPluginManager.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
 namespace Zend\Config;
 
 use Zend\ServiceManager\AbstractPluginManager;


### PR DESCRIPTION
In `Zend\Config\WriterPluginManager`, a file level doc-block is missing.
