### PR TITLE
fix the constructor's type-autodetection accepts wrong parameters

### DIFF
--- a/library/Zend/Validator/NotEmpty.php
+++ b/library/Zend/Validator/NotEmpty.php
@@ -90,7 +90,7 @@ class NotEmpty extends AbstractValidator
                 $detected = 0;
                 $found    = false;
                 foreach ($options as $option) {
-                    if (in_array($option, $this->constants)) {
+                    if (in_array($option, $this->constants, true)) {
                         $found = true;
                         $detected += array_search($option, $this->constants);
                     }

--- a/tests/ZendTest/Validator/NotEmptyTest.php
+++ b/tests/ZendTest/Validator/NotEmptyTest.php
@@ -589,6 +589,12 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($validator->getOption('messageTemplates'),
                                      'messageTemplates', $validator);
     }
+
+    public function testTypeAutoDetectionHasNoSideEffect()
+    {
+        $validator = new NotEmpty(array('translatorEnabled' => true));
+        $this->assertEquals(493, $validator->getType());
+    }
 }
 
 class ClassTest2


### PR DESCRIPTION
``` php
$validator = new \Zend\Validator\NotEmpty(array('translatorEnabled' => true));
var_dump($validator->getType());
var_dump($validator->isValid(''));
```

expects
493
false

but actually
1
true.

because if 'type' is not found in $options, the autodetection compares bool(true) to string(constants), it is true. And autodetector set 'type'  true.
So, in_array 's third parameter should be true.
