### PR TITLE
Add empty line after namespace declaration

### DIFF
--- a/library/Zend/Http/Header/Accept.php
+++ b/library/Zend/Http/Header/Accept.php
@@ -8,8 +8,8 @@
  */
 
 namespace Zend\Http\Header;
-use Zend\Http\Header\Accept\FieldValuePart;
 
+use Zend\Http\Header\Accept\FieldValuePart;
 
 /**
  * Accept Header

--- a/library/Zend/Http/Header/AcceptCharset.php
+++ b/library/Zend/Http/Header/AcceptCharset.php
@@ -8,6 +8,7 @@
  */
 
 namespace Zend\Http\Header;
+
 use Zend\Http\Header\Accept\FieldValuePart;
 
 /**

--- a/library/Zend/Http/Header/AcceptEncoding.php
+++ b/library/Zend/Http/Header/AcceptEncoding.php
@@ -8,6 +8,7 @@
  */
 
 namespace Zend\Http\Header;
+
 use Zend\Http\Header\Accept\FieldValuePart;
 
 /**

--- a/library/Zend/Http/Header/AcceptLanguage.php
+++ b/library/Zend/Http/Header/AcceptLanguage.php
@@ -8,8 +8,8 @@
  */
 
 namespace Zend\Http\Header;
-use Zend\Http\Header\Accept\FieldValuePart;
 
+use Zend\Http\Header\Accept\FieldValuePart;
 
 /**
  * Accept Language Header


### PR DESCRIPTION
In a few classes, empty lines after the use statements - as recommended by [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md#3-namespace-and-use-declarations) - are missing.

This PR fixes this.
