### PR TITLE
Fix get with body in ClientStatic

### DIFF
--- a/library/Zend/Http/ClientStatic.php
+++ b/library/Zend/Http/ClientStatic.php
@@ -60,7 +60,7 @@ class ClientStatic
         }
 
         if (!empty($body)) {
-            $request->setBody($body);
+            $request->setContent($body);
         }
 
         return static::getStaticClient()->send($request);

--- a/tests/ZendTest/Http/Client/StaticClientTest.php
+++ b/tests/ZendTest/Http/Client/StaticClientTest.php
@@ -81,6 +81,24 @@ class StaticClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test GET with body
+     */
+    public function testHttpGetWithBody()
+    {
+        $getBody = 'baz';
+
+        $response= HTTPClient::get($this->baseuri . 'testRawGetData.php',
+                                   array('foo' => 'bar'),
+                                   array(),
+                                   $getBody);
+
+        $this->assertTrue($response->isSuccess());
+        $this->assertContains('foo', $response->getBody());
+        $this->assertContains('bar', $response->getBody());
+        $this->assertContains($getBody, $response->getBody());
+    }
+
+    /**
      * Test simple POST
      */
     public function testHttpSimplePost()

--- a/tests/ZendTest/Http/Client/_files/testRawGetData.php
+++ b/tests/ZendTest/Http/Client/_files/testRawGetData.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Http
+ */
+
+echo serialize($_GET);
+readfile('php://input');


### PR DESCRIPTION
Changed ClientStatic to correctly accept a body. Before it was trying
to call setBody which didn't exist. Unit test added.

This change may be controversial as there is debate as to wether GET's
should have a body or not. However, the documentation for this class
says it is supported, so this fixes that broken functionality.
