### PR TITLE
Fix return annotations in case of fluent interface

### DIFF
--- a/library/Zend/Authentication/Adapter/DbTable/AbstractAdapter.php
+++ b/library/Zend/Authentication/Adapter/DbTable/AbstractAdapter.php
@@ -106,7 +106,7 @@ abstract class AbstractAdapter extends BaseAdapter
      * setTableName() - set the table name to be used in the select query
      *
      * @param  string $tableName
-     * @return DbTable Provides a fluent interface
+     * @return AbstractAdapter Provides a fluent interface
      */
     public function setTableName($tableName)
     {
@@ -118,7 +118,7 @@ abstract class AbstractAdapter extends BaseAdapter
      * setIdentityColumn() - set the column name to be used as the identity column
      *
      * @param  string $identityColumn
-     * @return DbTable Provides a fluent interface
+     * @return AbstractAdapter Provides a fluent interface
      */
     public function setIdentityColumn($identityColumn)
     {
@@ -130,7 +130,7 @@ abstract class AbstractAdapter extends BaseAdapter
      * setCredentialColumn() - set the column name to be used as the credential column
      *
      * @param  string $credentialColumn
-     * @return DbTable Provides a fluent interface
+     * @return AbstractAdapter Provides a fluent interface
      */
     public function setCredentialColumn($credentialColumn)
     {
@@ -144,7 +144,7 @@ abstract class AbstractAdapter extends BaseAdapter
      * false) parameters. Default is false.
      *
      * @param  int|bool $flag
-     * @return DbTable Provides a fluent interface
+     * @return AbstractAdapter Provides a fluent interface
      */
     public function setAmbiguityIdentity($flag)
     {

--- a/library/Zend/Authentication/Adapter/DbTable/AbstractAdapter.php
+++ b/library/Zend/Authentication/Adapter/DbTable/AbstractAdapter.php
@@ -107,7 +107,7 @@ abstract class AbstractAdapter extends BaseAdapter
      * setTableName() - set the table name to be used in the select query
      *
      * @param  string $tableName
-     * @return DbTable Provides a fluent interface
+     * @return AbstractAdapter Provides a fluent interface
      */
     public function setTableName($tableName)
     {
@@ -119,7 +119,7 @@ abstract class AbstractAdapter extends BaseAdapter
      * setIdentityColumn() - set the column name to be used as the identity column
      *
      * @param  string $identityColumn
-     * @return DbTable Provides a fluent interface
+     * @return AbstractAdapter Provides a fluent interface
      */
     public function setIdentityColumn($identityColumn)
     {
@@ -131,7 +131,7 @@ abstract class AbstractAdapter extends BaseAdapter
      * setCredentialColumn() - set the column name to be used as the credential column
      *
      * @param  string $credentialColumn
-     * @return DbTable Provides a fluent interface
+     * @return AbstractAdapter Provides a fluent interface
      */
     public function setCredentialColumn($credentialColumn)
     {
@@ -145,7 +145,7 @@ abstract class AbstractAdapter extends BaseAdapter
      * false) parameters. Default is false.
      *
      * @param  int|bool $flag
-     * @return DbTable Provides a fluent interface
+     * @return AbstractAdapter Provides a fluent interface
      */
     public function setAmbiguityIdentity($flag)
     {

--- a/library/Zend/Authentication/Adapter/DbTable/CallbackCheckAdapter.php
+++ b/library/Zend/Authentication/Adapter/DbTable/CallbackCheckAdapter.php
@@ -56,7 +56,7 @@ class CallbackCheckAdapter extends AbstractAdapter
      * credential.
      *
      * @param callable $validationCallback
-     * @return DbTable
+     * @return CallbackCheckAdapter
      * @throws Exception\InvalidArgumentException
      */
     public function setCredentialValidationCallback($validationCallback)

--- a/library/Zend/Authentication/Adapter/DbTable/CallbackCheckAdapter.php
+++ b/library/Zend/Authentication/Adapter/DbTable/CallbackCheckAdapter.php
@@ -57,7 +57,7 @@ class CallbackCheckAdapter extends AbstractAdapter
      * credential.
      *
      * @param callable $validationCallback
-     * @return DbTable
+     * @return CallbackCheckAdapter
      * @throws Exception\InvalidArgumentException
      */
     public function setCredentialValidationCallback($validationCallback)

--- a/library/Zend/Authentication/Adapter/DbTable/CredentialTreatmentAdapter.php
+++ b/library/Zend/Authentication/Adapter/DbTable/CredentialTreatmentAdapter.php
@@ -62,7 +62,7 @@ class CredentialTreatmentAdapter extends AbstractAdapter
      *  'MD5(?)'
      *
      * @param  string $treatment
-     * @return DbTable Provides a fluent interface
+     * @return CredentialTreatmentAdapter Provides a fluent interface
      */
     public function setCredentialTreatment($treatment)
     {

--- a/library/Zend/Authentication/Adapter/DbTable/CredentialTreatmentAdapter.php
+++ b/library/Zend/Authentication/Adapter/DbTable/CredentialTreatmentAdapter.php
@@ -63,7 +63,7 @@ class CredentialTreatmentAdapter extends AbstractAdapter
      *  'MD5(?)'
      *
      * @param  string $treatment
-     * @return DbTable Provides a fluent interface
+     * @return CredentialTreatmentAdapter Provides a fluent interface
      */
     public function setCredentialTreatment($treatment)
     {

--- a/library/Zend/Authentication/Adapter/Http/ApacheResolver.php
+++ b/library/Zend/Authentication/Adapter/Http/ApacheResolver.php
@@ -50,7 +50,7 @@ class ApacheResolver implements ResolverInterface
      * Set the path to the credentials file
      *
      * @param  string $path
-     * @return FileResolver Provides a fluent interface
+     * @return ApacheResolver Provides a fluent interface
      * @throws Exception\InvalidArgumentException if path is not readable
      */
     public function setFile($path)

--- a/library/Zend/Barcode/Object/AbstractObject.php
+++ b/library/Zend/Barcode/Object/AbstractObject.php
@@ -226,7 +226,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Set barcode state from options array
      * @param  array $options
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      */
     public function setOptions($options)
     {
@@ -243,7 +243,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set barcode namespace for autoloading
      *
      * @param string $namespace
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      */
     public function setBarcodeNamespace($namespace)
     {
@@ -273,7 +273,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Set height of the barcode bar
      * @param integer $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarHeight($value)
@@ -299,7 +299,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Set thickness of thin bar
      * @param integer $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarThinWidth($value)
@@ -325,7 +325,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Set thickness of thick bar
      * @param integer $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarThickWidth($value)
@@ -352,7 +352,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set factor applying to
      * thinBarWidth - thickBarWidth - barHeight - fontSize
      * @param float $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFactor($value)
@@ -379,7 +379,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Set color of the barcode and text
      * @param string $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setForeColor($value)
@@ -408,7 +408,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Set the color of the background
      * @param integer $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBackgroundColor($value)
@@ -437,7 +437,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Activate/deactivate drawing of the bar
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      */
     public function setWithBorder($value)
     {
@@ -476,7 +476,7 @@ abstract class AbstractObject implements ObjectInterface
 
     /**
      * Allow fast inversion of font/bars color and background color
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      */
     public function setReverseColor()
     {
@@ -489,7 +489,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Set orientation of barcode and text
      * @param float $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setOrientation($value)
@@ -510,7 +510,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Set text to encode
      * @param string $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      */
     public function setText($value)
     {
@@ -580,7 +580,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Activate/deactivate drawing of text to encode
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      */
     public function setDrawText($value)
     {
@@ -601,7 +601,7 @@ abstract class AbstractObject implements ObjectInterface
      * Activate/deactivate the adjustment of the position
      * of the characters to the position of the bars
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setStretchText($value)
@@ -625,7 +625,7 @@ abstract class AbstractObject implements ObjectInterface
      * of the checksum character
      * added to the barcode text
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      */
     public function setWithChecksum($value)
     {
@@ -650,7 +650,7 @@ abstract class AbstractObject implements ObjectInterface
      * of the checksum character
      * added to the barcode text
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setWithChecksumInText($value)
@@ -676,7 +676,7 @@ abstract class AbstractObject implements ObjectInterface
      *  - if integer between 1 and 5, use gd built-in fonts
      *  - if string, $value is assumed to be the path to a TTF font
      * @param integer|string $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFont($value)
@@ -716,7 +716,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Set the size of the font in case of TTF
      * @param float $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFontSize($value)

--- a/library/Zend/Barcode/Object/AbstractObject.php
+++ b/library/Zend/Barcode/Object/AbstractObject.php
@@ -272,7 +272,7 @@ abstract class AbstractObject implements ObjectInterface
 
     /**
      * Set height of the barcode bar
-     * @param integer $value
+     * @param int $value
      * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
@@ -298,7 +298,7 @@ abstract class AbstractObject implements ObjectInterface
 
     /**
      * Set thickness of thin bar
-     * @param integer $value
+     * @param int $value
      * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
@@ -324,7 +324,7 @@ abstract class AbstractObject implements ObjectInterface
 
     /**
      * Set thickness of thick bar
-     * @param integer $value
+     * @param int $value
      * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
@@ -407,7 +407,7 @@ abstract class AbstractObject implements ObjectInterface
 
     /**
      * Set the color of the background
-     * @param integer $value
+     * @param int $value
      * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
@@ -675,7 +675,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set the font:
      *  - if integer between 1 and 5, use gd built-in fonts
      *  - if string, $value is assumed to be the path to a TTF font
-     * @param integer|string $value
+     * @param int|string $value
      * @return AbstractObject
      * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */

--- a/library/Zend/Barcode/Object/AbstractObject.php
+++ b/library/Zend/Barcode/Object/AbstractObject.php
@@ -226,7 +226,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Set barcode state from options array
      * @param  array $options
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      */
     public function setOptions($options)
     {
@@ -243,7 +243,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set barcode namespace for autoloading
      *
      * @param string $namespace
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      */
     public function setBarcodeNamespace($namespace)
     {
@@ -272,9 +272,9 @@ abstract class AbstractObject implements ObjectInterface
 
     /**
      * Set height of the barcode bar
-     * @param int $value
-     * @return \Zend\Barcode\Object\ObjectInterface
-     * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
+     * @param integer $value
+     * @return AbstractObject
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarHeight($value)
     {
@@ -298,9 +298,9 @@ abstract class AbstractObject implements ObjectInterface
 
     /**
      * Set thickness of thin bar
-     * @param int $value
-     * @return \Zend\Barcode\Object\ObjectInterface
-     * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
+     * @param integer $value
+     * @return AbstractObject
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarThinWidth($value)
     {
@@ -324,9 +324,9 @@ abstract class AbstractObject implements ObjectInterface
 
     /**
      * Set thickness of thick bar
-     * @param int $value
-     * @return \Zend\Barcode\Object\ObjectInterface
-     * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
+     * @param integer $value
+     * @return AbstractObject
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarThickWidth($value)
     {
@@ -352,8 +352,8 @@ abstract class AbstractObject implements ObjectInterface
      * Set factor applying to
      * thinBarWidth - thickBarWidth - barHeight - fontSize
      * @param float $value
-     * @return \Zend\Barcode\Object\ObjectInterface
-     * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
+     * @return AbstractObject
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFactor($value)
     {
@@ -379,8 +379,8 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Set color of the barcode and text
      * @param string $value
-     * @return \Zend\Barcode\Object\ObjectInterface
-     * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
+     * @return AbstractObject
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setForeColor($value)
     {
@@ -407,9 +407,9 @@ abstract class AbstractObject implements ObjectInterface
 
     /**
      * Set the color of the background
-     * @param int $value
-     * @return \Zend\Barcode\Object\ObjectInterface
-     * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
+     * @param integer $value
+     * @return AbstractObject
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBackgroundColor($value)
     {
@@ -437,7 +437,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Activate/deactivate drawing of the bar
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      */
     public function setWithBorder($value)
     {
@@ -476,7 +476,7 @@ abstract class AbstractObject implements ObjectInterface
 
     /**
      * Allow fast inversion of font/bars color and background color
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      */
     public function setReverseColor()
     {
@@ -489,8 +489,8 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Set orientation of barcode and text
      * @param float $value
-     * @return \Zend\Barcode\Object\ObjectInterface
-     * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
+     * @return AbstractObject
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setOrientation($value)
     {
@@ -510,7 +510,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Set text to encode
      * @param string $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      */
     public function setText($value)
     {
@@ -580,7 +580,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Activate/deactivate drawing of text to encode
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      */
     public function setDrawText($value)
     {
@@ -601,8 +601,8 @@ abstract class AbstractObject implements ObjectInterface
      * Activate/deactivate the adjustment of the position
      * of the characters to the position of the bars
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
-     * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
+     * @return AbstractObject
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setStretchText($value)
     {
@@ -625,7 +625,7 @@ abstract class AbstractObject implements ObjectInterface
      * of the checksum character
      * added to the barcode text
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject
      */
     public function setWithChecksum($value)
     {
@@ -650,8 +650,8 @@ abstract class AbstractObject implements ObjectInterface
      * of the checksum character
      * added to the barcode text
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
-     * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
+     * @return AbstractObject
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setWithChecksumInText($value)
     {
@@ -675,9 +675,9 @@ abstract class AbstractObject implements ObjectInterface
      * Set the font:
      *  - if integer between 1 and 5, use gd built-in fonts
      *  - if string, $value is assumed to be the path to a TTF font
-     * @param int|string $value
-     * @return \Zend\Barcode\Object\ObjectInterface
-     * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
+     * @param integer|string $value
+     * @return AbstractObject
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFont($value)
     {
@@ -716,8 +716,8 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Set the size of the font in case of TTF
      * @param float $value
-     * @return \Zend\Barcode\Object\ObjectInterface
-     * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
+     * @return AbstractObject
+     * @throw \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFontSize($value)
     {

--- a/library/Zend/Barcode/Object/Code25interleaved.php
+++ b/library/Zend/Barcode/Object/Code25interleaved.php
@@ -32,7 +32,7 @@ class Code25interleaved extends Code25
     /**
      * Activate/deactivate drawing of bearer bars
      * @param  bool $value
-     * @return Code25
+     * @return Code25interleaved
      */
     public function setWithBearerBars($value)
     {

--- a/library/Zend/Barcode/Renderer/Image.php
+++ b/library/Zend/Barcode/Renderer/Image.php
@@ -109,7 +109,7 @@ class Image extends AbstractRenderer
      *
      * @param mixed $value
      * @throws Exception\OutOfRangeException
-     * @return self
+     * @return Image
      */
     public function setWidth($value)
     {

--- a/library/Zend/Barcode/Renderer/Svg.php
+++ b/library/Zend/Barcode/Renderer/Svg.php
@@ -75,7 +75,7 @@ class Svg extends AbstractRenderer
      *
      * @param mixed $value
      * @throws Exception\OutOfRangeException
-     * @return self
+     * @return Svg
      */
     public function setWidth($value)
     {

--- a/library/Zend/Cache/Storage/Adapter/AdapterOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/AdapterOptions.php
@@ -150,7 +150,7 @@ class AdapterOptions extends AbstractOptions
      * Enable/Disable reading data from cache.
      *
      * @param  bool $readable
-     * @return AbstractAdapter
+     * @return AdapterOptions
      */
     public function setReadable($readable)
     {

--- a/library/Zend/Cache/Storage/Adapter/DbaIterator.php
+++ b/library/Zend/Cache/Storage/Adapter/DbaIterator.php
@@ -89,7 +89,7 @@ class DbaIterator implements IteratorInterface
      * Set iterator mode
      *
      * @param int $mode
-     * @return ApcIterator Fluent interface
+     * @return DbaIterator Fluent interface
      */
     public function setMode($mode)
     {

--- a/library/Zend/Cache/Storage/Adapter/DbaOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/DbaOptions.php
@@ -95,7 +95,7 @@ class DbaOptions extends AdapterOptions
      *
      *
      * @param string $mode
-     * @return \Zend\Cache\Storage\Adapter\DbaOptions
+     * @return DbaOptions
      */
     public function setMode($mode)
     {
@@ -109,6 +109,11 @@ class DbaOptions extends AdapterOptions
         return $this->mode;
     }
 
+    /**
+     * @param string $handler
+     * @return DbaOptions
+     * @throws Exception\ExtensionNotLoadedException
+     */
     public function setHandler($handler)
     {
         $handler = (string) $handler;

--- a/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
@@ -434,7 +434,7 @@ class RedisResourceManager
      *
      * @param string $id
      * @param string $password
-     * @return RedisResource
+     * @return RedisResourceManager
      */
     public function setPassword($id, $password)
     {
@@ -471,7 +471,7 @@ class RedisResourceManager
      *
      * @param string $id
      * @param int $database
-     * @return RedisResource
+     * @return RedisResourceManager
      */
     public function setDatabase($id, $database)
     {

--- a/library/Zend/Cache/Storage/Plugin/PluginOptions.php
+++ b/library/Zend/Cache/Storage/Plugin/PluginOptions.php
@@ -183,7 +183,7 @@ class PluginOptions extends AbstractOptions
      *
      * @param  string|SerializerAdapter $serializer
      * @throws Exception\InvalidArgumentException
-     * @return Serializer
+     * @return PluginOptions
      */
     public function setSerializer($serializer)
     {

--- a/library/Zend/Code/Generator/DocBlockGenerator.php
+++ b/library/Zend/Code/Generator/DocBlockGenerator.php
@@ -194,7 +194,7 @@ class DocBlockGenerator extends AbstractGenerator
      * Set the word wrap
      *
      * @param bool $value
-     * @return \Zend\Code\Generator\DocBlockGenerator
+     * @return DocBlockGenerator
      */
     public function setWordWrap($value)
     {

--- a/library/Zend/Code/Generator/PropertyGenerator.php
+++ b/library/Zend/Code/Generator/PropertyGenerator.php
@@ -171,7 +171,6 @@ class PropertyGenerator extends AbstractMemberGenerator
     public function setDefaultValue($defaultValue, $defaultValueType = PropertyValueGenerator::TYPE_AUTO, $defaultValueOutputMode = PropertyValueGenerator::OUTPUT_MULTIPLE_LINE)
     {
         if (!($defaultValue instanceof PropertyValueGenerator)) {
-
             $defaultValue = new PropertyValueGenerator($defaultValue, $defaultValueType, $defaultValueOutputMode);
         }
 

--- a/library/Zend/Code/Generator/ValueGenerator.php
+++ b/library/Zend/Code/Generator/ValueGenerator.php
@@ -114,8 +114,7 @@ class ValueGenerator extends AbstractGenerator
      * Add constant to list
      *
      * @param string $constant
-     *
-     * @return $this
+     * @return ValueGenerator
      */
     public function addConstant($constant)
     {
@@ -128,7 +127,6 @@ class ValueGenerator extends AbstractGenerator
      * Delete constant from constant list
      *
      * @param string $constant
-     *
      * @return bool
      */
     public function deleteConstant($constant)

--- a/library/Zend/Config/Reader/Ini.php
+++ b/library/Zend/Config/Reader/Ini.php
@@ -34,7 +34,7 @@ class Ini implements ReaderInterface
      * Set nest separator.
      *
      * @param  string $separator
-     * @return self
+     * @return Ini
      */
     public function setNestSeparator($separator)
     {

--- a/library/Zend/Config/Writer/Ini.php
+++ b/library/Zend/Config/Writer/Ini.php
@@ -32,7 +32,7 @@ class Ini extends AbstractWriter
      * Set nest separator.
      *
      * @param  string $separator
-     * @return self
+     * @return Ini
      */
     public function setNestSeparator($separator)
     {

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -308,7 +308,7 @@ class Getopt
      *
      * @param  array $argv
      * @throws \Zend\Console\Exception\InvalidArgumentException When not given an array as parameter
-     * @return \Zend\Console\Getopt Provides a fluent interface
+     * @return Getopt Provides a fluent interface
      */
     public function addArguments($argv)
     {
@@ -326,7 +326,7 @@ class Getopt
      *
      * @param  array $argv
      * @throws \Zend\Console\Exception\InvalidArgumentException When not given an array as parameter
-     * @return \Zend\Console\Getopt Provides a fluent interface
+     * @return Getopt Provides a fluent interface
      */
     public function setArguments($argv)
     {
@@ -344,7 +344,7 @@ class Getopt
      * the behavior of Zend_Console_Getopt.
      *
      * @param  array $getoptConfig
-     * @return \Zend\Console\Getopt Provides a fluent interface
+     * @return Getopt Provides a fluent interface
      */
     public function setOptions($getoptConfig)
     {
@@ -363,7 +363,7 @@ class Getopt
      *
      * @param  string $configKey
      * @param  string $configValue
-     * @return \Zend\Console\Getopt Provides a fluent interface
+     * @return Getopt Provides a fluent interface
      */
     public function setOption($configKey, $configValue)
     {
@@ -378,7 +378,7 @@ class Getopt
      * These are appended to the rules defined when the constructor was called.
      *
      * @param  array $rules
-     * @return \Zend\Console\Getopt Provides a fluent interface
+     * @return Getopt Provides a fluent interface
      */
     public function addRules($rules)
     {
@@ -605,7 +605,7 @@ class Getopt
      *
      * @param  array $aliasMap
      * @throws \Zend\Console\Exception\ExceptionInterface
-     * @return \Zend\Console\Getopt Provides a fluent interface
+     * @return Getopt Provides a fluent interface
      */
     public function setAliases($aliasMap)
     {
@@ -635,7 +635,7 @@ class Getopt
      * mapping option name (short or long) to the help string.
      *
      * @param  array $helpMap
-     * @return \Zend\Console\Getopt Provides a fluent interface
+     * @return Getopt Provides a fluent interface
      */
     public function setHelp($helpMap)
     {
@@ -656,7 +656,7 @@ class Getopt
      * Also find option parameters, and remaining arguments after
      * all options have been parsed.
      *
-     * @return \Zend\Console\Getopt|null Provides a fluent interface
+     * @return Getopt|null Provides a fluent interface
      */
     public function parse()
     {

--- a/library/Zend/Console/Request.php
+++ b/library/Zend/Console/Request.php
@@ -127,7 +127,7 @@ class Request extends Message implements RequestInterface
      * primary API for value setting, for that see env())
      *
      * @param \Zend\Stdlib\Parameters $env
-     * @return \Zend\Console\Request
+     * @return Request
      */
     public function setEnv(Parameters $env)
     {

--- a/library/Zend/Db/Adapter/Driver/IbmDb2/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/IbmDb2/Connection.php
@@ -141,7 +141,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     /**
      * Connect
      *
-     * @return ConnectionInterface
+     * @return Connection
      */
     public function connect()
     {
@@ -197,7 +197,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     /**
      * Disconnect
      *
-     * @return ConnectionInterface
+     * @return Connection
      */
     public function disconnect()
     {

--- a/library/Zend/Db/Adapter/Driver/IbmDb2/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/IbmDb2/Statement.php
@@ -93,7 +93,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param $sql
-     * @return mixed
+     * @return Statement
      */
     public function setSql($sql)
     {
@@ -115,7 +115,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set parameter container
      *
      * @param ParameterContainer $parameterContainer
-     * @return mixed
+     * @return Statement
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {
@@ -135,6 +135,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param $resource
+     * @return Statement
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
      */
     public function setResource($resource)
@@ -143,6 +144,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
             throw new Exception\InvalidArgumentException('Resource must be of type DB2 Statement');
         }
         $this->resource = $resource;
+        return $this;
     }
 
     /**

--- a/library/Zend/Db/Adapter/Platform/Mysql.php
+++ b/library/Zend/Db/Adapter/Platform/Mysql.php
@@ -29,7 +29,7 @@ class Mysql implements PlatformInterface
     /**
      * @param \Zend\Db\Adapter\Driver\Mysqli\Mysqli|\Zend\Db\Adapter\Driver\Pdo\Pdo||\mysqli|\PDO $driver
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
-     * @return $this
+     * @return Mysql
      */
     public function setDriver($driver)
     {

--- a/library/Zend/Db/Adapter/Platform/Postgresql.php
+++ b/library/Zend/Db/Adapter/Platform/Postgresql.php
@@ -29,7 +29,7 @@ class Postgresql implements PlatformInterface
     /**
      * @param \Zend\Db\Adapter\Driver\Pgsql\Pgsql|\Zend\Db\Adapter\Driver\Pdo\Pdo|resource|\PDO $driver
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
-     * @return $this
+     * @return Postgresql
      */
     public function setDriver($driver)
     {

--- a/library/Zend/Db/Adapter/Platform/SqlServer.php
+++ b/library/Zend/Db/Adapter/Platform/SqlServer.php
@@ -29,7 +29,7 @@ class SqlServer implements PlatformInterface
     /**
      * @param \Zend\Db\Adapter\Driver\Sqlsrv\Sqlsrv|\Zend\Db\Adapter\Driver\Pdo\Pdo||resource|\PDO $driver
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
-     * @return $this
+     * @return SqlServer
      */
     public function setDriver($driver)
     {

--- a/library/Zend/Db/Adapter/Platform/Sqlite.php
+++ b/library/Zend/Db/Adapter/Platform/Sqlite.php
@@ -29,7 +29,7 @@ class Sqlite implements PlatformInterface
     /**
      * @param \Zend\Db\Adapter\Driver\Pdo\Pdo||\PDO $driver
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
-     * @return $this
+     * @return Sqlite
      */
     public function setDriver($driver)
     {

--- a/library/Zend/Db/ResultSet/AbstractResultSet.php
+++ b/library/Zend/Db/ResultSet/AbstractResultSet.php
@@ -53,7 +53,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      * Set the data source for the result set
      *
      * @param  Iterator|IteratorAggregate|ResultInterface $dataSource
-     * @return ResultSet
+     * @return AbstractResultSet
      * @throws Exception\InvalidArgumentException
      */
     public function initialize($dataSource)

--- a/library/Zend/Db/ResultSet/HydratingResultSet.php
+++ b/library/Zend/Db/ResultSet/HydratingResultSet.php
@@ -42,7 +42,7 @@ class HydratingResultSet extends AbstractResultSet
      *
      * @param  object $objectPrototype
      * @throws Exception\InvalidArgumentException
-     * @return ResultSet
+     * @return HydratingResultSet
      */
     public function setObjectPrototype($objectPrototype)
     {

--- a/library/Zend/Db/RowGateway/AbstractRowGateway.php
+++ b/library/Zend/Db/RowGateway/AbstractRowGateway.php
@@ -241,7 +241,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
      *
      * @param  string $offset
      * @param  mixed $value
-     * @return RowGateway
+     * @return AbstractRowGateway
      */
     public function offsetSet($offset, $value)
     {

--- a/library/Zend/Db/Sql/Predicate/Predicate.php
+++ b/library/Zend/Db/Sql/Predicate/Predicate.php
@@ -220,7 +220,7 @@ class Predicate extends PredicateSet
      *
      * @param $expression
      * @param $parameters
-     * @return $this
+     * @return Predicate
      */
     public function expression($expression, $parameters)
     {

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -115,7 +115,7 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
      * @param  Where|\Closure|string|array $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
      * @throws Exception\InvalidArgumentException
-     * @return Select
+     * @return Update
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {

--- a/library/Zend/Di/Definition/Builder/InjectionMethod.php
+++ b/library/Zend/Di/Definition/Builder/InjectionMethod.php
@@ -26,7 +26,7 @@ class InjectionMethod
 
     /**
      * @param  string|null $name
-     * @return self
+     * @return InjectionMethod
      */
     public function setName($name)
     {

--- a/library/Zend/Di/Definition/ClassDefinition.php
+++ b/library/Zend/Di/Definition/ClassDefinition.php
@@ -49,7 +49,7 @@ class ClassDefinition implements DefinitionInterface, PartialMarker
 
     /**
      * @param  null|\Callable|array|string $instantiator
-     * @return self
+     * @return ClassDefinition
      */
     public function setInstantiator($instantiator)
     {
@@ -60,7 +60,7 @@ class ClassDefinition implements DefinitionInterface, PartialMarker
 
     /**
      * @param  string[] $supertypes
-     * @return self
+     * @return ClassDefinition
      */
     public function setSupertypes(array $supertypes)
     {
@@ -72,7 +72,7 @@ class ClassDefinition implements DefinitionInterface, PartialMarker
     /**
      * @param  string    $method
      * @param  bool|null $isRequired
-     * @return self
+     * @return ClassDefinition
      */
     public function addMethod($method, $isRequired = null)
     {

--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -76,7 +76,7 @@ class Di implements DependencyInjectionInterface
 
     /**
      * @param  DefinitionList $definitions
-     * @return self
+     * @return Di
      */
     public function setDefinitionList(DefinitionList $definitions)
     {

--- a/library/Zend/Di/InstanceManager.php
+++ b/library/Zend/Di/InstanceManager.php
@@ -438,7 +438,7 @@ class InstanceManager /* implements InstanceManagerInterface */
      *
      * @param  string $interfaceOrAbstract
      * @param  string $preferredImplementation
-     * @return self
+     * @return InstanceManager
      */
     public function addTypePreference($interfaceOrAbstract, $preferredImplementation)
     {
@@ -456,7 +456,7 @@ class InstanceManager /* implements InstanceManagerInterface */
      *
      * @param  string    $interfaceOrAbstract
      * @param  string    $preferredType
-     * @return bool|self
+     * @return bool|InstanceManager
      */
     public function removeTypePreference($interfaceOrAbstract, $preferredType)
     {

--- a/library/Zend/Feed/PubSubHubbub/HttpResponse.php
+++ b/library/Zend/Feed/PubSubHubbub/HttpResponse.php
@@ -81,7 +81,7 @@ class HttpResponse
      * @param  string $name
      * @param  string $value
      * @param  bool $replace
-     * @return \Zend\Feed\PubSubHubbub\HttpResponse
+     * @return HttpResponse
      */
     public function setHeader($name, $value, $replace = false)
     {
@@ -176,7 +176,7 @@ class HttpResponse
      * Set body content
      *
      * @param  string $content
-     * @return \Zend\Feed\PubSubHubbub\HttpResponse
+     * @return HttpResponse
      */
     public function setContent($content)
     {

--- a/library/Zend/Feed/PubSubHubbub/Subscriber/Callback.php
+++ b/library/Zend/Feed/PubSubHubbub/Subscriber/Callback.php
@@ -44,7 +44,7 @@ class Callback extends PubSubHubbub\AbstractCallback
      * Required if usePathParameter is enabled for the Subscriber.
      *
      * @param  string $key
-     * @return \Zend\Feed\PubSubHubbub\Subscriber\Callback
+     * @return Callback
      */
     public function setSubscriptionKey($key)
     {
@@ -180,7 +180,7 @@ class Callback extends PubSubHubbub\AbstractCallback
      * Topic we've subscribed to.
      *
      * @param  string $feed
-     * @return \Zend\Feed\PubSubHubbub\Subscriber\Callback
+     * @return Callback
      */
     public function setFeedUpdate($feed)
     {

--- a/library/Zend/Feed/Reader/AbstractEntry.php
+++ b/library/Zend/Feed/Reader/AbstractEntry.php
@@ -151,7 +151,7 @@ abstract class AbstractEntry
      * Set the XPath query
      *
      * @param  DOMXPath $xpath
-     * @return \Zend\Feed\Reader\AbstractEntry
+     * @return AbstractEntry
      */
     public function setXpath(DOMXPath $xpath)
     {

--- a/library/Zend/Feed/Reader/Extension/AbstractFeed.php
+++ b/library/Zend/Feed/Reader/Extension/AbstractFeed.php
@@ -120,7 +120,7 @@ abstract class AbstractFeed
      * Set the XPath query
      *
      * @param  DOMXPath $xpath
-     * @return AbstractEntry
+     * @return AbstractFeed
      */
     public function setXpath(DOMXPath $xpath = null)
     {

--- a/library/Zend/Feed/Writer/Deleted.php
+++ b/library/Zend/Feed/Writer/Deleted.php
@@ -37,7 +37,6 @@ class Deleted
      *
      * @param  $encoding
      * @throws Exception\InvalidArgumentException
-     * @return string|null
      * @return Deleted
      */
     public function setEncoding($encoding)

--- a/library/Zend/Feed/Writer/Renderer/Entry/Atom/Deleted.php
+++ b/library/Zend/Feed/Writer/Renderer/Entry/Atom/Deleted.php
@@ -30,7 +30,7 @@ class Deleted
     /**
      * Render atom entry
      *
-     * @return \Zend\Feed\Writer\Renderer\Entry\Atom
+     * @return Deleted
      */
     public function render()
     {

--- a/library/Zend/Feed/Writer/Renderer/Entry/AtomDeleted.php
+++ b/library/Zend/Feed/Writer/Renderer/Entry/AtomDeleted.php
@@ -32,7 +32,7 @@ class AtomDeleted extends Renderer\AbstractRenderer implements Renderer\Renderer
     /**
      * Render atom entry
      *
-     * @return \Zend\Feed\Writer\Renderer\Entry\Atom
+     * @return AtomDeleted
      */
     public function render()
     {

--- a/library/Zend/Feed/Writer/Renderer/Feed/Atom/Source.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/Atom/Source.php
@@ -28,7 +28,7 @@ class Source extends AbstractAtom implements \Zend\Feed\Writer\Renderer\Renderer
     /**
      * Render Atom Feed Metadata (Source element)
      *
-     * @return \Zend\Feed\Writer\Renderer\Feed\Atom
+     * @return Source
      */
     public function render()
     {

--- a/library/Zend/Feed/Writer/Renderer/Feed/AtomSource.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/AtomSource.php
@@ -32,7 +32,7 @@ class AtomSource extends AbstractAtom implements Renderer\RendererInterface
     /**
      * Render Atom Feed Metadata (Source element)
      *
-     * @return \Zend\Feed\Writer\Renderer\Feed\Atom
+     * @return AtomSource
      */
     public function render()
     {

--- a/library/Zend/Feed/Writer/Renderer/Feed/Rss.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/Rss.php
@@ -34,7 +34,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Render RSS feed
      *
-     * @return self
+     * @return Rss
      */
     public function render()
     {

--- a/library/Zend/File/Transfer/Adapter/Http.php
+++ b/library/Zend/File/Transfer/Adapter/Http.php
@@ -57,7 +57,7 @@ class Http extends AbstractAdapter
      * Remove an individual validator
      *
      * @param  string $name
-     * @return AbstractAdapter
+     * @return Http
      */
     public function removeValidator($name)
     {
@@ -71,7 +71,7 @@ class Http extends AbstractAdapter
     /**
      * Clear the validators
      *
-     * @return AbstractAdapter
+     * @return Http
      */
     public function clearValidators()
     {

--- a/library/Zend/Filter/AbstractUnicode.php
+++ b/library/Zend/Filter/AbstractUnicode.php
@@ -15,7 +15,7 @@ abstract class AbstractUnicode extends AbstractFilter
      * Set the input encoding for the given string
      *
      * @param  string|null $encoding
-     * @return StringToLower
+     * @return AbstractUnicode
      * @throws Exception\InvalidArgumentException
      * @throws Exception\ExtensionNotLoadedException
      */

--- a/library/Zend/Filter/Boolean.php
+++ b/library/Zend/Filter/Boolean.php
@@ -90,7 +90,7 @@ class Boolean extends AbstractFilter
      *
      * @param  int|array $type
      * @throws Exception\InvalidArgumentException
-     * @return bool
+     * @return Boolean
      */
     public function setType($type = null)
     {
@@ -137,7 +137,7 @@ class Boolean extends AbstractFilter
      * @param  bool $flag When true this filter works like cast
      *                       When false it recognises only true and false
      *                       and all other values are returned as is
-     * @return bool
+     * @return Boolean
      */
     public function setCasting($flag = true)
     {
@@ -158,7 +158,7 @@ class Boolean extends AbstractFilter
     /**
      * @param  array|Traversable $translations
      * @throws Exception\InvalidArgumentException
-     * @return bool
+     * @return Boolean
      */
     public function setTranslations($translations)
     {

--- a/library/Zend/Filter/Boolean.php
+++ b/library/Zend/Filter/Boolean.php
@@ -90,7 +90,7 @@ class Boolean extends AbstractFilter
      *
      * @param  integer|array $type
      * @throws Exception\InvalidArgumentException
-     * @return bool
+     * @return Boolean
      */
     public function setType($type = null)
     {
@@ -137,7 +137,7 @@ class Boolean extends AbstractFilter
      * @param  bool $flag When true this filter works like cast
      *                       When false it recognises only true and false
      *                       and all other values are returned as is
-     * @return bool
+     * @return Boolean
      */
     public function setCasting($flag = true)
     {
@@ -158,7 +158,7 @@ class Boolean extends AbstractFilter
     /**
      * @param  array|Traversable $translations
      * @throws Exception\InvalidArgumentException
-     * @return bool
+     * @return Boolean
      */
     public function setTranslations($translations)
     {

--- a/library/Zend/Filter/Callback.php
+++ b/library/Zend/Filter/Callback.php
@@ -40,7 +40,7 @@ class Callback extends AbstractFilter
      *
      * @param  callable $callback
      * @throws Exception\InvalidArgumentException
-     * @return self
+     * @return Callback
      */
     public function setCallback($callback)
     {

--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -36,7 +36,7 @@ class DateTimeFormatter extends AbstractFilter
      * Set the format string accepted by date() to use when formatting a string
      *
      * @param  string $format
-     * @return \Zend\Filter\DateTimeFormatter
+     * @return DateTimeFormatter
      */
     public function setFormat($format)
     {

--- a/library/Zend/Filter/File/Rename.php
+++ b/library/Zend/Filter/File/Rename.php
@@ -69,7 +69,7 @@ class Rename extends Filter\AbstractFilter
      * 'randomize' => Shall target files have a random postfix attached?
      *
      * @param  string|array $options Old file or directory to be rewritten
-     * @return \Zend\Filter\File\Rename
+     * @return Rename
      */
     public function setFile($options)
     {
@@ -200,7 +200,7 @@ class Rename extends Filter\AbstractFilter
      * Supports single and nested arrays
      *
      * @param  array $options
-     * @return array
+     * @return Rename
      */
     protected function _convertOptions($options)
     {

--- a/library/Zend/Filter/FilterChain.php
+++ b/library/Zend/Filter/FilterChain.php
@@ -44,6 +44,11 @@ class FilterChain extends AbstractFilter implements Countable
         }
     }
 
+    /**
+     * @param array|\Traversable $options
+     * @return FilterChain
+     * @throws Exception\InvalidArgumentException
+     */
     public function setOptions($options)
     {
         if (!is_array($options) && !$options instanceof \Traversable) {

--- a/library/Zend/Filter/Null.php
+++ b/library/Zend/Filter/Null.php
@@ -70,7 +70,7 @@ class Null extends AbstractFilter
      *
      * @param  integer|array $type
      * @throws Exception\InvalidArgumentException
-     * @return bool
+     * @return Null
      */
     public function setType($type = null)
     {

--- a/library/Zend/Filter/Null.php
+++ b/library/Zend/Filter/Null.php
@@ -70,7 +70,7 @@ class Null extends AbstractFilter
      *
      * @param  int|array $type
      * @throws Exception\InvalidArgumentException
-     * @return bool
+     * @return Null
      */
     public function setType($type = null)
     {

--- a/library/Zend/Filter/UriNormalize.php
+++ b/library/Zend/Filter/UriNormalize.php
@@ -51,7 +51,7 @@ class UriNormalize extends AbstractFilter
      * normalize the URI and thus may affect the resulting normalize URI.
      *
      * @param  string $defaultScheme
-     * @return \Zend\Filter\UriNormalize
+     * @return UriNormalize
      */
     public function setDefaultScheme($defaultScheme)
     {
@@ -71,7 +71,7 @@ class UriNormalize extends AbstractFilter
      * real-world user mishaps, it may yield unexpected results at times.
      *
      * @param  string $enforcedScheme
-     * @return \Zend\Filter\UriNormalize
+     * @return UriNormalize
      */
     public function setEnforcedScheme($enforcedScheme)
     {

--- a/library/Zend/Filter/UriNormalize.php
+++ b/library/Zend/Filter/UriNormalize.php
@@ -50,7 +50,7 @@ class UriNormalize extends AbstractFilter
      * normalize the URI and thus may affect the resulting normalize URI.
      *
      * @param  string $defaultScheme
-     * @return \Zend\Filter\UriNormalize
+     * @return UriNormalize
      */
     public function setDefaultScheme($defaultScheme)
     {
@@ -70,7 +70,7 @@ class UriNormalize extends AbstractFilter
      * real-world user mishaps, it may yield unexpected results at times.
      *
      * @param  string $enforcedScheme
-     * @return \Zend\Filter\UriNormalize
+     * @return UriNormalize
      */
     public function setEnforcedScheme($enforcedScheme)
     {

--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -78,7 +78,7 @@ class Element implements
      * Set value for name
      *
      * @param  string $name
-     * @return Element|ElementInterface
+     * @return Element
      */
     public function setName($name)
     {
@@ -102,7 +102,7 @@ class Element implements
      * - label_attributes: attributes to use when the label is rendered
      *
      * @param  array|Traversable $options
-     * @return Element|ElementInterface
+     * @return Element
      * @throws Exception\InvalidArgumentException
      */
     public function setOptions($options)
@@ -158,7 +158,7 @@ class Element implements
      *
      * @param  string $key
      * @param  mixed  $value
-     * @return Element|ElementInterface
+     * @return Element
      */
     public function setAttribute($key, $value)
     {
@@ -189,7 +189,7 @@ class Element implements
      * Remove a single attribute
      *
      * @param string $key
-     * @return ElementInterface
+     * @return Element
      */
     public function removeAttribute($key)
     {
@@ -214,7 +214,7 @@ class Element implements
      * Implementation will decide if this will overwrite or merge.
      *
      * @param  array|Traversable $arrayOrTraversable
-     * @return Element|ElementInterface
+     * @return Element
      * @throws Exception\InvalidArgumentException
      */
     public function setAttributes($arrayOrTraversable)
@@ -246,7 +246,7 @@ class Element implements
      * Remove many attributes at once
      *
      * @param array $keys
-     * @return ElementInterface
+     * @return Element
      */
     public function removeAttributes(array $keys)
     {
@@ -260,7 +260,7 @@ class Element implements
     /**
      * Clear all attributes
      *
-     * @return Element|ElementInterface
+     * @return Element
      */
     public function clearAttributes()
     {
@@ -293,8 +293,8 @@ class Element implements
     /**
      * Set the label used for this element
      *
-     * @param $label
-     * @return Element|ElementInterface
+     * @param string $label
+     * @return Element
      */
     public function setLabel($label)
     {
@@ -319,7 +319,7 @@ class Element implements
      * Set the attributes to use with the label
      *
      * @param array $labelAttributes
-     * @return Element|ElementInterface
+     * @return Element
      */
     public function setLabelAttributes(array $labelAttributes)
     {
@@ -341,7 +341,7 @@ class Element implements
      * Set a list of messages to report when validation fails
      *
      * @param  array|Traversable $messages
-     * @return Element|ElementInterface
+     * @return Element
      * @throws Exception\InvalidArgumentException
      */
     public function setMessages($messages)

--- a/library/Zend/Form/Element/Checkbox.php
+++ b/library/Zend/Form/Element/Checkbox.php
@@ -214,7 +214,7 @@ class Checkbox extends Element implements InputProviderInterface
      * Checks or unchecks the checkbox.
      *
      * @param mixed $value A boolean flag or string that is checked against the "checked value".
-     * @return Element
+     * @return Checkbox
      */
     public function setValue($value)
     {

--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -145,7 +145,7 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
      * In this case the "object" is a collection of objects
      *
      * @param  array|Traversable $object
-     * @return Fieldset|FieldsetInterface
+     * @return Collection
      * @throws Exception\InvalidArgumentException
      */
     public function setObject($object)
@@ -285,7 +285,7 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
     /**
      * Set the initial count of target element
      *
-     * @param $count
+     * @param int $count
      * @return Collection
      */
     public function setCount($count)

--- a/library/Zend/Form/Element/DateTimeSelect.php
+++ b/library/Zend/Form/Element/DateTimeSelect.php
@@ -69,7 +69,7 @@ class DateTimeSelect extends DateSelect
      * - should_show_seconds: if set to true, the seconds select is shown
      *
      * @param array|\Traversable $options
-     * @return DateSelect
+     * @return DateTimeSelect
      */
     public function setOptions($options)
     {
@@ -122,7 +122,7 @@ class DateTimeSelect extends DateSelect
      * Set the hour attributes
      *
      * @param  array $hourAttributes
-     * @return DateSelect
+     * @return DateTimeSelect
      */
     public function setHourAttributes(array $hourAttributes)
     {
@@ -144,7 +144,7 @@ class DateTimeSelect extends DateSelect
      * Set the minute attributes
      *
      * @param  array $minuteAttributes
-     * @return DateSelect
+     * @return DateTimeSelect
      */
     public function setMinuteAttributes(array $minuteAttributes)
     {
@@ -166,7 +166,7 @@ class DateTimeSelect extends DateSelect
      * Set the second attributes
      *
      * @param  array $secondAttributes
-     * @return DateSelect
+     * @return DateTimeSelect
      */
     public function setSecondAttributes(array $secondAttributes)
     {

--- a/library/Zend/Form/Element/MultiCheckbox.php
+++ b/library/Zend/Form/Element/MultiCheckbox.php
@@ -73,7 +73,7 @@ class MultiCheckbox extends Checkbox
      * - value_options: list of values and labels for the select options
      *
      * @param  array|\Traversable $options
-     * @return MultiCheckbox|ElementInterface
+     * @return MultiCheckbox
      * @throws InvalidArgumentException
      */
     public function setOptions($options)
@@ -96,7 +96,7 @@ class MultiCheckbox extends Checkbox
      *
      * @param  string $key
      * @param  mixed  $value
-     * @return MultiCheckbox|ElementInterface
+     * @return MultiCheckbox
      */
     public function setAttribute($key, $value)
     {

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -105,7 +105,7 @@ class Select extends Element implements InputProviderInterface
      * _ empty_option: should an empty option be prepended to the options ?
      *
      * @param  array|Traversable $options
-     * @return Select|ElementInterface
+     * @return Select
      * @throws InvalidArgumentException
      */
     public function setOptions($options)
@@ -136,7 +136,7 @@ class Select extends Element implements InputProviderInterface
      *
      * @param  string $key
      * @param  mixed  $value
-     * @return Select|ElementInterface
+     * @return Select
      */
     public function setAttribute($key, $value)
     {

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -83,7 +83,7 @@ class Fieldset extends Element implements FieldsetInterface
      * - use_as_base_fieldset: is this fieldset use as the base fieldset?
      *
      * @param  array|Traversable $options
-     * @return Element|ElementInterface
+     * @return Fieldset
      * @throws Exception\InvalidArgumentException
      */
     public function setOptions($options)
@@ -101,7 +101,7 @@ class Fieldset extends Element implements FieldsetInterface
      * Compose a form factory to use when calling add() with a non-element/fieldset
      *
      * @param  Factory $factory
-     * @return Form
+     * @return Fieldset
      */
     public function setFormFactory(Factory $factory)
     {
@@ -134,7 +134,7 @@ class Fieldset extends Element implements FieldsetInterface
      * @todo   Should we detect if the element/fieldset name conflicts?
      * @param  array|Traversable|ElementInterface $elementOrFieldset
      * @param  array                              $flags
-     * @return Fieldset|FieldsetInterface
+     * @return Fieldset
      * @throws Exception\InvalidArgumentException
      */
     public function add($elementOrFieldset, array $flags = array())
@@ -222,7 +222,7 @@ class Fieldset extends Element implements FieldsetInterface
      * Remove a named element or fieldset
      *
      * @param  string $elementOrFieldset
-     * @return FieldsetInterface
+     * @return Fieldset
      */
     public function remove($elementOrFieldset)
     {
@@ -249,7 +249,7 @@ class Fieldset extends Element implements FieldsetInterface
      *
      * @param string $elementOrFieldset
      * @param int $priority
-     * @return FieldsetInterface
+     * @return Fieldset
      */
     public function setPriority($elementOrFieldset, $priority)
     {
@@ -287,7 +287,7 @@ class Fieldset extends Element implements FieldsetInterface
      * Set a hash of element names/messages to use when validation fails
      *
      * @param  array|Traversable $messages
-     * @return Element|ElementInterface|FieldsetInterface
+     * @return Fieldset
      * @throws Exception\InvalidArgumentException
      */
     public function setMessages($messages)
@@ -428,7 +428,7 @@ class Fieldset extends Element implements FieldsetInterface
      * Set the object used by the hydrator
      *
      * @param  object $object
-     * @return Fieldset|FieldsetInterface
+     * @return Fieldset
      * @throws Exception\InvalidArgumentException
      */
     public function setObject($object)
@@ -470,7 +470,7 @@ class Fieldset extends Element implements FieldsetInterface
      * Set the hydrator to use when binding an object to the element
      *
      * @param  HydratorInterface $hydrator
-     * @return FieldsetInterface
+     * @return Fieldset
      */
     public function setHydrator(HydratorInterface $hydrator)
     {

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -133,7 +133,7 @@ class Form extends Fieldset implements FormInterface
      *
      * @param  array|Traversable|ElementInterface $elementOrFieldset
      * @param  array                              $flags
-     * @return \Zend\Form\Fieldset|\Zend\Form\FieldsetInterface|\Zend\Form\FormInterface
+     * @return Form
      */
     public function add($elementOrFieldset, array $flags = array())
     {
@@ -193,7 +193,7 @@ class Form extends Fieldset implements FormInterface
      * Typically, also passes data on to the composed input filter.
      *
      * @param  array|\ArrayAccess|Traversable $data
-     * @return Form|FormInterface
+     * @return Form
      * @throws Exception\InvalidArgumentException
      */
     public function setData($data)
@@ -223,7 +223,7 @@ class Form extends Fieldset implements FormInterface
      *
      * @param  object $object
      * @param  int $flags
-     * @return mixed|void
+     * @return Form
      * @throws Exception\InvalidArgumentException
      */
     public function bind($object, $flags = FormInterface::VALUES_NORMALIZED)
@@ -253,7 +253,7 @@ class Form extends Fieldset implements FormInterface
      * Set the hydrator to use when binding an object to the element
      *
      * @param  HydratorInterface $hydrator
-     * @return FieldsetInterface
+     * @return Form
      */
     public function setHydrator(HydratorInterface $hydrator)
     {
@@ -337,7 +337,7 @@ class Form extends Fieldset implements FormInterface
      * Set flag indicating whether or not to bind values on successful validation
      *
      * @param  int $bindOnValidateFlag
-     * @return void|Form
+     * @return Form
      * @throws Exception\InvalidArgumentException
      */
     public function setBindOnValidate($bindOnValidateFlag)
@@ -502,7 +502,7 @@ class Form extends Fieldset implements FormInterface
      * Typically, proxies to the composed input filter
      *
      * @throws Exception\InvalidArgumentException
-     * @return Form|FormInterface
+     * @return Form
      */
     public function setValidationGroup()
     {
@@ -591,7 +591,7 @@ class Form extends Fieldset implements FormInterface
      * Set the input filter used by this form
      *
      * @param  InputFilterInterface $inputFilter
-     * @return FormInterface
+     * @return Form
      */
     public function setInputFilter(InputFilterInterface $inputFilter)
     {

--- a/library/Zend/Form/View/Helper/Captcha/AbstractWord.php
+++ b/library/Zend/Form/View/Helper/Captcha/AbstractWord.php
@@ -42,7 +42,7 @@ abstract class AbstractWord extends FormInput
      * Proxies to {@link render()}.
      *
      * @param  ElementInterface $element
-     * @return string
+     * @return string|AbstractWord
      */
     public function __invoke(ElementInterface $element = null)
     {

--- a/library/Zend/Form/View/Helper/Captcha/ReCaptcha.php
+++ b/library/Zend/Form/View/Helper/Captcha/ReCaptcha.php
@@ -22,7 +22,7 @@ class ReCaptcha extends FormInput
      * Proxies to {@link render()}.
      *
      * @param  ElementInterface $element
-     * @return string
+     * @return string|ReCaptcha
      */
     public function __invoke(ElementInterface $element = null)
     {

--- a/library/Zend/Form/View/Helper/Form.php
+++ b/library/Zend/Form/View/Helper/Form.php
@@ -37,7 +37,7 @@ class Form extends AbstractHelper
      * Invoke as function
      *
      * @param  null|FormInterface $form
-     * @return Form
+     * @return string|Form
      */
     public function __invoke(FormInterface $form = null)
     {

--- a/library/Zend/Form/View/Helper/FormDateTimeSelect.php
+++ b/library/Zend/Form/View/Helper/FormDateTimeSelect.php
@@ -34,7 +34,7 @@ class FormDateTimeSelect extends FormDateSelectHelper
      * @param int              $dateType
      * @param int|null|string  $timeType
      * @param null|string      $locale
-     * @return string
+     * @return string|FormDateTimeSelect
      */
     public function __invoke(
         ElementInterface $element = null,

--- a/library/Zend/Form/View/Helper/FormMonthSelect.php
+++ b/library/Zend/Form/View/Helper/FormMonthSelect.php
@@ -54,7 +54,7 @@ class FormMonthSelect extends AbstractHelper
      * @param  ElementInterface $element
      * @param  int              $dateType
      * @param  null|string      $locale
-     * @return FormDateSelect
+     * @return string|FormMonthSelect
      */
     public function __invoke(ElementInterface $element = null, $dateType = IntlDateFormatter::LONG, $locale = null)
     {
@@ -177,7 +177,7 @@ class FormMonthSelect extends AbstractHelper
      * Set date formatter
      *
      * @param  int $dateType
-     * @return FormDateSelect
+     * @return FormMonthSelect
      */
     public function setDateType($dateType)
     {
@@ -205,7 +205,7 @@ class FormMonthSelect extends AbstractHelper
      * Set locale
      *
      * @param  string $locale
-     * @return FormDateSelect
+     * @return FormMonthSelect
      */
     public function setLocale($locale)
     {

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -633,7 +633,7 @@ class Client implements Stdlib\DispatchableInterface
      * Set streaming for received data
      *
      * @param string|bool $streamfile Stream file, true for temp file, false/null for no streaming
-     * @return \Zend\Http\Client
+     * @return Client
      */
     public function setStream($streamfile = true)
     {

--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -558,7 +558,6 @@ class Socket implements HttpAdapter, StreamInterface
 
     /**
      * Close the connection to the server
-     *
      */
     public function close()
     {
@@ -596,7 +595,7 @@ class Socket implements HttpAdapter, StreamInterface
      * Set output stream for the response
      *
      * @param resource $stream
-     * @return \Zend\Http\Client\Adapter\Socket
+     * @return Socket
      */
     public function setOutputStream($stream)
     {
@@ -608,7 +607,6 @@ class Socket implements HttpAdapter, StreamInterface
      * Destructor: make sure the socket is disconnected
      *
      * If we are in persistent TCP mode, will not close the connection
-     *
      */
     public function __destruct()
     {

--- a/library/Zend/Http/Client/Adapter/Test.php
+++ b/library/Zend/Http/Client/Adapter/Test.php
@@ -62,7 +62,7 @@ class Test implements AdapterInterface
      * Set the nextRequestWillFail flag
      *
      * @param  bool $flag
-     * @return \Zend\Http\Client\Adapter\Test
+     * @return Test
      */
     public function setNextRequestWillFail($flag)
     {

--- a/library/Zend/Http/Header/AbstractAccept.php
+++ b/library/Zend/Http/Header/AbstractAccept.php
@@ -239,7 +239,7 @@ abstract class AbstractAccept implements HeaderInterface
      * @param  int|float $priority
      * @param  array (optional) $params
      * @throws Exception\InvalidArgumentException
-     * @return Accept
+     * @return AbstractAccept
      */
     protected function addType($type, $priority = 1, array $params = array())
     {

--- a/library/Zend/Http/Header/Age.php
+++ b/library/Zend/Http/Header/Age.php
@@ -70,7 +70,7 @@ class Age implements HeaderInterface
      * Set number of seconds
      *
      * @param int $delta
-     * @return RetryAfter
+     * @return Age
      */
     public function setDeltaSeconds($delta)
     {

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -116,7 +116,7 @@ class Request extends HttpRequest
      * Set the request URI.
      *
      * @param  string $requestUri
-     * @return self
+     * @return Request
      */
     public function setRequestUri($requestUri)
     {
@@ -141,7 +141,7 @@ class Request extends HttpRequest
      * Set the base URL.
      *
      * @param  string $baseUrl
-     * @return self
+     * @return Request
      */
     public function setBaseUrl($baseUrl)
     {
@@ -166,7 +166,7 @@ class Request extends HttpRequest
      * Set the base path.
      *
      * @param  string $basePath
-     * @return self
+     * @return Request
      */
     public function setBasePath($basePath)
     {

--- a/library/Zend/I18n/Validator/Alnum.php
+++ b/library/Zend/I18n/Validator/Alnum.php
@@ -74,7 +74,7 @@ class Alnum extends AbstractValidator
      * Sets the allowWhiteSpace option
      *
      * @param  bool $allowWhiteSpace
-     * @return AlnumFilter Provides a fluent interface
+     * @return Alnum Provides a fluent interface
      */
     public function setAllowWhiteSpace($allowWhiteSpace)
     {

--- a/library/Zend/I18n/Validator/PhoneNumber.php
+++ b/library/Zend/I18n/Validator/PhoneNumber.php
@@ -117,8 +117,8 @@ class PhoneNumber extends AbstractValidator
     /**
      * Allow Possible
      *
-     * @param  boolean|null $possible
-     * @return PhoneNumber|boolean
+     * @param  bool|null $possible
+     * @return PhoneNumber|bool
      */
     public function allowPossible($possible = null)
     {

--- a/library/Zend/I18n/Validator/PhoneNumber.php
+++ b/library/Zend/I18n/Validator/PhoneNumber.php
@@ -101,7 +101,7 @@ class PhoneNumber extends AbstractValidator
      * Allowed Types
      *
      * @param  array|null $types
-     * @return self|array
+     * @return PhoneNumber|array
      */
     public function allowedTypes(array $types = null)
     {
@@ -117,8 +117,8 @@ class PhoneNumber extends AbstractValidator
     /**
      * Allow Possible
      *
-     * @param  bool|null $possible
-     * @return self|bool
+     * @param  boolean|null $possible
+     * @return PhoneNumber|boolean
      */
     public function allowPossible($possible = null)
     {
@@ -145,7 +145,7 @@ class PhoneNumber extends AbstractValidator
      * Set Country
      *
      * @param  string $country
-     * @return self
+     * @return PhoneNumber
      */
     public function setCountry($country)
     {

--- a/library/Zend/I18n/Validator/PhoneNumber.php
+++ b/library/Zend/I18n/Validator/PhoneNumber.php
@@ -101,7 +101,7 @@ class PhoneNumber extends AbstractValidator
      * Allowed Types
      *
      * @param  array|null $types
-     * @return self|array
+     * @return PhoneNumber|array
      */
     public function allowedTypes(array $types = null)
     {
@@ -118,7 +118,7 @@ class PhoneNumber extends AbstractValidator
      * Allow Possible
      *
      * @param  boolean|null $possible
-     * @return self|boolean
+     * @return PhoneNumber|boolean
      */
     public function allowPossible($possible = null)
     {
@@ -145,7 +145,7 @@ class PhoneNumber extends AbstractValidator
      * Set Country
      *
      * @param  string $country
-     * @return self
+     * @return PhoneNumber
      */
     public function setCountry($country)
     {

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -54,7 +54,7 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
      * @param  InputInterface|InputFilterInterface $input
      * @param  null|string                         $name Name used to retrieve this input
      * @throws Exception\InvalidArgumentException
-     * @return InputFilterInterface
+     * @return BaseInputFilter
      */
     public function add($input, $name = null)
     {
@@ -116,7 +116,7 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
      * Remove a named input
      *
      * @param  string $name
-     * @return InputFilterInterface
+     * @return BaseInputFilter
      */
     public function remove($name)
     {
@@ -129,7 +129,7 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
      *
      * @param  array|Traversable $data
      * @throws Exception\InvalidArgumentException
-     * @return InputFilterInterface
+     * @return BaseInputFilter
      */
     public function setData($data)
     {
@@ -318,7 +318,7 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
      * each specifying a single input.
      *
      * @param  mixed $name
-     * @return InputFilterInterface
+     * @return BaseInputFilter
      */
     public function setValidationGroup($name)
     {

--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -97,7 +97,7 @@ class Input implements InputInterface, EmptyContextInterface
 
     /**
      * @param bool $continueIfEmpty
-     * @return \Zend\InputFilter\Input
+     * @return Input
      */
     public function setContinueIfEmpty($continueIfEmpty)
     {

--- a/library/Zend/Json/Server/Error.php
+++ b/library/Zend/Json/Server/Error.php
@@ -67,7 +67,7 @@ class Error
      * Set error code
      *
      * @param  int $code
-     * @return \Zend\Json\Server\Error
+     * @return Error
      */
     public function setCode($code)
     {
@@ -99,7 +99,7 @@ class Error
      * Set error message
      *
      * @param  string $message
-     * @return \Zend\Json\Server\Error
+     * @return Error
      */
     public function setMessage($message)
     {
@@ -125,7 +125,7 @@ class Error
      * Set error data
      *
      * @param  mixed $data
-     * @return \Zend\Json\Server\Error
+     * @return Error
      */
     public function setData($data)
     {

--- a/library/Zend/Json/Server/Request.php
+++ b/library/Zend/Json/Server/Request.php
@@ -56,7 +56,7 @@ class Request
      * Set request state
      *
      * @param  array $options
-     * @return \Zend\Json\Server\Request
+     * @return Request
      */
     public function setOptions(array $options)
     {
@@ -77,7 +77,7 @@ class Request
      *
      * @param  mixed $value
      * @param  string $key
-     * @return \Zend\Json\Server\Request
+     * @return Request
      */
     public function addParam($value, $key = null)
     {
@@ -95,7 +95,7 @@ class Request
      * Add many params
      *
      * @param  array $params
-     * @return \Zend\Json\Server\Request
+     * @return Request
      */
     public function addParams(array $params)
     {
@@ -109,7 +109,7 @@ class Request
      * Overwrite params
      *
      * @param  array $params
-     * @return \Zend\Json\Server\Request
+     * @return Request
      */
     public function setParams(array $params)
     {
@@ -146,7 +146,7 @@ class Request
      * Set request method
      *
      * @param  string $name
-     * @return \Zend\Json\Server\Request
+     * @return Request
      */
     public function setMethod($name)
     {
@@ -182,7 +182,7 @@ class Request
      * Set request identifier
      *
      * @param  mixed $name
-     * @return \Zend\Json\Server\Request
+     * @return Request
      */
     public function setId($name)
     {
@@ -204,7 +204,7 @@ class Request
      * Set JSON-RPC version
      *
      * @param  string $version
-     * @return \Zend\Json\Server\Request
+     * @return Request
      */
     public function setVersion($version)
     {

--- a/library/Zend/Json/Server/Response.php
+++ b/library/Zend/Json/Server/Response.php
@@ -231,7 +231,7 @@ class Response
      * Set args
      *
      * @param mixed $args
-     * @return self
+     * @return Response
      */
     public function setArgs($args)
     {

--- a/library/Zend/Json/Server/Smd.php
+++ b/library/Zend/Json/Server/Smd.php
@@ -109,7 +109,7 @@ class Smd
      *
      * @param  string $transport
      * @throws Exception\InvalidArgumentException
-     * @return \Zend\Json\Server\Smd
+     * @return Smd
      */
     public function setTransport($transport)
     {
@@ -162,7 +162,7 @@ class Smd
      *
      * @param  string $type
      * @throws Exception\InvalidArgumentException
-     * @return \Zend\Json\Server\Smd
+     * @return Smd
      */
     public function setContentType($type)
     {

--- a/library/Zend/Ldap/Node.php
+++ b/library/Zend/Ldap/Node.php
@@ -1041,7 +1041,7 @@ class Node extends Node\AbstractNode implements \Iterator, \RecursiveIterator
      * Return the current attribute.
      * Implements Iterator
      *
-     * @return array
+     * @return Node
      */
     public function current()
     {

--- a/library/Zend/Log/Writer/AbstractWriter.php
+++ b/library/Zend/Log/Writer/AbstractWriter.php
@@ -158,7 +158,7 @@ abstract class AbstractWriter implements WriterInterface
      * Set filter plugin manager
      *
      * @param  string|FilterPluginManager $plugins
-     * @return self
+     * @return AbstractWriter
      * @throws Exception\InvalidArgumentException
      */
     public function setFilterPluginManager($plugins)
@@ -207,7 +207,7 @@ abstract class AbstractWriter implements WriterInterface
      * Set formatter plugin manager
      *
      * @param  string|FormatterPluginManager $plugins
-     * @return self
+     * @return AbstractWriter
      * @throws Exception\InvalidArgumentException
      */
     public function setFormatterPluginManager($plugins)
@@ -285,7 +285,7 @@ abstract class AbstractWriter implements WriterInterface
      *
      * @param  string|Formatter\FormatterInterface $formatter
      * @param  array|null $options
-     * @return self
+     * @return AbstractWriter
      * @throws Exception\InvalidArgumentException
      */
     public function setFormatter($formatter, array $options = null)

--- a/library/Zend/Log/Writer/FingersCrossed.php
+++ b/library/Zend/Log/Writer/FingersCrossed.php
@@ -104,7 +104,7 @@ class FingersCrossed extends AbstractWriter
      *
      * @param  string|WriterInterface $writer
      * @param  array|null $options
-     * @return self
+     * @return FingersCrossed
      * @throws Exception\InvalidArgumentException
      */
     public function setWriter($writer, array $options = null)

--- a/library/Zend/Log/Writer/MongoDB.php
+++ b/library/Zend/Log/Writer/MongoDB.php
@@ -88,7 +88,7 @@ class MongoDB extends AbstractWriter
      * This writer does not support formatting.
      *
      * @param string|FormatterInterface $formatter
-     * @return WriterInterface
+     * @return MongoDB
      */
     public function setFormatter($formatter)
     {

--- a/library/Zend/Mail/Header/HeaderInterface.php
+++ b/library/Zend/Mail/Header/HeaderInterface.php
@@ -30,7 +30,7 @@ interface HeaderInterface
      * Factory to generate a header object from a string
      *
      * @param string $headerLine
-     * @return self
+     * @return HeaderInterface
      */
     public static function fromString($headerLine);
 
@@ -53,7 +53,7 @@ interface HeaderInterface
      * Set header encoding
      *
      * @param  string $encoding
-     * @return self
+     * @return HeaderInterface
      */
     public function setEncoding($encoding);
 

--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -61,7 +61,7 @@ abstract class AbstractRestfulController extends AbstractController
      * Set the route match/query parameter name containing the identifier
      *
      * @param  string $name
-     * @return self
+     * @return AbstractRestfulController
      */
     public function setIdentifierName($name)
     {

--- a/library/Zend/Mvc/Router/Console/RouteMatch.php
+++ b/library/Zend/Mvc/Router/Console/RouteMatch.php
@@ -56,7 +56,7 @@ class RouteMatch extends BaseRouteMatch
      *
      * @see    BaseRouteMatch::setMatchedRouteName()
      * @param  string $name
-     * @return self
+     * @return RouteMatch
      */
     public function setMatchedRouteName($name)
     {

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -379,7 +379,7 @@ class TreeRouteStack extends SimpleRouteStack
      * Set the base URL.
      *
      * @param  string $baseUrl
-     * @return self
+     * @return TreeRouteStack
      */
     public function setBaseUrl($baseUrl)
     {

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -253,7 +253,7 @@ class TreeRouteStack extends SimpleRouteStack
      * Set the base URL.
      *
      * @param  string $baseUrl
-     * @return self
+     * @return TreeRouteStack
      */
     public function setBaseUrl($baseUrl)
     {

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -324,7 +324,7 @@ class Mvc extends AbstractPage
      *
      * @see getHref()
      * @param  array|string|null $query    URL query part
-     * @return self   fluent interface, returns self
+     * @return Mvc Fluent interface
      */
     public function setQuery($query)
     {

--- a/library/Zend/Permissions/Rbac/Rbac.php
+++ b/library/Zend/Permissions/Rbac/Rbac.php
@@ -45,7 +45,7 @@ class Rbac extends AbstractIterator
      *
      * @param  string|RoleInterface               $child
      * @param  array|RoleInterface|null           $parents
-     * @return self
+     * @return Rbac
      * @throws Exception\InvalidArgumentException
      */
     public function addRole($child, $parents = null)

--- a/library/Zend/Soap/Client/DotNet.php
+++ b/library/Zend/Soap/Client/DotNet.php
@@ -118,7 +118,7 @@ class DotNet extends SOAPClient
      * Sets the cURL client to use.
      *
      * @param  CurlClient $curlClient The cURL client.
-     * @return self Fluent interface.
+     * @return DotNet Fluent interface.
      */
     public function setCurlClient(CurlClient $curlClient)
     {
@@ -133,7 +133,7 @@ class DotNet extends SOAPClient
      *
      * @param  array|\Traversable $options Options.
      * @throws \InvalidArgumentException If an unsupported option is passed.
-     * @return self Fluent interface.
+     * @return DotNet Fluent interface.
      */
     public function setOptions($options)
     {

--- a/library/Zend/Validator/Db/AbstractDb.php
+++ b/library/Zend/Validator/Db/AbstractDb.php
@@ -163,7 +163,7 @@ abstract class AbstractDb extends AbstractValidator
      * Sets a new database adapter
      *
      * @param  DbAdapter $adapter
-     * @return self Provides a fluent interface
+     * @return AbstractDb Provides a fluent interface
      */
     public function setAdapter(DbAdapter $adapter)
     {
@@ -185,7 +185,7 @@ abstract class AbstractDb extends AbstractValidator
      * Sets a new exclude clause
      *
      * @param string|array $exclude
-     * @return self Provides a fluent interface
+     * @return AbstractDb Provides a fluent interface
      */
     public function setExclude($exclude)
     {
@@ -229,7 +229,7 @@ abstract class AbstractDb extends AbstractValidator
      * Sets a new table
      *
      * @param string $table
-     * @return self Provides a fluent interface
+     * @return AbstractDb Provides a fluent interface
      */
     public function setTable($table)
     {
@@ -251,7 +251,7 @@ abstract class AbstractDb extends AbstractValidator
      * Sets a new schema
      *
      * @param string $schema
-     * @return self Provides a fluent interface
+     * @return AbstractDb Provides a fluent interface
      */
     public function setSchema($schema)
     {
@@ -263,7 +263,7 @@ abstract class AbstractDb extends AbstractValidator
      * Sets the select object to be used by the validator
      *
      * @param  Select $select
-     * @return self Provides a fluent interface
+     * @return AbstractDb Provides a fluent interface
      */
     public function setSelect(Select $select)
     {

--- a/library/Zend/Validator/EmailAddress.php
+++ b/library/Zend/Validator/EmailAddress.php
@@ -108,7 +108,7 @@ class EmailAddress extends AbstractValidator
      *
      * @param  string $messageString
      * @param  string $messageKey     OPTIONAL
-     * @return AbstractValidator Provides a fluent interface
+     * @return EmailAddress Provides a fluent interface
      */
     public function setMessage($messageString, $messageKey = null)
     {

--- a/library/Zend/Validator/File/Exists.php
+++ b/library/Zend/Validator/File/Exists.php
@@ -84,7 +84,7 @@ class Exists extends AbstractValidator
      * Sets the file directory which will be checked
      *
      * @param  string|array $directory The directories to validate
-     * @return Extension Provides a fluent interface
+     * @return Exists Provides a fluent interface
      */
     public function setDirectory($directory)
     {
@@ -97,7 +97,7 @@ class Exists extends AbstractValidator
      * Adds the file directory which will be checked
      *
      * @param  string|array $directory The directory to add for validation
-     * @return Extension Provides a fluent interface
+     * @return Exists Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function addDirectory($directory)

--- a/library/Zend/Validator/File/Md5.php
+++ b/library/Zend/Validator/File/Md5.php
@@ -56,7 +56,7 @@ class Md5 extends Hash
      * Sets the md5 hash for one or multiple files
      *
      * @param  string|array $options
-     * @return Hash Provides a fluent interface
+     * @return Md5 Provides a fluent interface
      */
     public function setMd5($options)
     {
@@ -68,7 +68,7 @@ class Md5 extends Hash
      * Adds the md5 hash for one or multiple files
      *
      * @param  string|array $options
-     * @return Hash Provides a fluent interface
+     * @return Md5 Provides a fluent interface
      */
     public function addMd5($options)
     {

--- a/library/Zend/Validator/File/Sha1.php
+++ b/library/Zend/Validator/File/Sha1.php
@@ -56,7 +56,7 @@ class Sha1 extends Hash
      * Sets the sha1 hash for one or multiple files
      *
      * @param  string|array $options
-     * @return Hash Provides a fluent interface
+     * @return Sha1 Provides a fluent interface
      */
     public function setSha1($options)
     {
@@ -68,7 +68,7 @@ class Sha1 extends Hash
      * Adds the sha1 hash for one or multiple files
      *
      * @param  string|array $options
-     * @return Hash Provides a fluent interface
+     * @return Sha1 Provides a fluent interface
      */
     public function addSha1($options)
     {

--- a/library/Zend/Validator/File/Size.php
+++ b/library/Zend/Validator/File/Size.php
@@ -94,7 +94,7 @@ class Size extends AbstractValidator
      * Should messages return bytes as integer or as string in SI notation
      *
      * @param  bool $byteString Use bytestring ?
-     * @return integer
+     * @return Size
      */
     public function useByteString($byteString = true)
     {

--- a/library/Zend/Validator/File/Size.php
+++ b/library/Zend/Validator/File/Size.php
@@ -94,7 +94,7 @@ class Size extends AbstractValidator
      * Should messages return bytes as integer or as string in SI notation
      *
      * @param  bool $byteString Use bytestring ?
-     * @return int
+     * @return Size
      */
     public function useByteString($byteString = true)
     {

--- a/library/Zend/Validator/Ip.php
+++ b/library/Zend/Validator/Ip.php
@@ -41,7 +41,7 @@ class Ip extends AbstractValidator
      *
      * @param array|Traversable $options
      * @throws Exception\InvalidArgumentException If there is any kind of IP allowed or $options is not an array or Traversable.
-     * @return AbstractValidator
+     * @return Ip
      */
     public function setOptions($options = array())
     {

--- a/library/Zend/Validator/IsInstanceOf.php
+++ b/library/Zend/Validator/IsInstanceOf.php
@@ -82,7 +82,7 @@ class IsInstanceOf extends AbstractValidator
      * Set class name
      *
      * @param  string $className
-     * @return self
+     * @return IsInstanceOf
      */
     public function setClassName($className)
     {

--- a/library/Zend/View/Helper/BasePath.php
+++ b/library/Zend/View/Helper/BasePath.php
@@ -49,7 +49,7 @@ class BasePath extends AbstractHelper
      * Set the base path.
      *
      * @param  string $basePath
-     * @return self
+     * @return BasePath
      */
     public function setBasePath($basePath)
     {


### PR DESCRIPTION
Fix wrong return annotations and improve consistency in case of fluent interface.
- Fix wrong class in return annotations
- Use relative namespaces
- Use current class name
- Remove self and $this
