### PR TITLE
Ability to load custom form classes from FormElementManager in Mvc.

### DIFF
--- a/library/Zend/Mvc/Service/FormElementManagerFactory.php
+++ b/library/Zend/Mvc/Service/FormElementManagerFactory.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Mvc\Service;
 
+use Zend\Form\Form;
 use Zend\Form\FormElementManager;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -25,6 +26,16 @@ class FormElementManagerFactory extends AbstractPluginManagerFactory
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $plugins = parent::createService($serviceLocator);
+        if ($serviceLocator->has('Di')) {
+            $di = $serviceLocator->get('Di');
+            $im = $di->instanceManager();
+            if (!$im->getTypePreferences('Zend\Form\FormInterface')) {
+                $form = new Form;
+                $im->setTypePreference('Zend\Form\FormInterface', array($form));
+            }
+            $plugins->addPeeringServiceManager($serviceLocator);
+            $plugins->setRetrieveFromPeeringManagerFirst(true);
+        }
         return $plugins;
     }
 }

--- a/tests/ZendTest/Mvc/Service/FormElementManagerFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/FormElementManagerFactoryTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc\Service;
+
+use ArrayObject;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mvc\Service\FormElementManagerFactory;
+use Zend\Mvc\Service\DiFactory;
+use Zend\Mvc\Service\DiAbstractServiceFactoryFactory;
+use Zend\Mvc\Service\DiServiceInitializerFactory;
+use Zend\ServiceManager\Config;
+use Zend\ServiceManager\ServiceManager;
+use Zend\Mvc\Exception;
+use Zend\Form\FormElementManager;
+
+class FormElementManagerFactoryTest extends TestCase
+{
+    /**
+     * @var ServiceManager
+     */
+    protected $services;
+
+    /**
+     * @var \Zend\Mvc\Controller\ControllerManager
+     */
+    protected $loader;
+
+    public function setUp()
+    {
+        $formElementManagerFactory = new FormElementManagerFactory();
+        $config = new ArrayObject(array('di' => array()));
+        $this->services = new ServiceManager();
+        $this->services->setService('Zend\ServiceManager\ServiceLocatorInterface', $this->services);
+        $this->services->setFactory('FormElementManager', $formElementManagerFactory);
+        $this->services->setService('Config', $config);
+        $this->services->setFactory('Di', new DiFactory());
+        $this->services->setFactory('DiAbstractServiceFactory', new DiAbstractServiceFactoryFactory());
+        $this->services->setFactory('DiServiceInitializer', new DiServiceInitializerFactory());
+    }
+
+    public function testWillGetFormElementManager()
+    {
+        $formElementManager = $this->services->get('FormElementManager');
+        $this->assertInstanceof('Zend\Form\FormElementManager', $formElementManager);
+    }
+
+    public function testWillInstantiateFormFromInvokable()
+    {
+        $formElementManager = $this->services->get('FormElementManager');
+        $form = $formElementManager->get('form');
+        $this->assertInstanceof('Zend\Form\Form', $form);
+    }
+
+    public function testWillInstantiateFormFromDiAbstractFactory()
+    {
+        //without DiAbstractFactory
+        $standaloneFormElementManager = new FormElementManager();
+        $this->assertFalse($standaloneFormElementManager->has('ZendTest\Mvc\Service\TestAsset\CustomForm'));
+        //with DiAbstractFactory
+        $formElementManager = $this->services->get('FormElementManager');
+        $this->assertTrue($formElementManager->has('ZendTest\Mvc\Service\TestAsset\CustomForm'));
+        $form = $formElementManager->get('ZendTest\Mvc\Service\TestAsset\CustomForm');
+        $this->assertInstanceof('ZendTest\Mvc\Service\TestAsset\CustomForm', $form);
+    }
+}

--- a/tests/ZendTest/Mvc/Service/TestAsset/CustomForm.php
+++ b/tests/ZendTest/Mvc/Service/TestAsset/CustomForm.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace ZendTest\Mvc\Service\TestAsset;
+
+use Zend\Form\Form;
+use Zend\Stdlib\Hydrator\ClassMethods as ClassMethodsHydrator;
+
+class CustomForm extends Form
+{
+    public function __construct()
+    {
+        parent::__construct('test_form');
+
+        $this->setAttribute('method', 'post')
+             ->setHydrator(new ClassMethodsHydrator());
+
+        $this->add(array(
+            'name' => 'submit',
+            'attributes' => array(
+                'type' => 'submit'
+            )
+        ));
+    }
+}


### PR DESCRIPTION
with Mvc

``` php
$formElementManager = $serviceLocator->get('FormElementManager');
$form = $formElementManager->get('MyApplication\Form\ContactForm');

```

raise Exception 
Caused by
Zend\Form\Exception\InvalidElementException: Plugin of type Zend\Form\Factory is invalid; must implement Zend\Form\ElementInterface

Because the ElementInterface depends on Zend\Form\Factory and the FormElementManager tries to get from DiAbstractFactory in it(as ServiceManager). So the FormElementManager::validatePlugin throws Exception.
We can avoid this corruption with setting Application's ServiceLocator as peeringServiceManager. yes.

Next, the ElementPrepareAwareInterface requires 'Zend\Form\FormInterface'. 

cause
Zend\Di\Exception\RuntimeException: Invalid instantiator of type "NULL" for "Zend\Form\FormInterface".

Thus feed a mock object to type-preference

If the ElementPrepareAwareInterface problem (issue #3818 and PR #4370) was resolved, Feeding type-preferences is not necessary.

relative to #3818
https://github.com/zendframework/zf2/pull/4370

``` php
        $di = new \Zend\Di\Di;
        $element = $di->get('Zend\Form\Form');
```

raise 
'Zend\Di\Exception\RuntimeException' with message 'Invalid instantiator of type "NULL" for "Zend\Form\FormInterface".
