### PR TITLE
Add render method to formHelper fixes #4371

### DIFF
--- a/library/Zend/Form/View/Helper/FormLabel.php
+++ b/library/Zend/Form/View/Helper/FormLabel.php
@@ -54,14 +54,21 @@ class FormLabel extends AbstractHelper
      * @param  ElementInterface $element
      * @param  null|string      $labelContent
      * @param  string           $position
+     * @param  string           $translatorTextDomain
      * @throws Exception\DomainException
-     * @return FormLabel
+     * @return string|FormLabel
      */
-    public function __invoke(ElementInterface $element = null, $labelContent = null, $position = null)
+    public function __invoke(ElementInterface $element = null, $labelContent = null, $position = null, $translatorTextDomain = null)
     {
         $this->element = $element;
         $this->labelContent = $labelContent;
         $this->position = $position;
+        if ($translatorTextDomain) {
+            $this->setTranslatorTextDomain($translatorTextDomain);
+        }
+        if ($this->element) {
+            return $this->render($this->element, $this->labelContent, $this->position);
+        }
         return $this;
     }
 

--- a/library/Zend/Form/View/Helper/FormLabel.php
+++ b/library/Zend/Form/View/Helper/FormLabel.php
@@ -73,6 +73,26 @@ class FormLabel extends AbstractHelper
     }
 
     /**
+     * Set element
+     * @param \Zend\Form\ElementInterface $element
+     * @return \Zend\Form\View\Helper\FormLabel
+     */
+    public function setElement(ElementInterface $element)
+    {
+        $this->element = $element;
+        return $this;
+    }
+
+    /**
+     * Get element
+     * @return ElementInterface
+     */
+    public function getElement()
+    {
+        return $this->element;
+    }
+
+    /**
      * Convenient method to cast label to string
      *
      * @return string

--- a/library/Zend/Form/View/Helper/FormLabel.php
+++ b/library/Zend/Form/View/Helper/FormLabel.php
@@ -92,14 +92,10 @@ class FormLabel extends AbstractHelper
      * @param  null|string      $labelContent
      * @param  string           $position
      * @throws Exception\DomainException
-     * @return string|FormLabel
+     * @return string
      */
     public function render(ElementInterface $element = null, $labelContent = null, $position = null)
     {
-        if (!$element) {
-            return $this;
-        }
-
         $openTag = $this->openTag($element);
         $label   = '';
         if ($labelContent === null || $position !== null) {

--- a/library/Zend/Form/View/Helper/FormLabel.php
+++ b/library/Zend/Form/View/Helper/FormLabel.php
@@ -28,7 +28,55 @@ class FormLabel extends AbstractHelper
     );
 
     /**
+     * Form element
+     * @var ElementInterface
+     */
+    protected $element;
+
+    /**
+     * Label overide
+     * @var string
+     */
+    protected $labelContent;
+
+    /**
+     * Label position
+     * @var string
+     */
+    protected $position;
+
+    /**
      * Generate a form label, optionally with content
+     *
+     * Always generates a "for" statement, as we cannot assume the form input
+     * will be provided in the $labelContent.
+     *
+     * @param  ElementInterface $element
+     * @param  null|string      $labelContent
+     * @param  string           $position
+     * @throws Exception\DomainException
+     * @return FormLabel
+     */
+    public function __invoke(ElementInterface $element = null, $labelContent = null, $position = null)
+    {
+        $this->element = $element;
+        $this->labelContent = $labelContent;
+        $this->position = $position;
+        return $this;
+    }
+
+    /**
+     * Convenient method to cast label to string
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $this->render($this->element, $this->labelContent, $this->position);
+    }
+
+    /**
+     * Render a form label, optionally with content
      *
      * Always generates a "for" statement, as we cannot assume the form input
      * will be provided in the $labelContent.
@@ -39,7 +87,7 @@ class FormLabel extends AbstractHelper
      * @throws Exception\DomainException
      * @return string|FormLabel
      */
-    public function __invoke(ElementInterface $element = null, $labelContent = null, $position = null)
+    public function render(ElementInterface $element = null, $labelContent = null, $position = null)
     {
         if (!$element) {
             return $this;
@@ -50,16 +98,19 @@ class FormLabel extends AbstractHelper
         if ($labelContent === null || $position !== null) {
             $label = $element->getLabel();
             if (empty($label)) {
-                throw new Exception\DomainException(sprintf(
-                    '%s expects either label content as the second argument, ' .
+                throw new Exception\DomainException(
+                    sprintf(
+                        '%s expects either label content as the second argument, ' .
                         'or that the element provided has a label attribute; neither found',
-                    __METHOD__
-                ));
+                        __METHOD__
+                    )
+                );
             }
 
             if (null !== ($translator = $this->getTranslator())) {
                 $label = $translator->translate(
-                    $label, $this->getTranslatorTextDomain()
+                    $label,
+                    $this->getTranslatorTextDomain()
                 );
             }
         }
@@ -103,19 +154,23 @@ class FormLabel extends AbstractHelper
         }
 
         if (!$attributesOrElement instanceof ElementInterface) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects an array or Zend\Form\ElementInterface instance; received "%s"',
-                __METHOD__,
-                (is_object($attributesOrElement) ? get_class($attributesOrElement) : gettype($attributesOrElement))
-            ));
+            throw new Exception\InvalidArgumentException(
+                sprintf(
+                    '%s expects an array or Zend\Form\ElementInterface instance; received "%s"',
+                    __METHOD__,
+                    (is_object($attributesOrElement) ? get_class($attributesOrElement) : gettype($attributesOrElement))
+                )
+            );
         }
 
         $id = $this->getId($attributesOrElement);
         if (null === $id) {
-            throw new Exception\DomainException(sprintf(
-                '%s expects the Element provided to have either a name or an id present; neither found',
-                __METHOD__
-            ));
+            throw new Exception\DomainException(
+                sprintf(
+                    '%s expects the Element provided to have either a name or an id present; neither found',
+                    __METHOD__
+                )
+            );
         }
 
         $labelAttributes = $attributesOrElement->getLabelAttributes();


### PR DESCRIPTION
The formLabel helper offers no way to acces ::setTranslatorTextDomain, it returns an object if you not pass the element but you cannot set the element after.
If you do pass an element it will only return a string.

https://github.com/zendframework/zf2/issues/4371
