### PR TITLE
CollectionInputFilter returns always valid for empty collections

### DIFF
--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -29,6 +29,11 @@ class CollectionInputFilter extends InputFilter
     protected $collectionInvalidInputs;
 
     /*
+     * @var bool
+     */
+    protected $isRequired = false;
+
+    /*
      * @var int
      */
     protected $count = null;
@@ -88,6 +93,29 @@ class CollectionInputFilter extends InputFilter
     }
 
     /**
+     * Set if the collection can be empty
+     *
+     * @param bool $isRequired
+     * @return CollectionInputFilter
+     */
+    public function setIsRequired($isRequired)
+    {
+        $this->isRequired = $isRequired;
+        return $this;
+    }
+
+    /**
+     * Get if collection can be empty
+     *
+     * @return bool
+     */
+    public function getIsRequired()
+    {
+        return $this->isRequired;
+    }
+
+
+    /**
      * Set the count of data to validate
      *
      * @param int $count
@@ -128,6 +156,9 @@ class CollectionInputFilter extends InputFilter
         $valid = true;
 
         if ($this->getCount() < 1) {
+            if ($this->isRequired) {
+                $valid = false;
+            }
             return $valid;
         }
 

--- a/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
@@ -354,4 +354,31 @@ class CollectionInputFilterTest extends TestCase
 
         $this->assertTrue($this->filter->isValid());
     }
+
+    public function testEmptyCollectionIsValidByDefault()
+    {
+        $data = array();
+
+        $this->filter->setInputFilter($this->getBaseInputFilter());
+        $this->filter->setData($data);
+
+        $this->assertTrue($this->filter->isValid());
+    }
+
+    public function testEmptyCollectionIsNotValidIfRequired()
+    {
+        $data = array();
+
+        $this->filter->setInputFilter($this->getBaseInputFilter());
+        $this->filter->setData($data);
+        $this->filter->setIsRequired(true);
+
+        $this->assertFalse($this->filter->isValid());
+    }
+
+    public function testSetRequired()
+    {
+        $this->filter->setIsRequired(true);
+        $this->assertEquals(true,$this->filter->getIsRequired());
+    }
 }


### PR DESCRIPTION
this pull request adds a required flag to an InputFilterCollection

if you have nested arrays, it's impossible to enfoce at least one entry.

``` php
$offers = array(
    array(
        'name' => 't-shirt',
        'prices' => array(
            // i need at least one price! 
                        // array('color' => 'black', 'price' => 149)
        ),
    ),
);
```

for example - this is very useful for mongodb documents.
