### PR TITLE
Patch remove aware element prepare aware interface

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -15,11 +15,11 @@ use Zend\Form\ElementInterface;
 use Zend\Form\Exception;
 use Zend\Form\Fieldset;
 use Zend\Form\FieldsetInterface;
-use Zend\Form\FieldsetPrepareAwareInterface;
+use Zend\Form\FieldsetPrepareInterface;
 use Zend\Form\FormInterface;
 use Zend\Stdlib\ArrayUtils;
 
-class Collection extends Fieldset implements FieldsetPrepareAwareInterface
+class Collection extends Fieldset implements FieldsetPrepareInterface
 {
     /**
      * Default template placeholder

--- a/library/Zend/Form/Element/Csrf.php
+++ b/library/Zend/Form/Element/Csrf.php
@@ -10,12 +10,12 @@
 namespace Zend\Form\Element;
 
 use Zend\Form\Element;
-use Zend\Form\ElementPrepareAwareInterface;
+use Zend\Form\ElementPrepareInterface;
 use Zend\Form\FormInterface;
 use Zend\InputFilter\InputProviderInterface;
 use Zend\Validator\Csrf as CsrfValidator;
 
-class Csrf extends Element implements InputProviderInterface, ElementPrepareAwareInterface
+class Csrf extends Element implements InputProviderInterface, ElementPrepareInterface
 {
     /**
      * Seed attributes

--- a/library/Zend/Form/Element/File.php
+++ b/library/Zend/Form/Element/File.php
@@ -20,14 +20,14 @@ namespace Zend\Form\Element;
 
 use Zend\Form\FormInterface;
 use Zend\Form\Element;
-use Zend\Form\ElementPrepareAwareInterface;
+use Zend\Form\ElementPrepareInterface;
 use Zend\InputFilter\InputProviderInterface;
 
 /**
  * @copyright  Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class File extends Element implements InputProviderInterface, ElementPrepareAwareInterface
+class File extends Element implements InputProviderInterface, ElementPrepareInterface
 {
     /**
      * Seed attributes

--- a/library/Zend/Form/Element/MonthSelect.php
+++ b/library/Zend/Form/Element/MonthSelect.php
@@ -11,13 +11,13 @@ namespace Zend\Form\Element;
 
 use DateTime;
 use Zend\Form\Element;
-use Zend\Form\ElementPrepareAwareInterface;
+use Zend\Form\ElementPrepareInterface;
 use Zend\Form\FormInterface;
 use Zend\InputFilter\InputProviderInterface;
 use Zend\Validator\ValidatorInterface;
 use Zend\Validator\Regex as RegexValidator;
 
-class MonthSelect extends Element implements InputProviderInterface, ElementPrepareAwareInterface
+class MonthSelect extends Element implements InputProviderInterface, ElementPrepareInterface
 {
     /**
      * Select form element that contains values for month

--- a/library/Zend/Form/Element/Password.php
+++ b/library/Zend/Form/Element/Password.php
@@ -20,13 +20,13 @@ namespace Zend\Form\Element;
 
 use Zend\Form\FormInterface;
 use Zend\Form\Element;
-use Zend\Form\ElementPrepareAwareInterface;
+use Zend\Form\ElementPrepareInterface;
 
 /**
  * @copyright  Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Password extends Element implements ElementPrepareAwareInterface
+class Password extends Element implements ElementPrepareInterface
 {
     /**
      * Seed attributes

--- a/library/Zend/Form/ElementPrepareInterface.php
+++ b/library/Zend/Form/ElementPrepareInterface.php
@@ -9,12 +9,13 @@
 
 namespace Zend\Form;
 
-interface FieldsetPrepareAwareInterface
+interface ElementPrepareInterface
 {
     /**
-     * Prepare the fieldset element (called while this fieldset is added to another one)
+     * Prepare the form element (mostly used for rendering purposes)
      *
+     * @param FormInterface $form
      * @return mixed
      */
-    public function prepareFieldset();
+    public function prepareElement(FormInterface $form);
 }

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -179,7 +179,7 @@ class Fieldset extends Element implements FieldsetInterface
         $this->byName[$name] = $elementOrFieldset;
 
         if ($elementOrFieldset instanceof FieldsetInterface) {
-            if ($elementOrFieldset instanceof FieldsetPrepareAwareInterface) {
+            if ($elementOrFieldset instanceof FieldsetPrepareInterface) {
                 $elementOrFieldset->prepareFieldset();
             }
 
@@ -364,7 +364,7 @@ class Fieldset extends Element implements FieldsetInterface
             $elementOrFieldset->setName($name . '[' . $elementOrFieldset->getName() . ']');
 
             // Recursively prepare elements
-            if ($elementOrFieldset instanceof ElementPrepareAwareInterface) {
+            if ($elementOrFieldset instanceof ElementPrepareInterface) {
                 $elementOrFieldset->prepareElement($form);
             }
         }

--- a/library/Zend/Form/FieldsetInterface.php
+++ b/library/Zend/Form/FieldsetInterface.php
@@ -17,7 +17,7 @@ interface FieldsetInterface extends
     Countable,
     IteratorAggregate,
     ElementInterface,
-    ElementPrepareAwareInterface,
+    ElementPrepareInterface,
     FormFactoryAwareInterface
 {
     /**

--- a/library/Zend/Form/FieldsetPrepareInterface.php
+++ b/library/Zend/Form/FieldsetPrepareInterface.php
@@ -9,13 +9,12 @@
 
 namespace Zend\Form;
 
-interface ElementPrepareAwareInterface
+interface FieldsetPrepareInterface
 {
     /**
-     * Prepare the form element (mostly used for rendering purposes)
+     * Prepare the fieldset element (called while this fieldset is added to another one)
      *
-     * @param FormInterface $form
      * @return mixed
      */
-    public function prepareElement(FormInterface $form);
+    public function prepareFieldset();
 }

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -176,7 +176,7 @@ class Form extends Fieldset implements FormInterface
             $this->prepareElement($this);
         } else {
             foreach ($this->getIterator() as $elementOrFieldset) {
-                if ($elementOrFieldset instanceof ElementPrepareAwareInterface) {
+                if ($elementOrFieldset instanceof ElementPrepareInterface) {
                     $elementOrFieldset->prepareElement($this);
                 }
             }

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1471,4 +1471,11 @@ class FormTest extends TestCase
         $this->form->remove('file_resource');
         $this->assertEquals($form, $this->form);
     }
+
+    public function testRetrieveFromDi()
+    {
+        $di = new \Zend\Di\Di;
+        $element = $di->get('Zend\Form\Form');
+        $this->assertInstanceof('Zend\Form\Form', $element);
+    }
 }


### PR DESCRIPTION
relative to #3818

``` php
        $di = new \Zend\Di\Di;
        $element = $di->get('Zend\Form\Form');
```

raise 
'Zend\Di\Exception\RuntimeException' with message 'Invalid instantiator of type "NULL" for "Zend\Form\FormInterface".

In standard di settings with RuntimeDefinition, the ElementPrepareAwareInterface::prepareElement 's  parameter  is marked as required. Di try to resolve it but can't find an intended instance.
